### PR TITLE
chore(ci): add 18-minute timeout to claude-review job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,7 @@ jobs:
   claude-review:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 18
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary

Adds an explicit `timeout-minutes: 18` to the `claude-review` job in `.github/workflows/claude-code-review.yml`.

Without this, the job inherits GitHub Actions' default 6-hour timeout, which means a hung `anthropics/claude-code-action@v1` run (observed on layervai/qurl-python#8) consumes runner minutes and leaves a stale `in_progress` status check on the PR for hours.

## Tailored timeout

The `18`-minute value is derived from this repo's observed `claude-review` run times across the last 30 successful runs:

- **p50:** 129s
- **p95:** 7.85min
- **max:** 9min
- **mean:** 166s

Formula: `max(8, ceil(p95_minutes * 2) + 2)` — 2× p95 + 2-minute safety margin, floored at 8 minutes. This gives each repo a bound that's generous relative to its own historical upper-bound while still catching future hangs within a reasonable window.

## Test plan

- [x] Single-line diff (only the new `timeout-minutes` line is added)
- [x] Base64-roundtrip validated
- [ ] Next `claude-review` run on this repo should complete normally within the timeout

## Context

Companion PRs are being opened across all 10 layervai repos that use this workflow, each with its own tailored timeout based on the repo's p95. Motivated by the stuck run at https://github.com/layervai/qurl-python/actions/runs/24288312714 which burned ~18 minutes before manual cancellation.