### PR TITLE
fix(cli): address review findings for auth login

### DIFF
--- a/apps/cli/cmd/auth.go
+++ b/apps/cli/cmd/auth.go
@@ -81,6 +81,9 @@ func runAuthLogin(cmd *cobra.Command, opts *globalOpts, keyName string, scopes [
 	if len(scopes) == 0 {
 		scopes = allScopes
 	}
+	if err := validateScopes(scopes); err != nil {
+		return err
+	}
 
 	flowCfg := &auth.DeviceFlowConfig{
 		Domain:   domain,
@@ -148,6 +151,7 @@ func runAuthLogin(cmd *cobra.Command, opts *globalOpts, keyName string, scopes [
 		w.ln()
 		w.printf("  Warning: could not save config: %v\n", saveErr)
 		w.printf("  Your API key (save manually): %s\n", keyResp.APIKey)
+		w.printf("  Store this key securely — it will not be shown again.\n")
 		return saveErr
 	}
 
@@ -288,6 +292,20 @@ func resolveEndpoint(opts *globalOpts) string {
 		ep = defaultEndpoint
 	}
 	return ep
+}
+
+// validateScopes checks that all provided scopes are recognized.
+func validateScopes(scopes []string) error {
+	valid := make(map[string]bool, len(allScopes))
+	for _, s := range allScopes {
+		valid[s] = true
+	}
+	for _, s := range scopes {
+		if !valid[s] {
+			return fmt.Errorf("unknown scope %q (valid: %s)", s, strings.Join(allScopes, ", "))
+		}
+	}
+	return nil
 }
 
 // resolveKeyName returns the key name from flag or generates a default.

--- a/apps/cli/cmd/auth_test.go
+++ b/apps/cli/cmd/auth_test.go
@@ -352,6 +352,18 @@ func TestAuthLoginCustomScopes(t *testing.T) {
 	}
 }
 
+func TestAuthLoginInvalidScopes(t *testing.T) {
+	t.Setenv("QURL_AUTH0_CLIENT_ID", "test-client-id")
+
+	_, err := runAuthCmd(t, "auth", "login", "--no-browser", "--scopes", "invalid:scope")
+	if err == nil {
+		t.Fatal("expected error for invalid scope")
+	}
+	if !strings.Contains(err.Error(), "unknown scope") {
+		t.Errorf("error should mention unknown scope: %v", err)
+	}
+}
+
 func TestAuthLogoutSuccess(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("QURL_API_KEY", "")

--- a/apps/cli/internal/auth/apikey.go
+++ b/apps/cli/internal/auth/apikey.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	jsonContentType  = "application/json"
-	bearerPrefix     = "Bearer "
-	defaultHTTPTimer = 30 * time.Second
+	jsonContentType    = "application/json"
+	bearerPrefix       = "Bearer "
+	defaultHTTPTimeout = 30 * time.Second
 )
 
 // CreateKeyRequest is the request body for creating an API key via JWT.
@@ -41,7 +41,7 @@ type createKeyEnvelope struct {
 // If httpClient is nil, a default client with 30s timeout is used.
 func CreateAPIKey(ctx context.Context, httpClient *http.Client, baseURL, jwt string, input CreateKeyRequest) (*CreateKeyResponse, error) {
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: defaultHTTPTimer}
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
 
 	body, err := json.Marshal(input)

--- a/apps/cli/internal/auth/browser.go
+++ b/apps/cli/internal/auth/browser.go
@@ -2,20 +2,33 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
 )
 
 // OpenBrowser attempts to open the given URL in the user's default browser.
-// Returns an error if the browser could not be launched.
+// Only HTTPS URLs are accepted to prevent command injection via malicious URIs.
+// Returns an error if the URL is invalid or the browser could not be launched.
 func OpenBrowser(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("refusing to open non-HTTPS URL: %s", u.Scheme)
+	}
+
+	validated := u.String()
 	ctx := context.Background()
+
 	switch runtime.GOOS {
 	case "darwin":
-		return exec.CommandContext(ctx, "open", rawURL).Start() //nolint:gosec // rawURL is an Auth0 verification URI, not user-controlled shell input
+		return exec.CommandContext(ctx, "open", validated).Start() //nolint:gosec // validated as HTTPS URL from Auth0 server response
 	case "windows":
-		return exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", rawURL).Start() //nolint:gosec // rawURL is an Auth0 verification URI
+		return exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", validated).Start() //nolint:gosec // validated as HTTPS URL from Auth0 server response
 	default:
-		return exec.CommandContext(ctx, "xdg-open", rawURL).Start() //nolint:gosec // rawURL is an Auth0 verification URI
+		return exec.CommandContext(ctx, "xdg-open", validated).Start() //nolint:gosec // validated as HTTPS URL from Auth0 server response
 	}
 }

--- a/apps/cli/internal/auth/device_flow.go
+++ b/apps/cli/internal/auth/device_flow.go
@@ -190,58 +190,59 @@ func (d *DeviceFlow) PollForToken(ctx context.Context, deviceCode string, interv
 		case <-time.After(pollInterval):
 		}
 
-		token, retry, err := d.pollOnce(ctx, endpoint, encodedForm)
+		token, slowDown, err := d.pollOnce(ctx, endpoint, encodedForm)
 		if err != nil {
 			return nil, err
 		}
 		if token != nil {
 			return token, nil
 		}
-		if retry > 0 {
-			pollInterval = retry
+		if slowDown {
+			// Per RFC 8628 section 3.5, increase the current interval by 5 seconds.
+			pollInterval += slowDownIncrement
 		}
 	}
 }
 
 // pollOnce makes a single token poll request. It returns the token on success,
-// a new poll interval if the server requested slow-down, or an error.
-func (d *DeviceFlow) pollOnce(ctx context.Context, endpoint, encodedForm string) (*TokenResponse, time.Duration, error) {
+// slowDown=true if the server requested a slow-down, or an error.
+func (d *DeviceFlow) pollOnce(ctx context.Context, endpoint, encodedForm string) (*TokenResponse, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(encodedForm))
 	if err != nil {
-		return nil, 0, fmt.Errorf("build token request: %w", err)
+		return nil, false, fmt.Errorf("build token request: %w", err)
 	}
 	req.Header.Set("Content-Type", formContentType)
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, fmt.Errorf("poll for token: %w", err)
+		return nil, false, fmt.Errorf("poll for token: %w", err)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	_ = resp.Body.Close()
 	if err != nil {
-		return nil, 0, fmt.Errorf("read token response: %w", err)
+		return nil, false, fmt.Errorf("read token response: %w", err)
 	}
 
 	if resp.StatusCode == http.StatusOK {
 		var token TokenResponse
 		if err := json.Unmarshal(body, &token); err != nil {
-			return nil, 0, fmt.Errorf("parse token response: %w", err)
+			return nil, false, fmt.Errorf("parse token response: %w", err)
 		}
-		return &token, 0, nil
+		return &token, false, nil
 	}
 
 	var oauthErr DeviceFlowError
 	if err := json.Unmarshal(body, &oauthErr); err != nil {
-		return nil, 0, fmt.Errorf("parse error response (status %d): %w", resp.StatusCode, err)
+		return nil, false, fmt.Errorf("parse error response (status %d): %w", resp.StatusCode, err)
 	}
 
 	switch oauthErr.Code {
 	case errCodePending:
-		return nil, 0, nil
+		return nil, false, nil
 	case errCodeSlowDown:
-		return nil, defaultPollInterval + slowDownIncrement, nil
+		return nil, true, nil
 	default:
-		return nil, 0, &oauthErr
+		return nil, false, &oauthErr
 	}
 }

--- a/apps/cli/internal/auth/device_flow_test.go
+++ b/apps/cli/internal/auth/device_flow_test.go
@@ -105,7 +105,7 @@ func TestRequestDeviceCodeError(t *testing.T) {
 	}
 
 	var dfe *DeviceFlowError
-	if !errorAs(err, &dfe) {
+	if !errors.As(err, &dfe) {
 		t.Fatalf("expected DeviceFlowError, got %T: %v", err, err)
 	}
 	if dfe.Code != "unauthorized_client" {
@@ -245,8 +245,8 @@ func TestPollForTokenSlowDown(t *testing.T) {
 	if token.AccessToken != "jwt-slow" {
 		t.Errorf("AccessToken = %q, want %q", token.AccessToken, "jwt-slow")
 	}
-	// After slow_down, interval increases to defaultPollInterval + slowDownIncrement = 10s.
-	// First poll at 1s (returns slow_down), second poll at 10s. Total >= 5s.
+	// After slow_down, interval increases from 1s to 1s+5s = 6s per RFC 8628 section 3.5.
+	// First poll at 1s (returns slow_down), second poll at 6s. Total >= 5s.
 	if elapsed < 5*time.Second {
 		t.Errorf("elapsed %v too short — slow_down should increase poll interval", elapsed)
 	}
@@ -272,7 +272,7 @@ func TestPollForTokenExpired(t *testing.T) {
 	}
 
 	var dfe *DeviceFlowError
-	if !errorAs(err, &dfe) {
+	if !errors.As(err, &dfe) {
 		t.Fatalf("expected DeviceFlowError, got %T: %v", err, err)
 	}
 	if !dfe.IsExpired() {
@@ -300,7 +300,7 @@ func TestPollForTokenDenied(t *testing.T) {
 	}
 
 	var dfe *DeviceFlowError
-	if !errorAs(err, &dfe) {
+	if !errors.As(err, &dfe) {
 		t.Fatalf("expected DeviceFlowError, got %T: %v", err, err)
 	}
 	if !dfe.IsDenied() {
@@ -373,9 +373,4 @@ func TestAuthBaseURL(t *testing.T) {
 			}
 		})
 	}
-}
-
-// errorAs is a wrapper around errors.As for the DeviceFlowError type.
-func errorAs(err error, target **DeviceFlowError) bool {
-	return errors.As(err, target)
 }


### PR DESCRIPTION
## Summary

Fixes issues identified in the code review on #34:

- **Fix RFC 8628 slow_down bug**: The `pollOnce` method was resetting the poll interval to a fixed 10s on every `slow_down` response instead of incrementing the current interval by 5s. Per RFC 8628 §3.5, repeated slow_down responses should cause cumulative backoff.
- **URL validation in OpenBrowser**: Validate that the URL is well-formed HTTPS before passing it to OS commands, mitigating risk if the Auth0 server response were compromised.
- **Client-side scope validation**: Reject invalid `--scopes` values immediately instead of waiting for server-side rejection.
- **Rename `defaultHTTPTimer` → `defaultHTTPTimeout`** for clarity.
- **Add "store securely" hint** when config save fails and the API key is printed to terminal.
- **Remove `errorAs` test wrapper**, use `errors.As` directly for readability.
- **Add test** for invalid scope rejection.

## Test plan

- [x] Existing slow_down test still passes with corrected interval logic
- [x] New `TestAuthLoginInvalidScopes` verifies client-side scope validation
- [x] All files pass `gofmt`

https://claude.ai/code/session_01CYNdozoeDuBVaCVZd1Ebpi