### PR TITLE
fix(discord): follow-ups #86, #87, #89 from multi-tenant PR

### DIFF
--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -5,14 +5,27 @@
 // boot in prod with missing secrets OR die on a spurious false-positive.
 
 // Required at boot in EVERY environment. Gated on `isOpenNHPActive`,
-// NOT `isMultiTenant`: the GITHUB_* + BASE_URL + GUILD_ID vars only
-// matter when /auth + /webhook routes are actually mounted. A
-// single-guild-plain deployment (GUILD_ID set but ENABLE_OPENNHP_FEATURES
-// off) never mounts those routes, so demanding dummy values just to
-// pass the boot check would be a papercut for every customer server.
+// NOT `isMultiTenant`: the GITHUB_* vars only matter when /auth +
+// /webhook routes are actually mounted. A single-guild-plain deployment
+// (GUILD_ID set but ENABLE_OPENNHP_FEATURES off) never mounts those
+// routes, so demanding dummy values just to pass the boot check would
+// be a papercut for every customer server.
+//
+// Explicitly NOT on this list even in OpenNHP mode:
+//   - GUILD_ID: if isOpenNHPActive === true then !isMultiTenant, which
+//     means the snowflake validator in config.js already accepted a
+//     17-20 digit value. Re-checking truthiness here would never catch
+//     a missing GUILD_ID — the upstream check is the authority.
+//   - BASE_URL: config.js supplies an unconditional "http://localhost:3000"
+//     default, so `cfg.BASE_URL` is always truthy. The real enforcement
+//     is the https-startswith check in index.js, which runs regardless
+//     of this required-list membership.
+// Listing either would be decorative — the downstream checks are the
+// authority. Keeping this list to the keys whose absence is actually a
+// boot blocker.
 function bootRequired(isOpenNHPActive) {
   if (!isOpenNHPActive) return ['DISCORD_TOKEN'];
-  return ['DISCORD_TOKEN', 'GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET', 'GUILD_ID', 'BASE_URL'];
+  return ['DISCORD_TOKEN', 'GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET'];
 }
 
 // Additionally required when NODE_ENV=production. QURL_API_KEY is the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2421,10 +2421,49 @@ function getActiveCommands() {
     : commands.filter(cmd => CUSTOMER_SAFE_COMMANDS.has(cmd.data.name));
 }
 
+// Proactively clear stale guild-scoped command registrations from any
+// guild the bot is in. Discord's guild and global command namespaces do
+// not purge each other on a fresh .set() call, so a bot that previously
+// ran in OpenNHP mode (GUILD_ID=X, full command set registered to guild
+// X) and is now redeployed in multi-tenant or single-guild-plain mode
+// will leave /link, /leaderboard, etc. visible in X's slash-command
+// autocomplete until Discord's cache ages out. The dispatch-time filter
+// in handleCommand prevents those stale commands from doing anything
+// harmful, but users still see dead commands in the picker. Issuing
+// .set([], guildId) clears the guild-scoped set; any ALIVE guild-scoped
+// registration for the CURRENT mode gets reinstalled by the main
+// registerCommands path below.
+//
+// Scoped to non-OpenNHP modes: in OpenNHP mode we intentionally register
+// guild-scoped commands to config.GUILD_ID, so purging there would
+// race with the upcoming set(). Only iterates guilds the bot is
+// actually in (client.guilds.cache) — we can't and shouldn't enumerate
+// guilds we've never joined.
+async function purgeStaleGuildCommands(client) {
+  if (config.isOpenNHPActive) return; // guild-scoped register is the goal in OpenNHP mode
+  for (const guild of client.guilds.cache.values()) {
+    try {
+      const existing = await client.application.commands.fetch({ guildId: guild.id });
+      if (existing.size === 0) continue;
+      await client.application.commands.set([], guild.id);
+      logger.info(`Purged ${existing.size} stale guild-scoped commands from ${guild.name} (${guild.id})`);
+    } catch (error) {
+      // Don't fail boot on a purge error — the dispatch-time filter in
+      // handleCommand is the correctness guarantee; purge is UX polish.
+      logger.warn(`Could not purge stale commands from guild ${guild.id}`, { error: error.message });
+    }
+  }
+}
+
 // Register commands with Discord. `config.isOpenNHPActive` is the
 // single source of truth for "this deployment exercises the OpenNHP
 // community surface" — see config.js for the derivation.
 async function registerCommands(client) {
+  // Purge first — prevents stale OpenNHP-era registrations in guilds the
+  // bot is still in. See purgeStaleGuildCommands for details + why this
+  // is scoped to non-OpenNHP modes.
+  await purgeStaleGuildCommands(client);
+
   const activeCommands = getActiveCommands();
   const commandData = activeCommands.map(cmd => cmd.data.toJSON());
 

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -244,10 +244,10 @@ async function verifyBotPermissions() {
       .map(([name]) => name);
     if (missing.length > 0) {
       logger.error('Bot is missing required Discord permissions in guild', {
-        guild: guild?.name, missing, opennhp: config.isOpenNHPActive,
+        guild: guild?.name, missing, opennhp_active: config.isOpenNHPActive,
       });
     } else {
-      logger.info('Bot permissions OK', { guild: guild?.name, opennhp: config.isOpenNHPActive });
+      logger.info('Bot permissions OK', { guild: guild?.name, opennhp_active: config.isOpenNHPActive });
     }
   } catch (err) {
     logger.warn('Could not verify bot permissions at boot', { error: err.message });
@@ -278,7 +278,7 @@ client.once('ready', async () => {
   if (config.isOpenNHPActive) {
     setupWeeklyDigest();
   }
-  logger.info(`Watching guild: ${guild?.name}`, { opennhp: config.isOpenNHPActive });
+  logger.info(`Watching guild: ${guild?.name}`, { opennhp_active: config.isOpenNHPActive });
 });
 
 // Handle role/channel deletion - refresh cache

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -18,10 +18,10 @@ const {
 } = require('../src/boot-requirements');
 
 describe('bootRequired', () => {
-  it('OpenNHP-active mode demands the OpenNHP-linking env vars', () => {
+  it('OpenNHP-active mode demands DISCORD_TOKEN + GITHUB_* (but not GUILD_ID or BASE_URL — those are enforced upstream)', () => {
     expect(bootRequired(true).sort()).toEqual([
-      'BASE_URL', 'DISCORD_TOKEN', 'GITHUB_CLIENT_ID',
-      'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET', 'GUILD_ID',
+      'DISCORD_TOKEN', 'GITHUB_CLIENT_ID',
+      'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET',
     ]);
   });
 
@@ -55,9 +55,9 @@ describe('missingBootKeys', () => {
   });
 
   it('surfaces exact missing keys (not just a count) in OpenNHP mode', () => {
-    const cfg = { DISCORD_TOKEN: 't', GUILD_ID: '123' };
+    const cfg = { DISCORD_TOKEN: 't' };
     expect(missingBootKeys(cfg, true).sort()).toEqual([
-      'BASE_URL', 'GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET',
+      'GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET',
     ]);
   });
 
@@ -75,7 +75,7 @@ describe('missingBootKeys', () => {
   it('treats empty strings as missing (not just undefined)', () => {
     const cfg = {
       DISCORD_TOKEN: '', GITHUB_CLIENT_ID: '', GITHUB_CLIENT_SECRET: 'x',
-      GITHUB_WEBHOOK_SECRET: 'x', GUILD_ID: '123', BASE_URL: 'https://h',
+      GITHUB_WEBHOOK_SECRET: 'x',
     };
     expect(missingBootKeys(cfg, true).sort()).toEqual([
       'DISCORD_TOKEN', 'GITHUB_CLIENT_ID',

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -8,16 +8,16 @@
 jest.mock('../src/config', () => ({
   DISCORD_TOKEN: 'test-token',
   DISCORD_CLIENT_ID: 'test-client',
-  GUILD_ID: 'guild-1',
   // This suite exercises the OpenNHP community features path (role
   // auto-creation, role assignment, welcome DM, badge/digest posts).
-  // Those gate on config.isOpenNHPActive in src/discord.js — set both
-  // this and the raw flag so the legacy happy paths stay covered.
-  // A separate suite (tests/opennhp-gating.test.js) covers the
-  // flag=false branches.
-  ENABLE_OPENNHP_FEATURES: true,
-  isMultiTenant: false,
-  isOpenNHPActive: true,
+  // Mode-derivation (GUILD_ID, isMultiTenant, ENABLE_OPENNHP_FEATURES,
+  // isOpenNHPActive) comes from the helper so a new derived field
+  // added to src/config.js is picked up here automatically. A separate
+  // suite (tests/opennhp-gating.test.js) covers the flag=false branches.
+  ...require('./helpers/buildConfigMock').buildConfigMock({
+    guildId: 'guild-1',
+    enableOpenNHP: true,
+  }),
   CONTRIBUTOR_ROLE_NAME: 'Contributor',
   ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
   CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',

--- a/apps/discord/tests/helpers/buildConfigMock.js
+++ b/apps/discord/tests/helpers/buildConfigMock.js
@@ -1,0 +1,38 @@
+// Test-side reconstitution of the three-mode derivation that lives in
+// src/config.js. Each test file that does `jest.mock('../src/config', ...)`
+// previously had to hard-code all three derived fields
+// (`isMultiTenant`, `ENABLE_OPENNHP_FEATURES`, `isOpenNHPActive`) in
+// lockstep — if any one drifted, tests passed for the wrong reason.
+//
+// This helper takes the two inputs (guildId, enableOpenNHP) and
+// produces the same shape the real config module exports. A 4th
+// derived field added to config.js would be added here once, and
+// every test suite that uses this helper picks up the new field
+// automatically.
+//
+// Usage:
+//   const { buildConfigMock } = require('./helpers/buildConfigMock');
+//   jest.mock('../src/config', () => ({
+//     ...jest.requireActual('./helpers/buildConfigMock').buildConfigMock({
+//       guildId: 'guild-1',
+//       enableOpenNHP: true,
+//     }),
+//     // test-specific overrides (role-name strings, thresholds, etc.)
+//     CONTRIBUTOR_ROLE_NAME: 'Contributor',
+//     ...
+//   }));
+
+function buildConfigMock({ guildId = null, enableOpenNHP = false } = {}) {
+  const normalizedGuildId = guildId || null;
+  const isMultiTenant = !normalizedGuildId;
+  const isOpenNHPActive = !isMultiTenant && enableOpenNHP === true;
+
+  return {
+    GUILD_ID: normalizedGuildId,
+    isMultiTenant,
+    ENABLE_OPENNHP_FEATURES: enableOpenNHP === true,
+    isOpenNHPActive,
+  };
+}
+
+module.exports = { buildConfigMock };

--- a/apps/discord/tests/multi-tenant.test.js
+++ b/apps/discord/tests/multi-tenant.test.js
@@ -114,7 +114,10 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     const commandsModule = require('../src/commands');
 
     const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = { application: { commands: { set: mockSet } } };
+    const mockClient = {
+      application: { commands: { set: mockSet, fetch: jest.fn().mockResolvedValue(new Map()) } },
+      guilds: { cache: new Map() },
+    };
     await commandsModule.registerCommands(mockClient);
 
     expect(mockSet).toHaveBeenCalledTimes(1);
@@ -131,7 +134,10 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     const commandsModule = require('../src/commands');
 
     const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = { application: { commands: { set: mockSet } } };
+    const mockClient = {
+      application: { commands: { set: mockSet, fetch: jest.fn().mockResolvedValue(new Map()) } },
+      guilds: { cache: new Map() },
+    };
     await commandsModule.registerCommands(mockClient);
 
     expect(mockSet).toHaveBeenCalledTimes(1);
@@ -149,7 +155,10 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     const commandsModule = require('../src/commands');
 
     const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = { application: { commands: { set: mockSet } } };
+    const mockClient = {
+      application: { commands: { set: mockSet, fetch: jest.fn().mockResolvedValue(new Map()) } },
+      guilds: { cache: new Map() },
+    };
     await commandsModule.registerCommands(mockClient);
 
     expect(mockSet).toHaveBeenCalledTimes(1);
@@ -158,8 +167,113 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     // Only /qurl, even in single-guild mode, because OpenNHP features are off
     expect(data.map(c => c.name).sort()).toEqual(['qurl']);
     expect(data.map(c => c.name)).not.toContain('link');
-    expect(data.map(c => c.name)).not.toContain('leaderboard');
-    expect(data.map(c => c.name)).not.toContain('forcelink');
+  });
+});
+
+describe('registerCommands stale-command purge (issue #86)', () => {
+  // When the bot was previously in OpenNHP mode and has since flipped
+  // to non-OpenNHP mode, prior guild-scoped /link etc. registrations
+  // persist in those guilds' slash-command caches. registerCommands
+  // should proactively clear them so users don't see dead commands in
+  // autocomplete. Only runs in non-OpenNHP modes — in OpenNHP mode the
+  // fresh guild-scoped .set() is the whole point.
+  let originalGuildId;
+  let originalFlag;
+  beforeAll(() => {
+    originalGuildId = process.env.GUILD_ID;
+    originalFlag = process.env.ENABLE_OPENNHP_FEATURES;
+  });
+  afterAll(() => {
+    if (originalGuildId === undefined) delete process.env.GUILD_ID; else process.env.GUILD_ID = originalGuildId;
+    if (originalFlag === undefined) delete process.env.ENABLE_OPENNHP_FEATURES; else process.env.ENABLE_OPENNHP_FEATURES = originalFlag;
+    jest.resetModules();
+  });
+  beforeEach(() => { jest.resetModules(); });
+
+  it('multi-tenant mode: purges stale guild-scoped registrations from every guild the bot is in', async () => {
+    delete process.env.GUILD_ID;
+    delete process.env.ENABLE_OPENNHP_FEATURES;
+    const commandsModule = require('../src/commands');
+
+    // Two guilds with stale registrations, one empty guild (should not be purged)
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce(new Map([['cmd-1', {}], ['cmd-2', {}], ['cmd-3', {}]])) // guild A: 3 stale
+      .mockResolvedValueOnce(new Map([['cmd-4', {}]]))                                 // guild B: 1 stale
+      .mockResolvedValueOnce(new Map());                                               // guild C: empty — skip
+    const mockSet = jest.fn().mockResolvedValue(undefined);
+    const mockClient = {
+      application: { commands: { set: mockSet, fetch: mockFetch } },
+      guilds: { cache: new Map([
+        ['ga', { id: 'ga', name: 'A' }],
+        ['gb', { id: 'gb', name: 'B' }],
+        ['gc', { id: 'gc', name: 'C' }],
+      ]) },
+    };
+
+    await commandsModule.registerCommands(mockClient);
+
+    // fetch called once per guild (3)
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // set called 3 times total: 2 purges (empty array + guildId) + 1 final global register
+    expect(mockSet).toHaveBeenCalledTimes(3);
+    // Verify purge args: empty array, guildId
+    const purgeCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length === 0);
+    expect(purgeCalls).toHaveLength(2);
+    expect(purgeCalls.map(c => c[1]).sort()).toEqual(['ga', 'gb']);
+    // Verify registration: the qurl command, no guildId (global)
+    const registerCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length > 0);
+    expect(registerCalls).toHaveLength(1);
+    expect(registerCalls[0][1]).toBeUndefined();
+  });
+
+  it('OpenNHP mode: does NOT purge (guild-scoped registration is the goal)', async () => {
+    process.env.GUILD_ID = '123456789012345678';
+    process.env.ENABLE_OPENNHP_FEATURES = 'true';
+    const commandsModule = require('../src/commands');
+
+    const mockFetch = jest.fn();
+    const mockSet = jest.fn().mockResolvedValue(undefined);
+    const mockClient = {
+      application: { commands: { set: mockSet, fetch: mockFetch } },
+      guilds: { cache: new Map([['ga', { id: 'ga', name: 'A' }]]) },
+    };
+
+    await commandsModule.registerCommands(mockClient);
+
+    // fetch never called — purge skipped in OpenNHP mode
+    expect(mockFetch).not.toHaveBeenCalled();
+    // set called once for the register, no preceding empty-array purge
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    expect(mockSet.mock.calls[0][0].length).toBeGreaterThan(0);
+  });
+
+  it('non-OpenNHP mode: purge failure in one guild does not block registration', async () => {
+    delete process.env.GUILD_ID;
+    delete process.env.ENABLE_OPENNHP_FEATURES;
+    const commandsModule = require('../src/commands');
+
+    const mockFetch = jest.fn()
+      .mockRejectedValueOnce(new Error('Missing Access'))     // guild A: can't enumerate
+      .mockResolvedValueOnce(new Map([['cmd-1', {}]]));      // guild B: succeeds
+    const mockSet = jest.fn().mockResolvedValue(undefined);
+    const mockClient = {
+      application: { commands: { set: mockSet, fetch: mockFetch } },
+      guilds: { cache: new Map([
+        ['ga', { id: 'ga', name: 'A' }],
+        ['gb', { id: 'gb', name: 'B' }],
+      ]) },
+    };
+
+    await commandsModule.registerCommands(mockClient);
+
+    // Guild A's fetch failed but we still tried guild B
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // Only guild B got purged (A failed before reaching set)
+    const purgeCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length === 0);
+    expect(purgeCalls.map(c => c[1])).toEqual(['gb']);
+    // Final register still ran despite guild A's purge failure
+    const registerCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length > 0);
+    expect(registerCalls).toHaveLength(1);
   });
 });
 

--- a/apps/discord/tests/multi-tenant.test.js
+++ b/apps/discord/tests/multi-tenant.test.js
@@ -79,6 +79,34 @@ describe('multi-tenant mode — config.js GUILD_ID normalization', () => {
     expect(cfg.GUILD_ID).toBeNull();
     expect(cfg.isMultiTenant).toBe(true);
   });
+
+  it('warns when unsupported combo is set: GUILD_ID unset + ENABLE_OPENNHP_FEATURES=true', () => {
+    // Claude review flagged this as an "operator-UX feature without a
+    // test" — if someone removes the warning in a future refactor,
+    // operators who set ENABLE_OPENNHP_FEATURES=true intending to
+    // enable OpenNHP mode would silently get multi-tenant instead
+    // with no signal their intent was ignored.
+    const originalFlag = process.env.ENABLE_OPENNHP_FEATURES;
+    delete process.env.GUILD_ID;
+    process.env.ENABLE_OPENNHP_FEATURES = 'true';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      jest.resetModules();
+      const cfg = require('../src/config');
+      expect(cfg.isMultiTenant).toBe(true);
+      expect(cfg.isOpenNHPActive).toBe(false); // flag effectively ignored
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ignored when GUILD_ID is unset'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      if (originalFlag === undefined) {
+        delete process.env.ENABLE_OPENNHP_FEATURES;
+      } else {
+        process.env.ENABLE_OPENNHP_FEATURES = originalFlag;
+      }
+    }
+  });
 });
 
 describe('multi-tenant mode — registerCommands command filtering', () => {
@@ -381,13 +409,24 @@ describe('handleCommand dispatch-time filter', () => {
 
     await handleCommand(interaction);
 
-    // The real /link handler ran — it called reply with something
-    // OTHER than the "no longer available" string. (In the already-
-    // linked path it replies with a message about the existing link.)
+    // The real /link handler ran. With getLinkByDiscord mocked to
+    // return { github_username: 'existing' }, the already-linked
+    // branch should fire — its positive signal is that the reply
+    // embed references the existing GitHub username. This is a
+    // specific-content assertion rather than a negation, so a future
+    // /link UX tweak that accidentally mentions "no longer available"
+    // (e.g. in the disambiguation text for a relink flow) wouldn't
+    // produce a false positive.
     const replyArgs = reply.mock.calls[0]?.[0];
     expect(replyArgs).toBeDefined();
-    const replyContent = typeof replyArgs === 'string' ? replyArgs : (replyArgs.content || JSON.stringify(replyArgs));
-    expect(replyContent).not.toContain('no longer available');
+    const serialized = typeof replyArgs === 'string' ? replyArgs : JSON.stringify(replyArgs);
+    // Either "existing" appears (already-linked confirmation) or
+    // "github" (the OAuth flow embed URL) — both are positive signals
+    // that the real /link handler ran, as opposed to the stale-command
+    // short-circuit. The stale-command branch replies with exactly
+    // "This command is no longer available in this server." which
+    // contains neither of those strings.
+    expect(serialized.toLowerCase()).toMatch(/existing|github/);
   });
 });
 

--- a/apps/discord/tests/opennhp-gating.test.js
+++ b/apps/discord/tests/opennhp-gating.test.js
@@ -18,10 +18,12 @@
 jest.mock('../src/config', () => ({
   DISCORD_TOKEN: 'test-token',
   DISCORD_CLIENT_ID: 'test-client',
-  GUILD_ID: 'guild-1',
-  isMultiTenant: false,
-  ENABLE_OPENNHP_FEATURES: false,
-  isOpenNHPActive: false,
+  // Mode-derivation via the shared helper — single-guild-plain
+  // (GUILD_ID set, flag off) → isOpenNHPActive=false.
+  ...require('./helpers/buildConfigMock').buildConfigMock({
+    guildId: 'guild-1',
+    enableOpenNHP: false,
+  }),
   CONTRIBUTOR_ROLE_NAME: 'Contributor',
   ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
   CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',


### PR DESCRIPTION
Single follow-up PR closing three issues opened during the PR #82 pr-polish cycle. **Stacks on [#82](https://github.com/layervai/qurl-integrations/pull/82)** — targets \`feat/multi-tenant-mode\` rather than \`main\` so the diff is scoped to just the follow-up work. After #82 merges, GitHub will auto-retarget this to \`main\` (or I can retarget manually).

## #86 — clear stale guild-scoped command registrations on mode flip

New \`purgeStaleGuildCommands(client)\` in \`apps/discord/src/commands.js\` runs on every boot in non-OpenNHP mode. Iterates \`client.guilds.cache\`, fetches any registered guild-scoped commands per guild, and \`.set([], guildId)\`s them away before the main \`.set()\` writes the current mode's commands. Per-guild fetch failure doesn't block others (logged at warn, main registration still proceeds). Skipped in OpenNHP mode — fresh guild-scoped \`.set()\` is the whole point there.

Three new tests in \`tests/multi-tenant.test.js\`:
- multi-tenant: purges from every guild the bot is in (3-guild scenario with one empty guild that's correctly skipped)
- OpenNHP mode: does NOT purge
- non-OpenNHP mode: per-guild error doesn't block registration

## #87 — OAUTH_STATE_SECRET defense-in-depth at call site

**Already implemented.** \`commands.js:stateSecret()\` at lines 55-80 already throws in any non-test environment when both \`OAUTH_STATE_SECRET\` and \`GITHUB_CLIENT_SECRET\` are missing. That's the defense-in-depth the issue was asking for, placed at the call site (state mint + state verify) rather than a handler wrapper — catches every code path that could use the secret, not just the two current routes.

No code change in this PR for #87; it's closed by this PR via the explanation above.

## #89 — test mock helper for 3-mode config derivation

New \`apps/discord/tests/helpers/buildConfigMock.js\` exports a pure \`buildConfigMock({ guildId, enableOpenNHP })\` that reconstitutes the three derived fields (\`GUILD_ID\`, \`isMultiTenant\`, \`ENABLE_OPENNHP_FEATURES\`, \`isOpenNHPActive\`) in one place. A 4th derived field added to \`src/config.js\` is then picked up automatically by any suite using the helper.

Migrated the two test files whose gating logic depends on the derivation:
- \`tests/discord.test.js\` (flag=true path)
- \`tests/opennhp-gating.test.js\` (flag=false path)

Remaining test files use fewer of the derived fields and don't benefit from migration; future authors are pointed at the helper by its JSDoc.

## Additional cleanup surfaced during review

While folding, the prior pr-polish Claude review on these commits flagged four cheap fixes, also included here:

- **bootRequired(true) dead checks removed**: \`GUILD_ID\` and \`BASE_URL\` were listed as required but can never appear missing (snowflake validator and unconditional default respectively). Dropped both; downstream enforcement is the authority.
- **Unsupported-combo warn now has a test**: \`tests/multi-tenant.test.js\` spies \`console.warn\` to pin the \"ignored when GUILD_ID is unset\" message so a future refactor can't silently drop it.
- **handleCommand OpenNHP-mode assertion tightened**: previously negated \"no longer available\"; now asserts a positive signal (\"existing\"/\"github\") that the real \`/link\` handler ran.
- **Log field rename**: \`opennhp\` → \`opennhp_active\` (3 sites) — disambiguates \"is this guild OpenNHP?\" vs \"is OpenNHP mode active?\".

## Test plan

- [x] All 532 tests pass (up from 528 — +3 purge tests + 1 unsupported-combo warn test)
- [x] \`npm run lint\` clean
- [ ] Merge #82 first, then retarget this PR to \`main\`
- [ ] After both land, the next qurl-bot-discord deploy's \`/link\` autocomplete should stop showing in customer guilds where the bot previously registered OpenNHP commands

## Closes

- Closes #86
- Closes #87 (already implemented — verified in this PR)
- Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)