### PR TITLE
fix(shared): reject leading/trailing whitespace in idempotency keys

### DIFF
--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -55,12 +55,15 @@ const MaxIdempotencyKeyLength = 256
 var ErrIdempotencyKeyTooLong = errors.New("idempotency key exceeds 256 bytes")
 
 // ErrIdempotencyKeyInvalid is returned by Create when CreateInput.IdempotencyKey
-// contains bytes that aren't valid in an HTTP header value (CR, LF, NUL, or
-// other non-printable control characters). Without this check, Go's HTTP
-// transport would reject the request with `net/http: invalid header field
-// value` — a confusing low-level error rather than a typed sentinel the
-// caller can `errors.Is` against.
-var ErrIdempotencyKeyInvalid = errors.New("idempotency key contains invalid header-value bytes (CR/LF/NUL/control)")
+// contains bytes that aren't valid in an HTTP header value: CR/LF/NUL/control
+// bytes, non-ASCII bytes, OR leading/trailing whitespace. The first three
+// would otherwise cause Go's HTTP transport to reject with an opaque
+// `net/http: invalid header field value`; the whitespace case is more
+// subtle — RFC 7230's OWS rule trims leading/trailing space and tab on
+// the wire, so the upstream dedup hash would silently see a key
+// different from what the caller passed. Either way, fail-fast with a
+// typed sentinel.
+var ErrIdempotencyKeyInvalid = errors.New("idempotency key contains invalid bytes (CR/LF/NUL/control, non-ASCII, or leading/trailing whitespace)")
 
 // StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
@@ -215,12 +218,20 @@ func isHeaderSafeASCIIByte(b byte) bool {
 
 // validateIdempotencyKey enforces the constraints documented on
 // HeaderIdempotencyKey: ≤MaxIdempotencyKeyLength bytes and header-safe
-// ASCII only. Empty key is valid (means "no header sent"). Extracted
-// as a helper so future write methods that need idempotency (#148) can
-// reuse the same contract.
+// ASCII only, with no leading/trailing whitespace (RFC 7230 OWS would
+// trim those on the wire, silently changing the upstream dedup hash).
+// Empty key is valid (means "no header sent"). Extracted as a helper
+// so future write methods that need idempotency (#148) can reuse the
+// same contract.
 func validateIdempotencyKey(key string) error {
 	if len(key) > MaxIdempotencyKeyLength {
 		return ErrIdempotencyKeyTooLong
+	}
+	if key != "" {
+		first, last := key[0], key[len(key)-1]
+		if first == ' ' || first == '\t' || last == ' ' || last == '\t' {
+			return ErrIdempotencyKeyInvalid
+		}
 	}
 	for i := range len(key) {
 		if !isHeaderSafeASCIIByte(key[i]) {
@@ -247,6 +258,10 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
+	// Set Idempotency-Key here (not in do()) because it's request-specific,
+	// not transport-wide — Content-Type/Authorization/User-Agent are
+	// set in do() because they apply to every request. Either way the
+	// header survives retries since do() reuses the same *http.Request.
 	if input.IdempotencyKey != "" {
 		req.Header.Set(HeaderIdempotencyKey, input.IdempotencyKey)
 	}

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -21,6 +21,17 @@ func testClient(url, key string) *Client {
 	return New(url, key, WithRetry(0))
 }
 
+// withDelaysForTest collapses retry/backoff delays to 1ns. Reaches into
+// unexported fields, which only works because tests are same-package —
+// preferable to a public knob since the values aren't meaningful outside
+// of test speed.
+func withDelaysForTest() Option {
+	return func(c *Client) {
+		c.baseDelay = 1
+		c.maxDelay = 1
+	}
+}
+
 // apiEnvelope wraps data in the API response envelope.
 func apiEnvelope(t *testing.T, w http.ResponseWriter, data any) {
 	t.Helper()
@@ -425,7 +436,7 @@ func TestRetryOn503(t *testing.T) {
 	c := New(srv.URL, "test-key",
 		WithRetry(3),
 		// Use very short delays for test speed.
-		func(cl *Client) { cl.baseDelay = 1; cl.maxDelay = 1 },
+		withDelaysForTest(),
 	)
 	got, err := c.Get(context.Background(), "r_test")
 	if err != nil {
@@ -450,7 +461,7 @@ func TestRetryExhausted(t *testing.T) {
 
 	c := New(srv.URL, "test-key",
 		WithRetry(2),
-		func(cl *Client) { cl.baseDelay = 1; cl.maxDelay = 1 },
+		withDelaysForTest(),
 	)
 	_, err := c.Get(context.Background(), "r_test")
 	if err == nil {
@@ -480,7 +491,7 @@ func TestNoRetryOn4xx(t *testing.T) {
 
 	c := New(srv.URL, "test-key",
 		WithRetry(3),
-		func(cl *Client) { cl.baseDelay = 1; cl.maxDelay = 1 },
+		withDelaysForTest(),
 	)
 	_, err := c.Get(context.Background(), "r_test")
 	if err == nil {
@@ -612,7 +623,7 @@ func TestCreateIdempotencyKeyPreservedAcrossRetry(t *testing.T) {
 
 	c := New(srv.URL, "test-key",
 		WithRetry(3),
-		func(cl *Client) { cl.baseDelay = 1; cl.maxDelay = 1 },
+		withDelaysForTest(),
 	)
 	_, err := c.Create(context.Background(), CreateInput{
 		TargetURL:      "https://example.com",
@@ -691,6 +702,11 @@ func TestValidateIdempotencyKey(t *testing.T) {
 		{"single ASCII char", "a", nil},
 		{"sha256-hex (Slack canonical)", strings.Repeat("0123456789abcdef", 4), nil}, // 64 chars
 		{"max-length boundary", strings.Repeat("x", MaxIdempotencyKeyLength), nil},
+		{"internal space accepted", "key with spaces", nil},
+		{"leading space rejected (would be trimmed by OWS)", " abc", ErrIdempotencyKeyInvalid},
+		{"trailing space rejected (would be trimmed by OWS)", "abc ", ErrIdempotencyKeyInvalid},
+		{"leading tab rejected (would be trimmed by OWS)", "\tabc", ErrIdempotencyKeyInvalid},
+		{"trailing tab rejected (would be trimmed by OWS)", "abc\t", ErrIdempotencyKeyInvalid},
 		{"one byte over cap", strings.Repeat("x", MaxIdempotencyKeyLength+1), ErrIdempotencyKeyTooLong},
 		{"CR injection", "abc\rdef", ErrIdempotencyKeyInvalid},
 		{"LF injection", "abc\ndef", ErrIdempotencyKeyInvalid},
@@ -742,37 +758,68 @@ func TestCreateIdempotencyKeyRejectsInvalidBytes(t *testing.T) {
 	if hits.Load() != 0 {
 		t.Errorf("server should not be hit on invalid-byte keys; got %d hits", hits.Load())
 	}
+}
 
-	// Positive cases: pin the inverse contract — anything not in the
-	// reject set should make it on the wire.
-	srvOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
+	// Inverse-contract tests: anything outside the reject set must
+	// reach the wire unchanged. Split out from RejectsInvalidBytes so
+	// "rejects" actually means rejects (no positive cases hidden in
+	// the same parent test).
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get(HeaderIdempotencyKey)
 		apiEnvelope(t, w, map[string]any{"resource_id": "r_valid"})
 	}))
-	defer srvOK.Close()
-	cOK := testClient(srvOK.URL, "test-key")
+	defer srv.Close()
+	c := testClient(srv.URL, "test-key")
 
-	t.Run("all printable ASCII (0x20-0x7E) accepted", func(t *testing.T) {
+	t.Run("all printable ASCII 0x21-0x7E (excluding boundary space)", func(t *testing.T) {
+		// Skip 0x20 (space) here because it's only valid mid-key —
+		// validator rejects it as the first or last byte (RFC 7230
+		// OWS would trim it on the wire). Mid-key space is covered
+		// by the "internal space" subtest below.
 		var b strings.Builder
-		for c := byte(0x20); c <= 0x7E; c++ {
-			b.WriteByte(c)
+		for byteVal := byte(0x21); byteVal <= 0x7E; byteVal++ {
+			b.WriteByte(byteVal)
 		}
-		if _, err := cOK.Create(context.Background(), CreateInput{
+		want := b.String()
+		if _, err := c.Create(context.Background(), CreateInput{
 			TargetURL:      "https://example.com",
-			IdempotencyKey: b.String(),
+			IdempotencyKey: want,
 		}); err != nil {
 			t.Errorf("unexpected error %v", err)
+		}
+		if gotKey != want {
+			t.Errorf("header drift: got %q, want %q", gotKey, want)
 		}
 	})
 
-	t.Run("tab (0x09) accepted", func(t *testing.T) {
-		// Documented exception: validator accepts tab even though it's
-		// a control byte. Real-world keys won't include it, but the
-		// validator's contract permits it; pin that explicitly.
-		if _, err := cOK.Create(context.Background(), CreateInput{
+	t.Run("internal space accepted and preserved", func(t *testing.T) {
+		// Mid-key space is permitted; only boundary whitespace
+		// triggers OWS-trim by the wire.
+		want := "key with spaces"
+		if _, err := c.Create(context.Background(), CreateInput{
 			TargetURL:      "https://example.com",
-			IdempotencyKey: "key\twith\ttabs",
+			IdempotencyKey: want,
 		}); err != nil {
 			t.Errorf("unexpected error %v", err)
+		}
+		if gotKey != want {
+			t.Errorf("header drift: got %q, want %q", gotKey, want)
+		}
+	})
+
+	t.Run("internal tab accepted and preserved", func(t *testing.T) {
+		// Mid-key tab is permitted by the validator; pin it.
+		want := "key\twith\ttabs"
+		if _, err := c.Create(context.Background(), CreateInput{
+			TargetURL:      "https://example.com",
+			IdempotencyKey: want,
+		}); err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+		if gotKey != want {
+			t.Errorf("header drift: got %q, want %q", gotKey, want)
 		}
 	})
 }


### PR DESCRIPTION
## Why

Follow-up to PR #147 (Idempotency-Key support, landed at \`5ac225a\`). PR #147 was merged before the CR-round-4 feedback could be applied; this PR addresses those 4 items, including one real correctness bug.

## The bug: silent header-value truncation

CR-round-4 on PR #147 suggested adding a test pinning whether \`IdempotencyKey\` is preserved verbatim across the wire. Writing the test exposed that **RFC 7230's OWS rule** (Optional Whitespace) trims leading/trailing space and tab from header values on the wire — so a caller passing \`\"  abc  \"\` arrives at \`qurl-service\`'s idempotency-store as \`\"abc\"\`, silently changing the dedup partition-key hash.

For a Slack-retry-driven dedup contract this is the wrong failure mode: a caller could believe they have a unique key per workspace (say, \`\" workspace \" + trigger_id\`) and unwittingly collide with a different workspace's key after the wire trims it.

**Fix**: \`validateIdempotencyKey\` now rejects keys with leading/trailing space or tab. Same \`ErrIdempotencyKeyInvalid\` sentinel (godoc updated to enumerate the new case). Internal whitespace remains valid — only boundary OWS gets rejected.

## Other CR-round-4 items applied

| Item | Action |
|---|---|
| Asymmetry between \`Idempotency-Key\` (set in \`Create\`) and \`Content-Type\`/\`Authorization\`/\`User-Agent\` (set in \`do()\`) | Added a one-line comment near \`req.Header.Set(HeaderIdempotencyKey, ...)\` explaining the distinction (request-specific vs transport-wide) |
| \`func(cl *Client) { cl.baseDelay = 1; cl.maxDelay = 1 }\` reaches into private fields at 4 inline call-sites | Extracted to \`withDelaysForTest()\` helper |
| Positive subtests (\"all printable ASCII accepted\", \"tab accepted\") buried inside \`TestCreateIdempotencyKeyRejectsInvalidBytes\` | Split into new \`TestCreateIdempotencyKeyAcceptsValidBytes\` so test names accurately describe what they pin. New test also asserts header-byte fidelity (the original positive subtests only checked \`err == nil\`, missing wire-side drift) |
| OWS rejection coverage | 4 new \`TestValidateIdempotencyKey\` cases (leading-space/tab, trailing-space/tab) + 1 internal-space positive control. \`TestCreateIdempotencyKeyAcceptsValidBytes\` skips 0x20 in the \"all printable ASCII\" subtest since it would appear at the boundary; mid-string space covered by a separate subtest |

## What's NOT in this PR (explicit no-change from CR-round-4)

- **Loop-style** (\`for i := range len(s)\` vs \`for i := 0; i < len(s); i++\`) — CR explicitly says \"either is fine; up to you\"; round-2 already approved the range form. Not flipping.
- **\`isHeaderSafeASCIIByte\` single-use helper** — CR says \"Keeping it broken out is also reasonable if PR #148 is going to share it across multiple write methods — the PR description says it will, so the helper is justified. No change needed.\"
- **\`errors.New\` constant drift on the 256 message** — CR says \"Fine as-is — flagging only because someone scanning the diff later may want to pre-empt the question.\"

## Verification

\`\`\`bash
cd /Users/posey/code/layerv3/qurl-integrations
make check  # fmt + vet + golangci-lint + go test -race -count=1 ./...
\`\`\`

Output: 0 lint issues, all packages pass. New test count: \`shared/client/client_test.go\` now has 11 idempotency-related test functions (was 10), with the OWS coverage strengthening the dedup-correctness contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)