### PR TITLE
docs: rebrand QURL → qURL across user-facing surfaces

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: "https://layerv.ai"
-    description: "QURL CLI - manage secure links from the command line"
+    description: "qURL CLI - manage secure links from the command line"
     license: "MIT"
     install: |
       bin.install "qurl"
@@ -77,7 +77,7 @@ nfpms:
     vendor: LayerV
     homepage: "https://layerv.ai"
     maintainer: "LayerV <support@layerv.ai>"
-    description: "QURL CLI - manage secure links from the command line"
+    description: "qURL CLI - manage secure links from the command line"
     license: "MIT"
     formats:
       - deb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 
 ## Project Overview
 
-Go monorepo for QURL integrations (Slack, Teams, Discord, CLI, Zapier, etc.).
+Go monorepo for qURL integrations (Slack, Teams, Discord, CLI, Zapier, etc.).
 Each integration lives in `apps/{name}/` with independent release tracks.
 Shared code lives in `shared/`.
 
@@ -113,5 +113,5 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
 
 - **Auth:** Start with workspace API keys (qurl-api-keys table exists). Per-user OAuth later.
 - **Runtime (Slack):** AWS Lambda behind API Gateway. Event-driven, scales to zero.
-- **Shared client:** `shared/client/` wraps the QURL API. Not a standalone module yet.
+- **Shared client:** `shared/client/` wraps the qURL API. Not a standalone module yet.
 - **Release:** Release Please monorepo mode with per-app version tracks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ Examples:
 - **App-private code:** `apps/{name}/internal/`
 - **Shared code:** `shared/{package}/` — changes here affect ALL apps
 
+### Brand spelling
+
+The product brand is **`qURL`** (case-sensitive: lowercase `q`, uppercase `URL`). Use `qURL` in user-visible prose, log/error messages, doc comments, README content, and anything a human reads.
+
+The following stay literal — don't "finish" the rebrand:
+- Go identifiers: types/structs/funcs (`QURL`, `QURLClient`, `Qurl`, `CreateQurlRequest`, `QURLLink`)
+- Env vars (`QURL_API_KEY`, `QURL_ENDPOINT`, `QURL_BASE_URL`, `QURL_TIMEOUT`)
+- DDB table/column names and JSON keys (`qurl_sends`, `qurl_send_configs`, `qurl_link`, `qurl_id`)
+- Wire-protocol HTTP headers (`QURL-Signature`, `X-QURL-*`) and User-Agent strings (`qurl-cli/...`, `qurl-go-client/...`, `qurl-discord-bot/1.0`)
+- Slash command names (`/qurl send`, `/qurl help`) and the CLI binary `qurl`
+- OAuth scope identifiers (`qurl:read`, `qurl:write`, `qurl:resolve`)
+- Domain literals (`qurl.link`, `qurl.site`, `q.layerv.xyz`)
+- Man-page section titles (`QURL(1)` — system-reference convention)
+
+When upstream qurl-service rebrands its API error strings, the test fixtures in this repo that mirror them (`"QURL not found"`, `"QURL API error (...)"`, `"token limit per QURL reached"` etc.) need to update in lockstep — `git grep TODO(upstream-rebrand)` finds the doc-comment markers.
+
 ## Linting
 
 This repo uses `golangci-lint` v2.10.1 with 28+ linters enabled (see `.golangci.yml`). Key rules:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Open-source integrations for [qURL](https://layerv.ai) — quantum-style URLs that make protected resources invisible by default.
+Open-source integrations for [qURL™](https://layerv.ai) — Quantum URLs that make protected resources invisible by default.
+
+> **Quantum URL (qURL)** · The internet has a hidden layer. This is how you enter.
 
 qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock opens temporary firewall access for the caller's IP — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Open-source integrations for [QURL](https://layerv.ai) — quantum-style URLs that make protected resources invisible by default.
+Open-source integrations for [qURL](https://layerv.ai) — quantum-style URLs that make protected resources invisible by default.
 
-QURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A QURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock opens temporary firewall access for the caller's IP — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
+qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock opens temporary firewall access for the caller's IP — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
 
-This monorepo contains Go-based platform integrations (Slack, Teams, Discord), a CLI tool, and shared libraries for creating and managing QURLs.
+This monorepo contains Go-based platform integrations (Slack, Teams, Discord), a CLI tool, and shared libraries for creating and managing qURLs.
 
 ## Structure
 
 ```
 apps/           Per-integration applications (independent release tracks)
   slack/        Slack bot — slash commands, link unfurling, notifications
-  cli/          CLI tool for QURL
+  cli/          CLI tool for qURL
   teams/        Microsoft Teams (planned)
   discord/      Discord bot (planned)
   zapier/       Zapier integration (planned)
 shared/         Shared libraries used by all integrations
-  client/       QURL API client
+  client/       qURL API client
   auth/         API key helpers
   events/       Webhook event parsing
   formatting/   Chat message templates
@@ -36,7 +36,7 @@ Language-specific SDKs have been extracted into standalone repositories:
 
 ## Configuration
 
-All integrations connect to the QURL API. The endpoint is configurable via the `QURL_ENDPOINT` environment variable (defaults to `https://api.layerv.xyz`). Authentication is handled via API keys set in the `QURL_API_KEY` environment variable.
+All integrations connect to the qURL API. The endpoint is configurable via the `QURL_ENDPOINT` environment variable (defaults to `https://api.layerv.xyz`). Authentication is handled via API keys set in the `QURL_API_KEY` environment variable.
 
 ## Development
 

--- a/apps/cli/cmd/commands_test.go
+++ b/apps/cli/cmd/commands_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// apiEnvelope wraps data in the QURL API response envelope.
+// apiEnvelope wraps data in the qURL API response envelope.
 func apiEnvelope(t *testing.T, w http.ResponseWriter, data any) {
 	t.Helper()
 	if err := json.NewEncoder(w).Encode(map[string]any{
@@ -20,7 +20,7 @@ func apiEnvelope(t *testing.T, w http.ResponseWriter, data any) {
 	}
 }
 
-// newMockServer creates a test server that handles QURL API routes.
+// newMockServer creates a test server that handles qURL API routes.
 func newMockServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -552,7 +552,7 @@ func TestCreateCommandQuiet(t *testing.T) {
 	if !strings.Contains(out, "qurl.link") {
 		t.Errorf("expected link in quiet output: %s", out)
 	}
-	if strings.Contains(out, "QURL created") {
+	if strings.Contains(out, "qURL created") {
 		t.Error("quiet mode should not include table header")
 	}
 }

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -18,7 +18,7 @@ func createCmd(opts *globalOpts) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create <target-url>",
-		Short: "Create a QURL for a target URL",
+		Short: "Create a qURL for a target URL",
 		Example: `  qurl create https://api.example.com/data
   qurl create https://internal.example.com --expires 1h --one-time
   qurl create https://dashboard.example.com -d "Admin access" -e 7d`,
@@ -46,7 +46,7 @@ func createCmd(opts *globalOpts) *cobra.Command {
 
 			result, err := c.Create(cmd.Context(), input)
 			if err != nil {
-				return fmt.Errorf("create QURL: %w", err)
+				return fmt.Errorf("create qURL: %w", err)
 			}
 
 			if opts.quiet {

--- a/apps/cli/cmd/delete.go
+++ b/apps/cli/cmd/delete.go
@@ -16,7 +16,7 @@ func deleteCmd(opts *globalOpts) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "delete <resource-id>",
-		Short:             "Revoke/delete a QURL",
+		Short:             "Revoke/delete a qURL",
 		Example:           "  qurl delete r_k8xqp9h2sj9 --yes",
 		Args:              cobra.ExactArgs(1),
 		Aliases:           []string{"revoke"},
@@ -29,12 +29,12 @@ func deleteCmd(opts *globalOpts) *cobra.Command {
 			}
 
 			if dryRun {
-				_, err := fmt.Fprintf(cmd.OutOrStdout(), "Would revoke QURL %s (dry run, no changes made)\n", id)
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "Would revoke qURL %s (dry run, no changes made)\n", id)
 				return err
 			}
 
 			if !yes {
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Revoke QURL %s? This cannot be undone. [y/N] ", id); err != nil {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Revoke qURL %s? This cannot be undone. [y/N] ", id); err != nil {
 					return err
 				}
 				scanner := bufio.NewScanner(cmd.InOrStdin())
@@ -54,10 +54,10 @@ func deleteCmd(opts *globalOpts) *cobra.Command {
 			}
 
 			if err := c.Delete(cmd.Context(), id); err != nil {
-				return fmt.Errorf("delete QURL: %w", err)
+				return fmt.Errorf("delete qURL: %w", err)
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "QURL %s has been revoked.\n", id)
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "qURL %s has been revoked.\n", id)
 			return err
 		},
 	}

--- a/apps/cli/cmd/docs.go
+++ b/apps/cli/cmd/docs.go
@@ -38,7 +38,7 @@ func docsCmd() *cobra.Command {
 			switch mode {
 			case "man":
 				header := &doc.GenManHeader{
-					Title:   "QURL",
+					Title:   "qURL",
 					Section: "1",
 					Source:  "LayerV",
 				}

--- a/apps/cli/cmd/docs.go
+++ b/apps/cli/cmd/docs.go
@@ -37,8 +37,12 @@ func docsCmd() *cobra.Command {
 
 			switch mode {
 			case "man":
+				// Man-page section headers are conventionally uppercase
+				// (CURL(1), GIT(1), etc.). Keep "QURL" here even though the
+				// brand is "qURL" — system references follow the convention,
+				// not the brand-prose rule.
 				header := &doc.GenManHeader{
-					Title:   "qURL",
+					Title:   "QURL",
 					Section: "1",
 					Source:  "LayerV",
 				}

--- a/apps/cli/cmd/extend.go
+++ b/apps/cli/cmd/extend.go
@@ -13,7 +13,7 @@ func extendCmd(opts *globalOpts) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "extend <resource-id>",
-		Short:             "Extend QURL expiration",
+		Short:             "Extend qURL expiration",
 		Example:           "  qurl extend r_k8xqp9h2sj9 --by 24h",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: resourceIDCompletion(opts),
@@ -34,7 +34,7 @@ func extendCmd(opts *globalOpts) *cobra.Command {
 				ExtendBy: extendBy,
 			})
 			if err != nil {
-				return fmt.Errorf("extend QURL: %w", err)
+				return fmt.Errorf("extend qURL: %w", err)
 			}
 
 			return opts.formatter().FormatQURL(cmd.OutOrStdout(), qurl)

--- a/apps/cli/cmd/get.go
+++ b/apps/cli/cmd/get.go
@@ -9,7 +9,7 @@ import (
 func getCmd(opts *globalOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "get <resource-id>",
-		Short:             "Get QURL details",
+		Short:             "Get qURL details",
 		Example:           "  qurl get r_k8xqp9h2sj9",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: resourceIDCompletion(opts),
@@ -25,7 +25,7 @@ func getCmd(opts *globalOpts) *cobra.Command {
 
 			qurl, err := c.Get(cmd.Context(), args[0])
 			if err != nil {
-				return fmt.Errorf("get QURL: %w", err)
+				return fmt.Errorf("get qURL: %w", err)
 			}
 
 			return opts.formatter().FormatQURL(cmd.OutOrStdout(), qurl)

--- a/apps/cli/cmd/list.go
+++ b/apps/cli/cmd/list.go
@@ -19,7 +19,7 @@ func listCmd(opts *globalOpts) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List QURLs",
+		Short: "List qURLs",
 		Example: `  qurl list
   qurl list --status active --limit 50
   qurl list --sort created_at:desc
@@ -46,14 +46,14 @@ func listCmd(opts *globalOpts) *cobra.Command {
 				Sort:   sort,
 			})
 			if err != nil {
-				return fmt.Errorf("list QURLs: %w", err)
+				return fmt.Errorf("list qURLs: %w", err)
 			}
 
 			return opts.formatter().FormatList(cmd.OutOrStdout(), result)
 		},
 	}
 
-	cmd.Flags().IntVarP(&limit, "limit", "l", 20, "Maximum number of QURLs to return")
+	cmd.Flags().IntVarP(&limit, "limit", "l", 20, "Maximum number of qURLs to return")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor from a previous list response")
 	cmd.Flags().StringVar(&status, "status", "", "Filter by status (active, expired, revoked, consumed)")
 	cmd.Flags().StringVar(&query, "query", "", "Search description and target URL")

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -9,9 +9,9 @@ import (
 func mintCmd(opts *globalOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "mint <resource-id>",
-		Short: "Mint a new access link for a QURL",
-		Long: `Creates a new access token and link for an existing QURL resource.
-Useful for multi-use QURLs where you want to generate additional access links.`,
+		Short: "Mint a new access link for a qURL",
+		Long: `Creates a new access token and link for an existing qURL resource.
+Useful for multi-use qURLs where you want to generate additional access links.`,
 		Example: `  qurl mint r_k8xqp9h2sj9
   LINK=$(qurl mint r_k8xqp9h2sj9 -q)`,
 		Args:              cobra.ExactArgs(1),

--- a/apps/cli/cmd/resolve.go
+++ b/apps/cli/cmd/resolve.go
@@ -16,8 +16,8 @@ import (
 func resolveCmd(opts *globalOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "resolve [access-token]",
-		Short: "Resolve a QURL access token (headless)",
-		Long: `Resolve a QURL access token to get the target URL and open firewall access.
+		Short: "Resolve a qURL access token (headless)",
+		Long: `Resolve a qURL access token to get the target URL and open firewall access.
 After resolution, the target URL is accessible from your IP for the duration
 specified in the access grant.
 
@@ -48,7 +48,7 @@ The access token can be provided as an argument, via stdin, or interactively:
 				AccessToken: token,
 			})
 			if err != nil {
-				return fmt.Errorf("resolve QURL: %w", err)
+				return fmt.Errorf("resolve qURL: %w", err)
 			}
 
 			return opts.formatter().FormatResolve(cmd.OutOrStdout(), result)

--- a/apps/cli/cmd/root.go
+++ b/apps/cli/cmd/root.go
@@ -38,8 +38,8 @@ func rootCmd(version string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "qurl",
-		Short: "QURL CLI - manage secure links from the command line",
-		Long: `QURL CLI creates, resolves, and manages QURL secure links.
+		Short: "qURL CLI - manage secure links from the command line",
+		Long: `qURL CLI creates, resolves, and manages qURL secure links.
 
 Authentication (in order of precedence):
   1. --api-key flag (visible in process list — prefer env var)
@@ -47,8 +47,8 @@ Authentication (in order of precedence):
   3. ~/.config/qurl/config.yaml (or --profile <name>)
 
 Get started:
-  qurl create https://example.com        Create a QURL
-  qurl list                              List active QURLs
+  qurl create https://example.com        Create a qURL
+  qurl list                              List active qURLs
   qurl resolve <access-token>            Resolve a token (headless)
   qurl quota                             Check your usage
   qurl completion bash                   Generate shell completions`,
@@ -157,7 +157,7 @@ func resolveValue(envKey string, flag *string, configKey string, cfg *config.Con
 }
 
 // errorPrefix extracts the wrapping context before the APIError message
-// (e.g., "create QURL: " from "create QURL: Not Found (404)").
+// (e.g., "create qURL: " from "create qURL: Not Found (404)").
 func errorPrefix(err error, apiErr *client.APIError) string {
 	wrapper := err.Error()
 	if wrapper == apiErr.Error() {

--- a/apps/cli/cmd/root_test.go
+++ b/apps/cli/cmd/root_test.go
@@ -162,9 +162,9 @@ func TestFormatError_WrappedAPIError(t *testing.T) {
 		StatusCode: 404,
 		Title:      "Not Found",
 	}
-	wrapped := fmt.Errorf("create QURL: %w", apiErr)
+	wrapped := fmt.Errorf("create qURL: %w", apiErr)
 	got := formatError(wrapped)
-	if !strings.Contains(got, "create QURL") {
+	if !strings.Contains(got, "create qURL") {
 		t.Errorf("expected wrapping context in output: %s", got)
 	}
 	if !strings.Contains(got, "Not Found") {

--- a/apps/cli/cmd/update.go
+++ b/apps/cli/cmd/update.go
@@ -14,7 +14,7 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update <resource-id>",
-		Short: "Update a QURL's properties",
+		Short: "Update a qURL's properties",
 		Example: `  qurl update r_k8xqp9h2sj9 --description "Production API access"
   qurl update r_k8xqp9h2sj9 -d ""  # clear description`,
 		Args:              cobra.ExactArgs(1),
@@ -40,7 +40,7 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 
 			qurl, err := c.Update(cmd.Context(), args[0], input)
 			if err != nil {
-				return fmt.Errorf("update QURL: %w", err)
+				return fmt.Errorf("update qURL: %w", err)
 			}
 
 			return opts.formatter().FormatQURL(cmd.OutOrStdout(), qurl)

--- a/apps/cli/internal/output/formatter.go
+++ b/apps/cli/internal/output/formatter.go
@@ -52,7 +52,7 @@ func NewTableFormatter() TableFormatter {
 	}
 }
 
-// FormatQURL formats a single QURL as a key-value table.
+// FormatQURL formats a single qURL as a key-value table.
 func (f TableFormatter) FormatQURL(w io.Writer, qurl *client.QURL) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	wr := &errWriter{w: tw}
@@ -82,7 +82,7 @@ func (f TableFormatter) FormatQURL(w io.Writer, qurl *client.QURL) error {
 func (f TableFormatter) FormatCreate(w io.Writer, output *client.CreateOutput) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	wr := &errWriter{w: tw}
-	wr.printf("%s\n\n", f.green.Sprint("QURL created"))
+	wr.printf("%s\n\n", f.green.Sprint("qURL created"))
 	wr.printf("%s\t%s\n", f.bold.Sprint("ID:"), output.ResourceID)
 	wr.printf("%s\t%s\n", f.bold.Sprint("Link:"), output.QURLLink)
 	wr.printf("%s\t%s\n", f.bold.Sprint("Site:"), output.QURLSite)
@@ -92,10 +92,10 @@ func (f TableFormatter) FormatCreate(w io.Writer, output *client.CreateOutput) e
 	return wr.flush(tw)
 }
 
-// FormatList formats a list of QURLs as a columnar table.
+// FormatList formats a list of qURLs as a columnar table.
 func (f TableFormatter) FormatList(w io.Writer, output *client.ListOutput) error {
 	if len(output.QURLs) == 0 {
-		_, err := fmt.Fprintln(w, f.dim.Sprint("No QURLs found."))
+		_, err := fmt.Fprintln(w, f.dim.Sprint("No qURLs found."))
 		return err
 	}
 
@@ -171,10 +171,10 @@ func (f TableFormatter) FormatQuota(w io.Writer, output *client.QuotaOutput) err
 	if output.Usage != nil {
 		u := output.Usage
 		if output.RateLimits != nil && output.RateLimits.MaxActiveQURLs > 0 {
-			wr.printf("%s\t%d / %d\n", f.bold.Sprint("Active QURLs:"),
+			wr.printf("%s\t%d / %d\n", f.bold.Sprint("Active qURLs:"),
 				u.ActiveQURLs, output.RateLimits.MaxActiveQURLs)
 		} else {
-			wr.printf("%s\t%d\n", f.bold.Sprint("Active QURLs:"), u.ActiveQURLs)
+			wr.printf("%s\t%d\n", f.bold.Sprint("Active qURLs:"), u.ActiveQURLs)
 		}
 		wr.printf("%s\t%d\n", f.bold.Sprint("Created (period):"), u.QURLsCreated)
 		wr.printf("%s\t%d\n", f.bold.Sprint("Total accesses:"), u.TotalAccesses)
@@ -202,7 +202,7 @@ func (f TableFormatter) colorStatus(status string) string {
 // JSONFormatter outputs raw JSON.
 type JSONFormatter struct{}
 
-// FormatQURL formats a single QURL as JSON.
+// FormatQURL formats a single qURL as JSON.
 func (JSONFormatter) FormatQURL(w io.Writer, qurl *client.QURL) error {
 	return writeJSON(w, qurl)
 }
@@ -212,7 +212,7 @@ func (JSONFormatter) FormatCreate(w io.Writer, output *client.CreateOutput) erro
 	return writeJSON(w, output)
 }
 
-// FormatList formats a list of QURLs as JSON.
+// FormatList formats a list of qURLs as JSON.
 func (JSONFormatter) FormatList(w io.Writer, output *client.ListOutput) error {
 	return writeJSON(w, output)
 }

--- a/apps/cli/internal/output/formatter_test.go
+++ b/apps/cli/internal/output/formatter_test.go
@@ -141,7 +141,7 @@ func TestTableFormatListEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FormatList: %v", err)
 	}
-	if !strings.Contains(buf.String(), "No QURLs found") {
+	if !strings.Contains(buf.String(), "No qURLs found") {
 		t.Errorf("expected empty message, got:\n%s", buf.String())
 	}
 }

--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -20,7 +20,7 @@ DISCORD_CLIENT_ID=your_discord_application_client_id
 #   GUILD_ID unset + ENABLE_OPENNHP_FEATURES=false → Multi-tenant plain
 #     /qurl send tool. Commands register globally (up to 1 hr Discord
 #     cache propagation); bot works in every guild it's invited to.
-#     Each guild admin runs /qurl setup to configure their own QURL
+#     Each guild admin runs /qurl setup to configure their own qURL
 #     API key (stored encrypted, per-guild). This is the public-bot
 #     default.
 #
@@ -121,7 +121,7 @@ ADMIN_USER_IDS=
 # CONTRIBUTE_CHANNEL_NAME=contribute
 # GITHUB_FEED_CHANNEL_NAME=github-feed
 
-# QURL (secure resource sharing)
+# qURL (secure resource sharing)
 QURL_API_KEY=your_qurl_api_key
 # Set QURL_ENDPOINT explicitly — defaults to production if omitted in prod,
 # or http://localhost:8080 otherwise.

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -1,17 +1,17 @@
-# QURL Discord Bot
+# qURL Discord Bot
 
-Discord bot for QURL-powered secure resource sharing, plus GitHub OAuth
+Discord bot for qURL-powered secure resource sharing, plus GitHub OAuth
 linking and auto Contributor-role assignment for community members.
 
 ## Features
 
-- **`/qurl send`** — share a file or Google Maps location as a one-time QURL
+- **`/qurl send`** — share a file or Google Maps location as a one-time qURL
   link, delivered to each recipient via DM. Targets: a specific user, the
   visible members of the current text channel, or your voice channel.
 - **`/qurl revoke`** — revoke all links from a previous `/qurl send`.
 - **`/qurl help`** — command reference.
 - **`/qurl setup`** / **`/qurl status`** — admin-only, configure the
-  guild's QURL API key (stored AES-256-GCM encrypted at rest).
+  guild's qURL API key (stored AES-256-GCM encrypted at rest).
 - **GitHub OAuth Linking**: `/link` verifies GitHub identity; the callback
   is session-cookie-bound to prevent leaked-URL takeover.
 - **Auto Role Assignment**: merged PRs in allowed orgs award the
@@ -25,11 +25,11 @@ linking and auto Contributor-role assignment for community members.
 
 | Command | Description |
 |---------|-------------|
-| `/qurl send` | Send a file or location as one-time QURL links to a user / channel / voice-channel |
+| `/qurl send` | Send a file or location as one-time qURL links to a user / channel / voice-channel |
 | `/qurl revoke` | Revoke links from a previous send |
 | `/qurl help` | Usage reference |
-| `/qurl setup` | *(admin)* Configure the guild's QURL API key |
-| `/qurl status` | *(admin)* Check whether QURL is configured |
+| `/qurl setup` | *(admin)* Configure the guild's qURL API key |
+| `/qurl status` | *(admin)* Check whether qURL is configured |
 | `/link` | Link your GitHub account to Discord |
 | `/unlink` | Unlink your GitHub account |
 | `/whois [@user]` | Look up a member's GitHub handle |
@@ -49,7 +49,7 @@ linking and auto Contributor-role assignment for community members.
 - A Discord bot application
 - A GitHub OAuth App
 - A hosting target with a public HTTPS URL (ECS, Railway, Fly, etc.)
-- A QURL API key from https://layerv.ai
+- A qURL API key from https://layerv.ai
 
 ### 1. Configure Discord
 
@@ -79,7 +79,7 @@ inline; the sections below call out the non-obvious ones.
 without them, see `src/index.js`):
 
 - `METRICS_TOKEN` — bearer token for `/metrics`
-- `QURL_API_KEY` — default QURL key (individual guilds can override via
+- `QURL_API_KEY` — default qURL key (individual guilds can override via
   `/qurl setup`)
 - `KEY_ENCRYPTION_KEY` — 32 random bytes, base64. Generate with:
   ```
@@ -124,7 +124,7 @@ npm start
 - `src/discord.js` — discord.js client + role/channel cache
 - `src/database.js` — SQLite (better-sqlite3, WAL) + encrypted guild keys
 - `src/connector.js` — qurl-s3-connector client (SSRF-guarded CDN fetch)
-- `src/qurl.js` — QURL API client (private-IP blocklist on target URLs)
+- `src/qurl.js` — qURL API client (private-IP blocklist on target URLs)
 - `src/routes/oauth.js` — GitHub OAuth (atomic state consumption,
   session-cookie binding, retry + background revoke sweeper)
 - `src/routes/webhooks.js` — GitHub HMAC-verified webhooks, per-IP

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qurl-discord-bot",
   "version": "2.1.0",
-  "description": "QURL Discord bot — /qurl send for secure one-time resource sharing, GitHub OAuth linking, auto Contributor role",
+  "description": "qURL Discord bot — /qurl send for secure one-time resource sharing, GitHub OAuth linking, auto Contributor role",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -184,7 +184,7 @@ module.exports = {
   // Welcome message (for new member DM)
   WELCOME_DM_ENABLED: process.env.WELCOME_DM_ENABLED !== 'false',
 
-  // QURL. In production we fall back to the real endpoints; in dev we fall
+  // qURL. In production we fall back to the real endpoints; in dev we fall
   // back to localhost so a missing .env file doesn't silently hit prod APIs.
   // index.js enforces that both env vars are set when NODE_ENV=production.
   QURL_API_KEY: process.env.QURL_API_KEY,

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -34,7 +34,7 @@ async function cdnFetchFollowSafe(sourceUrl) {
 // Log the raw connector body at debug level and throw a body-free Error.
 // Mirrors qurl.js — connector responses may echo request headers/tokens, and
 // upstream callers log err.message into application logs.
-// QURL API error codes the connector can pass back via the `error` string.
+// qURL API error codes the connector can pass back via the `error` string.
 // Surface them as Error.apiCode so the caller can branch on a typed value
 // instead of substring-matching the human-readable message (which the
 // connector / upstream API can rephrase without notice).
@@ -217,7 +217,7 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
 
 /**
  * Re-register an already-downloaded file buffer with the connector.
- * Creates a new QURL resource (with a fresh token pool) without
+ * Creates a new qURL resource (with a fresh token pool) without
  * re-downloading from Discord CDN. Used when the per-resource token
  * quota (10) is exhausted and more recipients need links.
  */
@@ -305,7 +305,7 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
   // Bound `n` defensively — callers in this codebase already cap at 10
   // (TOKENS_PER_RESOURCE) or 50 (recipient max), but mintLinks is exported
   // so validate at the API boundary. Negative or non-integer values would
-  // make the QURL backend behave unpredictably; 100 is a comfortable ceiling.
+  // make the qURL backend behave unpredictably; 100 is a comfortable ceiling.
   if (!Number.isInteger(n) || n < 1 || n > 100) {
     throw new Error(`Invalid link count (n must be integer 1..100): ${n}`);
   }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -38,6 +38,12 @@ async function cdnFetchFollowSafe(sourceUrl) {
 // Surface them as Error.apiCode so the caller can branch on a typed value
 // instead of substring-matching the human-readable message (which the
 // connector / upstream API can rephrase without notice).
+// TODO(upstream-rebrand): The "QURL" in /token limit per QURL reached/i
+// mirrors the literal string returned by upstream qurl-service today.
+// When the upstream API rebrands its error text to "qURL", update this
+// regex (and the matching test fixtures in connector-coverage.test.js
+// and commands-comprehensive.test.js) in lockstep — otherwise quota-
+// exceeded errors will silently fall through to a generic classification.
 const QUOTA_EXCEEDED_PATTERNS = [
   /quota[\s_-]?exceeded/i,
   /token limit per QURL reached/i,

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -38,12 +38,6 @@ async function cdnFetchFollowSafe(sourceUrl) {
 // Surface them as Error.apiCode so the caller can branch on a typed value
 // instead of substring-matching the human-readable message (which the
 // connector / upstream API can rephrase without notice).
-// TODO(upstream-rebrand): The "QURL" in /token limit per QURL reached/i
-// mirrors the literal string returned by upstream qurl-service today.
-// When the upstream API rebrands its error text to "qURL", update this
-// regex (and the matching test fixtures in connector-coverage.test.js
-// and commands-comprehensive.test.js) in lockstep — otherwise quota-
-// exceeded errors will silently fall through to a generic classification.
 const QUOTA_EXCEEDED_PATTERNS = [
   /quota[\s_-]?exceeded/i,
   /token limit per QURL reached/i,

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -10,10 +10,10 @@ const COLORS = {
   GOLD: 0xF1C40F,         // Gold - achievements/milestones
   GITHUB_GREEN: 0x238636, // GitHub green - issues/PRs
   GITHUB_PURPLE: 0x6e5494,// GitHub purple - commits
-  QURL_BRAND: 0x00d4ff,   // Cyan - QURL delivery embeds
+  QURL_BRAND: 0x00d4ff,   // Cyan - qURL delivery embeds
 };
 
-// QURL resource types
+// qURL resource types
 const RESOURCE_TYPES = {
   FILE: 'file',
   MAPS: 'maps',

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -91,7 +91,7 @@ db.exec(`
   CREATE UNIQUE INDEX IF NOT EXISTS idx_contributions_unique ON contributions(repo, pr_number);
   CREATE INDEX IF NOT EXISTS idx_badges_discord ON badges(discord_id);
 
-  -- QURL send tracking
+  -- qURL send tracking
   CREATE TABLE IF NOT EXISTS qurl_sends (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     send_id TEXT NOT NULL,
@@ -111,7 +111,7 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_qurl_sends_send_id ON qurl_sends(send_id);
   CREATE INDEX IF NOT EXISTS idx_qurl_sends_created ON qurl_sends(created_at);
 
-  -- QURL send configuration (one row per send, used for "Add Recipients")
+  -- qURL send configuration (one row per send, used for "Add Recipients")
   CREATE TABLE IF NOT EXISTS qurl_send_configs (
     send_id TEXT PRIMARY KEY,
     sender_discord_id TEXT NOT NULL,
@@ -673,7 +673,7 @@ const dbModule = {
     };
   },
 
-  // --- QURL SENDS ---
+  // --- qURL SENDS ---
 
   recordQURLSend({ sendId, senderDiscordId, recipientDiscordId, resourceId, resourceType, qurlLink, expiresIn, channelId, targetType }) {
     const stmt = db.prepare(`
@@ -867,7 +867,7 @@ const dbModule = {
     return safe;
   },
 
-  // Returns the decrypted guild key. ONLY for use at the last-mile QURL
+  // Returns the decrypted guild key. ONLY for use at the last-mile qURL
   // API call — never log or render this value. Callers that need to show
   // the admin that a key is configured should use getGuildConfig + compute
   // a sha256 fingerprint (see /qurl status in commands.js).

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -220,7 +220,7 @@ function setupWeeklyDigest() {
 // The required set depends on ENABLE_OPENNHP_FEATURES. The vanilla /qurl
 // send tool only needs 4 perms (ViewChannel for target:channel/voice
 // member enumeration, SendMessages for interaction replies, EmbedLinks
-// for QURL link previews, UseApplicationCommands for slash commands).
+// for qURL link previews, UseApplicationCommands for slash commands).
 // ManageRoles/ManageChannels are OpenNHP-only — demanding them in every
 // guild would produce a confusing "missing permissions" error in guilds
 // that correctly granted only the 4 runtime perms.

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -9,7 +9,7 @@ const { missingBootKeys, missingProdKeys } = require('./boot-requirements');
 
 // Multi-tenant mode: when GUILD_ID is unset (or not a valid snowflake), the
 // bot treats itself as a public multi-server app. Commands register globally,
-// per-guild QURL API keys come from /qurl setup (stored encrypted in
+// per-guild qURL API keys come from /qurl setup (stored encrypted in
 // guild_configs), and OpenNHP-specific features (contributor roles, welcome
 // DMs, GitHub OAuth linking, PR webhook notifications) are dormant because
 // no single guild is being tracked.
@@ -238,7 +238,7 @@ process.on('SIGINT', () => {
 
 // Start everything
 async function start() {
-  logger.info('Starting QURL Discord Bot...');
+  logger.info('Starting qURL Discord Bot...');
   logger.info(`Version: ${require('../package.json').version}`);
   logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
 

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -3,7 +3,7 @@ const logger = require('./logger');
 const dns = require('dns').promises;
 
 /**
- * Lightweight QURL API client using fetch.
+ * Lightweight qURL API client using fetch.
  * Avoids ESM/CJS compatibility issues with the @layerv/qurl SDK.
  */
 
@@ -29,7 +29,7 @@ async function qurlFetch(method, path, body, apiKey) {
   if (body) baseOpts.body = JSON.stringify(body);
 
   // Up to 3 attempts total (initial + 2 retries) with exponential backoff
-  // plus jitter. A single transient 503 or network blip from QURL's infra
+  // plus jitter. A single transient 503 or network blip from qURL's infra
   // no longer fails a whole /qurl send. Non-retryable statuses + non-network
   // errors throw immediately.
   const maxAttempts = 3;
@@ -44,7 +44,7 @@ async function qurlFetch(method, path, body, apiKey) {
       lastErr = err;
       if (attempt < maxAttempts - 1) {
         const delay = 200 * Math.pow(2, attempt) + Math.floor(Math.random() * 100);
-        logger.warn('QURL API network error, retrying', { method, path, attempt, delay, error: err.message });
+        logger.warn('qURL API network error, retrying', { method, path, attempt, delay, error: err.message });
         await new Promise(r => setTimeout(r, delay));
         continue;
       }
@@ -53,19 +53,19 @@ async function qurlFetch(method, path, body, apiKey) {
 
     if (!resp.ok) {
       // Log only status + body length. Including the raw body would be
-      // dangerous: the QURL API error response may echo request headers or
+      // dangerous: the qURL API error response may echo request headers or
       // tokens, and anyone flipping LOG_LEVEL=debug during an incident would
       // then tail those into logs.
       let bodyLen = 0;
       try { bodyLen = (await resp.text()).length; } catch { /* ignore */ }
-      logger.debug('QURL API error', { method, path, status: resp.status, bodyLen, attempt });
+      logger.debug('qURL API error', { method, path, status: resp.status, bodyLen, attempt });
       if (RETRYABLE_STATUSES.has(resp.status) && attempt < maxAttempts - 1) {
         const delay = 200 * Math.pow(2, attempt) + Math.floor(Math.random() * 100);
-        logger.warn('QURL API transient failure, retrying', { method, path, status: resp.status, attempt, delay });
+        logger.warn('qURL API transient failure, retrying', { method, path, status: resp.status, attempt, delay });
         await new Promise(r => setTimeout(r, delay));
         continue;
       }
-      throw new Error(`QURL API ${method} ${path} failed (${resp.status})`);
+      throw new Error(`qURL API ${method} ${path} failed (${resp.status})`);
     }
 
     if (resp.status === 204) return null;
@@ -74,13 +74,13 @@ async function qurlFetch(method, path, body, apiKey) {
   }
   // Unreachable in practice — the loop either returns or throws — but keeps
   // the control flow explicit for reviewers.
-  throw lastErr || new Error(`QURL API ${method} ${path} exhausted retries`);
+  throw lastErr || new Error(`qURL API ${method} ${path} exhausted retries`);
 }
 
 // Reject hostnames that resolve (by syntax) to loopback, link-local, or
 // RFC1918 private ranges. Defense-in-depth against a caller passing
 // `http://169.254.169.254/latest/meta-data/...` or similar; even if the
-// downstream QURL API is the one that actually fetches, we block at our
+// downstream qURL API is the one that actually fetches, we block at our
 // own input validation layer.
 function isPrivateHost(host) {
   if (!host) return true;
@@ -139,13 +139,13 @@ function isPrivateHost(host) {
 // to a private/internal range. Defense against DNS rebinding: a malicious
 // domain could answer `isPrivateHost` (which is syntactic) with a public IP
 // but then resolve to 169.254.169.254 or 127.0.0.1 at fetch time on the
-// QURL backend. We resolve up-front and pass the result to the QURL API so
+// qURL backend. We resolve up-front and pass the result to the qURL API so
 // the backend can pin to the same IPs we verified — the API has its own
 // SSRF guard but we also block here.
 //
 // DEPENDENCY: This is defense-in-depth ONLY — there is an unavoidable
 // TOCTOU window between our dns.lookup() here and the actual fetch on the
-// QURL API backend (DNS can rebind in that gap). The QURL API MUST have
+// qURL API backend (DNS can rebind in that gap). The qURL API MUST have
 // its own DNS-level SSRF guard (resolve + check in the same syscall, or
 // IP-pinned fetch). Do not remove this check assuming the API layer is
 // enough, and do not remove the API-layer check assuming this is enough.
@@ -158,7 +158,7 @@ async function assertNotPrivateAfterResolve(hostname) {
     addrs = await dns.lookup(hostname, { all: true, verbatim: true });
   } catch (err) {
     // Resolution failure is NOT a pass — reject so a typo or non-existent
-    // host fails here rather than leaking to the QURL API as an opaque error.
+    // host fails here rather than leaking to the qURL API as an opaque error.
     throw new Error(`Target URL hostname could not be resolved: ${err.code || err.message}`);
   }
   for (const { address } of addrs) {
@@ -190,7 +190,7 @@ async function createOneTimeLink(targetUrl, expiresIn, description, apiKey) {
     description,
   }, apiKey);
 
-  logger.info('Created one-time QURL', { resource_id: result.resource_id, expires_in: expiresIn });
+  logger.info('Created one-time qURL', { resource_id: result.resource_id, expires_in: expiresIn });
   return result;
 }
 
@@ -203,7 +203,7 @@ function validateResourceId(resourceId) {
 async function deleteLink(resourceId, apiKey) {
   validateResourceId(resourceId);
   await qurlFetch('DELETE', `/qurls/${resourceId}`, null, apiKey);
-  logger.info('Revoked QURL', { resource_id: resourceId });
+  logger.info('Revoked qURL', { resource_id: resourceId });
 }
 
 async function getResourceStatus(resourceId, apiKey) {

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -81,7 +81,7 @@ app.use(express.json({ limit: '1mb' }));
 app.get('/', (req, res) => {
   res.json({
     status: 'ok',
-    service: 'QURL Discord Bot',
+    service: 'qURL Discord Bot',
   });
 });
 

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1480,6 +1480,9 @@ describe('/qurl send — link creation failure', () => {
     // Simulate connector mint_link returning 502 wrapping a qURL API
     // 403 quota_exceeded — connector.js's throwConnectorError tags this
     // as Error.apiCode='quota_exceeded'.
+    // TODO(upstream-rebrand): "QURL" in apiDetail mirrors upstream's
+    // current error text. Update in lockstep with the regex in
+    // connector.js when upstream qurl-service rebrands its error text.
     const quotaErr = new Error('Connector mint_link failed (502)');
     quotaErr.status = 502;
     quotaErr.apiCode = 'quota_exceeded';

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -939,7 +939,7 @@ describe('/qurl help subcommand', () => {
     expect(content).toContain('https://layerv.ai');
     // (2) self-destruct note covers both access AND expiry
     expect(content).toMatch(/self-destruct on first access.*expiry elapses/);
-    // (3) Terms block disambiguates "protected resource" from "qurl"
+    // (3) Terms block disambiguates "protected resource" from "qURL"
     expect(content).toContain('protected resource');
     expect(content).toContain('access link');
     // (4) Large-servers note uses plain language, not GUILD_PRESENCES jargon
@@ -1477,7 +1477,7 @@ describe('/qurl send — link creation failure', () => {
   it('shows quota-specific message on quota_exceeded API error (file)', async () => {
     const recipients = [{ id: 'r1', username: 'Alice' }];
     mockGetText.mockReturnValue(recipients);
-    // Simulate connector mint_link returning 502 wrapping a QURL API
+    // Simulate connector mint_link returning 502 wrapping a qURL API
     // 403 quota_exceeded — connector.js's throwConnectorError tags this
     // as Error.apiCode='quota_exceeded'.
     const quotaErr = new Error('Connector mint_link failed (502)');

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1480,9 +1480,6 @@ describe('/qurl send — link creation failure', () => {
     // Simulate connector mint_link returning 502 wrapping a qURL API
     // 403 quota_exceeded — connector.js's throwConnectorError tags this
     // as Error.apiCode='quota_exceeded'.
-    // TODO(upstream-rebrand): "QURL" in apiDetail mirrors upstream's
-    // current error text. Update in lockstep with the regex in
-    // connector.js when upstream qurl-service rebrands its error text.
     const quotaErr = new Error('Connector mint_link failed (502)');
     quotaErr.status = 502;
     quotaErr.apiCode = 'quota_exceeded';

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -112,7 +112,12 @@ describe('Connector client — coverage boost', () => {
   });
 
   describe('throwConnectorError — quota_exceeded tagging', () => {
-    // The connector wraps upstream QURL API errors as
+    // TODO(upstream-rebrand): The "QURL" in these fixtures mirrors the
+    // literal error text upstream qurl-service returns today. When the
+    // upstream API rebrands its error text to "qURL", update these
+    // fixtures (and the corresponding regex in connector.js) in lockstep.
+    //
+    // The connector wraps upstream qURL API errors as
     //   { success: false, error: "QURL API error (403): quota exceeded: token limit per QURL reached (12/10)", links: [] }
     // throwConnectorError must surface this as Error.apiCode = 'quota_exceeded'
     // so the /qurl send catch block can show a specific user-facing message

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -112,11 +112,6 @@ describe('Connector client — coverage boost', () => {
   });
 
   describe('throwConnectorError — quota_exceeded tagging', () => {
-    // TODO(upstream-rebrand): The "QURL" in these fixtures mirrors the
-    // literal error text upstream qurl-service returns today. When the
-    // upstream API rebrands its error text to "qURL", update these
-    // fixtures (and the corresponding regex in connector.js) in lockstep.
-    //
     // The connector wraps upstream qURL API errors as
     //   { success: false, error: "QURL API error (403): quota exceeded: token limit per QURL reached (12/10)", links: [] }
     // throwConnectorError must surface this as Error.apiCode = 'quota_exceeded'

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -252,8 +252,8 @@ describe('database module', () => {
     });
   });
 
-  describe('qurl sends', () => {
-    it('records and retrieves qurl send', () => {
+  describe('qURL sends', () => {
+    it('records and retrieves qURL send', () => {
       db.recordQURLSend({ sendId: 'qs1', senderDiscordId: 'sender1', recipientDiscordId: 'rcpt1', resourceId: 'res1', resourceType: 'file', qurlLink: 'https://q.test/1', expiresIn: '24h', channelId: 'ch1', targetType: 'user' });
       const sends = db.getRecentSends('sender1');
       expect(sends.length).toBeGreaterThanOrEqual(1);

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -12,7 +12,7 @@ jest.mock('../src/logger', () => ({
 
 const originalFetch = globalThis.fetch;
 
-describe('QURL client — getResourceStatus (line 51)', () => {
+describe('qURL client — getResourceStatus (line 51)', () => {
   let qurl;
 
   beforeEach(() => {
@@ -65,7 +65,7 @@ describe('QURL client — getResourceStatus (line 51)', () => {
     });
 
     await expect(qurl.getResourceStatus('bad-id'))
-      .rejects.toThrow(/QURL API GET.*failed.*404/);
+      .rejects.toThrow(/qURL API GET.*failed.*404/);
   });
 
   it('returns null for 204 response (no content)', async () => {
@@ -91,7 +91,7 @@ describe('QURL client — getResourceStatus (line 51)', () => {
   });
 });
 
-describe('QURL client — retry logic on transient failures', () => {
+describe('qURL client — retry logic on transient failures', () => {
   let qurl;
   beforeEach(() => {
     jest.resetModules();
@@ -151,7 +151,7 @@ describe('QURL client — retry logic on transient failures', () => {
   });
 });
 
-describe('QURL client — createOneTimeLink happy path', () => {
+describe('qURL client — createOneTimeLink happy path', () => {
   let qurl;
   beforeEach(() => {
     jest.resetModules();

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1,5 +1,5 @@
 /**
- * Tests for /qurl send feature — helper functions, QURL client, connector client,
+ * Tests for /qurl send feature — helper functions, qURL client, connector client,
  * places client, and database methods.
  */
 
@@ -487,10 +487,10 @@ describe('Helper functions', () => {
 });
 
 // =========================================================================
-// 2. QURL Client (src/qurl.js)
+// 2. qURL Client (src/qurl.js)
 // =========================================================================
 
-describe('QURL client', () => {
+describe('qURL client', () => {
   let qurl;
 
   beforeEach(() => {
@@ -549,7 +549,7 @@ describe('QURL client', () => {
       });
 
       await expect(qurl.createOneTimeLink('https://example.com', '1h', 'desc'))
-        .rejects.toThrow(/QURL API POST.*failed.*500/);
+        .rejects.toThrow(/qURL API POST.*failed.*500/);
     });
 
     it('includes authorization header', async () => {
@@ -588,7 +588,7 @@ describe('QURL client', () => {
         text: async () => 'Not Found',
       });
 
-      await expect(qurl.deleteLink('bad-id')).rejects.toThrow(/QURL API DELETE.*failed.*404/);
+      await expect(qurl.deleteLink('bad-id')).rejects.toThrow(/qURL API DELETE.*failed.*404/);
     });
   });
 });

--- a/apps/discord/tests/server.test.js
+++ b/apps/discord/tests/server.test.js
@@ -56,7 +56,7 @@ describe('Server', () => {
       const res = await request(app).get('/');
       expect(res.status).toBe(200);
       expect(res.body.status).toBe('ok');
-      expect(res.body.service).toBe('QURL Discord Bot');
+      expect(res.body.service).toBe('qURL Discord Bot');
     });
   });
 

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -1,13 +1,13 @@
-# QURL Slack Integration
+# qURL Slack Integration
 
-Slack bot for creating and managing QURLs via slash commands, with link unfurling and channel notifications.
+Slack bot for creating and managing qURLs via slash commands, with link unfurling and channel notifications.
 
 ## Features
 
-- `/qurl create <url>` — Create a QURL
-- `/qurl list` — List recent QURLs
+- `/qurl create <url>` — Create a qURL
+- `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
-- Channel notifications on QURL events (planned)
+- Channel notifications on qURL events (planned)
 
 ## Architecture
 
@@ -34,5 +34,5 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `SLACK_SIGNING_SECRET` | Yes | Slack app signing secret |
-| `QURL_API_KEY` | Yes | QURL API key for this workspace |
-| `QURL_ENDPOINT` | No | QURL API base URL (default: `https://api.layerv.xyz`) |
+| `QURL_API_KEY` | Yes | qURL API key for this workspace |
+| `QURL_ENDPOINT` | No | qURL API base URL (default: `https://api.layerv.xyz`) |

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -21,7 +21,7 @@ import (
 
 const methodPost = "POST"
 
-const authFailureMessage = "Failed to authenticate. Please check your QURL API key configuration."
+const authFailureMessage = "Failed to authenticate. Please check your qURL API key configuration."
 
 // sigFailureResponse is the terse body we return for every 401 from the
 // signature-verify path. Distinguishing which check failed is already
@@ -215,11 +215,11 @@ func (h *Handler) handleCreate(ctx context.Context, values url.Values) (events.A
 
 	result, err := c.Create(ctx, client.CreateInput{TargetURL: targetURL})
 	if err != nil {
-		slog.Error("failed to create QURL", "error", err, "target_url", targetURL)
-		return respondSlack("Failed to create QURL: " + err.Error())
+		slog.Error("failed to create qURL", "error", err, "target_url", targetURL)
+		return respondSlack("Failed to create qURL: " + err.Error())
 	}
 
-	return respondSlack(fmt.Sprintf("QURL created!\n*Link:* %s\n*Target:* %s", result.QURLLink, targetURL))
+	return respondSlack(fmt.Sprintf("qURL created!\n*Link:* %s\n*Target:* %s", result.QURLLink, targetURL))
 }
 
 func (h *Handler) handleList(ctx context.Context, values url.Values) (events.APIGatewayProxyResponse, error) {
@@ -231,12 +231,12 @@ func (h *Handler) handleList(ctx context.Context, values url.Values) (events.API
 
 	result, err := c.List(ctx, client.ListInput{Limit: 5})
 	if err != nil {
-		slog.Error("failed to list QURLs", "error", err)
-		return respondSlack("Failed to list QURLs: " + err.Error())
+		slog.Error("failed to list qURLs", "error", err)
+		return respondSlack("Failed to list qURLs: " + err.Error())
 	}
 
 	if len(result.QURLs) == 0 {
-		return respondSlack("No QURLs found.")
+		return respondSlack("No qURLs found.")
 	}
 
 	lines := make([]string, 0, len(result.QURLs))
@@ -249,7 +249,7 @@ func (h *Handler) handleList(ctx context.Context, values url.Values) (events.API
 		lines = append(lines, line)
 	}
 
-	return respondSlack("*Recent QURLs:*\n" + strings.Join(lines, "\n"))
+	return respondSlack("*Recent qURLs:*\n" + strings.Join(lines, "\n"))
 }
 
 // authenticatedClient resolves an API key for the team and returns a configured client.
@@ -283,11 +283,11 @@ func (h *Handler) handleInteraction(req *events.APIGatewayProxyRequest) (events.
 }
 
 func helpMessage() string {
-	return `*/qurl* — Create and manage QURLs from Slack
+	return `*/qurl* — Create and manage qURLs from Slack
 
 *Commands:*
-• ` + "`/qurl create <url>`" + ` — Create a QURL for the given URL
-• ` + "`/qurl list`" + ` — Show your 5 most recent QURLs
+• ` + "`/qurl create <url>`" + ` — Create a qURL for the given URL
+• ` + "`/qurl list`" + ` — Show your 5 most recent qURLs
 • ` + "`/qurl help`" + ` — Show this help message`
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -287,7 +287,7 @@ func TestSlashCommand_Base64Body_Help(t *testing.T) {
 }
 
 // Strengthens the body-threading fence: a signed create command must
-// actually reach handleCreate (which hits the mock QURL server).
+// actually reach handleCreate (which hits the mock qURL server).
 func TestSlashCommand_Base64Body_Create(t *testing.T) {
 	var qurlCalled bool
 	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -323,7 +323,7 @@ func TestSlashCommand_Base64Body_Create(t *testing.T) {
 		t.Fatalf("base64 create: status = %d, want 200; body=%s", resp.StatusCode, resp.Body)
 	}
 	if !qurlCalled {
-		t.Error("QURL backend was never called — handleCreate didn't run; body threading regressed")
+		t.Error("qURL backend was never called — handleCreate didn't run; body threading regressed")
 	}
 }
 

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -4,7 +4,7 @@
 BOT_TOKEN=your_discord_bot_token
 BOT_CLIENT_ID=your_discord_bot_client_id
 
-# QURL API
+# qURL API
 QURL_API_KEY=your_qurl_api_key
 # Replace with your test/staging endpoints — do NOT run E2E against production.
 UPLOAD_API_URL=https://connector.example.com:9808

--- a/e2e/helpers/discord-api.ts
+++ b/e2e/helpers/discord-api.ts
@@ -108,7 +108,7 @@ export async function waitForMessage(
   throw new Error(`No matching message in ${channelId} within ${timeout}ms`);
 }
 
-/** Extract QURL link from an embed */
+/** Extract qURL link from an embed */
 export function extractQurlLink(msg: DiscordMessage): string | null {
   const allText = msg.embeds.map(e =>
     [e.description, ...(e.fields?.map(f => f.value) ?? [])].join(' ')

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -1,5 +1,5 @@
 /**
- * QURL service + connector HTTP API client for E2E testing.
+ * qURL service + connector HTTP API client for E2E testing.
  * Drives file upload, link minting, link access, and revocation.
  */
 
@@ -41,7 +41,7 @@ export async function uploadFile(
   return res.json() as Promise<{ resource_id: string; hash: string }>;
 }
 
-/** Mint a one-time QURL link for a resource */
+/** Mint a one-time qURL link for a resource */
 export async function mintLink(
   mintUrl: string,
   apiKey: string,
@@ -78,7 +78,7 @@ export async function mintLink(
   };
 }
 
-/** Access a QURL link and return the HTTP result */
+/** Access a qURL link and return the HTTP result */
 export async function accessLink(url: string): Promise<LinkAccessResult> {
   const res = await fetch(url, { redirect: 'follow' });
   return {
@@ -89,7 +89,7 @@ export async function accessLink(url: string): Promise<LinkAccessResult> {
   };
 }
 
-/** Access a QURL link without following redirects */
+/** Access a qURL link without following redirects */
 export async function accessLinkNoRedirect(url: string): Promise<LinkAccessResult> {
   const res = await fetch(url, { redirect: 'manual' });
   return {
@@ -99,7 +99,7 @@ export async function accessLinkNoRedirect(url: string): Promise<LinkAccessResul
   };
 }
 
-/** Revoke a QURL link by resource_id (revokes entire resource) */
+/** Revoke a qURL link by resource_id (revokes entire resource) */
 export async function revokeLink(
   baseUrl: string,
   apiKey: string,

--- a/e2e/tests/discord-channels.test.ts
+++ b/e2e/tests/discord-channels.test.ts
@@ -135,7 +135,7 @@ describe('Discord: Guild Members', () => {
       const humans = members.filter((m: any) => !m.user?.bot);
       console.log(`Members: ${humans.length} humans + ${bots.length} bots`);
 
-      // The QURL bot should be in the list
+      // The qURL bot should be in the list
       const qurlBot = members.find((m: any) => m.user?.id === env.BOT_CLIENT_ID);
       expect(qurlBot).toBeDefined();
     } catch (e) {
@@ -177,7 +177,7 @@ describe('Discord: Send to Channel', () => {
           { name: 'Resource Type', value: 'Test', inline: true },
           { name: 'Status', value: 'Passing', inline: true },
         ],
-        footer: { text: 'QURL E2E Test Suite' },
+        footer: { text: 'qURL E2E Test Suite' },
       }],
     });
     expect(msg.embeds.length).toBe(1);

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -3,14 +3,14 @@
  *
  * Covers the revoke path for actual file resources (images/PDFs/etc.) — the
  * other revoke tests (smoke.test.ts, link-lifecycle.test.ts) only exercise
- * URL-based qurls (`target_url=https://example.com/...`). This file fills
+ * URL-based qURLs (`target_url=https://example.com/...`). This file fills
  * the gap by uploading a real file via the connector's `/upload` endpoint,
  * verifying the viewer URL responds, revoking by resource_id, and confirming
- * the QURL resource is marked revoked via getLinkStatus.
+ * the qURL resource is marked revoked via getLinkStatus.
  *
- * Revoke semantics: `DELETE /v1/resources/{id}` kills the QURL-layer token
+ * Revoke semantics: `DELETE /v1/resources/{id}` kills the qURL-layer token
  * chain (qurl.link / qurl.site). The underlying md5-addressed fileviewer
- * URL is NOT gated by the QURL API — it remains reachable to anyone who
+ * URL is NOT gated by the qURL API — it remains reachable to anyone who
  * knows the md5 until the S3 lifecycle (~8 days) expires it. The canonical
  * revoke assertion is `getLinkStatus` returning 404, matching the pattern
  * at smoke.test.ts:103.
@@ -36,7 +36,7 @@ interface UploadResponse {
 
 /** Upload an in-memory image buffer and return the viewer URL + resource_id.
  *
- * Retries on 429 rate-limit bursts from the upstream QURL API — the connector
+ * Retries on 429 rate-limit bursts from the upstream qURL API — the connector
  * responds with `{success:true, resource_url:..., error:"QURL creation failed:
  * ... 429 ..."}` and no `resource_id`. Treat that as transient and back off.
  */
@@ -102,7 +102,7 @@ describe('File Revoke', () => {
     expect(revoked).toBe(true);
 
     // Canonical post-revoke assertion today — matches smoke.test.ts:103.
-    // The md5-addressed fileviewer URL is NOT yet gated by the QURL-layer
+    // The md5-addressed fileviewer URL is NOT yet gated by the qURL-layer
     // revoke (product decision to FIX that is in infra#139, implementation
     // folded into infra#93's synchronous-delete-on-revoke scope).
     // TODO(infra#93/#139): add `expect((await fetch(upload.viewerUrl)).status).toBe(404)`

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -39,6 +39,10 @@ interface UploadResponse {
  * Retries on 429 rate-limit bursts from the upstream qURL API — the connector
  * responds with `{success:true, resource_url:..., error:"QURL creation failed:
  * ... 429 ..."}` and no `resource_id`. Treat that as transient and back off.
+ *
+ * TODO(upstream-rebrand): the literal "QURL creation failed" mirrors upstream's
+ * current error text. Update this doc comment when upstream qurl-service
+ * rebrands its error strings.
  */
 async function uploadImage(
   buf: Uint8Array,

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -35,7 +35,7 @@ interface UploadResponse {
 
 /** Upload a google-map JSON payload to the connector and get back the resource URL.
  *
- * Retries transient 429 rate-limits from the upstream QURL API — the connector's
+ * Retries transient 429 rate-limits from the upstream qURL API — the connector's
  * upload returns `{success:true, resource_url:..., error:"QURL creation failed:
  * ... 429 ..."}` without a `resource_id` when the internal mint is throttled. A
  * silent undefined resource_id breaks downstream revoke tests; surface it loudly
@@ -80,7 +80,7 @@ async function uploadMapLocation(
   for (let i = 0; i < maxAttempts; i++) {
     const out = await attempt();
     if ('retry' in out) {
-      // Linear 1.5s / 3s / 6s backoff — QURL API's rate window is short enough
+      // Linear 1.5s / 3s / 6s backoff — qURL API's rate window is short enough
       // that exponential doesn't buy much on test bursts.
       await new Promise((r) => setTimeout(r, baseDelayMs * (i + 1)));
       continue;
@@ -298,14 +298,14 @@ describe('Google Maps: Edge Cases', () => {
 describe('Google Maps: Revoke', () => {
   // NOTE on revoke semantics (today vs. after infra#93/#139 ship):
   //
-  // Today: `DELETE /v1/resources/{id}` kills the QURL-layer token chain
+  // Today: `DELETE /v1/resources/{id}` kills the qURL-layer token chain
   // (qurl.link / qurl.site / resource status endpoint) but the
   // md5-addressed fileviewer URL still serves the content.
   //
   // Product decision (infra#139, accepted): revoke SHOULD also hard-kill
   // the fileviewer URL. Implementation is folded into infra#93 — on revoke,
   // the connector's new `DELETE /api/resources/:md5` fires synchronously
-  // alongside the QURL-layer delete, removing the S3 object, which makes
+  // alongside the qURL-layer delete, removing the S3 object, which makes
   // subsequent fileviewer /view/:md5 requests 404 naturally.
   //
   // These tests verify today's revoke contract via `getLinkStatus()` → 404
@@ -315,7 +315,7 @@ describe('Google Maps: Revoke', () => {
   // is preserved in the pre-revoke read so a no-API-key deploy still fails
   // these tests loudly regardless.
 
-  test('revoke location qurl → getLinkStatus returns 404', async () => {
+  test('revoke location qURL → getLinkStatus returns 404', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       query: 'Revoke Test, Boston',

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -40,6 +40,10 @@ interface UploadResponse {
  * ... 429 ..."}` without a `resource_id` when the internal mint is throttled. A
  * silent undefined resource_id breaks downstream revoke tests; surface it loudly
  * and retry with backoff instead.
+ *
+ * TODO(upstream-rebrand): the literal "QURL creation failed" mirrors upstream's
+ * current error text. Update this doc comment when upstream qurl-service
+ * rebrands its error strings.
  */
 async function uploadMapLocation(
   payload: Record<string, unknown>,

--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -1,5 +1,5 @@
 /**
- * Location variant tests — mint QURL links targeting various URL formats.
+ * Location variant tests — mint qURL links targeting various URL formats.
  */
 
 // TODO: Add afterAll cleanup to revoke/delete test resources

--- a/e2e/tests/negative-paths.test.ts
+++ b/e2e/tests/negative-paths.test.ts
@@ -38,7 +38,7 @@ describe('Negative: Invalid Mint Requests', () => {
 });
 
 describe('Negative: Invalid Access', () => {
-  test('access non-existent qurl path returns SPA (fragment-based)', async () => {
+  test('access non-existent qURL path returns SPA (fragment-based)', async () => {
     const res = await qurl.accessLink('https://qurl.link.layerv.xyz/#at_nonexistent_token_xxx');
     // SPA always loads; client-side handles invalid tokens
     expect(res.status).toBe(200);

--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -1,6 +1,6 @@
 /**
- * Smoke test — verifies the core QURL flow end-to-end:
- * 1. Mint a one-time link via QURL API
+ * Smoke test — verifies the core qURL flow end-to-end:
+ * 1. Mint a one-time link via qURL API
  * 2. Access it (should succeed)
  * 3. Access again (should fail — one-time)
  * 4. Mint another, revoke it, access (should fail)
@@ -43,7 +43,7 @@ describe('Smoke: Bot connectivity', () => {
   });
 });
 
-describe('Smoke: QURL link lifecycle', () => {
+describe('Smoke: qURL link lifecycle', () => {
   let qurlLink: string;
   let qurlId: string;
 
@@ -68,7 +68,7 @@ describe('Smoke: QURL link lifecycle', () => {
   });
 
   test('link status shows accessed after first open', async () => {
-    // QURL links use fragments — SPA always returns 200.
+    // qURL links use fragments — SPA always returns 200.
     // Verify via the resource status API using the resource_id from minting.
     try {
       const status = await qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, qurlId);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# QURL CLI installer
+# qURL CLI installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/layervai/qurl-integrations/main/scripts/install.sh | sh
 set -e
 

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -1,4 +1,4 @@
-// Package auth provides authentication helpers for QURL integrations.
+// Package auth provides authentication helpers for qURL integrations.
 package auth
 
 import (
@@ -9,7 +9,7 @@ import (
 
 // Provider resolves API credentials for a given workspace.
 type Provider interface {
-	// APIKey returns the QURL API key for the given workspace ID.
+	// APIKey returns the qURL API key for the given workspace ID.
 	APIKey(ctx context.Context, workspaceID string) (string, error)
 }
 

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -1,4 +1,4 @@
-// Package client provides a Go client for the QURL API.
+// Package client provides a Go client for the qURL API.
 package client
 
 import (
@@ -23,16 +23,16 @@ const (
 	defaultMaxDelay   = 30 * time.Second
 )
 
-// StatusActive indicates the QURL is live and accepting access requests.
+// StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
 
-// StatusExpired indicates the QURL's TTL has elapsed.
+// StatusExpired indicates the qURL's TTL has elapsed.
 const StatusExpired = "expired"
 
-// StatusRevoked indicates the QURL was manually revoked (deleted).
+// StatusRevoked indicates the qURL was manually revoked (deleted).
 const StatusRevoked = "revoked"
 
-// StatusConsumed indicates a one-time QURL has been used.
+// StatusConsumed indicates a one-time qURL has been used.
 const StatusConsumed = "consumed"
 
 // Logger is an optional interface for debug logging.
@@ -40,7 +40,7 @@ type Logger interface {
 	Printf(format string, args ...any)
 }
 
-// Client is a QURL API client.
+// Client is a qURL API client.
 type Client struct {
 	baseURL    string
 	apiKey     string
@@ -76,7 +76,7 @@ func WithLogger(l Logger) Option {
 	return func(c *Client) { c.logger = l }
 }
 
-// New creates a QURL API client.
+// New creates a qURL API client.
 func New(baseURL, apiKey string, opts ...Option) *Client {
 	c := &Client{
 		baseURL:    baseURL,
@@ -103,7 +103,7 @@ func (c *Client) logf(format string, args ...any) {
 
 // --- Response envelope ---
 
-// apiResponse is the success response envelope from the QURL API.
+// apiResponse is the success response envelope from the qURL API.
 type apiResponse struct {
 	Data json.RawMessage `json:"data"`
 	Meta *ResponseMeta   `json:"meta,omitempty"`
@@ -117,9 +117,9 @@ type ResponseMeta struct {
 	NextCursor string `json:"next_cursor,omitempty"`
 }
 
-// --- QURL types (match API schema) ---
+// --- qURL types (match API schema) ---
 
-// QURL represents a QURL resource as returned by the API.
+// QURL represents a qURL resource as returned by the API.
 type QURL struct {
 	ResourceID   string        `json:"resource_id"`
 	TargetURL    string        `json:"target_url"`
@@ -134,7 +134,7 @@ type QURL struct {
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }
 
-// AccessPolicy defines access restrictions for a QURL.
+// AccessPolicy defines access restrictions for a qURL.
 type AccessPolicy struct {
 	IPAllowlist  []string `json:"ip_allowlist,omitempty"`
 	IPDenylist   []string `json:"ip_denylist,omitempty"`
@@ -142,7 +142,7 @@ type AccessPolicy struct {
 	GeoDenylist  []string `json:"geo_denylist,omitempty"`
 }
 
-// CreateInput is the input for creating a QURL.
+// CreateInput is the input for creating a qURL.
 type CreateInput struct {
 	TargetURL    string        `json:"target_url"`
 	Description  string        `json:"description,omitempty"`
@@ -152,7 +152,7 @@ type CreateInput struct {
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }
 
-// CreateOutput is the response from creating a QURL.
+// CreateOutput is the response from creating a qURL.
 type CreateOutput struct {
 	ResourceID string     `json:"resource_id"`
 	QURLLink   string     `json:"qurl_link"`
@@ -160,7 +160,7 @@ type CreateOutput struct {
 	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
 }
 
-// Create creates a new QURL.
+// Create creates a new qURL.
 func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -179,7 +179,7 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 	return &out, nil
 }
 
-// Get retrieves a QURL by ID.
+// Get retrieves a qURL by ID.
 func (c *Client) Get(ctx context.Context, id string) (*QURL, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/qurls/"+url.PathEscape(id), http.NoBody)
 	if err != nil {
@@ -193,7 +193,7 @@ func (c *Client) Get(ctx context.Context, id string) (*QURL, error) {
 	return &qurl, nil
 }
 
-// ListInput is the input for listing QURLs.
+// ListInput is the input for listing qURLs.
 type ListInput struct {
 	Limit  int
 	Cursor string
@@ -202,14 +202,14 @@ type ListInput struct {
 	Sort   string
 }
 
-// ListOutput is the output of listing QURLs.
+// ListOutput is the output of listing qURLs.
 type ListOutput struct {
 	QURLs      []QURL `json:"qurls"`
 	NextCursor string `json:"next_cursor,omitempty"`
 	HasMore    bool   `json:"has_more,omitempty"`
 }
 
-// List retrieves a paginated list of QURLs.
+// List retrieves a paginated list of qURLs.
 func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error) {
 	params := url.Values{}
 	if input.Limit > 0 {
@@ -252,7 +252,7 @@ func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error)
 	return out, nil
 }
 
-// Delete revokes a QURL by ID.
+// Delete revokes a qURL by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/qurls/"+url.PathEscape(id), http.NoBody)
 	if err != nil {
@@ -262,25 +262,25 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 	return err
 }
 
-// ExtendInput holds input for extending a QURL.
+// ExtendInput holds input for extending a qURL.
 type ExtendInput struct {
 	ExtendBy  string     `json:"extend_by,omitempty"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
-// Extend extends a QURL's expiration.
+// Extend extends a qURL's expiration.
 // Both Extend and Update use PATCH /v1/qurls/:id — the server differentiates
 // by request body fields (extend_by/expires_at vs description).
 func (c *Client) Extend(ctx context.Context, id string, input ExtendInput) (*QURL, error) {
 	return c.patchQURL(ctx, id, input)
 }
 
-// UpdateInput holds input for updating a QURL's mutable properties.
+// UpdateInput holds input for updating a qURL's mutable properties.
 type UpdateInput struct {
 	Description *string `json:"description,omitempty"`
 }
 
-// Update updates a QURL's mutable properties.
+// Update updates a qURL's mutable properties.
 func (c *Client) Update(ctx context.Context, id string, input UpdateInput) (*QURL, error) {
 	return c.patchQURL(ctx, id, input)
 }
@@ -310,7 +310,7 @@ type MintOutput struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
-// MintLink mints a new access link for a QURL.
+// MintLink mints a new access link for a qURL.
 func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls/"+url.PathEscape(id)+"/mint_link", http.NoBody)
 	if err != nil {
@@ -326,7 +326,7 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 
 // --- Resolve ---
 
-// ResolveInput holds input for headless QURL resolution.
+// ResolveInput holds input for headless qURL resolution.
 type ResolveInput struct {
 	AccessToken string `json:"access_token"`
 }
@@ -345,7 +345,7 @@ type AccessGrant struct {
 	SrcIP     string `json:"src_ip"`
 }
 
-// Resolve resolves a QURL access token, triggering a network access request
+// Resolve resolves a qURL access token, triggering a network access request
 // to open the firewall for the caller's IP.
 func (c *Client) Resolve(ctx context.Context, input ResolveInput) (*ResolveOutput, error) {
 	body, err := json.Marshal(input)
@@ -410,7 +410,7 @@ func (c *Client) GetQuota(ctx context.Context) (*QuotaOutput, error) {
 
 // --- Error types (RFC 7807) ---
 
-// APIError represents an error response from the QURL API.
+// APIError represents an error response from the qURL API.
 type APIError struct {
 	StatusCode    int
 	Code          string

--- a/shared/events/events.go
+++ b/shared/events/events.go
@@ -1,9 +1,9 @@
-// Package events provides webhook event parsing for QURL integrations.
+// Package events provides webhook event parsing for qURL integrations.
 package events
 
 import "time"
 
-// Type identifies a QURL webhook event type.
+// Type identifies a qURL webhook event type.
 type Type string
 
 // Webhook event types.
@@ -14,7 +14,7 @@ const (
 	TypeQURLDeleted Type = "qurl.deleted"
 )
 
-// Event is a QURL webhook event.
+// Event is a qURL webhook event.
 type Event struct {
 	Type      Type      `json:"type"`
 	ID        string    `json:"id"`

--- a/shared/formatting/formatting.go
+++ b/shared/formatting/formatting.go
@@ -1,4 +1,4 @@
-// Package formatting provides chat message templates for QURL notifications.
+// Package formatting provides chat message templates for qURL notifications.
 package formatting
 
 import (
@@ -7,12 +7,12 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-// QURLCreated formats a message for a newly created QURL.
+// QURLCreated formats a message for a newly created qURL.
 func QURLCreated(q *client.CreateOutput) string {
-	return "QURL created: " + q.QURLLink
+	return "qURL created: " + q.QURLLink
 }
 
-// QURLDetails formats a detailed view of a QURL.
+// QURLDetails formats a detailed view of a qURL.
 func QURLDetails(q *client.QURL) string {
 	return fmt.Sprintf("*%s*\nTarget: %s\nStatus: %s",
 		q.ResourceID, q.TargetURL, q.Status)

--- a/shared/observability/observability.go
+++ b/shared/observability/observability.go
@@ -1,2 +1,2 @@
-// Package observability provides OpenTelemetry setup for QURL integrations.
+// Package observability provides OpenTelemetry setup for qURL integrations.
 package observability


### PR DESCRIPTION
## Summary

Updates the brand spelling to **qURL** (case-sensitive) across user-visible strings in the CLI, Discord/Slack bots (excluding the discord embed copy in PR #124), code comments, docs, and test descriptions across **51 files** (191 line replacements, 1:1 swaps).

## Why

The product brand is `qURL`. CLI command help text, Cobra `Long`/`Short`/`Example` strings (which appear in `qurl --help`), Discord/Slack bot user-visible messages, log output, README files, and code comments were inconsistently spelled `QURL` / `Qurl` / `qurl`. This brings the integration surfaces in line.

## Coordination with PR #124

PR **#124** (`vikramlayerv:feat/discord-bot-dm-help-copy`) is doing the same rebrand inside the Discord bot embed copy. To avoid conflict, this PR explicitly **excludes** the three files in #124's scope:

- `apps/discord/src/commands.js`
- `apps/discord/src/templates/page.js`
- `apps/discord/tests/templates.test.js`

Everything else in the repo (including other Discord files like `apps/discord/src/qurl.js`, `apps/discord/tests/*`, and the Discord README) is in scope here.

## What changed

- **Go (CLI / Slack / shared)** — Cobra command `Short`/`Long`/`Example` prose, log messages, error messages, godoc comments, table headers
- **JS (Discord bot, scripts)** — JSDoc, log messages, embed text, README prose
- **TS (e2e)** — test descriptions and comments
- **Markdown (READMEs, CLAUDE.md)** — headings and prose
- **YAML/sh** — install script, `.env.example`, `.goreleaser.yml` comments

## What was intentionally not changed

Identifier-style references kept as-is — touching them would break the build, runtime, or wire contract:

- Go/JS/TS class/struct/type/func names: `QurlClient`, `QurlError`, `Qurl`, `QurlSummary`, `QurlListResponse`, `CreateQurlRequest`, etc.
- Constants/env vars: `QURL_API_URL`, `QURL_API_KEY`, `QURL_BASE_URL`, `QURL_TIMEOUT`
- CLI binary name (`qurl`) — kept literal in `Example:` blocks, install scripts, Homebrew formula, shell completions
- Discord slash commands `/qurl send|revoke|help|setup|status` and Slack slash command `/qurl` — kept literal (slash command identifiers)
- DDB/SQL table & column names: `qurl_sends`, `qurl_send_configs`, `qurl_api_key`, `qurl_link`, `qurls`
- Wire-protocol User-Agent values: `qurl-cli/...`, `qurl-go-client/...`, `qurl-discord-bot/1.0`
- Repo identifier (`qurl-integrations`), Go module path (`github.com/layervai/qurl-integrations`)
- Domain literals: `qurl.link`, `qurl.site`, `q.layerv.xyz`
- Repository scope identifiers: `qurl:read`, `qurl:write`, `qurl:resolve`
- Test mock fixtures mirroring upstream API responses (`"QURL not found"`, `"QURL API error (403)..."`, `"token limit per QURL reached"`) — will sync alongside the upstream qurl-service rebrand to keep mocks accurate

## Test plan

- [x] `go build ./... && go test ./...` — all packages pass
- [x] `cd apps/discord && npm test` — 24 suites / 530 tests pass with coverage
- [x] `cd e2e && tsc --noEmit && jest --listTests` — compiles, tests discoverable (live env required to actually run)
- [x] Test assertions updated in lockstep where source strings changed (`commands_test.go`, `formatter_test.go`, `qurl-coverage.test.js`, `qurl-send.test.js`, `root_test.go`)
- [x] Grep verification: every remaining `QURL`/`Qurl` hit outside the excluded #124 files is a justifiable identifier