### PR TITLE
ci(discord): migrate trigger-deploy from DEPLOY_PAT to GitHub App

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -73,14 +73,17 @@ jobs:
   trigger-deploy:
     needs: [build-and-test, docker-check]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    # `event_type` must match the receiver's `repository_dispatch.types` in
-    # qurl-integrations-infra/.github/workflows/qurl-bot-discord-deploy.yml —
-    # a typo silently no-ops the deploy.
-    permissions:
-      contents: read
+    # The reusable authenticates via App secrets; the caller's GITHUB_TOKEN
+    # isn't read by any step, so deny everything.
+    permissions: {}
     uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
     with:
       target_repo: qurl-integrations-infra
+      # `event_type` must match the receiver's `repository_dispatch.types` at
+      # qurl-integrations-infra/.github/workflows/qurl-bot-discord-deploy.yml.
+      # An off-allowlist value hard-fails in the reusable; an allowlisted
+      # value that misses the receiver silently no-ops (HTTP 204 from the
+      # dispatch API but no workflow fires).
       event_type: discord-bot-deploy
       client_payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
     # Explicit `secrets:` map (not `inherit`) keeps the reusable's surface

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -84,7 +84,7 @@ jobs:
     # Replaces the prior DEPLOY_PAT + peter-evans/repository-dispatch
     # pattern. SHA-pinned per the org's reusable-workflow convention;
     # bumps require an explicit PR. Closes #75.
-    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@__OPS_ROUTINES_WORKFLOWS_SHA__
+    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0
     with:
       target_repo: qurl-integrations-infra
       event_type: discord-bot-deploy

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -72,21 +72,23 @@ jobs:
 
   trigger-deploy:
     needs: [build-and-test, docker-check]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      # SECURITY: DEPLOY_PAT must be a *fine-grained* personal access token
-      # scoped to:
-      #   - Repository: layervai/qurl-integrations-infra (ONLY)
-      #   - Permissions: Contents = Read and write (repository_dispatch)
-      # A classic PAT with broad 'repo' scope would let a compromised run of
-      # this workflow trigger deploys or modify content on ANY repo the
-      # token-owner has access to. Rotate on any suspected exposure.
-      - name: Trigger deploy in infra repo
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.DEPLOY_PAT }}
-          repository: layervai/qurl-integrations-infra
-          event-type: discord-bot-deploy
-          client-payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
+    # SECURITY: dispatch goes through the dispatch-deploy reusable in
+    # layervai/ops-routines-workflows (the public mirror). The reusable:
+    #   - Mints a token from the qurl-deploy-dispatcher GitHub App
+    #     (contents:write + metadata:read on qurl-integrations-infra
+    #     ONLY). No personal-access-token in the loop.
+    #   - Enforces target_repo + event_type allowlist; a compromised
+    #     consumer cannot dispatch outside the approved set.
+    #   - Scopes the minted token to a single receiver via `repositories:`.
+    # Replaces the prior DEPLOY_PAT + peter-evans/repository-dispatch
+    # pattern. SHA-pinned per the org's reusable-workflow convention;
+    # bumps require an explicit PR. Closes #75.
+    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@__OPS_ROUTINES_WORKFLOWS_SHA__
+    with:
+      target_repo: qurl-integrations-infra
+      event_type: discord-bot-deploy
+      client_payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
+    secrets:
+      app_id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+      app_private_key: ${{ secrets.DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -73,22 +73,26 @@ jobs:
   trigger-deploy:
     needs: [build-and-test, docker-check]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    # SECURITY: dispatch goes through the dispatch-deploy reusable in
-    # layervai/ops-routines-workflows (the public mirror). The reusable:
-    #   - Mints a token from the qurl-deploy-dispatcher GitHub App
-    #     (contents:write + metadata:read on qurl-integrations-infra
-    #     ONLY). No personal-access-token in the loop.
-    #   - Enforces target_repo + event_type allowlist; a compromised
-    #     consumer cannot dispatch outside the approved set.
-    #   - Scopes the minted token to a single receiver via `repositories:`.
-    # Replaces the prior DEPLOY_PAT + peter-evans/repository-dispatch
-    # pattern. SHA-pinned per the org's reusable-workflow convention;
-    # bumps require an explicit PR. Closes #75.
-    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0
+    # Replaces inline DEPLOY_PAT + peter-evans/repository-dispatch with
+    # a reusable that mints a narrowly-scoped GitHub App token. No PAT
+    # in the loop. Closes #75. Reusable docs (allowlist enforcement,
+    # token scoping, JSON-payload contract):
+    # https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/dispatch-deploy.yml
+    # `event_type` matches the receiver's `repository_dispatch.types` in
+    # qurl-integrations-infra/.github/workflows/qurl-bot-discord-deploy.yml.
+    permissions:
+      contents: read
+    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
     with:
       target_repo: qurl-integrations-infra
       event_type: discord-bot-deploy
       client_payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
+    # Explicit map (not `secrets: inherit`) so the reusable only sees
+    # the two App secrets it declares, not every secret on this repo.
+    # DEPLOY_DISPATCHER_APP_* are org-level, `visibility: selected` for
+    # qurl-integrations + ops-routines-workflows; see
+    # layervai/ops-routines/runbooks/mirror-bypass-allowance.md for the
+    # broader app-secret model.
     secrets:
       app_id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
       app_private_key: ${{ secrets.DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -73,13 +73,9 @@ jobs:
   trigger-deploy:
     needs: [build-and-test, docker-check]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    # Replaces inline DEPLOY_PAT + peter-evans/repository-dispatch with
-    # a reusable that mints a narrowly-scoped GitHub App token. No PAT
-    # in the loop. Closes #75. Reusable docs (allowlist enforcement,
-    # token scoping, JSON-payload contract):
-    # https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/dispatch-deploy.yml
-    # `event_type` matches the receiver's `repository_dispatch.types` in
-    # qurl-integrations-infra/.github/workflows/qurl-bot-discord-deploy.yml.
+    # `event_type` must match the receiver's `repository_dispatch.types` in
+    # qurl-integrations-infra/.github/workflows/qurl-bot-discord-deploy.yml —
+    # a typo silently no-ops the deploy.
     permissions:
       contents: read
     uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
@@ -87,12 +83,8 @@ jobs:
       target_repo: qurl-integrations-infra
       event_type: discord-bot-deploy
       client_payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
-    # Explicit map (not `secrets: inherit`) so the reusable only sees
-    # the two App secrets it declares, not every secret on this repo.
-    # DEPLOY_DISPATCHER_APP_* are org-level, `visibility: selected` for
-    # qurl-integrations + ops-routines-workflows; see
-    # layervai/ops-routines/runbooks/mirror-bypass-allowance.md for the
-    # broader app-secret model.
+    # Explicit `secrets:` map (not `inherit`) keeps the reusable's surface
+    # to the two named App secrets even as more secrets get added here.
     secrets:
       app_id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
       app_private_key: ${{ secrets.DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Why

Issue #75 has been open since the rest of the org migrated off personal-access-tokens to GitHub Apps; this workflow was the straggler. As a result Discord deploys haven't been firing reliably on main pushes — `DEPLOY_PAT` is fragile and tied to a human account.

## What

Replaces the inline `peter-evans/repository-dispatch` step + `secrets.DEPLOY_PAT` with a call to the `dispatch-deploy.yml` reusable in [layervai/ops-routines-workflows](https://github.com/layervai/ops-routines-workflows) (the public mirror), pinned at `@86d4de84b95cf923bfdd11e3384a1f0deecfbef0` (`v0.5.0`).

The reusable:
- **Mints a token from the dedicated `qurl-deploy-dispatcher` GitHub App** (App ID `3549303`), `contents:write` + `metadata:read` only, installed solely on `qurl-integrations-infra`. Far narrower than the old PAT's user-bound permission set — see issue #75 for the rationale.
- **Scopes the minted token to a single receiver** via `repositories:`, even though the App is installed in the org. A leaked dispatch token cannot reach any other receiver.
- **Enforces a `target_repo:event_type` allowlist** that this consumer cannot bypass via inputs (current allowlist: `qurl-integrations-infra:discord-bot-deploy` and `qurl-integrations-infra:slack-bot-deploy`).
- **Has its own `timeout-minutes: 5`** in the reusable (matches the old caller's bound — verified in `dispatch-deploy.yml`).

## Why safer than `DEPLOY_PAT`

| | Old (PAT) | New (App) |
|---|---|---|
| Bound to | A human's token-owner permissions | Purpose-built App, single-purpose |
| Reach | Any repo the human had `repo` scope on | `qurl-integrations-infra` only |
| Lifetime | Static, manually rotated | Minted on demand, 1-hour expiry |
| Compromise blast radius | Up to whatever the token-owner could touch | Single repo, single permission set |

## Org-side setup (already done outside this PR)

- `qurl-deploy-dispatcher` GitHub App created, installed on `qurl-integrations-infra` only.
- Org secrets `DEPLOY_DISPATCHER_APP_ID` + `DEPLOY_DISPATCHER_APP_PRIVATE_KEY` minted with `visibility: selected`, allowlisted for `qurl-integrations` + `ops-routines-workflows`.
- End-to-end dispatch capability verified against `qurl-integrations-infra` using a sentinel `event_type` (HTTP 204).

## Receiver allowlist match

- Reusable allowlist (in `dispatch-deploy.yml`): contains `qurl-integrations-infra:discord-bot-deploy`.
- Receiver (`qurl-integrations-infra/.github/workflows/qurl-bot-discord-deploy.yml`): declares `repository_dispatch.types: [discord-bot-deploy]`.

## Verification (after merge)

1. Push to main triggers this workflow (path filter includes `.github/workflows/discord.yml`).
2. `gh run list -R layervai/qurl-integrations-infra -w qurl-bot-discord-deploy.yml -L 1` shows a fresh run within 60s with `event: repository_dispatch`.
3. The deploy job runs end-to-end against sandbox.

## Follow-ups

- Delete the `DEPLOY_PAT` repo secret after the first successful main-branch dispatch confirms the migration. Tracked at #145.
- Extract a per-app trigger-deploy shim if a third caller appears (Teams/Zapier). Tracked at #144.

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)