### PR TITLE
fix(ci): allow AGPL-3.0 for TruffleHog in dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,4 +21,8 @@ jobs:
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0
+          # TruffleHog is AGPL-3.0 but runs only in CI (secret scanning),
+          # not in distributed code. AGPL obligations don't apply to tools
+          # you execute — only to code you distribute or expose as a service.
+          allow-dependencies-licenses: "pkg:githubactions/trufflesecurity/trufflehog"
           comment-summary-in-pr: always


### PR DESCRIPTION
## Summary

Dependabot PR #33 (TruffleHog 3.93.7 → 3.94.0) fails the dependency review because TruffleHog is AGPL-3.0 and our deny-list blocks AGPL.

## Why this is safe

TruffleHog runs only in CI for secret scanning. AGPL obligations apply to code you **distribute** or **expose as a network service** — not to tools you execute in your own CI pipeline. We don't ship TruffleHog to users or expose it as a service.

## Fix

Add `allow-dependencies-licenses` for the specific TruffleHog Action package, keeping the global AGPL deny-list intact for actual dependencies.

## After merge

Rebase Dependabot PR #33 (`@dependabot rebase`) — it should pass dependency review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)