### PR TITLE
chore: replace phantom @layervai/platform team in CODEOWNERS with real humans

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,26 @@
 # CODEOWNERS - Define code ownership for automatic review requests
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Branch protection on main has `require_code_owner_reviews = true`.
+# That setting only has force when the patterns below resolve to real
+# humans. The previous revision pointed every rule at @layervai/platform,
+# a team that does not exist in this org (404 via the API), so "require
+# code owner reviews" silently no-op'd — branch protection passed on
+# any single approval from any org member with review rights. This
+# revision pins to active humans so the gate actually gates.
 
 # Default owners for everything
-* @layervai/platform
+* @justin-layerv @Kevin-layerV @vikramlayerv
 
-# Infrastructure and CI require platform team review
-/.github/workflows/ @layervai/platform
+# Infrastructure and CI require review
+/.github/workflows/ @justin-layerv @Kevin-layerV @vikramlayerv
 
-# Shared code changes affect all apps — require platform review
-shared/ @layervai/platform
+# Shared code changes affect all apps — require review
+shared/ @justin-layerv @Kevin-layerV @vikramlayerv
 
 # Repo config
-/.github/ @layervai/platform
-Makefile @layervai/platform
-.golangci.yml @layervai/platform
-.pre-commit-config.yaml @layervai/platform
-.editorconfig @layervai/platform
+/.github/ @justin-layerv @Kevin-layerV @vikramlayerv
+Makefile @justin-layerv @Kevin-layerV @vikramlayerv
+.golangci.yml @justin-layerv @Kevin-layerV @vikramlayerv
+.pre-commit-config.yaml @justin-layerv @Kevin-layerV @vikramlayerv
+.editorconfig @justin-layerv @Kevin-layerV @vikramlayerv


### PR DESCRIPTION
## Why

`require_code_owner_reviews = true` is set on main's branch protection. That gate only has force when the CODEOWNERS patterns resolve to real humans. The previous revision pointed every rule at `@layervai/platform`:

```
$ gh api orgs/layervai/teams/platform
{"message":"Not Found", "status":"404"}
```

A missing team in CODEOWNERS is treated as "no code owner for this file," which makes `require_code_owner_reviews` a no-op for every path in the repo — any single approval from any org member satisfies branch protection. Today that's why Vikram's Discord PRs merge on a single review from whoever happens to be online (PR #82 merged on one approval from @Kevin-layerV).

## What changes

One-to-one substitution: `@layervai/platform` → `@justin-layerv @Kevin-layerV @vikramlayerv`. No new paths added, no structural changes. Just making the existing rules point at humans who actually exist.

## Effect

- **Vikram's PRs** (any path): require approval from @justin-layerv or @Kevin-layerV, since GitHub disallows self-approval. That's the real intent the phantom team was meant to encode.
- **Justin's / Kevin's PRs**: require approval from one of the other two. No single-point-of-failure.
- **Other contributors** (e.g. @haochangjiu on `feat/email-bot`): require approval from one of the three.

## What this does NOT do

- **No new per-path rules.** Minimal surface: replace-only. If we later want `/apps/discord/` scoped to an on-call rotation, that's a follow-up.
- **No CI/workflow changes.** This is a policy fix, not a behavior change in any job.
- **No change to other repos.** A parallel PR in `qurl-integrations-infra` adds @Kevin-layerV to its CODEOWNERS so that repo has the same three-human gate.

## Verification

```
$ gh api users/justin-layerv --jq .login    # justin-layerv
$ gh api users/Kevin-layerV --jq .login     # Kevin-layerV
$ gh api users/vikramlayerv --jq .login     # vikramlayerv
```

All three handles resolve (not phantom). First was confirmed by `gh api user` when generating this PR; the other two were confirmed via recent review activity on PR #82 (@Kevin-layerV) and commit history (@vikramlayerv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)