### PR TITLE
ci: bump dep-age shims to ops-routines-workflows v0.2.0

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -39,7 +39,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
     with:
       min_age_days: 7
     permissions:

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -39,7 +39,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
     with:
       # Container images get 14 days (vs 7 for source-package
       # ecosystems) — base-image vendors typically take longer to

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -41,7 +41,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
     with:
       min_age_days: 7
     permissions:

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -38,7 +38,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@c70260f4919aa91e3b5e1494b32d3a8b90f9c592 # v0.1.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
     with:
       min_age_days: 7
       # Scoped to apps/discord — the only Python app in this Go


### PR DESCRIPTION
Picks up the colliding-job-ID rename from ops-routines#18 (check-dependency-age → check-go-age / check-pip-age). Branch protection required-check names updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)