### PR TITLE
ci(deps): auto-lowercase dependabot PR titles

### DIFF
--- a/.github/workflows/dependabot-pr-title.yml
+++ b/.github/workflows/dependabot-pr-title.yml
@@ -1,0 +1,36 @@
+name: Fix Dependabot PR Title
+
+# Dependabot capitalizes the first word of PR titles (e.g., "Bump foo from 1.0 to 2.0"),
+# which fails the Conventional Commits PR title check (subjectPattern: ^[a-z].+$).
+# This workflow lowercases the subject to fix it automatically.
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  fix-title:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lowercase PR title subject
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            // Match "type(scope): Subject" and lowercase the first letter of Subject
+            const fixed = title.replace(/^([a-z]+\([^)]*\):\s*)([A-Z])/, (_, prefix, first) => prefix + first.toLowerCase());
+            if (fixed !== title) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                title: fixed,
+              });
+              core.info(`Fixed PR title: "${title}" → "${fixed}"`);
+            } else {
+              core.info(`PR title already valid: "${title}"`);
+            }

--- a/.github/workflows/dependabot-pr-title.yml
+++ b/.github/workflows/dependabot-pr-title.yml
@@ -6,7 +6,7 @@ name: Fix Dependabot PR Title
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   pull-requests: write
@@ -21,8 +21,8 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            // Match "type(scope): Subject" and lowercase the first letter of Subject
-            const fixed = title.replace(/^([a-z]+\([^)]*\):\s*)([A-Z])/, (_, prefix, first) => prefix + first.toLowerCase());
+            // Match "type(scope): Subject" or "type: Subject" and lowercase the first letter
+            const fixed = title.replace(/^([a-z]+(?:\([^)]*\))?:\s*)([A-Z])/, (_, prefix, first) => prefix + first.toLowerCase());
             if (fixed !== title) {
               await github.rest.pulls.update({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- Dependabot capitalizes the first word of PR titles (e.g., `chore(deps): Bump foo`), which fails the `pr-title.yml` check (`subjectPattern: ^[a-z].+$`)
- Adds a workflow that triggers on dependabot PR opens and lowercases the subject: `Bump` → `bump`
- Also manually fixed PR #21's title

## Test plan

- [x] PR #21 title fixed: `chore(deps): bump golang.org/x/term from 0.40.0 to 0.41.0 in the minor-and-patch group`
- [ ] Next dependabot PR should auto-fix within seconds of opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)