### PR TITLE
fix(discord): label /qurl status as admin-only in description + help

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2254,7 +2254,7 @@ const commands = [
       )
       .addSubcommand(sub =>
         sub.setName('status')
-          .setDescription('Check if QURL is configured for this server')
+          .setDescription('Check if QURL is configured (admin only)')
       ),
     async execute(interaction) {
       const sub = interaction.options.getSubcommand();
@@ -2410,7 +2410,7 @@ const commands = [
           content: '**Qurl Bot — Help**\n\n' +
             '**Getting started:**\n' +
             '  `/qurl setup` — configure your API key (admin only)\n' +
-            '  `/qurl status` — check if QURL is configured\n\n' +
+            '  `/qurl status` — check if QURL is configured (admin only)\n\n' +
             '**Share resources securely via one-time links:**\n' +
             '  `/qurl send` — send a file and/or location to users\n' +
             '  `/qurl revoke` — revoke links from a previous send\n' +


### PR DESCRIPTION
## Summary

Two one-line tweaks to signal `/qurl status` is admin-only in places non-admins encounter *before* they try the command — the autocomplete tooltip and the `/qurl help` output. The runtime permission check at `apps/discord/src/commands.js:2354` is unchanged; this is cosmetic clarity only.

## Diff

```diff
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2254,7 +2254,7 @@ const commands = [
       )
       .addSubcommand(sub =>
         sub.setName('status')
-          .setDescription('Check if QURL is configured for this server')
+          .setDescription('Check if QURL is configured (admin only)')
       ),
@@ -2410,7 +2410,7 @@ const commands = [
           content: '**Qurl Bot — Help**\n\n' +
             '**Getting started:**\n' +
             '  `/qurl setup` — configure your API key (admin only)\n' +
-            '  `/qurl status` — check if QURL is configured\n\n' +
+            '  `/qurl status` — check if QURL is configured (admin only)\n\n' +
```

## Why Option B (cosmetic) over Option A (split command)

Discord's `default_member_permissions` applies at top-level commands, not per-subcommand. To truly hide `status` (and `setup`) from non-admins' autocomplete we'd have to split them into a separate top-level command (e.g. `/qurl-admin`), break the `/qurl <subcommand>` namespace, migrate existing admin muscle memory, and update tests + release notes. Not worth the disruption right after the multi-tenant rollout (PR #82 + infra #144).

Option B closes the immediate UX gap:
- **Autocomplete tooltip** now says "(admin only)" before a non-admin clicks
- **`/qurl help`** now matches `/qurl setup`'s existing admin-only label (consistency)
- **Runtime rejection** at `commands.js:2354` already exists — correct behavior when a non-admin does invoke it; unchanged

## What this PR does NOT do

- Does NOT hide `/qurl status` from non-admins' autocomplete (Discord API limitation; tracked as future consideration if the cosmetic fix proves insufficient).
- Does NOT change the `ManageGuild` runtime permission check.

## Test plan

- [x] `npm test` full suite: 546/546 pass
- [x] Targeted: `commands-comprehensive | coverage-boost | multi-tenant` — 126/126 pass
- [ ] Post-merge: redeploy bot, confirm the updated tooltip appears in playground Discord (Discord global-command cache may take up to ~1 hr after registration)

Reviewer: @justin-layerv.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>