### PR TITLE
feat(discord): gateway/HTTP process split via PROCESS_ROLE env var

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -39,6 +39,26 @@ GUILD_ID=
 # community guild's task-def.
 ENABLE_OPENNHP_FEATURES=false
 
+# Process role — selects which subset of the bot runs in this container.
+# Default: combined (legacy single-process behavior, backward-compatible).
+#
+#   combined — Gateway WebSocket + Express HTTP listener + cron jobs all
+#              in one process. The right shape for sandbox / local dev /
+#              any deployment that hasn't opted into the split.
+#
+#   gateway  — Discord Gateway client + interaction handlers + cron jobs.
+#              No HTTP listener. Deploy as a singleton (desired_count=1):
+#              Discord bot tokens admit only one active Gateway connection
+#              per token, and two concurrent logins flap session identity.
+#
+#   http     — Express listener (OAuth callbacks, webhooks, /health,
+#              /metrics) only. No Gateway login. Can scale horizontally
+#              behind an ALB. Reads `client.rest` (token seeded by
+#              http-only-init.js) for outbound Discord REST calls.
+#
+# Unknown values fail boot loudly. Leave unset to default to combined.
+# PROCESS_ROLE=combined
+
 # GitHub OAuth App — REQUIRED only when ENABLE_OPENNHP_FEATURES=true.
 # Single-guild-plain and multi-tenant deployments don't mount /auth or
 # /webhook routes and don't need these values — the boot check

--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-dynamodb": "^3.1036.0",
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "better-sqlite3": "~12.8.0",
+        "discord-api-types": "^0.38.33",
         "discord.js": "~14.25.1",
         "express": "~5.2.1",
         "helmet": "~7.2.0",

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -24,6 +24,7 @@
     "@aws-sdk/client-dynamodb": "^3.1036.0",
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "better-sqlite3": "~12.8.0",
+    "discord-api-types": "^0.38.33",
     "discord.js": "~14.25.1",
     "express": "~5.2.1",
     "helmet": "~7.2.0",

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -48,4 +48,46 @@ function missingProdKeys(env, isOpenNHPActive) {
   return prodRequired(isOpenNHPActive).filter(k => !env[k]);
 }
 
-module.exports = { bootRequired, prodRequired, missingBootKeys, missingProdKeys };
+// Process-role parsing for the gateway/HTTP split. Lifted out of
+// index.js so the invalid-value path is testable without spawning a
+// child process — same shape as missingBootKeys above. See
+// .env.example's PROCESS_ROLE block for the operator-facing
+// description of each role.
+const VALID_PROCESS_ROLES = Object.freeze(['combined', 'gateway', 'http']);
+
+// Normalize and validate a PROCESS_ROLE value. Returns
+// `{role, isGateway, isHttp}` on success; throws an Error tagged
+// with `code = 'INVALID_PROCESS_ROLE'` on an unknown role so index.js
+// can surface a single boot-fail log line + exit(1) without
+// re-implementing the validation.
+//
+// Accepts the raw env-var string (or undefined). Empty / whitespace-only
+// values fall back to 'combined' — matching the documented default and
+// avoiding a false-positive boot failure when an SSM-seeded param is
+// templated to "" or " ".
+function resolveProcessRole(rawValue) {
+  const trimmed = String(rawValue ?? '').trim();
+  const role = trimmed || 'combined';
+  if (!VALID_PROCESS_ROLES.includes(role)) {
+    const err = new Error(
+      `Invalid PROCESS_ROLE: '${role}'. Valid values: ${VALID_PROCESS_ROLES.join(', ')}. ` +
+      `Set PROCESS_ROLE to one of these, or leave unset to default to 'combined'.`
+    );
+    err.code = 'INVALID_PROCESS_ROLE';
+    throw err;
+  }
+  return {
+    role,
+    isGateway: role === 'gateway' || role === 'combined',
+    isHttp: role === 'http' || role === 'combined',
+  };
+}
+
+module.exports = {
+  bootRequired,
+  prodRequired,
+  missingBootKeys,
+  missingProdKeys,
+  VALID_PROCESS_ROLES,
+  resolveProcessRole,
+};

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -1,0 +1,128 @@
+// discord-rest — Discord REST client wrappers (no Gateway / WebSocket).
+//
+// discord.js's Client object connects to the Discord Gateway via
+// WebSocket and maintains a long-lived guild/user cache. That's the
+// right shape for the bot's event-driven interactions work, but it's
+// the wrong shape for HTTP-process tasks:
+//   - Only one Gateway connection may be active per bot token at a
+//     time. An HTTP-process replica that called `client.login()`
+//     would conflict with the gateway process, causing a session-
+//     identity flap every few seconds.
+//   - HTTP traffic (OAuth callbacks, GitHub webhooks, /health probes)
+//     doesn't need the cache at all — every interaction is one-shot
+//     and the REST API gives us fresh data.
+//
+// This module wraps `@discordjs/rest` with the small subset of
+// operations HTTP-side code needs: DM delivery, role assignment, DM
+// channel existence checks. Callable from the gateway process too
+// (it just makes REST calls alongside its Gateway connection), so
+// the same helpers work in either role — no "which process am I"
+// logic inside the helpers.
+//
+// Auth: the bot token is read once at module-load via
+// `config.DISCORD_TOKEN`. Same token as the gateway — Discord scopes
+// tokens to applications, not connection types.
+
+const { REST } = require('@discordjs/rest');
+const { Routes } = require('discord-api-types/v10');
+const config = require('./config');
+const logger = require('./logger');
+
+// One REST client per process — discord.js's REST client is stateful
+// only in that it holds the token + rate-limit buckets. Rate-limit
+// buckets are per-process by default, which is fine for a two-process
+// split (gateway + HTTP rarely hit the same endpoint concurrently at
+// a volume that matters).
+const rest = new REST({ version: '10' });
+if (config.DISCORD_TOKEN) {
+  rest.setToken(config.DISCORD_TOKEN);
+}
+
+/**
+ * Send a direct message to a Discord user via REST (no Gateway).
+ *
+ * Two-call flow:
+ *   1. POST /users/@me/channels → creates (or returns existing) DM
+ *      channel, returns { id }.
+ *   2. POST /channels/:id/messages → posts the message body.
+ *
+ * Returns `{ ok: true, channelId }` on success, `{ ok: false, error }`
+ * on failure. Callers log/branch on `.ok` rather than letting
+ * exceptions propagate — matches the ergonomics of the legacy
+ * gateway-based `sendDM` in `discord.js`.
+ *
+ * @param {string} userId — Discord snowflake.
+ * @param {object} message — discord.js-compatible message payload
+ *   (content, embeds, components, etc.). Passed through verbatim to
+ *   the REST endpoint.
+ */
+async function sendDM(userId, message) {
+  if (!config.DISCORD_TOKEN) {
+    return { ok: false, error: 'DISCORD_TOKEN not configured' };
+  }
+  try {
+    const channel = await rest.post(Routes.userChannels(), {
+      body: { recipient_id: userId },
+    });
+    await rest.post(Routes.channelMessages(channel.id), {
+      body: message,
+    });
+    return { ok: true, channelId: channel.id };
+  } catch (err) {
+    // Discord returns HTTP 403 "Cannot send messages to this user"
+    // when the recipient has DMs disabled or has blocked the bot —
+    // expected operational error, not a bug. Logged at info level
+    // to avoid oncall noise; caller decides whether to fall back
+    // to a channel mention.
+    const level = err.status === 403 ? 'info' : 'error';
+    logger[level]('sendDM via REST failed', {
+      userId, status: err.status, message: err.message,
+    });
+    return { ok: false, error: err.message, status: err.status };
+  }
+}
+
+/**
+ * Add a role to a guild member via REST (no Gateway).
+ * Idempotent on the Discord side — re-adding an existing role is
+ * a no-op.
+ */
+async function addRoleToMember(guildId, userId, roleId) {
+  if (!config.DISCORD_TOKEN) {
+    return { ok: false, error: 'DISCORD_TOKEN not configured' };
+  }
+  try {
+    await rest.put(Routes.guildMemberRole(guildId, userId, roleId));
+    return { ok: true };
+  } catch (err) {
+    logger.error('addRoleToMember via REST failed', {
+      guildId, userId, roleId, status: err.status, message: err.message,
+    });
+    return { ok: false, error: err.message, status: err.status };
+  }
+}
+
+/**
+ * Remove a role from a guild member via REST (no Gateway).
+ */
+async function removeRoleFromMember(guildId, userId, roleId) {
+  if (!config.DISCORD_TOKEN) {
+    return { ok: false, error: 'DISCORD_TOKEN not configured' };
+  }
+  try {
+    await rest.delete(Routes.guildMemberRole(guildId, userId, roleId));
+    return { ok: true };
+  } catch (err) {
+    logger.error('removeRoleFromMember via REST failed', {
+      guildId, userId, roleId, status: err.status, message: err.message,
+    });
+    return { ok: false, error: err.message, status: err.status };
+  }
+}
+
+module.exports = {
+  rest,
+  sendDM,
+  addRoleToMember,
+  removeRoleFromMember,
+};

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -120,6 +120,10 @@ async function removeRoleFromMember(guildId, userId, roleId) {
   }
 }
 
+// TODO(pr-4d): migrate routes/oauth.js + routes/webhooks.js to call
+// these helpers instead of the gateway-cache helpers in src/discord.js.
+// Today the helpers below are unused production code — they're the
+// landing pads for the route migration after this PR ships.
 module.exports = {
   rest,
   sendDM,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -30,7 +30,6 @@
 
 const { Routes } = require('discord-api-types/v10');
 const { client } = require('./discord');
-const config = require('./config');
 const logger = require('./logger');
 
 // Shared instance — same object as `require('./discord').client.rest`.
@@ -55,10 +54,13 @@ const rest = client.rest;
  *   (content, embeds, components, etc.). Passed through verbatim to
  *   the REST endpoint.
  */
+// Note: DISCORD_TOKEN presence is enforced at boot by
+// boot-requirements.js (it's in the bootRequired list for every
+// mode). The helpers below trust that guarantee — no defensive
+// `if (!config.DISCORD_TOKEN)` short-circuit here. Matches the
+// pattern in src/discord.js and http-only-init.js.
+
 async function sendDM(userId, message) {
-  if (!config.DISCORD_TOKEN) {
-    return { ok: false, error: 'DISCORD_TOKEN not configured' };
-  }
   try {
     const channel = await rest.post(Routes.userChannels(), {
       body: { recipient_id: userId },
@@ -75,8 +77,12 @@ async function sendDM(userId, message) {
     // to keep oncall signal-to-noise high. Caller decides whether to
     // fall back to a channel mention.
     const level = err.status === 403 ? 'info' : 'error';
+    // `errorMessage` (not `message`) so the log key doesn't shadow the
+    // function parameter `message` (the DM body) — readers searching
+    // for "message that failed to send" should land on the body, not
+    // the error string.
     logger[level]('sendDM via REST failed', {
-      userId, status: err.status, message: err.message,
+      userId, status: err.status, errorMessage: err.message,
     });
     return { ok: false, error: err.message, status: err.status };
   }
@@ -88,15 +94,12 @@ async function sendDM(userId, message) {
  * a no-op.
  */
 async function addRoleToMember(guildId, userId, roleId) {
-  if (!config.DISCORD_TOKEN) {
-    return { ok: false, error: 'DISCORD_TOKEN not configured' };
-  }
   try {
     await rest.put(Routes.guildMemberRole(guildId, userId, roleId));
     return { ok: true };
   } catch (err) {
     logger.error('addRoleToMember via REST failed', {
-      guildId, userId, roleId, status: err.status, message: err.message,
+      guildId, userId, roleId, status: err.status, errorMessage: err.message,
     });
     return { ok: false, error: err.message, status: err.status };
   }
@@ -106,15 +109,12 @@ async function addRoleToMember(guildId, userId, roleId) {
  * Remove a role from a guild member via REST (no Gateway).
  */
 async function removeRoleFromMember(guildId, userId, roleId) {
-  if (!config.DISCORD_TOKEN) {
-    return { ok: false, error: 'DISCORD_TOKEN not configured' };
-  }
   try {
     await rest.delete(Routes.guildMemberRole(guildId, userId, roleId));
     return { ok: true };
   } catch (err) {
     logger.error('removeRoleFromMember via REST failed', {
-      guildId, userId, roleId, status: err.status, message: err.message,
+      guildId, userId, roleId, status: err.status, errorMessage: err.message,
     });
     return { ok: false, error: err.message, status: err.status };
   }

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -1,42 +1,41 @@
-// discord-rest — Discord REST client wrappers (no Gateway / WebSocket).
+// discord-rest — Discord REST helpers, sharing client.rest with discord.js.
 //
-// discord.js's Client object connects to the Discord Gateway via
-// WebSocket and maintains a long-lived guild/user cache. That's the
-// right shape for the bot's event-driven interactions work, but it's
-// the wrong shape for HTTP-process tasks:
-//   - Only one Gateway connection may be active per bot token at a
-//     time. An HTTP-process replica that called `client.login()`
-//     would conflict with the gateway process, causing a session-
-//     identity flap every few seconds.
-//   - HTTP traffic (OAuth callbacks, GitHub webhooks, /health probes)
-//     doesn't need the cache at all — every interaction is one-shot
-//     and the REST API gives us fresh data.
+// Background: HTTP-process tasks (OAuth callbacks, GitHub webhooks,
+// /health probes) don't need the Gateway WebSocket — every interaction
+// is one-shot and the REST API gives fresh data. Only one Gateway
+// connection may be active per bot token, so an http-only replica
+// behind an ALB must NOT call client.login() (it would flap session
+// identity against the gateway singleton).
 //
-// This module wraps `@discordjs/rest` with the small subset of
-// operations HTTP-side code needs: DM delivery, role assignment, DM
-// channel existence checks. Callable from the gateway process too
-// (it just makes REST calls alongside its Gateway connection), so
-// the same helpers work in either role — no "which process am I"
-// logic inside the helpers.
+// This module exposes the small subset of REST operations http-side
+// code needs (DM delivery, role assignment) with an `{ ok, status,
+// error }`-shaped return value rather than thrown exceptions —
+// callers branch on `.ok` instead of try/catching.
 //
-// Auth: the bot token is read once at module-load via
-// `config.DISCORD_TOKEN`. Same token as the gateway — Discord scopes
-// tokens to applications, not connection types.
+// Why share `client.rest`: `@discordjs/rest`'s rate-limit buckets are
+// per-instance, not per-process. A second `new REST(...)` would
+// negotiate `POST /channels/:id/messages` independently from the
+// helpers in `src/discord.js`, so a 429 hit by one wouldn't back off
+// the other. Reusing `client.rest` keeps the bucket state shared.
+// The Client object is already required at module load by `index.js`
+// regardless of role; importing it here adds no extra weight.
+//
+// Auth: the bot token lands on `client.rest` from one of two paths —
+//   - combined / gateway modes: `client.login()` calls `setToken()`
+//     internally as part of opening the WebSocket.
+//   - http-only mode: `src/http-only-init.js` calls `setToken()`
+//     explicitly because login() is gated off in that role.
+// Either way, the helpers below see a token-bearing rest by the time
+// they're invoked from a route handler.
 
-const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v10');
+const { client } = require('./discord');
 const config = require('./config');
 const logger = require('./logger');
 
-// One REST client per process — discord.js's REST client is stateful
-// only in that it holds the token + rate-limit buckets. Rate-limit
-// buckets are per-process by default, which is fine for a two-process
-// split (gateway + HTTP rarely hit the same endpoint concurrently at
-// a volume that matters).
-const rest = new REST({ version: '10' });
-if (config.DISCORD_TOKEN) {
-  rest.setToken(config.DISCORD_TOKEN);
-}
+// Shared instance — same object as `require('./discord').client.rest`.
+// Re-exported below for tests + potential direct use.
+const rest = client.rest;
 
 /**
  * Send a direct message to a Discord user via REST (no Gateway).
@@ -69,11 +68,12 @@ async function sendDM(userId, message) {
     });
     return { ok: true, channelId: channel.id };
   } catch (err) {
-    // Discord returns HTTP 403 "Cannot send messages to this user"
-    // when the recipient has DMs disabled or has blocked the bot —
-    // expected operational error, not a bug. Logged at info level
-    // to avoid oncall noise; caller decides whether to fall back
-    // to a channel mention.
+    // Discord returns HTTP 403 for several recipient-side reasons:
+    // DMs disabled, the bot was blocked, server-level DM restrictions,
+    // or "Missing Access" when there's no shared guild. All are
+    // expected operational outcomes (not bugs), so log at info level
+    // to keep oncall signal-to-noise high. Caller decides whether to
+    // fall back to a channel mention.
     const level = err.status === 403 ? 'info' : 'error';
     logger[level]('sendDM via REST failed', {
       userId, status: err.status, message: err.message,

--- a/apps/discord/src/http-only-init.js
+++ b/apps/discord/src/http-only-init.js
@@ -18,29 +18,81 @@
 // that can't reach Discord can't service its own routes, so we
 // crash-loop and let the orchestrator reschedule rather than
 // silently start with a cold cache and 5xx every webhook.
+//
+// Cache invalidation: in combined / gateway mode, the
+// `client.on('roleDelete' / 'channelDelete')` handlers in
+// `src/discord.js` invalidate the cache when guild admins delete
+// tracked roles or channels. Those events ride the Gateway and
+// don't fire in http-only mode. To close the resulting staleness
+// window we run a periodic REST refreshCache() (every
+// REFRESH_INTERVAL_MS) so deletions propagate within one interval
+// rather than waiting for a replica restart.
+
+// 10-minute refresh interval — short enough that a deleted role
+// stays cached for at most one window before invalidation, long
+// enough that the periodic two-REST-call cost (guild.roles.fetch +
+// guild.channels.fetch) is rounding error against the bot's normal
+// REST budget. Tunable via env var if a future operator needs more
+// or less aggressive invalidation.
+const REFRESH_INTERVAL_MS = (() => {
+  const raw = process.env.HTTP_ONLY_REFRESH_INTERVAL_MS;
+  if (!raw) return 10 * 60 * 1000;
+  const parsed = parseInt(raw, 10);
+  // Reject non-positive / NaN. Bare-minimum 30s floor so a misconfigured
+  // 1ms doesn't hammer the Discord REST API.
+  if (!Number.isFinite(parsed) || parsed < 30_000) return 10 * 60 * 1000;
+  return parsed;
+})();
 
 /**
  * Initialize a process running under `PROCESS_ROLE=http` so its
  * route handlers can hit Discord via REST without a Gateway login.
  *
- * Two side effects:
+ * Side effects:
  *   - `client.rest.setToken(config.DISCORD_TOKEN)` so REST calls
  *     authenticate (login() is the normal seeder; we skip it here).
- *   - `await refreshCache()` when GUILD_ID is set, so single-guild
- *     OAuth + webhook handlers find a populated cache on the first
- *     request. Multi-tenant deployments (GUILD_ID unset) skip the
- *     refresh — refreshCache is a no-op there, and the OpenNHP
- *     routes that consume the cache aren't mounted anyway.
+ *   - Initial `await refreshCache()` when GUILD_ID is set, so
+ *     single-guild OAuth + webhook handlers find a populated cache
+ *     on the first request. Multi-tenant deployments (GUILD_ID
+ *     unset) skip the refresh — refreshCache is a no-op there, and
+ *     the OpenNHP routes that consume the cache aren't mounted
+ *     anyway.
+ *   - Periodic `setInterval` calling refreshCache every
+ *     REFRESH_INTERVAL_MS, gated on the same GUILD_ID check.
+ *     `.unref()` so the timer doesn't block process exit;
+ *     `gracefulShutdown` in index.js explicitly clears it for
+ *     symmetry with the other intervals.
+ *   - Boot-time `logger.warn` naming the cache-invalidation
+ *     limitation in http-only mode so future grep-from-logs lands
+ *     on the periodic-refresh strategy.
  *
- * Pure dependency injection (client, config, refreshCache passed
- * in) — keeps the helper testable without importing the heavy
- * discord.js Client at test time.
+ * Returns the periodic-refresh timer so the caller can clearInterval
+ * on shutdown. Returns `null` in multi-tenant mode (no timer set up).
+ *
+ * Pure dependency injection (client, config, refreshCache, logger
+ * passed in) — keeps the helper testable without importing the
+ * heavy discord.js Client at test time.
  */
-async function initHttpOnly({ client, config, refreshCache }) {
+async function initHttpOnly({ client, config, refreshCache, logger }) {
   client.rest.setToken(config.DISCORD_TOKEN);
-  if (config.GUILD_ID) {
-    await refreshCache();
+  if (!config.GUILD_ID) {
+    return null;
   }
+  await refreshCache();
+  logger.warn(
+    'http-only mode: Gateway-driven cache invalidation (roleDelete/channelDelete) is unavailable. ' +
+    `Periodic REST refreshCache compensates every ${Math.round(REFRESH_INTERVAL_MS / 60_000)} minute(s). ` +
+    'See src/http-only-init.js for rationale; tune via HTTP_ONLY_REFRESH_INTERVAL_MS env var.'
+  );
+  const timer = setInterval(() => {
+    refreshCache().catch(err => {
+      logger.error('Periodic refreshCache failed in http-only mode (will retry next interval)', {
+        errorMessage: err?.message,
+      });
+    });
+  }, REFRESH_INTERVAL_MS);
+  timer.unref();
+  return timer;
 }
 
-module.exports = { initHttpOnly };
+module.exports = { initHttpOnly, REFRESH_INTERVAL_MS };

--- a/apps/discord/src/http-only-init.js
+++ b/apps/discord/src/http-only-init.js
@@ -34,15 +34,42 @@
 // guild.channels.fetch) is rounding error against the bot's normal
 // REST budget. Tunable via env var if a future operator needs more
 // or less aggressive invalidation.
+const DEFAULT_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+const MIN_REFRESH_INTERVAL_MS = 30_000;
 const REFRESH_INTERVAL_MS = (() => {
   const raw = process.env.HTTP_ONLY_REFRESH_INTERVAL_MS;
-  if (!raw) return 10 * 60 * 1000;
+  if (!raw) return DEFAULT_REFRESH_INTERVAL_MS;
   const parsed = parseInt(raw, 10);
-  // Reject non-positive / NaN. Bare-minimum 30s floor so a misconfigured
-  // 1ms doesn't hammer the Discord REST API.
-  if (!Number.isFinite(parsed) || parsed < 30_000) return 10 * 60 * 1000;
+  // Reject non-positive / NaN / sub-30s. The 30s floor exists so a
+  // misconfigured 1ms doesn't hammer the Discord REST API. Surface the
+  // rejection at boot — a silent fall-through to the default would
+  // leave operators wondering why their `HTTP_ONLY_REFRESH_INTERVAL_MS=
+  // 15000` ask isn't taking effect.
+  if (!Number.isFinite(parsed) || parsed < MIN_REFRESH_INTERVAL_MS) {
+    // Use console.warn — logger isn't loaded this early in module init
+    // (logger.js itself is required at module load and may not yet be
+    // ready depending on require order).
+    console.warn(
+      `[http-only-init] HTTP_ONLY_REFRESH_INTERVAL_MS=${JSON.stringify(raw)} rejected ` +
+      `(must be a positive integer >= ${MIN_REFRESH_INTERVAL_MS}ms); ` +
+      `using default ${DEFAULT_REFRESH_INTERVAL_MS}ms.`
+    );
+    return DEFAULT_REFRESH_INTERVAL_MS;
+  }
   return parsed;
 })();
+
+// Pretty-print an interval for log output: "10 minute(s)" when the
+// interval is a clean multiple of a minute, "<n>ms" otherwise. Avoids
+// the "every 1 minute(s)" rounding artifact when REFRESH_INTERVAL_MS
+// is set to e.g. 45_000 via env override.
+function formatInterval(ms) {
+  if (ms >= 60_000 && ms % 60_000 === 0) {
+    const minutes = ms / 60_000;
+    return `${minutes} minute(s)`;
+  }
+  return `${ms}ms`;
+}
 
 /**
  * Initialize a process running under `PROCESS_ROLE=http` so its
@@ -81,7 +108,7 @@ async function initHttpOnly({ client, config, refreshCache, logger }) {
   await refreshCache();
   logger.warn(
     'http-only mode: Gateway-driven cache invalidation (roleDelete/channelDelete) is unavailable. ' +
-    `Periodic REST refreshCache compensates every ${Math.round(REFRESH_INTERVAL_MS / 60_000)} minute(s). ` +
+    `Periodic REST refreshCache compensates every ${formatInterval(REFRESH_INTERVAL_MS)}. ` +
     'See src/http-only-init.js for rationale; tune via HTTP_ONLY_REFRESH_INTERVAL_MS env var.'
   );
   const timer = setInterval(() => {

--- a/apps/discord/src/http-only-init.js
+++ b/apps/discord/src/http-only-init.js
@@ -1,0 +1,46 @@
+// http-only-init — boot wiring for `PROCESS_ROLE=http` replicas.
+//
+// In combined / gateway mode, `client.login()` does two things our
+// route handlers depend on: (1) it sets the bot token on
+// `client.rest`, so REST helpers can authenticate, and (2) the
+// resulting `ready` event triggers refreshCache(), populating
+// guild/roles/channels for OAuth + webhook handlers.
+//
+// http-only mode skips login() (Discord bot tokens admit only one
+// active Gateway connection per token, so the http-only replica
+// must not collide with the gateway singleton). Without the two
+// side effects above, every helper that touches REST — sendDM,
+// channels.X.send, member.roles.add — fails with a 401 on the
+// first request. This module reproduces both side effects via the
+// REST path so the http replica can serve traffic immediately.
+//
+// Failures here are intentionally fatal: an http-only replica
+// that can't reach Discord can't service its own routes, so we
+// crash-loop and let the orchestrator reschedule rather than
+// silently start with a cold cache and 5xx every webhook.
+
+/**
+ * Initialize a process running under `PROCESS_ROLE=http` so its
+ * route handlers can hit Discord via REST without a Gateway login.
+ *
+ * Two side effects:
+ *   - `client.rest.setToken(config.DISCORD_TOKEN)` so REST calls
+ *     authenticate (login() is the normal seeder; we skip it here).
+ *   - `await refreshCache()` when GUILD_ID is set, so single-guild
+ *     OAuth + webhook handlers find a populated cache on the first
+ *     request. Multi-tenant deployments (GUILD_ID unset) skip the
+ *     refresh — refreshCache is a no-op there, and the OpenNHP
+ *     routes that consume the cache aren't mounted anyway.
+ *
+ * Pure dependency injection (client, config, refreshCache passed
+ * in) — keeps the helper testable without importing the heavy
+ * discord.js Client at test time.
+ */
+async function initHttpOnly({ client, config, refreshCache }) {
+  client.rest.setToken(config.DISCORD_TOKEN);
+  if (config.GUILD_ID) {
+    await refreshCache();
+  }
+}
+
+module.exports = { initHttpOnly };

--- a/apps/discord/src/http-only-init.js
+++ b/apps/discord/src/http-only-init.js
@@ -102,6 +102,12 @@ function formatInterval(ms) {
  */
 async function initHttpOnly({ client, config, refreshCache, logger }) {
   client.rest.setToken(config.DISCORD_TOKEN);
+  // Falsy check is intentional and aligned with config.js's GUILD_ID
+  // normalization: anything that isn't a 17-20 digit Discord snowflake
+  // (unset env, "PLACEHOLDER", whitespace-only, etc.) lands as `null`
+  // there, so we treat all falsy values uniformly as multi-tenant mode.
+  // '0' is technically truthy in JS but isn't a valid snowflake anyway —
+  // config.js's regex check would have rejected it upstream.
   if (!config.GUILD_ID) {
     return null;
   }

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -5,7 +5,7 @@ const { registerCommands, handleCommand } = require('./commands');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const db = require('./store');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
-const { missingBootKeys, missingProdKeys } = require('./boot-requirements');
+const { missingBootKeys, missingProdKeys, resolveProcessRole } = require('./boot-requirements');
 const { initHttpOnly } = require('./http-only-init');
 
 // Process role — selects which subset of the bot runs in this
@@ -58,14 +58,15 @@ const { initHttpOnly } = require('./http-only-init');
 // tracked channels; if this becomes load-bearing, a periodic
 // REST-driven `refreshCache()` would close the gap without
 // needing a Gateway connection.
-const PROCESS_ROLE = (process.env.PROCESS_ROLE || 'combined').trim();
-const VALID_ROLES = ['combined', 'gateway', 'http'];
-if (!VALID_ROLES.includes(PROCESS_ROLE)) {
-  logger.error(`Invalid PROCESS_ROLE: '${PROCESS_ROLE}'. Valid values: ${VALID_ROLES.join(', ')}. Set PROCESS_ROLE to one of these, or leave unset to default to 'combined'.`);
+// Resolve PROCESS_ROLE via the helper in boot-requirements.js so the
+// invalid-value path is unit-testable without a child-process spawn.
+let PROCESS_ROLE, isGateway, isHttp;
+try {
+  ({ role: PROCESS_ROLE, isGateway, isHttp } = resolveProcessRole(process.env.PROCESS_ROLE));
+} catch (err) {
+  logger.error(err.message);
   process.exit(1);
 }
-const isGateway = PROCESS_ROLE === 'gateway' || PROCESS_ROLE === 'combined';
-const isHttp = PROCESS_ROLE === 'http' || PROCESS_ROLE === 'combined';
 logger.info('Process role configured', { role: PROCESS_ROLE, isGateway, isHttp });
 
 // Multi-tenant mode: when GUILD_ID is unset (or not a valid snowflake), the

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1,11 +1,12 @@
 const config = require('./config');
 const logger = require('./logger');
-const { client, shutdown: discordShutdown } = require('./discord');
+const { client, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const db = require('./store');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
 const { missingBootKeys, missingProdKeys } = require('./boot-requirements');
+const { initHttpOnly } = require('./http-only-init');
 
 // Process role — selects which subset of the bot runs in this
 // container. Three modes:
@@ -35,12 +36,19 @@ const { missingBootKeys, missingProdKeys } = require('./boot-requirements');
 // routes import), but `client.login()` is gated on `isGateway`.
 // Creating a Client without login() does NOT open a WebSocket —
 // the WS only opens on login. HTTP-only replicas therefore never
-// collide with the gateway singleton. Routes that currently call
-// gateway-backed helpers (routes/oauth.js, routes/webhooks.js
-// imports from `./discord`) should progressively migrate to
-// `discord-rest.js` so the gateway client can eventually be
-// moved entirely behind a role check — tracked as a follow-up
-// once the split is in prod and patterns stabilize.
+// collide with the gateway singleton.
+//
+// http-only mode (`PROCESS_ROLE=http`) needs two things login()
+// would otherwise do for free: (1) a token on `client.rest` so
+// REST helpers (sendDM, channels.X.send, member.roles.add) can
+// authenticate, and (2) an initial `refreshCache()` so the
+// route handlers find a populated guild/roles/channels cache on
+// the first OAuth callback or webhook. Both are seeded
+// explicitly in start() below — see the `else if (isHttp)`
+// branch. Migration to `discord-rest.js` (lighter, no Client
+// object needed at all) remains a follow-up; today's helpers
+// already work in either role once the token + cache are in
+// place.
 const PROCESS_ROLE = (process.env.PROCESS_ROLE || 'combined').trim();
 const VALID_ROLES = ['combined', 'gateway', 'http'];
 if (!VALID_ROLES.includes(PROCESS_ROLE)) {
@@ -329,6 +337,13 @@ async function start() {
         t.unref();
       }),
     ]);
+  } else if (isHttp) {
+    // Pure http-only mode: seed the REST token + warm the cache without
+    // a Gateway login. See src/http-only-init.js for the rationale.
+    // Failures are fatal — propagated through start().catch() into
+    // gracefulShutdown(1) so a Discord-unreachable replica crash-loops
+    // instead of silently serving 5xx.
+    await initHttpOnly({ client, config, refreshCache });
   }
 }
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -71,6 +71,12 @@ try {
   // no WebSocket. A future "fix" routing this through gracefulShutdown
   // would either fail (undefined reference) or block on shutdown
   // teardown that has nothing to do.
+  //
+  // The logger.error above is guaranteed-flushed because src/logger.js
+  // writes synchronously via console.error → process.stderr.write
+  // (no winston/pino async transport). If logger.js ever moves to an
+  // async transport, this boot-fail path needs an explicit flush or a
+  // direct console.error fallback so the message survives the exit.
   process.exit(1);
 }
 logger.info('Process role configured', { role: PROCESS_ROLE, isGateway, isHttp });
@@ -351,7 +357,18 @@ async function start() {
   // init-before-listen pattern to combined mode if the health-gate
   // assumption ever weakens.
   if (isHttp && !isGateway) {
-    httpRefreshTimer = await initHttpOnly({ client, config, refreshCache, logger });
+    const timer = await initHttpOnly({ client, config, refreshCache, logger });
+    // Tight race: SIGTERM during the await above runs gracefulShutdown,
+    // which clears `httpRefreshTimer` (still null) and proceeds. The
+    // setInterval inside initHttpOnly then registers AFTER the
+    // clearInterval already happened. Guard against that here so a stray
+    // refreshCache() doesn't fire mid-teardown. (.unref() means it can't
+    // block exit either way; this just keeps the log noise clean.)
+    if (isShuttingDown && timer) {
+      clearInterval(timer);
+    } else {
+      httpRefreshTimer = timer;
+    }
   }
 
   // HTTP listener — OAuth callback, webhooks, health, metrics.

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -44,11 +44,20 @@ const { initHttpOnly } = require('./http-only-init');
 // authenticate, and (2) an initial `refreshCache()` so the
 // route handlers find a populated guild/roles/channels cache on
 // the first OAuth callback or webhook. Both are seeded
-// explicitly in start() below — see the `else if (isHttp)`
-// branch. Migration to `discord-rest.js` (lighter, no Client
-// object needed at all) remains a follow-up; today's helpers
-// already work in either role once the token + cache are in
-// place.
+// explicitly in start() below — see the `if (isHttp && !isGateway)`
+// branch (runs BEFORE startServer so the ALB can't route a
+// request through a half-initialized replica).
+//
+// Known gap (acceptable for now): cache invalidation in http-only
+// mode. The `client.on('roleDelete' / 'channelDelete')` handlers
+// in src/discord.js only fire when the Gateway is connected, so
+// deletions made on the OpenNHP guild stay cached as stale
+// references until the replica restarts. The lazy refresh in
+// each helper checks `if (!channels.X)` — non-null but stale
+// doesn't trigger a refresh. OpenNHP guild admins rarely delete
+// tracked channels; if this becomes load-bearing, a periodic
+// REST-driven `refreshCache()` would close the gap without
+// needing a Gateway connection.
 const PROCESS_ROLE = (process.env.PROCESS_ROLE || 'combined').trim();
 const VALID_ROLES = ['combined', 'gateway', 'http'];
 if (!VALID_ROLES.includes(PROCESS_ROLE)) {
@@ -306,6 +315,22 @@ async function start() {
   logger.info(`Version: ${require('../package.json').version}`);
   logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
 
+  // Pure http-only mode: seed the REST token + warm the cache BEFORE
+  // opening the listener. Otherwise there's a race window where the
+  // ALB can route OAuth callbacks / webhooks to a replica whose
+  // `client.rest` has no token and whose channel/role cache is cold —
+  // the request would 401 inside sendDM / assignContributorRole.
+  // See src/http-only-init.js for the full rationale. Failures are
+  // fatal — propagated through start().catch() into gracefulShutdown(1)
+  // so a Discord-unreachable replica crash-loops instead of silently
+  // serving 5xx. Combined mode keeps the legacy ordering (login() runs
+  // last, after the listener) — that race exists pre-PR and isn't a
+  // regression here; the steady-state cold-start risk that justified
+  // the swap is specific to ALB-fronted http replicas.
+  if (isHttp && !isGateway) {
+    await initHttpOnly({ client, config, refreshCache });
+  }
+
   // HTTP listener — OAuth callback, webhooks, health, metrics.
   // Skipped in `gateway`-only mode; the ALB targets HTTP replicas
   // only. `combined` keeps the legacy single-process behavior.
@@ -314,10 +339,15 @@ async function start() {
   }
 
   // Background retry-revoke for any OAuth tokens whose initial
-  // revoke failed. Only on the gateway side — the sweeper calls
-  // into Discord via the gateway client (`user.send()` etc.) and
-  // would need to be refactored to `discord-rest.js` before
-  // running in `http`-only mode. Tracked as a follow-up.
+  // revoke failed. Pinned to `isGateway` not because of any Discord
+  // dependency (the sweeper only calls api.github.com — no Discord
+  // client / REST calls anywhere in src/orphan-token-sweeper.js) but
+  // to keep the sweeper a singleton: N HTTP replicas racing on the
+  // same orphaned-tokens table would each claim and re-revoke every
+  // row. Pinning to the single gateway process avoids that without
+  // a distributed work queue. If this ever needs to scale beyond one
+  // worker, replace with SQS / a Redis lock — not by spreading the
+  // sweeper across HTTP replicas.
   if (isGateway) {
     startOrphanTokenSweeper();
   }
@@ -337,13 +367,6 @@ async function start() {
         t.unref();
       }),
     ]);
-  } else if (isHttp) {
-    // Pure http-only mode: seed the REST token + warm the cache without
-    // a Gateway login. See src/http-only-init.js for the rationale.
-    // Failures are fatal — propagated through start().catch() into
-    // gracefulShutdown(1) so a Discord-unreachable replica crash-loops
-    // instead of silently serving 5xx.
-    await initHttpOnly({ client, config, refreshCache });
   }
 }
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -258,6 +258,7 @@ process.on('uncaughtException', error => {
 
 // Graceful shutdown
 let httpServer = null;
+let httpRefreshTimer = null;
 let isShuttingDown = false;
 
 async function gracefulShutdown(code = 0) {
@@ -283,6 +284,14 @@ async function gracefulShutdown(code = 0) {
       });
     }
     stopServerIntervals();
+    // Periodic REST refreshCache in http-only mode is .unref()ed so it
+    // wouldn't block exit on its own, but clearing explicitly keeps
+    // shutdown symmetric with the other intervals (server.js, oauth.js
+    // rateLimitStore sweep, webhooks.js badSig sweep) and avoids one
+    // last refresh firing mid-teardown.
+    if (httpRefreshTimer) {
+      clearInterval(httpRefreshTimer);
+    }
     // Discord client shutdown only meaningful when we're the gateway
     // role. HTTP-only replicas never called login(), so there's no
     // WebSocket to close — discordShutdown() on an un-logged-in
@@ -321,15 +330,22 @@ async function start() {
   // ALB can route OAuth callbacks / webhooks to a replica whose
   // `client.rest` has no token and whose channel/role cache is cold —
   // the request would 401 inside sendDM / assignContributorRole.
-  // See src/http-only-init.js for the full rationale. Failures are
-  // fatal — propagated through start().catch() into gracefulShutdown(1)
-  // so a Discord-unreachable replica crash-loops instead of silently
-  // serving 5xx. Combined mode keeps the legacy ordering (login() runs
-  // last, after the listener) — that race exists pre-PR and isn't a
-  // regression here; the steady-state cold-start risk that justified
-  // the swap is specific to ALB-fronted http replicas.
+  // See src/http-only-init.js for the full rationale (token + cache
+  // + periodic-REST-refresh that compensates for missing roleDelete /
+  // channelDelete events). Failures are fatal — propagated through
+  // start().catch() into gracefulShutdown(1) so a Discord-unreachable
+  // replica crash-loops instead of silently serving 5xx.
+  //
+  // Combined mode keeps the legacy listener-then-login ordering. The
+  // same cold-start race window exists every restart there
+  // (listener up, client.rest token unset), but ECS health-check
+  // gating typically dominates: traffic doesn't route to the task
+  // until /health passes, and /health doesn't depend on Discord.
+  // Not a regression here (matches pre-PR); follow-up to apply the
+  // init-before-listen pattern to combined mode if the health-gate
+  // assumption ever weakens.
   if (isHttp && !isGateway) {
-    await initHttpOnly({ client, config, refreshCache });
+    httpRefreshTimer = await initHttpOnly({ client, config, refreshCache, logger });
   }
 
   // HTTP listener — OAuth callback, webhooks, health, metrics.

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -7,6 +7,50 @@ const db = require('./store');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
 const { missingBootKeys, missingProdKeys } = require('./boot-requirements');
 
+// Process role — selects which subset of the bot runs in this
+// container. Three modes:
+//
+//   combined (default) — legacy single-process shape. Gateway
+//                        client logs in; Express HTTP server
+//                        listens; cron jobs run. Backward-compatible
+//                        for any env that hasn't opted into the
+//                        split (sandbox pre-migration, local dev).
+//
+//   gateway — Discord Gateway WebSocket + interaction handlers +
+//             cron jobs. No Express listener. Deployed as a
+//             singleton (desired_count=1) because a Discord bot
+//             token admits only one active Gateway connection —
+//             two concurrent logins cause a session-identity flap
+//             every few seconds as each replaces the other's
+//             WebSocket.
+//
+//   http — Express listener only (OAuth callback + GitHub
+//          webhooks + /health + /metrics). No Gateway login.
+//          Can scale horizontally behind an ALB. Outbound Discord
+//          API calls go through `discord-rest.js` (REST-only, no
+//          persistent connection).
+//
+// Invariant: `discord.js`'s Client object is still required at
+// module load (it exposes `sendDM` et al. that the current HTTP
+// routes import), but `client.login()` is gated on `isGateway`.
+// Creating a Client without login() does NOT open a WebSocket —
+// the WS only opens on login. HTTP-only replicas therefore never
+// collide with the gateway singleton. Routes that currently call
+// gateway-backed helpers (routes/oauth.js, routes/webhooks.js
+// imports from `./discord`) should progressively migrate to
+// `discord-rest.js` so the gateway client can eventually be
+// moved entirely behind a role check — tracked as a follow-up
+// once the split is in prod and patterns stabilize.
+const PROCESS_ROLE = (process.env.PROCESS_ROLE || 'combined').trim();
+const VALID_ROLES = ['combined', 'gateway', 'http'];
+if (!VALID_ROLES.includes(PROCESS_ROLE)) {
+  logger.error(`Invalid PROCESS_ROLE: '${PROCESS_ROLE}'. Valid values: ${VALID_ROLES.join(', ')}. Set PROCESS_ROLE to one of these, or leave unset to default to 'combined'.`);
+  process.exit(1);
+}
+const isGateway = PROCESS_ROLE === 'gateway' || PROCESS_ROLE === 'combined';
+const isHttp = PROCESS_ROLE === 'http' || PROCESS_ROLE === 'combined';
+logger.info('Process role configured', { role: PROCESS_ROLE, isGateway, isHttp });
+
 // Multi-tenant mode: when GUILD_ID is unset (or not a valid snowflake), the
 // bot treats itself as a public multi-server app. Commands register globally,
 // per-guild qURL API keys come from /qurl setup (stored encrypted in
@@ -158,18 +202,24 @@ if (process.env.NODE_ENV === 'production') {
   }
 }
 
-// Register commands when ready
-client.once('ready', async () => {
-  await registerCommands(client);
-});
+// Gateway-only event wiring. HTTP-only replicas skip these because
+// they never login() and so the client never fires these events —
+// but the `.on()` registrations would still leak handler references
+// and register no-op listeners, so gate them for clarity.
+if (isGateway) {
+  // Register commands when ready
+  client.once('ready', async () => {
+    await registerCommands(client);
+  });
 
-// Handle interactions
-client.on('interactionCreate', handleCommand);
+  // Handle interactions
+  client.on('interactionCreate', handleCommand);
 
-// Error handling
-client.on('error', error => {
-  logger.error('Discord client error', { error: error.message });
-});
+  // Error handling
+  client.on('error', error => {
+    logger.error('Discord client error', { error: error.message });
+  });
+}
 
 // Log and continue on unhandled rejections. The old behavior killed the
 // entire process on any stray rejection (transient Discord timeouts, network
@@ -215,7 +265,13 @@ async function gracefulShutdown(code = 0) {
       });
     }
     stopServerIntervals();
-    await discordShutdown();
+    // Discord client shutdown only meaningful when we're the gateway
+    // role. HTTP-only replicas never called login(), so there's no
+    // WebSocket to close — discordShutdown() on an un-logged-in
+    // client just releases the event emitter handles.
+    if (isGateway) {
+      await discordShutdown();
+    }
     await db.close();
     logger.info('Shutdown complete');
   } catch (error) {
@@ -242,23 +298,38 @@ async function start() {
   logger.info(`Version: ${require('../package.json').version}`);
   logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
 
-  // Start web server
-  httpServer = startServer();
+  // HTTP listener — OAuth callback, webhooks, health, metrics.
+  // Skipped in `gateway`-only mode; the ALB targets HTTP replicas
+  // only. `combined` keeps the legacy single-process behavior.
+  if (isHttp) {
+    httpServer = startServer();
+  }
 
-  // Background retry-revoke for any OAuth tokens whose initial revoke
-  // failed. Runs hourly on top of the 7-day purge in database.js.
-  startOrphanTokenSweeper();
+  // Background retry-revoke for any OAuth tokens whose initial
+  // revoke failed. Only on the gateway side — the sweeper calls
+  // into Discord via the gateway client (`user.send()` etc.) and
+  // would need to be refactored to `discord-rest.js` before
+  // running in `http`-only mode. Tracked as a follow-up.
+  if (isGateway) {
+    startOrphanTokenSweeper();
+  }
 
-  // Login to Discord with a 30s deadline. client.login() doesn't expose a
-  // native timeout; if the Discord API is unreachable the call can hang
-  // indefinitely and block boot without any log line pointing at the cause.
-  await Promise.race([
-    client.login(config.DISCORD_TOKEN),
-    new Promise((_, reject) => {
-      const t = setTimeout(() => reject(new Error('Discord login timed out after 30s')), 30_000);
-      t.unref();
-    }),
-  ]);
+  // Login to Discord with a 30s deadline. client.login() doesn't
+  // expose a native timeout; if the Discord API is unreachable
+  // the call can hang indefinitely and block boot without any
+  // log line pointing at the cause. Gated on `isGateway` — the
+  // HTTP-only replica must NOT open a second Gateway connection
+  // on the same bot token; Discord would flap session identity
+  // between the two WebSockets every few seconds.
+  if (isGateway) {
+    await Promise.race([
+      client.login(config.DISCORD_TOKEN),
+      new Promise((_, reject) => {
+        const t = setTimeout(() => reject(new Error('Discord login timed out after 30s')), 30_000);
+        t.unref();
+      }),
+    ]);
+  }
 }
 
 start().catch(error => {

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -65,6 +65,12 @@ try {
   ({ role: PROCESS_ROLE, isGateway, isHttp } = resolveProcessRole(process.env.PROCESS_ROLE));
 } catch (err) {
   logger.error(err.message);
+  // Direct process.exit (not gracefulShutdown) is intentional: this
+  // runs at module-top-level, before gracefulShutdown is even defined,
+  // and there's no state to tear down — no DB open, no HTTP listener,
+  // no WebSocket. A future "fix" routing this through gracefulShutdown
+  // would either fail (undefined reference) or block on shutdown
+  // teardown that has nothing to do.
   process.exit(1);
 }
 logger.info('Process role configured', { role: PROCESS_ROLE, isGateway, isHttp });

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -15,6 +15,8 @@ const {
   prodRequired,
   missingBootKeys,
   missingProdKeys,
+  VALID_PROCESS_ROLES,
+  resolveProcessRole,
 } = require('../src/boot-requirements');
 
 describe('bootRequired', () => {
@@ -103,5 +105,57 @@ describe('missingProdKeys', () => {
     expect(missingProdKeys(env, true).sort()).toEqual([
       'KEY_ENCRYPTION_KEY', 'QURL_API_KEY',
     ]);
+  });
+});
+
+describe('resolveProcessRole', () => {
+  it('VALID_PROCESS_ROLES is the canonical set in stable order (combined first as the default)', () => {
+    expect(VALID_PROCESS_ROLES).toEqual(['combined', 'gateway', 'http']);
+    expect(Object.isFrozen(VALID_PROCESS_ROLES)).toBe(true);
+  });
+
+  it.each([
+    ['combined', { role: 'combined', isGateway: true, isHttp: true }],
+    ['gateway', { role: 'gateway', isGateway: true, isHttp: false }],
+    ['http', { role: 'http', isGateway: false, isHttp: true }],
+  ])('resolves %s to expected role flags', (input, expected) => {
+    expect(resolveProcessRole(input)).toEqual(expected);
+  });
+
+  it.each([undefined, null, '', '   ', '\t'])(
+    'falls back to combined for unset / whitespace-only value (%p)',
+    (input) => {
+      expect(resolveProcessRole(input)).toEqual({
+        role: 'combined', isGateway: true, isHttp: true,
+      });
+    }
+  );
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(resolveProcessRole('  http  ')).toEqual({
+      role: 'http', isGateway: false, isHttp: true,
+    });
+  });
+
+  it('throws on unknown role with INVALID_PROCESS_ROLE code (so index.js can exit(1))', () => {
+    let caught;
+    try {
+      resolveProcessRole('gatewayy');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.code).toBe('INVALID_PROCESS_ROLE');
+    // Message names the bad value AND lists the valid ones — operators
+    // pasting the log line into a ticket should see both immediately.
+    expect(caught.message).toMatch(/'gatewayy'/);
+    expect(caught.message).toMatch(/combined, gateway, http/);
+  });
+
+  it('rejects case-variant roles (no silent normalization)', () => {
+    // SQLITE-vs-sqlite parity: an env-templating bug that produces
+    // 'GATEWAY' should fail loud, not silently coerce.
+    expect(() => resolveProcessRole('GATEWAY')).toThrow(/GATEWAY/);
+    expect(() => resolveProcessRole('Combined')).toThrow(/Combined/);
   });
 });

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -2,10 +2,18 @@
  * Unit tests for src/discord-rest.js — the REST-only Discord
  * helpers used by the HTTP-process role in the gateway/http split.
  *
- * Mocks `@discordjs/rest` at the module level so tests don't hit
- * the Discord API. Asserts both the happy path AND the expected
- * graceful-failure shape (`{ ok: false, status, error }`) so
- * callers can branch without catching exceptions.
+ * Mocks `../src/discord` to inject a fake `client.rest` so tests
+ * don't hit the Discord API. The shared-bucket invariant (one REST
+ * instance per process, reused across legacy gateway-cache helpers
+ * and these REST-only helpers) means the test must mock at the
+ * discord.js Client boundary rather than `@discordjs/rest`.
+ *
+ * Asserts both the happy path AND the expected graceful-failure
+ * shape (`{ ok: false, status, error }`) so callers can branch
+ * without catching exceptions. Also asserts the exact REST routes
+ * (POST /users/@me/channels, PUT /guilds/:guild/members/:user/roles/:role,
+ * etc.) so a future refactor that swaps Routes.userChannels for
+ * Routes.channelMessages would fail this suite at PR time.
  */
 
 jest.mock('../src/config', () => ({
@@ -21,32 +29,37 @@ jest.mock('../src/logger', () => ({
   debug: jest.fn(),
 }));
 
-// Mock the REST class before discord-rest imports it. jest.mock's
-// factory runs before any other module code, so the mock object
-// must be created inside the factory (naming it `mockRest` or
-// similar with the `mock` prefix lets jest hoist it). Expose the
-// instance via a module-level accessor so tests can interact with it.
-jest.mock('@discordjs/rest', () => {
+// Mock ../src/discord to expose a controllable client.rest. discord-rest
+// reads `client.rest` at module load and reuses it for every REST call,
+// so the mock object created here doubles as the spy surface for tests.
+jest.mock('../src/discord', () => {
   const mockRestInstance = {
-    setToken: jest.fn().mockReturnThis(),
     post: jest.fn(),
     put: jest.fn(),
     delete: jest.fn(),
   };
   return {
-    REST: jest.fn().mockImplementation(() => mockRestInstance),
+    client: { rest: mockRestInstance },
     __mockRestInstance: mockRestInstance,
   };
 });
 
-const restMock = require('@discordjs/rest').__mockRestInstance;
+const restMock = require('../src/discord').__mockRestInstance;
 
-const { sendDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
+const { rest: exportedRest, sendDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
 
 beforeEach(() => {
   restMock.post.mockReset();
   restMock.put.mockReset();
   restMock.delete.mockReset();
+});
+
+describe('module wiring', () => {
+  it('re-exports the shared client.rest instance (not a new one)', () => {
+    // Sharing the rate-limit bucket state is the whole reason this module
+    // imports client.rest instead of constructing its own REST().
+    expect(exportedRest).toBe(restMock);
+  });
 });
 
 describe('sendDM via REST', () => {
@@ -57,13 +70,15 @@ describe('sendDM via REST', () => {
     const result = await sendDM('user-1', { content: 'hi' });
     expect(result).toEqual({ ok: true, channelId: 'channel-1' });
     expect(restMock.post).toHaveBeenCalledTimes(2);
-    // First call: create DM channel with recipient_id
+    // First call: create DM channel — POST /users/@me/channels.
+    expect(restMock.post.mock.calls[0][0]).toBe('/users/@me/channels');
     expect(restMock.post.mock.calls[0][1]).toEqual({ body: { recipient_id: 'user-1' } });
-    // Second call: post message body to that channel
+    // Second call: post message body to that channel.
+    expect(restMock.post.mock.calls[1][0]).toBe('/channels/channel-1/messages');
     expect(restMock.post.mock.calls[1][1]).toEqual({ body: { content: 'hi' } });
   });
 
-  it('returns ok:false on 403 (DM disabled / blocked) — expected operational error', async () => {
+  it('returns ok:false on 403 (DM disabled / blocked / Missing Access) — expected operational error', async () => {
     const err = new Error('Cannot send messages to this user');
     err.status = 403;
     restMock.post.mockRejectedValueOnce(err);
@@ -85,13 +100,13 @@ describe('sendDM via REST', () => {
     // Re-mock config to return empty token, re-require module.
     jest.resetModules();
     jest.doMock('../src/config', () => ({ DISCORD_TOKEN: '', PENDING_LINK_EXPIRY_MINUTES: 10 }));
-    const freshMock = { setToken: jest.fn().mockReturnThis(), post: jest.fn() };
-    jest.doMock('@discordjs/rest', () => ({ REST: jest.fn().mockImplementation(() => freshMock) }));
+    const freshRest = { post: jest.fn(), put: jest.fn(), delete: jest.fn() };
+    jest.doMock('../src/discord', () => ({ client: { rest: freshRest } }));
     const fresh = require('../src/discord-rest');
     const result = await fresh.sendDM('user-1', { content: 'hi' });
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/DISCORD_TOKEN/);
-    expect(freshMock.post).not.toHaveBeenCalled();
+    expect(freshRest.post).not.toHaveBeenCalled();
   });
 });
 
@@ -101,6 +116,8 @@ describe('addRoleToMember via REST', () => {
     const result = await addRoleToMember('guild-1', 'user-1', 'role-1');
     expect(result).toEqual({ ok: true });
     expect(restMock.put).toHaveBeenCalledTimes(1);
+    // PUT /guilds/:guild/members/:user/roles/:role — verbatim route.
+    expect(restMock.put.mock.calls[0][0]).toBe('/guilds/guild-1/members/user-1/roles/role-1');
   });
 
   it('returns ok:false + status on error', async () => {
@@ -119,5 +136,7 @@ describe('removeRoleFromMember via REST', () => {
     const result = await removeRoleFromMember('guild-1', 'user-1', 'role-1');
     expect(result).toEqual({ ok: true });
     expect(restMock.delete).toHaveBeenCalledTimes(1);
+    // DELETE /guilds/:guild/members/:user/roles/:role — same path shape as PUT.
+    expect(restMock.delete.mock.calls[0][0]).toBe('/guilds/guild-1/members/user-1/roles/role-1');
   });
 });

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -16,12 +16,6 @@
  * Routes.channelMessages would fail this suite at PR time.
  */
 
-jest.mock('../src/config', () => ({
-  DISCORD_TOKEN: 'fake-test-token',
-  PENDING_LINK_EXPIRY_MINUTES: 10,
-  DATABASE_PATH: ':memory:',
-}));
-
 jest.mock('../src/logger', () => ({
   info: jest.fn(),
   warn: jest.fn(),
@@ -96,17 +90,20 @@ describe('sendDM via REST', () => {
     expect(result.status).toBe(503);
   });
 
-  it('short-circuits when DISCORD_TOKEN is not configured', async () => {
-    // Re-mock config to return empty token, re-require module.
-    jest.resetModules();
-    jest.doMock('../src/config', () => ({ DISCORD_TOKEN: '', PENDING_LINK_EXPIRY_MINUTES: 10 }));
-    const freshRest = { post: jest.fn(), put: jest.fn(), delete: jest.fn() };
-    jest.doMock('../src/discord', () => ({ client: { rest: freshRest } }));
-    const fresh = require('../src/discord-rest');
-    const result = await fresh.sendDM('user-1', { content: 'hi' });
+  it('returns ok:false on partial-failure (channel created, message-post failed)', async () => {
+    // Documented two-call flow: a successful channel create followed by a
+    // failed message-post must surface the post failure rather than
+    // silently masking it as success. Locks in the {ok:false, status,
+    // error} shape for the second-call branch so a refactor swapping the
+    // try-block boundary can't regress it.
+    restMock.post
+      .mockResolvedValueOnce({ id: 'channel-1' }) // create channel succeeds
+      .mockRejectedValueOnce(Object.assign(new Error('rate limited'), { status: 429 }));
+    const result = await sendDM('user-1', { content: 'hi' });
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/DISCORD_TOKEN/);
-    expect(freshRest.post).not.toHaveBeenCalled();
+    expect(result.status).toBe(429);
+    expect(result.error).toBe('rate limited');
+    expect(restMock.post).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for src/discord-rest.js — the REST-only Discord
+ * helpers used by the HTTP-process role in the gateway/http split.
+ *
+ * Mocks `@discordjs/rest` at the module level so tests don't hit
+ * the Discord API. Asserts both the happy path AND the expected
+ * graceful-failure shape (`{ ok: false, status, error }`) so
+ * callers can branch without catching exceptions.
+ */
+
+jest.mock('../src/config', () => ({
+  DISCORD_TOKEN: 'fake-test-token',
+  PENDING_LINK_EXPIRY_MINUTES: 10,
+  DATABASE_PATH: ':memory:',
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+// Mock the REST class before discord-rest imports it. jest.mock's
+// factory runs before any other module code, so the mock object
+// must be created inside the factory (naming it `mockRest` or
+// similar with the `mock` prefix lets jest hoist it). Expose the
+// instance via a module-level accessor so tests can interact with it.
+jest.mock('@discordjs/rest', () => {
+  const mockRestInstance = {
+    setToken: jest.fn().mockReturnThis(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  };
+  return {
+    REST: jest.fn().mockImplementation(() => mockRestInstance),
+    __mockRestInstance: mockRestInstance,
+  };
+});
+
+const restMock = require('@discordjs/rest').__mockRestInstance;
+
+const { sendDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
+
+beforeEach(() => {
+  restMock.post.mockReset();
+  restMock.put.mockReset();
+  restMock.delete.mockReset();
+});
+
+describe('sendDM via REST', () => {
+  it('creates DM channel then posts message, returns ok:true', async () => {
+    restMock.post
+      .mockResolvedValueOnce({ id: 'channel-1' }) // create channel
+      .mockResolvedValueOnce({}); // post message
+    const result = await sendDM('user-1', { content: 'hi' });
+    expect(result).toEqual({ ok: true, channelId: 'channel-1' });
+    expect(restMock.post).toHaveBeenCalledTimes(2);
+    // First call: create DM channel with recipient_id
+    expect(restMock.post.mock.calls[0][1]).toEqual({ body: { recipient_id: 'user-1' } });
+    // Second call: post message body to that channel
+    expect(restMock.post.mock.calls[1][1]).toEqual({ body: { content: 'hi' } });
+  });
+
+  it('returns ok:false on 403 (DM disabled / blocked) — expected operational error', async () => {
+    const err = new Error('Cannot send messages to this user');
+    err.status = 403;
+    restMock.post.mockRejectedValueOnce(err);
+    const result = await sendDM('user-1', { content: 'hi' });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  it('returns ok:false on other errors, logs at error level', async () => {
+    const err = new Error('Network broken');
+    err.status = 503;
+    restMock.post.mockRejectedValueOnce(err);
+    const result = await sendDM('user-1', { content: 'hi' });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+  });
+
+  it('short-circuits when DISCORD_TOKEN is not configured', async () => {
+    // Re-mock config to return empty token, re-require module.
+    jest.resetModules();
+    jest.doMock('../src/config', () => ({ DISCORD_TOKEN: '', PENDING_LINK_EXPIRY_MINUTES: 10 }));
+    const freshMock = { setToken: jest.fn().mockReturnThis(), post: jest.fn() };
+    jest.doMock('@discordjs/rest', () => ({ REST: jest.fn().mockImplementation(() => freshMock) }));
+    const fresh = require('../src/discord-rest');
+    const result = await fresh.sendDM('user-1', { content: 'hi' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/DISCORD_TOKEN/);
+    expect(freshMock.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('addRoleToMember via REST', () => {
+  it('PUTs to guildMemberRole endpoint, returns ok:true', async () => {
+    restMock.put.mockResolvedValueOnce({});
+    const result = await addRoleToMember('guild-1', 'user-1', 'role-1');
+    expect(result).toEqual({ ok: true });
+    expect(restMock.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns ok:false + status on error', async () => {
+    const err = new Error('Forbidden');
+    err.status = 403;
+    restMock.put.mockRejectedValueOnce(err);
+    const result = await addRoleToMember('guild-1', 'user-1', 'role-1');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+  });
+});
+
+describe('removeRoleFromMember via REST', () => {
+  it('DELETEs guildMemberRole endpoint, returns ok:true', async () => {
+    restMock.delete.mockResolvedValueOnce({});
+    const result = await removeRoleFromMember('guild-1', 'user-1', 'role-1');
+    expect(result).toEqual({ ok: true });
+    expect(restMock.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/discord/tests/http-only-init.test.js
+++ b/apps/discord/tests/http-only-init.test.js
@@ -174,3 +174,54 @@ describe('initHttpOnly', () => {
     expect(REFRESH_INTERVAL_MS).toBeLessThanOrEqual(30 * 60 * 1000);
   });
 });
+
+describe('HTTP_ONLY_REFRESH_INTERVAL_MS env override', () => {
+  // Re-loads the module under different env values to verify the
+  // module-load-time validation. Each case isolates its env mutation
+  // and module cache so the canonical export above stays intact.
+  const originalEnv = process.env.HTTP_ONLY_REFRESH_INTERVAL_MS;
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.HTTP_ONLY_REFRESH_INTERVAL_MS;
+    else process.env.HTTP_ONLY_REFRESH_INTERVAL_MS = originalEnv;
+    warnSpy.mockRestore();
+    jest.resetModules();
+  });
+
+  it('accepts a valid override and uses it instead of the default', () => {
+    process.env.HTTP_ONLY_REFRESH_INTERVAL_MS = '60000';
+    jest.isolateModules(() => {
+      const { REFRESH_INTERVAL_MS: overridden } = require('../src/http-only-init');
+      expect(overridden).toBe(60_000);
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects sub-30s values with a console.warn naming the bad input', () => {
+    process.env.HTTP_ONLY_REFRESH_INTERVAL_MS = '15000';
+    jest.isolateModules(() => {
+      const { REFRESH_INTERVAL_MS: overridden } = require('../src/http-only-init');
+      // Falls back to default — silent fall-through would leave operators
+      // wondering why their `=15000` ask isn't taking effect.
+      expect(overridden).toBe(10 * 60 * 1000);
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/HTTP_ONLY_REFRESH_INTERVAL_MS=/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/15000/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/rejected/);
+  });
+
+  it('rejects non-numeric values with a console.warn', () => {
+    process.env.HTTP_ONLY_REFRESH_INTERVAL_MS = 'soon';
+    jest.isolateModules(() => {
+      const { REFRESH_INTERVAL_MS: overridden } = require('../src/http-only-init');
+      expect(overridden).toBe(10 * 60 * 1000);
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/"soon"/);
+  });
+});

--- a/apps/discord/tests/http-only-init.test.js
+++ b/apps/discord/tests/http-only-init.test.js
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for src/http-only-init.js — the boot wiring that
+ * lets `PROCESS_ROLE=http` replicas serve OAuth + webhook traffic
+ * without a Gateway login.
+ *
+ * The fix this guards against: pre-fix, http-only mode skipped
+ * client.login() (correctly — only one Gateway connection per
+ * bot token) but never seeded client.rest with the token, so the
+ * very first sendDM / channel.send / member.roles.add returned
+ * 401. We assert here that initHttpOnly() does both side effects
+ * login() would normally do (token + cache refresh).
+ */
+
+const { initHttpOnly } = require('../src/http-only-init');
+
+function makeClient() {
+  return {
+    rest: {
+      setToken: jest.fn(),
+    },
+  };
+}
+
+describe('initHttpOnly', () => {
+  it('sets the bot token on client.rest and warms the cache (single-guild)', async () => {
+    const client = makeClient();
+    const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+    await initHttpOnly({ client, config, refreshCache });
+
+    expect(client.rest.setToken).toHaveBeenCalledTimes(1);
+    expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
+    expect(refreshCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds the token first, then refreshes (refreshCache uses REST so token must already be set)', async () => {
+    const client = makeClient();
+    const callOrder = [];
+    client.rest.setToken.mockImplementation(() => callOrder.push('setToken'));
+    const refreshCache = jest.fn().mockImplementation(async () => {
+      callOrder.push('refreshCache');
+    });
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+    await initHttpOnly({ client, config, refreshCache });
+
+    expect(callOrder).toEqual(['setToken', 'refreshCache']);
+  });
+
+  it('skips refreshCache when GUILD_ID is unset (multi-tenant mode)', async () => {
+    const client = makeClient();
+    const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: null };
+
+    await initHttpOnly({ client, config, refreshCache });
+
+    expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
+    expect(refreshCache).not.toHaveBeenCalled();
+  });
+
+  it('skips refreshCache when GUILD_ID is empty string', async () => {
+    const client = makeClient();
+    const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '' };
+
+    await initHttpOnly({ client, config, refreshCache });
+
+    expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
+    expect(refreshCache).not.toHaveBeenCalled();
+  });
+
+  it('propagates refreshCache rejection so start() fails loud', async () => {
+    // An http-only replica that can't reach Discord must not silently
+    // start serving — gracefulShutdown(1) is the expected outcome so
+    // ECS reschedules the task instead of serving 5xx.
+    const client = makeClient();
+    const err = new Error('Discord unreachable');
+    const refreshCache = jest.fn().mockRejectedValue(err);
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+    await expect(initHttpOnly({ client, config, refreshCache })).rejects.toThrow('Discord unreachable');
+    // Token is still seeded before the refresh attempt so a manual retry
+    // (e.g. via the lazy refresh in route handlers) doesn't re-401.
+    expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
+  });
+});

--- a/apps/discord/tests/http-only-init.test.js
+++ b/apps/discord/tests/http-only-init.test.js
@@ -8,10 +8,12 @@
  * bot token) but never seeded client.rest with the token, so the
  * very first sendDM / channel.send / member.roles.add returned
  * 401. We assert here that initHttpOnly() does both side effects
- * login() would normally do (token + cache refresh).
+ * login() would normally do (token + cache refresh) AND sets up
+ * the periodic refresh that compensates for the missing
+ * roleDelete/channelDelete events.
  */
 
-const { initHttpOnly } = require('../src/http-only-init');
+const { initHttpOnly, REFRESH_INTERVAL_MS } = require('../src/http-only-init');
 
 function makeClient() {
   return {
@@ -21,17 +23,24 @@ function makeClient() {
   };
 }
 
+function makeLogger() {
+  return { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+}
+
 describe('initHttpOnly', () => {
   it('sets the bot token on client.rest and warms the cache (single-guild)', async () => {
     const client = makeClient();
     const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
     const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
 
-    await initHttpOnly({ client, config, refreshCache });
+    const timer = await initHttpOnly({ client, config, refreshCache, logger });
 
     expect(client.rest.setToken).toHaveBeenCalledTimes(1);
     expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
     expect(refreshCache).toHaveBeenCalledTimes(1);
+    expect(timer).not.toBeNull();
+    clearInterval(timer);
   });
 
   it('seeds the token first, then refreshes (refreshCache uses REST so token must already be set)', async () => {
@@ -41,33 +50,43 @@ describe('initHttpOnly', () => {
     const refreshCache = jest.fn().mockImplementation(async () => {
       callOrder.push('refreshCache');
     });
+    const logger = makeLogger();
     const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
 
-    await initHttpOnly({ client, config, refreshCache });
+    const timer = await initHttpOnly({ client, config, refreshCache, logger });
 
     expect(callOrder).toEqual(['setToken', 'refreshCache']);
+    clearInterval(timer);
   });
 
-  it('skips refreshCache when GUILD_ID is unset (multi-tenant mode)', async () => {
+  it('skips refreshCache + timer when GUILD_ID is unset (multi-tenant mode)', async () => {
     const client = makeClient();
     const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
     const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: null };
 
-    await initHttpOnly({ client, config, refreshCache });
+    const timer = await initHttpOnly({ client, config, refreshCache, logger });
 
     expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
     expect(refreshCache).not.toHaveBeenCalled();
+    expect(timer).toBeNull();
+    // No WARN — multi-tenant http-only doesn't have a single-guild
+    // cache that could go stale, so the periodic-refresh disclaimer
+    // would be misleading.
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('skips refreshCache when GUILD_ID is empty string', async () => {
+  it('skips refreshCache + timer when GUILD_ID is empty string', async () => {
     const client = makeClient();
     const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
     const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '' };
 
-    await initHttpOnly({ client, config, refreshCache });
+    const timer = await initHttpOnly({ client, config, refreshCache, logger });
 
     expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
     expect(refreshCache).not.toHaveBeenCalled();
+    expect(timer).toBeNull();
   });
 
   it('propagates refreshCache rejection so start() fails loud', async () => {
@@ -77,11 +96,81 @@ describe('initHttpOnly', () => {
     const client = makeClient();
     const err = new Error('Discord unreachable');
     const refreshCache = jest.fn().mockRejectedValue(err);
+    const logger = makeLogger();
     const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
 
-    await expect(initHttpOnly({ client, config, refreshCache })).rejects.toThrow('Discord unreachable');
+    await expect(initHttpOnly({ client, config, refreshCache, logger })).rejects.toThrow('Discord unreachable');
     // Token is still seeded before the refresh attempt so a manual retry
     // (e.g. via the lazy refresh in route handlers) doesn't re-401.
     expect(client.rest.setToken).toHaveBeenCalledWith('tok-abc');
+  });
+
+  it('logs a WARN naming the cache-invalidation limitation in single-guild http-only mode', async () => {
+    const client = makeClient();
+    const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+    const timer = await initHttpOnly({ client, config, refreshCache, logger });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toMatch(/http-only mode/);
+    expect(logger.warn.mock.calls[0][0]).toMatch(/cache invalidation/i);
+    expect(logger.warn.mock.calls[0][0]).toMatch(/HTTP_ONLY_REFRESH_INTERVAL_MS/);
+    clearInterval(timer);
+  });
+
+  describe('periodic refresh', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('schedules a setInterval at REFRESH_INTERVAL_MS that calls refreshCache', async () => {
+      const client = makeClient();
+      const refreshCache = jest.fn().mockResolvedValue(undefined);
+      const logger = makeLogger();
+      const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+      const timer = await initHttpOnly({ client, config, refreshCache, logger });
+
+      expect(refreshCache).toHaveBeenCalledTimes(1); // initial
+      jest.advanceTimersByTime(REFRESH_INTERVAL_MS);
+      expect(refreshCache).toHaveBeenCalledTimes(2); // periodic
+      jest.advanceTimersByTime(REFRESH_INTERVAL_MS);
+      expect(refreshCache).toHaveBeenCalledTimes(3);
+      clearInterval(timer);
+    });
+
+    it('catches periodic-refresh rejections and logs at error (does not crash the process)', async () => {
+      // A transient Discord outage during a periodic refresh must not
+      // surface as an unhandledRejection that takes down the http
+      // replica. The next interval retries automatically.
+      const client = makeClient();
+      const refreshCache = jest.fn()
+        .mockResolvedValueOnce(undefined) // initial succeeds
+        .mockRejectedValueOnce(Object.assign(new Error('transient 503'), { status: 503 }));
+      const logger = makeLogger();
+      const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+      const timer = await initHttpOnly({ client, config, refreshCache, logger });
+
+      jest.advanceTimersByTime(REFRESH_INTERVAL_MS);
+      // setInterval callbacks queue microtasks; flush them.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error.mock.calls[0][0]).toMatch(/Periodic refreshCache failed/);
+      expect(logger.error.mock.calls[0][1]).toEqual({ errorMessage: 'transient 503' });
+      clearInterval(timer);
+    });
+  });
+
+  it('REFRESH_INTERVAL_MS exposes a sane default (≥30s, ≤30min)', () => {
+    expect(REFRESH_INTERVAL_MS).toBeGreaterThanOrEqual(30_000);
+    expect(REFRESH_INTERVAL_MS).toBeLessThanOrEqual(30 * 60 * 1000);
   });
 });


### PR DESCRIPTION
## Summary

**PR 4c of 4** — stacked on PR #116. Minimum viable gateway/HTTP split that lets the bot run as either a Gateway-singleton or an HTTP-only replica (or combined for backward compat).

**Rationale**: Discord bot tokens admit only one active Gateway connection per token. To horizontally scale the HTTP side (OAuth callbacks, GitHub webhooks, `/health`, `/metrics`) behind an ALB, the Gateway connection must stay pinned to a single replica. This PR lets a single codebase serve both roles via the `PROCESS_ROLE` env var.

Base branch: `feat/discord-store-async-ddb` (PR #116). Will rebase to main once 4b merges.

## What's in this PR

- **`PROCESS_ROLE` env var** (default `combined` — legacy behavior preserved). Three modes: `combined`, `gateway`, `http`.
- **`src/index.js`** — gates `client.login()`, interaction handlers, and `startOrphanTokenSweeper()` on `isGateway`; gates `startServer()` on `isHttp`. Unknown PROCESS_ROLE fails loud at boot.
- **`src/discord-rest.js`** — wraps `@discordjs/rest` with `sendDM`, `addRoleToMember`, `removeRoleFromMember`. REST-only, no WebSocket, callable from either role.

## What's NOT in this PR

- **Full migration of `routes/oauth.js` + `routes/webhooks.js`** to `discord-rest.js`. See commit message for the path forward.
- **Internal state-query endpoint**. Today no cross-process state query is needed — the only voice-gated command is `/qurl send voice` which runs on the gateway side and reads `interaction.member.voice` from the interaction payload directly.
- **Infra side** (task def split + ALB target group) — in the greenfield bot module PR.

## Test plan

- [x] `npm test`: 624 tests, 29 suites, all passing (+7 from new `tests/discord-rest.test.js`)
- [x] `npm run lint` clean
- [x] `PROCESS_ROLE` invalid value fails boot with listed options (via startup throw)
- [ ] After merge: infra PR wires a `combined` task def by default, follow-up flag-day switches prod to split `gateway`/`http` services

🤖 Generated with [Claude Code](https://claude.com/claude-code)