### PR TITLE
fix(discord): polish /qurl send dropdown and add DM late-drop hint

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -883,19 +883,39 @@ async function handleSend(interaction, apiKey) {
       // next 5 min on the DM channel and reply once with a reattach
       // hint if a late attachment arrives. Single-shot (max:1) so it
       // auto-tears down.
+      //
+      // Concurrency guard: discord.js MessageCollectors do NOT consume —
+      // both this stale collector and a fresh /qurl send's 60s collector
+      // observe the same DM message when filters match. Without the
+      // sendCooldowns.has check inside .then(), a user who retries within
+      // the 5-min window would see their successful retry produce a
+      // contradictory "60 seconds expired" reply right after sending. The
+      // guard short-circuits in exactly that case: setCooldown fires
+      // synchronously at handleSend entry, so by the time .then() runs,
+      // cooldowns.has(userId) is true iff a fresh send is in flight (or
+      // just completed within the cooldown TTL). The fresh flow's own
+      // collector handles the attachment in that case.
       if (captureChannel.type === ChannelType.DM) {
+        const senderUserId = interaction.user.id;
         captureChannel.awaitMessages({
-          filter: (m) => m.author.id === interaction.user.id && m.attachments.size > 0,
+          filter: (m) => m.author.id === senderUserId && m.attachments.size > 0,
           max: 1,
           time: 5 * 60000,
         }).then((late) => {
           const lateMsg = late.first();
-          if (lateMsg) {
-            lateMsg.reply('⏳ 60 seconds expired — please run `/qurl send` again to reattach.').catch((rErr) => logger.warn('Failed to send late-drop reattach hint', {
-              sendNonce, userId: interaction.user.id, error: rErr?.message,
-            }));
-          }
-        }).catch(() => { /* timed out without a late drop — expected */ });
+          if (!lateMsg) return;
+          if (sendCooldowns.has(senderUserId)) return;
+          lateMsg.reply('⏳ 60 seconds expired — please run `/qurl send` again to reattach.').catch((rErr) => logger.warn('Failed to send late-drop reattach hint', {
+            sendNonce, userId: senderUserId, error: rErr?.message,
+          }));
+        }).catch((err) => {
+          // awaitMessages without errors:['time'] resolves with an empty
+          // Collection on timeout (handled above as !lateMsg) — anything
+          // reaching this catch is an actual fetch / permission failure.
+          logger.debug('Late-drop awaitMessages rejected (non-timeout)', {
+            sendNonce, userId: senderUserId, error: err?.message,
+          });
+        });
       }
       clearCooldown(interaction.user.id);
       return interaction.editReply({ content: 'No file received within 60 seconds. Send cancelled.', components: [] }).catch(logIgnoredDiscordErr);
@@ -1187,8 +1207,10 @@ async function handleSend(interaction, apiKey) {
   // for it to resolve to from a text channel). Conditional inclusion
   // keeps the text-channel dropdown to two options instead of dangling
   // a third "You must be in a voice channel" option that always errors.
-  const isVoiceContext = interaction.channel.type === ChannelType.GuildVoice ||
-                          interaction.channel.type === ChannelType.GuildStageVoice;
+  const isVoiceContext = (
+    interaction.channel.type === ChannelType.GuildVoice
+    || interaction.channel.type === ChannelType.GuildStageVoice
+  );
 
   const formRows = () => {
     const rows = [];
@@ -1198,7 +1220,7 @@ async function handleSend(interaction, apiKey) {
       { label: 'Everyone in this channel', value: 'channel', description: 'All members of this text channel (excl. bots and you)', default: target === 'channel' },
     ];
     if (isVoiceContext) {
-      targetOptions.push({ label: 'Everyone on voice', value: 'voice', description: 'Members currently connected via voice (excl. bots and you)', default: target === 'voice' });
+      targetOptions.push({ label: 'Everyone in your voice channel', value: 'voice', description: 'Members currently connected via voice (excl. bots and you)', default: target === 'voice' });
     }
     rows.push(new ActionRowBuilder().addComponents(
       new StringSelectMenuBuilder()

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -190,6 +190,21 @@ function isAllowedFileType(contentType) {
 const addRecipientsLocks = new Set();
 
 const sendCooldowns = new Map();
+
+// Per-userId generation counter for the DM late-drop catcher. Each
+// time the 60s file-capture window times out, we arm a fire-and-
+// forget 5-min awaitMessages on the DM channel. discord.js
+// MessageCollectors do NOT consume — multiple stale catchers from
+// repeated timeouts (default cooldown 30s, capture window 60s, so
+// stacking is realistic) would all observe the same late drop and
+// each fire a "60 seconds expired" reply. Counter approach: each
+// new catcher captures the post-increment value and bails in its
+// .then() if a newer catcher has been armed. The Map is cleaned in
+// the catcher's .then() (whether or not it fires the reply); a
+// stale catcher whose .then() never fires before the user is
+// forgotten will just see a future (unrelated) catcher's increment
+// and bail naturally on its own resolution.
+const lateDropGenerations = new Map();
 // Hard ceiling so a bad actor spraying unique user IDs (or a bug generating
 // them) can't grow the Map beyond this. Above this, the 10%-drop eviction
 // still fires; if that fails to reclaim, setCooldown drops the oldest
@@ -884,24 +899,45 @@ async function handleSend(interaction, apiKey) {
       // hint if a late attachment arrives. Single-shot (max:1) so it
       // auto-tears down.
       //
-      // Concurrency guard: discord.js MessageCollectors do NOT consume —
-      // both this stale collector and a fresh /qurl send's 60s collector
-      // observe the same DM message when filters match. Without the
-      // sendCooldowns.has check inside .then(), a user who retries within
-      // the 5-min window would see their successful retry produce a
-      // contradictory "60 seconds expired" reply right after sending. The
-      // guard short-circuits in exactly that case: setCooldown fires
-      // synchronously at handleSend entry, so by the time .then() runs,
-      // cooldowns.has(userId) is true iff a fresh send is in flight (or
-      // just completed within the cooldown TTL). The fresh flow's own
-      // collector handles the attachment in that case.
-      if (captureChannel.type === ChannelType.DM) {
+      // Two concurrency hazards both apply, both guarded:
+      //
+      // 1. STACKING — repeated timeouts within 5 min (achievable since
+      //    QURL_SEND_COOLDOWN_MS defaults to 30s while the capture window
+      //    is 60s) would otherwise arm multiple catchers; a single late
+      //    drop would fire each catcher's .then() and produce N reply
+      //    messages. lateDropGenerations bumps a per-userId counter on
+      //    each arm; each catcher captures its own generation and bails
+      //    if a newer one has been armed.
+      //
+      // 2. RACE WITH FRESH SEND — discord.js MessageCollectors do NOT
+      //    consume, so a stale catcher and a fresh /qurl send's 60s
+      //    collector both observe the same DM message. Without a guard,
+      //    a user who retries inside the 5-min window would see their
+      //    successful retry produce a contradictory "60 seconds expired"
+      //    reply. setCooldown fires synchronously at handleSend entry,
+      //    so sendCooldowns.has(userId) is true while a fresh send is
+      //    in flight (entry is removed by clearCooldown on every exit
+      //    path — the guard window is the in-flight duration only, NOT
+      //    the full QURL_SEND_COOLDOWN_MS). The fresh flow's own
+      //    collector handles the attachment in that case.
+      //
+      // Catcher is NOT armed on non-timeout errors (channel destroyed,
+      // gateway disconnect, perms revoked). In those cases there was
+      // never a working capture path, so a fresh awaitMessages on the
+      // same channel would just fail again.
+      if (!isUnexpected && captureChannel.type === ChannelType.DM) {
         const senderUserId = interaction.user.id;
+        const myGeneration = (lateDropGenerations.get(senderUserId) || 0) + 1;
+        lateDropGenerations.set(senderUserId, myGeneration);
         captureChannel.awaitMessages({
           filter: (m) => m.author.id === senderUserId && m.attachments.size > 0,
           max: 1,
           time: 5 * 60000,
         }).then((late) => {
+          // Stale-catcher bail: a newer late-drop catcher has been armed
+          // (user timed out again). Only the newest catcher fires.
+          if (lateDropGenerations.get(senderUserId) !== myGeneration) return;
+          lateDropGenerations.delete(senderUserId);
           const lateMsg = late.first();
           if (!lateMsg) return;
           if (sendCooldowns.has(senderUserId)) return;
@@ -911,8 +947,13 @@ async function handleSend(interaction, apiKey) {
         }).catch((err) => {
           // awaitMessages without errors:['time'] resolves with an empty
           // Collection on timeout (handled above as !lateMsg) — anything
-          // reaching this catch is an actual fetch / permission failure.
-          logger.debug('Late-drop awaitMessages rejected (non-timeout)', {
+          // reaching this catch is an actual fetch / permission failure,
+          // which means the late-drop feature is non-functional for this
+          // user this session. logger.warn (not debug) so it surfaces.
+          if (lateDropGenerations.get(senderUserId) === myGeneration) {
+            lateDropGenerations.delete(senderUserId);
+          }
+          logger.warn('Late-drop awaitMessages rejected (non-timeout)', {
             sendNonce, userId: senderUserId, error: err?.message,
           });
         });
@@ -3454,6 +3495,7 @@ module.exports = {
       batchSettled,
       expiryToISO,
       sendCooldowns,
+      lateDropGenerations,
       handleAddRecipients,
       buildDeliveryPayload,
       resolveSenderAlias,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -965,9 +965,13 @@ async function handleSend(interaction, apiKey) {
           // reaching this catch is an actual fetch / permission failure,
           // which means the late-drop feature is non-functional for this
           // user this session. logger.warn (not debug) so it surfaces.
-          if (lateDropGenerations.get(senderUserId) === myGeneration) {
-            lateDropGenerations.delete(senderUserId);
-          }
+          //
+          // Mirror the .then() generation gate: under stacking, N stale
+          // catchers can reject simultaneously on a real channel failure
+          // (gateway disconnect drops them all). Without this gate, that
+          // produces N warn lines for the same incident.
+          if (lateDropGenerations.get(senderUserId) !== myGeneration) return;
+          lateDropGenerations.delete(senderUserId);
           logger.warn('Late-drop awaitMessages rejected (non-timeout)', {
             sendNonce, userId: senderUserId, error: err?.message,
           });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -877,6 +877,26 @@ async function handleSend(interaction, apiKey) {
           sendNonce, userId: interaction.user.id, error: dErr?.message,
         }));
       }
+      // Late-drop catcher: users routinely come back to the DM and drop
+      // the file after the 60s window has already passed, then wonder
+      // why nothing happened. Set up a fire-and-forget listener for the
+      // next 5 min on the DM channel and reply once with a reattach
+      // hint if a late attachment arrives. Single-shot (max:1) so it
+      // auto-tears down.
+      if (captureChannel.type === ChannelType.DM) {
+        captureChannel.awaitMessages({
+          filter: (m) => m.author.id === interaction.user.id && m.attachments.size > 0,
+          max: 1,
+          time: 5 * 60000,
+        }).then((late) => {
+          const lateMsg = late.first();
+          if (lateMsg) {
+            lateMsg.reply('⏳ 60 seconds expired — please run `/qurl send` again to reattach.').catch((rErr) => logger.warn('Failed to send late-drop reattach hint', {
+              sendNonce, userId: interaction.user.id, error: rErr?.message,
+            }));
+          }
+        }).catch(() => { /* timed out without a late drop — expected */ });
+      }
       clearCooldown(interaction.user.id);
       return interaction.editReply({ content: 'No file received within 60 seconds. Send cancelled.', components: [] }).catch(logIgnoredDiscordErr);
     }
@@ -1162,18 +1182,29 @@ async function handleSend(interaction, apiKey) {
     return content;
   };
 
+  // The voice-target option only makes sense from a voice / stage-voice
+  // channel (it routes through the sender's voiceState — there's nothing
+  // for it to resolve to from a text channel). Conditional inclusion
+  // keeps the text-channel dropdown to two options instead of dangling
+  // a third "You must be in a voice channel" option that always errors.
+  const isVoiceContext = interaction.channel.type === ChannelType.GuildVoice ||
+                          interaction.channel.type === ChannelType.GuildStageVoice;
+
   const formRows = () => {
     const rows = [];
 
+    const targetOptions = [
+      { label: 'A specific user', value: 'user', description: 'Pick one user to send to', default: target === 'user' },
+      { label: 'Everyone in this channel', value: 'channel', description: 'All members of this text channel (excl. bots and you)', default: target === 'channel' },
+    ];
+    if (isVoiceContext) {
+      targetOptions.push({ label: 'Everyone on voice', value: 'voice', description: 'Members currently connected via voice (excl. bots and you)', default: target === 'voice' });
+    }
     rows.push(new ActionRowBuilder().addComponents(
       new StringSelectMenuBuilder()
         .setCustomId(ids.targetSelect)
         .setPlaceholder('Recipient(s) — choose type')
-        .addOptions(
-          { label: 'A specific user', value: 'user', description: 'Pick one user to send to', default: target === 'user' },
-          { label: 'Everyone in this channel', value: 'channel', description: 'All members of this text channel (excl. bots and you)', default: target === 'channel' },
-          { label: 'Everyone in your voice channel', value: 'voice', description: 'You must be in a voice channel', default: target === 'voice' },
-        )
+        .addOptions(...targetOptions)
     ));
 
     if (target === 'user') {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -204,6 +204,15 @@ const sendCooldowns = new Map();
 // stale catcher whose .then() never fires before the user is
 // forgotten will just see a future (unrelated) catcher's increment
 // and bail naturally on its own resolution.
+//
+// No eviction ceiling here (unlike sendCooldowns above): the Map is
+// bounded to at most one entry per user with an active catcher,
+// because each new arm both increments the user's entry and the
+// catcher's terminal .then()/.catch() deletes it. A user with a
+// pending catcher contributes exactly one entry; a user with no
+// active catcher contributes zero. So the steady-state size is
+// bounded by the number of users currently inside their 5-min
+// late-drop window, which is naturally small.
 const lateDropGenerations = new Map();
 // Hard ceiling so a bad actor spraying unique user IDs (or a bug generating
 // them) can't grow the Map beyond this. Above this, the 10%-drop eviction
@@ -925,6 +934,12 @@ async function handleSend(interaction, apiKey) {
       // gateway disconnect, perms revoked). In those cases there was
       // never a working capture path, so a fresh awaitMessages on the
       // same channel would just fail again.
+      //
+      // The DM-type check is belt-and-suspenders: both branches that
+      // assign captureChannel above today set a DM channel, so this is
+      // effectively always true. The gate pins the invariant against a
+      // future refactor that introduces a non-DM capture path (e.g. a
+      // staff-only ephemeral capture in a guild channel).
       if (!isUnexpected && captureChannel.type === ChannelType.DM) {
         const senderUserId = interaction.user.id;
         const myGeneration = (lateDropGenerations.get(senderUserId) || 0) + 1;

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -504,6 +504,42 @@ describe('handleSend — Step 2: file path', () => {
     expect(sendCooldowns.has('user-1')).toBe(false);
   });
 
+  it('replies to a late attachment drop in DM after the 60s window with a reattach hint', async () => {
+    // After the 60s file-capture window times out, the bot's slash-command
+    // interaction is gone — but users routinely come back and drop the
+    // file anyway. Without a follow-up listener the late drop disappears
+    // into the void and the user wonders why nothing happened. The
+    // fire-and-forget late-drop catcher in the awaitMessages timeout path
+    // listens for the next ~5 min and replies once with a clear next step.
+    const lateReply = jest.fn().mockResolvedValue(undefined);
+    const lateAttachmentMessage = { reply: lateReply };
+    let lateResolved;
+    const lateCapturePromise = new Promise((resolve) => { lateResolved = resolve; });
+    const dmAwaitMessages = jest.fn()
+      // First call (the 60s window) — Collection-shaped timeout.
+      .mockRejectedValueOnce({ size: 0, first: () => null })
+      // Second call (the 5-min late-drop catcher) — resolve with one
+      // late attachment, recording resolution so the test can await it.
+      .mockImplementationOnce(() => {
+        const result = { first: () => lateAttachmentMessage };
+        lateResolved();
+        return Promise.resolve(result);
+      });
+    const dmPromptDelete = jest.fn().mockResolvedValue(undefined);
+    const dmSend = jest.fn().mockResolvedValue({ delete: dmPromptDelete });
+    const interaction = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction);
+    // Wait for the fire-and-forget listener's .then() to settle.
+    await lateCapturePromise;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(dmAwaitMessages).toHaveBeenCalledTimes(2);
+    expect(lateReply).toHaveBeenCalledWith(expect.stringContaining('60 seconds expired'));
+    expect(lateReply).toHaveBeenCalledWith(expect.stringContaining('reattach'));
+  });
+
   it('deletes the stale DM "Ready!" prompt when capture times out (no orphan in DM thread)', async () => {
     // Regression guard: without the cleanup in the awaitMessages catch
     // path, a timeout would leave the bot's "Ready! Drop your file
@@ -751,6 +787,52 @@ describe('handleSend — Step 3: final form', () => {
     await cmd.execute(interaction);
     expect(mockGetTextChannelMembers).toHaveBeenCalled();
     expect(sendBtn.update).toHaveBeenCalled();
+  });
+
+  it('hides the voice-target option from the dropdown when invoked from a text channel', async () => {
+    // Voice-target only resolves via the sender's voiceState — there is
+    // nothing for it to do from a text channel. Showing a permanently-
+    // erroring "You must be in a voice channel" option is dead weight;
+    // text-channel context drops to two options (user + channel).
+    const cancel = makeCompInt(ids.cancelBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), cancel],
+      // Default channel.type is 0 (GuildText) — text-channel context.
+    });
+    await cmd.execute(interaction);
+    const initialFormCall = interaction.editReply.mock.calls.find(
+      (c) => c[0] && Array.isArray(c[0].components) && c[0].components.length > 0,
+    );
+    expect(initialFormCall).toBeDefined();
+    const targetRow = initialFormCall[0].components[0];
+    const targetSelect = targetRow.components[0];
+    const optionsArg = targetSelect.addOptions.mock.calls[0];
+    const labels = optionsArg.map((o) => o.label);
+    expect(labels).toEqual(['A specific user', 'Everyone in this channel']);
+    expect(labels).not.toContain(expect.stringContaining('voice'));
+  });
+
+  it('shows the voice-target option (renamed to "Everyone on voice") when invoked from a voice channel', async () => {
+    // Inverse of the text-channel test — and pins the renamed label
+    // ("Everyone on voice", was "Everyone in your voice channel"). The
+    // shorter label is less ambiguous about the recipient set being the
+    // currently-connected voice members rather than "members of the voice
+    // channel" in some broader sense.
+    const cancel = makeCompInt(ids.cancelBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), cancel],
+      channel: { type: 2 }, // GuildVoice
+    });
+    await cmd.execute(interaction);
+    const initialFormCall = interaction.editReply.mock.calls.find(
+      (c) => c[0] && Array.isArray(c[0].components) && c[0].components.length > 0,
+    );
+    expect(initialFormCall).toBeDefined();
+    const targetRow = initialFormCall[0].components[0];
+    const targetSelect = targetRow.components[0];
+    const optionsArg = targetSelect.addOptions.mock.calls[0];
+    const labels = optionsArg.map((o) => o.label);
+    expect(labels).toEqual(['A specific user', 'Everyone in this channel', 'Everyone on voice']);
   });
 
   it('target=channel re-prompts when channel has no other members', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -540,6 +540,70 @@ describe('handleSend — Step 2: file path', () => {
     expect(lateReply).toHaveBeenCalledWith(expect.stringContaining('reattach'));
   });
 
+  it('skips the late-drop reply when a fresh /qurl send is in flight (concurrency guard)', async () => {
+    // discord.js MessageCollectors do NOT consume — both a stale late-drop
+    // collector and a fresh /qurl send's 60s collector observe the same
+    // DM message when filters match. Without the sendCooldowns.has guard
+    // inside .then(), a user who retries within the 5-min window would
+    // see their successful retry produce a contradictory "60 seconds
+    // expired" reply right after sending. This test pins the guard:
+    // populate sendCooldowns AFTER cmd.execute returns (its clearCooldown
+    // ran during teardown) and BEFORE resolving the late-drop promise,
+    // simulating a fresh /qurl send racing with the stale catcher.
+    const lateReply = jest.fn().mockResolvedValue(undefined);
+    const lateAttachmentMessage = { reply: lateReply };
+    let resolveLate;
+    const dmAwaitMessages = jest.fn()
+      .mockRejectedValueOnce({ size: 0, first: () => null })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveLate = resolve; }));
+    const dmPromptDelete = jest.fn().mockResolvedValue(undefined);
+    const dmSend = jest.fn().mockResolvedValue({ delete: dmPromptDelete });
+    const interaction = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction);
+    expect(dmAwaitMessages).toHaveBeenCalledTimes(2);
+    // Simulate the user retrying /qurl send within the 5-min window —
+    // setCooldown fires synchronously at the top of handleSend, so by the
+    // time the stale catcher's .then() runs, sendCooldowns.has(userId)
+    // is true.
+    sendCooldowns.set('user-1', Date.now());
+    resolveLate({ first: () => lateAttachmentMessage });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(lateReply).not.toHaveBeenCalled();
+  });
+
+  it('does not reply when the 5-min late-drop window itself times out cleanly (no late drop)', async () => {
+    // Common path: 60s window times out, user never returns, 5 min pass,
+    // late-drop awaitMessages resolves with an empty Collection. The
+    // catcher must early-return on `!lateMsg` without attempting any
+    // .reply or logging a warning.
+    let lateResolved;
+    const lateCapturePromise = new Promise((resolve) => { lateResolved = resolve; });
+    const dmAwaitMessages = jest.fn()
+      .mockRejectedValueOnce({ size: 0, first: () => null })
+      .mockImplementationOnce(() => {
+        lateResolved();
+        return Promise.resolve({ first: () => null }); // empty Collection
+      });
+    const dmPromptDelete = jest.fn().mockResolvedValue(undefined);
+    const dmSend = jest.fn().mockResolvedValue({ delete: dmPromptDelete });
+    const interaction = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction);
+    await lateCapturePromise;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(dmAwaitMessages).toHaveBeenCalledTimes(2);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('reattach'),
+      expect.any(Object),
+    );
+  });
+
   it('deletes the stale DM "Ready!" prompt when capture times out (no orphan in DM thread)', async () => {
     // Regression guard: without the cleanup in the awaitMessages catch
     // path, a timeout would leave the bot's "Ready! Drop your file
@@ -809,15 +873,16 @@ describe('handleSend — Step 3: final form', () => {
     const optionsArg = targetSelect.addOptions.mock.calls[0];
     const labels = optionsArg.map((o) => o.label);
     expect(labels).toEqual(['A specific user', 'Everyone in this channel']);
-    expect(labels).not.toContain(expect.stringContaining('voice'));
   });
 
-  it('shows the voice-target option (renamed to "Everyone on voice") when invoked from a voice channel', async () => {
-    // Inverse of the text-channel test — and pins the renamed label
-    // ("Everyone on voice", was "Everyone in your voice channel"). The
-    // shorter label is less ambiguous about the recipient set being the
-    // currently-connected voice members rather than "members of the voice
-    // channel" in some broader sense.
+  it('shows the voice-target option when invoked from a voice channel (label unchanged in this PR)', async () => {
+    // Inverse of the text-channel test. The voice-target label stays
+    // "Everyone in your voice channel" in this PR — the destination
+    // wording (a single collapsed "Everyone in this voice channel")
+    // is owned by the follow-up that fixes the recipient-scope bug.
+    // Doing the rename twice (once here, once on collapse) shifts UX
+    // in close succession; landing the final phrasing in one place is
+    // less churn for users.
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
       awaitQueue: [locInitBtn(), cancel],
@@ -832,7 +897,26 @@ describe('handleSend — Step 3: final form', () => {
     const targetSelect = targetRow.components[0];
     const optionsArg = targetSelect.addOptions.mock.calls[0];
     const labels = optionsArg.map((o) => o.label);
-    expect(labels).toEqual(['A specific user', 'Everyone in this channel', 'Everyone on voice']);
+    expect(labels).toEqual(['A specific user', 'Everyone in this channel', 'Everyone in your voice channel']);
+  });
+
+  it('shows the voice-target option from a stage-voice channel too', async () => {
+    // GuildStageVoice (type 13) is in the same isVoiceContext branch as
+    // GuildVoice (type 2). Pin both so a future tightening of the type
+    // check doesn't silently drop the option for stage-voice users.
+    const cancel = makeCompInt(ids.cancelBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), cancel],
+      channel: { type: 13 }, // GuildStageVoice
+    });
+    await cmd.execute(interaction);
+    const initialFormCall = interaction.editReply.mock.calls.find(
+      (c) => c[0] && Array.isArray(c[0].components) && c[0].components.length > 0,
+    );
+    expect(initialFormCall).toBeDefined();
+    const targetSelect = initialFormCall[0].components[0].components[0];
+    const labels = targetSelect.addOptions.mock.calls[0].map((o) => o.label);
+    expect(labels).toContain('Everyone in your voice channel');
   });
 
   it('target=channel re-prompts when channel has no other members', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -191,7 +191,7 @@ const randomUUIDSpy = jest.spyOn(crypto, 'randomUUID').mockReturnValue('mock-sen
 
 const { commands, _test } = require('../src/commands');
 const logger = require('../src/logger');
-const { sendCooldowns, setCooldown, setActiveFileSends, memberFetchCache } = _test;
+const { sendCooldowns, setCooldown, setActiveFileSends, memberFetchCache, lateDropGenerations } = _test;
 
 afterAll(() => {
   randomBytesSpy.mockRestore();
@@ -309,6 +309,7 @@ function makeAttachmentMessage(attachment) {
 beforeEach(() => {
   jest.clearAllMocks();
   sendCooldowns.clear();
+  if (lateDropGenerations) lateDropGenerations.clear();
   if (memberFetchCache) memberFetchCache.clear();
   if (typeof setActiveFileSends === 'function') setActiveFileSends(0);
   // Default happy-path mints / uploads — individual tests override.
@@ -602,6 +603,74 @@ describe('handleSend — Step 2: file path', () => {
       expect.stringContaining('reattach'),
       expect.any(Object),
     );
+  });
+
+  it('only the newest late-drop catcher fires when multiple stack on the same DM', async () => {
+    // Repeated 60s timeouts within 5 min would otherwise stack catchers
+    // — a single late drop would fire each one's .then() and produce N
+    // copies of the reattach reply. The per-userId generation counter
+    // ensures only the newest catcher's .then() fires the reply; older
+    // catchers see a newer generation and bail.
+    const lateReply = jest.fn().mockResolvedValue(undefined);
+    const lateAttachmentMessage = { reply: lateReply };
+    let resolveOldest;
+    let resolveNewest;
+    const dmAwaitMessages = jest.fn()
+      // First /qurl send: 60s window timeout → oldest catcher armed
+      .mockRejectedValueOnce({ size: 0, first: () => null })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveOldest = resolve; }))
+      // Second /qurl send: 60s window timeout → newest catcher armed (supersedes oldest)
+      .mockRejectedValueOnce({ size: 0, first: () => null })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveNewest = resolve; }));
+    const dmPromptDelete = jest.fn().mockResolvedValue(undefined);
+    const dmSend = jest.fn().mockResolvedValue({ delete: dmPromptDelete });
+    const interaction1 = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction1);
+    expect(dmAwaitMessages).toHaveBeenCalledTimes(2); // first 60s + first late-drop arm
+
+    const interaction2 = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction2);
+    expect(dmAwaitMessages).toHaveBeenCalledTimes(4); // second 60s + second late-drop arm
+
+    // Resolve OLDEST first — it should bail because the newer generation
+    // has already been recorded.
+    resolveOldest({ first: () => lateAttachmentMessage });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(lateReply).not.toHaveBeenCalled();
+
+    // Resolve NEWEST — it's the live one, fires the reply.
+    resolveNewest({ first: () => lateAttachmentMessage });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(lateReply).toHaveBeenCalledTimes(1);
+    expect(lateReply).toHaveBeenCalledWith(expect.stringContaining('60 seconds expired'));
+  });
+
+  it('does not arm the late-drop catcher on a non-timeout awaitMessages error', async () => {
+    // discord.js v14: awaitMessages with errors:['time'] rejects with a
+    // Collection on timeout, but rejects with an Error if the channel
+    // got destroyed mid-await / perms revoked / gateway disconnected.
+    // In that case the capture path was already broken — arming a fresh
+    // 5-min listener on the same channel would just fail again. The
+    // catcher is gated on !isUnexpected for that reason.
+    const dmPromptDelete = jest.fn().mockResolvedValue(undefined);
+    const dmSend = jest.fn().mockResolvedValue({ delete: dmPromptDelete });
+    const dmAwaitMessages = jest.fn().mockRejectedValueOnce(new Error('Channel destroyed'));
+    const interaction = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction);
+    // Only the original 60s capture attempted; no late-drop arm.
+    expect(dmAwaitMessages).toHaveBeenCalledTimes(1);
+    expect(lateDropGenerations.has('user-1')).toBe(false);
   });
 
   it('deletes the stale DM "Ready!" prompt when capture times out (no orphan in DM thread)', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -651,6 +651,12 @@ describe('handleSend — Step 2: file path', () => {
     await new Promise((resolve) => setImmediate(resolve));
     expect(lateReply).toHaveBeenCalledTimes(1);
     expect(lateReply).toHaveBeenCalledWith(expect.stringContaining('60 seconds expired'));
+    // Cleanup invariant: lateDropGenerations is bounded to one entry
+    // per user with an active catcher. After the live catcher fires,
+    // the user's entry must be removed so the Map can't accumulate
+    // — this is what justifies the "no eviction ceiling" choice on
+    // the Map declaration.
+    expect(lateDropGenerations.has('user-1')).toBe(false);
   });
 
   it('does not arm the late-drop catcher on a non-timeout awaitMessages error', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -574,6 +574,12 @@ describe('handleSend — Step 2: file path', () => {
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
     expect(lateReply).not.toHaveBeenCalled();
+    // Cleanup invariant on the cooldown-bail path: even when the reply
+    // is suppressed, the user's lateDropGenerations entry must be
+    // removed. Pinned so a future refactor that moves the cooldown
+    // check above the delete doesn't silently leak Map entries on
+    // every cooldown-bail.
+    expect(lateDropGenerations.has('user-1')).toBe(false);
   });
 
   it('does not reply when the 5-min late-drop window itself times out cleanly (no late drop)', async () => {
@@ -657,6 +663,45 @@ describe('handleSend — Step 2: file path', () => {
     // — this is what justifies the "no eviction ceiling" choice on
     // the Map declaration.
     expect(lateDropGenerations.has('user-1')).toBe(false);
+  });
+
+  it('stacking + simultaneous channel failure: only the newest catcher logs the warn', async () => {
+    // Pairs with the stacking-dedupe test above. Under stacking, a
+    // gateway disconnect / channel destroy can reject ALL armed
+    // late-drop awaitMessages at once. Without the .catch generation
+    // gate, that produces N warn lines for the same incident — only
+    // the newest catcher should log.
+    let rejectOldest;
+    let rejectNewest;
+    const dmAwaitMessages = jest.fn()
+      .mockRejectedValueOnce({ size: 0, first: () => null }) // first 60s window timeout
+      .mockImplementationOnce(() => new Promise((_, rej) => { rejectOldest = rej; }))
+      .mockRejectedValueOnce({ size: 0, first: () => null }) // second 60s window timeout
+      .mockImplementationOnce(() => new Promise((_, rej) => { rejectNewest = rej; }));
+    const dmPromptDelete = jest.fn().mockResolvedValue(undefined);
+    const dmSend = jest.fn().mockResolvedValue({ delete: dmPromptDelete });
+
+    const interaction1 = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction1);
+    const interaction2 = makeInteraction({
+      awaitQueue: [fileInitBtn()],
+      dm: { send: dmSend, awaitMessages: dmAwaitMessages },
+    });
+    await cmd.execute(interaction2);
+
+    // Reject both simultaneously (channel destroyed).
+    rejectOldest(new Error('Channel destroyed'));
+    rejectNewest(new Error('Channel destroyed'));
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Only the newest catcher should have warned. Filter the calls
+    // because earlier file-capture awaitMessages may also produce warns.
+    const lateWarns = logger.warn.mock.calls.filter((args) => args[0] === 'Late-drop awaitMessages rejected (non-timeout)');
+    expect(lateWarns).toHaveLength(1);
   });
 
   it('does not arm the late-drop catcher on a non-timeout awaitMessages error', async () => {
@@ -936,7 +981,7 @@ describe('handleSend — Step 3: final form', () => {
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
       awaitQueue: [locInitBtn(), cancel],
-      // Default channel.type is 0 (GuildText) — text-channel context.
+      channel: { type: 0 }, // GuildText — explicit so a future helper-default change doesn't silently flip the test's premise.
     });
     await cmd.execute(interaction);
     const initialFormCall = interaction.editReply.mock.calls.find(


### PR DESCRIPTION
Two small UX fixes on the \`/qurl send\` recipient dropdown and DM file-capture flow.

> **Pairs with #174** — that PR collapses the voice-target option into a single \`Everyone in this voice channel\` entry that resolves to voice-connected only (and fixes the \`@everyone\` view-perm scope bug). To avoid renaming the voice-target label twice in close succession, the rename moves to #174 alongside the collapse; this PR keeps the original \`Everyone in your voice channel\` label.

## Summary

1. **Hide voice-target option from the dropdown when invoked from a non-voice channel.** The voice target resolves via the sender's \`voiceState\` — from a text channel it only ever produces a "You must be in a voice channel" re-prompt, so dropping the option keeps the text-channel dropdown to two meaningful choices (user + channel).
2. **DM late-drop reattach hint.** After the 60s file-capture window in the DM-pivot path times out, set up a fire-and-forget 5-min listener for late attachment drops. If the user belatedly drops the file, the bot replies in DM with a clear next step (\`⏳ 60 seconds expired — please run /qurl send again to reattach\`) instead of the drop disappearing into the void with no feedback.

## Concurrency hazards on the late-drop catcher (both guarded)

\`discord.js\` \`MessageCollector\`s do **not** consume — multiple stale catchers and a fresh \`/qurl send\`'s 60s collector all observe the same DM message when filters match. Two distinct hazards apply:

**1. Stacking.** Repeated 60s timeouts within 5 min (achievable since \`QURL_SEND_COOLDOWN_MS\` defaults to 30s while the capture window is 60s) would arm multiple catchers; a single late drop would fire each catcher's \`.then()\` and produce N copies of the reattach reply. Guarded by a per-userId generation counter (\`lateDropGenerations\` Map) — each new arm post-increments; each catcher captures its own generation in closure and bails in \`.then()\` if a newer generation has been recorded.

**2. Race with fresh send.** A user who retries inside the 5-min window would see their successful retry produce a contradictory "60 seconds expired" reply right after sending. Guarded by \`sendCooldowns.has(userId)\` — \`setCooldown\` fires synchronously at \`handleSend\` entry, so the guard window is the in-flight duration of the fresh send. The fresh flow's own collector handles the attachment in that case.

The catcher is **not** armed on non-timeout \`awaitMessages\` rejections (channel destroyed, gateway disconnect, perms revoked) — gated on \`!isUnexpected\` so it doesn't waste a fresh listener on a broken capture path.

## Not in this PR

The \`Everyone in this channel\` scope bug in voice context (currently sends to the whole guild because the option resolves via \`@everyone\` view-perm scope on default servers). That fix is in **#174** — collapsing both options into a single \`Everyone in this voice channel\` entry that resolves to voice-connected only. Until #174 lands, voice-channel users should pick \`Everyone in your voice channel\` to avoid the over-broad recipient set.

## Files

- \`apps/discord/src/commands.js\` — dropdown rebuild (conditional voice option) + late-drop \`awaitMessages\` listener with generation-counter dedupe + fresh-send guard + non-timeout-error gate. \`lateDropGenerations\` Map alongside \`sendCooldowns\` near the top.
- \`apps/discord/tests/qurl-send-state-machine.test.js\` — seven new tests covering: hide-from-text, show-from-voice, show-from-stage-voice, late-drop reply, fresh-send concurrency guard, clean 5-min timeout (no late drop), stacking dedupe (only newest catcher fires), non-timeout-error gate (no catcher armed).

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` — 748 passing (+7 new since main)
- [ ] Smoke test in real Discord: invoke \`/qurl send\` from a text channel, confirm only 2 dropdown options
- [ ] Smoke test: invoke \`/qurl send\` from a voice channel, confirm 3 dropdown options
- [ ] Smoke test (concurrency): drop file > 60s after first prompt and confirm bot DMs the reattach hint; immediately run \`/qurl send\` again and drop a file inside the new flow — confirm no spurious "60 seconds expired" follow-up
- [ ] Smoke test (stacking): time out three sends in a row, then drop a single file — confirm only one reattach reply

## Review iteration

- Round 1: Justin's review (CHANGES_REQUESTED) — title check, concurrency bug walkthrough, label rename pushback, dead-weight test assertion. All addressed in commit \`4d99477\`.
- Round 2: Claude reviewer's re-review on \`4d99477\` — stacking catchers (real bug, before-merge), comment overclaim on cooldown TTL, non-timeout-error gate, log-level swap. All addressed in commit \`817f453\`.