### PR TITLE
fix(discord): polish /qurl help — clickable link, expiry note, glossary, plain-language scaling

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2316,7 +2316,7 @@ const commands = [
             signal: AbortSignal.timeout(10000),
           });
           if (resp.status === 401 || resp.status === 403) {
-            return modalSubmit.editReply({ content: '❌ **Invalid API key.** Double-check your key at **layerv.ai**.' });
+            return modalSubmit.editReply({ content: '❌ **Invalid API key.** Double-check your key at **https://layerv.ai**.' });
           }
           if (!resp.ok) {
             return modalSubmit.editReply({ content: `❌ **QURL API error** (${resp.status}). Try again later.` });
@@ -2376,7 +2376,7 @@ const commands = [
         }
         return interaction.reply({
           content: '❌ **QURL is not configured for this server.**\n\n' +
-            '1. Sign up at **layerv.ai** to get your API key\n' +
+            '1. Sign up at **https://layerv.ai** to get your API key\n' +
             '2. Run `/qurl setup api_key:lv_live_your_key_here`\n\n' +
             'Only server administrators can run setup.',
           ephemeral: true,
@@ -2391,7 +2391,7 @@ const commands = [
           return interaction.reply({
             content: '❌ **QURL is not configured for this server.**\n\n' +
               'A server admin needs to run `/qurl setup` first.\n' +
-              'Sign up at **layerv.ai** to get your API key.',
+              'Sign up at **https://layerv.ai** to get your API key.',
             ephemeral: true,
           });
         }
@@ -2418,13 +2418,14 @@ const commands = [
             '  1. Use `/qurl send` and choose a target (user, channel, or voice)\n' +
             '  2. Attach a file and/or search for a location\n' +
             '  3. Each recipient gets a unique, single-use link by DM\n' +
-            '  4. Links self-destruct on access\n\n' +
-            '**Note on large servers:** `channel` and `voice` targets rely on ' +
-            "Discord's member cache. Without the `GUILD_PRESENCES` privileged " +
-            'intent, very large guilds (~1000+ members) may silently miss ' +
-            'members who appear offline — prefer `user` target if you need a ' +
-            'guaranteed recipient.\n\n' +
-            'Sign up at **layerv.ai** to get your API key.',
+            '  4. Links self-destruct on first access, or when the expiry elapses — whichever comes first\n\n' +
+            '**Terms:** a *protected resource* is the file or location you\'re sharing. ' +
+            'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
+            'You create a qurl for a protected resource each time you run `/qurl send`.\n\n' +
+            '**Large servers (~1000+ members):** when sending to a `channel` or `voice` target, ' +
+            'members who appear offline in Discord may be skipped. ' +
+            'If you need to reach a specific person for sure, use the `user` target.\n\n' +
+            'Sign up at **https://layerv.ai** to get your API key.',
           ephemeral: true,
         });
       }

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -914,6 +914,36 @@ describe('/qurl help subcommand', () => {
       }),
     );
   });
+
+  // Positive assertions for the four copy fixes in PR #98. Without these,
+  // the only other help-text assertion is `stringContaining('Qurl Bot')`,
+  // which would stay green if every fix below were reverted. Pinning them
+  // here catches accidental regressions on the next edit to this block.
+  it('includes the four copy fixes from PR #98', async () => {
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'help'),
+      },
+    });
+
+    await cmd.execute(interaction);
+
+    const { content } = interaction.reply.mock.calls[0][0];
+
+    // (1) layerv.ai URL carries the scheme so Discord auto-linkifies it
+    expect(content).toContain('https://layerv.ai');
+    // (2) self-destruct note covers both access AND expiry
+    expect(content).toMatch(/self-destruct on first access.*expiry elapses/);
+    // (3) Terms block disambiguates "protected resource" from "qurl"
+    expect(content).toContain('protected resource');
+    expect(content).toContain('access link');
+    // (4) Large-servers note uses plain language, not GUILD_PRESENCES jargon
+    expect(content).toContain('Large servers');
+    expect(content).not.toContain('GUILD_PRESENCES');
+  });
 });
 
 describe('/qurl send — cooldown and API key checks', () => {


### PR DESCRIPTION
## Summary
Four copy-only fixes to the \`/qurl help\` output and adjacent user-facing strings, all triaged from Kevin's QA review of the production bot:

1. **Prepend \`https://\` to every \`**layerv.ai**\` reference (4 sites).** Discord does not auto-linkify bare \`layerv.ai\`; the old text rendered as plain bold. Users couldn't click through to sign up.
2. **Self-destruct note now covers expiry too.** Was: \`"Links self-destruct on access"\`. Now: \`"Links self-destruct on first access, or when the expiry elapses — whichever comes first"\`. The prior copy contradicted the 30m/1h/6h/24h/7d expiry choices \`/qurl send\` already offers.
3. **Added a Terms block.** Reviewers kept conflating "protected resource" (the file/location) with "qurl" (the access link). One short paragraph disambiguates them.
4. **Rewrote the GUILD_PRESENCES note in plain language.** The previous copy dropped \`GUILD_PRESENCES privileged intent\` and \`Discord's member cache\` on end users who have no reason to know those terms. Actionable advice preserved — *"use the \`user\` target if you need a guaranteed recipient."*

## Scope
- One file: \`apps/discord/src/commands.js\` (+11 / −10)
- No logic changes. Strictly user-facing copy.
- All 543 existing tests pass.
- The existing \`/qurl help\` test (\`tests/commands-comprehensive.test.js:897\`) asserts on \`stringContaining('Qurl Bot')\`, still green.

## Out of scope (separate discussion)
- **Branding normalization** (\`QURL\` vs \`qURL\` vs \`Qurl\`) — this PR preserves the existing stray \`Qurl Bot\` header casing pending a product call on the canonical form.
- **Pointing \`https://layerv.ai\` at a dedicated signup page** — if/when there's a \`/signup\` URL, a one-line follow-up can switch all 4 references at once.
- **Uninstalling the old Python bot from \`qurl-test-bot-playground\`** — this is the root cause of the ghost \`/qurl list\` and \`/qurl clear\` commands Kevin reported; tracked as an operational action, not a code change.

## Test plan
- [x] \`npx jest\` in \`apps/discord\` — 543/543 passing
- [ ] Post-merge: run \`/qurl help\` in the test guild and confirm the link is clickable and the new copy renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)