### PR TITLE
feat(discord): replace /qurl setup API-key paste with OAuth-redirect flow

### DIFF
--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -16,6 +16,7 @@
         "discord.js": "~14.25.1",
         "express": "~5.2.1",
         "helmet": "~7.2.0",
+        "jose": "~5.9.6",
         "node-cron": "~4.2.1"
       },
       "devDependencies": {
@@ -6324,6 +6325,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -28,6 +28,7 @@
     "discord.js": "~14.25.1",
     "express": "~5.2.1",
     "helmet": "~7.2.0",
+    "jose": "~5.9.6",
     "node-cron": "~4.2.1"
   },
   "devDependencies": {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -20,6 +20,7 @@ const logger = require('./logger');
 const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, AUDIT_EVENTS } = require('./constants');
 const { expiryToISO, expiryToMs } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
+const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 
@@ -3136,7 +3137,6 @@ const commands = [
 
         // OAuth path — preferred when configured.
         if (config.isQurlOAuthConfigured) {
-          const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
           const state = signQurlOAuthState(interaction.guildId, interaction.user.id);
           const startUrl = `${config.BASE_URL}/oauth/qurl/start?state=${encodeURIComponent(state)}`;
           return interaction.reply({

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3136,9 +3136,6 @@ const commands = [
 
         // OAuth path — preferred when configured.
         if (config.isQurlOAuthConfigured) {
-          // Lazy-require to avoid a circular dependency in the test harness:
-          // qurl-oauth-state.js → config.js, which is already required at
-          // the top of commands.js.
           const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
           const state = signQurlOAuthState(interaction.guildId, interaction.user.id);
           const startUrl = `${config.BASE_URL}/oauth/qurl/start?state=${encodeURIComponent(state)}`;
@@ -3148,7 +3145,8 @@ const commands = [
               + 'Sign in with your layerv.ai account and consent. The bot will mint a qURL '
               + 'API key owned by your account — all usage on this server will bill to you. '
               + 'No copy-paste needed.\n\n'
-              + '_This link expires in 5 minutes and can only be used once._',
+              + '_This link expires in 5 minutes and is bound to your browser session — '
+              + 'open it in the same tab where you ran `/qurl setup`._',
             ephemeral: true,
           });
         }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3252,11 +3252,38 @@ const commands = [
             .update(plaintextKey)
             .digest('hex')
             .slice(0, 8);
+
+          // #185 admin-offboarding nudge: the qURL key is owned by the
+          // admin who ran setup (Auth0 sub claim); usage bills to their
+          // qURL account even after they leave. Surface a passive notice
+          // so a remaining ManageGuild admin knows to rerun setup to
+          // take over billing. Best-effort — a Discord API blip just
+          // omits the notice rather than failing the whole status read.
+          let originalAdminLeftNotice = '';
+          if (guildConfig.configured_by) {
+            try {
+              await interaction.guild.members.fetch(guildConfig.configured_by);
+            } catch (err) {
+              // discord.js throws DiscordAPIError code 10007 ("Unknown
+              // Member") when the user is no longer in the guild. Any
+              // other error (rate limit, transient) → skip the nudge
+              // silently rather than mis-flag a present admin.
+              if (err?.code === 10007) {
+                originalAdminLeftNotice =
+                  '\n\n⚠️ The admin who originally ran `/qurl setup` (<@' +
+                  guildConfig.configured_by + '>) has left this server. ' +
+                  'qURL usage continues to bill to their layerv.ai account. ' +
+                  'A current `ManageGuild` admin can run `/qurl setup` again to take over billing.';
+              }
+            }
+          }
+
           return interaction.reply({
             content: `✅ **qURL is configured**\n` +
               `Key fingerprint: \`${keyFingerprint}\`\n` +
               `Configured by: <@${guildConfig.configured_by}>\n` +
-              `Last updated: ${guildConfig.updated_at}`,
+              `Last updated: ${guildConfig.updated_at}` +
+              originalAdminLeftNotice,
             ephemeral: true,
           });
         }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3113,7 +3113,19 @@ const commands = [
     async execute(interaction) {
       const sub = interaction.options.getSubcommand();
 
-      // /qurl setup — admin-only, configure API key for this server
+      // /qurl setup — admin-only, configure API key for this server.
+      //
+      // Default flow (when AUTH0_* env vars are configured): replies with
+      // a one-shot OAuth-redirect link. Admin clicks → Auth0 sign-in +
+      // consent → server-side callback mints a guild-scoped API key on
+      // qurl-service (admin-owned, billed to the admin's qURL account)
+      // and persists it via the Store abstraction. NO API key paste.
+      //
+      // Fallback flow (AUTH0_* unset, e.g. early sandbox before Justin
+      // registers the Auth0 app): reverts to the legacy modal-paste UX
+      // so the bot stays usable until OAuth is wired end-to-end. The
+      // fallback can be removed in a follow-up once the OAuth path is
+      // live in prod.
       if (sub === 'setup') {
         if (!interaction.guildId) {
           return interaction.reply({ content: 'This command can only be used in a server, not in DMs.', ephemeral: true });
@@ -3121,9 +3133,30 @@ const commands = [
         if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
           return interaction.reply({ content: 'Only server administrators can configure qURL.', ephemeral: true });
         }
-        // Refuse to accept a guild API key unless encryption-at-rest is
-        // configured. Falling through to the crypto module's plaintext
-        // fallback would silently store a billing-sensitive secret on disk.
+
+        // OAuth path — preferred when configured.
+        if (config.isQurlOAuthConfigured) {
+          // Lazy-require to avoid a circular dependency in the test harness:
+          // qurl-oauth-state.js → config.js, which is already required at
+          // the top of commands.js.
+          const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
+          const state = signQurlOAuthState(interaction.guildId, interaction.user.id);
+          const startUrl = `${config.BASE_URL}/oauth/qurl/start?state=${encodeURIComponent(state)}`;
+          return interaction.reply({
+            content: '🔐 **Connect qURL to this server**\n\n'
+              + `**[Click here to authorize qURL](${startUrl})**\n\n`
+              + 'Sign in with your layerv.ai account and consent. The bot will mint a qURL '
+              + 'API key owned by your account — all usage on this server will bill to you. '
+              + 'No copy-paste needed.\n\n'
+              + '_This link expires in 5 minutes and can only be used once._',
+            ephemeral: true,
+          });
+        }
+
+        // Legacy modal-paste fallback. Refuse to accept a guild API key
+        // unless encryption-at-rest is configured. Falling through to the
+        // crypto module's plaintext fallback would silently store a
+        // billing-sensitive secret on disk.
         if (!process.env.KEY_ENCRYPTION_KEY) {
           logger.error('Refusing /qurl setup: KEY_ENCRYPTION_KEY is not set');
           return interaction.reply({

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3293,49 +3293,24 @@ const commands = [
       if (sub === 'send') return handleSend(interaction, resolvedApiKey);
       if (sub === 'revoke') return handleRevoke(interaction, resolvedApiKey);
       if (sub === 'help') {
-        // Rendered output (after Discord's markdown parser):
-        //
-        //   qURL Bot — Help
-        //
-        //   Getting started — Share resources securely via one-time links:
-        //     /qurl send — send a file or location to users
-        //     /qurl revoke — revoke links from a previous send
-        //     /qurl help — show this message
-        //
-        //   How it works:
-        //     1. Run /qurl send and pick "Send File" or "Send Location"
-        //     2. (Files only) I'll DM you privately — drop the file there,
-        //        not in the public channel
-        //     3. Choose recipient(s), expiry, and optionally a personal
-        //        message — then click Send
-        //     4. Recipients get a one-time link by DM that self-destructs
-        //        on first access (or when the expiry elapses)
-        //
-        //   Setting up (for Admins):
-        //     /qurl setup — configure your API key (admin only)
-        //     /qurl status — check if qURL is configured (admin only)
-        //
-        //   Terms: a protected resource is the file or location you're
-        //   sharing. A qurl (or access link) is the single-use URL that
-        //   delivers it. You create a qurl for a protected resource each
-        //   time you run /qurl send.
-        //
-        //   Large servers (~1000+ members): when sending to "Everyone in
-        //   this channel" or "Everyone in your voice channel", members
-        //   who appear offline in Discord may be skipped. If you need
-        //   to reach a specific person for sure, pick "A specific user".
-        //
-        //   Sign up at https://layerv.ai to get your API key.
-        //
-        // Section order (post-PR #124): user-facing flow first (Getting
-        // started → How it works), then admin-only setup, then glossary
-        // (Terms), then operational caveat (Large servers), then signup.
-        // PR #134 rewrote /qurl send as a button-driven flow — the
-        // "How it works" steps below describe the new shape (no slash
-        // options; pick Send File / Send Location → DM-pivot for files
-        // → recipient/expiry/message form → Send). If the flow changes
-        // again, update both the rendered-output ASCII above AND the
-        // string concatenation below to keep them in sync.
+        // Section order: user-facing flow first (Getting started → How it
+        // works), then admin-only setup (now the OAuth-redirect flow per
+        // PR #177), then glossary (Terms), then operational caveat
+        // (Large servers). The "Setting up" section pivots based on
+        // whether OAuth is configured — when it is, we describe the
+        // /qurl setup OAuth flow + the "Add to Discord" install-flow
+        // entry point. When unset (sandbox before Auth0 secrets land),
+        // we keep the legacy "API key paste" wording so the help text
+        // matches what /qurl setup actually does at that moment.
+        const oauthSetupSection = config.isQurlOAuthConfigured
+          ? '**Setting up (for Admins):**\n'
+            + '  `/qurl setup` — connect qURL via OAuth (admin only). Click the link, sign in to layerv.ai, consent. No API key paste.\n'
+            + '  `/qurl status` — check if qURL is configured (admin only)\n\n'
+            + '_Adding the bot to a new server?_ Use the "Add to Discord" link on **https://layerv.ai** — '
+            + 'it walks you through server selection, permissions consent, and qURL connection in one click chain.\n\n'
+          : '**Setting up (for Admins):**\n'
+            + '  `/qurl setup` — configure your API key (admin only)\n'
+            + '  `/qurl status` — check if qURL is configured (admin only)\n\n';
         return interaction.reply({
           content: '**qURL Bot — Help**\n\n' +
             '**Getting started — Share resources securely via one-time links:**\n' +
@@ -3353,16 +3328,14 @@ const commands = [
             '  2. (Files only) I\'ll DM you privately — drop the file there, not in the public channel\n' +
             '  3. Choose recipient(s), expiry, and optionally a personal message — then click **Send**\n' +
             '  4. Recipients get a one-time link by DM that self-destructs on first access (or when the expiry elapses)\n\n' +
-            '**Setting up (for Admins):**\n' +
-            '  `/qurl setup` — configure your API key (admin only)\n' +
-            '  `/qurl status` — check if qURL is configured (admin only)\n\n' +
+            oauthSetupSection +
             '**Terms:** a *protected resource* is the file or location you\'re sharing. ' +
             'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
             'You create a qurl for a protected resource each time you run `/qurl send`.\n\n' +
             '**Large servers (~1000+ members):** when sending to **Everyone in this channel** ' +
             'or **Everyone in your voice channel**, members who appear offline in Discord may be skipped. ' +
             'If you need to reach a specific person for sure, pick **A specific user**.\n\n' +
-            'Sign up at **https://layerv.ai** to get your API key.',
+            'Learn more at **https://layerv.ai**.',
           ephemeral: true,
         });
       }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3146,7 +3146,7 @@ const commands = [
               + 'API key owned by your account — all usage on this server will bill to you. '
               + 'No copy-paste needed.\n\n'
               + '_This link expires in 5 minutes and is bound to your browser session — '
-              + 'open it in the same tab where you ran `/qurl setup`._',
+              + 'open it in the same browser where you ran `/qurl setup`._',
             ephemeral: true,
           });
         }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3137,6 +3137,20 @@ const commands = [
 
         // OAuth path — preferred when configured.
         if (config.isQurlOAuthConfigured) {
+          // Fail-fast on encryption-at-rest BEFORE minting the OAuth
+          // setup link — otherwise the admin clicks through, completes
+          // the full Auth0 dance, and only then sees the 503 from
+          // /oauth/qurl/start. Same actionable message as the legacy
+          // modal-paste branch below; round-9.6 #4 surface symmetry.
+          if (!process.env.KEY_ENCRYPTION_KEY) {
+            logger.error('Refusing /qurl setup (OAuth path): KEY_ENCRYPTION_KEY is not set');
+            return interaction.reply({
+              content: '❌ **qURL is not ready to accept setup on this server.**\n\n'
+                + 'The bot operator needs to set `KEY_ENCRYPTION_KEY` (encryption-at-rest) before '
+                + '/qurl setup can store keys safely. Ask them to check the deployment env.',
+              ephemeral: true,
+            });
+          }
           const state = signQurlOAuthState(interaction.guildId, interaction.user.id);
           const startUrl = `${config.BASE_URL}/oauth/qurl/start?state=${encodeURIComponent(state)}`;
           return interaction.reply({
@@ -3287,11 +3301,22 @@ const commands = [
             ephemeral: true,
           });
         }
+        // Branch the not-configured copy on the active setup flow so
+        // the instructions match what /qurl setup actually accepts —
+        // OAuth-redirect (no api_key arg) vs legacy modal-paste.
+        // Pre-OAuth this hardcoded `setup api_key:lv_live_your_key_here`,
+        // which never matched the modal flow either; fixed in round-9.6
+        // alongside the OAuth-redirect path documentation.
+        const notConfiguredCopy = config.isQurlOAuthConfigured
+          ? '❌ **qURL is not configured for this server.**\n\n'
+            + 'Run `/qurl setup` to connect — you\'ll be redirected to layerv.ai to authorize, '
+            + 'and the bot will mint an API key bound to your server. Only server administrators can run setup.'
+          : '❌ **qURL is not configured for this server.**\n\n'
+            + '1. Sign up at **https://layerv.ai** to get your API key\n'
+            + '2. Run `/qurl setup` and paste the key into the modal\n\n'
+            + 'Only server administrators can run setup.';
         return interaction.reply({
-          content: '❌ **qURL is not configured for this server.**\n\n' +
-            '1. Sign up at **https://layerv.ai** to get your API key\n' +
-            '2. Run `/qurl setup api_key:lv_live_your_key_here`\n\n' +
-            'Only server administrators can run setup.',
+          content: notConfiguredCopy,
           ephemeral: true,
         });
       }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -111,16 +111,35 @@ const isQurlOAuthConfigured = Boolean(
   && process.env.AUTH0_AUDIENCE,
 );
 
+// True when the Stage-2 "Add to Discord, select server" install flow can
+// run end-to-end: needs the bot's Discord OAuth2 client secret (separate
+// from the bot token used for normal operations) on top of qURL OAuth.
+// The /oauth/discord/callback route gates on this; it returns 503 with a
+// "not configured" page when false, so the install link still completes
+// (bot lands in the server) but the chained Auth0 leg won't run until
+// Justin sets DISCORD_CLIENT_SECRET in SSM.
+const isDiscordInstallConfigured = Boolean(
+  isQurlOAuthConfigured && process.env.DISCORD_CLIENT_SECRET,
+);
+
 // Configuration from environment variables
 module.exports = {
   // Discord
   DISCORD_TOKEN: process.env.DISCORD_TOKEN,
   DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+  // Required for the Stage-2 "Add to Discord, select server" install
+  // callback (src/routes/discord-install.js). Not used by normal bot
+  // operations — only by the OAuth2 token exchange when an admin
+  // installs the bot via the install link. Optional: omit and the
+  // /oauth/discord/callback route will return 503 with a documented
+  // "not configured" page until Justin sets the secret.
+  DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
   GUILD_ID: normalizedGuildId,
   isMultiTenant,
   ENABLE_OPENNHP_FEATURES: enableOpenNHPFeatures,
   isOpenNHPActive,
   isQurlOAuthConfigured,
+  isDiscordInstallConfigured,
 
   // Role names for progression
   CONTRIBUTOR_ROLE_NAME: process.env.CONTRIBUTOR_ROLE_NAME || 'Contributor',

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -108,13 +108,18 @@ const isOpenNHPActive = !isMultiTenant && enableOpenNHPFeatures;
 // path activates) instead of crashing mid-flow.
 function isValidAuth0DomainShape(d) {
   if (typeof d !== 'string' || !d) return false;
+  // DNS-shape cap: RFC 1035 maxes at 253 chars total. Auth0 domains in
+  // practice are short (e.g., layerv.us.auth0.com), but an explicit
+  // cap is clearer than relying on a regex bound.
+  if (d.length > 253) return false;
   // Reject any scheme prefix or path — domain only.
   if (/[:/?#]/.test(d)) return false;
-  // Bare hostname, lowercase letters/digits/dots/dashes, must contain
-  // at least one dot (rejects "placeholder" / "localhost" while
-  // permitting custom Auth0 domains like auth.layerv.ai). Length cap
-  // matches DNS label limits in aggregate.
-  return /^[a-z0-9][a-z0-9.-]{2,253}\.[a-z]{2,}$/i.test(d);
+  // Bare hostname, letters/digits/dots/dashes, must contain at least
+  // one dot (rejects "placeholder" / "localhost" while permitting
+  // custom Auth0 domains like auth.layerv.ai). Case-insensitive on
+  // input — Auth0 domains are canonically lowercase but we don't
+  // reject mixed case.
+  return /^[a-z0-9][a-z0-9.-]+\.[a-z]{2,}$/i.test(d);
 }
 
 // True when all four Auth0 env vars are present AND AUTH0_DOMAIN is a

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -99,6 +99,18 @@ if (!normalizedGuildId && enableOpenNHPFeatures) {
 // what "multi-tenant" means — only touches this file.
 const isOpenNHPActive = !isMultiTenant && enableOpenNHPFeatures;
 
+// True when all four Auth0 env vars are present — `/qurl setup` then
+// uses the OAuth-redirect flow. False = degrade to the legacy modal-paste
+// flow (kept until Justin registers the Auth0 app + sets prod SSM secrets).
+// Single derivation point so commands.js + routes/qurl-oauth.js + server.js
+// agree on what "configured" means.
+const isQurlOAuthConfigured = Boolean(
+  process.env.AUTH0_DOMAIN
+  && process.env.AUTH0_CLIENT_ID
+  && process.env.AUTH0_CLIENT_SECRET
+  && process.env.AUTH0_AUDIENCE,
+);
+
 // Configuration from environment variables
 module.exports = {
   // Discord
@@ -108,6 +120,7 @@ module.exports = {
   isMultiTenant,
   ENABLE_OPENNHP_FEATURES: enableOpenNHPFeatures,
   isOpenNHPActive,
+  isQurlOAuthConfigured,
 
   // Role names for progression
   CONTRIBUTOR_ROLE_NAME: process.env.CONTRIBUTOR_ROLE_NAME || 'Contributor',
@@ -131,6 +144,17 @@ module.exports = {
   GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
   GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
+
+  // qURL OAuth (Auth0) — for /qurl setup admin consent flow.
+  // When unset, /qurl setup falls back to the legacy modal-paste path so the
+  // bot stays usable until Justin registers the Auth0 application + drops
+  // these into prod SSM. See project_qurl_bot_onboarding_model.md memory for
+  // the OAuth-app shape (Regular Web Application, callback URL = BASE_URL +
+  // /oauth/qurl/callback, scopes qurl:write + qurl:read).
+  AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+  AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+  AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
+  AUTH0_AUDIENCE: process.env.AUTH0_AUDIENCE,
 
   // Allowed GitHub organizations (comma-separated)
   ALLOWED_GITHUB_ORGS: (process.env.ALLOWED_GITHUB_ORGS || 'OpenNHP').split(',').map(s => s.trim().toLowerCase()).filter(Boolean),

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -99,13 +99,32 @@ if (!normalizedGuildId && enableOpenNHPFeatures) {
 // what "multi-tenant" means — only touches this file.
 const isOpenNHPActive = !isMultiTenant && enableOpenNHPFeatures;
 
-// True when all four Auth0 env vars are present — `/qurl setup` then
-// uses the OAuth-redirect flow. False = degrade to the legacy modal-paste
-// flow (kept until Justin registers the Auth0 app + sets prod SSM secrets).
-// Single derivation point so commands.js + routes/qurl-oauth.js + server.js
+// AUTH0_DOMAIN must be a bare hostname — the codebase composes it as
+// `https://${AUTH0_DOMAIN}/...` for the JWKS endpoint, /authorize, and
+// /oauth/token. Round-9 #2: typo'd values like 'https://layerv.auth0.com'
+// or a placeholder string would silently flip isQurlOAuthConfigured on,
+// then break under load with a confusing URL parse error. Reject at
+// config-load time so the bot fails to enable OAuth (legacy fallback
+// path activates) instead of crashing mid-flow.
+function isValidAuth0DomainShape(d) {
+  if (typeof d !== 'string' || !d) return false;
+  // Reject any scheme prefix or path — domain only.
+  if (/[:/?#]/.test(d)) return false;
+  // Bare hostname, lowercase letters/digits/dots/dashes, must contain
+  // at least one dot (rejects "placeholder" / "localhost" while
+  // permitting custom Auth0 domains like auth.layerv.ai). Length cap
+  // matches DNS label limits in aggregate.
+  return /^[a-z0-9][a-z0-9.-]{2,253}\.[a-z]{2,}$/i.test(d);
+}
+
+// True when all four Auth0 env vars are present AND AUTH0_DOMAIN is a
+// well-shaped hostname — `/qurl setup` then uses the OAuth-redirect
+// flow. False = degrade to the legacy modal-paste flow (kept until
+// Justin registers the Auth0 app + sets prod SSM secrets). Single
+// derivation point so commands.js + routes/qurl-oauth.js + server.js
 // agree on what "configured" means.
 const isQurlOAuthConfigured = Boolean(
-  process.env.AUTH0_DOMAIN
+  isValidAuth0DomainShape(process.env.AUTH0_DOMAIN)
   && process.env.AUTH0_CLIENT_ID
   && process.env.AUTH0_CLIENT_SECRET
   && process.env.AUTH0_AUDIENCE,

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -15,14 +15,26 @@
 // One unbroken click chain from "Add to Discord" → "qURL is ready" — no
 // admin-visible step between Discord consent and Auth0 consent.
 //
-// CSRF posture:
+// CSRF posture (read together with qurl-oauth.js:renderSuccess):
 //   The `state` param Discord echoes is best-effort (admins paste the
 //   "Add to Discord" link from layerv.ai, not from a per-session form),
-//   so we don't validate it as a session-bound token. The CSRF guarantee
-//   comes from the Discord token-exchange step: only Discord can mint a
-//   `code` that pairs with our DISCORD_CLIENT_ID/SECRET, so an attacker
-//   forging a /oauth/discord/callback request without going through
-//   Discord OAuth2 can't get past the token exchange.
+//   so we don't validate it as a session-bound token. The defense
+//   stacks across two surfaces:
+//   1. Forged-callback rejection — only Discord can mint a `code` that
+//      pairs with our DISCORD_CLIENT_ID/SECRET, so an attacker forging
+//      a /oauth/discord/callback request without going through Discord
+//      OAuth2 can't get past the token exchange.
+//   2. Confused-deputy mitigation (LOAD-BEARING — do not remove without
+//      replacing) — an attacker who pre-runs Discord install in their
+//      own browser then forwards the chained Auth0-redirect URL to a
+//      victim WOULD pass step 1, because the Discord code is real.
+//      The success page in qurl-oauth.js's renderSuccess surfaces the
+//      bound (guildId, qurlAccountEmail, keyPrefix) tuple so the
+//      victim can spot the mismatch ("this isn't my server" / "this
+//      isn't my qURL email") before usage starts. This is the only
+//      thing standing between confused-deputy and a silent attacker
+//      key-bind, until the Auth0 consent screen is templated to show
+//      the target Discord guild (out of scope here — see PR #177).
 
 const express = require('express');
 const config = require('../config');
@@ -60,6 +72,19 @@ router.get('/callback', rateLimit, async (req, res) => {
     const reason = !config.isQurlOAuthConfigured ? 'AUTH0_* unset' : 'DISCORD_CLIENT_SECRET unset';
     logger.warn('Discord install callback hit but not configured', { reason, ip: req.ip });
     return renderNotConfigured(res, reason);
+  }
+  // Fail-fast: same encryption-at-rest guard as /oauth/qurl/start.
+  // Bot is already in the server at this point (Discord install ran
+  // before this redirect), so failing here just blocks the chained
+  // qURL OAuth — admin can run /qurl setup later to retry. Without
+  // this, we'd burn the Discord code on a token exchange + a Users
+  // /@me round-trip + an Auth0 round-trip before failing at the qURL
+  // callback's persist-time guard.
+  if (!process.env.KEY_ENCRYPTION_KEY) {
+    logger.error('Refusing /oauth/discord/callback: KEY_ENCRYPTION_KEY is not set');
+    return renderError(res, 503, 'qURL setup not provisioned',
+      'The bot is in your server, but the operator hasn\'t configured encryption-at-rest yet (KEY_ENCRYPTION_KEY).'
+      + ' Once that\'s set, run /qurl setup in your server.');
   }
   if (req.query.error) {
     logger.warn('Discord install callback received error from Discord', {

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -139,6 +139,28 @@ router.get('/callback', rateLimit, async (req, res) => {
     return renderError(res, 400, 'Bot install incomplete', 'Discord did not return the server you selected. Please click "Add to Discord" again.');
   }
 
+  // First-install vs re-install gate for prompt=consent. Hoisted above
+  // the Discord handshake on purpose — the lookup needs only `guildId`
+  // (already in req.query), not `discordUserId`, so doing it here means
+  // a slow-DDB blip can't delay the Discord token-exchange + /users/@me
+  // round-trips for an installer who's just sitting on the redirect
+  // page. The handshake-timeout window stays bounded by DISCORD_TIMEOUT_MS
+  // alone. PR #177 follow-up C.8 + post-round-8 review.
+  let isReInstall = false;
+  try {
+    const existing = await db.getGuildConfig(guildId);
+    isReInstall = Boolean(existing && existing.configured_by);
+  } catch (err) {
+    // Bias toward consent prompt on DDB failure — the cost is one extra
+    // click for an admin who just signed in (mild), versus silently
+    // skipping consent on a true re-install which blocks key rotation
+    // entirely (worse).
+    logger.info('Failed to read guild config for prompt=consent gating; defaulting to re-install path', {
+      error: err?.message, guildId,
+    });
+    isReInstall = true;
+  }
+
   // 1. Exchange code at Discord for an access_token. The token itself
   //    isn't long-lived state we keep — we only use it to call /users/@me
   //    once and learn the installing user's Discord ID, which we then
@@ -232,24 +254,11 @@ router.get('/callback', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
-  // prompt=consent only on re-install (guild_configs row already has
-  // a `configured_by`). For a true first install — the bot has never
-  // touched this guild before — let Auth0's default flow run so the
-  // admin doesn't see a redundant consent screen stacked on the
-  // standard sign-in. On re-install, force consent so the admin can
-  // rotate the key. Mirrors /oauth/qurl/start. PR #177 follow-up C.8.
-  let isReInstall = false;
-  try {
-    const existing = await db.getGuildConfig(guildId);
-    isReInstall = Boolean(existing && existing.configured_by);
-  } catch (err) {
-    logger.warn('Failed to read guild config for prompt=consent gating; defaulting to re-install path', {
-      error: err?.message, guildId,
-    });
-    isReInstall = true;
-  }
+  // prompt=consent only on re-install — gate evaluated above the
+  // handshake. See the `isReInstall` block at the top of this handler
+  // for rationale.
   if (isReInstall) authorizeUrl.searchParams.set('prompt', 'consent');
-  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId });
+  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, isReInstall });
   return res.redirect(302, authorizeUrl.toString());
 });
 

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -38,10 +38,16 @@
 
 const express = require('express');
 const config = require('../config');
+const db = require('../store');
 const logger = require('../logger');
 const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
+const {
+  QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_COOKIE_PATH,
+  QURL_OAUTH_COOKIE_TTL_SECONDS,
+} = require('../utils/oauth-cookies');
 
 // Network-call timeouts — same shape as routes/qurl-oauth.js. Centralized
 // so a future "Discord OAuth2 is slow under load" tuning is one constant
@@ -57,6 +63,13 @@ function renderNotConfigured(res, reason) {
   // When AUTH0_* itself is unset, /qurl setup falls back to modal-paste
   // and the admin needs an out-of-band channel to layerv.ai. Branch the
   // remediation copy on `reason`.
+  //
+  // SECURITY: `reason` is logged but NOT rendered to the page. Echoing
+  // 'AUTH0_* unset' or 'DISCORD_CLIENT_SECRET unset' to the browser
+  // would tell a probing attacker exactly which secret an operator
+  // hasn't provisioned yet. Match qurl-oauth.js renderNotConfigured's
+  // generic wire shape. PR #177 follow-up C.4.
+  logger.info('renderNotConfigured', { reason });
   const remediation = reason && reason.startsWith('AUTH0')
     ? 'The bot was added to your server. Contact your layerv.ai admin to finish setup once the qURL OAuth application is registered.'
     : 'The bot was added to your server successfully — run /qurl setup in-Discord once the operator finishes provisioning.';
@@ -64,7 +77,7 @@ function renderNotConfigured(res, reason) {
     title: 'qURL Setup Not Configured',
     icon: '⚠️',
     heading: 'qURL setup is not configured yet',
-    message: `${remediation} (Reason: ${reason})`,
+    message: remediation,
     type: 'warning',
   }));
 }
@@ -202,26 +215,40 @@ router.get('/callback', rateLimit, async (req, res) => {
   // Auth0-redirect URL to victim — see PR #177 review item 3 + the
   // success-page binding readout that surfaces guild + qURL email
   // for visual sanity-check before the admin closes the tab.
-  res.cookie('qurl_setup_session', qurlState, {
+  res.cookie(QURL_OAUTH_SESSION_COOKIE, qurlState, {
     httpOnly: true,
     secure: req.protocol === 'https',
     sameSite: 'lax',
-    maxAge: 5 * 60 * 1000,
-    path: '/oauth',
+    maxAge: QURL_OAUTH_COOKIE_TTL_SECONDS * 1000,
+    path: QURL_OAUTH_COOKIE_PATH,
   });
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
   authorizeUrl.searchParams.set('redirect_uri', `${config.BASE_URL}/oauth/qurl/callback`);
-  // offline_access dropped per PR #177 review item 5 — no refresh-token use.
-  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid profile email');
+  // offline_access dropped per PR #177 review item 5 — no refresh-token
+  // use. `profile` dropped per follow-up C.2 — only the `email` claim
+  // is read from the id_token.
+  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
-  // prompt=consent so re-installing via "Add to Discord" actually re-
-  // prompts the admin at Auth0 — without it, Auth0 silently re-uses
-  // the prior consent and a re-mint can't be triggered. Same rationale
-  // as the /oauth/qurl/start path; keeping the two flows symmetric.
-  authorizeUrl.searchParams.set('prompt', 'consent');
+  // prompt=consent only on re-install (guild_configs row already has
+  // a `configured_by`). For a true first install — the bot has never
+  // touched this guild before — let Auth0's default flow run so the
+  // admin doesn't see a redundant consent screen stacked on the
+  // standard sign-in. On re-install, force consent so the admin can
+  // rotate the key. Mirrors /oauth/qurl/start. PR #177 follow-up C.8.
+  let isReInstall = false;
+  try {
+    const existing = await db.getGuildConfig(guildId);
+    isReInstall = Boolean(existing && existing.configured_by);
+  } catch (err) {
+    logger.warn('Failed to read guild config for prompt=consent gating; defaulting to re-install path', {
+      error: err?.message, guildId,
+    });
+    isReInstall = true;
+  }
+  if (isReInstall) authorizeUrl.searchParams.set('prompt', 'consent');
   logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId });
   return res.redirect(302, authorizeUrl.toString());
 });

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -44,6 +44,7 @@ const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
 const { getIsReRun } = require('../utils/guild-config-state');
+const { singleStringParam } = require('../utils/query-params');
 
 // Network-call timeouts — same shape as routes/qurl-oauth.js. Centralized
 // so a future "Discord OAuth2 is slow under load" tuning is one constant
@@ -113,8 +114,8 @@ router.get('/callback', rateLimit, async (req, res) => {
     });
     return renderError(res, 400, 'Authorization declined', 'You declined consent or Discord returned an error.');
   }
-  const code = String(req.query.code || '');
-  const guildId = String(req.query.guild_id || '');
+  const code = singleStringParam(req.query.code);
+  const guildId = singleStringParam(req.query.guild_id);
   if (!code) {
     return renderError(res, 400, 'Missing authorization code', 'Discord did not return an authorization code.');
   }

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -43,8 +43,9 @@ const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
-const { getIsReRun } = require('../utils/guild-config-state');
+const { shouldPromptConsent } = require('../utils/guild-config-state');
 const { singleStringParam } = require('../utils/query-params');
+const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
 
 // Network-call timeouts — same shape as routes/qurl-oauth.js. Centralized
 // so a future "Discord OAuth2 is slow under load" tuning is one constant
@@ -53,18 +54,11 @@ const DISCORD_TIMEOUT_MS = 15000;
 
 const router = express.Router();
 
-// SECURITY (C.4): `reason` is logged but NOT rendered to the page.
-// Echoing 'AUTH0_* unset' or 'DISCORD_CLIENT_SECRET unset' would tell
-// a probing attacker which secret the operator hasn't shipped yet.
+// 503 surface delegates to the shared helper — single source of truth
+// for the wire-vs-log split (C.4 invariant). The `surface` arg picks
+// the discord-install-specific remediation copy.
 function renderNotConfigured(res, reason) {
-  logger.info('Discord install not configured', { reason });
-  return res.status(503).send(renderPage({
-    title: 'qURL Setup Not Configured',
-    icon: '⚠️',
-    heading: 'qURL setup is not configured yet',
-    message: 'The bot was added to your server. Setup will be available once your layerv.ai operator finishes provisioning — try /qurl setup in your server later, or contact them out of band.',
-    type: 'warning',
-  }));
+  return renderNotConfiguredPage(res, 'discord-install', reason);
 }
 
 // `detail` describes the immediate failure; we append a remediation
@@ -132,10 +126,10 @@ router.get('/callback', rateLimit, async (req, res) => {
   // off in parallel with the Discord handshake below — the result is
   // only consumed at redirect time (it flips one query-param), so
   // serializing it would add DDB latency to every install with no
-  // user-facing benefit. getIsReRun's failsafe biases toward `true` on
+  // user-facing benefit. shouldPromptConsent's failsafe biases toward `true` on
   // throw — re-prompting an already-consenting admin is mild friction;
   // skipping consent on a true re-install blocks key rotation.
-  const isReInstallPromise = getIsReRun(guildId, 'discord-install /callback');
+  const promptConsentPromise = shouldPromptConsent(guildId, 'discord-install /callback');
 
   // 1. Exchange code at Discord for an access_token. The token itself
   //    isn't long-lived state we keep — we only use it to call /users/@me
@@ -212,8 +206,8 @@ router.get('/callback', rateLimit, async (req, res) => {
   // surfaces (guild, qURL email) for visual sanity-check.
   setQurlOAuthCookie(res, req, qurlState);
   // Resolve the parallel DDB read kicked off above; bias toward consent
-  // on throw is built into getIsReRun.
-  const isReInstall = await isReInstallPromise;
+  // on throw is built into shouldPromptConsent.
+  const promptConsent = await promptConsentPromise;
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
@@ -223,8 +217,8 @@ router.get('/callback', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
-  if (isReInstall) authorizeUrl.searchParams.set('prompt', 'consent');
-  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, isReInstall });
+  if (promptConsent) authorizeUrl.searchParams.set('prompt', 'consent');
+  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, promptConsent });
   return res.redirect(302, authorizeUrl.toString());
 });
 

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -51,23 +51,38 @@ const DISCORD_TIMEOUT_MS = 15000;
 const router = express.Router();
 
 function renderNotConfigured(res, reason) {
+  // Wording: "/qurl setup later" is the right next step ONLY when this
+  // 503 is from a partial config (DISCORD_CLIENT_SECRET unset, but
+  // AUTH0_* set — the slash command would still take the OAuth path).
+  // When AUTH0_* itself is unset, /qurl setup falls back to modal-paste
+  // and the admin needs an out-of-band channel to layerv.ai. Branch the
+  // remediation copy on `reason`.
+  const remediation = reason && reason.startsWith('AUTH0')
+    ? 'The bot was added to your server. Contact your layerv.ai admin to finish setup once the qURL OAuth application is registered.'
+    : 'The bot was added to your server successfully — run /qurl setup in-Discord once the operator finishes provisioning.';
   return res.status(503).send(renderPage({
     title: 'qURL Setup Not Configured',
     icon: '⚠️',
     heading: 'qURL setup is not configured yet',
-    message: 'The Auth0 application or Discord OAuth secret has not been registered. '
-      + 'The bot was added to your server successfully — run /qurl setup later or '
-      + `contact your layerv.ai admin. (Reason: ${reason})`,
+    message: `${remediation} (Reason: ${reason})`,
     type: 'warning',
   }));
 }
 
-function renderError(res, statusCode, headline, detail) {
+// `detail` should describe the immediate failure; we append a remediation
+// hint specific to the surface the failure landed on. The default hint
+// ("run /qurl setup directly") makes sense after a Discord OAuth handshake
+// failure — bot is already installed, qURL setup can be retried in-Discord
+// — but DOESN'T make sense on the not-configured 503, where /qurl setup
+// would also fail because the same env vars are missing. The
+// `remediation` override lets the caller pick the right copy.
+function renderError(res, statusCode, headline, detail, remediation) {
+  const tail = remediation ?? ' If the bot is already in your server, run /qurl setup directly.';
   return res.status(statusCode).send(renderPage({
     title: 'Discord Install Failed',
     icon: '❌',
     heading: headline,
-    message: detail + ' If the bot is already in your server, run /qurl setup directly.',
+    message: detail + tail,
     type: 'error',
   }));
 }
@@ -88,8 +103,8 @@ router.get('/callback', rateLimit, async (req, res) => {
   if (!process.env.KEY_ENCRYPTION_KEY) {
     logger.error('Refusing /oauth/discord/callback: KEY_ENCRYPTION_KEY is not set');
     return renderError(res, 503, 'qURL setup not provisioned',
-      'The bot is in your server, but the operator hasn\'t configured encryption-at-rest yet (KEY_ENCRYPTION_KEY).'
-      + ' Once that\'s set, run /qurl setup in your server.');
+      'The bot is in your server, but the operator hasn\'t configured encryption-at-rest yet (KEY_ENCRYPTION_KEY).',
+      ' Once that\'s set, run /qurl setup in your server.');
   }
   if (req.query.error) {
     logger.warn('Discord install callback received error from Discord', {
@@ -157,7 +172,14 @@ router.get('/callback', rateLimit, async (req, res) => {
     const user = await userResp.json();
     discordUserId = user?.id;
     if (typeof discordUserId !== 'string' || !discordUserId) {
-      logger.error('Discord /users/@me returned no user id', { user });
+      // Log the response shape (key set) but NOT the values — Discord's
+      // /users/@me payload can include username, global_name, avatar
+      // hash, locale, and (with email scope) email. None of those are
+      // safe to retain in operational logs without an explicit infosec
+      // sign-off; key names alone tell us why the contract drifted.
+      logger.error('Discord /users/@me returned no user id', {
+        responseKeys: user ? Object.keys(user) : null,
+      });
       return renderError(res, 502, 'Authorization failed', 'Discord returned an unexpected response.');
     }
   } catch (err) {

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -38,16 +38,12 @@
 
 const express = require('express');
 const config = require('../config');
-const db = require('../store');
 const logger = require('../logger');
 const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
-const {
-  QURL_OAUTH_SESSION_COOKIE,
-  QURL_OAUTH_COOKIE_PATH,
-  QURL_OAUTH_COOKIE_TTL_SECONDS,
-} = require('../utils/oauth-cookies');
+const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
+const { getIsReRun } = require('../utils/guild-config-state');
 
 // Network-call timeouts — same shape as routes/qurl-oauth.js. Centralized
 // so a future "Discord OAuth2 is slow under load" tuning is one constant
@@ -56,46 +52,31 @@ const DISCORD_TIMEOUT_MS = 15000;
 
 const router = express.Router();
 
+// SECURITY (C.4): `reason` is logged but NOT rendered to the page.
+// Echoing 'AUTH0_* unset' or 'DISCORD_CLIENT_SECRET unset' would tell
+// a probing attacker which secret the operator hasn't shipped yet.
 function renderNotConfigured(res, reason) {
-  // Wording: "/qurl setup later" is the right next step ONLY when this
-  // 503 is from a partial config (DISCORD_CLIENT_SECRET unset, but
-  // AUTH0_* set — the slash command would still take the OAuth path).
-  // When AUTH0_* itself is unset, /qurl setup falls back to modal-paste
-  // and the admin needs an out-of-band channel to layerv.ai. Branch the
-  // remediation copy on `reason`.
-  //
-  // SECURITY: `reason` is logged but NOT rendered to the page. Echoing
-  // 'AUTH0_* unset' or 'DISCORD_CLIENT_SECRET unset' to the browser
-  // would tell a probing attacker exactly which secret an operator
-  // hasn't provisioned yet. Match qurl-oauth.js renderNotConfigured's
-  // generic wire shape. PR #177 follow-up C.4.
-  logger.info('renderNotConfigured', { reason });
-  const remediation = reason && reason.startsWith('AUTH0')
-    ? 'The bot was added to your server. Contact your layerv.ai admin to finish setup once the qURL OAuth application is registered.'
-    : 'The bot was added to your server successfully — run /qurl setup in-Discord once the operator finishes provisioning.';
+  logger.info('Discord install not configured', { reason });
   return res.status(503).send(renderPage({
     title: 'qURL Setup Not Configured',
     icon: '⚠️',
     heading: 'qURL setup is not configured yet',
-    message: remediation,
+    message: 'The bot was added to your server. Setup will be available once your layerv.ai operator finishes provisioning — try /qurl setup in your server later, or contact them out of band.',
     type: 'warning',
   }));
 }
 
-// `detail` should describe the immediate failure; we append a remediation
-// hint specific to the surface the failure landed on. The default hint
-// ("run /qurl setup directly") makes sense after a Discord OAuth handshake
-// failure — bot is already installed, qURL setup can be retried in-Discord
-// — but DOESN'T make sense on the not-configured 503, where /qurl setup
-// would also fail because the same env vars are missing. The
-// `remediation` override lets the caller pick the right copy.
-function renderError(res, statusCode, headline, detail, remediation) {
-  const tail = remediation ?? ' If the bot is already in your server, run /qurl setup directly.';
+// `detail` describes the immediate failure; we append a remediation
+// hint that fits AFTER a Discord OAuth handshake failure (bot is
+// already installed, retry through /qurl setup in-Discord). Other
+// surfaces (the encryption-at-rest 503) use renderPage directly with
+// surface-specific copy — see the inline call site.
+function renderError(res, statusCode, headline, detail) {
   return res.status(statusCode).send(renderPage({
     title: 'Discord Install Failed',
     icon: '❌',
     heading: headline,
-    message: detail + tail,
+    message: detail + ' If the bot is already in your server, run /qurl setup directly.',
     type: 'error',
   }));
 }
@@ -115,9 +96,16 @@ router.get('/callback', rateLimit, async (req, res) => {
   // callback's persist-time guard.
   if (!process.env.KEY_ENCRYPTION_KEY) {
     logger.error('Refusing /oauth/discord/callback: KEY_ENCRYPTION_KEY is not set');
-    return renderError(res, 503, 'qURL setup not provisioned',
-      'The bot is in your server, but the operator hasn\'t configured encryption-at-rest yet (KEY_ENCRYPTION_KEY).',
-      ' Once that\'s set, run /qurl setup in your server.');
+    // Inline copy: the standard renderError tail ("run /qurl setup
+    // directly") would fail too — same env-var gap. Specific copy
+    // tells the admin to wait for the operator.
+    return res.status(503).send(renderPage({
+      title: 'Discord Install Failed',
+      icon: '❌',
+      heading: 'qURL setup not provisioned',
+      message: 'The bot is in your server, but the operator hasn\'t configured encryption-at-rest yet (KEY_ENCRYPTION_KEY). Once that\'s set, run /qurl setup in your server.',
+      type: 'error',
+    }));
   }
   if (req.query.error) {
     logger.warn('Discord install callback received error from Discord', {
@@ -139,27 +127,14 @@ router.get('/callback', rateLimit, async (req, res) => {
     return renderError(res, 400, 'Bot install incomplete', 'Discord did not return the server you selected. Please click "Add to Discord" again.');
   }
 
-  // First-install vs re-install gate for prompt=consent. Hoisted above
-  // the Discord handshake on purpose — the lookup needs only `guildId`
-  // (already in req.query), not `discordUserId`, so doing it here means
-  // a slow-DDB blip can't delay the Discord token-exchange + /users/@me
-  // round-trips for an installer who's just sitting on the redirect
-  // page. The handshake-timeout window stays bounded by DISCORD_TIMEOUT_MS
-  // alone. PR #177 follow-up C.8 + post-round-8 review.
-  let isReInstall = false;
-  try {
-    const existing = await db.getGuildConfig(guildId);
-    isReInstall = Boolean(existing && existing.configured_by);
-  } catch (err) {
-    // Bias toward consent prompt on DDB failure — the cost is one extra
-    // click for an admin who just signed in (mild), versus silently
-    // skipping consent on a true re-install which blocks key rotation
-    // entirely (worse).
-    logger.info('Failed to read guild config for prompt=consent gating; defaulting to re-install path', {
-      error: err?.message, guildId,
-    });
-    isReInstall = true;
-  }
+  // First-install vs re-install gate for prompt=consent (C.8). Kicked
+  // off in parallel with the Discord handshake below — the result is
+  // only consumed at redirect time (it flips one query-param), so
+  // serializing it would add DDB latency to every install with no
+  // user-facing benefit. getIsReRun's failsafe biases toward `true` on
+  // throw — re-prompting an already-consenting admin is mild friction;
+  // skipping consent on a true re-install blocks key rotation.
+  const isReInstallPromise = getIsReRun(guildId, 'discord-install /callback');
 
   // 1. Exchange code at Discord for an access_token. The token itself
   //    isn't long-lived state we keep — we only use it to call /users/@me
@@ -227,36 +202,26 @@ router.get('/callback', rateLimit, async (req, res) => {
   //    redirect to Auth0; the existing /oauth/qurl/callback will finish
   //    the flow (mint qurl-service API key, persist, DM admin).
   const qurlState = signQurlOAuthState(guildId, discordUserId);
-  // Set the same double-submit CSRF cookie that /oauth/qurl/start sets,
-  // so /oauth/qurl/callback's cookie === state check passes for the
-  // Stage-2 chain too. Path /oauth (not /oauth/discord) so the cookie
-  // is visible to /oauth/qurl/callback further along the chain.
-  // Mitigates leaked install-callback URL replay across browsers; does
-  // not fully prevent confused-deputy where attacker pre-runs
-  // /oauth/discord/callback in their own browser then forwards the
-  // Auth0-redirect URL to victim — see PR #177 review item 3 + the
-  // success-page binding readout that surfaces guild + qURL email
-  // for visual sanity-check before the admin closes the tab.
-  res.cookie(QURL_OAUTH_SESSION_COOKIE, qurlState, {
-    httpOnly: true,
-    secure: req.protocol === 'https',
-    sameSite: 'lax',
-    maxAge: QURL_OAUTH_COOKIE_TTL_SECONDS * 1000,
-    path: QURL_OAUTH_COOKIE_PATH,
-  });
+  // Same double-submit CSRF cookie /oauth/qurl/start sets — Stage-2
+  // chain shares the cookie with the qurl-oauth callback. Mitigates
+  // leaked install-callback URL replay across browsers; does NOT fully
+  // close confused-deputy (attacker pre-runs /oauth/discord/callback in
+  // their own browser then forwards the Auth0-redirect URL to victim) —
+  // the success-page binding readout in qurl-oauth.js's renderSuccess
+  // surfaces (guild, qURL email) for visual sanity-check.
+  setQurlOAuthCookie(res, req, qurlState);
+  // Resolve the parallel DDB read kicked off above; bias toward consent
+  // on throw is built into getIsReRun.
+  const isReInstall = await isReInstallPromise;
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
   authorizeUrl.searchParams.set('redirect_uri', `${config.BASE_URL}/oauth/qurl/callback`);
-  // offline_access dropped per PR #177 review item 5 — no refresh-token
-  // use. `profile` dropped per follow-up C.2 — only the `email` claim
-  // is read from the id_token.
+  // offline_access dropped per PR #177 review item 5; `profile` dropped
+  // per follow-up C.2 — only the `email` claim is read from id_token.
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
-  // prompt=consent only on re-install — gate evaluated above the
-  // handshake. See the `isReInstall` block at the top of this handler
-  // for rationale.
   if (isReInstall) authorizeUrl.searchParams.set('prompt', 'consent');
   logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, isReInstall });
   return res.redirect(302, authorizeUrl.toString());

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -29,6 +29,7 @@ const config = require('../config');
 const logger = require('../logger');
 const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
+const { rateLimit } = require('../utils/oauth-rate-limit');
 
 const router = express.Router();
 
@@ -54,7 +55,7 @@ function renderError(res, statusCode, headline, detail) {
   }));
 }
 
-router.get('/callback', async (req, res) => {
+router.get('/callback', rateLimit, async (req, res) => {
   if (!config.isDiscordInstallConfigured) {
     const reason = !config.isQurlOAuthConfigured ? 'AUTH0_* unset' : 'DISCORD_CLIENT_SECRET unset';
     logger.warn('Discord install callback hit but not configured', { reason, ip: req.ip });
@@ -139,11 +140,29 @@ router.get('/callback', async (req, res) => {
   //    redirect to Auth0; the existing /oauth/qurl/callback will finish
   //    the flow (mint qurl-service API key, persist, DM admin).
   const qurlState = signQurlOAuthState(guildId, discordUserId);
+  // Set the same double-submit CSRF cookie that /oauth/qurl/start sets,
+  // so /oauth/qurl/callback's cookie === state check passes for the
+  // Stage-2 chain too. Path /oauth (not /oauth/discord) so the cookie
+  // is visible to /oauth/qurl/callback further along the chain.
+  // Mitigates leaked install-callback URL replay across browsers; does
+  // not fully prevent confused-deputy where attacker pre-runs
+  // /oauth/discord/callback in their own browser then forwards the
+  // Auth0-redirect URL to victim — see PR #177 review item 3 + the
+  // success-page binding readout that surfaces guild + qURL email
+  // for visual sanity-check before the admin closes the tab.
+  res.cookie('qurl_setup_session', qurlState, {
+    httpOnly: true,
+    secure: req.protocol === 'https',
+    sameSite: 'lax',
+    maxAge: 5 * 60 * 1000,
+    path: '/oauth',
+  });
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
   authorizeUrl.searchParams.set('redirect_uri', `${config.BASE_URL}/oauth/qurl/callback`);
-  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read offline_access openid profile email');
+  // offline_access dropped per PR #177 review item 5 — no refresh-token use.
+  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid profile email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
   authorizeUrl.searchParams.set('prompt', 'consent');

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -37,7 +37,6 @@ const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
-const { shouldPromptConsent } = require('../utils/guild-config-state');
 const { singleStringParam } = require('../utils/query-params');
 const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
 
@@ -132,10 +131,14 @@ router.get('/callback', rateLimit, async (req, res) => {
   // happened and the redundant consent screen on first install adds
   // friction without security gain.
   //
-  // We still kick off the guild-config read in parallel so the
-  // completion log line carries `previouslyConfigured` for ops
-  // (distinguishes a fresh-add from a re-install in metrics).
-  const previouslyConfiguredPromise = shouldPromptConsent(guildId, 'discord-install /callback');
+  // No DDB read here — the previous round-9 build kicked off
+  // shouldPromptConsent in parallel for a "previouslyConfigured"
+  // log field, but with prompt=consent unconditional that helper's
+  // bias-toward-true semantics were wrong for an informational
+  // metric. If we ever want the first-install vs re-install signal,
+  // pull it from setGuildApiKey's audit log or call getGuildConfig
+  // directly with a try/catch that distinguishes hit/miss/error.
+  // Round-9.6 item #3.
 
   // 1. Exchange code at Discord for an access_token. The token itself
   //    isn't long-lived state we keep — we only use it to call /users/@me
@@ -211,9 +214,6 @@ router.get('/callback', rateLimit, async (req, res) => {
   // the success-page binding readout in qurl-oauth.js's renderSuccess
   // surfaces (guild, qURL email) for visual sanity-check.
   setQurlOAuthCookie(res, req, qurlState);
-  // Resolve the parallel DDB read for the completion log only; the
-  // Auth0 prompt=consent decision is fixed for Stage-2 above.
-  const previouslyConfigured = await previouslyConfiguredPromise;
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
@@ -223,10 +223,10 @@ router.get('/callback', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
-  // ALWAYS prompt=consent on Stage-2 (per round-9 item #1) — see
-  // `previouslyConfiguredPromise` block at the top of this handler.
+  // ALWAYS prompt=consent on Stage-2 (per round-9 item #1) — see the
+  // confused-deputy block at the top of this handler.
   authorizeUrl.searchParams.set('prompt', 'consent');
-  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, previouslyConfigured });
+  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId });
   return res.redirect(302, authorizeUrl.toString());
 });
 

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -190,6 +190,10 @@ router.get('/callback', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid profile email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
+  // prompt=consent so re-installing via "Add to Discord" actually re-
+  // prompts the admin at Auth0 — without it, Auth0 silently re-uses
+  // the prior consent and a re-mint can't be triggered. Same rationale
+  // as the /oauth/qurl/start path; keeping the two flows symmetric.
   authorizeUrl.searchParams.set('prompt', 'consent');
   logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId });
   return res.redirect(302, authorizeUrl.toString());

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -1,0 +1,154 @@
+// Stage-2 entry point — "Add to Discord, select server" install flow.
+//
+// User-facing experience:
+//   1. Admin clicks the static "Add to Discord" link on layerv.ai
+//      (URL shape documented in project_qurl_bot_onboarding_model.md memory).
+//   2. Discord shows the standard "Which server?" picker → admin selects.
+//   3. Discord shows the bot's permission consent → admin clicks Authorize.
+//   4. Discord redirects HERE: /oauth/discord/callback?code=…&guild_id=…&state=…
+//   5. This route exchanges the Discord code for an access_token, calls
+//      /users/@me to get the admin's Discord user ID, then 302-chains to
+//      Auth0 with a qURL OAuth state binding (guildId + discordUserId)
+//      so the existing /oauth/qurl/callback can finish the flow (mint
+//      qURL API key on qurl-service, persist to guild_configs, DM admin).
+//
+// One unbroken click chain from "Add to Discord" → "qURL is ready" — no
+// admin-visible step between Discord consent and Auth0 consent.
+//
+// CSRF posture:
+//   The `state` param Discord echoes is best-effort (admins paste the
+//   "Add to Discord" link from layerv.ai, not from a per-session form),
+//   so we don't validate it as a session-bound token. The CSRF guarantee
+//   comes from the Discord token-exchange step: only Discord can mint a
+//   `code` that pairs with our DISCORD_CLIENT_ID/SECRET, so an attacker
+//   forging a /oauth/discord/callback request without going through
+//   Discord OAuth2 can't get past the token exchange.
+
+const express = require('express');
+const config = require('../config');
+const logger = require('../logger');
+const { renderPage } = require('../templates/page');
+const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
+
+const router = express.Router();
+
+function renderNotConfigured(res, reason) {
+  return res.status(503).send(renderPage({
+    title: 'qURL Setup Not Configured',
+    icon: '⚠️',
+    heading: 'qURL setup is not configured yet',
+    message: 'The Auth0 application or Discord OAuth secret has not been registered. '
+      + 'The bot was added to your server successfully — run /qurl setup later or '
+      + `contact your layerv.ai admin. (Reason: ${reason})`,
+    type: 'warning',
+  }));
+}
+
+function renderError(res, statusCode, headline, detail) {
+  return res.status(statusCode).send(renderPage({
+    title: 'Discord Install Failed',
+    icon: '❌',
+    heading: headline,
+    message: detail + ' If the bot is already in your server, run /qurl setup directly.',
+    type: 'error',
+  }));
+}
+
+router.get('/callback', async (req, res) => {
+  if (!config.isDiscordInstallConfigured) {
+    const reason = !config.isQurlOAuthConfigured ? 'AUTH0_* unset' : 'DISCORD_CLIENT_SECRET unset';
+    logger.warn('Discord install callback hit but not configured', { reason, ip: req.ip });
+    return renderNotConfigured(res, reason);
+  }
+  if (req.query.error) {
+    logger.warn('Discord install callback received error from Discord', {
+      error: req.query.error, errorDescription: req.query.error_description, ip: req.ip,
+    });
+    return renderError(res, 400, 'Authorization declined', 'You declined consent or Discord returned an error.');
+  }
+  const code = String(req.query.code || '');
+  const guildId = String(req.query.guild_id || '');
+  if (!code) {
+    return renderError(res, 400, 'Missing authorization code', 'Discord did not return an authorization code.');
+  }
+  if (!guildId) {
+    // Discord only includes guild_id when the user actually installed the
+    // bot to a server. Missing guild_id means the install was abandoned
+    // mid-flow or the bot's OAuth2 install link was invoked without
+    // scope=bot — flag for triage.
+    logger.warn('Discord install callback missing guild_id', { ip: req.ip });
+    return renderError(res, 400, 'Bot install incomplete', 'Discord did not return the server you selected. Please click "Add to Discord" again.');
+  }
+
+  // 1. Exchange code at Discord for an access_token. The token itself
+  //    isn't long-lived state we keep — we only use it to call /users/@me
+  //    once and learn the installing user's Discord ID, which we then
+  //    bind into the qURL OAuth state.
+  let discordUserId;
+  try {
+    const tokenResp = await fetch('https://discord.com/api/oauth2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: config.DISCORD_CLIENT_ID,
+        client_secret: config.DISCORD_CLIENT_SECRET,
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: `${config.BASE_URL}/oauth/discord/callback`,
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!tokenResp.ok) {
+      const errBody = await tokenResp.text().catch(() => '');
+      logger.error('Discord token exchange failed', {
+        status: tokenResp.status, body: errBody.slice(0, 500),
+      });
+      return renderError(res, 502, 'Authorization failed', 'Could not complete the Discord install.');
+    }
+    const tokenJson = await tokenResp.json();
+    const accessToken = tokenJson.access_token;
+    if (!accessToken) {
+      logger.error('Discord token response missing access_token');
+      return renderError(res, 502, 'Authorization failed', 'Discord returned an unexpected response.');
+    }
+    // 2. /users/@me — minimal-scope identity probe. The bot install
+    //    grants us `identify`-equivalent access via the bot scope; this
+    //    call gives us the admin's Discord user ID so the qURL OAuth
+    //    state can bind to it (matches the existing /qurl setup state).
+    const userResp = await fetch('https://discord.com/api/users/@me', {
+      headers: { 'Authorization': `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!userResp.ok) {
+      logger.error('Discord /users/@me failed', { status: userResp.status });
+      return renderError(res, 502, 'Authorization failed', 'Could not identify the installing user.');
+    }
+    const user = await userResp.json();
+    discordUserId = user?.id;
+    if (typeof discordUserId !== 'string' || !discordUserId) {
+      logger.error('Discord /users/@me returned no user id', { user });
+      return renderError(res, 502, 'Authorization failed', 'Discord returned an unexpected response.');
+    }
+  } catch (err) {
+    logger.error('Discord OAuth handshake threw', { error: err?.message });
+    return renderError(res, 502, 'Authorization failed', 'A network error occurred during the Discord handshake.');
+  }
+
+  // 3. Now we have (guildId, discordUserId) — the same shape as the
+  //    /qurl setup slash-command state. Mint a qURL OAuth state and
+  //    redirect to Auth0; the existing /oauth/qurl/callback will finish
+  //    the flow (mint qurl-service API key, persist, DM admin).
+  const qurlState = signQurlOAuthState(guildId, discordUserId);
+  const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
+  authorizeUrl.searchParams.set('redirect_uri', `${config.BASE_URL}/oauth/qurl/callback`);
+  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read offline_access openid profile email');
+  authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
+  authorizeUrl.searchParams.set('state', qurlState);
+  authorizeUrl.searchParams.set('prompt', 'consent');
+  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId });
+  return res.redirect(302, authorizeUrl.toString());
+});
+
+module.exports = router;

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -15,26 +15,20 @@
 // One unbroken click chain from "Add to Discord" → "qURL is ready" — no
 // admin-visible step between Discord consent and Auth0 consent.
 //
-// CSRF posture (read together with qurl-oauth.js:renderSuccess):
-//   The `state` param Discord echoes is best-effort (admins paste the
-//   "Add to Discord" link from layerv.ai, not from a per-session form),
-//   so we don't validate it as a session-bound token. The defense
-//   stacks across two surfaces:
-//   1. Forged-callback rejection — only Discord can mint a `code` that
-//      pairs with our DISCORD_CLIENT_ID/SECRET, so an attacker forging
-//      a /oauth/discord/callback request without going through Discord
-//      OAuth2 can't get past the token exchange.
-//   2. Confused-deputy mitigation (LOAD-BEARING — do not remove without
-//      replacing) — an attacker who pre-runs Discord install in their
-//      own browser then forwards the chained Auth0-redirect URL to a
-//      victim WOULD pass step 1, because the Discord code is real.
-//      The success page in qurl-oauth.js's renderSuccess surfaces the
-//      bound (guildId, qurlAccountEmail, keyPrefix) tuple so the
-//      victim can spot the mismatch ("this isn't my server" / "this
-//      isn't my qURL email") before usage starts. This is the only
-//      thing standing between confused-deputy and a silent attacker
-//      key-bind, until the Auth0 consent screen is templated to show
-//      the target Discord guild (out of scope here — see PR #177).
+// CSRF posture (LOAD-BEARING — do not remove without replacing):
+//   Discord's echoed `state` param is intentionally NOT validated here —
+//   admins land via a static "Add to Discord" link on layerv.ai, not a
+//   per-session form, so there's no session-bound token to check
+//   against. Defense stacks on two surfaces:
+//     1. Token exchange — only Discord can mint a `code` that pairs
+//        with our DISCORD_CLIENT_ID/SECRET; a forged callback can't
+//        get past the POST /oauth2/token call.
+//     2. Success-page binding readout in qurl-oauth.js's renderSuccess
+//        surfaces (guildId, qurlAccountEmail, keyPrefix) so a victim
+//        of attacker-pre-runs-install-then-forwards-URL can spot the
+//        mismatch before usage starts.
+//   Issue #179 tracks the cross-repo signed-install-state work that
+//   would close the asterisk on (2) by validating state at the entry.
 
 const express = require('express');
 const config = require('../config');

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -43,6 +43,11 @@ const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 
+// Network-call timeouts — same shape as routes/qurl-oauth.js. Centralized
+// so a future "Discord OAuth2 is slow under load" tuning is one constant
+// to flip.
+const DISCORD_TIMEOUT_MS = 15000;
+
 const router = express.Router();
 
 function renderNotConfigured(res, reason) {
@@ -122,7 +127,7 @@ router.get('/callback', rateLimit, async (req, res) => {
         code,
         redirect_uri: `${config.BASE_URL}/oauth/discord/callback`,
       }),
-      signal: AbortSignal.timeout(15000),
+      signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS),
     });
     if (!tokenResp.ok) {
       const errBody = await tokenResp.text().catch(() => '');
@@ -143,7 +148,7 @@ router.get('/callback', rateLimit, async (req, res) => {
     //    state can bind to it (matches the existing /qurl setup state).
     const userResp = await fetch('https://discord.com/api/users/@me', {
       headers: { 'Authorization': `Bearer ${accessToken}` },
-      signal: AbortSignal.timeout(15000),
+      signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS),
     });
     if (!userResp.ok) {
       logger.error('Discord /users/@me failed', { status: userResp.status });

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -78,8 +78,10 @@ function renderError(res, statusCode, headline, detail) {
 
 router.get('/callback', rateLimit, async (req, res) => {
   if (!config.isDiscordInstallConfigured) {
+    // Single log line lives in renderNotConfiguredPage (round-9 item
+    // #7). Reason is computed here because the helper would otherwise
+    // need access to two config flags.
     const reason = !config.isQurlOAuthConfigured ? 'AUTH0_* unset' : 'DISCORD_CLIENT_SECRET unset';
-    logger.warn('Discord install callback hit but not configured', { reason, ip: req.ip });
     return renderNotConfigured(res, reason);
   }
   // Fail-fast: same encryption-at-rest guard as /oauth/qurl/start.
@@ -102,9 +104,13 @@ router.get('/callback', rateLimit, async (req, res) => {
       type: 'error',
     }));
   }
-  if (req.query.error) {
+  // Round-9 item #5: funnel through singleStringParam for symmetry.
+  const errorParam = singleStringParam(req.query.error);
+  if (errorParam) {
     logger.warn('Discord install callback received error from Discord', {
-      error: req.query.error, errorDescription: req.query.error_description, ip: req.ip,
+      error: errorParam,
+      errorDescription: singleStringParam(req.query.error_description),
+      ip: req.ip,
     });
     return renderError(res, 400, 'Authorization declined', 'You declined consent or Discord returned an error.');
   }
@@ -122,14 +128,20 @@ router.get('/callback', rateLimit, async (req, res) => {
     return renderError(res, 400, 'Bot install incomplete', 'Discord did not return the server you selected. Please click "Add to Discord" again.');
   }
 
-  // First-install vs re-install gate for prompt=consent (C.8). Kicked
-  // off in parallel with the Discord handshake below — the result is
-  // only consumed at redirect time (it flips one query-param), so
-  // serializing it would add DDB latency to every install with no
-  // user-facing benefit. shouldPromptConsent's failsafe biases toward `true` on
-  // throw — re-prompting an already-consenting admin is mild friction;
-  // skipping consent on a true re-install blocks key rotation.
-  const promptConsentPromise = shouldPromptConsent(guildId, 'discord-install /callback');
+  // Stage-2 ALWAYS sets prompt=consent on the chained Auth0 redirect,
+  // independent of first-install vs re-install. Stage-2 is the
+  // confused-deputy attack surface (a forwarded /oauth/discord/callback
+  // URL); the explicit consent screen is one extra defense per
+  // Justin's PR #177 round-9 item #1. Stage-1 (/oauth/qurl/start)
+  // gates differently — it's reached from inside the guild via the
+  // /qurl setup slash command, so guild-membership-proof has already
+  // happened and the redundant consent screen on first install adds
+  // friction without security gain.
+  //
+  // We still kick off the guild-config read in parallel so the
+  // completion log line carries `previouslyConfigured` for ops
+  // (distinguishes a fresh-add from a re-install in metrics).
+  const previouslyConfiguredPromise = shouldPromptConsent(guildId, 'discord-install /callback');
 
   // 1. Exchange code at Discord for an access_token. The token itself
   //    isn't long-lived state we keep — we only use it to call /users/@me
@@ -205,9 +217,9 @@ router.get('/callback', rateLimit, async (req, res) => {
   // the success-page binding readout in qurl-oauth.js's renderSuccess
   // surfaces (guild, qURL email) for visual sanity-check.
   setQurlOAuthCookie(res, req, qurlState);
-  // Resolve the parallel DDB read kicked off above; bias toward consent
-  // on throw is built into shouldPromptConsent.
-  const promptConsent = await promptConsentPromise;
+  // Resolve the parallel DDB read for the completion log only; the
+  // Auth0 prompt=consent decision is fixed for Stage-2 above.
+  const previouslyConfigured = await previouslyConfiguredPromise;
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
@@ -217,8 +229,10 @@ router.get('/callback', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
-  if (promptConsent) authorizeUrl.searchParams.set('prompt', 'consent');
-  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, promptConsent });
+  // ALWAYS prompt=consent on Stage-2 (per round-9 item #1) — see
+  // `previouslyConfiguredPromise` block at the top of this handler.
+  authorizeUrl.searchParams.set('prompt', 'consent');
+  logger.info('Discord install complete; chaining to Auth0', { guildId, discordUserId, previouslyConfigured });
   return res.redirect(302, authorizeUrl.toString());
 });
 

--- a/apps/discord/src/routes/oauth.js
+++ b/apps/discord/src/routes/oauth.js
@@ -165,36 +165,7 @@ async function checkHistoricalContributions(discordId, githubUsername, accessTok
 // PR #177 review feedback. The `rateLimit` symbol below is a re-export
 // for backward compat with this file's existing call sites.
 const { rateLimit } = require('../utils/oauth-rate-limit');
-
-// Minimal cookie parse — avoids pulling in cookie-parser. Format is
-// `name=value; name=value; ...`; we only need one named cookie so tolerate
-// other pairs without depending on full RFC parsing.
-function readCookie(req, name) {
-  const header = req.headers.cookie;
-  if (!header) return null;
-  // Collect ALL values for `name` rather than returning the first match.
-  // A browser extension or a sibling-subdomain can legitimately produce
-  // duplicate cookies with the same name; rather than trust the first
-  // (browser-ordered) one, we require uniqueness — any ambiguity means
-  // we cannot safely bind the session, so treat it as "no cookie".
-  const matches = [];
-  for (const part of header.split(';')) {
-    const eq = part.indexOf('=');
-    if (eq === -1) continue;
-    const k = part.slice(0, eq).trim();
-    if (k !== name) continue;
-    // Attacker-controlled cookies can contain malformed %-encoding
-    // (e.g. `%ZZ`); decodeURIComponent would throw URIError and crash
-    // the request handler. Treat a malformed cookie as "no cookie".
-    try {
-      matches.push(decodeURIComponent(part.slice(eq + 1).trim()));
-    } catch {
-      return null;
-    }
-    if (matches.length > 1) return null;
-  }
-  return matches.length === 1 ? matches[0] : null;
-}
+const { readCookie } = require('../utils/cookies');
 
 const OAUTH_SESSION_COOKIE = 'qurl_oauth_session';
 const COOKIE_TTL_SECONDS = 15 * 60; // 15 minutes

--- a/apps/discord/src/routes/oauth.js
+++ b/apps/discord/src/routes/oauth.js
@@ -160,95 +160,11 @@ async function checkHistoricalContributions(discordId, githubUsername, accessTok
   }
 }
 
-// Simple in-memory rate limiter with periodic eviction.
-// SCALING: single-instance only. If this bot ever runs horizontally (multiple
-// ECS tasks behind a LB), move this to Redis so limits are shared — otherwise
-// each replica carries its own counter and effective rate is N × configured.
-const rateLimitStore = new Map();
-
-// Node.js single-threaded: no true data race, but eviction could theoretically
-// interleave with a request's filter→set. Acceptable for in-memory rate limiting.
-
-// Evict stale entries on a 30-second timer (was 5 minutes). Under a burst
-// from many unique IPs, a longer sweep interval lets the Map grow much
-// larger than the per-request 10% eviction can keep up with. 30s is a
-// sweet spot: short enough to bound steady-state memory, long enough to
-// not matter as load.
-setInterval(() => {
-  const cutoff = Date.now() - config.RATE_LIMIT_WINDOW_MS * 2;
-  for (const [ip, requests] of rateLimitStore) {
-    const recent = requests.filter(t => t > cutoff);
-    if (recent.length === 0) rateLimitStore.delete(ip);
-    else rateLimitStore.set(ip, recent);
-  }
-}, 30 * 1000).unref();
-
-// Absolute cap on how many timestamps we keep per IP so an abusive IP can't
-// grow its array unboundedly between eviction sweeps.
-const MAX_REQUESTS_PER_IP = Math.max(config.RATE_LIMIT_MAX_REQUESTS * 4, 100);
-// Hard ceiling on total Map size. Under a distributed attack from many
-// unique IPs the 10% drop eviction can't keep up if new IPs arrive faster
-// than the sweep runs. Once the Map exceeds this, new-IP requests get 429
-// until the next sweep reclaims space — better to shed load than OOM.
-const MAX_STORE_SIZE = 20000;
-
-function rateLimit(req, res, next) {
-  const ip = req.ip || 'unknown'; // req.ip uses x-forwarded-for via 'trust proxy' (server.js)
-  const now = Date.now();
-  const windowStart = now - config.RATE_LIMIT_WINDOW_MS;
-
-  // Hard memory ceiling: if the store is already at MAX_STORE_SIZE and this
-  // is a new IP, shed the request rather than grow the Map further. Known
-  // IPs still get served because they're not growing the Map.
-  if (rateLimitStore.size >= MAX_STORE_SIZE && !rateLimitStore.has(ip)) {
-    logger.warn('Rate limit store at hard cap, rejecting new IP', { ip, size: rateLimitStore.size });
-    return res.status(429).send(renderPage({
-      title: 'Too Many Requests',
-      icon: '⏳',
-      heading: 'Service Overloaded',
-      message: 'The service is under heavy load. Please try again in a moment.',
-      type: 'warning',
-    }));
-  }
-
-  const requests = (rateLimitStore.get(ip) || []).filter(time => time > windowStart);
-
-  if (requests.length >= config.RATE_LIMIT_MAX_REQUESTS) {
-    logger.warn('Rate limit exceeded', { ip });
-    // HTML response — the OAuth routes are opened in the user's browser from
-    // a Discord-rendered link, so a rendered page is the right UX. The
-    // webhook rate-limiter returns JSON because its consumer is GitHub's
-    // webhook client, which expects JSON. Don't "normalize" these.
-    return res.status(429).send(renderPage({
-      title: 'Too Many Requests',
-      icon: '⏳',
-      heading: 'Slow Down!',
-      message: 'You\'ve made too many requests. Please wait a moment and try again.',
-      type: 'warning',
-    }));
-  }
-
-  requests.push(now);
-  // Trim the per-IP array to MAX_REQUESTS_PER_IP so one IP can't accumulate
-  // thousands of timestamps between sweeps. Keep the most recent entries.
-  if (requests.length > MAX_REQUESTS_PER_IP) {
-    requests.splice(0, requests.length - MAX_REQUESTS_PER_IP);
-  }
-  rateLimitStore.set(ip, requests);
-  // Under a distributed attack from many unique IPs, evicting only one
-  // entry at a time can't keep up. When we cross 10k, drop the oldest 10%
-  // (Map iteration is insertion order) so the store reclaims meaningfully.
-  if (rateLimitStore.size >= 10000) {
-    const dropCount = Math.max(1, Math.floor(rateLimitStore.size / 10));
-    const it = rateLimitStore.keys();
-    for (let i = 0; i < dropCount; i++) {
-      const k = it.next().value;
-      if (k === undefined) break;
-      rateLimitStore.delete(k);
-    }
-  }
-  next();
-}
+// Rate-limit middleware lives in utils/oauth-rate-limit.js so the qURL
+// OAuth + Discord install routers share the same per-IP budget — see
+// PR #177 review feedback. The `rateLimit` symbol below is a re-export
+// for backward compat with this file's existing call sites.
+const { rateLimit } = require('../utils/oauth-rate-limit');
 
 // Minimal cookie parse — avoids pulling in cookie-parser. Format is
 // `name=value; name=value; ...`; we only need one named cookie so tolerate

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -13,9 +13,13 @@
 //      billed to the admin's qURL account), DMs the admin "qURL is ready",
 //      renders a success page.
 //
-// Stage 2 (new-install entry point — bot install + OAuth chained off the
-// "Add to Discord" link) is a follow-up: needs Discord developer-portal
-// redirect URI registration. Tracked in the PR description.
+// Stage 2 (new-install entry point — "Add to Discord" link → Discord
+// OAuth2 install → server pick → consent → chained Auth0 leg) ships in
+// this same PR via routes/discord-install.js, which terminates at the
+// same /oauth/qurl/callback handler below. Both flows share the cookie
+// (path=/oauth) and the qURL OAuth state shape, so the callback's
+// CSRF check, KEY_ENCRYPTION_KEY guard, mint, persist, and DM are
+// stage-agnostic.
 const crypto = require('crypto');
 const express = require('express');
 const config = require('../config');
@@ -76,18 +80,27 @@ function renderNotConfigured(res) {
 
 // Success page surfaces the guild ID, key prefix, and qURL account email
 // so the admin can sanity-check the binding before closing the tab. This
-// is a user-visible mitigation against the Stage-2 confused-deputy class
-// of attack flagged in the PR #177 review: in a hypothetical
-// attacker-pre-runs-the-Discord-callback scenario, the state would carry
-// the attacker's discord_user_id + guild_id while the qURL account is
-// the victim's. Showing both halves of the binding lets the admin spot a
-// mismatch ("this isn't my server name" / "this isn't my qURL email")
-// before usage starts.
+// is the LOAD-BEARING user-visible mitigation against the Stage-2
+// confused-deputy class of attack flagged in the PR #177 review: in a
+// hypothetical attacker-pre-runs-the-Discord-callback scenario, the
+// state would carry the attacker's discord_user_id + guild_id while the
+// qURL account email is the victim's. Showing both halves of the
+// binding lets the admin spot a mismatch ("this isn't my server" /
+// "this isn't my qURL email") before usage starts.
+//
+// Subtext is plain prose — `renderPage` HTML-escapes the whole string at
+// render time, so any inline tags (<code>, <strong>, etc.) would render
+// as literal angle brackets. The values themselves still ride through
+// renderPage's escapeHtml so untrusted input can't smuggle script tags;
+// the trade-off is that the values aren't visually distinguished
+// (no monospace formatting). That's an acceptable cost for the
+// security guarantee: the goal is "admin reads the values" not
+// "admin enjoys nice typography."
 function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   const detailLines = [];
-  if (guildId) detailLines.push(`Discord guild: <code>${escapeHtmlForRender(guildId)}</code>`);
-  if (qurlAccountEmail) detailLines.push(`qURL account: <code>${escapeHtmlForRender(qurlAccountEmail)}</code>`);
-  if (keyPrefix) detailLines.push(`API key prefix: <code>${escapeHtmlForRender(keyPrefix)}</code>`);
+  if (guildId) detailLines.push(`Discord guild: ${guildId}`);
+  if (qurlAccountEmail) detailLines.push(`qURL account: ${qurlAccountEmail}`);
+  if (keyPrefix) detailLines.push(`API key prefix: ${keyPrefix}`);
   const subtext = detailLines.length > 0
     ? detailLines.join(' · ') + ' — confirm these match before closing.'
     : undefined;
@@ -99,20 +112,6 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
     subtext,
     type: 'success',
   }));
-}
-
-// renderPage's `subtext` field is HTML-escaped at render-time per its
-// docstring, but the values we pass in (guildId, keyPrefix, email) are
-// directly interpolated into <code> tags above the renderPage call —
-// so we escape here too. Belt-and-suspenders against a future caller
-// passing untrusted input through this helper.
-function escapeHtmlForRender(s) {
-  return String(s)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 }
 
 function renderError(res, statusCode, headline, detail) {

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -14,8 +14,9 @@ const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { verifyAuth0IdToken } = require('../utils/auth0-jwks');
 const { readCookie } = require('../utils/cookies');
-const { getIsReRun } = require('../utils/guild-config-state');
+const { shouldPromptConsent } = require('../utils/guild-config-state');
 const { singleStringParam } = require('../utils/query-params');
+const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
 
 // Network-call timeouts. Centralized so a future tuning of "qurl-service
 // is slow under load" doesn't require a hunt-and-replace across both
@@ -45,19 +46,11 @@ const {
   clearQurlOAuthCookie,
 } = require('../utils/oauth-cookies');
 
-// Coarse-grained 503 page when AUTH0_* env vars aren't set yet (Auth0 app
-// not registered / Justin hasn't set the prod SSM secrets). Single source
-// of "not configured" surface so the start route + callback route surface
-// the same message and the same 503 status.
+// 503 not-configured surface — shared with discord-install.js via
+// utils/oauth-not-configured.js (single source of truth for the
+// wire-vs-log split per PR #177 / C.4).
 function renderNotConfigured(res) {
-  return res.status(503).send(renderPage({
-    title: 'qURL Setup Not Configured',
-    icon: '⚠️',
-    heading: 'qURL setup is not configured yet',
-    message: 'The Auth0 application for the qURL Discord bot has not been registered yet. '
-      + 'Run /qurl setup again later, or contact your layerv.ai admin.',
-    type: 'warning',
-  }));
+  return renderNotConfiguredPage(res, 'qurl-setup');
 }
 
 // Success page surfaces the guild ID, key prefix, and qURL account email
@@ -73,6 +66,12 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   if (guildId) details.push({ label: 'Discord guild', value: guildId });
   if (qurlAccountEmail) details.push({ label: 'qURL account', value: qurlAccountEmail });
   if (keyPrefix) details.push({ label: 'API key prefix', value: keyPrefix });
+  // Cache-Control: no-store keeps the binding readout (qURL email,
+  // key prefix) out of any intermediate cache — back/forward cache,
+  // browser disk cache, ALB cache. Low cost, prevents the tab from
+  // surfacing a stale binding readout if the admin closes and
+  // re-opens. PR #177 round-9 review item #1.
+  res.setHeader('Cache-Control', 'no-store');
   return res.status(200).send(renderPage({
     title: 'qURL Connected',
     icon: '✅',
@@ -130,7 +129,7 @@ router.get('/start', rateLimit, async (req, res) => {
   // skip the redundant screen. Failsafe + bias direction live in
   // utils/guild-config-state.js (re-run on DDB error — silently
   // skipping consent on a real re-run would block rotation).
-  const isReRun = await getIsReRun(verified.payload.guildId, 'qurl-oauth /start');
+  const promptConsent = await shouldPromptConsent(verified.payload.guildId, 'qurl-oauth /start');
   // Double-submit CSRF cookie: value is the same state token the URL
   // carries to Auth0. /callback re-checks cookie === query.state.
   // Same-browser flows pass; leaked URLs in other browsers fail.
@@ -157,7 +156,7 @@ router.get('/start', rateLimit, async (req, res) => {
   // can't actually issue a new key. On first install, omit so the
   // admin doesn't see a redundant "are you sure?" screen on top of
   // the standard sign-in. Gate evaluated above. PR #177 follow-up C.8.
-  if (isReRun) authorizeUrl.searchParams.set('prompt', 'consent');
+  if (promptConsent) authorizeUrl.searchParams.set('prompt', 'consent');
   return res.redirect(302, authorizeUrl.toString());
 });
 
@@ -258,8 +257,14 @@ router.get('/callback', rateLimit, async (req, res) => {
     }
     const tokenJson = await tokenResp.json();
     accessToken = tokenJson.access_token;
-    if (!accessToken) {
-      logger.error('Auth0 token response missing access_token');
+    // Type-narrow before we consume the value: a non-string here would
+    // flow into the `Authorization: Bearer ${accessToken}` template
+    // literal of the qURL-service mint call (and the orphan-cleanup
+    // DELETE), corrupting the upstream auth header. Auth0's spec
+    // mandates string, but defense-in-depth — Justin's PR #177 review
+    // round 9 item #4.
+    if (typeof accessToken !== 'string' || !accessToken) {
+      logger.error('Auth0 token response missing or non-string access_token');
       return renderError(res, 502, 'Authorization failed', 'Auth0 returned an unexpected response. Please run /qurl setup again.');
     }
     // id_token email extraction with full JWKS verification. The email
@@ -274,7 +279,11 @@ router.get('/callback', rateLimit, async (req, res) => {
     // page renders without the qURL-account-email line. Ops sees a
     // logger.debug for triage. We do NOT fall back to unverified
     // decode — a forged email would be worse than no email.
-    if (tokenJson.id_token) {
+    // id_token is optional (Auth0 may legitimately omit on a non-openid
+    // grant); strict-string check prevents a numeric/null value from
+    // being passed into jose.jwtVerify which would surface as a
+    // confusing decode error rather than a clean "no email" path.
+    if (typeof tokenJson.id_token === 'string' && tokenJson.id_token) {
       // Distinct local — the outer `verified` (line ~258) carries the
       // qURL-OAuth-state verification result; this one carries the
       // Auth0 id_token JWKS verification result. Same shape, different
@@ -327,15 +336,25 @@ router.get('/callback', rateLimit, async (req, res) => {
     // below targets if persistence then fails. Treating a missing
     // key_id as success would leave us unable to clean up an orphan
     // billing-active key on the admin's account if DDB throws —
-    // safer to refuse upfront so the admin retries with a complete
-    // mint response. PR #177 follow-up C.3.
-    if (!apiKey || !keyId) {
-      logger.error('qURL API key response missing required fields', {
-        guildId, hasApiKey: Boolean(apiKey), hasKeyId: Boolean(keyId),
+    // safer to refuse upfront. Strict-string check (not just truthy)
+    // so an upstream contract drift to numeric/object can't poison
+    // db.setGuildApiKey or the encodeURIComponent in the DELETE URL.
+    // PR #177 follow-up C.3 + round-9 review item #4.
+    if (typeof apiKey !== 'string' || !apiKey
+        || typeof keyId !== 'string' || !keyId) {
+      logger.error('qURL API key response missing or non-string required fields', {
+        guildId,
+        apiKeyType: typeof apiKey,
+        keyIdType: typeof keyId,
       });
       return renderError(res, 502, 'Could not provision qURL key',
         'qurl-service returned an unexpected response. Please contact your layerv.ai admin.');
     }
+    // key_prefix is informational (used in the success readout + DM); a
+    // non-string value from a bad upstream would render as `[object
+    // Object]` in HTML. Coerce to undefined so renderSuccess simply
+    // skips the row rather than exposing a contract drift.
+    if (typeof keyPrefix !== 'string') keyPrefix = undefined;
   } catch (err) {
     logger.error('qURL API key mint threw', { error: err?.message, guildId });
     return renderError(res, 502, 'Could not provision qURL key',
@@ -356,23 +375,24 @@ router.get('/callback', rateLimit, async (req, res) => {
     // Fire-and-forget — even if the cleanup fails, the user-facing 500
     // response below is the right outcome (admin runs /qurl setup
     // again to retry; the orphan only persists if delete also fails).
-    if (keyId) {
-      fetch(`${config.QURL_ENDPOINT}/v1/api-keys/${encodeURIComponent(keyId)}`, {
-        method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-        signal: AbortSignal.timeout(ORPHAN_DELETE_TIMEOUT_MS),
+    // `keyId` is guaranteed non-empty here — the missing-key_id 502
+    // earlier in the handler returned before this block can run, so
+    // the historical `if (keyId)` guard was dead code (round-9 #5).
+    fetch(`${config.QURL_ENDPOINT}/v1/api-keys/${encodeURIComponent(keyId)}`, {
+      method: 'DELETE',
+      headers: { 'Authorization': `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(ORPHAN_DELETE_TIMEOUT_MS),
+    })
+      .then((r) => {
+        if (!r.ok) {
+          logger.warn('Best-effort orphan-key delete returned non-ok', {
+            status: r.status, keyId, guildId,
+          });
+        }
       })
-        .then((r) => {
-          if (!r.ok) {
-            logger.warn('Best-effort orphan-key delete returned non-ok', {
-              status: r.status, keyId, guildId,
-            });
-          }
-        })
-        .catch((dErr) => logger.warn('Best-effort orphan-key delete threw', {
-          error: dErr?.message, keyId, guildId,
-        }));
-    }
+      .catch((dErr) => logger.warn('Best-effort orphan-key delete threw', {
+        error: dErr?.message, keyId, guildId,
+      }));
     return renderError(res, 500, 'qURL key provisioned but not stored',
       'Your qURL API key was created but the bot could not save it. Please run /qurl setup again. '
       + 'If this keeps happening, contact your layerv.ai admin.');

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -1,25 +1,8 @@
-// qURL OAuth routes — replaces the API-key-paste modal in /qurl setup.
-//
-// Flow (Stage 1 — existing-install entry point via /qurl setup):
-//   1. Admin runs /qurl setup in Discord → bot replies ephemerally with a
-//      one-shot link to /oauth/qurl/start?state=<signed JWT>.
-//   2. Admin clicks → /oauth/qurl/start verifies state, redirects to Auth0
-//      authorize URL (response_type=code, scope=qurl:write+qurl:read).
-//   3. Admin signs in to layerv.ai (Auth0) + consents.
-//   4. Auth0 → /oauth/qurl/callback?code=…&state=…
-//   5. Callback verifies state, exchanges code at Auth0 token endpoint for
-//      an access_token JWT, calls qurl-service POST /v1/api-keys with the
-//      JWT, persists the minted key in guild_configs (admin-owned —
-//      billed to the admin's qURL account), DMs the admin "qURL is ready",
-//      renders a success page.
-//
-// Stage 2 (new-install entry point — "Add to Discord" link → Discord
-// OAuth2 install → server pick → consent → chained Auth0 leg) ships in
-// this same PR via routes/discord-install.js, which terminates at the
-// same /oauth/qurl/callback handler below. Both flows share the cookie
-// (path=/oauth) and the qURL OAuth state shape, so the callback's
-// CSRF check, KEY_ENCRYPTION_KEY guard, mint, persist, and DM are
-// stage-agnostic.
+// qURL OAuth routes — Stage 1 entry (/oauth/qurl/start via /qurl setup)
+// and the shared callback (/oauth/qurl/callback) that Stage 2
+// (routes/discord-install.js) also chains into. Step-by-step user
+// experience and CSRF posture live in the PR #177 description; Stage-2
+// confused-deputy mitigation is documented in discord-install.js.
 const crypto = require('crypto');
 const express = require('express');
 const config = require('../config');
@@ -30,6 +13,8 @@ const { sendDM } = require('../discord');
 const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { verifyAuth0IdToken } = require('../utils/auth0-jwks');
+const { readCookie } = require('../utils/cookies');
+const { getIsReRun } = require('../utils/guild-config-state');
 
 // Network-call timeouts. Centralized so a future tuning of "qurl-service
 // is slow under load" doesn't require a hunt-and-replace across both
@@ -49,36 +34,15 @@ const router = express.Router();
 // to anyone with a layerv.ai login" to "5 minutes AND the same browser
 // that opened the link."
 //
-// Cookie name + path constants live in utils/oauth-cookies.js so the
+// Cookie name + setter shape live in utils/oauth-cookies.js so the
 // Stage-2 chain (routes/discord-install.js sets the same cookie before
 // chaining to Auth0) can't drift — single source of truth. PR #177
 // follow-up C.1.
 const {
   QURL_OAUTH_SESSION_COOKIE,
-  QURL_OAUTH_COOKIE_PATH,
-  QURL_OAUTH_COOKIE_TTL_SECONDS: COOKIE_TTL_SECONDS,
+  setQurlOAuthCookie,
+  clearQurlOAuthCookie,
 } = require('../utils/oauth-cookies');
-
-function readCookie(req, name) {
-  const header = req.headers.cookie;
-  if (!header) return null;
-  // Reject duplicate cookies (browser extension / sibling-subdomain race) —
-  // ambiguity = no binding, treat as "no cookie".
-  const matches = [];
-  for (const part of header.split(';')) {
-    const eq = part.indexOf('=');
-    if (eq === -1) continue;
-    const k = part.slice(0, eq).trim();
-    if (k !== name) continue;
-    try {
-      matches.push(decodeURIComponent(part.slice(eq + 1).trim()));
-    } catch {
-      return null;
-    }
-    if (matches.length > 1) return null;
-  }
-  return matches.length === 1 ? matches[0] : null;
-}
 
 // Coarse-grained 503 page when AUTH0_* env vars aren't set yet (Auth0 app
 // not registered / Justin hasn't set the prod SSM secrets). Single source
@@ -112,9 +76,11 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
     title: 'qURL Connected',
     icon: '✅',
     heading: 'qURL is connected to your Discord server.',
-    message: 'You can close this tab and return to Discord. /qurl send is ready.',
+    // CTA folded into message so the "confirm before closing" cue
+    // always rides next to the binding readout, including when the
+    // qURL-account-email line is missing (JWKS verify failure).
+    message: 'Confirm the binding below matches your server, then close this tab and return to Discord. /qurl send is ready.',
     details,
-    subtext: details.length > 0 ? 'Confirm these match before closing.' : undefined,
     type: 'success',
   }));
 }
@@ -158,46 +124,18 @@ router.get('/start', rateLimit, async (req, res) => {
     logger.warn('qURL OAuth start rejected invalid state', { reason: verified.reason });
     return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired (links last 5 minutes).');
   }
-  // First-install vs re-run gate for prompt=consent. If the guild has
-  // never been configured (no `configured_by`), let Auth0's default
-  // behavior decide whether to show the consent screen — most admins
-  // see it once. On a re-run, force prompt=consent so the admin can
-  // rotate the key or switch qURL accounts (without it Auth0 silently
-  // re-uses the prior consent and a re-mint can't be triggered).
-  // PR #177 follow-up C.8.
-  let isReRun = false;
-  try {
-    const existing = await db.getGuildConfig(verified.payload.guildId);
-    isReRun = Boolean(existing && existing.configured_by);
-  } catch (err) {
-    // DDB blip: bias toward the safer-for-rotation path (prompt=consent).
-    // Re-prompting an already-consenting admin is mildly annoying;
-    // skipping consent on what is actually a re-run blocks key rotation.
-    // info-level — this is a benign fallback, not an error condition.
-    // A flaky DDB shouldn't spam warns (which on-call grep-tails).
-    logger.info('Failed to read guild config for prompt=consent gating; defaulting to re-run path', {
-      error: err?.message,
-    });
-    isReRun = true;
-  }
-  // Double-submit CSRF cookie: cookie value is the same state token the
-  // URL carries to Auth0. /callback re-checks (timing-safe) that
-  // cookie === query.state. Same-browser flows have both; leaked URLs
-  // opened in other browsers don't have the cookie and fail.
-  // Path is /oauth (not /oauth/qurl) so the same cookie also covers the
-  // Stage-2 "Add to Discord" entry path /oauth/discord/callback when
-  // that flow chains through to /oauth/qurl/callback.
-  // `secure: req.protocol === 'https'` relies on `trust proxy` being set
-  // in server.js so req.protocol reflects the X-Forwarded-Proto header
-  // from the ALB. Flipping `trust proxy` off would silently downgrade
-  // production cookies to insecure.
-  res.cookie(QURL_OAUTH_SESSION_COOKIE, state, {
-    httpOnly: true,
-    secure: req.protocol === 'https',
-    sameSite: 'lax',
-    maxAge: COOKIE_TTL_SECONDS * 1000,
-    path: QURL_OAUTH_COOKIE_PATH,
-  });
+  // First-install vs re-run gate for prompt=consent (C.8). On re-run,
+  // force prompt=consent so admins can rotate keys; on first install,
+  // skip the redundant screen. Failsafe + bias direction live in
+  // utils/guild-config-state.js (re-run on DDB error — silently
+  // skipping consent on a real re-run would block rotation).
+  const isReRun = await getIsReRun(verified.payload.guildId, 'qurl-oauth /start');
+  // Double-submit CSRF cookie: value is the same state token the URL
+  // carries to Auth0. /callback re-checks cookie === query.state.
+  // Same-browser flows pass; leaked URLs in other browsers fail.
+  // Cookie shape (path=/oauth so it spans Stage-2 chain, HttpOnly,
+  // SameSite=Lax, Secure-when-HTTPS) lives in utils/oauth-cookies.js.
+  setQurlOAuthCookie(res, req, state);
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
@@ -272,26 +210,21 @@ router.get('/callback', rateLimit, async (req, res) => {
     logger.warn('qURL OAuth callback missing session cookie', { ip: req.ip });
     return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
   }
-  let cookieMatches = false;
-  try {
-    const cookieBuf = Buffer.from(cookieState);
-    const stateBuf = Buffer.from(state);
-    cookieMatches = cookieBuf.length === stateBuf.length
-      && crypto.timingSafeEqual(cookieBuf, stateBuf);
-  } catch {
-    cookieMatches = false;
-  }
+  // Both inputs are strings (cookieState early-returned if null;
+  // state = String(req.query.state || '')), so Buffer.from doesn't
+  // throw. Length check before timingSafeEqual handles the only
+  // remaining failure mode.
+  const cookieBuf = Buffer.from(cookieState);
+  const stateBuf = Buffer.from(state);
+  const cookieMatches = cookieBuf.length === stateBuf.length
+    && crypto.timingSafeEqual(cookieBuf, stateBuf);
   if (!cookieMatches) {
     logger.warn('qURL OAuth callback cookie/state mismatch', { ip: req.ip });
     return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
   }
   // Cookie is consumed — clear it so a refreshed callback URL can't
-  // re-bind. Fresh /qurl setup runs mint a new state and set a new
-  // cookie. Path MUST match the /start + /oauth/discord/callback
-  // Set-Cookie path (/oauth, the shared constant) — clearing with a
-  // mismatched path is a no-op and the browser keeps the cookie alive
-  // until TTL.
-  res.clearCookie(QURL_OAUTH_SESSION_COOKIE, { path: QURL_OAUTH_COOKIE_PATH });
+  // re-bind. Path-must-match invariant lives in clearQurlOAuthCookie.
+  clearQurlOAuthCookie(res);
   const { guildId, discordUserId } = verified.payload;
 
   // 1. Exchange the code for an access_token + id_token (Auth0 token
@@ -408,27 +341,13 @@ router.get('/callback', rateLimit, async (req, res) => {
       'A network error occurred while provisioning your qURL key. Please run /qurl setup again.');
   }
 
-  // 3. Persist the key. setGuildApiKey is idempotent (upsert), so
-  //    re-running /qurl setup overwrites the prior key — the previous
-  //    key remains valid on qurl-service until the admin manually
-  //    revokes it via layerv.ai.
-  //
-  //    Read the prior config row first so the completion log line can
-  //    distinguish first-install from rotation (`isReRun` field). The
-  //    /start (and discord-install) gate already evaluates this for
-  //    prompt=consent, but the callback doesn't see that decision —
-  //    re-querying here is the cheapest way to surface the distinction
-  //    in operational logs without threading state through the
-  //    signed state token. DDB blip → log without the field, don't
-  //    block the persist.
-  let isReRun = null;
-  try {
-    const existing = await db.getGuildConfig(guildId);
-    isReRun = Boolean(existing && existing.configured_by);
-  } catch {
-    // intentionally silent — the persist below is what matters; the
-    // log enrichment is best-effort.
-  }
+  // 3. Persist the key. setGuildApiKey is idempotent (upsert) — the
+  //    previous key (if any) remains valid on qurl-service until the
+  //    admin manually revokes it via layerv.ai. Read the prior config
+  //    first so the completion log line can flag first-install vs
+  //    rotation (obs.M2). DDB blip biases isReRun toward `true` — fine
+  //    for log enrichment.
+  const isReRun = await getIsReRun(guildId, 'qurl-oauth /callback');
   try {
     await db.setGuildApiKey(guildId, apiKey, discordUserId);
   } catch (err) {

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -27,8 +27,16 @@ const db = require('../store');
 const logger = require('../logger');
 const { renderPage } = require('../templates/page');
 const { sendDM } = require('../discord');
-const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
+const { verifyQurlOAuthState, b64urlDecode } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
+
+// Network-call timeouts. Centralized so a future tuning of "qurl-service
+// is slow under load" doesn't require a hunt-and-replace across both
+// route files. 15s matches the existing per-call budget; the 5s and 10s
+// values are for cleanup paths that should fail faster.
+const AUTH0_TIMEOUT_MS = 15000;
+const QURL_SERVICE_TIMEOUT_MS = 15000;
+const ORPHAN_DELETE_TIMEOUT_MS = 10000;
 
 const router = express.Router();
 
@@ -264,17 +272,22 @@ router.get('/callback', rateLimit, async (req, res) => {
   let accessToken;
   let qurlAccountEmail;
   try {
+    // OAuth2 spec is application/x-www-form-urlencoded for the token
+    // endpoint. Auth0 accepts JSON too, but form-urlencoded is the
+    // canonical shape and matches the Discord token-exchange call in
+    // routes/discord-install.js — symmetric across both providers
+    // removes a "why is this one different?" reader question.
     const tokenResp = await fetch(`https://${config.AUTH0_DOMAIN}/oauth/token`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
         grant_type: 'authorization_code',
         client_id: config.AUTH0_CLIENT_ID,
         client_secret: config.AUTH0_CLIENT_SECRET,
         code,
         redirect_uri: `${config.BASE_URL}/oauth/qurl/callback`,
       }),
-      signal: AbortSignal.timeout(15000),
+      signal: AbortSignal.timeout(AUTH0_TIMEOUT_MS),
     });
     if (!tokenResp.ok) {
       const errBody = await tokenResp.text().catch(() => '');
@@ -290,14 +303,18 @@ router.get('/callback', rateLimit, async (req, res) => {
     // Best-effort id_token email extraction. JWT decode without
     // signature verification — the id_token came from Auth0 over TLS
     // in this same response, so signature verification is redundant
-    // for a display-only readout. Wrap in try/catch because we do NOT
-    // want a malformed id_token to fail the whole setup flow.
+    // for a display-only readout. (See PR #177 review note: the email
+    // becomes a load-bearing visual cue against confused-deputy on
+    // Stage 2, but the security claim of the readout is still "trust
+    // Auth0's TLS response" — full verification would require JWKS
+    // caching and is out of scope here.) Reuses b64urlDecode from
+    // utils/qurl-oauth-state.js for consistent base64-url handling.
     try {
       const idToken = tokenJson.id_token;
       if (typeof idToken === 'string') {
         const parts = idToken.split('.');
         if (parts.length === 3) {
-          const payload = JSON.parse(Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+          const payload = JSON.parse(b64urlDecode(parts[1]).toString('utf8'));
           if (typeof payload.email === 'string') qurlAccountEmail = payload.email;
         }
       }
@@ -324,7 +341,7 @@ router.get('/callback', rateLimit, async (req, res) => {
         'Accept': 'application/json',
       },
       body: JSON.stringify({ name: keyName, scopes: ['qurl:write', 'qurl:read'] }),
-      signal: AbortSignal.timeout(15000),
+      signal: AbortSignal.timeout(QURL_SERVICE_TIMEOUT_MS),
     });
     if (!mintResp.ok) {
       const errBody = await mintResp.text().catch(() => '');
@@ -368,7 +385,7 @@ router.get('/callback', rateLimit, async (req, res) => {
       fetch(`${config.QURL_ENDPOINT}/v1/api-keys/${encodeURIComponent(keyId)}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${accessToken}` },
-        signal: AbortSignal.timeout(10000),
+        signal: AbortSignal.timeout(ORPHAN_DELETE_TIMEOUT_MS),
       })
         .then((r) => {
           if (!r.ok) {

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -1,0 +1,221 @@
+// qURL OAuth routes — replaces the API-key-paste modal in /qurl setup.
+//
+// Flow (Stage 1 — existing-install entry point via /qurl setup):
+//   1. Admin runs /qurl setup in Discord → bot replies ephemerally with a
+//      one-shot link to /oauth/qurl/start?state=<signed JWT>.
+//   2. Admin clicks → /oauth/qurl/start verifies state, redirects to Auth0
+//      authorize URL (response_type=code, scope=qurl:write+qurl:read).
+//   3. Admin signs in to layerv.ai (Auth0) + consents.
+//   4. Auth0 → /oauth/qurl/callback?code=…&state=…
+//   5. Callback verifies state, exchanges code at Auth0 token endpoint for
+//      an access_token JWT, calls qurl-service POST /v1/api-keys with the
+//      JWT, persists the minted key in guild_configs (admin-owned —
+//      billed to the admin's qURL account), DMs the admin "qURL is ready",
+//      renders a success page.
+//
+// Stage 2 (new-install entry point — bot install + OAuth chained off the
+// "Add to Discord" link) is a follow-up: needs Discord developer-portal
+// redirect URI registration. Tracked in the PR description.
+const express = require('express');
+const config = require('../config');
+const db = require('../store');
+const logger = require('../logger');
+const { renderPage } = require('../templates/page');
+const { sendDM } = require('../discord');
+const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
+
+const router = express.Router();
+
+// Coarse-grained 503 page when AUTH0_* env vars aren't set yet (Auth0 app
+// not registered / Justin hasn't set the prod SSM secrets). Single source
+// of "not configured" surface so the start route + callback route surface
+// the same message and the same 503 status.
+function renderNotConfigured(res) {
+  return res.status(503).send(renderPage({
+    title: 'qURL Setup Not Configured',
+    icon: '⚠️',
+    heading: 'qURL setup is not configured yet',
+    message: 'The Auth0 application for the qURL Discord bot has not been registered yet. '
+      + 'Run /qurl setup again later, or contact your layerv.ai admin.',
+    type: 'warning',
+  }));
+}
+
+function renderSuccess(res) {
+  return res.status(200).send(renderPage({
+    title: 'qURL Connected',
+    icon: '✅',
+    heading: 'qURL is connected to your Discord server.',
+    message: 'You can close this tab and return to Discord. /qurl send is ready.',
+    type: 'success',
+  }));
+}
+
+function renderError(res, statusCode, headline, detail) {
+  return res.status(statusCode).send(renderPage({
+    title: 'qURL Setup Failed',
+    icon: '❌',
+    heading: headline,
+    message: detail + ' Run /qurl setup in Discord to start over.',
+    type: 'error',
+  }));
+}
+
+// /oauth/qurl/start — admin lands here after clicking the link in
+// /qurl setup's ephemeral reply. Validate the state, then 302 to Auth0
+// with the same state (so we can re-validate it on the callback).
+router.get('/start', (req, res) => {
+  if (!config.isQurlOAuthConfigured) {
+    logger.warn('qURL OAuth start hit but Auth0 not configured', { ip: req.ip });
+    return renderNotConfigured(res);
+  }
+  const state = String(req.query.state || '');
+  const verified = verifyQurlOAuthState(state);
+  if (!verified.ok) {
+    logger.warn('qURL OAuth start rejected invalid state', { reason: verified.reason });
+    return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired (links last 5 minutes).');
+  }
+  const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
+  authorizeUrl.searchParams.set('redirect_uri', `${config.BASE_URL}/oauth/qurl/callback`);
+  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read offline_access openid profile email');
+  authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
+  authorizeUrl.searchParams.set('state', state);
+  // prompt=consent so re-running /qurl setup actually re-prompts, even if
+  // the admin already authorized — otherwise Auth0 silently re-uses the
+  // prior consent and a re-mint can't be triggered by an admin who wants
+  // to rotate the key.
+  authorizeUrl.searchParams.set('prompt', 'consent');
+  return res.redirect(302, authorizeUrl.toString());
+});
+
+// /oauth/qurl/callback — Auth0 redirects here after the admin consents.
+// Validate state, exchange code → access_token, mint a guild-scoped API
+// key on qurl-service, persist it via the Store abstraction, DM the admin.
+router.get('/callback', async (req, res) => {
+  if (!config.isQurlOAuthConfigured) {
+    logger.warn('qURL OAuth callback hit but Auth0 not configured', { ip: req.ip });
+    return renderNotConfigured(res);
+  }
+  // Surface Auth0 error_description verbatim only in logs — render a safe
+  // generic message to the browser so an attacker can't smuggle HTML via
+  // an error URL.
+  if (req.query.error) {
+    logger.warn('qURL OAuth callback received error from Auth0', {
+      error: req.query.error, errorDescription: req.query.error_description, ip: req.ip,
+    });
+    return renderError(res, 400, 'Authorization declined', 'You declined consent or Auth0 returned an error.');
+  }
+  const code = String(req.query.code || '');
+  const state = String(req.query.state || '');
+  if (!code) {
+    return renderError(res, 400, 'Missing authorization code', 'Auth0 did not return an authorization code.');
+  }
+  const verified = verifyQurlOAuthState(state);
+  if (!verified.ok) {
+    logger.warn('qURL OAuth callback rejected invalid state', { reason: verified.reason });
+    return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired.');
+  }
+  const { guildId, discordUserId } = verified.payload;
+
+  // 1. Exchange the code for an access_token (Auth0 token endpoint).
+  let accessToken;
+  try {
+    const tokenResp = await fetch(`https://${config.AUTH0_DOMAIN}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        client_id: config.AUTH0_CLIENT_ID,
+        client_secret: config.AUTH0_CLIENT_SECRET,
+        code,
+        redirect_uri: `${config.BASE_URL}/oauth/qurl/callback`,
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!tokenResp.ok) {
+      const errBody = await tokenResp.text().catch(() => '');
+      logger.error('Auth0 token exchange failed', { status: tokenResp.status, body: errBody.slice(0, 500) });
+      return renderError(res, 502, 'Authorization failed', 'Could not complete the Auth0 handshake. Please run /qurl setup again.');
+    }
+    const tokenJson = await tokenResp.json();
+    accessToken = tokenJson.access_token;
+    if (!accessToken) {
+      logger.error('Auth0 token response missing access_token');
+      return renderError(res, 502, 'Authorization failed', 'Auth0 returned an unexpected response. Please run /qurl setup again.');
+    }
+  } catch (err) {
+    logger.error('Auth0 token exchange threw', { error: err?.message });
+    return renderError(res, 502, 'Authorization failed', 'A network error occurred during the Auth0 handshake. Please run /qurl setup again.');
+  }
+
+  // 2. Mint a guild-scoped qURL API key via POST /v1/api-keys, owned by
+  //    the admin's qURL account (the Auth0 JWT's sub claim is the owner).
+  let apiKey;
+  let keyPrefix;
+  try {
+    const keyName = `Discord guild ${guildId}`;
+    const mintResp = await fetch(`${config.QURL_ENDPOINT}/v1/api-keys`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({ name: keyName, scopes: ['qurl:write', 'qurl:read'] }),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!mintResp.ok) {
+      const errBody = await mintResp.text().catch(() => '');
+      logger.error('qURL API key mint failed', {
+        status: mintResp.status, body: errBody.slice(0, 500), guildId,
+      });
+      return renderError(res, 502, 'Could not provision qURL key',
+        'qurl-service rejected the API-key request. Please run /qurl setup again, or contact your layerv.ai admin.');
+    }
+    const mintJson = await mintResp.json();
+    apiKey = mintJson?.data?.api_key;
+    keyPrefix = mintJson?.data?.key_prefix;
+    if (!apiKey) {
+      logger.error('qURL API key response missing api_key', { guildId });
+      return renderError(res, 502, 'Could not provision qURL key',
+        'qurl-service returned an unexpected response. Please contact your layerv.ai admin.');
+    }
+  } catch (err) {
+    logger.error('qURL API key mint threw', { error: err?.message, guildId });
+    return renderError(res, 502, 'Could not provision qURL key',
+      'A network error occurred while provisioning your qURL key. Please run /qurl setup again.');
+  }
+
+  // 3. Persist the key. setGuildApiKey is idempotent (upsert), so re-running
+  //    /qurl setup overwrites the prior key — the previous key remains valid
+  //    on qurl-service until the admin manually revokes it via layerv.ai.
+  try {
+    await db.setGuildApiKey(guildId, apiKey, discordUserId);
+  } catch (err) {
+    logger.error('Failed to persist guild API key after successful mint', {
+      error: err?.message, guildId, discordUserId,
+    });
+    // Key was minted but not stored — the admin still has it (it's owned
+    // by their qURL account) but the bot can't see it. Surface a clear
+    // remediation rather than failing silently.
+    return renderError(res, 500, 'qURL key provisioned but not stored',
+      'Your qURL API key was created but the bot could not save it. Please run /qurl setup again. '
+      + 'If this keeps happening, contact your layerv.ai admin.');
+  }
+  logger.info('qURL OAuth setup complete', {
+    guildId, configuredBy: discordUserId, keyPrefix,
+  });
+
+  // 4. DM the admin so they have a confirmation that doesn't depend on the
+  //    browser tab. Fire-and-forget — a delivery failure shouldn't block
+  //    the success page (DMs may be disabled by the admin's privacy
+  //    settings, in which case the bot already has the working key).
+  sendDM(discordUserId, '✅ **qURL is connected to your Discord server.** Your team can now use `/qurl send`. All usage will be billed to your qURL account.')
+    .catch((err) => logger.warn('Failed to DM admin after qURL setup', { error: err?.message, discordUserId }));
+
+  return renderSuccess(res);
+});
+
+module.exports = router;

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -15,6 +15,7 @@ const { rateLimit } = require('../utils/oauth-rate-limit');
 const { verifyAuth0IdToken } = require('../utils/auth0-jwks');
 const { readCookie } = require('../utils/cookies');
 const { getIsReRun } = require('../utils/guild-config-state');
+const { singleStringParam } = require('../utils/query-params');
 
 // Network-call timeouts. Centralized so a future tuning of "qurl-service
 // is slow under load" doesn't require a hunt-and-replace across both
@@ -118,7 +119,7 @@ router.get('/start', rateLimit, async (req, res) => {
     return renderError(res, 503, 'qURL setup not provisioned',
       'The bot operator needs to set KEY_ENCRYPTION_KEY (encryption-at-rest) before qURL setup can store keys safely.');
   }
-  const state = String(req.query.state || '');
+  const state = singleStringParam(req.query.state);
   const verified = verifyQurlOAuthState(state);
   if (!verified.ok) {
     logger.warn('qURL OAuth start rejected invalid state', { reason: verified.reason });
@@ -190,8 +191,8 @@ router.get('/callback', rateLimit, async (req, res) => {
     });
     return renderError(res, 400, 'Authorization declined', 'You declined consent or Auth0 returned an error.');
   }
-  const code = String(req.query.code || '');
-  const state = String(req.query.state || '');
+  const code = singleStringParam(req.query.code);
+  const state = singleStringParam(req.query.state);
   if (!code) {
     return renderError(res, 400, 'Missing authorization code', 'Auth0 did not return an authorization code.');
   }
@@ -343,11 +344,7 @@ router.get('/callback', rateLimit, async (req, res) => {
 
   // 3. Persist the key. setGuildApiKey is idempotent (upsert) — the
   //    previous key (if any) remains valid on qurl-service until the
-  //    admin manually revokes it via layerv.ai. Read the prior config
-  //    first so the completion log line can flag first-install vs
-  //    rotation (obs.M2). DDB blip biases isReRun toward `true` — fine
-  //    for log enrichment.
-  const isReRun = await getIsReRun(guildId, 'qurl-oauth /callback');
+  //    admin manually revokes it via layerv.ai.
   try {
     await db.setGuildApiKey(guildId, apiKey, discordUserId);
   } catch (err) {
@@ -381,7 +378,7 @@ router.get('/callback', rateLimit, async (req, res) => {
       + 'If this keeps happening, contact your layerv.ai admin.');
   }
   logger.info('qURL OAuth setup complete', {
-    guildId, configuredBy: discordUserId, keyPrefix, isReRun,
+    guildId, configuredBy: discordUserId, keyPrefix,
   });
 
   // 4. DM the admin so they have a confirmation that doesn't depend on the

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -16,6 +16,7 @@
 // Stage 2 (new-install entry point — bot install + OAuth chained off the
 // "Add to Discord" link) is a follow-up: needs Discord developer-portal
 // redirect URI registration. Tracked in the PR description.
+const crypto = require('crypto');
 const express = require('express');
 const config = require('../config');
 const db = require('../store');
@@ -23,8 +24,40 @@ const logger = require('../logger');
 const { renderPage } = require('../templates/page');
 const { sendDM } = require('../discord');
 const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
+const { rateLimit } = require('../utils/oauth-rate-limit');
 
 const router = express.Router();
+
+// Browser-session cookie binding (parallel to /auth/github's qurl_oauth_session
+// pattern). /start sets a HttpOnly cookie holding a random 16-byte token;
+// /callback re-checks it. If a leaked /qurl setup ephemeral URL is opened
+// in a different browser, the cookie won't match and the callback rejects
+// before reaching Auth0 — narrows the leaked-URL window from "5 minutes
+// to anyone with a layerv.ai login" to "5 minutes AND the same browser
+// that opened the link."
+const QURL_OAUTH_SESSION_COOKIE = 'qurl_setup_session';
+const COOKIE_TTL_SECONDS = 5 * 60;
+
+function readCookie(req, name) {
+  const header = req.headers.cookie;
+  if (!header) return null;
+  // Reject duplicate cookies (browser extension / sibling-subdomain race) —
+  // ambiguity = no binding, treat as "no cookie".
+  const matches = [];
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const k = part.slice(0, eq).trim();
+    if (k !== name) continue;
+    try {
+      matches.push(decodeURIComponent(part.slice(eq + 1).trim()));
+    } catch {
+      return null;
+    }
+    if (matches.length > 1) return null;
+  }
+  return matches.length === 1 ? matches[0] : null;
+}
 
 // Coarse-grained 503 page when AUTH0_* env vars aren't set yet (Auth0 app
 // not registered / Justin hasn't set the prod SSM secrets). Single source
@@ -41,14 +74,45 @@ function renderNotConfigured(res) {
   }));
 }
 
-function renderSuccess(res) {
+// Success page surfaces the guild ID, key prefix, and qURL account email
+// so the admin can sanity-check the binding before closing the tab. This
+// is a user-visible mitigation against the Stage-2 confused-deputy class
+// of attack flagged in the PR #177 review: in a hypothetical
+// attacker-pre-runs-the-Discord-callback scenario, the state would carry
+// the attacker's discord_user_id + guild_id while the qURL account is
+// the victim's. Showing both halves of the binding lets the admin spot a
+// mismatch ("this isn't my server name" / "this isn't my qURL email")
+// before usage starts.
+function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
+  const detailLines = [];
+  if (guildId) detailLines.push(`Discord guild: <code>${escapeHtmlForRender(guildId)}</code>`);
+  if (qurlAccountEmail) detailLines.push(`qURL account: <code>${escapeHtmlForRender(qurlAccountEmail)}</code>`);
+  if (keyPrefix) detailLines.push(`API key prefix: <code>${escapeHtmlForRender(keyPrefix)}</code>`);
+  const subtext = detailLines.length > 0
+    ? detailLines.join(' · ') + ' — confirm these match before closing.'
+    : undefined;
   return res.status(200).send(renderPage({
     title: 'qURL Connected',
     icon: '✅',
     heading: 'qURL is connected to your Discord server.',
     message: 'You can close this tab and return to Discord. /qurl send is ready.',
+    subtext,
     type: 'success',
   }));
+}
+
+// renderPage's `subtext` field is HTML-escaped at render-time per its
+// docstring, but the values we pass in (guildId, keyPrefix, email) are
+// directly interpolated into <code> tags above the renderPage call —
+// so we escape here too. Belt-and-suspenders against a future caller
+// passing untrusted input through this helper.
+function escapeHtmlForRender(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function renderError(res, statusCode, headline, detail) {
@@ -62,9 +126,13 @@ function renderError(res, statusCode, headline, detail) {
 }
 
 // /oauth/qurl/start — admin lands here after clicking the link in
-// /qurl setup's ephemeral reply. Validate the state, then 302 to Auth0
-// with the same state (so we can re-validate it on the callback).
-router.get('/start', (req, res) => {
+// /qurl setup's ephemeral reply. Validate the state, set a session-bound
+// cookie carrying the same state, then 302 to Auth0 with the state in
+// the URL. The /callback handler re-checks cookie === query.state — a
+// classic double-submit CSRF binding. If the link leaks and is opened
+// in a different browser, the cookie is absent and /callback rejects
+// before any Auth0 token exchange or qurl-service mint runs.
+router.get('/start', rateLimit, (req, res) => {
   if (!config.isQurlOAuthConfigured) {
     logger.warn('qURL OAuth start hit but Auth0 not configured', { ip: req.ip });
     return renderNotConfigured(res);
@@ -75,11 +143,28 @@ router.get('/start', (req, res) => {
     logger.warn('qURL OAuth start rejected invalid state', { reason: verified.reason });
     return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired (links last 5 minutes).');
   }
+  // Double-submit CSRF cookie: cookie value is the same state token the
+  // URL carries to Auth0. /callback re-checks (timing-safe) that
+  // cookie === query.state. Same-browser flows have both; leaked URLs
+  // opened in other browsers don't have the cookie and fail.
+  // Path is /oauth (not /oauth/qurl) so the same cookie also covers the
+  // Stage-2 "Add to Discord" entry path /oauth/discord/callback when
+  // that flow chains through to /oauth/qurl/callback.
+  res.cookie(QURL_OAUTH_SESSION_COOKIE, state, {
+    httpOnly: true,
+    secure: req.protocol === 'https',
+    sameSite: 'lax',
+    maxAge: COOKIE_TTL_SECONDS * 1000,
+    path: '/oauth',
+  });
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
   authorizeUrl.searchParams.set('redirect_uri', `${config.BASE_URL}/oauth/qurl/callback`);
-  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read offline_access openid profile email');
+  // Drop offline_access — we don't store/use refresh tokens (the API key
+  // mint is one-shot), so requesting them is unnecessary attack surface
+  // per PR #177 review.
+  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid profile email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', state);
   // prompt=consent so re-running /qurl setup actually re-prompts, even if
@@ -93,10 +178,23 @@ router.get('/start', (req, res) => {
 // /oauth/qurl/callback — Auth0 redirects here after the admin consents.
 // Validate state, exchange code → access_token, mint a guild-scoped API
 // key on qurl-service, persist it via the Store abstraction, DM the admin.
-router.get('/callback', async (req, res) => {
+router.get('/callback', rateLimit, async (req, res) => {
   if (!config.isQurlOAuthConfigured) {
     logger.warn('qURL OAuth callback hit but Auth0 not configured', { ip: req.ip });
     return renderNotConfigured(res);
+  }
+  // Same encryption-at-rest guard the legacy modal-paste path enforces in
+  // commands.js: refuse to persist a billing-sensitive API key when
+  // KEY_ENCRYPTION_KEY is unset, even if the OAuth handshake otherwise
+  // succeeds. Without this, a non-prod boot with AUTH0_* set but
+  // KEY_ENCRYPTION_KEY unset would silently store keys in plaintext via
+  // the crypto module's plaintext-tolerated fallback. boot-requirements
+  // only marks KEY_ENCRYPTION_KEY as `prodRequired`, so the guard here
+  // is the load-bearing check for non-prod environments.
+  if (!process.env.KEY_ENCRYPTION_KEY) {
+    logger.error('Refusing /oauth/qurl/callback: KEY_ENCRYPTION_KEY is not set');
+    return renderError(res, 503, 'qURL setup not provisioned',
+      'The bot operator needs to set KEY_ENCRYPTION_KEY (encryption-at-rest) before qURL setup can store keys safely.');
   }
   // Surface Auth0 error_description verbatim only in logs — render a safe
   // generic message to the browser so an attacker can't smuggle HTML via
@@ -117,10 +215,40 @@ router.get('/callback', async (req, res) => {
     logger.warn('qURL OAuth callback rejected invalid state', { reason: verified.reason });
     return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired.');
   }
+  // Double-submit CSRF cookie check. /start set a cookie carrying the
+  // same state value; /callback verifies cookie === query.state via
+  // timing-safe compare. Same-browser flows pass; leaked-URL replays
+  // in a different browser fail here BEFORE any Auth0 token exchange
+  // or qurl-service mint runs.
+  const cookieState = readCookie(req, QURL_OAUTH_SESSION_COOKIE);
+  if (!cookieState) {
+    logger.warn('qURL OAuth callback missing session cookie', { ip: req.ip });
+    return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
+  }
+  let cookieMatches = false;
+  try {
+    const cookieBuf = Buffer.from(cookieState);
+    const stateBuf = Buffer.from(state);
+    cookieMatches = cookieBuf.length === stateBuf.length
+      && crypto.timingSafeEqual(cookieBuf, stateBuf);
+  } catch {
+    cookieMatches = false;
+  }
+  if (!cookieMatches) {
+    logger.warn('qURL OAuth callback cookie/state mismatch', { ip: req.ip });
+    return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
+  }
+  // Cookie is consumed — clear it so a refreshed callback URL can't
+  // re-bind. Fresh /qurl setup runs mint a new state and set a new
+  // cookie.
+  res.clearCookie(QURL_OAUTH_SESSION_COOKIE, { path: '/oauth' });
   const { guildId, discordUserId } = verified.payload;
 
-  // 1. Exchange the code for an access_token (Auth0 token endpoint).
+  // 1. Exchange the code for an access_token + id_token (Auth0 token
+  //    endpoint). The id_token's `email` claim feeds the success-page
+  //    binding readout (sanity-check display, not a security boundary).
   let accessToken;
+  let qurlAccountEmail;
   try {
     const tokenResp = await fetch(`https://${config.AUTH0_DOMAIN}/oauth/token`, {
       method: 'POST',
@@ -145,6 +273,23 @@ router.get('/callback', async (req, res) => {
       logger.error('Auth0 token response missing access_token');
       return renderError(res, 502, 'Authorization failed', 'Auth0 returned an unexpected response. Please run /qurl setup again.');
     }
+    // Best-effort id_token email extraction. JWT decode without
+    // signature verification — the id_token came from Auth0 over TLS
+    // in this same response, so signature verification is redundant
+    // for a display-only readout. Wrap in try/catch because we do NOT
+    // want a malformed id_token to fail the whole setup flow.
+    try {
+      const idToken = tokenJson.id_token;
+      if (typeof idToken === 'string') {
+        const parts = idToken.split('.');
+        if (parts.length === 3) {
+          const payload = JSON.parse(Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+          if (typeof payload.email === 'string') qurlAccountEmail = payload.email;
+        }
+      }
+    } catch (err) {
+      logger.debug('id_token email extraction failed (non-fatal)', { error: err?.message });
+    }
   } catch (err) {
     logger.error('Auth0 token exchange threw', { error: err?.message });
     return renderError(res, 502, 'Authorization failed', 'A network error occurred during the Auth0 handshake. Please run /qurl setup again.');
@@ -153,6 +298,7 @@ router.get('/callback', async (req, res) => {
   // 2. Mint a guild-scoped qURL API key via POST /v1/api-keys, owned by
   //    the admin's qURL account (the Auth0 JWT's sub claim is the owner).
   let apiKey;
+  let keyId;
   let keyPrefix;
   try {
     const keyName = `Discord guild ${guildId}`;
@@ -176,6 +322,7 @@ router.get('/callback', async (req, res) => {
     }
     const mintJson = await mintResp.json();
     apiKey = mintJson?.data?.api_key;
+    keyId = mintJson?.data?.key_id;
     keyPrefix = mintJson?.data?.key_prefix;
     if (!apiKey) {
       logger.error('qURL API key response missing api_key', { guildId });
@@ -188,18 +335,38 @@ router.get('/callback', async (req, res) => {
       'A network error occurred while provisioning your qURL key. Please run /qurl setup again.');
   }
 
-  // 3. Persist the key. setGuildApiKey is idempotent (upsert), so re-running
-  //    /qurl setup overwrites the prior key — the previous key remains valid
-  //    on qurl-service until the admin manually revokes it via layerv.ai.
+  // 3. Persist the key. setGuildApiKey is idempotent (upsert), so
+  //    re-running /qurl setup overwrites the prior key — the previous
+  //    key remains valid on qurl-service until the admin manually
+  //    revokes it via layerv.ai.
   try {
     await db.setGuildApiKey(guildId, apiKey, discordUserId);
   } catch (err) {
     logger.error('Failed to persist guild API key after successful mint', {
-      error: err?.message, guildId, discordUserId,
+      error: err?.message, guildId, discordUserId, keyId,
     });
-    // Key was minted but not stored — the admin still has it (it's owned
-    // by their qURL account) but the bot can't see it. Surface a clear
-    // remediation rather than failing silently.
+    // Key was minted but not stored. Best-effort delete on qurl-service
+    // so retries don't pile up orphan keys under the admin's account.
+    // Fire-and-forget — even if the cleanup fails, the user-facing 500
+    // response below is the right outcome (admin runs /qurl setup
+    // again to retry; the orphan only persists if delete also fails).
+    if (keyId) {
+      fetch(`${config.QURL_ENDPOINT}/v1/api-keys/${encodeURIComponent(keyId)}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+        signal: AbortSignal.timeout(10000),
+      })
+        .then((r) => {
+          if (!r.ok) {
+            logger.warn('Best-effort orphan-key delete returned non-ok', {
+              status: r.status, keyId, guildId,
+            });
+          }
+        })
+        .catch((dErr) => logger.warn('Best-effort orphan-key delete threw', {
+          error: dErr?.message, keyId, guildId,
+        }));
+    }
     return renderError(res, 500, 'qURL key provisioned but not stored',
       'Your qURL API key was created but the bot could not save it. Please run /qurl setup again. '
       + 'If this keeps happening, contact your layerv.ai admin.');
@@ -212,10 +379,16 @@ router.get('/callback', async (req, res) => {
   //    browser tab. Fire-and-forget — a delivery failure shouldn't block
   //    the success page (DMs may be disabled by the admin's privacy
   //    settings, in which case the bot already has the working key).
-  sendDM(discordUserId, '✅ **qURL is connected to your Discord server.** Your team can now use `/qurl send`. All usage will be billed to your qURL account.')
+  //    Include the key prefix so the admin can match it against
+  //    `/qurl status` and against the layerv.ai dashboard, which
+  //    matters for spotting binding mismatches in the rare confused-
+  //    deputy edge case (see PR #177 review item 3).
+  const dmLines = ['✅ **qURL is connected to your Discord server.** Your team can now use `/qurl send`. All usage will be billed to your qURL account.'];
+  if (keyPrefix) dmLines.push(`Key prefix: \`${keyPrefix}\``);
+  sendDM(discordUserId, dmLines.join('\n'))
     .catch((err) => logger.warn('Failed to DM admin after qURL setup', { error: err?.message, discordUserId }));
 
-  return renderSuccess(res);
+  return renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail });
 });
 
 module.exports = router;

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -66,12 +66,8 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   if (guildId) details.push({ label: 'Discord guild', value: guildId });
   if (qurlAccountEmail) details.push({ label: 'qURL account', value: qurlAccountEmail });
   if (keyPrefix) details.push({ label: 'API key prefix', value: keyPrefix });
-  // Cache-Control: no-store keeps the binding readout (qURL email,
-  // key prefix) out of any intermediate cache — back/forward cache,
-  // browser disk cache, ALB cache. Low cost, prevents the tab from
-  // surfacing a stale binding readout if the admin closes and
-  // re-opens. PR #177 round-9 review item #1.
-  res.setHeader('Cache-Control', 'no-store');
+  // Cache-Control: no-store is set as a router-level default in
+  // server.js for every /oauth/* response — see noStoreHeaders.
   return res.status(200).send(renderPage({
     title: 'qURL Connected',
     icon: '✅',
@@ -85,12 +81,6 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   }));
 }
 
-// Error pages intentionally do NOT set `Cache-Control: no-store`
-// (unlike renderSuccess) — the headline + detail strings here don't
-// surface secrets (no api_key / email / key prefix). If a future
-// edit adds key-prefix-leaking detail to an error path, set
-// `res.setHeader('Cache-Control', 'no-store')` at the call site.
-// Round-9 item #4 — explicit so the invariant is searchable.
 function renderError(res, statusCode, headline, detail) {
   return res.status(statusCode).send(renderPage({
     title: 'qURL Setup Failed',

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -214,9 +214,9 @@ router.get('/callback', rateLimit, async (req, res) => {
     return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
   }
   // Both inputs are strings (cookieState early-returned if null;
-  // state = String(req.query.state || '')), so Buffer.from doesn't
-  // throw. Length check before timingSafeEqual handles the only
-  // remaining failure mode.
+  // state came through singleStringParam, which returns '' for any
+  // non-string), so Buffer.from doesn't throw. Length check before
+  // timingSafeEqual handles the only remaining failure mode.
   const cookieBuf = Buffer.from(cookieState);
   const stateBuf = Buffer.from(state);
   const cookieMatches = cookieBuf.length === stateBuf.length

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -27,8 +27,9 @@ const db = require('../store');
 const logger = require('../logger');
 const { renderPage } = require('../templates/page');
 const { sendDM } = require('../discord');
-const { verifyQurlOAuthState, b64urlDecode } = require('../utils/qurl-oauth-state');
+const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
+const { verifyAuth0IdToken } = require('../utils/auth0-jwks');
 
 // Network-call timeouts. Centralized so a future tuning of "qurl-service
 // is slow under load" doesn't require a hunt-and-replace across both
@@ -47,8 +48,16 @@ const router = express.Router();
 // before reaching Auth0 — narrows the leaked-URL window from "5 minutes
 // to anyone with a layerv.ai login" to "5 minutes AND the same browser
 // that opened the link."
-const QURL_OAUTH_SESSION_COOKIE = 'qurl_setup_session';
-const COOKIE_TTL_SECONDS = 5 * 60;
+//
+// Cookie name + path constants live in utils/oauth-cookies.js so the
+// Stage-2 chain (routes/discord-install.js sets the same cookie before
+// chaining to Auth0) can't drift — single source of truth. PR #177
+// follow-up C.1.
+const {
+  QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_COOKIE_PATH,
+  QURL_OAUTH_COOKIE_TTL_SECONDS: COOKIE_TTL_SECONDS,
+} = require('../utils/oauth-cookies');
 
 function readCookie(req, name) {
   const header = req.headers.cookie;
@@ -87,37 +96,25 @@ function renderNotConfigured(res) {
 }
 
 // Success page surfaces the guild ID, key prefix, and qURL account email
-// so the admin can sanity-check the binding before closing the tab. This
-// is the LOAD-BEARING user-visible mitigation against the Stage-2
-// confused-deputy class of attack flagged in the PR #177 review: in a
-// hypothetical attacker-pre-runs-the-Discord-callback scenario, the
-// state would carry the attacker's discord_user_id + guild_id while the
-// qURL account email is the victim's. Showing both halves of the
-// binding lets the admin spot a mismatch ("this isn't my server" /
-// "this isn't my qURL email") before usage starts.
-//
-// Subtext is plain prose — `renderPage` HTML-escapes the whole string at
-// render time, so any inline tags (<code>, <strong>, etc.) would render
-// as literal angle brackets. The values themselves still ride through
-// renderPage's escapeHtml so untrusted input can't smuggle script tags;
-// the trade-off is that the values aren't visually distinguished
-// (no monospace formatting). That's an acceptable cost for the
-// security guarantee: the goal is "admin reads the values" not
-// "admin enjoys nice typography."
+// as a structured label/value list (renderPage `details`) — the LOAD-
+// BEARING visual mitigation against the Stage-2 confused-deputy class:
+// if attacker pre-runs Discord install in their browser then forwards
+// the chained Auth0-redirect URL to a victim, the readout shows
+// (attacker's guild + victim's qURL email) so the victim can spot the
+// mismatch before /qurl send usage starts. PR #177 follow-up C.5 —
+// upgraded from the prior grey-prose subtext for visual prominence.
 function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
-  const detailLines = [];
-  if (guildId) detailLines.push(`Discord guild: ${guildId}`);
-  if (qurlAccountEmail) detailLines.push(`qURL account: ${qurlAccountEmail}`);
-  if (keyPrefix) detailLines.push(`API key prefix: ${keyPrefix}`);
-  const subtext = detailLines.length > 0
-    ? detailLines.join(' · ') + ' — confirm these match before closing.'
-    : undefined;
+  const details = [];
+  if (guildId) details.push({ label: 'Discord guild', value: guildId });
+  if (qurlAccountEmail) details.push({ label: 'qURL account', value: qurlAccountEmail });
+  if (keyPrefix) details.push({ label: 'API key prefix', value: keyPrefix });
   return res.status(200).send(renderPage({
     title: 'qURL Connected',
     icon: '✅',
     heading: 'qURL is connected to your Discord server.',
     message: 'You can close this tab and return to Discord. /qurl send is ready.',
-    subtext,
+    details,
+    subtext: details.length > 0 ? 'Confirm these match before closing.' : undefined,
     type: 'success',
   }));
 }
@@ -139,7 +136,7 @@ function renderError(res, statusCode, headline, detail) {
 // classic double-submit CSRF binding. If the link leaks and is opened
 // in a different browser, the cookie is absent and /callback rejects
 // before any Auth0 token exchange or qurl-service mint runs.
-router.get('/start', rateLimit, (req, res) => {
+router.get('/start', rateLimit, async (req, res) => {
   if (!config.isQurlOAuthConfigured) {
     logger.warn('qURL OAuth start hit but Auth0 not configured', { ip: req.ip });
     return renderNotConfigured(res);
@@ -161,6 +158,26 @@ router.get('/start', rateLimit, (req, res) => {
     logger.warn('qURL OAuth start rejected invalid state', { reason: verified.reason });
     return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired (links last 5 minutes).');
   }
+  // First-install vs re-run gate for prompt=consent. If the guild has
+  // never been configured (no `configured_by`), let Auth0's default
+  // behavior decide whether to show the consent screen — most admins
+  // see it once. On a re-run, force prompt=consent so the admin can
+  // rotate the key or switch qURL accounts (without it Auth0 silently
+  // re-uses the prior consent and a re-mint can't be triggered).
+  // PR #177 follow-up C.8.
+  let isReRun = false;
+  try {
+    const existing = await db.getGuildConfig(verified.payload.guildId);
+    isReRun = Boolean(existing && existing.configured_by);
+  } catch (err) {
+    // DDB blip: bias toward the safer-for-rotation path (prompt=consent).
+    // Re-prompting an already-consenting admin is mildly annoying;
+    // skipping consent on what is actually a re-run blocks key rotation.
+    logger.warn('Failed to read guild config for prompt=consent gating; defaulting to re-run path', {
+      error: err?.message,
+    });
+    isReRun = true;
+  }
   // Double-submit CSRF cookie: cookie value is the same state token the
   // URL carries to Auth0. /callback re-checks (timing-safe) that
   // cookie === query.state. Same-browser flows have both; leaked URLs
@@ -177,7 +194,7 @@ router.get('/start', rateLimit, (req, res) => {
     secure: req.protocol === 'https',
     sameSite: 'lax',
     maxAge: COOKIE_TTL_SECONDS * 1000,
-    path: '/oauth',
+    path: QURL_OAUTH_COOKIE_PATH,
   });
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
@@ -186,14 +203,20 @@ router.get('/start', rateLimit, (req, res) => {
   // Drop offline_access — we don't store/use refresh tokens (the API key
   // mint is one-shot), so requesting them is unnecessary attack surface
   // per PR #177 review.
-  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid profile email');
+  // Scope set: qurl:write + qurl:read for the API-key mint, openid +
+  // email for the id_token's email claim (used by the success-page
+  // binding readout). `profile` was previously requested but never
+  // read — narrowing per PR #177 follow-up C.2 to tighten the
+  // consent-screen "what is this app asking for?" UX.
+  authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', state);
-  // prompt=consent so re-running /qurl setup actually re-prompts, even if
-  // the admin already authorized — otherwise Auth0 silently re-uses the
-  // prior consent and a re-mint can't be triggered by an admin who wants
-  // to rotate the key.
-  authorizeUrl.searchParams.set('prompt', 'consent');
+  // prompt=consent only on re-run (key-rotation flow) — without it
+  // Auth0 silently re-uses prior consent and re-running /qurl setup
+  // can't actually issue a new key. On first install, omit so the
+  // admin doesn't see a redundant "are you sure?" screen on top of
+  // the standard sign-in. Gate evaluated above. PR #177 follow-up C.8.
+  if (isReRun) authorizeUrl.searchParams.set('prompt', 'consent');
   return res.redirect(302, authorizeUrl.toString());
 });
 
@@ -262,8 +285,11 @@ router.get('/callback', rateLimit, async (req, res) => {
   }
   // Cookie is consumed — clear it so a refreshed callback URL can't
   // re-bind. Fresh /qurl setup runs mint a new state and set a new
-  // cookie.
-  res.clearCookie(QURL_OAUTH_SESSION_COOKIE, { path: '/oauth' });
+  // cookie. Path MUST match the /start + /oauth/discord/callback
+  // Set-Cookie path (/oauth, the shared constant) — clearing with a
+  // mismatched path is a no-op and the browser keeps the cookie alive
+  // until TTL.
+  res.clearCookie(QURL_OAUTH_SESSION_COOKIE, { path: QURL_OAUTH_COOKIE_PATH });
   const { guildId, discordUserId } = verified.payload;
 
   // 1. Exchange the code for an access_token + id_token (Auth0 token
@@ -300,26 +326,27 @@ router.get('/callback', rateLimit, async (req, res) => {
       logger.error('Auth0 token response missing access_token');
       return renderError(res, 502, 'Authorization failed', 'Auth0 returned an unexpected response. Please run /qurl setup again.');
     }
-    // Best-effort id_token email extraction. JWT decode without
-    // signature verification — the id_token came from Auth0 over TLS
-    // in this same response, so signature verification is redundant
-    // for a display-only readout. (See PR #177 review note: the email
-    // becomes a load-bearing visual cue against confused-deputy on
-    // Stage 2, but the security claim of the readout is still "trust
-    // Auth0's TLS response" — full verification would require JWKS
-    // caching and is out of scope here.) Reuses b64urlDecode from
-    // utils/qurl-oauth-state.js for consistent base64-url handling.
-    try {
-      const idToken = tokenJson.id_token;
-      if (typeof idToken === 'string') {
-        const parts = idToken.split('.');
-        if (parts.length === 3) {
-          const payload = JSON.parse(b64urlDecode(parts[1]).toString('utf8'));
-          if (typeof payload.email === 'string') qurlAccountEmail = payload.email;
-        }
+    // id_token email extraction with full JWKS verification. The email
+    // is the load-bearing visual cue against the Stage-2 confused-
+    // deputy class — promoting the security claim from "trust Auth0's
+    // TLS response" to "verify the JWT signature against Auth0's
+    // JWKS" closes the asterisk on that mitigation. See PR #177
+    // follow-up issue #178 / section B.
+    //
+    // Failure to verify is non-fatal: the qURL key still gets minted
+    // (the access_token mint already succeeded above) and the success
+    // page renders without the qURL-account-email line. Ops sees a
+    // logger.debug for triage. We do NOT fall back to unverified
+    // decode — a forged email would be worse than no email.
+    if (tokenJson.id_token) {
+      const verified = await verifyAuth0IdToken(tokenJson.id_token);
+      if (verified.ok && typeof verified.payload?.email === 'string') {
+        qurlAccountEmail = verified.payload.email;
+      } else if (!verified.ok) {
+        logger.debug('id_token verification failed (non-fatal — success page renders without email)', {
+          reason: verified.reason,
+        });
       }
-    } catch (err) {
-      logger.debug('id_token email extraction failed (non-fatal)', { error: err?.message });
     }
   } catch (err) {
     logger.error('Auth0 token exchange threw', { error: err?.message });
@@ -355,8 +382,17 @@ router.get('/callback', rateLimit, async (req, res) => {
     apiKey = mintJson?.data?.api_key;
     keyId = mintJson?.data?.key_id;
     keyPrefix = mintJson?.data?.key_prefix;
-    if (!apiKey) {
-      logger.error('qURL API key response missing api_key', { guildId });
+    // Both api_key AND key_id are required: api_key is what we persist
+    // for the bot to use; key_id is what the orphan-cleanup DELETE
+    // below targets if persistence then fails. Treating a missing
+    // key_id as success would leave us unable to clean up an orphan
+    // billing-active key on the admin's account if DDB throws —
+    // safer to refuse upfront so the admin retries with a complete
+    // mint response. PR #177 follow-up C.3.
+    if (!apiKey || !keyId) {
+      logger.error('qURL API key response missing required fields', {
+        guildId, hasApiKey: Boolean(apiKey), hasKeyId: Boolean(keyId),
+      });
       return renderError(res, 502, 'Could not provision qURL key',
         'qurl-service returned an unexpected response. Please contact your layerv.ai admin.');
     }

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -137,6 +137,17 @@ router.get('/start', rateLimit, (req, res) => {
     logger.warn('qURL OAuth start hit but Auth0 not configured', { ip: req.ip });
     return renderNotConfigured(res);
   }
+  // Fail-fast: refuse the OAuth round-trip if KEY_ENCRYPTION_KEY is unset
+  // here rather than after the admin completes Auth0 sign-in + consent.
+  // The /callback path enforces the same guard, but reaching it burns
+  // Auth0's `code` for nothing and produces a confusing "Authorization
+  // failed at the very end" UX. Same principle as the legacy
+  // modal-paste path's pre-modal check (commands.js).
+  if (!process.env.KEY_ENCRYPTION_KEY) {
+    logger.error('Refusing /oauth/qurl/start: KEY_ENCRYPTION_KEY is not set');
+    return renderError(res, 503, 'qURL setup not provisioned',
+      'The bot operator needs to set KEY_ENCRYPTION_KEY (encryption-at-rest) before qURL setup can store keys safely.');
+  }
   const state = String(req.query.state || '');
   const verified = verifyQurlOAuthState(state);
   if (!verified.ok) {

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -160,6 +160,10 @@ router.get('/start', rateLimit, (req, res) => {
   // Path is /oauth (not /oauth/qurl) so the same cookie also covers the
   // Stage-2 "Add to Discord" entry path /oauth/discord/callback when
   // that flow chains through to /oauth/qurl/callback.
+  // `secure: req.protocol === 'https'` relies on `trust proxy` being set
+  // in server.js so req.protocol reflects the X-Forwarded-Proto header
+  // from the ALB. Flipping `trust proxy` off would silently downgrade
+  // production cookies to insecure.
   res.cookie(QURL_OAUTH_SESSION_COOKIE, state, {
     httpOnly: true,
     secure: req.protocol === 'https',

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -173,7 +173,9 @@ router.get('/start', rateLimit, async (req, res) => {
     // DDB blip: bias toward the safer-for-rotation path (prompt=consent).
     // Re-prompting an already-consenting admin is mildly annoying;
     // skipping consent on what is actually a re-run blocks key rotation.
-    logger.warn('Failed to read guild config for prompt=consent gating; defaulting to re-run path', {
+    // info-level — this is a benign fallback, not an error condition.
+    // A flaky DDB shouldn't spam warns (which on-call grep-tails).
+    logger.info('Failed to read guild config for prompt=consent gating; defaulting to re-run path', {
       error: err?.message,
     });
     isReRun = true;
@@ -339,12 +341,16 @@ router.get('/callback', rateLimit, async (req, res) => {
     // logger.debug for triage. We do NOT fall back to unverified
     // decode — a forged email would be worse than no email.
     if (tokenJson.id_token) {
-      const verified = await verifyAuth0IdToken(tokenJson.id_token);
-      if (verified.ok && typeof verified.payload?.email === 'string') {
-        qurlAccountEmail = verified.payload.email;
-      } else if (!verified.ok) {
+      // Distinct local — the outer `verified` (line ~258) carries the
+      // qURL-OAuth-state verification result; this one carries the
+      // Auth0 id_token JWKS verification result. Same shape, different
+      // payload — keep them lexically separate to avoid reader confusion.
+      const idTokenVerified = await verifyAuth0IdToken(tokenJson.id_token);
+      if (idTokenVerified.ok && typeof idTokenVerified.payload?.email === 'string') {
+        qurlAccountEmail = idTokenVerified.payload.email;
+      } else if (!idTokenVerified.ok) {
         logger.debug('id_token verification failed (non-fatal — success page renders without email)', {
-          reason: verified.reason,
+          reason: idTokenVerified.reason,
         });
       }
     }
@@ -406,6 +412,23 @@ router.get('/callback', rateLimit, async (req, res) => {
   //    re-running /qurl setup overwrites the prior key — the previous
   //    key remains valid on qurl-service until the admin manually
   //    revokes it via layerv.ai.
+  //
+  //    Read the prior config row first so the completion log line can
+  //    distinguish first-install from rotation (`isReRun` field). The
+  //    /start (and discord-install) gate already evaluates this for
+  //    prompt=consent, but the callback doesn't see that decision —
+  //    re-querying here is the cheapest way to surface the distinction
+  //    in operational logs without threading state through the
+  //    signed state token. DDB blip → log without the field, don't
+  //    block the persist.
+  let isReRun = null;
+  try {
+    const existing = await db.getGuildConfig(guildId);
+    isReRun = Boolean(existing && existing.configured_by);
+  } catch {
+    // intentionally silent — the persist below is what matters; the
+    // log enrichment is best-effort.
+  }
   try {
     await db.setGuildApiKey(guildId, apiKey, discordUserId);
   } catch (err) {
@@ -439,7 +462,7 @@ router.get('/callback', rateLimit, async (req, res) => {
       + 'If this keeps happening, contact your layerv.ai admin.');
   }
   logger.info('qURL OAuth setup complete', {
-    guildId, configuredBy: discordUserId, keyPrefix,
+    guildId, configuredBy: discordUserId, keyPrefix, isReRun,
   });
 
   // 4. DM the admin so they have a confirmation that doesn't depend on the

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -85,6 +85,12 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   }));
 }
 
+// Error pages intentionally do NOT set `Cache-Control: no-store`
+// (unlike renderSuccess) — the headline + detail strings here don't
+// surface secrets (no api_key / email / key prefix). If a future
+// edit adds key-prefix-leaking detail to an error path, set
+// `res.setHeader('Cache-Control', 'no-store')` at the call site.
+// Round-9 item #4 — explicit so the invariant is searchable.
 function renderError(res, statusCode, headline, detail) {
   return res.status(statusCode).send(renderPage({
     title: 'qURL Setup Failed',
@@ -104,7 +110,9 @@ function renderError(res, statusCode, headline, detail) {
 // before any Auth0 token exchange or qurl-service mint runs.
 router.get('/start', rateLimit, async (req, res) => {
   if (!config.isQurlOAuthConfigured) {
-    logger.warn('qURL OAuth start hit but Auth0 not configured', { ip: req.ip });
+    // Single log line per request lives in renderNotConfiguredPage —
+    // dropping the route-level warn (round-9 item #7 harmonization
+    // with discord-install.js's surface).
     return renderNotConfigured(res);
   }
   // Fail-fast: refuse the OAuth round-trip if KEY_ENCRYPTION_KEY is unset
@@ -165,7 +173,6 @@ router.get('/start', rateLimit, async (req, res) => {
 // key on qurl-service, persist it via the Store abstraction, DM the admin.
 router.get('/callback', rateLimit, async (req, res) => {
   if (!config.isQurlOAuthConfigured) {
-    logger.warn('qURL OAuth callback hit but Auth0 not configured', { ip: req.ip });
     return renderNotConfigured(res);
   }
   // Same encryption-at-rest guard the legacy modal-paste path enforces in
@@ -184,9 +191,15 @@ router.get('/callback', rateLimit, async (req, res) => {
   // Surface Auth0 error_description verbatim only in logs — render a safe
   // generic message to the browser so an attacker can't smuggle HTML via
   // an error URL.
-  if (req.query.error) {
+  // Funnel error params through singleStringParam for symmetry with
+  // code/state — array shapes from `?error=a&error=b` log as empty
+  // strings rather than stringified arrays. Round-9 item #5.
+  const errorParam = singleStringParam(req.query.error);
+  if (errorParam) {
     logger.warn('qURL OAuth callback received error from Auth0', {
-      error: req.query.error, errorDescription: req.query.error_description, ip: req.ip,
+      error: errorParam,
+      errorDescription: singleStringParam(req.query.error_description),
+      ip: req.ip,
     });
     return renderError(res, 400, 'Authorization declined', 'You declined consent or Auth0 returned an error.');
   }
@@ -292,7 +305,14 @@ router.get('/callback', rateLimit, async (req, res) => {
       if (idTokenVerified.ok && typeof idTokenVerified.payload?.email === 'string') {
         qurlAccountEmail = idTokenVerified.payload.email;
       } else if (!idTokenVerified.ok) {
-        logger.debug('id_token verification failed (non-fatal — success page renders without email)', {
+        // Severity at this call site mirrors auth0-jwks.js's internal
+        // split (round-9 item #6): clock-skew expiry is benign + noisy;
+        // signature/claim/JWKS failures are the only signal of a forged
+        // or wrong-tenant id_token attempt and need to surface above
+        // default prod log filters.
+        const benign = idTokenVerified.reason === 'ERR_JWT_EXPIRED';
+        const log = benign ? logger.debug : logger.warn;
+        log('id_token verification failed (non-fatal — success page renders without email)', {
           reason: idTokenVerified.reason,
         });
       }

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -199,6 +199,18 @@ if (config.isOpenNHPActive) {
   logger.info('Single-guild plain mode (ENABLE_OPENNHP_FEATURES=false): /auth and /webhook routes not mounted.');
 }
 
+// Cache-Control: no-store on every response from the OAuth surfaces —
+// success page surfaces guild + qURL email + key prefix; error pages
+// could leak detail in the future; not-configured page is also OAuth-
+// adjacent. Applying as a router-level default removes a conditional
+// invariant per-handler (round-9 #6) and is zero-cost on these
+// low-traffic paths. Also vary on Set-Cookie so any intermediate that
+// honors Vary doesn't cross-cache between authenticated tabs.
+function noStoreHeaders(req, res, next) {
+  res.setHeader('Cache-Control', 'no-store');
+  next();
+}
+
 // qURL OAuth routes (/oauth/qurl/start + /oauth/qurl/callback) — separate
 // from the OpenNHP gate above. These always mount because /qurl setup is
 // the canonical path for any guild (multi-tenant or single-guild) to
@@ -207,7 +219,7 @@ if (config.isOpenNHPActive) {
 // page when AUTH0_* env vars are unset, rather than a hard 404). That way
 // flipping the AUTH0_* secrets in SSM is the only step needed to turn
 // OAuth on — no code change or env-flag re-flip required.
-app.use('/oauth/qurl', qurlOAuthRouter);
+app.use('/oauth/qurl', noStoreHeaders, qurlOAuthRouter);
 if (!config.isQurlOAuthConfigured) {
   logger.info('qURL OAuth routes mounted in not-configured mode (AUTH0_* env vars unset). /qurl setup will fall back to the legacy modal-paste path.');
 }
@@ -218,7 +230,7 @@ if (!config.isQurlOAuthConfigured) {
 // stable regardless of config; the route gates internally on
 // config.isDiscordInstallConfigured (returns 503 when DISCORD_CLIENT_SECRET
 // or AUTH0_* unset).
-app.use('/oauth/discord', discordInstallRouter);
+app.use('/oauth/discord', noStoreHeaders, discordInstallRouter);
 if (!config.isDiscordInstallConfigured) {
   logger.info('Discord install callback mounted in not-configured mode (DISCORD_CLIENT_SECRET or AUTH0_* env vars unset).');
 }

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -8,6 +8,7 @@ const logger = require('./logger');
 const { renderPage } = require('./templates/page');
 const oauthRouter = require('./routes/oauth');
 const qurlOAuthRouter = require('./routes/qurl-oauth');
+const discordInstallRouter = require('./routes/discord-install');
 const webhooksRouter = require('./routes/webhooks');
 
 const app = express();
@@ -200,6 +201,17 @@ if (config.isOpenNHPActive) {
 app.use('/oauth/qurl', qurlOAuthRouter);
 if (!config.isQurlOAuthConfigured) {
   logger.info('qURL OAuth routes mounted in not-configured mode (AUTH0_* env vars unset). /qurl setup will fall back to the legacy modal-paste path.');
+}
+
+// Stage-2 Discord install callback. Mounts at /oauth/discord/callback —
+// the redirect_uri Discord OAuth2 hits when an admin clicks "Add to
+// Discord" + selects a server. Always mount so the redirect URI is
+// stable regardless of config; the route gates internally on
+// config.isDiscordInstallConfigured (returns 503 when DISCORD_CLIENT_SECRET
+// or AUTH0_* unset).
+app.use('/oauth/discord', discordInstallRouter);
+if (!config.isDiscordInstallConfigured) {
+  logger.info('Discord install callback mounted in not-configured mode (DISCORD_CLIENT_SECRET or AUTH0_* env vars unset).');
 }
 
 // Error handler (Express requires the 4-arg signature; `next` unused)

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -18,15 +18,24 @@ const app = express();
 // Leaving it unset (dev direct-connect) ignores X-Forwarded-For so a local
 // caller can't spoof it to bypass rate limiting. Staging behind an LB
 // should set TRUST_PROXY=1 even with NODE_ENV != production.
+//
+// SECURITY: ALWAYS pass a finite POSITIVE integer to `app.set('trust
+// proxy', …)`. Express also accepts `true` (trust ALL hops) and `'true'`
+// (string), both of which let an attacker spoof X-Forwarded-For via any
+// upstream proxy to rotate their apparent IP and bypass the per-IP rate
+// limiter. The parseInt + Number.isFinite + > 0 chain below rejects all
+// of those: `'true'` / `'yes'` parse to NaN, negative values are
+// dropped, and a missing env falls through to the production-only
+// default of `1` (one hop = the ALB) rather than `true`.
 if (process.env.TRUST_PROXY) {
   const hops = parseInt(process.env.TRUST_PROXY, 10);
   if (Number.isFinite(hops) && hops > 0) {
     app.set('trust proxy', hops);
   } else {
-    logger.warn(`Ignoring invalid TRUST_PROXY=${process.env.TRUST_PROXY}`);
+    logger.warn(`Ignoring invalid TRUST_PROXY=${process.env.TRUST_PROXY} (must be a positive integer hop count, NOT 'true')`);
   }
 } else if (process.env.NODE_ENV === 'production') {
-  // Default for production if nothing configured.
+  // Default for production if nothing configured. Numeric, NEVER boolean.
   app.set('trust proxy', 1);
 }
 

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -7,6 +7,7 @@ const db = require('./store');
 const logger = require('./logger');
 const { renderPage } = require('./templates/page');
 const oauthRouter = require('./routes/oauth');
+const qurlOAuthRouter = require('./routes/qurl-oauth');
 const webhooksRouter = require('./routes/webhooks');
 
 const app = express();
@@ -186,6 +187,19 @@ if (config.isOpenNHPActive) {
   logger.info('Multi-tenant mode: /auth and /webhook routes not mounted (OpenNHP GitHub integration is dormant).');
 } else {
   logger.info('Single-guild plain mode (ENABLE_OPENNHP_FEATURES=false): /auth and /webhook routes not mounted.');
+}
+
+// qURL OAuth routes (/oauth/qurl/start + /oauth/qurl/callback) — separate
+// from the OpenNHP gate above. These always mount because /qurl setup is
+// the canonical path for any guild (multi-tenant or single-guild) to
+// configure a qURL API key, and the route gates internally on
+// config.isQurlOAuthConfigured (returns 503 with a "not configured yet"
+// page when AUTH0_* env vars are unset, rather than a hard 404). That way
+// flipping the AUTH0_* secrets in SSM is the only step needed to turn
+// OAuth on — no code change or env-flag re-flip required.
+app.use('/oauth/qurl', qurlOAuthRouter);
+if (!config.isQurlOAuthConfigured) {
+  logger.info('qURL OAuth routes mounted in not-configured mode (AUTH0_* env vars unset). /qurl setup will fall back to the legacy modal-paste path.');
 }
 
 // Error handler (Express requires the 4-arg signature; `next` unused)

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -204,8 +204,8 @@ if (config.isOpenNHPActive) {
 // could leak detail in the future; not-configured page is also OAuth-
 // adjacent. Applying as a router-level default removes a conditional
 // invariant per-handler (round-9 #6) and is zero-cost on these
-// low-traffic paths. Also vary on Set-Cookie so any intermediate that
-// honors Vary doesn't cross-cache between authenticated tabs.
+// low-traffic paths. `no-store` alone is sufficient — intermediates
+// MUST NOT cache regardless of any other header.
 function noStoreHeaders(req, res, next) {
   res.setHeader('Cache-Control', 'no-store');
   next();

--- a/apps/discord/src/templates/page.js
+++ b/apps/discord/src/templates/page.js
@@ -23,18 +23,35 @@ const TYPE_COLORS = {
 };
 
 /**
- * Render a styled HTML page
+ * Render a styled HTML page.
+ *
+ * `details` (optional) renders a label/value list above the subtext —
+ * used by the qURL OAuth success page to surface the (guild, qURL email,
+ * key prefix) binding readout in distinct typography. Each entry's label
+ * and value pass through `escapeHtml` so untrusted values can't smuggle
+ * markup. PR #177 follow-up C.5 — replaces the prior prose-only subtext
+ * which read flat against the page background.
+ *
  * @param {Object} options
  * @param {string} options.title - Page title
  * @param {string} options.icon - Emoji icon
  * @param {string} options.heading - Main heading
- * @param {string} options.message - Message body (HTML-escaped at render time)
- * @param {string} [options.subtext] - Optional subtext
+ * @param {string} options.message - Message body
+ * @param {string} [options.subtext] - Optional subtext (rendered after `details`)
+ * @param {Array<{label:string,value:string}>} [options.details] - Structured key/value rows
  * @param {'success'|'error'|'warning'|'info'} [options.type='info'] - Page type for coloring
  * @param {boolean} [options.showDiscordButton=false] - Show "Open Discord" button
  */
-function renderPage({ title, icon, heading, message, subtext, type = 'info', showDiscordButton = false }) {
+function renderPage({ title, icon, heading, message, subtext, details, type = 'info', showDiscordButton = false }) {
   const color = TYPE_COLORS[type] || TYPE_COLORS.info;
+
+  const detailsHtml = Array.isArray(details) && details.length > 0
+    ? `<dl class="details">${details.map((d) => `
+            <div class="row">
+              <dt>${escapeHtml(d.label)}</dt>
+              <dd>${escapeHtml(d.value)}</dd>
+            </div>`).join('')}</dl>`
+    : '';
 
   return `
     <!DOCTYPE html>
@@ -82,6 +99,31 @@ function renderPage({ title, icon, heading, message, subtext, type = 'info', sho
           font-size: 16px;
           line-height: 1.5;
         }
+        .details {
+          margin: 20px 0 12px 0;
+          padding: 16px;
+          background: rgba(0,0,0,0.25);
+          border-radius: 8px;
+          text-align: left;
+          font-size: 14px;
+        }
+        .details .row {
+          display: flex;
+          justify-content: space-between;
+          padding: 4px 0;
+          gap: 12px;
+        }
+        .details dt {
+          color: #aaa;
+          flex-shrink: 0;
+        }
+        .details dd {
+          margin: 0;
+          color: #fff;
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          word-break: break-all;
+          text-align: right;
+        }
         .subtext {
           font-size: 14px;
           color: #888;
@@ -122,6 +164,7 @@ function renderPage({ title, icon, heading, message, subtext, type = 'info', sho
         <div class="icon">${escapeHtml(icon)}</div>
         <h1>${escapeHtml(heading)}</h1>
         <p class="message">${escapeHtml(message)}</p>
+        ${detailsHtml}
         ${subtext ? `<p class="subtext">${escapeHtml(subtext)}</p>` : ''}
         ${showDiscordButton ? `
           <a href="discord://" class="btn">Open Discord</a>

--- a/apps/discord/src/utils/auth0-jwks.js
+++ b/apps/discord/src/utils/auth0-jwks.js
@@ -20,9 +20,9 @@ let _jwksFn = null;
 
 function getJwks() {
   if (_jwksFn) return _jwksFn;
-  if (!config.AUTH0_DOMAIN) {
-    throw new Error('AUTH0_DOMAIN is not configured — cannot build JWKS endpoint URL');
-  }
+  // verifyAuth0IdToken short-circuits on `!config.AUTH0_DOMAIN` BEFORE
+  // calling getJwks(), so the unset case is unreachable here. No
+  // defensive throw — dead code is worse than relying on the contract.
   // jose.createRemoteJWKSet returns a function that fetches + caches the
   // JWKS, with built-in key-id-miss refresh. Defaults: 5-min cache TTL,
   // 30-sec cooldown between refresh attempts on miss. Acceptable for our
@@ -64,9 +64,15 @@ async function verifyAuth0IdToken(idToken) {
     });
     return { ok: true, payload };
   } catch (err) {
-    logger.debug('Auth0 id_token verification failed', {
-      // jose error codes: ERR_JWS_SIGNATURE_VERIFICATION_FAILED,
-      // ERR_JWT_EXPIRED, ERR_JWT_CLAIM_VALIDATION_FAILED, ERR_JWKS_NO_MATCHING_KEY, etc.
+    // Severity split: signature/claim/JWKS failures are the only signal
+    // we have of a forged or wrong-tenant id_token — log warn so they
+    // surface above the default prod log filter. Expiry is benign clock
+    // skew and noisy under load — debug. jose error codes:
+    // ERR_JWS_SIGNATURE_VERIFICATION_FAILED, ERR_JWT_EXPIRED,
+    // ERR_JWT_CLAIM_VALIDATION_FAILED, ERR_JWKS_NO_MATCHING_KEY, etc.
+    const benign = err?.code === 'ERR_JWT_EXPIRED';
+    const log = benign ? logger.debug : logger.warn;
+    log('Auth0 id_token verification failed', {
       code: err?.code, message: err?.message,
     });
     return { ok: false, reason: err?.code || 'verify_failed' };
@@ -74,12 +80,15 @@ async function verifyAuth0IdToken(idToken) {
 }
 
 // Test seam — lets unit tests inject a JWKS mock without spinning up an
-// HTTPS endpoint. Production callers don't use this.
+// HTTPS endpoint. Exported only outside production so a misimport in
+// prod can't replace the verifier with a stub mid-request — same
+// pattern as `utils/crypto.js`'s `_resetKeyCache`.
 function _setJwksFnForTesting(fn) {
   _jwksFn = fn;
 }
 
-module.exports = {
-  verifyAuth0IdToken,
-  _setJwksFnForTesting,
-};
+const exports_ = { verifyAuth0IdToken };
+if (process.env.NODE_ENV !== 'production') {
+  exports_._setJwksFnForTesting = _setJwksFnForTesting;
+}
+module.exports = exports_;

--- a/apps/discord/src/utils/auth0-jwks.js
+++ b/apps/discord/src/utils/auth0-jwks.js
@@ -1,0 +1,85 @@
+// Auth0 id_token JWT verification with cached JWKS.
+//
+// Replaces the previous "decode the base64 payload, trust the TLS chain"
+// pattern in routes/qurl-oauth.js. The success-page binding readout
+// surfaces the email claim from the id_token as a load-bearing
+// confused-deputy mitigation; making it cryptographically verified (vs
+// "the response came from Auth0") removes the asterisk on that
+// security claim — see PR #177 follow-up issue #178 / section B.
+//
+// Implementation: `jose` library, lazy-fetched JWKS cached in-process.
+// The cache refreshes on a key-id miss so a quiet Auth0 key rotation
+// doesn't leave us pinned on a retired key. Cache is per-Node-process;
+// not shared across replicas — fine because each replica's cache
+// converges independently in seconds.
+const jose = require('jose');
+const config = require('../config');
+const logger = require('../logger');
+
+let _jwksFn = null;
+
+function getJwks() {
+  if (_jwksFn) return _jwksFn;
+  if (!config.AUTH0_DOMAIN) {
+    throw new Error('AUTH0_DOMAIN is not configured — cannot build JWKS endpoint URL');
+  }
+  // jose.createRemoteJWKSet returns a function that fetches + caches the
+  // JWKS, with built-in key-id-miss refresh. Defaults: 5-min cache TTL,
+  // 30-sec cooldown between refresh attempts on miss. Acceptable for our
+  // workload (id_tokens are minted once per /qurl setup completion).
+  _jwksFn = jose.createRemoteJWKSet(
+    new URL(`https://${config.AUTH0_DOMAIN}/.well-known/jwks.json`),
+    { cooldownDuration: 30000, cacheMaxAge: 5 * 60 * 1000 },
+  );
+  return _jwksFn;
+}
+
+/**
+ * Verifies an Auth0 id_token's signature, issuer, audience, and expiry.
+ *
+ * Returns { ok: true, payload } on success, or { ok: false, reason }
+ * on any verification failure. Reasons are coarse-grained on the wire
+ * ("invalid"); caller logs the granular cause for triage.
+ *
+ * Issuer expected: `https://${AUTH0_DOMAIN}/` (Auth0's standard issuer
+ * shape). Audience expected: AUTH0_CLIENT_ID (per OIDC spec, id_tokens
+ * are audienced to the OAuth client, NOT to the API audience the
+ * access_token uses).
+ */
+async function verifyAuth0IdToken(idToken) {
+  if (typeof idToken !== 'string' || !idToken) {
+    return { ok: false, reason: 'no_token' };
+  }
+  if (!config.AUTH0_DOMAIN || !config.AUTH0_CLIENT_ID) {
+    return { ok: false, reason: 'auth0_not_configured' };
+  }
+  try {
+    const { payload } = await jose.jwtVerify(idToken, getJwks(), {
+      issuer: `https://${config.AUTH0_DOMAIN}/`,
+      audience: config.AUTH0_CLIENT_ID,
+      // Default `clockTolerance` is 0 — production Auth0 clock drift is
+      // negligible. Explicit so a future "tolerate skew?" question has
+      // a clear answer site.
+      clockTolerance: 0,
+    });
+    return { ok: true, payload };
+  } catch (err) {
+    logger.debug('Auth0 id_token verification failed', {
+      // jose error codes: ERR_JWS_SIGNATURE_VERIFICATION_FAILED,
+      // ERR_JWT_EXPIRED, ERR_JWT_CLAIM_VALIDATION_FAILED, ERR_JWKS_NO_MATCHING_KEY, etc.
+      code: err?.code, message: err?.message,
+    });
+    return { ok: false, reason: err?.code || 'verify_failed' };
+  }
+}
+
+// Test seam — lets unit tests inject a JWKS mock without spinning up an
+// HTTPS endpoint. Production callers don't use this.
+function _setJwksFnForTesting(fn) {
+  _jwksFn = fn;
+}
+
+module.exports = {
+  verifyAuth0IdToken,
+  _setJwksFnForTesting,
+};

--- a/apps/discord/src/utils/auth0-jwks.js
+++ b/apps/discord/src/utils/auth0-jwks.js
@@ -79,16 +79,9 @@ async function verifyAuth0IdToken(idToken) {
   }
 }
 
-// Test seam — lets unit tests inject a JWKS mock without spinning up an
-// HTTPS endpoint. Exported only outside production so a misimport in
-// prod can't replace the verifier with a stub mid-request — same
-// pattern as `utils/crypto.js`'s `_resetKeyCache`.
-function _setJwksFnForTesting(fn) {
-  _jwksFn = fn;
-}
-
-const exports_ = { verifyAuth0IdToken };
-if (process.env.NODE_ENV !== 'production') {
-  exports_._setJwksFnForTesting = _setJwksFnForTesting;
-}
-module.exports = exports_;
+// Tests mock at the `jose` boundary (jest.mock('jose')) rather than
+// reaching into this module's internal cache, so no test seam is
+// exported. Earlier rounds had a `_setJwksFnForTesting` escape hatch
+// that no test ever called — dropped per Justin's PR #177 round-9
+// review item #10.
+module.exports = { verifyAuth0IdToken };

--- a/apps/discord/src/utils/cookies.js
+++ b/apps/discord/src/utils/cookies.js
@@ -1,0 +1,33 @@
+// Shared cookie parser — extracted because both `routes/oauth.js`
+// (GitHub OAuth) and `routes/qurl-oauth.js` (qURL OAuth) had the same
+// strict-uniqueness, malformed-pct-tolerant implementation. Single
+// source of truth keeps the two CSRF flows from drifting on what
+// counts as "no cookie."
+//
+// Format is `name=value; name=value; ...`; we only need one named
+// cookie, but a browser extension or a sibling-subdomain can produce
+// duplicates with the same name — any ambiguity = no binding,
+// treat as "no cookie."
+function readCookie(req, name) {
+  const header = req.headers.cookie;
+  if (!header) return null;
+  const matches = [];
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const k = part.slice(0, eq).trim();
+    if (k !== name) continue;
+    // Attacker-controlled cookies can contain malformed %-encoding
+    // (e.g. `%ZZ`); decodeURIComponent would throw URIError. Treat a
+    // malformed cookie as "no cookie".
+    try {
+      matches.push(decodeURIComponent(part.slice(eq + 1).trim()));
+    } catch {
+      return null;
+    }
+    if (matches.length > 1) return null;
+  }
+  return matches.length === 1 ? matches[0] : null;
+}
+
+module.exports = { readCookie };

--- a/apps/discord/src/utils/guild-config-state.js
+++ b/apps/discord/src/utils/guild-config-state.js
@@ -25,6 +25,13 @@ const logger = require('../logger');
 async function getIsReRun(guildId, contextLabel) {
   try {
     const existing = await db.getGuildConfig(guildId);
+    // `configured_by` is the canonical "this guild has been set up
+    // before" signal — `setGuildApiKey` writes it atomically as part
+    // of the upsert that lands the API key, so the field is present
+    // iff a successful setup ran on this guild. Hand-edits or partial
+    // rollbacks could in theory leave a row with the api_key column
+    // but no `configured_by`; in that case we treat as first-install
+    // and let Auth0 default-flow run.
     return Boolean(existing && existing.configured_by);
   } catch (err) {
     // info-level — benign fallback, not an error condition. A flaky

--- a/apps/discord/src/utils/guild-config-state.js
+++ b/apps/discord/src/utils/guild-config-state.js
@@ -1,0 +1,39 @@
+// First-install vs re-run detection for the OAuth setup flows.
+//
+// Pattern was triplicated across qurl-oauth.js (`/start` + `/callback`
+// log enrichment) and discord-install.js (`/callback`). All three try
+// the DDB read, fold to `Boolean(existing && existing.configured_by)`,
+// and bias toward "treat as re-run" on throw — re-prompting an
+// already-consenting admin is mild friction; silently skipping consent
+// on a true re-run blocks key rotation entirely. Single helper keeps
+// the bias direction in one place.
+const db = require('../store');
+const logger = require('../logger');
+
+/**
+ * Returns true when the guild was previously configured (has a
+ * `configured_by` field on its guild_configs row). On DDB error,
+ * biases toward `true` — see header comment for rationale.
+ *
+ * @param {string} guildId
+ * @param {string} contextLabel — short tag for the log line (e.g.
+ *                                "qurl-oauth /start", "discord-install
+ *                                /callback") so on-call can grep the
+ *                                source.
+ * @returns {Promise<boolean>}
+ */
+async function getIsReRun(guildId, contextLabel) {
+  try {
+    const existing = await db.getGuildConfig(guildId);
+    return Boolean(existing && existing.configured_by);
+  } catch (err) {
+    // info-level — benign fallback, not an error condition. A flaky
+    // DDB shouldn't spam warns.
+    logger.info('Failed to read guild config for prompt=consent gating; defaulting to re-run path', {
+      context: contextLabel, error: err?.message, guildId,
+    });
+    return true;
+  }
+}
+
+module.exports = { getIsReRun };

--- a/apps/discord/src/utils/guild-config-state.js
+++ b/apps/discord/src/utils/guild-config-state.js
@@ -1,4 +1,4 @@
-// First-install vs re-run detection for the OAuth setup flows.
+// UX-gate decision for `prompt=consent` on the Auth0 redirect.
 //
 // Pattern was triplicated across qurl-oauth.js (`/start` + `/callback`
 // log enrichment) and discord-install.js (`/callback`). All three try
@@ -7,13 +7,21 @@
 // already-consenting admin is mild friction; silently skipping consent
 // on a true re-run blocks key rotation entirely. Single helper keeps
 // the bias direction in one place.
+//
+// Named for what it DOES (UX gate) rather than what it READS (re-run
+// detection) — the bias-on-throw policy means callers should treat
+// the return value as "should the consent screen fire?" not "is this
+// strictly a re-run?". Per Justin's PR #177 round-9 review item #9.
 const db = require('../store');
 const logger = require('../logger');
 
 /**
- * Returns true when the guild was previously configured (has a
- * `configured_by` field on its guild_configs row). On DDB error,
- * biases toward `true` — see header comment for rationale.
+ * Returns true when the Auth0 redirect should set `prompt=consent`.
+ * That happens when the guild was previously configured (has a
+ * `configured_by` field), OR when the DDB read fails — bias on
+ * throw goes toward "show consent" because re-prompting is mild
+ * friction while silently skipping consent on a real re-run blocks
+ * key rotation.
  *
  * @param {string} guildId
  * @param {string} contextLabel — short tag for the log line (e.g.
@@ -22,7 +30,7 @@ const logger = require('../logger');
  *                                source.
  * @returns {Promise<boolean>}
  */
-async function getIsReRun(guildId, contextLabel) {
+async function shouldPromptConsent(guildId, contextLabel) {
   try {
     const existing = await db.getGuildConfig(guildId);
     // `configured_by` is the canonical "this guild has been set up
@@ -36,11 +44,11 @@ async function getIsReRun(guildId, contextLabel) {
   } catch (err) {
     // info-level — benign fallback, not an error condition. A flaky
     // DDB shouldn't spam warns.
-    logger.info('Failed to read guild config for prompt=consent gating; defaulting to re-run path', {
+    logger.info('Failed to read guild config for prompt=consent gating; defaulting to consent-prompt', {
       context: contextLabel, error: err?.message, guildId,
     });
     return true;
   }
 }
 
-module.exports = { getIsReRun };
+module.exports = { shouldPromptConsent };

--- a/apps/discord/src/utils/oauth-cookies.js
+++ b/apps/discord/src/utils/oauth-cookies.js
@@ -4,13 +4,16 @@
 // MUST match exactly or the qurl-oauth callback's cookie/state CSRF
 // check 400s. PR #177 follow-up C.1.
 //
-// Path is intentionally `/oauth` (not `/oauth/qurl`) because Stage-2
-// chains across two callbacks under this prefix (/oauth/discord/callback
-// → /oauth/qurl/callback). If a third sibling router lands under
-// /oauth/… (say a Slack-link proxy), the session cookie will travel
-// there too — narrow the path or rename the cookie to scope away.
+// Path is `/oauth/qurl` (NOT the broader `/oauth`). The only reader
+// is the qurl-oauth callback at `/oauth/qurl/callback`; both Stage-1
+// (/oauth/qurl/start) and Stage-2 (/oauth/discord/callback) only
+// SET the cookie, so the Set-Cookie request URL doesn't constrain
+// the path attribute (the browser stores the cookie either way).
+// Narrow scope means a future router under `/oauth/...` (Slack link
+// proxy, Teams, etc.) won't silently inherit this cookie. Per
+// Justin's PR #177 round-9 item #2.
 const QURL_OAUTH_SESSION_COOKIE = 'qurl_setup_session';
-const QURL_OAUTH_COOKIE_PATH = '/oauth';
+const QURL_OAUTH_COOKIE_PATH = '/oauth/qurl';
 const QURL_OAUTH_COOKIE_TTL_SECONDS = 5 * 60;
 
 // Single shape for the double-submit CSRF cookie set by both

--- a/apps/discord/src/utils/oauth-cookies.js
+++ b/apps/discord/src/utils/oauth-cookies.js
@@ -1,0 +1,20 @@
+// Shared cookie constants for the qURL OAuth flows. Extracted from
+// routes/qurl-oauth.js so the Stage-2 chain (routes/discord-install.js →
+// /oauth/qurl/callback) can't drift on the cookie name or path — both
+// MUST match exactly or the qurl-oauth callback's cookie/state CSRF
+// check 400s. PR #177 follow-up C.1.
+//
+// Path is intentionally `/oauth` (not `/oauth/qurl`) because Stage-2
+// chains across two callbacks under this prefix (/oauth/discord/callback
+// → /oauth/qurl/callback). If a third sibling router lands under
+// /oauth/… (say a Slack-link proxy), the session cookie will travel
+// there too — narrow the path or rename the cookie to scope away.
+const QURL_OAUTH_SESSION_COOKIE = 'qurl_setup_session';
+const QURL_OAUTH_COOKIE_PATH = '/oauth';
+const QURL_OAUTH_COOKIE_TTL_SECONDS = 5 * 60;
+
+module.exports = {
+  QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_COOKIE_PATH,
+  QURL_OAUTH_COOKIE_TTL_SECONDS,
+};

--- a/apps/discord/src/utils/oauth-cookies.js
+++ b/apps/discord/src/utils/oauth-cookies.js
@@ -13,8 +13,32 @@ const QURL_OAUTH_SESSION_COOKIE = 'qurl_setup_session';
 const QURL_OAUTH_COOKIE_PATH = '/oauth';
 const QURL_OAUTH_COOKIE_TTL_SECONDS = 5 * 60;
 
+// Single shape for the double-submit CSRF cookie set by both
+// /oauth/qurl/start (Stage 1) and /oauth/discord/callback (Stage 2).
+// `secure: req.protocol === 'https'` requires `trust proxy` to be on
+// in server.js so req.protocol reflects X-Forwarded-Proto from the ALB
+// — flipping that off would silently downgrade prod cookies. Keeping
+// the cookie shape in one place makes Stage-1/Stage-2 drift impossible.
+function setQurlOAuthCookie(res, req, value) {
+  res.cookie(QURL_OAUTH_SESSION_COOKIE, value, {
+    httpOnly: true,
+    secure: req.protocol === 'https',
+    sameSite: 'lax',
+    maxAge: QURL_OAUTH_COOKIE_TTL_SECONDS * 1000,
+    path: QURL_OAUTH_COOKIE_PATH,
+  });
+}
+
+// Path MUST match the Set-Cookie path or the browser keeps the cookie
+// alive until TTL — locking the path here removes that footgun.
+function clearQurlOAuthCookie(res) {
+  res.clearCookie(QURL_OAUTH_SESSION_COOKIE, { path: QURL_OAUTH_COOKIE_PATH });
+}
+
 module.exports = {
   QURL_OAUTH_SESSION_COOKIE,
   QURL_OAUTH_COOKIE_PATH,
   QURL_OAUTH_COOKIE_TTL_SECONDS,
+  setQurlOAuthCookie,
+  clearQurlOAuthCookie,
 };

--- a/apps/discord/src/utils/oauth-not-configured.js
+++ b/apps/discord/src/utils/oauth-not-configured.js
@@ -1,0 +1,44 @@
+// Shared 503 "qURL setup is not configured" page used by both
+// /oauth/qurl/start (Stage 1) and /oauth/discord/callback (Stage 2).
+//
+// SECURITY (PR #177 follow-up C.4): the env-var `reason` is logged on
+// the operator side but MUST NOT appear in the rendered HTML —
+// echoing names like "AUTH0_* unset" or "DISCORD_CLIENT_SECRET unset"
+// would tell a probing attacker which secret an operator hasn't
+// shipped yet. This module is the single source of truth for the
+// wire-vs-log split so the two routers can't drift on it.
+const { renderPage } = require('../templates/page');
+const logger = require('../logger');
+
+/**
+ * Render a 503 not-configured page. The `surface` arg picks the
+ * remediation copy that fits the entry point — Stage-1 (/qurl setup)
+ * and Stage-2 (/oauth/discord/callback) land here for different
+ * reasons and the admin's next step differs.
+ *
+ * @param {import('express').Response} res
+ * @param {'qurl-setup'|'discord-install'} surface
+ * @param {string} [reason] - logged-only env-var hint; do NOT render
+ */
+function renderNotConfiguredPage(res, surface, reason) {
+  // Belt-and-suspenders: pin the log shape so on-call has a uniform
+  // grep target across both routers (`/qurl-setup not configured`
+  // and `discord-install not configured`).
+  const context = surface === 'discord-install' ? 'discord-install' : 'qurl-setup';
+  logger.info(`${context} not configured`, { reason });
+
+  const message = surface === 'discord-install'
+    ? 'The bot was added to your server. Setup will be available once your layerv.ai operator finishes provisioning — try /qurl setup in your server later, or contact them out of band.'
+    : 'The Auth0 application for the qURL Discord bot has not been registered yet. '
+      + 'Run /qurl setup again later, or contact your layerv.ai admin.';
+
+  return res.status(503).send(renderPage({
+    title: 'qURL Setup Not Configured',
+    icon: '⚠️',
+    heading: 'qURL setup is not configured yet',
+    message,
+    type: 'warning',
+  }));
+}
+
+module.exports = { renderNotConfiguredPage };

--- a/apps/discord/src/utils/oauth-rate-limit.js
+++ b/apps/discord/src/utils/oauth-rate-limit.js
@@ -1,0 +1,96 @@
+// Shared rate-limit middleware for OAuth callback routes.
+//
+// Extracted from src/routes/oauth.js so the GitHub OAuth flow, the qURL
+// OAuth flow, and the Discord install flow all share the same per-IP
+// budget — otherwise each router carries its own counter and an attacker
+// can amplify by hammering the same IP across multiple routes.
+//
+// SCALING: single-instance only. If this bot ever runs horizontally
+// (multiple ECS tasks behind a LB), move this to Redis so limits are
+// shared — otherwise each replica carries its own counter and effective
+// rate is N × configured.
+const config = require('../config');
+const logger = require('../logger');
+const { renderPage } = require('../templates/page');
+
+const rateLimitStore = new Map();
+
+// Evict stale entries on a 30-second timer (was 5 minutes). Under a burst
+// from many unique IPs, a longer sweep interval lets the Map grow much
+// larger than the per-request 10% eviction can keep up with. 30s is a
+// sweet spot: short enough to bound steady-state memory, long enough to
+// not matter as load.
+const sweepHandle = setInterval(() => {
+  const cutoff = Date.now() - config.RATE_LIMIT_WINDOW_MS * 2;
+  for (const [ip, requests] of rateLimitStore) {
+    const recent = requests.filter(t => t > cutoff);
+    if (recent.length === 0) rateLimitStore.delete(ip);
+    else rateLimitStore.set(ip, recent);
+  }
+}, 30 * 1000);
+sweepHandle.unref();
+
+// Absolute cap on how many timestamps we keep per IP so an abusive IP
+// can't grow its array unboundedly between eviction sweeps.
+const MAX_REQUESTS_PER_IP = Math.max(config.RATE_LIMIT_MAX_REQUESTS * 4, 100);
+// Hard ceiling on total Map size. Under a distributed attack from many
+// unique IPs the 10% drop eviction can't keep up if new IPs arrive faster
+// than the sweep runs. Once the Map exceeds this, new-IP requests get 429
+// until the next sweep reclaims space — better to shed load than OOM.
+const MAX_STORE_SIZE = 20000;
+
+function rateLimit(req, res, next) {
+  const ip = req.ip || 'unknown'; // req.ip uses x-forwarded-for via 'trust proxy' (server.js)
+  const now = Date.now();
+  const windowStart = now - config.RATE_LIMIT_WINDOW_MS;
+
+  // Hard memory ceiling: if the store is already at MAX_STORE_SIZE and
+  // this is a new IP, shed the request rather than grow the Map further.
+  // Known IPs still get served because they're not growing the Map.
+  if (rateLimitStore.size >= MAX_STORE_SIZE && !rateLimitStore.has(ip)) {
+    logger.warn('Rate limit store at hard cap, rejecting new IP', { ip, size: rateLimitStore.size });
+    return res.status(429).send(renderPage({
+      title: 'Too Many Requests',
+      icon: '⏳',
+      heading: 'Service Overloaded',
+      message: 'The service is under heavy load. Please try again in a moment.',
+      type: 'warning',
+    }));
+  }
+
+  const requests = (rateLimitStore.get(ip) || []).filter(time => time > windowStart);
+  if (requests.length >= config.RATE_LIMIT_MAX_REQUESTS) {
+    logger.warn('OAuth rate limit exceeded', { ip, path: req.path });
+    return res.status(429).send(renderPage({
+      title: 'Too Many Requests',
+      icon: '⏳',
+      heading: 'Slow Down!',
+      message: 'You\'ve made too many requests. Please wait a moment and try again.',
+      type: 'warning',
+    }));
+  }
+
+  requests.push(now);
+  // Trim the per-IP array to MAX_REQUESTS_PER_IP so one IP can't
+  // accumulate thousands of timestamps between sweeps.
+  if (requests.length > MAX_REQUESTS_PER_IP) {
+    requests.splice(0, requests.length - MAX_REQUESTS_PER_IP);
+  }
+  rateLimitStore.set(ip, requests);
+  // Under a distributed attack from many unique IPs, evicting only one
+  // entry at a time can't keep up. When we cross 10k, drop the oldest
+  // 10% (Map iteration is insertion order) so the store reclaims
+  // meaningfully.
+  if (rateLimitStore.size >= 10000) {
+    const dropCount = Math.max(1, Math.floor(rateLimitStore.size / 10));
+    const it = rateLimitStore.keys();
+    for (let i = 0; i < dropCount; i++) {
+      const k = it.next().value;
+      if (k === undefined) break;
+      rateLimitStore.delete(k);
+    }
+  }
+  return next();
+}
+
+module.exports = { rateLimit, rateLimitStore };

--- a/apps/discord/src/utils/oauth-rate-limit.js
+++ b/apps/discord/src/utils/oauth-rate-limit.js
@@ -93,4 +93,14 @@ function rateLimit(req, res, next) {
   return next();
 }
 
-module.exports = { rateLimit, rateLimitStore };
+// Stop the background sweep timer. Useful for tests that re-import
+// this module within the same process (the .unref() above keeps it
+// from holding the event loop alive on shutdown, but doesn't prevent
+// timer accumulation across module-cache resets in test runners).
+// Production callers don't need this — Node exits when the process
+// dies.
+function stopRateLimitSweep() {
+  clearInterval(sweepHandle);
+}
+
+module.exports = { rateLimit, rateLimitStore, stopRateLimitSweep };

--- a/apps/discord/src/utils/oauth-rate-limit.js
+++ b/apps/discord/src/utils/oauth-rate-limit.js
@@ -93,14 +93,4 @@ function rateLimit(req, res, next) {
   return next();
 }
 
-// Stop the background sweep timer. Useful for tests that re-import
-// this module within the same process (the .unref() above keeps it
-// from holding the event loop alive on shutdown, but doesn't prevent
-// timer accumulation across module-cache resets in test runners).
-// Production callers don't need this — Node exits when the process
-// dies.
-function stopRateLimitSweep() {
-  clearInterval(sweepHandle);
-}
-
-module.exports = { rateLimit, rateLimitStore, stopRateLimitSweep };
+module.exports = { rateLimit, rateLimitStore };

--- a/apps/discord/src/utils/query-params.js
+++ b/apps/discord/src/utils/query-params.js
@@ -1,0 +1,19 @@
+// Defense-in-depth helpers for parsing untrusted req.query values.
+//
+// Express parses repeated query params (`?code=a&code=b`) as arrays;
+// the route code's habitual `String(req.query.x || '')` then
+// stringifies the array as comma-joined ("a,b"). Auth0 + Discord
+// would reject the resulting token-exchange request, so this isn't a
+// known exploit — but rejecting up-front is cleaner posture than
+// passing a smuggled-comma payload through to upstream services.
+
+/**
+ * Returns `value` if it's a single string param, otherwise empty string.
+ * Use for any req.query field that the route logic treats as scalar
+ * (code, state, error, guild_id).
+ */
+function singleStringParam(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+module.exports = { singleStringParam };

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -136,7 +136,4 @@ module.exports = {
   verifyQurlOAuthState,
   STATE_KIND,
   STATE_TTL_SECONDS,
-  // Exported for reuse in qurl-oauth.js's id_token decode (avoids a
-  // second base64-url-decode implementation in this codebase).
-  b64urlDecode,
 };

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -15,7 +15,16 @@
 //
 // 5-minute TTL. After Auth0 redirects back, the callback re-verifies the
 // signature, parses the payload, checks `kind === 'qurl-oauth'`, and asserts
-// expiry. Any tampering or replay across the boundary fails.
+// expiry. Tampering across the boundary fails.
+//
+// Replay protection note: within the 5-minute TTL the same signed state
+// CAN be presented to /callback multiple times by the same browser
+// session — there's no consumed-nonce store. The practical impact is
+// bounded because Auth0's `code` parameter is single-use and short-lived
+// (so the second presentation needs a fresh Auth0 grant), and a re-mint
+// on the bot side is an idempotent upsert in guild_configs. The signed
+// state is NOT a one-shot token; it's an integrity envelope. PR copy and
+// route comments avoid the "single-use" framing for that reason.
 const crypto = require('crypto');
 const config = require('../config');
 

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -1,0 +1,130 @@
+// State token for the qURL OAuth flow (/qurl setup → Auth0 → mint API key).
+//
+// Distinct from the GitHub OAuth state in commands.js because the binding
+// shape is different: GitHub state binds discord_id only; qURL state binds
+// guild_id + discord_user_id + nonce + expiry. Sharing OAUTH_STATE_SECRET
+// with GitHub OAuth is fine — the differing payloads + a `kind` field make
+// cross-purpose forgery (replay a GitHub state as a qURL state, or vice
+// versa) impossible: the `kind` is HMAC-covered, so flipping it invalidates
+// the signature.
+//
+// Format:
+//   state = base64url(JSON({k: 'qurl-oauth', g: guildId, u: discordUserId,
+//                           n: nonce, e: expirySec})) + '.' + sigHex
+//   sig   = HMAC-SHA256(stateSecret(), payload).hex
+//
+// 5-minute TTL. After Auth0 redirects back, the callback re-verifies the
+// signature, parses the payload, checks `kind === 'qurl-oauth'`, and asserts
+// expiry. Any tampering or replay across the boundary fails.
+const crypto = require('crypto');
+const config = require('../config');
+
+const STATE_KIND = 'qurl-oauth';
+const STATE_TTL_SECONDS = 5 * 60;
+
+let _warnedFallback = false;
+const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
+
+// Mirrors stateSecret() in commands.js: prefer dedicated OAUTH_STATE_SECRET
+// so a compromised AUTH0_CLIENT_SECRET / GITHUB_CLIENT_SECRET can be rotated
+// independently. Falls back to GITHUB_CLIENT_SECRET for env-parity with the
+// existing GitHub OAuth flow; throws hard outside Jest if neither is set.
+function stateSecret() {
+  const dedicated = process.env.OAUTH_STATE_SECRET;
+  if (dedicated) return dedicated;
+  if (!config.GITHUB_CLIENT_SECRET) {
+    const inTestHarness = process.env.NODE_ENV === 'test'
+      && (process.env.JEST_WORKER_ID || process.env.CI === 'true');
+    if (!inTestHarness) {
+      throw new Error('Refusing to mint qURL OAuth state: OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET must be set.');
+    }
+    if (!_warnedFallback) {
+      // eslint-disable-next-line no-console
+      console.warn('qURL OAuth state HMAC using per-process random test fallback — set OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET');
+      _warnedFallback = true;
+    }
+    return _testFallbackSecret;
+  }
+  return config.GITHUB_CLIENT_SECRET;
+}
+
+function b64urlEncode(buf) {
+  return Buffer.from(buf).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlDecode(str) {
+  // Re-pad to a multiple of 4 — base64url-encoded payloads strip trailing '='.
+  const padded = str + '='.repeat((4 - (str.length % 4)) % 4);
+  return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function signQurlOAuthState(guildId, discordUserId) {
+  if (typeof guildId !== 'string' || !guildId) {
+    throw new TypeError('signQurlOAuthState: guildId must be a non-empty string');
+  }
+  if (typeof discordUserId !== 'string' || !discordUserId) {
+    throw new TypeError('signQurlOAuthState: discordUserId must be a non-empty string');
+  }
+  const nonce = crypto.randomBytes(16).toString('hex');
+  const expirySec = Math.floor(Date.now() / 1000) + STATE_TTL_SECONDS;
+  const payload = {
+    k: STATE_KIND,
+    g: guildId,
+    u: discordUserId,
+    n: nonce,
+    e: expirySec,
+  };
+  const encoded = b64urlEncode(JSON.stringify(payload));
+  const sig = crypto.createHmac('sha256', stateSecret())
+    .update(encoded)
+    .digest('hex');
+  return `${encoded}.${sig}`;
+}
+
+// Returns { ok: true, payload } on success, or { ok: false, reason } on
+// failure. Reasons are intentionally coarse-grained on the wire ("invalid",
+// "expired") so a probing attacker can't distinguish "wrong format" from
+// "wrong signature" — caller logs the granular reason for triage.
+function verifyQurlOAuthState(state) {
+  if (typeof state !== 'string') return { ok: false, reason: 'not_a_string' };
+  const parts = state.split('.');
+  if (parts.length !== 2) return { ok: false, reason: 'malformed_parts' };
+  const [encoded, sig] = parts;
+  if (!/^[A-Za-z0-9_-]+$/.test(encoded) || !/^[0-9a-f]{64}$/.test(sig)) {
+    return { ok: false, reason: 'malformed_chars' };
+  }
+  const expected = crypto.createHmac('sha256', stateSecret())
+    .update(encoded)
+    .digest('hex');
+  let sigOk = false;
+  try {
+    sigOk = crypto.timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'));
+  } catch {
+    return { ok: false, reason: 'sig_compare_threw' };
+  }
+  if (!sigOk) return { ok: false, reason: 'sig_mismatch' };
+
+  let payload;
+  try {
+    payload = JSON.parse(b64urlDecode(encoded).toString('utf8'));
+  } catch {
+    return { ok: false, reason: 'payload_unparseable' };
+  }
+  if (payload?.k !== STATE_KIND) return { ok: false, reason: 'wrong_kind' };
+  if (typeof payload.g !== 'string' || !payload.g) return { ok: false, reason: 'no_guild_id' };
+  if (typeof payload.u !== 'string' || !payload.u) return { ok: false, reason: 'no_user_id' };
+  if (typeof payload.e !== 'number') return { ok: false, reason: 'no_expiry' };
+  if (Math.floor(Date.now() / 1000) >= payload.e) return { ok: false, reason: 'expired' };
+  return {
+    ok: true,
+    payload: { guildId: payload.g, discordUserId: payload.u, nonce: payload.n, expirySec: payload.e },
+  };
+}
+
+module.exports = {
+  signQurlOAuthState,
+  verifyQurlOAuthState,
+  STATE_KIND,
+  STATE_TTL_SECONDS,
+};

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -51,9 +51,21 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 // new var, drop OAUTH_STATE_SECRET. The 5-minute state TTL bounds the
 // "old links don't validate against the new key" window — no separate
 // dual-key reader needed.
+// Minimum acceptable secret length — per round-9 #4. 32 chars is the
+// floor for an HMAC-SHA256 secret with adequate entropy (matches the
+// `0`.repeat(64) test fixture's order of magnitude, well below the
+// 128-char hex secrets ops actually provisions). A 4-char accidental
+// value would HMAC just fine with no security; reject upfront.
+const MIN_STATE_SECRET_LENGTH = 32;
+
 function stateSecret() {
   const dedicated = process.env.QURL_OAUTH_STATE_SECRET || process.env.OAUTH_STATE_SECRET;
-  if (dedicated) return dedicated;
+  if (dedicated) {
+    if (dedicated.length < MIN_STATE_SECRET_LENGTH) {
+      throw new Error(`Refusing to mint qURL OAuth state: state-signing secret is shorter than ${MIN_STATE_SECRET_LENGTH} chars (got ${dedicated.length}). Provision a 64+ char value in SSM.`);
+    }
+    return dedicated;
+  }
   if (!config.GITHUB_CLIENT_SECRET) {
     const inTestHarness = process.env.NODE_ENV === 'test'
       && (process.env.JEST_WORKER_ID || process.env.CI === 'true');
@@ -66,6 +78,13 @@ function stateSecret() {
       _warnedFallback = true;
     }
     return _testFallbackSecret;
+  }
+  // GITHUB_CLIENT_SECRET fallback is also length-checked — Auth0 /
+  // GitHub provision 32+ char client secrets by default, but a manual
+  // /placeholder env on a misconfigured dev box would slip past
+  // otherwise.
+  if (config.GITHUB_CLIENT_SECRET.length < MIN_STATE_SECRET_LENGTH) {
+    throw new Error(`Refusing to mint qURL OAuth state: GITHUB_CLIENT_SECRET fallback is shorter than ${MIN_STATE_SECRET_LENGTH} chars.`);
   }
   return config.GITHUB_CLIENT_SECRET;
 }

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -136,4 +136,7 @@ module.exports = {
   verifyQurlOAuthState,
   STATE_KIND,
   STATE_TTL_SECONDS,
+  // Exported for reuse in qurl-oauth.js's id_token decode (avoids a
+  // second base64-url-decode implementation in this codebase).
+  b64urlDecode,
 };

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -34,22 +34,35 @@ const STATE_TTL_SECONDS = 5 * 60;
 let _warnedFallback = false;
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 
-// Mirrors stateSecret() in commands.js: prefer dedicated OAUTH_STATE_SECRET
-// so a compromised AUTH0_CLIENT_SECRET / GITHUB_CLIENT_SECRET can be rotated
-// independently. Falls back to GITHUB_CLIENT_SECRET for env-parity with the
-// existing GitHub OAuth flow; throws hard outside Jest if neither is set.
+// Secret precedence (highest first):
+//   1. QURL_OAUTH_STATE_SECRET — flow-dedicated, lets ops rotate the
+//      qURL OAuth signer without invalidating in-flight GitHub OAuth
+//      links. Preferred going forward.
+//   2. OAUTH_STATE_SECRET     — legacy shared secret (qURL + GitHub).
+//      kind-binding on the state token already prevents cross-purpose
+//      forgery, so sharing was secure; the precedence here is purely
+//      operational hygiene per PR #177 review (issue #184).
+//   3. GITHUB_CLIENT_SECRET   — last-ditch fallback for env-parity with
+//      the GitHub OAuth flow's signer.
+//   4. Test fallback          — per-process random secret for jest only.
+//
+// Rotation playbook: provision QURL_OAUTH_STATE_SECRET in SSM, deploy
+// (the dual-read happens automatically); once every replica has the
+// new var, drop OAUTH_STATE_SECRET. The 5-minute state TTL bounds the
+// "old links don't validate against the new key" window — no separate
+// dual-key reader needed.
 function stateSecret() {
-  const dedicated = process.env.OAUTH_STATE_SECRET;
+  const dedicated = process.env.QURL_OAUTH_STATE_SECRET || process.env.OAUTH_STATE_SECRET;
   if (dedicated) return dedicated;
   if (!config.GITHUB_CLIENT_SECRET) {
     const inTestHarness = process.env.NODE_ENV === 'test'
       && (process.env.JEST_WORKER_ID || process.env.CI === 'true');
     if (!inTestHarness) {
-      throw new Error('Refusing to mint qURL OAuth state: OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET must be set.');
+      throw new Error('Refusing to mint qURL OAuth state: QURL_OAUTH_STATE_SECRET or OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET must be set.');
     }
     if (!_warnedFallback) {
       // eslint-disable-next-line no-console
-      console.warn('qURL OAuth state HMAC using per-process random test fallback — set OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET');
+      console.warn('qURL OAuth state HMAC using per-process random test fallback — set QURL_OAUTH_STATE_SECRET');
       _warnedFallback = true;
     }
     return _testFallbackSecret;

--- a/apps/discord/tests/auth0-jwks.test.js
+++ b/apps/discord/tests/auth0-jwks.test.js
@@ -1,0 +1,90 @@
+// Tests for src/utils/auth0-jwks.js — the JWKS-cached id_token verifier
+// that replaced "decode the base64 payload, trust the TLS chain" in
+// qurl-oauth.js. The verifier is load-bearing for the success-page
+// binding readout's qURL-account-email line: a forged email there
+// would defeat the confused-deputy mitigation, so the verifier must
+// reject anything that isn't signature-, issuer-, audience-, and
+// expiry-valid against Auth0's published JWKS.
+//
+// We can't reach Auth0's HTTPS endpoint from a unit test (no creds, no
+// network in CI), so jose is mocked at the module boundary and we
+// exercise verifyAuth0IdToken's wrapper logic only.
+
+process.env.AUTH0_DOMAIN = 'layerv-test.auth0.com';
+process.env.AUTH0_CLIENT_ID = 'test-client-id';
+
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => 'fake-jwks-fn'),
+  jwtVerify: jest.fn(),
+}));
+
+const jose = require('jose');
+const { verifyAuth0IdToken } = require('../src/utils/auth0-jwks');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('verifyAuth0IdToken', () => {
+  it('returns no_token for a missing or non-string token', async () => {
+    expect(await verifyAuth0IdToken(undefined)).toEqual({ ok: false, reason: 'no_token' });
+    expect(await verifyAuth0IdToken('')).toEqual({ ok: false, reason: 'no_token' });
+    expect(await verifyAuth0IdToken(123)).toEqual({ ok: false, reason: 'no_token' });
+    expect(jose.jwtVerify).not.toHaveBeenCalled();
+  });
+
+  it('returns ok with the payload when jose.jwtVerify resolves', async () => {
+    jose.jwtVerify.mockResolvedValueOnce({
+      payload: { email: 'alice@layerv.test', sub: 'auth0|abc' },
+      protectedHeader: { alg: 'RS256' },
+    });
+    const res = await verifyAuth0IdToken('valid.jwt.sig');
+    expect(res.ok).toBe(true);
+    expect(res.payload.email).toBe('alice@layerv.test');
+    // Issuer and audience MUST be enforced — pin them so a future
+    // refactor doesn't quietly drop the validation.
+    const verifyArgs = jose.jwtVerify.mock.calls[0][2];
+    expect(verifyArgs.issuer).toBe('https://layerv-test.auth0.com/');
+    expect(verifyArgs.audience).toBe('test-client-id');
+  });
+
+  it('returns coarse-grained reason on signature/issuer/audience/expiry failures', async () => {
+    const err = new Error('signature verification failed');
+    err.code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED';
+    jose.jwtVerify.mockRejectedValueOnce(err);
+    const res = await verifyAuth0IdToken('tampered.jwt.sig');
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('ERR_JWS_SIGNATURE_VERIFICATION_FAILED');
+  });
+
+  it('returns verify_failed when jose throws without a code', async () => {
+    jose.jwtVerify.mockRejectedValueOnce(new Error('mystery'));
+    const res = await verifyAuth0IdToken('some.jwt.sig');
+    expect(res).toEqual({ ok: false, reason: 'verify_failed' });
+  });
+});
+
+describe('verifyAuth0IdToken — Auth0 not configured', () => {
+  it('returns auth0_not_configured when AUTH0_DOMAIN is unset (load-time guard)', async () => {
+    // The module reads AUTH0_DOMAIN via config; clearing it forces the
+    // verifier into its short-circuit path. Use jest.isolateModules so
+    // config.js is re-required against the cleared env (caching is per-
+    // worker and we'd otherwise see the stale value).
+    const saved = process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_DOMAIN;
+    try {
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('jose', () => ({
+          createRemoteJWKSet: jest.fn(() => 'fake-jwks-fn'),
+          jwtVerify: jest.fn(),
+        }));
+        // eslint-disable-next-line global-require
+        const { verifyAuth0IdToken: fresh } = require('../src/utils/auth0-jwks');
+        const res = await fresh('any.jwt.sig');
+        expect(res).toEqual({ ok: false, reason: 'auth0_not_configured' });
+      });
+    } finally {
+      process.env.AUTH0_DOMAIN = saved;
+    }
+  });
+});

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -1,0 +1,153 @@
+// Tests for src/routes/discord-install.js — the Stage-2 "Add to Discord"
+// install callback that chains the Discord OAuth2 install to the qURL
+// Auth0 leg. Covers:
+//   - 503 not-configured response (DISCORD_CLIENT_SECRET or AUTH0_* unset)
+//   - 400 missing code, missing guild_id, declined consent
+//   - 502 Discord token exchange failure, /users/@me failure
+//   - 302 happy path: redirects to Auth0 with a qURL OAuth state binding
+//     guild_id + discord_user_id
+
+process.env.OAUTH_STATE_SECRET = 'c'.repeat(64);
+process.env.AUTH0_DOMAIN = 'layerv-test.auth0.com';
+process.env.AUTH0_CLIENT_ID = 'test-auth0-client-id';
+process.env.AUTH0_CLIENT_SECRET = 'test-auth0-secret';
+process.env.AUTH0_AUDIENCE = 'https://api.layerv.test';
+process.env.DISCORD_CLIENT_ID = 'test-discord-client-id';
+process.env.DISCORD_CLIENT_SECRET = 'test-discord-secret';
+process.env.QURL_ENDPOINT = 'http://localhost:9999';
+process.env.BASE_URL = 'http://localhost:3000';
+process.env.GUILD_ID = '123456789012345678';
+
+jest.mock('../src/discord', () => ({
+  sendDM: jest.fn().mockResolvedValue(true),
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+}));
+
+jest.mock('../src/store', () => ({
+  setGuildApiKey: jest.fn().mockResolvedValue(undefined),
+  getGuildApiKey: jest.fn(),
+  getPendingLink: jest.fn(),
+  consumePendingLink: jest.fn(),
+}));
+
+jest.mock('../src/commands', () => ({
+  verifyStateBinding: jest.fn().mockReturnValue(true),
+  handleCommand: jest.fn(),
+  commands: [],
+  registerCommands: jest.fn(),
+}));
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const { verifyQurlOAuthState } = require('../src/utils/qurl-oauth-state');
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = originalFetch;
+});
+
+describe('Discord install callback', () => {
+  describe('GET /oauth/discord/callback', () => {
+    it('400s on missing code', async () => {
+      const res = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Missing authorization code');
+    });
+
+    it('400s on missing guild_id (admin abandoned mid-install)', async () => {
+      const res = await request(app).get('/oauth/discord/callback?code=disc-code');
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Bot install incomplete');
+    });
+
+    it('400s on Discord error param (admin declined consent)', async () => {
+      const res = await request(app).get(
+        '/oauth/discord/callback?error=access_denied&error_description=user+declined&guild_id=guild-1',
+      );
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Authorization declined');
+    });
+
+    it('502s when Discord token exchange fails', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false, status: 401, text: () => Promise.resolve('invalid_grant'),
+      });
+      const res = await request(app).get('/oauth/discord/callback?code=bad-code&guild_id=guild-1');
+      expect(res.status).toBe(502);
+      expect(res.text).toContain('Authorization failed');
+    });
+
+    it('502s when Discord /users/@me fails after successful token exchange', async () => {
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token', token_type: 'Bearer' }),
+        })
+        .mockResolvedValueOnce({
+          ok: false, status: 500,
+          text: () => Promise.resolve('Discord API error'),
+        });
+      const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(res.status).toBe(502);
+      expect(res.text).toContain('Could not identify the installing user');
+    });
+
+    it('302s to Auth0 on happy path with a valid qURL OAuth state', async () => {
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token', token_type: 'Bearer' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '987654321098765432', username: 'admin' }),
+        });
+      const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.location);
+      expect(loc.host).toBe('layerv-test.auth0.com');
+      expect(loc.pathname).toBe('/authorize');
+      expect(loc.searchParams.get('client_id')).toBe('test-auth0-client-id');
+      expect(loc.searchParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/qurl/callback');
+
+      // The state Discord callback minted must round-trip through the
+      // qURL OAuth state verifier with the right guild + discord-user
+      // bindings — that's how the Auth0 callback identifies who set
+      // up which guild.
+      const state = loc.searchParams.get('state');
+      const verified = verifyQurlOAuthState(state);
+      expect(verified.ok).toBe(true);
+      expect(verified.payload.guildId).toBe('guild-1');
+      expect(verified.payload.discordUserId).toBe('987654321098765432');
+    });
+
+    it('uses the right Discord token-exchange body shape (form-urlencoded with client creds)', async () => {
+      const fetchSpy = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '111' }),
+        });
+      globalThis.fetch = fetchSpy;
+      await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(fetchSpy).toHaveBeenCalled();
+      const tokenCall = fetchSpy.mock.calls[0];
+      expect(tokenCall[0]).toBe('https://discord.com/api/oauth2/token');
+      expect(tokenCall[1].method).toBe('POST');
+      expect(tokenCall[1].headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+      const bodyParams = new URLSearchParams(tokenCall[1].body.toString());
+      expect(bodyParams.get('client_id')).toBe('test-discord-client-id');
+      expect(bodyParams.get('client_secret')).toBe('test-discord-secret');
+      expect(bodyParams.get('grant_type')).toBe('authorization_code');
+      expect(bodyParams.get('code')).toBe('ok-code');
+      expect(bodyParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/discord/callback');
+    });
+  });
+});

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -8,6 +8,9 @@
 //     guild_id + discord_user_id
 
 process.env.OAUTH_STATE_SECRET = '0'.repeat(64);
+// KEY_ENCRYPTION_KEY required for the fail-fast guard added in PR #177
+// review round 3; matches the legacy modal-paste path's existing check.
+process.env.KEY_ENCRYPTION_KEY = '1'.repeat(64);
 process.env.AUTH0_DOMAIN = 'layerv-test.auth0.com';
 process.env.AUTH0_CLIENT_ID = 'test-auth0-client-id';
 process.env.AUTH0_CLIENT_SECRET = 'test-auth0-secret';
@@ -52,6 +55,22 @@ beforeEach(() => {
 
 describe('Discord install callback', () => {
   describe('GET /oauth/discord/callback', () => {
+    it('503s when KEY_ENCRYPTION_KEY is unset (fail-fast before Discord token exchange)', async () => {
+      // Bot is in the server already (Discord install ran), but the
+      // chained Auth0 leg can't safely proceed without encryption-at-
+      // rest configured. Failing here saves the Discord code from
+      // being burned on a doomed flow.
+      const saved = process.env.KEY_ENCRYPTION_KEY;
+      delete process.env.KEY_ENCRYPTION_KEY;
+      try {
+        const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+        expect(res.status).toBe(503);
+        expect(res.text).toMatch(/encryption-at-rest|KEY_ENCRYPTION_KEY/i);
+      } finally {
+        process.env.KEY_ENCRYPTION_KEY = saved;
+      }
+    });
+
     it('400s on missing code', async () => {
       const res = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
       expect(res.status).toBe(400);

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -115,7 +115,7 @@ describe('Discord install callback', () => {
       expect(res.text).toContain('Could not identify the installing user');
     });
 
-    it('302s to Auth0 on happy path with a valid qURL OAuth state', async () => {
+    it('302s to Auth0 on happy path with a valid qURL OAuth state and sets the CSRF cookie', async () => {
       globalThis.fetch = jest.fn()
         .mockResolvedValueOnce({
           ok: true, status: 200,
@@ -132,6 +132,9 @@ describe('Discord install callback', () => {
       expect(loc.pathname).toBe('/authorize');
       expect(loc.searchParams.get('client_id')).toBe('test-auth0-client-id');
       expect(loc.searchParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/qurl/callback');
+      // Auth0 scope must NOT include offline_access (refresh tokens not
+      // stored/used; dropped per PR #177 review item 5).
+      expect(loc.searchParams.get('scope')).not.toContain('offline_access');
 
       // The state Discord callback minted must round-trip through the
       // qURL OAuth state verifier with the right guild + discord-user
@@ -142,6 +145,20 @@ describe('Discord install callback', () => {
       expect(verified.ok).toBe(true);
       expect(verified.payload.guildId).toBe('guild-1');
       expect(verified.payload.discordUserId).toBe('987654321098765432');
+
+      // Cookie binding — Stage-2 chain must set the same `qurl_setup_session`
+      // cookie that /oauth/qurl/start sets, at path=/oauth so it's also
+      // visible to /oauth/qurl/callback further along the chain. Without
+      // this, the qURL callback's cookie === state CSRF check would 400
+      // and the entire Stage-2 flow would fail at runtime in sandbox/prod.
+      const setCookie = res.headers['set-cookie'];
+      expect(setCookie).toBeDefined();
+      const cookieHeader = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie;
+      expect(cookieHeader).toMatch(/qurl_setup_session=/);
+      expect(cookieHeader).toMatch(/HttpOnly/i);
+      expect(cookieHeader).toMatch(/SameSite=Lax/i);
+      expect(cookieHeader).toMatch(/Path=\/oauth(?:;|\s|$)/);
+      expect(cookieHeader).toContain(encodeURIComponent(state));
     });
 
     it('uses the right Discord token-exchange body shape (form-urlencoded with client creds)', async () => {

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -20,6 +20,10 @@ process.env.DISCORD_CLIENT_SECRET = 'test-discord-secret';
 process.env.QURL_ENDPOINT = 'http://localhost:9999';
 process.env.BASE_URL = 'http://localhost:3000';
 process.env.GUILD_ID = '123456789012345678';
+// Trust proxy so the Secure-cookie test can simulate ALB-fronted prod
+// via X-Forwarded-Proto: https (server.js reads TRUST_PROXY at module
+// load — must be set BEFORE require('../src/server') below).
+process.env.TRUST_PROXY = '1';
 
 jest.mock('../src/discord', () => ({
   sendDM: jest.fn().mockResolvedValue(true),
@@ -161,6 +165,28 @@ describe('Discord install callback', () => {
       expect(cookieHeader).toContain(encodeURIComponent(state));
     });
 
+    it('sets Secure flag on the cookie when behind a proxy that sets X-Forwarded-Proto: https', async () => {
+      // Defense vs trust-proxy regression: server.js sets `trust proxy`
+      // so req.protocol reflects X-Forwarded-Proto from the ALB. Flipping
+      // that off would silently downgrade prod cookies to insecure. Pin
+      // the wire-level shape here.
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '987654321098765432' }),
+        });
+      const res = await request(app)
+        .get('/oauth/discord/callback?code=ok-code&guild_id=guild-1')
+        .set('X-Forwarded-Proto', 'https');
+      expect(res.status).toBe(302);
+      const cookieHeader = (Array.isArray(res.headers['set-cookie']) ? res.headers['set-cookie'].join('\n') : res.headers['set-cookie']) || '';
+      expect(cookieHeader).toMatch(/Secure/);
+    });
+
     it('uses the right Discord token-exchange body shape (form-urlencoded with client creds)', async () => {
       const fetchSpy = jest.fn()
         .mockResolvedValueOnce({
@@ -185,5 +211,94 @@ describe('Discord install callback', () => {
       expect(bodyParams.get('code')).toBe('ok-code');
       expect(bodyParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/discord/callback');
     });
+  });
+});
+
+// Separate describe — exercises the not-configured 503 paths that
+// `isDiscordInstallConfigured` gates. Uses jest.isolateModulesAsync so
+// the env-var unsetting on this branch doesn't leak into the
+// configured-flow describe above (it's already past). Mirrors the
+// equivalent suite in tests/qurl-oauth.test.js for AUTH0_* unset.
+describe('discord-install — not configured', () => {
+  it('returns 503 with the AUTH0-unset reason when Auth0 env is missing', async () => {
+    const saved = {
+      AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+      AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+      AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
+      AUTH0_AUDIENCE: process.env.AUTH0_AUDIENCE,
+    };
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_CLIENT_ID;
+    delete process.env.AUTH0_CLIENT_SECRET;
+    delete process.env.AUTH0_AUDIENCE;
+    try {
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('../src/discord', () => ({
+          sendDM: jest.fn().mockResolvedValue(true),
+          assignContributorRole: jest.fn(),
+          notifyPRMerge: jest.fn(),
+          notifyBadgeEarned: jest.fn(),
+        }));
+        jest.doMock('../src/store', () => ({
+          setGuildApiKey: jest.fn(),
+          getGuildApiKey: jest.fn(),
+          getPendingLink: jest.fn(),
+          consumePendingLink: jest.fn(),
+        }));
+        jest.doMock('../src/commands', () => ({
+          verifyStateBinding: jest.fn().mockReturnValue(true),
+          handleCommand: jest.fn(),
+          commands: [],
+          registerCommands: jest.fn(),
+        }));
+        // eslint-disable-next-line global-require
+        const supertest = require('supertest');
+        // eslint-disable-next-line global-require
+        const { app: freshApp } = require('../src/server');
+        const res = await supertest(freshApp).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+        expect(res.status).toBe(503);
+        // Reason string mentions AUTH0 unset specifically (vs. the
+        // DISCORD_CLIENT_SECRET-unset case below).
+        expect(res.text).toMatch(/AUTH0_\* unset|not configured/i);
+      });
+    } finally {
+      Object.assign(process.env, saved);
+    }
+  });
+
+  it('returns 503 with the DISCORD_CLIENT_SECRET-unset reason when Auth0 is set but Discord secret is missing', async () => {
+    const saved = process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    try {
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('../src/discord', () => ({
+          sendDM: jest.fn().mockResolvedValue(true),
+          assignContributorRole: jest.fn(),
+          notifyPRMerge: jest.fn(),
+          notifyBadgeEarned: jest.fn(),
+        }));
+        jest.doMock('../src/store', () => ({
+          setGuildApiKey: jest.fn(),
+          getGuildApiKey: jest.fn(),
+          getPendingLink: jest.fn(),
+          consumePendingLink: jest.fn(),
+        }));
+        jest.doMock('../src/commands', () => ({
+          verifyStateBinding: jest.fn().mockReturnValue(true),
+          handleCommand: jest.fn(),
+          commands: [],
+          registerCommands: jest.fn(),
+        }));
+        // eslint-disable-next-line global-require
+        const supertest = require('supertest');
+        // eslint-disable-next-line global-require
+        const { app: freshApp } = require('../src/server');
+        const res = await supertest(freshApp).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+        expect(res.status).toBe(503);
+        expect(res.text).toMatch(/DISCORD_CLIENT_SECRET unset|not configured/i);
+      });
+    } finally {
+      process.env.DISCORD_CLIENT_SECRET = saved;
+    }
   });
 });

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -288,9 +288,16 @@ describe('discord-install — not configured', () => {
         const { app: freshApp } = require('../src/server');
         const res = await supertest(freshApp).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
         expect(res.status).toBe(503);
-        // Reason string mentions AUTH0 unset specifically (vs. the
-        // DISCORD_CLIENT_SECRET-unset case below).
-        expect(res.text).toMatch(/AUTH0_\* unset|not configured/i);
+        // Generic "not configured" copy on the wire (C.4); the env-var
+        // reason is logged but MUST NOT appear in the rendered HTML —
+        // echoing it would tell a probing attacker which secret an
+        // operator hasn't shipped yet. Env-var-shaped strings + the
+        // legacy "Reason:" prefix are the leak surfaces; the literal
+        // word "Auth0" alone is the user-visible service name and OK.
+        expect(res.text).toMatch(/not configured/i);
+        expect(res.text).not.toMatch(/AUTH0_[A-Z_]+/);
+        expect(res.text).not.toMatch(/DISCORD_CLIENT_SECRET/);
+        expect(res.text).not.toMatch(/Reason:/i);
       });
     } finally {
       Object.assign(process.env, saved);
@@ -326,7 +333,11 @@ describe('discord-install — not configured', () => {
         const { app: freshApp } = require('../src/server');
         const res = await supertest(freshApp).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
         expect(res.status).toBe(503);
-        expect(res.text).toMatch(/DISCORD_CLIENT_SECRET unset|not configured/i);
+        // C.4: generic copy on the wire; reason logged only.
+        expect(res.text).toMatch(/not configured/i);
+        expect(res.text).not.toMatch(/AUTH0_[A-Z_]+/);
+        expect(res.text).not.toMatch(/DISCORD_CLIENT_SECRET/);
+        expect(res.text).not.toMatch(/Reason:/i);
       });
     } finally {
       process.env.DISCORD_CLIENT_SECRET = saved;

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -144,11 +144,12 @@ describe('Discord install callback', () => {
       // Auth0 scope must NOT include offline_access (refresh tokens not
       // stored/used; dropped per PR #177 review item 5).
       expect(loc.searchParams.get('scope')).not.toContain('offline_access');
-      // C.8: Stage-2 first install (default mock returns no prior
-      // guild config) should NOT set prompt=consent — the admin's
-      // already going through one Auth0 sign-in screen, no need to
-      // stack a redundant consent screen on top.
-      expect(loc.searchParams.get('prompt')).toBeNull();
+      // Round-9 item #1: Stage-2 ALWAYS sets prompt=consent (independent
+      // of first-install vs re-install). Stage-2 is the URL-forwarding
+      // attack surface (forwarded /oauth/discord/callback → confused
+      // deputy); the explicit consent screen is one extra defense
+      // gate before the qURL key is bound to the admin's account.
+      expect(loc.searchParams.get('prompt')).toBe('consent');
 
       // The state Discord callback minted must round-trip through the
       // qURL OAuth state verifier with the right guild + discord-user
@@ -161,17 +162,18 @@ describe('Discord install callback', () => {
       expect(verified.payload.discordUserId).toBe('987654321098765432');
 
       // Cookie binding — Stage-2 chain must set the same `qurl_setup_session`
-      // cookie that /oauth/qurl/start sets, at path=/oauth so it's also
-      // visible to /oauth/qurl/callback further along the chain. Without
-      // this, the qURL callback's cookie === state CSRF check would 400
-      // and the entire Stage-2 flow would fail at runtime in sandbox/prod.
+      // cookie that /oauth/qurl/start sets — Stage-2 sets it at the
+      // discord-install handler so the chained /oauth/qurl/callback
+      // sees it. Path narrowed to /oauth/qurl per round-9 item #2 —
+      // the only reader is /oauth/qurl/callback so the broader /oauth
+      // was unnecessary scope.
       const setCookie = res.headers['set-cookie'];
       expect(setCookie).toBeDefined();
       const cookieHeader = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie;
       expect(cookieHeader).toMatch(/qurl_setup_session=/);
       expect(cookieHeader).toMatch(/HttpOnly/i);
       expect(cookieHeader).toMatch(/SameSite=Lax/i);
-      expect(cookieHeader).toMatch(/Path=\/oauth(?:;|\s|$)/);
+      expect(cookieHeader).toMatch(/Path=\/oauth\/qurl(?:;|\s|$)/);
       expect(cookieHeader).toContain(encodeURIComponent(state));
     });
 
@@ -197,11 +199,11 @@ describe('Discord install callback', () => {
       expect(cookieHeader).toMatch(/Secure/);
     });
 
-    it('sets prompt=consent on re-install (guild already has a configured_by)', async () => {
-      // C.8: bot was previously installed and uninstalled; reinstalling
-      // should force prompt=consent so the admin can rotate the key
-      // (without it Auth0 silently re-uses prior consent and re-mint
-      // can't be triggered).
+    it('still sets prompt=consent on re-install (guild already has a configured_by) — Stage-2 always prompts', async () => {
+      // Round-9 item #1 says always-on for Stage-2; this test pins
+      // the re-install branch produces the same redirect shape as
+      // first-install. Mock returns a prior config row to exercise
+      // the previouslyConfigured=true code path.
       db.getGuildConfig.mockResolvedValueOnce({ guild_id: 'guild-1', configured_by: '111' });
       globalThis.fetch = jest.fn()
         .mockResolvedValueOnce({

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -220,6 +220,58 @@ describe('Discord install callback', () => {
       expect(loc.searchParams.get('prompt')).toBe('consent');
     });
 
+    it('cookie set at /oauth/discord/callback rides through to /oauth/qurl/callback (round-trip pin per round-9 #8)', async () => {
+      // Round-9 #8 closed: the previous tests inspected the Set-Cookie
+      // header but didn't actually replay the cookie back on the qurl
+      // callback. Path=/oauth/qurl on the cookie + request URL
+      // /oauth/qurl/callback is the prefix-match the browser uses when
+      // deciding to send the cookie back; pin it end-to-end so a
+      // future path narrowing/widening can't silently break Stage-2.
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '987654321098765432' }),
+        });
+      const stage2 = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(stage2.status).toBe(302);
+      const setCookie = Array.isArray(stage2.headers['set-cookie'])
+        ? stage2.headers['set-cookie'].join('\n')
+        : stage2.headers['set-cookie'] || '';
+      const cookieMatch = setCookie.match(/qurl_setup_session=([^;]+)/);
+      expect(cookieMatch).not.toBeNull();
+      const cookieValue = cookieMatch[1];
+      const stateFromRedirect = new URL(stage2.headers.location).searchParams.get('state');
+      // The cookie value IS the state token (double-submit pattern).
+      expect(decodeURIComponent(cookieValue)).toBe(stateFromRedirect);
+
+      // Replay the cookie on /oauth/qurl/callback — the browser would
+      // do this because Path=/oauth/qurl matches the request path.
+      // Stub Auth0 + qurl-service so the chained callback can reach
+      // the cookie/state CSRF check.
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { key_id: 'key-1', api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      const stage1Callback = await request(app)
+        .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(stateFromRedirect)}`)
+        .set('Cookie', `qurl_setup_session=${cookieValue}`);
+      expect(stage1Callback.status).toBe(200);
+      // Reaching the success page proves the cookie/state CSRF check
+      // passed — i.e., the cookie minted on /oauth/discord/callback
+      // would actually travel to /oauth/qurl/callback in a real
+      // browser (path attribute does its job).
+      expect(stage1Callback.text).toContain('qURL is connected');
+    });
+
     it('uses the right Discord token-exchange body shape (form-urlencoded with client creds)', async () => {
       const fetchSpy = jest.fn()
         .mockResolvedValueOnce({

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -7,7 +7,7 @@
 //   - 302 happy path: redirects to Auth0 with a qURL OAuth state binding
 //     guild_id + discord_user_id
 
-process.env.OAUTH_STATE_SECRET = 'c'.repeat(64);
+process.env.OAUTH_STATE_SECRET = '0'.repeat(64);
 process.env.AUTH0_DOMAIN = 'layerv-test.auth0.com';
 process.env.AUTH0_CLIENT_ID = 'test-auth0-client-id';
 process.env.AUTH0_CLIENT_SECRET = 'test-auth0-secret';

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -35,6 +35,10 @@ jest.mock('../src/discord', () => ({
 jest.mock('../src/store', () => ({
   setGuildApiKey: jest.fn().mockResolvedValue(undefined),
   getGuildApiKey: jest.fn(),
+  // Default: no prior config — Stage 2 is normally a first install.
+  // Re-install path (prior `configured_by` present → prompt=consent set
+  // on the chained Auth0 redirect) gets its own test below.
+  getGuildConfig: jest.fn().mockResolvedValue(undefined),
   getPendingLink: jest.fn(),
   consumePendingLink: jest.fn(),
 }));
@@ -48,6 +52,7 @@ jest.mock('../src/commands', () => ({
 
 const request = require('supertest');
 const { app } = require('../src/server');
+const db = require('../src/store');
 const { verifyQurlOAuthState } = require('../src/utils/qurl-oauth-state');
 
 const originalFetch = globalThis.fetch;
@@ -139,6 +144,11 @@ describe('Discord install callback', () => {
       // Auth0 scope must NOT include offline_access (refresh tokens not
       // stored/used; dropped per PR #177 review item 5).
       expect(loc.searchParams.get('scope')).not.toContain('offline_access');
+      // C.8: Stage-2 first install (default mock returns no prior
+      // guild config) should NOT set prompt=consent — the admin's
+      // already going through one Auth0 sign-in screen, no need to
+      // stack a redundant consent screen on top.
+      expect(loc.searchParams.get('prompt')).toBeNull();
 
       // The state Discord callback minted must round-trip through the
       // qURL OAuth state verifier with the right guild + discord-user
@@ -185,6 +195,27 @@ describe('Discord install callback', () => {
       expect(res.status).toBe(302);
       const cookieHeader = (Array.isArray(res.headers['set-cookie']) ? res.headers['set-cookie'].join('\n') : res.headers['set-cookie']) || '';
       expect(cookieHeader).toMatch(/Secure/);
+    });
+
+    it('sets prompt=consent on re-install (guild already has a configured_by)', async () => {
+      // C.8: bot was previously installed and uninstalled; reinstalling
+      // should force prompt=consent so the admin can rotate the key
+      // (without it Auth0 silently re-uses prior consent and re-mint
+      // can't be triggered).
+      db.getGuildConfig.mockResolvedValueOnce({ guild_id: 'guild-1', configured_by: '111' });
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '987654321098765432' }),
+        });
+      const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.location);
+      expect(loc.searchParams.get('prompt')).toBe('consent');
     });
 
     it('uses the right Discord token-exchange body shape (form-urlencoded with client creds)', async () => {

--- a/apps/discord/tests/oauth-cookies.test.js
+++ b/apps/discord/tests/oauth-cookies.test.js
@@ -1,0 +1,65 @@
+// Unit tests for src/utils/oauth-cookies.js — locks the path-must-
+// match invariant on clearQurlOAuthCookie so a refactor that drops
+// the path arg silently bypasses cookie clearing in the browser.
+//
+// The happy-path /oauth/qurl/callback test in qurl-oauth.test.js
+// already pins this end-to-end via header inspection; this file
+// adds a unit-level regression fence so the helper itself can't
+// drift.
+
+const {
+  QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_COOKIE_PATH,
+  setQurlOAuthCookie,
+  clearQurlOAuthCookie,
+} = require('../src/utils/oauth-cookies');
+
+function fakeRes() {
+  return {
+    cookieCalls: [],
+    clearCookieCalls: [],
+    cookie(name, value, opts) { this.cookieCalls.push({ name, value, opts }); },
+    clearCookie(name, opts) { this.clearCookieCalls.push({ name, opts }); },
+  };
+}
+
+describe('utils/oauth-cookies', () => {
+  describe('setQurlOAuthCookie', () => {
+    it('sets the canonical cookie shape (HttpOnly, SameSite=Lax, Secure-when-HTTPS, path=/oauth)', () => {
+      const res = fakeRes();
+      setQurlOAuthCookie(res, { protocol: 'https' }, 'state-token-abc');
+      expect(res.cookieCalls).toHaveLength(1);
+      const call = res.cookieCalls[0];
+      expect(call.name).toBe(QURL_OAUTH_SESSION_COOKIE);
+      expect(call.value).toBe('state-token-abc');
+      expect(call.opts).toEqual({
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        maxAge: 5 * 60 * 1000,
+        path: QURL_OAUTH_COOKIE_PATH,
+      });
+    });
+
+    it('sets secure=false when behind plain HTTP (dev)', () => {
+      const res = fakeRes();
+      setQurlOAuthCookie(res, { protocol: 'http' }, 'state-token-abc');
+      expect(res.cookieCalls[0].opts.secure).toBe(false);
+    });
+  });
+
+  describe('clearQurlOAuthCookie', () => {
+    it('always passes Path=/oauth so the browser actually forgets the cookie', () => {
+      // Path-mismatch on clearCookie is silently a no-op — the browser
+      // keeps the cookie alive until TTL. Pinning the path arg here
+      // prevents a refactor that drops it from breaking one-shot
+      // binding semantics.
+      const res = fakeRes();
+      clearQurlOAuthCookie(res);
+      expect(res.clearCookieCalls).toHaveLength(1);
+      const call = res.clearCookieCalls[0];
+      expect(call.name).toBe(QURL_OAUTH_SESSION_COOKIE);
+      expect(call.opts).toEqual({ path: QURL_OAUTH_COOKIE_PATH });
+    });
+  });
+});

--- a/apps/discord/tests/qurl-oauth-state.test.js
+++ b/apps/discord/tests/qurl-oauth-state.test.js
@@ -129,4 +129,51 @@ describe('qurl-oauth-state', () => {
       expect(result.reason).toBe('wrong_kind');
     });
   });
+
+  describe('secret precedence (#184)', () => {
+    // Pins QURL_OAUTH_STATE_SECRET > OAUTH_STATE_SECRET fallback chain.
+    // Uses jest.isolateModulesAsync so the cached `_warnedFallback`
+    // and `_testFallbackSecret` in the module don't leak across tests.
+    it('prefers QURL_OAUTH_STATE_SECRET when set (state signs with the new secret, NOT OAUTH_STATE_SECRET)', async () => {
+      const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
+      const savedShared = process.env.OAUTH_STATE_SECRET;
+      process.env.QURL_OAUTH_STATE_SECRET = 'q'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+      try {
+        await jest.isolateModulesAsync(async () => {
+          // eslint-disable-next-line global-require
+          const { signQurlOAuthState: sign, verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
+          const state = sign('guild-1', 'user-2');
+          // The signature MUST be HMAC over the QURL_OAUTH_STATE_SECRET,
+          // not OAUTH_STATE_SECRET — verify it round-trips and that a
+          // payload signed with the SHARED secret no longer validates.
+          expect(verify(state).ok).toBe(true);
+          const [encoded] = state.split('.');
+          const wrongSig = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET).update(encoded).digest('hex');
+          const forged = `${encoded}.${wrongSig}`;
+          expect(verify(forged).ok).toBe(false);
+        });
+      } finally {
+        if (savedQurl === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
+        else process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+        process.env.OAUTH_STATE_SECRET = savedShared;
+      }
+    });
+
+    it('falls back to OAUTH_STATE_SECRET when QURL_OAUTH_STATE_SECRET is unset', async () => {
+      const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
+      delete process.env.QURL_OAUTH_STATE_SECRET;
+      // Keep the shared secret set (the file-level default).
+      try {
+        await jest.isolateModulesAsync(async () => {
+          // eslint-disable-next-line global-require
+          const { signQurlOAuthState: sign, verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
+          const state = sign('guild-1', 'user-2');
+          expect(verify(state).ok).toBe(true);
+        });
+      } finally {
+        if (savedQurl !== undefined) process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+      }
+    });
+  });
 });

--- a/apps/discord/tests/qurl-oauth-state.test.js
+++ b/apps/discord/tests/qurl-oauth-state.test.js
@@ -9,11 +9,14 @@
 //   4. cross-purpose — a state minted for a different `kind` rejects
 //      (defense-in-depth against replaying a GitHub-OAuth state here)
 
-// Set OAUTH_STATE_SECRET BEFORE requiring the module so stateSecret() picks
-// it up on first call. The module caches nothing, but the require chain
-// pulls in config which reads env on load.
-process.env.OAUTH_STATE_SECRET = 'a'.repeat(64);
+// Stable shared secret across the qurl-oauth-state and qurl-oauth route
+// suites. Both files set the SAME value so a Jest worker that loads the
+// state module from one test and uses it from the other doesn't see a
+// signature mismatch from the per-process cached fallback in the module
+// (cross-test leakage flagged in PR #177 review).
+process.env.OAUTH_STATE_SECRET = '0'.repeat(64);
 
+const crypto = require('crypto');
 const { signQurlOAuthState, verifyQurlOAuthState, STATE_TTL_SECONDS } = require('../src/utils/qurl-oauth-state');
 
 describe('qurl-oauth-state', () => {
@@ -117,7 +120,6 @@ describe('qurl-oauth-state', () => {
     it('rejects a payload with a wrong `kind` field (defense vs GitHub-OAuth state replay)', () => {
       // Construct a GitHub-OAuth-shaped payload and sign it with the same
       // secret — the verifier must reject because `k` is not 'qurl-oauth'.
-      const crypto = require('crypto');
       const payload = { k: 'github-oauth', g: 'guild-1', u: 'user-2', n: 'abc', e: Math.floor(Date.now() / 1000) + 60 };
       const encoded = Buffer.from(JSON.stringify(payload)).toString('base64')
         .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');

--- a/apps/discord/tests/qurl-oauth-state.test.js
+++ b/apps/discord/tests/qurl-oauth-state.test.js
@@ -1,0 +1,130 @@
+// Tests for src/utils/qurl-oauth-state.js — the HMAC-signed state token
+// the qURL OAuth flow rides through Auth0 (kept out of cookies because
+// the bot's HTTP server is stateless across deploys).
+//
+// Cover the four invariants the callback relies on:
+//   1. round-trip — sign then verify returns the original payload
+//   2. tamper resistance — flipping any byte invalidates the signature
+//   3. expiry — tokens older than STATE_TTL_SECONDS reject
+//   4. cross-purpose — a state minted for a different `kind` rejects
+//      (defense-in-depth against replaying a GitHub-OAuth state here)
+
+// Set OAUTH_STATE_SECRET BEFORE requiring the module so stateSecret() picks
+// it up on first call. The module caches nothing, but the require chain
+// pulls in config which reads env on load.
+process.env.OAUTH_STATE_SECRET = 'a'.repeat(64);
+
+const { signQurlOAuthState, verifyQurlOAuthState, STATE_TTL_SECONDS } = require('../src/utils/qurl-oauth-state');
+
+describe('qurl-oauth-state', () => {
+  describe('round-trip', () => {
+    it('signs and verifies a valid state', () => {
+      const state = signQurlOAuthState('guild-1', 'user-2');
+      const result = verifyQurlOAuthState(state);
+      expect(result.ok).toBe(true);
+      expect(result.payload.guildId).toBe('guild-1');
+      expect(result.payload.discordUserId).toBe('user-2');
+      expect(result.payload.expirySec).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      expect(result.payload.expirySec - Math.floor(Date.now() / 1000)).toBeLessThanOrEqual(STATE_TTL_SECONDS);
+    });
+
+    it('two states for the same inputs differ (nonce uniqueness)', () => {
+      const a = signQurlOAuthState('guild-1', 'user-2');
+      const b = signQurlOAuthState('guild-1', 'user-2');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on empty guildId', () => {
+      expect(() => signQurlOAuthState('', 'user-2')).toThrow(/guildId/);
+    });
+    it('throws on empty discordUserId', () => {
+      expect(() => signQurlOAuthState('guild-1', '')).toThrow(/discordUserId/);
+    });
+    it('throws on non-string guildId', () => {
+      expect(() => signQurlOAuthState(123, 'user-2')).toThrow(/guildId/);
+    });
+  });
+
+  describe('tamper resistance', () => {
+    it('rejects when the payload is mutated', () => {
+      const state = signQurlOAuthState('guild-1', 'user-2');
+      const [encoded, sig] = state.split('.');
+      // Decode, swap guildId, re-encode without re-signing — sig should now mismatch.
+      const decoded = JSON.parse(Buffer.from(encoded.replace(/-/g, '+').replace(/_/g, '/') + '==', 'base64').toString('utf8'));
+      decoded.g = 'guild-evil';
+      const tamperedEncoded = Buffer.from(JSON.stringify(decoded)).toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      const result = verifyQurlOAuthState(`${tamperedEncoded}.${sig}`);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('sig_mismatch');
+    });
+
+    it('rejects when the signature is mutated', () => {
+      const state = signQurlOAuthState('guild-1', 'user-2');
+      const [encoded, sig] = state.split('.');
+      // Flip the last hex char of the sig (preserves length + charset).
+      const lastChar = sig[sig.length - 1];
+      const flippedChar = lastChar === '0' ? '1' : '0';
+      const mutatedSig = sig.slice(0, -1) + flippedChar;
+      const result = verifyQurlOAuthState(`${encoded}.${mutatedSig}`);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('sig_mismatch');
+    });
+
+    it('rejects malformed inputs (single segment, wrong charset)', () => {
+      expect(verifyQurlOAuthState('').ok).toBe(false);
+      expect(verifyQurlOAuthState('not-a-state').ok).toBe(false);
+      expect(verifyQurlOAuthState('seg1.seg2.seg3').ok).toBe(false);
+      expect(verifyQurlOAuthState(null).ok).toBe(false);
+      expect(verifyQurlOAuthState(undefined).ok).toBe(false);
+    });
+  });
+
+  describe('expiry', () => {
+    it('rejects an expired token', async () => {
+      const realDateNow = Date.now;
+      try {
+        // Mint at t=0
+        Date.now = () => 0;
+        const state = signQurlOAuthState('guild-1', 'user-2');
+        // Verify at t=now+TTL+1 sec — should reject as expired.
+        Date.now = () => (STATE_TTL_SECONDS + 1) * 1000;
+        const result = verifyQurlOAuthState(state);
+        expect(result.ok).toBe(false);
+        expect(result.reason).toBe('expired');
+      } finally {
+        Date.now = realDateNow;
+      }
+    });
+
+    it('accepts a state right at the TTL boundary minus 1 sec', () => {
+      const realDateNow = Date.now;
+      try {
+        Date.now = () => 0;
+        const state = signQurlOAuthState('guild-1', 'user-2');
+        Date.now = () => (STATE_TTL_SECONDS - 1) * 1000;
+        const result = verifyQurlOAuthState(state);
+        expect(result.ok).toBe(true);
+      } finally {
+        Date.now = realDateNow;
+      }
+    });
+  });
+
+  describe('cross-purpose forgery', () => {
+    it('rejects a payload with a wrong `kind` field (defense vs GitHub-OAuth state replay)', () => {
+      // Construct a GitHub-OAuth-shaped payload and sign it with the same
+      // secret — the verifier must reject because `k` is not 'qurl-oauth'.
+      const crypto = require('crypto');
+      const payload = { k: 'github-oauth', g: 'guild-1', u: 'user-2', n: 'abc', e: Math.floor(Date.now() / 1000) + 60 };
+      const encoded = Buffer.from(JSON.stringify(payload)).toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      const sig = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET).update(encoded).digest('hex');
+      const result = verifyQurlOAuthState(`${encoded}.${sig}`);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('wrong_kind');
+    });
+  });
+});

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -65,7 +65,6 @@ jest.mock('../src/utils/auth0-jwks', () => ({
   verifyAuth0IdToken: jest.fn().mockResolvedValue({
     ok: true, payload: { email: 'alice@layerv.test', sub: 'auth0|abc' },
   }),
-  _setJwksFnForTesting: jest.fn(),
 }));
 
 const request = require('supertest');
@@ -160,6 +159,17 @@ describe('qurl-oauth routes', () => {
       } finally {
         process.env.KEY_ENCRYPTION_KEY = saved;
       }
+    });
+
+    it('rejects array-shaped state query (?state=a&state=b) via singleStringParam', async () => {
+      // Express parses repeated query params as arrays; `String([...])`
+      // would join with commas and pass through. singleStringParam
+      // returns '' for non-strings, which the verifier rejects upfront
+      // — pin the route-level wire shape so a future refactor that
+      // drops the helper still surfaces the regression.
+      const res = await request(app).get('/oauth/qurl/start?state=alpha&state=beta');
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Invalid setup link');
     });
 
     it('400s on tampered state', async () => {

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -1,19 +1,27 @@
 // Tests for src/routes/qurl-oauth.js — the OAuth-redirect setup flow that
 // replaces the API-key-paste modal in /qurl setup. Covers:
+//   - /start: 400 invalid-state, 302 redirect to Auth0, cookie set
+//   - /callback: 400 invalid state / missing cookie / cookie mismatch,
+//     502 Auth0 token-exchange failure, 502 qurl-service mint failure,
+//     200 happy path with mint + persist + DM, 500 + orphan-key cleanup
 //   - 503 not-configured response when AUTH0_* env vars are unset
-//   - /start: 400 invalid-state, 302 redirect to Auth0 on valid state
-//   - /callback: 400 invalid state, 502 Auth0 token-exchange failure,
-//     502 qurl-service mint failure, 200 happy path with mint + persist + DM
+//     (separate describe — uses jest.isolateModules to load the router
+//     with the env temporarily wiped).
 
 // Auth0 + state-secret env vars must be set BEFORE requiring the modules
-// that read them at load time.
-process.env.OAUTH_STATE_SECRET = 'b'.repeat(64);
+// that read them at load time. SAME OAUTH_STATE_SECRET as
+// qurl-oauth-state.test.js so cross-test ordering doesn't matter (per
+// PR #177 review on env-var leakage).
+process.env.OAUTH_STATE_SECRET = '0'.repeat(64);
 process.env.AUTH0_DOMAIN = 'layerv-test.auth0.com';
 process.env.AUTH0_CLIENT_ID = 'test-client-id';
 process.env.AUTH0_CLIENT_SECRET = 'test-client-secret';
 process.env.AUTH0_AUDIENCE = 'https://api.layerv.test';
 process.env.QURL_ENDPOINT = 'http://localhost:9999';
 process.env.BASE_URL = 'http://localhost:3000';
+// KEY_ENCRYPTION_KEY required for the persist-time guard added in PR #177
+// review round 2; matches the legacy modal-paste path's existing check.
+process.env.KEY_ENCRYPTION_KEY = '1'.repeat(64);
 // /qurl-oauth router mounts always; OpenNHP is a different gate
 process.env.GUILD_ID = '123456789012345678';
 
@@ -69,8 +77,32 @@ describe('qurl-oauth routes', () => {
       // callback can re-verify the same binding.
       expect(loc.searchParams.get('scope')).toContain('qurl:write');
       expect(loc.searchParams.get('scope')).toContain('qurl:read');
+      // offline_access dropped per PR #177 review — no refresh-token use.
+      expect(loc.searchParams.get('scope')).not.toContain('offline_access');
+      // prompt=consent is load-bearing for key rotation — re-running
+      // /qurl setup must actually re-prompt. Pin it here so a future
+      // refactor doesn't silently drop it.
+      expect(loc.searchParams.get('prompt')).toBe('consent');
       expect(loc.searchParams.get('state')).toBe(state);
       expect(loc.searchParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/qurl/callback');
+    });
+
+    it('sets a HttpOnly session cookie binding the browser to this state (CSRF guard)', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(302);
+      const setCookie = res.headers['set-cookie'];
+      expect(setCookie).toBeDefined();
+      const cookieHeader = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie;
+      expect(cookieHeader).toMatch(/qurl_setup_session=/);
+      expect(cookieHeader).toMatch(/HttpOnly/i);
+      expect(cookieHeader).toMatch(/SameSite=Lax/i);
+      // Cookie path /oauth (not /oauth/qurl) so it's also visible at
+      // /oauth/discord/callback for the Stage-2 chain.
+      expect(cookieHeader).toMatch(/Path=\/oauth(?:;|\s|$)/);
+      // Cookie value is the state itself (double-submit pattern); the
+      // callback re-checks cookie === query.state.
+      expect(cookieHeader).toContain(encodeURIComponent(state));
     });
 
     it('400s on missing state', async () => {
@@ -89,9 +121,17 @@ describe('qurl-oauth routes', () => {
   });
 
   describe('GET /oauth/qurl/callback', () => {
+    // Helper: build the Cookie header value the double-submit CSRF check
+    // expects on /callback. /start sets `qurl_setup_session=<state>`
+    // (URL-encoded so `.` and `=` survive); the verifier reads it back
+    // via decodeURIComponent. Tests skip the /start round-trip and set
+    // the cookie directly to keep each callback test independent.
+    const cookieFor = (state) => `qurl_setup_session=${encodeURIComponent(state)}`;
+
     it('400s on missing code', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
-      const res = await request(app).get(`/oauth/qurl/callback?state=${encodeURIComponent(state)}`);
+      const res = await request(app).get(`/oauth/qurl/callback?state=${encodeURIComponent(state)}`)
+        .set('Cookie', cookieFor(state));
       expect(res.status).toBe(400);
       expect(res.text).toContain('Missing authorization code');
     });
@@ -100,13 +140,33 @@ describe('qurl-oauth routes', () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       const res = await request(app).get(
         `/oauth/qurl/callback?state=${encodeURIComponent(state)}&error=access_denied&error_description=user+declined`,
-      );
+      ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(400);
       expect(res.text).toContain('Authorization declined');
     });
 
     it('400s on invalid state', async () => {
       const res = await request(app).get('/oauth/qurl/callback?code=auth0-code&state=garbage');
+      expect(res.status).toBe(400);
+    });
+
+    it('400s on missing CSRF cookie (leaked URL opened in different browser)', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      // No .set('Cookie', ...) — simulates a leaked URL opened in a fresh
+      // browser session. Must reject BEFORE any Auth0 token exchange.
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      );
+      expect(res.status).toBe(400);
+      expect(res.text).toMatch(/same browser tab/i);
+    });
+
+    it('400s on cookie/state mismatch (cookie from a different state)', async () => {
+      const stateA = signQurlOAuthState('guild-1', 'admin-2');
+      const stateB = signQurlOAuthState('guild-1', 'admin-2'); // different nonce → different state
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(stateA)}`,
+      ).set('Cookie', cookieFor(stateB));
       expect(res.status).toBe(400);
     });
 
@@ -119,7 +179,7 @@ describe('qurl-oauth routes', () => {
       });
       const res = await request(app).get(
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
-      );
+      ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(502);
       expect(res.text).toContain('Authorization failed');
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
@@ -128,19 +188,17 @@ describe('qurl-oauth routes', () => {
     it('502s when qurl-service mint fails', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       globalThis.fetch = jest.fn()
-        // Auth0 token exchange success
         .mockResolvedValueOnce({
           ok: true, status: 200,
           json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
         })
-        // qurl-service mint failure
         .mockResolvedValueOnce({
           ok: false, status: 500,
           text: () => Promise.resolve('internal error'),
         });
       const res = await request(app).get(
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
-      );
+      ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(502);
       expect(res.text).toContain('Could not provision qURL key');
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
@@ -164,32 +222,95 @@ describe('qurl-oauth routes', () => {
         });
       const res = await request(app).get(
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
-      );
+      ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(200);
       expect(res.text).toContain('qURL is connected');
-      // Key persisted via Store abstraction (DDB in prod).
       expect(db.setGuildApiKey).toHaveBeenCalledWith('guild-1', 'lv_live_abc123', 'admin-2');
-      // Admin DM'd with confirmation (fire-and-forget).
       expect(discord.sendDM).toHaveBeenCalledWith('admin-2', expect.stringContaining('qURL is connected'));
     });
 
-    it('500s when persist fails after successful mint (key minted but not stored)', async () => {
+    it('500s when persist fails after successful mint, and best-effort deletes the orphan key', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
-      globalThis.fetch = jest.fn()
+      const fetchSpy = jest.fn()
         .mockResolvedValueOnce({
           ok: true, status: 200,
           json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
         })
         .mockResolvedValueOnce({
           ok: true, status: 201,
-          json: () => Promise.resolve({ data: { api_key: 'lv_live_abc123', key_prefix: 'lv_live_abc1' } }),
-        });
+          json: () => Promise.resolve({ data: { key_id: 'key-orphan-1', api_key: 'lv_live_abc123', key_prefix: 'lv_live_abc1' } }),
+        })
+        // Best-effort orphan delete
+        .mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve('') });
+      globalThis.fetch = fetchSpy;
       db.setGuildApiKey.mockRejectedValueOnce(new Error('DDB throttled'));
       const res = await request(app).get(
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
-      );
+      ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(500);
       expect(res.text).toContain('provisioned but not stored');
+      // .then() of the fire-and-forget delete may settle after the
+      // response goes out; await one event-loop turn so the assertion
+      // sees the third fetch call.
+      await new Promise((resolve) => setImmediate(resolve));
+      const deleteCall = fetchSpy.mock.calls.find((c) => typeof c[1]?.method === 'string' && c[1].method === 'DELETE');
+      expect(deleteCall).toBeDefined();
+      expect(deleteCall[0]).toContain('/v1/api-keys/key-orphan-1');
     });
+  });
+});
+
+// Separate describe — exercises the not-configured 503 path. Uses
+// jest.isolateModules with the AUTH0_* env vars temporarily wiped so
+// the route's `config.isQurlOAuthConfigured` evaluates false on this
+// branch only. Without isolateModules, unsetting env after `config.js`
+// has been required wouldn't change the cached `isQurlOAuthConfigured`.
+describe('qurl-oauth — not configured (AUTH0_* env unset)', () => {
+  it('returns 503 with a "not configured" page on /start', async () => {
+    const saved = {
+      AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+      AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+      AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
+      AUTH0_AUDIENCE: process.env.AUTH0_AUDIENCE,
+    };
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_CLIENT_ID;
+    delete process.env.AUTH0_CLIENT_SECRET;
+    delete process.env.AUTH0_AUDIENCE;
+    try {
+      await jest.isolateModulesAsync(async () => {
+        // Re-mock dependencies inside the isolate so the freshly-loaded
+        // server.js + router pick them up.
+        jest.doMock('../src/discord', () => ({
+          sendDM: jest.fn().mockResolvedValue(true),
+          assignContributorRole: jest.fn(),
+          notifyPRMerge: jest.fn(),
+          notifyBadgeEarned: jest.fn(),
+        }));
+        jest.doMock('../src/store', () => ({
+          setGuildApiKey: jest.fn(),
+          getGuildApiKey: jest.fn(),
+          getPendingLink: jest.fn(),
+          consumePendingLink: jest.fn(),
+        }));
+        jest.doMock('../src/commands', () => ({
+          verifyStateBinding: jest.fn().mockReturnValue(true),
+          handleCommand: jest.fn(),
+          commands: [],
+          registerCommands: jest.fn(),
+        }));
+        // Re-require everything against the freshened module cache.
+        // eslint-disable-next-line global-require
+        const supertest = require('supertest');
+        // eslint-disable-next-line global-require
+        const { app: freshApp } = require('../src/server');
+        const res = await supertest(freshApp).get('/oauth/qurl/start?state=anything');
+        expect(res.status).toBe(503);
+        expect(res.text).toMatch(/not configured/i);
+      });
+    } finally {
+      // Restore env so subsequent tests run against the configured router.
+      Object.assign(process.env, saved);
+    }
   });
 });

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -132,7 +132,10 @@ describe('qurl-oauth routes', () => {
       expect(cookieHeader).toMatch(/SameSite=Lax/i);
       // Cookie path /oauth (not /oauth/qurl) so it's also visible at
       // /oauth/discord/callback for the Stage-2 chain.
-      expect(cookieHeader).toMatch(/Path=\/oauth(?:;|\s|$)/);
+      // Cookie path narrowed to /oauth/qurl (round-9 item #2): only
+      // the qurl-oauth callback reads it; broader /oauth was a future-
+      // router collision footgun.
+      expect(cookieHeader).toMatch(/Path=\/oauth\/qurl(?:;|\s|$)/);
       // Cookie value is the state itself (double-submit pattern); the
       // callback re-checks cookie === query.state.
       expect(cookieHeader).toContain(encodeURIComponent(state));
@@ -472,7 +475,7 @@ describe('qurl-oauth routes', () => {
       const headers = Array.isArray(setCookies) ? setCookies : [setCookies];
       const clearCookie = headers.find((h) => h.startsWith('qurl_setup_session=') && /Expires=Thu, 01 Jan 1970|Max-Age=0/i.test(h));
       expect(clearCookie).toBeDefined();
-      expect(clearCookie).toMatch(/Path=\/oauth(?:;|$)/);
+      expect(clearCookie).toMatch(/Path=\/oauth\/qurl(?:;|$)/);
     });
   });
 });

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -111,6 +111,23 @@ describe('qurl-oauth routes', () => {
       expect(res.text).toContain('Invalid setup link');
     });
 
+    it('503s when KEY_ENCRYPTION_KEY is unset (fail-fast before Auth0 round-trip)', async () => {
+      // Pre-Auth0 guard — refusing here keeps the admin from completing
+      // the full sign-in + consent dance only to fail at the persist
+      // step. Mirrors the legacy modal-paste path's pre-modal guard.
+      const saved = process.env.KEY_ENCRYPTION_KEY;
+      delete process.env.KEY_ENCRYPTION_KEY;
+      try {
+        const { signQurlOAuthState: sign } = require('../src/utils/qurl-oauth-state');
+        const state = sign('guild-1', 'admin-2');
+        const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`);
+        expect(res.status).toBe(503);
+        expect(res.text).toMatch(/qURL setup not provisioned|encryption-at-rest/i);
+      } finally {
+        process.env.KEY_ENCRYPTION_KEY = saved;
+      }
+    });
+
     it('400s on tampered state', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       // Flip the last char of the sig.

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -285,6 +285,13 @@ describe('qurl-oauth routes', () => {
 
     it('500s when persist fails after successful mint, and best-effort deletes the orphan key', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
+      // Deterministic flush: the third fetch call (orphan DELETE) is
+      // fire-and-forget from the route handler, so the response can
+      // ship before .then() runs. Resolve a controlled promise from
+      // inside the third mock so the test can `await` exactly that
+      // signal — no setImmediate flake.
+      let resolveDeleteFired;
+      const deleteFired = new Promise((resolve) => { resolveDeleteFired = resolve; });
       const fetchSpy = jest.fn()
         .mockResolvedValueOnce({
           ok: true, status: 200,
@@ -294,8 +301,12 @@ describe('qurl-oauth routes', () => {
           ok: true, status: 201,
           json: () => Promise.resolve({ data: { key_id: 'key-orphan-1', api_key: 'lv_live_abc123', key_prefix: 'lv_live_abc1' } }),
         })
-        // Best-effort orphan delete
-        .mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve('') });
+        // Third call = the orphan DELETE. Resolving the test-side
+        // promise here gives a precise "delete dispatched" signal.
+        .mockImplementationOnce(async () => {
+          resolveDeleteFired();
+          return { ok: true, status: 204, text: () => Promise.resolve('') };
+        });
       globalThis.fetch = fetchSpy;
       db.setGuildApiKey.mockRejectedValueOnce(new Error('DDB throttled'));
       const res = await request(app).get(
@@ -303,13 +314,36 @@ describe('qurl-oauth routes', () => {
       ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(500);
       expect(res.text).toContain('provisioned but not stored');
-      // .then() of the fire-and-forget delete may settle after the
-      // response goes out; await one event-loop turn so the assertion
-      // sees the third fetch call.
-      await new Promise((resolve) => setImmediate(resolve));
+      await deleteFired;
       const deleteCall = fetchSpy.mock.calls.find((c) => typeof c[1]?.method === 'string' && c[1].method === 'DELETE');
       expect(deleteCall).toBeDefined();
       expect(deleteCall[0]).toContain('/v1/api-keys/key-orphan-1');
+    });
+
+    it('clears the qurl_setup_session cookie on successful callback (one-shot binding)', async () => {
+      // Regression pin — without res.clearCookie, a refreshed callback
+      // URL could re-bind silently. Cookie should be cleared via a
+      // Set-Cookie header that zeroes the value AND uses Path=/oauth so
+      // the browser actually forgets it (path mismatch = no clear).
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { key_id: 'key-1', api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state));
+      expect(res.status).toBe(200);
+      const setCookies = res.headers['set-cookie'] || [];
+      const headers = Array.isArray(setCookies) ? setCookies : [setCookies];
+      const clearCookie = headers.find((h) => h.startsWith('qurl_setup_session=') && /Expires=Thu, 01 Jan 1970|Max-Age=0/i.test(h));
+      expect(clearCookie).toBeDefined();
+      expect(clearCookie).toMatch(/Path=\/oauth(?:;|$)/);
     });
   });
 });

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -130,8 +130,6 @@ describe('qurl-oauth routes', () => {
       expect(cookieHeader).toMatch(/qurl_setup_session=/);
       expect(cookieHeader).toMatch(/HttpOnly/i);
       expect(cookieHeader).toMatch(/SameSite=Lax/i);
-      // Cookie path /oauth (not /oauth/qurl) so it's also visible at
-      // /oauth/discord/callback for the Stage-2 chain.
       // Cookie path narrowed to /oauth/qurl (round-9 item #2): only
       // the qurl-oauth callback reads it; broader /oauth was a future-
       // router collision footgun.

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -183,6 +183,20 @@ describe('qurl-oauth routes', () => {
       const loc = new URL(res.headers.location);
       expect(loc.searchParams.get('prompt')).toBeNull();
     });
+
+    it('falls back to prompt=consent when getGuildConfig throws (DDB blip)', async () => {
+      // C.8 failsafe: if the lookup throws, bias toward the safer-for-
+      // rotation default. Re-prompting an already-consenting admin is
+      // mild friction; skipping consent on a real re-run blocks key
+      // rotation. Pin the bias direction here so a future refactor
+      // can't quietly flip it.
+      db.getGuildConfig.mockRejectedValueOnce(new Error('DDB throttled'));
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.location);
+      expect(loc.searchParams.get('prompt')).toBe('consent');
+    });
   });
 
   describe('GET /oauth/qurl/callback', () => {
@@ -374,7 +388,10 @@ describe('qurl-oauth routes', () => {
       expect(res.text).toMatch(/<dt>Discord guild<\/dt>\s*<dd>guild-1<\/dd>/);
       expect(res.text).toMatch(/<dt>API key prefix<\/dt>\s*<dd>lv_live_a<\/dd>/);
       // No qURL account line — verifier rejected the forged token.
-      expect(res.text).not.toContain('qURL account');
+      // Tight match: must specifically not have the <dt> row, so a
+      // future template change that re-labels the email field would
+      // still surface the regression.
+      expect(res.text).not.toMatch(/<dt>qURL account<\/dt>/);
     });
 
     it('renders success without qURL-account-email line when id_token field is absent from the Auth0 response', async () => {
@@ -396,7 +413,7 @@ describe('qurl-oauth routes', () => {
       ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(200);
       expect(res.text).toContain('qURL is connected');
-      expect(res.text).not.toContain('qURL account');
+      expect(res.text).not.toMatch(/<dt>qURL account<\/dt>/);
     });
 
     it('502s when qurl-service mint response has api_key but missing key_id (orphan-cleanup contract)', async () => {
@@ -497,6 +514,15 @@ describe('qurl-oauth — not configured (AUTH0_* env unset)', () => {
         const res = await supertest(freshApp).get('/oauth/qurl/start?state=anything');
         expect(res.status).toBe(503);
         expect(res.text).toMatch(/not configured/i);
+        // Defense-in-depth: qurl-oauth.js renderNotConfigured already
+        // doesn't include env-var names (unlike the legacy
+        // discord-install.js path that pre-C.4 leaked them). Pin here
+        // so a future refactor that adds a reason field can't regress.
+        // Env-var-shaped strings only — the literal word "Auth0" is the
+        // user-visible service name and is fine in copy.
+        expect(res.text).not.toMatch(/AUTH0_[A-Z_]+/);
+        expect(res.text).not.toMatch(/DISCORD_CLIENT_SECRET/);
+        expect(res.text).not.toMatch(/Reason:/i);
       });
     } finally {
       // Restore env so subsequent tests run against the configured router.

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -221,12 +221,18 @@ describe('qurl-oauth routes', () => {
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
     });
 
-    it('200s on happy path: mints key, persists, DMs admin, renders success', async () => {
+    it('200s on happy path: mints key, persists, DMs admin, renders success with binding readout', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
+      // id_token with an `email` claim — base64url-encoded JSON, no
+      // signature verification needed for a display-only readout (token
+      // came from Auth0 over TLS in the same response).
+      const idTokenPayload = Buffer.from(JSON.stringify({ email: 'alice@layerv.test', sub: 'auth0|abc' })).toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      const idToken = `header.${idTokenPayload}.sig`;
       globalThis.fetch = jest.fn()
         .mockResolvedValueOnce({
           ok: true, status: 200,
-          json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', id_token: idToken, token_type: 'Bearer', expires_in: 3600 }),
         })
         .mockResolvedValueOnce({
           ok: true, status: 201,
@@ -244,6 +250,19 @@ describe('qurl-oauth routes', () => {
       expect(res.text).toContain('qURL is connected');
       expect(db.setGuildApiKey).toHaveBeenCalledWith('guild-1', 'lv_live_abc123', 'admin-2');
       expect(discord.sendDM).toHaveBeenCalledWith('admin-2', expect.stringContaining('qURL is connected'));
+
+      // Confused-deputy mitigation: the success page must surface the
+      // bound (guild_id, qURL email, key prefix) tuple as readable
+      // text — NOT escaped HTML angle brackets. This is the load-
+      // bearing visual cue the admin uses to spot a mismatched
+      // binding before closing the tab.
+      expect(res.text).toContain('Discord guild: guild-1');
+      expect(res.text).toContain('qURL account: alice@layerv.test');
+      expect(res.text).toContain('API key prefix: lv_live_abc1');
+      // Belt-and-suspenders: assert NO literal escaped HTML lands in
+      // the subtext (e.g. `&lt;code&gt;...&lt;/code&gt;`) — that would
+      // mean we accidentally double-escaped the binding values.
+      expect(res.text).not.toMatch(/&lt;code&gt;/);
     });
 
     it('500s when persist fails after successful mint, and best-effort deletes the orphan key', async () => {

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -24,6 +24,10 @@ process.env.BASE_URL = 'http://localhost:3000';
 process.env.KEY_ENCRYPTION_KEY = '1'.repeat(64);
 // /qurl-oauth router mounts always; OpenNHP is a different gate
 process.env.GUILD_ID = '123456789012345678';
+// Trust proxy so the Secure-cookie test can simulate ALB-fronted prod
+// via X-Forwarded-Proto: https (server.js reads TRUST_PROXY at module
+// load — must be set BEFORE require('../src/server') below).
+process.env.TRUST_PROXY = '1';
 
 jest.mock('../src/discord', () => ({
   sendDM: jest.fn().mockResolvedValue(true),
@@ -85,6 +89,20 @@ describe('qurl-oauth routes', () => {
       expect(loc.searchParams.get('prompt')).toBe('consent');
       expect(loc.searchParams.get('state')).toBe(state);
       expect(loc.searchParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/qurl/callback');
+    });
+
+    it('sets Secure flag on the cookie when behind a proxy that sets X-Forwarded-Proto: https', async () => {
+      // Defense vs trust-proxy regression: server.js sets `trust proxy`
+      // so req.protocol reflects X-Forwarded-Proto from the ALB. Flipping
+      // that off would silently downgrade prod cookies to insecure. Pin
+      // the wire-level shape here.
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app)
+        .get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`)
+        .set('X-Forwarded-Proto', 'https');
+      expect(res.status).toBe(302);
+      const cookieHeader = (Array.isArray(res.headers['set-cookie']) ? res.headers['set-cookie'].join('\n') : res.headers['set-cookie']) || '';
+      expect(cookieHeader).toMatch(/Secure/);
     });
 
     it('sets a HttpOnly session cookie binding the browser to this state (CSRF guard)', async () => {

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -164,6 +164,21 @@ describe('qurl-oauth routes', () => {
       }
     });
 
+    it('emits Cache-Control: no-store on every /oauth/qurl/* response (router-level pin)', async () => {
+      // Round-9 #6 moved no-store from per-handler to a router-level
+      // middleware in server.js. Pin here so a refactor that drops
+      // the middleware (or an Express version bump that changes
+      // header-merge order) can't silently let an intermediate cache
+      // a success page that surfaces (guild + qURL email + key
+      // prefix). Also cover error/start surfaces so the invariant
+      // applies to every OAuth response, not just success.
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const start = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`);
+      expect(start.headers['cache-control']).toBe('no-store');
+      const startBad = await request(app).get('/oauth/qurl/start');
+      expect(startBad.headers['cache-control']).toBe('no-store');
+    });
+
     it('rejects array-shaped state query (?state=a&state=b) via singleStringParam', async () => {
       // Express parses repeated query params as arrays; `String([...])`
       // would join with commas and pass through. singleStringParam
@@ -251,6 +266,36 @@ describe('qurl-oauth routes', () => {
       );
       expect(res.status).toBe(400);
       expect(res.text).toMatch(/same browser tab/i);
+    });
+
+    it('cookie value URL-decodes to the same state used in the timingSafeEqual compare (round-9 #8 follow-up)', async () => {
+      // readCookie runs decodeURIComponent on the cookie value; the
+      // callback then does timingSafeEqual against query.state. The
+      // state token is base64url-safe by construction (no chars that
+      // encodeURIComponent escapes), so the encode/decode round-trip
+      // is effectively the identity — but if a future state-shape
+      // change introduces a `%`-needing char (e.g., dropping the
+      // base64url variant), this test would catch the drift before
+      // the cookie/state CSRF check silently fails for every user.
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      // Pre-condition: state IS URL-safe today; we want this assertion
+      // to start failing if a refactor introduces `%`-needing chars
+      // (so it forces a deliberate update of readCookie's contract).
+      expect(encodeURIComponent(state)).toBe(state);
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { key_id: 'key-1', api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      const res = await request(app)
+        .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`)
+        .set('Cookie', `qurl_setup_session=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('qURL is connected');
     });
 
     it('400s on cookie/state mismatch (cookie from a different state)', async () => {

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -39,6 +39,11 @@ jest.mock('../src/discord', () => ({
 jest.mock('../src/store', () => ({
   setGuildApiKey: jest.fn().mockResolvedValue(undefined),
   getGuildApiKey: jest.fn(),
+  // Default: pretend a prior config exists, so existing tests cover the
+  // re-run path (prompt=consent set). First-install behavior (no prior
+  // configured_by → prompt omitted) is exercised by an explicit override
+  // via .mockResolvedValueOnce(undefined) in its own test.
+  getGuildConfig: jest.fn().mockResolvedValue({ guild_id: 'guild-1', configured_by: 'admin-2' }),
   getPendingLink: jest.fn(),
   consumePendingLink: jest.fn(),
 }));
@@ -50,6 +55,17 @@ jest.mock('../src/commands', () => ({
   handleCommand: jest.fn(),
   commands: [],
   registerCommands: jest.fn(),
+}));
+
+// Mock the JWKS-backed id_token verifier so tests don't need a real Auth0
+// HTTPS endpoint. Default returns ok with the email claim for the happy
+// path; specific tests override via .mockResolvedValueOnce when they
+// want to exercise the verification-failure branch.
+jest.mock('../src/utils/auth0-jwks', () => ({
+  verifyAuth0IdToken: jest.fn().mockResolvedValue({
+    ok: true, payload: { email: 'alice@layerv.test', sub: 'auth0|abc' },
+  }),
+  _setJwksFnForTesting: jest.fn(),
 }));
 
 const request = require('supertest');
@@ -152,6 +168,20 @@ describe('qurl-oauth routes', () => {
       const tampered = state.slice(0, -1) + (state.slice(-1) === '0' ? '1' : '0');
       const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(tampered)}`);
       expect(res.status).toBe(400);
+    });
+
+    it('omits prompt=consent on first install (no prior guild config)', async () => {
+      // C.8: first-time setup should let Auth0's default flow run —
+      // no redundant consent screen stacked on sign-in. Re-runs (prior
+      // configured_by present) DO get prompt=consent so key rotation
+      // works; that's the default mock and is covered by the happy-path
+      // assertion above.
+      db.getGuildConfig.mockResolvedValueOnce(undefined);
+      const state = signQurlOAuthState('guild-fresh', 'admin-fresh');
+      const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.location);
+      expect(loc.searchParams.get('prompt')).toBeNull();
     });
   });
 
@@ -270,17 +300,14 @@ describe('qurl-oauth routes', () => {
       expect(discord.sendDM).toHaveBeenCalledWith('admin-2', expect.stringContaining('qURL is connected'));
 
       // Confused-deputy mitigation: the success page must surface the
-      // bound (guild_id, qURL email, key prefix) tuple as readable
-      // text — NOT escaped HTML angle brackets. This is the load-
-      // bearing visual cue the admin uses to spot a mismatched
-      // binding before closing the tab.
-      expect(res.text).toContain('Discord guild: guild-1');
-      expect(res.text).toContain('qURL account: alice@layerv.test');
-      expect(res.text).toContain('API key prefix: lv_live_abc1');
-      // Belt-and-suspenders: assert NO literal escaped HTML lands in
-      // the subtext (e.g. `&lt;code&gt;...&lt;/code&gt;`) — that would
-      // mean we accidentally double-escaped the binding values.
-      expect(res.text).not.toMatch(/&lt;code&gt;/);
+      // bound (guild_id, qURL email, key prefix) tuple as a structured
+      // label/value list. C.5 upgraded this from grey prose subtext to
+      // a `details` block (label in <dt>, value in <dd>) so the binding
+      // readout is visually prominent — load-bearing UI against
+      // confused-deputy attacks.
+      expect(res.text).toMatch(/<dt>Discord guild<\/dt>\s*<dd>guild-1<\/dd>/);
+      expect(res.text).toMatch(/<dt>qURL account<\/dt>\s*<dd>alice@layerv\.test<\/dd>/);
+      expect(res.text).toMatch(/<dt>API key prefix<\/dt>\s*<dd>lv_live_abc1<\/dd>/);
     });
 
     it('500s when persist fails after successful mint, and best-effort deletes the orphan key', async () => {
@@ -318,6 +345,81 @@ describe('qurl-oauth routes', () => {
       const deleteCall = fetchSpy.mock.calls.find((c) => typeof c[1]?.method === 'string' && c[1].method === 'DELETE');
       expect(deleteCall).toBeDefined();
       expect(deleteCall[0]).toContain('/v1/api-keys/key-orphan-1');
+    });
+
+    it('renders success without qURL-account-email line when id_token verification fails', async () => {
+      // Forged / wrong-issuer / wrong-audience / expired id_token must
+      // be rejected by the JWKS verifier — falling back to "decode
+      // without verification" would leak a forged email onto the
+      // load-bearing confused-deputy mitigation. Success page should
+      // still render (the API-key mint already succeeded), just
+      // without the qURL-account line.
+      const { verifyAuth0IdToken } = require('../src/utils/auth0-jwks');
+      verifyAuth0IdToken.mockResolvedValueOnce({ ok: false, reason: 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED' });
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', id_token: 'tampered.jwt.sig' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { key_id: 'key-123', api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state));
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('qURL is connected');
+      expect(res.text).toMatch(/<dt>Discord guild<\/dt>\s*<dd>guild-1<\/dd>/);
+      expect(res.text).toMatch(/<dt>API key prefix<\/dt>\s*<dd>lv_live_a<\/dd>/);
+      // No qURL account line — verifier rejected the forged token.
+      expect(res.text).not.toContain('qURL account');
+    });
+
+    it('renders success without qURL-account-email line when id_token field is absent from the Auth0 response', async () => {
+      // Auth0 may legitimately omit id_token if openid scope wasn't
+      // granted; success page should still render.
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          // Note: NO id_token field
+          json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { key_id: 'key-123', api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state));
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('qURL is connected');
+      expect(res.text).not.toContain('qURL account');
+    });
+
+    it('502s when qurl-service mint response has api_key but missing key_id (orphan-cleanup contract)', async () => {
+      // Both fields are required — without key_id, the orphan-key
+      // DELETE on persist failure can't target the right key. Fail
+      // upfront rather than mint+persist+then-fail-to-cleanup.
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          // api_key present, key_id missing
+          json: () => Promise.resolve({ data: { api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state));
+      expect(res.status).toBe(502);
+      expect(res.text).toContain('Could not provision qURL key');
+      expect(db.setGuildApiKey).not.toHaveBeenCalled();
     });
 
     it('clears the qurl_setup_session cookie on successful callback (one-shot binding)', async () => {

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -1,0 +1,195 @@
+// Tests for src/routes/qurl-oauth.js — the OAuth-redirect setup flow that
+// replaces the API-key-paste modal in /qurl setup. Covers:
+//   - 503 not-configured response when AUTH0_* env vars are unset
+//   - /start: 400 invalid-state, 302 redirect to Auth0 on valid state
+//   - /callback: 400 invalid state, 502 Auth0 token-exchange failure,
+//     502 qurl-service mint failure, 200 happy path with mint + persist + DM
+
+// Auth0 + state-secret env vars must be set BEFORE requiring the modules
+// that read them at load time.
+process.env.OAUTH_STATE_SECRET = 'b'.repeat(64);
+process.env.AUTH0_DOMAIN = 'layerv-test.auth0.com';
+process.env.AUTH0_CLIENT_ID = 'test-client-id';
+process.env.AUTH0_CLIENT_SECRET = 'test-client-secret';
+process.env.AUTH0_AUDIENCE = 'https://api.layerv.test';
+process.env.QURL_ENDPOINT = 'http://localhost:9999';
+process.env.BASE_URL = 'http://localhost:3000';
+// /qurl-oauth router mounts always; OpenNHP is a different gate
+process.env.GUILD_ID = '123456789012345678';
+
+jest.mock('../src/discord', () => ({
+  sendDM: jest.fn().mockResolvedValue(true),
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+}));
+
+jest.mock('../src/store', () => ({
+  setGuildApiKey: jest.fn().mockResolvedValue(undefined),
+  getGuildApiKey: jest.fn(),
+  getPendingLink: jest.fn(),
+  consumePendingLink: jest.fn(),
+}));
+
+// commands.js still requires verifyStateBinding for the GitHub OAuth route;
+// stub it to avoid pulling in the full command tree at module load.
+jest.mock('../src/commands', () => ({
+  verifyStateBinding: jest.fn().mockReturnValue(true),
+  handleCommand: jest.fn(),
+  commands: [],
+  registerCommands: jest.fn(),
+}));
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const db = require('../src/store');
+const discord = require('../src/discord');
+const { signQurlOAuthState } = require('../src/utils/qurl-oauth-state');
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = originalFetch;
+});
+
+describe('qurl-oauth routes', () => {
+  describe('GET /oauth/qurl/start', () => {
+    it('redirects to Auth0 authorize URL with the right params on valid state', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.location);
+      expect(loc.host).toBe('layerv-test.auth0.com');
+      expect(loc.pathname).toBe('/authorize');
+      expect(loc.searchParams.get('response_type')).toBe('code');
+      expect(loc.searchParams.get('client_id')).toBe('test-client-id');
+      expect(loc.searchParams.get('audience')).toBe('https://api.layerv.test');
+      // scopes include qurl:write + qurl:read; the state echoes back so the
+      // callback can re-verify the same binding.
+      expect(loc.searchParams.get('scope')).toContain('qurl:write');
+      expect(loc.searchParams.get('scope')).toContain('qurl:read');
+      expect(loc.searchParams.get('state')).toBe(state);
+      expect(loc.searchParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/qurl/callback');
+    });
+
+    it('400s on missing state', async () => {
+      const res = await request(app).get('/oauth/qurl/start');
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Invalid setup link');
+    });
+
+    it('400s on tampered state', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      // Flip the last char of the sig.
+      const tampered = state.slice(0, -1) + (state.slice(-1) === '0' ? '1' : '0');
+      const res = await request(app).get(`/oauth/qurl/start?state=${encodeURIComponent(tampered)}`);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /oauth/qurl/callback', () => {
+    it('400s on missing code', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app).get(`/oauth/qurl/callback?state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Missing authorization code');
+    });
+
+    it('400s on Auth0 error param (admin declined consent)', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app).get(
+        `/oauth/qurl/callback?state=${encodeURIComponent(state)}&error=access_denied&error_description=user+declined`,
+      );
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Authorization declined');
+    });
+
+    it('400s on invalid state', async () => {
+      const res = await request(app).get('/oauth/qurl/callback?code=auth0-code&state=garbage');
+      expect(res.status).toBe(400);
+    });
+
+    it('502s when Auth0 token exchange fails', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('unauthorized client'),
+      });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      );
+      expect(res.status).toBe(502);
+      expect(res.text).toContain('Authorization failed');
+      expect(db.setGuildApiKey).not.toHaveBeenCalled();
+    });
+
+    it('502s when qurl-service mint fails', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        // Auth0 token exchange success
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
+        })
+        // qurl-service mint failure
+        .mockResolvedValueOnce({
+          ok: false, status: 500,
+          text: () => Promise.resolve('internal error'),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      );
+      expect(res.status).toBe(502);
+      expect(res.text).toContain('Could not provision qURL key');
+      expect(db.setGuildApiKey).not.toHaveBeenCalled();
+    });
+
+    it('200s on happy path: mints key, persists, DMs admin, renders success', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            data: {
+              key_id: 'key-123', api_key: 'lv_live_abc123', key_prefix: 'lv_live_abc1',
+              name: 'Discord guild guild-1', status: 'active',
+            },
+          }),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('qURL is connected');
+      // Key persisted via Store abstraction (DDB in prod).
+      expect(db.setGuildApiKey).toHaveBeenCalledWith('guild-1', 'lv_live_abc123', 'admin-2');
+      // Admin DM'd with confirmation (fire-and-forget).
+      expect(discord.sendDM).toHaveBeenCalledWith('admin-2', expect.stringContaining('qURL is connected'));
+    });
+
+    it('500s when persist fails after successful mint (key minted but not stored)', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { api_key: 'lv_live_abc123', key_prefix: 'lv_live_abc1' } }),
+        });
+      db.setGuildApiKey.mockRejectedValueOnce(new Error('DDB throttled'));
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      );
+      expect(res.status).toBe(500);
+      expect(res.text).toContain('provisioned but not stored');
+    });
+  });
+});

--- a/apps/discord/tests/qurl-status-admin-left.test.js
+++ b/apps/discord/tests/qurl-status-admin-left.test.js
@@ -1,0 +1,125 @@
+// Tests for the /qurl status admin-offboarding nudge (#185).
+//
+// The status reply for a configured guild surfaces a passive notice
+// when the admin who originally ran setup has left the server —
+// remaining ManageGuild admins need to know that qURL usage is still
+// billing to the absent admin's layerv.ai account, and that running
+// /qurl setup again will re-bind the key to themselves.
+//
+// Best-effort detection: a Discord API blip during the
+// `members.fetch` call is treated as "skip the nudge", not "fail
+// the status read." The notice only fires on the specific
+// "Unknown Member" error code (10007) so transient errors don't
+// mis-flag a present admin as gone.
+
+process.env.OAUTH_STATE_SECRET = '0'.repeat(64);
+process.env.KEY_ENCRYPTION_KEY = '1'.repeat(64);
+process.env.GUILD_ID = '123456789012345678';
+
+jest.mock('../src/discord', () => ({
+  sendDM: jest.fn().mockResolvedValue(true),
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+}));
+
+jest.mock('../src/store', () => ({
+  setGuildApiKey: jest.fn().mockResolvedValue(undefined),
+  getGuildApiKey: jest.fn(),
+  getGuildConfig: jest.fn(),
+  getPendingLink: jest.fn(),
+  consumePendingLink: jest.fn(),
+}));
+
+const db = require('../src/store');
+const { handleCommand } = require('../src/commands');
+const { PermissionFlagsBits } = require('discord.js');
+
+// Minimal interaction stub for the /qurl status path. The real
+// discord.js Interaction has dozens of fields we don't need; only
+// the surface the status handler actually reads is mocked.
+function makeStatusInteraction({ memberFetchBehavior }) {
+  const reply = jest.fn();
+  return {
+    reply: reply.mockImplementation(() => Promise.resolve()),
+    isAutocomplete: () => false,
+    isChatInputCommand: () => true,
+    commandName: 'qurl',
+    options: { getSubcommand: () => 'status' },
+    guildId: 'guild-1',
+    memberPermissions: { has: (p) => p === PermissionFlagsBits.ManageGuild },
+    guild: {
+      members: { fetch: jest.fn().mockImplementation(memberFetchBehavior) },
+    },
+    user: { id: 'admin-current' },
+    _reply: reply,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  db.getGuildApiKey.mockResolvedValue('lv_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+});
+
+describe('/qurl status — admin-offboarding nudge (#185)', () => {
+  it('does NOT show the nudge when the original admin is still in the guild', async () => {
+    db.getGuildConfig.mockResolvedValueOnce({
+      guild_id: 'guild-1',
+      configured_by: 'admin-original',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    const interaction = makeStatusInteraction({
+      memberFetchBehavior: async () => ({ id: 'admin-original' }), // present
+    });
+    await handleCommand(interaction);
+    expect(interaction._reply).toHaveBeenCalledTimes(1);
+    const replyContent = interaction._reply.mock.calls[0][0].content;
+    expect(replyContent).toContain('qURL is configured');
+    expect(replyContent).not.toContain('has left this server');
+  });
+
+  it('shows the passive nudge when members.fetch throws DiscordAPIError 10007 (Unknown Member)', async () => {
+    db.getGuildConfig.mockResolvedValueOnce({
+      guild_id: 'guild-1',
+      configured_by: 'admin-departed',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    const interaction = makeStatusInteraction({
+      memberFetchBehavior: async () => {
+        const err = new Error('Unknown Member');
+        err.code = 10007;
+        throw err;
+      },
+    });
+    await handleCommand(interaction);
+    const replyContent = interaction._reply.mock.calls[0][0].content;
+    expect(replyContent).toContain('qURL is configured');
+    expect(replyContent).toContain('has left this server');
+    expect(replyContent).toContain('<@admin-departed>');
+    // Confirms the remediation guidance is on the wire — the whole
+    // point of the nudge is to tell remaining admins what to do next.
+    expect(replyContent).toMatch(/run.*\/qurl setup/i);
+  });
+
+  it('does NOT show the nudge on a transient Discord API error (avoids mis-flagging a present admin)', async () => {
+    db.getGuildConfig.mockResolvedValueOnce({
+      guild_id: 'guild-1',
+      configured_by: 'admin-original',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    const interaction = makeStatusInteraction({
+      memberFetchBehavior: async () => {
+        const err = new Error('429 Too Many Requests');
+        err.code = 429;
+        throw err;
+      },
+    });
+    await handleCommand(interaction);
+    const replyContent = interaction._reply.mock.calls[0][0].content;
+    expect(replyContent).toContain('qURL is configured');
+    // Critical: a rate-limit spike must NOT silently tell an admin
+    // their colleague is gone. Only the specific 10007 fires the
+    // notice.
+    expect(replyContent).not.toContain('has left this server');
+  });
+});

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -12,6 +12,15 @@ export interface E2EEnv {
   CHANNEL_ID: string;
 }
 
+export interface E2EOptionalEnv {
+  // Public HTTPS host for the bot's Express server (e.g.
+  // https://discord-bot-sandbox.layerv.ai). Used by the qURL-OAuth smoke
+  // test to hit /oauth/qurl/start. Optional — tests gracefully skip when
+  // unset. Production sandbox/prod values come from the same SSM source
+  // as the bot's BASE_URL config.
+  BOT_HTTP_URL?: string;
+}
+
 const REQUIRED: (keyof E2EEnv)[] = [
   'BOT_TOKEN', 'BOT_CLIENT_ID', 'QURL_API_KEY',
   'UPLOAD_API_URL', 'MINT_API_URL', 'GUILD_ID', 'CHANNEL_ID',
@@ -32,4 +41,11 @@ export function loadEnv(): E2EEnv {
     throw new Error(`Missing env vars: ${missing.join(', ')}`);
   }
   return env as unknown as E2EEnv;
+}
+
+/** Loads optional env vars without throwing on missing. */
+export function loadOptionalEnv(): E2EOptionalEnv {
+  return {
+    BOT_HTTP_URL: process.env.BOT_HTTP_URL,
+  };
 }

--- a/e2e/tests/qurl-oauth-setup.smoke.test.ts
+++ b/e2e/tests/qurl-oauth-setup.smoke.test.ts
@@ -57,6 +57,10 @@ const SUITE_ENABLED = Boolean(optEnv.BOT_HTTP_URL);
     //   - 503 if Auth0 not configured (route checks config first, before state)
     //   - 400 if Auth0 configured but state is missing/invalid
     expect([400, 503]).toContain(res.status);
+    // The bot serves an HTML page on every error path through this
+    // route (via renderPage) so a future change that accidentally
+    // returns JSON or a plain string surfaces here.
+    expect(res.headers.get('content-type') || '').toMatch(/text\/html/i);
     const body = await res.text();
     if (res.status === 400) {
       expect(body).toMatch(/Invalid setup link|setup link is invalid|expired/i);

--- a/e2e/tests/qurl-oauth-setup.smoke.test.ts
+++ b/e2e/tests/qurl-oauth-setup.smoke.test.ts
@@ -1,0 +1,91 @@
+/**
+ * qURL OAuth setup — bot HTTP-server smoke test.
+ *
+ * Pings the deployed bot's `/oauth/qurl/start` route and verifies the CSRF
+ * gate + not-configured gate behave as documented. Skips if `BOT_HTTP_URL`
+ * is unset (most environments don't configure the bot's public HTTP host
+ * for E2E because the URL changes per environment).
+ *
+ * What this test covers:
+ *   - The route is mounted (no 404 — proves server.js wiring).
+ *   - Garbage-state inputs are rejected before any redirect to Auth0
+ *     (CSRF guard works in the deployed env, not just locally).
+ *   - When AUTH0_* secrets aren't configured, the route returns 503 with
+ *     the documented "not configured" page (Stage-1 fallback path).
+ *
+ * What this test does NOT cover (manual runbook required — see comment):
+ *   - End-to-end Auth0 login + consent flow (requires Auth0 test tenant
+ *     credentials + a real browser; no Playwright in this E2E suite yet).
+ *   - The actual API-key mint via POST /v1/api-keys (the mint is reached
+ *     only after Auth0 returns a valid `code`, which we can't fake here).
+ *   - Persisting the minted key to DDB `guild_configs` (covered by unit
+ *     tests; verifying in the deployed env requires browser-driven OAuth).
+ *
+ * Manual smoke runbook (run after Justin registers the Auth0 application
+ * and sets prod SSM secrets):
+ *
+ *   1. In Discord, invite the bot to a sandbox test guild.
+ *   2. Run `/qurl setup` as the guild admin.
+ *   3. Click the ephemeral "Authorize qURL" link.
+ *   4. Sign in to layerv.ai (Auth0); consent to the requested scopes.
+ *   5. Verify the success page renders ("✅ qURL is connected to your
+ *      Discord server").
+ *   6. Verify a DM lands from the bot saying "qURL is connected to your
+ *      Discord server."
+ *   7. Verify DDB row exists: `aws dynamodb get-item --table-name
+ *      <table_prefix>guild-configs --key '{"guild_id":{"S":"<id>"}}'`.
+ *   8. Run `/qurl send` with a test recipient — confirm it succeeds
+ *      (proves the persisted key works through the connector + mint).
+ *   9. Run `/qurl status` — confirm it shows the key prefix.
+ */
+
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+import { loadOptionalEnv } from '../helpers/env';
+
+const optEnv = loadOptionalEnv();
+const SUITE_ENABLED = Boolean(optEnv.BOT_HTTP_URL);
+
+(SUITE_ENABLED ? describe : describe.skip)('qURL OAuth setup — bot HTTP smoke', () => {
+  const botUrl = optEnv.BOT_HTTP_URL!;
+
+  test('GET /oauth/qurl/start without state returns 400 (CSRF guard fires)', async () => {
+    const res = await fetch(`${botUrl}/oauth/qurl/start`);
+    // Two valid responses depending on whether AUTH0_* is configured:
+    //   - 503 if Auth0 not configured (route checks config first, before state)
+    //   - 400 if Auth0 configured but state is missing/invalid
+    expect([400, 503]).toContain(res.status);
+    const body = await res.text();
+    if (res.status === 400) {
+      expect(body).toMatch(/Invalid setup link|setup link is invalid|expired/i);
+    } else {
+      expect(body).toMatch(/not configured/i);
+    }
+  });
+
+  test('GET /oauth/qurl/start with garbage state returns 400 or 503', async () => {
+    const res = await fetch(`${botUrl}/oauth/qurl/start?state=not-a-valid-signed-state`);
+    expect([400, 503]).toContain(res.status);
+  });
+
+  test('GET /oauth/qurl/callback without code returns 400 or 503', async () => {
+    const res = await fetch(`${botUrl}/oauth/qurl/callback`);
+    expect([400, 503]).toContain(res.status);
+  });
+
+  test('GET /oauth/qurl/callback with Auth0 error param returns 400 or 503', async () => {
+    const res = await fetch(`${botUrl}/oauth/qurl/callback?error=access_denied&error_description=user+declined`);
+    expect([400, 503]).toContain(res.status);
+    const body = await res.text();
+    if (res.status === 400) {
+      expect(body).toMatch(/declined|invalid|expired/i);
+    }
+  });
+
+  test('GET /oauth/qurl/start route is mounted (not 404)', async () => {
+    const res = await fetch(`${botUrl}/oauth/qurl/start`);
+    expect(res.status).not.toBe(404);
+  });
+});


### PR DESCRIPTION
Replaces the /qurl setup BYOK modal-paste UX with a chained Discord+Auth0 OAuth flow. Admin clicks one link, selects a server, consents twice (Discord permissions + qURL access), lands back, bot is usable immediately. No API-key paste anywhere.

> **Stage-2 confused-deputy mitigations** — closed as part of this PR (commit 3db480c, round 8): JWKS-verified id_token + signed-state CSRF cookie + structured success-page binding readout. Cross-repo follow-ups (signed install link state, admin-rebind CloudWatch alarm) tracked in [#179](https://github.com/layervai/qurl-integrations/issues/179). [#178](https://github.com/layervai/qurl-integrations/issues/178) closed in favor of #179.

> **State payload** carries 5 fields, not 4: `{kind, guild_id, discord_user_id, nonce, expiry}`. The `kind` field is HMAC-covered and prevents cross-purpose forgery against the existing GitHub OAuth state (which uses the same OAUTH_STATE_SECRET).

> **Customer onboarding directive (Vikram, 2026-05-03):** *"workspace admin clicks 'Add to Discord, select server', consents, lands back, bot is usable immediately — no 'paste your qURL API key' step. Same low-friction pattern as the reverse-tunnel OAuth."*

Two entry points — both converge on the same Auth0 leg + key-mint + persist:

| Entry point | Used for | Endpoint |
|---|---|---|
| **"Add to Discord" link** (on layerv.ai) | New installs — bot isn't in the server yet | `/oauth/discord/callback` |
| **`/qurl setup` slash command** | Existing installs — bot already in the server | `/oauth/qurl/start` |

## Step-by-step experience for a Discord server admin (NEW INSTALL)

1. **Admin clicks "Add to Discord"** on layerv.ai. The link is a Discord OAuth2 install URL with redirect_uri pointing at the bot's HTTPS host: `https://discord.com/oauth2/authorize?client_id=<bot-app-id>&permissions=2147568640&scope=bot+applications.commands&response_type=code&redirect_uri=https://bot.layerv.ai/oauth/discord/callback`
2. **Discord shows the server picker dropdown.** Admin selects which server they want to add the bot to.
3. **Discord shows the bot's permission consent page.** Admin clicks **"Authorize"**.
4. **Bot is added to the selected server.** Discord redirects the admin's browser to `/oauth/discord/callback?code=…&guild_id=<selected>&state=…`.
5. **Bot's Discord install handler** (server-side):
   - Exchanges the `code` at `https://discord.com/api/oauth2/token` for an access_token
   - Calls `/users/@me` to get the admin's Discord user ID
   - Mints a qURL OAuth state binding `(guild_id, discord_user_id, nonce, expiry)` — HMAC-signed, 5-min TTL
   - Looks up `guild_configs` to decide first-install vs re-install (round 8 / C.8) — sets `prompt=consent` on the Auth0 redirect only on re-install
   - 302-redirects browser to Auth0 with that state
6. **Auth0 sign-in page** appears. Admin signs in with their layerv.ai account.
7. **Auth0 consent page** appears. Scopes: `qurl:write`, `qurl:read`, `openid email` (round 8 / C.2 narrowed `profile` away — only `email` is read).
8. **Admin clicks "Authorize."** Auth0 redirects to `/oauth/qurl/callback?code=…&state=…`.
9. **Bot's qURL OAuth callback** (server-side):
   - Re-validates the qURL OAuth state token (CSRF, expiry, kind)
   - Verifies the double-submit `qurl_setup_session` cookie (path=`/oauth/qurl` — narrowed in round-9 #2 from the broader `/oauth` to remove a future-router-collision footgun; only the qurl-oauth callback reads it)
   - Exchanges the `code` at Auth0's `/oauth/token` for an access_token JWT + id_token
   - **JWKS-verifies the id_token signature** (round 8 / B — `jose.jwtVerify` with cached JWKS, issuer + audience + expiry checks). Email claim is now cryptographically validated, not just TLS-trusted.
   - Calls `POST /v1/api-keys` with `Authorization: Bearer <jwt>`, body `{name: "Discord guild <id>", scopes: ["qurl:write", "qurl:read"]}`
   - Both `api_key` AND `key_id` are required (round 8 / C.3) — missing either returns 502
   - Persists `(guild_id, api_key, configured_by=discord_user_id)` via the Store abstraction → DDB `guild_configs` table
   - On persist failure, best-effort `DELETE /v1/api-keys/<key_id>` to clean up the orphan
10. **Admin sees the success page** with the structured binding readout (round 8 / C.5):
    > ✅ **qURL is connected to your Discord server.**
    >
    > Discord guild · `<guild>`
    > qURL account · `<email>`
    > API key prefix · `<prefix>`
    >
    > Confirm these match before closing.

    Load-bearing: this is the visual cue an admin uses to spot a confused-deputy mismatch. Email line shows only when JWKS verification succeeded.
11. **Admin receives a DM from the bot** confirming setup with the key prefix.
12. **Admin closes the tab** and returns to Discord. Any team member can now run `/qurl send`.

**Total elapsed time:** ~45 seconds. One unbroken chain from "Add to Discord" → "qURL is ready."

## Step-by-step for an EXISTING install (`/qurl setup`)

When the bot is already in the server (e.g., installed via the static invite URL pre-OAuth, or a follow-up admin wants to rotate the key):

1. Admin runs `/qurl setup` in the server.
2. Bot replies ephemerally: "🔐 Connect qURL to this server — [Click here to authorize qURL](…)"
3. Admin clicks → bot's `/oauth/qurl/start` validates state, sets the `qurl_setup_session` cookie (path=`/oauth/qurl`, HttpOnly, SameSite=Lax, Secure behind ALB), redirects to Auth0
4. `prompt=consent` is set only when this is a re-run (prior `configured_by` exists in `guild_configs`); first-time setups skip it for cleaner UX (round 8 / C.8)
5. Steps 6-12 above (Auth0 sign-in, consent, JWKS verify, mint, store, success page, DM, ready)

Same Auth0 leg, same mint/store/DM flow — just skips the Discord install step.

## Failure paths (both flows)

| Where it breaks | What admin sees | Remediation |
|---|---|---|
| Auth0 not configured | `/qurl setup` falls back to legacy modal-paste; `/oauth/discord/callback` returns 503 with generic copy (no longer leaks reason — round 8 / C.4) | None until OAuth is provisioned |
| Discord install state expired / tampered | 400 on `/oauth/discord/callback` | Click "Add to Discord" again |
| Admin declines consent on Discord page | Discord redirects with `?error=access_denied` → 400 page | Click "Add to Discord" again |
| Discord token exchange fails | 502 page: "Authorization failed" | Retry "Add to Discord" |
| Discord `/users/@me` fails | 502 page | Retry |
| qURL OAuth state expired (>5 min) | 400 page: "Invalid setup link — links last 5 minutes" | Click again |
| Cookie/state mismatch (leaked URL opened in different browser) | 400 page: "same browser tab" | Run `/qurl setup` from scratch |
| Auth0 token exchange fails | 502 page | Retry `/qurl setup` |
| qurl-service mint fails or returns missing key_id | 502 page: "Could not provision qURL key" | Retry |
| DDB write fails after successful mint | 500 page + best-effort orphan-key DELETE | Retry. (Mint is idempotent on retry — prior key remains valid until manually revoked.) |
| id_token JWKS verification fails | Success page renders WITHOUT the qURL-account email line; debug-logged | None — key still works; visual cue just unavailable |

## Round 8 — #178 items pulled into PR (commit 3db480c)

Per discussion that the items were risky enough to land in-place rather than chase as separate follow-ups:

- **B.** Auth0 id_token JWKS verification — `jose@~5.9.6` + `apps/discord/src/utils/auth0-jwks.js`. Full signature + issuer + audience + expiry validation. Email claim is now cryptographically verified.
- **C.1** Cookie constants dedupe → `apps/discord/src/utils/oauth-cookies.js`, both routers import. No more name/path drift between Stage 1 and Stage 2.
- **C.2** Drop `profile` Auth0 scope (only `email` is read).
- **C.3** Treat missing `key_id` as 502 alongside missing `api_key` — orphan-cleanup contract holds.
- **C.4** `/oauth/discord/callback` 503 no longer echoes the env-var reason; logged only.
- **C.5** Structured binding readout via `renderPage({ details })` — label/value styling instead of grey prose.
- **C.6** Cookie path `/oauth` doc comments at every Set-Cookie / clearCookie site.
- **C.7** Three test gaps closed (JWKS-fail, missing id_token, missing key_id) + new `tests/auth0-jwks.test.js` (5 unit tests for the verifier).
- **C.8** Gate `prompt=consent` on first-install vs re-run via `getGuildConfig` lookup.

## Round 9 — Justin review fixes + Phase-4 polish (commits 4fc839d → b4d05a8)

In-place fixes for [#184](https://github.com/layervai/qurl-integrations/issues/184) (separate `QURL_OAUTH_STATE_SECRET`) and [#185](https://github.com/layervai/qurl-integrations/issues/185) (admin-offboarding nudge in `/qurl status`), plus 4 sub-rounds of Claude-review feedback:

- **9.1** Type-narrow JSON extraction (`access_token` / `id_token` / `api_key` / `key_id`); dedup `renderNotConfigured` into shared `utils/oauth-not-configured.js`; drop dead `if (keyId)` branch; rename `getIsReRun` → `shouldPromptConsent` (UX-gate verb, not state-read); drop unused `_setJwksFnForTesting` test seam; cookie set/clear/round-trip pin tests.
- **9.2** Stage-2 ALWAYS sets `prompt=consent` (URL-forwarding attack surface); narrow cookie path from `/oauth` to `/oauth/qurl` (only the qurl-oauth callback reads it); harmonize warn/info on not-configured paths; `singleStringParam` on `req.query.error`/`error_description`; severity split on JWKS verify failure at the call site.
- **9.3** `isValidAuth0DomainShape` regex rejects scheme-prefixed / placeholder values at config-load (OAuth stays off, legacy fallback runs, no mid-flow URL parse crash); `MIN_STATE_SECRET_LENGTH = 32` floor on the HMAC signing secret; `Cache-Control: no-store` as a router-level middleware on every `/oauth/*` response.
- **9.4** Test pins: Cache-Control header emission + cookie URL-decode round-trip; trim `discord-install.js` CSRF-posture comment.

Deferred follow-ups (filed):
- [#186](https://github.com/layervai/qurl-integrations/issues/186) — concurrent /qurl setup race (different admins)
- [#187](https://github.com/layervai/qurl-integrations/issues/187) — PKCE on Auth0 leg
- [#188](https://github.com/layervai/qurl-integrations/issues/188) — CSP nonce for inline styles

## Files changed

| File | Change |
|---|---|
| `apps/discord/package.json` + `package-lock.json` | Add `jose@~5.9.6` dep |
| `apps/discord/src/utils/qurl-oauth-state.js` | HMAC-signed state token signer/verifier with kind-binding |
| `apps/discord/src/utils/auth0-jwks.js` | NEW (round 8) — JWKS-cached id_token verifier |
| `apps/discord/src/utils/oauth-cookies.js` | NEW (round 8) — shared cookie name/path/TTL constants |
| `apps/discord/src/routes/qurl-oauth.js` | Stage 1 `/oauth/qurl/start` + `/oauth/qurl/callback` |
| `apps/discord/src/routes/discord-install.js` | Stage 2 `/oauth/discord/callback` |
| `apps/discord/src/templates/page.js` | `renderPage` accepts `details: [{label, value}]` (round 8 / C.5) |
| `apps/discord/src/server.js` | Mounts both routers; gates internally |
| `apps/discord/src/commands.js` | `/qurl setup` + `/qurl help` pivot on `isQurlOAuthConfigured` |
| `apps/discord/src/config.js` | AUTH0_* + DISCORD_CLIENT_SECRET env vars |
| `apps/discord/tests/qurl-oauth-state.test.js` | 11 tests for state signing |
| `apps/discord/tests/qurl-oauth.test.js` | Supertest coverage incl. JWKS-fail / missing-id_token / missing-key_id (round 8) |
| `apps/discord/tests/discord-install.test.js` | Supertest coverage incl. first-install vs re-install prompt-consent gate (round 8) |
| `apps/discord/tests/auth0-jwks.test.js` | NEW (round 8) — 5 unit tests for the JWKS verifier |
| `e2e/tests/qurl-oauth-setup.smoke.test.ts` | Bot HTTP smoke against deployed sandbox/prod |

## qurl-service: NO changes

`POST /v1/api-keys` (Auth0-JWT-gated) already exists. The admin's Auth0 JWT carries the owner identity (`sub` claim), so qurl-service stores the key under the admin's account automatically.

## Out-of-band setup checklist (Justin owns)

This PR ships with the legacy modal-paste fallback active until the items below land.

**Auth0:**
- [ ] Auth0 application registered:
  - Application Type: **Regular Web Application**
  - Allowed Callback URLs: `https://<sandbox-bot-host>/oauth/qurl/callback`, `https://<prod-bot-host>/oauth/qurl/callback`
  - Token Endpoint Auth: `client_secret_post`
  - Grant Types: Authorization Code
  - Scopes available: `qurl:write`, `qurl:read`, `openid`, `email`
- [ ] Sandbox + prod SSM secrets:
  - `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_AUDIENCE`

**Discord OAuth2:**
- [ ] Discord developer portal — add redirect URIs:
  - **Sandbox app** (`1491271781716197426`): `https://<sandbox-bot-host>/oauth/discord/callback`
  - **Prod app** (`1495050474414411948`): `https://<prod-bot-host>/oauth/discord/callback`
- [ ] SSM: `DISCORD_CLIENT_SECRET` (separate from `DISCORD_TOKEN`)
- [ ] Update layerv.ai marketing/onboarding link to:
  ```
  https://discord.com/oauth2/authorize?client_id=1495050474414411948&permissions=2147568640&scope=bot+applications.commands&response_type=code&redirect_uri=https://<prod-bot-host>/oauth/discord/callback
  ```

**ECS:**
- [ ] Inject `AUTH0_*` + `DISCORD_CLIENT_SECRET` from SSM into task defs

**Smoke (manual runbook in test header):**
- [ ] Sandbox: `/qurl setup` → Auth0 → success → DM → `/qurl send` works
- [ ] Sandbox: "Add to Discord" → server picker → Discord consent → Auth0 → success → DM → `/qurl send` works
- [ ] Prod: same two flows after sandbox green

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 812 passing (round 7: 778 → round 9.4: +34 new across rounds 8 + 9.x: 11 JWKS-related, 5 auth0-jwks unit, 5 first-install/re-install/binding-readout, 2 secret-precedence, 3 admin-left, 4 round-9 hygiene + 4 round-9.3/9.4 pins)
- [x] State-token tamper / expiry / cross-purpose forgery rejection pinned
- [x] JWKS verify failure: success page renders WITHOUT the qURL-account-email line (forged-token security pin)
- [x] Missing id_token field: success still renders
- [x] Missing key_id: 502 (orphan-cleanup contract)
- [x] First-install vs re-install: `prompt=consent` gated on `getGuildConfig`
- [x] /qurl setup falls back to modal-paste cleanly when AUTH0_* unset
- [x] /qurl help text pivots between OAuth and legacy wording
- [ ] Sandbox smoke after Auth0 + Discord secrets land (Justin)
- [ ] Prod smoke after sandbox green (Justin)
