### PR TITLE
fix(discord): convert e2e reporter from .ts to .js so Jest can load it

### DIFF
--- a/e2e/helpers/discord-reporter.js
+++ b/e2e/helpers/discord-reporter.js
@@ -2,32 +2,20 @@
  * Posts a per-file E2E result summary embed to the test Discord
  * channel after every run.
  *
+ * Plain `.js` (not `.ts`) by deliberate choice: Jest's reporter
+ * loader uses Node's `require()` directly, with no `ts-jest` hook
+ * applied (the preset only transforms test files). A `.ts` reporter
+ * SyntaxErrors in CI on the first non-JS token. The logic is
+ * straightforward enough that JSDoc types on the load-bearing inputs
+ * are sufficient; converting back to TS would require either
+ * pre-compiling or a Node-level loader hook, both of which are heavier
+ * than the value provided.
+ *
  * Resilience contract: missing env vars / Discord errors / timeouts
  * warn under `[discord-reporter]` but never throw. Reporter is a
  * status surface, not a test gate.
  */
-import * as path from 'node:path';
-import type {
-  AggregatedResult,
-  Reporter,
-  TestContext,
-  TestResult,
-} from '@jest/reporters';
-
-interface EmbedField {
-  name: string;
-  value: string;
-  inline?: boolean;
-}
-
-interface DiscordEmbed {
-  title: string;
-  description: string;
-  color: number;
-  fields: EmbedField[];
-  footer?: { text: string };
-  timestamp?: string;
-}
+const path = require('node:path');
 
 // Discord embed limits: field value 1024, field count 25,
 // total payload 6000. Per-field cap clamped below; total tracked
@@ -50,7 +38,7 @@ const POST_TIMEOUT_MS = 8_000;
 // `MINT_API_URL` host disambiguates env without a new env var.
 // Substring match is fine while domains are `layerv.ai` / `layerv.xyz`;
 // reconsider if a `staging.layerv.ai`-style host ever lands.
-function envLabel(): string {
+function envLabel() {
   const url = process.env.MINT_API_URL ?? '';
   if (url.includes('layerv.ai')) return 'prod';
   if (url.includes('layerv.xyz')) return 'sandbox';
@@ -60,7 +48,7 @@ function envLabel(): string {
 // Discord footer text isn't auto-linkified — return the run URL for
 // the description (where Discord renders it as a clickable link).
 // Falls back to empty when running locally.
-function runUrl(): string {
+function runUrl() {
   const runId = process.env.GITHUB_RUN_ID;
   const repo = process.env.GITHUB_REPOSITORY;
   const server = process.env.GITHUB_SERVER_URL;
@@ -70,7 +58,7 @@ function runUrl(): string {
   return '';
 }
 
-function footerText(): string {
+function footerText() {
   const runId = process.env.GITHUB_RUN_ID;
   const sha = process.env.GITHUB_SHA;
   if (runId) {
@@ -80,7 +68,11 @@ function footerText(): string {
   return 'qURL E2E Test Suite';
 }
 
-function buildField(suite: TestResult): EmbedField {
+/**
+ * @param {{ testFilePath: string, numPassingTests: number, numFailingTests: number, numTotalTests: number, testResults: Array<{ status: string, title: string }> }} suite
+ * @returns {{ name: string, value: string }}
+ */
+function buildField(suite) {
   const file = path.basename(suite.testFilePath);
   // `numTotalTests` includes pending/todo, not just pass+fail. Using
   // the partial sum was misleading: a `3 passes + 1 it.skip` file
@@ -105,7 +97,10 @@ function buildField(suite: TestResult): EmbedField {
   return { name: file, value };
 }
 
-function buildEmbed(results: AggregatedResult): DiscordEmbed {
+/**
+ * @param {{ numPassedTests: number, numFailedTests: number, numTotalTests: number, startTime: number, testResults: Array }} results
+ */
+function buildEmbed(results) {
   const passed = results.numPassedTests;
   const failed = results.numFailedTests;
   const total = results.numTotalTests;
@@ -120,8 +115,8 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
   // matches the per-file `⏭ N` display below it.
   const skipped = total - passed - failed;
   const skippedSuffix = skipped > 0 ? ` (${skipped} skipped)` : '';
-  let color: number;
-  let description: string;
+  let color;
+  let description;
   if (total === 0) {
     color = COLOR_YELLOW;
     description = `⚠️ No tests ran · ${durationSec}s`;
@@ -144,21 +139,21 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
   // they originate in our own test code, not user input — Discord
   // embeds don't render markdown the way messages do, so this is the
   // intended trust boundary.
-  const fields: EmbedField[] = [];
-  let usedBytes = title.length + description.length + footerText().length;
+  const fields = [];
+  let usedChars = title.length + description.length + footerText().length;
   for (const suite of results.testResults) {
     if (fields.length >= FIELD_COUNT_MAX) break;
     const field = buildField(suite);
-    const fieldBytes = field.name.length + field.value.length;
-    if (usedBytes + fieldBytes > FIELDS_BUDGET) break;
+    const fieldChars = field.name.length + field.value.length;
+    if (usedChars + fieldChars > FIELDS_BUDGET) break;
     fields.push(field);
-    usedBytes += fieldBytes;
+    usedChars += fieldChars;
   }
   const truncated = results.testResults.length - fields.length;
   const truncatedNote = truncated > 0 ? ` (showing ${fields.length}/${results.testResults.length} files)` : '';
 
   // Run URL belongs in the description, not the footer — Discord
-  // doesn't linkify footer text (per claude-review pass 2).
+  // doesn't linkify footer text.
   const url = runUrl();
   const linkLine = url ? `\n[View run on GitHub](${url})` : '';
 
@@ -173,11 +168,10 @@ function buildEmbed(results: AggregatedResult): DiscordEmbed {
   };
 }
 
-async function postEmbed(embed: DiscordEmbed): Promise<void> {
+async function postEmbed(embed) {
   const token = process.env.BOT_TOKEN;
   const channelId = process.env.CHANNEL_ID;
   if (!token || !channelId) {
-    // eslint-disable-next-line no-console
     console.warn(
       '[discord-reporter] BOT_TOKEN or CHANNEL_ID unset — skipping Discord post (test results NOT affected).',
     );
@@ -201,7 +195,6 @@ async function postEmbed(embed: DiscordEmbed): Promise<void> {
 
     if (!res.ok) {
       const body = await res.text();
-      // eslint-disable-next-line no-console
       console.warn(
         `[discord-reporter] Discord POST returned ${res.status}: ${body.slice(0, 200)} (test results NOT affected).`,
       );
@@ -211,30 +204,30 @@ async function postEmbed(embed: DiscordEmbed): Promise<void> {
     const msg = isAbort
       ? `timeout after ${POST_TIMEOUT_MS}ms`
       : err instanceof Error ? err.message : String(err);
-    // eslint-disable-next-line no-console
     console.warn(`[discord-reporter] Discord POST ${msg} (test results NOT affected).`);
   } finally {
     clearTimeout(timer);
   }
 }
 
-export default class DiscordReporter implements Reporter {
-  constructor(_globalConfig: unknown, _reporterOptions: unknown) {}
+class DiscordReporter {
+  constructor(_globalConfig, _reporterOptions) {}
 
-  async onRunComplete(_contexts: Set<TestContext>, results: AggregatedResult): Promise<void> {
+  async onRunComplete(_contexts, results) {
     try {
       const embed = buildEmbed(results);
       await postEmbed(embed);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // eslint-disable-next-line no-console
       console.warn(`[discord-reporter] failed to post embed: ${msg} (test results NOT affected).`);
     }
   }
 
   // Returning `undefined` signals "no reporter-side error." Test
   // failures surface via jest's own exit code, independent of this hook.
-  getLastError(): Error | undefined {
+  getLastError() {
     return undefined;
   }
 }
+
+module.exports = DiscordReporter;

--- a/e2e/jest.config.ts
+++ b/e2e/jest.config.ts
@@ -14,7 +14,10 @@ const config: Config = {
   // delivery" signal that didn't reflect actual results). Reporter is
   // resilient: missing env vars / Discord errors warn but never throw,
   // so a broken reporter cannot turn a green run red.
-  reporters: ['default', '<rootDir>/helpers/discord-reporter.ts'],
+  // `.js` (not `.ts`): Jest's reporter loader uses Node `require()`
+  // directly with no ts-jest hook, so a TS reporter SyntaxErrors at
+  // load. See discord-reporter.js header for the full rationale.
+  reporters: ['default', '<rootDir>/helpers/discord-reporter.js'],
 };
 
 export default config;


### PR DESCRIPTION
## Why

Sandbox e2e-smoke broke immediately after [#171](https://github.com/layervai/qurl-integrations/pull/171) merged. [Run 25241566140](https://github.com/layervai/qurl-integrations-infra/actions/runs/25241566140):

```
SyntaxError: An error occurred while adding the reporter at path
".../e2e/helpers/discord-reporter.ts". Unexpected token '{'
```

## Root cause

Jest's **reporter loader uses Node's `require()` directly** with no `ts-jest` hook applied. The `preset: 'ts-jest'` in `jest.config.ts` only transforms *test files*; reporter paths are loaded raw by Node. The CI runner hit the first TypeScript token (a typed parameter shape in the `Reporter` interface import) and crashed before any test could run.

My pre-merge verification on #171 was `npx jest --listTests` — that lists tests but doesn't load reporters. The bug was hidden until the first real `jest` invocation in CI. Real bug, my mistake.

## Fix

Convert `e2e/helpers/discord-reporter.ts` → `discord-reporter.js`. Plain JS + JSDoc on the load-bearing inputs. Logic is **identical** to the .ts version:

- Same constants (FIELD_VALUE_MAX / FIELD_COUNT_MAX / FIELDS_BUDGET / POST_TIMEOUT_MS / colors)
- Same yellow/green/red branching (yellow on 0-tests-ran AND on all-skipped)
- Same per-file rollup with failure expansion + `… and N more` overflow
- Same total-embed budget enforcement during field construction
- Same `AbortController` 8s timeout
- Same resilience contract (warn under `[discord-reporter]`, never throw)
- Same env sniffing from `MINT_API_URL`
- Same run URL in description (since Discord doesn't linkify footer text)
- Same skipped-count surfacing in description

Only behavioral change: file extension and loss of compile-time type checking on reporter internals. JSDoc covers the surface that matters (`AggregatedResult` / `TestResult` shapes the caller feeds in).

## Verified locally

- `node -c e2e/helpers/discord-reporter.js` — syntax clean
- `node -e "const R = require('./helpers/discord-reporter.js'); new R({},{})"` — loads + instantiates cleanly via the same `require()` path Jest uses
- `npx jest --listTests` — config still loads with new reporter path

## Alternatives considered (rejected)

- **Compile reporter via build step** — adds a build artifact + watch loop; reporter is small enough not to justify the complexity.
- **`ts-node/register` loader hook in jest config** — works but adds runtime ts-node dep + register-time tax on every Jest invocation.

JS + JSDoc is the right balance for a 200-line file.

## Process learning

Pre-merge gap: `npx jest --listTests` doesn't exercise reporter loading. Folding `node -c` syntax-check + `require()` round-trip on the reporter into the e2e smoke step would prevent recurrence — out of scope for this PR but worth tracking. Filing as follow-up if Vikram wants.

## Test plan

- [x] Reporter loads via `require()` cleanly
- [x] `jest --listTests` exits clean (config loads)
- [ ] After merge: sandbox e2e-smoke green on next dispatch
- [ ] Embed posted to qurl-test-bot-playground (channel 1491271326235885679) at end of run

🤖 Generated with [Claude Code](https://claude.com/claude-code)