### PR TITLE
fix(shared): fall back to X-Request-ID header for request_id

### DIFF
--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -608,5 +608,10 @@ func (c *Client) parseError(resp *http.Response, body []byte) error {
 		}
 	}
 
+	// Fallback: read request ID from response header if not in body
+	if apiErr.RequestID == "" {
+		apiErr.RequestID = resp.Header.Get("X-Request-ID")
+	}
+
 	return apiErr
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -371,6 +371,76 @@ func TestAPIErrorRFC7807(t *testing.T) {
 	}
 }
 
+func TestAPIErrorRequestIDHeaderFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Request-ID", "req_from_header")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		resp := map[string]any{
+			"error": map[string]any{
+				"title":  "Internal Server Error",
+				"status": 500,
+				"detail": "DynamoDB ValidationException",
+				"code":   "internal_error",
+			},
+			// no "meta" — simulates the missing request_id in body
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	_, err := c.Get(context.Background(), "r_abc123test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.RequestID != "req_from_header" {
+		t.Errorf("got request_id %q, want %q", apiErr.RequestID, "req_from_header")
+	}
+}
+
+func TestAPIErrorRequestIDBodyTakesPrecedence(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Request-ID", "req_from_header")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		resp := map[string]any{
+			"error": map[string]any{
+				"title":  "Bad Request",
+				"status": 400,
+				"code":   "invalid_request",
+			},
+			"meta": map[string]string{"request_id": "req_from_body"},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	_, err := c.Get(context.Background(), "r_abc123test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	// Body value should take precedence over header
+	if apiErr.RequestID != "req_from_body" {
+		t.Errorf("got request_id %q, want %q (body should take precedence)", apiErr.RequestID, "req_from_body")
+	}
+}
+
 func TestAPIErrorRateLimit(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Retry-After", "30")


### PR DESCRIPTION
## Summary
- When error responses don't include `request_id` in the JSON body's `meta` object, fall back to reading the `X-Request-ID` response header
- Fixes empty `request_id` in Discord bot error logs — the server sets the header but the body may omit it for certain error types (e.g., DynamoDB ValidationException)

## Test plan
- [x] All existing client tests pass
- [x] Verify Discord bot error logs now show request_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)