### PR TITLE
feat(discord): structured audit events + 🔗 Step Through DM button

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1498,6 +1498,8 @@ async function handleSend(interaction, apiKey) {
         qurlLink: allLinks[i].qurl_link,
         resourceId: allLinks[i].resourceId,
       }));
+      logger.audit('upload_success', { send_id: sendId, kind: 'file' });
+      logger.audit('mint_success', { send_id: sendId, kind: 'file', count: qurlLinks.length, expires_in: expiresIn });
     } else {
       // Location send — upload JSON payload to connector, then mint in batches
       // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
@@ -1525,9 +1527,12 @@ async function handleSend(interaction, apiKey) {
         qurlLink: allLinks[i].qurl_link,
         resourceId: allLinks[i].resourceId,
       }));
+      logger.audit('upload_success', { send_id: sendId, kind: 'location' });
+      logger.audit('mint_success', { send_id: sendId, kind: 'location', count: qurlLinks.length, expires_in: expiresIn });
     }
   } catch (error) {
     logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
+    logger.audit('mint_failed', { send_id: sendId, kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location', api_code: error.apiCode || null });
     clearCooldown(interaction.user.id); // allow retry on failure
     releaseSlot();
     // Surface a specific message for known upstream failure codes so the
@@ -1606,6 +1611,7 @@ async function handleSend(interaction, apiKey) {
 
     const sent = await sendDM(link.recipientId, dmPayload);
     await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
+    logger.audit(sent ? 'dispatch_sent' : 'dispatch_failed', { send_id: sendId });
     return { recipientId: link.recipientId, username: recipient?.username, sent };
   }, 5);
 
@@ -2281,6 +2287,7 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
   await db.markSendRevoked(sendId, senderDiscordId);
 
   logger.info('Revoked send', { sendId, success, total: resourceIds.length });
+  logger.audit('revoke_success', { send_id: sendId, success, total: resourceIds.length });
   return { success, total: resourceIds.length };
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -267,7 +267,7 @@ function resolveSenderAlias(interaction) {
 // "what's on the other side is invisible to … scanners, bots, crawlers,
 // strangers") rather than literal ("shared a file with you") — the brand
 // goal is to convey the qURL hidden-layer model, not just announce a
-// file transfer. The qURL link is rendered as a `Step Through →` Link
+// file transfer. The qURL link is rendered as a `🔗 Step Through` Link
 // button rather than a bare URL field; recipients click the button to
 // open the link in their default browser.
 //
@@ -302,7 +302,7 @@ function resolveSenderAlias(interaction) {
 //     │  This is how you enter.                                     │   `qURL` → https://layerv.ai)
 //     │                                                             │
 //     │  ┌──────────────────────────┐                               │
-//     │  │   Step Through →         │  (Link button — opens qURL)
+//     │  │   🔗 Step Through        │  (Link button — opens qURL)
 //     │  └──────────────────────────┘                               │
 //     └─────────────────────────────────────────────────────────────┘
 //
@@ -389,11 +389,21 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     },
   );
 
-  // Link button: grey, single-click opens qurlLink in the recipient's
-  // browser. No interaction handler needed — Discord handles the redirect.
+  // Link button: opens qurlLink in the recipient's browser on a
+  // single click. No interaction handler needed — Discord handles
+  // the redirect.
+  //
+  // Style is `ButtonStyle.Link` because Discord requires URL buttons
+  // to be Link-style (Primary/Success/Danger/Secondary cannot carry
+  // a URL — they only fire interaction handlers). Link buttons render
+  // gray, which can read as "text" rather than a clickable affordance.
+  // The leading 🔗 emoji adds visual weight so the recipient sees a
+  // clear button shape; arrow `→` dropped from the label since the
+  // emoji conveys the same "go elsewhere" intent.
   const stepThrough = new ButtonBuilder()
     .setStyle(ButtonStyle.Link)
-    .setLabel('Step Through →')
+    .setEmoji('🔗')
+    .setLabel('Step Through')
     .setURL(qurlLink);
   const components = [new ActionRowBuilder().addComponents(stepThrough)];
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1606,27 +1606,25 @@ async function handleSend(interaction, apiKey) {
 
   const dmResults = await batchSettled(qurlLinks, async (link) => {
     const recipient = recipientMap.get(link.recipientId);
-    const dmPayload = buildDeliveryPayload({
-      // member.displayName resolves to nickname || globalName || username,
-      // so it works whether the sender has a per-guild nickname, only a
-      // global display name, or just the legacy @-handle.
-      senderAlias: resolveSenderAlias(interaction),
-      qurlLink: link.qurlLink,
-      expiresAt,
-      personalMessage,
-    });
-
-    // Audit in `finally` so the metric fires whether sendDM resolves to
-    // false OR throws. sendDM is contractually no-throw today (see
-    // apps/discord/src/discord.js — its own try/catch returns false on
-    // every failure mode), but try/finally locks the metric's accuracy
-    // against a future change to that contract: a thrown sendDM should
-    // still count as dispatch_failed, not silently disappear from
-    // CloudWatch. Audit also fires BEFORE the DB write so a DDB-layer
-    // throw can't suppress it — that's the failure mode the audit
-    // metric exists to measure.
+    // Audit in `finally` so the metric fires for every recipient regardless
+    // of where the dispatch fails — sendDM resolving to false, sendDM
+    // throwing (against contract — see apps/discord/src/discord.js), OR
+    // buildDeliveryPayload throwing (e.g. on a pathological personalMessage).
+    // Audit fires BEFORE the DB write so a DDB-layer throw can't suppress
+    // it either — that's the failure mode the audit metric exists to
+    // measure. Coverage spans the entire dispatch attempt, not just the
+    // network leg.
     let sent = false;
     try {
+      const dmPayload = buildDeliveryPayload({
+        // member.displayName resolves to nickname || globalName || username,
+        // so it works whether the sender has a per-guild nickname, only a
+        // global display name, or just the legacy @-handle.
+        senderAlias: resolveSenderAlias(interaction),
+        qurlLink: link.qurlLink,
+        expiresAt,
+        personalMessage,
+      });
       sent = await sendDM(link.recipientId, dmPayload);
     } finally {
       logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
@@ -2114,43 +2112,47 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // with their corresponding embed. Multi-link UX would benefit from
     // per-link button labels (e.g. "Step Through · report.pdf"), but
     // today links.length is always 1 so labels are uniform.
-    // Same Unix-seconds expiry computation as handleSend — see comment
-    // there. Computed once per recipient (cheap; the alternative would
-    // be threading a single timestamp through sendConfig).
-    const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
-    const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
-      // Same alias resolution as handleSend — see comment there for
-      // the nickname > globalName > username fallback rationale.
-      senderAlias: resolveSenderAlias(originalInteraction),
-      qurlLink: link.qurlLink,
-      expiresAt,
-      personalMessage: sendConfig.personal_message,
-    }));
-    // Contract with buildDeliveryPayload: each payload's `components`
-    // array contains exactly one ActionRow whose `components` are the
-    // per-link buttons. We pull each payload's first row's children
-    // (one Step Through button per link) and re-pack into 5-per-row
-    // ActionRows since Discord caps at 5 buttons per ActionRow.
-    const allEmbeds = payloads.flatMap(p => p.embeds);
-    const allButtons = payloads.flatMap(p => {
-      // Hard fail rather than silently drop buttons if the contract
-      // ever changes — easier to catch than a button quietly missing
-      // from a recipient's DM.
-      if (!p.components || !p.components[0] || !Array.isArray(p.components[0].components)) {
-        throw new Error('buildDeliveryPayload contract violated: expected components[0].components to be an array');
-      }
-      return p.components[0].components;
-    });
-    const allComponents = [];
-    for (let i = 0; i < allButtons.length; i += 5) {
-      allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
-    }
-
     // try/finally + before-DB-write — see handleSend's batchSettled
-    // callback for the full rationale (sendDM-throws AND DB-throw must
-    // both still emit the metric).
+    // callback for the full rationale (payload-build, sendDM-throws,
+    // AND DB-throw must all still emit the metric). Wraps the entire
+    // dispatch attempt — payload assembly, button re-packing, network
+    // call — so a malformed sendConfig (e.g. pathological
+    // personalMessage that throws inside buildDeliveryPayload) still
+    // counts as dispatch_failed instead of disappearing from CloudWatch.
     let sent = false;
     try {
+      // Same Unix-seconds expiry computation as handleSend — see comment
+      // there. Computed once per recipient (cheap; the alternative would
+      // be threading a single timestamp through sendConfig).
+      const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
+      const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
+        // Same alias resolution as handleSend — see comment there for
+        // the nickname > globalName > username fallback rationale.
+        senderAlias: resolveSenderAlias(originalInteraction),
+        qurlLink: link.qurlLink,
+        expiresAt,
+        personalMessage: sendConfig.personal_message,
+      }));
+      // Contract with buildDeliveryPayload: each payload's `components`
+      // array contains exactly one ActionRow whose `components` are the
+      // per-link buttons. We pull each payload's first row's children
+      // (one Step Through button per link) and re-pack into 5-per-row
+      // ActionRows since Discord caps at 5 buttons per ActionRow.
+      const allEmbeds = payloads.flatMap(p => p.embeds);
+      const allButtons = payloads.flatMap(p => {
+        // Hard fail rather than silently drop buttons if the contract
+        // ever changes — easier to catch than a button quietly missing
+        // from a recipient's DM.
+        if (!p.components || !p.components[0] || !Array.isArray(p.components[0].components)) {
+          throw new Error('buildDeliveryPayload contract violated: expected components[0].components to be an array');
+        }
+        return p.components[0].components;
+      });
+      const allComponents = [];
+      for (let i = 0; i < allButtons.length; i += 5) {
+        allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
+      }
+
       sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
     } finally {
       logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1532,7 +1532,7 @@ async function handleSend(interaction, apiKey) {
     }
   } catch (error) {
     logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
-    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location', api_code: error.apiCode || null });
+    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location', api_code: error.apiCode ?? null });
     clearCooldown(interaction.user.id); // allow retry on failure
     releaseSlot();
     // Surface a specific message for known upstream failure codes so the
@@ -2055,7 +2055,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', { error: error.message });
-    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: inFlightKind, api_code: error.apiCode || null });
+    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: inFlightKind, api_code: error.apiCode ?? null });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
@@ -2305,10 +2305,14 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
   // partial failures are surfaced in the reply message ("Revoked X/Y"),
   // and re-picking the same send from the dropdown wouldn't help anyway
   // since the failed resource_ids are the same.
+  // Emit BEFORE markSendRevoked for the same reason the dispatch
+  // emissions fire before updateSendDMStatus — a DB write throw must
+  // not suppress the audit metric, which is exactly the failure mode
+  // we're trying to measure.
+  logger.audit(AUDIT_EVENTS.REVOKE_SUCCESS, { send_id: sendId, success, total: resourceIds.length });
   await db.markSendRevoked(sendId, senderDiscordId);
 
   logger.info('Revoked send', { sendId, success, total: resourceIds.length });
-  logger.audit(AUDIT_EVENTS.REVOKE_SUCCESS, { send_id: sendId, success, total: resourceIds.length });
   return { success, total: resourceIds.length };
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1509,7 +1509,6 @@ async function handleSend(interaction, apiKey) {
         resourceId: allLinks[i].resourceId,
       }));
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
-      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'file', count: qurlLinks.length, expires_in: expiresIn });
     } else {
       // Location send — upload JSON payload to connector, then mint in batches
       // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
@@ -1538,11 +1537,9 @@ async function handleSend(interaction, apiKey) {
         resourceId: allLinks[i].resourceId,
       }));
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
-      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'location', count: qurlLinks.length, expires_in: expiresIn });
     }
   } catch (error) {
     logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
-    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location', api_code: error.apiCode ?? null });
     clearCooldown(interaction.user.id); // allow retry on failure
     releaseSlot();
     // Surface a specific message for known upstream failure codes so the
@@ -1957,15 +1954,8 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Cannot add recipients — send configuration is incomplete.', newResourceIds: [], delivered: 0, failed: 0 };
   }
 
-  // Tracks which kind was in flight when a throw escapes — `hasFile` and
-  // `hasLocation` can both be true (a single send-config that had both),
-  // so a "ternary on hasFile" mislabels the failure when location throws
-  // after the file path already succeeded. Set right before each block
-  // that can throw, read by the catch's logger.audit(MINT_FAILED).
-  let inFlightKind = null;
   try {
     if (hasFile) {
-      inFlightKind = 'file';
       // Re-download from the stored Discord CDN URL, then upload a fresh
       // resource so the 10-token pool is full. Re-upload again every
       // TOKENS_PER_RESOURCE recipients. The original resource is drained by
@@ -2019,11 +2009,6 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
-        // Emit mint_failed here too — the inner catch returns early, so the
-        // outer catch (which also emits) never sees these errors. Without
-        // this line the metric undercounts the most common file-path
-        // failure mode (Discord CDN URL expiry).
-        logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: 'file', api_code: err.apiCode ?? null });
         return { msg, newResourceIds: [], delivered: 0, failed: 0 };
       }
 
@@ -2046,10 +2031,8 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         });
       }
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
-      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'file', count: allLinks.length, expires_in: sendConfig.expires_in });
     }
     if (hasLocation) {
-      inFlightKind = 'location';
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
       const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey);
       const expiresAt = expiryToISO(sendConfig.expires_in);
@@ -2074,16 +2057,9 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         });
       });
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
-      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'location', count: allLinks.length, expires_in: sendConfig.expires_in });
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', { error: error.message });
-    // `?? 'unknown'` is defensive — the early `if (!hasFile && !hasLocation)`
-    // guard above means we never reach the catch with inFlightKind=null
-    // today, but a future refactor that adds a throwable op before the
-    // first inFlightKind assignment would otherwise emit `kind: null`,
-    // which the CloudWatch dimension can't bucket.
-    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: inFlightKind ?? 'unknown', api_code: error.apiCode ?? null });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1627,7 +1627,7 @@ async function handleSend(interaction, apiKey) {
       });
       sent = await sendDM(link.recipientId, dmPayload);
     } finally {
-      logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+      logger.audit(sent === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     }
     await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
     return { recipientId: link.recipientId, username: recipient?.username, sent };
@@ -2177,7 +2177,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
       sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
     } finally {
-      logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+      logger.audit(sent === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     }
     // updateSendDMStatus updates every qurl_sends row matching (sendId,
     // recipient.id), so a single call covers all links for this recipient.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1619,13 +1619,21 @@ async function handleSend(interaction, apiKey) {
       personalMessage,
     });
 
-    const sent = await sendDM(link.recipientId, dmPayload);
-    // Emit the audit event BEFORE the DB write — if updateSendDMStatus
-    // throws (e.g., transient DDB throttle), the recipient is still
-    // counted in CloudWatch metrics. Doing it after the DB write would
-    // silently drop the metric on every DB-layer hiccup, which is the
-    // exact failure mode the audit metric is supposed to measure.
-    logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+    // Audit in `finally` so the metric fires whether sendDM resolves to
+    // false OR throws. sendDM is contractually no-throw today (see
+    // apps/discord/src/discord.js — its own try/catch returns false on
+    // every failure mode), but try/finally locks the metric's accuracy
+    // against a future change to that contract: a thrown sendDM should
+    // still count as dispatch_failed, not silently disappear from
+    // CloudWatch. Audit also fires BEFORE the DB write so a DDB-layer
+    // throw can't suppress it — that's the failure mode the audit
+    // metric exists to measure.
+    let sent = false;
+    try {
+      sent = await sendDM(link.recipientId, dmPayload);
+    } finally {
+      logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+    }
     await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
     return { recipientId: link.recipientId, username: recipient?.username, sent };
   }, 5);
@@ -2070,7 +2078,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', { error: error.message });
-    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: inFlightKind, api_code: error.apiCode ?? null });
+    // `?? 'unknown'` is defensive — the early `if (!hasFile && !hasLocation)`
+    // guard above means we never reach the catch with inFlightKind=null
+    // today, but a future refactor that adds a throwable op before the
+    // first inFlightKind assignment would otherwise emit `kind: null`,
+    // which the CloudWatch dimension can't bucket.
+    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: inFlightKind ?? 'unknown', api_code: error.apiCode ?? null });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
@@ -2157,10 +2170,15 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
     }
 
-    const sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
-    // Audit BEFORE the DB write — see handleSend's batchSettled callback
-    // for the rationale (DB throw must not suppress the metric).
-    logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+    // try/finally + before-DB-write — see handleSend's batchSettled
+    // callback for the full rationale (sendDM-throws AND DB-throw must
+    // both still emit the metric).
+    let sent = false;
+    try {
+      sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
+    } finally {
+      logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+    }
     // updateSendDMStatus updates every qurl_sends row matching (sendId,
     // recipient.id), so a single call covers all links for this recipient.
     // The previous `for (let i = 0; i < links.length; i++)` loop wrote the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -17,7 +17,7 @@ const crypto = require('crypto');
 const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
-const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS } = require('./constants');
+const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, AUDIT_EVENTS } = require('./constants');
 const { expiryToISO, expiryToMs } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { deleteLink, getResourceStatus } = require('./qurl');
@@ -1498,8 +1498,8 @@ async function handleSend(interaction, apiKey) {
         qurlLink: allLinks[i].qurl_link,
         resourceId: allLinks[i].resourceId,
       }));
-      logger.audit('upload_success', { send_id: sendId, kind: 'file' });
-      logger.audit('mint_success', { send_id: sendId, kind: 'file', count: qurlLinks.length, expires_in: expiresIn });
+      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
+      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'file', count: qurlLinks.length, expires_in: expiresIn });
     } else {
       // Location send — upload JSON payload to connector, then mint in batches
       // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
@@ -1527,12 +1527,12 @@ async function handleSend(interaction, apiKey) {
         qurlLink: allLinks[i].qurl_link,
         resourceId: allLinks[i].resourceId,
       }));
-      logger.audit('upload_success', { send_id: sendId, kind: 'location' });
-      logger.audit('mint_success', { send_id: sendId, kind: 'location', count: qurlLinks.length, expires_in: expiresIn });
+      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
+      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'location', count: qurlLinks.length, expires_in: expiresIn });
     }
   } catch (error) {
     logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
-    logger.audit('mint_failed', { send_id: sendId, kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location', api_code: error.apiCode || null });
+    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location', api_code: error.apiCode || null });
     clearCooldown(interaction.user.id); // allow retry on failure
     releaseSlot();
     // Surface a specific message for known upstream failure codes so the
@@ -1610,8 +1610,13 @@ async function handleSend(interaction, apiKey) {
     });
 
     const sent = await sendDM(link.recipientId, dmPayload);
+    // Emit the audit event BEFORE the DB write — if updateSendDMStatus
+    // throws (e.g., transient DDB throttle), the recipient is still
+    // counted in CloudWatch metrics. Doing it after the DB write would
+    // silently drop the metric on every DB-layer hiccup, which is the
+    // exact failure mode the audit metric is supposed to measure.
+    logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    logger.audit(sent ? 'dispatch_sent' : 'dispatch_failed', { send_id: sendId });
     return { recipientId: link.recipientId, username: recipient?.username, sent };
   }, 5);
 
@@ -2010,6 +2015,8 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           label: `File (${sanitizeFilename(sendConfig.attachment_name || 'file')})`,
         });
       }
+      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
+      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'file', count: allLinks.length, expires_in: sendConfig.expires_in });
     }
     if (hasLocation) {
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
@@ -2035,9 +2042,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           resType: RESOURCE_TYPES.MAPS, label: sendConfig.location_name || 'Google Maps',
         });
       });
+      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
+      logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'location', count: allLinks.length, expires_in: sendConfig.expires_in });
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', { error: error.message });
+    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: hasFile ? 'file' : 'location', api_code: error.apiCode || null });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
@@ -2125,6 +2135,9 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
 
     const sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
+    // Audit BEFORE the DB write — see handleSend's batchSettled callback
+    // for the rationale (DB throw must not suppress the metric).
+    logger.audit(sent ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     // updateSendDMStatus updates every qurl_sends row matching (sendId,
     // recipient.id), so a single call covers all links for this recipient.
     // The previous `for (let i = 0; i < links.length; i++)` loop wrote the
@@ -2287,7 +2300,7 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
   await db.markSendRevoked(sendId, senderDiscordId);
 
   logger.info('Revoked send', { sendId, success, total: resourceIds.length });
-  logger.audit('revoke_success', { send_id: sendId, success, total: resourceIds.length });
+  logger.audit(AUDIT_EVENTS.REVOKE_SUCCESS, { send_id: sendId, success, total: resourceIds.length });
   return { success, total: resourceIds.length };
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2103,6 +2103,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
   const dmResults = await batchSettled(newRecipients, async (recipient) => {
     const links = recipientLinks[recipient.id];
+    // Defensive guard: recipientLinks is populated above for every newRecipient,
+    // so reaching this branch means an upstream invariant broke (recipient
+    // present in the loop input but missing from the link map). We skip
+    // both the network call AND the audit emission — the metric represents
+    // actual dispatch attempts, not "recipients listed in the input." A
+    // dropped audit here is correct: there is no transport leg to count.
     if (!links || links.length === 0) return { sent: false, username: recipient.username };
 
     // links.slice(0, 10) caps at Discord's 10-embed-per-message limit.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2001,6 +2001,11 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
+        // Emit mint_failed here too — the inner catch returns early, so the
+        // outer catch (which also emits) never sees these errors. Without
+        // this line the metric undercounts the most common file-path
+        // failure mode (Discord CDN URL expiry).
+        logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: 'file', api_code: err.apiCode ?? null });
         return { msg, newResourceIds: [], delivered: 0, failed: 0 };
       }
 
@@ -2308,8 +2313,13 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
   // Emit BEFORE markSendRevoked for the same reason the dispatch
   // emissions fire before updateSendDMStatus — a DB write throw must
   // not suppress the audit metric, which is exactly the failure mode
-  // we're trying to measure.
-  logger.audit(AUDIT_EVENTS.REVOKE_SUCCESS, { send_id: sendId, success, total: resourceIds.length });
+  // we're trying to measure. Distinguish all-failed (success === 0)
+  // from at-least-partial (success > 0) so the dashboard isn't
+  // misled into counting fully-failed revokes as successes.
+  if (resourceIds.length > 0) {
+    const event = success > 0 ? AUDIT_EVENTS.REVOKE_SUCCESS : AUDIT_EVENTS.REVOKE_FAILED;
+    logger.audit(event, { send_id: sendId, success, total: resourceIds.length });
+  }
   await db.markSendRevoked(sendId, senderDiscordId);
 
   logger.info('Revoked send', { sendId, success, total: resourceIds.length });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1952,6 +1952,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Cannot add recipients — send configuration is incomplete.', newResourceIds: [], delivered: 0, failed: 0 };
   }
 
+  // Tracks which prep paths actually completed so we can emit a single
+  // upload_success per send (not one per kind). A sendConfig with both
+  // file + location would otherwise fire two events for the same send,
+  // which double-counts UploadCount in CloudWatch unless the metric
+  // filter dimensions on `kind` (it doesn't, currently — see
+  // qurl-integrations-infra#309). The collapsed event keeps UploadCount
+  // = "number of fully-prepared sends" regardless of kind composition.
+  const preparedKinds = [];
   try {
     if (hasFile) {
       // Re-download from the stored Discord CDN URL, then upload a fresh
@@ -2028,7 +2036,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           label: `File (${sanitizeFilename(sendConfig.attachment_name || 'file')})`,
         });
       }
-      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
+      preparedKinds.push('file');
     }
     if (hasLocation) {
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
@@ -2054,7 +2062,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           resType: RESOURCE_TYPES.MAPS, label: sendConfig.location_name || 'Google Maps',
         });
       });
-      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
+      preparedKinds.push('location');
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', { error: error.message });
@@ -2063,6 +2071,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
     return { msg, newResourceIds: [], delivered: 0, failed: 0 };
+  }
+
+  // Single emission per send. `kind` carries the composition so a future
+  // CloudWatch dimension on it can break the count down per kind without
+  // double-counting mixed sends. Values: 'file' | 'location' | 'mixed'.
+  if (preparedKinds.length > 0) {
+    const kind = preparedKinds.length === 1 ? preparedKinds[0] : 'mixed';
+    logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind });
   }
 
   const recipientIds = Object.keys(recipientLinks);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1939,8 +1939,15 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Cannot add recipients — send configuration is incomplete.', newResourceIds: [], delivered: 0, failed: 0 };
   }
 
+  // Tracks which kind was in flight when a throw escapes — `hasFile` and
+  // `hasLocation` can both be true (a single send-config that had both),
+  // so a "ternary on hasFile" mislabels the failure when location throws
+  // after the file path already succeeded. Set right before each block
+  // that can throw, read by the catch's logger.audit(MINT_FAILED).
+  let inFlightKind = null;
   try {
     if (hasFile) {
+      inFlightKind = 'file';
       // Re-download from the stored Discord CDN URL, then upload a fresh
       // resource so the 10-token pool is full. Re-upload again every
       // TOKENS_PER_RESOURCE recipients. The original resource is drained by
@@ -2019,6 +2026,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       logger.audit(AUDIT_EVENTS.MINT_SUCCESS, { send_id: sendId, kind: 'file', count: allLinks.length, expires_in: sendConfig.expires_in });
     }
     if (hasLocation) {
+      inFlightKind = 'location';
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
       const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey);
       const expiresAt = expiryToISO(sendConfig.expires_in);
@@ -2047,7 +2055,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', { error: error.message });
-    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: hasFile ? 'file' : 'location', api_code: error.apiCode || null });
+    logger.audit(AUDIT_EVENTS.MINT_FAILED, { send_id: sendId, kind: inFlightKind, api_code: error.apiCode || null });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -95,6 +95,19 @@ const GOOD_FIRST_ISSUE_PATTERNS = [
 // integration (Discord, Slack, Teams, CLI, web/portal) gets them for
 // free without each re-implementing emission. Tracked separately; see
 // Justin's review comment on qurl-integrations-infra#309.
+//
+// SECRETS CONTRACT: logger.audit() bypasses the redact() pass on meta
+// (key-name redaction would blank legitimate dimensions like
+// `tokens_minted`). Callers MUST therefore pass only non-sensitive meta
+// values from a small, pre-vetted vocabulary: `send_id`, `kind`,
+// `count`, `expires_in`, `api_code`, `success`, `total`. Never pass
+// API keys, tokens, OAuth state, secrets, raw user input, or anything
+// whose value should not appear verbatim in CloudWatch. logger.audit()
+// emits a warn-level error if a meta key exactly matches one of a
+// small set of known secret-bearer names (`auth_token`, `api_key`,
+// `password`, etc. — see AUDIT_SECRET_KEYS in logger.js), but the
+// warn is defense-in-depth — the canonical contract enforcement is
+// the call-site review of every new audit emission.
 const AUDIT_EVENTS = {
   // UPLOAD_SUCCESS fires after upload + mintLinksInBatches + sufficiency
   // check all succeed — i.e. when the send is fully prepared and ready

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -78,6 +78,22 @@ const GOOD_FIRST_ISSUE_PATTERNS = [
   'help wanted',
 ];
 
+// Canonical event names emitted via logger.audit(). The CloudWatch metric
+// filters at qurl-integrations-infra/qurl-bot-discord/terraform/main.tf
+// pattern-match these strings, so a typo at a call site silently disables
+// the metric. Always import from here rather than passing literal strings.
+// Adding a new event: add the constant here, the call site, AND the
+// terraform filter (in the same merge train, since the filter is a no-op
+// without the emission and vice versa).
+const AUDIT_EVENTS = {
+  UPLOAD_SUCCESS: 'upload_success',
+  MINT_SUCCESS: 'mint_success',
+  MINT_FAILED: 'mint_failed',
+  DISPATCH_SENT: 'dispatch_sent',
+  DISPATCH_FAILED: 'dispatch_failed',
+  REVOKE_SUCCESS: 'revoke_success',
+};
+
 module.exports = {
   COLORS,
   RESOURCE_TYPES,
@@ -89,4 +105,5 @@ module.exports = {
   MAX_CONCURRENT_MONITORS,
   GITHUB_ACTIONS,
   GOOD_FIRST_ISSUE_PATTERNS,
+  AUDIT_EVENTS,
 };

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -85,10 +85,18 @@ const GOOD_FIRST_ISSUE_PATTERNS = [
 // Adding a new event: add the constant here, the call site, AND the
 // terraform filter (in the same merge train, since the filter is a no-op
 // without the emission and vice versa).
+//
+// Scope: this set covers events the qURL service cannot see — transport-
+// layer (DM dispatch), bulk-revoke outcomes (per-link API calls happen
+// at the service but the all-or-partial-success tally lives here), and
+// upload-to-connector results. Mint counts (`mint_success` / `mint_failed`)
+// are intentionally NOT here — they belong at the qURL service layer
+// with an `agent` dimension fed by an X-QURL-Agent header so every
+// integration (Discord, Slack, Teams, CLI, web/portal) gets them for
+// free without each re-implementing emission. Tracked separately; see
+// Justin's review comment on qurl-integrations-infra#309.
 const AUDIT_EVENTS = {
   UPLOAD_SUCCESS: 'upload_success',
-  MINT_SUCCESS: 'mint_success',
-  MINT_FAILED: 'mint_failed',
   DISPATCH_SENT: 'dispatch_sent',
   DISPATCH_FAILED: 'dispatch_failed',
   // REVOKE_SUCCESS fires when at least one per-link delete succeeded;

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -96,18 +96,20 @@ const GOOD_FIRST_ISSUE_PATTERNS = [
 // free without each re-implementing emission. Tracked separately; see
 // Justin's review comment on qurl-integrations-infra#309.
 //
-// SECRETS CONTRACT: logger.audit() bypasses the redact() pass on meta
-// (key-name redaction would blank legitimate dimensions like
-// `tokens_minted`). Callers MUST therefore pass only non-sensitive meta
-// values from a small, pre-vetted vocabulary: `send_id`, `kind`,
-// `count`, `expires_in`, `api_code`, `success`, `total`. Never pass
-// API keys, tokens, OAuth state, secrets, raw user input, or anything
-// whose value should not appear verbatim in CloudWatch. logger.audit()
-// emits a warn-level error if a meta key exactly matches one of a
-// small set of known secret-bearer names (`auth_token`, `api_key`,
-// `password`, etc. — see AUDIT_SECRET_KEYS in logger.js), but the
-// warn is defense-in-depth — the canonical contract enforcement is
-// the call-site review of every new audit emission.
+// SECRETS CONTRACT: callers SHOULD pass only non-sensitive meta values
+// from a small, pre-vetted vocabulary: `send_id`, `kind`, `count`,
+// `expires_in`, `api_code`, `success`, `total`. logger.audit()
+// defends in two layers if a caller still slips a secret-shaped key
+// in (top-level OR nested):
+//   1. The value is redacted to '[REDACTED]' in the emitted payload.
+//   2. A CloudWatch-visible `console.error` line names the offending
+//      key so the call site is grep-able from the dashboard.
+// Sibling keys are unaffected, so legitimate dimensions still flow.
+// Detection uses an EXACT-MATCH set (AUDIT_SECRET_KEYS in logger.js),
+// not the top-level logger's substring-based REDACT_SUBSTRINGS — that
+// way `tokens_minted` / `token_count` / similar legitimate dimensions
+// don't trigger false-positive redactions. The substring approach
+// would have made the redaction unsafe; exact-match makes it safe.
 const AUDIT_EVENTS = {
   // UPLOAD_SUCCESS fires after upload + mintLinksInBatches + sufficiency
   // check all succeed — i.e. when the send is fully prepared and ready

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -114,6 +114,14 @@ const AUDIT_EVENTS = {
   // to dispatch. It's not just the connector POST. Name is kept literal
   // ("upload_success") for back-compat with the upload_count terraform
   // filter; semantically closer to "prepare_success" or "links_ready".
+  //
+  // Emitted EXACTLY ONCE per send, even when handleAddRecipients runs
+  // both file and location prep paths. The meta `kind` field carries
+  // the composition: 'file' | 'location' | 'mixed'. Collapsing to one
+  // event prevents UploadCount from double-counting mixed sends if the
+  // CloudWatch filter doesn't dimension on kind. handleSend's branches
+  // are mutually exclusive so 'mixed' only ever shows up from
+  // handleAddRecipients on a sendConfig that has both file + location.
   UPLOAD_SUCCESS: 'upload_success',
   DISPATCH_SENT: 'dispatch_sent',
   DISPATCH_FAILED: 'dispatch_failed',

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -134,6 +134,13 @@ const AUDIT_EVENTS = {
   REVOKE_FAILED: 'revoke_failed',
 };
 
+// Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at
+// runtime can't silently break a CloudWatch metric (the literal string
+// would still work but the filter would stop matching). The other
+// constant objects in this file aren't frozen, but AUDIT_EVENTS is the
+// only one whose mutation is undetectable by tests.
+Object.freeze(AUDIT_EVENTS);
+
 module.exports = {
   COLORS,
   RESOURCE_TYPES,

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -96,6 +96,11 @@ const GOOD_FIRST_ISSUE_PATTERNS = [
 // free without each re-implementing emission. Tracked separately; see
 // Justin's review comment on qurl-integrations-infra#309.
 const AUDIT_EVENTS = {
+  // UPLOAD_SUCCESS fires after upload + mintLinksInBatches + sufficiency
+  // check all succeed — i.e. when the send is fully prepared and ready
+  // to dispatch. It's not just the connector POST. Name is kept literal
+  // ("upload_success") for back-compat with the upload_count terraform
+  // filter; semantically closer to "prepare_success" or "links_ready".
   UPLOAD_SUCCESS: 'upload_success',
   DISPATCH_SENT: 'dispatch_sent',
   DISPATCH_FAILED: 'dispatch_failed',

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -91,7 +91,13 @@ const AUDIT_EVENTS = {
   MINT_FAILED: 'mint_failed',
   DISPATCH_SENT: 'dispatch_sent',
   DISPATCH_FAILED: 'dispatch_failed',
+  // REVOKE_SUCCESS fires when at least one per-link delete succeeded;
+  // REVOKE_FAILED fires when every per-link delete threw (success === 0
+  // && total > 0). When total === 0 (nothing to revoke — already-revoked
+  // or unknown sendId) neither event fires. Splitting the two stops a
+  // dashboard from counting all-failed revokes as successes.
   REVOKE_SUCCESS: 'revoke_success',
+  REVOKE_FAILED: 'revoke_failed',
 };
 
 module.exports = {

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -126,6 +126,12 @@ const logger = {
   // pass meta from a small, pre-vetted set: send_id, kind, count,
   // expires_in, success, total).
   audit(event, meta = {}) {
+    // Default param only fires for `undefined`. A caller passing `null`
+    // (easy mistake from optional chaining: `someObj?.meta`) would
+    // otherwise crash `Object.keys(null)` BEFORE the protected
+    // try/catch around JSON.stringify, defeating the "audit never
+    // breaks user flow" contract. Coerce to {} for any non-object.
+    if (meta == null || typeof meta !== 'object') meta = {};
     // Defense-in-depth: warn if a meta key matches the exact-match
     // AUDIT_SECRET_KEYS set (auth_token, api_key, password, ...). We
     // don't redact (would corrupt dimensions) and we don't drop the
@@ -143,7 +149,7 @@ const logger = {
     // Spread meta first, then pin event + agent last so a caller passing
     // `agent` or `event` in meta cannot overwrite the canonical value the
     // CloudWatch filters key off of.
-    const audit = { ...meta, event, agent: 'discord' };
+    const auditPayload = { ...meta, event, agent: 'discord' };
     // Single-line JSON, parseable by `{ $.audit.event = "..." }`
     // CloudWatch filter syntax. No timestamp prefix — the JSON has
     // its own ts field. console.log adds a trailing newline.
@@ -155,7 +161,7 @@ const logger = {
     // break the user-visible flow; degrade to an error log instead.
     try {
       console.log(JSON.stringify({
-        audit,
+        audit: auditPayload,
         ts: formatTimestamp(),
       }));
     } catch (err) {

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -99,9 +99,11 @@ const logger = {
   //
   // Audit lines bypass currentLevel — they're observability, not
   // debug noise. They also bypass the redact() pass on `meta`
-  // (audit fields are pre-vetted by the caller; see call sites in
-  // commands.js + connector.js) so a redact substring like
-  // "token" appearing in a sendId doesn't get blanked.
+  // (audit fields are pre-vetted by the caller — see the AUDIT_EVENTS
+  // call sites in commands.js) so a redact substring like "token"
+  // appearing in a sendId doesn't get blanked. Callers MUST ensure
+  // they don't pass secrets into meta — the constants.js comment
+  // documents this contract.
   audit(event, meta = {}) {
     // Spread meta first, then pin event + agent last so a caller passing
     // `agent` or `event` in meta cannot overwrite the canonical value the

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -98,12 +98,11 @@ const logger = {
   // canonical: "discord" | "slack" | "teams" | "cli" | "web" | "api".
   //
   // Audit lines bypass currentLevel — they're observability, not
-  // debug noise. They also bypass the redact() pass on `meta`
-  // (audit fields are pre-vetted by the caller — see the AUDIT_EVENTS
-  // call sites in commands.js) so a redact substring like "token"
-  // appearing in a sendId doesn't get blanked. Callers MUST ensure
-  // they don't pass secrets into meta — the constants.js comment
-  // documents this contract.
+  // debug noise. They also bypass the redact() pass on `meta`. redact()
+  // matches on KEY name (not value), so future fields like `token_count`
+  // or `tokens_minted` would be blanked otherwise — which would corrupt
+  // a CloudWatch metric dimension. Callers MUST ensure they don't pass
+  // secrets into meta — the constants.js comment documents this contract.
   audit(event, meta = {}) {
     // Spread meta first, then pin event + agent last so a caller passing
     // `agent` or `event` in meta cannot overwrite the canonical value the
@@ -112,10 +111,20 @@ const logger = {
     // Single-line JSON, parseable by `{ $.audit.event = "..." }`
     // CloudWatch filter syntax. No timestamp prefix — the JSON has
     // its own ts field. console.log adds a trailing newline.
-    console.log(JSON.stringify({
-      audit,
-      ts: formatTimestamp(),
-    }));
+    //
+    // Wrap JSON.stringify in try/catch — a circular reference, BigInt,
+    // or other non-serializable value in meta would otherwise throw
+    // out of audit() and into the caller, which on the per-recipient
+    // batchSettled callback would fail an entire DM. Audit must never
+    // break the user-visible flow; degrade to an error log instead.
+    try {
+      console.log(JSON.stringify({
+        audit,
+        ts: formatTimestamp(),
+      }));
+    } catch (err) {
+      console.error(`[${formatTimestamp()}] ERROR: logger.audit serialization failed event=${sanitizeMessage(event)} reason=${sanitizeMessage(err.message)}`);
+    }
   },
 };
 

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -48,8 +48,10 @@ function isAuditSecretKey(key) {
 // Returns a cloned meta value with any object key in AUDIT_SECRET_KEYS
 // replaced by '[REDACTED]'. Recurses to depth 5 with redact()'s array
 // handling so a buried `{ context: { auth_token } }` is also covered.
-// Returns the second member of the tuple as the FIRST offending key
-// name observed, so audit() can include it in the warn line.
+// Also returns `secretKeys`, an array of every offending key observed
+// (deduped, in encounter order) so audit() can name all of them in
+// the warn line — partial reporting would let a caller fix one key
+// and re-run only to discover another the next time.
 //
 // Note on the contract shift: the original audit() bypassed redact()
 // entirely because the legacy substring-match REDACT_SUBSTRINGS would
@@ -60,35 +62,27 @@ function isAuditSecretKey(key) {
 // offending key without risk of corrupting a metric — and that's
 // strictly safer than emitting the secret verbatim and relying on a
 // dashboard sweep to catch it.
-function redactAuditSecrets(value, depth = 0) {
+function redactAuditSecrets(value, depth = 0, secretKeys = []) {
   if (depth > 5 || value == null || typeof value !== 'object') {
-    return { value, secretKey: null };
+    return { value, secretKeys };
   }
   if (Array.isArray(value)) {
-    let secretKey = null;
-    const arr = value.map((v) => {
-      const { value: cleaned, secretKey: childKey } = redactAuditSecrets(v, depth + 1);
-      if (childKey && !secretKey) secretKey = childKey;
-      return cleaned;
-    });
-    return { value: arr, secretKey };
+    const arr = value.map((v) => redactAuditSecrets(v, depth + 1, secretKeys).value);
+    return { value: arr, secretKeys };
   }
   const out = {};
-  let secretKey = null;
   for (const [k, v] of Object.entries(value)) {
     if (isAuditSecretKey(k)) {
       // Match redact()'s shape: blank only non-empty strings; non-string
       // values (numbers, null, etc.) survive — they can't carry a usable
       // secret on their own and zero-string-replace would lose type info.
       out[k] = typeof v === 'string' && v.length > 0 ? '[REDACTED]' : v;
-      if (!secretKey) secretKey = k;
+      if (!secretKeys.includes(k)) secretKeys.push(k);
     } else {
-      const { value: cleaned, secretKey: childKey } = redactAuditSecrets(v, depth + 1);
-      out[k] = cleaned;
-      if (childKey && !secretKey) secretKey = childKey;
+      out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
     }
   }
-  return { value: out, secretKey };
+  return { value: out, secretKeys };
 }
 
 function redact(value, depth = 0) {
@@ -186,15 +180,18 @@ const logger = {
     // offending key name so the operator log below can name it. Safe
     // to redact because exact-match doesn't false-positive on
     // legitimate dimensions (proven by the tokens_minted test).
-    const { value: cleanedMeta, secretKey } = redactAuditSecrets(meta);
-    if (secretKey) {
+    const { value: cleanedMeta, secretKeys } = redactAuditSecrets(meta);
+    if (secretKeys.length > 0) {
       // Logged via console.error so it surfaces at error level in
       // CloudWatch (the logger has no separate warn channel that
       // emits at error severity). Defense-in-depth alongside the
       // value redaction above — the redacted payload still emits,
-      // but the operator can grep the error log to find the
-      // misbehaving call site and remove the key from meta.
-      console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key "${sanitizeMessage(secretKey)}" in event=${sanitizeMessage(event)}; value redacted in emitted payload — caller must remove from meta`);
+      // but the operator can grep the error log to find every
+      // misbehaving call site and remove the key from meta. ALL
+      // offending keys are listed so a caller fixing the first
+      // doesn't have to re-run to discover the second.
+      const namedKeys = secretKeys.map(k => `"${sanitizeMessage(k)}"`).join(', ');
+      console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key(s) [${namedKeys}] in event=${sanitizeMessage(event)}; value(s) redacted in emitted payload — caller must remove from meta`);
     }
     // Spread cleaned meta first, then pin event + agent last so a
     // caller passing `agent` or `event` in meta cannot overwrite the

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -45,27 +45,50 @@ function isAuditSecretKey(key) {
   return AUDIT_SECRET_KEYS.has(String(key).toLowerCase());
 }
 
-// Walks a meta value recursively looking for any object key in
-// AUDIT_SECRET_KEYS. Returns the offending key name on first hit, or
-// null. Matches redact()'s depth cap (5) and array handling. Used by
-// audit() to surface a CloudWatch-visible warn when a caller buries a
-// secret inside a nested object — top-level-only iteration would miss
-// `{ context: { auth_token: '...' } }`.
-function findAuditSecretKey(value, depth = 0) {
-  if (depth > 5 || value == null || typeof value !== 'object') return null;
+// Returns a cloned meta value with any object key in AUDIT_SECRET_KEYS
+// replaced by '[REDACTED]'. Recurses to depth 5 with redact()'s array
+// handling so a buried `{ context: { auth_token } }` is also covered.
+// Returns the second member of the tuple as the FIRST offending key
+// name observed, so audit() can include it in the warn line.
+//
+// Note on the contract shift: the original audit() bypassed redact()
+// entirely because the legacy substring-match REDACT_SUBSTRINGS would
+// blank legitimate dimensions like `tokens_minted`. AUDIT_SECRET_KEYS
+// uses exact-match against a closed set of canonical secret names
+// (auth_token, api_key, password, ...), none of which collide with any
+// known legitimate audit dimension. So we can redact the value of an
+// offending key without risk of corrupting a metric — and that's
+// strictly safer than emitting the secret verbatim and relying on a
+// dashboard sweep to catch it.
+function redactAuditSecrets(value, depth = 0) {
+  if (depth > 5 || value == null || typeof value !== 'object') {
+    return { value, secretKey: null };
+  }
   if (Array.isArray(value)) {
-    for (const v of value) {
-      const found = findAuditSecretKey(v, depth + 1);
-      if (found) return found;
-    }
-    return null;
+    let secretKey = null;
+    const arr = value.map((v) => {
+      const { value: cleaned, secretKey: childKey } = redactAuditSecrets(v, depth + 1);
+      if (childKey && !secretKey) secretKey = childKey;
+      return cleaned;
+    });
+    return { value: arr, secretKey };
   }
+  const out = {};
+  let secretKey = null;
   for (const [k, v] of Object.entries(value)) {
-    if (isAuditSecretKey(k)) return k;
-    const found = findAuditSecretKey(v, depth + 1);
-    if (found) return found;
+    if (isAuditSecretKey(k)) {
+      // Match redact()'s shape: blank only non-empty strings; non-string
+      // values (numbers, null, etc.) survive — they can't carry a usable
+      // secret on their own and zero-string-replace would lose type info.
+      out[k] = typeof v === 'string' && v.length > 0 ? '[REDACTED]' : v;
+      if (!secretKey) secretKey = k;
+    } else {
+      const { value: cleaned, secretKey: childKey } = redactAuditSecrets(v, depth + 1);
+      out[k] = cleaned;
+      if (childKey && !secretKey) secretKey = childKey;
+    }
   }
-  return null;
+  return { value: out, secretKey };
 }
 
 function redact(value, depth = 0) {
@@ -138,40 +161,45 @@ const logger = {
   // canonical: "discord" | "slack" | "teams" | "cli" | "web" | "api".
   //
   // Audit lines bypass currentLevel — they're observability, not
-  // debug noise. They also bypass the redact() pass on `meta`. redact()
-  // matches on KEY name (not value), so future fields like `token_count`
-  // or `tokens_minted` would be blanked otherwise — which would corrupt
-  // a CloudWatch metric dimension. Callers MUST NOT pass secrets in meta:
-  // because audit() does not redact, a key like `auth_token` or
-  // `apiKey` lands in CloudWatch verbatim. The defense-in-depth warn
-  // below catches this at runtime; the static contract is enforced
-  // by the AUDIT_EVENTS allowlist in constants.js (callers always
-  // pass meta from a small, pre-vetted set: send_id, kind, count,
-  // expires_in, success, total).
+  // debug noise. They also bypass the top-level redact() pass on
+  // `meta` because that pass matches on KEY-name SUBSTRING and would
+  // blank legitimate dimensions like `tokens_minted` or `token_count`.
+  // Instead, audit() runs redactAuditSecrets() — same shape but uses
+  // exact-match against a closed AUDIT_SECRET_KEYS set so only canonical
+  // secret-bearer names (auth_token, api_key, password, ...) are
+  // blanked. Callers SHOULD still avoid passing secrets in meta —
+  // the AUDIT_EVENTS allowlist in constants.js documents the small,
+  // pre-vetted vocabulary (send_id, kind, count, expires_in, success,
+  // total). The redaction here is belt-and-suspenders: an error log
+  // fires too so a misbehaving caller is catchable in dashboards.
   audit(event, meta = {}) {
     // Default param only fires for `undefined`. A caller passing `null`
     // (easy mistake from optional chaining: `someObj?.meta`) would
-    // otherwise crash `Object.keys(null)` BEFORE the protected
+    // otherwise crash `Object.entries(null)` BEFORE the protected
     // try/catch around JSON.stringify, defeating the "audit never
-    // breaks user flow" contract. Coerce to {} for any non-object.
-    if (meta == null || typeof meta !== 'object') meta = {};
-    // Defense-in-depth: warn if any object key (top-level OR nested)
-    // in meta matches AUDIT_SECRET_KEYS (auth_token, api_key, password,
-    // ...). Recurses to depth 5 so a buried `{ context: { auth_token } }`
-    // still surfaces. Audit doesn't redact (would corrupt dimensions)
-    // and doesn't drop (must always emit), so we surface the violation
-    // as a CloudWatch-visible error log to make a misbehaving caller
-    // catchable in dashboards rather than silent. Exact-match (not
-    // substring) so legitimate dimensions like `tokens_minted` don't
-    // trigger false-positive warns.
-    const secretKey = findAuditSecretKey(meta);
+    // breaks user flow" contract. Also coerces arrays — typeof [] is
+    // 'object' so the typeof check alone would let `audit('x', [1,2])`
+    // through and produce a confusing `{0:1,1:2,event,agent}` payload.
+    if (meta == null || typeof meta !== 'object' || Array.isArray(meta)) meta = {};
+    // Targeted secret redaction: walk meta, replace the value of any
+    // key in AUDIT_SECRET_KEYS with '[REDACTED]', return the first
+    // offending key name so the operator log below can name it. Safe
+    // to redact because exact-match doesn't false-positive on
+    // legitimate dimensions (proven by the tokens_minted test).
+    const { value: cleanedMeta, secretKey } = redactAuditSecrets(meta);
     if (secretKey) {
-      console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key "${sanitizeMessage(secretKey)}" in event=${sanitizeMessage(event)}; emitting unredacted per audit contract — caller must remove from meta`);
+      // Logged via console.error so it surfaces at error level in
+      // CloudWatch (the logger has no separate warn channel that
+      // emits at error severity). Defense-in-depth alongside the
+      // value redaction above — the redacted payload still emits,
+      // but the operator can grep the error log to find the
+      // misbehaving call site and remove the key from meta.
+      console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key "${sanitizeMessage(secretKey)}" in event=${sanitizeMessage(event)}; value redacted in emitted payload — caller must remove from meta`);
     }
-    // Spread meta first, then pin event + agent last so a caller passing
-    // `agent` or `event` in meta cannot overwrite the canonical value the
-    // CloudWatch filters key off of.
-    const auditPayload = { ...meta, event, agent: 'discord' };
+    // Spread cleaned meta first, then pin event + agent last so a
+    // caller passing `agent` or `event` in meta cannot overwrite the
+    // canonical value the CloudWatch filters key off of.
+    const auditPayload = { ...cleanedMeta, event, agent: 'discord' };
     // Single-line JSON, parseable by `{ $.audit.event = "..." }`
     // CloudWatch filter syntax. No timestamp prefix — the JSON has
     // its own ts field. console.log adds a trailing newline.

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -83,6 +83,38 @@ const logger = {
       console.log(formatMessage('debug', message, meta));
     }
   },
+
+  // Structured audit event. Emitted as a JSON-only log line (no
+  // human-readable preamble) so CloudWatch Logs metric filters can
+  // pattern-match `{ $.audit.event = "<name>" }` and dimension by
+  // `$.audit.agent`. The terraform filters at
+  // qurl-integrations-infra/qurl-bot-discord/terraform/main.tf
+  // pick these up.
+  //
+  // `agent` is hard-coded to "discord" for this codebase. Future
+  // integrations (Slack, Teams, CLI, web/portal) emit their own
+  // constant value so a single CloudWatch metric Minted{Agent} can
+  // attribute mints across the whole product. The string set is
+  // canonical: "discord" | "slack" | "teams" | "cli" | "web" | "api".
+  //
+  // Audit lines bypass currentLevel — they're observability, not
+  // debug noise. They also bypass the redact() pass on `meta`
+  // (audit fields are pre-vetted by the caller; see call sites in
+  // commands.js + connector.js) so a redact substring like
+  // "token" appearing in a sendId doesn't get blanked.
+  audit(event, meta = {}) {
+    // Spread meta first, then pin event + agent last so a caller passing
+    // `agent` or `event` in meta cannot overwrite the canonical value the
+    // CloudWatch filters key off of.
+    const audit = { ...meta, event, agent: 'discord' };
+    // Single-line JSON, parseable by `{ $.audit.event = "..." }`
+    // CloudWatch filter syntax. No timestamp prefix — the JSON has
+    // its own ts field. console.log adds a trailing newline.
+    console.log(JSON.stringify({
+      audit,
+      ts: formatTimestamp(),
+    }));
+  },
 };
 
 module.exports = logger;

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -28,6 +28,23 @@ function shouldRedact(key) {
   return REDACT_SUBSTRINGS.some(s => k.includes(s));
 }
 
+// Exact key names that audit() refuses to emit silently — these are the
+// classic secret-bearers a caller is most likely to leak by accident.
+// Exact-match (not substring) so legitimate audit dimensions like
+// `tokens_minted` or `token_count` don't trigger false-positive warns.
+// REDACT_SUBSTRINGS is too aggressive for audit metadata: the bypass
+// exists precisely because legitimate dimensions can contain those
+// substrings.
+const AUDIT_SECRET_KEYS = new Set([
+  'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
+  'auth_token', 'access_token', 'refresh_token', 'bearer_token',
+  'session_token', 'private_key', 'client_secret', 'webhook_secret',
+]);
+
+function isAuditSecretKey(key) {
+  return AUDIT_SECRET_KEYS.has(String(key).toLowerCase());
+}
+
 function redact(value, depth = 0) {
   if (depth > 5 || value == null) return value;
   if (Array.isArray(value)) return value.map(v => redact(v, depth + 1));
@@ -101,9 +118,28 @@ const logger = {
   // debug noise. They also bypass the redact() pass on `meta`. redact()
   // matches on KEY name (not value), so future fields like `token_count`
   // or `tokens_minted` would be blanked otherwise — which would corrupt
-  // a CloudWatch metric dimension. Callers MUST ensure they don't pass
-  // secrets into meta — the constants.js comment documents this contract.
+  // a CloudWatch metric dimension. Callers MUST NOT pass secrets in meta:
+  // because audit() does not redact, a key like `auth_token` or
+  // `apiKey` lands in CloudWatch verbatim. The defense-in-depth warn
+  // below catches this at runtime; the static contract is enforced
+  // by the AUDIT_EVENTS allowlist in constants.js (callers always
+  // pass meta from a small, pre-vetted set: send_id, kind, count,
+  // expires_in, success, total).
   audit(event, meta = {}) {
+    // Defense-in-depth: warn if a meta key matches the exact-match
+    // AUDIT_SECRET_KEYS set (auth_token, api_key, password, ...). We
+    // don't redact (would corrupt dimensions) and we don't drop the
+    // value (audit must always emit), but we surface the violation
+    // as a CloudWatch-visible error log so a misbehaving caller is
+    // catchable in dashboards rather than failing silently. Uses
+    // exact-match instead of REDACT_SUBSTRINGS's includes() check
+    // so legitimate dimensions like `tokens_minted` don't trigger.
+    for (const key of Object.keys(meta)) {
+      if (isAuditSecretKey(key)) {
+        console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key "${sanitizeMessage(key)}" in event=${sanitizeMessage(event)}; emitting unredacted per audit contract — caller must remove from meta`);
+        break;
+      }
+    }
     // Spread meta first, then pin event + agent last so a caller passing
     // `agent` or `event` in meta cannot overwrite the canonical value the
     // CloudWatch filters key off of.
@@ -123,7 +159,7 @@ const logger = {
         ts: formatTimestamp(),
       }));
     } catch (err) {
-      console.error(`[${formatTimestamp()}] ERROR: logger.audit serialization failed event=${sanitizeMessage(event)} reason=${sanitizeMessage(err.message)}`);
+      console.error(`[${formatTimestamp()}] ERROR: logger.audit serialization failed event=${sanitizeMessage(event)} reason=${sanitizeMessage(err && err.message)}`);
     }
   },
 };

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -45,6 +45,29 @@ function isAuditSecretKey(key) {
   return AUDIT_SECRET_KEYS.has(String(key).toLowerCase());
 }
 
+// Walks a meta value recursively looking for any object key in
+// AUDIT_SECRET_KEYS. Returns the offending key name on first hit, or
+// null. Matches redact()'s depth cap (5) and array handling. Used by
+// audit() to surface a CloudWatch-visible warn when a caller buries a
+// secret inside a nested object — top-level-only iteration would miss
+// `{ context: { auth_token: '...' } }`.
+function findAuditSecretKey(value, depth = 0) {
+  if (depth > 5 || value == null || typeof value !== 'object') return null;
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      const found = findAuditSecretKey(v, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  }
+  for (const [k, v] of Object.entries(value)) {
+    if (isAuditSecretKey(k)) return k;
+    const found = findAuditSecretKey(v, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
 function redact(value, depth = 0) {
   if (depth > 5 || value == null) return value;
   if (Array.isArray(value)) return value.map(v => redact(v, depth + 1));
@@ -132,19 +155,18 @@ const logger = {
     // try/catch around JSON.stringify, defeating the "audit never
     // breaks user flow" contract. Coerce to {} for any non-object.
     if (meta == null || typeof meta !== 'object') meta = {};
-    // Defense-in-depth: warn if a meta key matches the exact-match
-    // AUDIT_SECRET_KEYS set (auth_token, api_key, password, ...). We
-    // don't redact (would corrupt dimensions) and we don't drop the
-    // value (audit must always emit), but we surface the violation
-    // as a CloudWatch-visible error log so a misbehaving caller is
-    // catchable in dashboards rather than failing silently. Uses
-    // exact-match instead of REDACT_SUBSTRINGS's includes() check
-    // so legitimate dimensions like `tokens_minted` don't trigger.
-    for (const key of Object.keys(meta)) {
-      if (isAuditSecretKey(key)) {
-        console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key "${sanitizeMessage(key)}" in event=${sanitizeMessage(event)}; emitting unredacted per audit contract — caller must remove from meta`);
-        break;
-      }
+    // Defense-in-depth: warn if any object key (top-level OR nested)
+    // in meta matches AUDIT_SECRET_KEYS (auth_token, api_key, password,
+    // ...). Recurses to depth 5 so a buried `{ context: { auth_token } }`
+    // still surfaces. Audit doesn't redact (would corrupt dimensions)
+    // and doesn't drop (must always emit), so we surface the violation
+    // as a CloudWatch-visible error log to make a misbehaving caller
+    // catchable in dashboards rather than silent. Exact-match (not
+    // substring) so legitimate dimensions like `tokens_minted` don't
+    // trigger false-positive warns.
+    const secretKey = findAuditSecretKey(meta);
+    if (secretKey) {
+      console.error(`[${formatTimestamp()}] ERROR: logger.audit received secret-shaped key "${sanitizeMessage(secretKey)}" in event=${sanitizeMessage(event)}; emitting unredacted per audit contract — caller must remove from meta`);
     }
     // Spread meta first, then pin event + agent last so a caller passing
     // `agent` or `event` in meta cannot overwrite the canonical value the

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -187,7 +187,26 @@ const logger = {
         ts: formatTimestamp(),
       }));
     } catch (err) {
-      console.error(`[${formatTimestamp()}] ERROR: logger.audit serialization failed event=${sanitizeMessage(event)} reason=${sanitizeMessage(err && err.message)}`);
+      // Two-tier degradation: emit a minimal audit line with a fixed
+      // synthetic event so CloudWatch metric filters can pattern-match
+      // `{ $.audit.event = "audit_serialization_failed" }` and surface
+      // the gap. The fallback payload only contains primitive strings
+      // — no caller meta — so it cannot itself trip JSON.stringify.
+      // If even this throws (effectively impossible), fall through to
+      // a plain error log so an operator still sees something.
+      try {
+        console.log(JSON.stringify({
+          audit: {
+            event: 'audit_serialization_failed',
+            agent: 'discord',
+            original_event: String(event),
+            reason: sanitizeMessage(err && err.message),
+          },
+          ts: formatTimestamp(),
+        }));
+      } catch (fallbackErr) {
+        console.error(`[${formatTimestamp()}] ERROR: logger.audit serialization failed event=${sanitizeMessage(event)} reason=${sanitizeMessage(err && err.message)} fallback_reason=${sanitizeMessage(fallbackErr && fallbackErr.message)}`);
+      }
     }
   },
 };

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -108,7 +108,7 @@ jest.mock('../src/config', () => ({
 }));
 
 jest.mock('../src/logger', () => ({
-  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
 }));
 
 jest.mock('../src/database', () => ({

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -46,11 +46,11 @@ jest.mock('discord.js', () => {
     ActionRowBuilder: jest.fn().mockImplementation(() => ({ addComponents: jest.fn().mockReturnThis() })),
     ButtonBuilder: jest.fn().mockImplementation(() => {
       const btn = {
-        _style: null, _label: null, _url: null, _customId: null,
+        _style: null, _label: null, _url: null, _customId: null, _emoji: null,
         setCustomId: jest.fn(function (id) { btn._customId = id; return btn; }),
         setLabel: jest.fn(function (l) { btn._label = l; return btn; }),
         setStyle: jest.fn(function (s) { btn._style = s; return btn; }),
-        setEmoji: jest.fn().mockReturnThis(),
+        setEmoji: jest.fn(function (e) { btn._emoji = e; return btn; }),
         setURL: jest.fn(function (u) { btn._url = u; return btn; }),
       };
       capturedButtons.push(btn);
@@ -246,13 +246,16 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // Locks the Step Through button shape: a future refactor that drops
   // `.setURL(qurlLink)` (or downgrades to a non-Link style) would leave
   // recipients with a button that doesn't navigate anywhere. This test
-  // asserts the button is built as Link-style with the supplied qURL.
+  // asserts the button is built as Link-style with the supplied qURL,
+  // and that the 🔗 emoji prefix survives — Link buttons render gray
+  // and the emoji is what carries the "this is a button" affordance.
   it('builds the Step Through button as a Link-style button with the qURL as its URL', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', qurlLink: 'https://qurl.link/#at_unique_token' });
     // Last button constructed in the buildDeliveryPayload call is the Step Through.
     const stepThrough = capturedButtons[capturedButtons.length - 1];
     expect(stepThrough).toBeDefined();
-    expect(stepThrough._label).toBe('Step Through →');
+    expect(stepThrough._label).toBe('Step Through');
+    expect(stepThrough._emoji).toBe('🔗');
     expect(stepThrough._style).toBe(5); // ButtonStyle.Link
     expect(stepThrough._url).toBe('https://qurl.link/#at_unique_token');
     expect(stepThrough.setURL).toHaveBeenCalledWith('https://qurl.link/#at_unique_token');

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -102,6 +102,7 @@ jest.mock('discord.js', () => ({
   ButtonBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setURL: jest.fn().mockReturnThis(),
   })),
@@ -127,6 +128,7 @@ jest.mock('discord.js', () => ({
   TextInputBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
     setPlaceholder: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -128,7 +128,6 @@ jest.mock('discord.js', () => ({
   TextInputBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
-    setEmoji: jest.fn().mockReturnThis(),
     setPlaceholder: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -40,6 +40,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
+  audit: jest.fn(),
 }));
 
 // Track EmbedBuilder instances for assertions

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -9,7 +9,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const originalFetch = globalThis.fetch;
 
@@ -27,7 +28,8 @@ describe('Connector client — coverage boost', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-  audit: jest.fn(),    }));
+      audit: jest.fn(),
+    }));
     connector = require('../src/connector');
   });
 
@@ -257,7 +259,8 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-  audit: jest.fn(),    }));
+      audit: jest.fn(),
+    }));
     connector = require('../src/connector');
   });
 

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -9,7 +9,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const originalFetch = globalThis.fetch;
 
@@ -27,7 +27,7 @@ describe('Connector client — coverage boost', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-    }));
+  audit: jest.fn(),    }));
     connector = require('../src/connector');
   });
 
@@ -257,7 +257,7 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-    }));
+  audit: jest.fn(),    }));
     connector = require('../src/connector');
   });
 

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -111,6 +111,7 @@ jest.mock('discord.js', () => ({
   ButtonBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setURL: jest.fn().mockReturnThis(),
   })),
@@ -136,6 +137,7 @@ jest.mock('discord.js', () => ({
   TextInputBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
     setPlaceholder: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -137,7 +137,6 @@ jest.mock('discord.js', () => ({
   TextInputBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
-    setEmoji: jest.fn().mockReturnThis(),
     setPlaceholder: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -50,7 +50,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 // Track EmbedBuilder calls
 const embedInstances = [];

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -50,7 +50,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 // Track EmbedBuilder calls
 const embedInstances = [];

--- a/apps/discord/tests/crypto.test.js
+++ b/apps/discord/tests/crypto.test.js
@@ -8,7 +8,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const nodeCrypto = require('crypto');
 const { encrypt, decrypt, _resetKeyCache } = require('../src/utils/crypto');

--- a/apps/discord/tests/crypto.test.js
+++ b/apps/discord/tests/crypto.test.js
@@ -8,7 +8,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const nodeCrypto = require('crypto');
 const { encrypt, decrypt, _resetKeyCache } = require('../src/utils/crypto');

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -13,7 +13,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const db = require('../src/database');
 

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -13,7 +13,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const db = require('../src/database');
 

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -26,7 +26,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 // Mock crypto wrapper: pass-through so tests can assert on
 // plaintext that flows into the DDB Item. Real encryption is

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -26,7 +26,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 // Mock crypto wrapper: pass-through so tests can assert on
 // plaintext that flows into the DDB Item. Real encryption is

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -21,7 +21,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 // Mock ../src/discord to expose a controllable client.rest. discord-rest
 // reads `client.rest` at module load and reuses it for every REST call,

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -21,7 +21,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 // Mock ../src/discord to expose a controllable client.rest. discord-rest
 // reads `client.rest` at module load and reuses it for every REST call,

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -35,7 +35,7 @@ jest.mock('../src/config', () => ({
 }));
 
 jest.mock('../src/logger', () => ({
-  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
 }));
 
 const mockDb = {

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -206,6 +206,36 @@ describe('logger', () => {
       expect(parsed.audit.auth_token).toBe('sk-abc123');
     });
 
+    it('warns on secret-shaped keys nested inside a meta object', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // Top-level-only iteration would miss this. Recursion is the
+      // whole point of the defense-in-depth — a caller passing
+      // `{ context: { auth_token: '...' } }` is the most realistic
+      // accidental-leak path (e.g., dumping an error context object).
+      logger.audit('upload_success', { send_id: 's1', context: { auth_token: 'sk-nested' } });
+
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('auth_token');
+      // Value still emits — audit doesn't redact, by contract.
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.context.auth_token).toBe('sk-nested');
+    });
+
+    it('warns on secret-shaped keys nested inside an array element', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.audit('upload_success', {
+        send_id: 's1',
+        history: [{ ts: 1, password: 'p1' }],
+      });
+
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('password');
+    });
+
     it('does NOT warn for legitimate dimension keys that contain "token" as a substring', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -132,12 +132,12 @@ describe('logger', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      logger.audit('mint_success', { send_id: 'abc', count: 3 });
+      logger.audit('upload_success', { send_id: 'abc', count: 3 });
 
       expect(consoleSpy.log).toHaveBeenCalledTimes(1);
       const line = consoleSpy.log.mock.calls[0][0];
       const parsed = JSON.parse(line);
-      expect(parsed.audit.event).toBe('mint_success');
+      expect(parsed.audit.event).toBe('upload_success');
       expect(parsed.audit.agent).toBe('discord');
       expect(parsed.audit.send_id).toBe('abc');
       expect(parsed.audit.count).toBe(3);
@@ -163,7 +163,7 @@ describe('logger', () => {
       // field like `tokens_minted` or `token_count` would otherwise
       // get blanked — which would corrupt a CloudWatch metric
       // dimension. Verify audit() bypasses redact for these keys.
-      logger.audit('mint_success', { tokens_minted: 7, send_id: 'send-1' });
+      logger.audit('upload_success', { tokens_minted: 7, send_id: 'send-1' });
 
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
       expect(parsed.audit.tokens_minted).toBe(7);
@@ -179,7 +179,7 @@ describe('logger', () => {
       // dispatch in batchSettled).
       const circ = {};
       circ.self = circ;
-      expect(() => logger.audit('mint_success', { circ })).not.toThrow();
+      expect(() => logger.audit('upload_success', { circ })).not.toThrow();
       expect(consoleSpy.error).toHaveBeenCalled();
       expect(consoleSpy.error.mock.calls[0][0]).toContain('logger.audit serialization failed');
     });
@@ -188,7 +188,7 @@ describe('logger', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      logger.audit('mint_success', { agent: 'slack', send_id: 'x' });
+      logger.audit('upload_success', { agent: 'slack', send_id: 'x' });
 
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
       expect(parsed.audit.agent).toBe('discord');

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -170,18 +170,28 @@ describe('logger', () => {
       expect(parsed.audit.send_id).toBe('send-1');
     });
 
-    it('catches JSON.stringify failures and logs an error instead of throwing', () => {
+    it('emits a fallback audit_serialization_failed event when JSON.stringify throws', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      // Circular ref — JSON.stringify throws TypeError. audit() must
-      // not propagate that to the caller (would fail per-recipient
-      // dispatch in batchSettled).
+      // Circular ref — JSON.stringify throws TypeError on the primary
+      // emission. audit() must (a) not propagate that to the caller
+      // (would fail per-recipient dispatch in batchSettled), and
+      // (b) still emit a CloudWatch-visible audit line so the gap is
+      // discoverable via metric filter, not just a free-text error log.
       const circ = {};
       circ.self = circ;
       expect(() => logger.audit('upload_success', { circ })).not.toThrow();
-      expect(consoleSpy.error).toHaveBeenCalled();
-      expect(consoleSpy.error.mock.calls[0][0]).toContain('logger.audit serialization failed');
+
+      // Fallback audit line was emitted with the synthetic event name.
+      const auditLines = consoleSpy.log.mock.calls.map(c => {
+        try { return JSON.parse(c[0]); } catch { return null; }
+      }).filter(Boolean);
+      const fallback = auditLines.find(l => l.audit && l.audit.event === 'audit_serialization_failed');
+      expect(fallback).toBeDefined();
+      expect(fallback.audit.agent).toBe('discord');
+      expect(fallback.audit.original_event).toBe('upload_success');
+      expect(typeof fallback.audit.reason).toBe('string');
     });
 
     it('warns but still emits when meta contains a secret-shaped key', () => {

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -194,56 +194,70 @@ describe('logger', () => {
       expect(typeof fallback.audit.reason).toBe('string');
     });
 
-    it('warns but still emits when meta contains a secret-shaped key', () => {
+    it('redacts secret-shaped key VALUES while keeping siblings intact + warns', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      // Defense-in-depth — the contract is "callers MUST not pass
-      // secrets," and audit() does not redact. The warn surfaces the
-      // violation as a CloudWatch-visible error log so a misbehaving
-      // caller is catchable in dashboards rather than silent. The
-      // value still emits unredacted because dropping would corrupt
-      // any legitimate dimension a CloudWatch filter is keying on.
       logger.audit('upload_success', { send_id: 's1', auth_token: 'sk-abc123' });
 
-      // Warn fired
+      // Warn fires with the offending key name.
       expect(consoleSpy.error).toHaveBeenCalled();
       expect(consoleSpy.error.mock.calls[0][0]).toContain('secret-shaped key');
       expect(consoleSpy.error.mock.calls[0][0]).toContain('auth_token');
-      // Audit line still emitted with the value verbatim
-      expect(consoleSpy.log).toHaveBeenCalled();
+      // Value redacted in the emitted payload — sibling key untouched.
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
-      expect(parsed.audit.auth_token).toBe('sk-abc123');
+      expect(parsed.audit.auth_token).toBe('[REDACTED]');
+      expect(parsed.audit.send_id).toBe('s1');
     });
 
-    it('warns on secret-shaped keys nested inside a meta object', () => {
+    it('redacts non-empty string values; non-string secret values pass through', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // null / number values can't carry a usable secret on their own
+      // — preserve type so a downstream parser doesn't choke on a
+      // string where it expected something else.
+      logger.audit('upload_success', { auth_token: null, api_key: 0 });
+
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.auth_token).toBeNull();
+      expect(parsed.audit.api_key).toBe(0);
+    });
+
+    it('redacts secret-shaped keys nested inside a meta object', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       // Top-level-only iteration would miss this. Recursion is the
-      // whole point of the defense-in-depth — a caller passing
-      // `{ context: { auth_token: '...' } }` is the most realistic
-      // accidental-leak path (e.g., dumping an error context object).
+      // whole point — a caller passing `{ context: { auth_token: '...' } }`
+      // is the most realistic accidental-leak path (e.g., dumping
+      // an error context object).
       logger.audit('upload_success', { send_id: 's1', context: { auth_token: 'sk-nested' } });
 
       expect(consoleSpy.error).toHaveBeenCalled();
       expect(consoleSpy.error.mock.calls[0][0]).toContain('auth_token');
-      // Value still emits — audit doesn't redact, by contract.
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
-      expect(parsed.audit.context.auth_token).toBe('sk-nested');
+      // Nested value redacted.
+      expect(parsed.audit.context.auth_token).toBe('[REDACTED]');
+      // Top-level send_id still flows.
+      expect(parsed.audit.send_id).toBe('s1');
     });
 
-    it('warns on secret-shaped keys nested inside an array element', () => {
+    it('redacts secret-shaped keys nested inside an array element', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       logger.audit('upload_success', {
         send_id: 's1',
-        history: [{ ts: 1, password: 'p1' }],
+        history: [{ ts: 1, password: 'p1' }, { ts: 2, password: 'p2' }],
       });
 
       expect(consoleSpy.error).toHaveBeenCalled();
       expect(consoleSpy.error.mock.calls[0][0]).toContain('password');
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.history[0].password).toBe('[REDACTED]');
+      expect(parsed.audit.history[0].ts).toBe(1);
+      expect(parsed.audit.history[1].password).toBe('[REDACTED]');
     });
 
     it('does NOT warn for legitimate dimension keys that contain "token" as a substring', () => {
@@ -313,6 +327,23 @@ describe('logger', () => {
         expect(line.audit.event).toBe('dispatch_sent');
         expect(line.audit.agent).toBe('discord');
       }
+    });
+
+    it('coerces array meta to {} so it does not spread into numeric-index keys', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // typeof [] === 'object', so a `typeof !== 'object'` guard alone
+      // would let an array through and produce `{0:1, 1:2, event, agent}`
+      // — confusing in CloudWatch and likely a caller bug. Coerce to
+      // empty meta instead.
+      expect(() => logger.audit('dispatch_sent', [1, 2, 3])).not.toThrow();
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.event).toBe('dispatch_sent');
+      expect(parsed.audit.agent).toBe('discord');
+      // No numeric-index keys leaked from the spread.
+      expect(parsed.audit['0']).toBeUndefined();
+      expect(parsed.audit['1']).toBeUndefined();
     });
   });
 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -126,4 +126,66 @@ describe('logger', () => {
     // ISO format: [2026-...T...Z]
     expect(output).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
   });
+
+  describe('audit', () => {
+    it('emits a parseable JSON line with event, agent, and ts', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.audit('mint_success', { send_id: 'abc', count: 3 });
+
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1);
+      const line = consoleSpy.log.mock.calls[0][0];
+      const parsed = JSON.parse(line);
+      expect(parsed.audit.event).toBe('mint_success');
+      expect(parsed.audit.agent).toBe('discord');
+      expect(parsed.audit.send_id).toBe('abc');
+      expect(parsed.audit.count).toBe(3);
+      expect(parsed.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('bypasses currentLevel (emits even at error level)', () => {
+      process.env.LOG_LEVEL = 'error';
+      logger = require('../src/logger');
+
+      logger.audit('dispatch_sent', { send_id: 'x' });
+
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.event).toBe('dispatch_sent');
+    });
+
+    it('does not redact secret-shaped meta keys (audit fields are pre-vetted)', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // A send_id or token-shaped field name must survive verbatim so a
+      // CloudWatch metric filter dimensioning on it sees the real value.
+      logger.audit('mint_success', { send_id: 'token-shaped-id-12345' });
+
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.send_id).toBe('token-shaped-id-12345');
+    });
+
+    it('agent is not overridable via meta', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.audit('mint_success', { agent: 'slack', send_id: 'x' });
+
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.agent).toBe('discord');
+    });
+
+    it('handles missing meta gracefully', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.audit('revoke_success');
+
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.event).toBe('revoke_success');
+      expect(parsed.audit.agent).toBe('discord');
+    });
+  });
 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -244,5 +244,35 @@ describe('logger', () => {
       expect(parsed.audit.event).toBe('revoke_success');
       expect(parsed.audit.agent).toBe('discord');
     });
+
+    it('coerces null meta to {} so Object.keys() does not throw', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // Default-param `meta = {}` only fires for `undefined`. A caller
+      // doing `logger.audit('x', someObj?.meta)` could easily pass null.
+      // The coerce-to-{} guard inside audit() must run BEFORE the
+      // Object.keys(meta) loop, otherwise null would crash audit() and
+      // bubble out of batchSettled — defeating the never-throw contract.
+      expect(() => logger.audit('dispatch_sent', null)).not.toThrow();
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.event).toBe('dispatch_sent');
+      expect(parsed.audit.agent).toBe('discord');
+    });
+
+    it('coerces non-object meta (string, number) to {} without crashing', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      expect(() => logger.audit('dispatch_sent', 'oops-stringly-typed')).not.toThrow();
+      expect(() => logger.audit('dispatch_sent', 42)).not.toThrow();
+      // Both emit a clean audit line with just event + agent.
+      const lines = consoleSpy.log.mock.calls.map(c => JSON.parse(c[0]));
+      expect(lines).toHaveLength(2);
+      for (const line of lines) {
+        expect(line.audit.event).toBe('dispatch_sent');
+        expect(line.audit.agent).toBe('discord');
+      }
+    });
   });
 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -184,6 +184,46 @@ describe('logger', () => {
       expect(consoleSpy.error.mock.calls[0][0]).toContain('logger.audit serialization failed');
     });
 
+    it('warns but still emits when meta contains a secret-shaped key', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // Defense-in-depth — the contract is "callers MUST not pass
+      // secrets," and audit() does not redact. The warn surfaces the
+      // violation as a CloudWatch-visible error log so a misbehaving
+      // caller is catchable in dashboards rather than silent. The
+      // value still emits unredacted because dropping would corrupt
+      // any legitimate dimension a CloudWatch filter is keying on.
+      logger.audit('upload_success', { send_id: 's1', auth_token: 'sk-abc123' });
+
+      // Warn fired
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('secret-shaped key');
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('auth_token');
+      // Audit line still emitted with the value verbatim
+      expect(consoleSpy.log).toHaveBeenCalled();
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.auth_token).toBe('sk-abc123');
+    });
+
+    it('does NOT warn for legitimate dimension keys that contain "token" as a substring', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // tokens_minted contains "token" as a substring but is NOT in
+      // AUDIT_SECRET_KEYS — it's a legitimate audit dimension. The
+      // warn must use exact-match (not substring) so this kind of
+      // key doesn't trigger a false positive every emission.
+      logger.audit('upload_success', { send_id: 's1', tokens_minted: 7, token_count: 3 });
+
+      // No warn for these substring-matching but non-secret keys.
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+      // Values emit verbatim.
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.tokens_minted).toBe(7);
+      expect(parsed.audit.token_count).toBe(3);
+    });
+
     it('agent is not overridable via meta', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -202,7 +202,7 @@ describe('logger', () => {
 
       // Warn fires with the offending key name.
       expect(consoleSpy.error).toHaveBeenCalled();
-      expect(consoleSpy.error.mock.calls[0][0]).toContain('secret-shaped key');
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('secret-shaped key');  // singular OR plural, matches "secret-shaped key" prefix
       expect(consoleSpy.error.mock.calls[0][0]).toContain('auth_token');
       // Value redacted in the emitted payload — sibling key untouched.
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
@@ -241,6 +241,42 @@ describe('logger', () => {
       expect(parsed.audit.context.auth_token).toBe('[REDACTED]');
       // Top-level send_id still flows.
       expect(parsed.audit.send_id).toBe('s1');
+    });
+
+    it('reports ALL offending secret-shaped keys in a single warn line', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // If a caller leaks both auth_token AND password, the warn must
+      // surface both — a single-key report would let them fix one and
+      // re-run before discovering the second.
+      logger.audit('upload_success', { send_id: 's1', auth_token: 'a', password: 'b' });
+
+      expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+      const msg = consoleSpy.error.mock.calls[0][0];
+      expect(msg).toContain('auth_token');
+      expect(msg).toContain('password');
+      // Both values redacted in the emitted payload.
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.auth_token).toBe('[REDACTED]');
+      expect(parsed.audit.password).toBe('[REDACTED]');
+    });
+
+    it('AUDIT_SECRET_KEYS entries are all lowercase (lookup uses .toLowerCase())', () => {
+      // The membership check is `AUDIT_SECRET_KEYS.has(key.toLowerCase())`,
+      // so an entry like 'API_Key' would silently never match. Lock the
+      // invariant so a future addition catches review.
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+      // Force re-require so we can pull AUDIT_SECRET_KEYS via the test
+      // export. The set isn't exported today; instead, exercise the
+      // invariant by feeding a deliberately mixed-case key and
+      // confirming it still triggers the warn.
+      logger.audit('upload_success', { Auth_Token: 'sk-xyz', PASSWORD: 'p' });
+      expect(consoleSpy.error).toHaveBeenCalled();
+      const msg = consoleSpy.error.mock.calls[0][0];
+      expect(msg.toLowerCase()).toContain('auth_token');
+      expect(msg.toLowerCase()).toContain('password');
     });
 
     it('redacts secret-shaped keys nested inside an array element', () => {

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -155,16 +155,33 @@ describe('logger', () => {
       expect(parsed.audit.event).toBe('dispatch_sent');
     });
 
-    it('does not redact secret-shaped meta keys (audit fields are pre-vetted)', () => {
+    it('does not redact meta keys whose names match REDACT_SUBSTRINGS', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      // A send_id or token-shaped field name must survive verbatim so a
-      // CloudWatch metric filter dimensioning on it sees the real value.
-      logger.audit('mint_success', { send_id: 'token-shaped-id-12345' });
+      // redact() matches on KEY name, not value. A future audit meta
+      // field like `tokens_minted` or `token_count` would otherwise
+      // get blanked — which would corrupt a CloudWatch metric
+      // dimension. Verify audit() bypasses redact for these keys.
+      logger.audit('mint_success', { tokens_minted: 7, send_id: 'send-1' });
 
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
-      expect(parsed.audit.send_id).toBe('token-shaped-id-12345');
+      expect(parsed.audit.tokens_minted).toBe(7);
+      expect(parsed.audit.send_id).toBe('send-1');
+    });
+
+    it('catches JSON.stringify failures and logs an error instead of throwing', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // Circular ref — JSON.stringify throws TypeError. audit() must
+      // not propagate that to the caller (would fail per-recipient
+      // dispatch in batchSettled).
+      const circ = {};
+      circ.self = circ;
+      expect(() => logger.audit('mint_success', { circ })).not.toThrow();
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('logger.audit serialization failed');
     });
 
     it('agent is not overridable via meta', () => {

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -262,7 +262,7 @@ describe('logger', () => {
       expect(parsed.audit.password).toBe('[REDACTED]');
     });
 
-    it('AUDIT_SECRET_KEYS entries are all lowercase (lookup uses .toLowerCase())', () => {
+    it('mixed-case secret-shaped keys are still detected via .toLowerCase() lookup', () => {
       // The membership check is `AUDIT_SECRET_KEYS.has(key.toLowerCase())`,
       // so an entry like 'API_Key' would silently never match. Lock the
       // invariant so a future addition catches review.

--- a/apps/discord/tests/oauth-state-binding.test.js
+++ b/apps/discord/tests/oauth-state-binding.test.js
@@ -15,7 +15,7 @@ jest.mock('../src/config', () => ({
 }));
 
 jest.mock('../src/logger', () => ({
-  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
 }));
 
 jest.mock('../src/discord', () => ({

--- a/apps/discord/tests/opennhp-gating.test.js
+++ b/apps/discord/tests/opennhp-gating.test.js
@@ -41,7 +41,7 @@ jest.mock('../src/config', () => ({
 }));
 
 const mockLogger = {
-  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
 };
 jest.mock('../src/logger', () => mockLogger);
 

--- a/apps/discord/tests/orphan-token-sweeper.test.js
+++ b/apps/discord/tests/orphan-token-sweeper.test.js
@@ -15,7 +15,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const db = require('../src/database');
 const { sweepOnce } = require('../src/orphan-token-sweeper');

--- a/apps/discord/tests/orphan-token-sweeper.test.js
+++ b/apps/discord/tests/orphan-token-sweeper.test.js
@@ -15,7 +15,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const db = require('../src/database');
 const { sweepOnce } = require('../src/orphan-token-sweeper');

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -7,7 +7,8 @@ jest.mock('../src/logger', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
-  debug: jest.fn(), audit: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
 }));
 
 const originalFetch = globalThis.fetch;
@@ -25,7 +26,8 @@ describe('qURL client — getResourceStatus (line 51)', () => {
       info: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),
-      debug: jest.fn(), audit: jest.fn(),
+      debug: jest.fn(),
+      audit: jest.fn(),
     }));
     qurl = require('../src/qurl');
   });

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -7,7 +7,7 @@ jest.mock('../src/logger', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
-  debug: jest.fn(),
+  debug: jest.fn(), audit: jest.fn(),
 }));
 
 const originalFetch = globalThis.fetch;
@@ -25,7 +25,7 @@ describe('qURL client — getResourceStatus (line 51)', () => {
       info: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),
-      debug: jest.fn(),
+      debug: jest.fn(), audit: jest.fn(),
     }));
     qurl = require('../src/qurl');
   });
@@ -100,7 +100,7 @@ describe('qURL client — retry logic on transient failures', () => {
       QURL_ENDPOINT: 'https://api.test.local',
     }));
     jest.mock('../src/logger', () => ({
-      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
     }));
     qurl = require('../src/qurl');
   });
@@ -160,7 +160,7 @@ describe('qURL client — createOneTimeLink happy path', () => {
       QURL_ENDPOINT: 'https://api.test.local',
     }));
     jest.doMock('../src/logger', () => ({
-      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
     }));
     jest.doMock('dns', () => ({
       promises: { lookup: jest.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]) },
@@ -181,7 +181,7 @@ describe('qURL client — createOneTimeLink happy path', () => {
   it('rejects when DNS lookup fails', async () => {
     jest.resetModules();
     jest.doMock('../src/config', () => ({ QURL_API_KEY: 'k', QURL_ENDPOINT: 'https://api.test.local' }));
-    jest.doMock('../src/logger', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }));
+    jest.doMock('../src/logger', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn() }));
     jest.doMock('dns', () => ({
       promises: { lookup: jest.fn().mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOTFOUND' })) },
     }));

--- a/apps/discord/tests/qurl-private-host.test.js
+++ b/apps/discord/tests/qurl-private-host.test.js
@@ -14,7 +14,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const { createOneTimeLink } = require('../src/qurl');
 

--- a/apps/discord/tests/qurl-private-host.test.js
+++ b/apps/discord/tests/qurl-private-host.test.js
@@ -14,7 +14,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const { createOneTimeLink } = require('../src/qurl');
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -597,6 +597,17 @@ describe('revokeAllLinks', () => {
     expect(mockDeleteLink).not.toHaveBeenCalled();
     expect(mockDb.markSendRevoked).toHaveBeenCalled();
   });
+
+  it('emits revoke_success audit event with success/total tally', async () => {
+    mockDb.getSendResourceIds.mockResolvedValueOnce(['res-1', 'res-2']);
+    mockDeleteLink.mockResolvedValue(undefined);
+
+    await revokeAllLinks('send-42', 'sender-1', 'apikey');
+
+    expect(logger.audit).toHaveBeenCalledWith('revoke_success', {
+      send_id: 'send-42', success: 2, total: 2,
+    });
+  });
 });
 
 // ===========================================================================
@@ -825,6 +836,35 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(result.newResourceIds).toEqual(expect.arrayContaining(['res-loc-new']));
     // updateSendDMStatus called once per recipient with SENT.
     expect(mockDb.updateSendDMStatus).toHaveBeenCalledTimes(2);
+    // Audit emission: upload_success + mint_success + dispatch_sent (×2 recipients).
+    const emitted = logger.audit.mock.calls.map(c => c[0]);
+    expect(emitted).toEqual(expect.arrayContaining(['upload_success', 'mint_success', 'dispatch_sent']));
+    expect(logger.audit).toHaveBeenCalledWith('mint_success', expect.objectContaining({
+      send_id: 'send-1', kind: 'location', count: 2,
+    }));
+    expect(emitted.filter(e => e === 'dispatch_sent')).toHaveLength(2);
+  });
+
+  it('emits mint_failed (not mint_success) when uploadJsonToConnector throws', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: null, actual_url: 'https://maps.example.com/x',
+      location_name: 'Eiffel Tower', expires_in: '5m',
+    });
+    const err = new Error('upstream 429');
+    err.apiCode = 'rate_limited';
+    mockUploadJsonToConnector.mockRejectedValueOnce(err);
+
+    await handleAddRecipients(
+      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    const emitted = logger.audit.mock.calls.map(c => c[0]);
+    expect(emitted).toContain('mint_failed');
+    expect(emitted).not.toContain('mint_success');
+    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
+      send_id: 'send-1', kind: 'location', api_code: 'rate_limited',
+    }));
   });
 
   it('reports failed DMs as failed in the return value', async () => {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -57,6 +57,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
+  audit: jest.fn(),
 }));
 
 jest.mock('discord.js', () => {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -598,7 +598,7 @@ describe('revokeAllLinks', () => {
     expect(mockDb.markSendRevoked).toHaveBeenCalled();
   });
 
-  it('emits revoke_success audit event with success/total tally', async () => {
+  it('emits revoke_success audit event with success/total tally when at least one link revoked', async () => {
     mockDb.getSendResourceIds.mockResolvedValueOnce(['res-1', 'res-2']);
     mockDeleteLink.mockResolvedValue(undefined);
 
@@ -607,6 +607,30 @@ describe('revokeAllLinks', () => {
     expect(logger.audit).toHaveBeenCalledWith('revoke_success', {
       send_id: 'send-42', success: 2, total: 2,
     });
+  });
+
+  it('emits revoke_failed (not revoke_success) when every per-link delete throws', async () => {
+    mockDb.getSendResourceIds.mockResolvedValueOnce(['res-1', 'res-2']);
+    mockDeleteLink.mockRejectedValue(new Error('429 rate limited'));
+
+    await revokeAllLinks('send-43', 'sender-1', 'apikey');
+
+    const events = logger.audit.mock.calls.map(c => c[0]);
+    expect(events).toContain('revoke_failed');
+    expect(events).not.toContain('revoke_success');
+    expect(logger.audit).toHaveBeenCalledWith('revoke_failed', {
+      send_id: 'send-43', success: 0, total: 2,
+    });
+  });
+
+  it('emits no audit event when there are no resources to revoke (avoids 0/0 noise)', async () => {
+    mockDb.getSendResourceIds.mockResolvedValueOnce([]);
+
+    await revokeAllLinks('send-44', 'sender-1', 'apikey');
+
+    const events = logger.audit.mock.calls.map(c => c[0]);
+    expect(events).not.toContain('revoke_success');
+    expect(events).not.toContain('revoke_failed');
   });
 });
 
@@ -740,6 +764,30 @@ describe('handleAddRecipients — file path failure modes', () => {
     );
 
     expect(result.msg).toMatch(/failed to prepare links/i);
+  });
+
+  // The file-path inner try/catch returns early before reaching the outer
+  // catch, so the outer catch's logger.audit(MINT_FAILED) never sees these
+  // errors. The inner catch must emit its own mint_failed or the metric
+  // undercounts the most common file-path failure mode (CDN URL expiry).
+  it('emits mint_failed when downloadAndUpload throws (inner-catch path)', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: '5m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    const err = new Error('403 Forbidden — URL expired');
+    err.apiCode = 'cdn_expired';
+    mockDownloadAndUpload.mockRejectedValueOnce(err);
+
+    await handleAddRecipients(
+      'send-9', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
+      send_id: 'send-9', kind: 'file', api_code: 'cdn_expired',
+    }));
   });
 
   it('reports underdelivery when mintLinks returns fewer links than recipients', async () => {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -65,6 +65,7 @@ jest.mock('discord.js', () => {
     const obj = {
       setCustomId: jest.fn().mockReturnThis(),
       setLabel: jest.fn().mockReturnThis(),
+      setEmoji: jest.fn().mockReturnThis(),
       setStyle: jest.fn().mockReturnThis(),
       setURL: jest.fn().mockReturnThis(),
       setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -767,30 +767,6 @@ describe('handleAddRecipients — file path failure modes', () => {
     expect(result.msg).toMatch(/failed to prepare links/i);
   });
 
-  // The file-path inner try/catch returns early before reaching the outer
-  // catch, so the outer catch's logger.audit(MINT_FAILED) never sees these
-  // errors. The inner catch must emit its own mint_failed or the metric
-  // undercounts the most common file-path failure mode (CDN URL expiry).
-  it('emits mint_failed when downloadAndUpload throws (inner-catch path)', async () => {
-    mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
-      attachment_url: 'https://cdn.discordapp.com/x.png',
-      attachment_name: 'x.png', attachment_content_type: 'image/png',
-    });
-    const err = new Error('403 Forbidden — URL expired');
-    err.apiCode = 'cdn_expired';
-    mockDownloadAndUpload.mockRejectedValueOnce(err);
-
-    await handleAddRecipients(
-      'send-9', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
-      makeInteraction(), 'apikey',
-    );
-
-    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
-      send_id: 'send-9', kind: 'file', api_code: 'cdn_expired',
-    }));
-  });
-
   it('reports underdelivery when mintLinks returns fewer links than recipients', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: 'res-1', expires_in: '5m',
@@ -885,72 +861,17 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(result.newResourceIds).toEqual(expect.arrayContaining(['res-loc-new']));
     // updateSendDMStatus called once per recipient with SENT.
     expect(mockDb.updateSendDMStatus).toHaveBeenCalledTimes(2);
-    // Audit emission: upload_success + mint_success + dispatch_sent (×2 recipients).
+    // Audit emission: upload_success + dispatch_sent (×2 recipients).
+    // mint_* is intentionally not emitted from the bot — see
+    // constants.js AUDIT_EVENTS comment.
     const emitted = logger.audit.mock.calls.map(c => c[0]);
-    expect(emitted).toEqual(expect.arrayContaining(['upload_success', 'mint_success', 'dispatch_sent']));
-    expect(logger.audit).toHaveBeenCalledWith('mint_success', expect.objectContaining({
-      send_id: 'send-1', kind: 'location', count: 2,
+    expect(emitted).toEqual(expect.arrayContaining(['upload_success', 'dispatch_sent']));
+    expect(logger.audit).toHaveBeenCalledWith('upload_success', expect.objectContaining({
+      send_id: 'send-1', kind: 'location',
     }));
     expect(emitted.filter(e => e === 'dispatch_sent')).toHaveLength(2);
-  });
-
-  it('emits mint_failed (not mint_success) when uploadJsonToConnector throws', async () => {
-    mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: null, actual_url: 'https://maps.example.com/x',
-      location_name: 'Eiffel Tower', expires_in: '5m',
-    });
-    const err = new Error('upstream 429');
-    err.apiCode = 'rate_limited';
-    mockUploadJsonToConnector.mockRejectedValueOnce(err);
-
-    await handleAddRecipients(
-      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
-      makeInteraction(), 'apikey',
-    );
-
-    const emitted = logger.audit.mock.calls.map(c => c[0]);
-    expect(emitted).toContain('mint_failed');
     expect(emitted).not.toContain('mint_success');
-    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
-      send_id: 'send-1', kind: 'location', api_code: 'rate_limited',
-    }));
-  });
-
-  // Locks in the inFlightKind invariant — a previous version of this code
-  // labeled the failure with `kind: hasFile ? 'file' : 'location'`, which
-  // misreports `kind: 'file'` when the file path succeeds and then the
-  // location path throws inside the same handleAddRecipients try block.
-  it('emits kind=location on mint_failed when file succeeds first and location then throws', async () => {
-    mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-orig', expires_in: '5m',
-      attachment_url: 'https://cdn.discordapp.com/x.png',
-      attachment_name: 'x.png', attachment_content_type: 'image/png',
-      // Both paths active.
-      actual_url: 'https://maps.example.com/x',
-      location_name: 'Eiffel Tower',
-    });
-    // File path succeeds.
-    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-file-new', fileBuffer: Buffer.from('x') });
-    mockMintLinks.mockResolvedValueOnce([
-      { qurl_link: 'https://q.test/1', resource_id: 'res-file-new' },
-    ]);
-    // Location path then throws.
-    const err = new Error('upstream 503');
-    err.apiCode = 'connector_unavailable';
-    mockUploadJsonToConnector.mockRejectedValueOnce(err);
-
-    await handleAddRecipients(
-      'send-7', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
-      makeInteraction(), 'apikey',
-    );
-
-    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
-      send_id: 'send-7', kind: 'location', api_code: 'connector_unavailable',
-    }));
-    // Sanity: file's mint_success DID fire before the location threw.
-    expect(logger.audit).toHaveBeenCalledWith('mint_success', expect.objectContaining({
-      send_id: 'send-7', kind: 'file',
-    }));
+    expect(emitted).not.toContain('mint_failed');
   });
 
   it('reports failed DMs as failed in the return value', async () => {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -867,6 +867,43 @@ describe('handleAddRecipients — happy path (location)', () => {
     }));
   });
 
+  // Locks in the inFlightKind invariant — a previous version of this code
+  // labeled the failure with `kind: hasFile ? 'file' : 'location'`, which
+  // misreports `kind: 'file'` when the file path succeeds and then the
+  // location path throws inside the same handleAddRecipients try block.
+  it('emits kind=location on mint_failed when file succeeds first and location then throws', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-orig', expires_in: '5m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+      // Both paths active.
+      actual_url: 'https://maps.example.com/x',
+      location_name: 'Eiffel Tower',
+    });
+    // File path succeeds.
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-file-new', fileBuffer: Buffer.from('x') });
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1', resource_id: 'res-file-new' },
+    ]);
+    // Location path then throws.
+    const err = new Error('upstream 503');
+    err.apiCode = 'connector_unavailable';
+    mockUploadJsonToConnector.mockRejectedValueOnce(err);
+
+    await handleAddRecipients(
+      'send-7', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
+      send_id: 'send-7', kind: 'location', api_code: 'connector_unavailable',
+    }));
+    // Sanity: file's mint_success DID fire before the location threw.
+    expect(logger.audit).toHaveBeenCalledWith('mint_success', expect.objectContaining({
+      send_id: 'send-7', kind: 'file',
+    }));
+  });
+
   it('reports failed DMs as failed in the return value', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: null, actual_url: 'https://maps.example.com/x',

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -874,6 +874,38 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(emitted).not.toContain('mint_failed');
   });
 
+  // Locks the single-emission contract: a sendConfig with both file
+  // AND location must NOT fire upload_success twice (would double-count
+  // UploadCount in CloudWatch). The kind field must be 'mixed'.
+  it('emits exactly ONE upload_success with kind=mixed when both file + location prep paths run', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-file-orig', expires_in: '5m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+      // Both paths active.
+      actual_url: 'https://maps.example.com/x',
+      location_name: 'Eiffel Tower',
+    });
+    // File path succeeds.
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-file-new', fileBuffer: Buffer.from('x') });
+    // mintLinks called twice (once per kind).
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/file', resource_id: 'res-file-new' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/loc', resource_id: 'res-loc-new' }]);
+    // Location path succeeds.
+    mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
+    mockSendDM.mockResolvedValue(true);
+
+    await handleAddRecipients(
+      'send-mixed', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    const uploadEvents = logger.audit.mock.calls.filter(c => c[0] === 'upload_success');
+    expect(uploadEvents).toHaveLength(1);
+    expect(uploadEvents[0][1]).toEqual({ send_id: 'send-mixed', kind: 'mixed' });
+  });
+
   it('reports failed DMs as failed in the return value', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: null, actual_url: 'https://maps.example.com/x',

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -1142,6 +1142,33 @@ describe('handleSend — audit emission', () => {
     const emitted = logger.audit.mock.calls.map(c => c[0]);
     expect(emitted).toContain('dispatch_sent');
   });
+
+  // Locks the try/finally invariant: sendDM is contractually no-throw
+  // today, but if a future change to sendDM lets it throw, the audit
+  // must still fire as dispatch_failed (not silently disappear when the
+  // promise rejection bubbles through batchSettled).
+  it('emits dispatch_failed when sendDM itself throws (contract regression guard)', async () => {
+    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
+    mockSendDM.mockRejectedValueOnce(new Error('Discord API 503'));
+    const locInit = makeCompInt(ids.initLoc, {
+      showModal: jest.fn().mockResolvedValue(undefined),
+      awaitModalSubmit: jest.fn().mockResolvedValue({
+        fields: { getTextInputValue: jest.fn(() => 'Test Place') },
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+      }),
+    });
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInit, targetChannel, sendBtn],
+    });
+    await cmd.execute(interaction);
+
+    const emitted = logger.audit.mock.calls.map(c => c[0]);
+    expect(emitted).toContain('dispatch_failed');
+    expect(emitted).not.toContain('dispatch_sent');
+  });
 });
 
 // ===========================================================================

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -1040,7 +1040,7 @@ describe('handleSend — end-to-end happy paths', () => {
 // ===========================================================================
 
 describe('handleSend — audit emission', () => {
-  it('emits upload_success + mint_success + dispatch_sent on the file happy path', async () => {
+  it('emits upload_success + dispatch_sent on the file happy path', async () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
@@ -1056,37 +1056,16 @@ describe('handleSend — audit emission', () => {
     await cmd.execute(interaction);
 
     const emitted = logger.audit.mock.calls.map(c => c[0]);
-    expect(emitted).toEqual(expect.arrayContaining(['upload_success', 'mint_success', 'dispatch_sent']));
-    expect(logger.audit).toHaveBeenCalledWith('mint_success', expect.objectContaining({
-      send_id: expect.any(String), kind: 'file', count: expect.any(Number),
+    expect(emitted).toEqual(expect.arrayContaining(['upload_success', 'dispatch_sent']));
+    expect(logger.audit).toHaveBeenCalledWith('upload_success', expect.objectContaining({
+      send_id: expect.any(String), kind: 'file',
     }));
-  });
-
-  it('emits mint_failed (not mint_success) when upload throws on the location path', async () => {
-    const err = new Error('upstream quota');
-    err.apiCode = 'quota_exceeded';
-    mockUploadJsonToConnector.mockRejectedValue(err);
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
-    const locInit = makeCompInt(ids.initLoc, {
-      showModal: jest.fn().mockResolvedValue(undefined),
-      awaitModalSubmit: jest.fn().mockResolvedValue({
-        fields: { getTextInputValue: jest.fn(() => 'Test Place') },
-        deferUpdate: jest.fn().mockResolvedValue(undefined),
-      }),
-    });
-    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
-    const sendBtn = makeCompInt(ids.sendBtn);
-    const interaction = makeInteraction({
-      awaitQueue: [locInit, targetChannel, sendBtn],
-    });
-    await cmd.execute(interaction);
-
-    const emitted = logger.audit.mock.calls.map(c => c[0]);
-    expect(emitted).toContain('mint_failed');
+    // mint_* events intentionally NOT emitted from the bot — they belong
+    // at the qURL service layer with an `agent` dimension. Locking that
+    // here so a future re-add doesn't sneak past review without an
+    // explicit decision to re-introduce per-integration emission.
     expect(emitted).not.toContain('mint_success');
-    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
-      send_id: expect.any(String), kind: 'location', api_code: 'quota_exceeded',
-    }));
+    expect(emitted).not.toContain('mint_failed');
   });
 
   it('emits dispatch_sent / dispatch_failed once per recipient, even on partial DM failure', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -47,6 +47,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
+  audit: jest.fn(),
 }));
 
 jest.mock('discord.js', () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -55,6 +55,7 @@ jest.mock('discord.js', () => {
     const obj = {
       setCustomId: jest.fn().mockReturnThis(),
       setLabel: jest.fn().mockReturnThis(),
+      setEmoji: jest.fn().mockReturnThis(),
       setStyle: jest.fn().mockReturnThis(),
       setURL: jest.fn().mockReturnThis(),
       setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -1032,6 +1032,118 @@ describe('handleSend — end-to-end happy paths', () => {
 });
 
 // ===========================================================================
+// 7b. Audit event emission — guards the contract that CloudWatch metric
+// filters in qurl-integrations-infra/qurl-bot-discord/terraform/main.tf
+// pattern-match against. A typo in an event name silently disables a
+// production metric, so these assertions live next to the happy paths.
+// ===========================================================================
+
+describe('handleSend — audit emission', () => {
+  it('emits upload_success + mint_success + dispatch_sent on the file happy path', async () => {
+    const fileInit = makeCompInt(ids.initFile);
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
+    const awaitMessages = jest.fn().mockResolvedValue(makeAttachmentMessage(attachment));
+    const interaction = makeInteraction({
+      awaitQueue: [fileInit, targetUser, userSelect, sendBtn],
+      awaitMessages,
+    });
+    await cmd.execute(interaction);
+
+    const emitted = logger.audit.mock.calls.map(c => c[0]);
+    expect(emitted).toEqual(expect.arrayContaining(['upload_success', 'mint_success', 'dispatch_sent']));
+    expect(logger.audit).toHaveBeenCalledWith('mint_success', expect.objectContaining({
+      send_id: expect.any(String), kind: 'file', count: expect.any(Number),
+    }));
+  });
+
+  it('emits mint_failed (not mint_success) when upload throws on the location path', async () => {
+    const err = new Error('upstream quota');
+    err.apiCode = 'quota_exceeded';
+    mockUploadJsonToConnector.mockRejectedValue(err);
+    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    const locInit = makeCompInt(ids.initLoc, {
+      showModal: jest.fn().mockResolvedValue(undefined),
+      awaitModalSubmit: jest.fn().mockResolvedValue({
+        fields: { getTextInputValue: jest.fn(() => 'Test Place') },
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+      }),
+    });
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInit, targetChannel, sendBtn],
+    });
+    await cmd.execute(interaction);
+
+    const emitted = logger.audit.mock.calls.map(c => c[0]);
+    expect(emitted).toContain('mint_failed');
+    expect(emitted).not.toContain('mint_success');
+    expect(logger.audit).toHaveBeenCalledWith('mint_failed', expect.objectContaining({
+      send_id: expect.any(String), kind: 'location', api_code: 'quota_exceeded',
+    }));
+  });
+
+  it('emits dispatch_sent / dispatch_failed once per recipient, even on partial DM failure', async () => {
+    mockGetTextChannelMembers.mockReturnValue([
+      { id: 'u2', username: 'Alice' },
+      { id: 'u3', username: 'Bob' },
+    ]);
+    mockMintLinks.mockResolvedValue([
+      { qurl_link: 'https://q.test/a' },
+      { qurl_link: 'https://q.test/b' },
+    ]);
+    mockSendDM.mockImplementation(async (recipientId) => recipientId === 'u2');
+    const locInit = makeCompInt(ids.initLoc, {
+      showModal: jest.fn().mockResolvedValue(undefined),
+      awaitModalSubmit: jest.fn().mockResolvedValue({
+        fields: { getTextInputValue: jest.fn(() => 'Test Place') },
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+      }),
+    });
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInit, targetChannel, sendBtn],
+    });
+    await cmd.execute(interaction);
+
+    const dispatchCalls = logger.audit.mock.calls.filter(c => c[0] === 'dispatch_sent' || c[0] === 'dispatch_failed');
+    expect(dispatchCalls).toHaveLength(2);
+    const events = dispatchCalls.map(c => c[0]).sort();
+    expect(events).toEqual(['dispatch_failed', 'dispatch_sent']);
+  });
+
+  it('emits dispatch_sent before the DB write, so a DDB throw cannot suppress the metric', async () => {
+    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
+    mockSendDM.mockResolvedValue(true);
+    // Make the DM-status DB write throw — audit must already have fired.
+    mockDb.updateSendDMStatus.mockRejectedValueOnce(new Error('DDB ProvisionedThroughputExceededException'));
+    const locInit = makeCompInt(ids.initLoc, {
+      showModal: jest.fn().mockResolvedValue(undefined),
+      awaitModalSubmit: jest.fn().mockResolvedValue({
+        fields: { getTextInputValue: jest.fn(() => 'Test Place') },
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+      }),
+    });
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInit, targetChannel, sendBtn],
+    });
+    await cmd.execute(interaction);
+
+    const emitted = logger.audit.mock.calls.map(c => c[0]);
+    expect(emitted).toContain('dispatch_sent');
+  });
+});
+
+// ===========================================================================
 // 7b. Channel-announcement post — sender displayName sanitization
 // ===========================================================================
 // The /qurl send back-half posts a public announcement in the channel

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -28,7 +28,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 // Mock dns.lookup so createOneTimeLink's DNS-rebinding guard doesn't hit
 // the network. Any public-looking hostname resolves to a public IP.
@@ -510,7 +511,8 @@ describe('qURL client', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-  audit: jest.fn(),    }));
+      audit: jest.fn(),
+    }));
 
     qurl = require('../src/qurl');
   });
@@ -615,7 +617,8 @@ describe('Connector client', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-  audit: jest.fn(),    }));
+      audit: jest.fn(),
+    }));
     jest.mock('form-data', () => {
       return jest.fn().mockImplementation(() => ({
         append: jest.fn(),
@@ -778,7 +781,8 @@ describe('Places client', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-  audit: jest.fn(),    }));
+      audit: jest.fn(),
+    }));
   });
 
   afterEach(() => {
@@ -1279,7 +1283,8 @@ describe('handleAddRecipients', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-  audit: jest.fn(),    }));
+      audit: jest.fn(),
+    }));
 
     // Mock discord.js
     jest.mock('discord.js', () => ({

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1350,7 +1350,6 @@ describe('handleAddRecipients', () => {
       TextInputBuilder: jest.fn().mockImplementation(() => ({
         setCustomId: jest.fn().mockReturnThis(),
         setLabel: jest.fn().mockReturnThis(),
-        setEmoji: jest.fn().mockReturnThis(),
         setPlaceholder: jest.fn().mockReturnThis(),
         setStyle: jest.fn().mockReturnThis(),
         setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -75,6 +75,7 @@ jest.mock('discord.js', () => ({
   ButtonBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setURL: jest.fn().mockReturnThis(),
   })),
@@ -1324,6 +1325,7 @@ describe('handleAddRecipients', () => {
       ButtonBuilder: jest.fn().mockImplementation(() => ({
         setCustomId: jest.fn().mockReturnThis(),
         setLabel: jest.fn().mockReturnThis(),
+        setEmoji: jest.fn().mockReturnThis(),
         setStyle: jest.fn().mockReturnThis(),
         setURL: jest.fn().mockReturnThis(),
       })),
@@ -1348,6 +1350,7 @@ describe('handleAddRecipients', () => {
       TextInputBuilder: jest.fn().mockImplementation(() => ({
         setCustomId: jest.fn().mockReturnThis(),
         setLabel: jest.fn().mockReturnThis(),
+        setEmoji: jest.fn().mockReturnThis(),
         setPlaceholder: jest.fn().mockReturnThis(),
         setStyle: jest.fn().mockReturnThis(),
         setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -28,7 +28,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 // Mock dns.lookup so createOneTimeLink's DNS-rebinding guard doesn't hit
 // the network. Any public-looking hostname resolves to a public IP.
@@ -510,7 +510,7 @@ describe('qURL client', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-    }));
+  audit: jest.fn(),    }));
 
     qurl = require('../src/qurl');
   });
@@ -615,7 +615,7 @@ describe('Connector client', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-    }));
+  audit: jest.fn(),    }));
     jest.mock('form-data', () => {
       return jest.fn().mockImplementation(() => ({
         append: jest.fn(),
@@ -778,7 +778,7 @@ describe('Places client', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-    }));
+  audit: jest.fn(),    }));
   });
 
   afterEach(() => {
@@ -1279,7 +1279,7 @@ describe('handleAddRecipients', () => {
       warn: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
-    }));
+  audit: jest.fn(),    }));
 
     // Mock discord.js
     jest.mock('discord.js', () => ({

--- a/apps/discord/tests/revoke-filter.test.js
+++ b/apps/discord/tests/revoke-filter.test.js
@@ -32,7 +32,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const db = require('../src/database');
 

--- a/apps/discord/tests/revoke-filter.test.js
+++ b/apps/discord/tests/revoke-filter.test.js
@@ -32,7 +32,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const db = require('../src/database');
 

--- a/apps/discord/tests/store-contract.test.js
+++ b/apps/discord/tests/store-contract.test.js
@@ -23,7 +23,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const { STORE_METHODS, STORE_CONSTANTS, assertStoreShape } = require('../src/store/contract');
 

--- a/apps/discord/tests/store-contract.test.js
+++ b/apps/discord/tests/store-contract.test.js
@@ -23,7 +23,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const { STORE_METHODS, STORE_CONSTANTS, assertStoreShape } = require('../src/store/contract');
 

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -8,7 +8,8 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-  audit: jest.fn(),}));
+  audit: jest.fn(),
+}));
 
 const { expiryToISO, expiryToMs } = require('../src/utils/time');
 

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -8,7 +8,7 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
-}));
+  audit: jest.fn(),}));
 
 const { expiryToISO, expiryToMs } = require('../src/utils/time');
 


### PR DESCRIPTION
## Summary

Two adjacent changes bundled into one PR (both touch `apps/discord/`,
both small, single review):

### 1. Structured audit events for CloudWatch metrics

Adds `logger.audit(event, meta)` and emits at `/qurl send` dispatch
+ revoke + upload paths. The terraform log-metric filters in
qurl-integrations-infra already key off `$.audit.event = "..."`
patterns, but no code path actually produced these lines.

This PR ships the missing half. Pairs with [`qurl-integrations-infra#309`](https://github.com/layervai/qurl-integrations-infra/pull/309)
(adds `Agent` dimension + new `RevokeFailed` filter).

#### Scope decision (per Justin's review on #309)

Mint counters (`mint_success` / `mint_failed`) are intentionally NOT
in this PR — they belong at the qURL service layer with an `agent`
dimension fed by an `X-QURL-Agent` header so every integration
(Discord, Slack, Teams, CLI, web/portal) gets them for free. Tracked
in [layervai/qurl-service#395](https://github.com/layervai/qurl-service/issues/395).

What stays here is what the qURL service can't see:
- `upload_success` — file/JSON uploads to qurl-s3-connector
- `dispatch_sent` / `dispatch_failed` — per-recipient DM delivery
- `revoke_success` / `revoke_failed` — the all-or-partial-success tally across N per-link DELETE calls (split so a dashboard isn't misled into counting fully-failed revokes as successes)

#### Audit shape
- `logger.audit(event, meta)` — emits `{ audit: { ...meta, event, agent: 'discord' }, ts }`
- `event` and `agent` pinned **after** the meta spread so a caller can't override them
- Bypasses `currentLevel` + `redact()` (audit fields are pre-vetted; key-name redaction would otherwise corrupt CloudWatch dimensions like `tokens_minted`)
- `JSON.stringify` wrapped in try/catch — circular ref / BigInt logs an error instead of throwing out of the per-recipient `batchSettled` callback
- Dispatch audit fires BEFORE the DB write (so a DDB throttle can't suppress the metric — the failure mode the audit metric exists to measure)
- `try/finally` around dispatch audit so a thrown sendDM still emits `dispatch_failed`

### 2. DM button: "Step Through →" → "🔗 Step Through"

Discord Link-style buttons render gray, which can read as plain text
rather than a clickable affordance. The leading 🔗 emoji adds visual
weight; the trailing → drops since the emoji conveys the "go elsewhere"
intent on its own.

## Test plan

- [x] `npx jest` — 753/753 pass (was 745 pre-PR)
- [x] Coverage on `commands.js` clears the 73/65/79/75 floor
- [x] 5 rounds of pr-polish + Claude review — converged to nits-only
- [ ] After deploy: confirm CloudWatch sees non-zero on `UploadCount`, `DispatchSentCount`, `DispatchFailedCount`, `RevokeCount`, `RevokeFailed` with `Agent=discord` (after #309 lands)
- [ ] After deploy: visually confirm the 🔗 emoji renders on the DM button across desktop + mobile Discord clients
- [ ] After qurl-service implements layervai/qurl-service#395: confirm `MintCount` / `MintFailed` populate from the service side

🤖 Generated with [Claude Code](https://claude.com/claude-code)