### PR TITLE
fix(discord): rename /qurl send options + revoke dropdown filter + descriptive labels + smoke test

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -602,8 +602,8 @@ async function handleSend(interaction, apiKey) {
     return interaction.reply({ content: 'QURL API key is not configured.', ephemeral: true });
   }
   const target = interaction.options.getString('target');
-  const expiresIn = interaction.options.getString('expiry') || '24h';
-  const rawMessage = interaction.options.getString('message');
+  const expiresIn = interaction.options.getString('expiry_optional') || '24h';
+  const rawMessage = interaction.options.getString('message_optional');
   const personalMessage = rawMessage ? sanitizeMessage(rawMessage) : null;
   const commandAttachment = interaction.options.getAttachment('file_optional');
 
@@ -2221,7 +2221,7 @@ const commands = [
               .setRequired(true)
               .setAutocomplete(true))
           .addStringOption(opt =>
-            opt.setName('expiry')
+            opt.setName('expiry_optional')
               .setDescription('Link expiry (default: 24h)')
               .setRequired(false)
               .addChoices(
@@ -2236,7 +2236,7 @@ const commands = [
               .setDescription('Optional — attach a file here if sharing a file')
               .setRequired(false))
           .addStringOption(opt =>
-            opt.setName('message')
+            opt.setName('message_optional')
               .setDescription('Optional note sent alongside the link')
               .setRequired(false))
       )

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1574,9 +1574,17 @@ function truncate(s, max = SELECT_MENU_FIELD_MAX) {
 // location name) over the previous abstract `${resource_type} to N users`.
 // Falls back gracefully for legacy rows that predate qurl_send_configs
 // being populated (LEFT JOIN produces null fields there).
-function formatRevokeLabel(s) {
+//
+// `channelName` is passed in by the caller (handleRevoke) from
+// `interaction.guild?.channels.cache.get(s.channel_id)?.name`. Discord
+// mention syntax (`<#id>`) does NOT render inside StringSelectMenu
+// option labels — passing the name explicitly is the only way to avoid
+// showing a raw snowflake to the user.
+function formatRevokeLabel(s, channelName) {
   const recipients = s.recipient_count === 1 ? '1 person' : `${s.recipient_count} people`;
-  const channelRef = s.target_type === 'user' ? 'DM' : (s.channel_id ? `#${s.channel_id}` : s.target_type);
+  const channelRef = s.target_type === 'user'
+    ? 'DM'
+    : (channelName ? `#${channelName}` : `${s.target_type} channel`);
 
   if (s.resource_type === 'file') {
     const name = s.attachment_name || 'file';
@@ -1625,11 +1633,21 @@ async function handleRevoke(interaction, apiKey) {
   const select = new StringSelectMenuBuilder()
     .setCustomId(`qurl_revoke_select_${revokeNonce}`)
     .setPlaceholder('Select a send to revoke')
-    .addOptions(recentSends.map(s => ({
-      label: formatRevokeLabel(s),
-      description: formatRevokeDescription(s),
-      value: s.send_id,
-    })));
+    .addOptions(recentSends.map(s => {
+      // StringSelectMenu labels are plain text — <#id> mention syntax
+      // does NOT resolve. Look up the channel name from the guild cache
+      // so users see `#general` instead of `#1123456789012345678`.
+      // Cache hit is cheap; if cache is cold (DM context, bot just
+      // restarted) the formatter falls through to a generic label.
+      const channelName = s.channel_id
+        ? interaction.guild?.channels.cache.get(s.channel_id)?.name ?? null
+        : null;
+      return {
+        label: formatRevokeLabel(s, channelName),
+        description: formatRevokeDescription(s),
+        value: s.send_id,
+      };
+    }));
 
   const row = new ActionRowBuilder().addComponents(select);
   const response = await interaction.editReply({

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1558,6 +1558,55 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
 // --- /qurl revoke handler ---
 
+// Discord caps StringSelectMenuOption label at 100 chars and description
+// at 100 chars. Truncating to 99 + `…` leaves one for safety and keeps the
+// rendering predictable across Discord clients.
+// https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
+const SELECT_MENU_FIELD_MAX = 100;
+
+function truncate(s, max = SELECT_MENU_FIELD_MAX) {
+  if (!s) return '';
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+// Render the /qurl revoke dropdown label from a row returned by
+// db.getRecentSends. Prefers the human-identifiable bit (filename or
+// location name) over the previous abstract `${resource_type} to N users`.
+// Falls back gracefully for legacy rows that predate qurl_send_configs
+// being populated (LEFT JOIN produces null fields there).
+function formatRevokeLabel(s) {
+  const recipients = s.recipient_count === 1 ? '1 person' : `${s.recipient_count} people`;
+  const channelRef = s.target_type === 'user' ? 'DM' : (s.channel_id ? `#${s.channel_id}` : s.target_type);
+
+  if (s.resource_type === 'file') {
+    const name = s.attachment_name || 'file';
+    return truncate(`📎 ${name} — ${recipients} (${channelRef})`);
+  }
+  if (s.resource_type === 'location') {
+    const name = s.location_name || 'location';
+    return truncate(`📍 ${name} — ${recipients} (${channelRef})`);
+  }
+  // Unknown resource type — keep the old abstract shape so we never
+  // render a bare empty label.
+  return truncate(`${s.resource_type} — ${recipients} (${channelRef})`);
+}
+
+function formatRevokeDescription(s) {
+  const when = new Date(s.created_at).toLocaleString();
+  const delivery = `${s.delivered_count}/${s.recipient_count} delivered`;
+  const expiry = `expires ${s.expires_in}`;
+  const base = `${when} · ${delivery} · ${expiry}`;
+  // If there's space left, append a truncated message preview so users
+  // can disambiguate sends with the same filename but different notes.
+  if (s.personal_message) {
+    const remaining = SELECT_MENU_FIELD_MAX - base.length - 4; // ` · "…"` overhead
+    if (remaining > 8) {
+      return truncate(`${base} · "${truncate(s.personal_message, remaining)}"`);
+    }
+  }
+  return truncate(base);
+}
+
 async function handleRevoke(interaction, apiKey) {
   if (!apiKey) {
     return interaction.reply({ content: 'QURL API key is not configured.', ephemeral: true });
@@ -1577,8 +1626,8 @@ async function handleRevoke(interaction, apiKey) {
     .setCustomId(`qurl_revoke_select_${revokeNonce}`)
     .setPlaceholder('Select a send to revoke')
     .addOptions(recentSends.map(s => ({
-      label: `${s.resource_type} to ${s.recipient_count} users (${s.target_type})`,
-      description: `${new Date(s.created_at).toLocaleString()} | ${s.delivered_count} delivered | Expires: ${s.expires_in}`,
+      label: formatRevokeLabel(s),
+      description: formatRevokeDescription(s),
       value: s.send_id,
     })));
 
@@ -1620,6 +1669,13 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
     if (r.status === 'fulfilled') success++;
     else logger.error('Failed to revoke QURL', { error: r.reason?.message });
   }
+
+  // Record the user's revocation intent so this send stops appearing in
+  // the /qurl revoke dropdown. We mark regardless of per-link success —
+  // partial failures are surfaced in the reply message ("Revoked X/Y"),
+  // and re-picking the same send from the dropdown wouldn't help anyway
+  // since the failed resource_ids are the same.
+  db.markSendRevoked(sendId, senderDiscordId);
 
   logger.info('Revoked send', { sendId, success, total: resourceIds.length });
   return { success, total: resourceIds.length };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2482,15 +2482,21 @@ const commands = [
       if (sub === 'help') {
         return interaction.reply({
           content: '**Qurl Bot — Help**\n\n' +
-            '**Getting started:**\n' +
+            '**Setting up (for Admins):**\n' +
             '  `/qurl setup` — configure your API key (admin only)\n' +
             '  `/qurl status` — check if QURL is configured\n\n' +
-            '**Share resources securely via one-time links:**\n' +
+            '**Getting started — Share resources securely via one-time links:**\n' +
             '  `/qurl send` — send a file and/or location to users\n' +
             '  `/qurl revoke` — revoke links from a previous send\n' +
             '  `/qurl help` — show this message\n\n' +
             '**How it works:**\n' +
-            '  1. Use `/qurl send` and choose a target (user, channel, or voice)\n' +
+            // Leading tab on "1." keeps Discord's markdown parser from
+            // treating it as the start of an ordered list (which would
+            // renumber it relative to the subsequent lines and visually
+            // misalign "1." with "2.", "3.", "4."). The tab indent now
+            // matches the two-space indent below, but bypasses the list
+            // auto-formatter.
+            '\t1. Use `/qurl send` and choose a target (user, channel, or voice)\n' +
             '  2. Attach a file and/or search for a location\n' +
             '  3. Each recipient gets a unique, single-use link by DM\n' +
             '  4. Links self-destruct on first access, or when the expiry elapses — whichever comes first\n\n' +

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -703,12 +703,15 @@ const dbModule = {
 
   getRecentSends(senderDiscordId, limit = 10) {
     // LEFT JOIN on qurl_send_configs so we can:
-    // 1. Filter out already-revoked sends (`revoked_at IS NULL`)
+    // 1. Filter out already-revoked sends. With LEFT JOIN, rows that
+    //    have no config match (legacy sends predating qurl_send_configs)
+    //    get c.revoked_at = NULL and are preserved — so the single
+    //    `c.revoked_at IS NULL` check covers BOTH "unrevoked" AND "no
+    //    config row at all". markSendRevoked below backfills a minimal
+    //    config row when called against a legacy send, so the filter
+    //    stays honest across both cases.
     // 2. Surface filename / location / message snippet in the /qurl revoke
     //    dropdown so users can identify WHICH send they're about to revoke.
-    // LEFT (not INNER) JOIN because historical rows in qurl_sends may
-    // predate qurl_send_configs being populated — those still show up,
-    // just without the descriptive fields.
     const stmt = db.prepare(`
       SELECT s.send_id, s.resource_type, s.target_type, s.channel_id, s.expires_in, s.created_at,
              COUNT(*) as recipient_count,
@@ -717,7 +720,7 @@ const dbModule = {
       FROM qurl_sends s
       LEFT JOIN qurl_send_configs c ON c.send_id = s.send_id
       WHERE s.sender_discord_id = ?
-        AND (c.revoked_at IS NULL OR c.send_id IS NULL)
+        AND c.revoked_at IS NULL
       GROUP BY s.send_id
       ORDER BY s.created_at DESC
       LIMIT ?
@@ -726,17 +729,43 @@ const dbModule = {
   },
 
   markSendRevoked(sendId, senderDiscordId) {
-    // Idempotent: hitting revoke twice on the same send is a no-op on the
-    // second call (revoked_at retains its earlier value). Also scoped by
-    // senderDiscordId so one user can't mark another user's send as
-    // revoked — defense-in-depth; the revoke handler is already gated on
-    // ownership upstream.
-    const stmt = db.prepare(`
+    // Scoped by senderDiscordId so one user can't mark another user's
+    // send as revoked — defense-in-depth; the revoke handler is already
+    // gated on ownership upstream.
+    //
+    // Two cases:
+    // (a) Normal path: a qurl_send_configs row exists for this send.
+    //     UPDATE flips revoked_at; a second revoke is a no-op because
+    //     of the `revoked_at IS NULL` guard.
+    // (b) Legacy path: the send predates qurl_send_configs being
+    //     populated, so no config row exists. Without this fallback,
+    //     markSendRevoked silently updates zero rows and the send
+    //     reappears in the /qurl revoke dropdown on the next invocation
+    //     — the exact failure mode this fix targets. Insert a minimal
+    //     config row (NOT NULL columns: send_id, sender_discord_id,
+    //     resource_type, expires_in) pulled from the qurl_sends row,
+    //     with only the revocation marker populated.
+    const updateStmt = db.prepare(`
       UPDATE qurl_send_configs
       SET revoked_at = CURRENT_TIMESTAMP
       WHERE send_id = ? AND sender_discord_id = ? AND revoked_at IS NULL
     `);
-    stmt.run(sendId, senderDiscordId);
+    const result = updateStmt.run(sendId, senderDiscordId);
+    if (result.changes > 0) return;
+
+    const legacyStmt = db.prepare(`
+      SELECT resource_type, expires_in FROM qurl_sends
+      WHERE send_id = ? AND sender_discord_id = ? LIMIT 1
+    `);
+    const legacy = legacyStmt.get(sendId, senderDiscordId);
+    if (!legacy) return; // nothing to mark — caller targeted a non-existent send
+
+    const insertStmt = db.prepare(`
+      INSERT OR IGNORE INTO qurl_send_configs
+        (send_id, sender_discord_id, resource_type, expires_in, revoked_at)
+      VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+    `);
+    insertStmt.run(sendId, senderDiscordId, legacy.resource_type, legacy.expires_in || '24h');
   },
 
   saveSendConfig({ sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl, expiresIn, personalMessage, locationName, attachmentName, attachmentContentType, attachmentUrl }) {

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -157,6 +157,10 @@ db.exec(`
 const SAFE_ALTERS = {
   attachment_content_type: 'ALTER TABLE qurl_send_configs ADD COLUMN attachment_content_type TEXT',
   attachment_url: 'ALTER TABLE qurl_send_configs ADD COLUMN attachment_url TEXT',
+  // Timestamp of when the sender hit /qurl revoke on this send. NULL ⇒ still
+  // revocable. Used to hide already-revoked sends from the /qurl revoke
+  // dropdown so users don't re-select a no-op and see "0/0 links revoked".
+  revoked_at: 'ALTER TABLE qurl_send_configs ADD COLUMN revoked_at TEXT',
 };
 for (const [col, sql] of Object.entries(SAFE_ALTERS)) {
   try {
@@ -698,17 +702,41 @@ const dbModule = {
   },
 
   getRecentSends(senderDiscordId, limit = 10) {
+    // LEFT JOIN on qurl_send_configs so we can:
+    // 1. Filter out already-revoked sends (`revoked_at IS NULL`)
+    // 2. Surface filename / location / message snippet in the /qurl revoke
+    //    dropdown so users can identify WHICH send they're about to revoke.
+    // LEFT (not INNER) JOIN because historical rows in qurl_sends may
+    // predate qurl_send_configs being populated — those still show up,
+    // just without the descriptive fields.
     const stmt = db.prepare(`
-      SELECT send_id, resource_type, target_type, channel_id, expires_in, created_at,
+      SELECT s.send_id, s.resource_type, s.target_type, s.channel_id, s.expires_in, s.created_at,
              COUNT(*) as recipient_count,
-             SUM(CASE WHEN dm_status = 'sent' THEN 1 ELSE 0 END) as delivered_count
-      FROM qurl_sends
-      WHERE sender_discord_id = ?
-      GROUP BY send_id
-      ORDER BY created_at DESC
+             SUM(CASE WHEN s.dm_status = 'sent' THEN 1 ELSE 0 END) as delivered_count,
+             c.attachment_name, c.location_name, c.personal_message
+      FROM qurl_sends s
+      LEFT JOIN qurl_send_configs c ON c.send_id = s.send_id
+      WHERE s.sender_discord_id = ?
+        AND (c.revoked_at IS NULL OR c.send_id IS NULL)
+      GROUP BY s.send_id
+      ORDER BY s.created_at DESC
       LIMIT ?
     `);
     return stmt.all(senderDiscordId, limit);
+  },
+
+  markSendRevoked(sendId, senderDiscordId) {
+    // Idempotent: hitting revoke twice on the same send is a no-op on the
+    // second call (revoked_at retains its earlier value). Also scoped by
+    // senderDiscordId so one user can't mark another user's send as
+    // revoked — defense-in-depth; the revoke handler is already gated on
+    // ownership upstream.
+    const stmt = db.prepare(`
+      UPDATE qurl_send_configs
+      SET revoked_at = CURRENT_TIMESTAMP
+      WHERE send_id = ? AND sender_discord_id = ? AND revoked_at IS NULL
+    `);
+    stmt.run(sendId, senderDiscordId);
   },
 
   saveSendConfig({ sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl, expiresIn, personalMessage, locationName, attachmentName, attachmentContentType, attachmentUrl }) {

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1008,7 +1008,7 @@ describe('/qurl send — user target flow', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'user';
-          if (name === 'expiry') return '24h';
+          if (name === 'expiry_optional') return '24h';
           return null;
         }),
         getAttachment: jest.fn(() => null),
@@ -1247,8 +1247,8 @@ describe('/qurl send — file flow (channel target, full path)', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
-          if (name === 'message') return 'Check this out';
+          if (name === 'expiry_optional') return '1h';
+          if (name === 'message_optional') return 'Check this out';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),
@@ -1316,7 +1316,7 @@ describe('/qurl send — location flow (channel target)', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '30m';
+          if (name === 'expiry_optional') return '30m';
           return null;
         }),
         getAttachment: jest.fn(() => null),
@@ -1617,7 +1617,7 @@ describe('/qurl send — DM failures', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
+          if (name === 'expiry_optional') return '1h';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),
@@ -1912,7 +1912,7 @@ describe('handleCommand — autocomplete', () => {
       isChatInputCommand: jest.fn(() => false),
       options: {
         ...makeInteraction().options,
-        getFocused: jest.fn(() => ({ name: 'expiry', value: '1h' })),
+        getFocused: jest.fn(() => ({ name: 'expiry_optional', value: '1h' })),
       },
     });
 
@@ -2374,7 +2374,7 @@ describe('collector button handlers — revoke and expand', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
+          if (name === 'expiry_optional') return '1h';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),
@@ -2429,7 +2429,7 @@ describe('collector button handlers — revoke and expand', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
+          if (name === 'expiry_optional') return '1h';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),
@@ -2482,7 +2482,7 @@ describe('collector button handlers — revoke and expand', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
+          if (name === 'expiry_optional') return '1h';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),
@@ -2538,7 +2538,7 @@ describe('monitorLinkStatus — via full send flow with fake timers', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
+          if (name === 'expiry_optional') return '1h';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -148,6 +148,7 @@ const mockDb = {
   updateSendDMStatus: jest.fn(),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
+  markSendRevoked: jest.fn(),
   getSendConfig: jest.fn(),
   saveSendConfig: jest.fn(),
   forceLink: jest.fn(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -157,6 +157,7 @@ const mockDb = {
   updateSendDMStatus: jest.fn(),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
+  markSendRevoked: jest.fn(),
   getSendConfig: jest.fn(),
   saveSendConfig: jest.fn(),
   forceLink: jest.fn(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -314,8 +314,8 @@ describe('buildDeliveryEmbed — location resource type', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
-          if (name === 'message') return 'Meet me here';
+          if (name === 'expiry_optional') return '1h';
+          if (name === 'message_optional') return 'Meet me here';
           return null;
         }),
         getAttachment: jest.fn(() => null),
@@ -368,7 +368,7 @@ describe('buildConfirmMsg — truncation with > 5 recipients + expand', () => {
         getSubcommand: jest.fn(() => 'send'),
         getString: jest.fn((name) => {
           if (name === 'target') return 'channel';
-          if (name === 'expiry') return '1h';
+          if (name === 'expiry_optional') return '1h';
           return null;
         }),
         getAttachment: jest.fn(() => attachment),
@@ -424,7 +424,7 @@ describe('collector — revoke button', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -461,7 +461,7 @@ describe('collector — revoke button', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -502,7 +502,7 @@ describe('collector — end timeout', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -536,7 +536,7 @@ describe('/qurl send — fewer mint links than recipients', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -610,7 +610,7 @@ describe('/qurl send — location URL param extraction', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => null),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -637,7 +637,7 @@ describe('/qurl send — location URL param extraction', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => null),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -715,7 +715,7 @@ describe('/qurl send — all location link creation fails', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => null),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -753,7 +753,7 @@ describe('collector — add recipients button', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -897,7 +897,7 @@ describe('/qurl send — voice target with members', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'voice'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'voice'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },
@@ -949,7 +949,7 @@ describe('/qurl send — DM batch with rejected promise', () => {
       options: {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'send'),
-        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry') return '1h'; return null; }),
+        getString: jest.fn((name) => { if (name === 'target') return 'channel'; if (name === 'expiry_optional') return '1h'; return null; }),
         getAttachment: jest.fn(() => attachment),
       },
       channel: { awaitMessageComponent: jest.fn().mockResolvedValue(resInteraction) },

--- a/apps/discord/tests/revoke-filter.test.js
+++ b/apps/discord/tests/revoke-filter.test.js
@@ -1,0 +1,116 @@
+/**
+ * Integration test for the `/qurl revoke` dropdown filter.
+ *
+ * The headline bug this PR fixes — "revoked sends stay visible in the
+ * dropdown" — is invisible to the existing unit tests because they
+ * mock `db.getRecentSends` directly. This test hits the real
+ * better-sqlite3 layer (in-memory via `DATABASE_PATH=:memory:`) to
+ * verify the actual SQL: `markSendRevoked` flips the state, and the
+ * next `getRecentSends` call filters the revoked send out.
+ *
+ * Without this coverage, a future edit that breaks the LEFT JOIN or
+ * the `c.revoked_at IS NULL` predicate in getRecentSends would go
+ * undetected until it regressed in prod.
+ */
+
+jest.mock('../src/config', () => ({
+  DATABASE_PATH: ':memory:',
+  // Supplied to keep the require graph from exploding on missing env
+  // vars — database.js reads PENDING_LINK_EXPIRY_MINUTES during its
+  // startup `cleanupExpiredPendingLinks` call.
+  PENDING_LINK_EXPIRY_MINUTES: 30,
+  QURL_API_KEY: 'x',
+  QURL_ENDPOINT: 'https://api.test.local',
+  GUILD_ID: 'guild-1',
+  isMultiTenant: false,
+  isOpenNHPActive: false,
+  ENABLE_OPENNHP_FEATURES: false,
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const db = require('../src/database');
+
+function seedSend({ sendId, senderDiscordId, resourceType = 'file', recipients = 1, withConfig = true }) {
+  for (let i = 0; i < recipients; i++) {
+    db.recordQURLSend({
+      sendId,
+      senderDiscordId,
+      recipientDiscordId: `recipient-${sendId}-${i}`,
+      resourceId: `res-${sendId}-${i}`,
+      resourceType,
+      qurlLink: `https://q.test/${sendId}-${i}`,
+      expiresIn: '24h',
+      channelId: 'channel-1',
+      targetType: 'channel',
+    });
+  }
+  if (withConfig) {
+    db.saveSendConfig({
+      sendId,
+      senderDiscordId,
+      resourceType,
+      connectorResourceId: null,
+      actualUrl: null,
+      expiresIn: '24h',
+      personalMessage: null,
+      locationName: null,
+      attachmentName: `${sendId}.pdf`,
+      attachmentContentType: 'application/pdf',
+      attachmentUrl: null,
+    });
+  }
+}
+
+describe('/qurl revoke dropdown filter (integration)', () => {
+  const sender = 'sender-1';
+
+  it('excludes sends marked revoked from getRecentSends, keeps unrevoked ones', () => {
+    seedSend({ sendId: 'keep-me', senderDiscordId: sender });
+    seedSend({ sendId: 'revoke-me', senderDiscordId: sender });
+
+    // Sanity: both visible before revocation.
+    const beforeIds = db.getRecentSends(sender, 10).map(s => s.send_id).sort();
+    expect(beforeIds).toEqual(['keep-me', 'revoke-me']);
+
+    db.markSendRevoked('revoke-me', sender);
+
+    const afterIds = db.getRecentSends(sender, 10).map(s => s.send_id);
+    expect(afterIds).toEqual(['keep-me']);
+  });
+
+  it('markSendRevoked is idempotent — second call is a no-op', () => {
+    seedSend({ sendId: 'double-revoke', senderDiscordId: sender });
+    db.markSendRevoked('double-revoke', sender);
+    expect(() => db.markSendRevoked('double-revoke', sender)).not.toThrow();
+    const afterIds = db.getRecentSends(sender, 10).map(s => s.send_id);
+    expect(afterIds).not.toContain('double-revoke');
+  });
+
+  it('markSendRevoked only affects the send owner', () => {
+    seedSend({ sendId: 'cross-user', senderDiscordId: sender });
+    db.markSendRevoked('cross-user', 'different-sender');
+    const afterIds = db.getRecentSends(sender, 10).map(s => s.send_id);
+    expect(afterIds).toContain('cross-user');
+  });
+
+  it('backfills a config row for legacy sends (qurl_sends without qurl_send_configs)', () => {
+    // Legacy path: the failure class flagged in code review —
+    // markSendRevoked without a fallback UPDATE'd 0 rows and the send
+    // reappeared in the dropdown on re-revoke.
+    seedSend({ sendId: 'legacy', senderDiscordId: sender, withConfig: false });
+
+    const beforeIds = db.getRecentSends(sender, 10).map(s => s.send_id);
+    expect(beforeIds).toContain('legacy');
+
+    db.markSendRevoked('legacy', sender);
+
+    const afterIds = db.getRecentSends(sender, 10).map(s => s.send_id);
+    expect(afterIds).not.toContain('legacy');
+  });
+});

--- a/e2e/tests/revoke.smoke.test.ts
+++ b/e2e/tests/revoke.smoke.test.ts
@@ -1,0 +1,68 @@
+/**
+ * QURL revoke end-to-end smoke test.
+ *
+ * Validates the one invariant the bot's /qurl revoke path depends on:
+ * calling `DELETE /v1/resources/{id}` against the deployed QURL API
+ * actually revokes the qurl — subsequent status checks return 404.
+ *
+ * This is the failure class covered here, not tested elsewhere in the
+ * post-deploy smoke filter (`smoke|google-maps|discord-channels`):
+ * - A QURL API regression that silently accepts the DELETE but keeps
+ *   the resource live would leave the /qurl revoke dropdown filter
+ *   (issue: already-revoked sends stay visible) *technically* correct
+ *   at the DB layer while being meaningless in practice.
+ * - Discord-dropdown rendering cannot be validated from smoke (no
+ *   slash-command invocation without a user token; see PR #101).
+ * - Scope-wise this is the narrowest test that proves the user-visible
+ *   revoke guarantee end-to-end.
+ *
+ * URL-based qurls (not file-based) are used here to keep the test fast
+ * and decoupled from the connector. File-based revoke is covered by
+ * file-revoke.test.ts, which currently sits outside the smoke filter.
+ */
+
+import { loadEnv } from '../helpers/env';
+import { mintLink, getLinkStatus, revokeLink } from '../helpers/qurl-api';
+
+describe('QURL revoke (smoke)', () => {
+  const env = loadEnv();
+
+  it('DELETE /v1/resources/{id} marks the resource revoked (subsequent status check fails)', async () => {
+    // Mint a URL-based qurl that points at an arbitrary public URL.
+    // max_uses=10 so the test doesn't accidentally self-consume the
+    // link by a successful access *before* the revoke fires.
+    const minted = await mintLink(env.MINT_API_URL, env.QURL_API_KEY, {
+      target_url: 'https://example.com/e2e-revoke-smoke',
+      expires_in: '1h',
+      description: 'e2e revoke-smoke test',
+      max_uses: 10,
+    });
+    expect(minted.resource_id).toBeTruthy();
+
+    // Sanity-check the resource exists before we revoke it. If this
+    // fails the revoke assertion below is meaningless — fail loud with
+    // a clear message rather than letting the later expect pass for
+    // the wrong reason.
+    const preStatus = await getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id);
+    expect(preStatus).toBeTruthy();
+
+    const revoked = await revokeLink(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id);
+    expect(revoked).toBe(true);
+
+    // Canonical revoke assertion: getLinkStatus throws on non-2xx, and
+    // the deployed QURL API returns 404 for revoked resources. Catching
+    // the error lets us inspect the status in the message so a
+    // different failure mode (500, 403) produces a diagnosable report
+    // rather than just "threw".
+    try {
+      await getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id);
+      throw new Error(
+        `getLinkStatus unexpectedly succeeded on revoked resource ${minted.resource_id} — ` +
+        `the QURL API is accepting DELETE but keeping the resource queryable.`,
+      );
+    } catch (err) {
+      const msg = String(err instanceof Error ? err.message : err);
+      expect(msg).toMatch(/404/);
+    }
+  });
+});

--- a/e2e/tests/revoke.smoke.test.ts
+++ b/e2e/tests/revoke.smoke.test.ts
@@ -50,19 +50,12 @@ describe('QURL revoke (smoke)', () => {
     expect(revoked).toBe(true);
 
     // Canonical revoke assertion: getLinkStatus throws on non-2xx, and
-    // the deployed QURL API returns 404 for revoked resources. Catching
-    // the error lets us inspect the status in the message so a
-    // different failure mode (500, 403) produces a diagnosable report
-    // rather than just "threw".
-    try {
-      await getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id);
-      throw new Error(
-        `getLinkStatus unexpectedly succeeded on revoked resource ${minted.resource_id} — ` +
-        `the QURL API is accepting DELETE but keeping the resource queryable.`,
-      );
-    } catch (err) {
-      const msg = String(err instanceof Error ? err.message : err);
-      expect(msg).toMatch(/404/);
-    }
+    // the deployed QURL API returns 404 for revoked resources.
+    // `rejects.toThrow(/404/)` gives a clean Jest diagnostic when the
+    // status is a different non-2xx (500, 403) — it surfaces what was
+    // actually thrown, no need for a manual try/catch dance.
+    await expect(
+      getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id),
+    ).rejects.toThrow(/404/);
   });
 });


### PR DESCRIPTION
## Summary
Three UX fixes on the \`/qurl send\` → \`/qurl revoke\` flow, plus one e2e smoke test for the revoke path.

## Changes

### 1. Rename \`/qurl send\` options to match \`_optional\` convention
- \`expiry\` → \`expiry_optional\`
- \`message\` → \`message_optional\`
- \`file_optional\` already existed; now all three optional params follow the same naming, and users can read required-vs-optional from the option name alone.

### 2. Hide already-revoked sends from \`/qurl revoke\` dropdown
Previously, hitting \`/qurl revoke\` twice on the same send would show it in the dropdown both times — second click returned \"Revoked 0/N links\" because the links were already dead at the QURL API layer but the UI had no way to know.

- New \`revoked_at TEXT\` column on \`qurl_send_configs\` (via the existing \`SAFE_ALTERS\` migration pattern — idempotent \`ALTER TABLE ADD COLUMN\`).
- \`revokeAllLinks\` now calls \`db.markSendRevoked(sendId, senderDiscordId)\` after the QURL API DELETE calls finish.
- \`getRecentSends\` LEFT JOINs \`qurl_send_configs\` and filters \`WHERE (c.revoked_at IS NULL OR c.send_id IS NULL)\`. LEFT (not INNER) JOIN preserves pre-config-era rows.

### 3. More descriptive \`/qurl revoke\` dropdown labels
**Before:** \`file to 3 users (channel)\` — no way to tell WHICH file
**After:** \`📎 quarterly-report.pdf — 3 people (#general)\`
or:       \`📍 Starbucks Downtown — 1 person (DM)\`

- \`getRecentSends\` JOIN exposes \`attachment_name\`, \`location_name\`, \`personal_message\` (previously in \`qurl_send_configs\` but unused here).
- New \`formatRevokeLabel\` / \`formatRevokeDescription\` helpers with Discord-100-char truncation. Description includes message snippet when present so users can disambiguate same-filename sends with different notes.

### 4. E2E smoke test for revoke end-to-end
\`e2e/tests/revoke.smoke.test.ts\` — validates \`DELETE /v1/resources/{id}\` against the deployed QURL API actually marks the resource revoked (subsequent \`getLinkStatus\` returns 404).

Existing \`file-revoke.test.ts\` covers this for file resources but sits outside the smoke filter (\`smoke|google-maps|discord-channels\`). This new test is URL-based (no connector dep) and runs on every deploy.

## Test plan
- [x] All 546 bot unit tests pass (added \`markSendRevoked: jest.fn()\` to two mockDb setups so revoke-handler tests stay green)
- [ ] E2E smoke test not validated locally (no QURL API key accessible) — uses the exact same helpers as \`link-lifecycle.test.ts\` and \`file-revoke.test.ts\` which are known to work against prod
- [ ] Post-merge: run \`/qurl revoke\` in the test guild and eyeball the new label/description formatting

## Explicitly out of scope
- Bulk revoke / bring back \`/clear\` — filed in feature wishlist [#99](https://github.com/layervai/qurl-integrations/issues/99)
- Testing the dropdown RENDERING itself — impossible without selfbotting (ToS); rendering logic is covered by the \`formatRevokeLabel\` / \`formatRevokeDescription\` pure functions which are unit-testable if a follow-up wants to pin them

🤖 Generated with [Claude Code](https://claude.com/claude-code)