### PR TITLE
feat(discord): migrate Discord bot from qurl-integrations-infra

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -41,14 +41,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('apps/discord/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/discord/requirements-dev.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Verify imports
         run: python -c "from validation import validate_resource_id; print('Import OK')"

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,79 @@
+name: "discord: Build and Test"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/discord/**'
+      - '.github/workflows/discord.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/discord/**'
+      - '.github/workflows/discord.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: apps/discord
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/discord/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Verify imports
+        run: python -c "from validation import validate_resource_id; print('Import OK')"
+
+      - name: Run tests
+        run: python -m pytest tests/ -q --tb=short
+
+  docker-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify Dockerfile builds
+        working-directory: apps/discord
+        run: docker build -t discord-bot-test .
+
+  trigger-deploy:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Trigger deploy in infra repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_PAT }}
+          repository: layervai/qurl-integrations-infra
+          event-type: discord-bot-deploy
+          client-payload: '{"sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}'

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'apps/discord/**'
+      - 'shared/**'
       - '.github/workflows/discord.yml'
   pull_request:
     branches: [main]
     paths:
       - 'apps/discord/**'
+      - 'shared/**'
       - '.github/workflows/discord.yml'
 
 permissions:

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -54,7 +54,7 @@ jobs:
           pip install ruff==0.11.8
 
       - name: Lint with ruff
-        run: ruff check --select E,F,W,B,UP --ignore E501 .
+        run: ruff check --select E,F,W,B,UP --ignore E501,UP007 .
 
       - name: Verify imports
         run: python -c "from validation import validate_resource_id; print('Import OK')"

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -12,6 +12,9 @@ on:
       - 'apps/discord/**'
       - '.github/workflows/discord.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -76,4 +79,4 @@ jobs:
           token: ${{ secrets.DEPLOY_PAT }}
           repository: layervai/qurl-integrations-infra
           event-type: discord-bot-deploy
-          client-payload: '{"sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}'
+          client-payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -51,6 +51,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+          pip install ruff
+
+      - name: Lint with ruff
+        run: ruff check --select E,F,W --ignore E501 .
 
       - name: Verify imports
         run: python -c "from validation import validate_resource_id; print('Import OK')"

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -51,10 +51,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install ruff
+          pip install ruff==0.11.8
 
       - name: Lint with ruff
-        run: ruff check --select E,F,W --ignore E501 .
+        run: ruff check --select E,F,W,B,UP --ignore E501 .
 
       - name: Verify imports
         run: python -c "from validation import validate_resource_id; print('Import OK')"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ pre-commit-run:
 ## Discord bot (Python)
 
 test-discord:
-	cd apps/discord && pip install -q -r requirements.txt && python -m pytest tests/ -q
+	cd apps/discord && pip install -q -r requirements-dev.txt && python -m pytest tests/ -q
 
 check-discord: test-discord
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt lint vet test test-race coverage build-slack build-cli docs man vendor release-snapshot security check clean
+.PHONY: all fmt lint vet test test-race coverage build-slack build-cli docs man vendor release-snapshot security check check-discord test-discord clean
 
 VERSION ?= dev
 
@@ -75,6 +75,13 @@ pre-commit-install:
 
 pre-commit-run:
 	pre-commit run --all-files
+
+## Discord bot (Python)
+
+test-discord:
+	cd apps/discord && pip install -q -r requirements.txt && python -m pytest tests/ -q
+
+check-discord: test-discord
 
 ## Full check (CI parity)
 

--- a/apps/discord/.dockerignore
+++ b/apps/discord/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.env
+.env.*
+data/
+*.db
+.venv/
+tests/
+docs/
+.git/
+.gitignore
+.dockerignore
+requirements-dev.txt
+README.md

--- a/apps/discord/.gitignore
+++ b/apps/discord/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.env
+data/
+*.db
+.venv/

--- a/apps/discord/Dockerfile
+++ b/apps/discord/Dockerfile
@@ -9,9 +9,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN mkdir -p /app/data && chmod 755 /app/data
+RUN adduser --disabled-password --gecos "" appuser \
+    && mkdir -p /app/data \
+    && chown -R appuser:appuser /app/data
 
 EXPOSE 3000
+
+USER appuser
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:3000/health || exit 1

--- a/apps/discord/Dockerfile
+++ b/apps/discord/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p /app/data && chmod 755 /app/data
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:3000/health || exit 1
+
+CMD ["python", "run.py"]

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -1,0 +1,91 @@
+# QURL Discord Bot
+
+Protect and share files on Discord through LayerV QURL. Users DM files to the bot, which uploads them to the QURL API and returns a resource ID. Owners then use slash commands to dispatch single-use, time-limited links to specific recipients via DM.
+
+## Features
+
+- **DM Upload:** Send a file to @QurlBot in DM to protect it and receive a resource ID
+- **Slash Commands:** `/qurl send`, `/qurl list`, `/qurl status`, `/qurl revoke`, `/qurl help`
+- **Owner-Only Dispatch:** Only the file owner can send links; guild-scoped
+- **Per-Recipient Links:** Each recipient gets a unique, single-use, 15-minute link via DM
+- **Input Validation:** File size (25 MB), file type (PNG, JPG, GIF, WebP, PDF), CDN allowlist, resource ID regex
+- **Rate Limiting:** 5 requests per user per minute (sliding window)
+- **SQLite Storage:** Persistent owner registry and dispatch audit log
+- **Health Check:** HTTP endpoint at `:3000/health`
+
+## Quick Start
+
+### 1. Create a Discord App
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications) and create a new application
+2. Under **Bot**, create a bot and copy the token
+3. Under **Privileged Gateway Intents**, enable:
+   - **Server Members Intent** (required for guild member verification)
+   - Note: Message Content Intent is NOT required (dispatch uses slash commands)
+4. Under **OAuth2 > URL Generator**, select `bot` + `applications.commands` scopes
+
+### 2. Configure Environment
+
+```bash
+cp .env.example .env
+# Edit .env with your credentials
+```
+
+### 3. Install and Run
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python run.py
+```
+
+## Project Structure
+
+```
+qurl-bot-discord/
+├── run.py                    # Entry point (bot + health server)
+├── config.py                 # pydantic-settings configuration
+├── db.py                     # SQLite owner registry + dispatch log
+├── validation.py             # Input validation (files, IDs, CDN URLs)
+├── rate_limiter.py           # Sliding window rate limiter
+├── adapters/
+│   └── discord_bot.py        # Discord slash commands + DM upload
+├── services/
+│   ├── upload_client.py      # QURL upload API client
+│   └── mint_link_client.py   # QURL mint_link API client
+├── terraform/                # EC2 infrastructure
+├── docs/                     # Design specs
+├── deploy.sh                 # Server deploy script
+├── requirements.txt          # Pinned dependencies
+└── .env.example              # Environment template
+```
+
+## Infrastructure
+
+- **EC2** on Amazon Linux 2023, managed by Terraform
+- **Outbound-only** networking (Discord WebSocket) — no HTTP/HTTPS ingress needed
+- **systemd** service running as `ec2-user`
+- **CI/CD** via GitHub Actions with OIDC authentication
+
+## Usage
+
+### Protect a File (DM)
+
+1. DM any supported file to @QurlBot
+2. Bot uploads it and replies with the resource ID and a link
+
+### Share with Users (Server)
+
+```
+/qurl send resource_id:r_abc123def users:@alice @bob
+```
+
+Each mentioned user receives a unique, single-use link via DM.
+
+### Other Commands
+
+- `/qurl list` — list your protected files
+- `/qurl status r_abc123def` — check dispatch stats
+- `/qurl revoke r_abc123def` — revoke a file
+- `/qurl help` — show help

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -483,7 +483,10 @@ async def on_message(message: discord.Message) -> None:
             if handled:
                 return
 
-        await message.reply("Send me a file or Google Maps link to protect it, or reply to a protected resource and @mention users to share.")
+        help_msg = "Send me a file to protect it, or reply to a protected resource and @mention users to share."
+        if settings.google_maps_enabled:
+            help_msg = "Send me a file or Google Maps link to protect it, or reply to a protected resource and @mention users to share."
+        await message.reply(help_msg)
         return
 
     user_id = str(message.author.id)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -446,7 +446,7 @@ async def _handle_maps_url(message: discord.Message, user_id: str) -> bool:
         return True
     except Exception as e:
         metrics.incr("UploadFailed")
-        logger.error("Map upload failed for user %s: %s", user_id, e)
+        logger.exception("Map upload failed for user %s", user_id)
         await message.reply("Something went wrong protecting the map location. Please try again.")
         return True
 

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
 import discord
@@ -444,7 +444,7 @@ async def _handle_maps_url(message: discord.Message, user_id: str) -> bool:
             f"\\_resource\\_id:{result['resource_id']}\\_"
         )
         return True
-    except Exception as e:
+    except Exception:
         metrics.incr("UploadFailed")
         logger.exception("Map upload failed for user %s", user_id)
         await message.reply("Something went wrong protecting the map location. Please try again.")

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -163,6 +163,14 @@ async def _resource_autocomplete(
 
 # --- Shared Dispatch Helper (used by both reply-to-share and /qurl send) ---
 
+# Known dispatch error mappings — module level so it's not recreated per exception.
+# HTTPStatusError handled separately (needs dynamic status code).
+_DISPATCH_ERRORS = {
+    discord.NotFound:       (DispatchStatus.DM_FAILED,   "user_not_found", "User not found"),
+    discord.Forbidden:      (DispatchStatus.DM_FAILED,   "dms_disabled",   "DMs disabled"),
+    httpx.TimeoutException: (DispatchStatus.MINT_FAILED, "mint_timeout",   "Failed to mint link"),
+}
+
 # Per-user semaphore: prevents one user's bulk dispatch from starving others.
 # 10 concurrent dispatches per sender; LRU eviction at 1000 entries.
 _user_sems: dict[str, asyncio.Semaphore] = {}
@@ -171,7 +179,12 @@ _USER_SEM_MAX_ENTRIES = 1000
 
 
 def _get_user_sem(sender_id: str) -> asyncio.Semaphore:
-    """Get or create a per-user dispatch semaphore with LRU eviction."""
+    """Get or create a per-user dispatch semaphore with LRU eviction.
+
+    No asyncio.Lock needed: this function is fully synchronous (no await points),
+    so the GIL prevents interleaving between coroutines. The entire pop-check-insert
+    sequence runs atomically.
+    """
     sem = _user_sems.pop(sender_id, None)  # Remove to re-insert at end (LRU refresh)
     if sem is None:
         # Evict oldest entry if at capacity
@@ -219,12 +232,7 @@ async def _dispatch_to_recipient(
             )
             return (recipient_id, DispatchStatus.SENT, None, recipient.display_name)
         except (discord.NotFound, discord.Forbidden, httpx.TimeoutException, httpx.HTTPStatusError) as exc:
-            # Known dispatch errors — single bookkeeping path
-            _DISPATCH_ERRORS = {
-                discord.NotFound:       (DispatchStatus.DM_FAILED,   "user_not_found", "User not found"),
-                discord.Forbidden:      (DispatchStatus.DM_FAILED,   "dms_disabled",   "DMs disabled"),
-                httpx.TimeoutException: (DispatchStatus.MINT_FAILED, "mint_timeout",   "Failed to mint link"),
-            }
+            # Known dispatch errors — uses module-level _DISPATCH_ERRORS mapping
             if type(exc) in _DISPATCH_ERRORS:
                 status, error_code, display = _DISPATCH_ERRORS[type(exc)]
             else:
@@ -374,7 +382,7 @@ async def _handle_maps_url(message: discord.Message, user_id: str) -> bool:
 
     has_query = validate_query(maps_data.get("query"))
     has_coords = maps_data.get("lat") is not None and validate_coordinates(
-        maps_data["lat"], maps_data.get("lng")
+        maps_data.get("lat"), maps_data.get("lng")
     )
     if not has_query and not has_coords:
         await message.reply("Could not parse the Google Maps URL. Please send a valid Maps link.")
@@ -384,7 +392,7 @@ async def _handle_maps_url(message: discord.Message, user_id: str) -> bool:
     caption = re.sub(MAPS_URL_RE, "", message.content or "").strip()[:500]
     caption = sanitize_query(caption) if caption else None
 
-    location_label = maps_data.get("query") or f"{maps_data['lat']},{maps_data['lng']}"
+    location_label = maps_data.get("query") or f"{maps_data.get('lat')},{maps_data.get('lng')}"
 
     try:
         payload = {
@@ -857,7 +865,10 @@ async def qurl_status(interaction: discord.Interaction, resource: str) -> None:
         client = get_http_client()
         resp = await client.get(url, headers=headers, timeout=10.0)
         if resp.status_code == 200:
-            data = resp.json()
+            try:
+                data = resp.json()
+            except (ValueError, TypeError):
+                data = {}
             payload = data.get("data", data)
             upstream_status = payload.get("status", "unknown")
             upstream_created = payload.get("created_at", "unknown")

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -784,8 +784,8 @@ async def qurl_revoke(interaction: discord.Interaction, resource: str) -> None:
     try:
         url = f"{settings.mint_link_api_url.rstrip('/')}/{rid}"
         headers = {"Authorization": f"Bearer {settings.qurl_api_key}"}
-        client = get_http_client(timeout=10.0)
-        resp = await client.delete(url, headers=headers)
+        client = get_http_client()
+        resp = await client.delete(url, headers=headers, timeout=10.0)
         if resp.status_code < 300:
             upstream_ok = True
         else:
@@ -854,8 +854,8 @@ async def qurl_status(interaction: discord.Interaction, resource: str) -> None:
     try:
         url = f"{settings.mint_link_api_url.rstrip('/')}/{rid}"
         headers = {"Authorization": f"Bearer {settings.qurl_api_key}"}
-        client = get_http_client(timeout=10.0)
-        resp = await client.get(url, headers=headers)
+        client = get_http_client()
+        resp = await client.get(url, headers=headers, timeout=10.0)
         if resp.status_code == 200:
             data = resp.json()
             payload = data.get("data", data)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -1,0 +1,902 @@
+"""Discord adapter for QURL bot — slash commands and DM upload flow."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+import discord
+import httpx
+from discord import app_commands
+from discord.ext import commands
+
+import metrics
+from bot_helpers import RESOURCE_ID_MARKER_RE, check_guild_members, format_dispatch_summary, is_expired
+from config import settings
+from db import (
+    DispatchStatus,
+    bind_guild,
+    delete_resource,
+    get_dispatch_stats,
+    get_owner,
+    delete_all_resources,
+    list_resources,
+    log_dispatch,
+    register_owner,
+    search_resources,
+    update_dispatch,
+)
+from rate_limiter import RateLimiter
+from services.maps_parser import (
+    MAPS_URL_RE,
+    detect_maps_url,
+    is_short_link,
+    is_unsupported_maps_format,
+    parse_maps_url,
+    resolve_short_link,
+    sanitize_query,
+    validate_coordinates,
+    validate_query,
+)
+from services.mint_link_client import mint_link
+from services.upload_client import upload_file
+from validation import (
+    DEFAULT_LINK_EXPIRY,
+    sanitize_filename,
+    split_message,
+    validate_cdn_url,
+    validate_expires,
+    validate_file_type,
+    validate_resource_id,
+    validate_snowflake,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- Expiry choices for /qurl send ---
+EXPIRY_CHOICES = [
+    app_commands.Choice(name="5 minutes", value="5m"),
+    app_commands.Choice(name="15 minutes (default)", value="15m"),
+    app_commands.Choice(name="1 hour", value="1h"),
+    app_commands.Choice(name="24 hours", value="24h"),
+    app_commands.Choice(name="7 days", value="7d"),
+]
+
+_EXPIRY_DISPLAY = {
+    "5m": "5 minutes",
+    "15m": "15 minutes",
+    "1h": "1 hour",
+    "24h": "24 hours",
+    "7d": "7 days",
+}
+rate_limiter = RateLimiter(settings.rate_limit_per_minute)
+
+# Cap concurrent uploads to bound peak memory (~5 x 25MB = 125MB worst case).
+# Validation (size, type, CDN) runs outside the semaphore for instant rejection.
+_upload_sem = asyncio.Semaphore(5)
+
+
+class QurlBot(commands.Bot):
+    def __init__(self) -> None:
+        intents = discord.Intents.default()
+        # MessageContent intent NOT required for slash commands or DM attachments.
+        # However, reply-to-share reads message.mentions in DM replies — Discord
+        # exempts DMs from the MessageContent privileged intent requirement, so
+        # mentions are populated without it. If this ever breaks, enable:
+        # intents.message_content = True
+        intents.dm_messages = True
+        intents.guilds = True
+        # members intent required for guild.fetch_member in check_guild_members (bot_helpers.py)
+        intents.members = True
+        super().__init__(command_prefix="!", intents=intents)
+
+    async def setup_hook(self) -> None:
+        if settings.sync_commands_globally:
+            await self.tree.sync()
+            logger.info("Slash commands synced globally (may take up to 1 hour to propagate)")
+        else:
+            logger.info("Skipping global command sync (set SYNC_COMMANDS_GLOBALLY=true to enable)")
+
+
+# M1: Simple module-level singleton — no get_bot() facade
+bot = QurlBot()
+
+
+def _format_discord_ts(iso_str: str | None, fallback: str = "unknown") -> str:
+    """Convert ISO 8601 timestamp to Discord relative timestamp format."""
+    if not iso_str:
+        return fallback
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        return f"<t:{int(dt.timestamp())}:R>"
+    except (ValueError, AttributeError):
+        return iso_str
+
+
+async def _resolve_owned_resource(
+    interaction: discord.Interaction, resource_id: str
+) -> tuple[str, dict] | None:
+    """Validate resource_id, check ownership. Returns (rid, owner_info) or None on failure."""
+    rid = resource_id.lstrip("$").strip()
+    if not validate_resource_id(rid):
+        await interaction.followup.send("Invalid resource ID format.", ephemeral=True)
+        return None
+    user_id = str(interaction.user.id)
+    owner_info = await asyncio.to_thread(get_owner, rid)
+    if not owner_info or owner_info["discord_user_id"] != user_id:
+        await interaction.followup.send(
+            "Resource not found or you are not the owner.", ephemeral=True
+        )
+        return None
+    return rid, owner_info
+
+
+async def _resource_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> list[app_commands.Choice[str]]:
+    """Autocomplete handler — shows user's resources by name. Uses DB-side filtering for performance."""
+    t0 = time.monotonic()
+    try:
+        user_id = str(interaction.user.id)
+        # Strip $ prefix for backwards compat with manual resource_id input (e.g. "$r_abc")
+        query = current.lower().lstrip("$")
+        resources = await asyncio.to_thread(search_resources, user_id, query, 25)
+        matches = []
+        for r in resources:
+            label = r.get("filename", r["resource_id"])
+            matches.append(app_commands.Choice(name=label[:100], value=r["resource_id"]))
+        return matches
+    except Exception:
+        logger.exception("Autocomplete failed for user %s", interaction.user.id)
+        return []
+    finally:
+        # Measure full callback wall time including failures (Discord enforces 3s timeout)
+        metrics.timing("AutocompleteLatency", (time.monotonic() - t0) * 1000)
+
+
+# --- Shared Dispatch Helper (used by both reply-to-share and /qurl send) ---
+
+# Per-user semaphore: prevents one user's bulk dispatch from starving others.
+# 10 concurrent dispatches per sender; LRU eviction at 1000 entries.
+_user_sems: dict[str, asyncio.Semaphore] = {}
+_USER_SEM_LIMIT = 10
+_USER_SEM_MAX_ENTRIES = 1000
+
+
+def _get_user_sem(sender_id: str) -> asyncio.Semaphore:
+    """Get or create a per-user dispatch semaphore with LRU eviction."""
+    sem = _user_sems.pop(sender_id, None)  # Remove to re-insert at end (LRU refresh)
+    if sem is None:
+        # Evict oldest entry if at capacity
+        if len(_user_sems) >= _USER_SEM_MAX_ENTRIES:
+            oldest = next(iter(_user_sems))
+            del _user_sems[oldest]
+        sem = asyncio.Semaphore(_USER_SEM_LIMIT)
+    _user_sems[sender_id] = sem  # Insert at end (most recent)
+    return sem
+
+
+async def _dispatch_to_recipient(
+    rid: str, sender_id: str, recipient_id: str, guild_id: str | None,
+    expires_in: str = DEFAULT_LINK_EXPIRY,
+) -> tuple[str, str, str | None, str]:
+    """Mint a link and DM one recipient. Returns (recipient_id, status, error, display_name)."""
+    async with _get_user_sem(sender_id):
+        t0 = time.monotonic()
+        dispatch_id = await asyncio.to_thread(
+            log_dispatch, rid, sender_id, recipient_id, guild_id
+        )
+        try:
+            # Fetch recipient BEFORE minting to avoid orphaned links if user doesn't exist
+            recipient = await bot.fetch_user(int(recipient_id))
+            mint_t0 = time.monotonic()
+            link_data = await mint_link(rid, recipient_id, expires_in=expires_in)
+            metrics.timing("MintApiLatency", (time.monotonic() - mint_t0) * 1000)
+            qurl_link = link_data["qurl_link"]
+            expires_at = link_data.get("expires_at", "")
+            expires_display = _format_discord_ts(expires_at, fallback=f"in {_EXPIRY_DISPLAY.get(expires_in, expires_in)}")
+            await recipient.send(
+                f"**You've been granted access to a resource.**\n\n"
+                f"{qurl_link}\n\n"
+                f"_Single use - expires {expires_display}_"
+            )
+            link_hash = hashlib.sha256(qurl_link.encode()).hexdigest()[:16]
+            await asyncio.to_thread(
+                update_dispatch, dispatch_id, DispatchStatus.SENT, None, link_hash
+            )
+            metrics.timing("DispatchLatency", (time.monotonic() - t0) * 1000)
+            metrics.incr("DispatchSent")
+            logger.info(
+                "dispatch_sent",
+                extra={"audit": {"event": "dispatch_sent", "resource": rid, "sender": sender_id, "recipient": recipient_id, "link_hash": link_hash}},
+            )
+            return (recipient_id, DispatchStatus.SENT, None, recipient.display_name)
+        except (discord.NotFound, discord.Forbidden, httpx.TimeoutException, httpx.HTTPStatusError, Exception) as exc:
+            # Dispatch error bookkeeping — single path for all failure types
+            _DISPATCH_ERRORS = {
+                discord.NotFound:       (DispatchStatus.DM_FAILED,   "user_not_found", "User not found"),
+                discord.Forbidden:      (DispatchStatus.DM_FAILED,   "dms_disabled",   "DMs disabled"),
+                httpx.TimeoutException: (DispatchStatus.MINT_FAILED, "mint_timeout",   "Failed to mint link"),
+            }
+            if type(exc) in _DISPATCH_ERRORS:
+                status, error_code, display = _DISPATCH_ERRORS[type(exc)]
+            elif isinstance(exc, httpx.HTTPStatusError):
+                status, error_code, display = DispatchStatus.MINT_FAILED, f"mint_{exc.response.status_code}", "Failed to mint link"
+            else:
+                status, error_code, display = DispatchStatus.MINT_FAILED, "mint_error", "Failed to mint link"
+            metrics.incr("DispatchFailed")
+            logger.info(
+                "dispatch_failed",
+                extra={"audit": {"event": "dispatch_failed", "resource": rid, "recipient": recipient_id, "error": error_code}},
+            )
+            await asyncio.to_thread(update_dispatch, dispatch_id, status, error_code)
+            return (recipient_id, status, display, recipient_id)
+
+
+async def _handle_reply_to_share(message: discord.Message) -> bool:
+    """Handle reply-to-share flow. Returns True if handled, False to fall through."""
+    ref = message.reference
+    if not ref or not ref.message_id:
+        return False
+
+    # Rate limit before any network/DB work
+    user_id = str(message.author.id)
+    if not rate_limiter.check(user_id):
+        metrics.incr("RateLimitHit")
+        await message.reply("Too many requests. Please wait a moment.")
+        return True
+
+    try:
+        parent = await message.channel.fetch_message(ref.message_id)
+    except (discord.NotFound, discord.HTTPException):
+        await message.reply("Could not read the replied message. Please try again.")
+        return True
+
+    # Only handle replies to bot's own messages
+    if not bot.user or parent.author.id != bot.user.id:
+        return False  # Not a bot message or bot not ready — fall through
+
+    # Extract resource_id from deterministic marker line — not arbitrary backtick strings
+    rid_match = RESOURCE_ID_MARKER_RE.search(parent.content)
+    if not rid_match:
+        await message.reply("Could not find a resource ID in that message.")
+        return True
+
+    rid = rid_match.group(1)
+    if not validate_resource_id(rid):
+        await message.reply("Invalid resource ID.")
+        return True
+
+    owner_info = await asyncio.to_thread(get_owner, rid)
+    if not owner_info or owner_info["discord_user_id"] != user_id:
+        await message.reply("You are not the owner of this resource.")
+        return True
+
+    if is_expired(owner_info.get("expires_at")):
+        await message.reply("This resource has expired.")
+        return True
+
+    # Parse mentioned users (exclude bot and self), validate snowflakes, deduplicate
+    bot_uid = bot.user.id if bot.user else None
+    recipient_ids = [
+        str(u.id) for u in message.mentions
+        if u.id != bot_uid and str(u.id) != user_id
+    ]
+    recipient_ids = list(dict.fromkeys(recipient_ids))
+    recipient_ids = [uid for uid in recipient_ids if validate_snowflake(uid)]
+
+    if not recipient_ids:
+        await message.reply("Please @mention at least one recipient.")
+        return True
+
+    if len(recipient_ids) > 25:
+        await message.reply("Maximum 25 recipients per share.")
+        return True
+
+    # Guild membership check: if resource is bound to a guild, verify recipients (parallel)
+    bound_guild = owner_info.get("guild_id")
+    if bound_guild:
+        try:
+            guild = bot.get_guild(int(bound_guild))
+            if guild:
+                recipient_ids = await check_guild_members(guild, recipient_ids)
+                if not recipient_ids:
+                    await message.reply("None of the mentioned users are in the resource's server.")
+                    return True
+            else:
+                logger.debug("Guild %s not in bot cache — skipping membership check for %s", bound_guild, rid)
+        except Exception as e:
+            logger.debug("Guild membership check skipped for %s: %s", rid, e)
+
+    await message.reply(f"Sending links to {len(recipient_ids)} user(s)...")
+
+    filename = owner_info.get("filename", rid)
+    tasks = [
+        _dispatch_to_recipient(rid, user_id, uid, bound_guild)
+        for uid in recipient_ids
+    ]
+    results = await asyncio.gather(*tasks)
+    summary = format_dispatch_summary(filename, results)
+    for part in split_message(summary):
+        await message.reply(part)
+    return True
+
+
+# --- Google Maps URL Handler ---
+
+
+async def _handle_maps_url(message: discord.Message, user_id: str) -> bool:
+    """Handle a DM containing a Google Maps URL. Returns True if handled."""
+    maps_url = detect_maps_url(message.content or "")
+    if not maps_url:
+        return False
+
+    if not rate_limiter.check(user_id):
+        metrics.incr("RateLimitHit")
+        await message.reply("Too many requests. Please wait a moment.")
+        return True
+
+    # Resolve short links (goo.gl, maps.app.goo.gl)
+    if is_short_link(maps_url):
+        resolved = await resolve_short_link(maps_url)
+        if resolved:
+            maps_url = resolved
+        else:
+            await message.reply(
+                "Could not resolve the short Maps link. Please send the full google.com/maps URL."
+            )
+            return True
+
+    # Directions, timeline, contrib, rpc — recognized but not supported
+    if is_unsupported_maps_format(maps_url):
+        await message.reply(
+            "This Google Maps URL format isn't supported. Please send a place or coordinate link."
+        )
+        return True
+
+    maps_data = parse_maps_url(maps_url)
+    if not maps_data:
+        await message.reply("Could not parse the Google Maps URL. Please send a valid Maps link.")
+        return True
+
+    has_query = validate_query(maps_data.get("query"))
+    has_coords = maps_data.get("lat") is not None and validate_coordinates(
+        maps_data["lat"], maps_data.get("lng")
+    )
+    if not has_query and not has_coords:
+        await message.reply("Could not parse the Google Maps URL. Please send a valid Maps link.")
+        return True
+
+    # Capture annotation context — text surrounding the URL that the user typed
+    caption = re.sub(MAPS_URL_RE, "", message.content or "").strip()[:500]
+    caption = sanitize_query(caption) if caption else None
+
+    location_label = maps_data.get("query") or f"{maps_data['lat']},{maps_data['lng']}"
+
+    try:
+        payload = {
+            "type": "google-map",
+            "query": maps_data.get("query"),
+            "lat": maps_data.get("lat"),
+            "lng": maps_data.get("lng"),
+        }
+        if caption:
+            payload["caption"] = caption
+
+        result = await upload_file(
+            file_bytes=json.dumps(payload).encode(),
+            filename="map.json",
+            content_type="application/json",
+            owner_id=user_id,
+        )
+
+        owner_filename = f"map:{location_label}"
+        if caption:
+            owner_filename += f"|{caption[:100]}"
+
+        await asyncio.to_thread(
+            register_owner,
+            result["resource_id"],
+            user_id,
+            None,
+            owner_filename,
+            result.get("expires_at"),
+        )
+
+        metrics.incr("UploadSuccess")
+        logger.info(
+            "upload_success",
+            extra={"audit": {"event": "upload_success", "type": "map", "user": user_id, "resource": result["resource_id"], "location": location_label}},
+        )
+
+        expires_display = _format_discord_ts(result.get("expires_at"))
+
+        await message.reply(
+            f"**Map location wrapped in a single-use link.**\n\n"
+            f"\u26a0\ufe0f Recipients can screenshot or read coordinates from the browser. "
+            f"The watermark traces any leak back to the specific recipient.\n\n"
+            f"**Location:** {location_label}\n"
+            f"**Link:** {result['qurl_link']}\n"
+            f"**Expires:** {expires_display}\n\n"
+            f"Reply to this message and @mention users to share, "
+            f"or use `/qurl send` in any server channel.\n"
+            f"\\_resource\\_id:{result['resource_id']}\\_"
+        )
+        return True
+    except Exception as e:
+        metrics.incr("UploadFailed")
+        logger.error("Map upload failed for user %s: %s", user_id, e)
+        await message.reply("Something went wrong protecting the map location. Please try again.")
+        return True
+
+
+# --- DM Upload Flow ---
+
+
+@bot.event
+async def on_message(message: discord.Message) -> None:
+    if message.author.bot:
+        return
+
+    # Only handle DMs
+    if not isinstance(message.channel, discord.DMChannel):
+        return
+
+    # --- Reply-to-share: user replies to a bot upload confirmation and @mentions recipients ---
+    if message.reference and message.mentions:
+        if message.attachments:
+            await message.reply(
+                "Can't share and upload at the same time. "
+                "Reply without an attachment to share, or send the file separately."
+            )
+            return
+        handled = await _handle_reply_to_share(message)
+        if handled:
+            return
+
+    # DM with no attachment — check for Maps URL, then help hint
+    if not message.attachments:
+        user_id = str(message.author.id)
+        if settings.google_maps_enabled:
+            handled = await _handle_maps_url(message, user_id)
+            if handled:
+                return
+
+        await message.reply("Send me a file or Google Maps link to protect it, or reply to a protected resource and @mention users to share.")
+        return
+
+    user_id = str(message.author.id)
+
+    if not rate_limiter.check(user_id):
+        metrics.incr("RateLimitHit")
+        await message.reply("Too many requests. Please wait a moment.")
+        return
+
+    # Warn about multiple attachments
+    if len(message.attachments) > 1:
+        await message.reply(
+            "Please send one file at a time. Only the first attachment will be processed."
+        )
+
+    attachment = message.attachments[0]
+
+    # Validate file size
+    max_bytes = settings.max_file_size_mb * 1024 * 1024
+    if attachment.size > max_bytes:
+        await message.reply(
+            f"File too large. Maximum size is {settings.max_file_size_mb}MB."
+        )
+        return
+
+    # Validate file type
+    content_type = attachment.content_type or ""
+    if not validate_file_type(content_type, attachment.filename):
+        await message.reply(
+            "Unsupported file type. Allowed: PNG, JPG, GIF, WebP, PDF."
+        )
+        return
+
+    # Validate CDN URL (SSRF protection)
+    if not validate_cdn_url(attachment.url, settings.cdn_url_allowlist):
+        await message.reply("Invalid attachment source.")
+        return
+
+    # Sanitize filename
+    safe_filename = sanitize_filename(attachment.filename)
+
+    async with _upload_sem:
+        try:
+            # Download file from Discord CDN with timeout
+            try:
+                file_bytes = await asyncio.wait_for(attachment.read(), timeout=15.0)
+            except asyncio.TimeoutError:
+                await message.reply("Download timed out. Please try again.")
+                return
+
+            # Re-check file size after download (metadata may differ from actual)
+            if len(file_bytes) > max_bytes:
+                await message.reply(f"File too large. Maximum size is {settings.max_file_size_mb}MB.")
+                return
+
+            # Upload to QURL API
+            result = await upload_file(
+                file_bytes=file_bytes,
+                filename=safe_filename,
+                content_type=content_type or "application/octet-stream",
+                owner_id=user_id,
+            )
+
+            # Register ownership in local DB (with expires_at)
+            await asyncio.to_thread(
+                register_owner,
+                result["resource_id"],
+                user_id,
+                None,
+                safe_filename,
+                result.get("expires_at"),
+            )
+
+            metrics.incr("UploadSuccess")
+            logger.info(
+                "upload_success",
+                extra={"audit": {"event": "upload_success", "user": user_id, "resource": result["resource_id"], "filename": safe_filename, "expires": result.get("expires_at", "unknown")}},
+            )
+
+            # Build reply
+            expires_display = _format_discord_ts(result.get("expires_at"))
+
+            await message.reply(
+                f"**Your resource has been protected!**\n\n"
+                f"**{safe_filename}**\n"
+                f"{result['qurl_link']}\n"
+                f"Expires {expires_display}\n\n"
+                f"This link is **single-use**. Once opened, it's consumed.\n\n"
+                f"**To share with others** — reply to this message and @mention them:\n"
+                f"> @alice @bob\n\n"
+                f"Or use `/qurl send` in any server channel (autocomplete will show your resources).\n"
+                f"\\_resource\\_id:{result['resource_id']}\\_"
+            )
+        except (httpx.HTTPStatusError, httpx.TimeoutException) as e:
+            metrics.incr("UploadFailed")
+            logger.error("Upload API error for user %s: %s", user_id, e)
+            await message.reply("Something went wrong. Please try again.")
+        except ValueError as e:
+            logger.error("Upload validation error for user %s: %s", user_id, e)
+            await message.reply("Something went wrong. Please try again.")
+        except Exception:
+            logger.exception("Unexpected upload error for user %s", user_id)
+            await message.reply("Something went wrong. Please try again.")
+
+
+# --- Slash Command Group ---
+
+qurl_group = app_commands.Group(name="qurl", description="Manage QURL protected resources")
+
+
+@qurl_group.command(name="send", description="Send protected resource links to users")
+@app_commands.describe(
+    resource="Select a resource to share (type to search)",
+    users="Users to send links to (@mention or comma-separated IDs)",
+    expires="How long each link lasts (default: 15 minutes)",
+)
+@app_commands.autocomplete(resource=_resource_autocomplete)
+@app_commands.choices(expires=EXPIRY_CHOICES)
+async def qurl_send(
+    interaction: discord.Interaction,
+    resource: str,
+    users: str,
+    expires: Optional[app_commands.Choice[str]] = None,
+) -> None:
+    """Dispatch per-recipient QURL links."""
+    user_id = str(interaction.user.id)
+
+    if not rate_limiter.check(user_id):
+        metrics.incr("RateLimitHit")
+        await interaction.response.send_message(
+            "Too many requests. Please wait a moment.", ephemeral=True
+        )
+        return
+
+    # Defer IMMEDIATELY before any async/DB work (3-second timeout fix)
+    await interaction.response.defer(ephemeral=True)
+
+    # Resolve expiry: Discord enforces choices at UI layer, but validate
+    # server-side as defense-in-depth (e.g. API calls bypassing Discord).
+    expires_value = expires.value if expires else DEFAULT_LINK_EXPIRY
+    if not validate_expires(expires_value):
+        await interaction.followup.send(
+            "Invalid expiry value.", ephemeral=True
+        )
+        return
+
+    metrics.incr(f"ExpiryChoice_{expires_value}")
+
+    # resource param comes from autocomplete (value = resource_id) or manual input
+    rid = resource.lstrip("$").strip()
+
+    # Validate resource_id format
+    if not validate_resource_id(rid):
+        await interaction.followup.send("Invalid resource ID format.", ephemeral=True)
+        return
+
+    # Check ownership (run in thread since SQLite is synchronous)
+    owner_info = await asyncio.to_thread(get_owner, rid)
+    if not owner_info:
+        await interaction.followup.send(
+            f"Resource `{rid}` not found.", ephemeral=True
+        )
+        return
+    if owner_info["discord_user_id"] != user_id:
+        await interaction.followup.send(
+            "You are not the owner of this resource.", ephemeral=True
+        )
+        return
+
+    # Check if resource has expired locally (before wasting API calls)
+    if is_expired(owner_info.get("expires_at")):
+        await interaction.followup.send("This resource has expired.", ephemeral=True)
+        return
+
+    # Guild scoping: bind to first dispatch guild
+    guild_id = str(interaction.guild_id) if interaction.guild_id else None
+
+    # B4: bind_guild returns rowcount — single DB round-trip, no race window
+    if not owner_info.get("guild_id"):
+        if guild_id:
+            bound = await asyncio.to_thread(bind_guild, rid, guild_id)
+            if not bound:
+                await interaction.followup.send(
+                    "This resource was just bound to another server. Please try again.",
+                    ephemeral=True,
+                )
+                return
+    elif owner_info["guild_id"] != guild_id:
+        await interaction.followup.send(
+            "This resource is bound to a different server.", ephemeral=True
+        )
+        return
+
+    # Parse mentioned users — handle commas, mentions, and raw IDs
+    tokens = [t.strip() for t in users.replace(" ", ",").split(",") if t.strip()]
+    parsed_ids = []
+    for token in tokens:
+        # Strip mention wrapper <@!123> or <@123>
+        m = re.match(r"^<@!?(\d+)>$", token)
+        if m:
+            parsed_ids.append(m.group(1))
+        elif token.isdigit():
+            parsed_ids.append(token)
+
+    # Deduplicate while preserving order
+    mentioned_ids = list(dict.fromkeys(parsed_ids))
+
+    # Validate snowflake format
+    mentioned_ids = [uid for uid in mentioned_ids if validate_snowflake(uid)]
+
+    if not mentioned_ids:
+        await interaction.followup.send(
+            "Please mention at least one user.", ephemeral=True
+        )
+        return
+
+    # Max 25 recipients
+    if len(mentioned_ids) > 25:
+        await interaction.followup.send(
+            "Maximum 25 recipients per dispatch.", ephemeral=True
+        )
+        return
+
+    # Filter out self and bot
+    bot_user_id = str(bot.user.id) if bot.user else ""
+    mentioned_ids = [
+        uid for uid in mentioned_ids if uid != user_id and uid != bot_user_id
+    ]
+
+    if not mentioned_ids:
+        await interaction.followup.send("No valid recipients.", ephemeral=True)
+        return
+
+    # Verify guild membership (parallel, shared helper)
+    if interaction.guild:
+        mentioned_ids = await check_guild_members(interaction.guild, mentioned_ids)
+
+    if not mentioned_ids:
+        await interaction.followup.send(
+            "None of the mentioned users are in this server.", ephemeral=True
+        )
+        return
+
+    await interaction.followup.send(
+        f"Dispatching links to {len(mentioned_ids)} user(s)...", ephemeral=True
+    )
+
+    # Use shared dispatch helper
+    tasks = [
+        _dispatch_to_recipient(rid, user_id, uid, guild_id, expires_in=expires_value)
+        for uid in mentioned_ids
+    ]
+    results = await asyncio.gather(*tasks)
+
+    filename = owner_info.get("filename", rid)
+    summary = format_dispatch_summary(filename, results)
+    for part in split_message(summary):
+        await interaction.followup.send(part, ephemeral=True)
+
+
+@qurl_group.command(name="list", description="List your protected resources")
+async def qurl_list(interaction: discord.Interaction) -> None:
+    user_id = str(interaction.user.id)
+    resources = await asyncio.to_thread(list_resources, user_id)
+
+    if not resources:
+        await interaction.response.send_message(
+            "No protected resources found.", ephemeral=True
+        )
+        return
+
+    lines = [f"**Your protected resources ({len(resources)}):**\n"]
+    for r in resources[:20]:  # Limit display
+        filename = r.get("filename", "untitled")
+        expires_ts = _format_discord_ts(r.get("expires_at"), fallback="")
+        expires_display = f" -- expires {expires_ts}" if expires_ts else ""
+        lines.append(f"- **{filename}**{expires_display} (`{r['resource_id']}`)")
+
+    # M7: Add "and N more" indicator when truncated
+    if len(resources) > 20:
+        lines.append(f"\n_...and {len(resources) - 20} more_")
+
+    text = "\n".join(lines)
+    parts = split_message(text)
+    await interaction.response.send_message(parts[0], ephemeral=True)
+    for part in parts[1:]:
+        await interaction.followup.send(part, ephemeral=True)
+
+
+@qurl_group.command(name="revoke", description="Revoke a protected resource")
+@app_commands.describe(resource="Select a resource to revoke (type to search)")
+@app_commands.autocomplete(resource=_resource_autocomplete)
+async def qurl_revoke(interaction: discord.Interaction, resource: str) -> None:
+    resource_id = resource
+    await interaction.response.defer(ephemeral=True)
+    result = await _resolve_owned_resource(interaction, resource_id)
+    if not result:
+        return
+    rid, _ = result
+
+    # M3: Local delete first (idempotent), then upstream
+    await asyncio.to_thread(delete_resource, rid)
+
+    # M4: Inline the httpx call (was _qurl_api_request)
+    upstream_ok = False
+    try:
+        url = f"{settings.mint_link_api_url.rstrip('/')}/{rid}"
+        headers = {"Authorization": f"Bearer {settings.qurl_api_key}"}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.delete(url, headers=headers)
+        if resp.status_code < 300:
+            upstream_ok = True
+        else:
+            logger.warning("Upstream revoke returned %d for %s", resp.status_code, rid)
+    except Exception as e:
+        logger.error("Upstream revoke failed for %s: %s", rid, e)
+
+    if upstream_ok:
+        metrics.incr("RevokeSuccess")
+        logger.info("revoke_success", extra={"audit": {"event": "revoke_success", "user": str(interaction.user.id), "resource": rid}})
+        await interaction.followup.send(f"Resource `{rid}` has been revoked.", ephemeral=True)
+    else:
+        await interaction.followup.send(
+            f"Resource `{rid}` removed locally, but upstream revoke failed. "
+            "The resource may still be active on the server.",
+            ephemeral=True,
+        )
+
+
+@qurl_group.command(name="clear", description="Delete all your protected resources")
+async def qurl_clear(interaction: discord.Interaction) -> None:
+    """Clear all local resources for the invoking user.
+
+    Design decision: only deletes local registry entries, does NOT revoke
+    upstream QURL links. Upstream revocation would require fetching all
+    resources, calling the revoke API for each, and handling partial failures.
+    For MVP, local-only clear with an explicit warning is acceptable.
+    See #31 for future upstream revocation consideration.
+    """
+    await interaction.response.defer(ephemeral=True)
+    user_id = str(interaction.user.id)
+
+    count = await asyncio.to_thread(delete_all_resources, user_id)
+
+    if count == 0:
+        await interaction.followup.send("You have no resources to clear.", ephemeral=True)
+        return
+
+    metrics.incr("ClearSuccess")
+    logger.info(
+        "clear_success",
+        extra={"audit": {"event": "clear_all", "user": user_id, "count": count}},
+    )
+    await interaction.followup.send(
+        f"Cleared **{count}** resource(s) from your local registry.\n\n"
+        "_Note: upstream QURL links may still be active until they expire._",
+        ephemeral=True,
+    )
+
+
+@qurl_group.command(name="status", description="Check status of a protected resource")
+@app_commands.describe(resource="Select a resource to check (type to search)")
+@app_commands.autocomplete(resource=_resource_autocomplete)
+async def qurl_status(interaction: discord.Interaction, resource: str) -> None:
+    resource_id = resource
+    await interaction.response.defer(ephemeral=True)
+    result = await _resolve_owned_resource(interaction, resource_id)
+    if not result:
+        return
+    rid, owner_info = result
+
+    stats = await asyncio.to_thread(get_dispatch_stats, rid)
+
+    # M4: Inline the httpx call (was _qurl_api_request)
+    upstream_lines = []
+    try:
+        url = f"{settings.mint_link_api_url.rstrip('/')}/{rid}"
+        headers = {"Authorization": f"Bearer {settings.qurl_api_key}"}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(url, headers=headers)
+        if resp.status_code == 200:
+            data = resp.json()
+            payload = data.get("data", data)
+            upstream_status = payload.get("status", "unknown")
+            upstream_created = payload.get("created_at", "unknown")
+            upstream_expires = payload.get("expires_at", "unknown")
+            upstream_lines.append(f"- Upstream status: {upstream_status}")
+            upstream_lines.append(f"- Upstream created: {upstream_created}")
+            upstream_lines.append(f"- Upstream expires: {upstream_expires}")
+        else:
+            upstream_lines.append(
+                f"- Upstream status: unavailable (HTTP {resp.status_code})"
+            )
+    except Exception as e:
+        logger.warning("Upstream GET for %s failed: %s", rid, e)
+        upstream_lines.append("- Upstream status: unavailable (request failed)")
+
+    upstream_section = "\n".join(upstream_lines)
+
+    await interaction.followup.send(
+        f"**Status for `{rid}`**\n"
+        f"- Resource: {owner_info.get('filename', 'unknown')}\n"
+        f"- Created: {owner_info['created_at']}\n"
+        f"- Links sent: {stats.get('sent', 0)}\n"
+        f"- Failed: {stats.get('failed', 0)}\n"
+        f"{upstream_section}",
+        ephemeral=True,
+    )
+
+
+@qurl_group.command(name="help", description="Show QURL bot help")
+async def qurl_help(interaction: discord.Interaction) -> None:
+    await interaction.response.send_message(
+        "**Qurl Bot -- Help**\n\n"
+        "DM a file or Maps link to @QurlBot to protect it.\n\n"
+        "**Sharing options:**\n"
+        "  Reply to the bot's DM and @mention users (easiest)\n"
+        "  `/qurl send` -- pick a resource from autocomplete, tag recipients\n\n"
+        "**Other commands:**\n"
+        "  `/qurl list` -- your protected resources\n"
+        "  `/qurl status` -- check link usage\n"
+        "  `/qurl revoke` -- revoke a resource and all links\n"
+        "  `/qurl clear` -- delete all your resources\n"
+        "  `/qurl help` -- show this message\n\n"
+        "Every recipient gets a unique, single-use link by DM.\n"
+        "Links self-destruct on access.",
+        ephemeral=True,
+    )
+
+
+bot.tree.add_command(qurl_group)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -14,6 +14,7 @@ from typing import Optional
 import discord
 import httpx
 from discord import app_commands
+from services.http_client import get_client as get_http_client
 from discord.ext import commands
 
 import metrics
@@ -217,8 +218,8 @@ async def _dispatch_to_recipient(
                 extra={"audit": {"event": "dispatch_sent", "resource": rid, "sender": sender_id, "recipient": recipient_id, "link_hash": link_hash}},
             )
             return (recipient_id, DispatchStatus.SENT, None, recipient.display_name)
-        except (discord.NotFound, discord.Forbidden, httpx.TimeoutException, httpx.HTTPStatusError, Exception) as exc:
-            # Dispatch error bookkeeping — single path for all failure types
+        except (discord.NotFound, discord.Forbidden, httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+            # Known dispatch errors — single bookkeeping path
             _DISPATCH_ERRORS = {
                 discord.NotFound:       (DispatchStatus.DM_FAILED,   "user_not_found", "User not found"),
                 discord.Forbidden:      (DispatchStatus.DM_FAILED,   "dms_disabled",   "DMs disabled"),
@@ -226,10 +227,8 @@ async def _dispatch_to_recipient(
             }
             if type(exc) in _DISPATCH_ERRORS:
                 status, error_code, display = _DISPATCH_ERRORS[type(exc)]
-            elif isinstance(exc, httpx.HTTPStatusError):
-                status, error_code, display = DispatchStatus.MINT_FAILED, f"mint_{exc.response.status_code}", "Failed to mint link"
             else:
-                status, error_code, display = DispatchStatus.MINT_FAILED, "mint_error", "Failed to mint link"
+                status, error_code, display = DispatchStatus.MINT_FAILED, f"mint_{exc.response.status_code}", "Failed to mint link"
             metrics.incr("DispatchFailed")
             logger.info(
                 "dispatch_failed",
@@ -237,6 +236,14 @@ async def _dispatch_to_recipient(
             )
             await asyncio.to_thread(update_dispatch, dispatch_id, status, error_code)
             return (recipient_id, status, display, recipient_id)
+        except Exception:
+            # Unexpected error — log full traceback so bugs surface instead of hiding
+            logger.exception("Unexpected dispatch error for %s -> %s", rid, recipient_id)
+            metrics.incr("DispatchFailed")
+            await asyncio.to_thread(
+                update_dispatch, dispatch_id, DispatchStatus.MINT_FAILED, "unexpected_error"
+            )
+            return (recipient_id, DispatchStatus.MINT_FAILED, "Failed to mint link", recipient_id)
 
 
 async def _handle_reply_to_share(message: discord.Message) -> bool:
@@ -777,8 +784,8 @@ async def qurl_revoke(interaction: discord.Interaction, resource: str) -> None:
     try:
         url = f"{settings.mint_link_api_url.rstrip('/')}/{rid}"
         headers = {"Authorization": f"Bearer {settings.qurl_api_key}"}
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(url, headers=headers)
+        client = get_http_client(timeout=10.0)
+        resp = await client.delete(url, headers=headers)
         if resp.status_code < 300:
             upstream_ok = True
         else:
@@ -847,8 +854,8 @@ async def qurl_status(interaction: discord.Interaction, resource: str) -> None:
     try:
         url = f"{settings.mint_link_api_url.rstrip('/')}/{rid}"
         headers = {"Authorization": f"Bearer {settings.qurl_api_key}"}
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(url, headers=headers)
+        client = get_http_client(timeout=10.0)
+        resp = await client.get(url, headers=headers)
         if resp.status_code == 200:
             data = resp.json()
             payload = data.get("data", data)

--- a/apps/discord/bot_helpers.py
+++ b/apps/discord/bot_helpers.py
@@ -45,16 +45,20 @@ def format_dispatch_summary(filename: str, results: list[tuple]) -> str:
     return "\n".join(lines)
 
 
+_guild_check_sem = asyncio.Semaphore(5)
+
+
 async def check_guild_members(
     guild: discord.Guild, user_ids: list[str]
 ) -> list[str]:
-    """Verify which user_ids are members of a guild. Parallel fetch, returns valid IDs."""
+    """Verify which user_ids are members of a guild. Parallel fetch with rate-limit semaphore."""
     async def _check_one(uid: str) -> str | None:
-        try:
-            await guild.fetch_member(int(uid))
-            return uid
-        except (discord.NotFound, discord.HTTPException):
-            return None
+        async with _guild_check_sem:
+            try:
+                await guild.fetch_member(int(uid))
+                return uid
+            except (discord.NotFound, discord.HTTPException):
+                return None
 
     checks = await asyncio.gather(*[_check_one(uid) for uid in user_ids])
     return [uid for uid in checks if uid]

--- a/apps/discord/bot_helpers.py
+++ b/apps/discord/bot_helpers.py
@@ -1,0 +1,60 @@
+"""Pure helper functions for the QURL Discord Bot.
+
+Extracted from adapters/discord_bot.py so tests can import directly
+without triggering Bot instantiation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime, timezone
+
+import discord
+
+from db import DispatchStatus
+
+# Deterministic marker for resource_id in bot DM messages.
+# Reply-to-share parses this marker — NOT arbitrary backtick-wrapped strings.
+# Format: \_resource\_id:r_xxx\_ on its own line (backslash-escaped to prevent Discord italics).
+RESOURCE_ID_MARKER_RE = re.compile(r"^\\_resource\\_id:(r_[a-zA-Z0-9_-]+)\\_$", re.MULTILINE)
+
+
+def is_expired(expires_at: str | None) -> bool:
+    """Check if a resource has expired based on local expires_at timestamp.
+
+    Returns False when parsing fails — lets the mint API decide.
+    """
+    if not expires_at:
+        return False
+    try:
+        exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        return exp < datetime.now(timezone.utc)
+    except (ValueError, AttributeError):
+        return False
+
+
+def format_dispatch_summary(filename: str, results: list[tuple]) -> str:
+    """Format dispatch results into a summary message."""
+    lines = [f"**Links sent for {filename}:**"]
+    for _uid, status, error, name in results:
+        if status == DispatchStatus.SENT:
+            lines.append(f"- {name} -- sent")
+        else:
+            lines.append(f"- {name} -- {error or status}")
+    return "\n".join(lines)
+
+
+async def check_guild_members(
+    guild: discord.Guild, user_ids: list[str]
+) -> list[str]:
+    """Verify which user_ids are members of a guild. Parallel fetch, returns valid IDs."""
+    async def _check_one(uid: str) -> str | None:
+        try:
+            await guild.fetch_member(int(uid))
+            return uid
+        except (discord.NotFound, discord.HTTPException):
+            return None
+
+    checks = await asyncio.gather(*[_check_one(uid) for uid in user_ids])
+    return [uid for uid in checks if uid]

--- a/apps/discord/bot_helpers.py
+++ b/apps/discord/bot_helpers.py
@@ -45,6 +45,9 @@ def format_dispatch_summary(filename: str, results: list[tuple]) -> str:
     return "\n".join(lines)
 
 
+# Global semaphore for guild member lookups — limits Discord API rate impact.
+# Shared across all users intentionally: Discord's rate limit is per-bot, not per-user.
+# 5 concurrent slots is conservative; increase if 3-second interaction timeouts occur.
 _guild_check_sem = asyncio.Semaphore(5)
 
 

--- a/apps/discord/config.py
+++ b/apps/discord/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     # (upload service type:google-map support) is deployed. Set
     # GOOGLE_MAPS_ENABLED=true in ECS task definition env vars to enable.
     # TODO: read from SSM Parameter Store at runtime for no-redeploy toggle.
-    google_maps_enabled: bool = False
+    google_maps_enabled: bool = True
 
     @field_validator("qurl_link_hostname")
     @classmethod

--- a/apps/discord/config.py
+++ b/apps/discord/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     # (upload service type:google-map support) is deployed. Set
     # GOOGLE_MAPS_ENABLED=true in ECS task definition env vars to enable.
     # TODO: read from SSM Parameter Store at runtime for no-redeploy toggle.
-    google_maps_enabled: bool = True
+    google_maps_enabled: bool = False
 
     @field_validator("qurl_link_hostname")
     @classmethod

--- a/apps/discord/config.py
+++ b/apps/discord/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     qurl_api_key: str
     upload_api_url: str = "https://getqurllink.layerv.ai"
     mint_link_api_url: str = "https://api.layerv.ai/v1/qurls"
+    host: str = "0.0.0.0"
     port: int = 3000
     cdn_url_allowlist: str = "cdn.discordapp.com,media.discordapp.net"
     rate_limit_per_minute: int = 5

--- a/apps/discord/config.py
+++ b/apps/discord/config.py
@@ -1,0 +1,47 @@
+"""Configuration management using pydantic-settings."""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Hostname: lowercase letters, digits, hyphens, dots. No port, no scheme.
+_HOSTNAME_RE = re.compile(r"^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$")
+
+
+class Settings(BaseSettings):
+    discord_bot_token: str
+    discord_client_id: str
+    qurl_api_key: str
+    upload_api_url: str = "https://getqurllink.layerv.ai"
+    mint_link_api_url: str = "https://api.layerv.ai/v1/qurls"
+    port: int = 3000
+    cdn_url_allowlist: str = "cdn.discordapp.com,media.discordapp.net"
+    rate_limit_per_minute: int = 5
+    max_file_size_mb: int = 25
+    db_path: str = "data/qurl_bot.db"
+    sync_commands_globally: bool = False
+    qurl_link_hostname: str = "qurl.link"
+    link_expires_in: str = "15m"
+    # Feature gate: Maps support is disabled by default until Phase 2
+    # (upload service type:google-map support) is deployed. Set
+    # GOOGLE_MAPS_ENABLED=true in ECS task definition env vars to enable.
+    # TODO: read from SSM Parameter Store at runtime for no-redeploy toggle.
+    google_maps_enabled: bool = False
+
+    @field_validator("qurl_link_hostname")
+    @classmethod
+    def _validate_hostname(cls, v: str) -> str:
+        v = v.strip().lower()
+        if not v or not _HOSTNAME_RE.match(v):
+            raise ValueError(f"QURL_LINK_HOSTNAME must be a valid hostname, got: {v!r}")
+        return v
+
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+
+settings = Settings()

--- a/apps/discord/db.py
+++ b/apps/discord/db.py
@@ -34,6 +34,7 @@ def _db_conn():
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
     try:
         yield conn
     finally:

--- a/apps/discord/db.py
+++ b/apps/discord/db.py
@@ -261,7 +261,7 @@ def get_dispatch_stats(resource_id: str) -> dict[str, int]:
         return stats
 
 
-def _prune_old_dispatches() -> int:
+def prune_old_dispatches() -> int:
     """Delete dispatch log entries older than 90 days. Returns count deleted."""
     with _db_conn() as conn:
         cursor = conn.execute(

--- a/apps/discord/db.py
+++ b/apps/discord/db.py
@@ -247,17 +247,16 @@ def get_dispatch_stats(resource_id: str) -> dict[str, int]:
             "SELECT status, COUNT(*) as cnt FROM dispatch_log WHERE resource_id = ? GROUP BY status",
             (resource_id,),
         ).fetchall()
-        stats: dict[str, int] = {}
-        failed_count = 0
+        stats: dict[str, int] = {"sent": 0, "pending": 0, "failed": 0}
         for row in rows:
             status = row["status"]
             count = row["cnt"]
             if status == "sent":
                 stats["sent"] = count
+            elif status == "pending":
+                stats["pending"] = count
             else:
-                failed_count += count
-        stats["sent"] = stats.get("sent", 0)
-        stats["failed"] = failed_count
+                stats["failed"] += count
         return stats
 
 

--- a/apps/discord/db.py
+++ b/apps/discord/db.py
@@ -1,0 +1,280 @@
+"""SQLite persistent storage for owner registry and dispatch log."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import sqlite3
+import stat
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class DispatchStatus:
+    PENDING = "pending"
+    SENT = "sent"
+    DM_FAILED = "dm_failed"
+    MINT_FAILED = "mint_failed"
+
+
+_db_path: str = "data/qurl_bot.db"
+
+
+@contextlib.contextmanager
+def _db_conn():
+    """Open-and-close a SQLite connection per call."""
+    dir_name = os.path.dirname(_db_path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
+    conn = sqlite3.connect(_db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def init_db(db_path: str = "data/qurl_bot.db") -> None:
+    """Initialize database tables."""
+    global _db_path
+    _db_path = db_path
+    with _db_conn() as conn:
+        conn.executescript(
+            """
+            -- NOTE: rebuilt from scratch on container restart / EFS loss.
+            -- Autocomplete UX silently degrades until users re-upload.
+            -- See #31 (item 20) for the planned hydration from qurl-service.
+            CREATE TABLE IF NOT EXISTS owner_registry (
+                resource_id   TEXT PRIMARY KEY,
+                discord_user_id TEXT NOT NULL,
+                guild_id      TEXT,
+                filename      TEXT,
+                expires_at    TEXT,
+                created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS dispatch_log (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                resource_id   TEXT NOT NULL,
+                sender_id     TEXT NOT NULL,
+                recipient_id  TEXT NOT NULL,
+                guild_id      TEXT,
+                dispatch_id   TEXT,
+                link_id_hash  TEXT,
+                status        TEXT NOT NULL DEFAULT 'pending',
+                error         TEXT,
+                created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                completed_at  TEXT,
+                FOREIGN KEY (resource_id) REFERENCES owner_registry(resource_id)
+                    ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_dispatch_resource
+                ON dispatch_log(resource_id, created_at);
+            CREATE INDEX IF NOT EXISTS idx_dispatch_pending
+                ON dispatch_log(status) WHERE status = 'pending';
+            CREATE INDEX IF NOT EXISTS idx_dispatch_id
+                ON dispatch_log(dispatch_id);
+            CREATE INDEX IF NOT EXISTS idx_owners_user
+                ON owner_registry(discord_user_id);
+            """
+        )
+        conn.commit()
+
+    # Set DB file permissions to 0600 (owner read/write only)
+    os.chmod(db_path, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def register_owner(
+    resource_id: str,
+    discord_user_id: str,
+    guild_id: str | None = None,
+    filename: str | None = None,
+    expires_at: str | None = None,
+) -> None:
+    """Register a resource owner. Does nothing if resource_id already exists."""
+    with _db_conn() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO owner_registry
+                (resource_id, discord_user_id, guild_id, filename, expires_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(resource_id) DO NOTHING
+            """,
+            (resource_id, discord_user_id, guild_id, filename, expires_at),
+        )
+        conn.commit()
+        if cursor.rowcount == 0:
+            logger.warning("Resource %s already registered — skipping", resource_id)
+
+
+def get_owner(resource_id: str) -> dict[str, Any] | None:
+    """Get owner info for a resource."""
+    with _db_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM owner_registry WHERE resource_id = ?", (resource_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+
+def list_resources(discord_user_id: str) -> list[dict[str, Any]]:
+    """List all resources owned by a user."""
+    with _db_conn() as conn:
+        rows = conn.execute(
+            "SELECT * FROM owner_registry WHERE discord_user_id = ? ORDER BY created_at DESC",
+            (discord_user_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def search_resources(
+    discord_user_id: str, query: str = "", limit: int = 25
+) -> list[dict[str, Any]]:
+    """Search resources by filename or resource_id. Optimized for autocomplete."""
+    with _db_conn() as conn:
+        if query:
+            # Escape SQL LIKE wildcards so % and _ are treated as literals
+            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            pattern = f"%{escaped}%"
+            rows = conn.execute(
+                """SELECT * FROM owner_registry
+                   WHERE discord_user_id = ?
+                     AND (filename LIKE ? ESCAPE '\\' OR resource_id LIKE ? ESCAPE '\\')
+                   ORDER BY created_at DESC LIMIT ?""",
+                (discord_user_id, pattern, pattern, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT * FROM owner_registry
+                   WHERE discord_user_id = ?
+                   ORDER BY created_at DESC LIMIT ?""",
+                (discord_user_id, limit),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def delete_resource(resource_id: str) -> None:
+    """Delete a resource and its dispatch log entries."""
+    with _db_conn() as conn:
+        conn.execute("DELETE FROM owner_registry WHERE resource_id = ?", (resource_id,))
+        conn.commit()
+
+
+def delete_all_resources(discord_user_id: str) -> int:
+    """Delete all resources owned by a user. Returns the count of deleted resources."""
+    with _db_conn() as conn:
+        cursor = conn.execute(
+            "DELETE FROM owner_registry WHERE discord_user_id = ?",
+            (discord_user_id,),
+        )
+        conn.commit()
+        return cursor.rowcount
+
+
+def bind_guild(resource_id: str, guild_id: str) -> bool:
+    """Bind resource to guild. Returns True if bound, False if already bound to another guild."""
+    with _db_conn() as conn:
+        cursor = conn.execute(
+            "UPDATE owner_registry SET guild_id = ? WHERE resource_id = ? AND guild_id IS NULL",
+            (guild_id, resource_id),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def log_dispatch(
+    resource_id: str,
+    sender_id: str,
+    recipient_id: str,
+    guild_id: str | None = None,
+) -> str:
+    """Log a dispatch attempt. Returns the dispatch_id (UUID)."""
+    dispatch_id = str(uuid.uuid4())
+    with _db_conn() as conn:
+        conn.execute(
+            """
+            INSERT INTO dispatch_log (resource_id, sender_id, recipient_id, guild_id, dispatch_id, status)
+            VALUES (?, ?, ?, ?, ?, 'pending')
+            """,
+            (resource_id, sender_id, recipient_id, guild_id, dispatch_id),
+        )
+        conn.commit()
+    return dispatch_id
+
+
+def update_dispatch(
+    dispatch_id: str,
+    status: str,
+    error: str | None = None,
+    link_id_hash: str | None = None,
+) -> None:
+    """Update a dispatch log entry by dispatch_id."""
+    with _db_conn() as conn:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        conn.execute(
+            """
+            UPDATE dispatch_log
+            SET status = ?, error = ?, link_id_hash = COALESCE(?, link_id_hash), completed_at = ?
+            WHERE dispatch_id = ?
+            """,
+            (status, error, link_id_hash, now, dispatch_id),
+        )
+        conn.commit()
+
+
+def get_pending_dispatches() -> list[dict[str, Any]]:
+    """Get all pending dispatch entries."""
+    with _db_conn() as conn:
+        rows = conn.execute(
+            "SELECT * FROM dispatch_log WHERE status = 'pending' ORDER BY created_at ASC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def get_dispatch_stats(resource_id: str) -> dict[str, int]:
+    """Get dispatch statistics for a resource."""
+    with _db_conn() as conn:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) as cnt FROM dispatch_log WHERE resource_id = ? GROUP BY status",
+            (resource_id,),
+        ).fetchall()
+        stats: dict[str, int] = {}
+        failed_count = 0
+        for row in rows:
+            status = row["status"]
+            count = row["cnt"]
+            if status == "sent":
+                stats["sent"] = count
+            else:
+                failed_count += count
+        stats["sent"] = stats.get("sent", 0)
+        stats["failed"] = failed_count
+        return stats
+
+
+def _prune_old_dispatches() -> int:
+    """Delete dispatch log entries older than 90 days. Returns count deleted."""
+    with _db_conn() as conn:
+        cursor = conn.execute(
+            "DELETE FROM dispatch_log WHERE created_at < datetime('now', '-90 days')"
+        )
+        conn.commit()
+        return cursor.rowcount
+
+
+def recover_stale_dispatches() -> int:
+    """Mark any pending dispatches as failed_recovered (crash recovery)."""
+    with _db_conn() as conn:
+        cursor = conn.execute(
+            "UPDATE dispatch_log SET status = 'failed_recovered' WHERE status = 'pending'"
+        )
+        conn.commit()
+        return cursor.rowcount

--- a/apps/discord/docs/discord_bot_spec.v34.md
+++ b/apps/discord/docs/discord_bot_spec.v34.md
@@ -1,0 +1,463 @@
+# Qurl Discord Bot — Design Document
+
+## 1. Overview
+
+Qurl Bot is a Discord bot developed by LayerV that protects files shared between users by wrapping them in secure, time-limited, single-use QURL links. There are two primary flows:
+
+1. **DM Upload Flow** — A file owner DMs a file directly to Qurl Bot. The bot uploads the file to `getqurllink.layerv.ai`, which stores the file in S3, registers it as a LayerV resource with `fileviewer.layerv.ai` as the access-controlled target, and returns a `resource_id` and `qurl_link`. The bot forwards both to the owner via DM. The owner can then share the `qurl_link` directly with anyone, or use the bot to dispatch per-recipient links.
+
+2. **Group Chat Dispatch Flow** — In a guild channel, a user @mentions Qurl Bot and includes a `resource_id` in the message (see §4.2). The bot does **not** verify resource ownership. It requests minted links from the configured mint-link service (`POST {MINT_LINK_API_URL}/{resource_id}` with `n` equal to the number of DM targets), maps each link to a mentioned user in order, and sends each link by DM. If no users are mentioned, the author receives a single link. No QURL is posted in the channel.
+
+**Key properties:**
+- **Owner-controlled distribution** — only the user who originally uploaded the file can trigger link dispatch
+- **Per-recipient links** — every `@mentioned` user receives their own unique, single-use QURL; no shared links, no replay attacks
+- **Invisible delivery** — links are always delivered by DM; they never appear in public or shared channels
+- **Stable file storage** — files are stored in S3 via `getqurllink.layerv.ai`, avoiding Discord CDN URL expiry
+- **Access-controlled viewing** — `fileviewer.layerv.ai` is the protected target; recipients access the file through the viewer only after their QURL resolves
+- **Self-destructing links** — once a link is clicked it is consumed and ceases to exist
+
+---
+
+## 2. User Scenario
+
+### 2.1 The Treasure Hunting Community
+
+Competitive treasure hunting groups on Discord coordinate in real time, sharing clues in the form of images, hand-drawn maps, annotated PDFs, and cipher sheets. These materials are sensitive by nature — a clue image leaked to the wrong team, cached on Discord's servers, or forwarded by a recipient gives an unfair advantage and undermines the hunt.
+
+The standard Discord workflow has two fundamental problems for this use case:
+
+1. **Permanence** — files uploaded to Discord channels or DMs are stored indefinitely on Discord's CDN. Any participant (or anyone who later gains access to the channel's history) can re-download the file long after it was intended to be seen.
+2. **Cacheability** — Discord generates persistent CDN URLs for attachments. These URLs can be copied, forwarded, indexed, or cached by third-party tools, browser history, and Discord's own servers, entirely outside the sender's control.
+
+**How Qurl Bot solves this:**
+
+A hunt organiser uploads a clue image by DMing it directly to Qurl Bot. The file is stored securely in LayerV's S3 storage — never on Discord's CDN — and wrapped in QURL access control. The organiser receives a `resource_id` and a `qurl_link` back in DM.
+
+When it is time to release the clue to a specific team, the organiser types `@QurlBot #r_abc123def @alice @bob` in the group channel. Each named player receives their own unique, single-use QURL link by DM. When a player clicks the link, the clue renders in `fileviewer.layerv.ai` in their browser — and the link is immediately consumed and destroyed. There is nothing left to forward, cache, or replay.
+
+**A concrete hunt round looks like this:**
+
+> 1. Organiser DMs the clue PDF to Qurl Bot → receives `resource_id: r_clue04` and an owner preview link.
+> 2. Round begins. Organiser posts in `#hunt-channel`: `@QurlBot #r_clue04 @team-alpha`.
+> 3. Each member of `@team-alpha` receives a private DM with their own one-time link. No clue appears in the channel.
+> 4. Players open their links, view the PDF in the browser. Each player's view is watermarked with their unique minted link ID — if anyone screenshots the clue and shares it, the leak can be traced back to the exact recipient. Links self-destruct on access.
+> 5. Ten minutes later, latecomers or rival teams who try the link — or attempt to find it in Discord history — find nothing. The clue has vanished.
+> 6. When the QURL link expires, the underlying file is permanently and irrecoverably destroyed from S3 storage — leaving no copy anywhere in the system.
+
+This model gives hunt organisers precise, per-player control over who sees a clue, when, and exactly once — without any file ever touching Discord's permanent storage. When the QURL link expires, the underlying file is permanently and irrecoverably destroyed from S3 storage — leaving no copy anywhere in the system.
+
+---
+
+## 3. Architecture
+
+### 3.1 Actors
+
+| Actor | Role |
+|---|---|
+| **File Owner** | Discord user who DMs a file to Qurl Bot to register it as a protected resource |
+| **Recipient** | Discord user who receives a one-time QURL link, either directly from the owner or dispatched by the bot |
+| **Qurl Bot** | Discord app (**Python** / **discord.py**). Handles DM file uploads, resource registration, and group chat link dispatch |
+| **Discord API** | Used by the bot to receive file attachments, verify guild membership, and send DMs |
+| **getqurllink.layerv.ai** | LayerV upload service. Accepts a file, stores it in S3, registers `fileviewer.layerv.ai/{file_id}` as a QURL resource, and returns `resource_id` + `qurl_link` |
+| **fileviewer.layerv.ai** | LayerV file viewer. Renders files (PDFs, images, etc.) in the browser; sits behind QURL access control — only reachable via a valid QURL token |
+| **LayerV QURL API** | Existing Go service at `api.layerv.ai`. Used by the bot to mint additional per-recipient links via `POST /v1/qurls/{resource_id}/mint_link` |
+| **Owner Registry** | Persisted map of `resource_id → discord_user_id`, maintained by the bot to enforce ownership on dispatch |
+
+### 3.2 Service Responsibilities
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Qurl Bot                               │
+│  DM Upload ──► getqurllink.layerv.ai ──► resource_id        │
+│                      + qurl_link (owner copy)               │
+│                                                             │
+│  Dispatch  ──► api.layerv.ai/mint_link ──► per-user links   │
+│               (one call per @mentioned user)                │
+└─────────────────────────────────────────────────────────────┘
+
+Recipient clicks qurl_link
+  → QURL resolves token
+  → opens fileviewer.layerv.ai/{file_id}
+  → token consumed (one-time-use)
+```
+
+### 3.3 Flow 1 — DM Upload
+
+```
+File Owner      Qurl Bot          getqurllink.layerv.ai
+     |               |                      |
+     |--DM: file---->|                      |
+     |               |                      |
+     |               |--POST /upload------->|
+     |               |                      |
+     |               |    [store file in S3]|
+     |               |    [register resource]
+     |               |<--{ resource_id,     |
+     |               |    qurl_link,        |
+     |               |    expires_at }------|
+     |               |                      |
+     |               | [store resource_id → discord_user_id]
+     |               |                      |
+     |<--DM: resource_id + qurl_link + expires_at + instructions
+```
+
+### 3.4 Flow 2 — Group Chat Dispatch
+
+```
+File Owner      Qurl Bot         Discord API     api.layerv.ai
+     |               |                |                |
+     |--@QurlBot #r_abc @alice @bob-->|                |
+     |               |                |                |
+     |               | [verify sender == owner of r_abc]
+     |               |                |                |
+     |               | for each @mentioned user:        |
+     |               |--POST /v1/qurls/r_abc/mint_link->|
+     |               |  { expires_in: "15m",            |
+     |               |    one_time_use: true,            |
+     |               |    label: "discord:user_id" }     |
+     |               |<--{ qurl_link, expires_at }-------|
+     |               |                |                |
+     |               |--DM qurl_link to @alice          |
+     |               |--DM qurl_link to @bob            |
+     |               |                |                |
+     |<--ACK (channel): "Links sent to 2 recipients"
+```
+
+---
+
+## 4. Bot Commands & Triggers
+
+### 4.1 DM Upload Trigger
+
+**Trigger:** User sends a DM directly to Qurl Bot containing a file attachment. No slash command needed — the attachment in a DM is the sole trigger.
+
+**Bot DM response:**
+```
+✅ Your file has been protected!
+
+Resource ID:  r_abc123def
+Link:         https://qurl.link/at_xyz789abc
+Expires:      in 7 days
+
+Share this link directly with one person, or send
+individual links to multiple users in a server:
+
+  @QurlBot #r_abc123def @user1 @user2 ...
+```
+
+### 4.2 Group Chat Dispatch Command
+
+**Trigger:** In a guild channel, message matching:
+```
+@QurlBot #<resource_id> @user1 [@user2 ...]
+```
+
+**Example:**
+```
+@QurlBot #r_abc123def @alice @bob @charlie
+```
+
+**Bot channel ACK (visible to all in channel):**
+```
+Links dispatched to 3 users.
+```
+
+**Recipient DM:**
+```
+🔗 You've been granted access to a file.
+
+https://qurl.link/at_def456ghi
+
+Single use · expires in 15 minutes
+```
+
+**Owner DM:**
+```
+✅ Dispatch complete for #r_abc123def
+
+• @alice — sent
+• @bob — sent
+• @charlie — ❌ DMs disabled, could not reach
+```
+
+---
+
+## 5. getqurllink.layerv.ai
+
+Handles the full upload-and-register pipeline. The bot sends a `multipart/form-data` POST with the raw file bytes and metadata; the service stores the file in S3, registers `fileviewer.layerv.ai/{file_id}` as the protected `target_url` on the LayerV QURL API, and returns a ready-to-use `resource_id` and `qurl_link`. The bot never constructs or handles the viewer URL directly.
+
+**Endpoint:** `POST https://getqurllink.layerv.ai/upload`
+**Auth:** `Authorization: Bearer <QURL_API_KEY>`
+**Request:** `multipart/form-data`
+
+| Field | Type | Description |
+|---|---|---|
+| `file` | binary | Raw file bytes fetched from Discord CDN |
+| `filename` | string | Original filename from the Discord attachment |
+| `owner_label` | string | `discord:<user_id>` — for audit trail |
+| `content_type` | string | MIME type of the file |
+
+**Response:**
+```json
+{
+  "resource_id": "r_abc123def",
+  "qurl_link":   "https://qurl.link/at_xyz789abc",
+  "expires_at":  "2026-12-31T23:59:59Z"
+}
+```
+
+**File lifecycle:** When the QURL link expires, `getqurllink.layerv.ai` permanently destroys the underlying file from S3 storage. No copy remains anywhere in the system after expiry.
+
+---
+
+## 6. fileviewer.layerv.ai
+
+A browser-based file viewer that renders protected files behind QURL access control. Recipients reach it only by resolving a valid QURL token — the viewer is not directly accessible by URL. The bot has no direct interaction with this service.
+
+**Access control:** `fileviewer.layerv.ai` has no public address and is not reachable directly from the internet — the only path in is through the QURL resolver and AC proxy chain. Direct access attempts are rejected before they reach the viewer.
+
+```
+Public internet
+─────────────────────────────────────────────────────────────────
+Recipient ──qurl_link──► QURL resolver ──token valid──► AC proxy
+    │                         │                              │
+    │                    invalid → rejected                  │
+    │                                                        │
+    │        ┌─ Private — not routable ─────────────────────┼──┐
+    │        │                                               │  │
+    │   ✕ no direct access                   ┌──────────────▼──┤
+    │        │                               │ fileviewer        │
+    │        │                               │ .layerv.ai        │
+    │        │                               │ renders +         │
+    │        │                               │ watermarks        │
+    │        │                               └──────┬───────────┘
+    │        │                                      │ fetch
+    │        │                               S3 storage
+    │        └──────────────────────────────────────────────────┘
+    │
+    └◄── rendered + watermarked view (via proxy)
+```
+
+**Watermarking:** When rendering a file, `fileviewer.layerv.ai` overlays the minted link ID (e.g. `at_def456ghi`) as a visible watermark on the rendered output. Because each recipient receives their own individually minted link with a unique ID, the watermark is unique per recipient. If a recipient takes a screenshot and the image circulates, the minted link ID in the watermark can be traced back to the exact recipient who leaked it — providing both a deterrent and a forensic audit trail.
+
+**Supported file types:** Images (PNG, JPG, GIF, WebP) and PDF. Additional file types will be supported in future releases.
+
+---
+
+## 7. LayerV QURL API
+
+### 7.1 mint_link
+
+Used exclusively in the dispatch flow to mint per-recipient links against an already-registered resource.
+
+- **Endpoint:** `POST https://api.layerv.ai/v1/qurls/{resource_id}/mint_link`
+- **Auth:** `Authorization: Bearer <QURL_API_KEY>`
+- **Request body:**
+
+```json
+{
+  "expires_in":   "15m",
+  "one_time_use": true,
+  "label":        "discord:RECIPIENT_USER_ID"
+}
+```
+
+- **Response:**
+
+```json
+{
+  "data": {
+    "qurl_link":  "https://qurl.link/at_def456ghi",
+    "expires_at": "2026-12-31T23:59:59Z"
+  }
+}
+```
+
+---
+
+## 8. Components
+
+### 8.1 Qurl Bot (Discord side)
+
+- **Runtime:** Python 3
+- **Framework:** discord.py
+- **Triggers:**
+  - `on_message` on DM channel with attachment → Upload Flow
+  - `on_message` on guild channel with bot mention and parsable `resource_id` → Dispatch Flow (attachments in guild are rejected)
+  - Slash `interaction` handlers exist in code but no commands are registered in the default configuration
+
+**Discord Gateway Intents (required):**
+- `Guilds`
+- `GuildMessages`
+- `MessageContent` ⚠️ — privileged intent; must be enabled in Discord Developer Portal
+- `DirectMessages`
+
+**OAuth2 bot permissions:**
+- `Send Messages`
+- `Send Messages in Threads`
+- `Read Message History`
+- `Use Slash Commands`
+
+### 8.2 Owner Registry
+
+```javascript
+// Production: replace with Redis or Postgres
+const ownerRegistry = new Map();
+// ownerRegistry.set('r_abc123def', '123456789012345678');
+```
+
+---
+
+## 9. Environment Variables
+
+| Variable | Description |
+|---|---|
+| `DISCORD_BOT_TOKEN` | Bot OAuth token. Used only for Discord API calls — never transmitted to LayerV |
+| `DISCORD_CLIENT_ID` | Application client ID, used for slash command registration at startup |
+| `QURL_API_KEY` | LayerV API key (`lv_live_...`). Used to authenticate with both `getqurllink.layerv.ai` and `api.layerv.ai` |
+| `PORT` | HTTP port for health-check endpoint (default: `3000`) |
+
+---
+
+## 10. Source excerpts (`adapters/discord_bot.py` and clients)
+
+```python
+class QURLDiscordBot(discord.Client):
+    def __init__(self, *, intents: discord.Intents):
+        super().__init__(intents=intents)
+        self.tree = app_commands.CommandTree(self)
+
+    async def setup_hook(self):
+        await self.tree.sync()
+
+    async def on_message(self, message: discord.Message):
+        if message.author.bot:
+            return
+        is_dm = isinstance(message.channel, discord.DMChannel)
+        is_mention = self.user and self.user.mentioned_in(message)
+        if not (is_dm or is_mention):
+            return
+        if not is_dm:
+            if message.attachments:
+                await message.channel.send(upload_channel_disabled_message)
+                return
+            if _extract_resource_id(preprocess_text(message.content or "", PLATFORM_DISCORD)):
+                await _handle_mint_link(self, message)
+                return
+            await message.channel.send(mint_link_prompt_message)
+            return
+        if message.attachments:
+            if settings.upload_api_url:
+                await _handle_file_upload(self, message, is_dm=True)
+            return
+        await message.channel.send(upload_only_prompt_message)
+
+
+def run_discord_bot():
+    intents = discord.Intents.default()
+    intents.message_content = True
+    intents.dm_messages = True
+    bot = QURLDiscordBot(intents=intents)
+    bot.run(settings.discord_token)
+```
+
+```python
+# services/mint_link_client.py
+async def mint_links(resource_id: str, n: int = 1, expires_at: str | None = None) -> MintLinkResult:
+    base = (settings.mint_link_api_url or "").rstrip("/")
+    url = f"{base}/{resource_id}"
+    payload = {}
+    if n > 1:
+        payload["n"] = min(max(n, 1), 10)
+    if expires_at:
+        payload["expires_at"] = expires_at
+    async with httpx.AsyncClient(timeout=30.0, verify=False) as client:
+        resp = await client.post(url, json=payload or {})
+```
+
+```python
+# services/upload_client.py
+async def upload_file(file_bytes: bytes, filename: str, content_type: str | None = None) -> UploadResult:
+    base = (settings.upload_api_url or "").rstrip("/")
+    url = f"{base}/api/upload"
+    files = {"file": (filename, file_bytes, content_type or "application/octet-stream")}
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(url, files=files)
+```
+
+---
+
+## 11. Data Flow Summary
+
+```
+Owner DMs file
+  │
+  ▼
+Qurl Bot fetches file bytes from Discord CDN
+  │
+  ▼
+POST getqurllink.layerv.ai/upload
+  │  (stores file in S3, registers fileviewer.layerv.ai/{id} as resource)
+  ▼
+← { resource_id, qurl_link, expires_at }
+  │
+  ├─ Bot stores resource_id → owner in registry
+  └─ Bot DMs owner: resource_id + qurl_link
+
+Owner dispatches in channel: @QurlBot #r_abc @alice @bob
+  │
+  ▼
+Bot verifies ownership
+  │
+  ├─ POST api.layerv.ai/v1/qurls/r_abc/mint_link  (for @alice)
+  │    ← { qurl_link_alice }  →  DM to @alice
+  │
+  └─ POST api.layerv.ai/v1/qurls/r_abc/mint_link  (for @bob)
+       ← { qurl_link_bob }    →  DM to @bob
+
+Recipient clicks link
+  │
+  ▼
+QURL resolves token → opens fileviewer.layerv.ai/{file_id}
+  → token consumed (one-time-use)
+  → file permanently deleted from S3 on expiry
+```
+
+---
+
+## 12. Security Notes
+
+- **Bot token never transmitted to LayerV** — used only for Discord API calls within the bot process
+- **QURL_API_KEY authenticates the bot to LayerV** — no shared secrets, no HMAC, no cross-language contracts
+- **Owner-only dispatch** — the `ownerRegistry` ensures no user can dispatch links for a resource they did not register
+- **Per-recipient single-use links** — each `@mention` triggers a separate `mint_link` call; links cannot be reused or forwarded for second access
+- **Links never in channels** — all QURL links are delivered exclusively by DM
+- **Watermark audit trail** — every minted link carries a unique ID watermarked on the rendered view; leaks are traceable to the exact recipient
+- **Full API audit trail** — every minted link carries `label: discord:<user_id>` for per-user attribution in the LayerV dashboard
+- **File destruction on expiry** — underlying S3 file is permanently deleted when the QURL expires
+- **Rate limiting** — 5 requests/user/minute on both flows
+
+---
+
+## 13. Production Considerations
+
+### 13.1 Owner Registry Persistence
+The in-memory `ownerRegistry` is lost on restart. Persist to Redis or Postgres keyed by `resource_id`, and repopulate from storage on bot startup.
+
+### 13.2 True Ephemeral Channel Replies
+`msg.reply()` in a guild channel is visible to everyone. Migrate the dispatch trigger to a slash command (`/qurl dispatch`) for true `{ ephemeral: true }` replies.
+
+### 13.3 Rate Limiting at Scale
+Replace the in-memory rate limiter with a Redis-backed sliding window for multi-instance production deployments.
+
+### 13.4 Discord Gateway Intents
+`MessageContent` is a privileged intent. It must be explicitly enabled in the Discord Developer Portal under **Bot → Privileged Gateway Intents**, or the dispatch trigger will silently never fire.
+
+---
+
+## 14. Discord Developer Portal Setup
+
+1. Create a new application at https://discord.com/developers/applications
+2. Under **Bot**: enable **Message Content Intent** and **Server Members Intent**
+3. Under **OAuth2 → URL Generator**: select scopes `bot` + `applications.commands`; select bot permissions: `Send Messages`, `Read Message History`, `Use Slash Commands`
+4. Invite the bot to your guild using the generated URL

--- a/apps/discord/docs/discord_bot_spec.v34.md
+++ b/apps/discord/docs/discord_bot_spec.v34.md
@@ -371,7 +371,7 @@ async def mint_links(resource_id: str, n: int = 1, expires_at: str | None = None
         payload["n"] = min(max(n, 1), 10)
     if expires_at:
         payload["expires_at"] = expires_at
-    async with httpx.AsyncClient(timeout=30.0, verify=False) as client:
+    async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(url, json=payload or {})
 ```
 

--- a/apps/discord/docs/discord_bot_spec.v34.zh-CN.md
+++ b/apps/discord/docs/discord_bot_spec.v34.zh-CN.md
@@ -1,0 +1,463 @@
+# Qurl Discord 机器人 — 设计文档
+
+## 1. 概述
+
+Qurl Bot 是 LayerV 开发的 Discord 机器人，通过将文件包装为安全、限时、单次使用的 QURL 链接来保护用户之间共享的文件。主要有两条流程：
+
+1. **私信上传流程** — 文件所有者直接向 Qurl Bot 私信发送文件。机器人将文件上传到 `getqurllink.layerv.ai`，该服务把文件存入 S3，将其注册为 LayerV 资源并以 `fileviewer.layerv.ai` 作为受控访问目标，然后返回 `resource_id` 与 `qurl_link`。机器人通过私信把这两项转发给所有者。所有者可以直接把 `qurl_link` 分享给他人，也可以通过机器人为每位收件人单独分发链接。
+
+2. **群聊分发流程** — 在服务器频道中，用户 @提及 Qurl Bot，并在消息中包含 `resource_id`（见 §4.2）。机器人**不**校验资源所有者。它向已配置的 mint-link 服务请求链接（`POST {MINT_LINK_API_URL}/{resource_id}`，其中 `n` 等于私信目标人数），按顺序将每条链接对应到被 @ 的用户，并通过私信发送。若未 @ 任何用户，则仅向发送者发送一条链接。频道内不会公开发布 QURL。
+
+**关键特性：**
+- **由所有者控制分发** — 只有最初上传文件的用户可以触发链接分发
+- **按收件人独立链接** — 每位被 `@提及` 的用户获得各自唯一、单次使用的 QURL；无共享链接，无重放攻击
+- **不可见投递** — 链接始终通过私信送达；不会出现在公开或共享频道中
+- **稳定文件存储** — 文件经 `getqurllink.layerv.ai` 存入 S3，避免 Discord CDN 链接过期问题
+- **受控访问浏览** — `fileviewer.layerv.ai` 为受保护目标；收件人仅在 QURL 解析通过后通过 viewer 访问文件
+- **链接自毁** — 链接一旦被点击即被消费并不再可用
+
+---
+
+## 2. 用户场景
+
+### 2.1 寻宝社群
+
+竞技类寻宝小队在 Discord 上实时协作，以图片、手绘地图、带批注的 PDF、密码表等形式分享线索。这些材料天然敏感——线索图泄露给错误队伍、缓存在 Discord 服务器上，或被收件人转发，都会破坏公平性。
+
+对此场景而言，常规 Discord 工作流有两个根本问题：
+
+1. **持久性** — 上传到频道或私信的文件会长期留在 Discord CDN 上。任何参与者（或之后获得频道历史访问权限的人）都可以在「本应可见窗口」之后很久仍重新下载文件。
+2. **可缓存性** — Discord 为附件生成持久的 CDN URL。这些 URL 可被第三方工具、浏览器历史、Discord 自身基础设施复制、转发、索引或缓存，完全超出发送者控制。
+
+**Qurl Bot 如何解决：**
+
+组织者将线索图通过私信发给 Qurl Bot。文件安全存放在 LayerV 的 S3 中——**从不**落在 Discord CDN 上——并包在 QURL 访问控制内。组织者会在私信中收到 `resource_id` 与 `qurl_link`。
+
+当需要向某支队伍放出线索时，组织者在群组频道输入 `@QurlBot #r_abc123def @alice @bob`。每位被点名的玩家都会在私信中收到各自唯一、单次使用的 QURL。玩家点击链接后，线索在浏览器中的 `fileviewer.layerv.ai` 内渲染——链接随即被消费并失效，无可转发、缓存或重放。
+
+**一轮具体寻宝可以这样进行：**
+
+> 1. 组织者将线索 PDF 私信发给 Qurl Bot → 收到 `resource_id: r_clue04` 以及所有者预览链接。  
+> 2. 回合开始。组织者在 `#hunt-channel` 发帖：`@QurlBot #r_clue04 @team-alpha`。  
+> 3. `@team-alpha` 的每位成员在私信中收到各自的一次性链接。频道内不会出现线索内容。  
+> 4. 玩家打开链接，在浏览器中查看 PDF。每位玩家的视图都会带有其唯一 mint 链接 ID 的水印——若有人截图外泄，可根据水印追溯到具体收件人。链接在访问后自毁。  
+> 5. 十分钟后，迟到者或对手尝试该链接——或在 Discord 历史里寻找——将一无所获，线索已消失。  
+> 6. 当 QURL 链接过期后，底层文件会从 S3 **永久且不可恢复地删除**——系统中不再保留任何副本。
+
+该模型使组织者可精确控制「谁、在何时、且恰好一次」看到线索——且文件从不进入 Discord 的永久存储。QURL 过期后，底层文件同样会从 S3 永久销毁，系统中不留副本。
+
+---
+
+## 3. 架构
+
+### 3.1 参与方
+
+| 参与方 | 角色 |
+|---|---|
+| **文件所有者** | 向 Qurl Bot 私信上传文件、将其登记为受保护资源的 Discord 用户 |
+| **收件人** | 收到一次性 QURL 的 Discord 用户（由所有者直接分享或由机器人分发） |
+| **Qurl Bot** | Discord 应用（**Python** / **discord.py**）。处理私信上传、资源登记与群聊链接分发 |
+| **Discord API** | 供机器人接收附件、校验服务器成员关系、发送私信等 |
+| **getqurllink.layerv.ai** | LayerV 上传服务。接收文件、存入 S3、将 `fileviewer.layerv.ai/{file_id}` 注册为 QURL 资源，并返回 `resource_id` + `qurl_link` |
+| **fileviewer.layerv.ai** | LayerV 文件查看器。在浏览器中渲染文件（PDF、图片等）；位于 QURL 访问控制之后——仅能通过有效 QURL 令牌访问 |
+| **LayerV QURL API** | 位于 `api.layerv.ai` 的既有 Go 服务。机器人通过 `POST /v1/qurls/{resource_id}/mint_link` 为已登记资源额外 mint 按收件人的链接 |
+| **所有者注册表** | 持久化的 `resource_id → discord_user_id` 映射，由机器人维护，用于在分发时强制执行所有权 |
+
+### 3.2 服务职责
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Qurl Bot                               │
+│  私信上传 ──► getqurllink.layerv.ai ──► resource_id         │
+│                      + qurl_link（所有者副本）               │
+│                                                             │
+│  分发  ──► api.layerv.ai/mint_link ──► 按用户链接           │
+│               （每位 @提及 用户各调用一次）                  │
+└─────────────────────────────────────────────────────────────┘
+
+收件人点击 qurl_link
+  → QURL 解析令牌
+  → 打开 fileviewer.layerv.ai/{file_id}
+  → 令牌被消费（一次性）
+```
+
+### 3.3 流程 1 — 私信上传
+
+```
+文件所有者      Qurl Bot          getqurllink.layerv.ai
+     |               |                      |
+     |--私信: 文件-->|                      |
+     |               |                      |
+     |               |--POST /upload------->|
+     |               |                      |
+     |               |    [文件写入 S3]     |
+     |               |    [注册资源]       |
+     |               |<--{ resource_id,     |
+     |               |    qurl_link,        |
+     |               |    expires_at }------|
+     |               |                      |
+     |               | [保存 resource_id → discord_user_id]
+     |               |                      |
+     |<--私信: resource_id + qurl_link + expires_at + 说明
+```
+
+### 3.4 流程 2 — 群聊分发
+
+```
+文件所有者      Qurl Bot         Discord API     api.layerv.ai
+     |               |                |                |
+     |--@QurlBot #r_abc @alice @bob-->|                |
+     |               |                |                |
+     |               | [校验发送者 == r_abc 的所有者]
+     |               |                |                |
+     |               | 对每位 @提及 用户:              |
+     |               |--POST /v1/qurls/r_abc/mint_link->|
+     |               |  { expires_in: "15m",            |
+     |               |    one_time_use: true,            |
+     |               |    label: "discord:user_id" }     |
+     |               |<--{ qurl_link, expires_at }-------|
+     |               |                |                |
+     |               |--私信 qurl_link 给 @alice        |
+     |               |--私信 qurl_link 给 @bob          |
+     |               |                |                |
+     |<--ACK（频道）: "已向 2 名收件人发送链接"
+```
+
+---
+
+## 4. 机器人命令与触发条件
+
+### 4.1 私信上传触发
+
+**触发：** 用户直接向 Qurl Bot 发送私信，且消息包含文件附件。无需斜杠命令——私信中的附件即为唯一触发条件。
+
+**机器人私信回复示例：**
+```
+✅ Your file has been protected!
+
+Resource ID:  r_abc123def
+Link:         https://qurl.link/at_xyz789abc
+Expires:      in 7 days
+
+Share this link directly with one person, or send
+individual links to multiple users in a server:
+
+  @QurlBot #r_abc123def @user1 @user2 ...
+```
+
+### 4.2 群聊分发命令
+
+**触发：** 在服务器频道中，消息符合：
+```
+@QurlBot #<resource_id> @user1 [@user2 ...]
+```
+
+**示例：**
+```
+@QurlBot #r_abc123def @alice @bob @charlie
+```
+
+**机器人在频道中的确认（频道内所有人可见）：**
+```
+Links dispatched to 3 users.
+```
+
+**收件人私信：**
+```
+🔗 You've been granted access to a file.
+
+https://qurl.link/at_def456ghi
+
+Single use · expires in 15 minutes
+```
+
+**所有者私信：**
+```
+✅ Dispatch complete for #r_abc123def
+
+• @alice — sent
+• @bob — sent
+• @charlie — ❌ DMs disabled, could not reach
+```
+
+---
+
+## 5. getqurllink.layerv.ai
+
+负责完整的上传与注册管线。机器人以 `multipart/form-data` POST 原始文件字节与元数据；服务将文件存入 S3，在 LayerV QURL API 上将 `fileviewer.layerv.ai/{file_id}` 登记为受保护的 `target_url`，并返回可直接使用的 `resource_id` 与 `qurl_link`。机器人从不直接构造或处理 viewer URL。
+
+**端点：** `POST https://getqurllink.layerv.ai/upload`  
+**鉴权：** `Authorization: Bearer <QURL_API_KEY>`  
+**请求：** `multipart/form-data`
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `file` | binary | 从 Discord CDN 拉取的原始文件字节 |
+| `filename` | string | Discord 附件原始文件名 |
+| `owner_label` | string | `discord:<user_id>` — 用于审计 |
+| `content_type` | string | 文件 MIME 类型 |
+
+**响应：**
+```json
+{
+  "resource_id": "r_abc123def",
+  "qurl_link":   "https://qurl.link/at_xyz789abc",
+  "expires_at":  "2026-12-31T23:59:59Z"
+}
+```
+
+**文件生命周期：** 当 QURL 链接过期时，`getqurllink.layerv.ai` 会永久删除 S3 中的底层文件。过期后系统中不再保留任何副本。
+
+---
+
+## 6. fileviewer.layerv.ai
+
+基于浏览器的文件查看器，在 QURL 访问控制后渲染受保护文件。收件人仅能通过解析有效 QURL 令牌到达该 viewer——不能通过普通 URL 直接访问。机器人与此服务无直接交互。
+
+**访问控制：** `fileviewer.layerv.ai` 无公网可直达地址，不能从互联网直接访问——唯一入口为 QURL 解析器与 AC 代理链。在到达 viewer 之前，直接访问尝试会被拒绝。
+
+```
+公网
+─────────────────────────────────────────────────────────────────
+收件人 ──qurl_link──► QURL 解析器 ──令牌有效──► AC 代理
+    │                         │                              │
+    │                    无效 → 拒绝                         │
+    │                                                        │
+    │        ┌─ 私网 — 不可路由 ────────────────────────────┼──┐
+    │        │                                               │  │
+    │   ✕ 不可直连                            ┌──────────────▼──┤
+    │        │                               │ fileviewer        │
+    │        │                               │ .layerv.ai        │
+    │        │                               │ 渲染 +            │
+    │        │                               │ 水印              │
+    │        │                               └──────┬───────────┘
+    │        │                                      │ 拉取
+    │        │                               S3 存储
+    │        └──────────────────────────────────────────────────┘
+    │
+    └◄── 经代理返回：渲染结果 + 水印视图
+```
+
+**水印：** 渲染文件时，`fileviewer.layerv.ai` 将 mint 出的链接 ID（例如 `at_def456ghi`）作为可见水印叠在输出上。因每位收件人获得各自独立 mint、ID 唯一的链接，水印对每位收件人唯一。若收件人截图外泄，水印中的 mint 链接 ID 可追溯到具体泄露者——兼具威慑与取证审计能力。
+
+**支持的文件类型：** 图片（PNG、JPG、GIF、WebP）与 PDF。后续版本将支持更多类型。
+
+---
+
+## 7. LayerV QURL API
+
+### 7.1 mint_link
+
+专用于分发流程：针对已登记资源为每位收件人 mint 链接。
+
+- **端点：** `POST https://api.layerv.ai/v1/qurls/{resource_id}/mint_link`
+- **鉴权：** `Authorization: Bearer <QURL_API_KEY>`
+- **请求体：**
+
+```json
+{
+  "expires_in":   "15m",
+  "one_time_use": true,
+  "label":        "discord:RECIPIENT_USER_ID"
+}
+```
+
+- **响应：**
+
+```json
+{
+  "data": {
+    "qurl_link":  "https://qurl.link/at_def456ghi",
+    "expires_at": "2026-12-31T23:59:59Z"
+  }
+}
+```
+
+---
+
+## 8. 组件
+
+### 8.1 Qurl Bot（Discord 侧）
+
+- **运行时：** Python 3
+- **框架：** discord.py
+- **触发：**
+  - 私信频道 `on_message` 且带附件 → 上传流程
+  - 服务器频道 `on_message` 且 @机器人且可解析 `resource_id` → 分发流程（频道内禁止上传附件）
+  - 斜杠 `interaction` 处理函数存在于代码中，但默认配置下未注册命令
+
+**Discord Gateway Intents（必需）：**
+- `Guilds`
+- `GuildMessages`
+- `MessageContent` ⚠️ — 特权 intent；须在 Discord 开发者门户中启用
+- `DirectMessages`
+
+**OAuth2 机器人权限：**
+- `Send Messages`
+- `Send Messages in Threads`
+- `Read Message History`
+- `Use Slash Commands`
+
+### 8.2 所有者注册表
+
+```javascript
+// 生产环境：可替换为 Redis 或 Postgres
+const ownerRegistry = new Map();
+// ownerRegistry.set('r_abc123def', '123456789012345678');
+```
+
+---
+
+## 9. 环境变量
+
+| 变量 | 说明 |
+|---|---|
+| `DISCORD_BOT_TOKEN` | 机器人 OAuth 令牌。仅用于 Discord API 调用——绝不发往 LayerV |
+| `DISCORD_CLIENT_ID` | 应用 Client ID，用于启动时注册斜杠命令 |
+| `QURL_API_KEY` | LayerV API 密钥（`lv_live_...`）。用于同时向 `getqurllink.layerv.ai` 与 `api.layerv.ai` 鉴权 |
+| `PORT` | 健康检查 HTTP 服务端口（默认：`3000`） |
+
+---
+
+## 10. 源码摘录（`adapters/discord_bot.py` 与客户端）
+
+```python
+class QURLDiscordBot(discord.Client):
+    def __init__(self, *, intents: discord.Intents):
+        super().__init__(intents=intents)
+        self.tree = app_commands.CommandTree(self)
+
+    async def setup_hook(self):
+        await self.tree.sync()
+
+    async def on_message(self, message: discord.Message):
+        if message.author.bot:
+            return
+        is_dm = isinstance(message.channel, discord.DMChannel)
+        is_mention = self.user and self.user.mentioned_in(message)
+        if not (is_dm or is_mention):
+            return
+        if not is_dm:
+            if message.attachments:
+                await message.channel.send(upload_channel_disabled_message)
+                return
+            if _extract_resource_id(preprocess_text(message.content or "", PLATFORM_DISCORD)):
+                await _handle_mint_link(self, message)
+                return
+            await message.channel.send(mint_link_prompt_message)
+            return
+        if message.attachments:
+            if settings.upload_api_url:
+                await _handle_file_upload(self, message, is_dm=True)
+            return
+        await message.channel.send(upload_only_prompt_message)
+
+
+def run_discord_bot():
+    intents = discord.Intents.default()
+    intents.message_content = True
+    intents.dm_messages = True
+    bot = QURLDiscordBot(intents=intents)
+    bot.run(settings.discord_token)
+```
+
+```python
+# services/mint_link_client.py
+async def mint_links(resource_id: str, n: int = 1, expires_at: str | None = None) -> MintLinkResult:
+    base = (settings.mint_link_api_url or "").rstrip("/")
+    url = f"{base}/{resource_id}"
+    payload = {}
+    if n > 1:
+        payload["n"] = min(max(n, 1), 10)
+    if expires_at:
+        payload["expires_at"] = expires_at
+    async with httpx.AsyncClient(timeout=30.0, verify=False) as client:
+        resp = await client.post(url, json=payload or {})
+```
+
+```python
+# services/upload_client.py
+async def upload_file(file_bytes: bytes, filename: str, content_type: str | None = None) -> UploadResult:
+    base = (settings.upload_api_url or "").rstrip("/")
+    url = f"{base}/api/upload"
+    files = {"file": (filename, file_bytes, content_type or "application/octet-stream")}
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(url, files=files)
+```
+
+---
+
+## 11. 数据流摘要
+
+```
+所有者私信发送文件
+  │
+  ▼
+Qurl Bot 从 Discord CDN 拉取文件字节
+  │
+  ▼
+POST getqurllink.layerv.ai/upload
+  │  （写入 S3，将 fileviewer.layerv.ai/{id} 登记为资源）
+  ▼
+← { resource_id, qurl_link, expires_at }
+  │
+  ├─ Bot 保存 resource_id → 所有者 到注册表
+  └─ Bot 私信所有者：resource_id + qurl_link
+
+所有者在频道分发：@QurlBot #r_abc @alice @bob
+  │
+  ▼
+Bot 校验所有权
+  │
+  ├─ POST api.layerv.ai/v1/qurls/r_abc/mint_link  （针对 @alice）
+  │    ← { qurl_link_alice }  →  私信 @alice
+  │
+  └─ POST api.layerv.ai/v1/qurls/r_abc/mint_link  （针对 @bob）
+       ← { qurl_link_bob }    →  私信 @bob
+
+收件人点击链接
+  │
+  ▼
+QURL 解析令牌 → 打开 fileviewer.layerv.ai/{file_id}
+  → 令牌被消费（一次性）
+  → 过期时从 S3 永久删除文件
+```
+
+---
+
+## 12. 安全说明
+
+- **机器人令牌从不发往 LayerV** — 仅在机器人进程内用于 Discord API
+- **QURL_API_KEY 用于向 LayerV 鉴权** — 无共享密钥、无 HMAC、无跨语言契约
+- **仅所有者可分发** — `ownerRegistry` 保证用户不能为他人登记的资源触发分发
+- **按收件人单次链接** — 每次 `@提及` 触发独立的 `mint_link` 调用；链接不可复用或通过转发二次访问
+- **链接永不出现在频道** — 所有 QURL 仅通过私信投递
+- **水印审计** — 每次 mint 的链接在渲染视图上带有唯一 ID 水印；泄露可追溯到具体收件人
+- **完整 API 审计** — 每次 mint 的链接带有 `label: discord:<user_id>`，可在 LayerV 控制台按用户归因
+- **过期即销毁文件** — QURL 过期时底层 S3 文件永久删除
+- **限流** — 两条流程均为每用户每分钟 5 次请求
+
+---
+
+## 13. 生产环境考量
+
+### 13.1 所有者注册表持久化
+内存中的 `ownerRegistry` 在进程重启后会丢失。应以 `resource_id` 为键持久化到 Redis 或 Postgres，并在机器人启动时从存储恢复。
+
+### 13.2 真正的仅自己可见频道回复
+服务器频道中的 `msg.reply()` 对所有人可见。可将分发触发迁移为斜杠命令（如 `/qurl dispatch`），以使用真正的 `{ ephemeral: true }` 回复。
+
+### 13.3 大规模限流
+多实例部署时，应将内存限流器替换为基于 Redis 的滑动窗口。
+
+### 13.4 Discord Gateway Intents
+`MessageContent` 为特权 intent。必须在 Discord 开发者门户 **Bot → Privileged Gateway Intents** 中显式启用，否则分发触发将**静默无法触发**。
+
+---
+
+## 14. Discord 开发者门户配置
+
+1. 在 https://discord.com/developers/applications 创建新应用  
+2. 在 **Bot** 下：启用 **Message Content Intent** 与 **Server Members Intent**  
+3. 在 **OAuth2 → URL Generator**：勾选作用域 `bot` + `applications.commands`；勾选机器人权限：`Send Messages`、`Read Message History`、`Use Slash Commands`  
+4. 使用生成的 URL 将机器人邀请到你的服务器  

--- a/apps/discord/docs/discord_bot_spec.v34.zh-CN.md
+++ b/apps/discord/docs/discord_bot_spec.v34.zh-CN.md
@@ -371,7 +371,7 @@ async def mint_links(resource_id: str, n: int = 1, expires_at: str | None = None
         payload["n"] = min(max(n, 1), 10)
     if expires_at:
         payload["expires_at"] = expires_at
-    async with httpx.AsyncClient(timeout=30.0, verify=False) as client:
+    async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(url, json=payload or {})
 ```
 

--- a/apps/discord/docs/google-maps-support-plan.md
+++ b/apps/discord/docs/google-maps-support-plan.md
@@ -1,0 +1,101 @@
+# Google Maps Support Plan
+
+## Overview
+
+Add Google Maps URL detection and protection to the QURL Discord bot. Users can DM a Google Maps link to the bot, which extracts location data and stores it as a protected QURL resource.
+
+## Design Decision: Option B (Coordinates Only)
+
+Store only coordinates/place query in a JSON payload, NOT the full embed URL. The viewer will inject its own Google Maps API key server-side. This avoids leaking API keys in stored data.
+
+### Stored payload format
+
+```json
+{
+  "type": "google-map",
+  "query": "Seattle, WA",
+  "lat": 47.6062,
+  "lng": -122.3321
+}
+```
+
+## Supported URL Formats
+
+| Format | Example | Extracted |
+|--------|---------|-----------|
+| Place | `google.com/maps/place/Seattle,WA` | query |
+| Place + coords | `google.com/maps/place/Seattle,+WA/@47.6,-122.3,15z` | query + lat/lng |
+| Coordinate | `google.com/maps/@47.6062,-122.3321,15z` | lat/lng |
+| Search | `google.com/maps/search/pizza+near+seattle` | query |
+| Embed | `google.com/maps/embed/v1/place?key=...&q=Seattle,WA` | query |
+| Short links | `goo.gl/maps/...`, `maps.app.goo.gl/...` | detected only (not parsed) |
+
+## Phases
+
+### Phase 1 (Current)
+
+- URL detection and parsing (`services/maps_parser.py`)
+- Integration into DM message handler
+- Upload map metadata as JSON via existing `upload_file` flow
+- Config flag: `GOOGLE_MAPS_ENABLED`
+
+### Phase 2 (Future)
+
+- Short link resolution (follow redirects to get canonical URL)
+- Viewer-side map rendering with server-injected API key
+- Map preview in Discord embed (static map image)
+
+### Phase 3 (Future)
+
+- Directions/route support
+- Street View support
+- Custom map styles
+
+## API Key Security (Required Before Launch)
+
+### Google Cloud Console (manual, 5 minutes)
+1. Go to https://console.cloud.google.com/apis/credentials
+2. Create or select the API key used for Maps Embed API
+3. Under "Application restrictions": set HTTP referrers to `https://fileviewer.layerv.ai/*`
+4. Under "API restrictions": restrict to "Maps Embed API" only
+5. Under "Quotas" (APIs & Services -> Maps Embed API -> Quotas):
+   set daily limit to 1,000 loads/day
+
+### AWS CloudWatch Alarm (add to Terraform)
+Add a CloudWatch alarm for map-resource views:
+- Metric: custom counter `MapResourceViews` emitted by the viewer
+- Threshold: sum > 500 in 1 hour
+- Action: SNS notification to ops team
+
+## Kill Switch
+
+The `GOOGLE_MAPS_ENABLED` env var (config.py) disables all Maps URL handling
+when set to `false`. For ECS deployments: update the env var in the ECS task
+definition and force a new deployment. This is the kill switch until SSM
+Parameter Store runtime reads are implemented.
+
+## Deployment Verification Protocol (Required Before Enabling)
+
+**Do NOT set `GOOGLE_MAPS_ENABLED=true` in any environment until this protocol is completed.**
+
+### Steps
+1. Confirm `GOOGLE_MAPS_ENABLED=false` in ECS task definition (Terraform default)
+2. Upload a test map payload manually:
+   ```bash
+   curl -X POST https://getqurllink.layerv.xyz/api/upload \
+     -F "file=@/dev/stdin;filename=map.json;type=application/json" \
+     <<< '{"type":"google-map","query":"Seattle,WA","lat":47.6,"lng":-122.3}'
+   ```
+3. Retrieve the resource via the returned qurl_link in a browser
+4. **Verify the recipient experience:**
+   - If the recipient sees a rendered map → Phase 2 viewer is deployed, safe to enable
+   - If the recipient sees raw JSON text → Phase 2 NOT deployed, do NOT enable
+   - If the upload returns 4xx → upload service rejects JSON, do NOT enable
+5. Record the result in a comment on the PR that enables the flag
+6. Only then: set `GOOGLE_MAPS_ENABLED=true` in Terraform and deploy
+
+### Why this matters
+If `GOOGLE_MAPS_ENABLED=true` is set before Phase 2 (viewer rendering) is deployed,
+recipients will see raw JSON containing coordinates in plaintext — worse than the
+problem we're solving. The kill switch prevents accidental exposure, but flipping it
+requires this verification.

--- a/apps/discord/metrics.py
+++ b/apps/discord/metrics.py
@@ -112,19 +112,15 @@ async def _flush() -> None:
         )
 
 
-_flush_running = False
+_flush_lock = asyncio.Lock()
 
 
 async def periodic_flush() -> None:
     """Background task that flushes metrics every FLUSH_INTERVAL seconds."""
-    global _flush_running
     while True:
         await asyncio.sleep(_FLUSH_INTERVAL)
-        if _flush_running:
+        if _flush_lock.locked():
             logger.warning("Previous metrics flush still running, skipping this cycle")
             continue
-        _flush_running = True
-        try:
+        async with _flush_lock:
             await _flush()
-        finally:
-            _flush_running = False

--- a/apps/discord/metrics.py
+++ b/apps/discord/metrics.py
@@ -112,15 +112,24 @@ async def _flush() -> None:
         )
 
 
-_flush_lock = asyncio.Lock()
+_flush_lock: asyncio.Lock | None = None
+
+
+def _get_flush_lock() -> asyncio.Lock:
+    """Lazily create flush lock inside the running event loop (Python 3.12 compat)."""
+    global _flush_lock
+    if _flush_lock is None:
+        _flush_lock = asyncio.Lock()
+    return _flush_lock
 
 
 async def periodic_flush() -> None:
     """Background task that flushes metrics every FLUSH_INTERVAL seconds."""
     while True:
         await asyncio.sleep(_FLUSH_INTERVAL)
-        if _flush_lock.locked():
+        lock = _get_flush_lock()
+        if lock.locked():
             logger.warning("Previous metrics flush still running, skipping this cycle")
             continue
-        async with _flush_lock:
+        async with lock:
             await _flush()

--- a/apps/discord/metrics.py
+++ b/apps/discord/metrics.py
@@ -1,0 +1,130 @@
+"""Lightweight CloudWatch custom metrics for QURL Discord Bot.
+
+Buffers metrics in memory and flushes to CloudWatch periodically.
+Falls back to logging if boto3 is unavailable or credentials are missing.
+
+Thread safety: incr() and timing() use a threading.Lock so they are safe
+to call from both the async event loop and asyncio.to_thread() workers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_NAMESPACE = "QurlBot"
+_FLUSH_INTERVAL = 60  # seconds
+_MAX_COUNTER_KEYS = 10_000
+_MAX_TIMING_SAMPLES = 10_000
+
+# In-memory buffers, protected by _sync_lock for thread-safe writes
+_counters: dict[str, float] = {}
+_timings: dict[str, list[float]] = {}
+_sync_lock = threading.Lock()
+
+
+def incr(metric: str, value: float = 1.0) -> None:
+    """Increment a counter metric. Thread-safe."""
+    with _sync_lock:
+        if metric in _counters:
+            _counters[metric] += value
+        elif len(_counters) < _MAX_COUNTER_KEYS:
+            _counters[metric] = value
+        else:
+            logger.warning("Metrics counter buffer full, dropping metric %s", metric)
+
+
+def timing(metric: str, duration_ms: float) -> None:
+    """Record a timing metric in milliseconds. Thread-safe."""
+    with _sync_lock:
+        if metric in _timings:
+            samples = _timings[metric]
+            if len(samples) < _MAX_TIMING_SAMPLES:
+                samples.append(duration_ms)
+        elif len(_timings) < _MAX_COUNTER_KEYS:
+            _timings[metric] = [duration_ms]
+        else:
+            logger.warning("Metrics timing buffer full, dropping metric %s", metric)
+
+
+async def _flush() -> None:
+    """Flush buffered metrics to CloudWatch."""
+    try:
+        import boto3
+    except ImportError:
+        logger.debug("boto3 not available — skipping CloudWatch metrics flush")
+        return
+
+    # Snapshot and reset buffers under the sync lock
+    with _sync_lock:
+        counters = dict(_counters)
+        _counters.clear()
+        timings_snapshot = {k: list(v) for k, v in _timings.items()}
+        _timings.clear()
+
+    if not counters and not timings_snapshot:
+        return
+
+    metric_data: list[dict[str, Any]] = []
+
+    for name, value in counters.items():
+        if value > 0:
+            metric_data.append({
+                "MetricName": name,
+                "Value": value,
+                "Unit": "Count",
+            })
+
+    for name, values in timings_snapshot.items():
+        if values:
+            metric_data.append({
+                "MetricName": name,
+                "StatisticValues": {
+                    "SampleCount": len(values),
+                    "Sum": sum(values),
+                    "Minimum": min(values),
+                    "Maximum": max(values),
+                },
+                "Unit": "Milliseconds",
+            })
+
+    if not metric_data:
+        return
+
+    try:
+        client = boto3.client("cloudwatch")
+        for i in range(0, len(metric_data), 25):
+            await asyncio.to_thread(
+                client.put_metric_data,
+                Namespace=_NAMESPACE,
+                MetricData=metric_data[i : i + 25],
+            )
+        logger.debug("Flushed %d metrics to CloudWatch", len(metric_data))
+    except Exception:
+        logger.error(
+            "metric_flush_failed",
+            extra={"audit": {"event": "metric_flush_failed", "count": len(metric_data)}},
+            exc_info=True,
+        )
+
+
+_flush_running = False
+
+
+async def periodic_flush() -> None:
+    """Background task that flushes metrics every FLUSH_INTERVAL seconds."""
+    global _flush_running
+    while True:
+        await asyncio.sleep(_FLUSH_INTERVAL)
+        if _flush_running:
+            logger.warning("Previous metrics flush still running, skipping this cycle")
+            continue
+        _flush_running = True
+        try:
+            await _flush()
+        finally:
+            _flush_running = False

--- a/apps/discord/rate_limiter.py
+++ b/apps/discord/rate_limiter.py
@@ -1,0 +1,49 @@
+"""Sliding window rate limiter."""
+
+import time
+from collections import defaultdict, deque
+
+
+class RateLimiter:
+    """Per-user sliding window rate limiter."""
+
+    def __init__(self, max_per_minute: int = 5):
+        self.max_per_minute = max_per_minute
+        self._windows: dict[str, deque[float]] = defaultdict(deque)
+        self._call_count = 0
+
+    def check(self, user_id: str) -> bool:
+        """
+        Check if a user is within the rate limit.
+
+        Returns True if the request is allowed, False if rate-limited.
+        Records the request timestamp if allowed.
+        """
+        now = time.monotonic()
+        window = self._windows[user_id]
+
+        # Periodic cleanup every 1000 calls
+        self._call_count += 1
+        if self._call_count % 1000 == 0:
+            self._cleanup(now)
+
+        # Remove timestamps older than 60 seconds
+        cutoff = now - 60.0
+        while window and window[0] < cutoff:
+            window.popleft()
+
+        if len(window) >= self.max_per_minute:
+            return False
+
+        window.append(now)
+        return True
+
+    def _cleanup(self, now: float) -> None:
+        """Remove stale entries from the window map."""
+        stale = [
+            uid
+            for uid, window in self._windows.items()
+            if not window or window[-1] < now - 60
+        ]
+        for uid in stale:
+            del self._windows[uid]

--- a/apps/discord/requirements-dev.txt
+++ b/apps/discord/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.4.2
+pytest-asyncio==0.25.3

--- a/apps/discord/requirements.txt
+++ b/apps/discord/requirements.txt
@@ -3,4 +3,4 @@ httpx==0.28.1
 pydantic-settings==2.8.1
 python-dotenv==1.1.0
 aiohttp==3.13.4
-boto3>=1.34.0
+boto3==1.42.71

--- a/apps/discord/requirements.txt
+++ b/apps/discord/requirements.txt
@@ -1,0 +1,6 @@
+discord.py==2.5.2
+httpx==0.28.1
+pydantic-settings==2.8.1
+python-dotenv==1.1.0
+aiohttp==3.13.4
+boto3>=1.34.0

--- a/apps/discord/requirements.txt
+++ b/apps/discord/requirements.txt
@@ -4,5 +4,3 @@ pydantic-settings==2.8.1
 python-dotenv==1.1.0
 aiohttp==3.13.4
 boto3==1.42.71
-pytest==8.4.2
-pytest-asyncio==1.2.0

--- a/apps/discord/requirements.txt
+++ b/apps/discord/requirements.txt
@@ -4,3 +4,5 @@ pydantic-settings==2.8.1
 python-dotenv==1.1.0
 aiohttp==3.13.4
 boto3==1.42.71
+pytest==8.4.2
+pytest-asyncio==1.2.0

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -166,9 +166,11 @@ async def main() -> None:
         logger.info("Starting Qurl Discord Bot...")
         await bot.start(settings.discord_bot_token)
     finally:
-        metrics_task.cancel()
-        retention_task.cancel()
-        await health_runner.cleanup()
+        if not _shutting_down:
+            # Signal handler didn't run — clean up here
+            metrics_task.cancel()
+            retention_task.cancel()
+            await health_runner.cleanup()
 
 
 if __name__ == "__main__":

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -49,7 +49,7 @@ class ApiKeyRedactor(logging.Filter):
     # M8: Expanded patterns to catch Bearer tokens
     _patterns = [
         re.compile(r"lv_(live|test)_[A-Za-z0-9_\-]+"),
-        re.compile(r"Bearer\s+[A-Za-z0-9._\-]{20,}"),
+        re.compile(r"Bearer\s+\S{10,}"),
     ]
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -143,12 +143,17 @@ async def main() -> None:
     retention_task = asyncio.create_task(_periodic_retention())
     metrics_task = asyncio.create_task(metrics_flush())
 
+    _shutting_down = False
+
     async def shutdown() -> None:
+        nonlocal _shutting_down
+        if _shutting_down:
+            return
+        _shutting_down = True
         logger.info("Shutting down...")
         metrics_task.cancel()
         retention_task.cancel()
         await bot.close()
-        # Close shared HTTP client pool
         from services.http_client import close_client
         await close_client()
         await health_runner.cleanup()

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -12,7 +12,7 @@ import time
 from aiohttp import web
 
 from config import settings
-from db import _prune_old_dispatches, init_db, recover_stale_dispatches
+from db import prune_old_dispatches, init_db, recover_stale_dispatches
 from metrics import periodic_flush as metrics_flush
 
 
@@ -96,9 +96,9 @@ async def start_health_server() -> web.AppRunner:
     app.router.add_get("/ready", ready_handler)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "0.0.0.0", settings.port)
+    site = web.TCPSite(runner, settings.host, settings.port)
     await site.start()
-    logger.info("Health server on 0.0.0.0:%d (/health, /ready)", settings.port)
+    logger.info("Health server on %s:%d (/health, /ready)", settings.host, settings.port)
     return runner
 
 
@@ -107,7 +107,7 @@ async def _periodic_retention() -> None:
     while True:
         await asyncio.sleep(86400)  # 24 hours
         try:
-            deleted = await asyncio.to_thread(_prune_old_dispatches)
+            deleted = await asyncio.to_thread(prune_old_dispatches)
             if deleted:
                 logger.info("Retention: pruned %d old dispatch log entries", deleted)
         except Exception as e:
@@ -153,7 +153,7 @@ async def main() -> None:
         await close_client()
         await health_runner.cleanup()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, lambda: asyncio.create_task(shutdown()))
 

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -1,0 +1,167 @@
+"""Entry point for QURL Discord Bot."""
+
+from __future__ import annotations
+
+import asyncio
+import json as json_mod
+import logging
+import re
+import signal
+import time
+
+from aiohttp import web
+
+from config import settings
+from db import _prune_old_dispatches, init_db, recover_stale_dispatches
+from metrics import periodic_flush as metrics_flush
+
+
+class AuditJsonFormatter(logging.Formatter):
+    """Emit AUDIT log records as structured JSON; all others as plain text.
+
+    Thread-safe: uses a local Formatter for plain text to avoid shared state.
+    """
+
+    _plain_formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    def format(self, record: logging.LogRecord) -> str:
+        audit = getattr(record, "audit", None)
+        if audit and isinstance(audit, dict):
+            entry = {
+                "timestamp": self.formatTime(record),
+                "level": record.levelname,
+                "logger": record.name,
+                "audit": audit,
+            }
+            return json_mod.dumps(entry, default=str)
+        return self._plain_formatter.format(record)
+
+
+handler = logging.StreamHandler()
+handler.setFormatter(AuditJsonFormatter())
+logging.basicConfig(level=logging.INFO, handlers=[handler])
+logger = logging.getLogger(__name__)
+
+
+class ApiKeyRedactor(logging.Filter):
+    """Redact API keys, Discord bot tokens, and Bearer tokens from log messages."""
+
+    # M8: Expanded patterns to catch Bearer tokens
+    _patterns = [
+        re.compile(r"lv_(live|test)_[A-Za-z0-9_\-]+"),
+        re.compile(r"Bearer\s+[A-Za-z0-9._\-]{20,}"),
+    ]
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = self._redact(record.msg) if isinstance(record.msg, str) else record.msg
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {k: self._redact(v) if isinstance(v, str) else v for k, v in record.args.items()}
+            elif isinstance(record.args, tuple):
+                record.args = tuple(self._redact(a) if isinstance(a, str) else a for a in record.args)
+        return True
+
+    def _redact(self, text: str) -> str:
+        for pattern in self._patterns:
+            text = pattern.sub("***REDACTED***", text)
+        return text
+
+
+logging.getLogger().addFilter(ApiKeyRedactor())
+
+start_time: float | None = None
+_bot_ref = None  # set during main()
+
+
+# M10: Separate /health (liveness, always 200) from /ready (readiness)
+async def health_handler(request: web.Request) -> web.Response:
+    """Liveness probe — always returns 200 if the process is running."""
+    uptime = int(time.time() - start_time) if start_time else 0
+    return web.json_response({"status": "ok", "uptime": uptime})
+
+
+async def ready_handler(request: web.Request) -> web.Response:
+    """Readiness probe — returns 200 only when bot is connected to Discord."""
+    ready = _bot_ref is not None and _bot_ref.is_ready()
+    return web.json_response(
+        {"status": "ready" if ready else "not_ready"},
+        status=200 if ready else 503,
+    )
+
+
+async def start_health_server() -> web.AppRunner:
+    """Start the health check HTTP server."""
+    app = web.Application()
+    app.router.add_get("/health", health_handler)
+    app.router.add_get("/ready", ready_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", settings.port)
+    await site.start()
+    logger.info("Health server on 0.0.0.0:%d (/health, /ready)", settings.port)
+    return runner
+
+
+async def _periodic_retention() -> None:
+    """Prune dispatch log entries older than 90 days, every 24 hours."""
+    while True:
+        await asyncio.sleep(86400)  # 24 hours
+        try:
+            deleted = await asyncio.to_thread(_prune_old_dispatches)
+            if deleted:
+                logger.info("Retention: pruned %d old dispatch log entries", deleted)
+        except Exception as e:
+            logger.error("Retention task failed: %s", e)
+
+
+async def main() -> None:
+    global start_time, _bot_ref
+    start_time = time.time()
+
+    # Init database
+    init_db(settings.db_path)
+    logger.info("Database initialized at %s", settings.db_path)
+
+    # M9 / B2: Mark stale pending dispatches as failed_recovered
+    recovered = recover_stale_dispatches()
+    if recovered:
+        logger.warning(
+            "Recovered %d stale pending dispatches from previous run (marked failed_recovered)",
+            recovered,
+        )
+
+    # Start health check
+    health_runner = await start_health_server()
+
+    # Import bot here to ensure config is loaded first
+    # M1: import bot directly (no get_bot() facade)
+    from adapters.discord_bot import bot
+
+    _bot_ref = bot
+
+    # B2: Start periodic retention task
+    retention_task = asyncio.create_task(_periodic_retention())
+    metrics_task = asyncio.create_task(metrics_flush())
+
+    async def shutdown() -> None:
+        logger.info("Shutting down...")
+        metrics_task.cancel()
+        retention_task.cancel()
+        await bot.close()
+        await health_runner.cleanup()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, lambda: asyncio.create_task(shutdown()))
+
+    try:
+        logger.info("Starting Qurl Discord Bot...")
+        await bot.start(settings.discord_bot_token)
+    finally:
+        metrics_task.cancel()
+        retention_task.cancel()
+        await health_runner.cleanup()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -148,6 +148,9 @@ async def main() -> None:
         metrics_task.cancel()
         retention_task.cancel()
         await bot.close()
+        # Close shared HTTP client pool
+        from services.http_client import close_client
+        await close_client()
         await health_runner.cleanup()
 
     loop = asyncio.get_event_loop()

--- a/apps/discord/services/http_client.py
+++ b/apps/discord/services/http_client.py
@@ -1,6 +1,7 @@
 """Shared httpx.AsyncClient with connection pooling.
 
 Reuses TCP+TLS connections across API calls. Created lazily on first use.
+Timeout is set per-request (not per-client) so callers control their own deadlines.
 Must be closed on shutdown via close_client().
 """
 
@@ -11,12 +12,12 @@ import httpx
 _client: httpx.AsyncClient | None = None
 
 
-def get_client(timeout: float = 30.0) -> httpx.AsyncClient:
-    """Get or create the shared AsyncClient."""
+def get_client() -> httpx.AsyncClient:
+    """Get or create the shared AsyncClient. Set timeout per-request, not here."""
     global _client
     if _client is None or _client.is_closed:
         _client = httpx.AsyncClient(
-            timeout=timeout,
+            timeout=30.0,  # default; callers override per-request
             limits=httpx.Limits(
                 max_connections=20,
                 max_keepalive_connections=10,

--- a/apps/discord/services/http_client.py
+++ b/apps/discord/services/http_client.py
@@ -1,0 +1,33 @@
+"""Shared httpx.AsyncClient with connection pooling.
+
+Reuses TCP+TLS connections across API calls. Created lazily on first use.
+Must be closed on shutdown via close_client().
+"""
+
+from __future__ import annotations
+
+import httpx
+
+_client: httpx.AsyncClient | None = None
+
+
+def get_client(timeout: float = 30.0) -> httpx.AsyncClient:
+    """Get or create the shared AsyncClient."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            timeout=timeout,
+            limits=httpx.Limits(
+                max_connections=20,
+                max_keepalive_connections=10,
+            ),
+        )
+    return _client
+
+
+async def close_client() -> None:
+    """Close the shared client. Call on bot shutdown."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+        _client = None

--- a/apps/discord/services/maps_parser.py
+++ b/apps/discord/services/maps_parser.py
@@ -199,6 +199,9 @@ async def resolve_short_link(url: str) -> str | None:
 
     current_url = url
     try:
+        # Intentionally NOT using the shared http_client pool: this resolver
+        # needs follow_redirects=False and isolated connection state for SSRF
+        # safety (each redirect is validated before following).
         async with httpx.AsyncClient(
             timeout=_RESOLVE_TIMEOUT,
             follow_redirects=False,

--- a/apps/discord/services/maps_parser.py
+++ b/apps/discord/services/maps_parser.py
@@ -127,6 +127,9 @@ def validate_coordinates(lat: float | None, lng: float | None) -> bool:
         return False  # One present, one missing
     if lat is None and lng is None:
         return True  # Both absent is valid (query-only)
+    import math
+    if math.isnan(lat) or math.isinf(lat) or math.isnan(lng) or math.isinf(lng):
+        return False
     if lat < -90 or lat > 90:
         return False
     if lng < -180 or lng > 180:

--- a/apps/discord/services/maps_parser.py
+++ b/apps/discord/services/maps_parser.py
@@ -179,11 +179,18 @@ async def resolve_short_link(url: str) -> str | None:
     Follow redirects from a Google Maps short link to get the final URL.
 
     SSRF hardening:
-    - Only follows redirects to allowlisted domains
-    - Blocks private/reserved IPs
+    - Only follows redirects to allowlisted domains (Google/goo.gl only)
+    - Blocks private/reserved IPs via async DNS check
     - Max 3 redirects
     - 3-second timeout
     - Single httpx client reused across hops
+
+    Known limitation (TOCTOU): _is_private_ip() resolves DNS separately from
+    the actual HTTP request. An attacker controlling DNS could return a public
+    IP for the check and a private IP for the request. This is mitigated by
+    the domain allowlist — only Google-owned domains are followed, making DNS
+    rebinding attacks impractical. If the allowlist is ever broadened, this
+    should be replaced with a custom transport that validates resolved IPs.
 
     Returns the final URL or None if resolution fails.
     """

--- a/apps/discord/services/maps_parser.py
+++ b/apps/discord/services/maps_parser.py
@@ -1,0 +1,244 @@
+"""Google Maps URL parser — extracts location data from various Maps URL formats."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from urllib.parse import urlparse, parse_qs, unquote_plus
+
+import httpx
+
+_CONTROL_CHARS_RE = re.compile(r'[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060-\u206f\ufeff]')
+
+
+def sanitize_query(query: str) -> str:
+    """Strip control characters, RTL overrides, zero-width chars, and HTML tags."""
+    # Remove HTML tag pairs and their content (e.g. <script>...</script>)
+    query = re.sub(r'<[^>]+>.*?</[^>]+>', '', query, flags=re.DOTALL)
+    # Remove any remaining standalone HTML tags
+    query = re.sub(r'<[^>]+>', '', query)
+    # Replace newlines/tabs with spaces before stripping control chars
+    query = query.replace('\n', ' ').replace('\r', ' ').replace('\t', ' ')
+    # Remove control characters and unicode formatting chars
+    query = _CONTROL_CHARS_RE.sub('', query)
+    # Collapse whitespace
+    query = ' '.join(query.split())
+    return query.strip()
+
+
+# Match any Google Maps URL loosely (for detection)
+MAPS_URL_RE = re.compile(
+    r'https?://(?:www\.)?(?:maps\.)?google\.com/maps/[^\s]+'
+    r'|https?://(?:goo\.gl/maps|maps\.app\.goo\.gl)/[\w-]+'
+)
+
+
+def detect_maps_url(text: str) -> str | None:
+    """Return the first Google Maps URL found in text, or None."""
+    m = MAPS_URL_RE.search(text)
+    if not m:
+        return None
+    url = m.group(0)
+    # Strip trailing punctuation that's likely part of prose, not the URL
+    url = url.rstrip("!.,;:?'\")]}»")
+    return url
+
+
+_UNSUPPORTED_PATHS = ("/maps/dir/", "/maps/timeline", "/maps/contrib", "/maps/rpc/")
+
+
+def is_unsupported_maps_format(url: str) -> bool:
+    """Check if the URL is a recognized but unsupported Maps format (directions, timeline, etc.)."""
+    if not url:
+        return False
+    parsed = urlparse(url)
+    path = parsed.path
+    return any(path.startswith(p) for p in _UNSUPPORTED_PATHS)
+
+
+def parse_maps_url(url: str) -> dict | None:
+    """
+    Extract location data from a Google Maps URL.
+
+    Returns dict with:
+        query: str | None — place name or search query
+        lat: float | None
+        lng: float | None
+    Or None if the URL is not a recognized Maps format.
+    """
+    if not url:
+        return None
+
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+
+    if host not in ("google.com", "www.google.com", "maps.google.com", "www.maps.google.com"):
+        return None
+
+    path = parsed.path
+    result = {"query": None, "lat": None, "lng": None}
+
+    # Embed URL: extract q= param
+    if "/maps/embed/" in path:
+        params = parse_qs(parsed.query)
+        q = params.get("q", [None])[0]
+        if q:
+            result["query"] = sanitize_query(unquote_plus(q))
+            return result
+        return None
+
+    # Place URL: /maps/place/QUERY[/@lat,lng,zoom]
+    m = re.match(r'/maps/place/([^/@]+)', path)
+    if m:
+        result["query"] = sanitize_query(unquote_plus(m.group(1)))
+        # Try to extract coordinates from the path
+        coord_match = re.search(r'@([-\d.]+),([-\d.]+)', path)
+        if coord_match:
+            try:
+                result["lat"] = float(coord_match.group(1))
+                result["lng"] = float(coord_match.group(2))
+            except ValueError:
+                pass
+        return result
+
+    # Coordinate URL: /maps/@lat,lng,zoom
+    m = re.match(r'/maps/@([-\d.]+),([-\d.]+)', path)
+    if m:
+        try:
+            result["lat"] = float(m.group(1))
+            result["lng"] = float(m.group(2))
+            result["query"] = f"{result['lat']},{result['lng']}"
+            return result
+        except ValueError:
+            return None
+
+    # Search URL: /maps/search/QUERY
+    m = re.match(r'/maps/search/([^/?\s]+)', path)
+    if m:
+        result["query"] = sanitize_query(unquote_plus(m.group(1)))
+        return result
+
+    return None
+
+
+def validate_coordinates(lat: float | None, lng: float | None) -> bool:
+    """Validate latitude and longitude ranges. Both must be present or both None."""
+    if (lat is None) != (lng is None):
+        return False  # One present, one missing
+    if lat is None and lng is None:
+        return True  # Both absent is valid (query-only)
+    if lat < -90 or lat > 90:
+        return False
+    if lng < -180 or lng > 180:
+        return False
+    return True
+
+
+def validate_query(query: str | None) -> bool:
+    """Validate map query string."""
+    if not query:
+        return False
+    # Reject queries that become empty after sanitization
+    if not sanitize_query(query):
+        return False
+    if len(query) > 500:
+        return False
+    return True
+
+
+# --- Short-link resolution with SSRF hardening ---
+
+_ALLOWED_REDIRECT_HOSTS = frozenset({
+    "google.com", "www.google.com",
+    "maps.google.com", "www.maps.google.com",
+    "goo.gl", "maps.app.goo.gl",
+})
+
+_MAX_REDIRECTS = 3
+_RESOLVE_TIMEOUT = 3.0
+
+
+async def _is_private_ip(hostname: str) -> bool:
+    """Check if hostname resolves to a private/reserved/link-local IP (async DNS)."""
+    import asyncio
+    try:
+        loop = asyncio.get_running_loop()
+        infos = await loop.getaddrinfo(hostname, None)
+        for info in infos:
+            addr = info[4][0]
+            ip = ipaddress.ip_address(addr)
+            if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
+                return True
+    except (OSError, ValueError):
+        pass
+    return False
+
+
+async def resolve_short_link(url: str) -> str | None:
+    """
+    Follow redirects from a Google Maps short link to get the final URL.
+
+    SSRF hardening:
+    - Only follows redirects to allowlisted domains
+    - Blocks private/reserved IPs
+    - Max 3 redirects
+    - 3-second timeout
+    - Single httpx client reused across hops
+
+    Returns the final URL or None if resolution fails.
+    """
+    if not url:
+        return None
+
+    current_url = url
+    try:
+        async with httpx.AsyncClient(
+            timeout=_RESOLVE_TIMEOUT,
+            follow_redirects=False,
+            verify=True,
+        ) as client:
+            for _ in range(_MAX_REDIRECTS):
+                parsed = urlparse(current_url)
+                host = (parsed.hostname or "").lower()
+
+                # Domain allowlist
+                if host not in _ALLOWED_REDIRECT_HOSTS:
+                    return None
+
+                # Private IP block
+                if await _is_private_ip(host):
+                    return None
+
+                resp = await client.head(current_url)
+
+                if resp.status_code in (301, 302, 303, 307, 308):
+                    location = resp.headers.get("location")
+                    if not location:
+                        return None
+
+                    # Validate redirect target
+                    next_parsed = urlparse(location)
+                    next_host = (next_parsed.hostname or "").lower()
+                    if next_host not in _ALLOWED_REDIRECT_HOSTS:
+                        return None
+                    if await _is_private_ip(next_host):
+                        return None
+
+                    current_url = location
+                    continue
+
+                # No more redirects — verify the final response is successful
+                if resp.status_code < 400:
+                    return current_url
+                return None  # 4xx/5xx final hop — resolution failed
+
+    except (httpx.HTTPError, httpx.TimeoutException, Exception):
+        return None
+
+    # Exhausted redirect limit — resolution failed
+    return None
+
+
+def is_short_link(url: str) -> bool:
+    """Check if a URL is a Google Maps short link."""
+    return bool(url and ("goo.gl" in url or "maps.app.goo.gl" in url))

--- a/apps/discord/services/mint_link_client.py
+++ b/apps/discord/services/mint_link_client.py
@@ -51,7 +51,10 @@ async def mint_link(
 
     resp.raise_for_status()
 
-    body = resp.json()
+    try:
+        body = resp.json()
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"Mint API returned non-JSON response: {e}") from e
 
     # Support nested "data" envelope
     data = body.get("data", body)

--- a/apps/discord/services/mint_link_client.py
+++ b/apps/discord/services/mint_link_client.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import logging
 from urllib.parse import urlparse
 
-import httpx
-
 from config import settings
+from services.http_client import get_client
 from validation import DEFAULT_LINK_EXPIRY
 
 logger = logging.getLogger(__name__)
@@ -47,8 +46,8 @@ async def mint_link(
         "label": f"discord:{recipient_id}",
     }
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(url, headers=headers, json=payload)
+    client = get_client(timeout=10.0)
+    resp = await client.post(url, headers=headers, json=payload)
 
     resp.raise_for_status()
 
@@ -59,7 +58,7 @@ async def mint_link(
 
     qurl_link = data.get("qurl_link") or data.get("qurlLink")
     if not qurl_link:
-        raise Exception("Mint link response missing qurl_link")
+        raise ValueError("Mint link response missing qurl_link")
 
     # Validate qurl_link hostname (configurable)
     parsed = urlparse(qurl_link)

--- a/apps/discord/services/mint_link_client.py
+++ b/apps/discord/services/mint_link_client.py
@@ -46,8 +46,8 @@ async def mint_link(
         "label": f"discord:{recipient_id}",
     }
 
-    client = get_client(timeout=10.0)
-    resp = await client.post(url, headers=headers, json=payload)
+    client = get_client()
+    resp = await client.post(url, headers=headers, json=payload, timeout=10.0)
 
     resp.raise_for_status()
 

--- a/apps/discord/services/mint_link_client.py
+++ b/apps/discord/services/mint_link_client.py
@@ -1,0 +1,72 @@
+"""Client for mint_link API (generate per-recipient QURL link)."""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+import httpx
+
+from config import settings
+from validation import DEFAULT_LINK_EXPIRY
+
+logger = logging.getLogger(__name__)
+
+
+async def mint_link(
+    resource_id: str, recipient_id: str, expires_in: str | None = None
+) -> dict:
+    """
+    Mint a single-use QURL link for a recipient.
+
+    POST to {mint_link_api_url}/{resource_id}/mint_link
+    Auth: Authorization: Bearer <QURL_API_KEY>
+
+    Args:
+        resource_id: QURL resource ID (e.g. r_abc123def)
+        recipient_id: Discord user ID of the recipient
+        expires_in: Optional duration (e.g. "15m", "1h", "24h"). Defaults to settings.link_expires_in.
+
+    Returns:
+        dict with keys: qurl_link, expires_at
+
+    Raises:
+        Exception on mint failure
+    """
+    base = settings.mint_link_api_url.rstrip("/")
+    url = f"{base}/{resource_id}/mint_link"
+
+    headers = {
+        "Authorization": f"Bearer {settings.qurl_api_key}",
+        "Content-Type": "application/json",
+    }
+
+    payload = {
+        "expires_in": expires_in or DEFAULT_LINK_EXPIRY,
+        "one_time_use": True,
+        "label": f"discord:{recipient_id}",
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(url, headers=headers, json=payload)
+
+    resp.raise_for_status()
+
+    body = resp.json()
+
+    # Support nested "data" envelope
+    data = body.get("data", body)
+
+    qurl_link = data.get("qurl_link") or data.get("qurlLink")
+    if not qurl_link:
+        raise Exception("Mint link response missing qurl_link")
+
+    # Validate qurl_link hostname (configurable)
+    parsed = urlparse(qurl_link)
+    if parsed.scheme != "https" or parsed.hostname != settings.qurl_link_hostname:
+        raise ValueError("Mint API returned invalid qurl_link")
+
+    return {
+        "qurl_link": qurl_link,
+        "expires_at": data.get("expires_at") or data.get("expiresAt", ""),
+    }

--- a/apps/discord/services/upload_client.py
+++ b/apps/discord/services/upload_client.py
@@ -52,8 +52,8 @@ async def upload_file(
         "one_time_use": "true",
     }
 
-    client = get_client(timeout=30.0)
-    resp = await client.post(url, headers=headers, files=files, data=data)
+    client = get_client()
+    resp = await client.post(url, headers=headers, files=files, data=data, timeout=30.0)
 
     resp.raise_for_status()
 

--- a/apps/discord/services/upload_client.py
+++ b/apps/discord/services/upload_client.py
@@ -3,9 +3,8 @@
 import logging
 from urllib.parse import urlparse
 
-import httpx
-
 from config import settings
+from services.http_client import get_client
 from validation import validate_resource_id
 
 logger = logging.getLogger(__name__)
@@ -53,8 +52,8 @@ async def upload_file(
         "one_time_use": "true",
     }
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(url, headers=headers, files=files, data=data)
+    client = get_client(timeout=30.0)
+    resp = await client.post(url, headers=headers, files=files, data=data)
 
     resp.raise_for_status()
 
@@ -67,7 +66,7 @@ async def upload_file(
     qurl_link = payload.get("qurl_link") or payload.get("qurlLink")
 
     if not resource_id or not qurl_link:
-        raise Exception("Upload response missing resource_id or qurl_link")
+        raise ValueError("Upload response missing resource_id or qurl_link")
 
     # Validate resource_id format
     rid = resource_id if isinstance(resource_id, str) else str(resource_id)

--- a/apps/discord/services/upload_client.py
+++ b/apps/discord/services/upload_client.py
@@ -1,0 +1,86 @@
+"""Client for file upload API (POST /upload)."""
+
+import logging
+from urllib.parse import urlparse
+
+import httpx
+
+from config import settings
+from validation import validate_resource_id
+
+logger = logging.getLogger(__name__)
+
+
+async def upload_file(
+    file_bytes: bytes,
+    filename: str,
+    content_type: str,
+    owner_id: str,
+) -> dict:
+    """
+    Upload a file to the QURL upload API.
+
+    POST multipart/form-data to {upload_api_url}/upload
+    Auth: Authorization: Bearer <QURL_API_KEY>
+
+    Args:
+        file_bytes: Raw file content
+        filename: Original filename (sanitized)
+        content_type: MIME type
+        owner_id: Discord user ID for owner labeling
+
+    Returns:
+        dict with keys: resource_id, qurl_link, expires_at
+
+    Raises:
+        Exception on upload failure
+    """
+    base = settings.upload_api_url.rstrip("/")
+    url = f"{base}/upload"
+
+    headers = {
+        "Authorization": f"Bearer {settings.qurl_api_key}",
+    }
+
+    files = {
+        "file": (filename, file_bytes, content_type),
+    }
+
+    data = {
+        "filename": filename,
+        "owner_label": f"discord:{owner_id}",
+        "content_type": content_type,
+        "one_time_use": "true",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, headers=headers, files=files, data=data)
+
+    resp.raise_for_status()
+
+    body = resp.json()
+
+    # Support nested "data" envelope
+    payload = body.get("data", body)
+
+    resource_id = payload.get("resource_id") or payload.get("resourceId")
+    qurl_link = payload.get("qurl_link") or payload.get("qurlLink")
+
+    if not resource_id or not qurl_link:
+        raise Exception("Upload response missing resource_id or qurl_link")
+
+    # Validate resource_id format
+    rid = resource_id if isinstance(resource_id, str) else str(resource_id)
+    if not validate_resource_id(rid):
+        raise ValueError("Upload returned invalid resource_id")
+
+    # Validate qurl_link hostname (configurable)
+    parsed = urlparse(qurl_link)
+    if parsed.scheme != "https" or parsed.hostname != settings.qurl_link_hostname:
+        raise ValueError("API returned qurl_link with unexpected hostname")
+
+    return {
+        "resource_id": rid,
+        "qurl_link": qurl_link,
+        "expires_at": payload.get("expires_at") or payload.get("expiresAt", ""),
+    }

--- a/apps/discord/services/upload_client.py
+++ b/apps/discord/services/upload_client.py
@@ -57,7 +57,10 @@ async def upload_file(
 
     resp.raise_for_status()
 
-    body = resp.json()
+    try:
+        body = resp.json()
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"Upload API returned non-JSON response: {e}") from e
 
     # Support nested "data" envelope
     payload = body.get("data", body)

--- a/apps/discord/tests/conftest.py
+++ b/apps/discord/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Shared test configuration — sets dummy env vars before any module import."""
+
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")

--- a/apps/discord/tests/test_api_key_redactor.py
+++ b/apps/discord/tests/test_api_key_redactor.py
@@ -1,0 +1,56 @@
+"""Tests for ApiKeyRedactor log filter."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from run import ApiKeyRedactor
+
+
+class TestApiKeyRedactor:
+    def setup_method(self):
+        self.redactor = ApiKeyRedactor()
+
+    def _make_record(self, msg, args=None):
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg=msg, args=args, exc_info=None,
+        )
+        return record
+
+    def test_redacts_lasso_live_key(self):
+        record = self._make_record("Key is lv_live_abc123def456_xyz789")
+        self.redactor.filter(record)
+        assert "lv_live_" not in record.msg
+        assert "***REDACTED***" in record.msg
+
+    def test_redacts_lasso_test_key(self):
+        record = self._make_record("Key is lv_test_abc123def456_xyz789")
+        self.redactor.filter(record)
+        assert "lv_test_" not in record.msg
+        assert "***REDACTED***" in record.msg
+
+    def test_redacts_bearer_token(self):
+        record = self._make_record("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature")
+        self.redactor.filter(record)
+        assert "eyJhbG" not in record.msg
+        assert "***REDACTED***" in record.msg
+
+    def test_preserves_normal_messages(self):
+        record = self._make_record("Normal log message with no secrets")
+        self.redactor.filter(record)
+        assert record.msg == "Normal log message with no secrets"
+
+    def test_redacts_in_args_tuple(self):
+        record = self._make_record("User %s key %s", ("user1", "lv_live_secret_key_here"))
+        self.redactor.filter(record)
+        assert "lv_live_" not in str(record.args)
+
+    def test_always_returns_true(self):
+        record = self._make_record("any message")
+        assert self.redactor.filter(record) is True

--- a/apps/discord/tests/test_audit_formatter.py
+++ b/apps/discord/tests/test_audit_formatter.py
@@ -1,0 +1,70 @@
+"""Tests for AuditJsonFormatter and structured AUDIT log events."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from run import AuditJsonFormatter
+
+
+class TestAuditJsonFormatter:
+    def setup_method(self):
+        self.formatter = AuditJsonFormatter()
+
+    def test_audit_record_outputs_json(self):
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="upload_success", args=None, exc_info=None,
+        )
+        record.audit = {"event": "upload_success", "user": "123", "resource": "r_abc"}
+        output = self.formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["audit"]["event"] == "upload_success"
+        assert parsed["audit"]["user"] == "123"
+        assert parsed["level"] == "INFO"
+
+    def test_non_audit_record_outputs_plain_text(self):
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="normal log message", args=None, exc_info=None,
+        )
+        output = self.formatter.format(record)
+        assert "normal log message" in output
+        # Should NOT be JSON
+        assert not output.startswith("{")
+
+    def test_audit_with_non_dict_falls_back_to_plain(self):
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="bad audit", args=None, exc_info=None,
+        )
+        record.audit = "not a dict"
+        output = self.formatter.format(record)
+        assert "bad audit" in output
+        assert not output.startswith("{")
+
+    def test_all_audit_events_have_required_fields(self):
+        """Verify each AUDIT event type includes the expected fields."""
+        events = [
+            {"event": "dispatch_sent", "resource": "r_x", "sender": "s1", "recipient": "r1", "link_hash": "abc123"},
+            {"event": "dispatch_failed", "resource": "r_x", "recipient": "r1", "error": "user_not_found"},
+            {"event": "upload_success", "user": "u1", "resource": "r_x", "filename": "f.pdf", "expires": "2099-01-01"},
+            {"event": "revoke_success", "user": "u1", "resource": "r_x"},
+        ]
+        for audit_data in events:
+            record = logging.LogRecord(
+                name="test", level=logging.INFO, pathname="", lineno=0,
+                msg=audit_data["event"], args=None, exc_info=None,
+            )
+            record.audit = audit_data
+            output = self.formatter.format(record)
+            parsed = json.loads(output)
+            assert parsed["audit"]["event"] == audit_data["event"]
+            for key in audit_data:
+                assert key in parsed["audit"], f"Missing field '{key}' in {audit_data['event']}"

--- a/apps/discord/tests/test_bot_helpers.py
+++ b/apps/discord/tests/test_bot_helpers.py
@@ -1,0 +1,124 @@
+"""Tests for bot_helpers.py — pure helper functions extracted from discord_bot.py."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from db import DispatchStatus
+from bot_helpers import RESOURCE_ID_MARKER_RE, format_dispatch_summary, is_expired
+
+
+class TestIsExpired:
+    def test_none_returns_false(self):
+        assert is_expired(None) is False
+
+    def test_empty_string_returns_false(self):
+        assert is_expired("") is False
+
+    def test_future_timestamp_returns_false(self):
+        assert is_expired("2099-12-31T23:59:59Z") is False
+
+    def test_past_timestamp_returns_true(self):
+        assert is_expired("2020-01-01T00:00:00Z") is True
+
+    def test_z_suffix(self):
+        assert is_expired("2020-06-15T12:00:00Z") is True
+
+    def test_offset_suffix(self):
+        assert is_expired("2020-06-15T12:00:00+00:00") is True
+
+    def test_malformed_returns_false(self):
+        assert is_expired("not-a-date") is False
+
+    def test_integer_returns_false(self):
+        assert is_expired("12345") is False
+
+
+class TestFormatDispatchSummary:
+    def test_all_sent(self):
+        results = [
+            ("123", DispatchStatus.SENT, None, "Alice"),
+            ("456", DispatchStatus.SENT, None, "Bob"),
+        ]
+        summary = format_dispatch_summary("test.pdf", results)
+        assert "**Links sent for test.pdf:**" in summary
+        assert "- Alice -- sent" in summary
+        assert "- Bob -- sent" in summary
+
+    def test_mixed_results(self):
+        results = [
+            ("123", DispatchStatus.SENT, None, "Alice"),
+            ("456", DispatchStatus.DM_FAILED, "DMs disabled", "Bob"),
+            ("789", DispatchStatus.MINT_FAILED, "Failed to mint link", "Charlie"),
+        ]
+        summary = format_dispatch_summary("doc.pdf", results)
+        assert "- Alice -- sent" in summary
+        assert "- Bob -- DMs disabled" in summary
+        assert "- Charlie -- Failed to mint link" in summary
+
+    def test_empty_results(self):
+        summary = format_dispatch_summary("file.png", [])
+        assert "**Links sent for file.png:**" in summary
+        assert summary.count("\n") == 0
+
+    def test_error_fallback_to_status(self):
+        results = [("123", "unknown_status", None, "Dave")]
+        summary = format_dispatch_summary("x.pdf", results)
+        assert "- Dave -- unknown_status" in summary
+
+
+class TestResourceIdMarkerRegex:
+    def test_extracts_from_bot_upload_dm(self):
+        msg = (
+            "**Your resource has been protected!**\n\n"
+            "**test.jpg**\n"
+            "https://qurl.link/at_xxx\n"
+            "Expires <t:1234567890:R>\n\n"
+            "Reply to this message and @mention users to share.\n"
+            "\\_resource\\_id:r_abc123def456\\_"
+        )
+        match = RESOURCE_ID_MARKER_RE.search(msg)
+        assert match is not None
+        assert match.group(1) == "r_abc123def456"
+
+    def test_no_match_without_marker(self):
+        msg = "Some text with `r_abc123def456` in backticks but no marker"
+        match = RESOURCE_ID_MARKER_RE.search(msg)
+        assert match is None
+
+    def test_no_match_for_arbitrary_backtick_resource_id(self):
+        """Regression test: backtick-wrapped resource IDs must NOT match."""
+        msg = "Could not provision `r_invalid_format` because the API returned 500."
+        match = RESOURCE_ID_MARKER_RE.search(msg)
+        assert match is None
+
+    def test_no_match_inline(self):
+        msg = "Something \\_resource\\_id:r_abc123\\_ in the middle of text"
+        match = RESOURCE_ID_MARKER_RE.search(msg)
+        # Only matches if marker is on its own line
+        assert match is None
+
+    def test_matches_with_hyphens_underscores(self):
+        msg = "\\_resource\\_id:r_abc-def_ghi\\_"
+        match = RESOURCE_ID_MARKER_RE.search(msg)
+        assert match is not None
+        assert match.group(1) == "r_abc-def_ghi"
+
+    def test_multiline_message_extracts_correct_id(self):
+        msg = "Some preamble\n\\_resource\\_id:r_first12345\\_\nSome footer"
+        match = RESOURCE_ID_MARKER_RE.search(msg)
+        assert match.group(1) == "r_first12345"
+
+
+class TestAutocompleteLabelTruncation:
+    def test_long_filename_truncated_to_100(self):
+        label = "a" * 120
+        assert len(label[:100]) == 100
+
+    def test_short_filename_fits(self):
+        label = "test.pdf"
+        assert len(label[:100]) == len(label)

--- a/apps/discord/tests/test_check_guild_members.py
+++ b/apps/discord/tests/test_check_guild_members.py
@@ -1,0 +1,64 @@
+"""Tests for _check_guild_members helper."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import discord
+import pytest
+
+from bot_helpers import check_guild_members
+
+
+@pytest.fixture
+def mock_guild():
+    guild = MagicMock(spec=discord.Guild)
+    return guild
+
+
+class TestCheckGuildMembers:
+    @pytest.mark.asyncio
+    async def test_all_members_found(self, mock_guild):
+        mock_guild.fetch_member = AsyncMock(return_value=MagicMock())
+        result = await check_guild_members(mock_guild, ["111", "222", "333"])
+        assert result == ["111", "222", "333"]
+        assert mock_guild.fetch_member.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_some_members_not_found(self, mock_guild):
+        async def fake_fetch(uid):
+            if uid == 222:
+                raise discord.NotFound(MagicMock(), "not found")
+            return MagicMock()
+
+        mock_guild.fetch_member = fake_fetch
+        result = await check_guild_members(mock_guild, ["111", "222", "333"])
+        assert result == ["111", "333"]
+
+    @pytest.mark.asyncio
+    async def test_all_members_not_found(self, mock_guild):
+        mock_guild.fetch_member = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(), "not found")
+        )
+        result = await check_guild_members(mock_guild, ["111", "222"])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_empty_user_list(self, mock_guild):
+        mock_guild.fetch_member = AsyncMock()
+        result = await check_guild_members(mock_guild, [])
+        assert result == []
+        mock_guild.fetch_member.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_exception_treated_as_not_found(self, mock_guild):
+        mock_guild.fetch_member = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(), "server error")
+        )
+        result = await check_guild_members(mock_guild, ["111"])
+        assert result == []

--- a/apps/discord/tests/test_clear_command.py
+++ b/apps/discord/tests/test_clear_command.py
@@ -1,0 +1,127 @@
+"""Tests for /qurl clear command and delete_all_resources DB function."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+from db import (
+    init_db,
+    register_owner,
+    delete_all_resources,
+    list_resources,
+    log_dispatch,
+    get_pending_dispatches,
+    search_resources,
+)
+from adapters.discord_bot import qurl_clear
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    init_db(path)
+    return path
+
+
+class TestDeleteAllResources:
+    def test_deletes_all_user_resources(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "a.png")
+        register_owner("r_bbbbbb123456", "user1", None, "b.png")
+        register_owner("r_cccccc123456", "user1", None, "c.png")
+
+        count = delete_all_resources("user1")
+        assert count == 3
+        assert list_resources("user1") == []
+
+    def test_does_not_delete_other_users(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "a.png")
+        register_owner("r_bbbbbb123456", "user2", None, "b.png")
+
+        count = delete_all_resources("user1")
+        assert count == 1
+        assert list_resources("user1") == []
+        assert len(list_resources("user2")) == 1
+
+    def test_returns_zero_when_no_resources(self, db_path):
+        count = delete_all_resources("user_with_nothing")
+        assert count == 0
+
+    def test_cascade_deletes_dispatch_log(self, db_path):
+        """ON DELETE CASCADE should remove dispatch_log entries when resource is deleted."""
+        register_owner("r_aaaaaa123456", "user1", None, "a.png")
+        log_dispatch("r_aaaaaa123456", "user1", "recipient1", None)
+        log_dispatch("r_aaaaaa123456", "user1", "recipient2", None)
+
+        delete_all_resources("user1")
+
+        # dispatch_log entries should be cascade-deleted
+        pending = get_pending_dispatches()
+        assert len([d for d in pending if d["resource_id"] == "r_aaaaaa123456"]) == 0
+
+    def test_autocomplete_empty_after_clear(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "photo.png")
+        register_owner("r_bbbbbb123456", "user1", None, "doc.pdf")
+
+        delete_all_resources("user1")
+        results = search_resources("user1", "", 25)
+        assert results == []
+
+
+class TestQURLClearCommand:
+    @pytest.fixture(autouse=True)
+    def mock_infra(self):
+        with patch("adapters.discord_bot.metrics"), \
+             patch("adapters.discord_bot.delete_all_resources") as mock_delete:
+            self.mock_delete = mock_delete
+            yield
+
+    @pytest.mark.asyncio
+    async def test_clear_with_resources(self):
+        self.mock_delete.return_value = 5
+        interaction = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 111222333444555666
+        interaction.response = AsyncMock()
+        interaction.followup = AsyncMock()
+
+        await qurl_clear.callback(interaction)
+
+        self.mock_delete.assert_called_once()
+        interaction.followup.send.assert_called_once()
+        msg = interaction.followup.send.call_args.args[0]
+        assert "5" in msg
+        assert "Cleared" in msg
+
+    @pytest.mark.asyncio
+    async def test_clear_with_no_resources(self):
+        self.mock_delete.return_value = 0
+        interaction = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 111222333444555666
+        interaction.response = AsyncMock()
+        interaction.followup = AsyncMock()
+
+        await qurl_clear.callback(interaction)
+
+        interaction.followup.send.assert_called_once()
+        msg = interaction.followup.send.call_args.args[0]
+        assert "no resources" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_clear_is_ephemeral(self):
+        self.mock_delete.return_value = 3
+        interaction = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 111222333444555666
+        interaction.response = AsyncMock()
+        interaction.followup = AsyncMock()
+
+        await qurl_clear.callback(interaction)
+
+        interaction.response.defer.assert_called_once_with(ephemeral=True)
+        assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True

--- a/apps/discord/tests/test_db.py
+++ b/apps/discord/tests/test_db.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 import pytest
 from db import init_db, register_owner, get_owner, list_resources, delete_resource, bind_guild, log_dispatch, update_dispatch, get_dispatch_stats
 

--- a/apps/discord/tests/test_db.py
+++ b/apps/discord/tests/test_db.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+import pytest
+from db import init_db, register_owner, get_owner, list_resources, delete_resource, bind_guild, log_dispatch, update_dispatch, get_dispatch_stats
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    init_db(path)
+    return path
+
+class TestOwnerRegistry:
+    def test_register_and_get(self, db_path):
+        register_owner("r_test123456", "user1", None, "test.png", "2026-12-31T00:00:00Z")
+        owner = get_owner("r_test123456")
+        assert owner is not None
+        assert owner["discord_user_id"] == "user1"
+
+    def test_conflict_does_not_replace(self, db_path):
+        register_owner("r_test123456", "user1", None, "test.png")
+        register_owner("r_test123456", "user2", None, "other.png")  # should be ignored
+        owner = get_owner("r_test123456")
+        assert owner["discord_user_id"] == "user1"  # not user2
+
+    def test_list_resources(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "a.png")
+        register_owner("r_bbbbbb123456", "user1", None, "b.png")
+        resources = list_resources("user1")
+        assert len(resources) == 2
+
+    def test_delete(self, db_path):
+        register_owner("r_test123456", "user1", None, "test.png")
+        delete_resource("r_test123456")
+        assert get_owner("r_test123456") is None
+
+    def test_bind_guild(self, db_path):
+        register_owner("r_test123456", "user1", None, "test.png")
+        result = bind_guild("r_test123456", "guild1")
+        assert result is True
+        owner = get_owner("r_test123456")
+        assert owner["guild_id"] == "guild1"
+
+    def test_bind_guild_no_overwrite(self, db_path):
+        register_owner("r_test123456", "user1", "guild1", "test.png")
+        result = bind_guild("r_test123456", "guild2")  # should not overwrite
+        assert result is False
+        owner = get_owner("r_test123456")
+        assert owner["guild_id"] == "guild1"
+
+class TestDispatchLog:
+    def test_log_and_update(self, db_path):
+        register_owner("r_test123456", "user1", None, "test.png")
+        dispatch_id = log_dispatch("r_test123456", "sender1", "recipient1", "guild1")
+        assert isinstance(dispatch_id, str)
+        assert len(dispatch_id) == 36  # UUID format
+        update_dispatch(dispatch_id, "sent")
+        stats = get_dispatch_stats("r_test123456")
+        assert stats["sent"] >= 1

--- a/apps/discord/tests/test_db_extended.py
+++ b/apps/discord/tests/test_db_extended.py
@@ -110,8 +110,8 @@ class TestGetDispatchStats:
 
         stats = get_dispatch_stats("r_stats_test1")
         assert stats["sent"] == 2
-        # pending + dm_failed = 2
-        assert stats["failed"] == 2
+        assert stats["pending"] == 1  # d4 still pending
+        assert stats["failed"] == 1   # d3 dm_failed
 
     def test_no_dispatches_returns_zeros(self, db_path):
         register_owner("r_stats_empty1", "user1", None, "file.png")
@@ -192,7 +192,8 @@ class TestFullRegisterDispatchStatsRoundtrip:
 
         stats = get_dispatch_stats("r_roundtrip01")
         assert stats["sent"] == 1
-        assert stats["failed"] == 2  # dm_failed + pending
+        assert stats["pending"] == 1  # d3 still pending
+        assert stats["failed"] == 1   # d2 dm_failed
 
 
 # --- B5 / M9: recover_stale_dispatches ---

--- a/apps/discord/tests/test_db_extended.py
+++ b/apps/discord/tests/test_db_extended.py
@@ -1,0 +1,220 @@
+"""Extended tests for db.py — covers bind_guild, get_pending_dispatches,
+get_dispatch_stats, DispatchStatus constants, init_db edge cases,
+expires_at round-trip, full round-trip, and recover_stale_dispatches."""
+
+import os
+import stat
+import tempfile
+
+import pytest
+
+from db import (
+    DispatchStatus,
+    bind_guild,
+    get_dispatch_stats,
+    get_owner,
+    get_pending_dispatches,
+    init_db,
+    log_dispatch,
+    recover_stale_dispatches,
+    register_owner,
+    update_dispatch,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = str(tmp_path / "test_ext.db")
+    init_db(path)
+    return path
+
+
+# --- DispatchStatus constants ---
+
+
+class TestDispatchStatusConstants:
+    def test_pending(self):
+        assert DispatchStatus.PENDING == "pending"
+
+    def test_sent(self):
+        assert DispatchStatus.SENT == "sent"
+
+    def test_dm_failed(self):
+        assert DispatchStatus.DM_FAILED == "dm_failed"
+
+    def test_mint_failed(self):
+        assert DispatchStatus.MINT_FAILED == "mint_failed"
+
+
+# --- bind_guild ---
+
+
+class TestBindGuild:
+    def test_bind_guild_when_null(self, db_path):
+        register_owner("r_bind_null_01", "user1", None, "file.png")
+        result = bind_guild("r_bind_null_01", "guild_abc")
+        assert result is True
+        owner = get_owner("r_bind_null_01")
+        assert owner["guild_id"] == "guild_abc"
+
+    def test_bind_guild_does_not_overwrite(self, db_path):
+        register_owner("r_bind_exist1", "user1", "guild_original", "file.png")
+        result = bind_guild("r_bind_exist1", "guild_attacker")
+        assert result is False
+        owner = get_owner("r_bind_exist1")
+        assert owner["guild_id"] == "guild_original"
+
+    def test_bind_guild_nonexistent_resource(self, db_path):
+        # Should not raise — just a no-op UPDATE, returns False
+        result = bind_guild("r_does_not_exist", "guild_x")
+        assert result is False
+
+
+# --- get_pending_dispatches ---
+
+
+class TestGetPendingDispatches:
+    def test_returns_only_pending(self, db_path):
+        register_owner("r_pend_test01", "user1", None, "file.png")
+        d1 = log_dispatch("r_pend_test01", "sender", "recip1")
+        d2 = log_dispatch("r_pend_test01", "sender", "recip2")
+        d3 = log_dispatch("r_pend_test01", "sender", "recip3")
+
+        # Mark d1 as sent, d3 as failed — only d2 stays pending
+        update_dispatch(d1, DispatchStatus.SENT)
+        update_dispatch(d3, DispatchStatus.MINT_FAILED, "error")
+
+        pending = get_pending_dispatches()
+        assert len(pending) == 1
+        assert pending[0]["dispatch_id"] == d2
+
+    def test_empty_when_none_pending(self, db_path):
+        assert get_pending_dispatches() == []
+
+
+# --- get_dispatch_stats ---
+
+
+class TestGetDispatchStats:
+    def test_counts_correctly(self, db_path):
+        register_owner("r_stats_test1", "user1", None, "file.png")
+        d1 = log_dispatch("r_stats_test1", "s", "r1")
+        d2 = log_dispatch("r_stats_test1", "s", "r2")
+        d3 = log_dispatch("r_stats_test1", "s", "r3")
+        d4 = log_dispatch("r_stats_test1", "s", "r4")
+
+        update_dispatch(d1, DispatchStatus.SENT)
+        update_dispatch(d2, DispatchStatus.SENT)
+        update_dispatch(d3, DispatchStatus.DM_FAILED, "blocked")
+        # d4 stays pending
+
+        stats = get_dispatch_stats("r_stats_test1")
+        assert stats["sent"] == 2
+        # pending + dm_failed = 2
+        assert stats["failed"] == 2
+
+    def test_no_dispatches_returns_zeros(self, db_path):
+        register_owner("r_stats_empty1", "user1", None, "file.png")
+        stats = get_dispatch_stats("r_stats_empty1")
+        assert stats["sent"] == 0
+        assert stats["failed"] == 0
+
+
+# --- init_db edge cases ---
+
+
+class TestInitDbEdgeCases:
+    def test_reinit_with_different_path(self, tmp_path):
+        """Calling init_db twice with different paths should use the new database."""
+        path1 = str(tmp_path / "db1.db")
+        path2 = str(tmp_path / "db2.db")
+        init_db(path1)
+        register_owner("r_init_close1", "user1", None, "file.png")
+        assert get_owner("r_init_close1") is not None
+
+        # Re-init with a different path
+        init_db(path2)
+        # Old data is gone (new database)
+        assert get_owner("r_init_close1") is None
+
+    def test_sets_file_permissions(self, tmp_path):
+        path = str(tmp_path / "perms.db")
+        init_db(path)
+        mode = os.stat(path).st_mode
+        # Should be 0600 (owner read/write only)
+        assert mode & (stat.S_IRUSR | stat.S_IWUSR) == (stat.S_IRUSR | stat.S_IWUSR)
+        assert not (mode & stat.S_IRGRP)
+        assert not (mode & stat.S_IROTH)
+
+
+# --- expires_at round-trip ---
+
+
+class TestRegisterOwnerExpiresAt:
+    def test_stores_and_retrieves_expires_at(self, db_path):
+        register_owner(
+            "r_expire_test1", "user1", None, "file.png", "2026-12-31T00:00:00Z"
+        )
+        owner = get_owner("r_expire_test1")
+        assert owner["expires_at"] == "2026-12-31T00:00:00Z"
+
+    def test_none_expires_at(self, db_path):
+        register_owner("r_expire_none1", "user1", None, "file.png", None)
+        owner = get_owner("r_expire_none1")
+        assert owner["expires_at"] is None
+
+
+# --- B5: Full register → dispatch → stats round-trip ---
+
+
+class TestFullRegisterDispatchStatsRoundtrip:
+    def test_full_register_dispatch_stats_roundtrip(self, db_path):
+        """register_owner -> log_dispatch -> update_dispatch -> get_dispatch_stats"""
+        register_owner("r_roundtrip01", "user1", "guild1", "test.pdf", "2026-06-01T00:00:00Z")
+
+        owner = get_owner("r_roundtrip01")
+        assert owner is not None
+        assert owner["discord_user_id"] == "user1"
+        assert owner["guild_id"] == "guild1"
+
+        d1 = log_dispatch("r_roundtrip01", "user1", "recip1", "guild1")
+        d2 = log_dispatch("r_roundtrip01", "user1", "recip2", "guild1")
+        d3 = log_dispatch("r_roundtrip01", "user1", "recip3", "guild1")
+
+        # UUID format
+        assert isinstance(d1, str) and len(d1) == 36
+        assert isinstance(d2, str) and len(d2) == 36
+        assert d1 != d2 != d3
+
+        update_dispatch(d1, DispatchStatus.SENT)
+        update_dispatch(d2, DispatchStatus.DM_FAILED, "DMs disabled")
+        # d3 stays pending
+
+        stats = get_dispatch_stats("r_roundtrip01")
+        assert stats["sent"] == 1
+        assert stats["failed"] == 2  # dm_failed + pending
+
+
+# --- B5 / M9: recover_stale_dispatches ---
+
+
+class TestRecoverStaleDispatches:
+    def test_marks_pending_as_failed_recovered(self, db_path):
+        register_owner("r_recover_001", "user1", None, "file.png")
+        d1 = log_dispatch("r_recover_001", "user1", "recip1")
+        d2 = log_dispatch("r_recover_001", "user1", "recip2")
+        d3 = log_dispatch("r_recover_001", "user1", "recip3")
+
+        # Mark d1 as sent — should not be affected
+        update_dispatch(d1, DispatchStatus.SENT)
+
+        # d2 and d3 are still pending
+        recovered = recover_stale_dispatches()
+        assert recovered == 2
+
+        # No more pending
+        pending = get_pending_dispatches()
+        assert len(pending) == 0
+
+    def test_returns_zero_when_nothing_pending(self, db_path):
+        assert recover_stale_dispatches() == 0

--- a/apps/discord/tests/test_db_extended.py
+++ b/apps/discord/tests/test_db_extended.py
@@ -4,7 +4,6 @@ expires_at round-trip, full round-trip, and recover_stale_dispatches."""
 
 import os
 import stat
-import tempfile
 
 import pytest
 
@@ -101,7 +100,7 @@ class TestGetDispatchStats:
         d1 = log_dispatch("r_stats_test1", "s", "r1")
         d2 = log_dispatch("r_stats_test1", "s", "r2")
         d3 = log_dispatch("r_stats_test1", "s", "r3")
-        d4 = log_dispatch("r_stats_test1", "s", "r4")
+        log_dispatch("r_stats_test1", "s", "r4")
 
         update_dispatch(d1, DispatchStatus.SENT)
         update_dispatch(d2, DispatchStatus.SENT)
@@ -203,8 +202,8 @@ class TestRecoverStaleDispatches:
     def test_marks_pending_as_failed_recovered(self, db_path):
         register_owner("r_recover_001", "user1", None, "file.png")
         d1 = log_dispatch("r_recover_001", "user1", "recip1")
-        d2 = log_dispatch("r_recover_001", "user1", "recip2")
-        d3 = log_dispatch("r_recover_001", "user1", "recip3")
+        log_dispatch("r_recover_001", "user1", "recip2")
+        log_dispatch("r_recover_001", "user1", "recip3")
 
         # Mark d1 as sent — should not be affected
         update_dispatch(d1, DispatchStatus.SENT)

--- a/apps/discord/tests/test_dispatch_errors.py
+++ b/apps/discord/tests/test_dispatch_errors.py
@@ -1,0 +1,120 @@
+"""Tests for consolidated dispatch error handling."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import discord
+import httpx
+import pytest
+
+from adapters.discord_bot import _dispatch_to_recipient, qurl_send
+from db import DispatchStatus
+from validation import validate_expires
+
+
+@pytest.fixture(autouse=True)
+def mock_infra():
+    """Mock infrastructure deps so _dispatch_to_recipient can run."""
+    with patch("adapters.discord_bot.log_dispatch", return_value="d-1"), \
+         patch("adapters.discord_bot.update_dispatch"), \
+         patch("adapters.discord_bot.metrics"):
+        yield
+
+
+class TestDispatchErrors:
+    @pytest.mark.asyncio
+    async def test_not_found_returns_dm_failed(self):
+        with patch("adapters.discord_bot.bot") as mock_bot:
+            mock_bot.fetch_user = AsyncMock(
+                side_effect=discord.NotFound(MagicMock(), "not found")
+            )
+            _, status, error, _ = await _dispatch_to_recipient(
+                "r_test123456", "111222333", "444555666", None
+            )
+        assert status == DispatchStatus.DM_FAILED
+        assert error == "User not found"
+
+    @pytest.mark.asyncio
+    async def test_forbidden_returns_dm_failed(self):
+        recipient = AsyncMock()
+        recipient.send = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "dms disabled")
+        )
+        with patch("adapters.discord_bot.bot") as mock_bot, \
+             patch("adapters.discord_bot.mint_link", new_callable=AsyncMock,
+                    return_value={"qurl_link": "https://qurl.link/at_x", "expires_at": ""}):
+            mock_bot.fetch_user = AsyncMock(return_value=recipient)
+            _, status, error, _ = await _dispatch_to_recipient(
+                "r_test123456", "111222333", "444555666", None
+            )
+        assert status == DispatchStatus.DM_FAILED
+        assert error == "DMs disabled"
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_mint_failed(self):
+        with patch("adapters.discord_bot.bot") as mock_bot, \
+             patch("adapters.discord_bot.mint_link", new_callable=AsyncMock,
+                    side_effect=httpx.TimeoutException("timeout")):
+            mock_bot.fetch_user = AsyncMock(return_value=MagicMock())
+            _, status, error, _ = await _dispatch_to_recipient(
+                "r_test123456", "111222333", "444555666", None
+            )
+        assert status == DispatchStatus.MINT_FAILED
+        assert error == "Failed to mint link"
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_mint_error(self):
+        with patch("adapters.discord_bot.bot") as mock_bot, \
+             patch("adapters.discord_bot.mint_link", new_callable=AsyncMock,
+                    side_effect=RuntimeError("unexpected")):
+            mock_bot.fetch_user = AsyncMock(return_value=MagicMock())
+            _, status, error, _ = await _dispatch_to_recipient(
+                "r_test123456", "111222333", "444555666", None
+            )
+        assert status == DispatchStatus.MINT_FAILED
+        assert error == "Failed to mint link"
+
+
+class TestExpiryRejectionPath:
+    """Even with Discord choices, verify server-side validation rejects invalid values."""
+
+    def test_invalid_expiry_blocked_by_validate_expires(self):
+        """An invalid expiry value must not pass validate_expires (defense-in-depth)."""
+        invalid_values = ["99m", "2h", "30d", "", "abc", None]
+        for val in invalid_values:
+            assert validate_expires(val) is False, f"Expected rejection for {val!r}"
+
+    @pytest.mark.asyncio
+    async def test_invalid_expiry_does_not_reach_dispatch(self):
+        """Simulate a crafted API call with an invalid expiry bypassing Discord UI.
+
+        The handler should reject before calling _dispatch_to_recipient.
+        """
+        interaction = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 111222333444555666
+        interaction.guild_id = None
+        interaction.guild = None
+        interaction.response = AsyncMock()
+        interaction.followup = AsyncMock()
+
+        # Create a fake Choice object with an invalid value
+        fake_choice = MagicMock()
+        fake_choice.value = "99m"  # not in EXPIRY_CHOICES_VALUES
+
+        with patch("adapters.discord_bot.rate_limiter") as mock_rl, \
+             patch("adapters.discord_bot._dispatch_to_recipient", new_callable=AsyncMock) as mock_dispatch:
+            mock_rl.check = MagicMock(return_value=True)
+            await qurl_send.callback(interaction, "r_test123456", "<@444555666>", expires=fake_choice)
+
+        # _dispatch_to_recipient must NOT have been called
+        mock_dispatch.assert_not_called()
+        # Should have sent an ephemeral rejection
+        interaction.followup.send.assert_called_once()
+        assert "invalid" in interaction.followup.send.call_args.args[0].lower()

--- a/apps/discord/tests/test_helpers.py
+++ b/apps/discord/tests/test_helpers.py
@@ -1,0 +1,109 @@
+"""Tests for helper functions and constants from adapters/discord_bot.py.
+
+We test the pure logic inline rather than importing from discord_bot.py,
+because that module creates a Bot instance on import (which requires a
+running event loop and valid Discord token). The logic tested here mirrors
+the actual implementation.
+"""
+
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from datetime import datetime, timezone
+
+
+class TestFormatDiscordTs:
+    """Test the _format_discord_ts logic (mirrored from discord_bot.py)."""
+
+    @staticmethod
+    def _format_discord_ts(iso_str, fallback="unknown"):
+        if not iso_str:
+            return fallback
+        try:
+            dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+            return f"<t:{int(dt.timestamp())}:R>"
+        except (ValueError, AttributeError):
+            return iso_str
+
+    def test_valid_iso_z(self):
+        result = self._format_discord_ts("2026-12-31T23:59:59Z")
+        assert result.startswith("<t:")
+        assert result.endswith(":R>")
+        # The timestamp should parse to a valid integer
+        ts_str = result[3:-3]
+        assert ts_str.isdigit() or (ts_str.startswith("-") and ts_str[1:].isdigit())
+
+    def test_valid_iso_with_offset(self):
+        result = self._format_discord_ts("2026-06-15T12:00:00+00:00")
+        assert result.startswith("<t:")
+        assert result.endswith(":R>")
+
+    def test_none_returns_fallback(self):
+        assert self._format_discord_ts(None) == "unknown"
+        assert self._format_discord_ts(None, fallback="N/A") == "N/A"
+
+    def test_empty_string_returns_fallback(self):
+        assert self._format_discord_ts("") == "unknown"
+
+    def test_invalid_iso_returns_original(self):
+        result = self._format_discord_ts("not-a-date")
+        assert result == "not-a-date"
+
+    def test_known_timestamp_value(self):
+        # 2026-01-01T00:00:00Z = 1767225600 unix
+        dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        expected_ts = int(dt.timestamp())
+        result = self._format_discord_ts("2026-01-01T00:00:00Z")
+        assert result == f"<t:{expected_ts}:R>"
+
+    def test_fallback_in_15_minutes(self):
+        """M6: When expires_at is empty, fallback should be deterministic."""
+        result = self._format_discord_ts("", fallback="in 15 minutes")
+        assert result == "in 15 minutes"
+
+        result = self._format_discord_ts(None, fallback="in 15 minutes")
+        assert result == "in 15 minutes"
+
+
+class TestConfigValidation:
+    """Test that missing required config fields raise an error."""
+
+    def test_missing_bot_token_raises(self):
+        from pydantic import ValidationError
+        from config import Settings
+
+        import pytest
+        with pytest.raises(ValidationError):
+            Settings(
+                discord_bot_token=None,  # type: ignore[arg-type]
+                discord_client_id="123",
+                qurl_api_key="lv_test_x",
+            )
+
+    def test_missing_api_key_raises(self):
+        from pydantic import ValidationError
+        from config import Settings
+
+        import pytest
+        with pytest.raises(ValidationError):
+            Settings(
+                discord_bot_token="tok",
+                discord_client_id="123",
+                qurl_api_key=None,  # type: ignore[arg-type]
+            )
+
+    def test_defaults_applied(self):
+        from config import Settings
+
+        s = Settings(
+            discord_bot_token="tok",
+            discord_client_id="123",
+            qurl_api_key="lv_test_x",
+        )
+        assert s.port == 3000
+        assert s.max_file_size_mb == 25
+        assert s.sync_commands_globally is False
+        assert s.qurl_link_hostname == "qurl.link"

--- a/apps/discord/tests/test_maps_integration.py
+++ b/apps/discord/tests/test_maps_integration.py
@@ -1,6 +1,5 @@
 """Integration tests for the on_message Google Maps flow in discord_bot.py."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/apps/discord/tests/test_maps_integration.py
+++ b/apps/discord/tests/test_maps_integration.py
@@ -1,0 +1,234 @@
+"""Integration tests for the on_message Google Maps flow in discord_bot.py."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_message(content: str = "", attachments=None):
+    """Create a mock Discord DM message."""
+    msg = AsyncMock()
+    msg.author = MagicMock()
+    msg.author.bot = False
+    msg.author.id = 123456789012345678
+    msg.content = content
+    msg.attachments = attachments or []
+    msg.channel = MagicMock()
+    msg.channel.__class__.__name__ = "DMChannel"
+    # Prevent reply-to-share handler from triggering
+    msg.reference = None
+    msg.mentions = []
+    msg.reply = AsyncMock()
+    return msg
+
+
+@pytest.fixture
+def mock_settings():
+    with patch("adapters.discord_bot.settings") as mock:
+        mock.google_maps_enabled = True
+        mock.max_file_size_mb = 25
+        mock.cdn_url_allowlist = "cdn.discordapp.com"
+        mock.rate_limit_per_minute = 5
+        mock.link_expires_in = "15m"
+        yield mock
+
+
+@pytest.fixture
+def mock_upload():
+    with patch("adapters.discord_bot.upload_file", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "resource_id": "r_map_test12345",
+            "qurl_link": "https://qurl.link/at_map_abc",
+            "expires_at": "2026-12-31T00:00:00Z",
+        }
+        yield mock
+
+
+@pytest.fixture
+def mock_register():
+    with patch("adapters.discord_bot.register_owner") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_rate_limiter():
+    with patch("adapters.discord_bot.rate_limiter") as mock:
+        mock.check = MagicMock(return_value=True)
+        yield mock
+
+
+class TestMapsIntegration:
+    @pytest.mark.asyncio
+    async def test_maps_url_detected_and_uploaded(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """A DM with a Google Maps URL should upload map metadata and reply with resource info."""
+        msg = _make_message("https://www.google.com/maps/place/Seattle,WA check this out")
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_called_once()
+        call_kw = mock_upload.call_args.kwargs if mock_upload.call_args.kwargs else {}
+        assert b"google-map" in call_kw.get("file_bytes", b"")
+
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "single-use link" in reply_text.lower()
+        assert "qurl.link" in reply_text
+
+    @pytest.mark.asyncio
+    async def test_maps_url_captures_annotation(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """Surrounding text (annotation) should be captured in the upload payload."""
+        msg = _make_message("https://www.google.com/maps/place/Seattle,WA this is where the treasure is buried")
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_called_once()
+        import json
+        call_kw = mock_upload.call_args.kwargs if mock_upload.call_args.kwargs else {}
+        payload = json.loads(call_kw.get("file_bytes", b"{}"))
+        assert payload.get("caption") == "this is where the treasure is buried"
+
+    @pytest.mark.asyncio
+    async def test_maps_url_upload_failure(
+        self, mock_settings, mock_register, mock_rate_limiter
+    ):
+        """Upload failure should show a generic error, not internal details."""
+        msg = _make_message("https://www.google.com/maps/place/Seattle,WA")
+
+        with patch("adapters.discord_bot.upload_file", new_callable=AsyncMock, side_effect=Exception("API down")), \
+             patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "something went wrong" in reply_text.lower()
+        assert "API down" not in reply_text
+
+    @pytest.mark.asyncio
+    async def test_maps_disabled_shows_help(
+        self, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """When GOOGLE_MAPS_ENABLED=false, Maps URLs should be ignored and help shown."""
+        msg = _make_message("https://www.google.com/maps/place/Seattle,WA")
+
+        with patch("adapters.discord_bot.settings") as mock_settings, \
+             patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            mock_settings.google_maps_enabled = False
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_not_called()
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "file" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_maps_request(
+        self, mock_settings, mock_upload, mock_register
+    ):
+        """Rate-limited users should get a rate limit message, not an upload."""
+        msg = _make_message("https://www.google.com/maps/place/Seattle,WA")
+
+        with patch("adapters.discord_bot.rate_limiter") as mock_rl, \
+             patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            mock_rl.check = MagicMock(return_value=False)
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_not_called()
+        msg.reply.assert_called_once()
+        assert "too many" in msg.reply.call_args.args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_shows_correct_error(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """A detected but unsupported Maps URL (contrib) should show the unsupported format error."""
+        msg = _make_message("https://www.google.com/maps/contrib/12345")
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_not_called()
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "isn't supported" in reply_text
+
+    @pytest.mark.asyncio
+    async def test_genuine_parse_failure_shows_error(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """A URL that passes detection but fails parsing should show parse error."""
+        msg = _make_message("https://www.google.com/maps/data=!1m1!2m2")
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_not_called()
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "could not parse" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_url_no_attachment_shows_help(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """A plain text DM with no URL and no file should show help."""
+        msg = _make_message("hello bot")
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_not_called()
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "file" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_short_link_resolved_and_uploaded(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """A goo.gl short link should be resolved then processed like a regular Maps URL."""
+        msg = _make_message("https://goo.gl/maps/abc123xyz")
+
+        with patch("adapters.discord_bot.resolve_short_link", new_callable=AsyncMock,
+                    return_value="https://www.google.com/maps/place/Portland,OR") as mock_resolve, \
+             patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_resolve.assert_called_once()
+        mock_upload.assert_called_once()
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "single-use link" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_short_link_resolution_failure(
+        self, mock_settings, mock_upload, mock_register, mock_rate_limiter
+    ):
+        """Failed short-link resolution should show a helpful error."""
+        msg = _make_message("https://maps.app.goo.gl/broken123")
+
+        with patch("adapters.discord_bot.resolve_short_link", new_callable=AsyncMock,
+                    return_value=None), \
+             patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_not_called()
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "could not resolve" in reply_text.lower()

--- a/apps/discord/tests/test_maps_parser.py
+++ b/apps/discord/tests/test_maps_parser.py
@@ -1,0 +1,304 @@
+"""Tests for Google Maps URL parser."""
+
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock, patch
+from services.maps_parser import detect_maps_url, is_short_link, is_unsupported_maps_format, parse_maps_url, resolve_short_link, sanitize_query, validate_coordinates, validate_query
+
+
+class TestDetectMapsUrl:
+    def test_place_url(self):
+        text = "check this out google.com/maps/place/Seattle,WA cool right?"
+        # detect_maps_url needs https://
+        text2 = "check https://www.google.com/maps/place/Seattle,WA out"
+        assert detect_maps_url(text2) is not None
+
+    def test_coordinate_url(self):
+        url = detect_maps_url("look at https://www.google.com/maps/@47.6062,-122.3321,15z")
+        assert url is not None
+        assert "47.6062" in url
+
+    def test_search_url(self):
+        url = detect_maps_url("https://www.google.com/maps/search/pizza+near+seattle")
+        assert url is not None
+
+    def test_embed_url(self):
+        url = detect_maps_url("https://www.google.com/maps/embed/v1/place?key=ABC&q=Seattle")
+        assert url is not None
+
+    def test_short_link(self):
+        url = detect_maps_url("check https://goo.gl/maps/abc123xyz")
+        assert url is not None
+
+    def test_maps_app_short_link(self):
+        url = detect_maps_url("https://maps.app.goo.gl/abc123")
+        assert url is not None
+
+    def test_no_maps_url(self):
+        assert detect_maps_url("just a regular message with no urls") is None
+
+    def test_non_google_url(self):
+        assert detect_maps_url("https://evil.com/maps/place/Seattle") is None
+
+    def test_trailing_punctuation_stripped(self):
+        url = detect_maps_url("check https://www.google.com/maps/place/Seattle,WA!")
+        assert url is not None
+        assert not url.endswith("!")
+
+    def test_trailing_period_stripped(self):
+        url = detect_maps_url("Visit https://www.google.com/maps/place/Seattle,WA.")
+        assert url is not None
+        assert not url.endswith(".")
+
+    def test_trailing_paren_stripped(self):
+        url = detect_maps_url("(see https://www.google.com/maps/place/Seattle,WA)")
+        assert url is not None
+        assert not url.endswith(")")
+
+
+class TestParseMapsUrl:
+    def test_place_url(self):
+        result = parse_maps_url("https://www.google.com/maps/place/Seattle,WA")
+        assert result is not None
+        assert result["query"] == "Seattle,WA"
+
+    def test_place_url_with_plus(self):
+        result = parse_maps_url("https://www.google.com/maps/place/Seattle,+WA")
+        assert result is not None
+        assert "Seattle" in result["query"]
+
+    def test_place_url_with_coordinates(self):
+        result = parse_maps_url("https://www.google.com/maps/place/Seattle,+WA/@47.6062,-122.3321,15z")
+        assert result is not None
+        assert result["query"] is not None
+        assert result["lat"] == pytest.approx(47.6062)
+        assert result["lng"] == pytest.approx(-122.3321)
+
+    def test_coordinate_url(self):
+        result = parse_maps_url("https://www.google.com/maps/@47.6062,-122.3321,15z")
+        assert result is not None
+        assert result["lat"] == pytest.approx(47.6062)
+        assert result["lng"] == pytest.approx(-122.3321)
+        assert result["query"] is not None  # auto-generated from coordinates
+
+    def test_search_url(self):
+        result = parse_maps_url("https://www.google.com/maps/search/pizza+near+seattle")
+        assert result is not None
+        assert "pizza" in result["query"].lower()
+
+    def test_embed_url(self):
+        result = parse_maps_url("https://www.google.com/maps/embed/v1/place?key=ABC&q=Seattle,WA")
+        assert result is not None
+        assert result["query"] == "Seattle,WA"
+
+    def test_invalid_url(self):
+        assert parse_maps_url("https://evil.com/maps/place/Seattle") is None
+
+    def test_empty_url(self):
+        assert parse_maps_url("") is None
+        assert parse_maps_url(None) is None
+
+    def test_maps_google_com_host(self):
+        result = parse_maps_url("https://maps.google.com/maps/place/Seattle,WA")
+        assert result is not None
+        assert result["query"] == "Seattle,WA"
+
+    def test_maps_url_without_recognized_path(self):
+        assert parse_maps_url("https://www.google.com/maps") is None
+
+    def test_encoded_plus_in_place(self):
+        """Literal + encoded as %2B should survive parsing."""
+        result = parse_maps_url("https://www.google.com/maps/place/C%2B%2B+Conference")
+        assert result is not None
+        assert "C++" in result["query"] or "C%2B%2B" not in result["query"]
+
+    def test_embed_url_no_q_param(self):
+        result = parse_maps_url("https://www.google.com/maps/embed/v1/place?key=ABC")
+        assert result is None
+
+    def test_short_link_returns_none(self):
+        """Short links are detected but not parseable (Phase 2)."""
+        assert parse_maps_url("https://goo.gl/maps/abc123") is None
+        assert parse_maps_url("https://maps.app.goo.gl/abc123") is None
+
+
+class TestValidateCoordinates:
+    def test_valid(self):
+        assert validate_coordinates(47.6, -122.3) is True
+
+    def test_extremes(self):
+        assert validate_coordinates(90, 180) is True
+        assert validate_coordinates(-90, -180) is True
+
+    def test_out_of_range_lat(self):
+        assert validate_coordinates(91, 0) is False
+        assert validate_coordinates(-91, 0) is False
+
+    def test_out_of_range_lng(self):
+        assert validate_coordinates(0, 181) is False
+        assert validate_coordinates(0, -181) is False
+
+    def test_none_values(self):
+        assert validate_coordinates(None, None) is True
+
+    def test_lat_only_rejected(self):
+        assert validate_coordinates(47.6, None) is False
+
+    def test_lng_only_rejected(self):
+        assert validate_coordinates(None, -122.3) is False
+
+
+class TestValidateQuery:
+    def test_valid(self):
+        assert validate_query("Seattle,WA") is True
+
+    def test_empty(self):
+        assert validate_query("") is False
+        assert validate_query(None) is False
+
+    def test_too_long(self):
+        assert validate_query("x" * 501) is False
+
+    def test_at_limit(self):
+        assert validate_query("x" * 500) is True
+
+
+class TestSanitizeQuery:
+    def test_strips_html_tags(self):
+        assert sanitize_query("<script>alert(1)</script>Seattle") == "Seattle"
+
+    def test_strips_control_chars(self):
+        assert sanitize_query("Seattle\x00WA") == "SeattleWA"
+
+    def test_strips_newlines(self):
+        assert sanitize_query("Seattle\nWA") == "Seattle WA"
+
+    def test_strips_rtl_override(self):
+        from services.maps_parser import sanitize_query
+        assert "\u202e" not in sanitize_query("Seattle\u202eWA")
+
+    def test_normal_query_unchanged(self):
+        assert sanitize_query("Seattle, WA") == "Seattle, WA"
+
+    def test_strips_bidi_isolate_chars(self):
+        assert "\u2066" not in sanitize_query("Seattle\u2066WA")
+        assert "\u2067" not in sanitize_query("Seattle\u2067WA")
+        assert "\u2069" not in sanitize_query("Seattle\u2069WA")
+
+
+class TestUnsupportedMapsFormat:
+    def test_directions_url(self):
+        assert is_unsupported_maps_format("https://www.google.com/maps/dir/Seattle/Portland") is True
+
+    def test_timeline_url(self):
+        assert is_unsupported_maps_format("https://www.google.com/maps/timeline") is True
+
+    def test_place_url_not_unsupported(self):
+        assert is_unsupported_maps_format("https://www.google.com/maps/place/Seattle") is False
+
+    def test_coordinate_url_not_unsupported(self):
+        assert is_unsupported_maps_format("https://www.google.com/maps/@47.6,-122.3,15z") is False
+
+    def test_empty_url(self):
+        assert is_unsupported_maps_format("") is False
+
+
+class TestIsShortLink:
+    def test_goo_gl(self):
+        assert is_short_link("https://goo.gl/maps/abc123") is True
+
+    def test_maps_app(self):
+        assert is_short_link("https://maps.app.goo.gl/abc123") is True
+
+    def test_google_com(self):
+        assert is_short_link("https://www.google.com/maps/place/Seattle") is False
+
+    def test_empty(self):
+        assert is_short_link("") is False
+
+
+class TestResolveShortLink:
+    @pytest.mark.asyncio
+    async def test_follows_redirect_to_google(self):
+        redirect_resp = MagicMock()
+        redirect_resp.status_code = 302
+        redirect_resp.headers = {"location": "https://www.google.com/maps/place/Seattle,WA"}
+
+        final_resp = MagicMock()
+        final_resp.status_code = 200
+        final_resp.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.head = AsyncMock(side_effect=[redirect_resp, final_resp])
+
+        with patch("services.maps_parser.httpx.AsyncClient", return_value=mock_client), \
+             patch("services.maps_parser._is_private_ip", new_callable=AsyncMock, return_value=False):
+            result = await resolve_short_link("https://goo.gl/maps/abc123")
+        assert result == "https://www.google.com/maps/place/Seattle,WA"
+
+    @pytest.mark.asyncio
+    async def test_blocks_redirect_to_non_google(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"location": "https://evil.com/steal"}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.head = AsyncMock(return_value=mock_resp)
+
+        with patch("services.maps_parser.httpx.AsyncClient", return_value=mock_client), \
+             patch("services.maps_parser._is_private_ip", new_callable=AsyncMock, return_value=False):
+            result = await resolve_short_link("https://goo.gl/maps/abc123")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_blocks_private_ip(self):
+        with patch("services.maps_parser._is_private_ip", new_callable=AsyncMock, return_value=True):
+            result = await resolve_short_link("https://goo.gl/maps/abc123")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_blocks_non_allowlisted_host(self):
+        result = await resolve_short_link("https://evil.com/redirect")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.head = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+
+        with patch("services.maps_parser.httpx.AsyncClient", return_value=mock_client), \
+             patch("services.maps_parser._is_private_ip", new_callable=AsyncMock, return_value=False):
+            result = await resolve_short_link("https://goo.gl/maps/abc123")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_final_hop_4xx_returns_none(self):
+        """A final response with 4xx status should return None, not the URL."""
+        redirect_resp = MagicMock()
+        redirect_resp.status_code = 302
+        redirect_resp.headers = {"location": "https://www.google.com/maps/place/Seattle,WA"}
+
+        final_resp = MagicMock()
+        final_resp.status_code = 404
+        final_resp.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.head = AsyncMock(side_effect=[redirect_resp, final_resp])
+
+        with patch("services.maps_parser.httpx.AsyncClient", return_value=mock_client), \
+             patch("services.maps_parser._is_private_ip", new_callable=AsyncMock, return_value=False):
+            result = await resolve_short_link("https://goo.gl/maps/abc123")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_url(self):
+        result = await resolve_short_link("")
+        assert result is None

--- a/apps/discord/tests/test_maps_parser.py
+++ b/apps/discord/tests/test_maps_parser.py
@@ -8,7 +8,6 @@ from services.maps_parser import detect_maps_url, is_short_link, is_unsupported_
 
 class TestDetectMapsUrl:
     def test_place_url(self):
-        text = "check this out google.com/maps/place/Seattle,WA cool right?"
         # detect_maps_url needs https://
         text2 = "check https://www.google.com/maps/place/Seattle,WA out"
         assert detect_maps_url(text2) is not None

--- a/apps/discord/tests/test_mint_link_client.py
+++ b/apps/discord/tests/test_mint_link_client.py
@@ -1,0 +1,190 @@
+"""Tests for services/mint_link_client.py — mock httpx, test success/failure/validation."""
+
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from services.mint_link_client import mint_link
+
+
+def _mock_client(response):
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=response)
+    return client
+
+
+def _mock_error_response(status_code: int):
+    """Create a mock response that raises httpx.HTTPStatusError on raise_for_status()."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    request = MagicMock(spec=httpx.Request)
+    request.url = "https://api.test/mint_link"
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status_code} error", request=request, response=resp
+    )
+    return resp
+
+
+class TestMintLinkSuccess:
+    @pytest.mark.asyncio
+    async def test_success_returns_qurl_link_and_expires(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "qurl_link": "https://qurl.link/at_mint123",
+            "expires_at": "2026-12-31T23:59:59Z",
+        }
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            result = await mint_link("r_test123456", "recipient1")
+        assert result["qurl_link"] == "https://qurl.link/at_mint123"
+        assert result["expires_at"] == "2026-12-31T23:59:59Z"
+
+    @pytest.mark.asyncio
+    async def test_success_with_data_envelope(self):
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.json.return_value = {
+            "data": {
+                "qurl_link": "https://qurl.link/at_env123",
+                "expires_at": "2027-01-01T00:00:00Z",
+            }
+        }
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            result = await mint_link("r_test123456", "recipient1")
+        assert result["qurl_link"] == "https://qurl.link/at_env123"
+
+    @pytest.mark.asyncio
+    async def test_success_with_camel_case_keys(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "qurlLink": "https://qurl.link/at_camel1",
+            "expiresAt": "2027-06-15T00:00:00Z",
+        }
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            result = await mint_link("r_test123456", "recipient1")
+        assert result["qurl_link"] == "https://qurl.link/at_camel1"
+        assert result["expires_at"] == "2027-06-15T00:00:00Z"
+
+
+class TestMintLinkErrors:
+    @pytest.mark.asyncio
+    async def test_http_500_raises(self):
+        resp = _mock_error_response(500)
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await mint_link("r_test123456", "recipient1")
+
+    @pytest.mark.asyncio
+    async def test_missing_qurl_link_raises(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"expires_at": "2026-12-31T00:00:00Z"}
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(Exception, match="missing qurl_link"):
+                await mint_link("r_test123456", "recipient1")
+
+
+class TestMintLinkValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_qurl_link_prefix_raises(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "qurl_link": "https://evil.com/steal_data",
+        }
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(ValueError, match="invalid qurl_link"):
+                await mint_link("r_test123456", "recipient1")
+
+    @pytest.mark.asyncio
+    async def test_http_scheme_rejected(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "qurl_link": "http://qurl.link/at_abc123",
+        }
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(ValueError, match="invalid qurl_link"):
+                await mint_link("r_test123456", "recipient1")
+
+    @pytest.mark.asyncio
+    async def test_custom_hostname_accepted(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "qurl_link": "https://custom.example.com/at_abc123",
+            "expires_at": "",
+        }
+        mock = _mock_client(resp)
+        with (
+            patch("services.mint_link_client.httpx.AsyncClient", return_value=mock),
+            patch("services.mint_link_client.settings") as mock_settings,
+        ):
+            mock_settings.qurl_api_key = "lv_test_fake"
+            mock_settings.mint_link_api_url = "https://api.layerv.ai/v1/qurls"
+            mock_settings.qurl_link_hostname = "custom.example.com"
+            result = await mint_link("r_test123456", "recipient1")
+        assert result["qurl_link"] == "https://custom.example.com/at_abc123"
+
+
+class TestMintLinkRequestBody:
+    @pytest.mark.asyncio
+    async def test_sends_correct_body(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "qurl_link": "https://qurl.link/at_body123",
+            "expires_at": "",
+        }
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            await mint_link("r_test123456", "recipient_xyz")
+
+        # Inspect the call arguments
+        call_kwargs = mock.post.call_args
+        assert "r_test123456" in call_kwargs.args[0]  # URL contains resource_id
+        payload = call_kwargs.kwargs["json"]
+        assert payload["one_time_use"] is True
+        assert payload["expires_in"] == "15m"
+        assert payload["label"] == "discord:recipient_xyz"
+
+
+class TestMintLinkExpiry:
+    @pytest.mark.asyncio
+    async def test_custom_expires_sent(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"qurl_link": "https://qurl.link/at_x", "expires_at": ""}
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            await mint_link("r_test123456", "r1", expires_in="1h")
+        payload = mock.post.call_args.kwargs["json"]
+        assert payload["expires_in"] == "1h"
+
+    @pytest.mark.asyncio
+    async def test_default_expires(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"qurl_link": "https://qurl.link/at_x", "expires_at": ""}
+        mock = _mock_client(resp)
+        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+            await mint_link("r_test123456", "r1")
+        payload = mock.post.call_args.kwargs["json"]
+        assert payload["expires_in"] == "15m"

--- a/apps/discord/tests/test_mint_link_client.py
+++ b/apps/discord/tests/test_mint_link_client.py
@@ -44,7 +44,7 @@ class TestMintLinkSuccess:
             "expires_at": "2026-12-31T23:59:59Z",
         }
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             result = await mint_link("r_test123456", "recipient1")
         assert result["qurl_link"] == "https://qurl.link/at_mint123"
         assert result["expires_at"] == "2026-12-31T23:59:59Z"
@@ -60,7 +60,7 @@ class TestMintLinkSuccess:
             }
         }
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             result = await mint_link("r_test123456", "recipient1")
         assert result["qurl_link"] == "https://qurl.link/at_env123"
 
@@ -73,7 +73,7 @@ class TestMintLinkSuccess:
             "expiresAt": "2027-06-15T00:00:00Z",
         }
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             result = await mint_link("r_test123456", "recipient1")
         assert result["qurl_link"] == "https://qurl.link/at_camel1"
         assert result["expires_at"] == "2027-06-15T00:00:00Z"
@@ -84,7 +84,7 @@ class TestMintLinkErrors:
     async def test_http_500_raises(self):
         resp = _mock_error_response(500)
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             with pytest.raises(httpx.HTTPStatusError):
                 await mint_link("r_test123456", "recipient1")
 
@@ -94,7 +94,7 @@ class TestMintLinkErrors:
         resp.status_code = 200
         resp.json.return_value = {"expires_at": "2026-12-31T00:00:00Z"}
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             with pytest.raises(Exception, match="missing qurl_link"):
                 await mint_link("r_test123456", "recipient1")
 
@@ -108,7 +108,7 @@ class TestMintLinkValidation:
             "qurl_link": "https://evil.com/steal_data",
         }
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             with pytest.raises(ValueError, match="invalid qurl_link"):
                 await mint_link("r_test123456", "recipient1")
 
@@ -120,7 +120,7 @@ class TestMintLinkValidation:
             "qurl_link": "http://qurl.link/at_abc123",
         }
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             with pytest.raises(ValueError, match="invalid qurl_link"):
                 await mint_link("r_test123456", "recipient1")
 
@@ -134,7 +134,7 @@ class TestMintLinkValidation:
         }
         mock = _mock_client(resp)
         with (
-            patch("services.mint_link_client.httpx.AsyncClient", return_value=mock),
+            patch("services.mint_link_client.get_client", return_value=mock),
             patch("services.mint_link_client.settings") as mock_settings,
         ):
             mock_settings.qurl_api_key = "lv_test_fake"
@@ -154,7 +154,7 @@ class TestMintLinkRequestBody:
             "expires_at": "",
         }
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             await mint_link("r_test123456", "recipient_xyz")
 
         # Inspect the call arguments
@@ -173,7 +173,7 @@ class TestMintLinkExpiry:
         resp.status_code = 200
         resp.json.return_value = {"qurl_link": "https://qurl.link/at_x", "expires_at": ""}
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             await mint_link("r_test123456", "r1", expires_in="1h")
         payload = mock.post.call_args.kwargs["json"]
         assert payload["expires_in"] == "1h"
@@ -184,7 +184,7 @@ class TestMintLinkExpiry:
         resp.status_code = 200
         resp.json.return_value = {"qurl_link": "https://qurl.link/at_x", "expires_at": ""}
         mock = _mock_client(resp)
-        with patch("services.mint_link_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.mint_link_client.get_client", return_value=mock):
             await mint_link("r_test123456", "r1")
         payload = mock.post.call_args.kwargs["json"]
         assert payload["expires_in"] == "15m"

--- a/apps/discord/tests/test_periodic_tasks.py
+++ b/apps/discord/tests/test_periodic_tasks.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import AsyncMock, patch
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
 os.environ.setdefault("DISCORD_CLIENT_ID", "123456")

--- a/apps/discord/tests/test_periodic_tasks.py
+++ b/apps/discord/tests/test_periodic_tasks.py
@@ -1,0 +1,49 @@
+"""Tests for periodic retention and metrics flush tasks."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+from db import init_db, register_owner, log_dispatch, prune_old_dispatches
+
+
+class TestPruneOldDispatches:
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        path = str(tmp_path / "test.db")
+        init_db(path)
+        return path
+
+    def test_prune_returns_zero_when_empty(self, db_path):
+        count = prune_old_dispatches()
+        assert count == 0
+
+    def test_prune_does_not_delete_recent(self, db_path):
+        register_owner("r_recent12345", "user1", None, "recent.pdf")
+        log_dispatch("r_recent12345", "user1", "recipient1", None)
+
+        count = prune_old_dispatches()
+        assert count == 0  # recent entries should not be pruned
+
+
+class TestMetricsFlush:
+    @pytest.mark.asyncio
+    async def test_flush_lock_prevents_overlap(self):
+        import metrics
+        # Lock should not be locked initially
+        assert not metrics._flush_lock.locked()
+
+        # Acquire lock to simulate in-progress flush
+        await metrics._flush_lock.acquire()
+        assert metrics._flush_lock.locked()
+
+        # Release
+        metrics._flush_lock.release()
+        assert not metrics._flush_lock.locked()

--- a/apps/discord/tests/test_periodic_tasks.py
+++ b/apps/discord/tests/test_periodic_tasks.py
@@ -37,13 +37,14 @@ class TestMetricsFlush:
     @pytest.mark.asyncio
     async def test_flush_lock_prevents_overlap(self):
         import metrics
+        lock = metrics._get_flush_lock()
         # Lock should not be locked initially
-        assert not metrics._flush_lock.locked()
+        assert not lock.locked()
 
         # Acquire lock to simulate in-progress flush
-        await metrics._flush_lock.acquire()
-        assert metrics._flush_lock.locked()
+        await lock.acquire()
+        assert lock.locked()
 
         # Release
-        metrics._flush_lock.release()
-        assert not metrics._flush_lock.locked()
+        lock.release()
+        assert not lock.locked()

--- a/apps/discord/tests/test_rate_limiter.py
+++ b/apps/discord/tests/test_rate_limiter.py
@@ -1,4 +1,3 @@
-import time
 from rate_limiter import RateLimiter
 
 class TestRateLimiter:

--- a/apps/discord/tests/test_rate_limiter.py
+++ b/apps/discord/tests/test_rate_limiter.py
@@ -1,0 +1,28 @@
+import time
+from rate_limiter import RateLimiter
+
+class TestRateLimiter:
+    def test_allows_under_limit(self):
+        rl = RateLimiter(max_per_minute=5)
+        for _ in range(5):
+            assert rl.check("user1") is True
+
+    def test_blocks_over_limit(self):
+        rl = RateLimiter(max_per_minute=5)
+        for _ in range(5):
+            rl.check("user1")
+        assert rl.check("user1") is False
+
+    def test_separate_users(self):
+        rl = RateLimiter(max_per_minute=2)
+        rl.check("user1")
+        rl.check("user1")
+        assert rl.check("user1") is False
+        assert rl.check("user2") is True
+
+    def test_cleanup_runs(self):
+        rl = RateLimiter(max_per_minute=5)
+        rl._call_count = 999
+        rl.check("user1")
+        # After 1000th call, cleanup should have run
+        assert rl._call_count == 1000

--- a/apps/discord/tests/test_reply_to_share.py
+++ b/apps/discord/tests/test_reply_to_share.py
@@ -1,0 +1,137 @@
+"""End-to-end tests for _handle_reply_to_share flow."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+
+def _make_bot_upload_message(resource_id: str = "r_test12345abcde") -> MagicMock:
+    """Create a mock of the bot's upload confirmation DM (parent message)."""
+    parent = MagicMock()
+    parent.author = MagicMock()
+    parent.author.id = 999  # bot user id
+    parent.content = (
+        "**Your resource has been protected!**\n\n"
+        "**test.jpg**\n"
+        "https://qurl.link/at_xxx\n"
+        "Expires <t:1234567890:R>\n\n"
+        "Reply to this message and @mention users to share.\n"
+        f"\\_resource\\_id:{resource_id}\\_"
+    )
+    return parent
+
+
+def _make_reply_message(mentions=None, attachments=None, content=""):
+    """Create a mock reply message with mentions."""
+    msg = AsyncMock()
+    msg.author = MagicMock()
+    msg.author.bot = False
+    msg.author.id = 111222333444555666
+    msg.content = content
+    msg.attachments = attachments or []
+    msg.reference = MagicMock()
+    msg.reference.message_id = 9999
+    msg.mentions = mentions or []
+    msg.channel = MagicMock()
+    msg.channel.fetch_message = AsyncMock()
+    msg.reply = AsyncMock()
+    return msg
+
+
+class TestReplyToShare:
+    @pytest.mark.asyncio
+    async def test_happy_path_dispatches_to_recipients(self):
+        """Reply to bot upload DM with @mentions dispatches links."""
+        recipient = MagicMock()
+        recipient.id = 777888999000111222
+        recipient.display_name = "Alice"
+
+        msg = _make_reply_message(mentions=[recipient])
+        parent = _make_bot_upload_message()
+        msg.channel.fetch_message.return_value = parent
+
+        with patch("adapters.discord_bot.bot") as mock_bot, \
+             patch("adapters.discord_bot.rate_limiter") as mock_rl, \
+             patch("adapters.discord_bot.get_owner") as mock_get_owner, \
+             patch("adapters.discord_bot._dispatch_to_recipient", new_callable=AsyncMock) as mock_dispatch:
+
+            mock_bot.user = MagicMock()
+            mock_bot.user.id = 999
+            mock_rl.check = MagicMock(return_value=True)
+            mock_get_owner.return_value = {
+                "discord_user_id": str(msg.author.id),
+                "guild_id": None,
+                "filename": "test.jpg",
+                "expires_at": "2099-12-31T00:00:00Z",
+            }
+            mock_dispatch.return_value = (str(recipient.id), "sent", None, "Alice")
+
+            from adapters.discord_bot import _handle_reply_to_share
+            result = await _handle_reply_to_share(msg)
+
+        assert result is True
+        msg.channel.fetch_message.assert_called_once()
+        mock_dispatch.assert_called_once()
+        # Summary reply sent
+        assert msg.reply.call_count >= 2  # "Sending links..." + summary
+
+    @pytest.mark.asyncio
+    async def test_reply_with_attachment_rejected(self):
+        """Reply with both mentions and attachment should be rejected by on_message."""
+        recipient = MagicMock()
+        recipient.id = 777888999000111222
+
+        msg = _make_reply_message(
+            mentions=[recipient],
+            attachments=[MagicMock()],  # has attachment
+        )
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__):
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        msg.reply.assert_called_once()
+        reply_text = msg.reply.call_args.args[0]
+        assert "can't share and upload" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_before_fetch(self):
+        """Rate limit should fire before fetching the parent message."""
+        msg = _make_reply_message(mentions=[MagicMock()])
+
+        with patch("adapters.discord_bot.rate_limiter") as mock_rl:
+            mock_rl.check = MagicMock(return_value=False)
+
+            from adapters.discord_bot import _handle_reply_to_share
+            result = await _handle_reply_to_share(msg)
+
+        assert result is True
+        # fetch_message should NOT have been called
+        msg.channel.fetch_message.assert_not_called()
+        assert "too many" in msg.reply.call_args.args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_non_bot_parent_falls_through(self):
+        """Reply to a non-bot message should return False (fall through)."""
+        msg = _make_reply_message(mentions=[MagicMock()])
+        parent = MagicMock()
+        parent.author.id = 555  # not the bot
+        msg.channel.fetch_message.return_value = parent
+
+        with patch("adapters.discord_bot.bot") as mock_bot, \
+             patch("adapters.discord_bot.rate_limiter") as mock_rl:
+            mock_bot.user = MagicMock()
+            mock_bot.user.id = 999
+            mock_rl.check = MagicMock(return_value=True)
+
+            from adapters.discord_bot import _handle_reply_to_share
+            result = await _handle_reply_to_share(msg)
+
+        assert result is False

--- a/apps/discord/tests/test_search_resources.py
+++ b/apps/discord/tests/test_search_resources.py
@@ -1,0 +1,78 @@
+"""Tests for search_resources DB function."""
+
+import pytest
+from db import init_db, register_owner, search_resources
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    init_db(path)
+    return path
+
+
+class TestSearchResources:
+    def test_empty_query_returns_recent(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "alpha.png")
+        register_owner("r_bbbbbb123456", "user1", None, "bravo.pdf")
+        results = search_resources("user1", "", 25)
+        assert len(results) == 2
+
+    def test_query_matches_filename(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "el-charro-beer.jpg")
+        register_owner("r_bbbbbb123456", "user1", None, "client-proposal.pdf")
+        results = search_resources("user1", "charro", 25)
+        assert len(results) == 1
+        assert results[0]["filename"] == "el-charro-beer.jpg"
+
+    def test_query_matches_resource_id(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "file.png")
+        results = search_resources("user1", "aaaaaa", 25)
+        assert len(results) == 1
+        assert results[0]["resource_id"] == "r_aaaaaa123456"
+
+    def test_query_case_insensitive(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "MyDocument.PDF")
+        results = search_resources("user1", "mydoc", 25)
+        assert len(results) == 1
+
+    def test_no_matches(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "file.png")
+        results = search_resources("user1", "nonexistent", 25)
+        assert len(results) == 0
+
+    def test_limit_respected(self, db_path):
+        for i in range(10):
+            register_owner(f"r_test{i:06d}abcd", "user1", None, f"file{i}.png")
+        results = search_resources("user1", "", 3)
+        assert len(results) == 3
+
+    def test_other_users_resources_not_returned(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "secret.pdf")
+        register_owner("r_bbbbbb123456", "user2", None, "other.pdf")
+        results = search_resources("user1", "", 25)
+        assert len(results) == 1
+        assert results[0]["discord_user_id"] == "user1"
+
+    def test_sql_wildcard_in_query(self, db_path):
+        """SQL wildcards % and _ in query should be treated as literals."""
+        register_owner("r_aaaaaa123456", "user1", None, "100%_complete.pdf")
+        register_owner("r_bbbbbb123456", "user1", None, "normal_file.png")
+        # Searching for "%" should only match the file with % in the name
+        results = search_resources("user1", "%", 25)
+        assert len(results) == 1
+        assert results[0]["filename"] == "100%_complete.pdf"
+
+    def test_underscore_wildcard_escaped(self, db_path):
+        """SQL _ wildcard in filename search should be treated as literal."""
+        register_owner("r_aaaaaa123456", "user1", None, "my_file.pdf")
+        register_owner("r_bbbbbb123456", "user1", None, "myXfile.pdf")
+        # Search for "my_f" should match only the file with underscore, not "myXfile"
+        results = search_resources("user1", "my_f", 25)
+        assert len(results) == 1
+        assert results[0]["filename"] == "my_file.pdf"
+
+    def test_empty_user_returns_nothing(self, db_path):
+        register_owner("r_aaaaaa123456", "user1", None, "file.png")
+        results = search_resources("nonexistent_user", "", 25)
+        assert len(results) == 0

--- a/apps/discord/tests/test_slash_commands.py
+++ b/apps/discord/tests/test_slash_commands.py
@@ -1,0 +1,91 @@
+"""Tests for /qurl status and /qurl revoke slash commands."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+from adapters.discord_bot import qurl_status, qurl_revoke
+
+
+def _mock_interaction(user_id: int = 111222333):
+    interaction = AsyncMock()
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.guild_id = None
+    return interaction
+
+
+class TestQURLStatus:
+    @pytest.mark.asyncio
+    async def test_status_shows_resource_info(self):
+        interaction = _mock_interaction()
+
+        with patch("adapters.discord_bot._resolve_owned_resource", new_callable=AsyncMock) as mock_resolve, \
+             patch("adapters.discord_bot.get_dispatch_stats", return_value={"sent": 3, "failed": 1}), \
+             patch("adapters.discord_bot.get_http_client") as mock_http:
+            mock_resolve.return_value = ("r_test123456", {
+                "filename": "test.pdf",
+                "created_at": "2026-04-01",
+                "expires_at": "2026-04-10T00:00:00Z",
+            })
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": {"status": "active"}}
+            mock_http.return_value.get = AsyncMock(return_value=mock_resp)
+
+            await qurl_status.callback(interaction, "r_test123456")
+
+        interaction.followup.send.assert_called_once()
+        msg = interaction.followup.send.call_args.args[0]
+        assert "r_test123456" in msg
+        assert "3" in msg  # sent count
+
+    @pytest.mark.asyncio
+    async def test_status_not_found(self):
+        interaction = _mock_interaction()
+
+        with patch("adapters.discord_bot._resolve_owned_resource", new_callable=AsyncMock, return_value=None):
+            await qurl_status.callback(interaction, "r_nonexistent")
+
+        interaction.followup.send.assert_not_called()
+
+
+class TestQURLRevoke:
+    @pytest.mark.asyncio
+    async def test_revoke_deletes_resource(self):
+        interaction = _mock_interaction()
+
+        with patch("adapters.discord_bot._resolve_owned_resource", new_callable=AsyncMock) as mock_resolve, \
+             patch("adapters.discord_bot.delete_resource") as mock_delete, \
+             patch("adapters.discord_bot.get_http_client") as mock_http, \
+             patch("adapters.discord_bot.metrics"), \
+             patch("adapters.discord_bot.logger"):
+            mock_resolve.return_value = ("r_test123456", {"filename": "test.pdf"})
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_http.return_value.delete = AsyncMock(return_value=mock_resp)
+
+            await qurl_revoke.callback(interaction, "r_test123456")
+
+        mock_delete.assert_called_once()
+        interaction.followup.send.assert_called_once()
+        msg = interaction.followup.send.call_args.args[0]
+        assert "revoked" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_revoke_not_found(self):
+        interaction = _mock_interaction()
+
+        with patch("adapters.discord_bot._resolve_owned_resource", new_callable=AsyncMock, return_value=None):
+            await qurl_revoke.callback(interaction, "r_nonexistent")
+
+        interaction.followup.send.assert_not_called()

--- a/apps/discord/tests/test_upload_client.py
+++ b/apps/discord/tests/test_upload_client.py
@@ -16,10 +16,8 @@ from services.upload_client import upload_file
 
 
 def _mock_client(response):
-    """Build a mock httpx.AsyncClient that returns *response* from .post()."""
+    """Build a mock client that returns *response* from .post()."""
     client = AsyncMock()
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
     client.post = AsyncMock(return_value=response)
     return client
 
@@ -54,7 +52,7 @@ class TestUploadClientSuccess:
     @pytest.mark.asyncio
     async def test_success_returns_expected_keys(self):
         mock = _mock_client(_ok_response())
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             result = await upload_file(
                 file_bytes=b"test content",
                 filename="test.png",
@@ -77,7 +75,7 @@ class TestUploadClientSuccess:
             }
         }
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             result = await upload_file(
                 file_bytes=b"x", filename="f.png",
                 content_type="image/png", owner_id="u",
@@ -94,7 +92,7 @@ class TestUploadClientSuccess:
             "expiresAt": "2027-06-01T00:00:00Z",
         }
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             result = await upload_file(
                 file_bytes=b"x", filename="f.png",
                 content_type="image/png", owner_id="u",
@@ -108,7 +106,7 @@ class TestUploadClientErrors:
     async def test_http_500_raises(self):
         resp = _mock_error_response(500)
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             with pytest.raises(httpx.HTTPStatusError):
                 await upload_file(
                     file_bytes=b"test", filename="test.png",
@@ -119,7 +117,7 @@ class TestUploadClientErrors:
     async def test_http_400_raises(self):
         resp = _mock_error_response(400)
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             with pytest.raises(httpx.HTTPStatusError):
                 await upload_file(
                     file_bytes=b"test", filename="test.png",
@@ -132,7 +130,7 @@ class TestUploadClientErrors:
         resp.status_code = 200
         resp.json.return_value = {"qurl_link": "https://qurl.link/at_x"}
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             with pytest.raises(Exception, match="missing resource_id"):
                 await upload_file(
                     file_bytes=b"test", filename="test.png",
@@ -145,7 +143,7 @@ class TestUploadClientValidation:
     async def test_invalid_resource_id_rejected(self):
         resp = _ok_response(resource_id="INVALID")
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             with pytest.raises(ValueError, match="invalid resource_id"):
                 await upload_file(
                     file_bytes=b"test", filename="test.png",
@@ -156,7 +154,7 @@ class TestUploadClientValidation:
     async def test_invalid_qurl_link_rejected(self):
         resp = _ok_response(qurl_link="https://evil.com/phishing")
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             with pytest.raises(ValueError, match="unexpected hostname"):
                 await upload_file(
                     file_bytes=b"test", filename="test.png",
@@ -167,7 +165,7 @@ class TestUploadClientValidation:
     async def test_http_scheme_rejected(self):
         resp = _ok_response(qurl_link="http://qurl.link/at_abc123")
         mock = _mock_client(resp)
-        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+        with patch("services.upload_client.get_client", return_value=mock):
             with pytest.raises(ValueError, match="unexpected hostname"):
                 await upload_file(
                     file_bytes=b"test", filename="test.png",
@@ -179,7 +177,7 @@ class TestUploadClientValidation:
         resp = _ok_response(qurl_link="https://custom.example.com/at_abc123")
         mock = _mock_client(resp)
         with (
-            patch("services.upload_client.httpx.AsyncClient", return_value=mock),
+            patch("services.upload_client.get_client", return_value=mock),
             patch("services.upload_client.settings") as mock_settings,
         ):
             mock_settings.qurl_api_key = "lv_test_fake"

--- a/apps/discord/tests/test_upload_client.py
+++ b/apps/discord/tests/test_upload_client.py
@@ -1,0 +1,192 @@
+"""Tests for services/upload_client.py — mock httpx, test success/failure/validation."""
+
+import os
+
+# Set env vars before importing config (module-level side effect)
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from services.upload_client import upload_file
+
+
+def _mock_client(response):
+    """Build a mock httpx.AsyncClient that returns *response* from .post()."""
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=response)
+    return client
+
+
+def _mock_error_response(status_code: int):
+    """Create a mock response that raises httpx.HTTPStatusError on raise_for_status()."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    request = MagicMock(spec=httpx.Request)
+    request.url = "https://api.test/upload"
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status_code} error", request=request, response=resp
+    )
+    return resp
+
+
+def _ok_response(**overrides):
+    """Build a mock 200 response with valid defaults."""
+    body = {
+        "resource_id": "r_test123456",
+        "qurl_link": "https://qurl.link/at_abc123",
+        "expires_at": "2026-12-31T00:00:00Z",
+    }
+    body.update(overrides)
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = body
+    return resp
+
+
+class TestUploadClientSuccess:
+    @pytest.mark.asyncio
+    async def test_success_returns_expected_keys(self):
+        mock = _mock_client(_ok_response())
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            result = await upload_file(
+                file_bytes=b"test content",
+                filename="test.png",
+                content_type="image/png",
+                owner_id="user123",
+            )
+        assert result["resource_id"] == "r_test123456"
+        assert result["qurl_link"] == "https://qurl.link/at_abc123"
+        assert result["expires_at"] == "2026-12-31T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_success_with_nested_data_envelope(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "data": {
+                "resource_id": "r_nested12345",
+                "qurl_link": "https://qurl.link/at_nested",
+                "expires_at": "2027-01-01T00:00:00Z",
+            }
+        }
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            result = await upload_file(
+                file_bytes=b"x", filename="f.png",
+                content_type="image/png", owner_id="u",
+            )
+        assert result["resource_id"] == "r_nested12345"
+
+    @pytest.mark.asyncio
+    async def test_success_with_camel_case_keys(self):
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.json.return_value = {
+            "resourceId": "r_camel_12345",
+            "qurlLink": "https://qurl.link/at_camel",
+            "expiresAt": "2027-06-01T00:00:00Z",
+        }
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            result = await upload_file(
+                file_bytes=b"x", filename="f.png",
+                content_type="image/png", owner_id="u",
+            )
+        assert result["resource_id"] == "r_camel_12345"
+        assert result["qurl_link"] == "https://qurl.link/at_camel"
+
+
+class TestUploadClientErrors:
+    @pytest.mark.asyncio
+    async def test_http_500_raises(self):
+        resp = _mock_error_response(500)
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await upload_file(
+                    file_bytes=b"test", filename="test.png",
+                    content_type="image/png", owner_id="user123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_http_400_raises(self):
+        resp = _mock_error_response(400)
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await upload_file(
+                    file_bytes=b"test", filename="test.png",
+                    content_type="image/png", owner_id="user123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_missing_resource_id_raises(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"qurl_link": "https://qurl.link/at_x"}
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(Exception, match="missing resource_id"):
+                await upload_file(
+                    file_bytes=b"test", filename="test.png",
+                    content_type="image/png", owner_id="user123",
+                )
+
+
+class TestUploadClientValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_resource_id_rejected(self):
+        resp = _ok_response(resource_id="INVALID")
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(ValueError, match="invalid resource_id"):
+                await upload_file(
+                    file_bytes=b"test", filename="test.png",
+                    content_type="image/png", owner_id="user123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_invalid_qurl_link_rejected(self):
+        resp = _ok_response(qurl_link="https://evil.com/phishing")
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(ValueError, match="unexpected hostname"):
+                await upload_file(
+                    file_bytes=b"test", filename="test.png",
+                    content_type="image/png", owner_id="user123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_http_scheme_rejected(self):
+        resp = _ok_response(qurl_link="http://qurl.link/at_abc123")
+        mock = _mock_client(resp)
+        with patch("services.upload_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(ValueError, match="unexpected hostname"):
+                await upload_file(
+                    file_bytes=b"test", filename="test.png",
+                    content_type="image/png", owner_id="user123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_custom_hostname_accepted(self):
+        resp = _ok_response(qurl_link="https://custom.example.com/at_abc123")
+        mock = _mock_client(resp)
+        with (
+            patch("services.upload_client.httpx.AsyncClient", return_value=mock),
+            patch("services.upload_client.settings") as mock_settings,
+        ):
+            mock_settings.qurl_api_key = "lv_test_fake"
+            mock_settings.upload_api_url = "https://getqurllink.layerv.ai"
+            mock_settings.qurl_link_hostname = "custom.example.com"
+            result = await upload_file(
+                file_bytes=b"test", filename="test.png",
+                content_type="image/png", owner_id="user123",
+            )
+        assert result["qurl_link"] == "https://custom.example.com/at_abc123"

--- a/apps/discord/tests/test_upload_flow.py
+++ b/apps/discord/tests/test_upload_flow.py
@@ -1,0 +1,62 @@
+"""End-to-end test for DM upload flow in on_message."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+
+def _make_upload_message():
+    msg = AsyncMock()
+    msg.author = MagicMock()
+    msg.author.bot = False
+    msg.author.id = 111222333444555666
+    msg.content = ""
+    msg.reference = None
+    msg.mentions = []
+    msg.channel = MagicMock()
+    msg.reply = AsyncMock()
+
+    attachment = MagicMock()
+    attachment.filename = "test.pdf"
+    attachment.size = 1024
+    attachment.content_type = "application/pdf"
+    attachment.url = "https://cdn.discordapp.com/attachments/123/456/test.pdf"
+    attachment.read = AsyncMock(return_value=b"fake pdf content")
+    msg.attachments = [attachment]
+
+    return msg
+
+
+class TestUploadFlow:
+    @pytest.mark.asyncio
+    async def test_upload_success(self):
+        msg = _make_upload_message()
+
+        with patch("adapters.discord_bot.discord.DMChannel", msg.channel.__class__), \
+             patch("adapters.discord_bot.rate_limiter") as mock_rl, \
+             patch("adapters.discord_bot.upload_file", new_callable=AsyncMock) as mock_upload, \
+             patch("adapters.discord_bot.register_owner"), \
+             patch("adapters.discord_bot.metrics"), \
+             patch("adapters.discord_bot.logger"):
+            mock_rl.check = MagicMock(return_value=True)
+            mock_upload.return_value = {
+                "resource_id": "r_upload12345",
+                "qurl_link": "https://qurl.link.layerv.xyz/#at_test",
+                "expires_at": "2026-12-31T00:00:00Z",
+            }
+
+            from adapters.discord_bot import on_message
+            await on_message(msg)
+
+        mock_upload.assert_called_once()
+        msg.reply.assert_called_once()
+        reply = msg.reply.call_args.args[0]
+        assert "protected" in reply.lower()
+        assert "qurl.link" in reply

--- a/apps/discord/tests/test_upload_semaphore.py
+++ b/apps/discord/tests/test_upload_semaphore.py
@@ -1,0 +1,87 @@
+"""Tests for upload concurrency semaphore — exercises real async behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+
+class TestUploadSemaphore:
+    def test_initial_limit_is_5(self):
+        """Module-level semaphore allows at most 5 concurrent uploads."""
+        from adapters.discord_bot import _upload_sem
+        assert _upload_sem._value == 5
+
+    def test_semaphore_is_module_level(self):
+        """Semaphore is shared across all upload calls (not per-user)."""
+        from adapters.discord_bot import _upload_sem as sem1
+        from adapters.discord_bot import _upload_sem as sem2
+        assert sem1 is sem2
+
+    @pytest.mark.asyncio
+    async def test_acquire_and_release(self):
+        """Real acquire reduces available slots; release restores them."""
+        sem = asyncio.Semaphore(5)
+        assert sem._value == 5
+        await sem.acquire()
+        assert sem._value == 4
+        await sem.acquire()
+        assert sem._value == 3
+        sem.release()
+        assert sem._value == 4
+        sem.release()
+        assert sem._value == 5
+
+    @pytest.mark.asyncio
+    async def test_sixth_acquire_blocks(self):
+        """With all 5 permits acquired, the 6th acquire blocks until one is released."""
+        sem = asyncio.Semaphore(5)
+
+        for _ in range(5):
+            await sem.acquire()
+        assert sem._value == 0
+
+        sixth_acquired = asyncio.Event()
+
+        async def try_sixth():
+            await sem.acquire()
+            sixth_acquired.set()
+
+        task = asyncio.create_task(try_sixth())
+        await asyncio.sleep(0.05)
+        assert not sixth_acquired.is_set(), "6th acquire should block when all permits taken"
+
+        sem.release()
+        await asyncio.sleep(0.05)
+        assert sixth_acquired.is_set(), "6th acquire should succeed after release"
+
+        # Cleanup
+        task.cancel()
+        for _ in range(4):
+            sem.release()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_respect_limit(self):
+        """At most 5 tasks run concurrently inside the semaphore."""
+        sem = asyncio.Semaphore(5)
+        active = 0
+        max_active = 0
+
+        async def worker():
+            nonlocal active, max_active
+            async with sem:
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0.02)
+                active -= 1
+
+        tasks = [asyncio.create_task(worker()) for _ in range(10)]
+        await asyncio.gather(*tasks)
+
+        assert max_active == 5, f"Expected max 5 concurrent, got {max_active}"

--- a/apps/discord/tests/test_user_semaphore.py
+++ b/apps/discord/tests/test_user_semaphore.py
@@ -1,0 +1,55 @@
+"""Tests for per-user dispatch semaphore with LRU eviction."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+from adapters.discord_bot import _get_user_sem, _user_sems, _USER_SEM_LIMIT, _USER_SEM_MAX_ENTRIES
+
+
+class TestGetUserSem:
+    def setup_method(self):
+        _user_sems.clear()
+
+    def test_creates_new_semaphore(self):
+        sem = _get_user_sem("user1")
+        assert sem is not None
+        assert sem._value == _USER_SEM_LIMIT
+
+    def test_returns_same_semaphore_on_second_call(self):
+        sem1 = _get_user_sem("user1")
+        sem2 = _get_user_sem("user1")
+        assert sem1 is sem2
+
+    def test_different_users_get_different_semaphores(self):
+        sem1 = _get_user_sem("user1")
+        sem2 = _get_user_sem("user2")
+        assert sem1 is not sem2
+
+    def test_lru_evicts_oldest_at_capacity(self):
+        # Fill to capacity
+        for i in range(_USER_SEM_MAX_ENTRIES):
+            _get_user_sem(f"user{i}")
+        assert len(_user_sems) == _USER_SEM_MAX_ENTRIES
+
+        # Adding one more evicts the oldest (user0)
+        _get_user_sem("new_user")
+        assert "new_user" in _user_sems
+        assert "user0" not in _user_sems
+        assert len(_user_sems) == _USER_SEM_MAX_ENTRIES
+
+    def test_lru_refreshes_on_access(self):
+        _get_user_sem("old")
+        _get_user_sem("middle")
+        _get_user_sem("recent")
+
+        # Access "old" to refresh it — it should move to end
+        _get_user_sem("old")
+
+        keys = list(_user_sems.keys())
+        assert keys[-1] == "old"
+        assert keys[0] == "middle"

--- a/apps/discord/tests/test_user_sems_concurrent.py
+++ b/apps/discord/tests/test_user_sems_concurrent.py
@@ -1,0 +1,64 @@
+"""Tests for _user_sems LRU eviction under concurrent access."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+os.environ.setdefault("DISCORD_CLIENT_ID", "123456")
+os.environ.setdefault("QURL_API_KEY", "lv_test_fake")
+
+import pytest
+
+from adapters.discord_bot import _get_user_sem, _user_sems, _USER_SEM_MAX_ENTRIES
+
+
+class TestUserSemsLRUConcurrent:
+    def setup_method(self):
+        _user_sems.clear()
+
+    def test_eviction_preserves_recent_users(self):
+        """Fill to capacity, access an old user, then add one more — old user should survive."""
+        for i in range(_USER_SEM_MAX_ENTRIES):
+            _get_user_sem(f"user{i}")
+
+        # Access user0 to refresh it (move to end)
+        _get_user_sem("user0")
+
+        # Add a new user — should evict user1 (oldest), not user0 (refreshed)
+        _get_user_sem("new_user")
+
+        assert "user0" in _user_sems, "Refreshed user should survive eviction"
+        assert "user1" not in _user_sems, "Oldest non-refreshed user should be evicted"
+        assert "new_user" in _user_sems
+
+    @pytest.mark.asyncio
+    async def test_semaphore_works_after_eviction_and_recreation(self):
+        """After a user is evicted and recreated, the new semaphore should work."""
+        _get_user_sem("evictme")
+        # Fill to capacity
+        for i in range(_USER_SEM_MAX_ENTRIES):
+            _get_user_sem(f"filler{i}")
+
+        # evictme should be gone
+        assert "evictme" not in _user_sems
+
+        # Recreate — should get a fresh semaphore
+        sem = _get_user_sem("evictme")
+        assert sem._value == 10
+
+        # Verify it actually works
+        await sem.acquire()
+        assert sem._value == 9
+        sem.release()
+        assert sem._value == 10
+
+    def test_concurrent_users_get_independent_semaphores(self):
+        """Two users' semaphores should be independent."""
+        sem_a = _get_user_sem("alice")
+        sem_b = _get_user_sem("bob")
+
+        assert sem_a is not sem_b
+        assert sem_a._value == 10
+        assert sem_b._value == 10

--- a/apps/discord/tests/test_user_sems_concurrent.py
+++ b/apps/discord/tests/test_user_sems_concurrent.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")

--- a/apps/discord/tests/test_validation.py
+++ b/apps/discord/tests/test_validation.py
@@ -1,0 +1,131 @@
+import pytest
+from validation import validate_resource_id, validate_file_size, validate_file_type, sanitize_filename, validate_cdn_url, validate_snowflake, split_message, validate_expires, DEFAULT_LINK_EXPIRY, EXPIRY_CHOICES_VALUES
+
+class TestValidateResourceId:
+    def test_valid(self):
+        assert validate_resource_id("r_abc123def456") == "r_abc123def456"
+
+    def test_with_dollar_prefix(self):
+        assert validate_resource_id("$r_abc123def456") is None  # validate_resource_id doesn't strip $
+
+    def test_too_short(self):
+        assert validate_resource_id("r_abc") is None
+
+    def test_too_long(self):
+        assert validate_resource_id("r_" + "a" * 33) is None
+
+    def test_invalid_chars(self):
+        assert validate_resource_id("r_abc/../../etc") is None
+
+    def test_no_prefix(self):
+        assert validate_resource_id("abc123def456") is None
+
+    def test_hyphens_underscores(self):
+        assert validate_resource_id("r_abc-123_def") == "r_abc-123_def"
+
+class TestValidateFileSize:
+    def test_under_limit(self):
+        assert validate_file_size(1024, max_mb=25) is True
+
+    def test_at_limit(self):
+        assert validate_file_size(25 * 1024 * 1024, max_mb=25) is True
+
+    def test_over_limit(self):
+        assert validate_file_size(25 * 1024 * 1024 + 1, max_mb=25) is False
+
+class TestValidateFileType:
+    def test_png(self):
+        assert validate_file_type("image/png", "test.png") is True
+
+    def test_pdf(self):
+        assert validate_file_type("application/pdf", "doc.pdf") is True
+
+    def test_exe(self):
+        assert validate_file_type("application/x-msdownload", "virus.exe") is False
+
+    def test_html(self):
+        assert validate_file_type("text/html", "page.html") is False
+
+    def test_mime_with_charset(self):
+        assert validate_file_type("image/jpeg; charset=utf-8", "photo.jpg") is True
+
+class TestSanitizeFilename:
+    def test_normal(self):
+        assert sanitize_filename("photo.png") == "photo.png"
+
+    def test_path_traversal(self):
+        result = sanitize_filename("../../etc/passwd")
+        assert "/" not in result
+        assert ".." not in result
+
+    def test_null_bytes(self):
+        assert "\x00" not in sanitize_filename("file\x00.png")
+
+    def test_long_name(self):
+        assert len(sanitize_filename("a" * 300 + ".png")) <= 255
+
+    def test_empty(self):
+        result = sanitize_filename("")
+        assert result == "unnamed"
+
+class TestValidateCdnUrl:
+    def test_valid_cdn(self):
+        assert validate_cdn_url("https://cdn.discordapp.com/attachments/123/456/file.png", "cdn.discordapp.com,media.discordapp.net") is True
+
+    def test_valid_media(self):
+        assert validate_cdn_url("https://media.discordapp.net/attachments/123/456/file.png", "cdn.discordapp.com,media.discordapp.net") is True
+
+    def test_invalid_host(self):
+        assert validate_cdn_url("https://evil.com/file.png", "cdn.discordapp.com,media.discordapp.net") is False
+
+    def test_http_rejected(self):
+        assert validate_cdn_url("http://cdn.discordapp.com/file.png", "cdn.discordapp.com,media.discordapp.net") is False
+
+    def test_malformed_url(self):
+        assert validate_cdn_url("not-a-url", "cdn.discordapp.com") is False
+
+class TestValidateSnowflake:
+    def test_valid(self):
+        assert validate_snowflake("123456789012345678") is True
+
+    def test_too_short(self):
+        assert validate_snowflake("1234567890") is False
+
+    def test_too_long(self):
+        assert validate_snowflake("123456789012345678901") is False
+
+    def test_non_numeric(self):
+        assert validate_snowflake("12345678901234567a") is False
+
+class TestSplitMessage:
+    def test_short_message(self):
+        assert split_message("hello", 2000) == ["hello"]
+
+    def test_exact_limit(self):
+        msg = "a" * 2000
+        assert split_message(msg, 2000) == [msg]
+
+    def test_over_limit(self):
+        msg = "line1\nline2\nline3\n" * 200
+        parts = split_message(msg, 2000)
+        assert all(len(p) <= 2000 for p in parts)
+        assert len(parts) > 1
+
+
+class TestValidateExpires:
+    def test_all_choices_valid(self):
+        for v in EXPIRY_CHOICES_VALUES:
+            assert validate_expires(v) is True
+
+    def test_default_is_valid(self):
+        assert validate_expires(DEFAULT_LINK_EXPIRY) is True
+
+    def test_invalid_values(self):
+        assert validate_expires("") is False
+        assert validate_expires("abc") is False
+        assert validate_expires("30d") is False
+        assert validate_expires("2h") is False
+        assert validate_expires("10m") is False
+
+    def test_none_is_false(self):
+        assert validate_expires(None) is False

--- a/apps/discord/tests/test_validation.py
+++ b/apps/discord/tests/test_validation.py
@@ -1,4 +1,3 @@
-import pytest
 from validation import validate_resource_id, validate_file_size, validate_file_type, sanitize_filename, validate_cdn_url, validate_snowflake, split_message, validate_expires, DEFAULT_LINK_EXPIRY, EXPIRY_CHOICES_VALUES
 
 class TestValidateResourceId:

--- a/apps/discord/validation.py
+++ b/apps/discord/validation.py
@@ -1,0 +1,175 @@
+"""Input validation utilities."""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urlparse
+
+# --- Link expiry constants ---
+DEFAULT_LINK_EXPIRY = "15m"
+
+EXPIRY_CHOICES_VALUES = {"5m", "15m", "1h", "24h", "7d"}
+
+
+def validate_expires(value: str) -> bool:
+    """Validate that the expiry value is one of the allowed choices."""
+    return isinstance(value, str) and value in EXPIRY_CHOICES_VALUES
+
+# Allowed MIME types for file uploads
+ALLOWED_CONTENT_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf",
+}
+
+# Allowed file extensions (fallback when content_type is missing)
+ALLOWED_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".pdf",
+}
+
+# Resource ID regex: r_ followed by 6-32 alphanumeric/underscore/hyphen chars
+_RESOURCE_ID_RE = re.compile(r"^r_[a-zA-Z0-9_-]{6,32}$")
+
+# Discord snowflake: 17-20 digit integer
+SNOWFLAKE_RE = re.compile(r"^\d{17,20}$")
+
+
+def validate_resource_id(text: str) -> str | None:
+    """
+    Validate a resource ID string.
+
+    Returns the cleaned resource_id if valid, or None if invalid.
+    """
+    text = text.strip()
+    if _RESOURCE_ID_RE.match(text):
+        return text
+    return None
+
+
+def validate_snowflake(uid: str) -> bool:
+    """Validate that a string is a valid Discord snowflake ID (17-20 digits)."""
+    return bool(SNOWFLAKE_RE.match(uid))
+
+
+def validate_file_size(size_bytes: int, max_mb: int = 25) -> bool:
+    """Check if file size is within the allowed limit."""
+    return 0 < size_bytes <= max_mb * 1024 * 1024
+
+
+def validate_file_type(content_type: str | None, filename: str | None) -> bool:
+    """
+    Validate file type by content_type and/or filename extension.
+
+    Returns True if the file type is allowed.
+
+    NOTE: MIME type is from Discord metadata (user-controlled). No magic-byte validation
+    is performed. The upstream file viewer should perform its own content-type verification.
+    """
+    # Check content_type first
+    if content_type:
+        # content_type may include params like "image/png; charset=utf-8"
+        mime = content_type.split(";")[0].strip().lower()
+        if mime in ALLOWED_CONTENT_TYPES:
+            return True
+
+    # Fallback to extension check
+    if filename:
+        _, ext = os.path.splitext(filename)
+        if ext.lower() in ALLOWED_EXTENSIONS:
+            return True
+
+    return False
+
+
+def sanitize_filename(filename: str) -> str:
+    """
+    Sanitize a filename for safe storage.
+
+    - Strip path separators and null bytes
+    - Limit to 255 characters
+    - Replace problematic characters
+    """
+    if not filename:
+        return "unnamed"
+
+    # Remove null bytes
+    filename = filename.replace("\x00", "")
+
+    # Extract just the filename (strip any path components)
+    filename = filename.replace("\\", "/")
+    filename = filename.split("/")[-1]
+
+    # Remove control characters
+    filename = re.sub(r"[\x00-\x1f\x7f]", "", filename)
+
+    # Replace sequences of whitespace with single space
+    filename = re.sub(r"\s+", " ", filename).strip()
+
+    # Limit length
+    if len(filename) > 255:
+        name, ext = os.path.splitext(filename)
+        filename = name[: 255 - len(ext)] + ext
+
+    if not filename:
+        return "unnamed"
+
+    return filename
+
+
+def validate_cdn_url(url: str, allowlist: str) -> bool:
+    """
+    Validate that a URL comes from an allowed CDN domain (SSRF protection).
+
+    Args:
+        url: The URL to validate
+        allowlist: Comma-separated list of allowed domains
+    """
+    if not url:
+        return False
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+
+    # Must be HTTPS
+    if parsed.scheme != "https":
+        return False
+
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+
+    allowed_domains = [d.strip().lower() for d in allowlist.split(",") if d.strip()]
+    hostname_lower = hostname.lower()
+
+    for domain in allowed_domains:
+        if hostname_lower == domain or hostname_lower.endswith("." + domain):
+            return True
+
+    return False
+
+
+def split_message(text: str, max_len: int = 2000) -> list[str]:
+    """Split a message into chunks that fit within Discord's character limit."""
+    if len(text) <= max_len:
+        return [text]
+    parts = []
+    while text:
+        if len(text) <= max_len:
+            parts.append(text)
+            break
+        split = text.rfind("\n", 0, max_len)
+        if split <= 0:
+            split = max_len
+        parts.append(text[:split])
+        text = text[split:].lstrip("\n")
+    return parts

--- a/apps/discord/validation.py
+++ b/apps/discord/validation.py
@@ -23,6 +23,7 @@ ALLOWED_CONTENT_TYPES = {
     "image/gif",
     "image/webp",
     "application/pdf",
+    "application/json",  # Used by Google Maps upload (type: google-map)
 }
 
 # Allowed file extensions (fallback when content_type is missing)

--- a/apps/discord/validation.py
+++ b/apps/discord/validation.py
@@ -23,8 +23,12 @@ ALLOWED_CONTENT_TYPES = {
     "image/gif",
     "image/webp",
     "application/pdf",
-    "application/json",  # Used by Google Maps upload (type: google-map)
 }
+
+# Maps uploads use application/json but bypass validate_file_type
+# (they go through _handle_maps_url, not the DM upload path).
+# Do NOT add application/json to ALLOWED_CONTENT_TYPES — it would
+# let users DM arbitrary .json files through the upload flow.
 
 # Allowed file extensions (fallback when content_type is missing)
 ALLOWED_EXTENSIONS = {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
       "bump-patch-for-minor-pre-major": true
     },
     "apps/discord": {
-      "release-type": "go",
+      "release-type": "python",
       "component": "discord",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

Phase 1 of Discord bot repo migration. Moves all Python bot code from `qurl-integrations-infra/qurl-bot-discord/` to `apps/discord/`. Terraform stays in the infra repo.

**Migration scope:** This PR moves the code as-is with targeted fixes for security, correctness, and CI gaps identified during review. It does NOT refactor architecture — that's Phase 2 work after the migration lands.

## What's included

- **apps/discord/** — full Discord bot: adapters, services, db, metrics, bot_helpers, config, validation, rate_limiter, run.py
- **247 tests** passing from new location
- **Dockerfile** — non-root user, .dockerignore, healthcheck
- **.github/workflows/discord.yml** — build + test + ruff lint + Docker check + trigger deploy
- **Makefile** — `make test-discord` and `make check-discord`
- **release-please-config.json** — discord release-type changed from `go` to `python`

## Fixes applied during review (12 rounds)

| Category | Fix |
|----------|-----|
| Security | Non-root Dockerfile, Bearer token redaction broadened, JSON parsing error handling, NaN/Inf coordinate bypass |
| Correctness | Idempotent shutdown guard, lazy asyncio.Lock (Python 3.12 safe), conditional help message, separate Exception handlers |
| Performance | Shared httpx client pool, per-request timeouts, SQLite busy_timeout, guild check semaphore |
| CI | ruff linting (pinned), requirements-dev.txt split, .dockerignore, shared/ path trigger |
| Code quality | Module-level dispatch error mapping, public function naming, TOCTOU documented |

## Known architectural debt (NOT in scope for migration)

These patterns exist in the production code today and are tracked for post-migration improvement:

| Item | Why deferred |
|------|-------------|
| 920-line discord_bot.py | Splitting into modules is a refactor, not a migration (qurl-integrations-infra#31 item 38) |
| No mypy/pyright in CI | Adding type checking would surface dozens of existing issues — separate PR (qurl-integrations-infra#31 item 39) |
| conftest.py uses setdefault | Switching to monkeypatch requires test refactor across all files (qurl-integrations-infra#31 item 40) |
| No integration tests against Discord API | Requires test infrastructure (mock Discord gateway) (qurl-integrations-infra#31 item 41) |
| SQLite connection-per-call | Migrating to aiosqlite/connection pool is an architectural change (qurl-integrations-infra#31 item 42) |
| DispatchStatus as plain class | Converting to StrEnum changes import paths (qurl-integrations-infra#31 item 43) |

These are all candidates for follow-up PRs once the migration is complete and the code is in the right repo.

## Migration phases

| Phase | Repo | Status |
|-------|------|--------|
| **1. Copy bot code here** | qurl-integrations | **This PR** |
| 2. Update infra deploy to pull from here | qurl-integrations-infra PR #67 | Ready |
| 3. Delete bot code from infra repo | qurl-integrations-infra | After verification |

## What stays in qurl-integrations-infra

- `qurl-bot-discord/terraform/` — all Terraform (ECS, ECR, EFS, CloudWatch, IAM)
- Deploy workflow (updated in Phase 2 to checkout this repo for Docker build)

## Test plan

- [x] 247 tests pass from `apps/discord/`
- [x] `make test-discord` works
- [x] ruff lint passes clean
- [x] Docker build succeeds in CI
- [x] CI workflow runs on PR with path filtering
- [ ] End-to-end: deploy from new repo and verify bot responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
