### PR TITLE
fix(discord): repoint ddb-store healthCheck at guild_configs

### DIFF
--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1436,11 +1436,10 @@ async function deleteOrphanedToken(id) {
 // ── Lifecycle ──
 
 // Cheap "is the data layer functional" probe for /health. Single
-// GetItem against a sentinel key on the smallest table (pending_links
-// — short TTL, low cardinality) verifies SDK init, network path,
-// IAM, and that the table exists, in one ~1-RCU round-trip. Throws
-// if any of those are broken so the orchestrator replaces the
-// container.
+// GetItem against a sentinel key on a low-cardinality table verifies
+// SDK init, network path, IAM, and that the table exists, in one
+// ~1-RCU round-trip. Throws if any of those are broken so the
+// orchestrator replaces the container.
 //
 // Why not Scan/getStats(): /health is hit at LB cadence (10–30s).
 // SqliteStore's old getStats() probe was constant-time aggregation
@@ -1450,9 +1449,24 @@ async function deleteOrphanedToken(id) {
 // any fleet. /metrics keeps the full aggregation — that's the right
 // home for it.
 async function healthCheck() {
+  // Probe `guild_configs` rather than `pending_links`. The latter was
+  // removed by qurl-integrations-infra PR #372 (the OpenNHP-only tables
+  // — pending_links, github_links, contributions, badges, streaks,
+  // milestones, weekly_stats, orphaned_oauth_tokens — were dropped as
+  // unused after audit). With pending_links gone, GetItem returned
+  // ResourceNotFoundException on every ALB probe → /health 503 → ECS
+  // circuit-breaker rolls back the deployment.
+  //
+  // Surviving tables are qurl_sends, qurl_send_configs, guild_configs.
+  // guild_configs is the right pick: lowest write rate (configured per
+  // guild, not per send), simplest key schema (just `guild_id` HASH),
+  // and exists in every env regardless of OpenNHP-feature flagging.
+  // GetItem on a missing key returns an empty result (no exception),
+  // so a sentinel `__healthcheck__` guild_id is safe and never collides
+  // with a real Discord guild snowflake (numeric only).
   await ddb.send(new GetCommand({
-    TableName: TABLES.pending_links,
-    Key: { state: '__healthcheck__' },
+    TableName: TABLES.guild_configs,
+    Key: { guild_id: '__healthcheck__' },
   }));
   return { ok: true };
 }

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1009,14 +1009,14 @@ describe('milestones', () => {
 // ── Health check ──
 
 describe('healthCheck', () => {
-  test('issues a single GetItem against pending_links sentinel key', async () => {
+  test('issues a single GetItem against guild_configs sentinel key', async () => {
     ddbMock.on(GetCommand).resolves({}); // sentinel key never exists
     const result = await store.healthCheck();
     expect(result).toEqual({ ok: true });
     const calls = ddbMock.commandCalls(GetCommand);
     expect(calls).toHaveLength(1);
-    expect(calls[0].args[0].input.TableName).toBe('test-prefix-pending-links');
-    expect(calls[0].args[0].input.Key).toEqual({ state: '__healthcheck__' });
+    expect(calls[0].args[0].input.TableName).toBe('test-prefix-guild-configs');
+    expect(calls[0].args[0].input.Key).toEqual({ guild_id: '__healthcheck__' });
   });
 
   test('does NOT touch any user-data table (no Scan, no leaderboard read)', async () => {


### PR DESCRIPTION
## Summary

The /health endpoint's data-layer probe (`ddb-store.js:healthCheck()`) was issuing `GetItem` on `TABLES.pending_links` every ALB health-check cycle. That table was dropped by qurl-integrations-infra PR #372 (the OpenNHP-only DDB tables — pending_links, github_links, contributions, badges, streaks, milestones, weekly_stats, orphaned_oauth_tokens — were removed as unused after audit), but PR #116 had already shipped this ddb-store.js whose `healthCheck()` probed pending_links. The two changes hadn't crossed.

## Live confirmation

```
$ aws dynamodb describe-table --table-name qurl-bot-discord-sandbox-pending-links
ResourceNotFoundException
```

Cascade:
- `GetItem` → `ResourceNotFoundException` → /health 503 → ALB target unhealthy → ECS deployment circuit-breaker → ["No rollback candidate" terraform apply failure](https://github.com/layervai/qurl-integrations-infra/actions/runs/25205463141) on a fresh service.

## Fix

Repoint healthCheck at `guild_configs` (one of the 3 surviving tables: `qurl_sends`, `qurl_send_configs`, `guild_configs`):

- **Lowest write rate** (per-guild config, not per-send), so health-check cadence (10–30s) won't show up in CloudWatch metrics for write-heavy tables.
- **Simplest key schema** (`guild_id` HASH, no SK/GSI).
- **Exists in every env** regardless of OpenNHP-feature flagging.
- `GetItem` on missing key returns empty Item (no exception); sentinel `__healthcheck__` never collides with Discord guild snowflakes (those are numeric).

Test (`tests/ddb-store.test.js:1011`) updated to match.

## Out of scope

The other `TABLES.pending_links` call sites (`createPendingLink`, `getPendingLink`, `deletePendingLink`, `consumePendingLink`) sit behind the OpenNHP feature flag (`enable_opennhp_features = \"false\"` in both sandbox and prod tfvars). They're unreached in current envs; leaving them in place pending the broader OpenNHP-vs-qurl-bot story clarification (separate effort).

## Rollback safety

`Rollback-Safe: yes - no schema changes, no DDB column removals, no breaking API changes`. Pure healthCheck redirect — the previous binary still runs against current infra (the prior binary's healthCheck would still 503 on rollback target since pending_links is gone anyway, but that's pre-existing).

## Test plan

- [x] `npx jest --testPathPatterns=ddb-store` — 81/81 passing locally
- [ ] CI green
- [ ] After merge: sandbox auto-deploy via `repository_dispatch types: [discord-bot-deploy]` redeploys discord bot with the fix
- [ ] qurl-integrations-infra sandbox apply unjams (ECS service reaches steady state, /health 200, e2e-smoke green)
- [ ] Re-dispatch promote-bot-discord-to-prod after sandbox green

## Cross-refs

- qurl-integrations-infra PR #372 (table removal — Justin)
- qurl-integrations PR #116 (DDB backend — Vikram)
- Failing run: https://github.com/layervai/qurl-integrations-infra/actions/runs/25205463141

🤖 Generated with [Claude Code](https://claude.com/claude-code)