### PR TITLE
fix(discord): always append informational note after /qurl revoke

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1218,8 +1218,13 @@ async function handleSend(interaction, apiKey) {
         await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
         try {
           const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
+          // When success < total, the delta is almost always links the recipient
+          // already opened — revoke is a no-op on used tokens by the QURL API's
+          // design. Surface that so users don't file phantom "partial failure"
+          // reports.
+          const usedNote = revoked.success < revoked.total ? '\nUsed links cannot be revoked.' : '';
           await interaction.editReply({
-            content: `Revoked ${revoked.success}/${revoked.total} links.`,
+            content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
             components: [],
           }).catch(logIgnoredDiscordErr);
         } catch (err) {
@@ -1665,8 +1670,13 @@ async function handleRevoke(interaction, apiKey) {
     const sendId = selectInteraction.values[0];
     const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
 
+    // When success < total, the delta is almost always links the recipient
+    // already opened — revoke is a no-op on used tokens by the QURL API's
+    // design. Surface that so users don't file phantom "partial failure"
+    // reports.
+    const usedNote = revoked.success < revoked.total ? '\nUsed links cannot be revoked.' : '';
     await selectInteraction.update({
-      content: `Revoked ${revoked.success}/${revoked.total} links.`,
+      content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
       components: [],
     });
   } catch {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1218,13 +1218,8 @@ async function handleSend(interaction, apiKey) {
         await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
         try {
           const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
-          // When success < total, the delta is almost always links the recipient
-          // already opened — revoke is a no-op on used tokens by the QURL API's
-          // design. Surface that so users don't file phantom "partial failure"
-          // reports.
-          const usedNote = revoked.success < revoked.total ? ' Used links cannot be revoked.' : '';
           await interaction.editReply({
-            content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
+            content: `Revoked ${revoked.success}/${revoked.total} links. Some links could not be revoked — they may have already been opened.`,
             components: [],
           }).catch(logIgnoredDiscordErr);
         } catch (err) {
@@ -1670,13 +1665,8 @@ async function handleRevoke(interaction, apiKey) {
     const sendId = selectInteraction.values[0];
     const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
 
-    // When success < total, the delta is almost always links the recipient
-    // already opened — revoke is a no-op on used tokens by the QURL API's
-    // design. Surface that so users don't file phantom "partial failure"
-    // reports.
-    const usedNote = revoked.success < revoked.total ? ' Used links cannot be revoked.' : '';
     await selectInteraction.update({
-      content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
+      content: `Revoked ${revoked.success}/${revoked.total} links. Some links could not be revoked — they may have already been opened.`,
       components: [],
     });
   } catch {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1219,7 +1219,7 @@ async function handleSend(interaction, apiKey) {
         try {
           const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
           await interaction.editReply({
-            content: `Revoked ${revoked.success}/${revoked.total} links. Some links could not be revoked — they may have already been opened.`,
+            content: `Revoked ${revoked.success}/${revoked.total} links. Note: already-opened links cannot be revoked.`,
             components: [],
           }).catch(logIgnoredDiscordErr);
         } catch (err) {
@@ -1666,7 +1666,7 @@ async function handleRevoke(interaction, apiKey) {
     const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
 
     await selectInteraction.update({
-      content: `Revoked ${revoked.success}/${revoked.total} links. Some links could not be revoked — they may have already been opened.`,
+      content: `Revoked ${revoked.success}/${revoked.total} links. Note: already-opened links cannot be revoked.`,
       components: [],
     });
   } catch {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1222,7 +1222,7 @@ async function handleSend(interaction, apiKey) {
           // already opened — revoke is a no-op on used tokens by the QURL API's
           // design. Surface that so users don't file phantom "partial failure"
           // reports.
-          const usedNote = revoked.success < revoked.total ? '\nUsed links cannot be revoked.' : '';
+          const usedNote = revoked.success < revoked.total ? ' Used links cannot be revoked.' : '';
           await interaction.editReply({
             content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
             components: [],
@@ -1674,7 +1674,7 @@ async function handleRevoke(interaction, apiKey) {
     // already opened — revoke is a no-op on used tokens by the QURL API's
     // design. Surface that so users don't file phantom "partial failure"
     // reports.
-    const usedNote = revoked.success < revoked.total ? '\nUsed links cannot be revoked.' : '';
+    const usedNote = revoked.success < revoked.total ? ' Used links cannot be revoked.' : '';
     await selectInteraction.update({
       content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
       components: [],

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -291,15 +291,11 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey) {
 /**
  * Mint one-time links for an uploaded resource via the connector.
  *
- * `one_time_use: true` is explicit because the Node.js migration
- * (PR #45) dropped this field when rewriting the Python
- * mint_link_client. Without it, upstream minted reusable links —
- * the "accessed same link 5 times" bug the user reported. The field
- * applies PER minted link: `n` recipients get `n` independent
+ * `one_time_use: true` is required — upstream default on some key
+ * tiers is unlimited, so omitting it produces reusable links. The
+ * field applies PER minted link: `n` recipients get `n` independent
  * one-time tokens, so one recipient opening their link doesn't
- * invalidate anyone else's. Python bot proved this shape in prod
- * for months; see qurl-bot-discord/services/mint_link_client.py:46
- * in the infra repo and qurl-integrations-infra#157.
+ * invalidate anyone else's.
  */
 async function mintLinks(resourceId, expiresAt, n, apiKey) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -290,6 +290,16 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey) {
 
 /**
  * Mint one-time links for an uploaded resource via the connector.
+ *
+ * `one_time_use: true` is explicit because the Node.js migration
+ * (PR #45) dropped this field when rewriting the Python
+ * mint_link_client. Without it, upstream minted reusable links —
+ * the "accessed same link 5 times" bug the user reported. The field
+ * applies PER minted link: `n` recipients get `n` independent
+ * one-time tokens, so one recipient opening their link doesn't
+ * invalidate anyone else's. Python bot proved this shape in prod
+ * for months; see qurl-bot-discord/services/mint_link_client.py:46
+ * in the infra repo and qurl-integrations-infra#157.
  */
 async function mintLinks(resourceId, expiresAt, n, apiKey) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
@@ -306,7 +316,7 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
   const response = await fetch(`${config.CONNECTOR_URL}/api/mint_link/${resourceId}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...connectorAuthHeaders(apiKey) },
-    body: JSON.stringify({ expires_at: expiresAt, n, max_uses: 1 }),
+    body: JSON.stringify({ expires_at: expiresAt, n, one_time_use: true }),
     signal: AbortSignal.timeout(30000),
   });
 

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -306,7 +306,7 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
   const response = await fetch(`${config.CONNECTOR_URL}/api/mint_link/${resourceId}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...connectorAuthHeaders(apiKey) },
-    body: JSON.stringify({ expires_at: expiresAt, n }),
+    body: JSON.stringify({ expires_at: expiresAt, n, max_uses: 1 }),
     signal: AbortSignal.timeout(30000),
   });
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -729,11 +729,14 @@ describe('Connector client', () => {
       const body = JSON.parse(opts.body);
       expect(body.expires_at).toBe('2026-01-16T00:00:00.000Z');
       expect(body.n).toBe(2);
-      // Regression guard: bot MUST send max_uses: 1 so minted links are
-      // one-time regardless of upstream API-key-tier defaults. Dropping
-      // this field reopens the "links were reusable" bug the user
-      // reported (commit a293b42 on qurl-integrations-infra).
-      expect(body.max_uses).toBe(1);
+      // Regression guard: bot MUST send one_time_use: true so each minted
+      // link is single-use. Proved correct by the pre-Node Python bot at
+      // qurl-bot-discord/services/mint_link_client.py:46 which used this
+      // exact field and produced genuinely one-time links. PR #45 dropped
+      // the field during the Node rewrite; that's the "links were reusable"
+      // regression the user reported. Companion infra PR #157 plumbs this
+      // field through the connector to the upstream QURL API.
+      expect(body.one_time_use).toBe(true);
       expect(result).toEqual(mockLinks);
     });
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -729,13 +729,9 @@ describe('Connector client', () => {
       const body = JSON.parse(opts.body);
       expect(body.expires_at).toBe('2026-01-16T00:00:00.000Z');
       expect(body.n).toBe(2);
-      // Regression guard: bot MUST send one_time_use: true so each minted
-      // link is single-use. Proved correct by the pre-Node Python bot at
-      // qurl-bot-discord/services/mint_link_client.py:46 which used this
-      // exact field and produced genuinely one-time links. PR #45 dropped
-      // the field during the Node rewrite; that's the "links were reusable"
-      // regression the user reported. Companion infra PR #157 plumbs this
-      // field through the connector to the upstream QURL API.
+      // Regression guard: bot MUST send one_time_use: true so each
+      // minted link is single-use. Dropping this field produces
+      // reusable links on some API-key tiers.
       expect(body.one_time_use).toBe(true);
       expect(result).toEqual(mockLinks);
     });

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -729,6 +729,11 @@ describe('Connector client', () => {
       const body = JSON.parse(opts.body);
       expect(body.expires_at).toBe('2026-01-16T00:00:00.000Z');
       expect(body.n).toBe(2);
+      // Regression guard: bot MUST send max_uses: 1 so minted links are
+      // one-time regardless of upstream API-key-tier defaults. Dropping
+      // this field reopens the "links were reusable" bug the user
+      // reported (commit a293b42 on qurl-integrations-infra).
+      expect(body.max_uses).toBe(1);
       expect(result).toEqual(mockLinks);
     });
 

--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -82,41 +82,52 @@ describe('Smoke: QURL link lifecycle', () => {
   });
 
   test('second access of the same one-time link FAILS (use count consumed)', async () => {
-    // Regression guard for the "links were reusable" bug. The first-access
-    // test above proves the token is accepted once; this test proves the
-    // token is NOT accepted twice. The qurl-api SPA returns 200 for the
-    // HTML shell either way — the source-of-truth for "was this token
-    // consumed?" is the resource status API, which must show use_count
-    // exhausted after the second (failed) resolution attempt.
-    //
-    // We do a second access first (which should fail at the NHP/resolver
-    // layer for the token, but the SPA layer still returns 200). Then we
-    // check status: use_count must still be exactly 1 — the failed second
-    // attempt must NOT increment the counter past max_uses.
+    // Regression guard for the reusable-links bug. Depends on the two
+    // prior tests setting qurlLink + qurlId — guard explicitly so a
+    // jest rerandomize or reordering doesn't silently no-op.
+    expect(qurlLink).toBeDefined();
+    expect(qurlId).toBeDefined();
+
+    // First-access must have already happened in the prior test and
+    // pushed use_count to exactly 1. Pin that baseline here so a broken
+    // system where the counter never increments would fail this test
+    // (the earlier `>= 1` assertion would pass at 0 too).
+    const baseline = await qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, qurlId);
+    expect(baseline.use_count).toBe(1);
+
     const res2 = await qurl.accessLink(qurlLink);
     console.log(`Second access: ${res2.status} -> ${res2.finalUrl}`);
 
+    // Two independent paths for "this token is dead":
+    //   (a) status endpoint reports use_count still === 1 after the
+    //       second attempt — the failed resolution MUST NOT increment
+    //       past max_uses. An increment to 2 is the exact bug shape.
+    //   (b) status endpoint returns 404 (some resource types return
+    //       this once a one-time QURL is fully consumed).
+    // Either proves the enforcement worked; we accept whichever path
+    // the API takes but tighten the pass conditions on both.
+    let statusAfter: Awaited<ReturnType<typeof qurl.getLinkStatus>> | null = null;
+    let statusError: Error | null = null;
     try {
-      const status = await qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, qurlId);
-      console.log(`Link status after 2nd access:`, JSON.stringify(status));
-      // The second access should not push use_count over max_uses (1).
-      // Either the status reports used_up / consumed, or use_count stays
-      // at 1 — both prove the token is no longer resolvable.
-      if (typeof status.use_count === 'number') {
-        expect(status.use_count).toBeLessThanOrEqual(1);
-      }
-      // Some API shapes expose a typed "consumed" / "remaining_uses" flag —
-      // assert loosely on either if present. Absence of the flag is OK,
-      // the use_count check above is the primary invariant.
-      if (typeof status.remaining_uses === 'number') {
-        expect(status.remaining_uses).toBe(0);
-      }
+      statusAfter = await qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, qurlId);
+      console.log(`Link status after 2nd access:`, JSON.stringify(statusAfter));
     } catch (e) {
-      // Status endpoint returning 404 on a fully-consumed one-time link is
-      // ALSO a valid signal that the link is dead — accept that path.
-      const msg = (e as Error).message;
-      console.log(`Status check after 2nd access: ${msg}`);
-      expect(msg).toMatch(/404|410|expired|consumed|not found/i);
+      statusError = e as Error;
+      console.log(`Link status after 2nd access (threw): ${statusError.message}`);
+    }
+
+    if (statusAfter !== null) {
+      // The failed second attempt must NOT increment the counter past 1.
+      expect(statusAfter.use_count).toBe(1);
+      if (typeof statusAfter.remaining_uses === 'number') {
+        expect(statusAfter.remaining_uses).toBe(0);
+      }
+    } else {
+      // Status-endpoint 404 is the OTHER valid signal that the token
+      // is dead. Accept only that specific shape — "expired" / "consumed"
+      // substrings were too permissive (could match unrelated errors).
+      expect(statusError).not.toBeNull();
+      expect(statusError!.message).toMatch(/\b404\b|\bnot found\b/i);
     }
   });
 });

--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -80,6 +80,45 @@ describe('Smoke: QURL link lifecycle', () => {
       console.log(`Status check: ${(e as Error).message} (may not be tracked server-side for SPA links)`);
     }
   });
+
+  test('second access of the same one-time link FAILS (use count consumed)', async () => {
+    // Regression guard for the "links were reusable" bug. The first-access
+    // test above proves the token is accepted once; this test proves the
+    // token is NOT accepted twice. The qurl-api SPA returns 200 for the
+    // HTML shell either way — the source-of-truth for "was this token
+    // consumed?" is the resource status API, which must show use_count
+    // exhausted after the second (failed) resolution attempt.
+    //
+    // We do a second access first (which should fail at the NHP/resolver
+    // layer for the token, but the SPA layer still returns 200). Then we
+    // check status: use_count must still be exactly 1 — the failed second
+    // attempt must NOT increment the counter past max_uses.
+    const res2 = await qurl.accessLink(qurlLink);
+    console.log(`Second access: ${res2.status} -> ${res2.finalUrl}`);
+
+    try {
+      const status = await qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, qurlId);
+      console.log(`Link status after 2nd access:`, JSON.stringify(status));
+      // The second access should not push use_count over max_uses (1).
+      // Either the status reports used_up / consumed, or use_count stays
+      // at 1 — both prove the token is no longer resolvable.
+      if (typeof status.use_count === 'number') {
+        expect(status.use_count).toBeLessThanOrEqual(1);
+      }
+      // Some API shapes expose a typed "consumed" / "remaining_uses" flag —
+      // assert loosely on either if present. Absence of the flag is OK,
+      // the use_count check above is the primary invariant.
+      if (typeof status.remaining_uses === 'number') {
+        expect(status.remaining_uses).toBe(0);
+      }
+    } catch (e) {
+      // Status endpoint returning 404 on a fully-consumed one-time link is
+      // ALSO a valid signal that the link is dead — accept that path.
+      const msg = (e as Error).message;
+      console.log(`Status check after 2nd access: ${msg}`);
+      expect(msg).toMatch(/404|410|expired|consumed|not found/i);
+    }
+  });
 });
 
 describe('Smoke: Revocation', () => {


### PR DESCRIPTION
## Summary

Always append a fixed informational note after every `/qurl revoke` result, regardless of outcome. Purely cosmetic — no conditionals, no special cases.

## New reply text (both sites)

```
Revoked X/Y links. Note: already-opened links cannot be revoked.
```

The note reads correctly in all cases:
- `3/3`: informational FYI (general rule about revoke semantics)
- `0/3`: implicit explanation for why zero succeeded
- `1/3`: same implicit explanation, plus the count gives the specifics

(Earlier iteration said "Some links could not be revoked…" — reviewer caught that this contradicts itself at 3/3. Rephrased as a general rule rather than a claim about the current operation.)

## Diff (summary — two call sites, identical change)

```diff
- const usedNote = revoked.success < revoked.total ? ' Used links cannot be revoked.' : '';
  await interaction.editReply({
-   content: `Revoked ${revoked.success}/${revoked.total} links.${usedNote}`,
+   content: `Revoked ${revoked.success}/${revoked.total} links. Note: already-opened links cannot be revoked.`,
    components: [],
  });
```

Call sites:
- `apps/discord/src/commands.js:1222` — post-send Revoke button handler (in `handleSend`)
- `apps/discord/src/commands.js:1669` — standalone `/qurl revoke` dropdown handler (in `handleRevoke`)

Net -10 lines (dropped the conditional + the reasoning comment that accompanied it).

## Scope explicitly NOT in this PR

- No per-link breakdown ("which recipients already opened")
- No `max_uses` / one-time-use changes (separate concern)
- No conditional logic based on success/total ratio
- No i18n

## Test plan

- [x] `npm test` full suite: 554/554 pass
- [x] Same string at both call sites (single-source style)

Reviewer: @justin-layerv.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>