### PR TITLE
docs(discord): document STORE_TYPE + DDB_TABLE_PREFIX in .env.example

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -59,6 +59,26 @@ ENABLE_OPENNHP_FEATURES=false
 # Unknown values fail boot loudly. Leave unset to default to combined.
 # PROCESS_ROLE=combined
 
+# Store backend — selects the bot's data layer at boot.
+#
+#   sqlite — better-sqlite3 over a file on a mounted volume (legacy).
+#            Sync; default. Suitable for single-task deployments where
+#            the volume is the source of truth for guild + user state.
+#   ddb    — DynamoDB-backed. Async. Required for the greenfield stack
+#            (multi-AZ, no shared filesystem). Reads `DDB_TABLE_PREFIX`
+#            for table-name scoping (default `qurl-bot-discord-sandbox`).
+#
+# Empty / whitespace-only values fall back to sqlite. Unknown non-empty
+# values fail boot. Leave unset to default to sqlite.
+# STORE_TYPE=sqlite
+
+# DDB table-name prefix when STORE_TYPE=ddb. Required (no default in
+# prod paths — the sandbox-shaped fallback is intentionally laptop-only
+# so a misconfigured prod can't silently bind to the wrong env's tables).
+# Tables are created by the `qurl-bot-ddb` Terraform module; this var
+# must match the module's `env` input.
+# DDB_TABLE_PREFIX=qurl-bot-discord-sandbox
+
 # GitHub OAuth App — REQUIRED only when ENABLE_OPENNHP_FEATURES=true.
 # Single-guild-plain and multi-tenant deployments don't mount /auth or
 # /webhook routes and don't need these values — the boot check


### PR DESCRIPTION
## Summary

Documents the two env vars introduced in #116 (`STORE_TYPE`) and consumed by the DdbStore backend (`DDB_TABLE_PREFIX`) in `apps/discord/.env.example`. Mirrors the style of the existing `PROCESS_ROLE` block.

No runtime change.

## Why now

This PR also serves as the **end-to-end probe of the dispatcher pipeline** (migration step 5):

- Push to main with `apps/discord/**` change → `discord.yml` `trigger-deploy` job → `repository_dispatch` to `qurl-integrations-infra` → `qurl-bot-discord-deploy.yml` picks it up → sandbox redeploys + e2e-smoke green.

If this lands and a sandbox deploy auto-fires within ~minute, the dispatcher path is validated and the migration train moves to step 6 (manual-seed runbook).

## Test plan

- [ ] CI green on `discord.yml`
- [ ] Merge to main
- [ ] `discord.yml` `trigger-deploy` job fires `repository_dispatch`
- [ ] `qurl-bot-discord-deploy.yml` on `qurl-integrations-infra` picks it up
- [ ] Sandbox redeploys
- [ ] e2e-smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)