### PR TITLE
fix(ci): remove remaining_uses check to unblock e2e-smoke compile

### DIFF
--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -118,10 +118,9 @@ describe('Smoke: QURL link lifecycle', () => {
 
     if (statusAfter !== null) {
       // The failed second attempt must NOT increment the counter past 1.
+      // An increment to 2 is the exact bug shape ("links were reusable")
+      // this test is here to catch.
       expect(statusAfter.use_count).toBe(1);
-      if (typeof statusAfter.remaining_uses === 'number') {
-        expect(statusAfter.remaining_uses).toBe(0);
-      }
     } else {
       // Status-endpoint 404 is the OTHER valid signal that the token
       // is dead. Accept only that specific shape — "expired" / "consumed"


### PR DESCRIPTION
Main CI broke — smoke.test.ts referenced statusAfter.remaining_uses but getLinkStatus helper return type is {use_count, status, expires_at}. TS2339 on lines 122-123.

Drop the check; primary invariant (use_count === 1 baseline AND === 1 after 2nd attempt) preserved.

- tsc --noEmit clean
- Fixes main e2e-smoke compilation