### PR TITLE
fix(discord): trim /qurl setup blurb + surface api_key_limit specifically

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3156,11 +3156,7 @@ const commands = [
           return interaction.reply({
             content: '🔐 **Connect qURL to this server**\n\n'
               + `**[Click here to authorize qURL](${startUrl})**\n\n`
-              + 'Sign in with your layerv.ai account and consent. The bot will mint a qURL '
-              + 'API key owned by your account — all usage on this server will bill to you. '
-              + 'No copy-paste needed.\n\n'
-              + '_This link expires in 5 minutes and is bound to your browser session — '
-              + 'open it in the same browser where you ran `/qurl setup`._',
+              + '_The link expires in 5 minutes._',
             ephemeral: true,
           });
         }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3156,7 +3156,7 @@ const commands = [
           return interaction.reply({
             content: '🔐 **Connect qURL to this server**\n\n'
               + `**[Click here to authorize qURL](${startUrl})**\n\n`
-              + '_The link expires in 5 minutes._',
+              + '_Open in this browser; the link expires in 5 minutes._',
             ephemeral: true,
           });
         }

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -331,21 +331,35 @@ router.get('/callback', rateLimit, async (req, res) => {
     });
     if (!mintResp.ok) {
       const errBody = await mintResp.text().catch(() => '');
-      logger.error('qURL API key mint failed', {
-        status: mintResp.status, body: errBody.slice(0, 500), guildId,
-      });
-      // RFC 7807 problem JSON; surface the api_key_limit case specifically
-      // so the admin sees the actual cause + the action they can take,
-      // not a generic "service rejected the request" wall.
+      // RFC 7807 problem JSON; surface specific cases (currently just
+      // api_key_limit) before the generic catch-all so the admin sees
+      // the actual cause + the action they can take, not a "service
+      // rejected the request" wall. Parse-fail / missing-code falls
+      // through to the generic branch.
       let problemCode = '';
       try {
         const parsed = JSON.parse(errBody);
         if (typeof parsed?.error?.code === 'string') problemCode = parsed.error.code;
-      } catch { /* not JSON — fall through to the generic branch */ }
+      } catch { /* not JSON — fall through */ }
+
       if (mintResp.status === 403 && problemCode === 'api_key_limit') {
-        return renderError(res, 403, 'qURL API key limit reached',
+        // User-quota hit, NOT a service failure. Log at warn (not
+        // error) so prod alerting / log-rate alarms can distinguish
+        // "qurl-service down" (logger.error) from "user on Free tier
+        // hit 3 keys" (logger.warn). Status 429 mirrors the actual
+        // semantic (Too Many Requests / quota) — qurl-service's 403
+        // is itself somewhat off-spec for a quota hit; we render the
+        // semantically correct status to the admin's browser.
+        logger.warn('qURL API key mint refused: api_key_limit', {
+          status: mintResp.status, problemCode, guildId,
+        });
+        return renderError(res, 429, 'qURL API key limit reached',
           'Your qURL account has hit its API key limit (Free tier allows 3). Delete an unused key in your layerv.ai dashboard, or upgrade your plan, then run /qurl setup again.');
       }
+
+      logger.error('qURL API key mint failed', {
+        status: mintResp.status, problemCode, body: errBody.slice(0, 500), guildId,
+      });
       return renderError(res, 502, 'Could not provision qURL key',
         'qurl-service rejected the API-key request. Please run /qurl setup again, or contact your layerv.ai admin.');
     }

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -334,6 +334,18 @@ router.get('/callback', rateLimit, async (req, res) => {
       logger.error('qURL API key mint failed', {
         status: mintResp.status, body: errBody.slice(0, 500), guildId,
       });
+      // RFC 7807 problem JSON; surface the api_key_limit case specifically
+      // so the admin sees the actual cause + the action they can take,
+      // not a generic "service rejected the request" wall.
+      let problemCode = '';
+      try {
+        const parsed = JSON.parse(errBody);
+        if (typeof parsed?.error?.code === 'string') problemCode = parsed.error.code;
+      } catch { /* not JSON — fall through to the generic branch */ }
+      if (mintResp.status === 403 && problemCode === 'api_key_limit') {
+        return renderError(res, 403, 'qURL API key limit reached',
+          'Your qURL account has hit its API key limit (Free tier allows 3). Delete an unused key in your layerv.ai dashboard, or upgrade your plan, then run /qurl setup again.');
+      }
       return renderError(res, 502, 'Could not provision qURL key',
         'qurl-service rejected the API-key request. Please run /qurl setup again, or contact your layerv.ai admin.');
     }

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -331,30 +331,26 @@ router.get('/callback', rateLimit, async (req, res) => {
     });
     if (!mintResp.ok) {
       const errBody = await mintResp.text().catch(() => '');
-      // RFC 7807 problem JSON; surface specific cases (currently just
-      // api_key_limit) before the generic catch-all so the admin sees
-      // the actual cause + the action they can take, not a "service
-      // rejected the request" wall. Parse-fail / missing-code falls
-      // through to the generic branch.
+      // Parse RFC 7807 problem JSON to discriminate user-quota hits
+      // (warn-level, dedicated 429 page) from service failures (error-
+      // level, generic 502 page). `<unparseable>` distinguishes "body
+      // wasn't JSON at all" from "JSON but no error.code" in logs.
       let problemCode = '';
       try {
         const parsed = JSON.parse(errBody);
         if (typeof parsed?.error?.code === 'string') problemCode = parsed.error.code;
-      } catch { /* not JSON — fall through */ }
+      } catch { problemCode = '<unparseable>'; }
 
       if (mintResp.status === 403 && problemCode === 'api_key_limit') {
-        // User-quota hit, NOT a service failure. Log at warn (not
-        // error) so prod alerting / log-rate alarms can distinguish
-        // "qurl-service down" (logger.error) from "user on Free tier
-        // hit 3 keys" (logger.warn). Status 429 mirrors the actual
-        // semantic (Too Many Requests / quota) — qurl-service's 403
-        // is itself somewhat off-spec for a quota hit; we render the
-        // semantically correct status to the admin's browser.
+        // logger.warn (not error) so prod alerting can distinguish
+        // user-quota hits from qurl-service outages. Status 429
+        // matches the actual semantic — qurl-service's 403 is off-
+        // spec for a quota hit (RFC 7231 §6.5.3 vs RFC 6585 §4).
         logger.warn('qURL API key mint refused: api_key_limit', {
           status: mintResp.status, problemCode, guildId,
         });
         return renderError(res, 429, 'qURL API key limit reached',
-          'Your qURL account has hit its API key limit (Free tier allows 3). Delete an unused key in your layerv.ai dashboard, or upgrade your plan, then run /qurl setup again.');
+          'Your qURL account has hit its API key limit. Delete an unused key in your layerv.ai dashboard, or upgrade your plan, then run /qurl setup again.');
       }
 
       logger.error('qURL API key mint failed', {

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -339,7 +339,7 @@ describe('qurl-oauth routes', () => {
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
     });
 
-    it('403s with key-limit-specific copy when qurl-service returns api_key_limit', async () => {
+    it('429s with key-limit-specific copy when qurl-service returns api_key_limit, does not persist or DM', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       globalThis.fetch = jest.fn()
         .mockResolvedValueOnce({
@@ -361,9 +361,40 @@ describe('qurl-oauth routes', () => {
       const res = await request(app).get(
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
       ).set('Cookie', cookieFor(state));
-      expect(res.status).toBe(403);
+      // 429 not 403 — qurl-service's 403 is off-spec for a quota hit;
+      // the bot renders the semantically correct status (RFC 7231:
+      // 429 = quota / rate-limit class).
+      expect(res.status).toBe(429);
       expect(res.text).toContain('qURL API key limit reached');
       expect(res.text).toContain('Delete an unused key');
+      expect(db.setGuildApiKey).not.toHaveBeenCalled();
+      // Failure path must not distort the dispatch / DM metrics —
+      // sendDM is reserved for successful provisioning.
+      expect(discord.sendDM).not.toHaveBeenCalled();
+    });
+
+    it('falls through to generic 502 when qurl-service returns valid JSON without error.code', async () => {
+      // Pin that the parse path can't accidentally match the api_key_limit
+      // branch when `code` is absent. A future field rename on qurl-service
+      // (e.g. `code` → `kind`) would land here; the user gets the generic
+      // 502 instead of a misclassified quota page.
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: false, status: 403,
+          text: () => Promise.resolve(JSON.stringify({
+            error: { title: 'Forbidden', status: 403, detail: 'no code field' },
+          })),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state));
+      expect(res.status).toBe(502);
+      expect(res.text).toContain('Could not provision qURL key');
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
     });
 

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -339,6 +339,34 @@ describe('qurl-oauth routes', () => {
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
     });
 
+    it('403s with key-limit-specific copy when qurl-service returns api_key_limit', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: false, status: 403,
+          text: () => Promise.resolve(JSON.stringify({
+            error: {
+              type: 'https://docs.layerv.ai/problems/api_key_limit',
+              title: 'API Key Limit Exceeded',
+              status: 403,
+              code: 'api_key_limit',
+              detail: 'You have reached the maximum number of API keys (3) for your plan.',
+            },
+          })),
+        });
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state));
+      expect(res.status).toBe(403);
+      expect(res.text).toContain('qURL API key limit reached');
+      expect(res.text).toContain('Delete an unused key');
+      expect(db.setGuildApiKey).not.toHaveBeenCalled();
+    });
+
     it('200s on happy path: mints key, persists, DMs admin, renders success with binding readout', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       // id_token with an `email` claim — base64url-encoded JSON, no


### PR DESCRIPTION
## Summary

Two cosmetic/UX fixes to the OAuth setup flow per Vikram's sandbox testing:

1. **`/qurl setup` ephemeral message** trim — drop the prose-heavy "Sign in with your layerv.ai account…no copy-paste needed" blurb and the multi-line browser-binding paragraph. Net delta: 7 lines → 3 lines, keeping the click-here link as the first-class info plus a one-line `_Open in this browser; the link expires in 5 minutes._` that retains the two load-bearing constraints (browser binding, expiry).

2. **`api_key_limit` error surface** — when the admin's qURL account is at the API-key cap, qurl-service returns RFC 7807 `403 / code: "api_key_limit"`. The bot was rendering a generic "qurl-service rejected the API-key request" page; the admin couldn't tell what was wrong without reading CloudWatch. Now: parse the response body, branch on `error.code === "api_key_limit"`, render specific copy that names the cause + the action. The branch logs at `warn` (not `error`) so prod alerting can distinguish user-quota hits from genuine service failures, and renders status **429 Too Many Requests** (semantically correct for quota — qurl-service's 403 is itself off-spec).

   New page copy (no hardcoded tier number — the dashboard is the source of truth for the actual cap):
   > **qURL API key limit reached** — Your qURL account has hit its API key limit. Delete an unused key in your layerv.ai dashboard, or upgrade your plan, then run /qurl setup again.

   Generic 502 branch is unchanged — still the fallback for everything that isn't `api_key_limit`. The fall-through path also tags the log with `problemCode: '<unparseable>'` when the response body isn't JSON at all (vs. parsed-but-no-code), so triage can distinguish the two failure shapes.

## Verification

- `eslint src tests --max-warnings 0` clean
- All 896 existing tests pass; two new tests cover the api_key_limit 429 branch + the fall-through-on-missing-`code` path

## Test plan

- [x] Existing tests pass; new tests pass
- [x] CI green
- [x] Sandbox manual: hit the qURL key cap, confirm new copy renders
- [x] Sandbox manual: run `/qurl setup` in test server, confirm trimmed ephemeral

🤖 Generated with [Claude Code](https://claude.com/claude-code)