### PR TITLE
feat(shared)!: align client types with latest API spec

### DIFF
--- a/apps/cli/cmd/commands_test.go
+++ b/apps/cli/cmd/commands_test.go
@@ -27,8 +27,9 @@ func newMockServer(t *testing.T) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/qurl":
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/qurls":
 			apiEnvelope(t, w, map[string]any{
+				"qurl_id":     "q_test123",
 				"resource_id": "r_test123",
 				"qurl_link":   "https://qurl.link/at_abc",
 				"qurl_site":   "https://r_test123.qurl.site",

--- a/apps/cli/cmd/completion.go
+++ b/apps/cli/cmd/completion.go
@@ -47,7 +47,7 @@ func resourceIDCompletion(opts *globalOpts) func(*cobra.Command, []string, strin
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
 		defer cancel()
-		result, err := c.List(ctx, client.ListInput{Limit: 20, Query: toComplete})
+		result, err := c.List(ctx, &client.ListInput{Limit: 20, Query: toComplete})
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -21,6 +21,10 @@ func createCmd(opts *globalOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <target-url>",
 		Short: "Create a qURL for a target URL",
+		Long: `Creates a new qURL for the given target URL.
+
+Note: AccessPolicy overrides (geo-fencing, IP restrictions) are only available
+via the SDK or API; the CLI exposes the common creation flags only.`,
 		Example: `  qurl create https://api.example.com/data
   qurl create https://internal.example.com --expires 1h --one-time
   qurl create https://dashboard.example.com -l "Admin access" -e 7d`,

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -62,12 +62,12 @@ func createCmd(opts *globalOpts) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&label, "label", "l", "", "Label for the QURL")
+	cmd.Flags().StringVarP(&label, "label", "l", "", "Label for the qURL")
 	cmd.Flags().StringVarP(&expiresIn, "expires", "e", "", "Expiration duration (e.g., 1h, 24h, 7d)")
 	cmd.Flags().BoolVar(&oneTimeUse, "one-time", false, "Single-use token (consumed after first access)")
 	cmd.Flags().IntVar(&maxSessions, "max-sessions", 0, "Maximum concurrent sessions (0 = unlimited)")
 	cmd.Flags().StringVar(&sessionDuration, "session-duration", "", "Session duration (e.g., 30m, 1h)")
-	cmd.Flags().StringVar(&customDomain, "custom-domain", "", "Custom domain for the QURL")
+	cmd.Flags().StringVar(&customDomain, "custom-domain", "", "Custom domain for the qURL")
 
 	return cmd
 }

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -10,10 +10,12 @@ import (
 
 func createCmd(opts *globalOpts) *cobra.Command {
 	var (
-		description string
-		expiresIn   string
-		oneTimeUse  bool
-		maxSessions int
+		label           string
+		expiresIn       string
+		oneTimeUse      bool
+		maxSessions     int
+		sessionDuration string
+		customDomain    string
 	)
 
 	cmd := &cobra.Command{
@@ -21,7 +23,7 @@ func createCmd(opts *globalOpts) *cobra.Command {
 		Short: "Create a QURL for a target URL",
 		Example: `  qurl create https://api.example.com/data
   qurl create https://internal.example.com --expires 1h --one-time
-  qurl create https://dashboard.example.com -d "Admin access" -e 7d`,
+  qurl create https://dashboard.example.com -l "Admin access" -e 7d`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateURL(args[0]); err != nil {
@@ -37,14 +39,16 @@ func createCmd(opts *globalOpts) *cobra.Command {
 			}
 
 			input := client.CreateInput{
-				TargetURL:   args[0],
-				Description: description,
-				ExpiresIn:   expiresIn,
-				OneTimeUse:  oneTimeUse,
-				MaxSessions: maxSessions,
+				TargetURL:       args[0],
+				Label:           label,
+				ExpiresIn:       expiresIn,
+				OneTimeUse:      oneTimeUse,
+				MaxSessions:     maxSessions,
+				SessionDuration: sessionDuration,
+				CustomDomain:    customDomain,
 			}
 
-			result, err := c.Create(cmd.Context(), input)
+			result, err := c.Create(cmd.Context(), &input)
 			if err != nil {
 				return fmt.Errorf("create QURL: %w", err)
 			}
@@ -58,10 +62,12 @@ func createCmd(opts *globalOpts) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&description, "description", "d", "", "Description")
+	cmd.Flags().StringVarP(&label, "label", "l", "", "Label for the QURL")
 	cmd.Flags().StringVarP(&expiresIn, "expires", "e", "", "Expiration duration (e.g., 1h, 24h, 7d)")
 	cmd.Flags().BoolVar(&oneTimeUse, "one-time", false, "Single-use token (consumed after first access)")
 	cmd.Flags().IntVar(&maxSessions, "max-sessions", 0, "Maximum concurrent sessions (0 = unlimited)")
+	cmd.Flags().StringVar(&sessionDuration, "session-duration", "", "Session duration (e.g., 30m, 1h)")
+	cmd.Flags().StringVar(&customDomain, "custom-domain", "", "Custom domain for the QURL")
 
 	return cmd
 }

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -32,6 +32,9 @@ func createCmd(opts *globalOpts) *cobra.Command {
 			if err := validateDuration(expiresIn); err != nil {
 				return err
 			}
+			if err := validateDuration(sessionDuration); err != nil {
+				return err
+			}
 
 			c, err := opts.newClient()
 			if err != nil {

--- a/apps/cli/cmd/extend.go
+++ b/apps/cli/cmd/extend.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 func extendCmd(opts *globalOpts) *cobra.Command {
@@ -30,9 +28,7 @@ func extendCmd(opts *globalOpts) *cobra.Command {
 				return err
 			}
 
-			qurl, err := c.Extend(cmd.Context(), args[0], client.ExtendInput{
-				ExtendBy: extendBy,
-			})
+			qurl, err := c.Extend(cmd.Context(), args[0], extendBy)
 			if err != nil {
 				return fmt.Errorf("extend QURL: %w", err)
 			}

--- a/apps/cli/cmd/list.go
+++ b/apps/cli/cmd/list.go
@@ -38,12 +38,12 @@ func listCmd(opts *globalOpts) *cobra.Command {
 				}
 			}
 
-			var errs []error
-			errs = append(errs, validateRFC3339("created-after", createdAfter))
-			errs = append(errs, validateRFC3339("created-before", createdBefore))
-			errs = append(errs, validateRFC3339("expires-before", expiresBefore))
-			errs = append(errs, validateRFC3339("expires-after", expiresAfter))
-			if err := errors.Join(errs...); err != nil {
+			if err := errors.Join(
+				validateRFC3339("created-after", createdAfter),
+				validateRFC3339("created-before", createdBefore),
+				validateRFC3339("expires-before", expiresBefore),
+				validateRFC3339("expires-after", expiresAfter),
+			); err != nil {
 				return err
 			}
 

--- a/apps/cli/cmd/list.go
+++ b/apps/cli/cmd/list.go
@@ -76,10 +76,10 @@ func listCmd(opts *globalOpts) *cobra.Command {
 	cmd.Flags().StringVar(&status, "status", "", "Filter by status (active, revoked)")
 	cmd.Flags().StringVar(&query, "query", "", "Search label, description, and target URL")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort field:direction (e.g., created_at:desc)")
-	cmd.Flags().StringVar(&createdAfter, "created-after", "", "Filter QURLs created after this date (RFC3339)")
-	cmd.Flags().StringVar(&createdBefore, "created-before", "", "Filter QURLs created before this date (RFC3339)")
-	cmd.Flags().StringVar(&expiresBefore, "expires-before", "", "Filter QURLs expiring before this date (RFC3339)")
-	cmd.Flags().StringVar(&expiresAfter, "expires-after", "", "Filter QURLs expiring after this date (RFC3339)")
+	cmd.Flags().StringVar(&createdAfter, "created-after", "", "Filter qURLs created after this date (RFC3339)")
+	cmd.Flags().StringVar(&createdBefore, "created-before", "", "Filter qURLs created before this date (RFC3339)")
+	cmd.Flags().StringVar(&expiresBefore, "expires-before", "", "Filter qURLs expiring before this date (RFC3339)")
+	cmd.Flags().StringVar(&expiresAfter, "expires-after", "", "Filter qURLs expiring after this date (RFC3339)")
 
 	return cmd
 }

--- a/apps/cli/cmd/list.go
+++ b/apps/cli/cmd/list.go
@@ -10,11 +10,15 @@ import (
 
 func listCmd(opts *globalOpts) *cobra.Command {
 	var (
-		limit  int
-		cursor string
-		status string
-		query  string
-		sort   string
+		limit         int
+		cursor        string
+		status        string
+		query         string
+		sort          string
+		createdAfter  string
+		createdBefore string
+		expiresBefore string
+		expiresAfter  string
 	)
 
 	cmd := &cobra.Command{
@@ -27,9 +31,9 @@ func listCmd(opts *globalOpts) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if status != "" {
 				switch status {
-				case client.StatusActive, client.StatusExpired, client.StatusRevoked, client.StatusConsumed:
+				case client.StatusActive, client.StatusRevoked:
 				default:
-					return fmt.Errorf("invalid status %q: must be active, expired, revoked, or consumed", status)
+					return fmt.Errorf("invalid status %q: must be active or revoked", status)
 				}
 			}
 
@@ -38,12 +42,16 @@ func listCmd(opts *globalOpts) *cobra.Command {
 				return err
 			}
 
-			result, err := c.List(cmd.Context(), client.ListInput{
-				Limit:  limit,
-				Cursor: cursor,
-				Status: status,
-				Query:  query,
-				Sort:   sort,
+			result, err := c.List(cmd.Context(), &client.ListInput{
+				Limit:         limit,
+				Cursor:        cursor,
+				Status:        status,
+				Query:         query,
+				Sort:          sort,
+				CreatedAfter:  createdAfter,
+				CreatedBefore: createdBefore,
+				ExpiresBefore: expiresBefore,
+				ExpiresAfter:  expiresAfter,
 			})
 			if err != nil {
 				return fmt.Errorf("list QURLs: %w", err)
@@ -55,9 +63,13 @@ func listCmd(opts *globalOpts) *cobra.Command {
 
 	cmd.Flags().IntVarP(&limit, "limit", "l", 20, "Maximum number of QURLs to return")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor from a previous list response")
-	cmd.Flags().StringVar(&status, "status", "", "Filter by status (active, expired, revoked, consumed)")
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status (active, revoked)")
 	cmd.Flags().StringVar(&query, "query", "", "Search description and target URL")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort field:direction (e.g., created_at:desc)")
+	cmd.Flags().StringVar(&createdAfter, "created-after", "", "Filter QURLs created after this date (RFC3339)")
+	cmd.Flags().StringVar(&createdBefore, "created-before", "", "Filter QURLs created before this date (RFC3339)")
+	cmd.Flags().StringVar(&expiresBefore, "expires-before", "", "Filter QURLs expiring before this date (RFC3339)")
+	cmd.Flags().StringVar(&expiresAfter, "expires-after", "", "Filter QURLs expiring after this date (RFC3339)")
 
 	return cmd
 }

--- a/apps/cli/cmd/list.go
+++ b/apps/cli/cmd/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -35,6 +36,15 @@ func listCmd(opts *globalOpts) *cobra.Command {
 				default:
 					return fmt.Errorf("invalid status %q: must be active or revoked", status)
 				}
+			}
+
+			var errs []error
+			errs = append(errs, validateRFC3339("created-after", createdAfter))
+			errs = append(errs, validateRFC3339("created-before", createdBefore))
+			errs = append(errs, validateRFC3339("expires-before", expiresBefore))
+			errs = append(errs, validateRFC3339("expires-after", expiresAfter))
+			if err := errors.Join(errs...); err != nil {
+				return err
 			}
 
 			c, err := opts.newClient()

--- a/apps/cli/cmd/list.go
+++ b/apps/cli/cmd/list.go
@@ -74,7 +74,7 @@ func listCmd(opts *globalOpts) *cobra.Command {
 	cmd.Flags().IntVarP(&limit, "limit", "l", 20, "Maximum number of QURLs to return")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor from a previous list response")
 	cmd.Flags().StringVar(&status, "status", "", "Filter by status (active, revoked)")
-	cmd.Flags().StringVar(&query, "query", "", "Search description and target URL")
+	cmd.Flags().StringVar(&query, "query", "", "Search label, description, and target URL")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort field:direction (e.g., created_at:desc)")
 	cmd.Flags().StringVar(&createdAfter, "created-after", "", "Filter QURLs created after this date (RFC3339)")
 	cmd.Flags().StringVar(&createdBefore, "created-before", "", "Filter QURLs created before this date (RFC3339)")

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -62,17 +62,21 @@ via the SDK or API; the CLI exposes the common per-link flags only.`,
 				cmd.Flags().Changed("session-duration")
 
 			if hasInput {
-				// All fields are assigned unconditionally. omitempty on bool/int fields
-				// strips false/0 from the JSON payload, so zero-value flags are naturally
-				// omitted — identical to what a Changed() gate would do, without the
-				// asymmetry. ExpiresAt is pointer-typed and requires parsing, so it is
-				// still gated on Changed().
+				// String and duration fields are assigned unconditionally: omitempty strips
+				// empty strings cleanly. Bool/int fields use pointer types (*bool/*int) so
+				// an explicit --one-time=false or --max-sessions=0 can be sent to the server
+				// as an explicit override rather than being silently dropped. Only build the
+				// pointer when the flag was actually set; a nil pointer omits the field.
 				input = &client.MintLinkInput{
 					ExpiresIn:       expiresIn,
 					Label:           label,
-					OneTimeUse:      oneTimeUse,
-					MaxSessions:     maxSessions,
 					SessionDuration: sessionDuration,
+				}
+				if cmd.Flags().Changed("one-time") {
+					input.OneTimeUse = &oneTimeUse
+				}
+				if cmd.Flags().Changed("max-sessions") {
+					input.MaxSessions = &maxSessions
 				}
 				if cmd.Flags().Changed("expires-at") {
 					t, parseErr := time.Parse(time.RFC3339, expiresAt)

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -42,6 +42,11 @@ via the SDK or API; the CLI exposes the common per-link flags only.`,
 			if err := validateDuration(sessionDuration); err != nil {
 				return err
 			}
+			if cmd.Flags().Changed("expires-at") {
+				if err := validateRFC3339("expires-at", expiresAt); err != nil {
+					return err
+				}
+			}
 
 			c, err := opts.newClient()
 			if err != nil {
@@ -79,10 +84,7 @@ via the SDK or API; the CLI exposes the common per-link flags only.`,
 					input.MaxSessions = &maxSessions
 				}
 				if cmd.Flags().Changed("expires-at") {
-					t, parseErr := time.Parse(time.RFC3339, expiresAt)
-					if parseErr != nil {
-						return fmt.Errorf("invalid --expires-at value: %w", parseErr)
-					}
+					t, _ := time.Parse(time.RFC3339, expiresAt) // already validated above
 					input.ExpiresAt = &t
 				}
 			}

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -51,8 +51,6 @@ Useful for multi-use QURLs where you want to generate additional access links.`,
 				input = &client.MintLinkInput{
 					ExpiresIn:       expiresIn,
 					Label:           label,
-					OneTimeUse:      oneTimeUse,
-					MaxSessions:     maxSessions,
 					SessionDuration: sessionDuration,
 				}
 				if cmd.Flags().Changed("expires-at") {
@@ -61,6 +59,12 @@ Useful for multi-use QURLs where you want to generate additional access links.`,
 						return fmt.Errorf("invalid --expires-at value: %w", parseErr)
 					}
 					input.ExpiresAt = &t
+				}
+				if cmd.Flags().Changed("one-time") {
+					input.OneTimeUse = oneTimeUse
+				}
+				if cmd.Flags().Changed("max-sessions") {
+					input.MaxSessions = maxSessions
 				}
 			}
 

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -40,6 +40,11 @@ Useful for multi-use QURLs where you want to generate additional access links.`,
 			}
 
 			var input *client.MintLinkInput
+			// Only build a MintLinkInput when the caller explicitly set at least one flag.
+			// Keeping input nil causes MintLink to send http.NoBody, which is a meaningful
+			// wire-level difference: the server uses a bodiless POST to mean "mint with
+			// the QURL's own defaults". Always building the struct (even with all zero
+			// values and omitempty fields) would send an empty JSON object instead.
 			hasInput := cmd.Flags().Changed("expires-in") ||
 				cmd.Flags().Changed("expires-at") ||
 				cmd.Flags().Changed("label") ||

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -23,7 +23,10 @@ func mintCmd(opts *globalOpts) *cobra.Command {
 		Use:   "mint <resource-id>",
 		Short: "Mint a new access link for a qURL",
 		Long: `Creates a new access token and link for an existing qURL resource.
-Useful for multi-use qURLs where you want to generate additional access links.`,
+Useful for multi-use qURLs where you want to generate additional access links.
+
+Note: AccessPolicy overrides (geo-fencing, IP restrictions) are only available
+via the SDK or API; the CLI exposes the common per-link flags only.`,
 		Example: `  qurl mint r_k8xqp9h2sj9
   qurl mint r_k8xqp9h2sj9 --expires-in 1h --one-time
   LINK=$(qurl mint r_k8xqp9h2sj9 -q)`,
@@ -31,6 +34,12 @@ Useful for multi-use qURLs where you want to generate additional access links.`,
 		ValidArgsFunction: resourceIDCompletion(opts),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateResourceID(args[0]); err != nil {
+				return err
+			}
+			if err := validateDuration(expiresIn); err != nil {
+				return err
+			}
+			if err := validateDuration(sessionDuration); err != nil {
 				return err
 			}
 

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -2,17 +2,30 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 func mintCmd(opts *globalOpts) *cobra.Command {
-	return &cobra.Command{
+	var (
+		expiresIn       string
+		expiresAt       string
+		label           string
+		oneTimeUse      bool
+		maxSessions     int
+		sessionDuration string
+	)
+
+	cmd := &cobra.Command{
 		Use:   "mint <resource-id>",
 		Short: "Mint a new access link for a QURL",
 		Long: `Creates a new access token and link for an existing QURL resource.
 Useful for multi-use QURLs where you want to generate additional access links.`,
 		Example: `  qurl mint r_k8xqp9h2sj9
+  qurl mint r_k8xqp9h2sj9 --expires-in 1h --one-time
   LINK=$(qurl mint r_k8xqp9h2sj9 -q)`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: resourceIDCompletion(opts),
@@ -26,7 +39,32 @@ Useful for multi-use QURLs where you want to generate additional access links.`,
 				return err
 			}
 
-			result, err := c.MintLink(cmd.Context(), args[0])
+			var input *client.MintLinkInput
+			hasInput := cmd.Flags().Changed("expires-in") ||
+				cmd.Flags().Changed("expires-at") ||
+				cmd.Flags().Changed("label") ||
+				cmd.Flags().Changed("one-time") ||
+				cmd.Flags().Changed("max-sessions") ||
+				cmd.Flags().Changed("session-duration")
+
+			if hasInput {
+				input = &client.MintLinkInput{
+					ExpiresIn:       expiresIn,
+					Label:           label,
+					OneTimeUse:      oneTimeUse,
+					MaxSessions:     maxSessions,
+					SessionDuration: sessionDuration,
+				}
+				if cmd.Flags().Changed("expires-at") {
+					t, parseErr := time.Parse(time.RFC3339, expiresAt)
+					if parseErr != nil {
+						return fmt.Errorf("invalid --expires-at value: %w", parseErr)
+					}
+					input.ExpiresAt = &t
+				}
+			}
+
+			result, err := c.MintLink(cmd.Context(), args[0], input)
 			if err != nil {
 				return fmt.Errorf("mint link: %w", err)
 			}
@@ -39,4 +77,13 @@ Useful for multi-use QURLs where you want to generate additional access links.`,
 			return opts.formatter().FormatMint(cmd.OutOrStdout(), result)
 		},
 	}
+
+	cmd.Flags().StringVar(&expiresIn, "expires-in", "", "Link expiration duration (e.g., 1h, 24h)")
+	cmd.Flags().StringVar(&expiresAt, "expires-at", "", "Link expiration time (RFC3339)")
+	cmd.Flags().StringVar(&label, "label", "", "Label for the minted link")
+	cmd.Flags().BoolVar(&oneTimeUse, "one-time", false, "Single-use link")
+	cmd.Flags().IntVar(&maxSessions, "max-sessions", 0, "Maximum concurrent sessions")
+	cmd.Flags().StringVar(&sessionDuration, "session-duration", "", "Session duration (e.g., 30m, 1h)")
+
+	return cmd
 }

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -53,9 +53,16 @@ Useful for multi-use qURLs where you want to generate additional access links.`,
 				cmd.Flags().Changed("session-duration")
 
 			if hasInput {
+				// All fields are assigned unconditionally. omitempty on bool/int fields
+				// strips false/0 from the JSON payload, so zero-value flags are naturally
+				// omitted — identical to what a Changed() gate would do, without the
+				// asymmetry. ExpiresAt is pointer-typed and requires parsing, so it is
+				// still gated on Changed().
 				input = &client.MintLinkInput{
 					ExpiresIn:       expiresIn,
 					Label:           label,
+					OneTimeUse:      oneTimeUse,
+					MaxSessions:     maxSessions,
 					SessionDuration: sessionDuration,
 				}
 				if cmd.Flags().Changed("expires-at") {
@@ -64,12 +71,6 @@ Useful for multi-use qURLs where you want to generate additional access links.`,
 						return fmt.Errorf("invalid --expires-at value: %w", parseErr)
 					}
 					input.ExpiresAt = &t
-				}
-				if cmd.Flags().Changed("one-time") {
-					input.OneTimeUse = oneTimeUse
-				}
-				if cmd.Flags().Changed("max-sessions") {
-					input.MaxSessions = maxSessions
 				}
 			}
 

--- a/apps/cli/cmd/update.go
+++ b/apps/cli/cmd/update.go
@@ -40,6 +40,11 @@ Note: The --description flag updates the resource-level description (maps to the
 					return err
 				}
 			}
+			if cmd.Flags().Changed("expires-at") {
+				if err := validateRFC3339("expires-at", expiresAt); err != nil {
+					return err
+				}
+			}
 
 			hasChange := cmd.Flags().Changed("description") ||
 				cmd.Flags().Changed("tags") ||
@@ -65,10 +70,7 @@ Note: The --description flag updates the resource-level description (maps to the
 				input.ExtendBy = extendBy
 			}
 			if cmd.Flags().Changed("expires-at") {
-				t, parseErr := time.Parse(time.RFC3339, expiresAt)
-				if parseErr != nil {
-					return fmt.Errorf("invalid --expires-at value: %w", parseErr)
-				}
+				t, _ := time.Parse(time.RFC3339, expiresAt) // already validated above
 				input.ExpiresAt = &t
 			}
 

--- a/apps/cli/cmd/update.go
+++ b/apps/cli/cmd/update.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -10,13 +11,19 @@ import (
 )
 
 func updateCmd(opts *globalOpts) *cobra.Command {
-	var description string
+	var (
+		description string
+		tags        []string
+		extendBy    string
+		expiresAt   string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "update <resource-id>",
 		Short: "Update a QURL's properties",
 		Example: `  qurl update r_k8xqp9h2sj9 --description "Production API access"
-  qurl update r_k8xqp9h2sj9 -d ""  # clear description`,
+  qurl update r_k8xqp9h2sj9 -d ""  # clear description
+  qurl update r_k8xqp9h2sj9 --tags prod,api --extend-by 24h`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: resourceIDCompletion(opts),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -24,8 +31,12 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 				return err
 			}
 
-			if !cmd.Flags().Changed("description") {
-				return errors.New("at least one flag must be set (e.g., --description)")
+			hasChange := cmd.Flags().Changed("description") ||
+				cmd.Flags().Changed("tags") ||
+				cmd.Flags().Changed("extend-by") ||
+				cmd.Flags().Changed("expires-at")
+			if !hasChange {
+				return errors.New("at least one flag must be set (e.g., --description, --tags, --extend-by, --expires-at)")
 			}
 
 			c, err := opts.newClient()
@@ -36,6 +47,19 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 			input := client.UpdateInput{}
 			if cmd.Flags().Changed("description") {
 				input.Description = &description
+			}
+			if cmd.Flags().Changed("tags") {
+				input.Tags = &tags
+			}
+			if cmd.Flags().Changed("extend-by") {
+				input.ExtendBy = extendBy
+			}
+			if cmd.Flags().Changed("expires-at") {
+				t, parseErr := time.Parse(time.RFC3339, expiresAt)
+				if parseErr != nil {
+					return fmt.Errorf("invalid --expires-at value: %w", parseErr)
+				}
+				input.ExpiresAt = &t
 			}
 
 			qurl, err := c.Update(cmd.Context(), args[0], input)
@@ -48,6 +72,9 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&description, "description", "d", "", "New description (use empty string to clear)")
+	cmd.Flags().StringSliceVar(&tags, "tags", nil, "Tags (comma-separated, e.g., prod,api)")
+	cmd.Flags().StringVar(&extendBy, "extend-by", "", "Extend expiration by duration (e.g., 24h, 7d)")
+	cmd.Flags().StringVar(&expiresAt, "expires-at", "", "Set exact expiration time (RFC3339)")
 
 	return cmd
 }

--- a/apps/cli/cmd/update.go
+++ b/apps/cli/cmd/update.go
@@ -21,6 +21,11 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <resource-id>",
 		Short: "Update a qURL's properties",
+		Long: `Updates mutable properties of a qURL.
+
+Note: The --description flag updates the resource-level description (maps to the API's
+"description" field on UpdateQurlRequest). This is intentionally different from
+"qurl create --label", which sets the qURL token label on creation.`,
 		Example: `  qurl update r_k8xqp9h2sj9 --description "Production API access"
   qurl update r_k8xqp9h2sj9 -d ""  # clear description
   qurl update r_k8xqp9h2sj9 --tags prod,api --extend-by 24h`,
@@ -41,7 +46,7 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 				cmd.Flags().Changed("extend-by") ||
 				cmd.Flags().Changed("expires-at")
 			if !hasChange {
-				return errors.New("at least one flag must be set (e.g., --description, --tags, --extend-by, --expires-at)")
+				return errors.New("must set at least one of: --description, --tags, --extend-by, --expires-at")
 			}
 
 			c, err := opts.newClient()

--- a/apps/cli/cmd/update.go
+++ b/apps/cli/cmd/update.go
@@ -30,6 +30,11 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 			if err := validateResourceID(args[0]); err != nil {
 				return err
 			}
+			if cmd.Flags().Changed("extend-by") {
+				if err := validateDuration(extendBy); err != nil {
+					return err
+				}
+			}
 
 			hasChange := cmd.Flags().Changed("description") ||
 				cmd.Flags().Changed("tags") ||

--- a/apps/cli/cmd/validate.go
+++ b/apps/cli/cmd/validate.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // durationPattern matches Go-style durations and day suffixes (e.g., "1h", "24h", "7d", "30m").
@@ -50,6 +51,18 @@ func validateResourceID(id string) error {
 	}
 	if len(id) < 4 {
 		return fmt.Errorf("invalid resource ID %q: too short", id)
+	}
+	return nil
+}
+
+// validateRFC3339 checks that the date string is a valid RFC3339 timestamp.
+// An empty string is accepted (the field is optional).
+func validateRFC3339(flag, value string) error {
+	if value == "" {
+		return nil // optional
+	}
+	if _, err := time.Parse(time.RFC3339, value); err != nil {
+		return fmt.Errorf("invalid --%s value %q: must be RFC3339 (e.g., 2026-01-01T00:00:00Z)", flag, value)
 	}
 	return nil
 }

--- a/apps/cli/cmd/validate_test.go
+++ b/apps/cli/cmd/validate_test.go
@@ -104,3 +104,27 @@ func TestValidateAccessToken(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRFC3339(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty ok", "", false},
+		{"valid UTC", "2026-01-01T00:00:00Z", false},
+		{"valid with offset", "2026-06-15T12:30:00+05:30", false},
+		{"date only", "2026-01-01", true},
+		{"invalid format", "Jan 1 2026", true},
+		{"garbage", "not-a-date", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRFC3339("test-flag", tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRFC3339(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/apps/cli/internal/output/formatter.go
+++ b/apps/cli/internal/output/formatter.go
@@ -197,6 +197,8 @@ func (f TableFormatter) colorStatus(status string) string {
 	case client.StatusActive:
 		return f.green.Sprint(status)
 	case client.StatusRevoked:
+		// "expired" and "consumed" are removed from the API spec as of this version;
+		// unknown statuses fall through to the default (uncolored) to stay readable.
 		return f.red.Sprint(status)
 	default:
 		return status

--- a/apps/cli/internal/output/formatter.go
+++ b/apps/cli/internal/output/formatter.go
@@ -84,7 +84,7 @@ func (f TableFormatter) FormatCreate(w io.Writer, output *client.CreateOutput) e
 	wr := &errWriter{w: tw}
 	wr.printf("%s\n\n", f.green.Sprint("qURL created"))
 	if output.QURLID != "" {
-		wr.printf("%s\t%s\n", f.bold.Sprint("QURL ID:"), output.QURLID)
+		wr.printf("%s\t%s\n", f.bold.Sprint("qURL ID:"), output.QURLID)
 	}
 	wr.printf("%s\t%s\n", f.bold.Sprint("ID:"), output.ResourceID)
 	wr.printf("%s\t%s\n", f.bold.Sprint("Link:"), output.QURLLink)

--- a/apps/cli/internal/output/formatter.go
+++ b/apps/cli/internal/output/formatter.go
@@ -62,18 +62,18 @@ func (f TableFormatter) FormatQURL(w io.Writer, qurl *client.QURL) error {
 	if qurl.Description != "" {
 		wr.printf("%s\t%s\n", f.bold.Sprint("Description:"), qurl.Description)
 	}
+	if len(qurl.Tags) > 0 {
+		wr.printf("%s\t%s\n", f.bold.Sprint("Tags:"), strings.Join(qurl.Tags, ", "))
+	}
 	if qurl.QURLSite != "" {
 		wr.printf("%s\t%s\n", f.bold.Sprint("Site:"), qurl.QURLSite)
+	}
+	if qurl.CustomDomain != nil && *qurl.CustomDomain != "" {
+		wr.printf("%s\t%s\n", f.bold.Sprint("Custom domain:"), *qurl.CustomDomain)
 	}
 	wr.printf("%s\t%s\n", f.bold.Sprint("Created:"), formatRelativeTime(qurl.CreatedAt))
 	if qurl.ExpiresAt != nil {
 		wr.printf("%s\t%s\n", f.bold.Sprint("Expires:"), formatExpiry(*qurl.ExpiresAt))
-	}
-	if qurl.OneTimeUse {
-		wr.printf("%s\t%s\n", f.bold.Sprint("One-time:"), "yes")
-	}
-	if qurl.MaxSessions > 0 {
-		wr.printf("%s\t%d\n", f.bold.Sprint("Max sessions:"), qurl.MaxSessions)
 	}
 	return wr.flush(tw)
 }
@@ -83,9 +83,15 @@ func (f TableFormatter) FormatCreate(w io.Writer, output *client.CreateOutput) e
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	wr := &errWriter{w: tw}
 	wr.printf("%s\n\n", f.green.Sprint("QURL created"))
+	if output.QurlID != "" {
+		wr.printf("%s\t%s\n", f.bold.Sprint("QURL ID:"), output.QurlID)
+	}
 	wr.printf("%s\t%s\n", f.bold.Sprint("ID:"), output.ResourceID)
 	wr.printf("%s\t%s\n", f.bold.Sprint("Link:"), output.QURLLink)
 	wr.printf("%s\t%s\n", f.bold.Sprint("Site:"), output.QURLSite)
+	if output.Label != "" {
+		wr.printf("%s\t%s\n", f.bold.Sprint("Label:"), output.Label)
+	}
 	if output.ExpiresAt != nil {
 		wr.printf("%s\t%s\n", f.bold.Sprint("Expires:"), formatExpiry(*output.ExpiresAt))
 	}
@@ -190,7 +196,7 @@ func (f TableFormatter) colorStatus(status string) string {
 	switch status {
 	case client.StatusActive:
 		return f.green.Sprint(status)
-	case client.StatusExpired, client.StatusRevoked, client.StatusConsumed:
+	case client.StatusRevoked:
 		return f.red.Sprint(status)
 	default:
 		return status

--- a/apps/cli/internal/output/formatter.go
+++ b/apps/cli/internal/output/formatter.go
@@ -83,8 +83,8 @@ func (f TableFormatter) FormatCreate(w io.Writer, output *client.CreateOutput) e
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	wr := &errWriter{w: tw}
 	wr.printf("%s\n\n", f.green.Sprint("qURL created"))
-	if output.QurlID != "" {
-		wr.printf("%s\t%s\n", f.bold.Sprint("QURL ID:"), output.QurlID)
+	if output.QURLID != "" {
+		wr.printf("%s\t%s\n", f.bold.Sprint("QURL ID:"), output.QURLID)
 	}
 	wr.printf("%s\t%s\n", f.bold.Sprint("ID:"), output.ResourceID)
 	wr.printf("%s\t%s\n", f.bold.Sprint("Link:"), output.QURLLink)

--- a/apps/cli/internal/output/formatter_test.go
+++ b/apps/cli/internal/output/formatter_test.go
@@ -66,10 +66,9 @@ func TestTableFormatQURL(t *testing.T) {
 		TargetURL:   "https://example.com",
 		Status:      "active",
 		Description: "Test QURL",
+		Tags:        []string{"prod", "api"},
 		QURLSite:    "https://r_abc123test.qurl.site",
 		CreatedAt:   time.Now().Add(-1 * time.Hour),
-		OneTimeUse:  true,
-		MaxSessions: 5,
 	}
 
 	var buf bytes.Buffer
@@ -79,7 +78,7 @@ func TestTableFormatQURL(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"r_abc123test", "https://example.com", "active", "Test QURL", "yes", "5"} {
+	for _, want := range []string{"r_abc123test", "https://example.com", "active", "Test QURL", "prod, api"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -88,9 +87,11 @@ func TestTableFormatQURL(t *testing.T) {
 
 func TestTableFormatCreate(t *testing.T) {
 	result := &client.CreateOutput{
+		QurlID:     "q_abc123test",
 		ResourceID: "r_abc123test",
 		QURLLink:   "https://qurl.link/at_abc123",
 		QURLSite:   "https://r_abc123test.qurl.site",
+		Label:      "test label",
 	}
 
 	var buf bytes.Buffer
@@ -100,7 +101,7 @@ func TestTableFormatCreate(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"created", "r_abc123test", "https://qurl.link/at_abc123"} {
+	for _, want := range []string{"created", "q_abc123test", "r_abc123test", "https://qurl.link/at_abc123", "test label"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -203,13 +204,15 @@ func TestTableFormatMint(t *testing.T) {
 }
 
 func TestTableFormatQuota(t *testing.T) {
+	pct := 4.5
 	output := &client.QuotaOutput{
 		Plan:        "growth",
 		PeriodStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
 		PeriodEnd:   time.Date(2026, 3, 31, 23, 59, 59, 0, time.UTC),
 		Usage: &client.UsageInfo{
-			ActiveQURLs:  45,
-			QURLsCreated: 150,
+			ActiveQURLs:        45,
+			QURLsCreated:       150,
+			ActiveQURLsPercent: &pct,
 		},
 		RateLimits: &client.RateLimits{
 			MaxActiveQURLs: 1000,

--- a/apps/cli/internal/output/formatter_test.go
+++ b/apps/cli/internal/output/formatter_test.go
@@ -87,7 +87,7 @@ func TestTableFormatQURL(t *testing.T) {
 
 func TestTableFormatCreate(t *testing.T) {
 	result := &client.CreateOutput{
-		QurlID:     "q_abc123test",
+		QURLID:     "q_abc123test",
 		ResourceID: "r_abc123test",
 		QURLLink:   "https://qurl.link/at_abc123",
 		QURLSite:   "https://r_abc123test.qurl.site",

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -213,7 +213,7 @@ func (h *Handler) handleCreate(ctx context.Context, values url.Values) (events.A
 		return respondSlack(authFailureMessage)
 	}
 
-	result, err := c.Create(ctx, client.CreateInput{TargetURL: targetURL})
+	result, err := c.Create(ctx, &client.CreateInput{TargetURL: targetURL})
 	if err != nil {
 		slog.Error("failed to create QURL", "error", err, "target_url", targetURL)
 		return respondSlack("Failed to create QURL: " + err.Error())
@@ -229,7 +229,7 @@ func (h *Handler) handleList(ctx context.Context, values url.Values) (events.API
 		return respondSlack(authFailureMessage)
 	}
 
-	result, err := c.List(ctx, client.ListInput{Limit: 5})
+	result, err := c.List(ctx, &client.ListInput{Limit: 5})
 	if err != nil {
 		slog.Error("failed to list QURLs", "error", err)
 		return respondSlack("Failed to list QURLs: " + err.Error())

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -166,8 +166,12 @@ type CreateOutput struct {
 	Label      string     `json:"label,omitempty"`
 }
 
-// Create creates a new QURL.
+// Create creates a new QURL. input must not be nil.
 func (c *Client) Create(ctx context.Context, input *CreateInput) (*CreateOutput, error) {
+	if input == nil {
+		return nil, errors.New("create input must not be nil")
+	}
+
 	body, err := json.Marshal(input)
 	if err != nil {
 		return nil, fmt.Errorf("marshal create input: %w", err)

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -26,7 +26,7 @@ const (
 // StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
 
-// StatusRevoked indicates the QURL was manually revoked (deleted).
+// StatusRevoked indicates the qURL was manually revoked (deleted).
 const StatusRevoked = "revoked"
 
 // Logger is an optional interface for debug logging.
@@ -161,7 +161,7 @@ type CreateInput struct {
 
 // CreateOutput is the response from creating a qURL.
 type CreateOutput struct {
-	QurlID     string     `json:"qurl_id"`
+	QURLID     string     `json:"qurl_id"`
 	ResourceID string     `json:"resource_id"`
 	QURLLink   string     `json:"qurl_link"`
 	QURLSite   string     `json:"qurl_site"`
@@ -169,7 +169,7 @@ type CreateOutput struct {
 	Label      string     `json:"label,omitempty"`
 }
 
-// Create creates a new QURL. input must not be nil.
+// Create creates a new qURL. input must not be nil.
 func (c *Client) Create(ctx context.Context, input *CreateInput) (*CreateOutput, error) {
 	if input == nil {
 		return nil, errors.New("create input must not be nil")
@@ -226,7 +226,7 @@ type ListOutput struct {
 	HasMore    bool   `json:"has_more,omitempty"`
 }
 
-// List retrieves a paginated list of QURLs.
+// List retrieves a paginated list of qURLs.
 func (c *Client) List(ctx context.Context, input *ListInput) (*ListOutput, error) {
 	if input == nil {
 		input = &ListInput{}
@@ -299,14 +299,19 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 type UpdateInput struct {
 	ExtendBy  string     `json:"extend_by,omitempty"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
-	Tags      *[]string  `json:"tags,omitempty"`
+	// Tags uses a pointer-to-slice to encode three states:
+	//   nil           → omitted from PATCH (leave tags unchanged)
+	//   &[]string{}   → sends "tags":[] (clear all tags)
+	//   &[]string{…}  → sends "tags":[…] (replace tags with this set)
+	Tags *[]string `json:"tags,omitempty"`
 	// Description updates the resource-level description. The API uses "description"
 	// for updates (not "label") per the UpdateQurlRequest schema — this is an
 	// intentional divergence from CreateInput.Label which maps to the QURL token label.
 	Description *string `json:"description,omitempty"`
 }
 
-// Extend extends a QURL's expiration.
+// Extend extends a qURL's expiration. It is a convenience wrapper around Update
+// with ExtendBy set; callers who need combined updates should use Update directly.
 func (c *Client) Extend(ctx context.Context, id, duration string) (*QURL, error) {
 	return c.Update(ctx, id, UpdateInput{ExtendBy: duration})
 }
@@ -347,7 +352,7 @@ type MintOutput struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
-// MintLink mints a new access link for a QURL.
+// MintLink mints a new access link for a qURL.
 func (c *Client) MintLink(ctx context.Context, id string, input *MintLinkInput) (*MintOutput, error) {
 	var bodyReader io.Reader = http.NoBody
 	if input != nil {
@@ -362,11 +367,8 @@ func (c *Client) MintLink(ctx context.Context, id string, input *MintLinkInput) 
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
-	if input != nil {
-		// Defense-in-depth: set Content-Type explicitly even though do() also sets it
-		// when a body is present, so the header is visible at the call site.
-		req.Header.Set("Content-Type", "application/json")
-	}
+	// Content-Type is managed centrally by do(): set when body is present, omitted
+	// for bodiless requests (input==nil path). See TestMintLink* for wire-level coverage.
 
 	var out MintOutput
 	if _, err := c.do(req, &out, "POST /v1/qurls/:id/mint_link"); err != nil {
@@ -377,7 +379,7 @@ func (c *Client) MintLink(ctx context.Context, id string, input *MintLinkInput) 
 
 // --- Batch ---
 
-// BatchCreateOutput holds the response from batch creating QURLs.
+// BatchCreateOutput holds the response from batch creating qURLs.
 type BatchCreateOutput struct {
 	Succeeded int               `json:"succeeded"`
 	Failed    int               `json:"failed"`
@@ -404,7 +406,7 @@ type BatchItemError struct {
 // maxBatchSize is the maximum number of items in a single batch create request.
 const maxBatchSize = 100
 
-// BatchCreate creates multiple QURLs at once (1-100 items).
+// BatchCreate creates multiple qURLs at once (1-100 items).
 func (c *Client) BatchCreate(ctx context.Context, items []*CreateInput) (*BatchCreateOutput, error) {
 	if len(items) == 0 || len(items) > maxBatchSize {
 		return nil, fmt.Errorf("batch size must be 1-%d, got %d", maxBatchSize, len(items))
@@ -503,7 +505,7 @@ type RateLimits struct {
 type UsageInfo struct {
 	QURLsCreated       int      `json:"qurls_created"`
 	ActiveQURLs        int      `json:"active_qurls"`
-	ActiveQURLsPercent *float64 `json:"active_qurls_percent"`
+	ActiveQURLsPercent *float64 `json:"active_qurls_percent,omitempty"`
 	TotalAccesses      int      `json:"total_accesses"`
 }
 

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -123,7 +123,10 @@ type QURL struct {
 	Description  string     `json:"description,omitempty"`
 	Tags         []string   `json:"tags,omitempty"`
 	QURLSite     string     `json:"qurl_site,omitempty"`
-	CustomDomain *string    `json:"custom_domain,omitempty"`
+	// CustomDomain is a pointer to distinguish "not set" (nil) from "explicitly empty" on
+	// API responses. CreateInput.CustomDomain is a plain string with omitempty, which is
+	// sufficient for write requests where absence and empty mean the same thing.
+	CustomDomain *string `json:"custom_domain,omitempty"`
 }
 
 // AIAgentPolicy controls access by AI agent categories.
@@ -398,10 +401,18 @@ type BatchItemError struct {
 	Message string `json:"message"`
 }
 
+// maxBatchSize is the maximum number of items in a single batch create request.
+const maxBatchSize = 100
+
 // BatchCreate creates multiple QURLs at once (1-100 items).
 func (c *Client) BatchCreate(ctx context.Context, items []*CreateInput) (*BatchCreateOutput, error) {
-	if len(items) == 0 || len(items) > 100 {
-		return nil, fmt.Errorf("batch size must be 1-100, got %d", len(items))
+	if len(items) == 0 || len(items) > maxBatchSize {
+		return nil, fmt.Errorf("batch size must be 1-%d, got %d", maxBatchSize, len(items))
+	}
+	for i, item := range items {
+		if item == nil {
+			return nil, fmt.Errorf("batch item at index %d must not be nil", i)
+		}
 	}
 
 	payload := struct {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -26,14 +26,8 @@ const (
 // StatusActive indicates the QURL is live and accepting access requests.
 const StatusActive = "active"
 
-// StatusExpired indicates the QURL's TTL has elapsed.
-const StatusExpired = "expired"
-
 // StatusRevoked indicates the QURL was manually revoked (deleted).
 const StatusRevoked = "revoked"
-
-// StatusConsumed indicates a one-time QURL has been used.
-const StatusConsumed = "consumed"
 
 // Logger is an optional interface for debug logging.
 type Logger interface {
@@ -121,59 +115,71 @@ type ResponseMeta struct {
 
 // QURL represents a QURL resource as returned by the API.
 type QURL struct {
-	ResourceID   string        `json:"resource_id"`
-	TargetURL    string        `json:"target_url"`
-	Status       string        `json:"status"`
-	CreatedAt    time.Time     `json:"created_at"`
-	ExpiresAt    *time.Time    `json:"expires_at,omitempty"`
-	OneTimeUse   bool          `json:"one_time_use"`
-	MaxSessions  int           `json:"max_sessions,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	QURLSite     string        `json:"qurl_site,omitempty"`
-	QURLLink     string        `json:"qurl_link,omitempty"`
-	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+	ResourceID   string     `json:"resource_id"`
+	TargetURL    string     `json:"target_url"`
+	Status       string     `json:"status"`
+	CreatedAt    time.Time  `json:"created_at"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	Tags         []string   `json:"tags,omitempty"`
+	QURLSite     string     `json:"qurl_site,omitempty"`
+	CustomDomain *string    `json:"custom_domain"`
+}
+
+// AIAgentPolicy controls access by AI agent categories.
+type AIAgentPolicy struct {
+	BlockAll        bool     `json:"block_all,omitempty"`
+	DenyCategories  []string `json:"deny_categories,omitempty"`
+	AllowCategories []string `json:"allow_categories,omitempty"`
 }
 
 // AccessPolicy defines access restrictions for a QURL.
 type AccessPolicy struct {
-	IPAllowlist  []string `json:"ip_allowlist,omitempty"`
-	IPDenylist   []string `json:"ip_denylist,omitempty"`
-	GeoAllowlist []string `json:"geo_allowlist,omitempty"`
-	GeoDenylist  []string `json:"geo_denylist,omitempty"`
+	IPAllowlist         []string       `json:"ip_allowlist,omitempty"`
+	IPDenylist          []string       `json:"ip_denylist,omitempty"`
+	GeoAllowlist        []string       `json:"geo_allowlist,omitempty"`
+	GeoDenylist         []string       `json:"geo_denylist,omitempty"`
+	UserAgentAllowRegex string         `json:"user_agent_allow_regex,omitempty"`
+	UserAgentDenyRegex  string         `json:"user_agent_deny_regex,omitempty"`
+	AIAgentPolicy       *AIAgentPolicy `json:"ai_agent_policy,omitempty"`
 }
 
 // CreateInput is the input for creating a QURL.
 type CreateInput struct {
-	TargetURL    string        `json:"target_url"`
-	Description  string        `json:"description,omitempty"`
-	ExpiresIn    string        `json:"expires_in,omitempty"`
-	OneTimeUse   bool          `json:"one_time_use,omitempty"`
-	MaxSessions  int           `json:"max_sessions,omitempty"`
-	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+	TargetURL       string        `json:"target_url"`
+	Label           string        `json:"label,omitempty"`
+	ExpiresIn       string        `json:"expires_in,omitempty"`
+	OneTimeUse      bool          `json:"one_time_use,omitempty"`
+	MaxSessions     int           `json:"max_sessions,omitempty"`
+	SessionDuration string        `json:"session_duration,omitempty"`
+	CustomDomain    string        `json:"custom_domain,omitempty"`
+	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
 }
 
 // CreateOutput is the response from creating a QURL.
 type CreateOutput struct {
+	QurlID     string     `json:"qurl_id"`
 	ResourceID string     `json:"resource_id"`
 	QURLLink   string     `json:"qurl_link"`
 	QURLSite   string     `json:"qurl_site"`
 	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	Label      string     `json:"label,omitempty"`
 }
 
 // Create creates a new QURL.
-func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
+func (c *Client) Create(ctx context.Context, input *CreateInput) (*CreateOutput, error) {
 	body, err := json.Marshal(input)
 	if err != nil {
 		return nil, fmt.Errorf("marshal create input: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurl", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
 	var out CreateOutput
-	if _, err := c.do(req, &out, "POST /v1/qurl"); err != nil {
+	if _, err := c.do(req, &out, "POST /v1/qurls"); err != nil {
 		return nil, err
 	}
 	return &out, nil
@@ -195,11 +201,15 @@ func (c *Client) Get(ctx context.Context, id string) (*QURL, error) {
 
 // ListInput is the input for listing QURLs.
 type ListInput struct {
-	Limit  int
-	Cursor string
-	Status string
-	Query  string
-	Sort   string
+	Limit         int
+	Cursor        string
+	Status        string
+	Query         string
+	Sort          string
+	CreatedAfter  string
+	CreatedBefore string
+	ExpiresBefore string
+	ExpiresAfter  string
 }
 
 // ListOutput is the output of listing QURLs.
@@ -210,7 +220,7 @@ type ListOutput struct {
 }
 
 // List retrieves a paginated list of QURLs.
-func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error) {
+func (c *Client) List(ctx context.Context, input *ListInput) (*ListOutput, error) {
 	params := url.Values{}
 	if input.Limit > 0 {
 		params.Set("limit", strconv.Itoa(input.Limit))
@@ -226,6 +236,18 @@ func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error)
 	}
 	if input.Sort != "" {
 		params.Set("sort", input.Sort)
+	}
+	if input.CreatedAfter != "" {
+		params.Set("created_after", input.CreatedAfter)
+	}
+	if input.CreatedBefore != "" {
+		params.Set("created_before", input.CreatedBefore)
+	}
+	if input.ExpiresBefore != "" {
+		params.Set("expires_before", input.ExpiresBefore)
+	}
+	if input.ExpiresAfter != "" {
+		params.Set("expires_after", input.ExpiresAfter)
 	}
 
 	u := c.baseURL + "/v1/qurls"
@@ -262,34 +284,24 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 	return err
 }
 
-// ExtendInput holds input for extending a QURL.
-type ExtendInput struct {
-	ExtendBy  string     `json:"extend_by,omitempty"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+// UpdateInput holds input for updating a QURL.
+type UpdateInput struct {
+	ExtendBy    string     `json:"extend_by,omitempty"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	Tags        *[]string  `json:"tags,omitempty"`
+	Description *string    `json:"description,omitempty"`
 }
 
 // Extend extends a QURL's expiration.
-// Both Extend and Update use PATCH /v1/qurls/:id — the server differentiates
-// by request body fields (extend_by/expires_at vs description).
-func (c *Client) Extend(ctx context.Context, id string, input ExtendInput) (*QURL, error) {
-	return c.patchQURL(ctx, id, input)
-}
-
-// UpdateInput holds input for updating a QURL's mutable properties.
-type UpdateInput struct {
-	Description *string `json:"description,omitempty"`
+func (c *Client) Extend(ctx context.Context, id, duration string) (*QURL, error) {
+	return c.Update(ctx, id, UpdateInput{ExtendBy: duration})
 }
 
 // Update updates a QURL's mutable properties.
 func (c *Client) Update(ctx context.Context, id string, input UpdateInput) (*QURL, error) {
-	return c.patchQURL(ctx, id, input)
-}
-
-// patchQURL sends a PATCH request to /v1/qurls/:id with the given body.
-func (c *Client) patchQURL(ctx context.Context, id string, input any) (*QURL, error) {
 	body, err := json.Marshal(input)
 	if err != nil {
-		return nil, fmt.Errorf("marshal patch input: %w", err)
+		return nil, fmt.Errorf("marshal update input: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.baseURL+"/v1/qurls/"+url.PathEscape(id), bytes.NewReader(body))
@@ -304,6 +316,17 @@ func (c *Client) patchQURL(ctx context.Context, id string, input any) (*QURL, er
 	return &qurl, nil
 }
 
+// MintLinkInput holds optional input for minting an access link.
+type MintLinkInput struct {
+	ExpiresIn       string        `json:"expires_in,omitempty"`
+	ExpiresAt       *time.Time    `json:"expires_at,omitempty"`
+	Label           string        `json:"label,omitempty"`
+	OneTimeUse      bool          `json:"one_time_use,omitempty"`
+	MaxSessions     int           `json:"max_sessions,omitempty"`
+	SessionDuration string        `json:"session_duration,omitempty"`
+	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
+}
+
 // MintOutput holds the result of minting an access link.
 type MintOutput struct {
 	QURLLink  string     `json:"qurl_link"`
@@ -311,14 +334,72 @@ type MintOutput struct {
 }
 
 // MintLink mints a new access link for a QURL.
-func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls/"+url.PathEscape(id)+"/mint_link", http.NoBody)
+func (c *Client) MintLink(ctx context.Context, id string, input *MintLinkInput) (*MintOutput, error) {
+	var bodyReader io.Reader = http.NoBody
+	if input != nil {
+		body, err := json.Marshal(input)
+		if err != nil {
+			return nil, fmt.Errorf("marshal mint input: %w", err)
+		}
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls/"+url.PathEscape(id)+"/mint_link", bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
 	var out MintOutput
 	if _, err := c.do(req, &out, "POST /v1/qurls/:id/mint_link"); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// --- Batch ---
+
+// BatchCreateOutput holds the response from batch creating QURLs.
+type BatchCreateOutput struct {
+	Succeeded int               `json:"succeeded"`
+	Failed    int               `json:"failed"`
+	Results   []BatchItemResult `json:"results"`
+}
+
+// BatchItemResult holds the result for a single item in a batch.
+type BatchItemResult struct {
+	Index      int             `json:"index"`
+	Success    bool            `json:"success"`
+	ResourceID string          `json:"resource_id,omitempty"`
+	QURLLink   string          `json:"qurl_link,omitempty"`
+	QURLSite   string          `json:"qurl_site,omitempty"`
+	ExpiresAt  *time.Time      `json:"expires_at,omitempty"`
+	Error      *BatchItemError `json:"error,omitempty"`
+}
+
+// BatchItemError holds error details for a failed batch item.
+type BatchItemError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// BatchCreate creates multiple QURLs at once (1-100 items).
+func (c *Client) BatchCreate(ctx context.Context, items []CreateInput) (*BatchCreateOutput, error) {
+	payload := struct {
+		Items []CreateInput `json:"items"`
+	}{Items: items}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal batch input: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls/batch", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var out BatchCreateOutput
+	if _, err := c.do(req, &out, "POST /v1/qurls/batch"); err != nil {
 		return nil, err
 	}
 	return &out, nil
@@ -384,14 +465,15 @@ type RateLimits struct {
 	ResolvePerMinute int `json:"resolve_per_minute"`
 	MaxActiveQURLs   int `json:"max_active_qurls"`
 	MaxTokensPerQURL int `json:"max_tokens_per_qurl"`
+	MaxExpirySeconds int `json:"max_expiry_seconds"`
 }
 
 // UsageInfo holds usage statistics.
 type UsageInfo struct {
-	QURLsCreated       int     `json:"qurls_created"`
-	ActiveQURLs        int     `json:"active_qurls"`
-	ActiveQURLsPercent float64 `json:"active_qurls_percent"`
-	TotalAccesses      int     `json:"total_accesses"`
+	QURLsCreated       int      `json:"qurls_created"`
+	ActiveQURLs        int      `json:"active_qurls"`
+	ActiveQURLsPercent *float64 `json:"active_qurls_percent"`
+	TotalAccesses      int      `json:"total_accesses"`
 }
 
 // GetQuota retrieves quota information.

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -355,8 +355,12 @@ func (c *Client) Update(ctx context.Context, id string, input UpdateInput) (*QUR
 // MintLinkInput sends a bodiless POST (server uses qURL defaults), while a non-nil
 // MintLinkInput (even &MintLinkInput{}) sends a JSON body.
 type MintLinkInput struct {
-	ExpiresIn       string        `json:"expires_in,omitempty"`
-	ExpiresAt       *time.Time    `json:"expires_at,omitempty"`
+	ExpiresIn string     `json:"expires_in,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	// Label is a plain string with omitempty — passing "" omits the field, which is
+	// the right behavior for an optional per-link label (there's no "clear label"
+	// concept on minting, unlike UpdateInput.Description which uses *string to support
+	// explicit clear via empty string).
 	Label           string        `json:"label,omitempty"`
 	OneTimeUse      *bool         `json:"one_time_use,omitempty"`
 	MaxSessions     *int          `json:"max_sessions,omitempty"`

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -115,14 +115,14 @@ type ResponseMeta struct {
 
 // QURL represents a QURL resource as returned by the API.
 type QURL struct {
-	ResourceID   string     `json:"resource_id"`
-	TargetURL    string     `json:"target_url"`
-	Status       string     `json:"status"`
-	CreatedAt    time.Time  `json:"created_at"`
-	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
-	Description  string     `json:"description,omitempty"`
-	Tags         []string   `json:"tags,omitempty"`
-	QURLSite     string     `json:"qurl_site,omitempty"`
+	ResourceID  string     `json:"resource_id"`
+	TargetURL   string     `json:"target_url"`
+	Status      string     `json:"status"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Tags        []string   `json:"tags,omitempty"`
+	QURLSite    string     `json:"qurl_site,omitempty"`
 	// CustomDomain is a pointer to distinguish "not set" (nil) from "explicitly empty" on
 	// API responses. CreateInput.CustomDomain is a plain string with omitempty, which is
 	// sufficient for write requests where absence and empty mean the same thing.

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -123,7 +123,7 @@ type QURL struct {
 	Description  string     `json:"description,omitempty"`
 	Tags         []string   `json:"tags,omitempty"`
 	QURLSite     string     `json:"qurl_site,omitempty"`
-	CustomDomain *string    `json:"custom_domain"`
+	CustomDomain *string    `json:"custom_domain,omitempty"`
 }
 
 // AIAgentPolicy controls access by AI agent categories.
@@ -294,10 +294,13 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 
 // UpdateInput holds input for updating a QURL.
 type UpdateInput struct {
-	ExtendBy    string     `json:"extend_by,omitempty"`
-	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
-	Tags        *[]string  `json:"tags,omitempty"`
-	Description *string    `json:"description,omitempty"`
+	ExtendBy  string     `json:"extend_by,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Tags      *[]string  `json:"tags,omitempty"`
+	// Description updates the resource-level description. The API uses "description"
+	// for updates (not "label") per the UpdateQurlRequest schema — this is an
+	// intentional divergence from CreateInput.Label which maps to the QURL token label.
+	Description *string `json:"description,omitempty"`
 }
 
 // Extend extends a QURL's expiration.
@@ -356,6 +359,11 @@ func (c *Client) MintLink(ctx context.Context, id string, input *MintLinkInput) 
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
+	if input != nil {
+		// Defense-in-depth: set Content-Type explicitly even though do() also sets it
+		// when a body is present, so the header is visible at the call site.
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	var out MintOutput
 	if _, err := c.do(req, &out, "POST /v1/qurls/:id/mint_link"); err != nil {
@@ -391,13 +399,13 @@ type BatchItemError struct {
 }
 
 // BatchCreate creates multiple QURLs at once (1-100 items).
-func (c *Client) BatchCreate(ctx context.Context, items []CreateInput) (*BatchCreateOutput, error) {
+func (c *Client) BatchCreate(ctx context.Context, items []*CreateInput) (*BatchCreateOutput, error) {
 	if len(items) == 0 || len(items) > 100 {
 		return nil, fmt.Errorf("batch size must be 1-100, got %d", len(items))
 	}
 
 	payload := struct {
-		Items []CreateInput `json:"items"`
+		Items []*CreateInput `json:"items"`
 	}{Items: items}
 
 	body, err := json.Marshal(payload)

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -227,6 +227,8 @@ type ListOutput struct {
 }
 
 // List retrieves a paginated list of qURLs.
+// A nil input is treated as &ListInput{} (all fields at defaults). Unlike Create,
+// List has no required fields so nil is silently accepted.
 func (c *Client) List(ctx context.Context, input *ListInput) (*ListOutput, error) {
 	if input == nil {
 		input = &ListInput{}
@@ -295,7 +297,9 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 	return err
 }
 
-// UpdateInput holds input for updating a QURL.
+// UpdateInput holds input for updating a qURL.
+// Note: session_duration and one_time_use are intentionally absent — the
+// UpdateQurlRequest schema in the API spec does not include them.
 type UpdateInput struct {
 	ExtendBy  string     `json:"extend_by,omitempty"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
@@ -353,6 +357,8 @@ type MintOutput struct {
 }
 
 // MintLink mints a new access link for a qURL.
+// Pass nil to mint with the qURL's own defaults (server uses bodiless POST).
+// Pass a non-nil MintLinkInput to override expiry, one-time-use, and other per-link settings.
 func (c *Client) MintLink(ctx context.Context, id string, input *MintLinkInput) (*MintOutput, error) {
 	var bodyReader io.Reader = http.NoBody
 	if input != nil {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -1,4 +1,10 @@
 // Package client provides a Go client for the qURL API.
+//
+// Nil-input conventions:
+//   - Create requires non-nil input (TargetURL is mandatory) and returns an error if nil.
+//   - List treats nil as &ListInput{} (no required fields, so nil is always safe).
+//   - MintLink(ctx, id, nil) sends a bodiless POST — the server mints with the qURL's own
+//     defaults. MintLink(ctx, id, &MintLinkInput{…}) sends a JSON body with per-link overrides.
 package client
 
 import (
@@ -340,12 +346,19 @@ func (c *Client) Update(ctx context.Context, id string, input UpdateInput) (*QUR
 }
 
 // MintLinkInput holds optional input for minting an access link.
+//
+// OneTimeUse and MaxSessions use pointer types so callers can explicitly override a
+// qURL's defaults to false/0 (e.g., "allow multiple sessions on a normally one-time
+// qURL"). A nil pointer omits the field from the JSON body, letting the server apply the
+// qURL-level default. The same logic applies to MintLink(ctx, id, nil): a nil
+// MintLinkInput sends a bodiless POST (server uses qURL defaults), while a non-nil
+// MintLinkInput (even &MintLinkInput{}) sends a JSON body.
 type MintLinkInput struct {
 	ExpiresIn       string        `json:"expires_in,omitempty"`
 	ExpiresAt       *time.Time    `json:"expires_at,omitempty"`
 	Label           string        `json:"label,omitempty"`
-	OneTimeUse      bool          `json:"one_time_use,omitempty"`
-	MaxSessions     int           `json:"max_sessions,omitempty"`
+	OneTimeUse      *bool         `json:"one_time_use,omitempty"`
+	MaxSessions     *int          `json:"max_sessions,omitempty"`
 	SessionDuration string        `json:"session_duration,omitempty"`
 	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
 }
@@ -409,13 +422,13 @@ type BatchItemError struct {
 	Message string `json:"message"`
 }
 
-// maxBatchSize is the maximum number of items in a single batch create request.
-const maxBatchSize = 100
+// MaxBatchSize is the maximum number of items in a single batch create request.
+const MaxBatchSize = 100
 
 // BatchCreate creates multiple qURLs at once (1-100 items).
 func (c *Client) BatchCreate(ctx context.Context, items []*CreateInput) (*BatchCreateOutput, error) {
-	if len(items) == 0 || len(items) > maxBatchSize {
-		return nil, fmt.Errorf("batch size must be 1-%d, got %d", maxBatchSize, len(items))
+	if len(items) == 0 || len(items) > MaxBatchSize {
+		return nil, fmt.Errorf("batch size must be 1-%d, got %d", MaxBatchSize, len(items))
 	}
 	for i, item := range items {
 		if item == nil {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -221,6 +221,10 @@ type ListOutput struct {
 
 // List retrieves a paginated list of QURLs.
 func (c *Client) List(ctx context.Context, input *ListInput) (*ListOutput, error) {
+	if input == nil {
+		input = &ListInput{}
+	}
+
 	params := url.Values{}
 	if input.Limit > 0 {
 		params.Set("limit", strconv.Itoa(input.Limit))
@@ -384,6 +388,10 @@ type BatchItemError struct {
 
 // BatchCreate creates multiple QURLs at once (1-100 items).
 func (c *Client) BatchCreate(ctx context.Context, items []CreateInput) (*BatchCreateOutput, error) {
+	if len(items) == 0 || len(items) > 100 {
+		return nil, fmt.Errorf("batch size must be 1-100, got %d", len(items))
+	}
+
 	payload := struct {
 		Items []CreateInput `json:"items"`
 	}{Items: items}
@@ -529,7 +537,6 @@ type apiErrorDetail struct {
 // --- HTTP plumbing ---
 
 func (c *Client) do(req *http.Request, out any, endpoint string) (*ResponseMeta, error) {
-	req.Header.Set("Content-Type", "application/json")
 	// NOTE: If you add header logging, redact the Authorization value to avoid leaking API keys.
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	if c.userAgent != "" {
@@ -546,6 +553,7 @@ func (c *Client) do(req *http.Request, out any, endpoint string) (*ResponseMeta,
 			return nil, fmt.Errorf("buffer request body: %w", err)
 		}
 		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	var lastErr error

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -304,8 +304,9 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 }
 
 // UpdateInput holds input for updating a qURL.
-// Note: session_duration and one_time_use are intentionally absent — the
-// UpdateQurlRequest schema in the API spec does not include them.
+// The UpdateQurlRequest schema defines exactly four mutable fields: extend_by, expires_at,
+// tags, and description. session_duration, one_time_use, access_policy, and custom_domain
+// are intentionally absent — the API does not support updating them after creation.
 type UpdateInput struct {
 	ExtendBy  string     `json:"extend_by,omitempty"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
@@ -423,6 +424,7 @@ type BatchItemError struct {
 }
 
 // MaxBatchSize is the maximum number of items in a single batch create request.
+// Matches the BatchCreateRequest schema constraint (api/openapi.yaml: items.maxItems=100).
 const MaxBatchSize = 100
 
 // BatchCreate creates multiple qURLs at once (1-100 items).
@@ -433,6 +435,9 @@ func (c *Client) BatchCreate(ctx context.Context, items []*CreateInput) (*BatchC
 	for i, item := range items {
 		if item == nil {
 			return nil, fmt.Errorf("batch item at index %d must not be nil", i)
+		}
+		if item.TargetURL == "" {
+			return nil, fmt.Errorf("batch item at index %d has empty target_url", i)
 		}
 	}
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -305,6 +307,29 @@ func TestMintLinkContentType(t *testing.T) {
 			t.Fatalf("MintLink: %v", err)
 		}
 	})
+}
+
+// TestMintLinkOmitEmpty verifies that MintLinkInput fields with zero values are
+// stripped by omitempty, so &MintLinkInput{} marshals to {} rather than a struct
+// with false/0/null fields. This locks the contract mint.go relies on when
+// omitting the Changed() gate for bool/int flags.
+func TestMintLinkOmitEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if got := strings.TrimSpace(string(body)); got != "{}" {
+			t.Errorf("expected body {}, got %q", got)
+		}
+		apiEnvelope(t, w, map[string]any{"qurl_link": "https://qurl.link/at_test"})
+	}))
+	t.Cleanup(srv.Close)
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.MintLink(context.Background(), testResourceID, &MintLinkInput{}); err != nil {
+		t.Fatalf("MintLink: %v", err)
+	}
 }
 
 func TestBatchCreate(t *testing.T) {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -283,7 +283,7 @@ func TestMintLinkContentType(t *testing.T) {
 			}
 			apiEnvelope(t, w, map[string]any{"qurl_link": "https://qurl.link/at_test"})
 		}))
-		defer srv.Close()
+		t.Cleanup(srv.Close)
 
 		c := testClient(srv.URL, "test-key")
 		if _, err := c.MintLink(context.Background(), testResourceID, nil); err != nil {
@@ -298,7 +298,7 @@ func TestMintLinkContentType(t *testing.T) {
 			}
 			apiEnvelope(t, w, map[string]any{"qurl_link": "https://qurl.link/at_test"})
 		}))
-		defer srv.Close()
+		t.Cleanup(srv.Close)
 
 		c := testClient(srv.URL, "test-key")
 		if _, err := c.MintLink(context.Background(), testResourceID, &MintLinkInput{Label: "x"}); err != nil {
@@ -530,7 +530,7 @@ func TestUpdateTags(t *testing.T) {
 					"status":      "active",
 				})
 			}))
-			defer srv.Close()
+			t.Cleanup(srv.Close)
 
 			c := testClient(srv.URL, "test-key")
 			_, err := c.Update(context.Background(), testResourceID, UpdateInput{Tags: tt.tags})

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -902,6 +902,19 @@ func TestBatchCreateNilItem(t *testing.T) {
 	}
 }
 
+func TestBatchCreateEmptyTargetURL(t *testing.T) {
+	c := testClient("http://unused", "test-key")
+
+	_, err := c.BatchCreate(context.Background(), []*CreateInput{
+		{TargetURL: "https://example.com"},
+		{TargetURL: ""},
+		{TargetURL: "https://example2.com"},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty target_url in batch item")
+	}
+}
+
 func TestCreateNilInput(t *testing.T) {
 	c := testClient("http://unused", "test-key")
 	_, err := c.Create(context.Background(), nil)

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -50,6 +50,10 @@ func TestCreate(t *testing.T) {
 		if input.TargetURL != "https://example.com" {
 			t.Errorf("expected target_url https://example.com, got %s", input.TargetURL)
 		}
+		// Verify the Description→Label rename is wired correctly at the wire level.
+		if input.Label != "test" {
+			t.Errorf("expected label 'test', got %q (Description→Label rename may be broken)", input.Label)
+		}
 
 		apiEnvelope(t, w, map[string]any{
 			"qurl_id":     "q_abc123test",
@@ -249,6 +253,11 @@ func TestMintLink(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/qurls/"+testResourceID+"/mint_link" {
 			t.Errorf("expected mint_link path, got %s", r.URL.Path)
+		}
+		// nil input must produce a bodiless POST so the server can distinguish
+		// "mint with QURL defaults" from "mint with an explicit (empty) override".
+		if r.ContentLength != 0 {
+			t.Errorf("expected no body for nil MintLinkInput, got ContentLength=%d", r.ContentLength)
 		}
 		apiEnvelope(t, w, map[string]any{
 			"qurl_link": "https://qurl.link/at_newtoken",
@@ -719,13 +728,13 @@ func TestBatchCreateValidation(t *testing.T) {
 		t.Fatal("expected error for empty batch")
 	}
 
-	items := make([]*CreateInput, 101)
+	items := make([]*CreateInput, maxBatchSize+1)
 	for i := range items {
 		items[i] = &CreateInput{TargetURL: "https://example.com"}
 	}
 	_, err = c.BatchCreate(context.Background(), items)
 	if err == nil {
-		t.Fatal("expected error for batch > 100")
+		t.Fatalf("expected error for batch > %d", maxBatchSize)
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -35,8 +35,8 @@ func TestCreate(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1/qurl" {
-			t.Errorf("expected /v1/qurl, got %s", r.URL.Path)
+		if r.URL.Path != "/v1/qurls" {
+			t.Errorf("expected /v1/qurls, got %s", r.URL.Path)
 		}
 		if r.Header.Get("Authorization") != "Bearer test-key" {
 			t.Errorf("expected Bearer test-key, got %s", r.Header.Get("Authorization"))
@@ -51,15 +51,17 @@ func TestCreate(t *testing.T) {
 		}
 
 		apiEnvelope(t, w, map[string]any{
+			"qurl_id":     "q_abc123test",
 			"resource_id": "r_abc123test",
 			"qurl_link":   "https://qurl.link/at_abc123",
 			"qurl_site":   "https://r_abc123test.qurl.site",
+			"label":       "test",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"})
+	got, err := c.Create(context.Background(), &CreateInput{TargetURL: "https://example.com", Label: "test"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -69,6 +71,9 @@ func TestCreate(t *testing.T) {
 	}
 	if got.QURLLink != "https://qurl.link/at_abc123" {
 		t.Errorf("got QURLLink %q, want %q", got.QURLLink, "https://qurl.link/at_abc123")
+	}
+	if got.QurlID != "q_abc123test" {
+		t.Errorf("got QurlID %q, want %q", got.QurlID, "q_abc123test")
 	}
 }
 
@@ -99,10 +104,10 @@ func TestGet(t *testing.T) {
 			t.Errorf("expected /v1/qurls/r_abc123test, got %s", r.URL.Path)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id":  "r_abc123test",
-			"target_url":   "https://example.com",
-			"status":       "active",
-			"one_time_use": false,
+			"resource_id": "r_abc123test",
+			"target_url":  "https://example.com",
+			"status":      "active",
+			"tags":        []string{"test", "api"},
 		})
 	}))
 	defer srv.Close()
@@ -118,6 +123,9 @@ func TestGet(t *testing.T) {
 	}
 	if got.Status != "active" {
 		t.Errorf("got Status %q, want %q", got.Status, "active")
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "test" {
+		t.Errorf("got Tags %v, want [test api]", got.Tags)
 	}
 }
 
@@ -150,7 +158,7 @@ func TestList(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.List(context.Background(), ListInput{Limit: 5, Status: "active"})
+	got, err := c.List(context.Background(), &ListInput{Limit: 5, Status: "active"})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -184,7 +192,7 @@ func TestListCursorEscaping(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.List(context.Background(), ListInput{Limit: 10, Cursor: "a=b&c=d"})
+	_, err := c.List(context.Background(), &ListInput{Limit: 10, Cursor: "a=b&c=d"})
 	if err != nil {
 		t.Fatalf("List with special cursor: %v", err)
 	}
@@ -248,11 +256,124 @@ func TestMintLink(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.MintLink(context.Background(), "r_abc123test")
+	got, err := c.MintLink(context.Background(), "r_abc123test", nil)
 	if err != nil {
 		t.Fatalf("MintLink: %v", err)
 	}
 	if got.QURLLink != "https://qurl.link/at_newtoken" {
+		t.Errorf("got QURLLink %q", got.QURLLink)
+	}
+}
+
+func TestBatchCreate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/qurls/batch" {
+			t.Errorf("expected /v1/qurls/batch, got %s", r.URL.Path)
+		}
+
+		var payload struct {
+			Items []CreateInput `json:"items"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(payload.Items) != 2 {
+			t.Errorf("expected 2 items, got %d", len(payload.Items))
+		}
+
+		apiEnvelope(t, w, map[string]any{
+			"succeeded": 2,
+			"failed":    0,
+			"results": []map[string]any{
+				{"index": 0, "success": true, "resource_id": "r_1", "qurl_link": "https://qurl.link/at_1"},
+				{"index": 1, "success": true, "resource_id": "r_2", "qurl_link": "https://qurl.link/at_2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.BatchCreate(context.Background(), []CreateInput{
+		{TargetURL: "https://a.com"},
+		{TargetURL: "https://b.com"},
+	})
+	if err != nil {
+		t.Fatalf("BatchCreate: %v", err)
+	}
+	if got.Succeeded != 2 {
+		t.Errorf("got Succeeded %d, want 2", got.Succeeded)
+	}
+	if len(got.Results) != 2 {
+		t.Errorf("got %d results, want 2", len(got.Results))
+	}
+}
+
+func TestListWithDateFilters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("created_after") != "2026-01-01T00:00:00Z" {
+			t.Errorf("expected created_after, got %q", r.URL.Query().Get("created_after"))
+		}
+		if r.URL.Query().Get("expires_before") != "2026-12-31T23:59:59Z" {
+			t.Errorf("expected expires_before, got %q", r.URL.Query().Get("expires_before"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"data": []map[string]any{},
+			"meta": map[string]any{"request_id": "req_test"},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	_, err := c.List(context.Background(), &ListInput{
+		CreatedAfter:  "2026-01-01T00:00:00Z",
+		ExpiresBefore: "2026-12-31T23:59:59Z",
+	})
+	if err != nil {
+		t.Fatalf("List with date filters: %v", err)
+	}
+}
+
+func TestMintLinkWithInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/qurls/r_abc123test/mint_link" {
+			t.Errorf("expected mint_link path, got %s", r.URL.Path)
+		}
+
+		var input MintLinkInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.Label != "test-link" {
+			t.Errorf("expected label 'test-link', got %q", input.Label)
+		}
+		if !input.OneTimeUse {
+			t.Error("expected one_time_use=true")
+		}
+
+		apiEnvelope(t, w, map[string]any{
+			"qurl_link":  "https://qurl.link/at_minted",
+			"expires_at": "2026-04-01T00:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.MintLink(context.Background(), "r_abc123test", &MintLinkInput{
+		Label:      "test-link",
+		OneTimeUse: true,
+	})
+	if err != nil {
+		t.Fatalf("MintLink: %v", err)
+	}
+	if got.QURLLink != "https://qurl.link/at_minted" {
 		t.Errorf("got QURLLink %q", got.QURLLink)
 	}
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -309,10 +309,10 @@ func TestMintLinkContentType(t *testing.T) {
 	})
 }
 
-// TestMintLinkOmitEmpty verifies that MintLinkInput fields with zero values are
-// stripped by omitempty, so &MintLinkInput{} marshals to {} rather than a struct
-// with false/0/null fields. This locks the contract mint.go relies on when
-// omitting the Changed() gate for bool/int flags.
+// TestMintLinkOmitEmpty verifies that &MintLinkInput{} marshals to {} at the wire
+// level. Pointer fields (OneTimeUse *bool, MaxSessions *int) are nil in the zero value
+// and are correctly omitted by omitempty. This test pairs with TestMintLinkOverrideToFalse,
+// which asserts that non-nil pointers (even false/0) are included.
 func TestMintLinkOmitEmpty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -416,21 +416,24 @@ func TestListWithDateFilters(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool { return &b }
+func intPtr(n int) *int   { return &n }
+
 func TestMintLinkWithInput(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/qurls/"+testResourceID+"/mint_link" {
 			t.Errorf("expected mint_link path, got %s", r.URL.Path)
 		}
 
-		var input MintLinkInput
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if input.Label != "test-link" {
-			t.Errorf("expected label 'test-link', got %q", input.Label)
+		if string(body["label"]) != `"test-link"` {
+			t.Errorf("expected label 'test-link', got %s", body["label"])
 		}
-		if !input.OneTimeUse {
-			t.Error("expected one_time_use=true")
+		if string(body["one_time_use"]) != "true" {
+			t.Errorf("expected one_time_use=true, got %s", body["one_time_use"])
 		}
 
 		apiEnvelope(t, w, map[string]any{
@@ -443,13 +446,47 @@ func TestMintLinkWithInput(t *testing.T) {
 	c := testClient(srv.URL, "test-key")
 	got, err := c.MintLink(context.Background(), testResourceID, &MintLinkInput{
 		Label:      "test-link",
-		OneTimeUse: true,
+		OneTimeUse: boolPtr(true),
 	})
 	if err != nil {
 		t.Fatalf("MintLink: %v", err)
 	}
 	if got.QURLLink != "https://qurl.link/at_minted" {
 		t.Errorf("got QURLLink %q", got.QURLLink)
+	}
+}
+
+// TestMintLinkOverrideToFalse verifies that explicitly setting OneTimeUse=false or
+// MaxSessions=0 sends the field on the wire (not silently omitted), allowing callers to
+// override a qURL's server-side default back to the zero value.
+func TestMintLinkOverrideToFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, ok := body["one_time_use"]; !ok {
+			t.Error("expected one_time_use field in body (should not be omitted when explicitly set to false)")
+		}
+		if string(body["one_time_use"]) != "false" {
+			t.Errorf("expected one_time_use=false, got %s", body["one_time_use"])
+		}
+		if _, ok := body["max_sessions"]; !ok {
+			t.Error("expected max_sessions field in body (should not be omitted when explicitly set to 0)")
+		}
+		if string(body["max_sessions"]) != "0" {
+			t.Errorf("expected max_sessions=0, got %s", body["max_sessions"])
+		}
+		apiEnvelope(t, w, map[string]any{"qurl_link": "https://qurl.link/at_test"})
+	}))
+	t.Cleanup(srv.Close)
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.MintLink(context.Background(), testResourceID, &MintLinkInput{
+		OneTimeUse:  boolPtr(false),
+		MaxSessions: intPtr(0),
+	}); err != nil {
+		t.Fatalf("MintLink: %v", err)
 	}
 }
 
@@ -842,13 +879,26 @@ func TestBatchCreateValidation(t *testing.T) {
 		t.Fatal("expected error for empty batch")
 	}
 
-	items := make([]*CreateInput, maxBatchSize+1)
+	items := make([]*CreateInput, MaxBatchSize+1)
 	for i := range items {
 		items[i] = &CreateInput{TargetURL: "https://example.com"}
 	}
 	_, err = c.BatchCreate(context.Background(), items)
 	if err == nil {
-		t.Fatalf("expected error for batch > %d", maxBatchSize)
+		t.Fatalf("expected error for batch > %d", MaxBatchSize)
+	}
+}
+
+func TestBatchCreateNilItem(t *testing.T) {
+	c := testClient("http://unused", "test-key")
+
+	_, err := c.BatchCreate(context.Background(), []*CreateInput{
+		{TargetURL: "https://example.com"},
+		nil,
+		{TargetURL: "https://example2.com"},
+	})
+	if err == nil {
+		t.Fatal("expected error for nil item in batch")
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -417,7 +417,7 @@ func TestListWithDateFilters(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
-func intPtr(n int) *int   { return &n }
+func intPtr(n int) *int    { return &n }
 
 func TestMintLinkWithInput(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -77,8 +77,8 @@ func TestCreate(t *testing.T) {
 	if got.QURLLink != "https://qurl.link/at_abc123" {
 		t.Errorf("got QURLLink %q, want %q", got.QURLLink, "https://qurl.link/at_abc123")
 	}
-	if got.QurlID != "q_abc123test" {
-		t.Errorf("got QurlID %q, want %q", got.QurlID, "q_abc123test")
+	if got.QURLID != "q_abc123test" {
+		t.Errorf("got QURLID %q, want %q", got.QURLID, "q_abc123test")
 	}
 }
 
@@ -275,6 +275,38 @@ func TestMintLink(t *testing.T) {
 	}
 }
 
+func TestMintLinkContentType(t *testing.T) {
+	t.Run("nil input has no Content-Type", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ct := r.Header.Get("Content-Type"); ct != "" {
+				t.Errorf("expected no Content-Type header for bodiless POST, got %q", ct)
+			}
+			apiEnvelope(t, w, map[string]any{"qurl_link": "https://qurl.link/at_test"})
+		}))
+		defer srv.Close()
+
+		c := testClient(srv.URL, "test-key")
+		if _, err := c.MintLink(context.Background(), testResourceID, nil); err != nil {
+			t.Fatalf("MintLink: %v", err)
+		}
+	})
+
+	t.Run("non-nil input has Content-Type application/json", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+				t.Errorf("expected Content-Type application/json, got %q", ct)
+			}
+			apiEnvelope(t, w, map[string]any{"qurl_link": "https://qurl.link/at_test"})
+		}))
+		defer srv.Close()
+
+		c := testClient(srv.URL, "test-key")
+		if _, err := c.MintLink(context.Background(), testResourceID, &MintLinkInput{Label: "x"}); err != nil {
+			t.Fatalf("MintLink: %v", err)
+		}
+	})
+}
+
 func TestBatchCreate(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -326,8 +358,14 @@ func TestListWithDateFilters(t *testing.T) {
 		if r.URL.Query().Get("created_after") != "2026-01-01T00:00:00Z" {
 			t.Errorf("expected created_after, got %q", r.URL.Query().Get("created_after"))
 		}
+		if r.URL.Query().Get("created_before") != "2026-06-01T00:00:00Z" {
+			t.Errorf("expected created_before, got %q", r.URL.Query().Get("created_before"))
+		}
 		if r.URL.Query().Get("expires_before") != "2026-12-31T23:59:59Z" {
 			t.Errorf("expected expires_before, got %q", r.URL.Query().Get("expires_before"))
+		}
+		if r.URL.Query().Get("expires_after") != "2026-07-01T00:00:00Z" {
+			t.Errorf("expected expires_after, got %q", r.URL.Query().Get("expires_after"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -344,7 +382,9 @@ func TestListWithDateFilters(t *testing.T) {
 	c := testClient(srv.URL, "test-key")
 	_, err := c.List(context.Background(), &ListInput{
 		CreatedAfter:  "2026-01-01T00:00:00Z",
+		CreatedBefore: "2026-06-01T00:00:00Z",
 		ExpiresBefore: "2026-12-31T23:59:59Z",
+		ExpiresAfter:  "2026-07-01T00:00:00Z",
 	})
 	if err != nil {
 		t.Fatalf("List with date filters: %v", err)
@@ -449,6 +489,55 @@ func TestUpdate(t *testing.T) {
 	}
 	if got.Description != testDescription {
 		t.Errorf("got Description %q, want %q", got.Description, testDescription)
+	}
+}
+
+func TestUpdateTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     *[]string
+		wantJSON string
+	}{
+		{
+			name:     "set tags",
+			tags:     &[]string{"prod", "api"},
+			wantJSON: `["prod","api"]`,
+		},
+		{
+			name:     "clear tags",
+			tags:     &[]string{},
+			wantJSON: `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]json.RawMessage
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				gotTags, ok := body["tags"]
+				if !ok {
+					t.Errorf("expected tags field in body, got %v", body)
+				} else if string(gotTags) != tt.wantJSON {
+					t.Errorf("got tags %s, want %s", gotTags, tt.wantJSON)
+				}
+
+				apiEnvelope(t, w, map[string]any{
+					"resource_id": testResourceID,
+					"target_url":  "https://example.com",
+					"status":      "active",
+				})
+			}))
+			defer srv.Close()
+
+			c := testClient(srv.URL, "test-key")
+			_, err := c.Update(context.Background(), testResourceID, UpdateInput{Tags: tt.tags})
+			if err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+		})
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -247,7 +247,7 @@ func TestResolve(t *testing.T) {
 
 func TestMintLink(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/qurls/r_abc123test/mint_link" {
+		if r.URL.Path != "/v1/qurls/"+testResourceID+"/mint_link" {
 			t.Errorf("expected mint_link path, got %s", r.URL.Path)
 		}
 		apiEnvelope(t, w, map[string]any{
@@ -297,7 +297,7 @@ func TestBatchCreate(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.BatchCreate(context.Background(), []CreateInput{
+	got, err := c.BatchCreate(context.Background(), []*CreateInput{
 		{TargetURL: "https://a.com"},
 		{TargetURL: "https://b.com"},
 	})
@@ -344,7 +344,7 @@ func TestListWithDateFilters(t *testing.T) {
 
 func TestMintLinkWithInput(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/qurls/r_abc123test/mint_link" {
+		if r.URL.Path != "/v1/qurls/"+testResourceID+"/mint_link" {
 			t.Errorf("expected mint_link path, got %s", r.URL.Path)
 		}
 
@@ -682,7 +682,7 @@ func TestBatchCreatePartialFailure(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.BatchCreate(context.Background(), []CreateInput{
+	got, err := c.BatchCreate(context.Background(), []*CreateInput{
 		{TargetURL: "https://valid.com"},
 		{TargetURL: "not-a-url"},
 	})
@@ -714,14 +714,14 @@ func TestBatchCreateValidation(t *testing.T) {
 		t.Fatal("expected error for empty batch")
 	}
 
-	_, err = c.BatchCreate(context.Background(), []CreateInput{})
+	_, err = c.BatchCreate(context.Background(), []*CreateInput{})
 	if err == nil {
 		t.Fatal("expected error for empty batch")
 	}
 
-	items := make([]CreateInput, 101)
+	items := make([]*CreateInput, 101)
 	for i := range items {
-		items[i] = CreateInput{TargetURL: "https://example.com"}
+		items[i] = &CreateInput{TargetURL: "https://example.com"}
 	}
 	_, err = c.BatchCreate(context.Background(), items)
 	if err == nil {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -729,6 +729,14 @@ func TestBatchCreateValidation(t *testing.T) {
 	}
 }
 
+func TestCreateNilInput(t *testing.T) {
+	c := testClient("http://unused", "test-key")
+	_, err := c.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil create input")
+	}
+}
+
 func TestDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const testDescription = "updated"
+const testResourceID = "r_abc123test"
 
 // testClient creates a client with retries disabled for fast unit tests.
 func testClient(url, key string) *Client {
@@ -52,7 +53,7 @@ func TestCreate(t *testing.T) {
 
 		apiEnvelope(t, w, map[string]any{
 			"qurl_id":     "q_abc123test",
-			"resource_id": "r_abc123test",
+			"resource_id": testResourceID,
 			"qurl_link":   "https://qurl.link/at_abc123",
 			"qurl_site":   "https://r_abc123test.qurl.site",
 			"label":       "test",
@@ -66,8 +67,8 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if got.ResourceID != "r_abc123test" {
-		t.Errorf("got ResourceID %q, want %q", got.ResourceID, "r_abc123test")
+	if got.ResourceID != testResourceID {
+		t.Errorf("got ResourceID %q, want %q", got.ResourceID, testResourceID)
 	}
 	if got.QURLLink != "https://qurl.link/at_abc123" {
 		t.Errorf("got QURLLink %q, want %q", got.QURLLink, "https://qurl.link/at_abc123")
@@ -104,7 +105,7 @@ func TestGet(t *testing.T) {
 			t.Errorf("expected /v1/qurls/r_abc123test, got %s", r.URL.Path)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_abc123test",
+			"resource_id": testResourceID,
 			"target_url":  "https://example.com",
 			"status":      "active",
 			"tags":        []string{"test", "api"},
@@ -113,13 +114,13 @@ func TestGet(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.Get(context.Background(), "r_abc123test")
+	got, err := c.Get(context.Background(), testResourceID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 
-	if got.ResourceID != "r_abc123test" {
-		t.Errorf("got ResourceID %q, want %q", got.ResourceID, "r_abc123test")
+	if got.ResourceID != testResourceID {
+		t.Errorf("got ResourceID %q, want %q", got.ResourceID, testResourceID)
 	}
 	if got.Status != "active" {
 		t.Errorf("got Status %q, want %q", got.Status, "active")
@@ -217,7 +218,7 @@ func TestResolve(t *testing.T) {
 
 		apiEnvelope(t, w, map[string]any{
 			"target_url":  "https://api.example.com/data",
-			"resource_id": "r_abc123test",
+			"resource_id": testResourceID,
 			"access_grant": map[string]any{
 				"expires_in": 305,
 				"granted_at": "2026-03-09T15:30:00Z",
@@ -256,7 +257,7 @@ func TestMintLink(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.MintLink(context.Background(), "r_abc123test", nil)
+	got, err := c.MintLink(context.Background(), testResourceID, nil)
 	if err != nil {
 		t.Fatalf("MintLink: %v", err)
 	}
@@ -366,7 +367,7 @@ func TestMintLinkWithInput(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.MintLink(context.Background(), "r_abc123test", &MintLinkInput{
+	got, err := c.MintLink(context.Background(), testResourceID, &MintLinkInput{
 		Label:      "test-link",
 		OneTimeUse: true,
 	})
@@ -423,7 +424,7 @@ func TestUpdate(t *testing.T) {
 		}
 
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_abc123test",
+			"resource_id": testResourceID,
 			"target_url":  "https://example.com",
 			"status":      "active",
 			"description": testDescription,
@@ -433,7 +434,7 @@ func TestUpdate(t *testing.T) {
 
 	c := testClient(srv.URL, "test-key")
 	desc := testDescription
-	got, err := c.Update(context.Background(), "r_abc123test", UpdateInput{Description: &desc})
+	got, err := c.Update(context.Background(), testResourceID, UpdateInput{Description: &desc})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -466,7 +467,7 @@ func TestAPIErrorRFC7807(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.Get(context.Background(), "r_abc123test")
+	_, err := c.Get(context.Background(), testResourceID)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -511,7 +512,7 @@ func TestAPIErrorRateLimit(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.Get(context.Background(), "r_abc123test")
+	_, err := c.Get(context.Background(), testResourceID)
 
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
@@ -608,6 +609,126 @@ func TestNoRetryOn4xx(t *testing.T) {
 	}
 }
 
+func TestListNilInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"data": []map[string]any{},
+			"meta": map[string]any{"request_id": "req_test"},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("List(nil): %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil output")
+	}
+}
+
+func TestExtend(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+
+		var input UpdateInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.ExtendBy != "24h" {
+			t.Errorf("expected extend_by '24h', got %q", input.ExtendBy)
+		}
+
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": testResourceID,
+			"target_url":  "https://example.com",
+			"status":      "active",
+			"expires_at":  "2026-04-02T00:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.Extend(context.Background(), testResourceID, "24h")
+	if err != nil {
+		t.Fatalf("Extend: %v", err)
+	}
+	if got.ResourceID != testResourceID {
+		t.Errorf("got ResourceID %q, want %q", got.ResourceID, testResourceID)
+	}
+	if got.ExpiresAt == nil {
+		t.Error("expected ExpiresAt to be set")
+	}
+}
+
+func TestBatchCreatePartialFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		apiEnvelope(t, w, map[string]any{
+			"succeeded": 1,
+			"failed":    1,
+			"results": []map[string]any{
+				{"index": 0, "success": true, "resource_id": "r_1", "qurl_link": "https://qurl.link/at_1"},
+				{"index": 1, "success": false, "error": map[string]string{"code": "invalid_url", "message": "target_url is not valid"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.BatchCreate(context.Background(), []CreateInput{
+		{TargetURL: "https://valid.com"},
+		{TargetURL: "not-a-url"},
+	})
+	if err != nil {
+		t.Fatalf("BatchCreate: %v", err)
+	}
+	if got.Succeeded != 1 {
+		t.Errorf("got Succeeded %d, want 1", got.Succeeded)
+	}
+	if got.Failed != 1 {
+		t.Errorf("got Failed %d, want 1", got.Failed)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(got.Results))
+	}
+	if got.Results[1].Error == nil {
+		t.Fatal("expected error on second result")
+	}
+	if got.Results[1].Error.Code != "invalid_url" {
+		t.Errorf("got error code %q, want %q", got.Results[1].Error.Code, "invalid_url")
+	}
+}
+
+func TestBatchCreateValidation(t *testing.T) {
+	c := testClient("http://unused", "test-key")
+
+	_, err := c.BatchCreate(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty batch")
+	}
+
+	_, err = c.BatchCreate(context.Background(), []CreateInput{})
+	if err == nil {
+		t.Fatal("expected error for empty batch")
+	}
+
+	items := make([]CreateInput, 101)
+	for i := range items {
+		items[i] = CreateInput{TargetURL: "https://example.com"}
+	}
+	_, err = c.BatchCreate(context.Background(), items)
+	if err == nil {
+		t.Fatal("expected error for batch > 100")
+	}
+}
+
 func TestDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
@@ -618,7 +739,7 @@ func TestDelete(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if err := c.Delete(context.Background(), "r_abc123test"); err != nil {
+	if err := c.Delete(context.Background(), testResourceID); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Update all shared client types to match current OpenAPI spec (breaking changes)
- Create endpoint moved from `POST /v1/qurl` to `POST /v1/qurls`
- `CreateInput.Description` renamed to `Label`; added `SessionDuration`, `CustomDomain`
- `QURL` struct: removed `OneTimeUse`, `MaxSessions`, `QURLLink`, `AccessPolicy`; added `Tags`, `CustomDomain`
- `ExtendInput` merged into `UpdateInput` with `Tags` support
- `MintLink()` now accepts optional `*MintLinkInput` with full per-QURL settings
- New `BatchCreate()` method for `POST /v1/qurls/batch`
- `AccessPolicy` expanded with `UserAgentAllowRegex`, `UserAgentDenyRegex`, `AIAgentPolicy`
- CLI commands updated: `--description` → `--label`, new filter/mint/batch flags
- Output formatters updated for new field shapes
- `Create()` and `List()` now accept pointer inputs (lint: hugeParam)
- Removed `StatusExpired` and `StatusConsumed` constants

## Test plan
- [x] `go build ./...` compiles all apps (CLI, Slack)
- [x] `go test ./...` passes all tests
- [x] `golangci-lint run` reports 0 issues
- [x] `gofmt -l .` reports no formatting issues
- [x] `go vet ./...` passes
- [x] Shared client tests pass (including new TestBatchCreate, TestListWithDateFilters, TestMintLinkWithInput)
- [x] CLI command tests pass
- [x] Formatter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)