### PR TITLE
feat(sdk): add TypeScript and Python SDKs for QURL API

### DIFF
--- a/apps/sdk-python/.gitignore
+++ b/apps/sdk-python/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/apps/sdk-python/README.md
+++ b/apps/sdk-python/README.md
@@ -1,0 +1,59 @@
+# layerv-qurl
+
+Python SDK for the [QURL API](https://docs.layerv.ai) — secure, time-limited access links for AI agents.
+
+## Installation
+
+```bash
+pip install layerv-qurl
+```
+
+For LangChain integration:
+
+```bash
+pip install layerv-qurl[langchain]
+```
+
+## Quick Start
+
+```python
+from layerv_qurl import QURLClient, CreateInput, ResolveInput
+
+client = QURLClient(api_key="lv_live_xxx")
+
+# Create a protected link
+result = client.create(CreateInput(
+    target_url="https://api.example.com/data",
+    expires_in="24h",
+    description="API access for agent"
+))
+print(result.qurl_link)
+
+# Resolve a token (opens firewall for your IP)
+access = client.resolve(ResolveInput(access_token="at_..."))
+print(f"Access granted to {access.target_url} for {access.access_grant.expires_in}s")
+```
+
+## LangChain Integration
+
+```python
+from layerv_qurl import QURLClient
+from layerv_qurl.langchain import QURLToolkit
+
+client = QURLClient(api_key="lv_live_xxx")
+toolkit = QURLToolkit(client=client)
+tools = toolkit.get_tools()  # [CreateQURLTool, ResolveQURLTool, ListQURLsTool, DeleteQURLTool]
+```
+
+## Configuration
+
+| Parameter | Required | Default |
+|-----------|----------|---------|
+| `api_key` | Yes | — |
+| `base_url` | No | `https://api.layerv.ai` |
+| `timeout` | No | `30.0` |
+| `max_retries` | No | `3` |
+
+## License
+
+MIT

--- a/apps/sdk-python/pyproject.toml
+++ b/apps/sdk-python/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "layerv-qurl"
+version = "0.1.0"
+description = "Python SDK for the QURL API - secure, time-limited access links"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    { name = "LayerV AI", email = "engineering@layerv.ai" },
+]
+keywords = ["qurl", "layerv", "security", "ai-agents", "zero-trust"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
+dependencies = [
+    "httpx>=0.27,<1",
+]
+
+[project.optional-dependencies]
+langchain = ["langchain-core>=0.3,<1"]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.24",
+    "respx>=0.22",
+    "ruff>=0.11",
+    "mypy>=1.14",
+]
+
+[project.urls]
+Homepage = "https://github.com/layervai/qurl-integrations"
+Repository = "https://github.com/layervai/qurl-integrations"
+Documentation = "https://docs.layerv.ai"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/layerv_qurl"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
+
+[tool.mypy]
+strict = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/apps/sdk-python/src/layerv_qurl/__init__.py
+++ b/apps/sdk-python/src/layerv_qurl/__init__.py
@@ -1,0 +1,39 @@
+"""QURL Python SDK — secure, time-limited access links for AI agents."""
+
+from layerv_qurl.client import QURLClient
+from layerv_qurl.errors import QURLError
+from layerv_qurl.types import (
+    AccessGrant,
+    AccessPolicy,
+    CreateInput,
+    CreateOutput,
+    ExtendInput,
+    ListOutput,
+    MintInput,
+    MintOutput,
+    QURL,
+    Quota,
+    ResolveInput,
+    ResolveOutput,
+    UpdateInput,
+)
+
+__all__ = [
+    "QURLClient",
+    "QURLError",
+    "AccessGrant",
+    "AccessPolicy",
+    "CreateInput",
+    "CreateOutput",
+    "ExtendInput",
+    "ListOutput",
+    "MintInput",
+    "MintOutput",
+    "QURL",
+    "Quota",
+    "ResolveInput",
+    "ResolveOutput",
+    "UpdateInput",
+]
+
+__version__ = "0.1.0"

--- a/apps/sdk-python/src/layerv_qurl/client.py
+++ b/apps/sdk-python/src/layerv_qurl/client.py
@@ -1,0 +1,295 @@
+"""QURL API client."""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import asdict
+from typing import Any
+
+import httpx
+
+from layerv_qurl.errors import QURLError
+from layerv_qurl.types import (
+    AccessGrant,
+    AccessPolicy,
+    CreateInput,
+    CreateOutput,
+    ExtendInput,
+    ListOutput,
+    MintInput,
+    MintOutput,
+    QURL,
+    Quota,
+    ResolveInput,
+    ResolveOutput,
+    UpdateInput,
+)
+
+DEFAULT_BASE_URL = "https://api.layerv.ai"
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_USER_AGENT = "qurl-python-sdk/0.1.0"
+
+_RETRYABLE_STATUS = {429, 502, 503, 504}
+
+
+class QURLClient:
+    """Synchronous QURL API client."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        user_agent: str = DEFAULT_USER_AGENT,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._max_retries = max_retries
+        self._client = http_client or httpx.Client(
+            timeout=timeout,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": user_agent,
+            },
+        )
+        self._owns_client = http_client is None
+
+    def close(self) -> None:
+        """Close the underlying HTTP client (only if owned by this instance)."""
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> QURLClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    # --- Public API ---
+
+    def create(self, input: CreateInput) -> CreateOutput:
+        """Create a new QURL."""
+        data = self._request("POST", "/v1/qurl", body=_serialize(input))
+        return CreateOutput(
+            resource_id=data["resource_id"],
+            qurl_link=data["qurl_link"],
+            qurl_site=data["qurl_site"],
+            expires_at=data.get("expires_at"),
+        )
+
+    def get(self, id: str) -> QURL:
+        """Get a QURL by ID."""
+        data = self._request("GET", f"/v1/qurls/{id}")
+        return _parse_qurl(data)
+
+    def list(
+        self,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+        status: str | None = None,
+        q: str | None = None,
+        sort: str | None = None,
+    ) -> ListOutput:
+        """List QURLs with optional filters."""
+        params: dict[str, str] = {}
+        if limit is not None:
+            params["limit"] = str(limit)
+        if cursor:
+            params["cursor"] = cursor
+        if status:
+            params["status"] = status
+        if q:
+            params["q"] = q
+        if sort:
+            params["sort"] = sort
+
+        data, meta = self._raw_request("GET", "/v1/qurls", params=params)
+        qurls = [_parse_qurl(q_data) for q_data in data] if isinstance(data, list) else []
+        return ListOutput(
+            qurls=qurls,
+            next_cursor=meta.get("next_cursor") if meta else None,
+            has_more=meta.get("has_more", False) if meta else False,
+        )
+
+    def delete(self, id: str) -> None:
+        """Delete (revoke) a QURL."""
+        self._request("DELETE", f"/v1/qurls/{id}")
+
+    def extend(self, id: str, input: ExtendInput) -> QURL:
+        """Extend a QURL's expiration."""
+        data = self._request("PATCH", f"/v1/qurls/{id}", body=_serialize(input))
+        return _parse_qurl(data)
+
+    def update(self, id: str, input: UpdateInput) -> QURL:
+        """Update a QURL's mutable properties."""
+        data = self._request("PATCH", f"/v1/qurls/{id}", body=_serialize(input))
+        return _parse_qurl(data)
+
+    def mint_link(self, id: str, input: MintInput | None = None) -> MintOutput:
+        """Mint a new access link for a QURL."""
+        body = _serialize(input) if input else None
+        data = self._request("POST", f"/v1/qurls/{id}/mint_link", body=body)
+        return MintOutput(qurl_link=data["qurl_link"], expires_at=data.get("expires_at"))
+
+    def resolve(self, input: ResolveInput) -> ResolveOutput:
+        """Resolve a QURL access token (headless).
+
+        Triggers an NHP knock to open firewall access for the caller's IP.
+        Requires ``qurl:resolve`` scope on the API key.
+        """
+        data = self._request("POST", "/v1/resolve", body=_serialize(input))
+        grant = None
+        if data.get("access_grant"):
+            g = data["access_grant"]
+            grant = AccessGrant(
+                expires_in=g["expires_in"], granted_at=g["granted_at"], src_ip=g["src_ip"]
+            )
+        return ResolveOutput(
+            target_url=data["target_url"],
+            resource_id=data["resource_id"],
+            access_grant=grant,
+        )
+
+    def get_quota(self) -> Quota:
+        """Get quota and usage information."""
+        data = self._request("GET", "/v1/quota")
+        return Quota(
+            plan=data.get("plan", ""),
+            period_start=data.get("period_start", ""),
+            period_end=data.get("period_end", ""),
+            rate_limits=data.get("rate_limits"),
+            usage=data.get("usage"),
+        )
+
+    # --- Internal HTTP plumbing ---
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> Any:
+        data, _ = self._raw_request(method, path, body=body, params=params)
+        return data
+
+    def _raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> tuple[Any, dict[str, Any] | None]:
+        url = f"{self._base_url}{path}"
+        last_error: Exception | None = None
+
+        for attempt in range(self._max_retries + 1):
+            if attempt > 0:
+                delay = self._retry_delay(attempt, last_error)
+                time.sleep(delay)
+
+            response = self._client.request(
+                method, url, json=body if body else None, params=params
+            )
+
+            if response.status_code < 400:
+                if response.status_code == 204 or not response.content:
+                    return None, None
+                envelope = response.json()
+                return envelope.get("data"), envelope.get("meta")
+
+            err = self._parse_error(response)
+            if response.status_code in _RETRYABLE_STATUS and attempt < self._max_retries:
+                last_error = err
+                continue
+            raise err
+
+        raise last_error or QURLError(
+            status=0, code="unknown", title="Request failed", detail="Exhausted retries"
+        )
+
+    def _parse_error(self, response: httpx.Response) -> QURLError:
+        retry_after = None
+        if response.status_code == 429:
+            ra = response.headers.get("Retry-After")
+            if ra and ra.isdigit():
+                retry_after = int(ra)
+
+        try:
+            envelope = response.json()
+            err = envelope.get("error", {})
+            return QURLError(
+                status=err.get("status", response.status_code),
+                code=err.get("code", "unknown"),
+                title=err.get("title", response.reason_phrase or ""),
+                detail=err.get("detail", ""),
+                invalid_fields=err.get("invalid_fields"),
+                request_id=envelope.get("meta", {}).get("request_id"),
+                retry_after=retry_after,
+            )
+        except Exception:
+            return QURLError(
+                status=response.status_code,
+                code="unknown",
+                title=response.reason_phrase or "",
+                detail=response.text,
+                retry_after=retry_after,
+            )
+
+    def _retry_delay(self, attempt: int, last_error: Exception | None) -> float:
+        if isinstance(last_error, QURLError) and last_error.retry_after:
+            return float(last_error.retry_after)
+        base = 0.5 * (2 ** (attempt - 1))
+        jitter = random.random() * base * 0.5  # noqa: S311
+        return min(base + jitter, 30.0)
+
+
+# --- Helpers ---
+
+
+def _serialize(obj: Any) -> dict[str, Any] | None:
+    if obj is None:
+        return None
+    d = asdict(obj)
+    # Remove None values and serialize nested dataclasses
+    result: dict[str, Any] = {}
+    for k, v in d.items():
+        if v is not None:
+            result[k] = v
+    return result
+
+
+def _parse_qurl(data: dict[str, Any]) -> QURL:
+    policy = None
+    if data.get("access_policy"):
+        p = data["access_policy"]
+        policy = AccessPolicy(
+            ip_allowlist=p.get("ip_allowlist"),
+            ip_denylist=p.get("ip_denylist"),
+            geo_allowlist=p.get("geo_allowlist"),
+            geo_denylist=p.get("geo_denylist"),
+            user_agent_allow_regex=p.get("user_agent_allow_regex"),
+            user_agent_deny_regex=p.get("user_agent_deny_regex"),
+        )
+    return QURL(
+        resource_id=data["resource_id"],
+        target_url=data["target_url"],
+        status=data["status"],
+        created_at=data["created_at"],
+        expires_at=data.get("expires_at"),
+        one_time_use=data.get("one_time_use", False),
+        max_sessions=data.get("max_sessions"),
+        description=data.get("description"),
+        qurl_site=data.get("qurl_site"),
+        qurl_link=data.get("qurl_link"),
+        access_policy=policy,
+    )

--- a/apps/sdk-python/src/layerv_qurl/errors.py
+++ b/apps/sdk-python/src/layerv_qurl/errors.py
@@ -1,0 +1,27 @@
+"""Error types for the QURL API client."""
+
+from __future__ import annotations
+
+
+class QURLError(Exception):
+    """Error raised by the QURL API client."""
+
+    def __init__(
+        self,
+        *,
+        status: int,
+        code: str,
+        title: str,
+        detail: str,
+        invalid_fields: dict[str, str] | None = None,
+        request_id: str | None = None,
+        retry_after: int | None = None,
+    ) -> None:
+        super().__init__(f"{title} ({status}): {detail}")
+        self.status = status
+        self.code = code
+        self.title = title
+        self.detail = detail
+        self.invalid_fields = invalid_fields
+        self.request_id = request_id
+        self.retry_after = retry_after

--- a/apps/sdk-python/src/layerv_qurl/langchain.py
+++ b/apps/sdk-python/src/layerv_qurl/langchain.py
@@ -1,0 +1,156 @@
+"""LangChain tool integration for QURL.
+
+Install with: pip install layerv-qurl[langchain]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+try:
+    from langchain_core.tools import BaseTool
+except ImportError as e:
+    raise ImportError(
+        "langchain-core is required for LangChain integration. "
+        "Install with: pip install layerv-qurl[langchain]"
+    ) from e
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForToolRun
+
+    from layerv_qurl.client import QURLClient
+
+
+class CreateQURLTool(BaseTool):
+    """Create a secure, time-limited access link to a protected URL."""
+
+    name: str = "create_qurl"
+    description: str = (
+        "Create a QURL — a secure, time-limited access link. "
+        "Input should be a JSON string with 'target_url' (required), "
+        "and optionally 'expires_in' (e.g. '24h', '7d'), 'description', "
+        "'one_time_use' (bool), 'max_sessions' (int)."
+    )
+    client: Any = None  # QURLClient, typed as Any for Pydantic compatibility
+
+    def _run(
+        self,
+        target_url: str,
+        expires_in: str = "24h",
+        description: str | None = None,
+        one_time_use: bool = False,
+        max_sessions: int | None = None,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> str:
+        from layerv_qurl.types import CreateInput
+
+        result = self.client.create(
+            CreateInput(
+                target_url=target_url,
+                expires_in=expires_in,
+                description=description,
+                one_time_use=one_time_use,
+                max_sessions=max_sessions,
+            )
+        )
+        return (
+            f"Created QURL {result.resource_id}\n"
+            f"Link: {result.qurl_link}\n"
+            f"Site: {result.qurl_site}\n"
+            f"Expires: {result.expires_at or 'N/A'}"
+        )
+
+
+class ResolveQURLTool(BaseTool):
+    """Resolve a QURL access token to open firewall access."""
+
+    name: str = "resolve_qurl"
+    description: str = (
+        "Resolve a QURL access token to gain firewall access to the protected resource. "
+        "Input should be the access token string (e.g. 'at_k8xqp9h2sj9lx7r4a')."
+    )
+    client: Any = None
+
+    def _run(
+        self,
+        access_token: str,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> str:
+        from layerv_qurl.types import ResolveInput
+
+        result = self.client.resolve(ResolveInput(access_token=access_token))
+        grant = result.access_grant
+        return (
+            f"Resolved: {result.target_url}\n"
+            f"Resource: {result.resource_id}\n"
+            f"Access expires in: {grant.expires_in}s\n"
+            f"Granted to IP: {grant.src_ip}"
+            if grant
+            else f"Resolved: {result.target_url}\nResource: {result.resource_id}"
+        )
+
+
+class ListQURLsTool(BaseTool):
+    """List active QURL links."""
+
+    name: str = "list_qurls"
+    description: str = (
+        "List active QURL links. Optionally filter by status (active, expired, revoked, consumed)."
+    )
+    client: Any = None
+
+    def _run(
+        self,
+        status: str = "active",
+        limit: int = 10,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> str:
+        result = self.client.list(status=status, limit=limit)
+        if not result.qurls:
+            return "No QURLs found."
+        lines = []
+        for q in result.qurls:
+            lines.append(f"- {q.resource_id}: {q.target_url} [{q.status}] expires={q.expires_at}")
+        return "\n".join(lines)
+
+
+class DeleteQURLTool(BaseTool):
+    """Revoke a QURL, immediately ending all access."""
+
+    name: str = "delete_qurl"
+    description: str = "Revoke (delete) a QURL by resource ID (e.g. 'r_k8xqp9h2sj9')."
+    client: Any = None
+
+    def _run(
+        self,
+        resource_id: str,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> str:
+        self.client.delete(resource_id)
+        return f"QURL {resource_id} has been revoked."
+
+
+class QURLToolkit:
+    """LangChain toolkit providing all QURL tools.
+
+    Usage::
+
+        from layerv_qurl import QURLClient
+        from layerv_qurl.langchain import QURLToolkit
+
+        client = QURLClient(api_key="lv_live_xxx")
+        toolkit = QURLToolkit(client=client)
+        tools = toolkit.get_tools()
+    """
+
+    def __init__(self, client: QURLClient) -> None:
+        self.client = client
+
+    def get_tools(self) -> list[BaseTool]:
+        """Return all QURL tools configured with the client."""
+        return [
+            CreateQURLTool(client=self.client),
+            ResolveQURLTool(client=self.client),
+            ListQURLsTool(client=self.client),
+            DeleteQURLTool(client=self.client),
+        ]

--- a/apps/sdk-python/src/layerv_qurl/types.py
+++ b/apps/sdk-python/src/layerv_qurl/types.py
@@ -1,0 +1,133 @@
+"""Type definitions for the QURL API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AccessPolicy:
+    """Access control policy for a QURL."""
+
+    ip_allowlist: list[str] | None = None
+    ip_denylist: list[str] | None = None
+    geo_allowlist: list[str] | None = None
+    geo_denylist: list[str] | None = None
+    user_agent_allow_regex: str | None = None
+    user_agent_deny_regex: str | None = None
+
+
+@dataclass
+class QURL:
+    """A QURL resource as returned by the API."""
+
+    resource_id: str
+    target_url: str
+    status: str
+    created_at: str
+    expires_at: str | None = None
+    one_time_use: bool = False
+    max_sessions: int | None = None
+    description: str | None = None
+    qurl_site: str | None = None
+    qurl_link: str | None = None
+    access_policy: AccessPolicy | None = None
+
+
+@dataclass
+class CreateInput:
+    """Input for creating a QURL."""
+
+    target_url: str
+    expires_in: str | None = None
+    one_time_use: bool = False
+    max_sessions: int | None = None
+    description: str | None = None
+    metadata: dict[str, str] | None = None
+    access_policy: AccessPolicy | None = None
+    custom_domain: str | None = None
+
+
+@dataclass
+class CreateOutput:
+    """Response from creating a QURL."""
+
+    resource_id: str
+    qurl_link: str
+    qurl_site: str
+    expires_at: str | None = None
+
+
+@dataclass
+class ExtendInput:
+    """Input for extending a QURL's expiration."""
+
+    extend_by: str | None = None
+    expires_at: str | None = None
+
+
+@dataclass
+class UpdateInput:
+    """Input for updating a QURL."""
+
+    description: str | None = None
+
+
+@dataclass
+class MintInput:
+    """Input for minting an access link."""
+
+    expires_at: str | None = None
+
+
+@dataclass
+class MintOutput:
+    """Response from minting an access link."""
+
+    qurl_link: str
+    expires_at: str | None = None
+
+
+@dataclass
+class ResolveInput:
+    """Input for headless QURL resolution."""
+
+    access_token: str
+
+
+@dataclass
+class AccessGrant:
+    """Details of the firewall access that was granted."""
+
+    expires_in: int
+    granted_at: str
+    src_ip: str
+
+
+@dataclass
+class ResolveOutput:
+    """Response from headless resolution."""
+
+    target_url: str
+    resource_id: str
+    access_grant: AccessGrant | None = None
+
+
+@dataclass
+class ListOutput:
+    """Response from listing QURLs."""
+
+    qurls: list[QURL] = field(default_factory=list)
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
+@dataclass
+class Quota:
+    """Quota and usage information."""
+
+    plan: str = ""
+    period_start: str = ""
+    period_end: str = ""
+    rate_limits: dict[str, int] | None = None
+    usage: dict[str, object] | None = None

--- a/apps/sdk-python/tests/test_client.py
+++ b/apps/sdk-python/tests/test_client.py
@@ -1,0 +1,196 @@
+"""Tests for the QURL Python client."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from layerv_qurl import QURLClient, QURLError
+from layerv_qurl.types import CreateInput, ExtendInput, ResolveInput
+
+
+BASE_URL = "https://api.test.layerv.ai"
+
+
+@pytest.fixture
+def client() -> QURLClient:
+    return QURLClient(api_key="lv_live_test", base_url=BASE_URL, max_retries=0)
+
+
+@respx.mock
+def test_create(client: QURLClient) -> None:
+    respx.post(f"{BASE_URL}/v1/qurl").mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "data": {
+                    "resource_id": "r_abc123def45",
+                    "qurl_link": "https://qurl.link/#at_test",
+                    "qurl_site": "https://r_abc123def45.qurl.site",
+                    "expires_at": "2026-03-15T10:00:00Z",
+                },
+                "meta": {"request_id": "req_1"},
+            },
+        )
+    )
+
+    result = client.create(CreateInput(target_url="https://example.com", expires_in="24h"))
+    assert result.resource_id == "r_abc123def45"
+    assert result.qurl_link == "https://qurl.link/#at_test"
+    assert result.qurl_site == "https://r_abc123def45.qurl.site"
+
+
+@respx.mock
+def test_get(client: QURLClient) -> None:
+    respx.get(f"{BASE_URL}/v1/qurls/r_abc123def45").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "resource_id": "r_abc123def45",
+                    "target_url": "https://example.com",
+                    "status": "active",
+                    "created_at": "2026-03-10T10:00:00Z",
+                    "expires_at": "2026-03-15T10:00:00Z",
+                    "one_time_use": False,
+                },
+                "meta": {"request_id": "req_2"},
+            },
+        )
+    )
+
+    result = client.get("r_abc123def45")
+    assert result.resource_id == "r_abc123def45"
+    assert result.status == "active"
+    assert result.target_url == "https://example.com"
+
+
+@respx.mock
+def test_list(client: QURLClient) -> None:
+    respx.get(f"{BASE_URL}/v1/qurls").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "resource_id": "r_abc123def45",
+                        "target_url": "https://example.com",
+                        "status": "active",
+                        "created_at": "2026-03-10T10:00:00Z",
+                    }
+                ],
+                "meta": {"has_more": False, "page_size": 20},
+            },
+        )
+    )
+
+    result = client.list(status="active", limit=10)
+    assert len(result.qurls) == 1
+    assert result.qurls[0].resource_id == "r_abc123def45"
+    assert result.has_more is False
+
+
+@respx.mock
+def test_delete(client: QURLClient) -> None:
+    respx.delete(f"{BASE_URL}/v1/qurls/r_abc123def45").mock(
+        return_value=httpx.Response(204)
+    )
+
+    client.delete("r_abc123def45")  # Should not raise
+
+
+@respx.mock
+def test_extend(client: QURLClient) -> None:
+    respx.patch(f"{BASE_URL}/v1/qurls/r_abc123def45").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "resource_id": "r_abc123def45",
+                    "target_url": "https://example.com",
+                    "status": "active",
+                    "created_at": "2026-03-10T10:00:00Z",
+                    "expires_at": "2026-03-20T10:00:00Z",
+                },
+            },
+        )
+    )
+
+    result = client.extend("r_abc123def45", ExtendInput(extend_by="7d"))
+    assert result.expires_at == "2026-03-20T10:00:00Z"
+
+
+@respx.mock
+def test_resolve(client: QURLClient) -> None:
+    respx.post(f"{BASE_URL}/v1/resolve").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "target_url": "https://api.example.com/data",
+                    "resource_id": "r_abc123def45",
+                    "access_grant": {
+                        "expires_in": 305,
+                        "granted_at": "2026-03-10T15:30:00Z",
+                        "src_ip": "203.0.113.42",
+                    },
+                },
+            },
+        )
+    )
+
+    result = client.resolve(ResolveInput(access_token="at_k8xqp9h2sj9lx7r4a"))
+    assert result.target_url == "https://api.example.com/data"
+    assert result.access_grant is not None
+    assert result.access_grant.expires_in == 305
+    assert result.access_grant.src_ip == "203.0.113.42"
+
+
+@respx.mock
+def test_error_handling(client: QURLClient) -> None:
+    respx.get(f"{BASE_URL}/v1/qurls/r_notfound0000").mock(
+        return_value=httpx.Response(
+            404,
+            json={
+                "error": {
+                    "type": "https://api.qurl.link/problems/not_found",
+                    "title": "Not Found",
+                    "status": 404,
+                    "detail": "QURL not found",
+                    "code": "not_found",
+                },
+                "meta": {"request_id": "req_err"},
+            },
+        )
+    )
+
+    with pytest.raises(QURLError) as exc_info:
+        client.get("r_notfound0000")
+
+    err = exc_info.value
+    assert err.status == 404
+    assert err.code == "not_found"
+    assert err.request_id == "req_err"
+
+
+@respx.mock
+def test_quota(client: QURLClient) -> None:
+    respx.get(f"{BASE_URL}/v1/quota").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "plan": "growth",
+                    "period_start": "2026-03-01T00:00:00Z",
+                    "period_end": "2026-04-01T00:00:00Z",
+                    "usage": {"active_qurls": 5, "qurls_created": 10},
+                },
+            },
+        )
+    )
+
+    result = client.get_quota()
+    assert result.plan == "growth"
+    assert result.usage is not None
+    assert result.usage["active_qurls"] == 5

--- a/apps/sdk-typescript/.gitignore
+++ b/apps/sdk-typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/sdk-typescript/README.md
+++ b/apps/sdk-typescript/README.md
@@ -1,0 +1,59 @@
+# @layerv/qurl
+
+TypeScript SDK for the [QURL API](https://docs.layerv.ai) — secure, time-limited access links for AI agents.
+
+## Installation
+
+```bash
+npm install @layerv/qurl
+```
+
+## Quick Start
+
+```typescript
+import { QURLClient } from '@layerv/qurl';
+
+const client = new QURLClient({ apiKey: 'lv_live_xxx' });
+
+// Create a protected link
+const result = await client.create({
+  target_url: 'https://api.example.com/data',
+  expires_in: '24h',
+  description: 'API access for agent',
+});
+console.log(result.qurl_link);
+
+// Resolve a token (opens firewall for your IP)
+const access = await client.resolve({ access_token: 'at_...' });
+console.log(`Access granted to ${access.target_url} for ${access.access_grant?.expires_in}s`);
+```
+
+## API
+
+### `new QURLClient(options)`
+
+| Option | Required | Default |
+|--------|----------|---------|
+| `apiKey` | Yes | — |
+| `baseUrl` | No | `https://api.layerv.ai` |
+| `maxRetries` | No | `3` |
+| `fetch` | No | `globalThis.fetch` |
+| `userAgent` | No | `qurl-typescript-sdk/0.1.0` |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `create(input)` | Create a protected link |
+| `get(id)` | Get QURL details |
+| `list(input?)` | List QURLs with filters |
+| `delete(id)` | Revoke a QURL |
+| `extend(id, input)` | Extend expiration |
+| `update(id, input)` | Update description |
+| `mintLink(id, input?)` | Mint a new access link |
+| `resolve(input)` | Resolve token + open firewall |
+| `getQuota()` | Get quota/usage info |
+
+## License
+
+MIT

--- a/apps/sdk-typescript/package-lock.json
+++ b/apps/sdk-typescript/package-lock.json
@@ -1,0 +1,1639 @@
+{
+  "name": "@layerv/qurl",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@layerv/qurl",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "prettier": "^3.5.3",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/apps/sdk-typescript/package.json
+++ b/apps/sdk-typescript/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@layerv/qurl",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the QURL API - secure, time-limited access links",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "format": "prettier --write 'src/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "qurl",
+    "layerv",
+    "security",
+    "ai-agents",
+    "zero-trust"
+  ],
+  "author": "LayerV AI",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/layervai/qurl-integrations",
+    "directory": "apps/sdk-typescript"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/sdk-typescript/src/client.test.ts
+++ b/apps/sdk-typescript/src/client.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from "vitest";
+import { QURLClient } from "./client.js";
+import { QURLError } from "./errors.js";
+
+function mockFetch(response: {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): typeof globalThis.fetch {
+  return vi.fn().mockResolvedValue({
+    ok: response.status >= 200 && response.status < 400,
+    status: response.status,
+    statusText: response.status === 200 ? "OK" : "Error",
+    headers: new Headers(response.headers ?? {}),
+    json: () => Promise.resolve(response.body),
+    text: () => Promise.resolve(JSON.stringify(response.body)),
+  } satisfies Partial<Response> as Response);
+}
+
+function createClient(fetchFn: typeof globalThis.fetch): QURLClient {
+  return new QURLClient({
+    apiKey: "lv_live_test",
+    baseUrl: "https://api.test.layerv.ai",
+    fetch: fetchFn,
+    maxRetries: 0,
+  });
+}
+
+describe("QURLClient", () => {
+  it("creates a QURL", async () => {
+    const fetch = mockFetch({
+      status: 201,
+      body: {
+        data: {
+          resource_id: "r_abc123def45",
+          qurl_link: "https://qurl.link/#at_test",
+          qurl_site: "https://r_abc123def45.qurl.site",
+          expires_at: "2026-03-15T10:00:00Z",
+        },
+        meta: { request_id: "req_1" },
+      },
+    });
+
+    const client = createClient(fetch);
+    const result = await client.create({
+      target_url: "https://example.com",
+      expires_in: "24h",
+    });
+
+    expect(result.resource_id).toBe("r_abc123def45");
+    expect(result.qurl_link).toBe("https://qurl.link/#at_test");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/qurl",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("gets a QURL", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: {
+          resource_id: "r_abc123def45",
+          target_url: "https://example.com",
+          status: "active",
+          created_at: "2026-03-10T10:00:00Z",
+        },
+      },
+    });
+
+    const client = createClient(fetch);
+    const result = await client.get("r_abc123def45");
+
+    expect(result.resource_id).toBe("r_abc123def45");
+    expect(result.status).toBe("active");
+  });
+
+  it("lists QURLs", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: [
+          {
+            resource_id: "r_abc123def45",
+            target_url: "https://example.com",
+            status: "active",
+            created_at: "2026-03-10T10:00:00Z",
+          },
+        ],
+        meta: { has_more: false, page_size: 20 },
+      },
+    });
+
+    const client = createClient(fetch);
+    const result = await client.list({ status: "active", limit: 10 });
+
+    expect(result.qurls).toHaveLength(1);
+    expect(result.qurls[0].resource_id).toBe("r_abc123def45");
+    expect(result.has_more).toBe(false);
+  });
+
+  it("deletes a QURL", async () => {
+    const fetch = mockFetch({ status: 204 });
+    const client = createClient(fetch);
+
+    await expect(client.delete("r_abc123def45")).resolves.toBeUndefined();
+  });
+
+  it("extends a QURL", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: {
+          resource_id: "r_abc123def45",
+          target_url: "https://example.com",
+          status: "active",
+          created_at: "2026-03-10T10:00:00Z",
+          expires_at: "2026-03-20T10:00:00Z",
+        },
+      },
+    });
+
+    const client = createClient(fetch);
+    const result = await client.extend("r_abc123def45", { extend_by: "7d" });
+
+    expect(result.expires_at).toBe("2026-03-20T10:00:00Z");
+  });
+
+  it("resolves a QURL token", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: {
+          target_url: "https://api.example.com/data",
+          resource_id: "r_abc123def45",
+          access_grant: {
+            expires_in: 305,
+            granted_at: "2026-03-10T15:30:00Z",
+            src_ip: "203.0.113.42",
+          },
+        },
+      },
+    });
+
+    const client = createClient(fetch);
+    const result = await client.resolve({
+      access_token: "at_k8xqp9h2sj9lx7r4a",
+    });
+
+    expect(result.target_url).toBe("https://api.example.com/data");
+    expect(result.access_grant?.expires_in).toBe(305);
+    expect(result.access_grant?.src_ip).toBe("203.0.113.42");
+  });
+
+  it("throws QURLError on API errors", async () => {
+    const fetch = mockFetch({
+      status: 404,
+      body: {
+        error: {
+          type: "https://api.qurl.link/problems/not_found",
+          title: "Not Found",
+          status: 404,
+          detail: "QURL not found",
+          code: "not_found",
+        },
+        meta: { request_id: "req_err" },
+      },
+    });
+
+    const client = createClient(fetch);
+
+    try {
+      await client.get("r_notfound0000");
+      expect.fail("Expected QURLError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(QURLError);
+      const qErr = err as QURLError;
+      expect(qErr.status).toBe(404);
+      expect(qErr.code).toBe("not_found");
+      expect(qErr.requestId).toBe("req_err");
+    }
+  });
+
+  it("sends correct auth header", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: {
+          plan: "growth",
+          period_start: "2026-03-01",
+          period_end: "2026-04-01",
+        },
+      },
+    });
+
+    const client = createClient(fetch);
+    await client.getQuota();
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer lv_live_test",
+        }),
+      }),
+    );
+  });
+
+  it("mints a link", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: {
+          qurl_link: "https://qurl.link/#at_newtoken",
+          expires_at: "2026-03-15T10:00:00Z",
+        },
+      },
+    });
+
+    const client = createClient(fetch);
+    const result = await client.mintLink("r_abc123def45");
+
+    expect(result.qurl_link).toBe("https://qurl.link/#at_newtoken");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/qurls/r_abc123def45/mint_link",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/sdk-typescript/src/client.ts
+++ b/apps/sdk-typescript/src/client.ts
@@ -1,0 +1,239 @@
+import { QURLError } from "./errors.js";
+import type {
+  ClientOptions,
+  CreateInput,
+  CreateOutput,
+  ExtendInput,
+  ListInput,
+  ListOutput,
+  MintInput,
+  MintOutput,
+  QURL,
+  QURLErrorData,
+  Quota,
+  ResolveInput,
+  ResolveOutput,
+  UpdateInput,
+} from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.layerv.ai";
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_USER_AGENT = "qurl-typescript-sdk/0.1.0";
+
+interface ApiResponse<T> {
+  data: T;
+  meta?: {
+    request_id?: string;
+    page_size?: number;
+    has_more?: boolean;
+    next_cursor?: string;
+  };
+}
+
+interface ApiErrorEnvelope {
+  error?: {
+    type?: string;
+    title: string;
+    status: number;
+    detail: string;
+    code: string;
+    invalid_fields?: Record<string, string>;
+  };
+  meta?: { request_id?: string };
+}
+
+/** QURL API client. */
+export class QURLClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+  private readonly maxRetries: number;
+  private readonly userAgent: string;
+
+  constructor(options: ClientOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+  }
+
+  /** Create a new QURL. */
+  async create(input: CreateInput): Promise<CreateOutput> {
+    return this.request<CreateOutput>("POST", "/v1/qurl", input);
+  }
+
+  /** Get a QURL by ID. */
+  async get(id: string): Promise<QURL> {
+    return this.request<QURL>("GET", `/v1/qurls/${encodeURIComponent(id)}`);
+  }
+
+  /** List QURLs with optional filters. */
+  async list(input: ListInput = {}): Promise<ListOutput> {
+    const params = new URLSearchParams();
+    if (input.limit) params.set("limit", String(input.limit));
+    if (input.cursor) params.set("cursor", input.cursor);
+    if (input.status) params.set("status", input.status);
+    if (input.q) params.set("q", input.q);
+    if (input.sort) params.set("sort", input.sort);
+
+    const query = params.toString();
+    const path = query ? `/v1/qurls?${query}` : "/v1/qurls";
+
+    const { data, meta } = await this.rawRequest<QURL[]>("GET", path);
+    return {
+      qurls: data,
+      next_cursor: meta?.next_cursor,
+      has_more: meta?.has_more ?? false,
+    };
+  }
+
+  /** Delete (revoke) a QURL. */
+  async delete(id: string): Promise<void> {
+    await this.request<void>(
+      "DELETE",
+      `/v1/qurls/${encodeURIComponent(id)}`,
+    );
+  }
+
+  /** Extend a QURL's expiration. */
+  async extend(id: string, input: ExtendInput): Promise<QURL> {
+    return this.request<QURL>(
+      "PATCH",
+      `/v1/qurls/${encodeURIComponent(id)}`,
+      input,
+    );
+  }
+
+  /** Update a QURL's mutable properties. */
+  async update(id: string, input: UpdateInput): Promise<QURL> {
+    return this.request<QURL>(
+      "PATCH",
+      `/v1/qurls/${encodeURIComponent(id)}`,
+      input,
+    );
+  }
+
+  /** Mint a new access link for a QURL. */
+  async mintLink(id: string, input?: MintInput): Promise<MintOutput> {
+    return this.request<MintOutput>(
+      "POST",
+      `/v1/qurls/${encodeURIComponent(id)}/mint_link`,
+      input,
+    );
+  }
+
+  /**
+   * Resolve a QURL access token (headless).
+   * Triggers an NHP knock to open firewall access for the caller's IP.
+   * Requires `qurl:resolve` scope on the API key.
+   */
+  async resolve(input: ResolveInput): Promise<ResolveOutput> {
+    return this.request<ResolveOutput>("POST", "/v1/resolve", input);
+  }
+
+  /** Get quota and usage information. */
+  async getQuota(): Promise<Quota> {
+    return this.request<Quota>("GET", "/v1/quota");
+  }
+
+  // --- Internal HTTP plumbing ---
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const { data } = await this.rawRequest<T>(method, path, body);
+    return data;
+  }
+
+  private async rawRequest<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<ApiResponse<T>> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+      "User-Agent": this.userAgent,
+    };
+
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      if (attempt > 0) {
+        const delay = this.retryDelay(attempt, lastError);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+
+      const response = await this.fetchFn(url, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      if (response.ok) {
+        if (response.status === 204) {
+          return { data: undefined as T };
+        }
+        const json = (await response.json()) as ApiResponse<T>;
+        return json;
+      }
+
+      const errorData = await this.parseError(response);
+      const err = new QURLError(errorData);
+
+      if (this.isRetryable(response.status) && attempt < this.maxRetries) {
+        lastError = err;
+        continue;
+      }
+
+      throw err;
+    }
+
+    throw lastError ?? new Error("Request failed after retries");
+  }
+
+  private async parseError(response: Response): Promise<QURLErrorData> {
+    try {
+      const json = (await response.json()) as ApiErrorEnvelope;
+      if (json.error) {
+        return {
+          status: json.error.status,
+          code: json.error.code,
+          title: json.error.title,
+          detail: json.error.detail,
+          invalid_fields: json.error.invalid_fields,
+          request_id: json.meta?.request_id,
+          retry_after: response.status === 429
+            ? parseInt(response.headers.get("Retry-After") ?? "", 10) || undefined
+            : undefined,
+        };
+      }
+    } catch {
+      // Non-JSON error response
+    }
+
+    return {
+      status: response.status,
+      code: "unknown",
+      title: response.statusText,
+      detail: "",
+    };
+  }
+
+  private isRetryable(status: number): boolean {
+    return status === 429 || status === 502 || status === 503 || status === 504;
+  }
+
+  private retryDelay(attempt: number, lastError?: Error): number {
+    if (lastError instanceof QURLError && lastError.retryAfter) {
+      return lastError.retryAfter * 1000;
+    }
+    const base = 500 * Math.pow(2, attempt - 1);
+    const jitter = Math.random() * base * 0.5;
+    return Math.min(base + jitter, 30_000);
+  }
+}

--- a/apps/sdk-typescript/src/errors.ts
+++ b/apps/sdk-typescript/src/errors.ts
@@ -1,0 +1,22 @@
+import type { QURLErrorData } from "./types.js";
+
+/** Error thrown by the QURL API client. */
+export class QURLError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly detail: string;
+  readonly invalidFields?: Record<string, string>;
+  readonly requestId?: string;
+  readonly retryAfter?: number;
+
+  constructor(data: QURLErrorData) {
+    super(`${data.title} (${data.status}): ${data.detail}`);
+    this.name = "QURLError";
+    this.status = data.status;
+    this.code = data.code;
+    this.detail = data.detail;
+    this.invalidFields = data.invalid_fields;
+    this.requestId = data.request_id;
+    this.retryAfter = data.retry_after;
+  }
+}

--- a/apps/sdk-typescript/src/index.ts
+++ b/apps/sdk-typescript/src/index.ts
@@ -1,0 +1,20 @@
+export { QURLClient } from "./client.js";
+export { QURLError } from "./errors.js";
+export type {
+  AccessGrant,
+  AccessPolicy,
+  ClientOptions,
+  CreateInput,
+  CreateOutput,
+  ExtendInput,
+  ListInput,
+  ListOutput,
+  MintInput,
+  MintOutput,
+  QURL,
+  QURLErrorData,
+  Quota,
+  ResolveInput,
+  ResolveOutput,
+  UpdateInput,
+} from "./types.js";

--- a/apps/sdk-typescript/src/types.ts
+++ b/apps/sdk-typescript/src/types.ts
@@ -1,0 +1,147 @@
+/** Access control policy for a QURL. */
+export interface AccessPolicy {
+  ip_allowlist?: string[];
+  ip_denylist?: string[];
+  geo_allowlist?: string[];
+  geo_denylist?: string[];
+  user_agent_allow_regex?: string;
+  user_agent_deny_regex?: string;
+}
+
+/** A QURL resource as returned by the API. */
+export interface QURL {
+  resource_id: string;
+  target_url: string;
+  status: "active" | "consumed" | "revoked" | "expired";
+  created_at: string;
+  expires_at?: string;
+  one_time_use: boolean;
+  max_sessions?: number;
+  description?: string;
+  qurl_site?: string;
+  qurl_link?: string;
+  access_policy?: AccessPolicy;
+}
+
+/** Input for creating a QURL. */
+export interface CreateInput {
+  target_url: string;
+  expires_in?: string;
+  one_time_use?: boolean;
+  max_sessions?: number;
+  description?: string;
+  metadata?: Record<string, string>;
+  access_policy?: AccessPolicy;
+  custom_domain?: string;
+}
+
+/** Response from creating a QURL. */
+export interface CreateOutput {
+  resource_id: string;
+  qurl_link: string;
+  qurl_site: string;
+  expires_at?: string;
+}
+
+/** Input for listing QURLs. */
+export interface ListInput {
+  limit?: number;
+  cursor?: string;
+  status?: string;
+  q?: string;
+  sort?: string;
+}
+
+/** Response from listing QURLs. */
+export interface ListOutput {
+  qurls: QURL[];
+  next_cursor?: string;
+  has_more: boolean;
+}
+
+/** Input for extending a QURL. */
+export interface ExtendInput {
+  extend_by?: string;
+  expires_at?: string;
+}
+
+/** Input for updating a QURL. */
+export interface UpdateInput {
+  description?: string;
+}
+
+/** Input for minting an access link. */
+export interface MintInput {
+  expires_at?: string;
+}
+
+/** Response from minting an access link. */
+export interface MintOutput {
+  qurl_link: string;
+  expires_at?: string;
+}
+
+/** Input for headless QURL resolution. */
+export interface ResolveInput {
+  access_token: string;
+}
+
+/** Details of the firewall access that was granted. */
+export interface AccessGrant {
+  expires_in: number;
+  granted_at: string;
+  src_ip: string;
+}
+
+/** Response from headless resolution. */
+export interface ResolveOutput {
+  target_url: string;
+  resource_id: string;
+  access_grant?: AccessGrant;
+}
+
+/** Quota information. */
+export interface Quota {
+  plan: string;
+  period_start: string;
+  period_end: string;
+  rate_limits?: {
+    create_per_minute: number;
+    create_per_hour: number;
+    list_per_minute: number;
+    resolve_per_minute: number;
+    max_active_qurls: number;
+    max_tokens_per_qurl: number;
+  };
+  usage?: {
+    qurls_created: number;
+    active_qurls: number;
+    active_qurls_percent: number;
+    total_accesses: number;
+  };
+}
+
+/** API error from the QURL service (RFC 7807). */
+export interface QURLErrorData {
+  status: number;
+  code: string;
+  title: string;
+  detail: string;
+  invalid_fields?: Record<string, string>;
+  request_id?: string;
+  retry_after?: number;
+}
+
+/** Client configuration options. */
+export interface ClientOptions {
+  /** API key (required). */
+  apiKey: string;
+  /** Base URL. Defaults to https://api.layerv.ai */
+  baseUrl?: string;
+  /** Custom fetch implementation. */
+  fetch?: typeof globalThis.fetch;
+  /** Maximum retry attempts for transient errors (429, 5xx). Default: 3. */
+  maxRetries?: number;
+  /** User-Agent header value. */
+  userAgent?: string;
+}

--- a/apps/sdk-typescript/tsconfig.json
+++ b/apps/sdk-typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- **TypeScript SDK** (`@layerv/qurl`) — Full API client with typed methods for all QURL operations (create, get, list, delete, extend, update, mint_link, resolve, getQuota). Uses native `fetch`, automatic retries with exponential backoff, RFC 7807 error parsing.
- **Python SDK** (`layerv-qurl`) — Synchronous API client using `httpx`. Includes **LangChain toolkit** (`QURLToolkit`) with 4 tools (create, resolve, list, delete). PEP 561 typed.
- Both SDKs mirror the Go shared client API contract and match the OpenAPI spec

## Test plan

- [x] TypeScript: 9 unit tests passing (`npm test`)
- [x] Python: 8 unit tests passing (`pytest`)
- [x] TypeScript: builds cleanly (`tsc`)
- [x] Go monorepo: `go build ./...` still passes
- [ ] Publish to npm as `@layerv/qurl`
- [ ] Publish to PyPI as `layerv-qurl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)