### PR TITLE
ci(slack): containerize build and wire trigger-deploy

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,13 +1,29 @@
-name: Slack Integration
+name: "slack: Build and Test"
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'apps/slack/**'
+      - 'shared/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/slack.yml'
   pull_request:
+    branches: [main]
+    paths:
+      - 'apps/slack/**'
+      - 'shared/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/slack.yml'
 
 permissions:
   contents: read
-  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   changes:
@@ -96,29 +112,61 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
 
-  build:
-    name: Build
+  docker-check:
+    name: Docker
     runs-on: ubuntu-latest
-    needs: [changes, lint, test]
+    needs: changes
     if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+      # Verify the Dockerfile builds end-to-end on the same arm64
+      # platform Fargate runs. Buildx is preinstalled on
+      # ubuntu-latest; QEMU emulates arm64 cleanly for the build
+      # since we don't run the binary here. The ECR push happens in
+      # qurl-integrations-infra's deploy workflow — this job only
+      # fences "Dockerfile is buildable from main" so a regression
+      # is caught at PR time, not at deploy time.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
-      - name: Build Lambda binary
-        env:
-          CGO_ENABLED: "0"
-          GOOS: linux
-          GOARCH: arm64
-        run: go build -o bootstrap ./apps/slack/cmd/
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Build slack bot image (linux/arm64)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          name: slack-lambda
-          path: bootstrap
-          retention-days: 7
+          context: .
+          file: apps/slack/Dockerfile
+          platforms: linux/arm64
+          push: false
+          # `load: false` would skip writing to the local daemon, which
+          # we don't need anyway — the build succeeding is the test.
+          # Cache via GHA backend so subsequent PR pushes don't repay
+          # the full module-download + compile cost.
+          cache-from: type=gha,scope=slack-docker
+          cache-to: type=gha,mode=max,scope=slack-docker
+          build-args: |
+            VERSION=${{ github.sha }}
+
+  trigger-deploy:
+    needs: [changes, lint, test, vulnerability-scan, docker-check]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.changes.outputs.app == 'true'
+    # The reusable authenticates via App secrets; the caller's GITHUB_TOKEN
+    # isn't read by any step, so deny everything.
+    permissions: {}
+    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
+    with:
+      target_repo: qurl-integrations-infra
+      # `event_type` must match the receiver's `repository_dispatch.types`
+      # at qurl-integrations-infra/.github/workflows/qurl-bot-slack-deploy.yml.
+      # That receiver lands in Phase 3 of the master plan; until then this
+      # dispatch is a no-op (HTTP 204 from the dispatch API but no workflow
+      # fires receiver-side). Mirrors the discord-bot-deploy pattern.
+      event_type: slack-bot-deploy
+      client_payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
+    # Explicit `secrets:` map (not `inherit`) keeps the reusable's surface
+    # to the two named App secrets even as more secrets get added here.
+    secrets:
+      app_id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+      app_private_key: ${{ secrets.DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -26,29 +26,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      app: ${{ steps.filter.outputs.app }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          filters: |
-            app:
-              - 'apps/slack/**'
-              - 'shared/**'
-              - 'go.mod'
-              - 'go.sum'
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -66,8 +46,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -96,8 +74,6 @@ jobs:
   vulnerability-scan:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -115,18 +91,10 @@ jobs:
   docker-check:
     name: Docker
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.app == 'true'
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Verify the Dockerfile builds end-to-end on the same arm64
-      # platform Fargate runs. Buildx is preinstalled on
-      # ubuntu-latest; QEMU emulates arm64 cleanly for the build
-      # since we don't run the binary here. The ECR push happens in
-      # qurl-integrations-infra's deploy workflow — this job only
-      # fences "Dockerfile is buildable from main" so a regression
-      # is caught at PR time, not at deploy time.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
@@ -140,29 +108,23 @@ jobs:
           file: apps/slack/Dockerfile
           platforms: linux/arm64
           push: false
-          # `load: false` would skip writing to the local daemon, which
-          # we don't need anyway — the build succeeding is the test.
-          # Cache via GHA backend so subsequent PR pushes don't repay
-          # the full module-download + compile cost.
           cache-from: type=gha,scope=slack-docker
           cache-to: type=gha,mode=max,scope=slack-docker
           build-args: |
             VERSION=${{ github.sha }}
 
   trigger-deploy:
-    needs: [changes, lint, test, vulnerability-scan, docker-check]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.changes.outputs.app == 'true'
+    needs: [lint, test, vulnerability-scan, docker-check]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     # The reusable authenticates via App secrets; the caller's GITHUB_TOKEN
     # isn't read by any step, so deny everything.
     permissions: {}
     uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
     with:
       target_repo: qurl-integrations-infra
-      # `event_type` must match the receiver's `repository_dispatch.types`
-      # at qurl-integrations-infra/.github/workflows/qurl-bot-slack-deploy.yml.
-      # That receiver lands in Phase 3 of the master plan; until then this
-      # dispatch is a no-op (HTTP 204 from the dispatch API but no workflow
-      # fires receiver-side). Mirrors the discord-bot-deploy pattern.
+      # An off-allowlist value hard-fails in the reusable; an allowlisted
+      # value that misses the receiver silently no-ops (HTTP 204 from the
+      # dispatch API but no workflow fires).
       event_type: slack-bot-deploy
       client_payload: '{"sha": "${{ github.sha }}", "ref": "refs/heads/main"}'
     # Explicit `secrets:` map (not `inherit`) keeps the reusable's surface

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Binaries
-bootstrap
 *.exe
 *.dll
 *.so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,6 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/qurl-bot-slack ./apps/sla
 ## Key Architecture Decisions
 
 - **Auth:** Start with workspace API keys (qurl-api-keys table exists). Per-user OAuth later.
-- **Runtime (Slack):** AWS Fargate (arm64, distroless container) behind an ALB. Always-on; the steady enterprise workload makes Lambda cold starts the wrong shape (memory: feedback_provisioned_concurrency_smell).
+- **Runtime (Slack):** AWS Fargate (arm64, distroless container) behind an ALB. Always-on; the steady enterprise workload makes Lambda cold starts the wrong shape.
 - **Shared client:** `shared/client/` wraps the qURL API. Not a standalone module yet.
 - **Release:** Release Please monorepo mode with per-app version tracks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ make check          # Full CI parity: fmt + vet + lint + test
 make lint           # golangci-lint only
 make test           # go test (no race)
 make test-race      # go test -race
-make build-slack    # Build Slack Lambda binary
+make build-slack    # Build Slack bot binary (also bundled into apps/slack/Dockerfile)
 make security       # govulncheck
 make fmt            # gofmt + goimports
 ```
@@ -120,14 +120,22 @@ go test -count=1 ./...             # Skip cache
 
 ## Build
 
-Lambda apps use `CGO_ENABLED=0 GOOS=linux GOARCH=arm64`:
+Production builds target `linux/arm64` (Graviton on Fargate). The
+canonical build path is the per-app Dockerfile (e.g. `apps/slack/Dockerfile`):
+
 ```bash
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
+docker buildx build --platform linux/arm64 \
+  -f apps/slack/Dockerfile -t qurl-bot-slack:dev .
+```
+
+For a local Go binary outside Docker (development, debugging):
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/qurl-bot-slack ./apps/slack/cmd/
 ```
 
 ## Key Architecture Decisions
 
 - **Auth:** Start with workspace API keys (qurl-api-keys table exists). Per-user OAuth later.
-- **Runtime (Slack):** AWS Lambda behind API Gateway. Event-driven, scales to zero.
+- **Runtime (Slack):** AWS Fargate (arm64, distroless container) behind an ALB. Always-on; the steady enterprise workload makes Lambda cold starts the wrong shape (memory: feedback_provisioned_concurrency_smell).
 - **Shared client:** `shared/client/` wraps the qURL API. Not a standalone module yet.
 - **Release:** Release Please monorepo mode with per-app version tracks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,9 +128,10 @@ docker buildx build --platform linux/arm64 \
   -f apps/slack/Dockerfile -t qurl-bot-slack:dev .
 ```
 
-For a local Go binary outside Docker (development, debugging):
+For a local Go binary outside Docker (development, debugging) — `make build-slack` is the supported path:
 ```bash
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/qurl-bot-slack ./apps/slack/cmd/
+make build-slack
+# binary lands at release/slack/qurl-bot-slack (gitignored)
 ```
 
 ## Key Architecture Decisions

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ coverage:
 ## Building
 
 build-slack:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o release/slack/qurl-bot-slack ./apps/slack/cmd/
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w -s -X main.version=$(VERSION)" -o release/slack/qurl-bot-slack ./apps/slack/cmd/
 
 build-cli: # Builds for host OS/arch (developer machine). Cross-compile manually if needed.
 	CGO_ENABLED=0 go build -ldflags="-w -s -X main.version=$(VERSION)" -o release/cli/qurl ./apps/cli/cmd/

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ coverage:
 ## Building
 
 build-slack:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o release/slack/bootstrap ./apps/slack/cmd/
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o release/slack/qurl-bot-slack ./apps/slack/cmd/
 
 build-cli: # Builds for host OS/arch (developer machine). Cross-compile manually if needed.
 	CGO_ENABLED=0 go build -ldflags="-w -s -X main.version=$(VERSION)" -o release/cli/qurl ./apps/cli/cmd/

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -4,7 +4,15 @@
 # ignore list (default frontend reads only `<context>/.dockerignore`,
 # which is the wrong place for a multi-app monorepo).
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
+# `--platform=$BUILDPLATFORM` pins the build stage to the runner's
+# native arch so amd64 CI runners don't pay QEMU's emulation cost
+# while compiling. Go cross-compiles natively, so the binary is still
+# `linux/arm64` (set via `GOARCH=$TARGETARCH` below) — the runtime
+# image stays on the requested target platform.
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -16,9 +24,12 @@ RUN go mod download
 COPY shared/ ./shared/
 COPY apps/slack/ ./apps/slack/
 
+# `VERSION` ARG sits below the source COPYs so a `--build-arg
+# VERSION=...` change only invalidates the build layer, not the
+# preceding source/dep layers. Don't move it up.
 ARG VERSION=dev
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -trimpath -mod=readonly -ldflags="-s -w -X main.version=${VERSION}" \
     -o /out/qurl-bot-slack ./apps/slack/cmd/
 

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -4,15 +4,7 @@
 # ignore list (default frontend reads only `<context>/.dockerignore`,
 # which is the wrong place for a multi-app monorepo).
 
-# `--platform=$BUILDPLATFORM` pins the build stage to the runner's
-# native arch so amd64 CI runners don't pay QEMU's emulation cost
-# while compiling. Go cross-compiles natively, so the binary is still
-# `linux/arm64` (set via `GOARCH=$TARGETARCH` below) — the runtime
-# image stays on the requested target platform.
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
-
-ARG TARGETOS
-ARG TARGETARCH
+FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
 
 WORKDIR /src
 
@@ -29,7 +21,7 @@ COPY apps/slack/ ./apps/slack/
 # preceding source/dep layers. Don't move it up.
 ARG VERSION=dev
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
     go build -trimpath -mod=readonly -ldflags="-s -w -X main.version=${VERSION}" \
     -o /out/qurl-bot-slack ./apps/slack/cmd/
 

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -4,7 +4,7 @@
 # ignore list (default frontend reads only `<context>/.dockerignore`,
 # which is the wrong place for a multi-app monorepo).
 
-FROM golang:1.26.2-alpine3.22@sha256:7ef941168f213aa115df2e61364d67682129e99dc8188b734139dea862cc7d31 AS build
+FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
 
 WORKDIR /src
 
@@ -19,13 +19,15 @@ COPY apps/slack/ ./apps/slack/
 ARG VERSION=dev
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-    go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
+    go build -trimpath -mod=readonly -ldflags="-s -w -X main.version=${VERSION}" \
     -o /out/qurl-bot-slack ./apps/slack/cmd/
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY --from=build /out/qurl-bot-slack /usr/local/bin/qurl-bot-slack
 
+# Documentation-only — actual port comes from `listenAddr` in
+# apps/slack/cmd/main.go. If that constant moves, update both.
 EXPOSE 8080
 
 USER nonroot:nonroot

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -1,0 +1,52 @@
+# Multi-stage build for the Slack bot.
+#
+# - Build stage: alpine + Go toolchain compiles a static ARM64 binary.
+#   CGO is off so the binary doesn't pull glibc/musl at runtime,
+#   matching the distroless static base.
+# - Runtime stage: distroless/static + nonroot user. No shell, no
+#   package manager, no busybox — minimum reachable surface for a
+#   process whose only job is HTTP-in / HTTP-out.
+#
+# Both bases are SHA-pinned so a tag-mover at upstream can't change
+# what we ship without a deliberate Dockerfile bump (matches the
+# action-pinning posture from CLAUDE.md / dep-age-check).
+
+FROM golang:1.26.2-alpine3.22@sha256:7ef941168f213aa115df2e61364d67682129e99dc8188b734139dea862cc7d31 AS build
+
+WORKDIR /src
+
+# Cache the module download layer separately from the source. Only
+# `go.mod`/`go.sum` invalidate the dependency graph; touching .go
+# files doesn't force a re-fetch of the dependency cache.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY apps/slack/ ./apps/slack/
+COPY shared/ ./shared/
+
+# `version` ldflag is set at build time so the qURL client User-Agent
+# pins a deploy to a specific git SHA. Default "dev" stays in for
+# local builds (`docker build .`); CI overrides via --build-arg.
+ARG VERSION=dev
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+    go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
+    -o /out/qurl-bot-slack ./apps/slack/cmd/
+
+# Runtime stage. distroless/static has no shell, so HEALTHCHECK can't
+# call curl/wget — Fargate health checks come from the ALB target
+# group hitting :8080/health, which is a stronger signal than a
+# container-local probe anyway.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
+
+COPY --from=build /out/qurl-bot-slack /usr/local/bin/qurl-bot-slack
+
+EXPOSE 8080
+
+# Distroless's nonroot user is uid 65532 — the ALB-only ingress
+# means root would offer no real value, and dropping privileges
+# closes a defense-in-depth gap if a future syscall (like
+# /proc/self/exe rewrites) ever became reachable.
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/qurl-bot-slack"]

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -1,52 +1,33 @@
-# Multi-stage build for the Slack bot.
-#
-# - Build stage: alpine + Go toolchain compiles a static ARM64 binary.
-#   CGO is off so the binary doesn't pull glibc/musl at runtime,
-#   matching the distroless static base.
-# - Runtime stage: distroless/static + nonroot user. No shell, no
-#   package manager, no busybox — minimum reachable surface for a
-#   process whose only job is HTTP-in / HTTP-out.
-#
-# Both bases are SHA-pinned so a tag-mover at upstream can't change
-# what we ship without a deliberate Dockerfile bump (matches the
-# action-pinning posture from CLAUDE.md / dep-age-check).
+# syntax=docker/dockerfile:1.7
+# The `# syntax=` directive opts into the modern BuildKit frontend so
+# `apps/slack/Dockerfile.dockerignore` is honored as the per-Dockerfile
+# ignore list (default frontend reads only `<context>/.dockerignore`,
+# which is the wrong place for a multi-app monorepo).
 
 FROM golang:1.26.2-alpine3.22@sha256:7ef941168f213aa115df2e61364d67682129e99dc8188b734139dea862cc7d31 AS build
 
 WORKDIR /src
 
-# Cache the module download layer separately from the source. Only
-# `go.mod`/`go.sum` invalidate the dependency graph; touching .go
-# files doesn't force a re-fetch of the dependency cache.
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY apps/slack/ ./apps/slack/
+# `shared/` is copied before `apps/slack/` so an app-only edit doesn't
+# invalidate the `shared/` layer's cache. Most PRs touch one app.
 COPY shared/ ./shared/
+COPY apps/slack/ ./apps/slack/
 
-# `version` ldflag is set at build time so the qURL client User-Agent
-# pins a deploy to a specific git SHA. Default "dev" stays in for
-# local builds (`docker build .`); CI overrides via --build-arg.
 ARG VERSION=dev
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
     go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
     -o /out/qurl-bot-slack ./apps/slack/cmd/
 
-# Runtime stage. distroless/static has no shell, so HEALTHCHECK can't
-# call curl/wget — Fargate health checks come from the ALB target
-# group hitting :8080/health, which is a stronger signal than a
-# container-local probe anyway.
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY --from=build /out/qurl-bot-slack /usr/local/bin/qurl-bot-slack
 
 EXPOSE 8080
 
-# Distroless's nonroot user is uid 65532 — the ALB-only ingress
-# means root would offer no real value, and dropping privileges
-# closes a defense-in-depth gap if a future syscall (like
-# /proc/self/exe rewrites) ever became reachable.
 USER nonroot:nonroot
 
 ENTRYPOINT ["/usr/local/bin/qurl-bot-slack"]

--- a/apps/slack/Dockerfile.dockerignore
+++ b/apps/slack/Dockerfile.dockerignore
@@ -1,35 +1,27 @@
-# BuildKit-specific per-Dockerfile ignore. Picked up because the
-# workflow passes `context: .` with `file: apps/slack/Dockerfile`, so
-# scoping ignores here keeps the Slack build's transferred context
-# small without affecting other apps that may build from the same
-# repo root in the future.
-#
-# The Dockerfile only COPYs `go.mod`, `go.sum`, `apps/slack/`, and
-# `shared/`, so anything outside that is wasted bytes in the buildx
-# transfer + cache key. Keeping `apps/discord/` and `apps/cli/` in
-# the context would also invalidate this Dockerfile's cache on
-# unrelated changes to those apps.
-
 .git
 .github
 .claude
 .DS_Store
 
-# Local build output (Makefile `make build-slack` writes here).
 release
 coverage.out
 *.test
 *.out
 
-# Other apps' source — irrelevant to the slack binary.
+# Other apps' source — irrelevant to the slack binary, and keeps an
+# unrelated app change from invalidating this Dockerfile's cache.
 apps/discord
 apps/cli
-
-# Generated docs / man pages.
+apps/teams
+apps/zapier
+e2e
+scripts
 docs
 man
+vendor
+go.work
+go.work.sum
 
-# Editor / IDE.
 .vscode
 .idea
 *.swp
@@ -38,7 +30,5 @@ man
 *.pem
 *.key
 
-# Top-level prose. The runtime image is distroless; READMEs add
-# nothing at runtime and just bloat the build context.
 *.md
 LICENSE

--- a/apps/slack/Dockerfile.dockerignore
+++ b/apps/slack/Dockerfile.dockerignore
@@ -4,7 +4,6 @@
 .DS_Store
 
 release
-coverage.out
 *.test
 *.out
 

--- a/apps/slack/Dockerfile.dockerignore
+++ b/apps/slack/Dockerfile.dockerignore
@@ -8,12 +8,13 @@ coverage.out
 *.test
 *.out
 
-# Other apps' source — irrelevant to the slack binary, and keeps an
-# unrelated app change from invalidating this Dockerfile's cache.
-apps/discord
-apps/cli
-apps/teams
-apps/zapier
+# Sibling apps' source trees — irrelevant to the slack binary, and
+# keeps an unrelated app change from invalidating this Dockerfile's
+# cache. Allow-list pattern (vs explicit deny) so a fifth app added
+# later doesn't silently leak into the build context.
+apps/*
+!apps/slack
+
 e2e
 scripts
 docs
@@ -30,5 +31,10 @@ go.work.sum
 *.pem
 *.key
 
+# Excluding *.md is a build-context optimization, not a strict
+# correctness requirement. If a future change adds `embed.FS` for a
+# markdown asset (help text, error template) under `apps/slack/`,
+# remove the exclusion or scope it — otherwise the container build
+# breaks while a local `go build` still works.
 *.md
 LICENSE

--- a/apps/slack/Dockerfile.dockerignore
+++ b/apps/slack/Dockerfile.dockerignore
@@ -1,0 +1,44 @@
+# BuildKit-specific per-Dockerfile ignore. Picked up because the
+# workflow passes `context: .` with `file: apps/slack/Dockerfile`, so
+# scoping ignores here keeps the Slack build's transferred context
+# small without affecting other apps that may build from the same
+# repo root in the future.
+#
+# The Dockerfile only COPYs `go.mod`, `go.sum`, `apps/slack/`, and
+# `shared/`, so anything outside that is wasted bytes in the buildx
+# transfer + cache key. Keeping `apps/discord/` and `apps/cli/` in
+# the context would also invalidate this Dockerfile's cache on
+# unrelated changes to those apps.
+
+.git
+.github
+.claude
+.DS_Store
+
+# Local build output (Makefile `make build-slack` writes here).
+release
+coverage.out
+*.test
+*.out
+
+# Other apps' source — irrelevant to the slack binary.
+apps/discord
+apps/cli
+
+# Generated docs / man pages.
+docs
+man
+
+# Editor / IDE.
+.vscode
+.idea
+*.swp
+
+# Defense-in-depth: never ship a local private key into the daemon.
+*.pem
+*.key
+
+# Top-level prose. The runtime image is distroless; READMEs add
+# nothing at runtime and just bloat the build context.
+*.md
+LICENSE

--- a/apps/slack/Dockerfile.dockerignore
+++ b/apps/slack/Dockerfile.dockerignore
@@ -30,10 +30,11 @@ go.work.sum
 *.pem
 *.key
 
-# Excluding *.md is a build-context optimization, not a strict
-# correctness requirement. If a future change adds `embed.FS` for a
-# markdown asset (help text, error template) under `apps/slack/`,
-# remove the exclusion or scope it — otherwise the container build
-# breaks while a local `go build` still works.
-*.md
+# Scoped narrowly so a future `embed.FS` of a markdown asset under
+# `apps/slack/` (help text, error template) still works in the
+# container build. Repo-root prose + per-app READMEs + docs/ are
+# the only things that can never be embed-needed.
+/*.md
+apps/*/README.md
+docs/**/*.md
 LICENSE

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -11,22 +11,30 @@ Slack bot for creating and managing qURLs via slash commands, with link unfurlin
 
 ## Architecture
 
-- **Runtime:** AWS Lambda (arm64) behind API Gateway
-- **Auth:** Workspace API key (per-user OAuth planned)
+- **Runtime:** AWS Fargate (arm64, distroless container) behind an
+  ALB that terminates TLS and routes `/slack/*` + `/health`.
+- **Auth:** Workspace API key (per-user OAuth planned, Phase 4).
 - **Endpoints:**
-  - `POST /slack/commands` — Slash command handler
-  - `POST /slack/events` — Event subscriptions (link unfurling)
-  - `POST /slack/interactions` — Interactive components
-  - `GET /health` — Health check
+  - `POST /slack/commands` — Slash command handler (ack-then-async)
+  - `POST /slack/events` — Event subscriptions (link unfurling planned)
+  - `POST /slack/interactions` — Interactive components (planned)
+  - `GET /health` — ALB target-group health probe
 
 ## Development
 
 ```bash
 # Run tests
-go test -count=1 ./apps/slack/...
+go test -race -count=1 ./apps/slack/...
 
-# Build
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bootstrap ./apps/slack/cmd/
+# Run locally (uses host networking; no AWS dependencies)
+QURL_ENDPOINT=https://api.layerv.xyz \
+SLACK_SIGNING_SECRET=... \
+QURL_API_KEY=... \
+  go run ./apps/slack/cmd/
+
+# Build the production container (linux/arm64 to match Fargate)
+docker buildx build --platform linux/arm64 \
+  -f apps/slack/Dockerfile -t qurl-bot-slack:dev .
 ```
 
 ## Environment Variables


### PR DESCRIPTION
## Summary

- Replace the Lambda `bootstrap` binary path with a multi-stage distroless Docker image (linux/arm64, SHA-pinned `golang:1.26.2-alpine` build base + `gcr.io/distroless/static-debian12:nonroot` runtime base) that the upcoming `qurl-webhook-runtime` Fargate module will deploy.
- Replace `slack.yml`'s "Build Lambda binary" job with a `docker-check` job that runs `docker buildx build --platform linux/arm64` against the new Dockerfile on every PR — fences "Dockerfile is buildable from main" so a regression is caught at PR time, not at deploy time.
- Add the `trigger-deploy` job mirroring `discord.yml`'s pattern: SHA-pinned `layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@v0.5.0`, `target_repo: qurl-integrations-infra`, `event_type: slack-bot-deploy`. Silently no-ops until the infra-side receiver lands in Phase 3 (matches the discord-deploy soft-launch pattern).
- Update `CLAUDE.md`, `apps/slack/README.md`, and the `Makefile` to describe Slack as a Fargate ECS app — closes #152.

## Why

Phase 2 of the Slack rollout is closing — code is now `net/http` server-shaped (PR #150) with ack-then-async + idempotency (PR #158). The build pipeline was the last Lambda-shaped artifact in the Slack tree; switching it now is a hard prerequisite for Phase 3's TF module to pull a real image. The runtime decision (Fargate over Lambda) is captured in memory `feedback_provisioned_concurrency_smell` — the 50-user enterprise rollout has a steady all-day workload, and the only way to make Lambda's cold-start tail latency tolerable on Slack's 3s slash-command ack budget is provisioned concurrency, which is the smell.

## Architecture

| Concern | Choice | Why |
|---|---|---|
| Build platform | `linux/arm64` (Graviton on Fargate) | Matches the production runtime; QEMU emulates cleanly on `ubuntu-latest` since we don't run the binary in CI. |
| Runtime base | `gcr.io/distroless/static-debian12:nonroot` (SHA-pinned) | No shell, no busybox, no package manager — minimum reachable surface for a process whose only job is HTTP-in/HTTP-out. `nonroot` (uid 65532) drops privileges. |
| Build base | `golang:1.26.2-alpine` (SHA-pinned `f8533084`, alpine:3.23 upstream) | Matches `go.mod` toolchain version; SHA-pin so a tag-mover at upstream can't change what we ship without a deliberate Dockerfile bump. The non-3.x-anchored tag picked the variant that was 15 days old at PR time (the 3.22-anchored variant was 13 days old, failing the 14-day dep-age-check). The build stage is throw-away, so the build-time alpine version doesn't reach the runtime image. |
| Static linking | `CGO_ENABLED=0` | No glibc/musl runtime dependency — required by `distroless/static`. |
| `HEALTHCHECK` directive | Omitted | Distroless has no shell, so a container-level probe can't call curl/wget. The ALB target group hitting `/health` is the real probe (and a stronger signal than a container-local check anyway). |
| Build context | `context: .` + `apps/slack/Dockerfile.dockerignore` | The Dockerfile only COPYs `go.mod`, `go.sum`, `apps/slack/`, `shared/` — the per-Dockerfile `.dockerignore` (BuildKit feature, requires `# syntax=docker/dockerfile:1.7`) drops the rest. Verified context size: ~1 kB transferred (down from full repo). |
| `version` ldflag | `-trimpath -mod=readonly -ldflags="-s -w -X main.version=${VERSION}"` | qURL client User-Agent pins a deploy to a specific git SHA; CI overrides via `--build-arg VERSION=${{ github.sha }}`. Default `dev` stays in for local builds. `-mod=readonly` ensures a corrupted/hand-edited `go.sum` fails loudly during the container build. |
| Cross-compile (deferred) | `--platform=$BUILDPLATFORM` cross-compile attempted in commit `be12aee`, reverted in `677a7a8` because the org's dep-age-check parser rejects `--platform=` flag tokens (parser bug, tracked in `ops-routines-workflows#4`). Re-applies in `#169` once unblocked. | Today the docker-check job runs the entire build under QEMU emulation on amd64 runners — minutes, not 30s. Acceptable cost while the parser fix lands. |
| BuildKit caching | `cache-from`/`cache-to: type=gha, scope=slack-docker` | Subsequent PR pushes don't repay the full module-download + compile cost. |
| `trigger-deploy` SHA-pin | `dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0` (v0.5.0) | Same pin as `discord.yml`; SHA-pinning matches `dep-age-check` posture. |

## Test plan

- [x] `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile -t qurl-bot-slack:dev .` — builds clean (local arm64 host: ~4s warm; CI under QEMU emulation: minutes — see `#169` for the cross-compile follow-up that fixes this)
- [x] Container runs cleanly under `docker run` with required env vars; `/health` returns 200; SIGTERM produces a clean exit
- [x] `make lint` — 0 issues
- [x] `go test -race -count=1 ./apps/slack/...` — clean
- [x] Build context size verified at ~1 kB (down from full repo) with the allow-list `Dockerfile.dockerignore` in place
- [x] `make build-slack VERSION=test-abc123` — verified version string in binary (Makefile target now matches the Dockerfile's ldflags)

## Closes

- #152 (Lambda-shape language scrub — covered in CLAUDE.md, README, Makefile, slack.yml step names)

## Follow-ups filed during review

- #157 — `slack: handle ssl_check periodically posted by Slack`
- #163 — `ci: extract shared trigger-deploy job for slack.yml + discord.yml`
- #164 — `slack: User-Agent should be 'qurl-bot-slack/<version>'`
- #165 — `slack: add OCI image labels for Phase 3 ECR push`
- #166 — `slack: add BuildKit cache mounts`
- #167 — `ci(slack): scope govulncheck`
- #168 — `slack: parameterize listen port via ENV PORT`
- #169 — `slack: re-apply --platform=BUILDPLATFORM cross-compile once age-check parser is fixed` (blocked on `layervai/ops-routines-workflows#4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)