### PR TITLE
ci: fix age-check shim so bypass label doesn't lock CI

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -23,17 +23,12 @@ permissions:
 
 jobs:
   age-check:
-    # Honor `age-check-bypass` at the shim level AS WELL AS inside the
-    # reusable workflow. Defense-in-depth: if the reusable workflow
-    # implementation ever drops the label check (or the reusable ref
-    # is bumped to a version that doesn't respect it), the shim still
-    # skips consistently.
-    #
-    # On `workflow_dispatch`, `github.event.pull_request` is null — the
-    # labels array evaluates empty and `contains(...)` is false, so the
-    # job always runs. That's the desired behavior: manual runs
-    # shouldn't be bypassable via PR labels.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    # No outer `if:` for `age-check-bypass`. The required status check
+    # is `age-check / Check GitHub Actions pin ages` (caller-job / reusable-inner-job).
+    # Skipping here means the reusable never runs and the inner job
+    # never reports → required check stuck at "Expected — Waiting"
+    # forever. The reusable's inner `if:` handles bypass and reports
+    # SKIPPED, which satisfies the required check.
     # Note: `timeout-minutes` is intentionally NOT set here. Per GH
     # docs (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -23,17 +23,12 @@ permissions:
 
 jobs:
   age-check:
-    # Honor `age-check-bypass` at the shim level AS WELL AS inside the
-    # reusable workflow. Defense-in-depth: if the reusable workflow
-    # implementation ever drops the label check (or the reusable ref
-    # is bumped to a version that doesn't respect it), the shim still
-    # skips consistently.
-    #
-    # On `workflow_dispatch`, `github.event.pull_request` is null — the
-    # labels array evaluates empty and `contains(...)` is false, so the
-    # job always runs. That's the desired behavior: manual runs
-    # shouldn't be bypassable via PR labels.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    # No outer `if:` for `age-check-bypass`. The required status check
+    # is `age-check / check-docker-age` (caller-job / reusable-inner-job).
+    # Skipping here means the reusable never runs and the inner job
+    # never reports → required check stuck at "Expected — Waiting"
+    # forever. The reusable's inner `if:` handles bypass and reports
+    # SKIPPED, which satisfies the required check.
     # Note: `timeout-minutes` is intentionally NOT set here. Per GH
     # docs (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -25,17 +25,12 @@ permissions:
 
 jobs:
   age-check:
-    # Honor `age-check-bypass` at the shim level AS WELL AS inside the
-    # reusable workflow. Defense-in-depth: if the reusable workflow
-    # implementation ever drops the label check (or the reusable ref
-    # is bumped to a version that doesn't respect it), the shim still
-    # skips consistently.
-    #
-    # On `workflow_dispatch`, `github.event.pull_request` is null — the
-    # labels array evaluates empty and `contains(...)` is false, so the
-    # job always runs. That's the desired behavior: manual runs
-    # shouldn't be bypassable via PR labels.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    # No outer `if:` for `age-check-bypass`. The required status check
+    # is `age-check / check-go-age` (caller-job / reusable-inner-job).
+    # Skipping here means the reusable never runs and the inner job
+    # never reports → required check stuck at "Expected — Waiting"
+    # forever. The reusable's inner `if:` handles bypass and reports
+    # SKIPPED, which satisfies the required check.
     # Note: `timeout-minutes` is intentionally NOT set here. Per GH
     # docs (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -22,17 +22,12 @@ permissions:
 
 jobs:
   age-check:
-    # Honor `age-check-bypass` at the shim level AS WELL AS inside the
-    # reusable workflow. Defense-in-depth: if the reusable workflow
-    # implementation ever drops the label check (or the reusable ref
-    # is bumped to a version that doesn't respect it), the shim still
-    # skips consistently.
-    #
-    # On `workflow_dispatch`, `github.event.pull_request` is null — the
-    # labels array evaluates empty and `contains(...)` is false, so the
-    # job always runs. That's the desired behavior: manual runs
-    # shouldn't be bypassable via PR labels.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    # No outer `if:` for `age-check-bypass`. The required status check
+    # is `age-check / check-pip-age` (caller-job / reusable-inner-job).
+    # Skipping here means the reusable never runs and the inner job
+    # never reports → required check stuck at "Expected — Waiting"
+    # forever. The reusable's inner `if:` handles bypass and reports
+    # SKIPPED, which satisfies the required check.
     # Note: `timeout-minutes` is intentionally NOT set here. Per GH
     # docs (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency


### PR DESCRIPTION
## Summary

Fleet rollout of the age-check shim bypass-reporting fix. Mirrors layervai/qurl-python#41 (already merged + validated unblocked layervai/qurl-python#37).

The shims gated the **outer** caller job on `age-check-bypass`. When the label is set, the outer job skips → the reusable workflow is never invoked → the inner job (the one whose name appears in the required status check, e.g. `age-check / check-X-age`) never reports → required context stuck at "Expected — Waiting for status to be reported" forever. The bypass label permanently *blocked* PRs instead of unblocking them.

The reusable workflow already carries the same `age-check-bypass` `if:` on its inner job. Letting the outer caller always run means the inner job evaluates the label, skips with `conclusion: skipped`, and **skipped satisfies a required status check**.

## Why this matters

Bypass exists for verified-CVE emergency updates and legitimate dependabot bumps that need to wait <7 days. Today, applying the label *blocks* the PR forever — defeating the only escape hatch we have. Hit on `qurl-python#37`; verified the fix unblocks correctly after merge.

## Test plan

- [x] qurl-python#41 merged; rebased qurl-python#37 now shows required contexts as `conclusion: skipped` and `mergeStateStatus: BLOCKED → MERGEABLE`
- [ ] CI passes on this PR (no label set → outer caller invokes reusable, inner check runs and reports SUCCESS — same as today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)