### PR TITLE
perf(discord): add timing instrumentation to /qurl send

### DIFF
--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -613,8 +613,6 @@ async def qurl_send(
 ) -> None:
     """Dispatch per-recipient QURL links."""
     cmd_t0 = time.monotonic()
-    def _elapsed() -> int:
-        return round((time.monotonic() - cmd_t0) * 1000)
     user_id = str(interaction.user.id)
 
     if not rate_limiter.check(user_id):
@@ -683,7 +681,7 @@ async def qurl_send(
         )
         return
 
-    logger.debug("qurl_send: ownership+guild", extra={"elapsed_ms": _elapsed()})
+    logger.debug("qurl_send: ownership+guild", extra={"elapsed_ms": int((time.monotonic() - cmd_t0) * 1000)})
 
     # Parse mentioned users — handle commas, mentions, and raw IDs
     tokens = [t.strip() for t in users.replace(" ", ",").split(",") if t.strip()]
@@ -727,9 +725,9 @@ async def qurl_send(
 
     # Verify guild membership (parallel, shared helper)
     if interaction.guild:
-        logger.debug("qurl_send: pre-guild-check", extra={"elapsed_ms": _elapsed()})
+        logger.debug("qurl_send: pre-guild-check", extra={"elapsed_ms": int((time.monotonic() - cmd_t0) * 1000)})
         mentioned_ids = await check_guild_members(interaction.guild, mentioned_ids)
-        logger.debug("qurl_send: post-guild-check", extra={"elapsed_ms": _elapsed()})
+        logger.debug("qurl_send: post-guild-check", extra={"elapsed_ms": int((time.monotonic() - cmd_t0) * 1000)})
 
     if not mentioned_ids:
         await interaction.followup.send(
@@ -746,12 +744,30 @@ async def qurl_send(
         _dispatch_to_recipient(rid, user_id, uid, guild_id, expires_in=expires_value)
         for uid in mentioned_ids
     ]
-    logger.debug("qurl_send: pre-dispatch", extra={"elapsed_ms": _elapsed(), "recipients": len(mentioned_ids)})
-    results = await asyncio.gather(*tasks)
-    total_ms = _elapsed()
-    succeeded = sum(1 for _, status, _, _ in results if status == DispatchStatus.SENT)
-    logger.info("qurl_send: complete", extra={"elapsed_ms": total_ms, "dispatched_to": len(mentioned_ids), "succeeded": succeeded, "resource_id": rid, "guild_id": guild_id})
-    metrics.timing("QUrlSendLatency", total_ms)
+    dispatched_to = len(mentioned_ids)
+    succeeded = 0
+    results: list = []
+    # try/finally so timing emits even if gather raises — failures are exactly
+    # the tail-latency cases this metric exists to surface.
+    try:
+        logger.debug("qurl_send: pre-dispatch", extra={"elapsed_ms": int((time.monotonic() - cmd_t0) * 1000), "recipients": dispatched_to})
+        results = await asyncio.gather(*tasks)
+        # Positional access instead of 4-tuple unpacking so a future return-shape
+        # change in _dispatch_to_recipient fails at the declaration, not here.
+        succeeded = sum(1 for r in results if r[1] == DispatchStatus.SENT)
+    finally:
+        total_ms = int((time.monotonic() - cmd_t0) * 1000)
+        logger.info(
+            "qurl_send: complete",
+            extra={
+                "elapsed_ms": total_ms,
+                "dispatched_to": dispatched_to,
+                "succeeded": succeeded,
+                "resource_id": rid,
+                "guild_id": guild_id,
+            },
+        )
+        metrics.timing("QurlSendCommandLatency", total_ms)
 
     filename = owner_info.get("filename", rid)
     summary = format_dispatch_summary(filename, results)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -749,7 +749,8 @@ async def qurl_send(
     logger.debug("qurl_send: pre-dispatch", extra={"elapsed_ms": _elapsed(), "recipients": len(mentioned_ids)})
     results = await asyncio.gather(*tasks)
     total_ms = _elapsed()
-    logger.info("qurl_send: complete", extra={"elapsed_ms": total_ms, "dispatched_to": len(mentioned_ids), "resource_id": rid, "guild_id": guild_id})
+    succeeded = sum(1 for _, status, _, _ in results if status == DispatchStatus.SENT)
+    logger.info("qurl_send: complete", extra={"elapsed_ms": total_ms, "dispatched_to": len(mentioned_ids), "succeeded": succeeded, "resource_id": rid, "guild_id": guild_id})
     metrics.timing("QUrlSendLatency", total_ms)
 
     filename = owner_info.get("filename", rid)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -645,7 +645,8 @@ async def qurl_send(
         return
 
     # Permanent instrumentation: helps diagnose slow /qurl send in production logs.
-    logger.debug("qurl_send: pre-ownership at %.0fms", (time.monotonic() - cmd_t0) * 1000)
+    # Guarded by DEBUG level — filtered in production unless explicitly enabled.
+    logger.debug("qurl_send: pre-ownership", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
     # Check ownership (run in thread since SQLite is synchronous)
     owner_info = await asyncio.to_thread(get_owner, rid)
     if not owner_info:
@@ -683,7 +684,7 @@ async def qurl_send(
         )
         return
 
-    logger.debug("qurl_send: ownership+guild took %.0fms", (time.monotonic() - cmd_t0) * 1000)
+    logger.debug("qurl_send: ownership+guild", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
 
     # Parse mentioned users — handle commas, mentions, and raw IDs
     tokens = [t.strip() for t in users.replace(" ", ",").split(",") if t.strip()]
@@ -727,9 +728,9 @@ async def qurl_send(
 
     # Verify guild membership (parallel, shared helper)
     if interaction.guild:
-        logger.debug("qurl_send: pre-guild-check at %.0fms", (time.monotonic() - cmd_t0) * 1000)
+        logger.debug("qurl_send: pre-guild-check", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
         mentioned_ids = await check_guild_members(interaction.guild, mentioned_ids)
-        logger.debug("qurl_send: post-guild-check at %.0fms", (time.monotonic() - cmd_t0) * 1000)
+        logger.debug("qurl_send: post-guild-check", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
 
     if not mentioned_ids:
         await interaction.followup.send(
@@ -746,9 +747,10 @@ async def qurl_send(
         _dispatch_to_recipient(rid, user_id, uid, guild_id, expires_in=expires_value)
         for uid in mentioned_ids
     ]
+    logger.debug("qurl_send: pre-dispatch", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000), "recipients": len(mentioned_ids)})
     results = await asyncio.gather(*tasks)
-    # INFO intentionally: summary visible in prod; bump to DEBUG for per-stage breakdown.
-    logger.info("qurl_send: total=%.0fms dispatched_to=%d", (time.monotonic() - cmd_t0) * 1000, len(mentioned_ids))
+    # INFO intentionally: summary visible in prod; DEBUG for per-stage breakdown.
+    logger.info("qurl_send: complete", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000), "dispatched_to": len(mentioned_ids), "resource_id": rid, "guild_id": guild_id})
 
     filename = owner_info.get("filename", rid)
     summary = format_dispatch_summary(filename, results)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -645,7 +645,7 @@ async def qurl_send(
         return
 
     # Permanent instrumentation: helps diagnose slow /qurl send in production logs.
-    logger.debug("qurl_send: defer took %.0fms", (time.monotonic() - cmd_t0) * 1000)
+    logger.debug("qurl_send: pre-ownership at %.0fms", (time.monotonic() - cmd_t0) * 1000)
     # Check ownership (run in thread since SQLite is synchronous)
     owner_info = await asyncio.to_thread(get_owner, rid)
     if not owner_info:

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -613,6 +613,8 @@ async def qurl_send(
 ) -> None:
     """Dispatch per-recipient QURL links."""
     cmd_t0 = time.monotonic()
+    def _elapsed() -> int:
+        return round((time.monotonic() - cmd_t0) * 1000)
     user_id = str(interaction.user.id)
 
     if not rate_limiter.check(user_id):
@@ -644,9 +646,6 @@ async def qurl_send(
         await interaction.followup.send("Invalid resource ID format.", ephemeral=True)
         return
 
-    # Permanent instrumentation: helps diagnose slow /qurl send in production logs.
-    # Guarded by DEBUG level — filtered in production unless explicitly enabled.
-    logger.debug("qurl_send: pre-ownership", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
     # Check ownership (run in thread since SQLite is synchronous)
     owner_info = await asyncio.to_thread(get_owner, rid)
     if not owner_info:
@@ -684,7 +683,7 @@ async def qurl_send(
         )
         return
 
-    logger.debug("qurl_send: ownership+guild", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
+    logger.debug("qurl_send: ownership+guild", extra={"elapsed_ms": _elapsed()})
 
     # Parse mentioned users — handle commas, mentions, and raw IDs
     tokens = [t.strip() for t in users.replace(" ", ",").split(",") if t.strip()]
@@ -728,9 +727,9 @@ async def qurl_send(
 
     # Verify guild membership (parallel, shared helper)
     if interaction.guild:
-        logger.debug("qurl_send: pre-guild-check", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
+        logger.debug("qurl_send: pre-guild-check", extra={"elapsed_ms": _elapsed()})
         mentioned_ids = await check_guild_members(interaction.guild, mentioned_ids)
-        logger.debug("qurl_send: post-guild-check", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000)})
+        logger.debug("qurl_send: post-guild-check", extra={"elapsed_ms": _elapsed()})
 
     if not mentioned_ids:
         await interaction.followup.send(
@@ -747,10 +746,11 @@ async def qurl_send(
         _dispatch_to_recipient(rid, user_id, uid, guild_id, expires_in=expires_value)
         for uid in mentioned_ids
     ]
-    logger.debug("qurl_send: pre-dispatch", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000), "recipients": len(mentioned_ids)})
+    logger.debug("qurl_send: pre-dispatch", extra={"elapsed_ms": _elapsed(), "recipients": len(mentioned_ids)})
     results = await asyncio.gather(*tasks)
-    # INFO intentionally: summary visible in prod; DEBUG for per-stage breakdown.
-    logger.info("qurl_send: complete", extra={"elapsed_ms": round((time.monotonic() - cmd_t0) * 1000), "dispatched_to": len(mentioned_ids), "resource_id": rid, "guild_id": guild_id})
+    total_ms = _elapsed()
+    logger.info("qurl_send: complete", extra={"elapsed_ms": total_ms, "dispatched_to": len(mentioned_ids), "resource_id": rid, "guild_id": guild_id})
+    metrics.timing("QUrlSendLatency", total_ms)
 
     filename = owner_info.get("filename", rid)
     summary = format_dispatch_summary(filename, results)

--- a/apps/discord/adapters/discord_bot.py
+++ b/apps/discord/adapters/discord_bot.py
@@ -612,6 +612,7 @@ async def qurl_send(
     expires: Optional[app_commands.Choice[str]] = None,
 ) -> None:
     """Dispatch per-recipient QURL links."""
+    cmd_t0 = time.monotonic()
     user_id = str(interaction.user.id)
 
     if not rate_limiter.check(user_id):
@@ -643,6 +644,8 @@ async def qurl_send(
         await interaction.followup.send("Invalid resource ID format.", ephemeral=True)
         return
 
+    # Permanent instrumentation: helps diagnose slow /qurl send in production logs.
+    logger.debug("qurl_send: defer took %.0fms", (time.monotonic() - cmd_t0) * 1000)
     # Check ownership (run in thread since SQLite is synchronous)
     owner_info = await asyncio.to_thread(get_owner, rid)
     if not owner_info:
@@ -679,6 +682,8 @@ async def qurl_send(
             "This resource is bound to a different server.", ephemeral=True
         )
         return
+
+    logger.debug("qurl_send: ownership+guild took %.0fms", (time.monotonic() - cmd_t0) * 1000)
 
     # Parse mentioned users — handle commas, mentions, and raw IDs
     tokens = [t.strip() for t in users.replace(" ", ",").split(",") if t.strip()]
@@ -722,7 +727,9 @@ async def qurl_send(
 
     # Verify guild membership (parallel, shared helper)
     if interaction.guild:
+        logger.debug("qurl_send: pre-guild-check at %.0fms", (time.monotonic() - cmd_t0) * 1000)
         mentioned_ids = await check_guild_members(interaction.guild, mentioned_ids)
+        logger.debug("qurl_send: post-guild-check at %.0fms", (time.monotonic() - cmd_t0) * 1000)
 
     if not mentioned_ids:
         await interaction.followup.send(
@@ -740,6 +747,8 @@ async def qurl_send(
         for uid in mentioned_ids
     ]
     results = await asyncio.gather(*tasks)
+    # INFO intentionally: summary visible in prod; bump to DEBUG for per-stage breakdown.
+    logger.info("qurl_send: total=%.0fms dispatched_to=%d", (time.monotonic() - cmd_t0) * 1000, len(mentioned_ids))
 
     filename = owner_info.get("filename", rid)
     summary = format_dispatch_summary(filename, results)

--- a/apps/discord/config.py
+++ b/apps/discord/config.py
@@ -31,6 +31,15 @@ class Settings(BaseSettings):
     # GOOGLE_MAPS_ENABLED=true in ECS task definition env vars to enable.
     # TODO: read from SSM Parameter Store at runtime for no-redeploy toggle.
     google_maps_enabled: bool = False
+    log_level: str = "INFO"
+
+    @field_validator("log_level")
+    @classmethod
+    def _validate_log_level(cls, v: str) -> str:
+        v = v.strip().upper()
+        if v not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
+            raise ValueError(f"LOG_LEVEL must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL, got: {v!r}")
+        return v
 
     @field_validator("qurl_link_hostname")
     @classmethod

--- a/apps/discord/run.py
+++ b/apps/discord/run.py
@@ -39,7 +39,7 @@ class AuditJsonFormatter(logging.Formatter):
 
 handler = logging.StreamHandler()
 handler.setFormatter(AuditJsonFormatter())
-logging.basicConfig(level=logging.INFO, handlers=[handler])
+logging.basicConfig(level=settings.log_level, handlers=[handler])
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Why

Users are reporting that the "Links sent" confirmation on `/qurl send` feels slow — sometimes seconds after they hit enter. We don't have any timing data on this path, so we can't tell whether the bottleneck is ownership/guild checks, guild-membership lookups, Discord DM fan-out, or the mint API. This PR adds enough instrumentation to attribute latency to a stage the next time a user complains.

## What

**New metric** — `QurlSendCommandLatency` emitted from `/qurl send`, always (including on exception via `try/finally`). Names the whole-command wall clock so we can dashboard p50/p95/p99 alongside the existing per-recipient `DispatchLatency`.

**Staged DEBUG checkpoints** in the command handler, gated behind a new `LOG_LEVEL` env var (default `INFO`). Ops can flip the bot to `LOG_LEVEL=DEBUG` during a diagnostic session without a code change; in steady state they stay silent so we don't balloon log volume.

**Final INFO summary** — one structured log per `/qurl send` with `elapsed_ms`, `dispatched_to`, `succeeded`, `resource_id`, `guild_id`. This is the line to filter on when investigating a report.

## Not "no functional changes"

Earlier revisions of this PR described it as "debug logs only". That wasn't quite right — we're emitting a new metric to CloudWatch and adding a config knob. No product behavior changes, but the observability surface does.

## Test plan
- [ ] `make check` green
- [ ] Manual: invoke `/qurl send` in sandbox Discord, confirm `QurlSendCommandLatency` appears in CloudWatch and the INFO summary line shows in CloudWatch Logs with `elapsed_ms` populated
- [ ] Set `LOG_LEVEL=DEBUG` on sandbox, invoke again, confirm the four checkpoint lines appear
- [ ] Force a DM-failed recipient, confirm `succeeded < dispatched_to` in the summary
- [ ] Simulate `asyncio.gather` cancellation (or equivalent failure injection), confirm the metric still emits via the `finally` branch