### PR TITLE
test(discord): post per-file e2e results embed to Discord on run completion

### DIFF
--- a/e2e/helpers/discord-reporter.ts
+++ b/e2e/helpers/discord-reporter.ts
@@ -29,9 +29,15 @@ interface DiscordEmbed {
   timestamp?: string;
 }
 
-// Discord embed limits: field value 1024, field count 25.
+// Discord embed limits: field value 1024, field count 25,
+// total payload 6000. Per-field cap clamped below; total tracked
+// during field construction so worst-case red runs don't 400.
 const FIELD_VALUE_MAX = 1024;
 const FIELD_COUNT_MAX = 25;
+const TOTAL_EMBED_MAX = 6000;
+// Leave 500 chars of headroom for title + description + footer +
+// JSON envelope; trip the budget while building fields, not after.
+const FIELDS_BUDGET = TOTAL_EMBED_MAX - 500;
 const MAX_FAILING_TESTS_PER_FILE = 5;
 const COLOR_GREEN = 0x2ecc71;
 const COLOR_RED = 0xe74c3c;
@@ -42,6 +48,8 @@ const COLOR_YELLOW = 0xf1c40f;
 const POST_TIMEOUT_MS = 8_000;
 
 // `MINT_API_URL` host disambiguates env without a new env var.
+// Substring match is fine while domains are `layerv.ai` / `layerv.xyz`;
+// reconsider if a `staging.layerv.ai`-style host ever lands.
 function envLabel(): string {
   const url = process.env.MINT_API_URL ?? '';
   if (url.includes('layerv.ai')) return 'prod';
@@ -49,17 +57,25 @@ function envLabel(): string {
   return '';
 }
 
-// GH Actions auto-populates these. Footer links the run page so
-// operators can click through from Discord; falls back to suite
-// name when running locally.
-function footerText(): string {
+// Discord footer text isn't auto-linkified — return the run URL for
+// the description (where Discord renders it as a clickable link).
+// Falls back to empty when running locally.
+function runUrl(): string {
   const runId = process.env.GITHUB_RUN_ID;
   const repo = process.env.GITHUB_REPOSITORY;
   const server = process.env.GITHUB_SERVER_URL;
-  const sha = process.env.GITHUB_SHA;
   if (runId && repo && server) {
+    return `${server}/${repo}/actions/runs/${runId}`;
+  }
+  return '';
+}
+
+function footerText(): string {
+  const runId = process.env.GITHUB_RUN_ID;
+  const sha = process.env.GITHUB_SHA;
+  if (runId) {
     const shortSha = sha ? ` · ${sha.slice(0, 7)}` : '';
-    return `${server}/${repo}/actions/runs/${runId}${shortSha}`;
+    return `run #${runId}${shortSha}`;
   }
   return 'qURL E2E Test Suite';
 }
@@ -97,14 +113,17 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
   const label = envLabel();
   const title = `qURL E2E Test Suite${label ? ` — ${label}` : ''}`;
 
-  // Yellow on no-tests-ran (config error / wrong matcher) so a
-  // misconfigured run doesn't ship a green checkmark with zero
-  // signal behind it.
+  // Yellow when nothing ran AND when everything was skipped: in both
+  // cases the suite produced zero pass/fail signal, so a green check
+  // would be misleading. Green requires `passed > 0 && failed === 0`.
   let color: number;
   let description: string;
   if (total === 0) {
     color = COLOR_YELLOW;
     description = `⚠️ No tests ran · ${durationSec}s`;
+  } else if (passed === 0 && failed === 0) {
+    color = COLOR_YELLOW;
+    description = `⚠️ All ${total} tests skipped · ${durationSec}s`;
   } else if (failed === 0) {
     color = COLOR_GREEN;
     description = `✅ All ${passed} tests passed · ${durationSec}s`;
@@ -113,15 +132,35 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
     description = `❌ ${failed} failed, ✅ ${passed} passed (of ${total}) · ${durationSec}s`;
   }
 
-  const fields = results.testResults
-    .slice(0, FIELD_COUNT_MAX)
-    .map(buildField);
+  // Build fields under the 6000-char total embed budget. Worst-case red
+  // run with 25 files × ~1024-char failure expansions blows the cap and
+  // Discord 400s the whole POST. Stop adding fields once the running
+  // total crosses FIELDS_BUDGET; surface the cutoff in the title-line
+  // truncation note. Test-titles flow into embed values unescaped:
+  // they originate in our own test code, not user input — Discord
+  // embeds don't render markdown the way messages do, so this is the
+  // intended trust boundary.
+  const fields: EmbedField[] = [];
+  let usedBytes = title.length + description.length + footerText().length;
+  for (const suite of results.testResults) {
+    if (fields.length >= FIELD_COUNT_MAX) break;
+    const field = buildField(suite);
+    const fieldBytes = field.name.length + field.value.length;
+    if (usedBytes + fieldBytes > FIELDS_BUDGET) break;
+    fields.push(field);
+    usedBytes += fieldBytes;
+  }
   const truncated = results.testResults.length - fields.length;
   const truncatedNote = truncated > 0 ? ` (showing ${fields.length}/${results.testResults.length} files)` : '';
 
+  // Run URL belongs in the description, not the footer — Discord
+  // doesn't linkify footer text (per claude-review pass 2).
+  const url = runUrl();
+  const linkLine = url ? `\n[View run on GitHub](${url})` : '';
+
   return {
     title,
-    description: description + truncatedNote,
+    description: description + truncatedNote + linkLine,
     color,
     fields,
     footer: { text: footerText() },

--- a/e2e/helpers/discord-reporter.ts
+++ b/e2e/helpers/discord-reporter.ts
@@ -1,30 +1,10 @@
 /**
- * Custom Jest reporter that posts a per-file E2E result summary to the
- * test Discord channel after every run.
+ * Posts a per-file E2E result summary embed to the test Discord
+ * channel after every run.
  *
- * Replaces the runtime signal previously carried by the static "embed
- * delivery" test in `tests/discord-channels.test.ts`: that test posted
- * a hardcoded `Status: Passing` embed regardless of whether other tests
- * passed, so an operator scrolling Discord could not tell at a glance
- * whether a run was actually green. This reporter posts one embed per
- * run with the real per-file rollup.
- *
- * Per-file rather than per-test: today there are ~39 tests across 4
- * files; per-test would burn the 25-field embed limit and force
- * truncation. Per-file rolls cleanly to 1 field per file with a small
- * pass/fail count, and only the failing file expands to show its
- * failing test names.
- *
- * Reporter is configured in `jest.config.ts`'s `reporters` array. It
- * runs in BOTH sandbox and prod (no env gating) — the test channel
- * routing already differs by env (sandbox = `vars.E2E_CHANNEL_ID`,
- * prod = SSM `/qurl-bot-e2e-smoke-production/CHANNEL_ID`), so each
- * env's embed lands in its own channel.
- *
- * Failure handling is deliberately defensive: a missing env var or a
- * Discord API hiccup posts a `[discord-reporter]` warning to stderr
- * but never throws. The reporter is informational; it must not turn a
- * green test run red just because Discord happens to be flaky.
+ * Resilience contract: missing env vars / Discord errors / timeouts
+ * warn under `[discord-reporter]` but never throw. Reporter is a
+ * status surface, not a test gate.
  */
 import * as path from 'node:path';
 import type {
@@ -49,30 +29,19 @@ interface DiscordEmbed {
   timestamp?: string;
 }
 
-// Discord embed hard limits (kept here so the truncation calls below
-// read against a documented constant rather than a magic number).
-//   - Field value: 1024 chars
-//   - Field count: 25
-//   - Footer text: 2048 chars
-// We size well under the per-field cap; the per-file rollup is short
-// by construction and even a fully-expanded failure block sits
-// comfortably below 1024.
+// Discord embed limits: field value 1024, field count 25.
 const FIELD_VALUE_MAX = 1024;
 const FIELD_COUNT_MAX = 25;
-
-// Show at most this many failing test titles per file. Beyond this,
-// append a `… and N more` line. Five is enough to communicate scope
-// without exhausting the field-value budget.
 const MAX_FAILING_TESTS_PER_FILE = 5;
-
-// Green / red Discord embed colors. Fixed integers; Discord renders
-// the left-side stripe in this color.
 const COLOR_GREEN = 0x2ecc71;
 const COLOR_RED = 0xe74c3c;
+const COLOR_YELLOW = 0xf1c40f;
 
-// Sniff the env label from MINT_API_URL rather than introducing a new
-// required env var. `api.layerv.ai` → prod, `api.layerv.xyz` →
-// sandbox; anything else → empty string (the title omits the dash).
+// Discord POST timeout. Reporter must never hold CI hostage on a
+// hung connection.
+const POST_TIMEOUT_MS = 8_000;
+
+// `MINT_API_URL` host disambiguates env without a new env var.
 function envLabel(): string {
   const url = process.env.MINT_API_URL ?? '';
   if (url.includes('layerv.ai')) return 'prod';
@@ -80,26 +49,31 @@ function envLabel(): string {
   return '';
 }
 
-// GitHub Actions auto-populates `GITHUB_RUN_ID`, `GITHUB_SERVER_URL`,
-// `GITHUB_REPOSITORY`, and `GITHUB_SHA` for every workflow run. When
-// running locally (no GH context) the footer falls back to the suite
-// name only.
+// GH Actions auto-populates these. Footer links the run page so
+// operators can click through from Discord; falls back to suite
+// name when running locally.
 function footerText(): string {
   const runId = process.env.GITHUB_RUN_ID;
   const repo = process.env.GITHUB_REPOSITORY;
+  const server = process.env.GITHUB_SERVER_URL;
   const sha = process.env.GITHUB_SHA;
-  if (runId && repo) {
+  if (runId && repo && server) {
     const shortSha = sha ? ` · ${sha.slice(0, 7)}` : '';
-    return `run #${runId}${shortSha}`;
+    return `${server}/${repo}/actions/runs/${runId}${shortSha}`;
   }
   return 'qURL E2E Test Suite';
 }
 
 function buildField(suite: TestResult): EmbedField {
   const file = path.basename(suite.testFilePath);
-  const total = suite.numPassingTests + suite.numFailingTests;
+  // `numTotalTests` includes pending/todo, not just pass+fail. Using
+  // the partial sum was misleading: a `3 passes + 1 it.skip` file
+  // would have rendered `✅ 3/3` despite running 4. Per claude-review.
+  const ran = suite.numPassingTests + suite.numFailingTests;
+  const skipped = suite.numTotalTests - ran;
   const icon = suite.numFailingTests === 0 ? '✅' : '❌';
-  let value = `${icon} ${suite.numPassingTests}/${total}`;
+  const skippedSuffix = skipped > 0 ? ` ⏭ ${skipped}` : '';
+  let value = `${icon} ${suite.numPassingTests}/${suite.numTotalTests}${skippedSuffix}`;
 
   if (suite.numFailingTests > 0) {
     const failing = suite.testResults
@@ -118,34 +92,41 @@ function buildField(suite: TestResult): EmbedField {
 function buildEmbed(results: AggregatedResult): DiscordEmbed {
   const passed = results.numPassedTests;
   const failed = results.numFailedTests;
+  const total = results.numTotalTests;
   const durationSec = ((Date.now() - results.startTime) / 1000).toFixed(1);
   const label = envLabel();
   const title = `qURL E2E Test Suite${label ? ` — ${label}` : ''}`;
 
-  const description =
-    failed === 0
-      ? `✅ All ${passed} tests passed · ${durationSec}s`
-      : `❌ ${failed} failed, ✅ ${passed} passed · ${durationSec}s`;
+  // Yellow on no-tests-ran (config error / wrong matcher) so a
+  // misconfigured run doesn't ship a green checkmark with zero
+  // signal behind it.
+  let color: number;
+  let description: string;
+  if (total === 0) {
+    color = COLOR_YELLOW;
+    description = `⚠️ No tests ran · ${durationSec}s`;
+  } else if (failed === 0) {
+    color = COLOR_GREEN;
+    description = `✅ All ${passed} tests passed · ${durationSec}s`;
+  } else {
+    color = COLOR_RED;
+    description = `❌ ${failed} failed, ✅ ${passed} passed (of ${total}) · ${durationSec}s`;
+  }
 
-  // Stable order: input is already sorted by file path in jest's
-  // results; basename ordering is deterministic across runs.
   const fields = results.testResults
     .slice(0, FIELD_COUNT_MAX)
     .map(buildField);
-
-  // If the suite ever grows past 25 files, the truncation slice above
-  // hides files past the limit. Surface that fact loudly in the
-  // description so the reader doesn't get a misleadingly-small list.
   const truncated = results.testResults.length - fields.length;
   const truncatedNote = truncated > 0 ? ` (showing ${fields.length}/${results.testResults.length} files)` : '';
 
   return {
     title,
     description: description + truncatedNote,
-    color: failed === 0 ? COLOR_GREEN : COLOR_RED,
+    color,
     fields,
     footer: { text: footerText() },
-    timestamp: new Date().toISOString(),
+    // Run-start time, not post time — matches what's on the GH run page.
+    timestamp: new Date(results.startTime).toISOString(),
   };
 }
 
@@ -160,34 +141,43 @@ async function postEmbed(embed: DiscordEmbed): Promise<void> {
     return;
   }
 
-  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bot ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ embeds: [embed] }),
-  });
+  // AbortController bounds the POST so a hung connection can't hold
+  // CI minutes hostage past the configured timeout.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bot ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ embeds: [embed] }),
+      signal: controller.signal,
+    });
 
-  if (!res.ok) {
-    const body = await res.text();
+    if (!res.ok) {
+      const body = await res.text();
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[discord-reporter] Discord POST returned ${res.status}: ${body.slice(0, 200)} (test results NOT affected).`,
+      );
+    }
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === 'AbortError';
+    const msg = isAbort
+      ? `timeout after ${POST_TIMEOUT_MS}ms`
+      : err instanceof Error ? err.message : String(err);
     // eslint-disable-next-line no-console
-    console.warn(
-      `[discord-reporter] Discord POST returned ${res.status}: ${body.slice(0, 200)} (test results NOT affected).`,
-    );
+    console.warn(`[discord-reporter] Discord POST ${msg} (test results NOT affected).`);
+  } finally {
+    clearTimeout(timer);
   }
 }
 
 export default class DiscordReporter implements Reporter {
-  // Jest constructs reporters with `(globalConfig, options)`. We don't
-  // need either; declare them with underscore prefix so the linter
-  // doesn't flag the unused parameters.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(_globalConfig: unknown, _reporterOptions: unknown) {}
 
-  // `_contexts` is unused (we read everything from `results`). Jest
-  // requires the parameter even when unused — drop into the leading
-  // underscore convention so noUnusedParameters is happy.
   async onRunComplete(_contexts: Set<TestContext>, results: AggregatedResult): Promise<void> {
     try {
       const embed = buildEmbed(results);
@@ -199,9 +189,8 @@ export default class DiscordReporter implements Reporter {
     }
   }
 
-  // Required by the Reporter interface but not used here. Returning
-  // null tells jest "no error from this reporter" — failing tests are
-  // still surfaced via jest's own exit code, independent of this hook.
+  // Returning `undefined` signals "no reporter-side error." Test
+  // failures surface via jest's own exit code, independent of this hook.
   getLastError(): Error | undefined {
     return undefined;
   }

--- a/e2e/helpers/discord-reporter.ts
+++ b/e2e/helpers/discord-reporter.ts
@@ -1,0 +1,208 @@
+/**
+ * Custom Jest reporter that posts a per-file E2E result summary to the
+ * test Discord channel after every run.
+ *
+ * Replaces the runtime signal previously carried by the static "embed
+ * delivery" test in `tests/discord-channels.test.ts`: that test posted
+ * a hardcoded `Status: Passing` embed regardless of whether other tests
+ * passed, so an operator scrolling Discord could not tell at a glance
+ * whether a run was actually green. This reporter posts one embed per
+ * run with the real per-file rollup.
+ *
+ * Per-file rather than per-test: today there are ~39 tests across 4
+ * files; per-test would burn the 25-field embed limit and force
+ * truncation. Per-file rolls cleanly to 1 field per file with a small
+ * pass/fail count, and only the failing file expands to show its
+ * failing test names.
+ *
+ * Reporter is configured in `jest.config.ts`'s `reporters` array. It
+ * runs in BOTH sandbox and prod (no env gating) — the test channel
+ * routing already differs by env (sandbox = `vars.E2E_CHANNEL_ID`,
+ * prod = SSM `/qurl-bot-e2e-smoke-production/CHANNEL_ID`), so each
+ * env's embed lands in its own channel.
+ *
+ * Failure handling is deliberately defensive: a missing env var or a
+ * Discord API hiccup posts a `[discord-reporter]` warning to stderr
+ * but never throws. The reporter is informational; it must not turn a
+ * green test run red just because Discord happens to be flaky.
+ */
+import * as path from 'node:path';
+import type {
+  AggregatedResult,
+  Reporter,
+  TestContext,
+  TestResult,
+} from '@jest/reporters';
+
+interface EmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+interface DiscordEmbed {
+  title: string;
+  description: string;
+  color: number;
+  fields: EmbedField[];
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+// Discord embed hard limits (kept here so the truncation calls below
+// read against a documented constant rather than a magic number).
+//   - Field value: 1024 chars
+//   - Field count: 25
+//   - Footer text: 2048 chars
+// We size well under the per-field cap; the per-file rollup is short
+// by construction and even a fully-expanded failure block sits
+// comfortably below 1024.
+const FIELD_VALUE_MAX = 1024;
+const FIELD_COUNT_MAX = 25;
+
+// Show at most this many failing test titles per file. Beyond this,
+// append a `… and N more` line. Five is enough to communicate scope
+// without exhausting the field-value budget.
+const MAX_FAILING_TESTS_PER_FILE = 5;
+
+// Green / red Discord embed colors. Fixed integers; Discord renders
+// the left-side stripe in this color.
+const COLOR_GREEN = 0x2ecc71;
+const COLOR_RED = 0xe74c3c;
+
+// Sniff the env label from MINT_API_URL rather than introducing a new
+// required env var. `api.layerv.ai` → prod, `api.layerv.xyz` →
+// sandbox; anything else → empty string (the title omits the dash).
+function envLabel(): string {
+  const url = process.env.MINT_API_URL ?? '';
+  if (url.includes('layerv.ai')) return 'prod';
+  if (url.includes('layerv.xyz')) return 'sandbox';
+  return '';
+}
+
+// GitHub Actions auto-populates `GITHUB_RUN_ID`, `GITHUB_SERVER_URL`,
+// `GITHUB_REPOSITORY`, and `GITHUB_SHA` for every workflow run. When
+// running locally (no GH context) the footer falls back to the suite
+// name only.
+function footerText(): string {
+  const runId = process.env.GITHUB_RUN_ID;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const sha = process.env.GITHUB_SHA;
+  if (runId && repo) {
+    const shortSha = sha ? ` · ${sha.slice(0, 7)}` : '';
+    return `run #${runId}${shortSha}`;
+  }
+  return 'qURL E2E Test Suite';
+}
+
+function buildField(suite: TestResult): EmbedField {
+  const file = path.basename(suite.testFilePath);
+  const total = suite.numPassingTests + suite.numFailingTests;
+  const icon = suite.numFailingTests === 0 ? '✅' : '❌';
+  let value = `${icon} ${suite.numPassingTests}/${total}`;
+
+  if (suite.numFailingTests > 0) {
+    const failing = suite.testResults
+      .filter((t) => t.status === 'failed')
+      .slice(0, MAX_FAILING_TESTS_PER_FILE)
+      .map((t) => `• ${t.title}`)
+      .join('\n');
+    const overflow = suite.numFailingTests - MAX_FAILING_TESTS_PER_FILE;
+    const overflowLine = overflow > 0 ? `\n• … and ${overflow} more` : '';
+    value = `${value}\n${failing}${overflowLine}`.slice(0, FIELD_VALUE_MAX);
+  }
+
+  return { name: file, value };
+}
+
+function buildEmbed(results: AggregatedResult): DiscordEmbed {
+  const passed = results.numPassedTests;
+  const failed = results.numFailedTests;
+  const durationSec = ((Date.now() - results.startTime) / 1000).toFixed(1);
+  const label = envLabel();
+  const title = `qURL E2E Test Suite${label ? ` — ${label}` : ''}`;
+
+  const description =
+    failed === 0
+      ? `✅ All ${passed} tests passed · ${durationSec}s`
+      : `❌ ${failed} failed, ✅ ${passed} passed · ${durationSec}s`;
+
+  // Stable order: input is already sorted by file path in jest's
+  // results; basename ordering is deterministic across runs.
+  const fields = results.testResults
+    .slice(0, FIELD_COUNT_MAX)
+    .map(buildField);
+
+  // If the suite ever grows past 25 files, the truncation slice above
+  // hides files past the limit. Surface that fact loudly in the
+  // description so the reader doesn't get a misleadingly-small list.
+  const truncated = results.testResults.length - fields.length;
+  const truncatedNote = truncated > 0 ? ` (showing ${fields.length}/${results.testResults.length} files)` : '';
+
+  return {
+    title,
+    description: description + truncatedNote,
+    color: failed === 0 ? COLOR_GREEN : COLOR_RED,
+    fields,
+    footer: { text: footerText() },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function postEmbed(embed: DiscordEmbed): Promise<void> {
+  const token = process.env.BOT_TOKEN;
+  const channelId = process.env.CHANNEL_ID;
+  if (!token || !channelId) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[discord-reporter] BOT_TOKEN or CHANNEL_ID unset — skipping Discord post (test results NOT affected).',
+    );
+    return;
+  }
+
+  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bot ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ embeds: [embed] }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[discord-reporter] Discord POST returned ${res.status}: ${body.slice(0, 200)} (test results NOT affected).`,
+    );
+  }
+}
+
+export default class DiscordReporter implements Reporter {
+  // Jest constructs reporters with `(globalConfig, options)`. We don't
+  // need either; declare them with underscore prefix so the linter
+  // doesn't flag the unused parameters.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(_globalConfig: unknown, _reporterOptions: unknown) {}
+
+  // `_contexts` is unused (we read everything from `results`). Jest
+  // requires the parameter even when unused — drop into the leading
+  // underscore convention so noUnusedParameters is happy.
+  async onRunComplete(_contexts: Set<TestContext>, results: AggregatedResult): Promise<void> {
+    try {
+      const embed = buildEmbed(results);
+      await postEmbed(embed);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.warn(`[discord-reporter] failed to post embed: ${msg} (test results NOT affected).`);
+    }
+  }
+
+  // Required by the Reporter interface but not used here. Returning
+  // null tells jest "no error from this reporter" — failing tests are
+  // still surfaced via jest's own exit code, independent of this hook.
+  getLastError(): Error | undefined {
+    return undefined;
+  }
+}

--- a/e2e/helpers/discord-reporter.ts
+++ b/e2e/helpers/discord-reporter.ts
@@ -116,6 +116,10 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
   // Yellow when nothing ran AND when everything was skipped: in both
   // cases the suite produced zero pass/fail signal, so a green check
   // would be misleading. Green requires `passed > 0 && failed === 0`.
+  // Skipped count surfaces in the description suffix so the top-line
+  // matches the per-file `⏭ N` display below it.
+  const skipped = total - passed - failed;
+  const skippedSuffix = skipped > 0 ? ` (${skipped} skipped)` : '';
   let color: number;
   let description: string;
   if (total === 0) {
@@ -126,10 +130,10 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
     description = `⚠️ All ${total} tests skipped · ${durationSec}s`;
   } else if (failed === 0) {
     color = COLOR_GREEN;
-    description = `✅ All ${passed} tests passed · ${durationSec}s`;
+    description = `✅ All ${passed} tests passed${skippedSuffix} · ${durationSec}s`;
   } else {
     color = COLOR_RED;
-    description = `❌ ${failed} failed, ✅ ${passed} passed (of ${total}) · ${durationSec}s`;
+    description = `❌ ${failed} failed, ✅ ${passed} passed${skippedSuffix} (of ${total}) · ${durationSec}s`;
   }
 
   // Build fields under the 6000-char total embed budget. Worst-case red

--- a/e2e/jest.config.ts
+++ b/e2e/jest.config.ts
@@ -8,6 +8,13 @@ const config: Config = {
   testTimeout: 120_000,
   verbose: true,
   maxWorkers: 1, // Serial — shared Discord channel state
+  // `default` keeps jest's stock console output for CI logs;
+  // `discord-reporter` posts a per-file pass/fail rollup embed to the
+  // test channel after every run (replaces the static "embed
+  // delivery" signal that didn't reflect actual results). Reporter is
+  // resilient: missing env vars / Discord errors warn but never throw,
+  // so a broken reporter cannot turn a green run red.
+  reporters: ['default', '<rootDir>/helpers/discord-reporter.ts'],
 };
 
 export default config;


### PR DESCRIPTION
## Why

The current static embed in `e2e/tests/discord-channels.test.ts:170-185` posts a hardcoded `Status: Passing` field regardless of whether other tests in the suite passed. That's misleading — an operator scrolling the test channel sees "Passing" even when the suite is red.

Vikram requested: *"Better to show test names in concise and results in Pass or fail for each test."*

## What this PR adds

A Jest custom reporter at `e2e/helpers/discord-reporter.ts` that posts a real per-file pass/fail rollup embed to the test channel after every run, via Jest's `onRunComplete` hook.

The static embed test stays (it still proves embed delivery works as a suite-internal check); the new reporter posts a separate results-summary embed.

## Embed shape (per-file rollup, failure-only expansion)

```
Title:       qURL E2E Test Suite — sandbox / prod
Description: ✅ All 39 tests passed · 13.2s     (or red counterpart on failure)
Color:       green / red
Fields:
  google-maps.test.ts:            ✅ 16/16
  discord-channels.test.ts:       ✅ 11/11
  discord-commands.smoke.test.ts: ✅ 2/2
  smoke.test.ts:                  ✅ 9/9
Footer:      run #25231969251 · 2b5e61b
```

On failure, the failing file expands inline with the failing test titles (max 5 + `… and N more` overflow, capped to Discord's 1024-char field-value limit).

## Both envs

Reporter runs unconditionally — channel routing already differs by env via the existing config sources (sandbox: `vars.E2E_CHANNEL_ID`; prod: SSM `/qurl-bot-e2e-smoke-production/CHANNEL_ID`). Each env's embed lands in its own test channel.

## Resilience (informational, never blocks)

The reporter is a status surface, not a test gate. Failure paths:
- Missing `BOT_TOKEN` / `CHANNEL_ID` → log `[discord-reporter]` warning, return cleanly
- Discord API non-2xx → log status + first 200 chars of body, return
- Any thrown exception → caught at the `onRunComplete` boundary, logged

A broken reporter must not turn a green run red. The `[discord-reporter]` prefix makes filtering CI logs easy.

## Why per-file (not per-test)

The suite is currently 39 tests across 11 files. Per-test would burn the 25-field embed limit and force truncation; per-file rolls cleanly to 1 field per file with a small pass/fail count, and only the failing file expands. If the suite ever passes 25 files, the title note `(showing X/Y files)` surfaces the truncation.

## Why Jest reporter (not a test in `afterAll`)

Reporters get the full `AggregatedResult` after all tests complete, including per-file timing and failure messages. An `afterAll` hook would only have access to its own file's results, making cross-file rollup impossible.

## Verification

- [x] `npx tsc --noEmit --skipLibCheck` — no new type errors (the existing `moduleResolution=node10` deprecation warning is pre-existing)
- [x] `npx jest --listTests` — config loads with new reporter, all 11 test files discovered
- [ ] Sandbox auto-deploy on next push to `qurl-integrations-infra/qurl-bot-discord/services/**`: embed appears in qurl-test-bot-playground
- [ ] Prod smoke-only re-dispatch: embed appears in prod test guild
- [ ] Embed shape correct: per-file rollup, color reflects overall result, footer has GH run ID + short SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)