### PR TITLE
feat(slack): ack-then-async slash commands with idempotency

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -35,4 +35,5 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
 |----------|----------|-------------|
 | `SLACK_SIGNING_SECRET` | Yes | Slack app signing secret |
 | `QURL_API_KEY` | Yes | qURL API key for this workspace |
-| `QURL_ENDPOINT` | No | qURL API base URL (default: `https://api.layerv.xyz`) |
+| `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.xyz`) |
+| `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -75,14 +75,28 @@ func run() error {
 	authProvider := auth.EnvProvider{EnvVar: "QURL_API_KEY"}
 	userAgent := "qurl-slack/" + version
 
+	// signalCtx feeds two seams: the main goroutine (to detect
+	// SIGTERM and trigger srv.Shutdown) and Handler.BaseContext (so
+	// async slash-command workers observe cancellation through the
+	// same signal). Threading the same ctx into both keeps the
+	// shutdown story coherent — a worker mid-POST to response_url
+	// receives ctx.Canceled at the same instant Shutdown starts
+	// refusing new connections.
+	signalCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	handler := internal.NewHandler(internal.Config{
 		AuthProvider:       &authProvider,
 		SlackSigningSecret: slackSigningSecret,
+		BaseContext:        signalCtx,
 		NewClient: func(apiKey string) *client.Client {
 			return client.New(qurlEndpoint, apiKey,
+				// The async worker has up to 25s before its context fires;
+				// the qURL client may retry transient 429/5xx within that
+				// budget. WithRetry(2) gives two retries with the existing
+				// exponential-backoff schedule before bubbling to the user.
 				client.WithUserAgent(userAgent),
-				// Synchronous ack path — Slack's 3s budget rules out retries here.
-				client.WithRetry(0),
+				client.WithRetry(2),
 			)
 		},
 	})
@@ -111,18 +125,21 @@ func run() error {
 		return fmt.Errorf("bind %s: %w", listenAddr, err)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
 	shutdownDone := make(chan struct{})
 	go func() {
-		<-ctx.Done()
+		<-signalCtx.Done()
 		slog.Info("received shutdown signal — draining HTTP server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			slog.Error("graceful shutdown failed", "error", err)
 		}
+		// Shutdown returns once HTTP handlers have responded. Slash-
+		// command handlers ack and return nearly instantly, so
+		// in-flight async workers (the goroutines runAsync spawned)
+		// outlive Shutdown. Wait drains them — their contexts are
+		// already canceled via signalCtx, so they return promptly.
+		handler.Wait()
 		close(shutdownDone)
 	}()
 

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -30,6 +31,14 @@ const (
 	// per request — http.Server.WriteTimeout (15s) still bounds individual
 	// in-flight handlers; bumping shutdownTimeout above 25s won't extend
 	// long-running handlers, only the wait for short ones to drain.
+	//
+	// Budget contract: shutdownTimeout must comfortably exceed
+	// (srv.Shutdown drain time) + (internal.responseURLTimeout = 5s)
+	// so a healthy in-flight async worker has time to land its
+	// follow-up POST before WaitTimeout(remaining) gives up. With
+	// ack-and-spawn handlers, srv.Shutdown finishes in milliseconds —
+	// the worst-case pre-Wait drain is dominated by per-handler
+	// completion (instant), leaving ~25s for response_url POSTs.
 	shutdownTimeout = 25 * time.Second
 	// maxHeaderBytes is well above Slack's realistic header size (sig +
 	// timestamp + standard headers fit comfortably in 2 KiB) but bounds
@@ -75,6 +84,12 @@ func run() error {
 	authProvider := auth.EnvProvider{EnvVar: "QURL_API_KEY"}
 	userAgent := "qurl-slack/" + version
 
+	// Optional pool-cap override. Empty/invalid env yields 0, which
+	// internal.NewHandler interprets as "use default" (50). Lets
+	// operators tune saturation without a recompile when a workspace
+	// load shape diverges from the documented enterprise default.
+	maxConcurrentAsync, _ := strconv.Atoi(os.Getenv("QURL_SLACK_MAX_CONCURRENT_ASYNC"))
+
 	// signalCtx feeds two seams: the main goroutine (to detect
 	// SIGTERM and trigger srv.Shutdown) and Handler.BaseContext (so
 	// async slash-command workers observe cancellation through the
@@ -89,6 +104,7 @@ func run() error {
 		AuthProvider:       &authProvider,
 		SlackSigningSecret: slackSigningSecret,
 		BaseContext:        signalCtx,
+		MaxConcurrentAsync: maxConcurrentAsync,
 		NewClient: func(apiKey string) *client.Client {
 			return client.New(qurlEndpoint, apiKey,
 				// The async worker has up to 25s before its context fires;

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -32,13 +32,19 @@ const (
 	// in-flight handlers; bumping shutdownTimeout above 25s won't extend
 	// long-running handlers, only the wait for short ones to drain.
 	//
-	// Budget contract: shutdownTimeout must comfortably exceed
-	// (srv.Shutdown drain time) + (internal.responseURLTimeout = 5s)
-	// so a healthy in-flight async worker has time to land its
-	// follow-up POST before WaitTimeout(remaining) gives up. With
-	// ack-and-spawn handlers, srv.Shutdown finishes in milliseconds —
-	// the worst-case pre-Wait drain is dominated by per-handler
-	// completion (instant), leaving ~25s for response_url POSTs.
+	// Budget contract: shutdownTimeout is sized against the EXPECTED
+	// drain, not the theoretical max. The expected drain is
+	// dominated by:
+	//   srv.Shutdown (≈0ms — handlers ack and return instantly)
+	//   + qURL call returns ctx.Canceled almost instantly on signal
+	//   + responseURLTimeout (5s) for the failure follow-up POST
+	//
+	// The theoretical max is asyncWorkTimeout (25s) + 5s = 30s,
+	// which would wedge if a worker ignored ctx — that's why
+	// handler.WaitTimeout caps the wait at the remaining budget
+	// rather than calling Wait. The 25s default leaves comfortable
+	// headroom for the expected case while staying well inside
+	// Fargate's 30s SIGTERM→SIGKILL window.
 	shutdownTimeout = 25 * time.Second
 	// maxHeaderBytes is well above Slack's realistic header size (sig +
 	// timestamp + standard headers fit comfortably in 2 KiB) but bounds

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -98,10 +98,18 @@ func run() error {
 	maxConcurrentAsync := 0
 	if raw := os.Getenv("QURL_SLACK_MAX_CONCURRENT_ASYNC"); raw != "" {
 		parsed, err := strconv.Atoi(raw)
-		if err != nil {
+		switch {
+		case err != nil:
 			slog.Warn("ignoring malformed QURL_SLACK_MAX_CONCURRENT_ASYNC; falling back to default", //nolint:gosec // G706: raw is env-var input; slog's JSON handler escapes control bytes in attribute values, same posture as the request-path slog sites.
 				"raw", raw, "error", err)
-		} else {
+		case parsed <= 0:
+			// NewHandler treats 0/negative as "use default", but a
+			// negative value is more likely a typo or env-substitution
+			// mishap than an intentional choice — surface it the same
+			// way as malformed input so it doesn't silently swallow.
+			slog.Warn("ignoring non-positive QURL_SLACK_MAX_CONCURRENT_ASYNC; falling back to default", //nolint:gosec // G706: raw is env-var input; slog's JSON handler escapes control bytes in attribute values, same posture as the request-path slog sites.
+				"raw", raw)
+		default:
 			maxConcurrentAsync = parsed
 		}
 	}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -90,11 +90,21 @@ func run() error {
 	authProvider := auth.EnvProvider{EnvVar: "QURL_API_KEY"}
 	userAgent := "qurl-slack/" + version
 
-	// Optional pool-cap override. Empty/invalid env yields 0, which
-	// internal.NewHandler interprets as "use default" (50). Lets
-	// operators tune saturation without a recompile when a workspace
-	// load shape diverges from the documented enterprise default.
-	maxConcurrentAsync, _ := strconv.Atoi(os.Getenv("QURL_SLACK_MAX_CONCURRENT_ASYNC"))
+	// Optional pool-cap override. Empty env is "use default" silently;
+	// non-empty-but-malformed env is a misconfiguration we surface at
+	// startup so it doesn't get discovered during a saturation
+	// incident. Either way the value reaching NewHandler may be 0,
+	// which Handler interprets as "use the built-in default (50)".
+	maxConcurrentAsync := 0
+	if raw := os.Getenv("QURL_SLACK_MAX_CONCURRENT_ASYNC"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			slog.Warn("ignoring malformed QURL_SLACK_MAX_CONCURRENT_ASYNC; falling back to default", //nolint:gosec // G706: raw is env-var input; slog's JSON handler escapes control bytes in attribute values, same posture as the request-path slog sites.
+				"raw", raw, "error", err)
+		} else {
+			maxConcurrentAsync = parsed
+		}
+	}
 
 	// signalCtx feeds two seams: the main goroutine (to detect
 	// SIGTERM and trigger srv.Shutdown) and Handler.BaseContext (so

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -129,6 +129,7 @@ func run() error {
 	go func() {
 		<-signalCtx.Done()
 		slog.Info("received shutdown signal — draining HTTP server")
+		shutdownStart := time.Now()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
@@ -137,9 +138,17 @@ func run() error {
 		// Shutdown returns once HTTP handlers have responded. Slash-
 		// command handlers ack and return nearly instantly, so
 		// in-flight async workers (the goroutines runAsync spawned)
-		// outlive Shutdown. Wait drains them — their contexts are
-		// already canceled via signalCtx, so they return promptly.
-		handler.Wait()
+		// outlive Shutdown. WaitTimeout drains them within whatever
+		// of shutdownTimeout remains — a misbehaving worker that
+		// ignored its ctx can't wedge the process past Fargate's
+		// hard kill.
+		drainBudget := shutdownTimeout - time.Since(shutdownStart)
+		if drainBudget < 0 {
+			drainBudget = 0
+		}
+		if !handler.WaitTimeout(drainBudget) {
+			slog.Warn("async drain timed out — exiting with workers still in flight", "budget", drainBudget)
+		}
 		close(shutdownDone)
 	}()
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -54,6 +54,15 @@ const (
 	// response_url is valid for 30 minutes, but in practice qURL API calls
 	// resolve in <1s; 25s is the deadline beyond which the user is better
 	// served by a "failed" follow-up than an indefinite "Working on it…".
+	//
+	// Interaction with WithRetry(2): the qURL client uses exponential
+	// backoff with a 30s cap (shared/client.defaultMaxDelay). Under a
+	// 5xx storm, retry backoff alone could in principle exceed the
+	// remaining ctx budget — `c.waitForRetry` honors ctx and returns
+	// ctx.Err() in that case, which surfaces as a non-*APIError and
+	// hits sanitizeAPIError's prefix-only fallback. Trade-off is
+	// intentional: cap the user's wait at this deadline rather than
+	// let retries dominate.
 	asyncWorkTimeout = 25 * time.Second
 
 	// responseURLTimeout bounds the POST to Slack's response_url. Slack's
@@ -169,8 +178,30 @@ func NewHandler(cfg Config) *Handler {
 //
 // Wait is a no-op if no async work is in flight, so the cmd path can
 // always call it on every shutdown without conditionals.
+//
+// In production, prefer WaitTimeout — an unbounded Wait() leaves the
+// process exposed to a future regression where a worker ignores its
+// ctx, wedging shutdown past the platform's hard-kill window.
 func (h *Handler) Wait() {
 	h.wg.Wait()
+}
+
+// WaitTimeout drains in-flight async workers, returning early after d.
+// Returns true on clean drain; false on timeout (workers still in
+// flight). cmd/main.go uses this so a misbehaving worker can't block
+// graceful shutdown past the SIGTERM→SIGKILL window.
+func (h *Handler) WaitTimeout(d time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		h.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
 }
 
 // defaultResponseURLClient is the http.Client used to POST follow-up
@@ -345,7 +376,12 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 		respondSlack(w, helpMessage())
 	case strings.HasPrefix(text, "create "):
 		h.handleCreate(w, values)
-	case strings.HasPrefix(text, "list"):
+	case text == "list" || strings.HasPrefix(text, "list "):
+		// Prefix-match `"list"` alone matched `listing`, `lists`,
+		// `list-foo` — silently routing them to the list handler
+		// where they'd ignore the trailing tokens. The exact-match
+		// + trailing-space fork shows the user a "Unknown subcommand"
+		// help nudge instead.
 		h.handleList(w, values)
 	default:
 		// Surfaced to telemetry so a workspace using a stale slash-command

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/layervai/qurl-integrations/shared/auth"
@@ -18,6 +19,16 @@ import (
 )
 
 const authFailureMessage = "Failed to authenticate. Please check your qURL API key configuration."
+
+// ackWorkingOnIt is the user-visible ephemeral text returned synchronously
+// while async work runs. The hourglass keeps the user oriented that a
+// follow-up via response_url is on its way.
+const ackWorkingOnIt = ":hourglass: Working on it…"
+
+// ackBusy is returned when the bounded async pool is saturated. Surfacing
+// this to the user (rather than silently dropping) makes back-pressure
+// visible and gives them an actionable next step.
+const ackBusy = ":warning: Slack bot is busy — please retry in a moment."
 
 const (
 	headerSlackSignature = "X-Slack-Signature"
@@ -29,6 +40,26 @@ const (
 	pathSlackCommands     = "/slack/commands"
 	pathSlackEvents       = "/slack/events"
 	pathSlackInteractions = "/slack/interactions"
+)
+
+const (
+	// defaultMaxConcurrentAsync caps in-flight goroutines. A Slack-side
+	// flood (replay storm, runaway integration) drops with ackBusy past
+	// this threshold rather than unbounded-spawning until the task OOMs.
+	// 50 is generous for steady-state — the target customer (50 active
+	// users) won't sustain >1 click/sec across the whole workspace.
+	defaultMaxConcurrentAsync = 50
+
+	// asyncWorkTimeout caps how long a single async job may run. Slack's
+	// response_url is valid for 30 minutes, but in practice qURL API calls
+	// resolve in <1s; 25s is the deadline beyond which the user is better
+	// served by a "failed" follow-up than an indefinite "Working on it…".
+	asyncWorkTimeout = 25 * time.Second
+
+	// responseURLTimeout bounds the POST to Slack's response_url. Slack's
+	// hooks endpoint typically responds in <500ms; 5s catches transient
+	// blips without holding a goroutine slot for the full asyncWorkTimeout.
+	responseURLTimeout = 5 * time.Second
 )
 
 // maxRequestBodyBytes caps the request body the handler will read. Slack
@@ -51,6 +82,23 @@ type Config struct {
 	AuthProvider       auth.Provider
 	SlackSigningSecret string
 	NewClient          func(apiKey string) *client.Client
+
+	// BaseContext is the server-lifetime parent of every async work
+	// goroutine's context. SIGTERM cancels it, which propagates to
+	// in-flight qURL API calls and response_url POSTs so they release
+	// the worker slot promptly during shutdown. Defaults to
+	// context.Background() if nil — fine for tests, not for production
+	// (cmd/main.go threads the signal-canceled context).
+	BaseContext context.Context
+
+	// MaxConcurrentAsync caps in-flight async goroutines. Zero or
+	// negative falls back to defaultMaxConcurrentAsync.
+	MaxConcurrentAsync int
+
+	// ResponseURLClient is the HTTP client used to POST follow-up
+	// messages to Slack's response_url. Nil means "use a default *http.Client
+	// with responseURLTimeout"; tests inject one to assert payloads.
+	ResponseURLClient *http.Client
 }
 
 // Handler processes Slack events and commands.
@@ -59,11 +107,74 @@ type Handler struct {
 	// now is injected so tests can pin the clock for timestamp-skew checks
 	// without touching a package global. Defaults to time.Now.
 	now func() time.Time
+	// baseCtx is captured at NewHandler time from cfg.BaseContext (or
+	// context.Background()). Each async goroutine derives a
+	// context.WithTimeout(baseCtx, asyncWorkTimeout) — canceling baseCtx
+	// (via SIGTERM in main.go) signals every in-flight worker.
+	baseCtx context.Context
+	// wg tracks live async workers so cmd/main.go's Wait() can drain
+	// them after http.Server.Shutdown returns. wg.Add MUST happen on
+	// the request goroutine (before the `go` keyword) — adding inside
+	// the spawned goroutine races Wait().
+	wg sync.WaitGroup
+	// sem is a buffered-channel semaphore bounding concurrent async
+	// workers to len(sem) capacity. Send-with-default-drop gives back-
+	// pressure feedback to the user as ackBusy rather than queueing.
+	sem chan struct{}
+	// responseURLClient is owned per-Handler so tests can inject a
+	// transport and so the lifetime is tied to the handler (not the
+	// per-request goroutine).
+	responseURLClient *http.Client
+	// validateResponseURLFn defaults to validateResponseURL — pinned to
+	// https://hooks.slack.com/* in production. Tests override it to
+	// permit httptest server URLs (which are http://127.0.0.1:NNNNN).
+	// Field rather than parameter so the production default needs no
+	// per-deploy wiring.
+	validateResponseURLFn func(string) error
 }
 
 // NewHandler creates a new Slack handler.
 func NewHandler(cfg Config) *Handler {
-	return &Handler{cfg: cfg, now: time.Now}
+	baseCtx := cfg.BaseContext
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	maxAsync := cfg.MaxConcurrentAsync
+	if maxAsync <= 0 {
+		maxAsync = defaultMaxConcurrentAsync
+	}
+	respClient := cfg.ResponseURLClient
+	if respClient == nil {
+		respClient = &http.Client{
+			Timeout: responseURLTimeout,
+			// Refuse redirects: validateResponseURL pins the initial host
+			// to hooks.slack.com, but Go's default 10-redirect follow
+			// would let a 30x bounce land on any host. Returning
+			// ErrUseLastResponse surfaces the redirect to the caller
+			// without dialing the target.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	return &Handler{
+		cfg:                   cfg,
+		now:                   time.Now,
+		baseCtx:               baseCtx,
+		sem:                   make(chan struct{}, maxAsync),
+		responseURLClient:     respClient,
+		validateResponseURLFn: validateResponseURL,
+	}
+}
+
+// Wait blocks until every async worker spawned by this handler has
+// returned. Call it after http.Server.Shutdown so the process doesn't
+// exit while a goroutine is still mid-POST to Slack's response_url.
+//
+// Wait is a no-op if no async work is in flight, so the cmd path can
+// always call it on every shutdown without conditionals.
+func (h *Handler) Wait() {
+	h.wg.Wait()
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -135,7 +246,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.URL.Path {
 	case pathSlackCommands:
-		h.handleSlashCommand(r.Context(), w, body)
+		// r.Context() is intentionally NOT threaded into the slash-command
+		// dispatch: handleCreate/handleList spawn goroutines that outlive
+		// the HTTP response, and r.Context() cancels as soon as ServeHTTP
+		// returns. Async work uses h.baseCtx instead.
+		h.handleSlashCommand(w, body)
 	case pathSlackEvents:
 		h.handleEvent(w, body)
 	case pathSlackInteractions:
@@ -199,7 +314,7 @@ func classifySlackErr(err error) string {
 	}
 }
 
-func (h *Handler) handleSlashCommand(ctx context.Context, w http.ResponseWriter, body []byte) {
+func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 	values, err := url.ParseQuery(string(body))
 	if err != nil {
 		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid form body"})
@@ -215,9 +330,9 @@ func (h *Handler) handleSlashCommand(ctx context.Context, w http.ResponseWriter,
 	case text == "" || text == "help":
 		respondSlack(w, helpMessage())
 	case strings.HasPrefix(text, "create "):
-		h.handleCreate(ctx, w, values)
+		h.handleCreate(w, values)
 	case strings.HasPrefix(text, "list"):
-		h.handleList(ctx, w, values)
+		h.handleList(w, values)
 	default:
 		// Surfaced to telemetry so a workspace using a stale slash-command
 		// spec is visible in dashboards (rather than only via user reports).
@@ -226,64 +341,24 @@ func (h *Handler) handleSlashCommand(ctx context.Context, w http.ResponseWriter,
 	}
 }
 
-func (h *Handler) handleCreate(ctx context.Context, w http.ResponseWriter, values url.Values) {
+func (h *Handler) handleCreate(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get("text"))
-	targetURL := strings.TrimPrefix(text, "create ")
-	targetURL = strings.TrimSpace(targetURL)
+	targetURL := strings.TrimSpace(strings.TrimPrefix(text, "create "))
 
 	if targetURL == "" {
 		respondSlack(w, "Usage: `/qurl create <url>`")
 		return
 	}
 
-	c, err := h.authenticatedClient(ctx, values.Get("team_id"))
-	if err != nil {
-		slog.Error("failed to get API key", "error", err)
-		respondSlack(w, authFailureMessage)
-		return
-	}
-
-	result, err := c.Create(ctx, client.CreateInput{TargetURL: targetURL})
-	if err != nil {
-		slog.Error("failed to create qURL", "error", err, "target_url", targetURL)
-		respondSlack(w, "Failed to create qURL: "+err.Error())
-		return
-	}
-
-	respondSlack(w, fmt.Sprintf("qURL created!\n*Link:* %s\n*Target:* %s", result.QURLLink, targetURL))
+	h.runAsync(w, "create", values, func(ctx context.Context, log *slog.Logger) {
+		h.processCreate(ctx, log, values, targetURL)
+	})
 }
 
-func (h *Handler) handleList(ctx context.Context, w http.ResponseWriter, values url.Values) {
-	c, err := h.authenticatedClient(ctx, values.Get("team_id"))
-	if err != nil {
-		slog.Error("failed to get API key", "error", err)
-		respondSlack(w, authFailureMessage)
-		return
-	}
-
-	result, err := c.List(ctx, client.ListInput{Limit: 5})
-	if err != nil {
-		slog.Error("failed to list qURLs", "error", err)
-		respondSlack(w, "Failed to list qURLs: "+err.Error())
-		return
-	}
-
-	if len(result.QURLs) == 0 {
-		respondSlack(w, "No qURLs found.")
-		return
-	}
-
-	lines := make([]string, 0, len(result.QURLs))
-	for i := range result.QURLs {
-		q := &result.QURLs[i]
-		line := fmt.Sprintf("• `%s` → %s [%s]", q.ResourceID, q.TargetURL, q.Status)
-		if q.Description != "" {
-			line = fmt.Sprintf("• *%s* — `%s` → %s [%s]", q.Description, q.ResourceID, q.TargetURL, q.Status)
-		}
-		lines = append(lines, line)
-	}
-
-	respondSlack(w, "*Recent qURLs:*\n"+strings.Join(lines, "\n"))
+func (h *Handler) handleList(w http.ResponseWriter, values url.Values) {
+	h.runAsync(w, "list", values, func(ctx context.Context, log *slog.Logger) {
+		h.processList(ctx, log, values)
+	})
 }
 
 // authenticatedClient resolves an API key for the team and returns a configured client.

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -202,10 +202,12 @@ func (h *Handler) WaitTimeout(d time.Duration) bool {
 		h.wg.Wait()
 		close(done)
 	}()
+	t := time.NewTimer(d)
+	defer t.Stop()
 	select {
 	case <-done:
 		return true
-	case <-time.After(d):
+	case <-t.C:
 		return false
 	}
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -145,17 +145,7 @@ func NewHandler(cfg Config) *Handler {
 	}
 	respClient := cfg.ResponseURLClient
 	if respClient == nil {
-		respClient = &http.Client{
-			Timeout: responseURLTimeout,
-			// Refuse redirects: validateResponseURL pins the initial host
-			// to hooks.slack.com, but Go's default 10-redirect follow
-			// would let a 30x bounce land on any host. Returning
-			// ErrUseLastResponse surfaces the redirect to the caller
-			// without dialing the target.
-			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+		respClient = defaultResponseURLClient()
 	}
 	return &Handler{
 		cfg:                   cfg,
@@ -175,6 +165,24 @@ func NewHandler(cfg Config) *Handler {
 // always call it on every shutdown without conditionals.
 func (h *Handler) Wait() {
 	h.wg.Wait()
+}
+
+// defaultResponseURLClient is the http.Client used to POST follow-up
+// messages to Slack's response_url unless the caller injects one.
+//
+// CheckRedirect refusing redirects is load-bearing for the
+// host-pinning posture: validateResponseURL only validates the URL the
+// caller provided, so a 30x bounce from hooks.slack.com to any host
+// would otherwise be silently followed (Go's default cap is 10 hops).
+// Returning ErrUseLastResponse surfaces the 30x to the caller without
+// dialing the redirected target.
+func defaultResponseURLClient() *http.Client {
+	return &http.Client{
+		Timeout: responseURLTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -376,12 +376,13 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 		respondSlack(w, helpMessage())
 	case strings.HasPrefix(text, "create "):
 		h.handleCreate(w, values)
-	case text == "list" || strings.HasPrefix(text, "list "):
-		// Prefix-match `"list"` alone matched `listing`, `lists`,
-		// `list-foo` — silently routing them to the list handler
-		// where they'd ignore the trailing tokens. The exact-match
-		// + trailing-space fork shows the user a "Unknown subcommand"
-		// help nudge instead.
+	case text == "list":
+		// Exact match only: the looser `HasPrefix(text, "list")` form
+		// matched `listing`, `lists`, `list-foo` (silently routing
+		// them to the list handler) AND `list extra args` (which
+		// processList ignores). Anything other than the bare token
+		// falls through to the unknown-subcommand branch and gets a
+		// help nudge.
 		h.handleList(w, values)
 	default:
 		// Surfaced to telemetry so a workspace using a stale slash-command

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -130,7 +130,13 @@ type Handler struct {
 	// permit httptest server URLs (which are http://127.0.0.1:NNNNN).
 	// Field rather than parameter so the production default needs no
 	// per-deploy wiring.
-	validateResponseURLFn func(string) error
+	//
+	// Returns a *url.URL on success rather than just an error so the
+	// caller dials the validated/reconstructed URL — the production
+	// validator pins Scheme and Host to literal constants on the
+	// returned value, which is the SSRF-sanitization pattern CodeQL's
+	// taint analysis recognizes.
+	validateResponseURLFn func(string) (*url.URL, error)
 }
 
 // NewHandler creates a new Slack handler.

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -190,6 +190,12 @@ func (h *Handler) Wait() {
 // Returns true on clean drain; false on timeout (workers still in
 // flight). cmd/main.go uses this so a misbehaving worker can't block
 // graceful shutdown past the SIGTERM→SIGKILL window.
+//
+// Note: on the timeout path the inner h.wg.Wait goroutine outlives
+// this call until the underlying workers actually finish. This is fine
+// in the cmd shutdown path (the process is exiting) but means
+// WaitTimeout is NOT appropriate as a hot-path drain primitive — only
+// use at end-of-life.
 func (h *Handler) WaitTimeout(d time.Duration) bool {
 	done := make(chan struct{})
 	go func() {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -66,7 +66,7 @@ func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 	// production validator rejects. Override here so the async path
 	// runs end-to-end; the production validator gets its own table
 	// test in process_test.go.
-	h.validateResponseURLFn = func(string) error { return nil }
+	h.validateResponseURLFn = url.Parse
 	// LIFO: this drain runs before any httptest server cleanup, so a
 	// goroutine still mid-call to qurlServer doesn't race the close.
 	t.Cleanup(h.Wait)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -62,6 +62,14 @@ func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 		},
 	})
 	h.now = func() time.Time { return fixedNow }
+	// Tests target httptest servers (http://127.0.0.1:NNNNN) that the
+	// production validator rejects. Override here so the async path
+	// runs end-to-end; the production validator gets its own table
+	// test in process_test.go.
+	h.validateResponseURLFn = func(string) error { return nil }
+	// LIFO: this drain runs before any httptest server cleanup, so a
+	// goroutine still mid-call to qurlServer doesn't race the close.
+	t.Cleanup(h.Wait)
 	return h
 }
 
@@ -126,7 +134,10 @@ func TestSlashCommandHelp(t *testing.T) {
 	}
 }
 
-func TestSlashCommandCreate(t *testing.T) {
+func TestSlashCommandCreate_AcksWithWorkingOnIt(t *testing.T) {
+	// Ack contract for /qurl create: the synchronous response is the
+	// ephemeral working-on-it message. The actual qURL link is
+	// delivered later via response_url (covered in process_test.go).
 	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		resp := map[string]any{
@@ -135,9 +146,7 @@ func TestSlashCommandCreate(t *testing.T) {
 				"qurl_link":   "https://qurl.link/at_testtoken",
 				"qurl_site":   "https://r_abc123test.qurl.site",
 			},
-			"meta": map[string]string{
-				"request_id": "req_test",
-			},
+			"meta": map[string]string{"request_id": "req_test"},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Errorf("encode response: %v", err)
@@ -149,9 +158,10 @@ func TestSlashCommandCreate(t *testing.T) {
 
 	h := newTestHandler(t, qurlSrv)
 	body := url.Values{
-		"command": {"/qurl"},
-		"text":    {"create https://example.com"},
-		"team_id": {"T123"},
+		"command":    {"/qurl"},
+		"text":       {"create https://example.com"},
+		"team_id":    {"T123"},
+		"trigger_id": {"trig-1"},
 	}.Encode()
 
 	w := httptest.NewRecorder()
@@ -167,6 +177,9 @@ func TestSlashCommandCreate(t *testing.T) {
 	}
 	if result["response_type"] != "ephemeral" {
 		t.Errorf("expected ephemeral response, got %q", result["response_type"])
+	}
+	if result["text"] != ackWorkingOnIt {
+		t.Errorf("ack text = %q, want %q", result["text"], ackWorkingOnIt)
 	}
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -281,12 +281,15 @@ func (h *Handler) postResponse(log *slog.Logger, responseURL, text string) {
 
 	// Read up to a small cap of the body so a 4xx from Slack
 	// (`invalid_url`, `channel_not_found`, etc.) is visible in the
-	// warn log rather than swallowed. Then drain anything past the
-	// cap so Go's transport can recycle the connection — without the
-	// trailing Discard, keep-alive degrades silently if Slack ever
-	// returns a body larger than the cap.
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	_, _ = io.Copy(io.Discard, resp.Body)
+	// warn log rather than swallowed. If the LimitReader actually
+	// hit the cap, drain the remainder so Go's transport can recycle
+	// the connection — without that, keep-alive degrades silently if
+	// Slack ever returns a body larger than the cap.
+	const respBodyCap = 4096
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, respBodyCap))
+	if len(respBody) == respBodyCap {
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}
 	if resp.StatusCode >= 400 {
 		log.Warn("response_url returned non-2xx", "status", resp.StatusCode, "body", string(respBody))
 	}

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -279,11 +279,14 @@ func (h *Handler) postResponse(log *slog.Logger, responseURL, text string) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Read up to a small cap of the body so HTTP keep-alive can
-	// recycle the connection AND so a 4xx from Slack
+	// Read up to a small cap of the body so a 4xx from Slack
 	// (`invalid_url`, `channel_not_found`, etc.) is visible in the
-	// warn log rather than swallowed.
+	// warn log rather than swallowed. Then drain anything past the
+	// cap so Go's transport can recycle the connection — without the
+	// trailing Discard, keep-alive degrades silently if Slack ever
+	// returns a body larger than the cap.
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode >= 400 {
 		log.Warn("response_url returned non-2xx", "status", resp.StatusCode, "body", string(respBody))
 	}

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -216,7 +216,8 @@ func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseUR
 		log.Warn("missing response_url — async result has nowhere to go")
 		return
 	}
-	if err := h.validateResponseURLFn(responseURL); err != nil {
+	target, err := h.validateResponseURLFn(responseURL)
+	if err != nil {
 		log.Warn("invalid response_url — refusing to dial", "error", err)
 		return
 	}
@@ -232,7 +233,14 @@ func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseUR
 		return
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(body))
+	// Dial the URL the validator returned, NOT the original
+	// responseURL string. The production validator constructs the
+	// returned URL with Scheme and Host pinned to literal-string
+	// constants, so the network destination is statically determined
+	// and CodeQL's go/request-forgery taint analysis is satisfied
+	// (validateResponseURLFn is the sanitizer; target is the safe
+	// post-sanitizer value).
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
 	if err != nil {
 		log.Error("build response_url request failed", "error", err)
 		return
@@ -257,19 +265,33 @@ func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseUR
 // an attacker who finds a way past the signature gate (or a future
 // regression there) still can't pivot the bot into an arbitrary-host
 // SSRF emitter.
-func validateResponseURL(rawURL string) error {
+//
+// On success, returns a *url.URL whose Scheme and Host are set to
+// literal-string constants (NOT propagated from the parsed input).
+// This is load-bearing for SSRF taint analysis: the dial target's
+// network destination is statically determined, so CodeQL's
+// go/request-forgery query treats this function as the sanitizer.
+// The Path/RawQuery still flow from the input but those don't change
+// the network destination.
+func validateResponseURL(rawURL string) (*url.URL, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return fmt.Errorf("parse response_url: %w", err)
+		return nil, fmt.Errorf("parse response_url: %w", err)
 	}
 	if u.Scheme != "https" {
-		return fmt.Errorf("response_url scheme %q is not https", u.Scheme)
+		return nil, fmt.Errorf("response_url scheme %q is not https", u.Scheme)
 	}
 	// Hostname strips any port suffix; Slack doesn't send explicit ports
 	// today, but treating ports as transparent matches user intent and
 	// dodges a future regression where a port appears.
 	if u.Hostname() != slackResponseURLHost {
-		return fmt.Errorf("response_url host %q is not %s", u.Hostname(), slackResponseURLHost)
+		return nil, fmt.Errorf("response_url host %q is not %s", u.Hostname(), slackResponseURLHost)
 	}
-	return nil
+	return &url.URL{
+		Scheme:   "https",
+		Host:     slackResponseURLHost,
+		Path:     u.Path,
+		RawPath:  u.RawPath,
+		RawQuery: u.RawQuery,
+	}, nil
 }

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -112,7 +113,7 @@ func (h *Handler) processCreate(ctx context.Context, log *slog.Logger, values ur
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("failed to get API key", "error", err)
-		h.postResponse(ctx, log, responseURL, authFailureMessage)
+		h.postResponse(log, responseURL, authFailureMessage)
 		return
 	}
 
@@ -122,11 +123,11 @@ func (h *Handler) processCreate(ctx context.Context, log *slog.Logger, values ur
 	})
 	if err != nil {
 		log.Error("failed to create qURL", "error", err, "target_url", targetURL)
-		h.postResponse(ctx, log, responseURL, sanitizeAPIError(err, "Failed to create qURL"))
+		h.postResponse(log, responseURL, sanitizeAPIError(err, "Failed to create qURL"))
 		return
 	}
 
-	h.postResponse(ctx, log, responseURL, fmt.Sprintf("qURL created!\n*Link:* %s\n*Target:* %s", result.QURLLink, targetURL))
+	h.postResponse(log, responseURL, fmt.Sprintf("qURL created!\n*Link:* %s\n*Target:* %s", result.QURLLink, targetURL))
 }
 
 // processList runs the asynchronous /qurl list work: page through the
@@ -138,18 +139,18 @@ func (h *Handler) processList(ctx context.Context, log *slog.Logger, values url.
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("failed to get API key", "error", err)
-		h.postResponse(ctx, log, responseURL, authFailureMessage)
+		h.postResponse(log, responseURL, authFailureMessage)
 		return
 	}
 
 	result, err := c.List(ctx, client.ListInput{Limit: 5})
 	if err != nil {
 		log.Error("failed to list qURLs", "error", err)
-		h.postResponse(ctx, log, responseURL, sanitizeAPIError(err, "Failed to list qURLs"))
+		h.postResponse(log, responseURL, sanitizeAPIError(err, "Failed to list qURLs"))
 		return
 	}
 
-	h.postResponse(ctx, log, responseURL, formatListMessage(result.QURLs))
+	h.postResponse(log, responseURL, formatListMessage(result.QURLs))
 }
 
 // idempotencyKeyForCreate hashes the workspace + trigger so the qURL
@@ -178,7 +179,11 @@ func sanitizeAPIError(err error, prefix string) string {
 	}
 	msg := prefix
 	if apiErr.Title != "" {
-		msg = prefix + ": " + apiErr.Title
+		// Trim a trailing period from Title so the appended one
+		// below doesn't double-punctuate (some upstream servers
+		// emit "Internal Server Error." — surfacing that verbatim
+		// reads as "...Server Error..").
+		msg = prefix + ": " + strings.TrimRight(apiErr.Title, ".")
 	}
 	if apiErr.RequestID != "" {
 		msg += fmt.Sprintf(" (Reference: `%s`)", apiErr.RequestID)
@@ -211,7 +216,15 @@ func formatListMessage(qurls []client.QURL) string {
 // Validates scheme+host before dialing so a malformed (or attacker-
 // controlled, in the event of a signature-gate bypass) URL can't make
 // the bot a generic SSRF emitter.
-func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseURL, text string) {
+//
+// Note: the worker's ctx is intentionally NOT used for the HTTP
+// request. On SIGTERM the worker ctx is canceled, which has already
+// failed the qURL call upstream — we still owe the user the failure
+// follow-up. Deriving from context.Background() with a tight
+// responseURLTimeout lets the follow-up land before Fargate's hard
+// kill while still bounding the goroutine's lifetime.
+// handler.Wait()/WaitTimeout in main blocks process exit.
+func (h *Handler) postResponse(log *slog.Logger, responseURL, text string) {
 	if responseURL == "" {
 		log.Warn("missing response_url — async result has nowhere to go")
 		return
@@ -233,6 +246,9 @@ func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseUR
 		return
 	}
 
+	deliverCtx, cancel := context.WithTimeout(context.Background(), responseURLTimeout)
+	defer cancel()
+
 	// Dial the URL the validator returned, NOT the original
 	// responseURL string. The production validator constructs the
 	// returned URL with Scheme and Host pinned to literal-string
@@ -240,7 +256,7 @@ func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseUR
 	// and CodeQL's go/request-forgery taint analysis is satisfied
 	// (validateResponseURLFn is the sanitizer; target is the safe
 	// post-sanitizer value).
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(deliverCtx, http.MethodPost, target.String(), bytes.NewReader(body))
 	if err != nil {
 		log.Error("build response_url request failed", "error", err)
 		return
@@ -254,8 +270,13 @@ func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseUR
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// Read up to a small cap of the body so HTTP keep-alive can
+	// recycle the connection AND so a 4xx from Slack
+	// (`invalid_url`, `channel_not_found`, etc.) is visible in the
+	// warn log rather than swallowed.
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode >= 400 {
-		log.Warn("response_url returned non-2xx", "status", resp.StatusCode)
+		log.Warn("response_url returned non-2xx", "status", resp.StatusCode, "body", string(respBody))
 	}
 }
 
@@ -281,10 +302,18 @@ func validateResponseURL(rawURL string) (*url.URL, error) {
 	if u.Scheme != "https" {
 		return nil, fmt.Errorf("response_url scheme %q is not https", u.Scheme)
 	}
+	// Reject embedded userinfo (https://x:y@hooks.slack.com/...). Slack
+	// will never send those; rejecting tightens the canonical-shape
+	// contract and removes a footgun on the SSRF fence.
+	if u.User != nil {
+		return nil, errors.New("response_url contains userinfo")
+	}
 	// Hostname strips any port suffix; Slack doesn't send explicit ports
 	// today, but treating ports as transparent matches user intent and
 	// dodges a future regression where a port appears.
-	if u.Hostname() != slackResponseURLHost {
+	// EqualFold is RFC 3986-correct: DNS hostnames are case-insensitive,
+	// so a Hooks.Slack.Com URL that resolves identically must validate.
+	if !strings.EqualFold(u.Hostname(), slackResponseURLHost) {
 		return nil, fmt.Errorf("response_url host %q is not %s", u.Hostname(), slackResponseURLHost)
 	}
 	return &url.URL{

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"github.com/layervai/qurl-integrations/shared/client"
@@ -155,8 +156,16 @@ func (h *Handler) processList(ctx context.Context, log *slog.Logger, values url.
 
 // idempotencyKeyForCreate hashes the workspace + trigger so the qURL
 // service dedupes Slack-side retries.
+//
+// Inputs are length-framed before hashing so a future rev of Slack's
+// ID format that introduced a colon couldn't collide distinct (team,
+// trigger) pairs into the same key. Today's IDs (T-prefixed alphanum
+// teams; UUID-shaped trigger IDs) don't contain colons, but pinning
+// the contract via length-framing is cheap and removes the assumption.
 func idempotencyKeyForCreate(teamID, triggerID string) string {
-	sum := sha256.Sum256([]byte("slack:" + teamID + ":" + triggerID))
+	pre := "slack:" + strconv.Itoa(len(teamID)) + ":" + teamID +
+		":" + strconv.Itoa(len(triggerID)) + ":" + triggerID
+	sum := sha256.Sum256([]byte(pre))
 	return hex.EncodeToString(sum[:])
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -1,0 +1,267 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"runtime/debug"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// fieldResponseURL is the form field Slack sends with every slash command;
+// follow-up messages are POSTed back to this URL within 30 minutes (5
+// posts per command). Treated as opaque — slashing into it would risk
+// SSRF if the signature gate ever broke, so postResponse validates the
+// scheme and host before dialing.
+const fieldResponseURL = "response_url"
+
+// slackResponseURLHost is Slack's webhook ingress for slash-command
+// follow-ups. Pinning the host before dialing is defense-in-depth: a
+// supply-chain compromise that flipped some Slack-supplied URL would
+// otherwise let attackers turn this binary into an SSRF emitter.
+// The host string is the only Slack-controlled identifier the Slack
+// docs guarantee for this surface.
+const slackResponseURLHost = "hooks.slack.com"
+
+// runAsync acks the request synchronously with ackWorkingOnIt and runs
+// `work` in a bounded-pool goroutine. Returns after the ack is written.
+//
+// Concurrency contract:
+//   - sem reservation must succeed before wg.Add and ack — otherwise a
+//     burst that overflows the pool would still consume the user's
+//     "Working on it…" expectation. Saturation gets ackBusy instead.
+//   - wg.Add MUST happen on the request goroutine (before `go`). Adding
+//     inside the spawned goroutine races with Wait() during shutdown.
+//   - The goroutine context derives from h.baseCtx, NOT r.Context() —
+//     r.Context() cancels as soon as ServeHTTP returns, which is
+//     immediately after the ack here.
+func (h *Handler) runAsync(w http.ResponseWriter, command string, values url.Values, work func(ctx context.Context, log *slog.Logger)) {
+	// Bind the per-request log scope once. Every emission below this
+	// point inherits team/channel/trigger attribution. The form-field
+	// values are user-controlled but slog's JSON handler escapes
+	// control bytes in attribute values — same log-injection posture
+	// as the request-path slog sites in handler.go.
+	log := slog.With(
+		"command", command,
+		"team_id", values.Get("team_id"),
+		"channel_id", values.Get("channel_id"),
+		"trigger_id", values.Get("trigger_id"),
+	)
+
+	select {
+	case h.sem <- struct{}{}:
+	default:
+		log.Warn("async pool saturated — dropping request")
+		respondSlack(w, ackBusy)
+		return
+	}
+
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		defer func() { <-h.sem }()
+		defer func() {
+			if rec := recover(); rec != nil {
+				// A panicking goroutine in a long-lived process is
+				// disqualifying — log + stack so the cause is in
+				// CloudWatch, then swallow so the deferred sem release
+				// and wg.Done still run.
+				log.Error("panic in async slash-command worker", "recover", rec, "stack", string(debug.Stack()))
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(h.baseCtx, asyncWorkTimeout)
+		defer cancel()
+		work(ctx, log)
+	}()
+
+	respondSlack(w, ackWorkingOnIt)
+}
+
+// processCreate runs the asynchronous /qurl create work: resolve the
+// per-workspace API key, call the qURL API with an idempotency key, and
+// POST the result back via response_url.
+//
+// Idempotency-Key construction: sha256("slack:" + team_id + ":" +
+// trigger_id) hex-encoded — 64 ASCII bytes, well under the 256-byte
+// header cap, and reveals no PII on transit. Slack guarantees a unique
+// trigger_id per click; matching keys come from Slack's own retry path
+// (3s ack timeout exceeded), so collisions are exactly the dedup target.
+func (h *Handler) processCreate(ctx context.Context, log *slog.Logger, values url.Values, targetURL string) {
+	responseURL := values.Get(fieldResponseURL)
+	teamID := values.Get("team_id")
+	triggerID := values.Get("trigger_id")
+
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("failed to get API key", "error", err)
+		h.postResponse(ctx, log, responseURL, authFailureMessage)
+		return
+	}
+
+	result, err := c.Create(ctx, client.CreateInput{
+		TargetURL:      targetURL,
+		IdempotencyKey: idempotencyKeyForCreate(teamID, triggerID),
+	})
+	if err != nil {
+		log.Error("failed to create qURL", "error", err, "target_url", targetURL)
+		h.postResponse(ctx, log, responseURL, sanitizeAPIError(err, "Failed to create qURL"))
+		return
+	}
+
+	h.postResponse(ctx, log, responseURL, fmt.Sprintf("qURL created!\n*Link:* %s\n*Target:* %s", result.QURLLink, targetURL))
+}
+
+// processList runs the asynchronous /qurl list work: page through the
+// most recent qURLs and POST a formatted summary back via response_url.
+func (h *Handler) processList(ctx context.Context, log *slog.Logger, values url.Values) {
+	responseURL := values.Get(fieldResponseURL)
+	teamID := values.Get("team_id")
+
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("failed to get API key", "error", err)
+		h.postResponse(ctx, log, responseURL, authFailureMessage)
+		return
+	}
+
+	result, err := c.List(ctx, client.ListInput{Limit: 5})
+	if err != nil {
+		log.Error("failed to list qURLs", "error", err)
+		h.postResponse(ctx, log, responseURL, sanitizeAPIError(err, "Failed to list qURLs"))
+		return
+	}
+
+	h.postResponse(ctx, log, responseURL, formatListMessage(result.QURLs))
+}
+
+// idempotencyKeyForCreate hashes the workspace + trigger so the qURL
+// service dedupes Slack-side retries.
+func idempotencyKeyForCreate(teamID, triggerID string) string {
+	sum := sha256.Sum256([]byte("slack:" + teamID + ":" + triggerID))
+	return hex.EncodeToString(sum[:])
+}
+
+// sanitizeAPIError builds a user-safe message from a (possibly non-nil)
+// qURL API error. The full *client.APIError is logged at the call site;
+// what reaches Slack is bounded to:
+//
+//   - `prefix` (caller-supplied static text)
+//   - `apiErr.Title` — qURL service or net/http standard text, stable
+//     and not a leak surface
+//   - `apiErr.RequestID` — operator handle for support correlation
+//
+// Notably absent: `apiErr.Detail`, which can carry server-side internals
+// (DB error strings, internal hostnames, stack-trace fragments via the
+// non-RFC-7807 fallback path in shared/client).
+func sanitizeAPIError(err error, prefix string) string {
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) {
+		return prefix + "."
+	}
+	msg := prefix
+	if apiErr.Title != "" {
+		msg = prefix + ": " + apiErr.Title
+	}
+	if apiErr.RequestID != "" {
+		msg += fmt.Sprintf(" (Reference: `%s`)", apiErr.RequestID)
+	}
+	return msg + "."
+}
+
+// formatListMessage renders /qurl list results as Slack mrkdwn.
+func formatListMessage(qurls []client.QURL) string {
+	if len(qurls) == 0 {
+		return "No qURLs found."
+	}
+	lines := make([]string, 0, len(qurls))
+	for i := range qurls {
+		q := &qurls[i]
+		line := fmt.Sprintf("• `%s` → %s [%s]", q.ResourceID, q.TargetURL, q.Status)
+		if q.Description != "" {
+			line = fmt.Sprintf("• *%s* — `%s` → %s [%s]", q.Description, q.ResourceID, q.TargetURL, q.Status)
+		}
+		lines = append(lines, line)
+	}
+	return "*Recent qURLs:*\n" + strings.Join(lines, "\n")
+}
+
+// postResponse POSTs an ephemeral follow-up to Slack's response_url.
+// Errors are logged, never re-raised — the user will retry the command
+// if the follow-up never arrives, which is preferable to retrying our
+// own POST and risking a duplicate-message storm at Slack.
+//
+// Validates scheme+host before dialing so a malformed (or attacker-
+// controlled, in the event of a signature-gate bypass) URL can't make
+// the bot a generic SSRF emitter.
+func (h *Handler) postResponse(ctx context.Context, log *slog.Logger, responseURL, text string) {
+	if responseURL == "" {
+		log.Warn("missing response_url — async result has nowhere to go")
+		return
+	}
+	if err := h.validateResponseURLFn(responseURL); err != nil {
+		log.Warn("invalid response_url — refusing to dial", "error", err)
+		return
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"response_type": "ephemeral",
+		"text":          text,
+	})
+	if err != nil {
+		// json.Marshal of a map[string]string can't fail in practice; log
+		// and bail rather than POSTing a half-baked body.
+		log.Error("marshal response_url payload failed", "error", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(body))
+	if err != nil {
+		log.Error("build response_url request failed", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.responseURLClient.Do(req)
+	if err != nil {
+		log.Error("response_url POST failed", "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		log.Warn("response_url returned non-2xx", "status", resp.StatusCode)
+	}
+}
+
+// validateResponseURL fences the response_url POST destination to
+// hooks.slack.com over HTTPS. The Slack request signature already
+// authenticates the form body, but a defense-in-depth host check means
+// an attacker who finds a way past the signature gate (or a future
+// regression there) still can't pivot the bot into an arbitrary-host
+// SSRF emitter.
+func validateResponseURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse response_url: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("response_url scheme %q is not https", u.Scheme)
+	}
+	// Hostname strips any port suffix; Slack doesn't send explicit ports
+	// today, but treating ports as transparent matches user intent and
+	// dodges a future regression where a port appears.
+	if u.Hostname() != slackResponseURLHost {
+		return fmt.Errorf("response_url host %q is not %s", u.Hostname(), slackResponseURLHost)
+	}
+	return nil
+}

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -67,6 +67,14 @@ func (h *Handler) runAsync(w http.ResponseWriter, command string, values url.Val
 
 	h.wg.Add(1)
 	go func() {
+		// Defer LIFO is load-bearing here: on panic, the recover
+		// runs FIRST (innermost), absorbs the panic, then sem
+		// release and wg.Done run unwinding outward. Reordering
+		// these — putting recover above the sem release, say —
+		// would silently leak a slot and a wg counter on every
+		// panic. The ctx cancel is innermost-of-innermost so
+		// children of that ctx see cancellation before the worker
+		// frame returns.
 		defer h.wg.Done()
 		defer func() { <-h.sem }()
 		defer func() {

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -67,7 +67,10 @@ func createCommandBody(targetURL, teamID, triggerID, responseURL string) string 
 }
 
 // waitFor polls until cond returns true or the deadline elapses. Used
-// to gate on async post-ack work without hard sleeps.
+// to gate on async post-ack work without hard sleeps. The 10ms tick
+// keeps the success path snappy while the timeout argument bounds the
+// failure path; callers should pass a value that absorbs race-detector
+// load on a busy CI runner.
 func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -75,7 +78,7 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
 		if cond() {
 			return
 		}
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("condition not met within %s", timeout)
 }
@@ -363,8 +366,9 @@ func TestHandle_PoolSaturationDropsWithBusyAck(t *testing.T) {
 	// Wait until both workers are actually parked in the qURL handler;
 	// otherwise the third send could race ahead while a slot is still
 	// unclaimed.
-	waitFor(t, time.Second, func() bool {
-		// Two slots taken means a third reservation will fail.
+	waitFor(t, 2*time.Second, func() bool {
+		// Two slots taken means a third reservation will fail. 2s
+		// gives the race detector + a busy CI runner enough headroom.
 		return len(h.sem) == 2
 	})
 	third := send("trig-3")
@@ -806,32 +810,86 @@ func TestHandler_WaitTimeout_DrainsOnSuccess(t *testing.T) {
 	}
 }
 
-// TestHandle_ListPrefixDoesNotMatchListing fences the tightened
-// prefix match for "/qurl list": before, "listing" matched as a list
-// prefix and silently routed to processList. Now it falls through to
-// the unknown-subcommand branch with a help nudge.
-func TestHandle_ListPrefixDoesNotMatchListing(t *testing.T) {
-	srv, hits := countingQURLServer(t)
-	h := newTestHandler(t, srv)
+// TestHandle_PostResponseRefusesRedirectsEndToEnd is the end-to-end
+// counterpart to TestResponseURLClient_RefusesRedirects: it goes
+// through processCreate → postResponse so a regression that wired the
+// request through a non-default *http.Client at the call site is
+// caught here even if the client unit test still passed.
+func TestHandle_PostResponseRefusesRedirectsEndToEnd(t *testing.T) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r1","qurl_link":"https://qurl.link/x"}}`))
+	}))
+	t.Cleanup(qurlSrv.Close)
 
-	body := url.Values{
-		"command": {"/qurl"},
-		"text":    {"listing"},
-		"team_id": {"T123"},
-	}.Encode()
+	t.Setenv("QURL_API_KEY", "test-key")
 
+	// Evil host — should never see traffic if redirect-refusal works.
+	var evilHits atomic.Int32
+	evilSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(evilSrv.Close)
+
+	// response_url server returns 302 to the evil host.
+	var responseURLHits atomic.Int32
+	responseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		responseURLHits.Add(1)
+		http.Redirect(w, r, evilSrv.URL, http.StatusFound)
+	}))
+	t.Cleanup(responseSrv.Close)
+
+	h := newTestHandler(t, qurlSrv)
+	body := createCommandBody("https://example.com", "T123", "trig-redir-e2e", responseSrv.URL)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	h.Wait()
 
-	var ack map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if got := responseURLHits.Load(); got != 1 {
+		t.Errorf("response_url server hit count = %d, want 1 (initial POST)", got)
 	}
-	if !strings.Contains(ack["text"], "Unknown subcommand") {
-		t.Errorf("expected 'Unknown subcommand' help nudge for `listing`, got: %q", ack["text"])
+	if got := evilHits.Load(); got != 0 {
+		t.Errorf("evil server hit count = %d, want 0 (redirect must be refused)", got)
 	}
-	// And no upstream qURL request was made.
-	if got := hits.Load(); got != 0 {
-		t.Errorf("upstream qURL hits for `listing`: got %d, want 0", got)
+}
+
+// TestHandle_ListExactMatchOnly fences the tightened "/qurl list"
+// matcher: the looser HasPrefix(text, "list") form matched `listing`,
+// `lists`, `list-foo` (silently routing them to processList) AND
+// `list extra args` (which processList ignores). Now only the bare
+// token reaches processList — anything else falls through to the
+// unknown-subcommand branch.
+func TestHandle_ListExactMatchOnly(t *testing.T) {
+	cases := []string{
+		"listing",
+		"lists",
+		"list-foo",
+		"list foo bar", // trailing tokens — list takes no args
+	}
+	for _, text := range cases {
+		t.Run(text, func(t *testing.T) {
+			srv, hits := countingQURLServer(t)
+			h := newTestHandler(t, srv)
+			body := url.Values{
+				"command": {"/qurl"},
+				"text":    {text},
+				"team_id": {"T123"},
+			}.Encode()
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+			var ack map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !strings.Contains(ack["text"], "Unknown subcommand") {
+				t.Errorf("expected 'Unknown subcommand' help nudge for %q, got: %q", text, ack["text"])
+			}
+			if got := hits.Load(); got != 0 {
+				t.Errorf("upstream qURL hits for %q: got %d, want 0", text, got)
+			}
+		})
 	}
 }

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -284,11 +284,19 @@ func TestHandle_AsyncCreateSanitizesAPIError(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 
 	rec := newResponseURLRecorder(t)
-	h := newTestHandler(t, qurlSrv)
-	// Disable retries so the test isn't 30s long when 500 is returned.
-	h.cfg.NewClient = func(apiKey string) *client.Client {
-		return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
-	}
+	// Build the handler from a Config that already disables retries so
+	// a 500 doesn't push the test toward the 30s retry budget. Cleaner
+	// than mutating cfg.NewClient post-construction.
+	h := NewHandler(Config{
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: testSigningSecret,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
+		},
+	})
+	h.now = func() time.Time { return fixedNow }
+	h.validateResponseURLFn = url.Parse
+	t.Cleanup(h.Wait)
 
 	body := createCommandBody("https://example.com", "T123", "trig-err", rec.URL)
 	w := httptest.NewRecorder()

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -1,0 +1,671 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// responseURLRecorder is an httptest.Server that captures every
+// response_url POST it receives. Tests use it to assert the body the
+// async worker delivered after the synchronous ack.
+type responseURLRecorder struct {
+	URL string
+
+	mu    sync.Mutex
+	posts []map[string]string
+}
+
+// posts returns a snapshot of the captured payloads.
+func (r *responseURLRecorder) Posts() []map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.posts)
+}
+
+func newResponseURLRecorder(t *testing.T) *responseURLRecorder {
+	t.Helper()
+	rec := &responseURLRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.mu.Lock()
+		rec.posts = append(rec.posts, body)
+		rec.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	rec.URL = srv.URL
+	return rec
+}
+
+// createCommandBody builds a /slack/commands form payload for a
+// /qurl create call. response_url is parameterized so a test can wire
+// it at the recorder it controls.
+func createCommandBody(targetURL, teamID, triggerID, responseURL string) string {
+	return url.Values{
+		"command":      {"/qurl"},
+		"text":         {"create " + targetURL},
+		"team_id":      {teamID},
+		"channel_id":   {"C123"},
+		"trigger_id":   {triggerID},
+		"response_url": {responseURL},
+	}.Encode()
+}
+
+// waitFor polls until cond returns true or the deadline elapses. Used
+// to gate on async post-ack work without hard sleeps.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}
+
+// TestHandle_AckIsFastUnderSlowAPI fences the load-bearing UX promise:
+// no matter how slow the qURL upstream is, the handler must ack within
+// Slack's 3s budget — a 50ms cap leaves room for ~60x slowdown before
+// the timeout starts to bite.
+func TestHandle_AckIsFastUnderSlowAPI(t *testing.T) {
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Far longer than the 50ms ack budget — synchronous code would
+		// exceed it; the async path returns the ack first and hits the
+		// upstream off the request goroutine.
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r1","qurl_link":"https://qurl.link/x"}}`))
+	}))
+	t.Cleanup(slowSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := newTestHandler(t, slowSrv)
+
+	body := createCommandBody("https://example.com", "T123", "trig-fast", rec.URL)
+
+	start := time.Now()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	elapsed := time.Since(start)
+
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("ack took %v, want ≤50ms", elapsed)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	var ack map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil {
+		t.Fatalf("unmarshal ack: %v", err)
+	}
+	if ack["text"] != ackWorkingOnIt {
+		t.Errorf("ack text = %q, want %q", ack["text"], ackWorkingOnIt)
+	}
+}
+
+// TestHandle_AsyncCreatePostsResultToResponseURL fences the round-trip:
+// after the ack, the worker POSTs the qURL link via response_url.
+func TestHandle_AsyncCreatePostsResultToResponseURL(t *testing.T) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r_abc","qurl_link":"https://qurl.link/at_token"}}`))
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := newTestHandler(t, qurlSrv)
+
+	body := createCommandBody("https://example.com", "T123", "trig-create", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	h.Wait() // drain the async worker before asserting on what it posted.
+
+	posts := rec.Posts()
+	if len(posts) != 1 {
+		t.Fatalf("response_url POST count = %d, want 1; posts=%v", len(posts), posts)
+	}
+	got := posts[0]
+	if got["response_type"] != "ephemeral" {
+		t.Errorf("response_url response_type = %q, want ephemeral", got["response_type"])
+	}
+	if !strings.Contains(got["text"], "https://qurl.link/at_token") {
+		t.Errorf("response_url text missing qURL link: %q", got["text"])
+	}
+}
+
+// TestHandle_AsyncCreateSurfacesIdempotencyKey fences the dedup contract:
+// every /qurl create with a fixed team_id+trigger_id MUST carry the same
+// Idempotency-Key. Slack's 3s ack timeout is below typical qURL API
+// latency under load, so Slack-side retries are real — the qURL service
+// uses this header to fold them into a single resource creation.
+func TestHandle_AsyncCreateSurfacesIdempotencyKey(t *testing.T) {
+	var seenKey string
+	var keyMu sync.Mutex
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		k := r.Header.Get(client.HeaderIdempotencyKey)
+		keyMu.Lock()
+		seenKey = k
+		keyMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r1","qurl_link":"https://qurl.link/x"}}`))
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := newTestHandler(t, qurlSrv)
+
+	body := createCommandBody("https://example.com", "T999", "trig-dedup", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	h.Wait()
+
+	keyMu.Lock()
+	got := seenKey
+	keyMu.Unlock()
+	if got == "" {
+		t.Fatal("upstream saw no Idempotency-Key header")
+	}
+	want := idempotencyKeyForCreate("T999", "trig-dedup")
+	if got != want {
+		t.Errorf("Idempotency-Key = %q, want %q", got, want)
+	}
+}
+
+// TestHandle_ConcurrentCreateSharesIdempotencyKey is the load-bearing
+// dedup integration test: 100 concurrent /qurl create requests with the
+// same trigger_id must all carry the same Idempotency-Key. Anything
+// less is a regression that re-introduces duplicate qURLs under
+// Slack's retry storm.
+func TestHandle_ConcurrentCreateSharesIdempotencyKey(t *testing.T) {
+	const concurrency = 100
+
+	var keys sync.Map
+	var hits atomic.Int32
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if k := r.Header.Get(client.HeaderIdempotencyKey); k != "" {
+			keys.LoadOrStore(k, struct{}{})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r1","qurl_link":"https://qurl.link/x"}}`))
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	// Pool capacity bumped so all concurrency requests are dispatched
+	// (the dedup property is what's under test, not back-pressure).
+	h := NewHandler(Config{
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: testSigningSecret,
+		MaxConcurrentAsync: concurrency,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlSrv.URL, apiKey)
+		},
+	})
+	h.now = func() time.Time { return fixedNow }
+	h.validateResponseURLFn = func(string) error { return nil }
+	t.Cleanup(h.Wait)
+
+	body := createCommandBody("https://example.com", "T-concurrent", "trig-shared", rec.URL)
+
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+		}()
+	}
+	wg.Wait()
+	h.Wait()
+
+	if got := hits.Load(); got != concurrency {
+		t.Errorf("upstream hits = %d, want %d (pool was sized for full dispatch)", got, concurrency)
+	}
+	var uniqueKeys int
+	keys.Range(func(_, _ any) bool { uniqueKeys++; return true })
+	if uniqueKeys != 1 {
+		t.Errorf("upstream observed %d unique Idempotency-Keys across %d requests, want 1", uniqueKeys, concurrency)
+	}
+}
+
+// TestHandle_AsyncCreateSanitizesAPIError fences the sanitization
+// contract: a qURL API error reaches the user as the safe Title +
+// RequestID, and the unsafe Detail (which can leak server internals)
+// stays out of the user-facing payload.
+func TestHandle_AsyncCreateSanitizesAPIError(t *testing.T) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		// `detail` carries a representative server-side internal — a
+		// regression that surfaced this string to users would leak
+		// implementation details (here: a synthetic stack hint).
+		_, _ = fmt.Fprint(w, `{"error":{"type":"about:blank","title":"Internal Server Error","status":500,"detail":"db: connection to internal-host:5432 refused (stack: ...)","code":"SECRET_LEAK_HOOK"},"meta":{"request_id":"req_abc123"}}`)
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := newTestHandler(t, qurlSrv)
+	// Disable retries so the test isn't 30s long when 500 is returned.
+	h.cfg.NewClient = func(apiKey string) *client.Client {
+		return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
+	}
+
+	body := createCommandBody("https://example.com", "T123", "trig-err", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	h.Wait()
+
+	posts := rec.Posts()
+	if len(posts) != 1 {
+		t.Fatalf("response_url POST count = %d, want 1", len(posts))
+	}
+	text := posts[0]["text"]
+
+	// Detail must NOT appear — it carries server internals.
+	if strings.Contains(text, "internal-host") || strings.Contains(text, "stack") {
+		t.Errorf("sanitization leak: response contains Detail substring: %q", text)
+	}
+	// Title is safe and informative.
+	if !strings.Contains(text, "Internal Server Error") {
+		t.Errorf("expected Title in user-facing text, got: %q", text)
+	}
+	// RequestID is the operator-correlation handle.
+	if !strings.Contains(text, "req_abc123") {
+		t.Errorf("expected RequestID in user-facing text, got: %q", text)
+	}
+}
+
+// TestHandle_PoolSaturationDropsWithBusyAck fences back-pressure: when
+// the bounded async pool is full, further requests get ackBusy
+// instantly rather than queueing or unbounded-spawning. Two concurrent
+// long-running workers fill the pool; the third request must drop.
+func TestHandle_PoolSaturationDropsWithBusyAck(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		// Defensive: unblock any worker still waiting on release so
+		// h.Wait() can drain. Idempotent close via select.
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r1"}}`))
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := NewHandler(Config{
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: testSigningSecret,
+		MaxConcurrentAsync: 2,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
+		},
+	})
+	h.now = func() time.Time { return fixedNow }
+	h.validateResponseURLFn = func(string) error { return nil }
+	t.Cleanup(h.Wait)
+
+	send := func(triggerID string) string {
+		body := createCommandBody("https://example.com", "T123", triggerID, rec.URL)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+		var ack map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil {
+			t.Fatalf("unmarshal ack: %v", err)
+		}
+		return ack["text"]
+	}
+
+	first := send("trig-1")
+	second := send("trig-2")
+	// Wait until both workers are actually parked in the qURL handler;
+	// otherwise the third send could race ahead while a slot is still
+	// unclaimed.
+	waitFor(t, time.Second, func() bool {
+		// Two slots taken means a third reservation will fail.
+		return len(h.sem) == 2
+	})
+	third := send("trig-3")
+
+	if first != ackWorkingOnIt || second != ackWorkingOnIt {
+		t.Errorf("first/second acks should be working-on-it; got %q / %q", first, second)
+	}
+	if third != ackBusy {
+		t.Errorf("third (saturated) ack = %q, want %q", third, ackBusy)
+	}
+
+	// Release the parked workers so h.Wait() drains.
+	close(release)
+}
+
+// TestHandle_AsyncListPostsResultToResponseURL fences /qurl list's
+// async path including the empty-list and populated-list code paths.
+func TestHandle_AsyncListPostsResultToResponseURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		respJSON string
+		want     string
+	}{
+		{
+			name:     "no qurls",
+			respJSON: `{"data":[]}`,
+			want:     "No qURLs found.",
+		},
+		{
+			name:     "with qurls",
+			respJSON: `{"data":[{"resource_id":"r1","target_url":"https://example.com","status":"active"}]}`,
+			want:     "*Recent qURLs:*",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.respJSON))
+			}))
+			t.Cleanup(qurlSrv.Close)
+
+			t.Setenv("QURL_API_KEY", "test-key")
+
+			rec := newResponseURLRecorder(t)
+			h := newTestHandler(t, qurlSrv)
+			body := url.Values{
+				"command":      {"/qurl"},
+				"text":         {"list"},
+				"team_id":      {"T123"},
+				"trigger_id":   {"trig-list"},
+				"response_url": {rec.URL},
+			}.Encode()
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+			h.Wait()
+
+			posts := rec.Posts()
+			if len(posts) != 1 {
+				t.Fatalf("response_url POST count = %d, want 1", len(posts))
+			}
+			if !strings.Contains(posts[0]["text"], tc.want) {
+				t.Errorf("response_url text = %q, want substring %q", posts[0]["text"], tc.want)
+			}
+		})
+	}
+}
+
+// TestHandle_PanicInAsyncWorkRecovers fences the panic-recovery defer
+// in runAsync. A panicking auth.Provider must not crash the process or
+// leak a wg slot — the goroutine returns cleanly via the recover, sem
+// releases, and h.Wait drains.
+func TestHandle_PanicInAsyncWorkRecovers(t *testing.T) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	rec := newResponseURLRecorder(t)
+	h := NewHandler(Config{
+		AuthProvider:       panickingProvider{},
+		SlackSigningSecret: testSigningSecret,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
+		},
+	})
+	h.now = func() time.Time { return fixedNow }
+	h.validateResponseURLFn = func(string) error { return nil }
+
+	body := createCommandBody("https://example.com", "T123", "trig-panic", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	// h.Wait() blocks if the panic wasn't recovered cleanly (wg.Done
+	// would leak); the test would hang on a regression that broke
+	// the recover path.
+	h.Wait()
+
+	// Sem slot must be released too.
+	if got := len(h.sem); got != 0 {
+		t.Errorf("sem leak after panic: len(sem) = %d, want 0", got)
+	}
+}
+
+// panickingProvider implements auth.Provider but panics on APIKey, used
+// to exercise runAsync's panic-recovery defer.
+type panickingProvider struct{}
+
+func (panickingProvider) APIKey(_ context.Context, _ string) (string, error) {
+	panic("provider panic for test")
+}
+
+// TestValidateResponseURL fences the production validator: only HTTPS
+// to hooks.slack.com is accepted. Anything else is a refusal — even a
+// signature-passing request can't pivot the bot into an SSRF emitter.
+func TestValidateResponseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "valid Slack hooks URL", raw: "https://hooks.slack.com/commands/T1/abc/xyz", wantErr: false},
+		{name: "valid Slack hooks URL with explicit 443", raw: "https://hooks.slack.com:443/commands/T1/abc/xyz", wantErr: false},
+		{name: "rejects http (no TLS)", raw: "http://hooks.slack.com/commands/T1/abc/xyz", wantErr: true},
+		{name: "rejects non-Slack host", raw: "https://attacker.example/commands/T1/abc/xyz", wantErr: true},
+		{name: "rejects subdomain trick", raw: "https://hooks.slack.com.attacker.example/path", wantErr: true},
+		{name: "rejects empty URL", raw: "", wantErr: true},
+		{name: "rejects relative path", raw: "/oops", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateResponseURL(tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateResponseURL(%q) err = %v, wantErr = %v", tc.raw, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestResponseURLClient_RefusesRedirects fences the redirect-refusal
+// posture on the default response_url client: a 30x from
+// hooks.slack.com to any other host must NOT be followed. Without the
+// CheckRedirect override, Go's default would silently follow up to 10
+// redirects, defeating the validateResponseURL host pin.
+func TestResponseURLClient_RefusesRedirects(t *testing.T) {
+	h := NewHandler(Config{
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: testSigningSecret,
+		NewClient:          func(string) *client.Client { return nil },
+	})
+
+	var followCount atomic.Int32
+	var redirectTo string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		followCount.Add(1)
+		// Always 302 to ourselves — without redirect-refusal the
+		// follower would loop until Go's 10-redirect cap, accumulating
+		// follow hits.
+		http.Redirect(w, r, redirectTo, http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+	redirectTo = srv.URL
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := h.responseURLClient.Do(req)
+	if err != nil {
+		t.Fatalf("client returned error instead of surfacing 302: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want 302 (caller sees the redirect, doesn't follow)", resp.StatusCode)
+	}
+	if got := followCount.Load(); got != 1 {
+		t.Errorf("server hit count = %d, want 1 (any >1 means a redirect was followed)", got)
+	}
+}
+
+// TestSanitizeAPIError fences the user-facing message contract for a
+// range of qURL API error shapes. A regression that surfaced Detail or
+// dropped RequestID would change the security/observability posture.
+func TestSanitizeAPIError(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		prefix  string
+		wantSub []string
+		notSub  []string
+	}{
+		{
+			name: "APIError with title and request id",
+			err: &client.APIError{
+				StatusCode: 500,
+				Title:      "Internal Server Error",
+				Detail:     "db: leaked-internal-host failed",
+				RequestID:  "req_xyz",
+			},
+			prefix:  "Failed to create qURL",
+			wantSub: []string{"Failed to create qURL", "Internal Server Error", "req_xyz"},
+			notSub:  []string{"leaked-internal-host"},
+		},
+		{
+			name: "APIError without title",
+			err: &client.APIError{
+				StatusCode: 500,
+				Detail:     "internal error",
+				RequestID:  "req_abc",
+			},
+			prefix:  "Failed to create qURL",
+			wantSub: []string{"Failed to create qURL", "req_abc"},
+			notSub:  []string{"internal error"},
+		},
+		{
+			name:    "non-APIError falls back to prefix only",
+			err:     errors.New("some opaque transport error"),
+			prefix:  "Failed to list qURLs",
+			wantSub: []string{"Failed to list qURLs"},
+			notSub:  []string{"opaque transport"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeAPIError(tc.err, tc.prefix)
+			for _, s := range tc.wantSub {
+				if !strings.Contains(got, s) {
+					t.Errorf("sanitizeAPIError missing %q in %q", s, got)
+				}
+			}
+			for _, s := range tc.notSub {
+				if strings.Contains(got, s) {
+					t.Errorf("sanitizeAPIError leaked %q in %q", s, got)
+				}
+			}
+		})
+	}
+}
+
+// TestIdempotencyKeyForCreate fences the key construction: deterministic
+// for a given (team_id, trigger_id), distinct across teams or triggers.
+func TestIdempotencyKeyForCreate(t *testing.T) {
+	cases := []struct {
+		teamA, trigA, teamB, trigB string
+		wantEqual                  bool
+	}{
+		{"T1", "trig1", "T1", "trig1", true},
+		{"T1", "trig1", "T2", "trig1", false},
+		{"T1", "trig1", "T1", "trig2", false},
+		{"T1", "trig1", "T1trig1", "", false}, // ensure colon framing isn't ambiguous
+	}
+	for i, tc := range cases {
+		a := idempotencyKeyForCreate(tc.teamA, tc.trigA)
+		b := idempotencyKeyForCreate(tc.teamB, tc.trigB)
+		if (a == b) != tc.wantEqual {
+			t.Errorf("case %d: equal=%v, want %v (a=%q b=%q)", i, a == b, tc.wantEqual, a, b)
+		}
+		if len(a) != 64 {
+			t.Errorf("case %d: key length = %d, want 64 (sha256 hex)", i, len(a))
+		}
+	}
+}
+
+// TestHandle_AsyncWorkObservesBaseContextCancellation fences the
+// shutdown-cancellation contract: when h.baseCtx is canceled, an
+// in-flight worker exits promptly rather than blocking shutdown.
+func TestHandle_AsyncWorkObservesBaseContextCancellation(t *testing.T) {
+	// Block forever so cancellation is the only exit.
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	baseCtx, baseCancel := context.WithCancel(context.Background())
+	rec := newResponseURLRecorder(t)
+	h := NewHandler(Config{
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: testSigningSecret,
+		BaseContext:        baseCtx,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
+		},
+	})
+	h.now = func() time.Time { return fixedNow }
+	h.validateResponseURLFn = func(string) error { return nil }
+
+	body := createCommandBody("https://example.com", "T123", "trig-cancel", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	// Worker is parked in qURL upstream. Cancel baseCtx; worker
+	// context fires; httpClient.Do returns; goroutine exits.
+	baseCancel()
+
+	done := make(chan struct{})
+	go func() {
+		h.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("h.Wait did not return within 2s after baseCtx cancellation")
+	}
+}

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -233,14 +233,21 @@ func TestHandle_ConcurrentCreateSharesIdempotencyKey(t *testing.T) {
 	t.Cleanup(h.Wait)
 
 	body := createCommandBody("https://example.com", "T-concurrent", "trig-shared", rec.URL)
+	// Sign once on the test goroutine. Doing it inside each spawned
+	// goroutine would mean 100 redundant HMAC computations and would
+	// expose us to t.Helper / t.Fatalf inside non-test goroutines —
+	// which leaves wg.Wait blocked on a runtime.Goexit'd worker.
+	sig, ts := signSlackBody(t, body)
 
 	var wg sync.WaitGroup
 	for range concurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			w := httptest.NewRecorder()
-			h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+			r := httptest.NewRequest(http.MethodPost, "/slack/commands", strings.NewReader(body))
+			r.Header.Set(headerSlackSignature, sig)
+			r.Header.Set(headerSlackTimestamp, ts)
+			h.ServeHTTP(httptest.NewRecorder(), r)
 		}()
 	}
 	wg.Wait()
@@ -311,15 +318,13 @@ func TestHandle_AsyncCreateSanitizesAPIError(t *testing.T) {
 // long-running workers fill the pool; the third request must drop.
 func TestHandle_PoolSaturationDropsWithBusyAck(t *testing.T) {
 	release := make(chan struct{})
-	t.Cleanup(func() {
-		// Defensive: unblock any worker still waiting on release so
-		// h.Wait() can drain. Idempotent close via select.
-		select {
-		case <-release:
-		default:
-			close(release)
-		}
-	})
+	var releaseOnce sync.Once
+	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
+	// Failure path: a t.Fatalf before the explicit releaseAll below
+	// would otherwise leave the parked worker goroutines blocked,
+	// hanging h.Wait() in t.Cleanup. sync.Once makes the explicit
+	// close + the cleanup safe to both call.
+	t.Cleanup(releaseAll)
 	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		<-release
 		w.Header().Set("Content-Type", "application/json")
@@ -372,7 +377,7 @@ func TestHandle_PoolSaturationDropsWithBusyAck(t *testing.T) {
 	}
 
 	// Release the parked workers so h.Wait() drains.
-	close(release)
+	releaseAll()
 }
 
 // TestHandle_AsyncListPostsResultToResponseURL fences /qurl list's

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -491,9 +491,11 @@ func TestValidateResponseURL(t *testing.T) {
 	}{
 		{name: "valid Slack hooks URL", raw: "https://hooks.slack.com/commands/T1/abc/xyz", wantErr: false},
 		{name: "valid Slack hooks URL with explicit 443", raw: "https://hooks.slack.com:443/commands/T1/abc/xyz", wantErr: false},
+		{name: "valid Slack hooks URL with mixed-case host", raw: "https://Hooks.Slack.Com/commands/T1/abc/xyz", wantErr: false},
 		{name: "rejects http (no TLS)", raw: "http://hooks.slack.com/commands/T1/abc/xyz", wantErr: true},
 		{name: "rejects non-Slack host", raw: "https://attacker.example/commands/T1/abc/xyz", wantErr: true},
 		{name: "rejects subdomain trick", raw: "https://hooks.slack.com.attacker.example/path", wantErr: true},
+		{name: "rejects embedded userinfo", raw: "https://user:pw@hooks.slack.com/commands/T1/abc/xyz", wantErr: true},
 		{name: "rejects empty URL", raw: "", wantErr: true},
 		{name: "rejects relative path", raw: "/oops", wantErr: true},
 	}
@@ -603,6 +605,16 @@ func TestSanitizeAPIError(t *testing.T) {
 			wantSub: []string{"Failed to list qURLs"},
 			notSub:  []string{"opaque transport"},
 		},
+		{
+			name: "Title with trailing period does not double-punctuate",
+			err: &client.APIError{
+				StatusCode: 500,
+				Title:      "Internal Server Error.",
+			},
+			prefix:  "Failed to create qURL",
+			wantSub: []string{"Internal Server Error"},
+			notSub:  []string{".."},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -687,5 +699,139 @@ func TestHandle_AsyncWorkObservesBaseContextCancellation(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("h.Wait did not return within 2s after baseCtx cancellation")
+	}
+}
+
+// TestHandle_OrphanAckPreventionOnBaseContextCancel fences the
+// orphan-ack contract: when baseCtx cancels mid-flight (SIGTERM
+// reaches the worker after the qURL call has started), the failure
+// follow-up MUST still reach response_url. postResponse therefore uses
+// a context decoupled from the worker's, scoped to responseURLTimeout.
+func TestHandle_OrphanAckPreventionOnBaseContextCancel(t *testing.T) {
+	// qURL upstream blocks on r.Context().Done() so the only exit is
+	// cancellation. After baseCancel, c.Create returns ctx.Canceled —
+	// processCreate then sanitizes and calls postResponse. If
+	// postResponse used the worker ctx, that POST would fail too
+	// (orphan ack); with a fresh context it should succeed.
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	baseCtx, baseCancel := context.WithCancel(context.Background())
+	rec := newResponseURLRecorder(t)
+	h := NewHandler(Config{
+		AuthProvider:       &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		SlackSigningSecret: testSigningSecret,
+		BaseContext:        baseCtx,
+		NewClient: func(apiKey string) *client.Client {
+			return client.New(qurlSrv.URL, apiKey, client.WithRetry(0))
+		},
+	})
+	h.now = func() time.Time { return fixedNow }
+	h.validateResponseURLFn = url.Parse
+
+	body := createCommandBody("https://example.com", "T123", "trig-orphan", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	// Cancel baseCtx mid-flight (simulates SIGTERM). The worker's
+	// qURL call returns ctx.Canceled, processCreate calls
+	// postResponse with the failure, and that POST must land.
+	baseCancel()
+	h.Wait()
+
+	posts := rec.Posts()
+	if len(posts) != 1 {
+		t.Fatalf("response_url POST count = %d, want 1 (failure follow-up must reach Slack on shutdown)", len(posts))
+	}
+	if !strings.Contains(posts[0]["text"], "Failed to create qURL") {
+		t.Errorf("expected sanitized failure text in follow-up, got: %q", posts[0]["text"])
+	}
+}
+
+// TestHandler_WaitTimeout fences the bounded-drain contract: if a
+// worker outlives the budget, WaitTimeout returns false rather than
+// blocking the caller indefinitely. This is the cheap insurance against
+// a future regression where a worker stops honoring its ctx.
+func TestHandler_WaitTimeout(t *testing.T) {
+	// qURL upstream blocks indefinitely on a non-ctx-honoring channel,
+	// simulating a worker that ignored ctx.
+	block := make(chan struct{})
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-block
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := newTestHandler(t, qurlSrv)
+	// Register the block-release AFTER newTestHandler so LIFO runs it
+	// BEFORE newTestHandler's t.Cleanup(h.Wait) — otherwise h.Wait
+	// blocks on the parked worker and t.Cleanup deadlocks.
+	t.Cleanup(func() { close(block) })
+
+	body := createCommandBody("https://example.com", "T123", "trig-waittimeout", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	if drained := h.WaitTimeout(50 * time.Millisecond); drained {
+		t.Errorf("WaitTimeout returned true with worker still parked; want false")
+	}
+}
+
+// TestHandler_WaitTimeout_DrainsOnSuccess fences the success path:
+// when workers complete inside the budget, WaitTimeout returns true.
+func TestHandler_WaitTimeout_DrainsOnSuccess(t *testing.T) {
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"resource_id":"r1","qurl_link":"https://qurl.link/x"}}`))
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	t.Setenv("QURL_API_KEY", "test-key")
+
+	rec := newResponseURLRecorder(t)
+	h := newTestHandler(t, qurlSrv)
+
+	body := createCommandBody("https://example.com", "T123", "trig-waittimeout-ok", rec.URL)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	if drained := h.WaitTimeout(2 * time.Second); !drained {
+		t.Errorf("WaitTimeout returned false on a fast-completing worker; want true")
+	}
+}
+
+// TestHandle_ListPrefixDoesNotMatchListing fences the tightened
+// prefix match for "/qurl list": before, "listing" matched as a list
+// prefix and silently routed to processList. Now it falls through to
+// the unknown-subcommand branch with a help nudge.
+func TestHandle_ListPrefixDoesNotMatchListing(t *testing.T) {
+	srv, hits := countingQURLServer(t)
+	h := newTestHandler(t, srv)
+
+	body := url.Values{
+		"command": {"/qurl"},
+		"text":    {"listing"},
+		"team_id": {"T123"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+
+	var ack map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(ack["text"], "Unknown subcommand") {
+		t.Errorf("expected 'Unknown subcommand' help nudge for `listing`, got: %q", ack["text"])
+	}
+	// And no upstream qURL request was made.
+	if got := hits.Load(); got != 0 {
+		t.Errorf("upstream qURL hits for `listing`: got %d, want 0", got)
 	}
 }

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -229,7 +229,7 @@ func TestHandle_ConcurrentCreateSharesIdempotencyKey(t *testing.T) {
 		},
 	})
 	h.now = func() time.Time { return fixedNow }
-	h.validateResponseURLFn = func(string) error { return nil }
+	h.validateResponseURLFn = url.Parse
 	t.Cleanup(h.Wait)
 
 	body := createCommandBody("https://example.com", "T-concurrent", "trig-shared", rec.URL)
@@ -344,7 +344,7 @@ func TestHandle_PoolSaturationDropsWithBusyAck(t *testing.T) {
 		},
 	})
 	h.now = func() time.Time { return fixedNow }
-	h.validateResponseURLFn = func(string) error { return nil }
+	h.validateResponseURLFn = url.Parse
 	t.Cleanup(h.Wait)
 
 	send := func(triggerID string) string {
@@ -453,7 +453,7 @@ func TestHandle_PanicInAsyncWorkRecovers(t *testing.T) {
 		},
 	})
 	h.now = func() time.Time { return fixedNow }
-	h.validateResponseURLFn = func(string) error { return nil }
+	h.validateResponseURLFn = url.Parse
 
 	body := createCommandBody("https://example.com", "T123", "trig-panic", rec.URL)
 	w := httptest.NewRecorder()
@@ -481,6 +481,8 @@ func (panickingProvider) APIKey(_ context.Context, _ string) (string, error) {
 // TestValidateResponseURL fences the production validator: only HTTPS
 // to hooks.slack.com is accepted. Anything else is a refusal — even a
 // signature-passing request can't pivot the bot into an SSRF emitter.
+// Successful returns must also have Scheme/Host pinned to the literal
+// constants (the SSRF-sanitization contract CodeQL relies on).
 func TestValidateResponseURL(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -497,9 +499,22 @@ func TestValidateResponseURL(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateResponseURL(tc.raw)
+			u, err := validateResponseURL(tc.raw)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("validateResponseURL(%q) err = %v, wantErr = %v", tc.raw, err, tc.wantErr)
+			}
+			if !tc.wantErr {
+				// On success, Scheme and Host must be the pinned
+				// literal constants (NOT propagated from input).
+				// This is the CodeQL-recognizable sanitization
+				// pattern; a regression that returned the parsed
+				// URL unchanged would re-introduce the SSRF flow.
+				if u.Scheme != "https" {
+					t.Errorf("validated URL Scheme = %q, want %q", u.Scheme, "https")
+				}
+				if u.Host != slackResponseURLHost {
+					t.Errorf("validated URL Host = %q, want %q", u.Host, slackResponseURLHost)
+				}
 			}
 		})
 	}
@@ -653,7 +668,7 @@ func TestHandle_AsyncWorkObservesBaseContextCancellation(t *testing.T) {
 		},
 	})
 	h.now = func() time.Time { return fixedNow }
-	h.validateResponseURLFn = func(string) error { return nil }
+	h.validateResponseURLFn = url.Parse
 
 	body := createCommandBody("https://example.com", "T123", "trig-cancel", rec.URL)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Convert `/qurl create` and `/qurl list` from synchronous to ack-then-async: handler returns `:hourglass: Working on it…` within ~50ms, then a goroutine calls the qURL API and POSTs the result to Slack's `response_url`. Slack's 3-second ack budget is below typical qURL latency under enterprise load, so synchronous-and-fast is no longer a sustainable shape.
- Add an `Idempotency-Key` header (`sha256("slack:"+team_id+":"+trigger_id)`) to every `/qurl create` so Slack-side retries (3s ack timeout exceeded) fold into a single resource at the qURL service. Closes the dedup gap PR-B2 was filed for.
- Bump `client.WithRetry(0) → WithRetry(2)`. The synchronous path couldn't afford retries (3s ack budget). The async worker has 25s, so transient 429/5xx are now safe to retry on the existing exponential-backoff schedule before bubbling to the user.
- Defense-in-depth on response_url: pin scheme+host to `https://hooks.slack.com` (using `Hostname()` so explicit `:443` still passes), and the response_url client refuses redirects so a 30x can't pivot the bot into a generic SSRF emitter even if the signature gate were bypassed.
- Sanitize qURL API errors before they reach Slack — `Title` + `RequestID` surface (operator-correlation), `Detail` (server-side internals: DB error strings, internal hostnames, stack-trace fragments) stays in slog only. Folds in #156.
- Wire `Handler.BaseContext` to the SIGTERM-cancelled `signal.NotifyContext`, and call `handler.Wait()` after `srv.Shutdown` so the process drains async workers before exit.

## Why expanded behaviour beyond "convert to async"

The `WithRetry(0) → WithRetry(2)` change is a coupled-but-not-obvious knock-on of the async unlock. Calling it out here so reviewers don't ask later — synchronous-with-retries was incompatible with Slack's 3s budget; async-with-retries is the right shape now.

## Architecture

| Concern | Choice | Why |
|---|---|---|
| Goroutine context | Derived from `Handler.BaseContext`, NOT `r.Context()` | `r.Context()` cancels as soon as `ServeHTTP` returns, which is immediately after the ack — wrong cancellation signal. |
| Drain on shutdown | `sync.WaitGroup` on `Handler`; `Wait()` called in main after `srv.Shutdown` | Guarantees the process doesn't exit while a goroutine is mid-POST to `response_url`. |
| Bounded concurrency | 50-slot buffered channel, `select`-with-`default` drop | A Slack-side flood gets fast `:warning: busy` feedback rather than queueing or unbounded-spawning until OOM. |
| Per-worker timeout | 25s `context.WithTimeout(baseCtx, …)` | Generous over typical qURL latency (~1s) but well under Slack's `response_url` 30-min TTL. |
| Panic recovery | `defer recover()` inside the goroutine | A panicking goroutine in a long-lived process is disqualifying — recover-and-log so the deferred sem release and `wg.Done` always run. |
| Idempotency key | `sha256("slack:"+team_id+":"+trigger_id)` | 64 hex chars (well under the 256-byte cap), no PII on transit, matches qURL service's per-owner key contract. |

## Test plan

- [x] `make lint` clean
- [x] `go test -race -count=1 ./apps/slack/...` clean
- [x] `go test -race -count=30 -run TestHandle_AckIsFastUnderSlowAPI` — confirm the 50ms ack budget is not flaky under race-detector load
- [x] End-to-end smoke: bind, `/health` 200, `/missing` 404, SIGTERM exit 0
- [x] 100-concurrent `/qurl create` dedup test — every upstream request carries the same `Idempotency-Key` header
- [x] Pool-saturation test — 3rd request past a capacity-2 pool gets `ackBusy`
- [x] Panic-recovery test — panicking `auth.Provider` doesn't leak `wg`/`sem` slots
- [x] `validateResponseURL` table test — accept `https://hooks.slack.com`, accept `:443`, reject `http://`, reject other hosts, reject the `hooks.slack.com.attacker.example` subdomain trick
- [x] Redirect-refusal test — server responds 302; client surfaces 302 to caller, doesn't follow
- [x] Sanitizer leak test — qURL `Detail` of `db: leaked-internal-host failed` does not appear in user-facing payload; `Title` + `RequestID` do appear
- [x] Base-context cancellation test — `baseCancel()` lets `h.Wait` return within 2s

## Filed follow-ups

- #157 — `slack: handle ssl_check periodically posted by Slack` (advisor polish item; current behaviour 200s with help text, Slack accepts any 200 so non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)