### PR TITLE
fix(shared): client.Create uses /v1/qurls (plural), not /v1/qurl

### DIFF
--- a/apps/cli/cmd/commands_test.go
+++ b/apps/cli/cmd/commands_test.go
@@ -27,7 +27,7 @@ func newMockServer(t *testing.T) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/qurl":
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/qurls":
 			apiEnvelope(t, w, map[string]any{
 				"resource_id": "r_test123",
 				"qurl_link":   "https://qurl.link/at_abc",

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -254,7 +254,7 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 		return nil, fmt.Errorf("marshal create input: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurl", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -267,7 +267,7 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 	}
 
 	var out CreateOutput
-	if _, err := c.do(req, &out, "POST /v1/qurl"); err != nil {
+	if _, err := c.do(req, &out, "POST /v1/qurls"); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -50,8 +50,8 @@ func TestCreate(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1/qurl" {
-			t.Errorf("expected /v1/qurl, got %s", r.URL.Path)
+		if r.URL.Path != "/v1/qurls" {
+			t.Errorf("expected /v1/qurls, got %s", r.URL.Path)
 		}
 		if r.Header.Get("Authorization") != "Bearer test-key" {
 			t.Errorf("expected Bearer test-key, got %s", r.Header.Get("Authorization"))


### PR DESCRIPTION
## Summary

`shared/client.Create` posted to `{baseURL}/v1/qurl` (singular). Every other method on this same client (`Get`, `List`, `Delete`, `Patch/Extend/Update`, `MintLink`) correctly uses `/v1/qurls/...` plural; Discord's JS client also uses plural (`apps/discord/src/commands.js:3037`). The singular form was a typo that 404s on every qurl service host:

```
POST https://api.layerv.ai/v1/qurl   → 404 (route not present)
POST https://api.layerv.ai/v1/qurls  → 201 (route present, succeeds)
```

## Symptom

Slack bot's first end-to-end sandbox test today returned:
```
Failed to create qURL: Not Found
```

Companion fix in [qurl-integrations-infra#412](https://github.com/layervai/qurl-integrations-infra/pull/412) (already merged) corrects the endpoint **host** (`api.layerv.ai` vs `.xyz`); this PR closes the **path** half. Both must land before the bot's `/qurl-sandbox create` slash command works.

## Why CI didn't catch it

The `client_test.go` assertion at line 53 also matched the wrong singular path:

```go
if r.URL.Path != "/v1/qurl" { ... }
```

The test was verifying **internal consistency** (test server matched whatever the client sent) rather than the **actual API contract**. Both the production code AND its test had the same typo, so they reinforced each other. Updated together so the test now fences the correct path.

## Changes
- `shared/client/client.go:257,270` — `/v1/qurl` → `/v1/qurls` (request URL + log/metric label)
- `shared/client/client_test.go:53,54` — assert `/v1/qurls`

## Test plan
- [x] `go test -count=1 ./shared/client/...` — passes
- [x] `go test -count=1 ./apps/slack/...` — passes
- [x] `make lint` — 0 issues
- [ ] Post-merge: rebuild + redeploy slack bot image; rerun `/qurl-sandbox create https://example.com` from the LayerVai workspace; expect a real qurl link in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)