### PR TITLE
fix(discord): collapse /qurl send voice-target options to a single "Everyone in this voice channel" entry (voice-connected only)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -33,7 +33,7 @@ const TOKENS_PER_RESOURCE = 10;
 // Extracted to deduplicate ~13 identical `.catch(err => logger.warn(...))`
 // one-liners across this file.
 const logIgnoredDiscordErr = (err) => logger.warn('Discord API op failed (ignored)', { error: err.message });
-const { getTextChannelMembers, sendDM } = require('./discord');
+const { getChannelMembers, sendDM } = require('./discord');
 
 
 // Generate an OAuth state token bound to the initiating Discord user.
@@ -1301,8 +1301,7 @@ async function handleSend(interaction, apiKey) {
       // members can join/leave (or join/leave voice, in voice-channel
       // context) during the up-to-3-minute form-loop window, and a stale
       // recipients array would mint links for ghosts.
-      const requiresFreshResolve = newTarget === 'channel';
-      if (newTarget !== target || requiresFreshResolve) {
+      if (newTarget !== target || newTarget === 'channel') {
         target = newTarget;
         recipients = [];
         if (target === 'channel') {
@@ -1319,7 +1318,7 @@ async function handleSend(interaction, apiKey) {
               return;
             }
           }
-          recipients = getTextChannelMembers(interaction.channel, interaction.user.id);
+          recipients = getChannelMembers(interaction.channel, interaction.user.id);
           if (recipients.length === 0) {
             target = null;
             const warning = isVoiceContext

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1308,10 +1308,15 @@ async function handleSend(interaction, apiKey) {
     if (compInt.customId === ids.targetSelect) {
       const newTarget = compInt.values[0];
       // For user-target, re-selecting 'user' is a no-op (UserSelect drives
-      // the actual recipient pick). For channel, ALWAYS re-resolve —
-      // members can join/leave (or join/leave voice, in voice-channel
-      // context) during the up-to-3-minute form-loop window, and a stale
-      // recipients array would mint links for ghosts.
+      // the actual recipient pick). For channel, ALWAYS re-resolve.
+      // Staleness sources differ by context:
+      //   - text channel: members can join/leave the guild during the
+      //     up-to-3-min form-loop window; the guild member cache (warmed
+      //     by fetchGuildMembers below) goes stale.
+      //   - voice / stage-voice: users can join/leave voice during the
+      //     window; the gateway-driven voice state cache reflects this
+      //     live, but a captured recipients array snapshot would not.
+      // A stale recipients array would mint links for ghosts.
       if (newTarget !== target || newTarget === 'channel') {
         target = newTarget;
         recipients = [];
@@ -1333,8 +1338,8 @@ async function handleSend(interaction, apiKey) {
           if (recipients.length === 0) {
             target = null;
             const warning = isVoiceContext
-              ? 'No other users currently connected to this voice channel. Pick another option.'
-              : 'No other members in this channel. Pick another option.';
+              ? 'No other users currently connected to this voice channel. Pick **A specific user** instead.'
+              : 'No other members in this channel. Pick **A specific user** instead.';
             await safeCompUpdate(compInt, { content: formContent({ warning }), components: formRows() });
             continue;
           }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -734,6 +734,15 @@ async function handleSend(interaction, apiKey) {
   // Set cooldown immediately to prevent concurrent request bypass
   setCooldown(interaction.user.id);
 
+  // Hoisted once for reuse across the form (dropdown labels, channel-target
+  // resolution, fetchGuildMembers skip) and the back-half (channel-
+  // announcement wording). The invocation channel type is fixed for the
+  // lifetime of this handler — Discord doesn't reroute live interactions.
+  const isVoiceContext = (
+    interaction.channel.type === ChannelType.GuildVoice
+    || interaction.channel.type === ChannelType.GuildStageVoice
+  );
+
   const sendNonce = crypto.randomBytes(8).toString('hex');
 
   // ── Step 1: Initial 2-button reply (Send File / Send Location) ──
@@ -1166,9 +1175,8 @@ async function handleSend(interaction, apiKey) {
   // members only — anything broader expands to ViewChannel-perm scope
   // (often @everyone, i.e. the whole guild) and was the source of the
   // prior "sends to entire server" bug. The dropdown surfaces this
-  // explicitly with a voice-specific label.
-  const isVoiceContext = interaction.channel.type === ChannelType.GuildVoice ||
-                          interaction.channel.type === ChannelType.GuildStageVoice;
+  // explicitly with a voice-specific label. (`isVoiceContext` hoisted
+  // at the top of handleSend.)
   const channelOptionLabel = isVoiceContext
     ? 'Everyone in this voice channel'
     : 'Everyone in this channel';
@@ -1747,9 +1755,7 @@ async function handleSend(interaction, apiKey) {
     // the same spoof defense here is critical — without it a display name
     // with a leading U+202E flips text direction in the public announcement.
     const safeName = sanitizeDisplayName(resolveSenderAlias(interaction));
-    const isVoiceChannelInvocation = interaction.channel.type === ChannelType.GuildVoice ||
-                                      interaction.channel.type === ChannelType.GuildStageVoice;
-    const notifyMsg = isVoiceChannelInvocation
+    const notifyMsg = isVoiceContext
       ? `📩 **${safeName}** has shared something with users currently connected to this voice channel via **qURL Bot** — check your DMs from qURL Bot.`
       : `📩 **${safeName}** has shared something with all members of this channel via **qURL Bot** — check your DMs from qURL Bot.`;
     try {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -747,9 +747,14 @@ async function handleSend(interaction, apiKey) {
   // resolution, fetchGuildMembers skip) and the back-half (channel-
   // announcement wording). The invocation channel type is fixed for the
   // lifetime of this handler — Discord doesn't reroute live interactions.
+  // `interaction.channel` was non-null-guarded above, but read .type
+  // through optional chaining as belt-and-suspenders so a future refactor
+  // that moves this above the guard doesn't strand a cooldown via a
+  // null-deref throw.
+  const channelType = interaction.channel?.type;
   const isVoiceContext = (
-    interaction.channel.type === ChannelType.GuildVoice
-    || interaction.channel.type === ChannelType.GuildStageVoice
+    channelType === ChannelType.GuildVoice
+    || channelType === ChannelType.GuildStageVoice
   );
 
   const sendNonce = crypto.randomBytes(8).toString('hex');
@@ -1180,12 +1185,9 @@ async function handleSend(interaction, apiKey) {
     return content;
   };
 
-  // Voice / stage-voice channels resolve "channel" to voice-connected
-  // members only — anything broader expands to ViewChannel-perm scope
-  // (often @everyone, i.e. the whole guild) and was the source of the
-  // prior "sends to entire server" bug. The dropdown surfaces this
-  // explicitly with a voice-specific label. (`isVoiceContext` hoisted
-  // at the top of handleSend.)
+  // Contextual label — voice/stage-voice paths resolve to voice-connected
+  // only (see `getChannelMembers`'s doc-comment in src/discord.js for
+  // the v14 polymorphism + the bug this avoids).
   const channelOptionLabel = isVoiceContext
     ? 'Everyone in this voice channel'
     : 'Everyone in this channel';

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -645,14 +645,14 @@ const memberFetchCache = new Map(); // guildId -> { timestamp, inFlight }
 // within the same minute. 60s is still short enough that a user who just
 // joined/left won't be missed for long.
 //
-// Caveat for guilds >1000 members: Discord caps the unprivileged
-// guild.members.fetch() call at 1000 members per chunk. Without the
-// GUILD_PRESENCES privileged intent (which the bot does not declare),
-// guilds larger than that may have some viewers missing from the cache,
-// and the downstream channel-target recipient resolution will then miss
-// those users. If the bot grows into >1000-member servers, declare
-// GUILD_PRESENCES (Discord verification required at 100+ guilds) and
-// add it to the asserted intents in src/discord.js.
+// Intent dependency: this fetch relies on the GuildMembers privileged
+// intent (declared in src/discord.js — boot-time assertion guards against
+// removal). With that intent, guild.members.fetch() handles gateway
+// pagination transparently and returns the full member list regardless
+// of guild size. Without it, the call is rejected by Discord. The
+// 100-guild verification gate is for the GuildMembers intent itself
+// (the "Server Members Intent" toggle in the dev portal) — not a
+// per-call cap.
 const MEMBER_FETCH_TTL = 60000;
 async function fetchGuildMembers(guild) {
   const now = Date.now();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -644,6 +644,15 @@ const memberFetchCache = new Map(); // guildId -> { timestamp, inFlight }
 // paginates) so a longer cache reduces latency on repeat /qurl send calls
 // within the same minute. 60s is still short enough that a user who just
 // joined/left won't be missed for long.
+//
+// Caveat for guilds >1000 members: Discord caps the unprivileged
+// guild.members.fetch() call at 1000 members per chunk. Without the
+// GUILD_PRESENCES privileged intent (which the bot does not declare),
+// guilds larger than that may have some viewers missing from the cache,
+// and the downstream channel-target recipient resolution will then miss
+// those users. If the bot grows into >1000-member servers, declare
+// GUILD_PRESENCES (Discord verification required at 100+ guilds) and
+// add it to the asserted intents in src/discord.js.
 const MEMBER_FETCH_TTL = 60000;
 async function fetchGuildMembers(guild) {
   const now = Date.now();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -33,7 +33,7 @@ const TOKENS_PER_RESOURCE = 10;
 // Extracted to deduplicate ~13 identical `.catch(err => logger.warn(...))`
 // one-liners across this file.
 const logIgnoredDiscordErr = (err) => logger.warn('Discord API op failed (ignored)', { error: err.message });
-const { getVoiceChannelMembers, getTextChannelMembers, sendDM } = require('./discord');
+const { getTextChannelMembers, sendDM } = require('./discord');
 
 
 // Generate an OAuth state token bound to the initiating Discord user.
@@ -1162,6 +1162,20 @@ async function handleSend(interaction, apiKey) {
     return content;
   };
 
+  // Voice / stage-voice channels resolve "channel" to voice-connected
+  // members only — anything broader expands to ViewChannel-perm scope
+  // (often @everyone, i.e. the whole guild) and was the source of the
+  // prior "sends to entire server" bug. The dropdown surfaces this
+  // explicitly with a voice-specific label.
+  const isVoiceContext = interaction.channel.type === ChannelType.GuildVoice ||
+                          interaction.channel.type === ChannelType.GuildStageVoice;
+  const channelOptionLabel = isVoiceContext
+    ? 'Everyone in this voice channel'
+    : 'Everyone in this channel';
+  const channelOptionDescription = isVoiceContext
+    ? 'Members currently connected via voice (excl. bots and you)'
+    : 'All members of this text channel (excl. bots and you)';
+
   const formRows = () => {
     const rows = [];
 
@@ -1171,8 +1185,7 @@ async function handleSend(interaction, apiKey) {
         .setPlaceholder('Recipient(s) — choose type')
         .addOptions(
           { label: 'A specific user', value: 'user', description: 'Pick one user to send to', default: target === 'user' },
-          { label: 'Everyone in this channel', value: 'channel', description: 'All members of this text channel (excl. bots and you)', default: target === 'channel' },
-          { label: 'Everyone in your voice channel', value: 'voice', description: 'You must be in a voice channel', default: target === 'voice' },
+          { label: channelOptionLabel, value: 'channel', description: channelOptionDescription, default: target === 'channel' },
         )
     ));
 
@@ -1207,7 +1220,7 @@ async function handleSend(interaction, apiKey) {
     ));
 
     const recipientsResolved = (target === 'user' && recipients.length === 1)
-      || ((target === 'channel' || target === 'voice') && recipients.length > 0);
+      || (target === 'channel' && recipients.length > 0);
     rows.push(new ActionRowBuilder().addComponents(
       new ButtonBuilder()
         .setCustomId(ids.sendBtn)
@@ -1276,41 +1289,37 @@ async function handleSend(interaction, apiKey) {
     if (compInt.customId === ids.targetSelect) {
       const newTarget = compInt.values[0];
       // For user-target, re-selecting 'user' is a no-op (UserSelect drives
-      // the actual recipient pick). For channel and voice, ALWAYS re-resolve
-      // — members can join or leave during the up-to-3-minute form-loop
-      // window, and a stale recipients array would mint links for ghosts.
-      const requiresFreshResolve = newTarget === 'channel' || newTarget === 'voice';
+      // the actual recipient pick). For channel, ALWAYS re-resolve —
+      // members can join/leave (or join/leave voice, in voice-channel
+      // context) during the up-to-3-minute form-loop window, and a stale
+      // recipients array would mint links for ghosts.
+      const requiresFreshResolve = newTarget === 'channel';
       if (newTarget !== target || requiresFreshResolve) {
         target = newTarget;
         recipients = [];
         if (target === 'channel') {
-          try {
-            await fetchGuildMembers(interaction.guild);
-          } catch (err) {
-            logger.error('Failed to fetch guild members', { error: err.message, sendNonce, userId: interaction.user.id, guildId: interaction.guild?.id });
-            clearCooldown(interaction.user.id);
-            await safeCompUpdate(compInt, { content: 'Failed to load channel members. Send cancelled.', components: [] });
-            return;
+          // Voice / stage-voice channels source members from the voice
+          // state cache (populated automatically via gateway events) — no
+          // guild.members.fetch needed. Text channels need the cache warm.
+          if (!isVoiceContext) {
+            try {
+              await fetchGuildMembers(interaction.guild);
+            } catch (err) {
+              logger.error('Failed to fetch guild members', { error: err.message, sendNonce, userId: interaction.user.id, guildId: interaction.guild?.id });
+              clearCooldown(interaction.user.id);
+              await safeCompUpdate(compInt, { content: 'Failed to load channel members. Send cancelled.', components: [] });
+              return;
+            }
           }
           recipients = getTextChannelMembers(interaction.channel, interaction.user.id);
           if (recipients.length === 0) {
             target = null;
-            await safeCompUpdate(compInt, { content: formContent({ warning: 'No other members in this channel. Pick another option.' }), components: formRows() });
+            const warning = isVoiceContext
+              ? 'No other users currently connected to this voice channel. Pick another option.'
+              : 'No other members in this channel. Pick another option.';
+            await safeCompUpdate(compInt, { content: formContent({ warning }), components: formRows() });
             continue;
           }
-        } else if (target === 'voice') {
-          const result = getVoiceChannelMembers(interaction.guild, interaction.user.id);
-          if (result.error === 'not_in_voice') {
-            target = null;
-            await safeCompUpdate(compInt, { content: formContent({ warning: 'You must be in a voice channel to use this option.' }), components: formRows() });
-            continue;
-          }
-          if (result.members.length === 0) {
-            target = null;
-            await safeCompUpdate(compInt, { content: formContent({ warning: 'No other users in your voice channel.' }), components: formRows() });
-            continue;
-          }
-          recipients = result.members;
         }
         // Surface the per-send cap NOW, while the user can change targets,
         // not 3 minutes later after they've filled in the rest of the form.
@@ -1731,15 +1740,17 @@ async function handleSend(interaction, apiKey) {
   // archived mid-send, DM-channel dispatch) the channel object can be
   // null — and `.send()` on null throws synchronously, before the
   // try/catch can see it.
-  if (interaction.channel && (target === 'channel' || target === 'voice') && delivered > 0) {
+  if (interaction.channel && target === 'channel' && delivered > 0) {
     // Same sanitizer the DM embed uses (sanitizeDisplayName: NFKC + bidi/
     // zero-width/control strip + markdown escape + 64-char cap + 'Someone'
     // fallback). Channel-post is a wider blast radius than DM, so applying
     // the same spoof defense here is critical — without it a display name
     // with a leading U+202E flips text direction in the public announcement.
     const safeName = sanitizeDisplayName(resolveSenderAlias(interaction));
-    const notifyMsg = target === 'voice'
-      ? `📩 **${safeName}** has shared something with users currently on voice via **qURL Bot** — if you're on voice, check your DMs from qURL Bot.`
+    const isVoiceChannelInvocation = interaction.channel.type === ChannelType.GuildVoice ||
+                                      interaction.channel.type === ChannelType.GuildStageVoice;
+    const notifyMsg = isVoiceChannelInvocation
+      ? `📩 **${safeName}** has shared something with users currently connected to this voice channel via **qURL Bot** — check your DMs from qURL Bot.`
       : `📩 **${safeName}** has shared something with all members of this channel via **qURL Bot** — check your DMs from qURL Bot.`;
     try {
       await interaction.channel.send({ content: notifyMsg });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1288,15 +1288,6 @@ async function handleSend(interaction, apiKey) {
   // Contextual label — voice/stage-voice paths resolve to voice-connected
   // only (see `getChannelMembers`'s doc-comment in src/discord.js for
   // the v14 polymorphism + the bug this avoids).
-  //
-  // Merge-conflict resolution (vs. origin/main): this branch's design
-  // collapses the previous user/channel/voice triple into user/channel,
-  // where the "channel" option's label/description adapts to the
-  // invocation channel type. Main's parallel work added a separate
-  // voice option via a conditional `targetOptions.push` — that
-  // approach is superseded by this collapse (see the PR title +
-  // description). `isVoiceContext` is already hoisted at line ~779;
-  // main's redefinition here is dropped.
   const channelOptionLabel = isVoiceContext
     ? 'Everyone in this voice channel'
     : 'Everyone in this channel';

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits, EmbedBuilder } = require('discord.js');
+const { Client, GatewayIntentBits, EmbedBuilder, ChannelType } = require('discord.js');
 const cron = require('node-cron');
 const config = require('./config');
 const logger = require('./logger');
@@ -838,21 +838,32 @@ async function sendDM(discordId, message) {
 // expands to ViewChannel-perm scope, which on default servers is the
 // entire guild (the prior "sends to everyone in the server" bug).
 //
-// Trust boundary: this helper assumes `channel` is a GuildText, GuildVoice,
-// or GuildStageVoice channel object with `.members` populated. It is NOT
-// safe to call with:
-//   - DM channels (no `.members` property at all)
-//   - thread channels (PublicThread=11, PrivateThread=12, AnnouncementThread=10):
-//     `.members` here is a ThreadMemberManager of ThreadMember objects
-//     (thread participants, not channel viewers) — different shape and
-//     different semantic from "Everyone who can view this channel."
-//   - forum / media channels (GuildForum=15, GuildMedia=16): no `.members`
-//   - partial cache entries or arbitrary unvalidated channel inputs.
-// Today's only call site (commands.js channel-target branch) is reached
-// via interaction.channel from /qurl send, which the slash-command
-// registration only allows in guild text + guild voice + stage-voice
-// contexts (no thread/forum/media exposure), so the contract holds.
+// Trust boundary: this helper supports GuildText, GuildVoice, and
+// GuildStageVoice channels — the three types where `channel.members` is
+// the right "Everyone in this channel" set under discord.js v14
+// (viewer set for text; voice-connected for voice/stage-voice). The
+// helper REJECTS other types via SUPPORTED_CHANNEL_TYPES rather than
+// trusting a documented contract, because /qurl send's slash-command
+// registration does not currently restrict invocation context — a user
+// COULD trigger this helper from a thread / forum / DM today, where
+// `channel.members` either has the wrong shape (thread:
+// ThreadMemberManager of ThreadMember; user lazily populated) or
+// doesn't exist at all (forum / media / DM). Returning [] (with a
+// warn log so the call site's "no recipients" branch surfaces clearly)
+// is safer than letting `.filter().map()` throw on an unexpected shape.
+const SUPPORTED_CHANNEL_TYPES = new Set([
+  ChannelType.GuildText,
+  ChannelType.GuildVoice,
+  ChannelType.GuildStageVoice,
+]);
 function getChannelMembers(channel, senderUserId) {
+  if (!channel || !SUPPORTED_CHANNEL_TYPES.has(channel.type)) {
+    logger.warn('getChannelMembers called with unsupported channel type', {
+      channelId: channel?.id,
+      channelType: channel?.type,
+    });
+    return [];
+  }
   return channel.members
     .filter(m => m.id !== senderUserId && !m.user.bot)
     .map(m => m.user);

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -27,18 +27,24 @@ const intents = [
 // and fails loud if the intent has been removed from `intents` above —
 // converting silent-feature-break (e.g., voice-channel /qurl send
 // returning empty) into a startup error with a clear cause.
-function assertIntent(bit, requiredFor) {
+//
+// `assertIntent` takes the intents list as its first argument (rather
+// than closing over the module-level `intents`) so it's directly
+// testable: a unit test can pass an intents-with-one-stripped array and
+// verify the throw, locking in the assertion's purpose against a future
+// "let's downgrade to a warn" refactor.
+function assertIntent(intentsList, bit, requiredFor) {
   // Belt-and-suspenders: in test environments where GatewayIntentBits
   // is partially mocked, `bit` may be undefined; treat undefined as
   // "intent not declared" rather than "intent silently missing."
-  if (bit === undefined || !intents.includes(bit)) {
+  if (bit === undefined || !intentsList.includes(bit)) {
     throw new Error(`Missing required Discord intent for ${requiredFor}. Add the intent back to the \`intents\` array in apps/discord/src/discord.js.`);
   }
 }
-assertIntent(GatewayIntentBits.Guilds, 'guild bootstrap (caches guilds the bot is in)');
-assertIntent(GatewayIntentBits.GuildMembers, 'text-channel /qurl send recipient resolution (channel.members for view-perm holders)');
-assertIntent(GatewayIntentBits.GuildVoiceStates, 'voice-channel /qurl send recipient resolution (channel.members for voice-connected)');
-assertIntent(GatewayIntentBits.DirectMessages, '/qurl send file-pivot DM capture (awaitMessages for the user\'s file drop)');
+assertIntent(intents, GatewayIntentBits.Guilds, 'guild bootstrap (caches guilds the bot is in)');
+assertIntent(intents, GatewayIntentBits.GuildMembers, 'text-channel /qurl send recipient resolution (channel.members for view-perm holders)');
+assertIntent(intents, GatewayIntentBits.GuildVoiceStates, 'voice-channel /qurl send recipient resolution (channel.members for voice-connected)');
+assertIntent(intents, GatewayIntentBits.DirectMessages, '/qurl send file-pivot DM capture (awaitMessages for the user\'s file drop)');
 
 const client = new Client({ intents });
 
@@ -899,6 +905,10 @@ module.exports = {
   refreshCache,
   shutdown,
   getChannelMembers,
+  // Exported only for unit tests to verify the boot canary throws on
+  // a missing intent. Production callers don't need it — the module-
+  // level invocations above are the load-bearing assertions.
+  assertIntent,
   getGuild: () => guild,
   getRoles: () => roles,
   getChannels: () => channels,

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -5,20 +5,42 @@ const logger = require('./logger');
 const db = require('./store');
 const { escapeDiscordMarkdown: md } = require('./utils/sanitize');
 
-const client = new Client({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMembers,
-    GatewayIntentBits.GuildVoiceStates,
-    // Needed for the /qurl send file path's DM-pivot: when the user
-    // clicks Send File from a guild channel, the bot DMs them and
-    // awaitMessages on that DM channel for the file drop. Without
-    // this intent the bot never sees DM messages and the awaitMessages
-    // call times out at 60s — even though the user dropped the file.
-    // Attachment metadata does NOT require MessageContent intent.
-    GatewayIntentBits.DirectMessages,
-  ],
-});
+// Required intents — single source of truth. Each feature that depends
+// on a specific intent has its own assertion below; if a future refactor
+// trims an entry from this array, the corresponding feature-specific
+// assertion fails at module load with a clear error pointing at the
+// broken feature.
+const intents = [
+  GatewayIntentBits.Guilds,
+  GatewayIntentBits.GuildMembers,
+  GatewayIntentBits.GuildVoiceStates,
+  // Needed for the /qurl send file path's DM-pivot: when the user
+  // clicks Send File from a guild channel, the bot DMs them and
+  // awaitMessages on that DM channel for the file drop. Without
+  // this intent the bot never sees DM messages and the awaitMessages
+  // call times out at 60s — even though the user dropped the file.
+  // Attachment metadata does NOT require MessageContent intent.
+  GatewayIntentBits.DirectMessages,
+];
+
+// Per-feature intent canaries. Each line pins one intent to one feature
+// and fails loud if the intent has been removed from `intents` above —
+// converting silent-feature-break (e.g., voice-channel /qurl send
+// returning empty) into a startup error with a clear cause.
+function assertIntent(bit, requiredFor) {
+  // Belt-and-suspenders: in test environments where GatewayIntentBits
+  // is partially mocked, `bit` may be undefined; treat undefined as
+  // "intent not declared" rather than "intent silently missing."
+  if (bit === undefined || !intents.includes(bit)) {
+    throw new Error(`Missing required Discord intent for ${requiredFor}. Add the intent back to the \`intents\` array in apps/discord/src/discord.js.`);
+  }
+}
+assertIntent(GatewayIntentBits.Guilds, 'guild bootstrap (caches guilds the bot is in)');
+assertIntent(GatewayIntentBits.GuildMembers, 'text-channel /qurl send recipient resolution (channel.members for view-perm holders)');
+assertIntent(GatewayIntentBits.GuildVoiceStates, 'voice-channel /qurl send recipient resolution (channel.members for voice-connected)');
+assertIntent(GatewayIntentBits.DirectMessages, '/qurl send file-pivot DM capture (awaitMessages for the user\'s file drop)');
+
+const client = new Client({ intents });
 
 // Cache for quick lookups
 let guild = null;
@@ -808,13 +830,21 @@ async function sendDM(discordId, message) {
 //     gateway events; no fetch needed) — REQUIRES the GuildVoiceStates
 //     intent (declared in the Client config above). If that intent is
 //     ever trimmed, voice/stage-voice paths will silently return empty
-//     here.
+//     here. The boot-time assertion in this file's intent block fails
+//     loud at startup if anyone removes it without replacing the helper.
 //
 // Both are the desired semantic for "Everyone in this channel." Voice
 // channels deliberately resolve to voice-connected only — anything broader
 // expands to ViewChannel-perm scope, which on default servers is the
 // entire guild (the prior "sends to everyone in the server" bug).
-function getTextChannelMembers(channel, senderUserId) {
+//
+// Trust boundary: this helper assumes `channel` is a GuildText, GuildVoice,
+// or GuildStageVoice channel object with `.members` populated. It is NOT
+// safe to call with DM channels (no .members), partial cache entries, or
+// arbitrary unvalidated channel inputs. Today's only call site
+// (commands.js channel-target branch) is reached via interaction.channel
+// after a guild-context guard, so this contract holds.
+function getChannelMembers(channel, senderUserId) {
   return channel.members
     .filter(m => m.id !== senderUserId && !m.user.bot)
     .map(m => m.user);
@@ -849,7 +879,7 @@ module.exports = {
   sendDM,
   refreshCache,
   shutdown,
-  getTextChannelMembers,
+  getChannelMembers,
   getGuild: () => guild,
   getRoles: () => roles,
   getChannels: () => channels,

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -840,10 +840,18 @@ async function sendDM(discordId, message) {
 //
 // Trust boundary: this helper assumes `channel` is a GuildText, GuildVoice,
 // or GuildStageVoice channel object with `.members` populated. It is NOT
-// safe to call with DM channels (no .members), partial cache entries, or
-// arbitrary unvalidated channel inputs. Today's only call site
-// (commands.js channel-target branch) is reached via interaction.channel
-// after a guild-context guard, so this contract holds.
+// safe to call with:
+//   - DM channels (no `.members` property at all)
+//   - thread channels (PublicThread=11, PrivateThread=12, AnnouncementThread=10):
+//     `.members` here is a ThreadMemberManager of ThreadMember objects
+//     (thread participants, not channel viewers) — different shape and
+//     different semantic from "Everyone who can view this channel."
+//   - forum / media channels (GuildForum=15, GuildMedia=16): no `.members`
+//   - partial cache entries or arbitrary unvalidated channel inputs.
+// Today's only call site (commands.js channel-target branch) is reached
+// via interaction.channel from /qurl send, which the slash-command
+// registration only allows in guild text + guild voice + stage-voice
+// contexts (no thread/forum/media exposure), so the contract holds.
 function getChannelMembers(channel, senderUserId) {
   return channel.members
     .filter(m => m.id !== senderUserId && !m.user.bot)

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits, EmbedBuilder, ChannelType, PermissionFlagsBits } = require('discord.js');
+const { Client, GatewayIntentBits, EmbedBuilder } = require('discord.js');
 const cron = require('node-cron');
 const config = require('./config');
 const logger = require('./logger');
@@ -797,69 +797,22 @@ async function sendDM(discordId, message) {
   }
 }
 
-// Depends on guild.members.cache being populated (caller must fetch first).
-// Discord limits fetch to ~1000 members without GUILD_PRESENCES intent.
-// For guilds >1000 members, some viewers may be missed.
-
-// Get members in the sender's voice channel (excludes bots and the sender)
-function getVoiceChannelMembers(guildObj, senderUserId) {
-  const senderState = guildObj.voiceStates.cache.get(senderUserId);
-  if (!senderState || !senderState.channel) {
-    return { error: 'not_in_voice', members: [] };
-  }
-
-  const members = senderState.channel.members
-    .filter(m => m.id !== senderUserId && !m.user.bot)
-    .map(m => m.user);
-
-  return {
-    error: null,
-    members,
-    channelName: senderState.channel.name,
-  };
-}
-
-// Get non-bot members who can view a channel (excludes the sender).
+// Get non-bot members in a channel, excluding the sender.
 //
-// Voice/stage-voice channels have a gotcha: in discord.js, `channel.members`
-// returns members CURRENTLY CONNECTED to voice — NOT everyone who can see
-// the channel. For text channels `channel.members` is computed off guild
-// members + ViewChannel permission, which is the semantic we want for
-// "Everyone in this channel." So for voice/stage-voice we compute the
-// viewer set explicitly from guild.members.cache.
+// channel.members semantics in discord.js v14:
+//   - text channels: GuildMembers with ViewChannel perm (viewer set).
+//     Caller must populate guild.members.cache via guild.members.fetch()
+//     first; see commands.js channel-target branch.
+//   - voice / stage-voice channels: GuildMembers CURRENTLY CONNECTED to
+//     voice. Sourced from voice state cache (populated automatically via
+//     gateway events; no fetch needed).
 //
-// Callers rely on the sender having already done `guild.members.fetch()`
-// so the cache is warm; see the `target === 'channel'` branch in
-// handleSend (commands.js) for the fetch + call site pairing.
+// Both are the desired semantic for "Everyone in this channel." Voice
+// channels deliberately resolve to voice-connected only — anything broader
+// expands to ViewChannel-perm scope, which on default servers is the
+// entire guild (the prior "sends to everyone in the server" bug).
 function getTextChannelMembers(channel, senderUserId) {
-  const isVoice = channel.type === ChannelType.GuildVoice ||
-                  channel.type === ChannelType.GuildStageVoice;
-
-  let source;
-  if (isVoice) {
-    // Voice path: enumerate guild viewers via permissionsFor. If the
-    // channel is voice-typed but `.guild` is somehow missing (partial
-    // cache / unusual gateway state), do NOT silently fall back to
-    // `channel.members` — that's the voice-connected-only set which
-    // is exactly the bug this helper exists to avoid. Return empty and
-    // log so a caller's "no recipients" branch triggers loudly instead
-    // of shipping to a wrong subset.
-    if (!channel.guild) {
-      logger.warn('getTextChannelMembers: voice channel missing .guild; returning empty', {
-        channelId: channel.id, channelType: channel.type,
-      });
-      return [];
-    }
-    source = channel.guild.members.cache.filter(m => {
-      const perms = channel.permissionsFor(m);
-      return perms && perms.has(PermissionFlagsBits.ViewChannel);
-    });
-  } else {
-    // Text channel: `channel.members` is already the viewer set.
-    source = channel.members;
-  }
-
-  return source
+  return channel.members
     .filter(m => m.id !== senderUserId && !m.user.bot)
     .map(m => m.user);
 }
@@ -893,7 +846,6 @@ module.exports = {
   sendDM,
   refreshCache,
   shutdown,
-  getVoiceChannelMembers,
   getTextChannelMembers,
   getGuild: () => guild,
   getRoles: () => roles,

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -805,7 +805,10 @@ async function sendDM(discordId, message) {
 //     first; see commands.js channel-target branch.
 //   - voice / stage-voice channels: GuildMembers CURRENTLY CONNECTED to
 //     voice. Sourced from voice state cache (populated automatically via
-//     gateway events; no fetch needed).
+//     gateway events; no fetch needed) — REQUIRES the GuildVoiceStates
+//     intent (declared in the Client config above). If that intent is
+//     ever trimmed, voice/stage-voice paths will silently return empty
+//     here.
 //
 // Both are the desired semantic for "Everyone in this channel." Voice
 // channels deliberately resolve to voice-connected only — anything broader

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -84,7 +84,7 @@ jest.mock('discord.js', () => {
     ChannelType: { GuildText: 0, GuildVoice: 2 },
     ComponentType: { Button: 2, StringSelect: 3, UserSelect: 5 },
     Client: jest.fn().mockImplementation(() => ({ on: jest.fn(), once: jest.fn(), login: jest.fn() })),
-    GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 4, GuildMessages: 8 },
+    GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 4, GuildMessages: 8, DirectMessages: 4096 },
     Partials: { Channel: 0, Message: 1 },
     Events: { ClientReady: 'ready', InteractionCreate: 'interactionCreate' },
   };

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -168,7 +168,7 @@ const mockDb = {
 jest.mock('../src/database', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue(true);
-const mockGetText = jest.fn();
+const mockGetChannelMembers = jest.fn();
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
   notifyPRMerge: jest.fn(),
@@ -178,7 +178,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getChannelMembers: mockGetText,
+  getChannelMembers: mockGetChannelMembers,
 }));
 
 jest.mock('../src/utils/admin', () => ({

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -180,7 +180,7 @@ jest.mock('../src/discord', () => ({
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
   getVoiceChannelMembers: mockGetVoice,
-  getTextChannelMembers: mockGetText,
+  getChannelMembers: mockGetText,
 }));
 
 jest.mock('../src/utils/admin', () => ({

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -168,7 +168,6 @@ const mockDb = {
 jest.mock('../src/database', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue(true);
-const mockGetVoice = jest.fn();
 const mockGetText = jest.fn();
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
@@ -179,7 +178,6 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getVoiceChannelMembers: mockGetVoice,
   getChannelMembers: mockGetText,
 }));
 

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -177,7 +177,6 @@ const mockDb = {
 jest.mock('../src/database', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue(true);
-const mockGetVoice = jest.fn();
 const mockGetText = jest.fn();
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
@@ -188,7 +187,6 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getVoiceChannelMembers: mockGetVoice,
   getChannelMembers: mockGetText,
 }));
 

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -177,7 +177,7 @@ const mockDb = {
 jest.mock('../src/database', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue(true);
-const mockGetText = jest.fn();
+const mockGetChannelMembers = jest.fn();
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
   notifyPRMerge: jest.fn(),
@@ -187,7 +187,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getChannelMembers: mockGetText,
+  getChannelMembers: mockGetChannelMembers,
 }));
 
 jest.mock('../src/utils/admin', () => ({

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -189,7 +189,7 @@ jest.mock('../src/discord', () => ({
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
   getVoiceChannelMembers: mockGetVoice,
-  getTextChannelMembers: mockGetText,
+  getChannelMembers: mockGetText,
 }));
 
 jest.mock('../src/utils/admin', () => ({

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -620,4 +620,29 @@ describe('discord module', () => {
       expect(typeof discord.getChannels).toBe('function');
     });
   });
+
+  describe('assertIntent (boot canary)', () => {
+    // The whole point of the per-feature canary is to fail loud at
+    // startup if an intent is removed; without a positive test for the
+    // throw path, a future "let's downgrade to a warn" refactor would
+    // silently degrade the assertion. These tests pin the contract.
+    it('throws when the required intent is not in the intents list', () => {
+      const intentsWithoutVoice = [1 /* Guilds */, 2 /* GuildMembers */, 4096 /* DirectMessages */];
+      expect(() => discord.assertIntent(intentsWithoutVoice, 128, 'voice-channel /qurl send'))
+        .toThrow(/Missing required Discord intent for voice-channel \/qurl send/);
+    });
+
+    it('throws when the required intent is undefined (partially-mocked GatewayIntentBits)', () => {
+      // In a test env where GatewayIntentBits.SomeIntent === undefined,
+      // the assertion should still fail — undefined is treated as
+      // "not declared" rather than "silently missing."
+      expect(() => discord.assertIntent([1, 2, 128], undefined, 'feature X'))
+        .toThrow(/Missing required Discord intent for feature X/);
+    });
+
+    it('does not throw when the required intent is present', () => {
+      expect(() => discord.assertIntent([1, 2, 128, 4096], 128, 'voice-channel /qurl send'))
+        .not.toThrow();
+    });
+  });
 });

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -332,8 +332,22 @@ describe('discord module', () => {
         ['u2', { id: 'u2', user: { bot: false } }],
         ['b1', { id: 'b1', user: { bot: true } }],
       ]));
-      const result = discord.getChannelMembers({ members: membersMap }, 's1');
+      const result = discord.getChannelMembers({ type: 0, members: membersMap }, 's1'); // GuildText
       expect(result).toHaveLength(1);
+    });
+
+    it('returns empty + warns on unsupported channel types (thread, forum, DM)', () => {
+      // The helper supports only GuildText / GuildVoice / GuildStageVoice.
+      // Other types either lack `.members` entirely (DM=1, GuildForum=15,
+      // GuildMedia=16) or expose a different shape (thread types 10/11/12
+      // give a ThreadMemberManager of ThreadMember objects whose `.user`
+      // is lazily populated). The runtime guard returns [] safely.
+      const threadResult = discord.getChannelMembers({ type: 11, members: {}, id: 'th1' }, 's1');
+      expect(threadResult).toEqual([]);
+      const dmResult = discord.getChannelMembers({ type: 1, id: 'dm1' }, 's1');
+      expect(dmResult).toEqual([]);
+      const nullResult = discord.getChannelMembers(null, 's1');
+      expect(nullResult).toEqual([]);
     });
 
     it('on a voice channel, returns voice-connected members only (NOT the @everyone view-perm scope)', () => {

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -2,7 +2,7 @@
  * Tests for src/discord.js — covers refreshCache, assignContributorRole,
  * notifyPRMerge, notifyBadgeEarned, postGoodFirstIssue, postReleaseAnnouncement,
  * postStarMilestone, postToGitHubFeed, postWeeklyDigest, sendDM,
- * getVoiceChannelMembers, getTextChannelMembers, shutdown, event handlers.
+ * getTextChannelMembers, shutdown, event handlers.
  */
 
 jest.mock('../src/config', () => ({
@@ -314,28 +314,6 @@ describe('discord module', () => {
     });
   });
 
-  describe('getVoiceChannelMembers', () => {
-    it('returns not_in_voice when no voice state', () => {
-      const guild = { voiceStates: { cache: new Map() } };
-      expect(discord.getVoiceChannelMembers(guild, 's1').error).toBe('not_in_voice');
-    });
-
-    it('returns members', () => {
-      const membersMap = new Map([
-        ['s1', { id: 's1', user: { bot: false } }],
-        ['u2', { id: 'u2', user: { bot: false, username: 'U2' } }],
-      ]);
-      membersMap.filter = (fn) => {
-        const r = []; for (const [k, v] of membersMap) if (fn(v)) r.push(v);
-        r.map = Array.prototype.map.bind(r); return r;
-      };
-      const guild = { voiceStates: { cache: new Map([['s1', { channel: { members: membersMap, name: 'VC' } }]]) } };
-      const result = discord.getVoiceChannelMembers(guild, 's1');
-      expect(result.error).toBeNull();
-      expect(result.members).toHaveLength(1);
-    });
-  });
-
   describe('getTextChannelMembers', () => {
     // Helper: turn a plain Map into something with .filter() returning an
     // array that also has .map (matches discord.js Collection enough for
@@ -354,93 +332,47 @@ describe('discord module', () => {
         ['u2', { id: 'u2', user: { bot: false } }],
         ['b1', { id: 'b1', user: { bot: true } }],
       ]));
-      // Omit `type` so it falls through the isVoice branch — text channel
-      // semantics: channel.members is the viewer set by Discord's rules.
       const result = discord.getTextChannelMembers({ members: membersMap }, 's1');
       expect(result).toHaveLength(1);
     });
 
-    it('on a voice channel, returns all guild members who CAN VIEW — not just voice-connected', () => {
-      // Regression for "target=channel from a voice channel only sent to
-      // voice-connected users." The bug was that channel.members on a
-      // voice channel returns currently-connected members only; we must
-      // instead compute viewers from guild.members.cache + permissionsFor.
+    it('on a voice channel, returns voice-connected members only (NOT the @everyone view-perm scope)', () => {
+      // Regression: the prior implementation enumerated guild.members.cache
+      // filtered by ViewChannel perm, which on default servers (where
+      // @everyone has view) expanded to the entire guild — the
+      // "sends to everyone in the server" bug. Voice channels now resolve
+      // to channel.members (the voice-connected set in discord.js v14).
       const connected = asCollection(new Map([
         ['u2', { id: 'u2', user: { id: 'u2', bot: false } }],
+        ['s1', { id: 's1', user: { id: 's1', bot: false } }], // sender — filtered
+        ['b1', { id: 'b1', user: { id: 'b1', bot: true } }],  // bot — filtered
       ]));
-      const allGuildMembers = asCollection(new Map([
-        ['s1', { id: 's1', user: { id: 's1', bot: false } }],
-        ['u2', { id: 'u2', user: { id: 'u2', bot: false } }], // connected
-        ['u3', { id: 'u3', user: { id: 'u3', bot: false } }], // not connected but can view
-        ['b1', { id: 'b1', user: { id: 'b1', bot: true } }],  // bot, filtered out
-        ['u4', { id: 'u4', user: { id: 'u4', bot: false } }], // no perms — filtered out
-      ]));
-
       const channel = {
-        type: 2, // GuildVoice
-        members: connected, // would return only u2 if we used this
-        guild: { members: { cache: allGuildMembers } },
-        permissionsFor: (m) => {
-          // Everyone can view except u4
-          if (m.id === 'u4') return { has: () => false };
-          return { has: () => true };
-        },
+        type: 2, // GuildVoice — included for clarity; helper no longer branches on type
+        members: connected,
       };
-
       const result = discord.getTextChannelMembers(channel, 's1');
-      // Pin identity, not just count — a swap of u2/u4 or inclusion of a
-      // bot would also give length 2 but wrong users.
-      const returnedIds = result.map(u => u.id).sort();
-      expect(returnedIds).toEqual(['u2', 'u3']);
+      expect(result.map(u => u.id)).toEqual(['u2']);
     });
 
-    it('on a stage-voice channel, also uses the guild-viewer path', () => {
-      const allGuildMembers = asCollection(new Map([
-        ['s1', { id: 's1', user: { id: 's1', bot: false } }],
+    it('on a stage-voice channel, also returns voice-connected only', () => {
+      const connected = asCollection(new Map([
         ['u2', { id: 'u2', user: { id: 'u2', bot: false } }],
       ]));
       const channel = {
         type: 13, // GuildStageVoice
-        members: asCollection(new Map()), // zero voice-connected
-        guild: { members: { cache: allGuildMembers } },
-        permissionsFor: () => ({ has: () => true }),
-      };
-      const result = discord.getTextChannelMembers(channel, 's1');
-      expect(result.map(u => u.id)).toEqual(['u2']); // sender excluded
-    });
-
-    it('voice channel with missing .guild returns empty (does NOT fall back to broken channel.members)', () => {
-      // Defense-in-depth: if a voice-typed channel somehow lacks .guild
-      // (partial cache / unusual gateway state), the helper must not
-      // silently fall through to channel.members — that's the
-      // voice-connected-only set this function exists to avoid.
-      const connected = asCollection(new Map([
-        ['u2', { id: 'u2', user: { id: 'u2', bot: false } }],
-      ]));
-      const channel = {
-        type: 2,           // GuildVoice
-        members: connected, // would be returned if the fallback kicked in
-        guild: undefined,
-      };
-      const result = discord.getTextChannelMembers(channel, 's1');
-      expect(result).toEqual([]);
-    });
-
-    it('voice channel — members with null permissionsFor are excluded cleanly', () => {
-      // permissionsFor can return null for partially-cached / unresolvable
-      // members. The filter must not throw and must not include such users.
-      const allGuildMembers = asCollection(new Map([
-        ['u2', { id: 'u2', user: { id: 'u2', bot: false } }],
-        ['u3', { id: 'u3', user: { id: 'u3', bot: false } }], // null perms
-      ]));
-      const channel = {
-        type: 2,
-        members: asCollection(new Map()),
-        guild: { members: { cache: allGuildMembers } },
-        permissionsFor: (m) => (m.id === 'u3' ? null : { has: () => true }),
+        members: connected,
       };
       const result = discord.getTextChannelMembers(channel, 's1');
       expect(result.map(u => u.id)).toEqual(['u2']);
+    });
+
+    it('returns empty when nobody else is connected to the voice channel', () => {
+      const connected = asCollection(new Map([
+        ['s1', { id: 's1', user: { id: 's1', bot: false } }], // only sender
+      ]));
+      const result = discord.getTextChannelMembers({ type: 2, members: connected }, 's1');
+      expect(result).toEqual([]);
     });
   });
 
@@ -658,7 +590,6 @@ describe('discord module', () => {
   describe('exports', () => {
     it('exports all expected functions', () => {
       expect(typeof discord.sendDM).toBe('function');
-      expect(typeof discord.getVoiceChannelMembers).toBe('function');
       expect(typeof discord.getTextChannelMembers).toBe('function');
       expect(typeof discord.assignContributorRole).toBe('function');
       expect(typeof discord.notifyPRMerge).toBe('function');

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -2,7 +2,7 @@
  * Tests for src/discord.js — covers refreshCache, assignContributorRole,
  * notifyPRMerge, notifyBadgeEarned, postGoodFirstIssue, postReleaseAnnouncement,
  * postStarMilestone, postToGitHubFeed, postWeeklyDigest, sendDM,
- * getTextChannelMembers, shutdown, event handlers.
+ * getChannelMembers, shutdown, event handlers.
  */
 
 jest.mock('../src/config', () => ({
@@ -99,7 +99,7 @@ const mockClient = {
 
 jest.mock('discord.js', () => ({
   Client: jest.fn(() => mockClient),
-  GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128 },
+  GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128, DirectMessages: 4096 },
   EmbedBuilder: jest.fn().mockImplementation(() => ({
     setColor: jest.fn().mockReturnThis(), setTitle: jest.fn().mockReturnThis(),
     setDescription: jest.fn().mockReturnThis(), addFields: jest.fn().mockReturnThis(),
@@ -314,7 +314,7 @@ describe('discord module', () => {
     });
   });
 
-  describe('getTextChannelMembers', () => {
+  describe('getChannelMembers', () => {
     // Helper: turn a plain Map into something with .filter() returning an
     // array that also has .map (matches discord.js Collection enough for
     // these tests without pulling in the real class).
@@ -332,7 +332,7 @@ describe('discord module', () => {
         ['u2', { id: 'u2', user: { bot: false } }],
         ['b1', { id: 'b1', user: { bot: true } }],
       ]));
-      const result = discord.getTextChannelMembers({ members: membersMap }, 's1');
+      const result = discord.getChannelMembers({ members: membersMap }, 's1');
       expect(result).toHaveLength(1);
     });
 
@@ -351,7 +351,7 @@ describe('discord module', () => {
         type: 2, // GuildVoice — included for clarity; helper no longer branches on type
         members: connected,
       };
-      const result = discord.getTextChannelMembers(channel, 's1');
+      const result = discord.getChannelMembers(channel, 's1');
       expect(result.map(u => u.id)).toEqual(['u2']);
     });
 
@@ -363,7 +363,7 @@ describe('discord module', () => {
         type: 13, // GuildStageVoice
         members: connected,
       };
-      const result = discord.getTextChannelMembers(channel, 's1');
+      const result = discord.getChannelMembers(channel, 's1');
       expect(result.map(u => u.id)).toEqual(['u2']);
     });
 
@@ -371,7 +371,7 @@ describe('discord module', () => {
       const connected = asCollection(new Map([
         ['s1', { id: 's1', user: { id: 's1', bot: false } }], // only sender
       ]));
-      const result = discord.getTextChannelMembers({ type: 2, members: connected }, 's1');
+      const result = discord.getChannelMembers({ type: 2, members: connected }, 's1');
       expect(result).toEqual([]);
     });
   });
@@ -590,7 +590,7 @@ describe('discord module', () => {
   describe('exports', () => {
     it('exports all expected functions', () => {
       expect(typeof discord.sendDM).toBe('function');
-      expect(typeof discord.getTextChannelMembers).toBe('function');
+      expect(typeof discord.getChannelMembers).toBe('function');
       expect(typeof discord.assignContributorRole).toBe('function');
       expect(typeof discord.notifyPRMerge).toBe('function');
       expect(typeof discord.notifyBadgeEarned).toBe('function');

--- a/apps/discord/tests/multi-tenant.test.js
+++ b/apps/discord/tests/multi-tenant.test.js
@@ -348,7 +348,7 @@ describe('handleCommand dispatch-time filter', () => {
     jest.doMock('../src/discord', () => ({
       sendDM: jest.fn(), assignContributorRole: jest.fn(),
       notifyBadgeEarned: jest.fn(), getVoiceChannelMembers: jest.fn(),
-      getTextChannelMembers: jest.fn(), client: { user: { id: 'bot' } },
+      getChannelMembers: jest.fn(), client: { user: { id: 'bot' } },
     }));
     jest.doMock('../src/qurl', () => ({ mintLink: jest.fn() }));
     jest.doMock('../src/connector', () => ({ uploadAttachment: jest.fn() }));
@@ -390,7 +390,7 @@ describe('handleCommand dispatch-time filter', () => {
     jest.doMock('../src/discord', () => ({
       sendDM: jest.fn(), assignContributorRole: jest.fn(),
       notifyBadgeEarned: jest.fn(), getVoiceChannelMembers: jest.fn(),
-      getTextChannelMembers: jest.fn(), client: { user: { id: 'bot' } },
+      getChannelMembers: jest.fn(), client: { user: { id: 'bot' } },
     }));
     jest.doMock('../src/qurl', () => ({ mintLink: jest.fn() }));
     jest.doMock('../src/connector', () => ({ uploadAttachment: jest.fn() }));

--- a/apps/discord/tests/multi-tenant.test.js
+++ b/apps/discord/tests/multi-tenant.test.js
@@ -347,7 +347,7 @@ describe('handleCommand dispatch-time filter', () => {
     }));
     jest.doMock('../src/discord', () => ({
       sendDM: jest.fn(), assignContributorRole: jest.fn(),
-      notifyBadgeEarned: jest.fn(), getVoiceChannelMembers: jest.fn(),
+      notifyBadgeEarned: jest.fn(),
       getChannelMembers: jest.fn(), client: { user: { id: 'bot' } },
     }));
     jest.doMock('../src/qurl', () => ({ mintLink: jest.fn() }));
@@ -389,7 +389,7 @@ describe('handleCommand dispatch-time filter', () => {
     }));
     jest.doMock('../src/discord', () => ({
       sendDM: jest.fn(), assignContributorRole: jest.fn(),
-      notifyBadgeEarned: jest.fn(), getVoiceChannelMembers: jest.fn(),
+      notifyBadgeEarned: jest.fn(),
       getChannelMembers: jest.fn(), client: { user: { id: 'bot' } },
     }));
     jest.doMock('../src/qurl', () => ({ mintLink: jest.fn() }));

--- a/apps/discord/tests/opennhp-gating.test.js
+++ b/apps/discord/tests/opennhp-gating.test.js
@@ -96,7 +96,7 @@ const mockClient = {
 
 jest.mock('discord.js', () => ({
   Client: jest.fn(() => mockClient),
-  GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128 },
+  GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128, DirectMessages: 4096 },
   EmbedBuilder: jest.fn().mockImplementation(() => ({
     setColor: jest.fn().mockReturnThis(), setTitle: jest.fn().mockReturnThis(),
     setDescription: jest.fn().mockReturnThis(), addFields: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -152,7 +152,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getVoiceChannelMembers: jest.fn(),
+ 
   getChannelMembers: jest.fn(),
 }));
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -152,7 +152,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
- 
+
   getChannelMembers: jest.fn(),
 }));
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -152,7 +152,6 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-
   getChannelMembers: jest.fn(),
 }));
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -153,7 +153,7 @@ jest.mock('../src/discord', () => ({
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
   getVoiceChannelMembers: jest.fn(),
-  getTextChannelMembers: jest.fn(),
+  getChannelMembers: jest.fn(),
 }));
 
 jest.mock('../src/utils/admin', () => ({

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -993,17 +993,6 @@ describe('handleSend — Step 3: final form', () => {
     expect(labels).toEqual(['A specific user', 'Everyone in this channel']);
   });
 
-  // Removed in this PR: two tests asserting the previous 3-option
-  // layout (`'Everyone in your voice channel'` as a separate option
-  // alongside text "Everyone in this channel"). Their own comment at
-  // the time of authoring named this PR ("the follow-up that fixes
-  // the recipient-scope bug") as the place to land the collapse.
-  // The collapsed design's voice-channel form is covered by
-  // `voice-channel form shows the collapsed "Everyone in this voice
-  // channel" label` below — same intent (the dropdown contains the
-  // voice path), shape that matches the now-canonical 2-option
-  // layout.
-
   it('target=channel re-prompts when channel has no other members', async () => {
     mockGetChannelMembers.mockReturnValue([]);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -1231,6 +1231,45 @@ describe('handleSend — channel-announcement post sanitizes sender displayName'
     // The sanitized name should appear (NFKC + strip leaves "Adminbob")
     expect(msg).toMatch(/Adminbob/);
   });
+
+  // Voice context wording diverges from the text-channel announcement.
+  // Pin both branches so a future operator-readability tweak doesn't
+  // regress one path silently. The wording difference is the only
+  // user-visible signal that the link went to voice-connected members
+  // only, not the entire view-perm scope.
+  it('text-channel announcement says "all members of this channel"', async () => {
+    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
+    const channelSend = jest.fn().mockResolvedValue(undefined);
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), targetChannel, sendBtn],
+      channel: { type: 0, send: channelSend }, // GuildText
+    });
+    await cmd.execute(interaction);
+    expect(channelSend).toHaveBeenCalledTimes(1);
+    const msg = channelSend.mock.calls[0][0].content;
+    expect(msg).toContain('all members of this channel');
+    expect(msg).not.toContain('voice channel');
+  });
+
+  it('voice-channel announcement says "currently connected to this voice channel"', async () => {
+    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
+    const channelSend = jest.fn().mockResolvedValue(undefined);
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), targetChannel, sendBtn],
+      channel: { type: 2, send: channelSend }, // GuildVoice
+    });
+    await cmd.execute(interaction);
+    expect(channelSend).toHaveBeenCalledTimes(1);
+    const msg = channelSend.mock.calls[0][0].content;
+    expect(msg).toContain('currently connected to this voice channel');
+    expect(msg).not.toContain('all members of this channel');
+  });
 });
 
 // ===========================================================================

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -133,7 +133,6 @@ const mockDb = {
 jest.mock('../src/database', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue(true);
-const mockGetVoiceChannelMembers = jest.fn();
 const mockGetTextChannelMembers = jest.fn();
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
@@ -144,7 +143,6 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getVoiceChannelMembers: mockGetVoiceChannelMembers,
   getTextChannelMembers: mockGetTextChannelMembers,
 }));
 
@@ -766,30 +764,60 @@ describe('handleSend — Step 3: final form', () => {
     }));
   });
 
-  it('target=voice re-prompts when sender is not in a voice channel', async () => {
-    mockGetVoiceChannelMembers.mockReturnValue({ error: 'not_in_voice' });
-    const targetVoice = makeCompInt(ids.targetSelect, { values: ['voice'] });
+  // Voice-channel invocation: target=channel resolves to voice-connected
+  // members only (the prior bug was that getTextChannelMembers filtered
+  // guild.members.cache by ViewChannel perm, which on default servers
+  // expanded to @everyone — sending to the entire guild). The fix routes
+  // through channel.members which discord.js v14 returns as voice-connected
+  // for voice/stage-voice channels. Also: no fetchGuildMembers call needed
+  // (voice state cache populates automatically via gateway events).
+  it('voice-channel invocation skips fetchGuildMembers and uses voice-connected only', async () => {
+    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    const guildFetch = jest.fn().mockResolvedValue(undefined);
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
-      awaitQueue: [locInitBtn(), targetVoice, cancel],
+      awaitQueue: [locInitBtn(), targetChannel, cancel],
+      channel: { type: 2 }, // GuildVoice
+      guild: { members: { fetch: guildFetch } },
     });
     await cmd.execute(interaction);
-    expect(targetVoice.update).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining('must be in a voice channel'),
+    expect(mockGetTextChannelMembers).toHaveBeenCalled();
+    expect(guildFetch).not.toHaveBeenCalled();
+  });
+
+  it('voice-channel empty re-prompt names the voice context', async () => {
+    mockGetTextChannelMembers.mockReturnValue([]);
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    const cancel = makeCompInt(ids.cancelBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), targetChannel, cancel],
+      channel: { type: 2 }, // GuildVoice
+    });
+    await cmd.execute(interaction);
+    expect(targetChannel.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('currently connected to this voice channel'),
     }));
   });
 
-  it('target=voice re-prompts when voice channel has no other members', async () => {
-    mockGetVoiceChannelMembers.mockReturnValue({ members: [] });
-    const targetVoice = makeCompInt(ids.targetSelect, { values: ['voice'] });
+  it('voice-channel form shows the collapsed "Everyone in this voice channel" label', async () => {
+    // The 1a + 1b collapse: voice context shows two options (user +
+    // "Everyone in this voice channel" → voice-connected only).
+    // Pin the label, the option count, and the absence of a separate
+    // "voice" option.
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
-      awaitQueue: [locInitBtn(), targetVoice, cancel],
+      awaitQueue: [locInitBtn(), cancel],
+      channel: { type: 2 }, // GuildVoice
     });
     await cmd.execute(interaction);
-    expect(targetVoice.update).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining('No other users in your voice channel'),
-    }));
+    const initialFormCall = interaction.editReply.mock.calls.find(
+      (c) => c[0] && Array.isArray(c[0].components) && c[0].components.length > 0,
+    );
+    expect(initialFormCall).toBeDefined();
+    const targetSelect = initialFormCall[0].components[0].components[0];
+    const labels = targetSelect.addOptions.mock.calls[0].map((o) => o.label);
+    expect(labels).toEqual(['A specific user', 'Everyone in this voice channel']);
   });
 
   it('expiry select updates the chosen expiry', async () => {
@@ -1154,7 +1182,7 @@ describe('handleSend — audit emission', () => {
 // 7b. Channel-announcement post — sender displayName sanitization
 // ===========================================================================
 // The /qurl send back-half posts a public announcement in the channel
-// when target is 'channel' or 'voice'. Because that post is wider blast
+// when target is 'channel'. Because that post is wider blast
 // radius than a DM, sanitizeDisplayName MUST strip bidi (U+202E) and
 // zero-width (U+200B) chars from the sender's displayName before it
 // goes out. This regression test was ported from the deleted
@@ -1308,17 +1336,6 @@ describe('handleSend — additional branch coverage', () => {
     const interaction = makeInteraction({ awaitQueue: [locInitBtn(), target1, target2, cancel] });
     await cmd.execute(interaction);
     expect(mockGetTextChannelMembers).toHaveBeenCalledTimes(2);
-  });
-
-  // C5b — voice re-select also re-resolves (same staleness concern).
-  it('re-resolves voice members on every voice re-select', async () => {
-    mockGetVoiceChannelMembers.mockReturnValue({ members: [{ id: 'u2', username: 'Alice' }] });
-    const target1 = makeCompInt(ids.targetSelect, { values: ['voice'] });
-    const target2 = makeCompInt(ids.targetSelect, { values: ['voice'] });
-    const cancel = makeCompInt(ids.cancelBtn);
-    const interaction = makeInteraction({ awaitQueue: [locInitBtn(), target1, target2, cancel] });
-    await cmd.execute(interaction);
-    expect(mockGetVoiceChannelMembers).toHaveBeenCalledTimes(2);
   });
 
   // C5d — switching target across types resets recipients (no leakage

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -143,7 +143,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getTextChannelMembers: mockGetTextChannelMembers,
+  getChannelMembers: mockGetTextChannelMembers,
 }));
 
 jest.mock('../src/utils/admin', () => ({
@@ -765,7 +765,7 @@ describe('handleSend — Step 3: final form', () => {
   });
 
   // Voice-channel invocation: target=channel resolves to voice-connected
-  // members only (the prior bug was that getTextChannelMembers filtered
+  // members only (the prior bug was that getChannelMembers filtered
   // guild.members.cache by ViewChannel perm, which on default servers
   // expanded to @everyone — sending to the entire guild). The fix routes
   // through channel.members which discord.js v14 returns as voice-connected
@@ -816,8 +816,15 @@ describe('handleSend — Step 3: final form', () => {
     );
     expect(initialFormCall).toBeDefined();
     const targetSelect = initialFormCall[0].components[0].components[0];
-    const labels = targetSelect.addOptions.mock.calls[0].map((o) => o.label);
+    const options = targetSelect.addOptions.mock.calls[0];
+    const labels = options.map((o) => o.label);
+    const values = options.map((o) => o.value);
     expect(labels).toEqual(['A specific user', 'Everyone in this voice channel']);
+    // Pin values too — "no separate voice option" intent. A future
+    // regression that re-introduces a third dropdown entry under a
+    // different label would still pass labels.toEqual([...]) with an
+    // exact-match array, but values would catch the structural change.
+    expect(values).toEqual(['user', 'channel']);
   });
 
   it('expiry select updates the chosen expiry', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -133,7 +133,7 @@ const mockDb = {
 jest.mock('../src/database', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue(true);
-const mockGetTextChannelMembers = jest.fn();
+const mockGetChannelMembers = jest.fn();
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
   notifyPRMerge: jest.fn(),
@@ -143,7 +143,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
-  getChannelMembers: mockGetTextChannelMembers,
+  getChannelMembers: mockGetChannelMembers,
 }));
 
 jest.mock('../src/utils/admin', () => ({
@@ -733,7 +733,7 @@ describe('handleSend — Step 3: final form', () => {
   });
 
   it('target=channel resolves text-channel members', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
       { id: 'u3', username: 'Bob' },
     ]);
@@ -747,12 +747,12 @@ describe('handleSend — Step 3: final form', () => {
       awaitQueue: [locInitBtn(), targetChannel, sendBtn],
     });
     await cmd.execute(interaction);
-    expect(mockGetTextChannelMembers).toHaveBeenCalled();
+    expect(mockGetChannelMembers).toHaveBeenCalled();
     expect(sendBtn.update).toHaveBeenCalled();
   });
 
   it('target=channel re-prompts when channel has no other members', async () => {
-    mockGetTextChannelMembers.mockReturnValue([]);
+    mockGetChannelMembers.mockReturnValue([]);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
@@ -772,7 +772,7 @@ describe('handleSend — Step 3: final form', () => {
   // for voice/stage-voice channels. Also: no fetchGuildMembers call needed
   // (voice state cache populates automatically via gateway events).
   it('voice-channel invocation skips fetchGuildMembers and uses voice-connected only', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     const guildFetch = jest.fn().mockResolvedValue(undefined);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const cancel = makeCompInt(ids.cancelBtn);
@@ -782,12 +782,12 @@ describe('handleSend — Step 3: final form', () => {
       guild: { members: { fetch: guildFetch } },
     });
     await cmd.execute(interaction);
-    expect(mockGetTextChannelMembers).toHaveBeenCalled();
+    expect(mockGetChannelMembers).toHaveBeenCalled();
     expect(guildFetch).not.toHaveBeenCalled();
   });
 
   it('voice-channel empty re-prompt names the voice context', async () => {
-    mockGetTextChannelMembers.mockReturnValue([]);
+    mockGetChannelMembers.mockReturnValue([]);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
@@ -895,7 +895,7 @@ describe('handleSend — recipients cap', () => {
     // targetSelect handler so the user isn't sandbagged after filling
     // in the rest of the form.
     const many = Array.from({ length: 51 }, (_, i) => ({ id: `u${i}`, username: `U${i}` }));
-    mockGetTextChannelMembers.mockReturnValue(many);
+    mockGetChannelMembers.mockReturnValue(many);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
@@ -963,7 +963,7 @@ describe('handleSend — end-to-end happy paths', () => {
     const err = new Error('upstream quota');
     err.apiCode = 'quota_exceeded';
     mockUploadJsonToConnector.mockRejectedValue(err);
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
     ]);
     const locInit = makeCompInt(ids.initLoc, {
@@ -985,7 +985,7 @@ describe('handleSend — end-to-end happy paths', () => {
   });
 
   it('aborts when the DB write fails after mint, before any DM goes out', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
     ]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
@@ -1010,7 +1010,7 @@ describe('handleSend — end-to-end happy paths', () => {
   });
 
   it('reports failed DM delivery in the post-send confirmation', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
       { id: 'u3', username: 'Bob' },
     ]);
@@ -1042,7 +1042,7 @@ describe('handleSend — end-to-end happy paths', () => {
   });
 
   it('returns a friendly message when mintLinks underdelivers', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
       { id: 'u3', username: 'Bob' },
     ]);
@@ -1104,7 +1104,7 @@ describe('handleSend — audit emission', () => {
   });
 
   it('emits dispatch_sent / dispatch_failed once per recipient, even on partial DM failure', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
       { id: 'u3', username: 'Bob' },
     ]);
@@ -1134,7 +1134,7 @@ describe('handleSend — audit emission', () => {
   });
 
   it('emits dispatch_sent before the DB write, so a DDB throw cannot suppress the metric', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
     mockSendDM.mockResolvedValue(true);
     // Make the DM-status DB write throw — audit must already have fired.
@@ -1162,7 +1162,7 @@ describe('handleSend — audit emission', () => {
   // must still fire as dispatch_failed (not silently disappear when the
   // promise rejection bubbles through batchSettled).
   it('emits dispatch_failed when sendDM itself throws (contract regression guard)', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
     mockSendDM.mockRejectedValueOnce(new Error('Discord API 503'));
     const locInit = makeCompInt(ids.initLoc, {
@@ -1210,7 +1210,7 @@ describe('handleSend — channel-announcement post sanitizes sender displayName'
   }
 
   it('strips RLO (U+202E) and ZWSP (U+200B) before posting to channel', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
     ]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
@@ -1245,7 +1245,7 @@ describe('handleSend — channel-announcement post sanitizes sender displayName'
   // user-visible signal that the link went to voice-connected members
   // only, not the entire view-perm scope.
   it('text-channel announcement says "all members of this channel"', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
     const channelSend = jest.fn().mockResolvedValue(undefined);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
@@ -1262,7 +1262,7 @@ describe('handleSend — channel-announcement post sanitizes sender displayName'
   });
 
   it('voice-channel announcement says "currently connected to this voice channel"', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
     const channelSend = jest.fn().mockResolvedValue(undefined);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
@@ -1375,19 +1375,19 @@ describe('handleSend — additional branch coverage', () => {
   // during the up-to-3-min form-loop window). Regression test for the
   // ghost-recipients bug Claude bot review flagged.
   it('re-resolves channel members on every channel re-select (no stale recipients)', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     const target1 = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const target2 = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({ awaitQueue: [locInitBtn(), target1, target2, cancel] });
     await cmd.execute(interaction);
-    expect(mockGetTextChannelMembers).toHaveBeenCalledTimes(2);
+    expect(mockGetChannelMembers).toHaveBeenCalledTimes(2);
   });
 
   // C5d — switching target across types resets recipients (no leakage
   // from a previously-picked user into a channel send, etc.).
   it('switches target across types and resets recipients each transition', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u3', username: 'Channeler' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u3', username: 'Channeler' }]);
     const target1 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick = makeCompInt(ids.userSelect, {
       users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
@@ -1475,7 +1475,7 @@ describe('handleSend — additional branch coverage', () => {
 
   // C9 — saveSendConfig failure is logged-and-swallowed; DMs still go out.
   it('logs but does not abort when saveSendConfig fails after delivery', async () => {
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/a' }]);
     mockDb.saveSendConfig.mockImplementationOnce(() => { throw new Error('disk full'); });
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
@@ -1493,7 +1493,7 @@ describe('handleSend — additional branch coverage', () => {
 
   // C10 — file-path mintLinks underdelivery (mirror of the location-path test).
   it('returns a friendly message when mintLinks underdelivers on the file path', async () => {
-    mockGetTextChannelMembers.mockReturnValue([
+    mockGetChannelMembers.mockReturnValue([
       { id: 'u2', username: 'Alice' },
       { id: 'u3', username: 'Bob' },
     ]);
@@ -1520,7 +1520,7 @@ describe('handleSend — additional branch coverage', () => {
     mockDownloadAndUpload.mockRejectedValueOnce(err);
     const fileInit = makeCompInt(ids.initFile);
     const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
-    mockGetTextChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
     const awaitMessages = jest.fn().mockResolvedValue(makeAttachmentMessage(attachment));

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -118,7 +118,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: jest.fn(),
-  getVoiceChannelMembers: jest.fn(),
+ 
   getChannelMembers: jest.fn(),
 }));
 
@@ -1381,7 +1381,7 @@ describe('handleAddRecipients', () => {
       postStarMilestone: jest.fn(),
       postToGitHubFeed: jest.fn(),
       sendDM: mockSendDM,
-      getVoiceChannelMembers: jest.fn(),
+     
       getChannelMembers: jest.fn(),
     }));
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -119,7 +119,7 @@ jest.mock('../src/discord', () => ({
   postToGitHubFeed: jest.fn(),
   sendDM: jest.fn(),
   getVoiceChannelMembers: jest.fn(),
-  getTextChannelMembers: jest.fn(),
+  getChannelMembers: jest.fn(),
 }));
 
 // Mock admin util
@@ -1382,7 +1382,7 @@ describe('handleAddRecipients', () => {
       postToGitHubFeed: jest.fn(),
       sendDM: mockSendDM,
       getVoiceChannelMembers: jest.fn(),
-      getTextChannelMembers: jest.fn(),
+      getChannelMembers: jest.fn(),
     }));
 
     // Mock admin util

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -118,7 +118,6 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: jest.fn(),
-
   getChannelMembers: jest.fn(),
 }));
 
@@ -1381,7 +1380,6 @@ describe('handleAddRecipients', () => {
       postStarMilestone: jest.fn(),
       postToGitHubFeed: jest.fn(),
       sendDM: mockSendDM,
-
       getChannelMembers: jest.fn(),
     }));
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -118,7 +118,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: jest.fn(),
- 
+
   getChannelMembers: jest.fn(),
 }));
 
@@ -1381,7 +1381,7 @@ describe('handleAddRecipients', () => {
       postStarMilestone: jest.fn(),
       postToGitHubFeed: jest.fn(),
       sendDM: mockSendDM,
-     
+
       getChannelMembers: jest.fn(),
     }));
 

--- a/e2e/tests/discord-channels.test.ts
+++ b/e2e/tests/discord-channels.test.ts
@@ -92,24 +92,23 @@ describe('Discord: Voice State', () => {
     // default servers and were the source of the prior "sends to entire
     // guild" bug.
     //
-    // The Discord REST API's `voice_states` endpoint is the canonical
-    // source of "currently connected to voice in this channel" — same
+    // The Discord REST API's `voice_states` field on GET /guilds/:id is
+    // the canonical source of "currently connected to voice" — same
     // signal the bot's voice state cache exposes via channel.members.
-    // This test asserts the bot can read voice states for the test
-    // guild and that the channel-scoped subset is what would feed the
-    // recipient pool.
+    // This test pins TWO real invariants:
+    //   1. Every entry in voice_states has a channel_id — i.e., voice
+    //      states are always channel-scoped (not guild-scoped).
+    //   2. Every voice_state.channel_id resolves to a voice or stage-
+    //      voice channel in the same guild — never to a text channel,
+    //      DM, or unknown ID. A future Discord API shape change that
+    //      broke this would surface here, not silently in the bot.
     const channels = await discordApi('GET', `/guilds/${env.GUILD_ID}/channels`);
     const voiceChannels = channels.filter((c: any) => c.type === 2 || c.type === 13);
     if (voiceChannels.length === 0) {
       console.log('No voice/stage channels in test guild — skipping invariant check');
       return;
     }
-    const voiceChannel = voiceChannels[0];
 
-    // GET /guilds/:id returns current voice_states inline. Filter for
-    // the target voice channel — that subset is exactly what /qurl
-    // send target=channel would resolve to in voice context, minus
-    // sender + bot filtering applied client-side.
     let guildSnapshot: any;
     try {
       guildSnapshot = await discordApi('GET', `/guilds/${env.GUILD_ID}?with_counts=true`);
@@ -119,16 +118,16 @@ describe('Discord: Voice State', () => {
     }
 
     const voiceStates: any[] = guildSnapshot.voice_states || [];
-    const inThisChannel = voiceStates.filter((vs: any) => vs.channel_id === voiceChannel.id);
-    // The set CAN legitimately be empty (nobody currently connected) —
-    // the invariant we're pinning is the SCOPE, not a non-empty count.
-    // The regression we'd catch is e.g. inThisChannel returning all
-    // guild members instead of voice-connected ones, which would surface
-    // as inThisChannel.length > voiceStates.length (impossible) or as
-    // entries with mismatched channel_id (caught by the filter shape).
-    inThisChannel.forEach((vs: any) => {
-      expect(vs.channel_id).toBe(voiceChannel.id);
+    const voiceChannelIds = new Set(voiceChannels.map((c: any) => c.id));
+    voiceStates.forEach((vs: any) => {
+      // Invariant 1: every voice state has a channel_id.
+      expect(typeof vs.channel_id).toBe('string');
+      // Invariant 2: voice states only reference voice / stage-voice
+      // channels in this guild — pins the API shape the bot relies on.
+      expect(voiceChannelIds.has(vs.channel_id)).toBe(true);
     });
+    const voiceChannel = voiceChannels[0];
+    const inThisChannel = voiceStates.filter((vs: any) => vs.channel_id === voiceChannel.id);
     console.log(
       `Voice channel #${voiceChannel.name}: ${inThisChannel.length} voice-connected member(s) ` +
       `would be in the "Everyone in this voice channel" recipient pool ` +

--- a/e2e/tests/discord-channels.test.ts
+++ b/e2e/tests/discord-channels.test.ts
@@ -83,20 +83,21 @@ describe('Discord: Voice State', () => {
     console.log(`Verified voice channel: #${voiceChannel.name}`);
   });
 
-  test('"Everyone in voice channel" recipient pool = guild members, NOT voice-connected members', async () => {
-    // Regression documentation for the bug where /qurl send `target=channel`
-    // invoked from a voice channel only delivered to voice-connected users.
-    // The fix in apps/discord/src/discord.js:getTextChannelMembers branches
-    // on channel.type: for GuildVoice/GuildStageVoice it enumerates
-    // guild.members.cache and filters by permissionsFor(ViewChannel),
-    // instead of using channel.members (which on a voice channel is just
-    // the voice-connected subset).
+  test('"Everyone in this voice channel" recipient pool = voice-connected members only', async () => {
+    // Pins the new invariant after the recipient-scope fix:
+    // /qurl send target=channel invoked from a voice channel resolves to
+    // VOICE-CONNECTED members only (channel.members on a GuildVoice /
+    // GuildStageVoice in discord.js v14). NOT the guild member list and
+    // NOT the ViewChannel-permission set — those expand to @everyone on
+    // default servers and were the source of the prior "sends to entire
+    // guild" bug.
     //
-    // This test asserts the prerequisites the fix relies on:
-    //   1) The test guild has at least one voice channel
-    //   2) The bot can enumerate guild members (the superset pool)
-    //   3) That pool is non-empty — so "Everyone" has someone to go to
-    //      even when zero users are connected to voice
+    // The Discord REST API's `voice_states` endpoint is the canonical
+    // source of "currently connected to voice in this channel" — same
+    // signal the bot's voice state cache exposes via channel.members.
+    // This test asserts the bot can read voice states for the test
+    // guild and that the channel-scoped subset is what would feed the
+    // recipient pool.
     const channels = await discordApi('GET', `/guilds/${env.GUILD_ID}/channels`);
     const voiceChannels = channels.filter((c: any) => c.type === 2 || c.type === 13);
     if (voiceChannels.length === 0) {
@@ -105,22 +106,33 @@ describe('Discord: Voice State', () => {
     }
     const voiceChannel = voiceChannels[0];
 
-    let guildMembers: any[] = [];
+    // GET /guilds/:id returns current voice_states inline. Filter for
+    // the target voice channel — that subset is exactly what /qurl
+    // send target=channel would resolve to in voice context, minus
+    // sender + bot filtering applied client-side.
+    let guildSnapshot: any;
     try {
-      guildMembers = await discordApi('GET', `/guilds/${env.GUILD_ID}/members?limit=100`);
+      guildSnapshot = await discordApi('GET', `/guilds/${env.GUILD_ID}?with_counts=true`);
     } catch (e) {
-      console.log('Guild member list requires Server Members intent:', (e as Error).message);
-      return; // premise untestable without the intent; unit tests still cover the logic
+      console.log('Guild snapshot fetch failed:', (e as Error).message);
+      return;
     }
 
-    // The pool the bot iterates for "Everyone in this channel" on a voice
-    // channel is the guild member list — it must be non-empty, otherwise
-    // the regression ("0 recipients in an active channel") could recur.
-    const humans = guildMembers.filter((m: any) => !m.user?.bot);
-    expect(humans.length).toBeGreaterThan(0);
+    const voiceStates: any[] = guildSnapshot.voice_states || [];
+    const inThisChannel = voiceStates.filter((vs: any) => vs.channel_id === voiceChannel.id);
+    // The set CAN legitimately be empty (nobody currently connected) —
+    // the invariant we're pinning is the SCOPE, not a non-empty count.
+    // The regression we'd catch is e.g. inThisChannel returning all
+    // guild members instead of voice-connected ones, which would surface
+    // as inThisChannel.length > voiceStates.length (impossible) or as
+    // entries with mismatched channel_id (caught by the filter shape).
+    inThisChannel.forEach((vs: any) => {
+      expect(vs.channel_id).toBe(voiceChannel.id);
+    });
     console.log(
-      `Voice channel #${voiceChannel.name}: guild has ${humans.length} human member(s) ` +
-      `in the "Everyone in this channel" pool (independent of voice-connected count).`,
+      `Voice channel #${voiceChannel.name}: ${inThisChannel.length} voice-connected member(s) ` +
+      `would be in the "Everyone in this voice channel" recipient pool ` +
+      `(scope = voice-connected only, NOT @everyone view-perm).`,
     );
   });
 });


### PR DESCRIPTION
Squashes the two redundant "everyone" options in voice-channel context into one — and fixes the "sends to everyone in the server" bug in the process.

> **Status:** polished, but pairing PR with a UX decision pending. See "Open question" below before merging. Companion PR #173 ships the smaller dropdown polish + DM late-drop hint independently and is mergeable on its own.

## The bug

When \`/qurl send\` was invoked from a voice channel, the \`Everyone in this channel\` option resolved via \`getTextChannelMembers\`, which enumerated \`guild.members.cache\` filtered by \`ViewChannel\` permission. On a default Discord server, \`@everyone\` has \`ViewChannel\` on the voice channel, so this expanded to **every member of the guild** — sending the qURL link to the entire server instead of the voice channel's audience.

After this PR, the voice-channel context resolves to voice-connected members only via \`channel.members\` (which discord.js v14 returns as voice-connected for voice/stage-voice channels, view-perm holders for text channels). Both are the right semantic for "Everyone in this channel" without permission expansion.

## What this PR ships

**Voice / stage-voice channel context — 2 options:**
- \`A specific user\`
- \`Everyone in this voice channel\` → voice-connected members only

**Text channel context — 2 options:**
- \`A specific user\`
- \`Everyone in this channel\` → text-channel viewer set (existing behavior)

The third dropdown option (\`Everyone in your voice channel\`) is removed entirely — after the scope fix, it returned the same recipient set as \`Everyone in this channel\` in voice context, just under a different label. One option per channel context, no redundancy.

## Implementation

- \`getTextChannelMembers\` (\`discord.js\`) simplified to use \`channel.members\` directly. The \`isVoice\` / \`permissionsFor\` branch is gone — the previous workaround for "voice channels need view-perm scope" was the bug.
- \`getVoiceChannelMembers\` deleted — the dropdown option that drove it is gone.
- \`commands.js\` dropdown rebuilds with two options; the second option's label and description adapt based on \`interaction.channel.type\`. Voice context skips \`fetchGuildMembers\` (voice state cache populates automatically via gateway events). Channel-announcement post adapts wording for voice context.
- \`target === 'voice'\` switch branch removed; \`recipientsResolved\` gate drops the voice clause.

## Open question

The collapse may overload the \`Everyone in this channel\` label in operator mental models. Two ways to think about this:

- **Today (this PR):** voice context label is \`Everyone in this voice channel\`, text context label is \`Everyone in this channel\`. The same value (\`channel\`) drives both, but the label is contextual.
- **Alternative:** keep two labels (\`Everyone in this channel\` + \`Everyone on voice\`) even though they resolve to the same set, on the theory that "voice-connected only" is worth a separate name.

I think the current form is the cleanest UX, but holding for review feedback before merging. PR #173 ships the rename to \`Everyone on voice\` independently, so the alternative remains a one-PR revert away.

## Files

- \`apps/discord/src/discord.js\` — \`getTextChannelMembers\` simplification + helper deletion + import cleanup
- \`apps/discord/src/commands.js\` — dropdown collapse + \`channel\` branch consolidation + channel-post adapt
- \`apps/discord/tests/discord.test.js\` — replaces the perm-filter regression tests with voice-connected pinning (sender/bot exclusion, empty case, stage-voice parity)
- \`apps/discord/tests/qurl-send-state-machine.test.js\` — new tests for voice-channel skip-fetch, voice-channel empty re-prompt copy, collapsed dropdown label

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` — 737 passing
- [ ] Smoke test in real Discord (voice channel): \`/qurl send\` shows two options, second is \`Everyone in this voice channel\`, sends only to voice-connected users
- [ ] Smoke test (text channel): \`/qurl send\` shows two options, second is \`Everyone in this channel\`, sends to text-channel viewers
- [ ] Smoke test: confirm channel-announcement post wording differs between text vs. voice context

## Conflict with PR #173

Both PRs modify the dropdown options block. Whichever lands first, the other will need a one-paragraph rebase. PR #173 is the "ready to ship" small fixes; this PR supersedes #173's voice-context dropdown changes once merged.