### PR TITLE
test(discord): pin anchored "Open in Google Maps" URL for query+coords case

### DIFF
--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -150,6 +150,32 @@ describe('Google Maps: Iframe Embed', () => {
     expect(html).toContain('https://www.google.com/maps/search/');
   });
 
+  test('"Open in Google Maps" URL is anchored to coords when query + lat/lng both supplied', async () => {
+    // Regression guard for the "Erbil restaurant" bug: when the bot
+    // uploads a named place that also carries lat/lng from Places
+    // autocomplete, the mapsURL (shown under "Open in Google Maps")
+    // must be a /maps/place/<name>/@<lat>,<lng>,17z form — NOT
+    // /maps/search/<name> — otherwise Google resolves the name on
+    // the recipient's side and opens a namesake near THEIR
+    // geolocation instead of the place the sender picked. Fixed in
+    // qurl-integrations-infra#155.
+    const upload = await uploadMapLocation({
+      type: 'google-map',
+      query: 'Erbil restaurant',
+      lat: 36.1911,
+      lng: 44.0094,
+    });
+
+    const html = await fetchViewerPage(upload.viewerUrl);
+    expect(html).toContain('Open in Google Maps');
+    // Anchored URL form: path segment with name + @lat,lng,17z suffix.
+    // The exact coord format uses %.7f precision on the server side.
+    expect(html).toMatch(/https:\/\/www\.google\.com\/maps\/place\/[^/]*\/@36\.1911000,44\.0094000,17z/);
+    // Must NOT fall back to the non-anchored search form for this input.
+    expect(html).not.toMatch(/https:\/\/www\.google\.com\/maps\/search\/[^"]*"[^>]*>\s*Open in Google Maps/);
+  });
+
+
   test('google-map page has correct styling (map-container, bar)', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -167,14 +167,22 @@ describe('Google Maps: Iframe Embed', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('Open in Google Maps');
-    // Anchored URL form: path segment with name + @lat,lng,17z suffix.
-    // The exact coord format uses %.7f precision on the server side.
-    expect(html).toMatch(/https:\/\/www\.google\.com\/maps\/place\/[^/]*\/@36\.1911000,44\.0094000,17z/);
-    // Must NOT fall back to the non-anchored search form for this input.
-    expect(html).not.toMatch(/https:\/\/www\.google\.com\/maps\/search\/[^"]*"[^>]*>\s*Open in Google Maps/);
+    // Anchored URL form: the NAME segment must pin the original query
+    // ("Erbil restaurant", with space as %20 or +) followed by the
+    // @lat,lng,17z anchor. Pinning the name — not just `[^/]*` — is
+    // what catches a regression that returns the right coords but the
+    // wrong place identity. `%.7f` formatting on the server side
+    // produces the trailing zeros.
+    expect(html).toMatch(
+      /https:\/\/www\.google\.com\/maps\/place\/Erbil(?:%20|\+)restaurant\/@36\.1911000,44\.0094000,17z/,
+    );
+    // Negative pin: /maps/search/Erbil must appear NOWHERE in the
+    // rendered HTML. It's only emitted by the pre-fix fallback path,
+    // so its presence is a direct regression signal. Looser than the
+    // prior href-structure-matching regex (which could be defeated by
+    // template reflows) but sharper at detecting the actual bug shape.
+    expect(html).not.toMatch(/\/maps\/search\/Erbil/);
   });
-
 
   test('google-map page has correct styling (map-container, bar)', async () => {
     const upload = await uploadMapLocation({


### PR DESCRIPTION
## Summary

Smoke coverage for the "Erbil restaurant" fix (connector-side) in **qurl-integrations-infra#155**.

Adds one e2e test case in `e2e/tests/google-maps.test.ts` that uploads a location with **both** `query` (named place) AND `lat`/`lng` (coordinates), fetches the viewer page, and asserts:

- Rendered HTML contains `/maps/place/<name>/@<lat>,<lng>,17z` (the anchored form)
- It does NOT fall back to `/maps/search/<name>` (the bug shape)

Without this, a future regression that swaps the handler back to `/maps/search/...` would only be caught by the Go unit tests in the infra repo — not by the public-repo CI that runs against the deployed connector.

## Context

The Erbil restaurant bug: `/qurl send` of a named place opened a **different** restaurant for the recipient because `/maps/search/<name>` resolves on the client side relative to the recipient's geolocation. The iframe (Embed API, server-side) showed the right place; only the "Open in Google Maps" link was broken. Fixed in connector by producing an anchored `/maps/place/<name>/@lat,lng,17z` URL when both query and coords are supplied.

## Merge ordering

**Merge this AFTER qurl-integrations-infra#155 deploys** — otherwise this test will fail against the current (unfixed) connector on `main`. If I see #155 land first, will verify this PR's CI stays green before merging.

## Test plan

- [ ] qurl-integrations-infra#155 merges + deploys
- [ ] This PR's e2e-smoke run goes green against the newly-deployed connector
- [ ] CI green (jest + eslint + Claude review + CodeQL + title check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)