### PR TITLE
chore: enforce supply chain age gating

### DIFF
--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -1,0 +1,86 @@
+name: Dependency Age Check
+
+on:
+  pull_request:
+    paths:
+      - "**/go.sum"
+
+permissions:
+  contents: read
+
+jobs:
+  check-dependency-age:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Go module release ages
+        env:
+          MIN_AGE_DAYS: "7"
+        run: |
+          set -euo pipefail
+
+          failed=false
+          base_ref="origin/${{ github.event.pull_request.base.ref }}"
+
+          changed_sums=$(git diff --name-only "${base_ref}...HEAD" -- '**/go.sum' 'go.sum' || true)
+
+          if [ -z "$changed_sums" ]; then
+            echo "No go.sum changes detected"
+            exit 0
+          fi
+
+          for sum_file in $changed_sums; do
+            echo "::group::Checking ${sum_file}"
+
+            new_deps=$(git diff "${base_ref}...HEAD" -- "$sum_file" \
+              | grep '^+' | grep -v '^+++' \
+              | awk '{print $1 " " $2}' \
+              | sed 's|/go.mod$||' \
+              | sort -u)
+
+            if [ -z "$new_deps" ]; then
+              echo "No new dependencies in ${sum_file}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            while IFS=' ' read -r module version; do
+              [[ "$version" =~ ^v ]] || continue
+
+              encoded_module=$(echo "$module" | sed 's/\([A-Z]\)/!\L\1/g')
+              info_url="https://proxy.golang.org/${encoded_module}/@v/${version}.info"
+
+              response=$(curl -sf "$info_url" 2>/dev/null || echo "")
+              if [ -z "$response" ]; then
+                echo "  Warning: could not fetch info for ${module}@${version}"
+                continue
+              fi
+
+              publish_time=$(echo "$response" | jq -r '.Time')
+              publish_epoch=$(date -d "$publish_time" +%s)
+              now_epoch=$(date +%s)
+              age_days=$(( (now_epoch - publish_epoch) / 86400 ))
+
+              if [ "$age_days" -lt "$MIN_AGE_DAYS" ]; then
+                echo "::error file=${sum_file}::${module}@${version} published ${age_days} day(s) ago (minimum: ${MIN_AGE_DAYS})"
+                failed=true
+              else
+                echo "  OK: ${module}@${version} (${age_days} days old)"
+              fi
+            done <<< "$new_deps"
+
+            echo "::endgroup::"
+          done
+
+          if [ "$failed" = true ]; then
+            echo ""
+            echo "::error::One or more Go dependencies are younger than ${MIN_AGE_DAYS} days."
+            echo "To bypass for emergency security updates, add the 'age-check-bypass' label to this PR."
+            exit 1
+          fi
+
+          echo "All Go dependencies are at least ${MIN_AGE_DAYS} days old"

--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -11,9 +11,10 @@ permissions:
 jobs:
   check-dependency-age:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -25,9 +26,10 @@ jobs:
           set -euo pipefail
 
           failed=false
+          now_epoch=$(date +%s)
           base_ref="origin/${BASE_REF}"
 
-          changed_sums=$(git diff --name-only "${base_ref}...HEAD" -- '**/go.sum' 'go.sum' || true)
+          changed_sums=$(git diff --name-only "${base_ref}...HEAD" -- '**/go.sum' || true)
 
           if [ -z "$changed_sums" ]; then
             echo "No go.sum changes detected"
@@ -55,7 +57,7 @@ jobs:
               encoded_module=$(echo "$module" | sed 's/\([A-Z]\)/!\L\1/g')
               info_url="https://proxy.golang.org/${encoded_module}/@v/${version}.info"
 
-              response=$(curl -sf "$info_url" 2>/dev/null || echo "")
+              response=$(curl -sf --retry 2 "$info_url" 2>/dev/null || echo "")
               if [ -z "$response" ]; then
                 echo "  Warning: could not fetch info for ${module}@${version}"
                 continue
@@ -63,7 +65,6 @@ jobs:
 
               publish_time=$(echo "$response" | jq -r '.Time')
               publish_epoch=$(date -d "$publish_time" +%s)
-              now_epoch=$(date +%s)
               age_days=$(( (now_epoch - publish_epoch) / 86400 ))
 
               if [ "$age_days" -lt "$MIN_AGE_DAYS" ]; then

--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -59,10 +59,10 @@ jobs:
             while IFS=' ' read -r module version; do
               [[ "$version" =~ ^v ]] || continue
 
-              # Pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-hash) are pinned commits,
-              # not published releases. The proxy may 404 or return misleading
-              # timestamps. Skip them — they are not supply chain attack vectors.
-              if [[ "$version" =~ ^v0\.0\.0-[0-9]{14}- ]]; then
+              # Pseudo-versions are pinned commits, not published releases.
+              # All three Go pseudo-version forms (v0.0.0-..., vX.Y.Z-0.…, vX.Y.(Z+1)-0.…)
+              # contain -0.YYYYMMDDHHMMSS-hash. The proxy may 404 or return misleading timestamps.
+              if [[ "$version" =~ -0\.[0-9]{14}-[0-9a-f]{12}$ ]]; then
                 echo "  SKIP: ${module}@${version} (pseudo-version)"
                 continue
               fi

--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -13,18 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Check Go module release ages
         env:
           MIN_AGE_DAYS: "7"
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
           failed=false
-          base_ref="origin/${{ github.event.pull_request.base.ref }}"
+          base_ref="origin/${BASE_REF}"
 
           changed_sums=$(git diff --name-only "${base_ref}...HEAD" -- '**/go.sum' 'go.sum' || true)
 

--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -111,3 +111,4 @@ jobs:
           fi
 
           echo "Checked ${checked} dependencies — all at least ${MIN_AGE_DAYS} days old"
+          echo "✅ Checked ${checked} dependencies — all at least ${MIN_AGE_DAYS} days old" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -1,9 +1,13 @@
+# ============================================================================
+# DEPENDENCY AGE CHECK - Block newly published Go modules (supply chain)
+# ============================================================================
 name: Dependency Age Check
 
 on:
   pull_request:
     paths:
       - "**/go.sum"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,27 +25,28 @@ jobs:
       - name: Check Go module release ages
         env:
           MIN_AGE_DAYS: "7"
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
           set -euo pipefail
 
           failed=false
+          checked=0
           now_epoch=$(date +%s)
           base_ref="origin/${BASE_REF}"
 
-          changed_sums=$(git diff --name-only "${base_ref}...HEAD" -- '**/go.sum' || true)
+          changed_sums=$(git diff --name-only "${base_ref}...HEAD" -- '**/go.sum' 'go.sum' || true)
 
           if [ -z "$changed_sums" ]; then
             echo "No go.sum changes detected"
             exit 0
           fi
 
-          for sum_file in $changed_sums; do
+          while IFS= read -r sum_file; do
             echo "::group::Checking ${sum_file}"
 
             new_deps=$(git diff "${base_ref}...HEAD" -- "$sum_file" \
-              | grep '^+' | grep -v '^+++' \
-              | awk '{print $1 " " $2}' \
+              | grep '^+[^+]' \
+              | awk '{sub(/^\+/, "", $1); print $1 " " $2}' \
               | sed 's|/go.mod$||' \
               | sort -u)
 
@@ -54,17 +59,37 @@ jobs:
             while IFS=' ' read -r module version; do
               [[ "$version" =~ ^v ]] || continue
 
+              # Pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-hash) are pinned commits,
+              # not published releases. The proxy may 404 or return misleading
+              # timestamps. Skip them — they are not supply chain attack vectors.
+              if [[ "$version" =~ ^v0\.0\.0-[0-9]{14}- ]]; then
+                echo "  SKIP: ${module}@${version} (pseudo-version)"
+                continue
+              fi
+
+              checked=$((checked + 1))
+
+              # Go module proxy encoding: uppercase letters become !lowercase
+              # per https://pkg.go.dev/cmd/go#hdr-Module_proxy_protocol
               encoded_module=$(echo "$module" | sed 's/\([A-Z]\)/!\L\1/g')
               info_url="https://proxy.golang.org/${encoded_module}/@v/${version}.info"
 
-              response=$(curl -sf --retry 2 "$info_url" 2>/dev/null || echo "")
+              # Fail-closed: if we can't verify a module's age, treat it as too young.
+              # This prevents bypass when proxy.golang.org is unreachable.
+              response=$(curl -sf -m 10 "$info_url" 2>/dev/null || echo "")
               if [ -z "$response" ]; then
-                echo "  Warning: could not fetch info for ${module}@${version}"
+                echo "::error file=${sum_file}::Could not verify age for ${module}@${version} (proxy.golang.org unreachable or module not found)"
+                failed=true
                 continue
               fi
 
               publish_time=$(echo "$response" | jq -r '.Time')
-              publish_epoch=$(date -d "$publish_time" +%s)
+              if ! publish_epoch=$(date -d "$publish_time" +%s 2>/dev/null); then
+                echo "::error file=${sum_file}::Could not parse publish timestamp for ${module}@${version}: ${publish_time}"
+                failed=true
+                continue
+              fi
+
               age_days=$(( (now_epoch - publish_epoch) / 86400 ))
 
               if [ "$age_days" -lt "$MIN_AGE_DAYS" ]; then
@@ -76,13 +101,13 @@ jobs:
             done <<< "$new_deps"
 
             echo "::endgroup::"
-          done
+          done <<< "$changed_sums"
 
           if [ "$failed" = true ]; then
             echo ""
-            echo "::error::One or more Go dependencies are younger than ${MIN_AGE_DAYS} days."
+            echo "::error::One or more Go dependencies failed the age check."
             echo "To bypass for emergency security updates, add the 'age-check-bypass' label to this PR."
             exit 1
           fi
 
-          echo "All Go dependencies are at least ${MIN_AGE_DAYS} days old"
+          echo "Checked ${checked} dependencies — all at least ${MIN_AGE_DAYS} days old"


### PR DESCRIPTION
## Summary
- Adds CI workflow that checks Go dependency publish dates against `proxy.golang.org`
- Blocks PRs introducing modules published less than 7 days ago
- Covers all go.sum files across the monorepo (apps/slack, apps/cli, libs)

## Why
Go has no native package manager age-gating. This CI check provides equivalent protection by querying the Go module proxy for publish timestamps.

## Override for critical updates
Add the `age-check-bypass` label to the PR.

## Test plan
- [ ] Workflow triggers on PRs that modify any `go.sum` in the monorepo
- [ ] Workflow skips when `age-check-bypass` label is present
- [ ] Existing dependencies (older than 7 days) pass the check