### PR TITLE
ci: migrate dep-age shims to ops-routines-workflows v0.1.0

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -45,4 +45,10 @@ jobs:
       min_age_days: 7
     permissions:
       contents: read
-    secrets: inherit
+    # Only the App credentials needed for cross-repo checkout of
+    # ops-routines (private/internal repo). Using `secrets: inherit`
+    # would forward ALL org/repo secrets to the reusable; this
+    # explicit block follows least-privilege.
+    secrets:
+      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
+      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -1,7 +1,6 @@
 # Dependency Age Check (GitHub Actions pins)
 # Thin shim calling shared reusable workflow.
-# Source: https://github.com/layervai/ops-routines/blob/main/.github/workflows/age-check-actions.yml
-# Implementation: https://github.com/layervai/ops-routines/blob/main/lib/age-check-actions.sh
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-actions.yml
 name: Dependency Age Check (Actions)
 
 # Fires on every PR (no path filter) so the status check always reports.

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -40,8 +40,9 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@2b9cb3575a74394cf56092d33ee4fdbab30afc9e # v0.1.4
+    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
     with:
       min_age_days: 7
     permissions:
       contents: read
+    secrets: inherit

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -40,15 +40,8 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
     with:
       min_age_days: 7
     permissions:
       contents: read
-    # Only the App credentials needed for cross-repo checkout of
-    # ops-routines (private/internal repo). Using `secrets: inherit`
-    # would forward ALL org/repo secrets to the reusable; this
-    # explicit block follows least-privilege.
-    secrets:
-      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
-      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -40,7 +40,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-docker.yml@2b9cb3575a74394cf56092d33ee4fdbab30afc9e # v0.1.4
+    uses: layervai/ops-routines/.github/workflows/age-check-docker.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
     with:
       # Container images get 14 days (vs 7 for source-package
       # ecosystems) — base-image vendors typically take longer to
@@ -50,3 +50,4 @@ jobs:
       min_age_days: 14
     permissions:
       contents: read
+    secrets: inherit

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -40,7 +40,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-docker.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
     with:
       # Container images get 14 days (vs 7 for source-package
       # ecosystems) — base-image vendors typically take longer to
@@ -50,10 +50,3 @@ jobs:
       min_age_days: 14
     permissions:
       contents: read
-    # Only the App credentials needed for cross-repo checkout of
-    # ops-routines (private/internal repo). Using `secrets: inherit`
-    # would forward ALL org/repo secrets to the reusable; this
-    # explicit block follows least-privilege.
-    secrets:
-      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
-      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -50,4 +50,10 @@ jobs:
       min_age_days: 14
     permissions:
       contents: read
-    secrets: inherit
+    # Only the App credentials needed for cross-repo checkout of
+    # ops-routines (private/internal repo). Using `secrets: inherit`
+    # would forward ALL org/repo secrets to the reusable; this
+    # explicit block follows least-privilege.
+    secrets:
+      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
+      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -1,7 +1,6 @@
 # Dependency Age Check (Docker)
 # Thin shim calling shared reusable workflow.
-# Source: https://github.com/layervai/ops-routines/blob/main/.github/workflows/age-check-docker.yml
-# Implementation: https://github.com/layervai/ops-routines/blob/main/lib/age-check-docker.sh
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-docker.yml
 name: Dependency Age Check (Docker)
 
 # Fires on every PR (no path filter) so the status check always reports.

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -47,4 +47,10 @@ jobs:
       min_age_days: 7
     permissions:
       contents: read
-    secrets: inherit
+    # Only the App credentials needed for cross-repo checkout of
+    # ops-routines (private/internal repo). Using `secrets: inherit`
+    # would forward ALL org/repo secrets to the reusable; this
+    # explicit block follows least-privilege.
+    secrets:
+      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
+      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -1,7 +1,6 @@
 # Dependency Age Check (Go modules)
 # Thin shim calling shared reusable workflow.
-# Source: https://github.com/layervai/ops-routines/blob/main/.github/workflows/age-check-go.yml
-# Implementation: https://github.com/layervai/ops-routines/blob/main/lib/age-check-go.sh
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-go.yml
 name: Dependency Age Check (Go)
 
 # Fires on every PR (no path filter) so the status check always reports.

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -42,15 +42,8 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-go.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
     with:
       min_age_days: 7
     permissions:
       contents: read
-    # Only the App credentials needed for cross-repo checkout of
-    # ops-routines (private/internal repo). Using `secrets: inherit`
-    # would forward ALL org/repo secrets to the reusable; this
-    # explicit block follows least-privilege.
-    secrets:
-      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
-      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -42,8 +42,9 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-go.yml@2b9cb3575a74394cf56092d33ee4fdbab30afc9e # v0.1.4
+    uses: layervai/ops-routines/.github/workflows/age-check-go.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
     with:
       min_age_days: 7
     permissions:
       contents: read
+    secrets: inherit

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -39,7 +39,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-pip.yml@2b9cb3575a74394cf56092d33ee4fdbab30afc9e # v0.1.4
+    uses: layervai/ops-routines/.github/workflows/age-check-pip.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
     with:
       min_age_days: 7
       # Scoped to apps/discord — the only Python app in this Go
@@ -48,3 +48,4 @@ jobs:
       working_directory: apps/discord
     permissions:
       contents: read
+    secrets: inherit

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -48,4 +48,10 @@ jobs:
       working_directory: apps/discord
     permissions:
       contents: read
-    secrets: inherit
+    # Only the App credentials needed for cross-repo checkout of
+    # ops-routines (private/internal repo). Using `secrets: inherit`
+    # would forward ALL org/repo secrets to the reusable; this
+    # explicit block follows least-privilege.
+    secrets:
+      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
+      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -39,7 +39,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines/.github/workflows/age-check-pip.yml@3922bbc6e7ebaef4d8225cfbd9754412137ebf66 # v0.1.8
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
     with:
       min_age_days: 7
       # Scoped to apps/discord — the only Python app in this Go
@@ -48,10 +48,3 @@ jobs:
       working_directory: apps/discord
     permissions:
       contents: read
-    # Only the App credentials needed for cross-repo checkout of
-    # ops-routines (private/internal repo). Using `secrets: inherit`
-    # would forward ALL org/repo secrets to the reusable; this
-    # explicit block follows least-privilege.
-    secrets:
-      OPS_ROUTINES_APP_ID: ${{ secrets.OPS_ROUTINES_APP_ID }}
-      OPS_ROUTINES_APP_PRIVATE_KEY: ${{ secrets.OPS_ROUTINES_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -1,7 +1,6 @@
 # Dependency Age Check (pip / Python)
 # Thin shim calling shared reusable workflow.
-# Source: https://github.com/layervai/ops-routines/blob/main/.github/workflows/age-check-pip.yml
-# Implementation: https://github.com/layervai/ops-routines/blob/main/lib/age-check-pip.sh
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-pip.yml
 name: Dependency Age Check (pip)
 
 # Fires on every PR (no path filter) so the status check always reports.


### PR DESCRIPTION
Validated on qurl-autosec + dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)