### PR TITLE
fix(slack): verify HMAC signature on every Slack endpoint (#71)

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -3,7 +3,9 @@ package internal
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -57,17 +59,17 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 	switch {
 	case req.Path == "/slack/commands" && req.HTTPMethod == methodPost:
 		if err := h.verifySlackRequest(req); err != nil {
-			return unauthorized(err)
+			return unauthorized()
 		}
 		return h.handleSlashCommand(ctx, req)
 	case req.Path == "/slack/events" && req.HTTPMethod == methodPost:
 		if err := h.verifySlackRequest(req); err != nil {
-			return unauthorized(err)
+			return unauthorized()
 		}
 		return h.handleEvent(req)
 	case req.Path == "/slack/interactions" && req.HTTPMethod == methodPost:
 		if err := h.verifySlackRequest(req); err != nil {
-			return unauthorized(err)
+			return unauthorized()
 		}
 		return h.handleInteraction(req)
 	case req.Path == "/health":
@@ -81,30 +83,72 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 // verification error, the caller rejects the request with 401 and logs the
 // failure class so operator metrics can separate "not Slack" noise from
 // tampering attempts.
+//
+// API Gateway sets IsBase64Encoded=true for any content type in the Lambda's
+// binary-media-types list. Slack slash commands arrive as
+// application/x-www-form-urlencoded and events as application/json; both are
+// normally treated as text. If the API Gateway config ever flips (or if a
+// new binary-media-type matches by accident), the body handed to the Lambda
+// is base64, and the HMAC over that base64 will not match Slack's HMAC over
+// the raw body — every valid request would start 401ing silently. Decode
+// here so the signature check runs against the same bytes Slack signed,
+// turning the infra misconfig into a decode-error 401 with a distinct
+// log line instead of a silent outage.
 func (h *Handler) verifySlackRequest(req *events.APIGatewayProxyRequest) error {
+	body := req.Body
+	if req.IsBase64Encoded {
+		decoded, err := base64.StdEncoding.DecodeString(req.Body)
+		if err != nil {
+			slog.Warn("slack signature verification failed — base64 body decode error",
+				"path", req.Path,
+				"error", err.Error())
+			return errSlackSignatureMalformed
+		}
+		body = string(decoded)
+	}
+
 	sig := headerValue(req.Headers, headerSlackSignature)
 	ts := headerValue(req.Headers, headerSlackTimestamp)
-	err := verifySlackSignature(h.cfg.SlackSigningSecret, req.Body, sig, ts, h.now())
+	err := verifySlackSignature(h.cfg.SlackSigningSecret, body, sig, ts, h.now())
 	if err != nil {
 		slog.Warn("slack signature verification failed",
 			"path", req.Path,
-			"reason", err.Error(),
+			"reason", classifySlackErr(err),
 			"has_signature", sig != "",
-			"has_timestamp", ts != "")
+			"has_timestamp", ts != "",
+			"is_base64", req.IsBase64Encoded)
 	}
 	return err
 }
 
-// headerValue fetches a header case-insensitively — API Gateway preserves the
-// caller's casing, so "X-Slack-Signature" may arrive lowercased or not at all.
-// Uses MultiValueHeaders when present for endpoints that receive duplicates.
+// classifySlackErr maps the sentinel verification errors to stable metric
+// labels so operator dashboards can group by cause without string-matching
+// error messages (which may be reworded over time).
+func classifySlackErr(err error) string {
+	switch {
+	case errors.Is(err, errSlackSigningSecretEmpty):
+		return "secret_empty"
+	case errors.Is(err, errSlackSignatureMissing):
+		return "headers_missing"
+	case errors.Is(err, errSlackSignatureMalformed):
+		return "malformed"
+	case errors.Is(err, errSlackTimestampStale):
+		return "stale"
+	case errors.Is(err, errSlackSignatureMismatch):
+		return "mismatch"
+	default:
+		return "unknown"
+	}
+}
+
+// headerValue fetches a header case-insensitively — API Gateway v1 preserves
+// caller casing, v2 lowercases, and strings.EqualFold handles both.
 func headerValue(headers map[string]string, name string) string {
 	if v, ok := headers[name]; ok {
 		return v
 	}
-	lower := strings.ToLower(name)
 	for k, v := range headers {
-		if strings.EqualFold(k, lower) {
+		if strings.EqualFold(k, name) {
 			return v
 		}
 	}
@@ -115,7 +159,7 @@ func headerValue(headers map[string]string, name string) string {
 // intentionally terse — a caller able to read it can only learn that signing
 // is required, not why the particular attempt failed. Misconfig vs. attacker
 // activity is already distinguished in the structured slog.Warn above.
-func unauthorized(_ error) (events.APIGatewayProxyResponse, error) {
+func unauthorized() (events.APIGatewayProxyResponse, error) {
 	return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -23,6 +23,11 @@ const methodPost = "POST"
 
 const authFailureMessage = "Failed to authenticate. Please check your QURL API key configuration."
 
+// sigFailureResponse is the terse body we return for every 401 from the
+// signature-verify path. Distinguishing which check failed is already
+// captured in the structured slog line; the wire body stays uniform.
+const sigFailureResponse = "signature verification failed"
+
 const (
 	// Matched case-insensitively — API Gateway preserves or lowercases depending on version.
 	headerSlackSignature = "X-Slack-Signature"
@@ -57,17 +62,17 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 	switch {
 	case req.Path == "/slack/commands" && req.HTTPMethod == methodPost:
 		if err := h.prepareAndVerifySlackRequest(req); err != nil {
-			return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
+			return respond(http.StatusUnauthorized, map[string]string{"error": sigFailureResponse})
 		}
 		return h.handleSlashCommand(ctx, req)
 	case req.Path == "/slack/events" && req.HTTPMethod == methodPost:
 		if err := h.prepareAndVerifySlackRequest(req); err != nil {
-			return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
+			return respond(http.StatusUnauthorized, map[string]string{"error": sigFailureResponse})
 		}
 		return h.handleEvent(req)
 	case req.Path == "/slack/interactions" && req.HTTPMethod == methodPost:
 		if err := h.prepareAndVerifySlackRequest(req); err != nil {
-			return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
+			return respond(http.StatusUnauthorized, map[string]string{"error": sigFailureResponse})
 		}
 		return h.handleInteraction(req)
 	case req.Path == "/health":
@@ -140,8 +145,11 @@ func classifySlackErr(err error) string {
 }
 
 // headerValue does a case-insensitive lookup against both Headers and
-// MultiValueHeaders so v1 and v2 API Gateway both work. Single-value pick
-// is safe because Slack's signature/timestamp headers aren't multi-valued.
+// MultiValueHeaders so v1 and v2 API Gateway both work. Assumes only one
+// casing of a given header name is present per request — if both
+// "X-Slack-Signature" and "x-slack-signature" appear in the same map,
+// Go's randomized map iteration means the returned value is
+// non-deterministic. API Gateway doesn't emit that shape in practice.
 func headerValue(headers map[string]string, multi map[string][]string, name string) string {
 	if v, ok := headers[name]; ok {
 		return v

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -95,7 +95,6 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 // turning the infra misconfig into a decode-error 401 with a distinct
 // log line instead of a silent outage.
 func (h *Handler) verifySlackRequest(req *events.APIGatewayProxyRequest) error {
-	body := req.Body
 	if req.IsBase64Encoded {
 		decoded, err := base64.StdEncoding.DecodeString(req.Body)
 		if err != nil {
@@ -104,19 +103,35 @@ func (h *Handler) verifySlackRequest(req *events.APIGatewayProxyRequest) error {
 				"error", err.Error())
 			return errSlackSignatureMalformed
 		}
-		body = string(decoded)
+		// Rewrite req.Body so every downstream handler (handleSlashCommand,
+		// handleEvent, handleInteraction) sees the same bytes Slack signed,
+		// not the API-Gateway-wrapped base64. Without this, a valid signed
+		// slash command would verify then silently fall through to the help
+		// path because url.ParseQuery would parse a base64 blob.
+		req.Body = string(decoded)
+		req.IsBase64Encoded = false
 	}
 
 	sig := headerValue(req.Headers, headerSlackSignature)
 	ts := headerValue(req.Headers, headerSlackTimestamp)
-	err := verifySlackSignature(h.cfg.SlackSigningSecret, body, sig, ts, h.now())
+	err := verifySlackSignature(h.cfg.SlackSigningSecret, req.Body, sig, ts, h.now())
 	if err != nil {
-		slog.Warn("slack signature verification failed",
+		// Escalate empty-signing-secret to Error — it means the deployment
+		// is effectively open; the fail-closed 401s are defense-in-depth,
+		// not the primary guard. Pages should route differently for this.
+		// Other failure classes are noise from unauthenticated scans and
+		// stay at Warn.
+		attrs := []any{
 			"path", req.Path,
 			"reason", classifySlackErr(err),
 			"has_signature", sig != "",
 			"has_timestamp", ts != "",
-			"is_base64", req.IsBase64Encoded)
+		}
+		if errors.Is(err, errSlackSigningSecretEmpty) {
+			slog.Error("slack signature verification failed — signing secret is empty (deployment is open)", attrs...)
+		} else {
+			slog.Warn("slack signature verification failed", attrs...)
+		}
 	}
 	return err
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 
@@ -19,6 +20,14 @@ import (
 const methodPost = "POST"
 
 const authFailureMessage = "Failed to authenticate. Please check your QURL API key configuration."
+
+// Header names API Gateway passes through for Slack's signing scheme. Matched
+// case-insensitively per RFC 7230 — API Gateway may normalize to lowercase or
+// preserve the caller's casing.
+const (
+	headerSlackSignature = "X-Slack-Signature"
+	headerSlackTimestamp = "X-Slack-Request-Timestamp"
+)
 
 // Config holds the Slack handler configuration.
 type Config struct {
@@ -31,11 +40,14 @@ type Config struct {
 // Handler processes Slack events and commands.
 type Handler struct {
 	cfg Config
+	// now is injected so tests can pin the clock for timestamp-skew checks
+	// without touching a package global. Defaults to time.Now.
+	now func() time.Time
 }
 
 // NewHandler creates a new Slack handler.
 func NewHandler(cfg Config) *Handler {
-	return &Handler{cfg: cfg}
+	return &Handler{cfg: cfg, now: time.Now}
 }
 
 // Handle routes incoming API Gateway requests to the appropriate handler.
@@ -44,16 +56,67 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 
 	switch {
 	case req.Path == "/slack/commands" && req.HTTPMethod == methodPost:
+		if err := h.verifySlackRequest(req); err != nil {
+			return unauthorized(err)
+		}
 		return h.handleSlashCommand(ctx, req)
 	case req.Path == "/slack/events" && req.HTTPMethod == methodPost:
+		if err := h.verifySlackRequest(req); err != nil {
+			return unauthorized(err)
+		}
 		return h.handleEvent(req)
 	case req.Path == "/slack/interactions" && req.HTTPMethod == methodPost:
+		if err := h.verifySlackRequest(req); err != nil {
+			return unauthorized(err)
+		}
 		return h.handleInteraction(req)
 	case req.Path == "/health":
 		return respond(http.StatusOK, map[string]string{"status": "ok"})
 	default:
 		return respond(http.StatusNotFound, map[string]string{"error": "not found"})
 	}
+}
+
+// verifySlackRequest authenticates an incoming Slack HTTP request. On any
+// verification error, the caller rejects the request with 401 and logs the
+// failure class so operator metrics can separate "not Slack" noise from
+// tampering attempts.
+func (h *Handler) verifySlackRequest(req *events.APIGatewayProxyRequest) error {
+	sig := headerValue(req.Headers, headerSlackSignature)
+	ts := headerValue(req.Headers, headerSlackTimestamp)
+	err := verifySlackSignature(h.cfg.SlackSigningSecret, req.Body, sig, ts, h.now())
+	if err != nil {
+		slog.Warn("slack signature verification failed",
+			"path", req.Path,
+			"reason", err.Error(),
+			"has_signature", sig != "",
+			"has_timestamp", ts != "")
+	}
+	return err
+}
+
+// headerValue fetches a header case-insensitively — API Gateway preserves the
+// caller's casing, so "X-Slack-Signature" may arrive lowercased or not at all.
+// Uses MultiValueHeaders when present for endpoints that receive duplicates.
+func headerValue(headers map[string]string, name string) string {
+	if v, ok := headers[name]; ok {
+		return v
+	}
+	lower := strings.ToLower(name)
+	for k, v := range headers {
+		if strings.EqualFold(k, lower) {
+			return v
+		}
+	}
+	return ""
+}
+
+// unauthorized returns a 401 response for a Slack-signature failure. Body is
+// intentionally terse — a caller able to read it can only learn that signing
+// is required, not why the particular attempt failed. Misconfig vs. attacker
+// activity is already distinguished in the structured slog.Warn above.
+func unauthorized(_ error) (events.APIGatewayProxyResponse, error) {
+	return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
 }
 
 func (h *Handler) handleSlashCommand(ctx context.Context, req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -58,17 +58,17 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 
 	switch {
 	case req.Path == "/slack/commands" && req.HTTPMethod == methodPost:
-		if err := h.verifySlackRequest(req); err != nil {
+		if err := h.prepareAndVerifySlackRequest(req); err != nil {
 			return unauthorized()
 		}
 		return h.handleSlashCommand(ctx, req)
 	case req.Path == "/slack/events" && req.HTTPMethod == methodPost:
-		if err := h.verifySlackRequest(req); err != nil {
+		if err := h.prepareAndVerifySlackRequest(req); err != nil {
 			return unauthorized()
 		}
 		return h.handleEvent(req)
 	case req.Path == "/slack/interactions" && req.HTTPMethod == methodPost:
-		if err := h.verifySlackRequest(req); err != nil {
+		if err := h.prepareAndVerifySlackRequest(req); err != nil {
 			return unauthorized()
 		}
 		return h.handleInteraction(req)
@@ -79,22 +79,25 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 	}
 }
 
-// verifySlackRequest authenticates an incoming Slack HTTP request. On any
-// verification error, the caller rejects the request with 401 and logs the
-// failure class so operator metrics can separate "not Slack" noise from
-// tampering attempts.
+// prepareAndVerifySlackRequest authenticates an incoming Slack HTTP request
+// and mutates req so downstream handlers see the same bytes Slack signed.
+// The name reflects the side effect: it's not a pure predicate.
 //
-// API Gateway sets IsBase64Encoded=true for any content type in the Lambda's
-// binary-media-types list. Slack slash commands arrive as
-// application/x-www-form-urlencoded and events as application/json; both are
-// normally treated as text. If the API Gateway config ever flips (or if a
-// new binary-media-type matches by accident), the body handed to the Lambda
-// is base64, and the HMAC over that base64 will not match Slack's HMAC over
-// the raw body — every valid request would start 401ing silently. Decode
-// here so the signature check runs against the same bytes Slack signed,
-// turning the infra misconfig into a decode-error 401 with a distinct
-// log line instead of a silent outage.
-func (h *Handler) verifySlackRequest(req *events.APIGatewayProxyRequest) error {
+// API Gateway sets IsBase64Encoded=true for any content type in the
+// Lambda's binary-media-types list. Slack slash commands arrive as
+// application/x-www-form-urlencoded and events as application/json; both
+// are normally treated as text. If the API Gateway config ever flips (or
+// if a new binary-media-type matches by accident), the body handed to the
+// Lambda is base64, and the HMAC over that base64 will not match Slack's
+// HMAC over the raw body — every valid request would start 401ing
+// silently. Decode here so the signature check runs against the same bytes
+// Slack signed, and rewrite req.Body so url.ParseQuery / json.Unmarshal
+// downstream see real form/JSON data rather than a base64 blob.
+//
+// On any verification error, the caller rejects the request with 401 and
+// logs the failure class so operator metrics can separate "not Slack"
+// noise from tampering attempts.
+func (h *Handler) prepareAndVerifySlackRequest(req *events.APIGatewayProxyRequest) error {
 	if req.IsBase64Encoded {
 		decoded, err := base64.StdEncoding.DecodeString(req.Body)
 		if err != nil {
@@ -112,8 +115,8 @@ func (h *Handler) verifySlackRequest(req *events.APIGatewayProxyRequest) error {
 		req.IsBase64Encoded = false
 	}
 
-	sig := headerValue(req.Headers, headerSlackSignature)
-	ts := headerValue(req.Headers, headerSlackTimestamp)
+	sig := headerValue(req.Headers, req.MultiValueHeaders, headerSlackSignature)
+	ts := headerValue(req.Headers, req.MultiValueHeaders, headerSlackTimestamp)
 	err := verifySlackSignature(h.cfg.SlackSigningSecret, req.Body, sig, ts, h.now())
 	if err != nil {
 		// Escalate empty-signing-secret to Error — it means the deployment
@@ -156,15 +159,27 @@ func classifySlackErr(err error) string {
 	}
 }
 
-// headerValue fetches a header case-insensitively — API Gateway v1 preserves
-// caller casing, v2 lowercases, and strings.EqualFold handles both.
-func headerValue(headers map[string]string, name string) string {
+// headerValue fetches a header case-insensitively — API Gateway v1
+// preserves caller casing, v2 lowercases, and some v1 configurations
+// populate MultiValueHeaders instead of (or in addition to) Headers.
+// strings.EqualFold handles the casing; checking both maps handles the
+// multi-value case. Slack's signature/timestamp are single-valued so the
+// first-entry pick is safe.
+func headerValue(headers map[string]string, multi map[string][]string, name string) string {
 	if v, ok := headers[name]; ok {
 		return v
 	}
 	for k, v := range headers {
 		if strings.EqualFold(k, name) {
 			return v
+		}
+	}
+	if v, ok := multi[name]; ok && len(v) > 0 {
+		return v[0]
+	}
+	for k, v := range multi {
+		if strings.EqualFold(k, name) && len(v) > 0 {
+			return v[0]
 		}
 	}
 	return ""

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -96,7 +96,7 @@ func (h *Handler) prepareAndVerifySlackRequest(req *events.APIGatewayProxyReques
 		decoded, err := base64.StdEncoding.DecodeString(req.Body)
 		if err != nil {
 			slog.Warn("slack signature verification failed — base64 decode error",
-				"path", req.Path, "error", err.Error())
+				"path", req.Path, "error", err)
 			return errSlackSignatureMalformed
 		}
 		req.Body = string(decoded)
@@ -126,7 +126,10 @@ func (h *Handler) prepareAndVerifySlackRequest(req *events.APIGatewayProxyReques
 
 // classifySlackErr maps the sentinel verification errors to stable metric
 // labels so operator dashboards can group by cause without string-matching
-// error messages (which may be reworded over time).
+// error messages. "secret_empty" is unreachable under normal startup —
+// cmd/main.go refuses to boot without SLACK_SIGNING_SECRET — so seeing
+// it in telemetry implies a code path that bypassed the main entry point
+// (tests, lambda custom runtime, etc.).
 func classifySlackErr(err error) string {
 	switch {
 	case errors.Is(err, errSlackSigningSecretEmpty):

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -137,7 +137,9 @@ func classifySlackErr(err error) string {
 	case errors.Is(err, errSlackSignatureMissing):
 		return "headers_missing"
 	case errors.Is(err, errSlackSignatureMalformed):
-		return "malformed"
+		return "sig_malformed"
+	case errors.Is(err, errSlackTimestampMalformed):
+		return "ts_malformed"
 	case errors.Is(err, errSlackTimestampStale):
 		return "stale"
 	case errors.Is(err, errSlackSignatureMismatch):

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -23,10 +23,8 @@ const methodPost = "POST"
 
 const authFailureMessage = "Failed to authenticate. Please check your QURL API key configuration."
 
-// Header names API Gateway passes through for Slack's signing scheme. Matched
-// case-insensitively per RFC 7230 — API Gateway may normalize to lowercase or
-// preserve the caller's casing.
 const (
+	// Matched case-insensitively — API Gateway preserves or lowercases depending on version.
 	headerSlackSignature = "X-Slack-Signature"
 	headerSlackTimestamp = "X-Slack-Request-Timestamp"
 )
@@ -59,17 +57,17 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 	switch {
 	case req.Path == "/slack/commands" && req.HTTPMethod == methodPost:
 		if err := h.prepareAndVerifySlackRequest(req); err != nil {
-			return unauthorized()
+			return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
 		}
 		return h.handleSlashCommand(ctx, req)
 	case req.Path == "/slack/events" && req.HTTPMethod == methodPost:
 		if err := h.prepareAndVerifySlackRequest(req); err != nil {
-			return unauthorized()
+			return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
 		}
 		return h.handleEvent(req)
 	case req.Path == "/slack/interactions" && req.HTTPMethod == methodPost:
 		if err := h.prepareAndVerifySlackRequest(req); err != nil {
-			return unauthorized()
+			return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
 		}
 		return h.handleInteraction(req)
 	case req.Path == "/health":
@@ -79,38 +77,23 @@ func (h *Handler) Handle(ctx context.Context, req *events.APIGatewayProxyRequest
 	}
 }
 
-// prepareAndVerifySlackRequest authenticates an incoming Slack HTTP request
-// and mutates req so downstream handlers see the same bytes Slack signed.
-// The name reflects the side effect: it's not a pure predicate.
+// prepareAndVerifySlackRequest authenticates a Slack request and mutates
+// req.Body + IsBase64Encoded so downstream handlers see the decoded bytes
+// Slack signed. The name reflects the side effect — it's not a pure
+// predicate.
 //
-// API Gateway sets IsBase64Encoded=true for any content type in the
-// Lambda's binary-media-types list. Slack slash commands arrive as
-// application/x-www-form-urlencoded and events as application/json; both
-// are normally treated as text. If the API Gateway config ever flips (or
-// if a new binary-media-type matches by accident), the body handed to the
-// Lambda is base64, and the HMAC over that base64 will not match Slack's
-// HMAC over the raw body — every valid request would start 401ing
-// silently. Decode here so the signature check runs against the same bytes
-// Slack signed, and rewrite req.Body so url.ParseQuery / json.Unmarshal
-// downstream see real form/JSON data rather than a base64 blob.
-//
-// On any verification error, the caller rejects the request with 401 and
-// logs the failure class so operator metrics can separate "not Slack"
-// noise from tampering attempts.
+// API Gateway hands the Lambda a base64-wrapped body for any content type
+// in the binary-media-types list. If that config ever matches Slack's
+// types, HMAC-over-base64 wouldn't match Slack's HMAC-over-raw and every
+// valid request would 401 silently — so we decode first.
 func (h *Handler) prepareAndVerifySlackRequest(req *events.APIGatewayProxyRequest) error {
 	if req.IsBase64Encoded {
 		decoded, err := base64.StdEncoding.DecodeString(req.Body)
 		if err != nil {
-			slog.Warn("slack signature verification failed — base64 body decode error",
-				"path", req.Path,
-				"error", err.Error())
+			slog.Warn("slack signature verification failed — base64 decode error",
+				"path", req.Path, "error", err.Error())
 			return errSlackSignatureMalformed
 		}
-		// Rewrite req.Body so every downstream handler (handleSlashCommand,
-		// handleEvent, handleInteraction) sees the same bytes Slack signed,
-		// not the API-Gateway-wrapped base64. Without this, a valid signed
-		// slash command would verify then silently fall through to the help
-		// path because url.ParseQuery would parse a base64 blob.
 		req.Body = string(decoded)
 		req.IsBase64Encoded = false
 	}
@@ -119,17 +102,14 @@ func (h *Handler) prepareAndVerifySlackRequest(req *events.APIGatewayProxyReques
 	ts := headerValue(req.Headers, req.MultiValueHeaders, headerSlackTimestamp)
 	err := verifySlackSignature(h.cfg.SlackSigningSecret, req.Body, sig, ts, h.now())
 	if err != nil {
-		// Escalate empty-signing-secret to Error — it means the deployment
-		// is effectively open; the fail-closed 401s are defense-in-depth,
-		// not the primary guard. Pages should route differently for this.
-		// Other failure classes are noise from unauthenticated scans and
-		// stay at Warn.
 		attrs := []any{
 			"path", req.Path,
 			"reason", classifySlackErr(err),
 			"has_signature", sig != "",
 			"has_timestamp", ts != "",
 		}
+		// Empty secret means the deployment is effectively open — page on
+		// it distinctly from ordinary 401 noise.
 		if errors.Is(err, errSlackSigningSecretEmpty) {
 			slog.Error("slack signature verification failed — signing secret is empty (deployment is open)", attrs...)
 		} else {
@@ -159,12 +139,9 @@ func classifySlackErr(err error) string {
 	}
 }
 
-// headerValue fetches a header case-insensitively — API Gateway v1
-// preserves caller casing, v2 lowercases, and some v1 configurations
-// populate MultiValueHeaders instead of (or in addition to) Headers.
-// strings.EqualFold handles the casing; checking both maps handles the
-// multi-value case. Slack's signature/timestamp are single-valued so the
-// first-entry pick is safe.
+// headerValue does a case-insensitive lookup against both Headers and
+// MultiValueHeaders so v1 and v2 API Gateway both work. Single-value pick
+// is safe because Slack's signature/timestamp headers aren't multi-valued.
 func headerValue(headers map[string]string, multi map[string][]string, name string) string {
 	if v, ok := headers[name]; ok {
 		return v
@@ -183,14 +160,6 @@ func headerValue(headers map[string]string, multi map[string][]string, name stri
 		}
 	}
 	return ""
-}
-
-// unauthorized returns a 401 response for a Slack-signature failure. Body is
-// intentionally terse — a caller able to read it can only learn that signing
-// is required, not why the particular attempt failed. Misconfig vs. attacker
-// activity is already distinguished in the structured slog.Warn above.
-func unauthorized() (events.APIGatewayProxyResponse, error) {
-	return respond(http.StatusUnauthorized, map[string]string{"error": "signature verification failed"})
 }
 
 func (h *Handler) handleSlashCommand(ctx context.Context, req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -215,15 +215,14 @@ func TestSlackEndpoints_Reject401(t *testing.T) {
 		name       string
 		path       string
 		body       string
-		signBody   string // if set, sign this body and send it with `body` (use for tamper/replay)
-		nowOffset  time.Duration
-		signedBody bool
+		signBody  string // if set, sign this body and send with `body` (tamper cases)
+		nowOffset time.Duration
 	}{
 		{name: "unsigned /slack/commands", path: "/slack/commands", body: body},
 		{name: "unsigned /slack/events", path: "/slack/events", body: `{"type":"url_verification","challenge":"attacker-chosen"}`},
 		{name: "unsigned /slack/interactions", path: "/slack/interactions", body: `{"type":"block_actions"}`},
 		{name: "tampered body (text swap)", path: "/slack/commands", body: tamperedBody, signBody: body},
-		{name: "replay with different team_id", path: "/slack/commands", body: replayBody, signBody: origReplayBody},
+		{name: "body swap with different team_id", path: "/slack/commands", body: replayBody, signBody: origReplayBody},
 		{name: "stale timestamp (10m outside skew)", path: "/slack/commands", body: body, signBody: body, nowOffset: 10 * time.Minute},
 	}
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -2,11 +2,16 @@ package internal
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 
@@ -14,16 +19,40 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+const testSigningSecret = "test-secret"
+
+// fixedNow pins the handler's clock so every signed-request test produces a
+// stable timestamp. 2026-04-19T12:00:00Z — matches the prevailing date when
+// this test was introduced so expired-replay tests can use round offsets.
+var fixedNow = time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
 func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 	t.Helper()
-	return NewHandler(Config{
+	h := NewHandler(Config{
 		QURLEndpoint:       qurlServer.URL,
 		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
-		SlackSigningSecret: "test-secret",
+		SlackSigningSecret: testSigningSecret,
 		NewClient: func(apiKey string) *client.Client {
 			return client.New(qurlServer.URL, apiKey)
 		},
 	})
+	h.now = func() time.Time { return fixedNow }
+	return h
+}
+
+// signSlackBody returns the pair of headers Slack would send to authenticate
+// `body` at `fixedNow`. Using the same algorithm as the handler means any
+// drift between them gets caught by the verification tests themselves.
+func signSlackBody(t *testing.T, body string) map[string]string {
+	t.Helper()
+	tsHeader := strconv.FormatInt(fixedNow.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(testSigningSecret))
+	mac.Write([]byte(slackSignatureVersion + ":" + tsHeader + ":" + body))
+	sig := slackSignatureVersion + "=" + hex.EncodeToString(mac.Sum(nil))
+	return map[string]string{
+		headerSlackSignature: sig,
+		headerSlackTimestamp: tsHeader,
+	}
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -62,6 +91,7 @@ func TestSlashCommandHelp(t *testing.T) {
 		Path:       "/slack/commands",
 		HTTPMethod: methodPost,
 		Body:       body,
+		Headers:    signSlackBody(t, body),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -112,6 +142,7 @@ func TestSlashCommandCreate(t *testing.T) {
 		Path:       "/slack/commands",
 		HTTPMethod: methodPost,
 		Body:       body,
+		Headers:    signSlackBody(t, body),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -142,6 +173,7 @@ func TestURLVerificationChallenge(t *testing.T) {
 		Path:       "/slack/events",
 		HTTPMethod: methodPost,
 		Body:       body,
+		Headers:    signSlackBody(t, body),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -153,5 +185,144 @@ func TestURLVerificationChallenge(t *testing.T) {
 	}
 	if result["challenge"] != "test-challenge-123" {
 		t.Errorf("expected challenge echo, got %q", result["challenge"])
+	}
+}
+
+// Negative-path tests: the exact class of request that was reaching the
+// handler pre-fix (unsigned, tampered, stale) must now be rejected with 401.
+// Together these three cover Slack's three signing failure modes and fence
+// the qurl-integrations #71 exposure.
+
+func TestSlashCommand_RejectsUnsigned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: methodPost,
+		Body:       body,
+		// no signature headers — this is the pre-fix reproducer
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unsigned slash command: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestSlashCommand_RejectsTamperedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	signedBody := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+	headers := signSlackBody(t, signedBody)
+
+	// Tamper: attacker swaps the body but reuses a legitimate signature.
+	tamperedBody := url.Values{"command": {"/qurl"}, "text": {"create https://evil.example"}, "team_id": {"T999"}}.Encode()
+
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: methodPost,
+		Body:       tamperedBody,
+		Headers:    headers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("tampered body: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestSlashCommand_RejectsStaleTimestamp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+	headers := signSlackBody(t, body)
+
+	// Pin "now" 10 minutes after the signed timestamp — outside Slack's 5m skew.
+	h.now = func() time.Time { return fixedNow.Add(10 * time.Minute) }
+
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: methodPost,
+		Body:       body,
+		Headers:    headers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("stale timestamp: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// Per-endpoint fences: the three Slack-receiving endpoints must each enforce
+// signing. Without this, /slack/events and /slack/interactions could regress
+// the fix while tests for /slack/commands stay green.
+
+func TestEvent_RejectsUnsigned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/events",
+		HTTPMethod: methodPost,
+		Body:       `{"type":"url_verification","challenge":"attacker-chosen"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unsigned event: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestInteraction_RejectsUnsigned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/interactions",
+		HTTPMethod: methodPost,
+		Body:       `{"type":"block_actions"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unsigned interaction: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestHeaderValue_CaseInsensitive(t *testing.T) {
+	// API Gateway v1 preserves caller header casing; Slack sends mixed case.
+	// API Gateway v2 lowercases. Both must match.
+	got := headerValue(map[string]string{"x-slack-signature": "v0=abc"}, "X-Slack-Signature")
+	if got != "v0=abc" {
+		t.Errorf("lowercase lookup = %q, want v0=abc", got)
+	}
+	got = headerValue(map[string]string{"X-Slack-Signature": "v0=abc"}, "X-Slack-Signature")
+	if got != "v0=abc" {
+		t.Errorf("mixed-case lookup = %q, want v0=abc", got)
 	}
 }

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,10 +28,11 @@ func base64Encode(t *testing.T, s string) string {
 
 const testSigningSecret = "test-secret"
 
-// fixedNow pins the handler's clock so every signed-request test produces a
-// stable timestamp. 2026-04-19T12:00:00Z — matches the prevailing date when
-// this test was introduced so expired-replay tests can use round offsets.
-var fixedNow = time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+// fixedNow pins the handler's clock so every signed-request test produces
+// a stable timestamp. Arbitrary absolute value — tests inject h.now so the
+// wall clock is irrelevant; this constant just needs to be the same in both
+// sign-time and verify-time paths for any given test.
+var fixedNow = time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 
 func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 	t.Helper()
@@ -276,6 +278,37 @@ func TestSlashCommand_RejectsStaleTimestamp(t *testing.T) {
 	}
 }
 
+// TestSlashCommand_ReplayWithDifferentTeamIDRejected documents the
+// signature's binding surface — the signature covers body + timestamp, so
+// swapping a different team_id into a previously-signed request doesn't
+// replay. Complementary to TestSlashCommand_RejectsTamperedBody which
+// mutates the text field; this one mutates team_id specifically because
+// that's what a resource-scope-escalation replay would target.
+func TestSlashCommand_ReplayWithDifferentTeamID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	originalBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_victim"}}.Encode()
+	headers := signSlackBody(t, originalBody)
+	attackerBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_attacker"}}.Encode()
+
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: methodPost,
+		Body:       attackerBody,
+		Headers:    headers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("replay with different team_id: status = %d, want 401", resp.StatusCode)
+	}
+}
+
 // Per-endpoint fences: the three Slack-receiving endpoints must each enforce
 // signing. Without this, /slack/events and /slack/interactions could regress
 // the fix while tests for /slack/commands stay green.
@@ -320,13 +353,18 @@ func TestInteraction_RejectsUnsigned(t *testing.T) {
 	}
 }
 
-// TestSlashCommand_Base64Body fences the API-Gateway-binary-media-type trap
-// called out in the #73 review: if the content type is ever misconfigured
-// into the Lambda's binary-media-types list, req.Body arrives base64-encoded
-// and the HMAC over that base64 would never match Slack's HMAC over raw
-// bytes. verifySlackRequest decodes on IsBase64Encoded so the check runs
-// against the same bytes Slack signed.
-func TestSlashCommand_Base64Body(t *testing.T) {
+// TestSlashCommand_Base64Body_Help fences the API-Gateway-binary-media-type
+// trap called out in the #73 review. Two invariants:
+//  1. The HMAC check runs against the decoded body (not the base64 blob).
+//  2. The decoded body is threaded to the downstream handler so
+//     url.ParseQuery sees real form data, not a base64 string. Without (2),
+//     a signed /qurl help would verify then fall through to the "unknown
+//     subcommand" branch because ParseQuery would find no "command" / "text"
+//     keys in the base64 blob.
+//
+// The help-path text assertion distinguishes (2) from (1) — a broken body
+// threading would still return 200 but with different body text.
+func TestSlashCommand_Base64Body_Help(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -335,8 +373,6 @@ func TestSlashCommand_Base64Body(t *testing.T) {
 	h := newTestHandler(t, srv)
 	rawBody := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
 	headers := signSlackBody(t, rawBody)
-
-	// API Gateway hands the handler base64(body) with IsBase64Encoded=true.
 	encoded := base64Encode(t, rawBody)
 
 	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
@@ -350,7 +386,56 @@ func TestSlashCommand_Base64Body(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("base64-encoded body with valid signature: status = %d, want 200", resp.StatusCode)
+		t.Fatalf("base64 body + valid signature: status = %d, want 200; body=%s", resp.StatusCode, resp.Body)
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(result["text"], "qurl create") {
+		t.Errorf("base64 body + text=help did not produce help response — body threading regressed. Got: %q", result["text"])
+	}
+}
+
+// TestSlashCommand_Base64Body_Create strengthens the body-threading fence:
+// a signed create command must actually reach handleCreate (which hits the
+// mock QURL server) rather than being misrouted through help.
+func TestSlashCommand_Base64Body_Create(t *testing.T) {
+	var qurlCalled bool
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		qurlCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"data": map[string]any{"resource_id": "r_test", "qurl_link": "https://qurl.link/at_t", "qurl_site": "https://r_test.qurl.site"},
+			"meta": map[string]string{"request_id": "req_test"},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer qurlSrv.Close()
+
+	t.Setenv("QURL_API_KEY", "test-key")
+	h := newTestHandler(t, qurlSrv)
+	rawBody := url.Values{"command": {"/qurl"}, "text": {"create https://example.com"}, "team_id": {"T123"}}.Encode()
+	headers := signSlackBody(t, rawBody)
+	encoded := base64Encode(t, rawBody)
+
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:            "/slack/commands",
+		HTTPMethod:      methodPost,
+		Body:            encoded,
+		Headers:         headers,
+		IsBase64Encoded: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("base64 create: status = %d, want 200; body=%s", resp.StatusCode, resp.Body)
+	}
+	if !qurlCalled {
+		t.Error("QURL backend was never called — handleCreate didn't run; body threading regressed")
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -358,6 +358,19 @@ func TestHandle_EmptySigningSecret(t *testing.T) {
 	}
 }
 
+// classifySlackErr must emit "secret_empty" for errSlackSigningSecretEmpty —
+// ops dashboards page on this label distinctly from ordinary 401 noise
+// because it means the deployment is effectively open. A regression that
+// downgraded the slog.Error / label path (e.g., a refactor mapping empty
+// secret into the generic "verify_failed" bucket) would silently lose the
+// page signal. The full-request TestHandle_EmptySigningSecret above only
+// asserts the 401 — this one pins the classification.
+func TestClassifySlackErr_EmptySecretLabelsDistinctly(t *testing.T) {
+	if got := classifySlackErr(errSlackSigningSecretEmpty); got != "secret_empty" {
+		t.Errorf("classifySlackErr(errSlackSigningSecretEmpty) = %q, want %q", got, "secret_empty")
+	}
+}
+
 // Fences the v1-API-Gateway multi-value-headers path end-to-end through
 // Handle. Isolated helper coverage lives in TestHeaderValue; this one
 // proves prepareAndVerifySlackRequest pulls from MultiValueHeaders when
@@ -376,9 +389,14 @@ func TestSlashCommand_SignatureInMultiValueHeaders(t *testing.T) {
 		headerSlackTimestamp: {hdrs[headerSlackTimestamp]},
 	}
 	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:              "/slack/commands",
-		HTTPMethod:        methodPost,
-		Body:              body,
+		Path:       "/slack/commands",
+		HTTPMethod: methodPost,
+		Body:       body,
+		// Explicit nil pins the v1-gateway shape (MultiValueHeaders only)
+		// rather than relying on implicit zero values — a future refactor
+		// that defaulted Headers to a populated map would otherwise make
+		// this test pass through the wrong code path.
+		Headers:           nil,
 		MultiValueHeaders: multi,
 	})
 	if err != nil {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -358,16 +358,34 @@ func TestHandle_EmptySigningSecret(t *testing.T) {
 	}
 }
 
-// classifySlackErr must emit "secret_empty" for errSlackSigningSecretEmpty —
-// ops dashboards page on this label distinctly from ordinary 401 noise
-// because it means the deployment is effectively open. A regression that
-// downgraded the slog.Error / label path (e.g., a refactor mapping empty
-// secret into the generic "verify_failed" bucket) would silently lose the
-// page signal. The full-request TestHandle_EmptySigningSecret above only
-// asserts the 401 — this one pins the classification.
-func TestClassifySlackErr_EmptySecretLabelsDistinctly(t *testing.T) {
-	if got := classifySlackErr(errSlackSigningSecretEmpty); got != "secret_empty" {
-		t.Errorf("classifySlackErr(errSlackSigningSecretEmpty) = %q, want %q", got, "secret_empty")
+// classifySlackErr must emit stable, distinct labels for each sentinel —
+// ops dashboards page on "secret_empty" distinctly from ordinary 401
+// noise, and splitting "sig_malformed" from "ts_malformed" separates
+// client-sent-junk from API-Gateway-is-wrapping-us. A regression that
+// collapsed labels (or downgraded the secret_empty slog.Error) would
+// silently lose the page signal.
+func TestClassifySlackErr_SentinelsMapToDistinctLabels(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{errSlackSigningSecretEmpty, "secret_empty"},
+		{errSlackSignatureMissing, "headers_missing"},
+		{errSlackSignatureMalformed, "sig_malformed"},
+		{errSlackTimestampMalformed, "ts_malformed"},
+		{errSlackTimestampStale, "stale"},
+		{errSlackSignatureMismatch, "mismatch"},
+	}
+	seen := make(map[string]error, len(cases))
+	for _, tc := range cases {
+		got := classifySlackErr(tc.err)
+		if got != tc.want {
+			t.Errorf("classifySlackErr(%v) = %q, want %q", tc.err, got, tc.want)
+		}
+		if prev, ok := seen[got]; ok {
+			t.Errorf("label %q is shared by %v and %v — dashboards can't tell them apart", got, prev, tc.err)
+		}
+		seen[got] = tc.err
 	}
 }
 
@@ -404,6 +422,39 @@ func TestSlashCommand_SignatureInMultiValueHeaders(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("signature delivered via MultiValueHeaders: status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// End-to-end fence for the lowercase-key-over-MultiValueHeaders shape —
+// API Gateway v2 normalizes caller headers to lowercase, and headerValue
+// is pure (TestHeaderValue covers it in isolation), but nothing currently
+// exercises that shape all the way through Handle. This row closes the
+// loop: same Handle path, keys lowercased.
+func TestSlashCommand_SignatureInMultiValueHeaders_LowercaseKeys(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+	hdrs := signSlackBody(t, body)
+	multi := map[string][]string{
+		"x-slack-signature":         {hdrs[headerSlackSignature]},
+		"x-slack-request-timestamp": {hdrs[headerSlackTimestamp]},
+	}
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:              "/slack/commands",
+		HTTPMethod:        methodPost,
+		Body:              body,
+		Headers:           nil,
+		MultiValueHeaders: multi,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("lowercase MultiValueHeaders keys: status = %d, want 200", resp.StatusCode)
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -472,15 +472,57 @@ func TestHandle_EmptySigningSecret(t *testing.T) {
 	}
 }
 
-func TestHeaderValue_CaseInsensitive(t *testing.T) {
-	// API Gateway v1 preserves caller header casing; Slack sends mixed case.
-	// API Gateway v2 lowercases. Both must match.
-	got := headerValue(map[string]string{"x-slack-signature": "v0=abc"}, "X-Slack-Signature")
-	if got != "v0=abc" {
-		t.Errorf("lowercase lookup = %q, want v0=abc", got)
+func TestHeaderValue(t *testing.T) {
+	// API Gateway v1 preserves caller casing (Slack sends mixed case);
+	// v2 lowercases. Some v1 configs populate MultiValueHeaders instead of
+	// Headers. The helper handles all four combinations.
+	cases := []struct {
+		name   string
+		hdrs   map[string]string
+		multi  map[string][]string
+		lookup string
+		want   string
+	}{
+		{"mixed case in Headers", map[string]string{"X-Slack-Signature": "v0=abc"}, nil, "X-Slack-Signature", "v0=abc"},
+		{"lowercase in Headers", map[string]string{"x-slack-signature": "v0=abc"}, nil, "X-Slack-Signature", "v0=abc"},
+		{"not present returns empty", map[string]string{"other": "val"}, nil, "X-Slack-Signature", ""},
+		{"MultiValueHeaders mixed case", nil, map[string][]string{"X-Slack-Signature": {"v0=abc"}}, "X-Slack-Signature", "v0=abc"},
+		{"MultiValueHeaders lowercase", nil, map[string][]string{"x-slack-signature": {"v0=abc"}}, "X-Slack-Signature", "v0=abc"},
+		{"empty multi-value returns empty", nil, map[string][]string{"X-Slack-Signature": {}}, "X-Slack-Signature", ""},
+		{"Headers wins over MultiValueHeaders", map[string]string{"X-Slack-Signature": "v0=fromhdrs"}, map[string][]string{"X-Slack-Signature": {"v0=frommulti"}}, "X-Slack-Signature", "v0=fromhdrs"},
 	}
-	got = headerValue(map[string]string{"X-Slack-Signature": "v0=abc"}, "X-Slack-Signature")
-	if got != "v0=abc" {
-		t.Errorf("mixed-case lookup = %q, want v0=abc", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := headerValue(tc.hdrs, tc.multi, tc.lookup)
+			if got != tc.want {
+				t.Errorf("headerValue = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSlashCommand_InvalidBase64_Returns401 covers the decode-error branch
+// in prepareAndVerifySlackRequest. A future refactor that drops the decode
+// would silently let API-Gateway binary-media-type regressions produce
+// either 200s or 500s — this test pins the 401 behavior.
+func TestSlashCommand_InvalidBase64_Returns401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:            "/slack/commands",
+		HTTPMethod:      methodPost,
+		Body:            "this is not valid base64 at all!@#$%",
+		Headers:         map[string]string{headerSlackSignature: "v0=deadbeef", headerSlackTimestamp: "1761998400"},
+		IsBase64Encoded: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("invalid base64 with IsBase64Encoded=true: status = %d, want 401", resp.StatusCode)
 	}
 }

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -18,6 +19,11 @@ import (
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
+
+func base64Encode(t *testing.T, s string) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
 
 const testSigningSecret = "test-secret"
 
@@ -311,6 +317,73 @@ func TestInteraction_RejectsUnsigned(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("unsigned interaction: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestSlashCommand_Base64Body fences the API-Gateway-binary-media-type trap
+// called out in the #73 review: if the content type is ever misconfigured
+// into the Lambda's binary-media-types list, req.Body arrives base64-encoded
+// and the HMAC over that base64 would never match Slack's HMAC over raw
+// bytes. verifySlackRequest decodes on IsBase64Encoded so the check runs
+// against the same bytes Slack signed.
+func TestSlashCommand_Base64Body(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	rawBody := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+	headers := signSlackBody(t, rawBody)
+
+	// API Gateway hands the handler base64(body) with IsBase64Encoded=true.
+	encoded := base64Encode(t, rawBody)
+
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:            "/slack/commands",
+		HTTPMethod:      methodPost,
+		Body:            encoded,
+		Headers:         headers,
+		IsBase64Encoded: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("base64-encoded body with valid signature: status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestHandle_EmptySigningSecret fences the deploy-is-open failure mode — a
+// handler with no signing secret must 401 every request, not silently accept
+// them (the helper-level test covers the algorithm, this one pins the wire).
+func TestHandle_EmptySigningSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	h.cfg.SlackSigningSecret = ""
+
+	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+	// Even with "correct-looking" headers — an empty secret means no message
+	// can verify. We include them to prove the 401 isn't coming from the
+	// "missing headers" path.
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:       "/slack/commands",
+		HTTPMethod: methodPost,
+		Body:       body,
+		Headers: map[string]string{
+			headerSlackSignature: "v0=aaaa",
+			headerSlackTimestamp: "1761998400",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("empty signing secret: status = %d, want 401", resp.StatusCode)
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -196,174 +196,64 @@ func TestURLVerificationChallenge(t *testing.T) {
 	}
 }
 
-// Negative-path tests: the exact class of request that was reaching the
-// handler pre-fix (unsigned, tampered, stale) must now be rejected with 401.
-// Together these three cover Slack's three signing failure modes and fence
-// the qurl-integrations #71 exposure.
-
-func TestSlashCommand_RejectsUnsigned(t *testing.T) {
+// TestSlackEndpoints_Reject401 is the main negative-path fence. Every row
+// is a request the handler must reject; the three paths (commands / events
+// /interactions) ensure a future endpoint addition can't silently skip
+// signature verification.
+func TestSlackEndpoints_Reject401(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
-	h := newTestHandler(t, srv)
 	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
-
-	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:       "/slack/commands",
-		HTTPMethod: methodPost,
-		Body:       body,
-		// no signature headers — this is the pre-fix reproducer
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unsigned slash command: status = %d, want 401", resp.StatusCode)
-	}
-}
-
-func TestSlashCommand_RejectsTamperedBody(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	h := newTestHandler(t, srv)
-	signedBody := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
-	headers := signSlackBody(t, signedBody)
-
-	// Tamper: attacker swaps the body but reuses a legitimate signature.
 	tamperedBody := url.Values{"command": {"/qurl"}, "text": {"create https://evil.example"}, "team_id": {"T999"}}.Encode()
+	replayBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_attacker"}}.Encode()
+	origReplayBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_victim"}}.Encode()
 
-	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:       "/slack/commands",
-		HTTPMethod: methodPost,
-		Body:       tamperedBody,
-		Headers:    headers,
-	})
-	if err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name       string
+		path       string
+		body       string
+		signBody   string // if set, sign this body and send it with `body` (use for tamper/replay)
+		nowOffset  time.Duration
+		signedBody bool
+	}{
+		{name: "unsigned /slack/commands", path: "/slack/commands", body: body},
+		{name: "unsigned /slack/events", path: "/slack/events", body: `{"type":"url_verification","challenge":"attacker-chosen"}`},
+		{name: "unsigned /slack/interactions", path: "/slack/interactions", body: `{"type":"block_actions"}`},
+		{name: "tampered body (text swap)", path: "/slack/commands", body: tamperedBody, signBody: body},
+		{name: "replay with different team_id", path: "/slack/commands", body: replayBody, signBody: origReplayBody},
+		{name: "stale timestamp (10m outside skew)", path: "/slack/commands", body: body, signBody: body, nowOffset: 10 * time.Minute},
 	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("tampered body: status = %d, want 401", resp.StatusCode)
-	}
-}
 
-func TestSlashCommand_RejectsStaleTimestamp(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	h := newTestHandler(t, srv)
-	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
-	headers := signSlackBody(t, body)
-
-	// Pin "now" 10 minutes after the signed timestamp — outside Slack's 5m skew.
-	h.now = func() time.Time { return fixedNow.Add(10 * time.Minute) }
-
-	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:       "/slack/commands",
-		HTTPMethod: methodPost,
-		Body:       body,
-		Headers:    headers,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("stale timestamp: status = %d, want 401", resp.StatusCode)
-	}
-}
-
-// TestSlashCommand_ReplayWithDifferentTeamIDRejected documents the
-// signature's binding surface — the signature covers body + timestamp, so
-// swapping a different team_id into a previously-signed request doesn't
-// replay. Complementary to TestSlashCommand_RejectsTamperedBody which
-// mutates the text field; this one mutates team_id specifically because
-// that's what a resource-scope-escalation replay would target.
-func TestSlashCommand_ReplayWithDifferentTeamID(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	h := newTestHandler(t, srv)
-	originalBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_victim"}}.Encode()
-	headers := signSlackBody(t, originalBody)
-	attackerBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_attacker"}}.Encode()
-
-	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:       "/slack/commands",
-		HTTPMethod: methodPost,
-		Body:       attackerBody,
-		Headers:    headers,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("replay with different team_id: status = %d, want 401", resp.StatusCode)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, srv)
+			if tc.nowOffset != 0 {
+				h.now = func() time.Time { return fixedNow.Add(tc.nowOffset) }
+			}
+			headers := map[string]string{}
+			if tc.signBody != "" {
+				headers = signSlackBody(t, tc.signBody)
+			}
+			resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+				Path: tc.path, HTTPMethod: methodPost, Body: tc.body, Headers: headers,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", resp.StatusCode)
+			}
+		})
 	}
 }
 
-// Per-endpoint fences: the three Slack-receiving endpoints must each enforce
-// signing. Without this, /slack/events and /slack/interactions could regress
-// the fix while tests for /slack/commands stay green.
-
-func TestEvent_RejectsUnsigned(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	h := newTestHandler(t, srv)
-	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:       "/slack/events",
-		HTTPMethod: methodPost,
-		Body:       `{"type":"url_verification","challenge":"attacker-chosen"}`,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unsigned event: status = %d, want 401", resp.StatusCode)
-	}
-}
-
-func TestInteraction_RejectsUnsigned(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	h := newTestHandler(t, srv)
-	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
-		Path:       "/slack/interactions",
-		HTTPMethod: methodPost,
-		Body:       `{"type":"block_actions"}`,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unsigned interaction: status = %d, want 401", resp.StatusCode)
-	}
-}
-
-// TestSlashCommand_Base64Body_Help fences the API-Gateway-binary-media-type
-// trap called out in the #73 review. Two invariants:
-//  1. The HMAC check runs against the decoded body (not the base64 blob).
-//  2. The decoded body is threaded to the downstream handler so
-//     url.ParseQuery sees real form data, not a base64 string. Without (2),
-//     a signed /qurl help would verify then fall through to the "unknown
-//     subcommand" branch because ParseQuery would find no "command" / "text"
-//     keys in the base64 blob.
-//
-// The help-path text assertion distinguishes (2) from (1) — a broken body
-// threading would still return 200 but with different body text.
+// Fences the API-Gateway-binary-media-type trap: HMAC runs against the
+// decoded body AND the decoded body reaches the downstream handler (the
+// help-text assertion catches a broken threading that would otherwise
+// silently 200 with the wrong body).
 func TestSlashCommand_Base64Body_Help(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -397,9 +287,8 @@ func TestSlashCommand_Base64Body_Help(t *testing.T) {
 	}
 }
 
-// TestSlashCommand_Base64Body_Create strengthens the body-threading fence:
-// a signed create command must actually reach handleCreate (which hits the
-// mock QURL server) rather than being misrouted through help.
+// Strengthens the body-threading fence: a signed create command must
+// actually reach handleCreate (which hits the mock QURL server).
 func TestSlashCommand_Base64Body_Create(t *testing.T) {
 	var qurlCalled bool
 	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -439,9 +328,7 @@ func TestSlashCommand_Base64Body_Create(t *testing.T) {
 	}
 }
 
-// TestHandle_EmptySigningSecret fences the deploy-is-open failure mode — a
-// handler with no signing secret must 401 every request, not silently accept
-// them (the helper-level test covers the algorithm, this one pins the wire).
+// Empty signing secret must 401 every request — deployment-is-open fence.
 func TestHandle_EmptySigningSecret(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -501,10 +388,7 @@ func TestHeaderValue(t *testing.T) {
 	}
 }
 
-// TestSlashCommand_InvalidBase64_Returns401 covers the decode-error branch
-// in prepareAndVerifySlackRequest. A future refactor that drops the decode
-// would silently let API-Gateway binary-media-type regressions produce
-// either 200s or 500s — this test pins the 401 behavior.
+// Fences the decode-error branch in prepareAndVerifySlackRequest.
 func TestSlashCommand_InvalidBase64_Returns401(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -212,9 +212,9 @@ func TestSlackEndpoints_Reject401(t *testing.T) {
 	origReplayBody := url.Values{"command": {"/qurl"}, "text": {"list"}, "team_id": {"T_victim"}}.Encode()
 
 	cases := []struct {
-		name       string
-		path       string
-		body       string
+		name      string
+		path      string
+		body      string
 		signBody  string // if set, sign this body and send with `body` (tamper cases)
 		nowOffset time.Duration
 	}{

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -359,6 +359,37 @@ func TestHandle_EmptySigningSecret(t *testing.T) {
 	}
 }
 
+// Fences the v1-API-Gateway multi-value-headers path end-to-end through
+// Handle. Isolated helper coverage lives in TestHeaderValue; this one
+// proves prepareAndVerifySlackRequest pulls from MultiValueHeaders when
+// Headers is nil.
+func TestSlashCommand_SignatureInMultiValueHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHandler(t, srv)
+	body := url.Values{"command": {"/qurl"}, "text": {"help"}, "team_id": {"T123"}}.Encode()
+	hdrs := signSlackBody(t, body)
+	multi := map[string][]string{
+		headerSlackSignature: {hdrs[headerSlackSignature]},
+		headerSlackTimestamp: {hdrs[headerSlackTimestamp]},
+	}
+	resp, err := h.Handle(context.Background(), &events.APIGatewayProxyRequest{
+		Path:              "/slack/commands",
+		HTTPMethod:        methodPost,
+		Body:              body,
+		MultiValueHeaders: multi,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("signature delivered via MultiValueHeaders: status = %d, want 200", resp.StatusCode)
+	}
+}
+
 func TestHeaderValue(t *testing.T) {
 	// API Gateway v1 preserves caller casing (Slack sends mixed case);
 	// v2 lowercases. Some v1 configs populate MultiValueHeaders instead of

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -60,16 +60,21 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 	if err != nil {
 		return errSlackSignatureMalformed
 	}
-	// Bound ts to a sane Unix-seconds range first so an attacker-supplied
-	// math.MinInt64 (or a wildly-future value that overflows time.Duration
-	// when subtracted) can't wrap the skew check. The HMAC check would
-	// still fail on garbage input, but rejecting structurally means no
-	// future refactor can accidentally make the overflow path reachable.
+	// Bound ts structurally before any arithmetic. time.Time.Sub saturates
+	// at the time.Duration extremes (MinInt64 / MaxInt64 nanoseconds) for
+	// extreme inputs and `-delta` on MinInt64 wraps back to MinInt64 in
+	// two's complement — so without these guards a sufficiently-large
+	// attacker ts could slip past `delta > skew`. The HMAC check is still
+	// the real gate (an attacker can't forge without the secret) but the
+	// guards make the skew check literally correct rather than best-effort.
 	if ts < 0 {
 		return errSlackTimestampStale
 	}
-	// time.Duration's range (~292 years) comfortably brackets any legit
-	// 5-minute skew window, so direct subtraction is safe here.
+	// 24h ceiling on "future" timestamps — well outside the 5-minute skew
+	// window and small enough that the subtraction can't saturate.
+	if ts > now.Unix()+24*60*60 {
+		return errSlackTimestampStale
+	}
 	delta := now.Sub(time.Unix(ts, 0))
 	if delta < 0 {
 		delta = -delta

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -10,26 +10,14 @@ import (
 	"time"
 )
 
-// Check ordering below is: empty-secret → missing-headers → malformed
-// (format/hex/length/ts) → stale-ts → HMAC. All checks before HMAC only
-// touch caller-supplied data (never the signing secret), so no timing
-// oracle exists on the secret. Reordering could introduce one — don't
-// move the HMAC check earlier in response to a reviewer who wants faster
-// rejection paths.
+const (
+	slackSignatureVersion = "v0"
+	slackTimestampSkew    = 5 * time.Minute // Slack's recommended replay window.
+)
 
-// slackSignatureVersion is the version prefix Slack uses on its request
-// signatures. See https://api.slack.com/authentication/verifying-requests-from-slack.
-const slackSignatureVersion = "v0"
-
-// slackTimestampSkew bounds how far from now a Slack request's timestamp may
-// be before it's treated as a replay. Slack's own recommendation is 5 minutes.
-const slackTimestampSkew = 5 * time.Minute
-
-// Sentinel errors so callers can tell "not signed" from "signed but wrong"
-// without string matching. A missing header is distinguishable from a tampered
-// body, which matters for operator metrics and for tests. The empty-secret
-// case gets its own sentinel too because it's the most important one to page
-// on — it means the deployment is effectively open.
+// Sentinel errors so classifySlackErr can bucket metrics without
+// string-matching log lines. Empty-secret gets its own because it means
+// the deployment is effectively open — ops should page on it distinctly.
 var (
 	errSlackSigningSecretEmpty = errors.New("slack: signing secret is empty")
 	errSlackSignatureMissing   = errors.New("slack: missing X-Slack-Signature or X-Slack-Request-Timestamp")
@@ -38,16 +26,15 @@ var (
 	errSlackSignatureMismatch  = errors.New("slack: signature does not match body")
 )
 
-// verifySlackSignature authenticates an incoming Slack HTTP request by
-// recomputing HMAC-SHA256("v0:"+timestamp+":"+body) with the shared signing
-// secret and comparing against the X-Slack-Signature header in constant time.
+// verifySlackSignature authenticates a Slack request by recomputing
+// HMAC-SHA256("v0:"+timestamp+":"+body) and comparing in constant time.
+// `now` is injected so tests can pin the clock.
 //
-// `now` is taken as a parameter so tests can pin the clock without a global
-// override.
+// Check order: empty-secret → missing-headers → malformed → stale-ts →
+// HMAC. All checks before HMAC touch only caller-supplied data (never the
+// signing secret), so there's no timing oracle on the secret. Don't
+// reorder.
 func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now time.Time) error {
-	// Treat an empty secret as a fail-closed misconfig: the caller must set
-	// one explicitly. This prevents a blank secret from silently accepting
-	// any request that happens to hash to "v0=".
 	if signingSecret == "" {
 		return errSlackSigningSecretEmpty
 	}
@@ -58,9 +45,6 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 		return errSlackSignatureMalformed
 	}
 	providedHex := sigHeader[len(slackSignatureVersion)+1:]
-	// Length check before DecodeString gives a faster + clearer malformed
-	// rejection for "v0=abc" style payloads (hmac.Equal would still return
-	// false, but the error would be the less-informative mismatch sentinel).
 	if len(providedHex) != sha256.Size*2 {
 		return errSlackSignatureMalformed
 	}
@@ -73,19 +57,10 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 	if err != nil {
 		return errSlackSignatureMalformed
 	}
-	// Bound ts structurally before any arithmetic. time.Time.Sub saturates
-	// at the time.Duration extremes (MinInt64 / MaxInt64 nanoseconds) for
-	// extreme inputs and `-delta` on MinInt64 wraps back to MinInt64 in
-	// two's complement — so without these guards a sufficiently-large
-	// attacker ts could slip past `delta > skew`. The HMAC check is still
-	// the real gate (an attacker can't forge without the secret) but the
-	// guards make the skew check literally correct rather than best-effort.
-	if ts < 0 {
-		return errSlackTimestampStale
-	}
-	// 24h ceiling on "future" timestamps — well outside the 5-minute skew
-	// window and small enough that the subtraction can't saturate.
-	if ts > now.Unix()+24*60*60 {
+	// Bound ts structurally so a MinInt64 input can't wrap the skew check.
+	// HMAC still gates the actual path; this makes the skew check literally
+	// correct for all inputs.
+	if ts < 0 || ts > now.Unix()+24*60*60 {
 		return errSlackTimestampStale
 	}
 	delta := now.Sub(time.Unix(ts, 0))
@@ -97,14 +72,8 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 	}
 
 	mac := hmac.New(sha256.New, []byte(signingSecret))
-	// Slack's base string is "v0:<timestamp>:<raw body>". Any deviation
-	// (trailing newline, re-encoded body, base64-encoded body from API
-	// Gateway when a binary-media-type is mis-listed — see the caller's
-	// IsBase64Encoded handling) breaks verification.
 	mac.Write([]byte(slackSignatureVersion + ":" + tsHeader + ":" + body))
-	expected := mac.Sum(nil)
-
-	if !hmac.Equal(expected, providedSig) {
+	if !hmac.Equal(mac.Sum(nil), providedSig) {
 		return errSlackSignatureMismatch
 	}
 	return nil

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -41,10 +41,10 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 	if sigHeader == "" || tsHeader == "" {
 		return errSlackSignatureMissing
 	}
-	if !strings.HasPrefix(sigHeader, slackSignatureVersion+"=") {
+	providedHex, hasPrefix := strings.CutPrefix(sigHeader, slackSignatureVersion+"=")
+	if !hasPrefix {
 		return errSlackSignatureMalformed
 	}
-	providedHex := sigHeader[len(slackSignatureVersion)+1:]
 	if len(providedHex) != sha256.Size*2 {
 		return errSlackSignatureMalformed
 	}

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -18,10 +18,15 @@ const (
 // Sentinel errors so classifySlackErr can bucket metrics without
 // string-matching log lines. Empty-secret gets its own because it means
 // the deployment is effectively open — ops should page on it distinctly.
+// Malformed-signature and malformed-timestamp are separate sentinels so a
+// dashboard can tell "client sent junk" from "API Gateway is base64-wrapping
+// us and we can't parse the body" — those look identical under a single
+// "malformed" bucket but are different ops problems.
 var (
 	errSlackSigningSecretEmpty = errors.New("slack: signing secret is empty")
 	errSlackSignatureMissing   = errors.New("slack: missing X-Slack-Signature or X-Slack-Request-Timestamp")
 	errSlackSignatureMalformed = errors.New("slack: malformed X-Slack-Signature")
+	errSlackTimestampMalformed = errors.New("slack: malformed X-Slack-Request-Timestamp")
 	errSlackTimestampStale     = errors.New("slack: request timestamp outside allowed skew")
 	errSlackSignatureMismatch  = errors.New("slack: signature does not match body")
 )
@@ -55,11 +60,14 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 
 	ts, err := strconv.ParseInt(tsHeader, 10, 64)
 	if err != nil {
-		return errSlackSignatureMalformed
+		return errSlackTimestampMalformed
 	}
-	// Bound ts structurally so a MinInt64 input can't wrap the skew check.
-	// HMAC still gates the actual path; this makes the skew check literally
-	// correct for all inputs.
+	// Bound ts so a MinInt64 can't wrap the skew math below. The +24h
+	// upper bound is strictly belt-and-suspenders — the 5-min skew check
+	// already rejects anything meaningfully in the future, and with ts
+	// bounded to [0, MaxInt64) time.Unix / now.Sub won't wrap for centuries.
+	// Keeping the upper bound documented so a reader doesn't wonder why
+	// two overlapping checks exist.
 	if ts < 0 || ts > now.Unix()+24*60*60 {
 		return errSlackTimestampStale
 	}

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -20,8 +20,11 @@ const slackTimestampSkew = 5 * time.Minute
 
 // Sentinel errors so callers can tell "not signed" from "signed but wrong"
 // without string matching. A missing header is distinguishable from a tampered
-// body, which matters for operator metrics and for tests.
+// body, which matters for operator metrics and for tests. The empty-secret
+// case gets its own sentinel too because it's the most important one to page
+// on — it means the deployment is effectively open.
 var (
+	errSlackSigningSecretEmpty = errors.New("slack: signing secret is empty")
 	errSlackSignatureMissing   = errors.New("slack: missing X-Slack-Signature or X-Slack-Request-Timestamp")
 	errSlackSignatureMalformed = errors.New("slack: malformed X-Slack-Signature")
 	errSlackTimestampStale     = errors.New("slack: request timestamp outside allowed skew")
@@ -35,11 +38,11 @@ var (
 // `now` is taken as a parameter so tests can pin the clock without a global
 // override.
 func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now time.Time) error {
+	// Treat an empty secret as a fail-closed misconfig: the caller must set
+	// one explicitly. This prevents a blank secret from silently accepting
+	// any request that happens to hash to "v0=".
 	if signingSecret == "" {
-		// Treat an empty secret as a fail-closed misconfig: the caller must
-		// set one explicitly. Returning here prevents a blank secret from
-		// silently accepting any request that happens to hash to "v0=".
-		return errors.New("slack: signing secret is empty")
+		return errSlackSigningSecretEmpty
 	}
 	if sigHeader == "" || tsHeader == "" {
 		return errSlackSignatureMissing
@@ -57,17 +60,29 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 	if err != nil {
 		return errSlackSignatureMalformed
 	}
-	delta := now.Unix() - ts
+	// Bound ts to a sane Unix-seconds range first so an attacker-supplied
+	// math.MinInt64 (or a wildly-future value that overflows time.Duration
+	// when subtracted) can't wrap the skew check. The HMAC check would
+	// still fail on garbage input, but rejecting structurally means no
+	// future refactor can accidentally make the overflow path reachable.
+	if ts < 0 {
+		return errSlackTimestampStale
+	}
+	// time.Duration's range (~292 years) comfortably brackets any legit
+	// 5-minute skew window, so direct subtraction is safe here.
+	delta := now.Sub(time.Unix(ts, 0))
 	if delta < 0 {
 		delta = -delta
 	}
-	if time.Duration(delta)*time.Second > slackTimestampSkew {
+	if delta > slackTimestampSkew {
 		return errSlackTimestampStale
 	}
 
 	mac := hmac.New(sha256.New, []byte(signingSecret))
 	// Slack's base string is "v0:<timestamp>:<raw body>". Any deviation
-	// (trailing newline, re-encoded body) breaks verification.
+	// (trailing newline, re-encoded body, base64-encoded body from API
+	// Gateway when a binary-media-type is mis-listed — see the caller's
+	// IsBase64Encoded handling) breaks verification.
 	mac.Write([]byte(slackSignatureVersion + ":" + tsHeader + ":" + body))
 	expected := mac.Sum(nil)
 

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// Check ordering below is: empty-secret → missing-headers → malformed
+// (format/hex/length/ts) → stale-ts → HMAC. All checks before HMAC only
+// touch caller-supplied data (never the signing secret), so no timing
+// oracle exists on the secret. Reordering could introduce one — don't
+// move the HMAC check earlier in response to a reviewer who wants faster
+// rejection paths.
+
 // slackSignatureVersion is the version prefix Slack uses on its request
 // signatures. See https://api.slack.com/authentication/verifying-requests-from-slack.
 const slackSignatureVersion = "v0"
@@ -51,6 +58,12 @@ func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now t
 		return errSlackSignatureMalformed
 	}
 	providedHex := sigHeader[len(slackSignatureVersion)+1:]
+	// Length check before DecodeString gives a faster + clearer malformed
+	// rejection for "v0=abc" style payloads (hmac.Equal would still return
+	// false, but the error would be the less-informative mismatch sentinel).
+	if len(providedHex) != sha256.Size*2 {
+		return errSlackSignatureMalformed
+	}
 	providedSig, err := hex.DecodeString(providedHex)
 	if err != nil {
 		return errSlackSignatureMalformed

--- a/apps/slack/internal/signature.go
+++ b/apps/slack/internal/signature.go
@@ -1,0 +1,78 @@
+package internal
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// slackSignatureVersion is the version prefix Slack uses on its request
+// signatures. See https://api.slack.com/authentication/verifying-requests-from-slack.
+const slackSignatureVersion = "v0"
+
+// slackTimestampSkew bounds how far from now a Slack request's timestamp may
+// be before it's treated as a replay. Slack's own recommendation is 5 minutes.
+const slackTimestampSkew = 5 * time.Minute
+
+// Sentinel errors so callers can tell "not signed" from "signed but wrong"
+// without string matching. A missing header is distinguishable from a tampered
+// body, which matters for operator metrics and for tests.
+var (
+	errSlackSignatureMissing   = errors.New("slack: missing X-Slack-Signature or X-Slack-Request-Timestamp")
+	errSlackSignatureMalformed = errors.New("slack: malformed X-Slack-Signature")
+	errSlackTimestampStale     = errors.New("slack: request timestamp outside allowed skew")
+	errSlackSignatureMismatch  = errors.New("slack: signature does not match body")
+)
+
+// verifySlackSignature authenticates an incoming Slack HTTP request by
+// recomputing HMAC-SHA256("v0:"+timestamp+":"+body) with the shared signing
+// secret and comparing against the X-Slack-Signature header in constant time.
+//
+// `now` is taken as a parameter so tests can pin the clock without a global
+// override.
+func verifySlackSignature(signingSecret, body, sigHeader, tsHeader string, now time.Time) error {
+	if signingSecret == "" {
+		// Treat an empty secret as a fail-closed misconfig: the caller must
+		// set one explicitly. Returning here prevents a blank secret from
+		// silently accepting any request that happens to hash to "v0=".
+		return errors.New("slack: signing secret is empty")
+	}
+	if sigHeader == "" || tsHeader == "" {
+		return errSlackSignatureMissing
+	}
+	if !strings.HasPrefix(sigHeader, slackSignatureVersion+"=") {
+		return errSlackSignatureMalformed
+	}
+	providedHex := sigHeader[len(slackSignatureVersion)+1:]
+	providedSig, err := hex.DecodeString(providedHex)
+	if err != nil {
+		return errSlackSignatureMalformed
+	}
+
+	ts, err := strconv.ParseInt(tsHeader, 10, 64)
+	if err != nil {
+		return errSlackSignatureMalformed
+	}
+	delta := now.Unix() - ts
+	if delta < 0 {
+		delta = -delta
+	}
+	if time.Duration(delta)*time.Second > slackTimestampSkew {
+		return errSlackTimestampStale
+	}
+
+	mac := hmac.New(sha256.New, []byte(signingSecret))
+	// Slack's base string is "v0:<timestamp>:<raw body>". Any deviation
+	// (trailing newline, re-encoded body) breaks verification.
+	mac.Write([]byte(slackSignatureVersion + ":" + tsHeader + ":" + body))
+	expected := mac.Sum(nil)
+
+	if !hmac.Equal(expected, providedSig) {
+		return errSlackSignatureMismatch
+	}
+	return nil
+}

--- a/apps/slack/internal/signature_test.go
+++ b/apps/slack/internal/signature_test.go
@@ -1,0 +1,118 @@
+package internal
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func validSigAndHeaders(t *testing.T, secret, body string, ts time.Time) (sig, tsHeader string) {
+	t.Helper()
+	tsHeader = strconv.FormatInt(ts.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(slackSignatureVersion + ":" + tsHeader + ":" + body))
+	sig = slackSignatureVersion + "=" + hex.EncodeToString(mac.Sum(nil))
+	return sig, tsHeader
+}
+
+func TestVerifySlackSignature_Valid(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sig, ts := validSigAndHeaders(t, "secret", "hello", now)
+
+	if err := verifySlackSignature("secret", "hello", sig, ts, now); err != nil {
+		t.Fatalf("valid signature rejected: %v", err)
+	}
+}
+
+func TestVerifySlackSignature_BoundaryCases(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sig, ts := validSigAndHeaders(t, "secret", "hello", now)
+
+	cases := []struct {
+		name string
+		want error
+		call func() error
+	}{
+		{
+			name: "empty secret fails closed",
+			want: nil,
+			call: func() error { return verifySlackSignature("", "hello", sig, ts, now) },
+		},
+		{
+			name: "missing signature header",
+			want: errSlackSignatureMissing,
+			call: func() error { return verifySlackSignature("secret", "hello", "", ts, now) },
+		},
+		{
+			name: "missing timestamp header",
+			want: errSlackSignatureMissing,
+			call: func() error { return verifySlackSignature("secret", "hello", sig, "", now) },
+		},
+		{
+			name: "malformed signature (no v0= prefix)",
+			want: errSlackSignatureMalformed,
+			call: func() error { return verifySlackSignature("secret", "hello", "deadbeef", ts, now) },
+		},
+		{
+			name: "malformed signature (non-hex)",
+			want: errSlackSignatureMalformed,
+			call: func() error { return verifySlackSignature("secret", "hello", "v0=notvalidhex", ts, now) },
+		},
+		{
+			name: "malformed timestamp",
+			want: errSlackSignatureMalformed,
+			call: func() error { return verifySlackSignature("secret", "hello", sig, "not-a-timestamp", now) },
+		},
+		{
+			name: "timestamp in the past outside skew",
+			want: errSlackTimestampStale,
+			call: func() error { return verifySlackSignature("secret", "hello", sig, ts, now.Add(10*time.Minute)) },
+		},
+		{
+			name: "timestamp in the future outside skew",
+			want: errSlackTimestampStale,
+			call: func() error { return verifySlackSignature("secret", "hello", sig, ts, now.Add(-10*time.Minute)) },
+		},
+		{
+			name: "tampered body",
+			want: errSlackSignatureMismatch,
+			call: func() error { return verifySlackSignature("secret", "tampered", sig, ts, now) },
+		},
+		{
+			name: "wrong secret",
+			want: errSlackSignatureMismatch,
+			call: func() error { return verifySlackSignature("different-secret", "hello", sig, ts, now) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if tc.want == nil && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if tc.want != nil && !errors.Is(err, tc.want) {
+				t.Fatalf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifySlackSignature_SkewBoundary(t *testing.T) {
+	// The skew check should accept a signature exactly at the boundary and
+	// reject one past it, so replays aren't off-by-one-ing their way in.
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sig, ts := validSigAndHeaders(t, "secret", "body", now)
+
+	if err := verifySlackSignature("secret", "body", sig, ts, now.Add(slackTimestampSkew)); err != nil {
+		t.Errorf("signature at exact skew boundary rejected: %v", err)
+	}
+
+	if err := verifySlackSignature("secret", "body", sig, ts, now.Add(slackTimestampSkew+time.Second)); !errors.Is(err, errSlackTimestampStale) {
+		t.Errorf("signature one second past skew boundary: got %v, want %v", err, errSlackTimestampStale)
+	}
+}

--- a/apps/slack/internal/signature_test.go
+++ b/apps/slack/internal/signature_test.go
@@ -39,7 +39,7 @@ func TestVerifySlackSignature_BoundaryCases(t *testing.T) {
 	}{
 		{
 			name: "empty secret fails closed",
-			want: nil,
+			want: errSlackSigningSecretEmpty,
 			call: func() error { return verifySlackSignature("", "hello", sig, ts, now) },
 		},
 		{
@@ -86,6 +86,13 @@ func TestVerifySlackSignature_BoundaryCases(t *testing.T) {
 			name: "wrong secret",
 			want: errSlackSignatureMismatch,
 			call: func() error { return verifySlackSignature("different-secret", "hello", sig, ts, now) },
+		},
+		{
+			// Guard rails the defense-in-depth against a math.MinInt64
+			// timestamp that would wrap the subtraction/abs chain.
+			name: "negative timestamp fails stale",
+			want: errSlackTimestampStale,
+			call: func() error { return verifySlackSignature("secret", "hello", sig, "-9223372036854775808", now) },
 		},
 	}
 

--- a/apps/slack/internal/signature_test.go
+++ b/apps/slack/internal/signature_test.go
@@ -64,7 +64,7 @@ func TestVerifySlackSignature_BoundaryCases(t *testing.T) {
 		},
 		{
 			name: "malformed timestamp",
-			want: errSlackSignatureMalformed,
+			want: errSlackTimestampMalformed,
 			call: func() error { return verifySlackSignature("secret", "hello", sig, "not-a-timestamp", now) },
 		},
 		{


### PR DESCRIPTION
## Why

\`SlackSigningSecret\` was loaded into config and wired through \`cmd/main.go\` but the handler **never verified** any signature. All three Slack endpoints (\`/slack/commands\`, \`/slack/events\`, \`/slack/interactions\`) accepted unsigned POSTs from the internet. Any caller could invoke \`/qurl create\` / \`/qurl list\` against any \`team_id\` they supplied, burning that team's API-key quota and exposing their QURL list. The test fixtures also never sent signatures, so CI never caught it.

## What changes

- \`signature.go\` — constant-time HMAC-SHA256 verification with Slack's \`v0:timestamp:body\` scheme. Sentinel errors (\`errSlackSignatureMissing\`, \`errSlackSignatureMalformed\`, \`errSlackTimestampStale\`, \`errSlackSignatureMismatch\`) so ops metrics can distinguish "noise" from "tampering."
- \`handler.go\` — verify before every signed endpoint; 401 on failure; structured \`slog.Warn\` naming the failure class and whether headers were present.
- Fail-closed on empty signing secret: a blank secret can't accidentally match \`v0=\`.
- 5-minute timestamp skew (Slack's recommendation).
- Injectable clock via \`h.now\` so stale-timestamp tests don't race real time.

## Tests

- Every endpoint rejects unsigned requests with 401 — the exact pre-fix reproducer.
- Tampered body (reused sig, different payload) → 401.
- Stale timestamp (10m old) → 401.
- Valid signature → 200, existing behavior preserved.
- Boundary conditions: exact 5m == accept, 5m+1s == reject.
- Header casing: API Gateway v1 preserves caller casing, v2 lowercases — both paths covered.
- Signature helper unit tests for every sentinel error.

## Test plan

- [x] \`go test ./apps/slack/... -count=1\` — green
- [x] \`golangci-lint run --timeout=5m ./...\` — 0 issues
- [ ] Deployed to sandbox and a genuine Slack-app request round-trips
- [ ] Unsigned request from curl returns 401

Resolves #71