### PR TITLE
fix(discord): refuse to persist orphan OAuth tokens when KEK is absent

### DIFF
--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -48,6 +48,19 @@ function missingProdKeys(env, isOpenNHPActive) {
   return prodRequired(isOpenNHPActive).filter(k => !env[k]);
 }
 
+// KEY_ENCRYPTION_KEY is independently required in any environment that
+// hands out real GitHub OAuth tokens — i.e. when GITHUB_CLIENT_SECRET is
+// set — even outside NODE_ENV=production. Without this gate, a staging
+// or preview deploy would pass index.js's prod block, hand out
+// `read:user` tokens, and then silently persist orphaned tokens in the
+// clear via crypto.encrypt's plaintext fallback. Returns the missing
+// keys so index.js can name them in the failure message; empty list
+// when GITHUB_CLIENT_SECRET is unset (no token-issuing surface).
+function missingKekRequiredKeys(env) {
+  if (!env.GITHUB_CLIENT_SECRET) return [];
+  return env.KEY_ENCRYPTION_KEY ? [] : ['KEY_ENCRYPTION_KEY'];
+}
+
 // Process-role parsing for the gateway/HTTP split. Lifted out of
 // index.js so the invalid-value path is testable without spawning a
 // child process — same shape as missingBootKeys above. See
@@ -88,6 +101,7 @@ module.exports = {
   prodRequired,
   missingBootKeys,
   missingProdKeys,
+  missingKekRequiredKeys,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 };

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -33,11 +33,13 @@ function bootRequired(isOpenNHPActive) {
 // deployments both rely on per-guild /qurl setup, so it's optional
 // outside the OpenNHP community server.
 //
-// KEY_ENCRYPTION_KEY appears here AND in missingKekRequiredKeys for
-// non-overlapping reasons: this entry catches prod deploys without
-// GITHUB_CLIENT_SECRET (KEK still protects guild_configs.qurl_api_key
-// + qurl_send_configs.attachment_url), while missingKekRequiredKeys
-// catches the staging/preview-with-OAuth case the prod block doesn't.
+// KEY_ENCRYPTION_KEY appears here AND in missingKekRequiredKeys.
+// The two checks overlap on prod-with-OAuth (both fail closed there);
+// the load-bearing distinct cases are: this entry catches prod
+// deploys WITHOUT GITHUB_CLIENT_SECRET (KEK still protects
+// guild_configs.qurl_api_key + qurl_send_configs.attachment_url),
+// while missingKekRequiredKeys catches the staging/preview-with-OAuth
+// case the prod block alone would not cover.
 function prodRequired(isOpenNHPActive) {
   if (!isOpenNHPActive) return ['METRICS_TOKEN', 'KEY_ENCRYPTION_KEY'];
   return ['METRICS_TOKEN', 'QURL_API_KEY', 'KEY_ENCRYPTION_KEY'];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -48,14 +48,10 @@ function missingProdKeys(env, isOpenNHPActive) {
   return prodRequired(isOpenNHPActive).filter(k => !env[k]);
 }
 
-// KEY_ENCRYPTION_KEY is independently required in any environment that
-// hands out real GitHub OAuth tokens — i.e. when GITHUB_CLIENT_SECRET is
-// set — even outside NODE_ENV=production. Without this gate, a staging
-// or preview deploy would pass index.js's prod block, hand out
-// `read:user` tokens, and then silently persist orphaned tokens in the
-// clear via crypto.encrypt's plaintext fallback. Returns the missing
-// keys so index.js can name them in the failure message; empty list
-// when GITHUB_CLIENT_SECRET is unset (no token-issuing surface).
+// KEY_ENCRYPTION_KEY is required independently of NODE_ENV whenever
+// GITHUB_CLIENT_SECRET is set — staging/preview environments hand out
+// real GitHub OAuth tokens, and crypto.encrypt's dev plaintext fallback
+// must never reach the orphan-token persistence path.
 function missingKekRequiredKeys(env) {
   if (!env.GITHUB_CLIENT_SECRET) return [];
   return env.KEY_ENCRYPTION_KEY ? [] : ['KEY_ENCRYPTION_KEY'];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -32,6 +32,12 @@ function bootRequired(isOpenNHPActive) {
 // global-fallback for /qurl send; single-guild-plain and multi-tenant
 // deployments both rely on per-guild /qurl setup, so it's optional
 // outside the OpenNHP community server.
+//
+// KEY_ENCRYPTION_KEY appears here AND in missingKekRequiredKeys for
+// non-overlapping reasons: this entry catches prod deploys without
+// GITHUB_CLIENT_SECRET (KEK still protects guild_configs.qurl_api_key
+// + qurl_send_configs.attachment_url), while missingKekRequiredKeys
+// catches the staging/preview-with-OAuth case the prod block doesn't.
 function prodRequired(isOpenNHPActive) {
   if (!isOpenNHPActive) return ['METRICS_TOKEN', 'KEY_ENCRYPTION_KEY'];
   return ['METRICS_TOKEN', 'QURL_API_KEY', 'KEY_ENCRYPTION_KEY'];

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -830,6 +830,11 @@ const dbModule = {
   },
 
   recordOrphanedToken(accessToken) {
+    // Caller invariant: accessToken is a non-empty string. encryptStrict
+    // passes null/undefined through unchanged (matching encrypt's
+    // ergonomics) and a NULL row would either store NULL or violate a
+    // future NOT NULL constraint silently — gate at the call site
+    // (oauth.js does this) rather than relying on the encryption layer.
     const stmt = db.prepare('INSERT INTO orphaned_oauth_tokens (access_token) VALUES (?)');
     stmt.run(encryptStrict(accessToken));
   },

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -1,5 +1,5 @@
 const Database = require('better-sqlite3');
-const { encrypt, decrypt } = require('./utils/crypto');
+const { encrypt, encryptStrict, decrypt } = require('./utils/crypto');
 const path = require('path');
 const fs = require('fs');
 const config = require('./config');
@@ -830,8 +830,12 @@ const dbModule = {
   },
 
   recordOrphanedToken(accessToken) {
+    // encryptStrict (not encrypt) so a missing KEY_ENCRYPTION_KEY refuses
+    // to persist instead of falling through to plaintext. The boot gate
+    // in index.js already blocks this path in any deploy that hands out
+    // real GitHub tokens; this is the in-process fail-closed backstop.
     const stmt = db.prepare('INSERT INTO orphaned_oauth_tokens (access_token) VALUES (?)');
-    stmt.run(encrypt(accessToken));
+    stmt.run(encryptStrict(accessToken));
   },
 
   countOrphanedTokens() {

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -830,10 +830,6 @@ const dbModule = {
   },
 
   recordOrphanedToken(accessToken) {
-    // encryptStrict (not encrypt) so a missing KEY_ENCRYPTION_KEY refuses
-    // to persist instead of falling through to plaintext. The boot gate
-    // in index.js already blocks this path in any deploy that hands out
-    // real GitHub tokens; this is the in-process fail-closed backstop.
     const stmt = db.prepare('INSERT INTO orphaned_oauth_tokens (access_token) VALUES (?)');
     stmt.run(encryptStrict(accessToken));
   },

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -830,11 +830,9 @@ const dbModule = {
   },
 
   recordOrphanedToken(accessToken) {
-    // Caller invariant: accessToken is a non-empty string. encryptStrict
-    // passes null/undefined through unchanged (matching encrypt's
-    // ergonomics) and a NULL row would either store NULL or violate a
-    // future NOT NULL constraint silently — gate at the call site
-    // (oauth.js does this) rather than relying on the encryption layer.
+    // Caller must gate non-null upstream — encryptStrict passes null
+    // through (see crypto.js for rationale), which would silently
+    // store NULL here. oauth.js's `if (accessToken)` is the gate.
     const stmt = db.prepare('INSERT INTO orphaned_oauth_tokens (access_token) VALUES (?)');
     stmt.run(encryptStrict(accessToken));
   },

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -177,6 +177,11 @@ if (process.env.NODE_ENV === 'production') {
 // encryptStrict as a backstop, but failing closed at boot is the loud
 // signal. Smoke-test the key material so a malformed value is caught here
 // instead of on the first encrypt() call minutes into serving traffic.
+//
+// Role-agnostic by design: a `gateway`-role process doesn't mount the
+// OAuth callback, but env vars are uniform across roles in a single
+// deploy, so one role refusing to boot while another silently degrades
+// is worse than refusing both.
 const kekMissing = missingKekRequiredKeys(process.env);
 if (kekMissing.length > 0) {
   logger.error(`GITHUB_CLIENT_SECRET is set but ${kekMissing.join(', ')} is missing — refusing to boot. Any deployment that issues real GitHub OAuth tokens must encrypt persisted credentials at rest.`);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -185,8 +185,11 @@ if (kekMissing.length > 0) {
 }
 if (process.env.KEY_ENCRYPTION_KEY) {
   try {
-    const { encrypt, decrypt } = require('./utils/crypto');
-    if (decrypt(encrypt('boot-smoke')) !== 'boot-smoke') {
+    // encryptStrict (not encrypt) so a future refactor that drops the
+    // outer env-var guard fails loudly here instead of silently falling
+    // through encrypt's plaintext-passthrough branch.
+    const { encryptStrict, decrypt } = require('./utils/crypto');
+    if (decrypt(encryptStrict('boot-smoke')) !== 'boot-smoke') {
       throw new Error('round-trip mismatch');
     }
   } catch (err) {

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -172,31 +172,21 @@ if (process.env.NODE_ENV === 'production') {
   }
 }
 
-// KEY_ENCRYPTION_KEY is required outside NODE_ENV=production whenever
-// GITHUB_CLIENT_SECRET is set: staging/preview environments hand out
-// real GitHub `read:user` tokens, and the orphan-token persistence path
-// must never silently degrade to plaintext via crypto.encrypt's
-// dev-mode fallback. recordOrphanedToken uses encryptStrict() as the
-// in-process backstop, but failing closed at boot is the loud signal.
+// Any deploy that issues real GitHub OAuth tokens must encrypt persisted
+// credentials at rest, in any NODE_ENV — the orphan-token path uses
+// encryptStrict as a backstop, but failing closed at boot is the loud
+// signal. Smoke-test the key material so a malformed value is caught here
+// instead of on the first encrypt() call minutes into serving traffic.
 const kekMissing = missingKekRequiredKeys(process.env);
 if (kekMissing.length > 0) {
   logger.error(`GITHUB_CLIENT_SECRET is set but ${kekMissing.join(', ')} is missing — refusing to boot. Any deployment that issues real GitHub OAuth tokens must encrypt persisted credentials at rest.`);
   logger.error('Generate KEY_ENCRYPTION_KEY with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'base64\'))"');
   process.exit(1);
 }
-
-// Crypto smoke test: catch a misconfigured KEY_ENCRYPTION_KEY at boot
-// instead of on the first encrypt() call (which could be an OAuth token
-// persist minutes into serving traffic). This validates the key material
-// can both encrypt AND decrypt, not just decode as base64. Runs whenever
-// the key is set (in any NODE_ENV), since a malformed key in staging
-// would otherwise silently fall through to the dev plaintext branch in
-// crypto.encrypt — exactly the failure mode this gate exists to catch.
 if (process.env.KEY_ENCRYPTION_KEY) {
   try {
     const { encrypt, decrypt } = require('./utils/crypto');
-    const probe = `boot-smoke-${Date.now()}`;
-    if (decrypt(encrypt(probe)) !== probe) {
+    if (decrypt(encrypt('boot-smoke')) !== 'boot-smoke') {
       throw new Error('round-trip mismatch');
     }
   } catch (err) {

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -5,7 +5,7 @@ const { registerCommands, handleCommand } = require('./commands');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const db = require('./store');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
-const { missingBootKeys, missingProdKeys, resolveProcessRole } = require('./boot-requirements');
+const { missingBootKeys, missingProdKeys, missingKekRequiredKeys, resolveProcessRole } = require('./boot-requirements');
 const { initHttpOnly } = require('./http-only-init');
 
 // Process role — selects which subset of the bot runs in this
@@ -170,11 +170,29 @@ if (process.env.NODE_ENV === 'production') {
     logger.error('OAUTH_STATE_SECRET must be set in production. Generate with: openssl rand -hex 32');
     process.exit(1);
   }
+}
 
-  // Crypto smoke test: catch a misconfigured KEY_ENCRYPTION_KEY at boot
-  // instead of on the first encrypt() call (which could be an OAuth token
-  // persist minutes into serving traffic). This validates the key material
-  // can both encrypt AND decrypt, not just decode as base64.
+// KEY_ENCRYPTION_KEY is required outside NODE_ENV=production whenever
+// GITHUB_CLIENT_SECRET is set: staging/preview environments hand out
+// real GitHub `read:user` tokens, and the orphan-token persistence path
+// must never silently degrade to plaintext via crypto.encrypt's
+// dev-mode fallback. recordOrphanedToken uses encryptStrict() as the
+// in-process backstop, but failing closed at boot is the loud signal.
+const kekMissing = missingKekRequiredKeys(process.env);
+if (kekMissing.length > 0) {
+  logger.error(`GITHUB_CLIENT_SECRET is set but ${kekMissing.join(', ')} is missing — refusing to boot. Any deployment that issues real GitHub OAuth tokens must encrypt persisted credentials at rest.`);
+  logger.error('Generate KEY_ENCRYPTION_KEY with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'base64\'))"');
+  process.exit(1);
+}
+
+// Crypto smoke test: catch a misconfigured KEY_ENCRYPTION_KEY at boot
+// instead of on the first encrypt() call (which could be an OAuth token
+// persist minutes into serving traffic). This validates the key material
+// can both encrypt AND decrypt, not just decode as base64. Runs whenever
+// the key is set (in any NODE_ENV), since a malformed key in staging
+// would otherwise silently fall through to the dev plaintext branch in
+// crypto.encrypt — exactly the failure mode this gate exists to catch.
+if (process.env.KEY_ENCRYPTION_KEY) {
   try {
     const { encrypt, decrypt } = require('./utils/crypto');
     const probe = `boot-smoke-${Date.now()}`;

--- a/apps/discord/src/routes/oauth.js
+++ b/apps/discord/src/routes/oauth.js
@@ -620,7 +620,14 @@ router.get('/github/callback', rateLimit, async (req, res) => {
             orphanQueueDepth: orphanCount,
           });
         } catch (dbErr) {
-          // Don't fail the response; the error is logged above.
+          // Don't fail the response; the error is logged above. Note:
+          // when recordOrphanedToken throws (e.g. encryptStrict refusing
+          // a no-KEK persist), the token is *lost* — orphaned at GitHub
+          // with no local record, no future revoke retry. The boot gate
+          // in index.js (missingKekRequiredKeys) makes this unreachable
+          // in any deploy that issues real GitHub tokens; this branch is
+          // the defense-in-depth tail for a misconfigured deploy that
+          // bypasses the gate.
           logger.error('Failed to record orphaned token for later sweep', { error: dbErr.message });
         }
       }

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1366,6 +1366,11 @@ async function getGuildConfigWithApiKey(guildId) {
 // ── Orphaned OAuth tokens ──
 
 async function recordOrphanedToken(accessToken) {
+  // Caller invariant: accessToken is a non-empty string. encryptStrict
+  // passes null/undefined through unchanged (matching encrypt's
+  // ergonomics); a null Item would surface as a confusing DDB
+  // ValidationException for the access_token attribute. Gate upstream
+  // (oauth.js does) rather than relying on the encryption layer.
   const ttlDays = parseInt(process.env.ORPHAN_TOKEN_RETENTION_DAYS, 10) || (process.env.NODE_ENV === 'production' ? 7 : 1);
   const expiresAt = Math.floor((Date.now() + ttlDays * 24 * 60 * 60 * 1000) / 1000);
   // Dedup on token_hash. A retry / replay of the same plaintext

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1381,10 +1381,6 @@ async function recordOrphanedToken(accessToken) {
       TableName: TABLES.orphaned_oauth_tokens,
       Item: {
         token_hash: sha256Hex(accessToken),
-        // encryptStrict (not encrypt) so a missing KEY_ENCRYPTION_KEY refuses
-        // to persist instead of falling through to plaintext. The boot gate
-        // in index.js already blocks this path in any deploy that hands out
-        // real GitHub tokens; this is the in-process fail-closed backstop.
         access_token: encryptStrict(accessToken),
         recorded_at: nowIso(),
         expires_at: expiresAt,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1366,11 +1366,9 @@ async function getGuildConfigWithApiKey(guildId) {
 // ── Orphaned OAuth tokens ──
 
 async function recordOrphanedToken(accessToken) {
-  // Caller invariant: accessToken is a non-empty string. encryptStrict
-  // passes null/undefined through unchanged (matching encrypt's
-  // ergonomics); a null Item would surface as a confusing DDB
-  // ValidationException for the access_token attribute. Gate upstream
-  // (oauth.js does) rather than relying on the encryption layer.
+  // Caller must gate non-null upstream — encryptStrict passes null
+  // through (see crypto.js for rationale), which would surface here
+  // as a confusing DDB ValidationException on access_token.
   const ttlDays = parseInt(process.env.ORPHAN_TOKEN_RETENTION_DAYS, 10) || (process.env.NODE_ENV === 'production' ? 7 : 1);
   const expiresAt = Math.floor((Date.now() + ttlDays * 24 * 60 * 60 * 1000) / 1000);
   // Dedup on token_hash. A retry / replay of the same plaintext

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -61,7 +61,7 @@ const {
   BatchWriteCommand,
 } = require('@aws-sdk/lib-dynamodb');
 
-const { encrypt, decrypt } = require('../utils/crypto');
+const { encrypt, encryptStrict, decrypt } = require('../utils/crypto');
 const config = require('../config');
 const logger = require('../logger');
 
@@ -1381,7 +1381,11 @@ async function recordOrphanedToken(accessToken) {
       TableName: TABLES.orphaned_oauth_tokens,
       Item: {
         token_hash: sha256Hex(accessToken),
-        access_token: encrypt(accessToken),
+        // encryptStrict (not encrypt) so a missing KEY_ENCRYPTION_KEY refuses
+        // to persist instead of falling through to plaintext. The boot gate
+        // in index.js already blocks this path in any deploy that hands out
+        // real GitHub tokens; this is the in-process fail-closed backstop.
+        access_token: encryptStrict(accessToken),
         recorded_at: nowIso(),
         expires_at: expiresAt,
       },

--- a/apps/discord/src/utils/crypto.js
+++ b/apps/discord/src/utils/crypto.js
@@ -69,10 +69,12 @@ function encrypt(plaintext) {
   if (plaintext == null) return plaintext;
   const key = getKey();
   if (!key) {
-    // Warn once per process so staging/preview environments without
-    // KEY_ENCRYPTION_KEY don't silently store secrets in plaintext.
-    // index.js fails boot in NODE_ENV=production so this branch only
-    // runs in dev/test/staging.
+    // Warn once per process so dev installs without KEY_ENCRYPTION_KEY
+    // don't silently store secrets in plaintext. index.js fails boot
+    // when NODE_ENV=production OR when GITHUB_CLIENT_SECRET is set, so
+    // this branch only runs in dev/test environments without OAuth
+    // wiring. For live third-party credentials, callers MUST use
+    // encryptStrict() instead.
     if (!plaintextWarned) {
       plaintextWarned = true;
       logger.warn('KEY_ENCRYPTION_KEY is not set — secrets are being stored in PLAINTEXT. Generate a key with `node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'base64\'))"` and set KEY_ENCRYPTION_KEY in the environment before using in any shared deployment.');
@@ -90,6 +92,10 @@ function encrypt(plaintext) {
 // any environment that hands out real GitHub tokens, so this is
 // defense-in-depth against a misconfigured deploy that bypasses the gate.
 function encryptStrict(plaintext) {
+  // Null/undefined pass through unchanged, intentionally matching
+  // encrypt(). Callers that should never see a null at this point
+  // (e.g. the orphan-token revoke path) gate the value upstream;
+  // tightening to a throw here would break that contract.
   if (plaintext == null) return plaintext;
   const key = getKey();
   if (!key) {

--- a/apps/discord/src/utils/crypto.js
+++ b/apps/discord/src/utils/crypto.js
@@ -79,6 +79,26 @@ function encrypt(plaintext) {
     }
     return plaintext;
   }
+  return encryptWithKey(key, plaintext);
+}
+
+// Fail-closed variant of encrypt(): throws when KEY_ENCRYPTION_KEY is unset
+// instead of silently returning plaintext. Use this on persistence paths
+// that handle live third-party credentials (e.g. orphaned GitHub OAuth
+// access tokens) where a plaintext fallback is unacceptable even in
+// dev/test/staging — the boot gate in index.js already requires KEK in
+// any environment that hands out real GitHub tokens, so this is
+// defense-in-depth against a misconfigured deploy that bypasses the gate.
+function encryptStrict(plaintext) {
+  if (plaintext == null) return plaintext;
+  const key = getKey();
+  if (!key) {
+    throw new Error('KEY_ENCRYPTION_KEY is required to persist this value but is not set. Refusing to store sensitive data in plaintext.');
+  }
+  return encryptWithKey(key, plaintext);
+}
+
+function encryptWithKey(key, plaintext) {
   const iv = crypto.randomBytes(12);
   const cipher = crypto.createCipheriv(ALGO, key, iv);
   const ct = Buffer.concat([cipher.update(String(plaintext), 'utf8'), cipher.final()]);
@@ -131,7 +151,7 @@ function decrypt(value) {
 // encrypt call mid-request).
 function _resetKeyCache() { cachedKey = null; cachedPrevKey = null; plaintextWarned = false; }
 
-const exports_ = { encrypt, decrypt };
+const exports_ = { encrypt, encryptStrict, decrypt };
 if (process.env.NODE_ENV !== 'production') {
   exports_._resetKeyCache = _resetKeyCache;
 }

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -15,6 +15,7 @@ const {
   prodRequired,
   missingBootKeys,
   missingProdKeys,
+  missingKekRequiredKeys,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 } = require('../src/boot-requirements');
@@ -105,6 +106,32 @@ describe('missingProdKeys', () => {
     expect(missingProdKeys(env, true).sort()).toEqual([
       'KEY_ENCRYPTION_KEY', 'QURL_API_KEY',
     ]);
+  });
+});
+
+describe('missingKekRequiredKeys', () => {
+  it('returns empty when GITHUB_CLIENT_SECRET is unset (no token-issuing surface, no KEK demand)', () => {
+    expect(missingKekRequiredKeys({})).toEqual([]);
+    // Empty string also counts as unset — same as missingBootKeys's robustness.
+    expect(missingKekRequiredKeys({ GITHUB_CLIENT_SECRET: '' })).toEqual([]);
+  });
+
+  it('flags KEY_ENCRYPTION_KEY when GITHUB_CLIENT_SECRET is set without KEK', () => {
+    expect(missingKekRequiredKeys({ GITHUB_CLIENT_SECRET: 'x' })).toEqual(['KEY_ENCRYPTION_KEY']);
+    // Empty-string KEK counts as missing (matches the
+    // boot-requirements `!env[k]` falsy treatment elsewhere).
+    expect(
+      missingKekRequiredKeys({ GITHUB_CLIENT_SECRET: 'x', KEY_ENCRYPTION_KEY: '' })
+    ).toEqual(['KEY_ENCRYPTION_KEY']);
+  });
+
+  it('returns empty when both are set, regardless of NODE_ENV', () => {
+    // Independent of NODE_ENV by design — staging/preview deploys with
+    // a real GitHub client secret must satisfy this gate even though
+    // missingProdKeys does not run for them.
+    expect(
+      missingKekRequiredKeys({ GITHUB_CLIENT_SECRET: 'x', KEY_ENCRYPTION_KEY: 'k' })
+    ).toEqual([]);
   });
 });
 

--- a/apps/discord/tests/crypto.test.js
+++ b/apps/discord/tests/crypto.test.js
@@ -12,7 +12,7 @@ jest.mock('../src/logger', () => ({
 }));
 
 const nodeCrypto = require('crypto');
-const { encrypt, decrypt, _resetKeyCache } = require('../src/utils/crypto');
+const { encrypt, encryptStrict, decrypt, _resetKeyCache } = require('../src/utils/crypto');
 
 const VALID_KEY = nodeCrypto.randomBytes(32).toString('base64');
 
@@ -104,6 +104,34 @@ describe('utils/crypto', () => {
       delete process.env.KEY_ENCRYPTION_KEY;
       _resetKeyCache();
       expect(() => decrypt(ct)).toThrow(/KEY_ENCRYPTION_KEY is not set/);
+    });
+  });
+
+  describe('encryptStrict (fail-closed variant for sensitive persistence)', () => {
+    it('produces ciphertext indistinguishable from encrypt() when KEK is set', () => {
+      process.env.KEY_ENCRYPTION_KEY = VALID_KEY;
+      _resetKeyCache();
+      const ct = encryptStrict('github-oauth-token');
+      expect(ct.startsWith('enc:v1:')).toBe(true);
+      expect(decrypt(ct)).toBe('github-oauth-token');
+    });
+
+    it('passes through null/undefined unchanged (matches encrypt() ergonomics)', () => {
+      process.env.KEY_ENCRYPTION_KEY = VALID_KEY;
+      _resetKeyCache();
+      expect(encryptStrict(null)).toBeNull();
+      expect(encryptStrict(undefined)).toBeUndefined();
+    });
+
+    it('throws — never returns plaintext — when KEY_ENCRYPTION_KEY is unset', () => {
+      _resetKeyCache();
+      expect(() => encryptStrict('github-oauth-token')).toThrow(/KEY_ENCRYPTION_KEY is required/);
+    });
+
+    it('throws on a malformed KEY_ENCRYPTION_KEY (no silent fallback)', () => {
+      process.env.KEY_ENCRYPTION_KEY = Buffer.from('too-short').toString('base64');
+      _resetKeyCache();
+      expect(() => encryptStrict('x')).toThrow(/KEY_ENCRYPTION_KEY is malformed/);
     });
   });
 });

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -27,9 +27,11 @@ const db = require('../src/database');
 
 afterAll(() => {
   db.close();
-  // Restore the prior env state so a future shared-runner setup
-  // (e.g. --runInBand merging suites into one worker) can't leak this
-  // suite's key into a sibling test file.
+  // Restore the prior env state symmetrically — `process.env.X = undefined`
+  // coerces to the literal string "undefined" and would silently poison
+  // sibling tests under `--runInBand`. The `if undefined ? delete : assign`
+  // shape (used here, in this file's inner test, and in
+  // orphan-token-sweeper.test.js) is the established pattern.
   if (KEK_PRIOR === undefined) {
     delete process.env.KEY_ENCRYPTION_KEY;
   } else {
@@ -409,9 +411,7 @@ describe('database module', () => {
         expect(() => db.recordOrphanedToken('gho_should_not_persist')).toThrow(/KEY_ENCRYPTION_KEY is required/);
         expect(db.countOrphanedTokens()).toBe(before);
       } finally {
-        // Restore symmetrically — `process.env.X = undefined` would coerce
-        // to the literal string "undefined" and quietly poison sibling
-        // tests under --runInBand. Matches the afterAll cleanup pattern.
+        // Symmetric env restore — see this file's afterAll for rationale.
         if (savedKey === undefined) {
           delete process.env.KEY_ENCRYPTION_KEY;
         } else {

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -16,6 +16,12 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
+// recordOrphanedToken uses encryptStrict which throws when KEY_ENCRYPTION_KEY
+// is unset. The orphaned-token test below requires a real key; the
+// fail-closed-without-KEK behavior is asserted in tests/crypto.test.js +
+// the dedicated test at the end of this file.
+process.env.KEY_ENCRYPTION_KEY = require('crypto').randomBytes(32).toString('base64');
+
 const db = require('../src/database');
 
 afterAll(() => {
@@ -378,6 +384,25 @@ describe('database module', () => {
       db.recordOrphanedToken('gho_fakefake1');
       db.recordOrphanedToken('gho_fakefake2');
       expect(db.countOrphanedTokens()).toBe(2);
+    });
+
+    it('refuses to persist when KEY_ENCRYPTION_KEY is unset (fail-closed, no plaintext fallback)', () => {
+      // Defense-in-depth backstop: the boot gate in index.js already
+      // refuses to start when GITHUB_CLIENT_SECRET is set without KEK,
+      // but if a misconfigured deploy ever bypasses that, the data
+      // layer must still refuse to write the token in the clear.
+      const before = db.countOrphanedTokens();
+      const savedKey = process.env.KEY_ENCRYPTION_KEY;
+      delete process.env.KEY_ENCRYPTION_KEY;
+      try {
+        const { _resetKeyCache } = require('../src/utils/crypto');
+        _resetKeyCache();
+        expect(() => db.recordOrphanedToken('gho_should_not_persist')).toThrow(/KEY_ENCRYPTION_KEY is required/);
+        expect(db.countOrphanedTokens()).toBe(before);
+      } finally {
+        process.env.KEY_ENCRYPTION_KEY = savedKey;
+        require('../src/utils/crypto')._resetKeyCache();
+      }
     });
   });
 });

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -409,7 +409,14 @@ describe('database module', () => {
         expect(() => db.recordOrphanedToken('gho_should_not_persist')).toThrow(/KEY_ENCRYPTION_KEY is required/);
         expect(db.countOrphanedTokens()).toBe(before);
       } finally {
-        process.env.KEY_ENCRYPTION_KEY = savedKey;
+        // Restore symmetrically — `process.env.X = undefined` would coerce
+        // to the literal string "undefined" and quietly poison sibling
+        // tests under --runInBand. Matches the afterAll cleanup pattern.
+        if (savedKey === undefined) {
+          delete process.env.KEY_ENCRYPTION_KEY;
+        } else {
+          process.env.KEY_ENCRYPTION_KEY = savedKey;
+        }
         require('../src/utils/crypto')._resetKeyCache();
       }
     });

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -20,12 +20,21 @@ jest.mock('../src/logger', () => ({
 // is unset. The orphaned-token test below requires a real key; the
 // fail-closed-without-KEK behavior is asserted in tests/crypto.test.js +
 // the dedicated test at the end of this file.
+const KEK_PRIOR = process.env.KEY_ENCRYPTION_KEY;
 process.env.KEY_ENCRYPTION_KEY = require('crypto').randomBytes(32).toString('base64');
 
 const db = require('../src/database');
 
 afterAll(() => {
   db.close();
+  // Restore the prior env state so a future shared-runner setup
+  // (e.g. --runInBand merging suites into one worker) can't leak this
+  // suite's key into a sibling test file.
+  if (KEK_PRIOR === undefined) {
+    delete process.env.KEY_ENCRYPTION_KEY;
+  } else {
+    process.env.KEY_ENCRYPTION_KEY = KEK_PRIOR;
+  }
 });
 
 describe('database module', () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -29,22 +29,15 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
-// Mock crypto wrapper: pass-through so tests can assert on
-// plaintext that flows into the DDB Item. Real encryption is
-// exercised by crypto.test.js. encryptStrict shares the encrypt
-// stub here — its fail-closed behavior is exercised in
-// crypto.test.js + database-module.test.js, and the
-// `mockFailClosed` toggle below lets this suite simulate the
-// throw without a process-wide env mutation.
-let mockFailClosed = false;
+// Mock crypto wrapper: pass-through so tests can assert on plaintext
+// that flows into the DDB Item. Real encryption + the encryptStrict
+// fail-closed behavior are exercised by crypto.test.js. encryptStrict
+// is a jest.fn so the no-KEK regression test below can override its
+// implementation per-call without a shared mutable flag.
+const mockEncryptStrict = jest.fn((v) => `enc:v1:IV:TAG:${Buffer.from(v || '').toString('hex')}`);
 jest.mock('../src/utils/crypto', () => ({
   encrypt: (v) => `enc:v1:IV:TAG:${Buffer.from(v || '').toString('hex')}`,
-  encryptStrict: (v) => {
-    if (mockFailClosed) {
-      throw new Error('KEY_ENCRYPTION_KEY is required to persist this value but is not set.');
-    }
-    return `enc:v1:IV:TAG:${Buffer.from(v || '').toString('hex')}`;
-  },
+  encryptStrict: mockEncryptStrict,
   decrypt: (v) => {
     if (!v || !v.startsWith('enc:v1:')) return v;
     const parts = v.split(':');
@@ -448,16 +441,14 @@ describe('orphaned tokens', () => {
 
   test('recordOrphanedToken: refuses to issue a Put when KEY_ENCRYPTION_KEY is unset (fail-closed, defense-in-depth backstop for index.js boot gate)', async () => {
     ddbMock.on(PutCommand).resolves({});
-    mockFailClosed = true;
-    try {
-      await expect(store.recordOrphanedToken('ghp_should_not_persist'))
-        .rejects.toThrow(/KEY_ENCRYPTION_KEY is required/);
-      // Critical: no DDB write was issued — the credential never leaves
-      // process memory. A retry that gains a key would re-attempt cleanly.
-      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
-    } finally {
-      mockFailClosed = false;
-    }
+    mockEncryptStrict.mockImplementationOnce(() => {
+      throw new Error('KEY_ENCRYPTION_KEY is required to persist this value but is not set.');
+    });
+    await expect(store.recordOrphanedToken('ghp_should_not_persist'))
+      .rejects.toThrow(/KEY_ENCRYPTION_KEY is required/);
+    // Critical: no DDB write was issued — the credential never leaves
+    // process memory. A retry that gains a key would re-attempt cleanly.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
   });
 
   test('decryptOrphanedToken: unwraps via crypto util (now async for contract parity)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -69,6 +69,10 @@ const store = require('../src/store/ddb-store');
 
 beforeEach(() => {
   ddbMock.reset();
+  // Reset any mockImplementation from prior tests. Today only
+  // mockImplementationOnce is used (auto-consumed), but a future test
+  // adding mockImplementation would otherwise leak across cases.
+  mockEncryptStrict.mockClear();
 });
 
 afterAll(async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -69,10 +69,13 @@ const store = require('../src/store/ddb-store');
 
 beforeEach(() => {
   ddbMock.reset();
-  // Reset any mockImplementation from prior tests. Today only
-  // mockImplementationOnce is used (auto-consumed), but a future test
-  // adding mockImplementation would otherwise leak across cases.
-  mockEncryptStrict.mockClear();
+  // mockReset (not mockClear) so a future test setting a sticky
+  // mockImplementation can't leak into the next case — mockClear only
+  // resets call history, leaving the implementation in place. Today
+  // only mockImplementationOnce is used (auto-consumed); the broader
+  // reset is the cheap defensive choice.
+  mockEncryptStrict.mockReset();
+  mockEncryptStrict.mockImplementation((v) => `enc:v1:IV:TAG:${Buffer.from(v || '').toString('hex')}`);
 });
 
 afterAll(async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -31,9 +31,20 @@ jest.mock('../src/logger', () => ({
 
 // Mock crypto wrapper: pass-through so tests can assert on
 // plaintext that flows into the DDB Item. Real encryption is
-// exercised by crypto.test.js.
+// exercised by crypto.test.js. encryptStrict shares the encrypt
+// stub here — its fail-closed behavior is exercised in
+// crypto.test.js + database-module.test.js, and the
+// `mockFailClosed` toggle below lets this suite simulate the
+// throw without a process-wide env mutation.
+let mockFailClosed = false;
 jest.mock('../src/utils/crypto', () => ({
   encrypt: (v) => `enc:v1:IV:TAG:${Buffer.from(v || '').toString('hex')}`,
+  encryptStrict: (v) => {
+    if (mockFailClosed) {
+      throw new Error('KEY_ENCRYPTION_KEY is required to persist this value but is not set.');
+    }
+    return `enc:v1:IV:TAG:${Buffer.from(v || '').toString('hex')}`;
+  },
   decrypt: (v) => {
     if (!v || !v.startsWith('enc:v1:')) return v;
     const parts = v.split(':');
@@ -433,6 +444,20 @@ describe('orphaned tokens', () => {
     err.name = 'ProvisionedThroughputExceededException';
     ddbMock.on(PutCommand).rejects(err);
     await expect(store.recordOrphanedToken('ghp_abc123')).rejects.toThrow(/throttled/);
+  });
+
+  test('recordOrphanedToken: refuses to issue a Put when KEY_ENCRYPTION_KEY is unset (fail-closed, defense-in-depth backstop for index.js boot gate)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    mockFailClosed = true;
+    try {
+      await expect(store.recordOrphanedToken('ghp_should_not_persist'))
+        .rejects.toThrow(/KEY_ENCRYPTION_KEY is required/);
+      // Critical: no DDB write was issued — the credential never leaves
+      // process memory. A retry that gains a key would re-attempt cleanly.
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    } finally {
+      mockFailClosed = false;
+    }
   });
 
   test('decryptOrphanedToken: unwraps via crypto util (now async for contract parity)', async () => {

--- a/apps/discord/tests/orphan-token-sweeper.test.js
+++ b/apps/discord/tests/orphan-token-sweeper.test.js
@@ -18,6 +18,11 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
+// recordOrphanedToken now uses encryptStrict, which fails closed when
+// KEY_ENCRYPTION_KEY is unset. The sweeper test fixture seeds rows
+// through the real database module, so a real key is required.
+process.env.KEY_ENCRYPTION_KEY = require('crypto').randomBytes(32).toString('base64');
+
 const db = require('../src/database');
 const { sweepOnce } = require('../src/orphan-token-sweeper');
 

--- a/apps/discord/tests/orphan-token-sweeper.test.js
+++ b/apps/discord/tests/orphan-token-sweeper.test.js
@@ -21,13 +21,24 @@ jest.mock('../src/logger', () => ({
 // recordOrphanedToken now uses encryptStrict, which fails closed when
 // KEY_ENCRYPTION_KEY is unset. The sweeper test fixture seeds rows
 // through the real database module, so a real key is required.
+const KEK_PRIOR = process.env.KEY_ENCRYPTION_KEY;
 process.env.KEY_ENCRYPTION_KEY = require('crypto').randomBytes(32).toString('base64');
 
 const db = require('../src/database');
 const { sweepOnce } = require('../src/orphan-token-sweeper');
 
 const originalFetch = globalThis.fetch;
-afterAll(() => { globalThis.fetch = originalFetch; db.close(); });
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  db.close();
+  // Restore the prior env state so a shared-runner setup can't leak
+  // this suite's key into a sibling test file.
+  if (KEK_PRIOR === undefined) {
+    delete process.env.KEY_ENCRYPTION_KEY;
+  } else {
+    process.env.KEY_ENCRYPTION_KEY = KEK_PRIOR;
+  }
+});
 
 describe('orphan token sweeper', () => {
   beforeEach(() => {

--- a/apps/discord/tests/orphan-token-sweeper.test.js
+++ b/apps/discord/tests/orphan-token-sweeper.test.js
@@ -31,8 +31,7 @@ const originalFetch = globalThis.fetch;
 afterAll(() => {
   globalThis.fetch = originalFetch;
   db.close();
-  // Restore the prior env state so a shared-runner setup can't leak
-  // this suite's key into a sibling test file.
+  // Symmetric env restore — see database-module.test.js afterAll for rationale.
   if (KEK_PRIOR === undefined) {
     delete process.env.KEY_ENCRYPTION_KEY;
   } else {


### PR DESCRIPTION
Closes #61.

## Why this matters

An OAuth-revoke retry that fails twice (network blip, GitHub 5xx) persists the caller's GitHub `read:user` token to an orphan-token queue for a background sweeper to retry later. Before this change that persistence path silently degraded to **plaintext** when `KEY_ENCRYPTION_KEY` was unset — `crypto.encrypt` warns once on the first call, then quietly returns the input unchanged for the rest of the process.

The boot gate that requires `KEY_ENCRYPTION_KEY` only fired in `NODE_ENV=production`, so any staging or preview environment wired up with a real `GITHUB_CLIENT_SECRET` would:

1. Hand out real `read:user` GitHub tokens via OAuth.
2. Fail closed on revoke (the very condition this code path exists to handle).
3. Quietly write the live, plaintext credential into SQLite or DynamoDB for the configured retention window (1 day in dev, 7 days in prod).

A staging deploy operating in this state was also a credible source of cross-environment data exfiltration — DE review on PR #45 flagged it.

## What changed

Three independent layers, each sufficient on its own:

### 1. `encryptStrict` — fail-closed envelope encryption
`utils/crypto.js` gains an `encryptStrict(plaintext)` sibling of `encrypt`. Same wire format, same key handling — the only difference is that it **throws** when `KEY_ENCRYPTION_KEY` is unset instead of returning the input as plaintext. `recordOrphanedToken` in both backends (SQLite via `database.js`, DynamoDB via `store/ddb-store.js`) switches to `encryptStrict` so the data layer itself refuses to produce a row that stores a live credential in the clear.

### 2. Boot gate hoisted out of `NODE_ENV=production`
`boot-requirements.js` gains `missingKekRequiredKeys(env)` — returns `['KEY_ENCRYPTION_KEY']` whenever `GITHUB_CLIENT_SECRET` is set but `KEK` is not, in any `NODE_ENV`. `index.js` calls it independently of the prod block and refuses to start with a clear, named error. The KEK round-trip smoke test (`encryptStrict → decrypt` probe) is hoisted out of the prod block too, so a malformed key in staging is caught at boot rather than on the first orphan-token write minutes into serving traffic.

### 3. Regression tests
- `tests/crypto.test.js`: `encryptStrict` throws on unset / malformed KEK, round-trips when set, no-ops on null/undefined.
- `tests/boot-requirements.test.js`: `missingKekRequiredKeys` flags the gap, ignores the unset-`GITHUB_CLIENT_SECRET` path, treats empty strings as missing.
- `tests/database-module.test.js` + `tests/ddb-store.test.js`: end-to-end fail-closed coverage on both `recordOrphanedToken` paths. The DDB test verifies **no Put is issued** — the credential never leaves process memory.
- `tests/orphan-token-sweeper.test.js`: now sets a real KEK at fixture setup so the sweeper still has data to walk.

## Caller-side impact

Pre-PR, a no-KEK env stored the orphaned token (in plaintext, bad) and the sweeper would later retry revocation. Post-PR, the same env logs at the existing `oauth.js` catch site (search for `Failed to record orphaned token for later sweep`) and the token is **lost** — orphaned at GitHub with no local record, no future revoke retry. The boot gate makes this unreachable in any deployment that issues real tokens; the catch site documents the trade-off as the defense-in-depth tail.

## Operator note: pre-existing plaintext rows

Any deploy that previously ran with `GITHUB_CLIENT_SECRET` set + `KEY_ENCRYPTION_KEY` unset (the exact scenario this PR addresses) accumulated plaintext orphan tokens in the DB. After this PR ships in those environments, the boot gate forces operators to set KEK before restarting — but historical plaintext rows are still present. `decrypt()` returns them as-is via the legacy-plaintext fallback (`utils/crypto.js`), so the sweeper still revokes them at GitHub. They age out on their own:

- **DynamoDB**: TTL on `expires_at` clears within `ORPHAN_TOKEN_RETENTION_DAYS` (7d prod / 1d dev).
- **SQLite**: `cleanupOrphanedTokens()` runs daily with the same retention window.

No manual intervention required. If oncall notices `enc:v1:`-less rows immediately post-upgrade, that's expected and self-healing.

## Out of scope (intentional)

The existing `encrypt()` plaintext-fallback for `guild_configs.qurl_api_key` and `qurl_send_configs.attachment_url` is unchanged. Those are operator-managed values from a `/qurl setup` slash command, not third-party-issued credentials with an active session at GitHub. Broadening the fail-closed scope is tracked at #190 (rename `encrypt → encryptOrPlaintext` to invert the default-bias). Boot smoke test for `KEY_ENCRYPTION_KEY_PREV` rotation tracked at #191. Boot-path integration tests tracked at #192.

## Test plan

- [x] `npx jest -i` (full discord suite): 759 pass, 0 fail
- [x] `npx eslint src tests --max-warnings 0`: clean
- [x] Manual trace of the no-KEK boot path with `GITHUB_CLIENT_SECRET` set in `NODE_ENV=staging` — fails fast with a named error
- [x] Manual trace of the no-KEK `recordOrphanedToken` path bypassing the boot gate — throws, no row written, error logged at the existing oauth.js catch site

🤖 Generated with [Claude Code](https://claude.com/claude-code)