### PR TITLE
feat(discord): flip recipient DM expiry verb to past tense at expiry

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -27,10 +27,6 @@ const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isA
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
-// EXPIRY_PREFIX_PRESENT used in buildDeliveryPayload's render path; the
-// matching EXPIRY_PREFIX_PAST is consumed by the expired-dm-label
-// sweeper. Both literals live in constants.js as the single source of
-// truth — see the block-comment there for the rationale.
 
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
@@ -236,6 +232,44 @@ async function batchSettled(items, fn, batchSize = 5) {
     results.push(...batchResults);
   }
   return results;
+}
+
+// Send a recipient DM and persist the resulting identifiers + absolute
+// expiry so the expired-dm-label sweeper can flip "Portal closes" →
+// "Portal closed" once the link expires. Pulled out of handleSend +
+// handleAddRecipients (the two callers) to keep the persist contract in
+// one place — both call sites used to repeat the same 14-line block,
+// which is the kind of copy-paste that drifts when one path changes
+// (e.g. a future column added to recordDMIdentifiers).
+//
+// recordDMIdentifiers failure is logged-and-swallowed: the DM was
+// already delivered, so we don't want to abort the batch — the only
+// downside is the tense stays present-tense forever for this row. The
+// `dm_message_id IS NULL` guard inside recordDMIdentifiers prevents an
+// /qurl-add-recipients call from clobbering identifiers persisted by
+// the original send.
+//
+// Returns the raw sendDM result ({ ok, channelId, messageId }) so the
+// caller can shape its own per-batch return value.
+async function sendDMAndPersist({ recipientDiscordId, payload, sendId, expiresAtUnix, contextLabel }) {
+  const sent = await sendDM(recipientDiscordId, payload);
+  db.updateSendDMStatus(sendId, recipientDiscordId, sent.ok ? DM_STATUS.SENT : DM_STATUS.FAILED);
+  if (sent.ok) {
+    try {
+      db.recordDMIdentifiers({
+        sendId,
+        recipientDiscordId,
+        dmChannelId: sent.channelId,
+        dmMessageId: sent.messageId,
+        expiresAtUnix,
+      });
+    } catch (err) {
+      logger.warn('recordDMIdentifiers failed; expired-tense edit will be skipped for this row', {
+        sendId, recipientId: recipientDiscordId, contextLabel, error: err.message,
+      });
+    }
+  }
+  return sent;
 }
 
 // Resolve the sender's display alias from an interaction, the same way
@@ -1177,29 +1211,13 @@ async function handleSend(interaction, apiKey) {
       personalMessage,
     });
 
-    const sent = await sendDM(link.recipientId, dmPayload);
-    db.updateSendDMStatus(sendId, link.recipientId, sent.ok ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    // Persist the recipient DM identifiers + absolute expiry so the
-    // expired-dm-label sweeper can edit "Portal closes" → "Portal closed"
-    // once the link expires. Logged-and-swallowed: if the persist fails,
-    // the recipient still has the DM (already delivered above) but the
-    // tense will stay present-tense forever for this row — acceptable
-    // degradation, not worth aborting the send.
-    if (sent.ok) {
-      try {
-        db.recordDMIdentifiers({
-          sendId,
-          recipientDiscordId: link.recipientId,
-          dmChannelId: sent.channelId,
-          dmMessageId: sent.messageId,
-          expiresAtUnix: expiresAt,
-        });
-      } catch (err) {
-        logger.warn('recordDMIdentifiers failed; expired-tense edit will be skipped for this row', {
-          sendId, recipientId: link.recipientId, error: err.message,
-        });
-      }
-    }
+    const sent = await sendDMAndPersist({
+      recipientDiscordId: link.recipientId,
+      payload: dmPayload,
+      sendId,
+      expiresAtUnix: expiresAt,
+      contextLabel: 'handleSend',
+    });
     return { recipientId: link.recipientId, username: recipient?.username, sent: sent.ok };
   }, 5);
 
@@ -1712,32 +1730,19 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
     }
 
-    const sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
-    // updateSendDMStatus updates every qurl_sends row matching (sendId,
-    // recipient.id), so a single call covers all links for this recipient.
-    // The previous `for (let i = 0; i < links.length; i++)` loop wrote the
-    // same update links.length times.
-    db.updateSendDMStatus(sendId, recipient.id, sent.ok ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    // Persist DM identifiers on the rows just inserted (the
-    // recordDMIdentifiers SQL is scoped to dm_message_id IS NULL, so it
-    // only fills in the new add-recipients rows and won't overwrite
-    // identifiers from the original /qurl send DM if this recipient was
-    // somehow already in the send).
-    if (sent.ok) {
-      try {
-        db.recordDMIdentifiers({
-          sendId,
-          recipientDiscordId: recipient.id,
-          dmChannelId: sent.channelId,
-          dmMessageId: sent.messageId,
-          expiresAtUnix: expiresAt,
-        });
-      } catch (err) {
-        logger.warn('recordDMIdentifiers failed (add-recipients path); expired-tense edit will be skipped', {
-          sendId, recipientId: recipient.id, error: err.message,
-        });
-      }
-    }
+    // updateSendDMStatus inside sendDMAndPersist updates every qurl_sends
+    // row matching (sendId, recipient.id), so a single call covers all
+    // links for this consolidated DM. recordDMIdentifiers is scoped to
+    // dm_message_id IS NULL inside the SQL — won't overwrite identifiers
+    // from the original /qurl send if a recipient was somehow already
+    // in the send.
+    const sent = await sendDMAndPersist({
+      recipientDiscordId: recipient.id,
+      payload: { embeds: allEmbeds, components: allComponents },
+      sendId,
+      expiresAtUnix: expiresAt,
+      contextLabel: 'handleAddRecipients',
+    });
     return { sent: sent.ok, username: recipient.username };
   }, 5);
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -27,6 +27,19 @@ const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isA
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
+// Recipient-DM expiry-line tense prefixes. The present-tense form is
+// rendered at send time inside buildDeliveryPayload; the
+// expired-dm-label sweeper (src/expired-dm-label-sweeper.js) flips the
+// prefix to past-tense once the link has actually expired.
+//
+// Both strings end with literal `<t:` so the substitution is anchored —
+// a stray "Portal closes" elsewhere in the embed (unlikely, but
+// defensive) won't trip the sweeper. Discord's relative-time markdown
+// (`<t:N:R>`) updates client-side automatically; only the verb needs
+// rewriting. Exported so the sweeper imports the same literals.
+const EXPIRY_PREFIX_PRESENT = '🕐 Portal closes <t:';
+const EXPIRY_PREFIX_PAST = '🕐 Portal closed <t:';
+
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
 // degraded, we log a warning and continue rather than fail the whole flow.
@@ -369,7 +382,11 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
         if (!Number.isFinite(expiresAt)) {
           throw new Error(`buildDeliveryPayload: expiresAt must be a finite Unix-seconds number (got ${expiresAt})`);
         }
-        return `\ud83d\udd50 Portal closes <t:${expiresAt}:R>`;
+        // Render present-tense at send. The expired-dm-label sweeper
+        // rewrites the prefix to past tense once the link expires \u2014
+        // see EXPIRY_PREFIX_PRESENT / EXPIRY_PREFIX_PAST and
+        // src/expired-dm-label-sweeper.js.
+        return `${EXPIRY_PREFIX_PRESENT}${expiresAt}:R>`;
       })(),
     },
     {
@@ -1169,8 +1186,29 @@ async function handleSend(interaction, apiKey) {
     });
 
     const sent = await sendDM(link.recipientId, dmPayload);
-    db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    return { recipientId: link.recipientId, username: recipient?.username, sent };
+    db.updateSendDMStatus(sendId, link.recipientId, sent.ok ? DM_STATUS.SENT : DM_STATUS.FAILED);
+    // Persist the recipient DM identifiers + absolute expiry so the
+    // expired-dm-label sweeper can edit "Portal closes" → "Portal closed"
+    // once the link expires. Logged-and-swallowed: if the persist fails,
+    // the recipient still has the DM (already delivered above) but the
+    // tense will stay present-tense forever for this row — acceptable
+    // degradation, not worth aborting the send.
+    if (sent.ok) {
+      try {
+        db.recordDMIdentifiers({
+          sendId,
+          recipientDiscordId: link.recipientId,
+          dmChannelId: sent.channelId,
+          dmMessageId: sent.messageId,
+          expiresAtUnix: expiresAt,
+        });
+      } catch (err) {
+        logger.warn('recordDMIdentifiers failed; expired-tense edit will be skipped for this row', {
+          sendId, recipientId: link.recipientId, error: err.message,
+        });
+      }
+    }
+    return { recipientId: link.recipientId, username: recipient?.username, sent: sent.ok };
   }, 5);
 
   for (const r of dmResults) {
@@ -1687,8 +1725,28 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // recipient.id), so a single call covers all links for this recipient.
     // The previous `for (let i = 0; i < links.length; i++)` loop wrote the
     // same update links.length times.
-    db.updateSendDMStatus(sendId, recipient.id, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    return { sent, username: recipient.username };
+    db.updateSendDMStatus(sendId, recipient.id, sent.ok ? DM_STATUS.SENT : DM_STATUS.FAILED);
+    // Persist DM identifiers on the rows just inserted (the
+    // recordDMIdentifiers SQL is scoped to dm_message_id IS NULL, so it
+    // only fills in the new add-recipients rows and won't overwrite
+    // identifiers from the original /qurl send DM if this recipient was
+    // somehow already in the send).
+    if (sent.ok) {
+      try {
+        db.recordDMIdentifiers({
+          sendId,
+          recipientDiscordId: recipient.id,
+          dmChannelId: sent.channelId,
+          dmMessageId: sent.messageId,
+          expiresAtUnix: expiresAt,
+        });
+      } catch (err) {
+        logger.warn('recordDMIdentifiers failed (add-recipients path); expired-tense edit will be skipped', {
+          sendId, recipientId: recipient.id, error: err.message,
+        });
+      }
+    }
+    return { sent: sent.ok, username: recipient.username };
   }, 5);
 
   for (const r of dmResults) {
@@ -2917,6 +2975,11 @@ module.exports = {
   registerCommands,
   handleCommand,
   verifyStateBinding,
+  // Expiry-line tense prefixes shared with src/expired-dm-label-sweeper.js.
+  // Exported so the sweeper substitutes against the same literals
+  // buildDeliveryPayload renders — single source of truth for the verb.
+  EXPIRY_PREFIX_PRESENT,
+  EXPIRY_PREFIX_PAST,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with
   // NODE_ENV=test (jest's default); production deploys set NODE_ENV=production.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -27,7 +27,6 @@ const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isA
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
-
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
 // degraded, we log a warning and continue rather than fail the whole flow.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -17,7 +17,7 @@ const crypto = require('crypto');
 const config = require('./config');
 const db = require('./database');
 const logger = require('./logger');
-const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS } = require('./constants');
+const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, EXPIRY_PREFIX_PRESENT } = require('./constants');
 const { expiryToISO, expiryToMs } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { deleteLink, getResourceStatus } = require('./qurl');
@@ -27,18 +27,10 @@ const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isA
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
-// Recipient-DM expiry-line tense prefixes. The present-tense form is
-// rendered at send time inside buildDeliveryPayload; the
-// expired-dm-label sweeper (src/expired-dm-label-sweeper.js) flips the
-// prefix to past-tense once the link has actually expired.
-//
-// Both strings end with literal `<t:` so the substitution is anchored —
-// a stray "Portal closes" elsewhere in the embed (unlikely, but
-// defensive) won't trip the sweeper. Discord's relative-time markdown
-// (`<t:N:R>`) updates client-side automatically; only the verb needs
-// rewriting. Exported so the sweeper imports the same literals.
-const EXPIRY_PREFIX_PRESENT = '🕐 Portal closes <t:';
-const EXPIRY_PREFIX_PAST = '🕐 Portal closed <t:';
+// EXPIRY_PREFIX_PRESENT used in buildDeliveryPayload's render path; the
+// matching EXPIRY_PREFIX_PAST is consumed by the expired-dm-label
+// sweeper. Both literals live in constants.js as the single source of
+// truth — see the block-comment there for the rationale.
 
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
@@ -2975,11 +2967,6 @@ module.exports = {
   registerCommands,
   handleCommand,
   verifyStateBinding,
-  // Expiry-line tense prefixes shared with src/expired-dm-label-sweeper.js.
-  // Exported so the sweeper substitutes against the same literals
-  // buildDeliveryPayload renders — single source of truth for the verb.
-  EXPIRY_PREFIX_PRESENT,
-  EXPIRY_PREFIX_PAST,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with
   // NODE_ENV=test (jest's default); production deploys set NODE_ENV=production.

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -61,6 +61,19 @@ const MAX_FILE_SIZE = 25 * 1024 * 1024;
 // up to 1 hour; a burst of sends could otherwise stack dozens of timers.
 const MAX_CONCURRENT_MONITORS = 50;
 
+// Recipient-DM expiry-line tense prefixes. Both buildDeliveryPayload (the
+// render path in commands.js) and the expired-dm-label sweeper (the edit
+// path in expired-dm-label-sweeper.js) reference these literals — single
+// source of truth so a future copy edit in one place can't drift from the
+// substitution target in the other.
+//
+// Strings end with literal `<t:` so the substitution is anchored — a
+// stray "Portal closes" elsewhere in the embed (unlikely, but defensive)
+// won't trip the sweeper. Discord's relative-time markdown (`<t:N:R>`)
+// auto-renders client-side; only the verb needs rewriting.
+const EXPIRY_PREFIX_PRESENT = '🕐 Portal closes <t:';
+const EXPIRY_PREFIX_PAST = '🕐 Portal closed <t:';
+
 // GitHub event actions we care about
 const GITHUB_ACTIONS = {
   PR_MERGED: 'closed',  // with merged=true
@@ -89,4 +102,6 @@ module.exports = {
   MAX_CONCURRENT_MONITORS,
   GITHUB_ACTIONS,
   GOOD_FIRST_ISSUE_PATTERNS,
+  EXPIRY_PREFIX_PRESENT,
+  EXPIRY_PREFIX_PAST,
 };

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -161,6 +161,15 @@ const SAFE_ALTERS = {
   // revocable. Used to hide already-revoked sends from the /qurl revoke
   // dropdown so users don't re-select a no-op and see "0/0 links revoked".
   revoked_at: 'ALTER TABLE qurl_send_configs ADD COLUMN revoked_at TEXT',
+  // Recipient-DM identifiers + absolute expiry, captured per-send so the
+  // expired-dm-label sweeper can flip "Portal closes <t:N:R>" to "Portal
+  // closed <t:N:R>" at expiry. Without these columns the sweeper has no
+  // handle on the message to edit. NULL on legacy rows predating this
+  // migration — the sweeper's IS NOT NULL guards exclude them.
+  dm_channel_id: 'ALTER TABLE qurl_sends ADD COLUMN dm_channel_id TEXT',
+  dm_message_id: 'ALTER TABLE qurl_sends ADD COLUMN dm_message_id TEXT',
+  expires_at_unix: 'ALTER TABLE qurl_sends ADD COLUMN expires_at_unix INTEGER',
+  expired_label_edited_at: 'ALTER TABLE qurl_sends ADD COLUMN expired_label_edited_at TEXT',
 };
 for (const [col, sql] of Object.entries(SAFE_ALTERS)) {
   try {
@@ -699,6 +708,66 @@ const dbModule = {
   updateSendDMStatus(sendId, recipientDiscordId, status) {
     const stmt = db.prepare('UPDATE qurl_sends SET dm_status = ? WHERE send_id = ? AND recipient_discord_id = ?');
     stmt.run(status, sendId, recipientDiscordId);
+  },
+
+  // Capture the Discord channel + message IDs of the recipient DM and the
+  // absolute expiry instant (Unix seconds) so the expired-dm-label sweeper
+  // can find this row and edit "Portal closes" → "Portal closed" once the
+  // link has actually expired. Called from commands.js right after a
+  // successful sendDM. A failure here doesn't block delivery (the recipient
+  // already has the DM); it just means the tense will stay present-tense
+  // forever for this row — logged-and-swallowed by the caller.
+  //
+  // `dm_message_id IS NULL` guard scopes the UPDATE to rows that haven't
+  // been recorded yet. This matters for /qurl add recipients: a recipient
+  // who already has rows from the original send AND the add-recipients
+  // call has rows for both, but the ADD path's qurl_sends rows are the
+  // ones with NULL identifiers right now — UPDATE without the guard
+  // would overwrite the original DM's identifiers and orphan its tense
+  // edit forever.
+  recordDMIdentifiers({ sendId, recipientDiscordId, dmChannelId, dmMessageId, expiresAtUnix }) {
+    const stmt = db.prepare(`
+      UPDATE qurl_sends
+      SET dm_channel_id = ?, dm_message_id = ?, expires_at_unix = ?
+      WHERE send_id = ? AND recipient_discord_id = ? AND dm_message_id IS NULL
+    `);
+    stmt.run(dmChannelId, dmMessageId, expiresAtUnix, sendId, recipientDiscordId);
+  },
+
+  // Sweeper input: rows whose link has expired AND we haven't yet edited the
+  // recipient DM to past-tense. `dm_status = 'sent'` excludes rows where the
+  // initial DM failed (no message exists to edit). `dm_message_id IS NOT NULL`
+  // excludes legacy rows predating the dm-identifiers migration. Ordered by
+  // expiry so the oldest unedited DMs land first if a sweep tail-truncates.
+  listExpiredUneditedDMs(batchSize = 50) {
+    const nowUnix = Math.floor(Date.now() / 1000);
+    return db.prepare(`
+      SELECT id, send_id, recipient_discord_id, dm_channel_id, dm_message_id
+      FROM qurl_sends
+      WHERE expires_at_unix IS NOT NULL
+        AND expires_at_unix < ?
+        AND expired_label_edited_at IS NULL
+        AND dm_message_id IS NOT NULL
+        AND dm_status = 'sent'
+      ORDER BY expires_at_unix ASC
+      LIMIT ?
+    `).all(nowUnix, batchSize);
+  },
+
+  // Mark every row sharing this dm_message_id as past-tense-edited. A
+  // single recipient DM from /qurl add recipients can carry up to 5 links
+  // → up to 5 qurl_sends rows pointing at the same dm_message_id. One
+  // successful (or permanent-failure) edit settles the entire group; this
+  // method does the bulk update so the sweeper doesn't re-attempt the same
+  // discord.js fetch + edit for sibling rows. NULL guard prevents
+  // double-stamping the timestamp on a re-sweep that races a manual
+  // marker.
+  markDMExpiredLabelEditedByMessageId(messageId) {
+    db.prepare(`
+      UPDATE qurl_sends
+      SET expired_label_edited_at = CURRENT_TIMESTAMP
+      WHERE dm_message_id = ? AND expired_label_edited_at IS NULL
+    `).run(messageId);
   },
 
   getRecentSends(senderDiscordId, limit = 10) {

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -195,6 +195,10 @@ const SAFE_INDEXES = [
   // WHERE matches the sweeper's predicate exactly so the planner can
   // satisfy the SELECT without touching most of qurl_sends. Without
   // this, the sweeper does a full table scan once/minute forever.
+  // The `dm_status = 'sent'` literal MUST stay in sync with
+  // DM_STATUS.SENT in constants.js — see the comment on
+  // listExpiredUneditedDMs below. Renaming the constant requires
+  // updating all three call sites in the same PR.
   "CREATE INDEX IF NOT EXISTS idx_qurl_sends_expiry_sweeper "
     + "ON qurl_sends(expires_at_unix) "
     + "WHERE expired_label_edited_at IS NULL "
@@ -772,6 +776,13 @@ const dbModule = {
   // initial DM failed (no message exists to edit). `dm_message_id IS NOT NULL`
   // excludes legacy rows predating the dm-identifiers migration. Ordered by
   // expiry so the oldest unedited DMs land first if a sweep tail-truncates.
+  //
+  // The literal `'sent'` MUST stay in sync with `DM_STATUS.SENT` in
+  // constants.js AND the partial-index WHERE clause on
+  // idx_qurl_sends_expiry_sweeper (see SAFE_INDEXES above) — all three
+  // need to be the same string for the index to satisfy this query. If
+  // `DM_STATUS.SENT` is ever renamed, update all three places in the
+  // same PR or the sweeper falls back to a full table scan.
   listExpiredUneditedDMs(batchSize = 50) {
     const nowUnix = Math.floor(Date.now() / 1000);
     return db.prepare(`

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -183,6 +183,39 @@ for (const [col, sql] of Object.entries(SAFE_ALTERS)) {
   }
 }
 
+// Partial indexes that reference SAFE_ALTERS-added columns. These MUST
+// run AFTER the ALTER block — SQLite parses column references at index
+// creation time, so an index on a not-yet-existing column would fail on
+// a fresh DB. Both indexes use partial-index WHERE clauses to keep the
+// index footprint tiny (only un-swept rows on the qurl_sends table) —
+// once a row's expired-label is edited, it drops out of the index.
+const SAFE_INDEXES = [
+  // Drives expired-dm-label-sweeper.js's listExpiredUneditedDMs every
+  // 60s. The leading column matches the sort/filter key; the partial-
+  // WHERE matches the sweeper's predicate exactly so the planner can
+  // satisfy the SELECT without touching most of qurl_sends. Without
+  // this, the sweeper does a full table scan once/minute forever.
+  "CREATE INDEX IF NOT EXISTS idx_qurl_sends_expiry_sweeper "
+    + "ON qurl_sends(expires_at_unix) "
+    + "WHERE expired_label_edited_at IS NULL "
+    + "AND dm_message_id IS NOT NULL "
+    + "AND dm_status = 'sent'",
+  // Drives markDMExpiredLabelEditedByMessageId — called once per unique
+  // message_id per sweep (up to 50× / minute). Partial form keeps it
+  // small since most legacy/failed-DM rows have NULL dm_message_id.
+  "CREATE INDEX IF NOT EXISTS idx_qurl_sends_dm_message_id "
+    + "ON qurl_sends(dm_message_id) "
+    + "WHERE dm_message_id IS NOT NULL",
+];
+for (const sql of SAFE_INDEXES) {
+  try {
+    db.exec(sql);
+  } catch (err) {
+    logger.error('SAFE_INDEXES exec failed', { sql, error: err.message });
+    throw err;
+  }
+}
+
 // Badge types (thresholds adjusted for realistic open source contribution cadence)
 const BADGE_TYPES = {
   FIRST_PR: 'first_pr',           // 🌱 First PR

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -808,7 +808,15 @@ async function sendDM(discordId, message) {
 //           retrying every minute forever.
 //   throw — transient failure (network, 5xx). Caller leaves row unedited
 //           so the next sweep retries.
-async function editDMToPastTense(channelId, messageId, fromPrefix, toPrefix) {
+async function editDMToPastTense(channelId, messageId) {
+  // Prefixes are read from constants directly — single caller (the
+  // expired-dm-label sweeper) and the literals are part of the contract
+  // with buildDeliveryPayload's render output. Pulling them in via
+  // require keeps the call site clean and prevents a future caller from
+  // accidentally passing undefined (which would silently make
+  // `String#includes` always false → row marked edited forever with the
+  // embed still present-tense).
+  const { EXPIRY_PREFIX_PRESENT: fromPrefix, EXPIRY_PREFIX_PAST: toPrefix } = require('./constants');
   try {
     const channel = await client.channels.fetch(channelId);
     if (!channel) return false;

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -4,6 +4,7 @@ const config = require('./config');
 const logger = require('./logger');
 const db = require('./database');
 const { escapeDiscordMarkdown: md } = require('./utils/sanitize');
+const { EXPIRY_PREFIX_PRESENT, EXPIRY_PREFIX_PAST } = require('./constants');
 
 const client = new Client({
   intents: [
@@ -809,14 +810,12 @@ async function sendDM(discordId, message) {
 //   throw — transient failure (network, 5xx). Caller leaves row unedited
 //           so the next sweep retries.
 async function editDMToPastTense(channelId, messageId) {
-  // Prefixes are read from constants directly — single caller (the
-  // expired-dm-label sweeper) and the literals are part of the contract
-  // with buildDeliveryPayload's render output. Pulling them in via
-  // require keeps the call site clean and prevents a future caller from
-  // accidentally passing undefined (which would silently make
-  // `String#includes` always false → row marked edited forever with the
-  // embed still present-tense).
-  const { EXPIRY_PREFIX_PRESENT: fromPrefix, EXPIRY_PREFIX_PAST: toPrefix } = require('./constants');
+  // Prefixes come from the module-top require of ./constants — single
+  // source of truth shared with buildDeliveryPayload's render path so
+  // a constant rename automatically propagates to the substitution
+  // target here without a separate edit.
+  const fromPrefix = EXPIRY_PREFIX_PRESENT;
+  const toPrefix = EXPIRY_PREFIX_PAST;
   try {
     const channel = await client.channels.fetch(channelId);
     if (!channel) return false;

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -777,16 +777,74 @@ async function postWeeklyDigest() {
   }
 }
 
-// Send DM to user
+// Send DM to user. Returns { ok, channelId, messageId } so callers that
+// need to edit the message later (e.g. the expired-dm-label sweeper, which
+// flips "Portal closes" → "Portal closed" once the link has expired) can
+// persist the identifiers. `ok=false` means delivery failed (user blocked
+// DMs, fetch error, etc.); channel/message IDs are null in that case.
 async function sendDM(discordId, message) {
   try {
     const user = await client.users.fetch(discordId);
-    await user.send(message);
+    const sent = await user.send(message);
     logger.debug('Sent DM', { discordId });
-    return true;
+    return { ok: true, channelId: sent.channelId, messageId: sent.id };
   } catch (error) {
     logger.warn(`Failed to DM user ${discordId}`, { error: error.message });
-    return false;
+    return { ok: false, channelId: null, messageId: null };
+  }
+}
+
+// Edit a previously-sent DM to flip the present-tense expiry verb to past
+// tense. Used by the expired-dm-label sweeper once `<t:N:R>` has already
+// rolled over to "X minutes ago". Discord's relative-time markdown updates
+// client-side automatically, but the surrounding literal "closes" stays
+// present-tense unless we rewrite the embed.
+//
+// Returns:
+//   true  — edit succeeded OR the embed was already past-tense / didn't
+//           contain the expected prefix (treat as done; don't retry).
+//   false — permanent failure (channel/message gone, missing access).
+//           Caller marks the row as edited to stop the sweeper from
+//           retrying every minute forever.
+//   throw — transient failure (network, 5xx). Caller leaves row unedited
+//           so the next sweep retries.
+async function editDMToPastTense(channelId, messageId, fromPrefix, toPrefix) {
+  try {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel) return false;
+    const msg = await channel.messages.fetch(messageId);
+    if (!msg) return false;
+
+    let mutated = false;
+    const newEmbeds = msg.embeds.map(e => {
+      const json = e.toJSON();
+      if (Array.isArray(json.fields)) {
+        json.fields = json.fields.map(f => {
+          if (typeof f.value === 'string' && f.value.includes(fromPrefix)) {
+            mutated = true;
+            return { ...f, value: f.value.replace(fromPrefix, toPrefix) };
+          }
+          return f;
+        });
+      }
+      return EmbedBuilder.from(json);
+    });
+
+    // No prefix found ⇒ either the embed shape changed or the message
+    // was already edited (e.g. an in-flight retry from a prior crash).
+    // Treat as done so the row is marked edited and we don't loop.
+    if (!mutated) return true;
+
+    await msg.edit({ embeds: newEmbeds });
+    return true;
+  } catch (err) {
+    // Discord error codes that mean "this DM is gone, don't retry":
+    //   10003 Unknown Channel       — channel was deleted
+    //   10008 Unknown Message       — message was deleted
+    //   50001 Missing Access        — bot was blocked / removed from DM
+    //   50007 Cannot send DM to user — recipient blocked DMs since send
+    if ([10003, 10008, 50001, 50007].includes(err.code)) return false;
+    throw err;
   }
 }
 
@@ -884,6 +942,7 @@ module.exports = {
   postToGitHubFeed,
   postWeeklyDigest,
   sendDM,
+  editDMToPastTense,
   refreshCache,
   shutdown,
   getVoiceChannelMembers,

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -873,6 +873,15 @@ async function editDMToPastTense(channelId, messageId) {
     //   50001 Missing Access         — bot was blocked / removed from DM
     //   50007 Cannot send DM to user — recipient blocked DMs since send
     //   50013 Missing Permissions    — Discord-side perm boundary changed on the DM
+    //
+    // Everything else (including 5xx and 429 rate-limit responses) falls
+    // through as transient — the sweeper leaves the row unmarked and the
+    // next sweep retries it. 429s in particular DO surface here when a
+    // post-outage backlog drains at concurrency=5 and bursts past Discord's
+    // route-scoped limit; deferring to the 60s sweep cadence is fine
+    // because (a) discord.js's own queue handles intra-call retry under
+    // most rate-limit shapes, and (b) the "wait one minute and try again"
+    // backoff dwarfs any Retry-After header Discord would send.
     if ([10003, 10008, 10013, 50001, 50007, 50013].includes(err.code)) return false;
     throw err;
   }

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -816,13 +816,19 @@ async function editDMToPastTense(channelId, messageId, fromPrefix, toPrefix) {
     if (!msg) return false;
 
     let mutated = false;
+    let alreadyPast = false;
     const newEmbeds = msg.embeds.map(e => {
       const json = e.toJSON();
       if (Array.isArray(json.fields)) {
         json.fields = json.fields.map(f => {
-          if (typeof f.value === 'string' && f.value.includes(fromPrefix)) {
-            mutated = true;
-            return { ...f, value: f.value.replace(fromPrefix, toPrefix) };
+          if (typeof f.value === 'string') {
+            if (f.value.includes(fromPrefix)) {
+              mutated = true;
+              return { ...f, value: f.value.replace(fromPrefix, toPrefix) };
+            }
+            if (f.value.includes(toPrefix)) {
+              alreadyPast = true;
+            }
           }
           return f;
         });
@@ -830,20 +836,36 @@ async function editDMToPastTense(channelId, messageId, fromPrefix, toPrefix) {
       return EmbedBuilder.from(json);
     });
 
-    // No prefix found ⇒ either the embed shape changed or the message
-    // was already edited (e.g. an in-flight retry from a prior crash).
-    // Treat as done so the row is marked edited and we don't loop.
-    if (!mutated) return true;
+    if (!mutated) {
+      // Two distinct branches matter for triage:
+      //   - alreadyPast: a prior sweep / restart already flipped the
+      //     embed; this is the benign retry path.
+      //   - neither: the prefix shape changed (Discord embed
+      //     normalization, or buildDeliveryPayload was refactored to
+      //     emit the verb in a different field/description). That's a
+      //     silent-skip bug class — log warn so a regression is
+      //     observable instead of marking the row "edited" forever
+      //     with the embed still present-tense.
+      if (!alreadyPast) {
+        logger.warn('editDMToPastTense: neither present nor past prefix found in embed — possible shape regression', {
+          channelId, messageId,
+        });
+      }
+      return true;
+    }
 
     await msg.edit({ embeds: newEmbeds });
     return true;
   } catch (err) {
-    // Discord error codes that mean "this DM is gone, don't retry":
-    //   10003 Unknown Channel       — channel was deleted
-    //   10008 Unknown Message       — message was deleted
-    //   50001 Missing Access        — bot was blocked / removed from DM
+    // Discord error codes that mean "this DM is gone or unreachable
+    // forever, don't retry":
+    //   10003 Unknown Channel        — channel was deleted
+    //   10008 Unknown Message        — message was deleted
+    //   10013 Unknown User           — recipient deleted/disabled their account
+    //   50001 Missing Access         — bot was blocked / removed from DM
     //   50007 Cannot send DM to user — recipient blocked DMs since send
-    if ([10003, 10008, 50001, 50007].includes(err.code)) return false;
+    //   50013 Missing Permissions    — Discord-side perm boundary changed on the DM
+    if ([10003, 10008, 10013, 50001, 50007, 50013].includes(err.code)) return false;
     throw err;
   }
 }

--- a/apps/discord/src/expired-dm-label-sweeper.js
+++ b/apps/discord/src/expired-dm-label-sweeper.js
@@ -137,16 +137,28 @@ async function sweepOnce() {
 }
 
 function startExpiredDMLabelSweeper() {
-  // First sweep 30s after boot — short delay so a bot restart still
-  // closes the tense gap quickly without colliding with Discord login
-  // and the initial guild-cache hydration.
+  // First sweep 60s after boot — covers the worst case where
+  // `client.login(...)` itself burns its full 30s deadline before the
+  // Discord client is ready. A 30s kick that races a 30s login window
+  // would have the first sweep fire against an unready client; the
+  // edits would throw and re-sweep next minute (self-healing) but it's
+  // a footgun. 60s clears the login deadline + leaves headroom for
+  // initial guild-cache hydration. Cost: at most 30s of "Portal closes
+  // X seconds ago" tense lag on the very first sweep after boot.
+  //
+  // Idempotency note: if `editDMToPastTense` lands the Discord edit but
+  // `markDMExpiredLabelEditedByMessageId` then throws (DB transient),
+  // the row stays unmarked → re-swept → editDMToPastTense finds the
+  // embed already past-tense → returns true silently → marked. The
+  // already-past branch in editDMToPastTense is the explicit safety
+  // net for this gap.
   const kick = setTimeout(() => {
     sweepOnce().catch(err => logger.error('Expired-DM-label sweep crash', { error: err.message }));
     const interval = setInterval(() => {
       sweepOnce().catch(err => logger.error('Expired-DM-label sweep crash', { error: err.message }));
     }, SWEEP_INTERVAL_MS);
     interval.unref();
-  }, 30 * 1000);
+  }, 60 * 1000);
   kick.unref();
 }
 

--- a/apps/discord/src/expired-dm-label-sweeper.js
+++ b/apps/discord/src/expired-dm-label-sweeper.js
@@ -1,0 +1,95 @@
+// Background job: edit recipient DMs from "Portal closes <t:N:R>" to
+// "Portal closed <t:N:R>" once expires_at_unix has passed. Discord's
+// <t:N:R> markdown auto-renders "5 hours ago" client-side, but the
+// surrounding literal verb stays present-tense unless we rewrite the
+// embed. The sweep finds qurl_sends rows where the link expired AND we
+// haven't already past-tense-edited that DM, then issues a single edit
+// per unique dm_message_id (one consolidated DM can carry multiple
+// links / multiple qurl_sends rows — one edit settles them all via
+// markDMExpiredLabelEditedByMessageId).
+//
+// 1-minute sweep interval is the worst-case latency a recipient sees
+// between "in 0 seconds" and "Portal closed N seconds ago" — within the
+// natural rounding boundary of Discord's relative-time renderer (which
+// shows "now" / "1 minute ago" buckets), so a tighter interval wouldn't
+// improve the user-visible experience.
+
+const db = require('./database');
+const logger = require('./logger');
+const discord = require('./discord');
+const { EXPIRY_PREFIX_PRESENT, EXPIRY_PREFIX_PAST } = require('./commands');
+
+const SWEEP_INTERVAL_MS = 60 * 1000; // 1 minute
+const BATCH = 50;
+
+async function sweepOnce() {
+  let rows;
+  try {
+    rows = db.listExpiredUneditedDMs(BATCH);
+  } catch (err) {
+    logger.error('Expired-DM-label sweep: list failed', { error: err.message });
+    return;
+  }
+  if (rows.length === 0) return;
+
+  // Dedupe by dm_message_id so we issue one Discord API edit per unique
+  // DM. Multiple links to the same recipient via /qurl add recipients
+  // share a single message_id; we still want to mark all sibling rows
+  // edited (markDMExpiredLabelEditedByMessageId handles that bulk update).
+  const seen = new Set();
+  let edited = 0;
+  let permanentFails = 0;
+  for (const row of rows) {
+    if (seen.has(row.dm_message_id)) continue;
+    seen.add(row.dm_message_id);
+
+    try {
+      const ok = await discord.editDMToPastTense(
+        row.dm_channel_id,
+        row.dm_message_id,
+        EXPIRY_PREFIX_PRESENT,
+        EXPIRY_PREFIX_PAST,
+      );
+      // ok === true  → edit landed (or was already past-tense). Mark all
+      //                sibling rows so we don't re-attempt next sweep.
+      // ok === false → permanent Discord failure (DM/channel gone, bot
+      //                blocked). Same marker — there's nothing to retry.
+      // throw        → transient. Don't mark; next sweep retries.
+      db.markDMExpiredLabelEditedByMessageId(row.dm_message_id);
+      if (ok) edited++;
+      else permanentFails++;
+    } catch (err) {
+      logger.warn('Expired-DM-label edit failed (will retry next sweep)', {
+        sendId: row.send_id,
+        recipientId: row.recipient_discord_id,
+        messageId: row.dm_message_id,
+        error: err.message,
+      });
+    }
+  }
+
+  if (edited > 0 || permanentFails > 0) {
+    logger.info('Expired-DM-label sweep complete', {
+      processedRows: rows.length,
+      uniqueMessages: seen.size,
+      edited,
+      permanentFails,
+    });
+  }
+}
+
+function startExpiredDMLabelSweeper() {
+  // First sweep 30s after boot — short delay so a bot restart still
+  // closes the tense gap quickly without colliding with Discord login
+  // and the initial guild-cache hydration.
+  const kick = setTimeout(() => {
+    sweepOnce().catch(err => logger.error('Expired-DM-label sweep crash', { error: err.message }));
+    const interval = setInterval(() => {
+      sweepOnce().catch(err => logger.error('Expired-DM-label sweep crash', { error: err.message }));
+    }, SWEEP_INTERVAL_MS);
+    interval.unref();
+  }, 30 * 1000);
+  kick.unref();
+}
+
+module.exports = { startExpiredDMLabelSweeper, sweepOnce };

--- a/apps/discord/src/expired-dm-label-sweeper.js
+++ b/apps/discord/src/expired-dm-label-sweeper.js
@@ -17,64 +17,108 @@
 const db = require('./database');
 const logger = require('./logger');
 const discord = require('./discord');
-const { EXPIRY_PREFIX_PRESENT, EXPIRY_PREFIX_PAST } = require('./commands');
+const { EXPIRY_PREFIX_PRESENT, EXPIRY_PREFIX_PAST } = require('./constants');
 
 const SWEEP_INTERVAL_MS = 60 * 1000; // 1 minute
 const BATCH = 50;
 
+// Re-entrancy guard. With a 60s interval and batch=50 sequential Discord
+// edits per sweep, a Discord 5xx outage can stretch a sweep past 60s; the
+// next setInterval tick would otherwise launch a second sweep that fetches
+// the same rows (neither has marked anything yet) and double-edits each
+// message. Idempotent (the second edit no-ops on already-past-tense embeds)
+// but doubles API traffic and log noise. Module-scoped flag wins because
+// `setInterval` doesn't await its callback.
+let sweeping = false;
+
 async function sweepOnce() {
-  let rows;
-  try {
-    rows = db.listExpiredUneditedDMs(BATCH);
-  } catch (err) {
-    logger.error('Expired-DM-label sweep: list failed', { error: err.message });
+  if (sweeping) {
+    // A prior sweep is still in flight (Discord slowness, large backlog).
+    // Skip this tick — the in-flight sweep will eventually mark its rows
+    // edited; the next tick after it finishes will pick up anything new.
+    logger.warn('Expired-DM-label sweep skipped (prior sweep still in flight)');
     return;
   }
-  if (rows.length === 0) return;
-
-  // Dedupe by dm_message_id so we issue one Discord API edit per unique
-  // DM. Multiple links to the same recipient via /qurl add recipients
-  // share a single message_id; we still want to mark all sibling rows
-  // edited (markDMExpiredLabelEditedByMessageId handles that bulk update).
-  const seen = new Set();
-  let edited = 0;
-  let permanentFails = 0;
-  for (const row of rows) {
-    if (seen.has(row.dm_message_id)) continue;
-    seen.add(row.dm_message_id);
-
+  sweeping = true;
+  try {
+    let rows;
     try {
-      const ok = await discord.editDMToPastTense(
-        row.dm_channel_id,
-        row.dm_message_id,
-        EXPIRY_PREFIX_PRESENT,
-        EXPIRY_PREFIX_PAST,
-      );
-      // ok === true  → edit landed (or was already past-tense). Mark all
-      //                sibling rows so we don't re-attempt next sweep.
-      // ok === false → permanent Discord failure (DM/channel gone, bot
-      //                blocked). Same marker — there's nothing to retry.
-      // throw        → transient. Don't mark; next sweep retries.
-      db.markDMExpiredLabelEditedByMessageId(row.dm_message_id);
-      if (ok) edited++;
-      else permanentFails++;
+      rows = db.listExpiredUneditedDMs(BATCH);
     } catch (err) {
-      logger.warn('Expired-DM-label edit failed (will retry next sweep)', {
-        sendId: row.send_id,
-        recipientId: row.recipient_discord_id,
-        messageId: row.dm_message_id,
-        error: err.message,
+      logger.error('Expired-DM-label sweep: list failed', { error: err.message });
+      return;
+    }
+    if (rows.length === 0) return;
+
+    // Dedupe by dm_message_id so we issue one Discord API edit per unique
+    // DM. Multiple links to the same recipient via /qurl add recipients
+    // share a single message_id; we still want to mark all sibling rows
+    // edited (markDMExpiredLabelEditedByMessageId handles that bulk update).
+    const seen = new Set();
+    let edited = 0;
+    let permanentFails = 0;
+    for (const row of rows) {
+      if (seen.has(row.dm_message_id)) continue;
+      seen.add(row.dm_message_id);
+
+      try {
+        const ok = await discord.editDMToPastTense(
+          row.dm_channel_id,
+          row.dm_message_id,
+          EXPIRY_PREFIX_PRESENT,
+          EXPIRY_PREFIX_PAST,
+        );
+        // ok === true  → edit landed (or was already past-tense). Mark all
+        //                sibling rows so we don't re-attempt next sweep.
+        // ok === false → permanent Discord failure (DM/channel gone, bot
+        //                blocked). Same marker — there's nothing to retry.
+        // throw        → transient. Don't mark; next sweep retries.
+        db.markDMExpiredLabelEditedByMessageId(row.dm_message_id);
+        if (ok) edited++;
+        else permanentFails++;
+      } catch (err) {
+        logger.warn('Expired-DM-label edit failed (will retry next sweep)', {
+          sendId: row.send_id,
+          recipientId: row.recipient_discord_id,
+          channelId: row.dm_channel_id,
+          messageId: row.dm_message_id,
+          error: err.message,
+        });
+      }
+    }
+
+    // Hitting the BATCH ceiling means there are more expired-but-unedited
+    // rows than one sweep can process — backlog likely from Discord
+    // outage, bot downtime, or a sudden spike in /qurl send. Log warn so
+    // dashboards can alert if the saturation persists across sweeps.
+    if (rows.length === BATCH) {
+      logger.warn('Expired-DM-label sweep hit batch ceiling — backlog likely', {
+        processedRows: rows.length,
+        batch: BATCH,
       });
     }
-  }
 
-  if (edited > 0 || permanentFails > 0) {
-    logger.info('Expired-DM-label sweep complete', {
-      processedRows: rows.length,
-      uniqueMessages: seen.size,
-      edited,
-      permanentFails,
-    });
+    // Permanent failures (DM gone, bot blocked) shouldn't fold into the
+    // happy-path info line — a sudden spike in `permanentFails` is a real
+    // operational signal (e.g. a region-wide Discord auth bug, or an embed
+    // shape regression making editDMToPastTense return false-positive).
+    // Separate warn keeps the signal scannable in log dashboards.
+    if (permanentFails > 0) {
+      logger.warn('Expired-DM-label sweep recorded permanent failures', {
+        processedRows: rows.length,
+        uniqueMessages: seen.size,
+        edited,
+        permanentFails,
+      });
+    } else if (edited > 0) {
+      logger.info('Expired-DM-label sweep complete', {
+        processedRows: rows.length,
+        uniqueMessages: seen.size,
+        edited,
+      });
+    }
+  } finally {
+    sweeping = false;
   }
 }
 

--- a/apps/discord/src/expired-dm-label-sweeper.js
+++ b/apps/discord/src/expired-dm-label-sweeper.js
@@ -73,14 +73,30 @@ async function sweepOnce() {
     let permanentFails = 0;
     for (let i = 0; i < uniqueRows.length; i += CONCURRENCY) {
       const batch = uniqueRows.slice(i, i + CONCURRENCY);
+      // Catch the mark separately from the edit so the warn log can
+      // distinguish "edit failed" from "edit succeeded but DB mark
+      // failed" — the latter is self-healing (next sweep finds the
+      // embed already past-tense and idempotently re-marks via the
+      // already-past branch in editDMToPastTense), but lumping it into
+      // the same log line as a real edit failure inflates the
+      // apparent edit-failure rate on dashboards.
       const results = await Promise.allSettled(batch.map(async (row) => {
         const ok = await discord.editDMToPastTense(row.dm_channel_id, row.dm_message_id);
-        // ok === true  → edit landed (or was already past-tense). Mark all
-        //                sibling rows so we don't re-attempt next sweep.
-        // ok === false → permanent Discord failure (DM/channel gone, bot
-        //                blocked). Same marker — there's nothing to retry.
-        // throw        → transient. Don't mark; next sweep retries.
-        db.markDMExpiredLabelEditedByMessageId(row.dm_message_id);
+        try {
+          db.markDMExpiredLabelEditedByMessageId(row.dm_message_id);
+        } catch (markErr) {
+          logger.warn('Expired-DM-label edit succeeded but DB mark failed (will be re-swept and idempotently marked)', {
+            sendId: row.send_id,
+            recipientId: row.recipient_discord_id,
+            channelId: row.dm_channel_id,
+            messageId: row.dm_message_id,
+            error: markErr.message,
+          });
+          // Still return `ok` — the Discord edit DID land. Next sweep
+          // finds the embed already past-tense (alreadyPast branch)
+          // and re-marks. Counting this as edited keeps dashboard
+          // numbers accurate; the warn above is the operational signal.
+        }
         return ok;
       }));
       for (let j = 0; j < results.length; j++) {
@@ -90,6 +106,8 @@ async function sweepOnce() {
           if (r.value) edited++;
           else permanentFails++;
         } else {
+          // Only the editDMToPastTense throw reaches this branch — the
+          // mark-failure path above catches its own error and returns ok.
           logger.warn('Expired-DM-label edit failed (will retry next sweep)', {
             sendId: row.send_id,
             recipientId: row.recipient_discord_id,

--- a/apps/discord/src/expired-dm-label-sweeper.js
+++ b/apps/discord/src/expired-dm-label-sweeper.js
@@ -17,10 +17,15 @@
 const db = require('./database');
 const logger = require('./logger');
 const discord = require('./discord');
-const { EXPIRY_PREFIX_PRESENT, EXPIRY_PREFIX_PAST } = require('./constants');
 
 const SWEEP_INTERVAL_MS = 60 * 1000; // 1 minute
 const BATCH = 50;
+// Edit concurrency. Discord per-channel/user edit rate limits are
+// generous (5+ req/s sustained); CONCURRENCY=5 drains a 50-row backlog
+// in ~3s instead of ~15s sequential, while leaving headroom under the
+// global rate limit. Mirrors `batchSettled` in commands.js without
+// importing it (keeps the sweeper self-contained).
+const CONCURRENCY = 5;
 
 // Re-entrancy guard. With a 60s interval and batch=50 sequential Discord
 // edits per sweep, a Discord 5xx outage can stretch a sweep past 60s; the
@@ -50,40 +55,49 @@ async function sweepOnce() {
     }
     if (rows.length === 0) return;
 
-    // Dedupe by dm_message_id so we issue one Discord API edit per unique
-    // DM. Multiple links to the same recipient via /qurl add recipients
-    // share a single message_id; we still want to mark all sibling rows
-    // edited (markDMExpiredLabelEditedByMessageId handles that bulk update).
-    const seen = new Set();
+    // Dedupe by dm_message_id BEFORE edit so a single consolidated DM
+    // (from /qurl add recipients carrying multiple links → multiple
+    // qurl_sends rows) gets exactly one Discord API edit. The bulk-mark
+    // by message_id below handles all sibling rows in one UPDATE.
+    // Computed up-front so the parallel batch below doesn't race the
+    // dedup Set.
+    const uniqueByMessageId = new Map();
+    for (const row of rows) {
+      if (!uniqueByMessageId.has(row.dm_message_id)) {
+        uniqueByMessageId.set(row.dm_message_id, row);
+      }
+    }
+    const uniqueRows = [...uniqueByMessageId.values()];
+
     let edited = 0;
     let permanentFails = 0;
-    for (const row of rows) {
-      if (seen.has(row.dm_message_id)) continue;
-      seen.add(row.dm_message_id);
-
-      try {
-        const ok = await discord.editDMToPastTense(
-          row.dm_channel_id,
-          row.dm_message_id,
-          EXPIRY_PREFIX_PRESENT,
-          EXPIRY_PREFIX_PAST,
-        );
+    for (let i = 0; i < uniqueRows.length; i += CONCURRENCY) {
+      const batch = uniqueRows.slice(i, i + CONCURRENCY);
+      const results = await Promise.allSettled(batch.map(async (row) => {
+        const ok = await discord.editDMToPastTense(row.dm_channel_id, row.dm_message_id);
         // ok === true  → edit landed (or was already past-tense). Mark all
         //                sibling rows so we don't re-attempt next sweep.
         // ok === false → permanent Discord failure (DM/channel gone, bot
         //                blocked). Same marker — there's nothing to retry.
         // throw        → transient. Don't mark; next sweep retries.
         db.markDMExpiredLabelEditedByMessageId(row.dm_message_id);
-        if (ok) edited++;
-        else permanentFails++;
-      } catch (err) {
-        logger.warn('Expired-DM-label edit failed (will retry next sweep)', {
-          sendId: row.send_id,
-          recipientId: row.recipient_discord_id,
-          channelId: row.dm_channel_id,
-          messageId: row.dm_message_id,
-          error: err.message,
-        });
+        return ok;
+      }));
+      for (let j = 0; j < results.length; j++) {
+        const r = results[j];
+        const row = batch[j];
+        if (r.status === 'fulfilled') {
+          if (r.value) edited++;
+          else permanentFails++;
+        } else {
+          logger.warn('Expired-DM-label edit failed (will retry next sweep)', {
+            sendId: row.send_id,
+            recipientId: row.recipient_discord_id,
+            channelId: row.dm_channel_id,
+            messageId: row.dm_message_id,
+            error: r.reason?.message ?? String(r.reason),
+          });
+        }
       }
     }
 
@@ -106,14 +120,14 @@ async function sweepOnce() {
     if (permanentFails > 0) {
       logger.warn('Expired-DM-label sweep recorded permanent failures', {
         processedRows: rows.length,
-        uniqueMessages: seen.size,
+        uniqueMessages: uniqueRows.length,
         edited,
         permanentFails,
       });
     } else if (edited > 0) {
       logger.info('Expired-DM-label sweep complete', {
         processedRows: rows.length,
-        uniqueMessages: seen.size,
+        uniqueMessages: uniqueRows.length,
         edited,
       });
     }

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -5,6 +5,7 @@ const { registerCommands, handleCommand } = require('./commands');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const db = require('./database');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
+const { startExpiredDMLabelSweeper } = require('./expired-dm-label-sweeper');
 const { missingBootKeys, missingProdKeys } = require('./boot-requirements');
 
 // Multi-tenant mode: when GUILD_ID is unset (or not a valid snowflake), the
@@ -248,6 +249,12 @@ async function start() {
   // Background retry-revoke for any OAuth tokens whose initial revoke
   // failed. Runs hourly on top of the 7-day purge in database.js.
   startOrphanTokenSweeper();
+
+  // Background past-tense edit for recipient DMs once their qURL link
+  // has expired. Discord's <t:N:R> markdown auto-rolls "in 5h" → "5h
+  // ago" client-side, but the literal verb in the surrounding text
+  // doesn't change unless we rewrite the embed. 1-min sweep interval.
+  startExpiredDMLabelSweeper();
 
   // Login to Discord with a 30s deadline. client.login() doesn't expose a
   // native timeout; if the Discord API is unreachable the call can hang

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -231,6 +231,43 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(portalField.value).not.toMatch(/Portal closes in \*\*\d/);
   });
 
+  // Load-bearing for the expired-dm-label sweeper:
+  // editDMToPastTense walks `json.fields[].value` and substitutes the
+  // EXPIRY_PREFIX_PRESENT literal. The substitution is anchored on the
+  // shared constant exported from constants.js \u2014 if buildDeliveryPayload
+  // is refactored to use a different prefix, render the verb in
+  // setDescription instead of addFields, or split the literal across
+  // multiple field entries, the sweeper silently stops working.
+  // The assertions below pin the contract on three axes:
+  //   (1) the rendered value uses the same EXPIRY_PREFIX_PRESENT the
+  //       sweeper imports \u2014 a constant rename in one place forces an
+  //       update in the other
+  //   (2) the prefix lives inside addFields[].value, NOT setDescription
+  //   (3) it appears exactly once in that field (substitution would
+  //       only flip the first occurrence; multiple would leave the rest
+  //       present-tense forever)
+  it('emits the EXPIRY_PREFIX_PRESENT literal in addFields exactly once (sweeper-edit invariant)', () => {
+    const { EXPIRY_PREFIX_PRESENT } = require('../src/constants');
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
+
+    // (1) + (2): walk only addFields contributions; setDescription is
+    //            captured separately on the embed builder mock.
+    const fieldValues = capturedEmbeds[0].addFields.mock.calls
+      .flatMap(call => call)
+      .map(f => f.value)
+      .filter(v => typeof v === 'string');
+    const matches = fieldValues.filter(v => v.includes(EXPIRY_PREFIX_PRESENT));
+    expect(matches.length).toBe(1);
+    // (3): only one occurrence within that field.
+    const occurrences = (matches[0].match(new RegExp(EXPIRY_PREFIX_PRESENT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
+    expect(occurrences).toBe(1);
+    // Belt-and-braces: setDescription must not carry the prefix.
+    const descCalls = capturedEmbeds[0].setDescription.mock.calls.flatMap(call => call);
+    for (const d of descCalls) {
+      expect(typeof d === 'string' ? d : '').not.toContain(EXPIRY_PREFIX_PRESENT);
+    }
+  });
+
   // Defensive guard: a future caller that drops `expiresAt` (or passes
   // null/undefined/NaN) would otherwise render literal "<t:undefined:R>"
   // or "<t:NaN:R>" to recipients. The fail-loud throw matches the

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -222,11 +222,14 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // embed ("Portal closes in **24 hours**" forever) would silently
   // regress this UX — the assertion below catches it.
   it('renders Discord native relative-time <t:N:R> for the Portal-closes line', () => {
+    const { EXPIRY_PREFIX_PRESENT } = require('../src/constants');
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
     const fields = capturedEmbeds[0].addFields.mock.calls.flatMap(call => call);
-    const portalField = fields.find(f => typeof f.value === 'string' && f.value.includes('Portal closes'));
+    const portalField = fields.find(f => typeof f.value === 'string' && f.value.includes(EXPIRY_PREFIX_PRESENT));
     expect(portalField).toBeDefined();
-    expect(portalField.value).toBe('\ud83d\udd50 Portal closes <t:1735689600:R>');
+    // Use the shared constant so a prefix rename in constants.js
+    // automatically propagates here \u2014 single source of truth.
+    expect(portalField.value).toBe(`${EXPIRY_PREFIX_PRESENT}1735689600:R>`);
     // Locks against accidental reversion to a static label
     expect(portalField.value).not.toMatch(/Portal closes in \*\*\d/);
   });

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -150,6 +150,7 @@ const mockDb = {
   recordQURLSend: jest.fn(),
   recordQURLSendBatch: jest.fn(),
   updateSendDMStatus: jest.fn(),
+  recordDMIdentifiers: jest.fn(),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   markSendRevoked: jest.fn(),
@@ -165,7 +166,7 @@ const mockDb = {
 };
 jest.mock('../src/database', () => mockDb);
 
-const mockSendDM = jest.fn().mockResolvedValue(true);
+const mockSendDM = jest.fn().mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 const mockGetVoice = jest.fn();
 const mockGetText = jest.fn();
 jest.mock('../src/discord', () => ({
@@ -1226,7 +1227,7 @@ describe('/qurl send — file flow (channel target, full path)', () => {
       { qurl_link: 'https://q.test/l1' },
       { qurl_link: 'https://q.test/l2' },
     ]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = {
       name: 'doc.pdf',
@@ -1299,7 +1300,7 @@ describe('/qurl send — file flow (channel target, full path)', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = {
       name: 'doc.pdf',
@@ -1357,7 +1358,7 @@ describe('/qurl send — location flow (channel target)', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     // The flow: channel target -> no file -> location button -> modal -> submit
     const modalSubmit = {
@@ -1410,7 +1411,7 @@ describe('/qurl send — location flow (channel target)', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = {
       fields: {
@@ -1660,8 +1661,8 @@ describe('/qurl send — DM failures', () => {
     ]);
     // First DM succeeds, second fails
     mockSendDM
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+      .mockResolvedValueOnce({ ok: true, channelId: 'c', messageId: 'm' })
+      .mockResolvedValueOnce({ ok: false, channelId: null, messageId: null });
 
     const attachment = {
       name: 'doc.pdf',
@@ -2212,7 +2213,7 @@ describe('/qurl send — Google Maps URL patterns in location value', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = {
       fields: {
@@ -2262,7 +2263,7 @@ describe('/qurl send — Google Maps URL patterns in location value', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = {
       fields: {
@@ -2311,7 +2312,7 @@ describe('/qurl send — Google Maps URL patterns in location value', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = {
       fields: {
@@ -2360,7 +2361,7 @@ describe('/qurl send — Google Maps URL patterns in location value', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = {
       fields: {
@@ -2413,7 +2414,7 @@ describe('collector button handlers — revoke and expand', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-col', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/c1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
     mockDb.getSendResourceIds.mockReturnValue(['conn-col']);
     mockDeleteLink.mockResolvedValue(undefined);
 
@@ -2472,7 +2473,7 @@ describe('collector button handlers — revoke and expand', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-exp', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue(recipients.map((_, i) => ({ qurl_link: `https://q.test/e${i}` })));
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };
@@ -2525,7 +2526,7 @@ describe('collector button handlers — revoke and expand', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-end', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/end1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };
@@ -2579,7 +2580,7 @@ describe('monitorLinkStatus — via full send flow with fake timers', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-m1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/m1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
     mockGetResourceStatus.mockResolvedValue({
       qurls: [
         { qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' },

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -159,6 +159,7 @@ const mockDb = {
   recordQURLSend: jest.fn(),
   recordQURLSendBatch: jest.fn(),
   updateSendDMStatus: jest.fn(),
+  recordDMIdentifiers: jest.fn(),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   markSendRevoked: jest.fn(),
@@ -174,7 +175,7 @@ const mockDb = {
 };
 jest.mock('../src/database', () => mockDb);
 
-const mockSendDM = jest.fn().mockResolvedValue(true);
+const mockSendDM = jest.fn().mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 const mockGetVoice = jest.fn();
 const mockGetText = jest.fn();
 jest.mock('../src/discord', () => ({
@@ -299,7 +300,7 @@ describe('buildDeliveryPayload — location resource type', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/loc' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = {
       fields: { getTextInputValue: jest.fn(() => 'https://maps.app.goo.gl/xyz') },
@@ -361,7 +362,7 @@ describe('buildConfirmMsg — truncation with > 5 recipients + expand', () => {
     mockMintLinks.mockResolvedValue(
       recipients.map((_, i) => ({ qurl_link: `https://q.test/l${i}` })),
     );
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };
@@ -417,7 +418,7 @@ describe('collector — revoke button', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
     mockDb.getSendResourceIds.mockReturnValue(['conn-1']);
     mockDeleteLink.mockResolvedValue(undefined);
 
@@ -455,7 +456,7 @@ describe('collector — revoke button', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
     mockDb.getSendResourceIds.mockImplementation(() => { throw new Error('DB down'); });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -497,7 +498,7 @@ describe('collector — end timeout', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };
@@ -610,7 +611,7 @@ describe('/qurl send — location URL param extraction', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/q1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = { fields: { getTextInputValue: jest.fn(() => 'https://www.google.com/maps/search/?q=Eiffel+Tower') }, deferUpdate: jest.fn().mockResolvedValue(undefined) };
     const resInteraction = { customId: `qurl_res_loc_${MOCK_NONCE}`, showModal: jest.fn().mockResolvedValue(undefined), awaitModalSubmit: jest.fn().mockResolvedValue(modalSubmit) };
@@ -637,7 +638,7 @@ describe('/qurl send — location URL param extraction', () => {
     mockGetText.mockReturnValue(recipients);
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-1', hash: 'h1', success: true });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/p1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const modalSubmit = { fields: { getTextInputValue: jest.fn(() => 'https://www.google.com/maps/place/Eiffel+Tower/@48.8,2.29,15z') }, deferUpdate: jest.fn().mockResolvedValue(undefined) };
     const resInteraction = { customId: `qurl_res_loc_${MOCK_NONCE}`, showModal: jest.fn().mockResolvedValue(undefined), awaitModalSubmit: jest.fn().mockResolvedValue(modalSubmit) };
@@ -748,7 +749,7 @@ describe('collector — add recipients button', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };
@@ -851,7 +852,7 @@ describe('collector — add recipients button', () => {
 
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'conn-2', fileBuffer: new ArrayBuffer(4) });
     mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/l2' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const newUser = { id: 'r2', bot: false, username: 'Bob' };
     const usersMap = new Map([['r2', newUser]]);
@@ -897,7 +898,7 @@ describe('/qurl send — voice target with members', () => {
     mockGetVoice.mockReturnValue({ error: null, members: [{ id: 'r1', username: 'Alice' }] });
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };
@@ -948,7 +949,7 @@ describe('/qurl send — DM batch with rejected promise', () => {
     mockGetText.mockReturnValue(recipients);
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-1', fileBuffer: new ArrayBuffer(10) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/l1' }, { qurl_link: 'https://q.test/l2' }]);
-    mockSendDM.mockResolvedValueOnce(true).mockRejectedValueOnce(new Error('DM blocked'));
+    mockSendDM.mockResolvedValueOnce({ ok: true, channelId: 'c', messageId: 'm' }).mockRejectedValueOnce(new Error('DM blocked'));
 
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 100, url: 'https://cdn.discordapp.com/doc.pdf' };
     const resInteraction = { customId: `qurl_res_file_${MOCK_NONCE}`, deferUpdate: jest.fn().mockResolvedValue(undefined) };

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -285,6 +285,116 @@ describe('database module', () => {
     });
   });
 
+  // SQLite-level coverage of the helpers consumed by the
+  // expired-dm-label sweeper (src/expired-dm-label-sweeper.js). The
+  // sweeper's own unit tests mock `db` entirely, so without these the
+  // SQL guards (dm_message_id IS NULL on update, the multi-clause WHERE
+  // on listExpiredUneditedDMs, the bulk-mark by message_id) live
+  // entirely in SQL with no real-DB exercise.
+  describe('expired-DM-label helpers', () => {
+    const NOW_UNIX = Math.floor(Date.now() / 1000);
+    const PAST = NOW_UNIX - 60;        // 1 minute ago — eligible
+    const FUTURE = NOW_UNIX + 3600;    // 1 hour from now — not yet expired
+
+    function addSend({ sendId, recipientId, status = 'sent' }) {
+      db.recordQURLSend({
+        sendId, senderDiscordId: 'sender-edm', recipientDiscordId: recipientId,
+        resourceId: `res-${sendId}-${recipientId}`, resourceType: 'file',
+        qurlLink: `https://q.test/${sendId}-${recipientId}`,
+        expiresIn: '24h', channelId: 'ch-edm', targetType: 'user',
+      });
+      // Default DM status is 'pending' from the schema; we lift to 'sent'
+      // unless the test wants the failed-DM exclusion path.
+      db.updateSendDMStatus(sendId, recipientId, status);
+    }
+
+    it('recordDMIdentifiers populates only NULL rows (overwrite-protection invariant)', () => {
+      // Original send — recipient gets identifiers.
+      addSend({ sendId: 'edm-overwrite', recipientId: 'rcpt-A' });
+      db.recordDMIdentifiers({
+        sendId: 'edm-overwrite', recipientDiscordId: 'rcpt-A',
+        dmChannelId: 'chan-original', dmMessageId: 'msg-original', expiresAtUnix: PAST,
+      });
+
+      // /qurl add recipients re-uses the same recipient (edge case): a
+      // SECOND row gets inserted for the same (sendId, recipientId).
+      addSend({ sendId: 'edm-overwrite', recipientId: 'rcpt-A' });
+      // Second recordDMIdentifiers call — SHOULD only fill the NULL row
+      // (the new one), NOT clobber the original.
+      db.recordDMIdentifiers({
+        sendId: 'edm-overwrite', recipientDiscordId: 'rcpt-A',
+        dmChannelId: 'chan-add-recipients', dmMessageId: 'msg-add-recipients', expiresAtUnix: PAST,
+      });
+
+      // Both rows should now have non-null identifiers; original is
+      // preserved, new one got the second pair.
+      const rows = db.listExpiredUneditedDMs(50);
+      const matchingRows = rows.filter(r => r.send_id === 'edm-overwrite' && r.recipient_discord_id === 'rcpt-A');
+      const messageIds = matchingRows.map(r => r.dm_message_id).sort();
+      expect(messageIds).toEqual(['msg-add-recipients', 'msg-original']);
+    });
+
+    it('listExpiredUneditedDMs excludes future-expiry rows', () => {
+      addSend({ sendId: 'edm-future', recipientId: 'rcpt-future' });
+      db.recordDMIdentifiers({
+        sendId: 'edm-future', recipientDiscordId: 'rcpt-future',
+        dmChannelId: 'c', dmMessageId: 'msg-future', expiresAtUnix: FUTURE,
+      });
+      const rows = db.listExpiredUneditedDMs(50);
+      expect(rows.find(r => r.dm_message_id === 'msg-future')).toBeUndefined();
+    });
+
+    it('listExpiredUneditedDMs excludes dm_status="failed" rows', () => {
+      addSend({ sendId: 'edm-failed', recipientId: 'rcpt-failed', status: 'failed' });
+      db.recordDMIdentifiers({
+        sendId: 'edm-failed', recipientDiscordId: 'rcpt-failed',
+        dmChannelId: 'c', dmMessageId: 'msg-failed', expiresAtUnix: PAST,
+      });
+      const rows = db.listExpiredUneditedDMs(50);
+      // Even though expiry is past and identifiers are present, dm_status='failed'
+      // means the DM never reached the recipient — there's no message to edit.
+      expect(rows.find(r => r.dm_message_id === 'msg-failed')).toBeUndefined();
+    });
+
+    it('listExpiredUneditedDMs excludes legacy rows with NULL dm_message_id', () => {
+      // recordQURLSend without recordDMIdentifiers leaves dm_message_id NULL
+      // (legacy migration path). These rows must be skipped — the sweeper has
+      // no message to edit.
+      addSend({ sendId: 'edm-legacy', recipientId: 'rcpt-legacy' });
+      const rows = db.listExpiredUneditedDMs(50);
+      expect(rows.find(r => r.send_id === 'edm-legacy')).toBeUndefined();
+    });
+
+    it('listExpiredUneditedDMs excludes already-edited rows', () => {
+      addSend({ sendId: 'edm-done', recipientId: 'rcpt-done' });
+      db.recordDMIdentifiers({
+        sendId: 'edm-done', recipientDiscordId: 'rcpt-done',
+        dmChannelId: 'c', dmMessageId: 'msg-done', expiresAtUnix: PAST,
+      });
+      db.markDMExpiredLabelEditedByMessageId('msg-done');
+      const rows = db.listExpiredUneditedDMs(50);
+      expect(rows.find(r => r.dm_message_id === 'msg-done')).toBeUndefined();
+    });
+
+    it('markDMExpiredLabelEditedByMessageId stamps every row sharing the message_id', () => {
+      // Two rows for the same consolidated DM (one message → multiple links).
+      addSend({ sendId: 'edm-bulk', recipientId: 'rcpt-bulk' });
+      addSend({ sendId: 'edm-bulk', recipientId: 'rcpt-bulk-2' });
+      db.recordDMIdentifiers({
+        sendId: 'edm-bulk', recipientDiscordId: 'rcpt-bulk',
+        dmChannelId: 'c', dmMessageId: 'msg-shared', expiresAtUnix: PAST,
+      });
+      db.recordDMIdentifiers({
+        sendId: 'edm-bulk', recipientDiscordId: 'rcpt-bulk-2',
+        dmChannelId: 'c', dmMessageId: 'msg-shared', expiresAtUnix: PAST,
+      });
+      db.markDMExpiredLabelEditedByMessageId('msg-shared');
+      // Both rows should now be excluded from the sweep.
+      const rows = db.listExpiredUneditedDMs(50);
+      expect(rows.find(r => r.dm_message_id === 'msg-shared')).toBeUndefined();
+    });
+  });
+
   describe('streak updates — consecutive months', () => {
     it('handles streak broken (gap > 1 month)', () => {
       // We can't easily control dates, but we can verify the flow

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -352,10 +352,11 @@ describe('discord module', () => {
       expect(edited.embeds[0].__fromJson.fields[2].value).toBe('world');
     });
 
-    it('returns true without calling edit when prefix is absent (no-op)', async () => {
-      // E.g. embed shape changed, or already past-tense — sweeper marks
-      // these as done and moves on; we don't want to spam edits.
-      const msg = buildMessage({ fieldValues: ['hello', 'world'] });
+    it('returns true silently when the embed already has the past-tense prefix (idempotent)', async () => {
+      // Benign retry path: a prior sweep / bot crash already flipped the
+      // embed; the next sweep finds past-tense, doesn't edit again, and
+      // does NOT warn.
+      const msg = buildMessage({ fieldValues: ['hello', 'P_PAST_<t:1234:R>'] });
       const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
       mockClient.channels.fetch.mockResolvedValue(channel);
 
@@ -364,11 +365,32 @@ describe('discord module', () => {
       expect(msg.edit).not.toHaveBeenCalled();
     });
 
-    it('returns false on permanent Discord error codes (10003/10008/50001/50007)', async () => {
-      // Each code maps to a permanent failure (DM/channel gone or bot blocked).
-      // Function returns false so the sweeper marks the row edited and
-      // doesn't retry every minute forever.
-      for (const code of [10003, 10008, 50001, 50007]) {
+    it('warns when neither present nor past prefix is found (shape regression signal)', async () => {
+      // Distinct from the already-past-tense path: this is the silent-
+      // skip bug class — embed shape drifted between render and edit.
+      // Function still returns true (so the row gets marked, not retried
+      // forever) but emits a warn so a regression is observable.
+      const msg = buildMessage({ fieldValues: ['hello', 'world'] });
+      const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
+      mockClient.channels.fetch.mockResolvedValue(channel);
+
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1', 'P_PRESENT_', 'P_PAST_');
+      expect(ok).toBe(true);
+      expect(msg.edit).not.toHaveBeenCalled();
+      // Logger spy: dump warn calls so the assertion is unambiguous.
+      const logger = require('../src/logger');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('shape regression'),
+        expect.objectContaining({ channelId: 'chan-1', messageId: 'msg-1' }),
+      );
+    });
+
+    it('returns false on permanent Discord error codes (10003/10008/10013/50001/50007/50013)', async () => {
+      // Each code maps to a permanent failure (DM/channel gone, recipient
+      // account gone, or bot blocked / perm boundary changed). Function
+      // returns false so the sweeper marks the row edited and doesn't
+      // retry every minute forever.
+      for (const code of [10003, 10008, 10013, 50001, 50007, 50013]) {
         mockClient.channels.fetch.mockRejectedValueOnce(Object.assign(new Error('discord'), { code }));
         const ok = await discord.editDMToPastTense('chan-x', 'msg-x', 'P_PRESENT_', 'P_PAST_');
         expect(ok).toBe(false);

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -324,6 +324,10 @@ describe('discord module', () => {
   });
 
   describe('editDMToPastTense', () => {
+    // Use the real prefixes so this test catches a constants.js rename
+    // automatically (the function imports from constants, not args).
+    const { EXPIRY_PREFIX_PRESENT, EXPIRY_PREFIX_PAST } = require('../src/constants');
+
     function buildMessage({ fieldValues, edit = jest.fn().mockResolvedValue(undefined) }) {
       return {
         edit,
@@ -337,16 +341,16 @@ describe('discord module', () => {
       };
     }
 
-    it('rewrites "Portal closes" → "Portal closed" when present', async () => {
-      const msg = buildMessage({ fieldValues: ['hello', 'P_PRESENT_<t:1234:R>', 'world'] });
+    it('rewrites present-prefix → past-prefix when present', async () => {
+      const msg = buildMessage({ fieldValues: ['hello', `${EXPIRY_PREFIX_PRESENT}1234:R>`, 'world'] });
       const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
       mockClient.channels.fetch.mockResolvedValue(channel);
 
-      const ok = await discord.editDMToPastTense('chan-1', 'msg-1', 'P_PRESENT_', 'P_PAST_');
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1');
       expect(ok).toBe(true);
       expect(msg.edit).toHaveBeenCalledTimes(1);
       const edited = msg.edit.mock.calls[0][0];
-      expect(edited.embeds[0].__fromJson.fields[1].value).toBe('P_PAST_<t:1234:R>');
+      expect(edited.embeds[0].__fromJson.fields[1].value).toBe(`${EXPIRY_PREFIX_PAST}1234:R>`);
       // Untouched fields stay identical.
       expect(edited.embeds[0].__fromJson.fields[0].value).toBe('hello');
       expect(edited.embeds[0].__fromJson.fields[2].value).toBe('world');
@@ -356,11 +360,11 @@ describe('discord module', () => {
       // Benign retry path: a prior sweep / bot crash already flipped the
       // embed; the next sweep finds past-tense, doesn't edit again, and
       // does NOT warn.
-      const msg = buildMessage({ fieldValues: ['hello', 'P_PAST_<t:1234:R>'] });
+      const msg = buildMessage({ fieldValues: ['hello', `${EXPIRY_PREFIX_PAST}1234:R>`] });
       const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
       mockClient.channels.fetch.mockResolvedValue(channel);
 
-      const ok = await discord.editDMToPastTense('chan-1', 'msg-1', 'P_PRESENT_', 'P_PAST_');
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1');
       expect(ok).toBe(true);
       expect(msg.edit).not.toHaveBeenCalled();
     });
@@ -374,10 +378,9 @@ describe('discord module', () => {
       const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
       mockClient.channels.fetch.mockResolvedValue(channel);
 
-      const ok = await discord.editDMToPastTense('chan-1', 'msg-1', 'P_PRESENT_', 'P_PAST_');
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1');
       expect(ok).toBe(true);
       expect(msg.edit).not.toHaveBeenCalled();
-      // Logger spy: dump warn calls so the assertion is unambiguous.
       const logger = require('../src/logger');
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('shape regression'),
@@ -392,7 +395,7 @@ describe('discord module', () => {
       // retry every minute forever.
       for (const code of [10003, 10008, 10013, 50001, 50007, 50013]) {
         mockClient.channels.fetch.mockRejectedValueOnce(Object.assign(new Error('discord'), { code }));
-        const ok = await discord.editDMToPastTense('chan-x', 'msg-x', 'P_PRESENT_', 'P_PAST_');
+        const ok = await discord.editDMToPastTense('chan-x', 'msg-x');
         expect(ok).toBe(false);
       }
     });
@@ -401,7 +404,7 @@ describe('discord module', () => {
       // 5xx, network errors, etc. — caller leaves the row unmarked so the
       // sweeper retries on the next sweep.
       mockClient.channels.fetch.mockRejectedValueOnce(Object.assign(new Error('500'), { code: 500 }));
-      await expect(discord.editDMToPastTense('chan-x', 'msg-x', 'P_PRESENT_', 'P_PAST_')).rejects.toThrow('500');
+      await expect(discord.editDMToPastTense('chan-x', 'msg-x')).rejects.toThrow('500');
     });
   });
 

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -93,6 +93,7 @@ const mockClient = {
   destroy: jest.fn(),
   guilds: { fetch: jest.fn().mockResolvedValue(mockGuild) },
   users: { fetch: jest.fn() },
+  channels: { fetch: jest.fn() },
   user: { tag: 'TestBot#0001' },
   application: { commands: { set: jest.fn() } },
 };
@@ -100,12 +101,18 @@ const mockClient = {
 jest.mock('discord.js', () => ({
   Client: jest.fn(() => mockClient),
   GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128 },
-  EmbedBuilder: jest.fn().mockImplementation(() => ({
-    setColor: jest.fn().mockReturnThis(), setTitle: jest.fn().mockReturnThis(),
-    setDescription: jest.fn().mockReturnThis(), addFields: jest.fn().mockReturnThis(),
-    setFooter: jest.fn().mockReturnThis(), setTimestamp: jest.fn().mockReturnThis(),
-    setURL: jest.fn().mockReturnThis(), setAuthor: jest.fn().mockReturnThis(),
-  })),
+  EmbedBuilder: Object.assign(
+    jest.fn().mockImplementation(() => ({
+      setColor: jest.fn().mockReturnThis(), setTitle: jest.fn().mockReturnThis(),
+      setDescription: jest.fn().mockReturnThis(), addFields: jest.fn().mockReturnThis(),
+      setFooter: jest.fn().mockReturnThis(), setTimestamp: jest.fn().mockReturnThis(),
+      setURL: jest.fn().mockReturnThis(), setAuthor: jest.fn().mockReturnThis(),
+    })),
+    // EmbedBuilder.from(json) — used by editDMToPastTense to clone the
+    // embed shape with a mutated field. Test shim returns the JSON
+    // directly so assertions can read fields off it.
+    { from: jest.fn().mockImplementation(json => ({ __fromJson: json })) },
+  ),
   ChannelType: { GuildText: 0, GuildVoice: 2, GuildStageVoice: 13 },
   PermissionFlagsBits: { ViewChannel: 1024n },
 }));
@@ -300,17 +307,79 @@ describe('discord module', () => {
   });
 
   describe('sendDM', () => {
-    it('sends DM and returns true', async () => {
-      const mockUser = { send: jest.fn().mockResolvedValue(true) };
+    it('sends DM and returns identifiers on success', async () => {
+      const mockUser = {
+        send: jest.fn().mockResolvedValue({ id: 'msg-123', channelId: 'chan-456' }),
+      };
       mockClient.users.fetch.mockResolvedValue(mockUser);
       const result = await discord.sendDM('u1', 'Hello');
-      expect(result).toBe(true);
+      expect(result).toEqual({ ok: true, channelId: 'chan-456', messageId: 'msg-123' });
     });
 
-    it('returns false on error', async () => {
+    it('returns ok:false with null IDs on error', async () => {
       mockClient.users.fetch.mockRejectedValue(new Error('fail'));
       const result = await discord.sendDM('u2', 'Hello');
-      expect(result).toBe(false);
+      expect(result).toEqual({ ok: false, channelId: null, messageId: null });
+    });
+  });
+
+  describe('editDMToPastTense', () => {
+    function buildMessage({ fieldValues, edit = jest.fn().mockResolvedValue(undefined) }) {
+      return {
+        edit,
+        embeds: [{
+          toJSON: () => ({
+            // Mirror Discord embed shape — fields[].value carries the
+            // expiry line; the function rewrites the matching value.
+            fields: fieldValues.map(v => ({ name: '​', value: v })),
+          }),
+        }],
+      };
+    }
+
+    it('rewrites "Portal closes" → "Portal closed" when present', async () => {
+      const msg = buildMessage({ fieldValues: ['hello', 'P_PRESENT_<t:1234:R>', 'world'] });
+      const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
+      mockClient.channels.fetch.mockResolvedValue(channel);
+
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1', 'P_PRESENT_', 'P_PAST_');
+      expect(ok).toBe(true);
+      expect(msg.edit).toHaveBeenCalledTimes(1);
+      const edited = msg.edit.mock.calls[0][0];
+      expect(edited.embeds[0].__fromJson.fields[1].value).toBe('P_PAST_<t:1234:R>');
+      // Untouched fields stay identical.
+      expect(edited.embeds[0].__fromJson.fields[0].value).toBe('hello');
+      expect(edited.embeds[0].__fromJson.fields[2].value).toBe('world');
+    });
+
+    it('returns true without calling edit when prefix is absent (no-op)', async () => {
+      // E.g. embed shape changed, or already past-tense — sweeper marks
+      // these as done and moves on; we don't want to spam edits.
+      const msg = buildMessage({ fieldValues: ['hello', 'world'] });
+      const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
+      mockClient.channels.fetch.mockResolvedValue(channel);
+
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1', 'P_PRESENT_', 'P_PAST_');
+      expect(ok).toBe(true);
+      expect(msg.edit).not.toHaveBeenCalled();
+    });
+
+    it('returns false on permanent Discord error codes (10003/10008/50001/50007)', async () => {
+      // Each code maps to a permanent failure (DM/channel gone or bot blocked).
+      // Function returns false so the sweeper marks the row edited and
+      // doesn't retry every minute forever.
+      for (const code of [10003, 10008, 50001, 50007]) {
+        mockClient.channels.fetch.mockRejectedValueOnce(Object.assign(new Error('discord'), { code }));
+        const ok = await discord.editDMToPastTense('chan-x', 'msg-x', 'P_PRESENT_', 'P_PAST_');
+        expect(ok).toBe(false);
+      }
+    });
+
+    it('throws on transient errors (so sweeper retries next interval)', async () => {
+      // 5xx, network errors, etc. — caller leaves the row unmarked so the
+      // sweeper retries on the next sweep.
+      mockClient.channels.fetch.mockRejectedValueOnce(Object.assign(new Error('500'), { code: 500 }));
+      await expect(discord.editDMToPastTense('chan-x', 'msg-x', 'P_PRESENT_', 'P_PAST_')).rejects.toThrow('500');
     });
   });
 

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -369,6 +369,31 @@ describe('discord module', () => {
       expect(msg.edit).not.toHaveBeenCalled();
     });
 
+    it('warns when the embed has no fields array at all (shape regression signal)', async () => {
+      // Edge case: a future render that emits the expiry into
+      // `description` instead of `addFields[]` (or any other shape
+      // change that drops `json.fields`) would silently cause the
+      // sweeper to mark every row "edited" without flipping the verb.
+      // The function takes the no-fields path through the Array.isArray
+      // guard, hits `if (!mutated)` with `alreadyPast === false`, and
+      // logs the shape-regression warn — confirmed below.
+      const msg = {
+        edit: jest.fn().mockResolvedValue(undefined),
+        embeds: [{ toJSON: () => ({ description: 'no-fields embed' /* no `fields` */ }) }],
+      };
+      const channel = { messages: { fetch: jest.fn().mockResolvedValue(msg) } };
+      mockClient.channels.fetch.mockResolvedValue(channel);
+
+      const ok = await discord.editDMToPastTense('chan-1', 'msg-1');
+      expect(ok).toBe(true);
+      expect(msg.edit).not.toHaveBeenCalled();
+      const logger = require('../src/logger');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('shape regression'),
+        expect.objectContaining({ channelId: 'chan-1', messageId: 'msg-1' }),
+      );
+    });
+
     it('warns when neither present nor past prefix is found (shape regression signal)', async () => {
       // Distinct from the already-past-tense path: this is the silent-
       // skip bug class — embed shape drifted between render and edit.

--- a/apps/discord/tests/expired-dm-label-sweeper.test.js
+++ b/apps/discord/tests/expired-dm-label-sweeper.test.js
@@ -18,13 +18,6 @@ jest.mock('../src/discord', () => ({
   editDMToPastTense: mockEditDMToPastTense,
 }));
 
-// Stub constants.js for just the prefixes the sweeper consumes — keeps
-// the test self-contained even if other constants change.
-jest.mock('../src/constants', () => ({
-  EXPIRY_PREFIX_PRESENT: 'PRESENT_PREFIX_',
-  EXPIRY_PREFIX_PAST: 'PAST_PREFIX_',
-}));
-
 const mockLogger = {
   info: jest.fn(),
   warn: jest.fn(),
@@ -57,8 +50,8 @@ describe('expired-dm-label-sweeper.sweepOnce', () => {
     await sweepOnce();
 
     expect(mockEditDMToPastTense).toHaveBeenCalledTimes(2);
-    expect(mockEditDMToPastTense).toHaveBeenCalledWith('c1', 'm1', 'PRESENT_PREFIX_', 'PAST_PREFIX_');
-    expect(mockEditDMToPastTense).toHaveBeenCalledWith('c2', 'm2', 'PRESENT_PREFIX_', 'PAST_PREFIX_');
+    expect(mockEditDMToPastTense).toHaveBeenCalledWith('c1', 'm1');
+    expect(mockEditDMToPastTense).toHaveBeenCalledWith('c2', 'm2');
     expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledTimes(2);
     expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m1');
     expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m2');

--- a/apps/discord/tests/expired-dm-label-sweeper.test.js
+++ b/apps/discord/tests/expired-dm-label-sweeper.test.js
@@ -1,0 +1,135 @@
+// Tests for the expired-dm-label sweeper. Covers:
+//   - empty queue is a no-op
+//   - happy path: edit + bulk-mark per unique message_id
+//   - permanent failure: edit returns false → still mark (don't retry forever)
+//   - transient failure: edit throws → DON'T mark (next sweep retries)
+//   - dedupe: multiple rows sharing one message_id → one edit call
+//   - DB list failure: caught + logged, no throw
+
+const mockListExpiredUneditedDMs = jest.fn();
+const mockMarkDMExpiredLabelEditedByMessageId = jest.fn();
+jest.mock('../src/database', () => ({
+  listExpiredUneditedDMs: mockListExpiredUneditedDMs,
+  markDMExpiredLabelEditedByMessageId: mockMarkDMExpiredLabelEditedByMessageId,
+}));
+
+const mockEditDMToPastTense = jest.fn();
+jest.mock('../src/discord', () => ({
+  editDMToPastTense: mockEditDMToPastTense,
+}));
+
+// Stub commands.js — the sweeper imports the prefix constants from there.
+// Inline mock keeps the test fast (commands.js drags discord.js, db, etc.).
+jest.mock('../src/commands', () => ({
+  EXPIRY_PREFIX_PRESENT: 'PRESENT_PREFIX_',
+  EXPIRY_PREFIX_PAST: 'PAST_PREFIX_',
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const { sweepOnce } = require('../src/expired-dm-label-sweeper');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('expired-dm-label-sweeper.sweepOnce', () => {
+  it('is a no-op when there are no expired unedited DMs', async () => {
+    mockListExpiredUneditedDMs.mockReturnValue([]);
+    await sweepOnce();
+    expect(mockEditDMToPastTense).not.toHaveBeenCalled();
+    expect(mockMarkDMExpiredLabelEditedByMessageId).not.toHaveBeenCalled();
+  });
+
+  it('edits each unique message and bulk-marks by message_id', async () => {
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+      { id: 2, send_id: 's2', recipient_discord_id: 'r2', dm_channel_id: 'c2', dm_message_id: 'm2' },
+    ]);
+    mockEditDMToPastTense.mockResolvedValue(true);
+
+    await sweepOnce();
+
+    expect(mockEditDMToPastTense).toHaveBeenCalledTimes(2);
+    expect(mockEditDMToPastTense).toHaveBeenCalledWith('c1', 'm1', 'PRESENT_PREFIX_', 'PAST_PREFIX_');
+    expect(mockEditDMToPastTense).toHaveBeenCalledWith('c2', 'm2', 'PRESENT_PREFIX_', 'PAST_PREFIX_');
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledTimes(2);
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m1');
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m2');
+  });
+
+  it('dedupes by dm_message_id — one edit call when multiple rows share a message', async () => {
+    // Three qurl_sends rows for one consolidated DM (e.g. /qurl add
+    // recipients delivered 3 links to the same recipient).
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+      { id: 2, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+      { id: 3, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+    ]);
+    mockEditDMToPastTense.mockResolvedValue(true);
+
+    await sweepOnce();
+
+    expect(mockEditDMToPastTense).toHaveBeenCalledTimes(1);
+    // markByMessageId is also called once — the SQL UPDATE matches all 3
+    // rows because they share dm_message_id, so one call covers the group.
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledTimes(1);
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m1');
+  });
+
+  it('marks edited even when edit returns false (permanent Discord failure)', async () => {
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+    ]);
+    // false = permanent failure (DM channel deleted, bot blocked, etc.).
+    // Marking anyway prevents the sweeper from retrying every minute forever.
+    mockEditDMToPastTense.mockResolvedValue(false);
+
+    await sweepOnce();
+
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m1');
+  });
+
+  it('does NOT mark when edit throws (transient failure → retry next sweep)', async () => {
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+    ]);
+    mockEditDMToPastTense.mockRejectedValue(new Error('discord 500'));
+
+    await sweepOnce();
+
+    expect(mockMarkDMExpiredLabelEditedByMessageId).not.toHaveBeenCalled();
+  });
+
+  it('continues sweeping siblings when one row throws', async () => {
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+      { id: 2, send_id: 's2', recipient_discord_id: 'r2', dm_channel_id: 'c2', dm_message_id: 'm2' },
+    ]);
+    mockEditDMToPastTense
+      .mockRejectedValueOnce(new Error('discord 500'))
+      .mockResolvedValueOnce(true);
+
+    await sweepOnce();
+
+    // m1 throws → not marked; m2 succeeds → marked. Sweeper doesn't bail
+    // on first error.
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledTimes(1);
+    expect(mockMarkDMExpiredLabelEditedByMessageId).toHaveBeenCalledWith('m2');
+  });
+
+  it('returns silently when listExpiredUneditedDMs throws', async () => {
+    mockListExpiredUneditedDMs.mockImplementation(() => {
+      throw new Error('db down');
+    });
+    // Should NOT throw — DB outage is logged and the sweep ends without
+    // attempting any edits.
+    await expect(sweepOnce()).resolves.toBeUndefined();
+    expect(mockEditDMToPastTense).not.toHaveBeenCalled();
+  });
+});

--- a/apps/discord/tests/expired-dm-label-sweeper.test.js
+++ b/apps/discord/tests/expired-dm-label-sweeper.test.js
@@ -18,19 +18,20 @@ jest.mock('../src/discord', () => ({
   editDMToPastTense: mockEditDMToPastTense,
 }));
 
-// Stub commands.js — the sweeper imports the prefix constants from there.
-// Inline mock keeps the test fast (commands.js drags discord.js, db, etc.).
-jest.mock('../src/commands', () => ({
+// Stub constants.js for just the prefixes the sweeper consumes — keeps
+// the test self-contained even if other constants change.
+jest.mock('../src/constants', () => ({
   EXPIRY_PREFIX_PRESENT: 'PRESENT_PREFIX_',
   EXPIRY_PREFIX_PAST: 'PAST_PREFIX_',
 }));
 
-jest.mock('../src/logger', () => ({
+const mockLogger = {
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+};
+jest.mock('../src/logger', () => mockLogger);
 
 const { sweepOnce } = require('../src/expired-dm-label-sweeper');
 
@@ -131,5 +132,91 @@ describe('expired-dm-label-sweeper.sweepOnce', () => {
     // attempting any edits.
     await expect(sweepOnce()).resolves.toBeUndefined();
     expect(mockEditDMToPastTense).not.toHaveBeenCalled();
+  });
+
+  it('skips the second sweep while the first is in flight (re-entrancy guard)', async () => {
+    // First sweep: rows + a deliberately slow editDMToPastTense so we can
+    // launch a second sweepOnce() while the first is still awaiting.
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+    ]);
+    let resolveEdit;
+    const editPromise = new Promise(res => { resolveEdit = res; });
+    mockEditDMToPastTense.mockReturnValue(editPromise);
+
+    const first = sweepOnce();
+    const second = sweepOnce();
+    resolveEdit(true);
+    await Promise.all([first, second]);
+
+    // Only one edit should have fired — the second sweep was skipped on
+    // entry. listExpiredUneditedDMs is called exactly once because the
+    // second sweep returns before fetching rows.
+    expect(mockEditDMToPastTense).toHaveBeenCalledTimes(1);
+    expect(mockListExpiredUneditedDMs).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Expired-DM-label sweep skipped (prior sweep still in flight)'
+    );
+  });
+
+  it('after a sweep completes, the next sweep is allowed (guard releases on success)', async () => {
+    // Regression check: the `finally` block must release the `sweeping`
+    // flag, otherwise a single completed sweep would block all future
+    // sweeps for the lifetime of the process.
+    mockListExpiredUneditedDMs.mockReturnValue([]);
+    await sweepOnce();
+    await sweepOnce();
+    expect(mockListExpiredUneditedDMs).toHaveBeenCalledTimes(2);
+  });
+
+  it('after a sweep throws, the next sweep is allowed (guard releases in finally)', async () => {
+    // The list-failure branch returns inside the try; the finally block
+    // must still release `sweeping` so a permanent DB error doesn't lock
+    // the sweeper out forever.
+    mockListExpiredUneditedDMs
+      .mockImplementationOnce(() => { throw new Error('db down'); })
+      .mockReturnValueOnce([]);
+    await sweepOnce();
+    await sweepOnce();
+    expect(mockListExpiredUneditedDMs).toHaveBeenCalledTimes(2);
+  });
+
+  it('emits saturation warn when the sweep fills the BATCH ceiling', async () => {
+    // BATCH = 50 rows ⇒ backlog signal. Build 50 unique-message-id rows.
+    const rows = Array.from({ length: 50 }, (_, i) => ({
+      id: i + 1,
+      send_id: `s${i + 1}`,
+      recipient_discord_id: `r${i + 1}`,
+      dm_channel_id: `c${i + 1}`,
+      dm_message_id: `m${i + 1}`,
+    }));
+    mockListExpiredUneditedDMs.mockReturnValue(rows);
+    mockEditDMToPastTense.mockResolvedValue(true);
+
+    await sweepOnce();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Expired-DM-label sweep hit batch ceiling — backlog likely',
+      expect.objectContaining({ processedRows: 50, batch: 50 }),
+    );
+  });
+
+  it('separates permanent-fail signal from happy-path info log', async () => {
+    // permanentFails > 0 must surface as warn, not just be folded into
+    // the info line — dashboards key on level for alerting.
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+    ]);
+    mockEditDMToPastTense.mockResolvedValue(false);
+
+    await sweepOnce();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Expired-DM-label sweep recorded permanent failures',
+      expect.objectContaining({ permanentFails: 1, edited: 0 }),
+    );
+    // No info-level "complete" line on the perm-fail path — the warn
+    // carries the same shape.
+    expect(mockLogger.info).not.toHaveBeenCalled();
   });
 });

--- a/apps/discord/tests/expired-dm-label-sweeper.test.js
+++ b/apps/discord/tests/expired-dm-label-sweeper.test.js
@@ -194,6 +194,46 @@ describe('expired-dm-label-sweeper.sweepOnce', () => {
     );
   });
 
+  it('distinguishes "edit succeeded but mark failed" from "edit failed"', async () => {
+    // If the Discord edit lands but the DB mark then throws (transient
+    // SQLite busy/lock), the sweeper must NOT log the same line as a
+    // real edit failure — otherwise dashboards conflate self-healing
+    // mark hiccups with actual edit failures and the apparent failure
+    // rate inflates. The fix wraps the mark call in its own try/catch
+    // and logs a distinct line that names the actual failure mode.
+    mockListExpiredUneditedDMs.mockReturnValue([
+      { id: 1, send_id: 's1', recipient_discord_id: 'r1', dm_channel_id: 'c1', dm_message_id: 'm1' },
+    ]);
+    mockEditDMToPastTense.mockResolvedValue(true);
+    mockMarkDMExpiredLabelEditedByMessageId.mockImplementationOnce(() => {
+      throw new Error('SQLITE_BUSY: database is locked');
+    });
+
+    await sweepOnce();
+
+    // Distinct warn line — the message text must NOT be the
+    // edit-failed wording (which is what callers would scan logs for
+    // if they were tracking edit failures).
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('edit succeeded but DB mark failed'),
+      expect.objectContaining({ messageId: 'm1' }),
+    );
+    // The edit-failed line must NOT have been logged for this row.
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Expired-DM-label edit failed'),
+      expect.anything(),
+    );
+    // The row counts as edited because the Discord-side edit DID
+    // land — next sweep finds the embed already past-tense and
+    // idempotently re-marks via the markDMExpiredLabelEditedByMessageId
+    // call from the already-past path. Confirm the happy-path info
+    // log fires (edited=1, permanentFails=0).
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Expired-DM-label sweep complete',
+      expect.objectContaining({ edited: 1 }),
+    );
+  });
+
   it('separates permanent-fail signal from happy-path info log', async () => {
     // permanentFails > 0 must surface as warn, not just be folded into
     // the info line — dashboards key on level for alerting.

--- a/apps/discord/tests/oauth.test.js
+++ b/apps/discord/tests/oauth.test.js
@@ -7,7 +7,7 @@ jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn().mockResolvedValue({ success: true }),
   notifyPRMerge: jest.fn(),
   notifyBadgeEarned: jest.fn(),
-  sendDM: jest.fn().mockResolvedValue(true),
+  sendDM: jest.fn().mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' }),
 }));
 
 jest.mock('../src/database', () => ({

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -99,6 +99,7 @@ jest.mock('../src/database', () => {
     recordQURLSend: jest.fn(),
     recordQURLSendBatch: jest.fn(),
     updateSendDMStatus: jest.fn(),
+    recordDMIdentifiers: jest.fn(),
     getRecentSends: jest.fn(() => []),
     getSendResourceIds: jest.fn(() => []),
     saveSendConfig: jest.fn(),
@@ -1358,13 +1359,14 @@ describe('handleAddRecipients', () => {
       recordQURLSend: jest.fn(),
       recordQURLSendBatch: jest.fn(),
       updateSendDMStatus: jest.fn(),
+      recordDMIdentifiers: jest.fn(),
       getRecentSends: jest.fn(() => []),
       getSendResourceIds: jest.fn(() => []),
     };
     jest.mock('../src/database', () => mockDb);
 
     // Mock discord helper
-    mockSendDM = jest.fn().mockResolvedValue(true);
+    mockSendDM = jest.fn().mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
     jest.mock('../src/discord', () => ({
       assignContributorRole: jest.fn(),
       notifyPRMerge: jest.fn(),
@@ -1530,7 +1532,7 @@ describe('handleAddRecipients', () => {
       { qurl_link: 'https://q.test/mint-2' },
     ]);
 
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1575,7 +1577,7 @@ describe('handleAddRecipients', () => {
       hash: 'loc-hash',
     });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/otl-1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Charlie' },
@@ -1611,7 +1613,7 @@ describe('handleAddRecipients', () => {
       success: true,
     });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/maps-1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Dana' },
@@ -1648,8 +1650,8 @@ describe('handleAddRecipients', () => {
 
     // First DM succeeds, second fails
     mockSendDM
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+      .mockResolvedValueOnce({ ok: true, channelId: 'c', messageId: 'm' })
+      .mockResolvedValueOnce({ ok: false, channelId: null, messageId: null });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1700,7 +1702,7 @@ describe('handleAddRecipients', () => {
       { qurl_link: 'https://q.test/link2' },
     ]);
 
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1771,7 +1773,7 @@ describe('handleAddRecipients', () => {
       .mockResolvedValueOnce(batch1Links)
       .mockResolvedValueOnce(batch2Links);
 
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const users = makeUsersCollection(userList);
     const result = await handleAddRecipients('send-batch', users, mockOriginalInteraction, 'test-api-key');
@@ -1805,7 +1807,7 @@ describe('handleAddRecipients', () => {
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res-C', fileBuffer: new ArrayBuffer(8) });
     const links = Array.from({ length: 8 }, (_, i) => ({ qurl_link: `https://q.test/l-${i}` }));
     mockMintLinks.mockResolvedValueOnce(links);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'c', messageId: 'm' });
 
     const users = makeUsersCollection(userList);
     const result = await handleAddRecipients('send-ok', users, mockOriginalInteraction, 'test-api-key');


### PR DESCRIPTION
## Summary

When a recipient views a /qurl send DM after the link has expired, they currently see `🕐 Portal closes 5 hours ago` — present-tense verb against a past-relative time. Discord's `<t:N:R>` markdown auto-updates the relative time client-side, but the literal verb stays present-tense unless we rewrite the embed.

This PR adds a 1-minute background sweeper that edits each recipient DM at expiry to flip the verb: `Portal closes <t:N:R>` → `Portal closed <t:N:R>`. Pre-expiry UX is unchanged (live countdown + "closes"); post-expiry the recipient sees `Portal closed 5 hours ago` — correct tense in both directions.

## Why a background sweeper (and not a copy change)

Three approaches considered:
- **Switch to absolute timestamp** (`<t:N:F>`): present-habitual reads naturally always but loses the live countdown that PR #124 v15 deliberately introduced.
- **Tense-neutral noun phrase** (`Auto-close <t:N:R>`): keeps countdown but loses the natural "closes/closed" verb framing.
- **Bot-side edit at expiry** (this PR): keeps the live countdown AND the natural verb, at the cost of new DB state + a minute-resolution sweep.

User explicitly chose the third option: pre-expiry behavior identical to today, post-expiry tense flips automatically.

## Changes

### Schema (idempotent SAFE_ALTERS)

Four new columns on `qurl_sends`:
- `dm_channel_id TEXT` — Discord DM channel for editing later
- `dm_message_id TEXT` — Discord message ID
- `expires_at_unix INTEGER` — absolute expiry (Unix seconds)
- `expired_label_edited_at TEXT` — sweeper's done-marker

Plus two partial indexes (added after SAFE_ALTERS so the column references resolve):
- `idx_qurl_sends_expiry_sweeper` — drives `listExpiredUneditedDMs` (the per-minute sweeper SELECT). Partial-index `WHERE` matches the predicate exactly.
- `idx_qurl_sends_dm_message_id` — drives `markDMExpiredLabelEditedByMessageId` (the bulk UPDATE per unique DM).

Legacy rows predating this migration have NULL identifiers and are excluded from the sweep via `dm_message_id IS NOT NULL`.

### `sendDM` return shape

Was: `boolean`.
Now: `{ ok: boolean, channelId: string|null, messageId: string|null }`.

A new `sendDMAndPersist` helper in `commands.js` owns the send + status update + identifier persist contract, called from both `handleSend` and `handleAddRecipients`. Test mocks updated for the new shape.

### New module: `src/expired-dm-label-sweeper.js`

- Runs every 60s after a 60s post-boot delay (delay covers `client.login()`'s own 30s deadline + cache hydration headroom; mirrors the orphan-token-sweeper boot dance)
- Re-entrancy guard (`sweeping` flag) prevents overlapping sweeps from doubling Discord traffic
- Batch size 50 per sweep, ordered by oldest-expiry first
- Dedupes by `dm_message_id` so multi-link consolidated DMs (from `/qurl add recipients`) get one edit call rather than N
- Concurrency 5 within each batch (`Promise.allSettled`) — drains a 50-row backlog in ~3s instead of ~15s sequential
- Permanent Discord failures (codes `10003`, `10008`, `10013`, `50001`, `50007`, `50013`) → mark anyway to stop retry storms
- Transient failures (5xx, 429, network) → leave unmarked, retry next sweep (60s cadence dwarfs any Retry-After Discord would send)
- Distinct log lines for "edit failed" vs "edit succeeded but DB mark failed" so dashboards don't conflate self-healing mark hiccups with real edit failures
- Saturation warn when sweep hits BATCH ceiling (backlog signal)
- Permanent-fails warn when count > 0 (separate from happy-path info)
- `interval.unref()` so the sweeper doesn't block process shutdown

### `editDMToPastTense` in `discord.js`

- Walks the message's embeds, replaces the first matching field's `Portal closes <t:` with `Portal closed <t:`
- No-op if the prefix isn't found AND the past prefix is found (idempotent re-sweep path)
- Logs warn if NEITHER prefix is found (shape regression — observable signal instead of silent skip)
- Components (the `Step Through →` button) preserved by passing only `embeds` to `msg.edit`
- Reads `EXPIRY_PREFIX_PRESENT/PAST` from constants.js at module top — same source of truth as `buildDeliveryPayload`

### Single source of truth for the prefix

`EXPIRY_PREFIX_PRESENT` / `EXPIRY_PREFIX_PAST` exported from `constants.js`. Both `buildDeliveryPayload` (render path) and the sweeper / `editDMToPastTense` (edit path) reference the same literals — a future copy edit can't drift between the two. The build-delivery-embed test imports the constants and pins three invariants (rendered value matches, lives in `addFields` not `setDescription`, appears exactly once).

## Test plan

- [x] `npm test` — 599/599 pass (added 19 new tests across the polish rounds: 12 sweeper, 6 editDMToPastTense, 6 DB-helpers via real SQLite, 1 build-delivery-embed sweeper-edit invariant — net +25 vs. base accounting for split / refactored cases)
- [x] `npm run lint` — clean (max-warnings 0)
- [ ] Post-deploy manual: send a `/qurl send` to yourself with a `30m` expiry. Check the DM at minute 0 (says `Portal closes in 30 minutes`), minute 31 (should say `Portal closed 1 minute ago` or similar — within ~60s of expiry)
- [ ] Post-deploy manual: send to multiple recipients via `/qurl add recipients`. Confirm all of their DMs flip together at expiry (one edit per consolidated DM)
- [ ] Post-deploy manual: block the bot from a test account, send a DM, let it expire. Sweeper should mark the row as edited even though the edit "failed" (permanent error code) — verify by checking `qurl_sends.expired_label_edited_at` is set after the next sweep

## Rollback

Plain revert. The added columns + partial indexes stay (harmless) but the sweeper stops, so DMs stuck mid-edit just keep their pre-revert tense — no data loss, no broken flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)