### PR TITLE
feat: scaffold qurl-integrations monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[*.go]
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{json,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,15 @@
 
 # Infrastructure and CI require platform team review
 /.github/workflows/ @layervai/platform
+/terraform/ @layervai/platform
 apps/*/deploy/ @layervai/platform
 
 # Shared code changes affect all apps — require platform review
 shared/ @layervai/platform
+
+# Repo config
+/.github/ @layervai/platform
+Makefile @layervai/platform
+.golangci.yml @layervai/platform
+.pre-commit-config.yaml @layervai/platform
+.editorconfig @layervai/platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS - Define code ownership for automatic review requests
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything
+* @layervai/platform
+
+# Infrastructure and CI require platform team review
+/.github/workflows/ @layervai/platform
+apps/*/deploy/ @layervai/platform
+
+# Shared code changes affect all apps — require platform review
+shared/ @layervai/platform

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,18 @@
 
 Brief description of changes.
 
+## Scope
+
+<!-- Which app does this PR change? Check one. -->
+
+- [ ] `apps/slack/`
+- [ ] `apps/teams/`
+- [ ] `apps/discord/`
+- [ ] `apps/cli/`
+- [ ] `apps/zapier/`
+- [ ] `shared/` (triggers tests for ALL apps — coordinate first)
+- [ ] `terraform/` / `.github/` (platform team only)
+
 ## Changes
 
 - Change 1
@@ -9,8 +21,8 @@ Brief description of changes.
 
 ## Test Plan
 
-- [ ] Tests pass locally (`go test ./...`)
-- [ ] Linting passes (`go vet ./...`)
+- [ ] `make check` passes locally
+- [ ] New tests added for new functionality
 - [ ] Manual testing completed
 
 ## Related Issues

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+Brief description of changes.
+
+## Changes
+
+- Change 1
+- Change 2
+
+## Test Plan
+
+- [ ] Tests pass locally (`go test ./...`)
+- [ ] Linting passes (`go vet ./...`)
+- [ ] Manual testing completed
+
+## Related Issues
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/*"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1fc90f3ed982521116d8ff6d85b948c9b12cae3e # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,4 +39,4 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-6 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,42 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,23 +30,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 6 AM UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-go-tidy.yml
+++ b/.github/workflows/dependabot-go-tidy.yml
@@ -1,0 +1,39 @@
+name: Dependabot Go Tidy
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: write
+
+jobs:
+  go-tidy:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run go mod tidy
+        run: go mod tidy
+
+      - name: Commit changes
+        run: |
+          git diff --quiet go.mod go.sum && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add go.mod go.sum
+          git commit -m "chore(deps): go mod tidy"
+          git push

--- a/.github/workflows/dependabot-go-tidy.yml
+++ b/.github/workflows/dependabot-go-tidy.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/dependabot-go-tidy.yml
+++ b/.github/workflows/dependabot-go-tidy.yml
@@ -1,22 +1,21 @@
 name: Dependabot Go Tidy
 
 on:
-  pull_request_target:
+  push:
+    branches:
+      - 'dependabot/**'
     paths:
       - 'go.mod'
       - 'go.sum'
 
 jobs:
   go-tidy:
-    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout PR branch
+      - name: Checkout branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/dependabot-go-tidy.yml
+++ b/.github/workflows/dependabot-go-tidy.yml
@@ -6,19 +6,17 @@ on:
       - 'go.mod'
       - 'go.sum'
 
-permissions:
-  contents: write
-
 jobs:
   go-tidy:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/dependabot-go-tidy.yml
+++ b/.github/workflows/dependabot-go-tidy.yml
@@ -1,7 +1,7 @@
 name: Dependabot Go Tidy
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'go.mod'
       - 'go.sum'
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout repository
+      - name: Checkout PR branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Review Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-3.0, AGPL-3.0
+          comment-summary-in-pr: always

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -36,6 +36,7 @@ jobs:
             cli
             zapier
             shared
+            infra
             ci
             deps
           requireScope: false

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,45 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          scopes: |
+            slack
+            teams
+            discord
+            cli
+            zapier
+            shared
+            ci
+            deps
+          requireScope: false
+          subjectPattern: ^[a-z].+$
+          subjectPatternError: |
+            PR title must start with a lowercase letter.
+            Example: "feat(slack): add slash command handler"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@c3e599b7163e8198a55467f3133db0e7b2a492cb # main
         with:
           extra_args: --only-verified

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -13,7 +13,7 @@ jobs:
     name: TruffleHog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,22 @@
+name: Secrets Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -9,14 +9,14 @@ permissions:
   contents: read
 
 jobs:
-  gitleaks:
-    name: Gitleaks
+  trufflehog:
+    name: TruffleHog
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -1,0 +1,35 @@
+name: Shared Tests (All Apps)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'shared/**'
+      - 'go.mod'
+      - 'go.sum'
+  pull_request:
+    paths:
+      - 'shared/**'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+jobs:
+  test-all:
+    name: Test All Apps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run all tests
+        run: go test -race -count=1 ./...
+
+      - name: Vet all
+        run: go vet ./...

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -17,6 +17,23 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.10.1
+          args: --timeout=5m
+
   test-all:
     name: Test All Apps
     runs-on: ubuntu-latest

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       shared: ${{ steps.filter.outputs.shared }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -33,15 +33,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.shared == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.10.1
           args: --timeout=5m
@@ -52,9 +52,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.shared == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -53,8 +53,8 @@ jobs:
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
           echo "Total coverage: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 60" | bc -l)" -eq 1 ]; then
-            echo "::error::Coverage ${COVERAGE}% is below 60% threshold"
+          if [ "$(echo "$COVERAGE < 40" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${COVERAGE}% is below 40% threshold"
             exit 1
           fi
 

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -45,8 +45,18 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run all tests
-        run: go test -race -count=1 ./...
+      - name: Run all tests with coverage
+        run: |
+          go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Check coverage threshold
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
+          echo "Total coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 60" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${COVERAGE}% is below 60% threshold"
+            exit 1
+          fi
 
       - name: Vet all
         run: go vet ./...

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -3,23 +3,34 @@ name: Shared Tests (All Apps)
 on:
   push:
     branches: [main]
-    paths:
-      - 'shared/**'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
-    paths:
-      - 'shared/**'
-      - 'go.mod'
-      - 'go.sum'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      shared: ${{ steps.filter.outputs.shared }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared:
+              - 'shared/**'
+              - 'go.mod'
+              - 'go.sum'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.shared == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +48,8 @@ jobs:
   test-all:
     name: Test All Apps
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.shared == 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -19,6 +19,23 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.10.1
+          args: --timeout=5m
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -36,10 +53,27 @@ jobs:
       - name: Vet
         run: go vet ./apps/slack/... ./shared/...
 
+  vulnerability-scan:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: test
+    needs: [lint, test]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -3,25 +3,35 @@ name: Slack Integration
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/slack/**'
-      - 'shared/**'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
-    paths:
-      - 'apps/slack/**'
-      - 'shared/**'
-      - 'go.mod'
-      - 'go.sum'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'apps/slack/**'
+              - 'shared/**'
+              - 'go.mod'
+              - 'go.sum'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +49,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -67,6 +79,8 @@ jobs:
   vulnerability-scan:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -84,7 +98,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [changes, lint, test]
+    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +126,7 @@ jobs:
     name: Deploy (Sandbox)
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.build.result == 'success'
     environment: slack-sandbox
     permissions:
       id-token: write
@@ -144,7 +159,7 @@ jobs:
     name: Deploy (Production)
     runs-on: ubuntu-latest
     needs: deploy-sandbox
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.deploy-sandbox.result == 'success'
     environment: slack-production
     permissions:
       id-token: write

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -56,8 +56,8 @@ jobs:
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
           echo "Total coverage: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 60" | bc -l)" -eq 1 ]; then
-            echo "::error::Coverage ${COVERAGE}% is below 60% threshold"
+          if [ "$(echo "$COVERAGE < 40" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${COVERAGE}% is below 40% threshold"
             exit 1
           fi
 

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -96,12 +96,20 @@ jobs:
           path: bootstrap
           retention-days: 7
 
-  deploy:
-    name: Deploy
+  deploy-sandbox:
+    name: Deploy (Sandbox)
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    # TODO: Add environment protection rule
-    # environment: slack-sandbox
+    environment: slack-sandbox
+    steps:
+      - run: echo "Deploy step placeholder — will be implemented with Terraform"
+
+  deploy-production:
+    name: Deploy (Production)
+    runs-on: ubuntu-latest
+    needs: deploy-sandbox
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment: slack-production
     steps:
       - run: echo "Deploy step placeholder — will be implemented with Terraform"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       app: ${{ steps.filter.outputs.app }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -34,15 +34,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.10.1
           args: --timeout=5m
@@ -53,9 +53,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -83,9 +83,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -102,9 +102,9 @@ jobs:
     needs: [changes, lint, test]
     if: needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -117,7 +117,7 @@ jobs:
         run: go build -o bootstrap ./apps/slack/cmd/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: slack-lambda
           path: bootstrap
@@ -133,15 +133,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: slack-lambda
           path: .
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_INTEGRATIONS_SANDBOX_ROLE_ARN }}
           aws-region: us-east-2
@@ -166,15 +166,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: slack-lambda
           path: .
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_INTEGRATIONS_PROD_ROLE_ARN }}
           aws-region: us-east-2

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -102,8 +102,32 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: slack-sandbox
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - run: echo "Deploy step placeholder — will be implemented with Terraform"
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: slack-lambda
+          path: .
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_INTEGRATIONS_SANDBOX_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Package Lambda
+        run: zip slack-lambda.zip bootstrap
+
+      - name: Deploy Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name integrations-slack-sandbox \
+            --zip-file fileb://slack-lambda.zip \
+            --publish
 
   deploy-production:
     name: Deploy (Production)
@@ -111,5 +135,29 @@ jobs:
     needs: deploy-sandbox
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: slack-production
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - run: echo "Deploy step placeholder — will be implemented with Terraform"
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: slack-lambda
+          path: .
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_INTEGRATIONS_PROD_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Package Lambda
+        run: zip slack-lambda.zip bootstrap
+
+      - name: Deploy Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name integrations-slack-prod \
+            --zip-file fileb://slack-lambda.zip \
+            --publish

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -47,8 +47,19 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run tests
-        run: go test -race -count=1 ./apps/slack/... ./shared/...
+      - name: Run tests with coverage
+        run: |
+          go test -race -count=1 -coverprofile=coverage.out -covermode=atomic \
+            ./apps/slack/... ./shared/...
+
+      - name: Check coverage threshold
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
+          echo "Total coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 60" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${COVERAGE}% is below 60% threshold"
+            exit 1
+          fi
 
       - name: Vet
         run: go vet ./apps/slack/... ./shared/...

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,73 @@
+name: Slack Integration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/slack/**'
+      - 'shared/**'
+      - 'go.mod'
+      - 'go.sum'
+  pull_request:
+    paths:
+      - 'apps/slack/**'
+      - 'shared/**'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test -race -count=1 ./apps/slack/... ./shared/...
+
+      - name: Vet
+        run: go vet ./apps/slack/... ./shared/...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build Lambda binary
+        env:
+          CGO_ENABLED: "0"
+          GOOS: linux
+          GOARCH: arm64
+        run: go build -o bootstrap ./apps/slack/cmd/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-lambda
+          path: bootstrap
+          retention-days: 7
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # TODO: Add environment protection rule
+    # environment: slack-sandbox
+    steps:
+      - run: echo "Deploy step placeholder — will be implemented with Terraform"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,40 @@
+name: Terraform Validate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [sandbox, prod]
+    defaults:
+      run:
+        working-directory: terraform/environments/${{ matrix.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.14"
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive ../../
+        working-directory: terraform
+
+      - name: Terraform init
+        run: terraform init -backend=false
+
+      - name: Terraform validate
+        run: terraform validate

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -23,9 +23,9 @@ jobs:
       run:
         working-directory: terraform/environments/${{ matrix.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: "~> 1.14"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Binaries
+bootstrap
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test
+*.test
+*.out
+coverage.html
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+
+# Build artifacts
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ Thumbs.db
 
 # Build artifacts
 dist/
+release/
+
+# Secrets — never commit these
+.env
+.env.*
+*.pem
+*.key

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,129 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+output:
+  sort-order:
+    - linter
+    - severity
+    - file
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/layervai/qurl-integrations
+
+linters:
+  default: none
+  enable:
+    # Bugs & Error Handling
+    - bodyclose        # HTTP response body must be closed
+    - errcheck         # Check error returns are handled
+    - errorlint        # Error wrapping issues (errors.Is/As)
+    - govet            # Reports suspicious constructs
+    - nilerr           # Returns nil when err is not nil
+    - nilnil           # Returns nil error with nil value
+    - noctx            # HTTP requests without context
+    - staticcheck      # Advanced static analysis
+    - unused           # Find unused code
+
+    # Complexity
+    - gocognit         # Cognitive complexity
+    - gocyclo          # Cyclomatic complexity
+
+    # Style & Consistency
+    - dogsled          # Too many blank identifiers
+    - dupl             # Code duplication detection
+    - exhaustive       # Exhaustive switch statements
+    - goconst          # Repeated strings that should be constants
+    - gocritic         # Opinionated style checks
+    - goprintffuncname # Printf-like function naming
+    - misspell         # Spelling mistakes
+    - nakedret         # Naked returns in long functions
+    - nolintlint       # Ill-formed nolint directives
+    - prealloc         # Slice preallocation suggestions
+    - revive           # Fast, extensible linter
+    - unconvert        # Unnecessary type conversions
+    - whitespace       # Unnecessary whitespace
+
+    # Performance
+    - copyloopvar      # Loop variable copy issues
+    - perfsprint       # Performance-aware sprintf
+
+    # Security
+    - gosec            # Security issues
+
+    # Testing
+    - tparallel        # Improper t.Parallel() usage
+
+  settings:
+    gocognit:
+      min-complexity: 30
+    gocyclo:
+      min-complexity: 20
+    dupl:
+      threshold: 150
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    misspell:
+      locale: US
+    nakedret:
+      max-func-lines: 30
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    perfsprint:
+      sprintf1: true
+      errorf: true
+      int-conversion: true
+    gosec:
+      excludes:
+        - G101  # Hardcoded credentials (false positives on variable names)
+        - G115  # Integer overflow (safe conversions)
+        - G704  # SSRF via taint analysis (API client takes user-provided URLs by design)
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+          arguments:
+            - checkPrivateReceivers
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: var-naming
+
+  exclusions:
+    generated: lax
+    rules:
+      # Relax complexity checks in tests
+      - linters:
+          - gocognit
+          - gocyclo
+          - dupl
+        path: _test\.go

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Install: pip install pre-commit && pre-commit install
+# Run all: pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: detect-private-key
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: go-fmt
+        name: go fmt
+        entry: gofmt -w
+        language: system
+        types: [go]
+
+      - id: go-mod-tidy
+        name: go mod tidy
+        entry: go mod tidy
+        language: system
+        pass_filenames: false
+        files: '(\.go|go\.mod|go\.sum)$'
+
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.10.1
+    hooks:
+      - id: golangci-lint
+        args: ['--timeout=5m']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,11 @@ repos:
       - id: detect-private-key
       - id: check-merge-conflict
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.3
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.88.30
     hooks:
-      - id: gitleaks
+      - id: trufflehog
+        args: ['--only-verified']
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,11 @@ repos:
       - id: detect-private-key
       - id: check-merge-conflict
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks
+
   - repo: local
     hooks:
       - id: go-fmt

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,7 @@
+{
+  "apps/slack": "0.1.0",
+  "apps/teams": "0.1.0",
+  "apps/discord": "0.1.0",
+  "apps/cli": "0.1.0",
+  "apps/zapier": "0.1.0"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md — qurl-integrations
+
+## Project Overview
+
+Monorepo for QURL integrations (Slack, Teams, Discord, CLI, Zapier, etc.).
+Each integration lives in `apps/{name}/` with independent release tracks.
+Shared code lives in `shared/`.
+
+## Repository Rules
+
+1. **Never push directly to main.** Always create a branch and PR.
+2. **Conventional Commits required.** Scope to the app: `feat(slack):`, `fix(teams):`, `chore(shared):`.
+3. **Path-filtered CI.** Each app has its own workflow. Changes to `shared/` trigger all app tests.
+4. **Independent releases.** Release Please monorepo mode. Each app has its own version and CHANGELOG.
+
+## Commit Format
+
+```
+<type>(<scope>): <description>
+
+type:  feat | fix | chore | docs | test | refactor | ci
+scope: slack | teams | discord | cli | zapier | shared
+```
+
+Examples:
+- `feat(slack): add slash command handler`
+- `fix(shared): retry on 429 in API client`
+- `ci(slack): add deploy step to workflow`
+
+## Code Conventions
+
+- **Language:** Go (matches nhp and qurl-service repos)
+- **Module:** `github.com/layervai/qurl-integrations`
+- **App entry points:** `apps/{name}/cmd/main.go`
+- **App-private code:** `apps/{name}/internal/`
+- **Shared code:** `shared/{package}/` — changes here affect ALL apps
+- **Per-app infra:** `apps/{name}/deploy/terraform/`
+
+## Testing
+
+```bash
+go test ./...                      # All tests
+go test ./apps/slack/...           # Single app
+go test ./shared/...               # Shared only
+go test -count=1 ./...             # Skip cache
+```
+
+## Build
+
+Lambda apps use `CGO_ENABLED=0 GOOS=linux GOARCH=arm64`:
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
+```
+
+## Key Architecture Decisions
+
+- **Auth:** Start with workspace API keys (qurl-api-keys table exists). Per-user OAuth later.
+- **Runtime (Slack):** AWS Lambda behind API Gateway. Event-driven, scales to zero.
+- **Shared client:** `shared/client/` wraps the QURL API. Not a standalone module yet.
+- **Release:** Release Please monorepo mode with per-app version tracks.
+- **Terraform:** Per-app in `apps/{name}/deploy/terraform/`. Isolated blast radius.
+
+## Related Repos
+
+- `layervai/nhp` — NHP server, AC, infrastructure
+- `layervai/qurl-service` — QURL API backend
+- `layervai/website` — Marketing site + QURL Playground

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,28 @@
 # CLAUDE.md — qurl-integrations
 
+## CRITICAL RULES - NEVER VIOLATE
+
+> **NEVER push directly to `main` branch.** All changes MUST go through a Pull Request, no exceptions. Create a branch, open a PR, and let CI run.
+
+> **All commits must be GPG/SSH signed.** Unsigned commits will be rejected by GitHub branch protection rules.
+
+> **All code must pass `golangci-lint` with zero issues.** The linter config is strict by design — fix the code, don't weaken the rules.
+
+## Code Change Workflow
+
+1. `git checkout main && git pull origin main`
+2. `git checkout -b <type>/<short-description>`
+3. Make changes
+4. `make check` (runs fmt, vet, lint, tests)
+5. `git push -u origin <branch>`
+6. `gh pr create --title "<type>(scope): description" --body "..."`
+7. Address code review feedback, then push fixes
+
 ## Project Overview
 
 Monorepo for QURL integrations (Slack, Teams, Discord, CLI, Zapier, etc.).
 Each integration lives in `apps/{name}/` with independent release tracks.
 Shared code lives in `shared/`.
-
-## Repository Rules
-
-1. **Never push directly to main.** Always create a branch and PR.
-2. **Conventional Commits required.** Scope to the app: `feat(slack):`, `fix(teams):`, `chore(shared):`.
-3. **Path-filtered CI.** Each app has its own workflow. Changes to `shared/` trigger all app tests.
-4. **Independent releases.** Release Please monorepo mode. Each app has its own version and CHANGELOG.
 
 ## Commit Format
 
@@ -35,6 +46,45 @@ Examples:
 - **App-private code:** `apps/{name}/internal/`
 - **Shared code:** `shared/{package}/` — changes here affect ALL apps
 - **Per-app infra:** `apps/{name}/deploy/terraform/`
+
+## Linting
+
+This repo uses `golangci-lint` v2.10.1 with 28+ linters enabled (see `.golangci.yml`). Key rules:
+
+- All errors must be checked (`errcheck`)
+- Use `errors.Is`/`errors.As`, not type assertions (`errorlint`)
+- No naked returns (`nakedret`)
+- Max cognitive complexity 30 / cyclomatic complexity 20
+- No code duplication over 150 tokens (`dupl`)
+- Repeated strings (3+ occurrences) must be constants (`goconst`)
+- All exported types/functions need comments (`revive`)
+- `nolint` directives require explanation and specific linter name (`nolintlint`)
+- Security scanning via `gosec`
+- Performance-aware formatting (`perfsprint`)
+
+## Pre-commit Hooks
+
+```bash
+# Install (one-time)
+pip install pre-commit && pre-commit install
+
+# Run manually
+pre-commit run --all-files
+```
+
+Hooks: trailing whitespace, EOF fixer, YAML/JSON validation, large file check, private key detection, merge conflict check, `gofmt`, `go mod tidy`, `golangci-lint`.
+
+## Common Commands
+
+```bash
+make check          # Full CI parity: fmt + vet + lint + test
+make lint           # golangci-lint only
+make test           # go test (no race)
+make test-race      # go test -race
+make build-slack    # Build Slack Lambda binary
+make security       # govulncheck
+make fmt            # gofmt + goimports
+```
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to qurl-integrations
+
+## Quick Start
+
+```bash
+# Clone and install tools
+git clone git@github.com:layervai/qurl-integrations.git
+cd qurl-integrations
+
+# Install pre-commit hooks (required — CI will catch what these catch, but faster locally)
+pip install pre-commit && pre-commit install
+
+# Verify everything works
+make check
+```
+
+## Your Sandbox
+
+Each integration lives in `apps/{name}/`. You own your app directory:
+
+```
+apps/
+  slack/          # Slack integration
+    cmd/main.go   # Lambda entry point
+    internal/     # App-private code — put your logic here
+    README.md
+  teams/          # Your app here
+  discord/        # Your app here
+```
+
+**You should primarily be working in `apps/{your-app}/`.**
+
+## Boundaries
+
+| Directory | Who owns it | Can you modify it? |
+|-----------|------------|-------------------|
+| `apps/{your-app}/` | You | Yes |
+| `apps/{other-app}/` | Other contractor | No — open an issue |
+| `shared/` | Platform team | PR requires platform review |
+| `terraform/` | Platform team | Do not modify |
+| `.github/` | Platform team | Do not modify |
+
+Changes to `shared/` trigger tests for ALL apps, so coordinate with other teams.
+
+## Workflow
+
+```bash
+# 1. Always start from latest main
+git checkout main && git pull
+
+# 2. Create a branch (never commit to main)
+git checkout -b feat/slack-thread-replies
+
+# 3. Write code, then verify
+make check                    # Full CI parity: fmt + vet + lint + test
+make build-slack              # Verify Lambda binary compiles (adjust for your app)
+
+# 4. Push and open a PR
+git push -u origin feat/slack-thread-replies
+gh pr create --title "feat(slack): add thread replies"
+```
+
+## PR Requirements
+
+All of these must pass before merge:
+
+- **PR title** follows [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`
+  - Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`
+  - Scopes: `slack`, `teams`, `discord`, `cli`, `zapier`, `shared`
+- **Linting** passes (golangci-lint with 28+ linters — see `.golangci.yml`)
+- **Tests** pass with `-race`
+- **Build** succeeds (Lambda binary)
+- **Code review** approved (CODEOWNERS auto-assigns reviewers)
+- **No high-severity vulnerabilities** in new dependencies
+- **No GPL-3.0 / AGPL-3.0** licensed dependencies
+
+## Code Conventions
+
+- **Error handling**: Always check errors. Use `errors.Is`/`errors.As`, not type assertions.
+- **Context**: Pass `context.Context` as the first parameter.
+- **Logging**: Use the shared observability package, not `fmt.Println` or `log`.
+- **HTTP clients**: Always pass context (`req.WithContext(ctx)`).
+- **Constants**: If you use the same string 3+ times, make it a constant.
+- **Complexity**: Max cognitive complexity 30, cyclomatic complexity 20.
+- **Tests**: Use `t.Parallel()` where possible. Table-driven tests preferred.
+
+## Using Shared Packages
+
+```go
+import (
+    "github.com/layervai/qurl-integrations/shared/client"
+    "github.com/layervai/qurl-integrations/shared/auth"
+    "github.com/layervai/qurl-integrations/shared/formatting"
+)
+```
+
+If you need something that doesn't exist in `shared/`, start by putting it in your app's `internal/` package. If multiple apps need it, open an issue to discuss promoting it to `shared/`.
+
+## Common Mistakes
+
+1. **Pushing to main** — Branch protection will reject it, but don't try.
+2. **Modifying `shared/` without coordination** — Your change runs tests for ALL apps.
+3. **Ignoring linter errors** — `//nolint` requires an explanation AND a specific linter name.
+4. **Adding large dependencies** — Dependency review will flag high-severity or GPL deps.
+5. **Hardcoding secrets** — Use SSM Parameter Store or Secrets Manager. `detect-private-key` hook catches some of this.
+6. **Skipping `make check`** — CI runs the same checks. Save yourself the round-trip.
+
+## Getting Help
+
+- **Build/CI issues**: Open an issue tagged `ci`
+- **Shared package questions**: Open an issue tagged `shared`
+- **Architecture decisions**: Check the app's README first, then ask in your team channel

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.PHONY: all fmt lint vet test test-race build-slack security check clean
+
+all: check build-slack
+
+## Formatting
+
+fmt:
+	gofmt -w .
+	goimports -w -local github.com/layervai/qurl-integrations .
+
+## Linting
+
+lint:
+	golangci-lint run --timeout=5m ./...
+
+vet:
+	go vet ./...
+
+## Testing
+
+test:
+	go test -count=1 ./...
+
+test-race:
+	go test -race -count=1 ./...
+
+## Building
+
+build-slack:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o release/slack/bootstrap ./apps/slack/cmd/
+
+## Security
+
+security:
+	govulncheck ./...
+
+## Pre-commit
+
+pre-commit-install:
+	pip install pre-commit
+	pre-commit install
+
+pre-commit-run:
+	pre-commit run --all-files
+
+## Full check (CI parity)
+
+check: fmt vet lint test-race
+
+## Cleanup
+
+clean:
+	rm -rf release/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt lint vet test test-race build-slack security check clean
+.PHONY: all fmt lint vet test test-race coverage build-slack security check clean
 
 all: check build-slack
 
@@ -23,6 +23,15 @@ test:
 
 test-race:
 	go test -race -count=1 ./...
+
+coverage:
+	@go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
+	@COVERAGE=$$(go tool cover -func=coverage.out | grep ^total: | awk '{print $$3}' | tr -d '%'); \
+	echo "Total coverage: $${COVERAGE}%"; \
+	if [ "$$(echo "$$COVERAGE < 60" | bc -l)" -eq 1 ]; then \
+		echo "FAIL: Coverage $${COVERAGE}% is below 60% threshold"; \
+		exit 1; \
+	fi
 
 ## Building
 
@@ -50,4 +59,4 @@ check: fmt vet lint test-race
 ## Cleanup
 
 clean:
-	rm -rf release/
+	rm -rf release/ coverage.out

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ coverage:
 	@go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
 	@COVERAGE=$$(go tool cover -func=coverage.out | grep ^total: | awk '{print $$3}' | tr -d '%'); \
 	echo "Total coverage: $${COVERAGE}%"; \
-	if [ "$$(echo "$$COVERAGE < 60" | bc -l)" -eq 1 ]; then \
-		echo "FAIL: Coverage $${COVERAGE}% is below 60% threshold"; \
+	if [ "$$(echo "$$COVERAGE < 40" | bc -l)" -eq 1 ]; then \
+		echo "FAIL: Coverage $${COVERAGE}% is below 40% threshold"; \
 		exit 1; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # qurl-integrations
-QURL integrations monorepo — Slack, Teams, Discord, CLI, Zapier, and more
+
+QURL integrations monorepo — Slack, Teams, Discord, CLI, Zapier, and more.
+
+## Structure
+
+```
+apps/           Per-integration applications (independent release tracks)
+  slack/        Slack bot — slash commands, link unfurling, notifications
+  teams/        Microsoft Teams (planned)
+  discord/      Discord bot (planned)
+  cli/          CLI tool (planned)
+  zapier/       Zapier integration (planned)
+shared/         Shared libraries used by all integrations
+  client/       QURL API client
+  auth/         Auth0 M2M + API key helpers
+  events/       Webhook event parsing
+  formatting/   Chat message templates
+  observability/ OpenTelemetry setup
+```
+
+## Development
+
+```bash
+# Run all tests
+go test ./...
+
+# Run tests for a specific app
+go test ./apps/slack/...
+
+# Build Slack Lambda
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
+```
+
+## Releases
+
+This repo uses [Release Please](https://github.com/googleapis/release-please) in monorepo mode.
+Each app has an independent version track:
+
+- Commits scoped to an app bump only that app: `feat(slack): add thread replies` → `slack/v0.2.0`
+- Changes to `shared/` bump all apps
+- Each app has its own `CHANGELOG.md`
+
+## CI
+
+Each app has a path-filtered workflow that only runs when its code (or shared code) changes.
+A `shared-test.yml` workflow runs all app tests when `shared/` is modified.

--- a/apps/slack/CHANGELOG.md
+++ b/apps/slack/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -1,0 +1,38 @@
+# QURL Slack Integration
+
+Slack bot for creating and managing QURLs via slash commands, with link unfurling and channel notifications.
+
+## Features
+
+- `/qurl create <url>` — Create a QURL
+- `/qurl list` — List recent QURLs
+- Link unfurling for `qurl.link` URLs (planned)
+- Channel notifications on QURL events (planned)
+
+## Architecture
+
+- **Runtime:** AWS Lambda (arm64) behind API Gateway
+- **Auth:** Workspace API key (per-user OAuth planned)
+- **Endpoints:**
+  - `POST /slack/commands` — Slash command handler
+  - `POST /slack/events` — Event subscriptions (link unfurling)
+  - `POST /slack/interactions` — Interactive components
+  - `GET /health` — Health check
+
+## Development
+
+```bash
+# Run tests
+go test -count=1 ./apps/slack/...
+
+# Build
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SLACK_SIGNING_SECRET` | Yes | Slack app signing secret |
+| `QURL_API_KEY` | Yes | QURL API key for this workspace |
+| `QURL_ENDPOINT` | No | QURL API base URL (default: `https://api.layerv.xyz`) |

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	qurlEndpoint := os.Getenv("QURL_ENDPOINT")
+	if qurlEndpoint == "" {
+		qurlEndpoint = "https://api.layerv.xyz"
+	}
+
+	slackSigningSecret := os.Getenv("SLACK_SIGNING_SECRET")
+	if slackSigningSecret == "" {
+		slog.Error("SLACK_SIGNING_SECRET is required")
+		os.Exit(1)
+	}
+
+	authProvider := auth.EnvProvider{EnvVar: "QURL_API_KEY"}
+
+	handler := internal.NewHandler(internal.Config{
+		QURLEndpoint:       qurlEndpoint,
+		AuthProvider:       &authProvider,
+		SlackSigningSecret: slackSigningSecret,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlEndpoint, apiKey)
+		},
+	})
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		return handler.Handle(ctx, req)
+	})
+}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1,3 +1,4 @@
+// Package main is the Lambda entrypoint for the Slack integration.
 package main
 
 import (
@@ -7,6 +8,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
@@ -39,6 +41,6 @@ func main() {
 	})
 
 	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-		return handler.Handle(ctx, req)
+		return handler.Handle(ctx, &req)
 	})
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1,0 +1,175 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// Config holds the Slack handler configuration.
+type Config struct {
+	QURLEndpoint       string
+	AuthProvider       auth.Provider
+	SlackSigningSecret string
+	NewClient          func(apiKey string) *client.Client
+}
+
+// Handler processes Slack events and commands.
+type Handler struct {
+	cfg Config
+}
+
+// NewHandler creates a new Slack handler.
+func NewHandler(cfg Config) *Handler {
+	return &Handler{cfg: cfg}
+}
+
+// Handle routes incoming API Gateway requests to the appropriate handler.
+func (h *Handler) Handle(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	slog.Info("received request", "path", req.Path, "method", req.HTTPMethod)
+
+	switch {
+	case req.Path == "/slack/commands" && req.HTTPMethod == "POST":
+		return h.handleSlashCommand(ctx, req)
+	case req.Path == "/slack/events" && req.HTTPMethod == "POST":
+		return h.handleEvent(ctx, req)
+	case req.Path == "/slack/interactions" && req.HTTPMethod == "POST":
+		return h.handleInteraction(ctx, req)
+	case req.Path == "/health":
+		return respond(http.StatusOK, map[string]string{"status": "ok"})
+	default:
+		return respond(http.StatusNotFound, map[string]string{"error": "not found"})
+	}
+}
+
+func (h *Handler) handleSlashCommand(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	values, err := url.ParseQuery(req.Body)
+	if err != nil {
+		return respond(http.StatusBadRequest, map[string]string{"error": "invalid form body"})
+	}
+
+	command := values.Get("command")
+	text := strings.TrimSpace(values.Get("text"))
+
+	slog.Info("slash command", "command", command, "text", text)
+
+	switch {
+	case text == "" || text == "help":
+		return respondSlack(helpMessage())
+	case strings.HasPrefix(text, "create "):
+		return h.handleCreate(ctx, values)
+	case strings.HasPrefix(text, "list"):
+		return h.handleList(ctx, values)
+	default:
+		return respondSlack(fmt.Sprintf("Unknown subcommand: `%s`. Try `/qurl help`.", text))
+	}
+}
+
+func (h *Handler) handleCreate(ctx context.Context, values url.Values) (events.APIGatewayProxyResponse, error) {
+	text := strings.TrimSpace(values.Get("text"))
+	targetURL := strings.TrimPrefix(text, "create ")
+	targetURL = strings.TrimSpace(targetURL)
+
+	if targetURL == "" {
+		return respondSlack("Usage: `/qurl create <url>`")
+	}
+
+	apiKey, err := h.cfg.AuthProvider.APIKey(ctx, values.Get("team_id"))
+	if err != nil {
+		slog.Error("failed to get API key", "error", err)
+		return respondSlack("Failed to authenticate. Please check your QURL API key configuration.")
+	}
+
+	c := h.cfg.NewClient(apiKey)
+	qurl, err := c.Create(ctx, client.CreateInput{TargetURL: targetURL})
+	if err != nil {
+		slog.Error("failed to create QURL", "error", err, "target_url", targetURL)
+		return respondSlack(fmt.Sprintf("Failed to create QURL: %v", err))
+	}
+
+	return respondSlack(fmt.Sprintf("QURL created!\n*Link:* %s\n*Target:* %s", qurl.LinkURL, qurl.TargetURL))
+}
+
+func (h *Handler) handleList(ctx context.Context, values url.Values) (events.APIGatewayProxyResponse, error) {
+	apiKey, err := h.cfg.AuthProvider.APIKey(ctx, values.Get("team_id"))
+	if err != nil {
+		slog.Error("failed to get API key", "error", err)
+		return respondSlack("Failed to authenticate. Please check your QURL API key configuration.")
+	}
+
+	c := h.cfg.NewClient(apiKey)
+	result, err := c.List(ctx, client.ListInput{Limit: 5})
+	if err != nil {
+		slog.Error("failed to list QURLs", "error", err)
+		return respondSlack(fmt.Sprintf("Failed to list QURLs: %v", err))
+	}
+
+	if len(result.QURLs) == 0 {
+		return respondSlack("No QURLs found.")
+	}
+
+	var lines []string
+	for _, q := range result.QURLs {
+		line := fmt.Sprintf("• %s → %s (%d clicks)", q.LinkURL, q.TargetURL, q.ClickCount)
+		if q.Title != "" {
+			line = fmt.Sprintf("• *%s* — %s → %s (%d clicks)", q.Title, q.LinkURL, q.TargetURL, q.ClickCount)
+		}
+		lines = append(lines, line)
+	}
+
+	return respondSlack("*Recent QURLs:*\n" + strings.Join(lines, "\n"))
+}
+
+func (h *Handler) handleEvent(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// Handle Slack URL verification challenge
+	var body struct {
+		Type      string `json:"type"`
+		Challenge string `json:"challenge"`
+	}
+	if err := json.Unmarshal([]byte(req.Body), &body); err == nil && body.Type == "url_verification" {
+		return respond(http.StatusOK, map[string]string{"challenge": body.Challenge})
+	}
+
+	// TODO: Handle link_shared events for unfurling
+	slog.Info("event received", "body_length", len(req.Body))
+	return respond(http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func (h *Handler) handleInteraction(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// TODO: Handle interactive components (buttons, modals)
+	slog.Info("interaction received", "body_length", len(req.Body))
+	return respond(http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func helpMessage() string {
+	return `*/qurl* — Create and manage QURLs from Slack
+
+*Commands:*
+• ` + "`/qurl create <url>`" + ` — Create a QURL for the given URL
+• ` + "`/qurl list`" + ` — Show your 5 most recent QURLs
+• ` + "`/qurl help`" + ` — Show this help message`
+}
+
+func respond(status int, body any) (events.APIGatewayProxyResponse, error) {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayProxyResponse{
+		StatusCode: status,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}, nil
+}
+
+func respondSlack(text string) (events.APIGatewayProxyResponse, error) {
+	return respond(http.StatusOK, map[string]string{
+		"response_type": "ephemeral",
+		"text":          text,
+	})
+}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1,3 +1,4 @@
+// Package internal contains Slack-specific handler logic.
 package internal
 
 import (
@@ -10,9 +11,12 @@ import (
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
+
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
+
+const methodPost = "POST"
 
 // Config holds the Slack handler configuration.
 type Config struct {
@@ -33,16 +37,16 @@ func NewHandler(cfg Config) *Handler {
 }
 
 // Handle routes incoming API Gateway requests to the appropriate handler.
-func (h *Handler) Handle(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	slog.Info("received request", "path", req.Path, "method", req.HTTPMethod)
 
 	switch {
-	case req.Path == "/slack/commands" && req.HTTPMethod == "POST":
+	case req.Path == "/slack/commands" && req.HTTPMethod == methodPost:
 		return h.handleSlashCommand(ctx, req)
-	case req.Path == "/slack/events" && req.HTTPMethod == "POST":
-		return h.handleEvent(ctx, req)
-	case req.Path == "/slack/interactions" && req.HTTPMethod == "POST":
-		return h.handleInteraction(ctx, req)
+	case req.Path == "/slack/events" && req.HTTPMethod == methodPost:
+		return h.handleEvent(req)
+	case req.Path == "/slack/interactions" && req.HTTPMethod == methodPost:
+		return h.handleInteraction(req)
 	case req.Path == "/health":
 		return respond(http.StatusOK, map[string]string{"status": "ok"})
 	default:
@@ -50,7 +54,7 @@ func (h *Handler) Handle(ctx context.Context, req events.APIGatewayProxyRequest)
 	}
 }
 
-func (h *Handler) handleSlashCommand(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+func (h *Handler) handleSlashCommand(ctx context.Context, req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	values, err := url.ParseQuery(req.Body)
 	if err != nil {
 		return respond(http.StatusBadRequest, map[string]string{"error": "invalid form body"})
@@ -92,7 +96,7 @@ func (h *Handler) handleCreate(ctx context.Context, values url.Values) (events.A
 	qurl, err := c.Create(ctx, client.CreateInput{TargetURL: targetURL})
 	if err != nil {
 		slog.Error("failed to create QURL", "error", err, "target_url", targetURL)
-		return respondSlack(fmt.Sprintf("Failed to create QURL: %v", err))
+		return respondSlack("Failed to create QURL: " + err.Error())
 	}
 
 	return respondSlack(fmt.Sprintf("QURL created!\n*Link:* %s\n*Target:* %s", qurl.LinkURL, qurl.TargetURL))
@@ -109,15 +113,16 @@ func (h *Handler) handleList(ctx context.Context, values url.Values) (events.API
 	result, err := c.List(ctx, client.ListInput{Limit: 5})
 	if err != nil {
 		slog.Error("failed to list QURLs", "error", err)
-		return respondSlack(fmt.Sprintf("Failed to list QURLs: %v", err))
+		return respondSlack("Failed to list QURLs: " + err.Error())
 	}
 
 	if len(result.QURLs) == 0 {
 		return respondSlack("No QURLs found.")
 	}
 
-	var lines []string
-	for _, q := range result.QURLs {
+	lines := make([]string, 0, len(result.QURLs))
+	for i := range result.QURLs {
+		q := &result.QURLs[i]
 		line := fmt.Sprintf("• %s → %s (%d clicks)", q.LinkURL, q.TargetURL, q.ClickCount)
 		if q.Title != "" {
 			line = fmt.Sprintf("• *%s* — %s → %s (%d clicks)", q.Title, q.LinkURL, q.TargetURL, q.ClickCount)
@@ -128,8 +133,8 @@ func (h *Handler) handleList(ctx context.Context, values url.Values) (events.API
 	return respondSlack("*Recent QURLs:*\n" + strings.Join(lines, "\n"))
 }
 
-func (h *Handler) handleEvent(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	// Handle Slack URL verification challenge
+func (h *Handler) handleEvent(req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// Handle Slack URL verification challenge.
 	var body struct {
 		Type      string `json:"type"`
 		Challenge string `json:"challenge"`
@@ -138,13 +143,13 @@ func (h *Handler) handleEvent(ctx context.Context, req events.APIGatewayProxyReq
 		return respond(http.StatusOK, map[string]string{"challenge": body.Challenge})
 	}
 
-	// TODO: Handle link_shared events for unfurling
+	// TODO: Handle link_shared events for unfurling.
 	slog.Info("event received", "body_length", len(req.Body))
 	return respond(http.StatusOK, map[string]string{"ok": "true"})
 }
 
-func (h *Handler) handleInteraction(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	// TODO: Handle interactive components (buttons, modals)
+func (h *Handler) handleInteraction(req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// TODO: Handle interactive components (buttons, modals).
 	slog.Info("interaction received", "body_length", len(req.Body))
 	return respond(http.StatusOK, map[string]string{"ok": "true"})
 }

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -1,0 +1,136 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
+	t.Helper()
+	return NewHandler(Config{
+		QURLEndpoint:       qurlServer.URL,
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: "test-secret",
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlServer.URL, apiKey)
+		},
+	})
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+		Path:       "/health",
+		HTTPMethod: "GET",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestSlashCommandHelp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	body := url.Values{
+		"command": {"/qurl"},
+		"text":    {"help"},
+		"team_id": {"T123"},
+	}.Encode()
+
+	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: "POST",
+		Body:       body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	json.Unmarshal([]byte(resp.Body), &result)
+	if result["text"] == "" {
+		t.Error("expected non-empty help text")
+	}
+}
+
+func TestSlashCommandCreate(t *testing.T) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(client.QURL{
+			ID:        "qurl_123",
+			ShortCode: "abc",
+			TargetURL: "https://example.com",
+			LinkURL:   "https://qurl.link.layerv.xyz/abc",
+		})
+	}))
+	defer qurlSrv.Close()
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	h := newTestHandler(t, qurlSrv)
+	body := url.Values{
+		"command": {"/qurl"},
+		"text":    {"create https://example.com"},
+		"team_id": {"T123"},
+	}.Encode()
+
+	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: "POST",
+		Body:       body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	json.Unmarshal([]byte(resp.Body), &result)
+	if result["response_type"] != "ephemeral" {
+		t.Errorf("expected ephemeral response, got %q", result["response_type"])
+	}
+}
+
+func TestURLVerificationChallenge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	body := `{"type":"url_verification","challenge":"test-challenge-123"}`
+
+	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+		Path:       "/slack/events",
+		HTTPMethod: "POST",
+		Body:       body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]string
+	json.Unmarshal([]byte(resp.Body), &result)
+	if result["challenge"] != "test-challenge-123" {
+		t.Errorf("expected challenge echo, got %q", result["challenge"])
+	}
+}

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
+
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
@@ -26,24 +27,28 @@ func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 }
 
 func TestHealthEndpoint(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 	defer srv.Close()
 
 	h := newTestHandler(t, srv)
-	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
 		Path:       "/health",
 		HTTPMethod: "GET",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
 }
 
 func TestSlashCommandHelp(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 	defer srv.Close()
 
 	h := newTestHandler(t, srv)
@@ -53,34 +58,38 @@ func TestSlashCommandHelp(t *testing.T) {
 		"team_id": {"T123"},
 	}.Encode()
 
-	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
 		Path:       "/slack/commands",
-		HTTPMethod: "POST",
+		HTTPMethod: methodPost,
 		Body:       body,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
 
 	var result map[string]string
-	json.Unmarshal([]byte(resp.Body), &result)
+	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if result["text"] == "" {
 		t.Error("expected non-empty help text")
 	}
 }
 
 func TestSlashCommandCreate(t *testing.T) {
-	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(client.QURL{
+		if err := json.NewEncoder(w).Encode(client.QURL{
 			ID:        "qurl_123",
 			ShortCode: "abc",
 			TargetURL: "https://example.com",
 			LinkURL:   "https://qurl.link.layerv.xyz/abc",
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer qurlSrv.Close()
 
@@ -93,35 +102,39 @@ func TestSlashCommandCreate(t *testing.T) {
 		"team_id": {"T123"},
 	}.Encode()
 
-	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
 		Path:       "/slack/commands",
-		HTTPMethod: "POST",
+		HTTPMethod: methodPost,
 		Body:       body,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
 
 	var result map[string]string
-	json.Unmarshal([]byte(resp.Body), &result)
+	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if result["response_type"] != "ephemeral" {
 		t.Errorf("expected ephemeral response, got %q", result["response_type"])
 	}
 }
 
 func TestURLVerificationChallenge(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 	defer srv.Close()
 
 	h := newTestHandler(t, srv)
 	body := `{"type":"url_verification","challenge":"test-challenge-123"}`
 
-	resp, err := h.Handle(context.Background(), events.APIGatewayProxyRequest{
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
 		Path:       "/slack/events",
-		HTTPMethod: "POST",
+		HTTPMethod: methodPost,
 		Body:       body,
 	})
 	if err != nil {
@@ -129,7 +142,9 @@ func TestURLVerificationChallenge(t *testing.T) {
 	}
 
 	var result map[string]string
-	json.Unmarshal([]byte(resp.Body), &result)
+	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if result["challenge"] != "test-challenge-123" {
 		t.Errorf("expected challenge echo, got %q", result["challenge"])
 	}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,252 @@
+# Contractor Onboarding
+
+Welcome to qurl-integrations. This doc covers everything you need to start shipping code.
+
+## 1. Repo Setup
+
+```bash
+git clone git@github.com:layervai/qurl-integrations.git
+cd qurl-integrations
+
+# Install pre-commit hooks (mandatory — blocks secrets and lint errors before push)
+pip install pre-commit && pre-commit install
+
+# Verify your setup
+make check
+```
+
+### Required tools
+
+- Go 1.26+ (`go version`)
+- golangci-lint v2.10+ (`golangci-lint --version`)
+- pre-commit (`pre-commit --version`)
+- gh CLI (`gh --version`) — for opening PRs
+
+## 2. Where Your Code Goes
+
+```
+apps/
+  slack/              # Slack integration (reference implementation)
+    cmd/main.go       # Lambda entry point
+    internal/         # Your handler logic, models, helpers
+    README.md         # App-specific docs
+  teams/              # <-- your app here
+  discord/            # <-- your app here
+shared/               # Shared libraries (platform team owns these)
+  client/             # QURL API client
+  auth/               # API key provider
+  formatting/         # Chat message templates
+  observability/      # Structured logging
+```
+
+Your work goes in `apps/{your-app}/`. Follow the Slack app as a reference.
+
+### Directory structure for a new app
+
+```
+apps/your-app/
+  cmd/main.go              # Lambda entrypoint
+  internal/
+    handler.go             # Request routing + business logic
+    handler_test.go        # Tests (required — CI enforces coverage)
+  README.md                # What it does, env vars, how to test
+  CHANGELOG.md             # Release Please manages this — start with "# Changelog\n"
+```
+
+### Entrypoint pattern
+
+Every app is an AWS Lambda behind API Gateway. Use this skeleton:
+
+```go
+package main
+
+import (
+    "context"
+    "log/slog"
+    "os"
+
+    "github.com/aws/aws-lambda-go/events"
+    "github.com/aws/aws-lambda-go/lambda"
+
+    "github.com/layervai/qurl-integrations/apps/yourapp/internal"
+    "github.com/layervai/qurl-integrations/shared/auth"
+    "github.com/layervai/qurl-integrations/shared/client"
+)
+
+func main() {
+    logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+    slog.SetDefault(logger)
+
+    endpoint := os.Getenv("QURL_ENDPOINT")
+    if endpoint == "" {
+        endpoint = "https://api.layerv.xyz"
+    }
+
+    authProvider := auth.EnvProvider{EnvVar: "QURL_API_KEY"}
+
+    handler := internal.NewHandler(internal.Config{
+        QURLEndpoint: endpoint,
+        AuthProvider: &authProvider,
+        NewClient: func(apiKey string) *client.Client {
+            return client.New(endpoint, apiKey)
+        },
+    })
+
+    lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+        return handler.Handle(ctx, &req)
+    })
+}
+```
+
+### Using the QURL API client
+
+```go
+import "github.com/layervai/qurl-integrations/shared/client"
+
+c := client.New("https://api.layerv.xyz", apiKey)
+
+// Create a QURL
+qurl, err := c.Create(ctx, client.CreateInput{TargetURL: "https://example.com"})
+
+// List QURLs
+result, err := c.List(ctx, client.ListInput{Limit: 10})
+```
+
+If you need something not in `shared/`, put it in your app's `internal/` first. Open an issue if multiple apps need it.
+
+## 3. Development Workflow
+
+```bash
+# Start from latest main
+git checkout main && git pull
+
+# Create a branch
+git checkout -b feat/teams-slash-commands
+
+# Write code + tests, then verify locally
+make check          # fmt + vet + lint + test (matches CI exactly)
+make coverage       # check you're above 40% threshold
+make build-slack    # or: go build ./apps/yourapp/cmd/
+
+# Push and open a PR
+git push -u origin feat/teams-slash-commands
+gh pr create --title "feat(teams): add slash command handler"
+```
+
+### What CI checks on every PR
+
+| Check | What it does |
+|-------|-------------|
+| **Lint** | golangci-lint with 28 linters |
+| **Test** | `go test -race` + 40% coverage minimum |
+| **Build** | Lambda binary compiles |
+| **Vulnerability Scan** | govulncheck |
+| **TruffleHog** | Scans for leaked secrets |
+| **PR Title** | Must match `type(scope): description` |
+| **Dependency Review** | Blocks high-severity or GPL deps |
+| **Code Review** | Platform team must approve |
+
+All checks must pass. PRs are squash-merged with the PR title as the commit message.
+
+### Things that will block your PR
+
+- Pushing to main (branch protection rejects it)
+- Hardcoded secrets (TruffleHog + GitHub push protection catch these)
+- Coverage below 40%
+- `//nolint` without an explanation and specific linter name
+- GPL-3.0 or AGPL-3.0 dependencies
+- Modifying `terraform/`, `.github/`, or `shared/` without platform team review
+
+## 4. AWS Access via IAM Identity Center
+
+You have access to the **sandbox account only**. Production is CI/CD only — you cannot access it directly.
+
+### First-time setup
+
+Add this to `~/.aws/config`:
+
+```ini
+[profile layerv-integrations]
+sso_session = layerv
+sso_account_id = <sandbox-account-id>
+sso_role_name = IntegrationsDeveloper
+region = us-east-2
+
+[sso-session layerv]
+sso_start_url = https://layerv.awsapps.com/start
+sso_region = us-east-2
+sso_registration_scopes = sso:account:access
+```
+
+Replace `<sandbox-account-id>` with the account ID provided in your onboarding email.
+
+### Daily usage
+
+```bash
+# Log in (opens browser, lasts 8 hours)
+aws sso login --profile layerv-integrations
+
+# Use it
+AWS_PROFILE=layerv-integrations aws lambda list-functions
+AWS_PROFILE=layerv-integrations aws logs tail /aws/lambda/integrations-slack-sandbox
+
+# Or export it for your session
+export AWS_PROFILE=layerv-integrations
+aws ssm get-parameter --name /integrations/slack/signing-secret
+```
+
+### What you can access
+
+| Service | Access |
+|---------|--------|
+| Lambda | Create, update, invoke, view logs |
+| API Gateway | Full management |
+| CloudWatch Logs | Read and write |
+| SSM Parameter Store | Read/write under `/integrations/*` |
+| Secrets Manager | Read/write under `integrations/*` |
+| S3 | Deploy artifact buckets only |
+
+### What you cannot access
+
+EC2, VPC, DynamoDB, ECS, EKS, RDS, IAM (except scoped), Route53, or any production account resources.
+
+### AWS Console access
+
+Visit https://layerv.awsapps.com/start, sign in, and select the sandbox account with `IntegrationsDeveloper` role.
+
+## 5. Secrets and Configuration
+
+Never hardcode secrets. Store them in the sandbox account:
+
+```bash
+# Store a secret
+AWS_PROFILE=layerv-integrations aws secretsmanager create-secret \
+  --name integrations/yourapp/api-key \
+  --secret-string "your-secret-value"
+
+# Store a config parameter
+AWS_PROFILE=layerv-integrations aws ssm put-parameter \
+  --name /integrations/yourapp/endpoint \
+  --type String \
+  --value "https://api.layerv.xyz"
+```
+
+Your Lambda reads these at startup via environment variables or SDK calls.
+
+## 6. Testing Your Lambda Locally
+
+```bash
+# Build the binary
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/yourapp/cmd/
+
+# Test with the Lambda RIE (Runtime Interface Emulator)
+# See: https://docs.aws.amazon.com/lambda/latest/dg/go-image.html#go-image-clients
+```
+
+Or just write good unit tests — they're faster and CI enforces them.
+
+## Questions?
+
+- **Build/CI issues**: Open an issue tagged `ci`
+- **Shared package questions**: Open an issue tagged `shared`
+- **AWS access issues**: Contact the platform team directly

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/layervai/qurl-integrations
 
-go 1.25.0
+go 1.26.0
 
 require github.com/aws/aws-lambda-go v1.53.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/layervai/qurl-integrations
+
+go 1.25.0
+
+require github.com/aws/aws-lambda-go v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/aws/aws-lambda-go v1.53.0 h1:uAMv6W/vCP/L494BAUSxe+8KVBIPK+SGPyapFt3FuMk=
+github.com/aws/aws-lambda-go v1.53.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    "apps/slack": {
+      "release-type": "go",
+      "component": "slack",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    "apps/teams": {
+      "release-type": "go",
+      "component": "teams",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    "apps/discord": {
+      "release-type": "go",
+      "component": "discord",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    "apps/cli": {
+      "release-type": "go",
+      "component": "cli",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    "apps/zapier": {
+      "release-type": "go",
+      "component": "zapier",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    }
+  }
+}

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -1,0 +1,28 @@
+// Package auth provides authentication helpers for QURL integrations.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// Provider resolves API credentials for a given workspace.
+type Provider interface {
+	// APIKey returns the QURL API key for the given workspace ID.
+	APIKey(ctx context.Context, workspaceID string) (string, error)
+}
+
+// EnvProvider reads the API key from an environment variable.
+// Suitable for single-workspace deployments and development.
+type EnvProvider struct {
+	EnvVar string
+}
+
+func (p EnvProvider) APIKey(_ context.Context, _ string) (string, error) {
+	key := os.Getenv(p.EnvVar)
+	if key == "" {
+		return "", fmt.Errorf("env var %s not set", p.EnvVar)
+	}
+	return key, nil
+}

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -19,6 +19,7 @@ type EnvProvider struct {
 	EnvVar string
 }
 
+// APIKey returns the API key from the configured environment variable.
 func (p EnvProvider) APIKey(_ context.Context, _ string) (string, error) {
 	key := os.Getenv(p.EnvVar)
 	if key == "" {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -1,0 +1,179 @@
+// Package client provides a Go client for the QURL API.
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const defaultTimeout = 30 * time.Second
+
+// Client is a QURL API client.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cl *Client) { cl.httpClient = c }
+}
+
+// New creates a QURL API client.
+func New(baseURL, apiKey string, opts ...Option) *Client {
+	c := &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// QURL represents a QURL resource.
+type QURL struct {
+	ID          string    `json:"id"`
+	ShortCode   string    `json:"short_code"`
+	TargetURL   string    `json:"target_url"`
+	Title       string    `json:"title,omitempty"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	ClickCount  int       `json:"click_count"`
+	LinkURL     string    `json:"link_url"`
+}
+
+// CreateInput is the input for creating a QURL.
+type CreateInput struct {
+	TargetURL   string `json:"target_url"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	ExpiresIn   string `json:"expires_in,omitempty"`
+}
+
+// Create creates a new QURL.
+func (c *Client) Create(ctx context.Context, input CreateInput) (*QURL, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create input: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var qurl QURL
+	if err := c.do(req, &qurl); err != nil {
+		return nil, err
+	}
+	return &qurl, nil
+}
+
+// Get retrieves a QURL by ID.
+func (c *Client) Get(ctx context.Context, id string) (*QURL, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/qurls/"+id, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var qurl QURL
+	if err := c.do(req, &qurl); err != nil {
+		return nil, err
+	}
+	return &qurl, nil
+}
+
+// ListInput is the input for listing QURLs.
+type ListInput struct {
+	Limit  int    `json:"limit,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// ListOutput is the output of listing QURLs.
+type ListOutput struct {
+	QURLs      []QURL `json:"qurls"`
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+// List retrieves a paginated list of QURLs.
+func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error) {
+	url := fmt.Sprintf("%s/v1/qurls?limit=%d", c.baseURL, input.Limit)
+	if input.Cursor != "" {
+		url += "&cursor=" + input.Cursor
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var out ListOutput
+	if err := c.do(req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Delete deletes a QURL by ID.
+func (c *Client) Delete(ctx context.Context, id string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/qurls/"+id, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	return c.do(req, nil)
+}
+
+// APIError represents an error response from the QURL API.
+type APIError struct {
+	StatusCode int    `json:"status_code"`
+	Message    string `json:"message"`
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("qurl api error (%d): %s", e.StatusCode, e.Message)
+}
+
+func (c *Client) do(req *http.Request, out any) error {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErr := &APIError{StatusCode: resp.StatusCode}
+		if json.Unmarshal(respBody, apiErr) != nil {
+			apiErr.Message = string(respBody)
+		}
+		return apiErr
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("unmarshal response: %w", err)
+		}
+	}
+	return nil
+}

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -45,15 +45,15 @@ func New(baseURL, apiKey string, opts ...Option) *Client {
 
 // QURL represents a QURL resource.
 type QURL struct {
-	ID          string    `json:"id"`
-	ShortCode   string    `json:"short_code"`
-	TargetURL   string    `json:"target_url"`
-	Title       string    `json:"title,omitempty"`
-	Description string    `json:"description,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
+	ID          string     `json:"id"`
+	ShortCode   string     `json:"short_code"`
+	TargetURL   string     `json:"target_url"`
+	Title       string     `json:"title,omitempty"`
+	Description string     `json:"description,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
-	ClickCount  int       `json:"click_count"`
-	LinkURL     string    `json:"link_url"`
+	ClickCount  int        `json:"click_count"`
+	LinkURL     string     `json:"link_url"`
 }
 
 // CreateInput is the input for creating a QURL.
@@ -85,7 +85,7 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*QURL, error) {
 
 // Get retrieves a QURL by ID.
 func (c *Client) Get(ctx context.Context, id string) (*QURL, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/qurls/"+id, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/qurls/"+id, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -116,7 +116,7 @@ func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error)
 		url += "&cursor=" + input.Cursor
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -130,7 +130,7 @@ func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error)
 
 // Delete deletes a QURL by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/qurls/"+id, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/qurls/"+id, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
@@ -143,6 +143,7 @@ type APIError struct {
 	Message    string `json:"message"`
 }
 
+// Error returns the error message.
 func (e *APIError) Error() string {
 	return fmt.Sprintf("qurl api error (%d): %s", e.StatusCode, e.Message)
 }
@@ -155,7 +156,7 @@ func (c *Client) do(req *http.Request, out any) error {
 	if err != nil {
 		return fmt.Errorf("http request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,7 +37,9 @@ func TestCreate(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(want)
+		if err := json.NewEncoder(w).Encode(want); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -57,7 +60,9 @@ func TestCreate(t *testing.T) {
 func TestAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		json.NewEncoder(w).Encode(map[string]string{"message": "invalid api key"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"message": "invalid api key"}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -67,8 +72,8 @@ func TestAPIError(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected *APIError, got %T", err)
 	}
 	if apiErr.StatusCode != 401 {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreate(t *testing.T) {
+	want := QURL{
+		ID:        "qurl_123",
+		ShortCode: "abc123",
+		TargetURL: "https://example.com",
+		LinkURL:   "https://qurl.link.layerv.xyz/abc123",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/qurls" {
+			t.Errorf("expected /v1/qurls, got %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("expected Bearer test-key, got %s", r.Header.Get("Authorization"))
+		}
+
+		var input CreateInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if input.TargetURL != "https://example.com" {
+			t.Errorf("expected target_url https://example.com, got %s", input.TargetURL)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-key")
+	got, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got.ID != want.ID {
+		t.Errorf("got ID %q, want %q", got.ID, want.ID)
+	}
+	if got.ShortCode != want.ShortCode {
+		t.Errorf("got ShortCode %q, want %q", got.ShortCode, want.ShortCode)
+	}
+}
+
+func TestAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"message": "invalid api key"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "bad-key")
+	_, err := c.Get(context.Background(), "qurl_123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 401 {
+		t.Errorf("got status %d, want 401", apiErr.StatusCode)
+	}
+}

--- a/shared/events/events.go
+++ b/shared/events/events.go
@@ -6,6 +6,7 @@ import "time"
 // Type identifies a QURL webhook event type.
 type Type string
 
+// Webhook event types.
 const (
 	TypeQURLCreated Type = "qurl.created"
 	TypeQURLClicked Type = "qurl.clicked"

--- a/shared/events/events.go
+++ b/shared/events/events.go
@@ -1,0 +1,22 @@
+// Package events provides webhook event parsing for QURL integrations.
+package events
+
+import "time"
+
+// Type identifies a QURL webhook event type.
+type Type string
+
+const (
+	TypeQURLCreated Type = "qurl.created"
+	TypeQURLClicked Type = "qurl.clicked"
+	TypeQURLExpired Type = "qurl.expired"
+	TypeQURLDeleted Type = "qurl.deleted"
+)
+
+// Event is a QURL webhook event.
+type Event struct {
+	Type      Type      `json:"type"`
+	ID        string    `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
+	Data      any       `json:"data"`
+}

--- a/shared/formatting/formatting.go
+++ b/shared/formatting/formatting.go
@@ -9,20 +9,18 @@ import (
 
 // QURLCreated formats a message for a newly created QURL.
 func QURLCreated(q *client.QURL) string {
-	msg := fmt.Sprintf("QURL created: %s", q.LinkURL)
 	if q.Title != "" {
-		msg = fmt.Sprintf("QURL created: *%s*\n%s → %s", q.Title, q.LinkURL, q.TargetURL)
+		return fmt.Sprintf("QURL created: *%s*\n%s → %s", q.Title, q.LinkURL, q.TargetURL)
 	}
-	return msg
+	return "QURL created: " + q.LinkURL
 }
 
 // QURLDetails formats a detailed view of a QURL.
 func QURLDetails(q *client.QURL) string {
-	msg := fmt.Sprintf("*%s*\nLink: %s\nTarget: %s\nClicks: %d",
-		q.ShortCode, q.LinkURL, q.TargetURL, q.ClickCount)
 	if q.Title != "" {
-		msg = fmt.Sprintf("*%s* (`%s`)\nLink: %s\nTarget: %s\nClicks: %d",
+		return fmt.Sprintf("*%s* (`%s`)\nLink: %s\nTarget: %s\nClicks: %d",
 			q.Title, q.ShortCode, q.LinkURL, q.TargetURL, q.ClickCount)
 	}
-	return msg
+	return fmt.Sprintf("*%s*\nLink: %s\nTarget: %s\nClicks: %d",
+		q.ShortCode, q.LinkURL, q.TargetURL, q.ClickCount)
 }

--- a/shared/formatting/formatting.go
+++ b/shared/formatting/formatting.go
@@ -1,0 +1,28 @@
+// Package formatting provides chat message templates for QURL notifications.
+package formatting
+
+import (
+	"fmt"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// QURLCreated formats a message for a newly created QURL.
+func QURLCreated(q *client.QURL) string {
+	msg := fmt.Sprintf("QURL created: %s", q.LinkURL)
+	if q.Title != "" {
+		msg = fmt.Sprintf("QURL created: *%s*\n%s → %s", q.Title, q.LinkURL, q.TargetURL)
+	}
+	return msg
+}
+
+// QURLDetails formats a detailed view of a QURL.
+func QURLDetails(q *client.QURL) string {
+	msg := fmt.Sprintf("*%s*\nLink: %s\nTarget: %s\nClicks: %d",
+		q.ShortCode, q.LinkURL, q.TargetURL, q.ClickCount)
+	if q.Title != "" {
+		msg = fmt.Sprintf("*%s* (`%s`)\nLink: %s\nTarget: %s\nClicks: %d",
+			q.Title, q.ShortCode, q.LinkURL, q.TargetURL, q.ClickCount)
+	}
+	return msg
+}

--- a/shared/observability/observability.go
+++ b/shared/observability/observability.go
@@ -1,0 +1,2 @@
+// Package observability provides OpenTelemetry setup for QURL integrations.
+package observability

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "layerv-terraform-state-886375649402"
+    key            = "qurl-integrations/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,9 @@
+module "integrations" {
+  source = "../../"
+
+  environment          = var.environment
+  account_id           = var.account_id
+  github_repo          = var.github_repo
+  allowed_environments = var.allowed_environments
+  allow_pull_requests  = var.allow_pull_requests
+}

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,4 @@
+environment          = "prod"
+account_id           = "886375649402"
+allowed_environments = ["slack-production", "teams-production", "discord-production"]
+allow_pull_requests  = false

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  type = string
+}
+
+variable "account_id" {
+  type = string
+}
+
+variable "github_repo" {
+  type    = string
+  default = "layervai/qurl-integrations"
+}
+
+variable "allowed_environments" {
+  type = list(string)
+}
+
+variable "allow_pull_requests" {
+  type    = bool
+  default = false
+}

--- a/terraform/environments/sandbox/backend.tf
+++ b/terraform/environments/sandbox/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "layerv-terraform-state-730883236711"
+    key            = "qurl-integrations/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}

--- a/terraform/environments/sandbox/main.tf
+++ b/terraform/environments/sandbox/main.tf
@@ -1,0 +1,9 @@
+module "integrations" {
+  source = "../../"
+
+  environment          = var.environment
+  account_id           = var.account_id
+  github_repo          = var.github_repo
+  allowed_environments = var.allowed_environments
+  allow_pull_requests  = var.allow_pull_requests
+}

--- a/terraform/environments/sandbox/terraform.tfvars
+++ b/terraform/environments/sandbox/terraform.tfvars
@@ -1,0 +1,4 @@
+environment          = "sandbox"
+account_id           = "730883236711"
+allowed_environments = ["slack-sandbox", "teams-sandbox", "discord-sandbox"]
+allow_pull_requests  = true

--- a/terraform/environments/sandbox/variables.tf
+++ b/terraform/environments/sandbox/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  type = string
+}
+
+variable "account_id" {
+  type = string
+}
+
+variable "github_repo" {
+  type    = string
+  default = "layervai/qurl-integrations"
+}
+
+variable "allowed_environments" {
+  type = list(string)
+}
+
+variable "allow_pull_requests" {
+  type    = bool
+  default = false
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,26 @@
+# Root module — qurl-integrations infrastructure
+#
+# Called from terraform/environments/{sandbox,prod}/main.tf
+
+provider "aws" {
+  region = "us-east-2"
+
+  default_tags {
+    tags = {
+      Project     = "qurl-integrations"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}
+
+module "ci" {
+  source = "./modules/ci"
+
+  environment          = var.environment
+  account_id           = var.account_id
+  github_repo          = var.github_repo
+  state_bucket         = "layerv-terraform-state-${var.account_id}"
+  allowed_environments = var.allowed_environments
+  allow_pull_requests  = var.allow_pull_requests
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.27"
+      version = "~> 6.35"
     }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,6 +2,17 @@
 #
 # Called from terraform/environments/{sandbox,prod}/main.tf
 
+terraform {
+  required_version = "~> 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.27"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-2"
 

--- a/terraform/modules/ci/main.tf
+++ b/terraform/modules/ci/main.tf
@@ -1,0 +1,315 @@
+# CI Module — GitHub Actions OIDC Provider + IAM Role
+#
+# Creates the OIDC identity provider and an IAM role that GitHub Actions
+# workflows can assume via OIDC federation. Permissions are scoped to
+# Lambda, API Gateway, CloudWatch, SSM, Secrets Manager, and S3 (state).
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# -----------------------------------------------------------------------------
+# OIDC Provider
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  tags = {
+    Name      = "GitHub Actions OIDC"
+    ManagedBy = "Terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# IAM Role — GitHub Actions
+# -----------------------------------------------------------------------------
+
+locals {
+  role_name = "integrations-${var.environment}-github-actions"
+
+  # Build the list of allowed OIDC sub claims
+  environment_conditions = [
+    for env in var.allowed_environments :
+    "repo:${var.github_repo}:environment:${env}"
+  ]
+
+  ref_conditions = ["repo:${var.github_repo}:ref:refs/heads/main"]
+
+  pr_conditions = var.allow_pull_requests ? ["repo:${var.github_repo}:pull_request"] : []
+
+  all_sub_conditions = concat(
+    local.environment_conditions,
+    local.ref_conditions,
+    local.pr_conditions,
+  )
+}
+
+data "aws_iam_policy_document" "github_actions_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = local.all_sub_conditions
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name                 = local.role_name
+  assume_role_policy   = data.aws_iam_policy_document.github_actions_trust.json
+  max_session_duration = 3600
+
+  tags = {
+    Name        = local.role_name
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# IAM Policies
+# -----------------------------------------------------------------------------
+
+# Lambda deployment
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    sid    = "LambdaManagement"
+    effect = "Allow"
+    actions = [
+      "lambda:CreateFunction",
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+      "lambda:ListFunctions",
+      "lambda:DeleteFunction",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:ListTags",
+      "lambda:AddPermission",
+      "lambda:RemovePermission",
+      "lambda:GetPolicy",
+      "lambda:PublishVersion",
+      "lambda:CreateAlias",
+      "lambda:UpdateAlias",
+      "lambda:DeleteAlias",
+      "lambda:GetAlias",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda" {
+  name   = "lambda-management"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.lambda.json
+}
+
+# API Gateway
+data "aws_iam_policy_document" "apigateway" {
+  statement {
+    sid    = "ApiGatewayManagement"
+    effect = "Allow"
+    actions = [
+      "apigateway:GET",
+      "apigateway:POST",
+      "apigateway:PUT",
+      "apigateway:PATCH",
+      "apigateway:DELETE",
+      "apigateway:TagResource",
+      "apigateway:UntagResource",
+    ]
+    resources = ["arn:aws:apigateway:${data.aws_region.current.name}::*"]
+  }
+}
+
+resource "aws_iam_role_policy" "apigateway" {
+  name   = "apigateway-management"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.apigateway.json
+}
+
+# CloudWatch Logs
+data "aws_iam_policy_document" "cloudwatch" {
+  statement {
+    sid    = "CloudWatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:DeleteLogGroup",
+      "logs:TagResource",
+      "logs:UntagResource",
+      "logs:PutRetentionPolicy",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cloudwatch" {
+  name   = "cloudwatch-logs"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.cloudwatch.json
+}
+
+# SSM Parameter Store
+data "aws_iam_policy_document" "ssm" {
+  statement {
+    sid    = "SSMParameters"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:PutParameter",
+      "ssm:DeleteParameter",
+      "ssm:DescribeParameters",
+      "ssm:AddTagsToResource",
+      "ssm:RemoveTagsFromResource",
+      "ssm:ListTagsForResource",
+    ]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/integrations/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ssm" {
+  name   = "ssm-parameters"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.ssm.json
+}
+
+# Secrets Manager
+data "aws_iam_policy_document" "secrets" {
+  statement {
+    sid    = "SecretsManager"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecret",
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:TagResource",
+      "secretsmanager:UntagResource",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:integrations/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "secrets" {
+  name   = "secrets-manager"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.secrets.json
+}
+
+# S3 — Terraform state + deploy artifacts
+data "aws_iam_policy_document" "s3" {
+  statement {
+    sid    = "TerraformState"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.state_bucket}",
+      "arn:aws:s3:::${var.state_bucket}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "s3" {
+  name   = "s3-state"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.s3.json
+}
+
+# DynamoDB — Terraform state locking
+data "aws_iam_policy_document" "dynamodb" {
+  statement {
+    sid    = "TerraformLocks"
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/terraform-locks",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "dynamodb" {
+  name   = "dynamodb-locks"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.dynamodb.json
+}
+
+# IAM — scoped to own role and Lambda execution role
+data "aws_iam_policy_document" "iam" {
+  statement {
+    sid    = "IAMManagement"
+    effect = "Allow"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:GetRole",
+      "iam:UpdateRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:ListRoleTags",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicyVersion",
+      "iam:ListEntitiesForPolicy",
+      "iam:PassRole",
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/integrations-*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/integrations-*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "iam" {
+  name   = "iam-management"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.iam.json
+}

--- a/terraform/modules/ci/main.tf
+++ b/terraform/modules/ci/main.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "apigateway" {
       "apigateway:TagResource",
       "apigateway:UntagResource",
     ]
-    resources = ["arn:aws:apigateway:${data.aws_region.current.name}::*"]
+    resources = ["arn:aws:apigateway:${data.aws_region.current.id}::*"]
   }
 }
 
@@ -187,7 +187,7 @@ data "aws_iam_policy_document" "ssm" {
       "ssm:ListTagsForResource",
     ]
     resources = [
-      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/integrations/*",
+      "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/integrations/*",
     ]
   }
 }
@@ -214,7 +214,7 @@ data "aws_iam_policy_document" "secrets" {
       "secretsmanager:UntagResource",
     ]
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:integrations/*",
+      "arn:aws:secretsmanager:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:secret:integrations/*",
     ]
   }
 }
@@ -260,7 +260,7 @@ data "aws_iam_policy_document" "dynamodb" {
       "dynamodb:DeleteItem",
     ]
     resources = [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/terraform-locks",
+      "arn:aws:dynamodb:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:table/terraform-locks",
     ]
   }
 }

--- a/terraform/modules/ci/outputs.tf
+++ b/terraform/modules/ci/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "ARN of the GitHub Actions IAM role"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "role_name" {
+  description = "Name of the GitHub Actions IAM role"
+  value       = aws_iam_role.github_actions.name
+}

--- a/terraform/modules/ci/variables.tf
+++ b/terraform/modules/ci/variables.tf
@@ -1,0 +1,35 @@
+variable "environment" {
+  description = "Environment name (sandbox or prod)"
+  type        = string
+  validation {
+    condition     = contains(["sandbox", "prod"], var.environment)
+    error_message = "Environment must be 'sandbox' or 'prod'."
+  }
+}
+
+variable "github_repo" {
+  description = "GitHub repository in org/repo format"
+  type        = string
+  default     = "layervai/qurl-integrations"
+}
+
+variable "account_id" {
+  description = "AWS account ID for this environment"
+  type        = string
+}
+
+variable "state_bucket" {
+  description = "S3 bucket name for Terraform state"
+  type        = string
+}
+
+variable "allowed_environments" {
+  description = "GitHub Actions environments allowed to assume this role"
+  type        = list(string)
+}
+
+variable "allow_pull_requests" {
+  description = "Whether to allow PRs to assume this role (sandbox only)"
+  type        = bool
+  default     = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,26 @@
+variable "environment" {
+  description = "Environment name (sandbox or prod)"
+  type        = string
+}
+
+variable "account_id" {
+  description = "AWS account ID for this environment"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository in org/repo format"
+  type        = string
+  default     = "layervai/qurl-integrations"
+}
+
+variable "allowed_environments" {
+  description = "GitHub Actions environments allowed to assume the CI role"
+  type        = list(string)
+}
+
+variable "allow_pull_requests" {
+  description = "Whether to allow PRs to assume the CI role (sandbox only)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

- Initializes the `qurl-integrations` monorepo with Go module, `apps/` and `shared/` directory structure
- Scaffolds the Slack integration: Lambda handler with `/qurl create`, `/qurl list`, `/qurl help` slash commands, URL verification challenge, event and interaction stubs
- Adds shared packages: QURL API client (with tests), auth provider, events, formatting, observability
- Configures Release Please monorepo mode for independent per-app versioning
- Full CI/CD and repo governance matching nhp/qurl-service standards

## CI & Governance

| Workflow | Purpose |
|----------|---------|
| `slack.yml` | Path-filtered build/test for Slack app |
| `shared-test.yml` | Runs all app tests when `shared/` changes |
| `release-please.yml` | Monorepo mode — independent version tracks per app |
| `codeql.yml` | Security analysis (Go + Actions), weekly + on PR/push |
| `claude-code-review.yml` | AI code review on PRs (skips dependabot) |
| `pr-title.yml` | Conventional commits validation with app scopes |
| `dependency-review.yml` | Fail on HIGH severity, deny GPL-3.0/AGPL-3.0 |
| `dependabot.yml` | Weekly Go + Actions dependency updates |
| `dependabot-go-tidy.yml` | Auto-fix go.mod/go.sum for dependabot PRs |

## Repo Config

- **Branch protection:** PR required, 1 approval, dismiss stale reviews, require last push approval, signed commits, no force push
- **CODEOWNERS:** `@layervai/platform` on `shared/`, `apps/*/deploy/`, `.github/workflows/`
- **PR template:** Summary, changes, test plan, related issues

## Test plan

- [x] `go test ./...` passes (7 tests across client + handler)
- [x] Lambda binary compiles: `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./apps/slack/cmd/`
- [ ] Verify CI workflows trigger correctly on PR paths
- [ ] After merge: verify Release Please creates initial release PRs
- [ ] Verify ANTHROPIC_API_KEY secret is added to repo for code review bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)