### PR TITLE
fix(e2e): revoke smoke uses accessLink, not getLinkStatus

### DIFF
--- a/e2e/tests/revoke.smoke.test.ts
+++ b/e2e/tests/revoke.smoke.test.ts
@@ -54,11 +54,22 @@ describe('QURL revoke (smoke)', () => {
     expect(revoked).toBe(true);
 
     // Canonical revoke assertion: the qurl link is no longer reachable.
-    // The deployed QURL API returns 404 for revoked resources; any
-    // non-2xx response is accepted here because the specific failure
-    // code is a QURL-API implementation detail and the user-visible
-    // invariant is just "the link stops working."
+    // Asserting `status >= 400` (not `.ok === false`) so a failure prints
+    // the actual HTTP code in Jest's diff — distinguishes "revoke
+    // silently succeeded" (2xx still served) from "SPA shell returns 200
+    // regardless of revocation state" (200 served, client-side error).
+    // Any 4xx/5xx is accepted because the specific failure code is a
+    // QURL-API implementation detail; the user-visible invariant is
+    // just "the link stops working."
     const postAccess = await accessLink(minted.qurl_link);
-    expect(postAccess.ok).toBe(false);
+    if (postAccess.status < 400) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[revoke.smoke] Post-revoke access returned ${postAccess.status} — expected 4xx/5xx. ` +
+        `finalUrl=${postAccess.finalUrl}. If this is an SPA shell serving 200 with a client-side ` +
+        `error, the revoke API may be working but this test needs a different probe.`,
+      );
+    }
+    expect(postAccess.status).toBeGreaterThanOrEqual(400);
   });
 });

--- a/e2e/tests/revoke.smoke.test.ts
+++ b/e2e/tests/revoke.smoke.test.ts
@@ -1,61 +1,64 @@
 /**
  * QURL revoke end-to-end smoke test.
  *
- * Validates the one invariant the bot's /qurl revoke path depends on:
- * calling `DELETE /v1/resources/{id}` against the deployed QURL API
- * actually revokes the qurl — subsequent status checks return 404.
+ * Validates the user-visible invariant that the bot's /qurl revoke path
+ * depends on: calling `DELETE /v1/resources/{id}` against the deployed
+ * QURL API actually revokes the qurl — follow-up accesses of the qurl
+ * link fail where they previously succeeded.
  *
- * This is the failure class covered here, not tested elsewhere in the
- * post-deploy smoke filter (`smoke|google-maps|discord-channels`):
- * - A QURL API regression that silently accepts the DELETE but keeps
- *   the resource live would leave the /qurl revoke dropdown filter
- *   (issue: already-revoked sends stay visible) *technically* correct
- *   at the DB layer while being meaningless in practice.
- * - Discord-dropdown rendering cannot be validated from smoke (no
- *   slash-command invocation without a user token; see PR #101).
- * - Scope-wise this is the narrowest test that proves the user-visible
- *   revoke guarantee end-to-end.
+ * Why `accessLink` and not `getLinkStatus`: the `/v1/qurls/{id}/status`
+ * endpoint is unreliable for URL-based qurls — it returns 404 for
+ * freshly-minted LIVE resources as well as revoked ones (see the
+ * graceful try/catch in `smoke.test.ts:78-81` acknowledging the same
+ * "may not be tracked server-side for SPA links" behavior). An earlier
+ * version of this test used getLinkStatus as both pre- and post-revoke
+ * probe; the pre-check failed in prod (resource returning 404 when
+ * still live) AND the post-check was passing tautologically (same 404
+ * regardless of revocation state). accessLink hits the actual user
+ * path (follow the qurl link, check HTTP status) and distinguishes
+ * live from revoked reliably.
  *
- * URL-based qurls (not file-based) are used here to keep the test fast
- * and decoupled from the connector. File-based revoke is covered by
- * file-revoke.test.ts, which currently sits outside the smoke filter.
+ * Why this test isn't redundant with `file-revoke.test.ts`: that file
+ * sits outside the current smoke filter (`smoke|google-maps|discord-channels`)
+ * and uses file-based qurls via the connector. This covers URL-based
+ * qurls and runs on every deploy.
  */
 
 import { loadEnv } from '../helpers/env';
-import { mintLink, getLinkStatus, revokeLink } from '../helpers/qurl-api';
+import { mintLink, accessLink, revokeLink } from '../helpers/qurl-api';
 
 describe('QURL revoke (smoke)', () => {
   const env = loadEnv();
 
-  it('DELETE /v1/resources/{id} marks the resource revoked (subsequent status check fails)', async () => {
-    // Mint a URL-based qurl that points at an arbitrary public URL.
-    // max_uses=10 so the test doesn't accidentally self-consume the
-    // link by a successful access *before* the revoke fires.
+  it('DELETE /v1/resources/{id} makes subsequent qurl-link access fail', async () => {
+    // Mint a URL-based qurl. max_uses=10 so the pre-revoke access
+    // doesn't self-consume the link before we can compare it against
+    // the post-revoke state.
     const minted = await mintLink(env.MINT_API_URL, env.QURL_API_KEY, {
       target_url: 'https://example.com/e2e-revoke-smoke',
       expires_in: '1h',
       description: 'e2e revoke-smoke test',
       max_uses: 10,
     });
+    expect(minted.qurl_link).toBeTruthy();
     expect(minted.resource_id).toBeTruthy();
 
-    // Sanity-check the resource exists before we revoke it. If this
-    // fails the revoke assertion below is meaningless — fail loud with
-    // a clear message rather than letting the later expect pass for
-    // the wrong reason.
-    const preStatus = await getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id);
-    expect(preStatus).toBeTruthy();
+    // Pre-revoke: link is live and reachable. If this fails the post-
+    // revoke assertion below is meaningless — fail loud with a status
+    // snapshot rather than letting the later expect pass for the wrong
+    // reason.
+    const preAccess = await accessLink(minted.qurl_link);
+    expect(preAccess.ok).toBe(true);
 
     const revoked = await revokeLink(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id);
     expect(revoked).toBe(true);
 
-    // Canonical revoke assertion: getLinkStatus throws on non-2xx, and
-    // the deployed QURL API returns 404 for revoked resources.
-    // `rejects.toThrow(/404/)` gives a clean Jest diagnostic when the
-    // status is a different non-2xx (500, 403) — it surfaces what was
-    // actually thrown, no need for a manual try/catch dance.
-    await expect(
-      getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, minted.resource_id),
-    ).rejects.toThrow(/404/);
+    // Canonical revoke assertion: the qurl link is no longer reachable.
+    // The deployed QURL API returns 404 for revoked resources; any
+    // non-2xx response is accepted here because the specific failure
+    // code is a QURL-API implementation detail and the user-visible
+    // invariant is just "the link stops working."
+    const postAccess = await accessLink(minted.qurl_link);
+    expect(postAccess.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Fixes the post-PR-#106 smoke failure. The new \`revoke.smoke.test.ts\` I added in #106 used \`getLinkStatus\` to probe whether a qurl was live/revoked. In prod that endpoint returns 404 for URL-based qurls regardless of state (the existing \`smoke.test.ts:78-81\` already acknowledges this with a graceful try/catch and comment "may not be tracked server-side for SPA links").

**Consequences of the broken test:**
- Pre-revoke sanity check failed in prod (resource returning 404 when still live) — post-#106 deploy smoke run failed
- Post-revoke assertion was passing tautologically (same 404 regardless of whether the revoke actually worked)

## Fix
Rewrite to use \`accessLink\` — follow the qurl link and check HTTP status — which is both the user-visible invariant AND distinguishes live from revoked reliably:

\`\`\`
pre-revoke:  accessLink(qurl_link).ok === true
revoke
post-revoke: accessLink(qurl_link).ok === false
\`\`\`

Same pattern as \`smoke.test.ts\`'s 'first access succeeds' test, which has run green against prod for months.

## Deliberately out of scope
- Asserting on the specific response code (404 vs 403 vs 410). That's a QURL-API implementation detail; the test pins the user-visible contract ("link stops working post-revoke"), not the internal status-code shape.

## Test plan
- [ ] CI green on this PR
- [ ] Post-merge: next deploy smoke run goes green (revoke.smoke.test.ts passes)
- [ ] Cannot validate locally — no QURL_API_KEY in my environment. Helpers (\`accessLink\`, \`mintLink\`, \`revokeLink\`) are the same ones \`smoke.test.ts\` uses successfully in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)