### PR TITLE
fix(discord): smoke-test import path drags in discord.js — extract pure-string render module

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2582,16 +2582,16 @@ function revokeReplyPayload(rendered) {
 // All wording assertions live against `renderRevokeContent` directly
 // (see `apps/discord/src/revoke-render.js` + the e2e smoke).
 function renderRevokeMsg(sendId, names, total, showAll, success = names.length) {
-  const data = renderRevokeContent(sendId, names, total, showAll, success);
+  const data = renderRevokeContent({ names, total, showAll, success });
   const row = data.needsExpand
     ? new ActionRowBuilder().addComponents(
       new ButtonBuilder()
-        .setCustomId(`qurl_revoke_expand_${data.sendId}`)
-        .setLabel(data.showAll ? 'Show Less' : 'Show All')
+        .setCustomId(`qurl_revoke_expand_${sendId}`)
+        .setLabel(showAll ? 'Show Less' : 'Show All')
         .setStyle(ButtonStyle.Secondary),
     )
     : null;
-  return { content: data.content, needsExpand: data.needsExpand, row, attachmentText: data.attachmentText };
+  return { ...data, row };
 }
 
 async function revokeAllLinks(sendId, senderDiscordId, apiKey) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2554,8 +2554,13 @@ async function handleRevoke(interaction, apiKey) {
   }
 }
 
-// Shared truncation limit for both send + revoke recipient lists.
-const REVOKE_TRUNC_LIMIT = 5;
+// Pure rendering / wording logic lives in `./revoke-render` so the
+// e2e smoke test can require it without pulling in `discord.js`.
+const {
+  REVOKE_TRUNC_LIMIT,
+  buildRevokeHeader,
+  renderRevokeContent,
+} = require('./revoke-render');
 
 // Builds the editReply payload from a `renderRevokeMsg` result. When
 // the rendered names list overflowed the Discord content cap,
@@ -2572,76 +2577,21 @@ function revokeReplyPayload(rendered) {
   return payload;
 }
 
-// Discord message content cap is 2000 chars. Leave headroom for the
-// header + "Revoked for: " prefix; force truncation in renderRevokeMsg
-// even when showAll=true if the full names list would push the total
-// over this. Without it, a Show All on ~80+ recipients would exceed
-// Discord's limit and the editReply would error.
-const REVOKE_CONTENT_SAFE_MAX = 1900;
-
-// Single source of truth for the "Revoked X/Y users[.]" header +
-// already-opened note. Used by both the inline-button path (via
-// renderRevokeMsg) and the slash-command /qurl revoke handler so a
-// future wording change lands in one place.
-function buildRevokeHeader(success, total) {
-  const note = total > 0 ? ' Note: already-opened links cannot be revoked.' : '';
-  return `Revoked ${success}/${total} user${total !== 1 ? 's' : ''}.${note}`;
-}
-
-// Builds the post-revoke confirmation message + Show All toggle row.
-// User-centric: `success`/`total` are unique-recipient counts; `names`
-// is the strict-success list. Returns `attachmentText` (newline-joined
-// full list) when the inline rendering would exceed Discord's 2000-char
-// content cap — caller wraps in an AttachmentBuilder. In attachment
-// mode the Show All button is suppressed since the file IS the full
-// list.
-//
-// `success` defaults to `names.length`. Pass it explicitly when the
-// authoritative count (e.g. DDB strict-success) may exceed the names
-// the caller could resolve — header reflects truth, names list
-// reflects what's renderable.
+// Wraps `renderRevokeContent` (pure data) and adds the discord.js
+// ActionRowBuilder/ButtonBuilder for the Show All / Show Less toggle.
+// All wording assertions live against `renderRevokeContent` directly
+// (see `apps/discord/src/revoke-render.js` + the e2e smoke).
 function renderRevokeMsg(sendId, names, total, showAll, success = names.length) {
-  let content = buildRevokeHeader(success, total);
-  let attachmentText = null;
-
-  if (names.length === 0) {
-    return { content, needsExpand: false, row: null, attachmentText };
-  }
-
-  // `names` are plain (sanitizeDisplayNamePlain at the call site) so
-  // they can land verbatim in the .txt attachment. Message content
-  // needs markdown escape per name to defuse `*phish*` / `[t](url)`
-  // injection — render-context split.
-  const escapedNames = names.map(escapeDiscordMarkdown);
-  const fullLine = `\nRevoked for: ${escapedNames.join(', ')}`;
-  const fullFits = content.length + fullLine.length <= REVOKE_CONTENT_SAFE_MAX;
-
-  if (!fullFits) {
-    // Full list won't fit inline → emit as a file attachment. Inline
-    // shows the first REVOKE_TRUNC_LIMIT names + "(see attached)" pointer.
-    const preview = escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ');
-    content += `\nRevoked for: ${preview} +${names.length - REVOKE_TRUNC_LIMIT} more (see attached)`;
-    attachmentText = names.join('\n');
-    return { content, needsExpand: false, row: null, attachmentText };
-  }
-
-  // Full list fits inline — current Show All / Show Less behavior.
-  if (showAll || names.length <= REVOKE_TRUNC_LIMIT) {
-    content += fullLine;
-  } else {
-    content += `\nRevoked for: ${escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ')} +${names.length - REVOKE_TRUNC_LIMIT} more`;
-  }
-
-  const needsExpand = names.length > REVOKE_TRUNC_LIMIT;
-  const row = needsExpand
+  const data = renderRevokeContent(sendId, names, total, showAll, success);
+  const row = data.needsExpand
     ? new ActionRowBuilder().addComponents(
       new ButtonBuilder()
-        .setCustomId(`qurl_revoke_expand_${sendId}`)
-        .setLabel(showAll ? 'Show Less' : 'Show All')
+        .setCustomId(`qurl_revoke_expand_${data.sendId}`)
+        .setLabel(data.showAll ? 'Show Less' : 'Show All')
         .setStyle(ButtonStyle.Secondary),
     )
     : null;
-  return { content, needsExpand, row, attachmentText };
+  return { content: data.content, needsExpand: data.needsExpand, row, attachmentText: data.attachmentText };
 }
 
 async function revokeAllLinks(sendId, senderDiscordId, apiKey) {

--- a/apps/discord/src/revoke-render.js
+++ b/apps/discord/src/revoke-render.js
@@ -1,0 +1,86 @@
+// Pure-string rendering of the post-revoke confirmation. Lives in its
+// own module — with zero deps on `discord.js`, `./store`, `./config`,
+// `./logger` — so the e2e wording-drift smoke (`e2e/tests/qurl-send-
+// revoke.smoke.test.ts`) can `require()` it without dragging in the
+// bot's whole runtime. Keep this file dep-free.
+//
+// `commands.js` is the only consumer that builds the Show All
+// `ActionRowBuilder`/`ButtonBuilder` from the returned `needsExpand` /
+// `showAll` shape — the row shape stays in commands.js so this module
+// has no discord.js coupling.
+
+const { escapeDiscordMarkdown } = require('./utils/sanitize');
+
+// Shared truncation limit for both send + revoke recipient lists.
+const REVOKE_TRUNC_LIMIT = 5;
+
+// Discord message content cap is 2000 chars. Leave headroom for the
+// header + "Revoked for: " prefix; force truncation in renderRevokeContent
+// even when showAll=true if the full names list would push the total
+// over this. Without it, a Show All on ~80+ recipients would exceed
+// Discord's limit and the editReply would error.
+const REVOKE_CONTENT_SAFE_MAX = 1900;
+
+// Single source of truth for the "Revoked X/Y users[.]" header +
+// already-opened note. Used by both the inline-button path (via
+// renderRevokeContent) and the slash-command /qurl revoke handler so
+// a future wording change lands in one place.
+function buildRevokeHeader(success, total) {
+  const note = total > 0 ? ' Note: already-opened links cannot be revoked.' : '';
+  return `Revoked ${success}/${total} user${total !== 1 ? 's' : ''}.${note}`;
+}
+
+// Builds the post-revoke confirmation message body. User-centric:
+// `success`/`total` are unique-recipient counts; `names` is the
+// strict-success list (plain — sanitizeDisplayNamePlain at the call
+// site). Returns `attachmentText` (newline-joined full list) when the
+// inline rendering would exceed Discord's 2000-char content cap —
+// caller wraps in an AttachmentBuilder. In attachment mode
+// `needsExpand=false` so the caller suppresses the Show All button
+// (the file IS the full list).
+//
+// `success` defaults to `names.length`. Pass it explicitly when the
+// authoritative count (e.g. DDB strict-success) may exceed the names
+// the caller could resolve — header reflects truth, names list
+// reflects what's renderable.
+function renderRevokeContent(sendId, names, total, showAll, success = names.length) {
+  let content = buildRevokeHeader(success, total);
+  let attachmentText = null;
+
+  if (names.length === 0) {
+    return { sendId, content, needsExpand: false, showAll, attachmentText };
+  }
+
+  // `names` are plain so they can land verbatim in the .txt attachment.
+  // Message content needs markdown escape per name to defuse `*phish*`
+  // / `[t](url)` injection — render-context split.
+  const escapedNames = names.map(escapeDiscordMarkdown);
+  const fullLine = `\nRevoked for: ${escapedNames.join(', ')}`;
+  const fullFits = content.length + fullLine.length <= REVOKE_CONTENT_SAFE_MAX;
+
+  if (!fullFits) {
+    // Full list won't fit inline → emit as a file attachment. Inline
+    // shows the first REVOKE_TRUNC_LIMIT names + "(see attached)" pointer.
+    const preview = escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ');
+    content += `\nRevoked for: ${preview} +${names.length - REVOKE_TRUNC_LIMIT} more (see attached)`;
+    attachmentText = names.join('\n');
+    return { sendId, content, needsExpand: false, showAll, attachmentText };
+  }
+
+  // Full list fits inline — current Show All / Show Less behavior.
+  if (showAll || names.length <= REVOKE_TRUNC_LIMIT) {
+    content += fullLine;
+  } else {
+    content += `\nRevoked for: ${escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ')} +${names.length - REVOKE_TRUNC_LIMIT} more`;
+  }
+
+  const needsExpand = names.length > REVOKE_TRUNC_LIMIT;
+  return { sendId, content, needsExpand, showAll, attachmentText };
+}
+
+module.exports = {
+  REVOKE_TRUNC_LIMIT,
+  REVOKE_CONTENT_SAFE_MAX,
+  buildRevokeHeader,
+  renderRevokeContent,
+};

--- a/apps/discord/src/revoke-render.js
+++ b/apps/discord/src/revoke-render.js
@@ -1,13 +1,6 @@
-// Pure-string rendering of the post-revoke confirmation. Lives in its
-// own module — with zero deps on `discord.js`, `./store`, `./config`,
-// `./logger` — so the e2e wording-drift smoke (`e2e/tests/qurl-send-
-// revoke.smoke.test.ts`) can `require()` it without dragging in the
-// bot's whole runtime. Keep this file dep-free.
-//
-// `commands.js` is the only consumer that builds the Show All
-// `ActionRowBuilder`/`ButtonBuilder` from the returned `needsExpand` /
-// `showAll` shape — the row shape stays in commands.js so this module
-// has no discord.js coupling.
+// Pure-string revoke rendering. No discord.js / store / config /
+// logger deps — keep this file dep-free so the e2e wording-drift
+// smoke can require it without the bot's runtime.
 
 const { escapeDiscordMarkdown } = require('./utils/sanitize');
 
@@ -20,6 +13,8 @@ const REVOKE_TRUNC_LIMIT = 5;
 // over this. Without it, a Show All on ~80+ recipients would exceed
 // Discord's limit and the editReply would error.
 const REVOKE_CONTENT_SAFE_MAX = 1900;
+
+const REVOKE_FOR_PREFIX = '\nRevoked for: ';
 
 // Single source of truth for the "Revoked X/Y users[.]" header +
 // already-opened note. Used by both the inline-button path (via
@@ -43,39 +38,34 @@ function buildRevokeHeader(success, total) {
 // authoritative count (e.g. DDB strict-success) may exceed the names
 // the caller could resolve — header reflects truth, names list
 // reflects what's renderable.
-function renderRevokeContent(sendId, names, total, showAll, success = names.length) {
+function renderRevokeContent({ names, total, showAll, success = names.length }) {
   let content = buildRevokeHeader(success, total);
-  let attachmentText = null;
 
   if (names.length === 0) {
-    return { sendId, content, needsExpand: false, showAll, attachmentText };
+    return { content, needsExpand: false, attachmentText: null };
   }
 
   // `names` are plain so they can land verbatim in the .txt attachment.
   // Message content needs markdown escape per name to defuse `*phish*`
   // / `[t](url)` injection — render-context split.
   const escapedNames = names.map(escapeDiscordMarkdown);
-  const fullLine = `\nRevoked for: ${escapedNames.join(', ')}`;
-  const fullFits = content.length + fullLine.length <= REVOKE_CONTENT_SAFE_MAX;
+  const fullLine = REVOKE_FOR_PREFIX + escapedNames.join(', ');
 
-  if (!fullFits) {
+  if (content.length + fullLine.length > REVOKE_CONTENT_SAFE_MAX) {
     // Full list won't fit inline → emit as a file attachment. Inline
     // shows the first REVOKE_TRUNC_LIMIT names + "(see attached)" pointer.
     const preview = escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ');
-    content += `\nRevoked for: ${preview} +${names.length - REVOKE_TRUNC_LIMIT} more (see attached)`;
-    attachmentText = names.join('\n');
-    return { sendId, content, needsExpand: false, showAll, attachmentText };
+    content += `${REVOKE_FOR_PREFIX}${preview} +${names.length - REVOKE_TRUNC_LIMIT} more (see attached)`;
+    return { content, needsExpand: false, attachmentText: names.join('\n') };
   }
 
   // Full list fits inline — current Show All / Show Less behavior.
   if (showAll || names.length <= REVOKE_TRUNC_LIMIT) {
     content += fullLine;
   } else {
-    content += `\nRevoked for: ${escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ')} +${names.length - REVOKE_TRUNC_LIMIT} more`;
+    content += `${REVOKE_FOR_PREFIX}${escapedNames.slice(0, REVOKE_TRUNC_LIMIT).join(', ')} +${names.length - REVOKE_TRUNC_LIMIT} more`;
   }
-
-  const needsExpand = names.length > REVOKE_TRUNC_LIMIT;
-  return { sendId, content, needsExpand, showAll, attachmentText };
+  return { content, needsExpand: names.length > REVOKE_TRUNC_LIMIT, attachmentText: null };
 }
 
 module.exports = {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -814,6 +814,28 @@ describe('renderRevokeMsg', () => {
   });
 });
 
+// Pinned because `buildRevokeHeader` is the ONLY wording the slash-
+// command `/qurl revoke` path uses (no Recipients line — see
+// commands.js's slash handler). Unit-test the helper directly so a
+// future wording change reaches the slash-command surface even if no
+// `renderRevokeMsg` test happens to hit the same shape.
+describe('buildRevokeHeader (slash-command revoke path)', () => {
+  // eslint-disable-next-line global-require
+  const { buildRevokeHeader } = require('../src/revoke-render');
+
+  it('zero-attempt: "Revoked 0/0 users." (no already-opened note)', () => {
+    expect(buildRevokeHeader(0, 0)).toBe('Revoked 0/0 users.');
+  });
+
+  it('singular: "Revoked 1/1 user." (singular noun + already-opened note)', () => {
+    expect(buildRevokeHeader(1, 1)).toBe('Revoked 1/1 user. Note: already-opened links cannot be revoked.');
+  });
+
+  it('plural: "Revoked 3/5 users." includes already-opened note when total > 0', () => {
+    expect(buildRevokeHeader(3, 5)).toBe('Revoked 3/5 users. Note: already-opened links cannot be revoked.');
+  });
+});
+
 // ===========================================================================
 // handleAddRecipients
 // ===========================================================================

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -814,11 +814,8 @@ describe('renderRevokeMsg', () => {
   });
 });
 
-// Pinned because `buildRevokeHeader` is the ONLY wording the slash-
-// command `/qurl revoke` path uses (no Recipients line — see
-// commands.js's slash handler). Unit-test the helper directly so a
-// future wording change reaches the slash-command surface even if no
-// `renderRevokeMsg` test happens to hit the same shape.
+// Slash-command /qurl revoke uses buildRevokeHeader directly (no
+// Recipients line); unit-test it so wording stays pinned.
 describe('buildRevokeHeader (slash-command revoke path)', () => {
   // eslint-disable-next-line global-require
   const { buildRevokeHeader } = require('../src/revoke-render');

--- a/e2e/tests/qurl-send-revoke.smoke.test.ts
+++ b/e2e/tests/qurl-send-revoke.smoke.test.ts
@@ -2,31 +2,25 @@
  * Smoke contract for the post-revoke confirmation message format
  * (`/qurl send` → click Revoke → bot edits the ephemeral confirmation).
  *
- * Imports `renderRevokeMsg` from the bot src so a wording change in
- * commands.js fails this smoke gate at deploy time.
+ * Imports `renderRevokeContent` from `apps/discord/src/revoke-render.js`
+ * — a pure-string module with no `discord.js` / store / config / logger
+ * dependencies. Importing from `apps/discord/src/commands.js` directly
+ * would drag in those transitive runtime deps and fail to load in the
+ * smoke runner (which only installs `e2e/` deps; `apps/discord/
+ * node_modules` isn't present in CI).
  *
  * The unit tests in apps/discord/tests/qurl-send-back-half.test.js
  * cover the same surface during the bot's own CI. This file's value
- * is at the post-deploy smoke layer.
+ * is at the post-deploy smoke layer — wording drift in the bot's
+ * post-revoke message fails the smoke gate at deploy time.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const cmds = require('../../apps/discord/src/commands');
-// `_test` is gated on NODE_ENV !== 'production'. If this smoke is ever
-// run with production env (e.g. to mirror prod), the destructure below
-// would throw "Cannot destructure ... of undefined". Fail loudly with
-// a curated message so the next operator knows what's wrong.
-if (!cmds._test) {
-  throw new Error(
-    'qurl-send-revoke.smoke.test.ts requires NODE_ENV !== "production" to access commands.js _test exports. ' +
-    'Run jest with the default NODE_ENV=test, or unset NODE_ENV.',
-  );
-}
-const { renderRevokeMsg, REVOKE_TRUNC_LIMIT } = cmds._test;
+const { renderRevokeContent, REVOKE_TRUNC_LIMIT } = require('../../apps/discord/src/revoke-render');
 
 describe('qURL send revoke confirmation format (smoke)', () => {
   test('full-list format: "Revoked X/Y users" + "Revoked for: alice, bob"', () => {
-    const r = renderRevokeMsg('send-1', ['alice', 'bob', 'carol'], 3, false);
+    const r = renderRevokeContent('send-1', ['alice', 'bob', 'carol'], 3, false);
     expect(r.content).toMatch(/^Revoked 3\/3 users\./);
     expect(r.content).toContain('Revoked for: alice, bob, carol');
     expect(r.content).not.toMatch(/\+\d+ more/);
@@ -34,31 +28,31 @@ describe('qURL send revoke confirmation format (smoke)', () => {
 
   test(`truncated format: "+N more" when names exceed REVOKE_TRUNC_LIMIT (${REVOKE_TRUNC_LIMIT})`, () => {
     const names = Array.from({ length: REVOKE_TRUNC_LIMIT + 3 }, (_, i) => `u${i}`);
-    const r = renderRevokeMsg('send-2', names, names.length, false);
+    const r = renderRevokeContent('send-2', names, names.length, false);
     expect(r.content).toMatch(/\+3 more$/m);
     expect(r.needsExpand).toBe(true);
   });
 
   test('no-success format: "Revoked 0/N" omits "Revoked for:" line', () => {
-    const r = renderRevokeMsg('send-3', [], 5, false);
+    const r = renderRevokeContent('send-3', [], 5, false);
     expect(r.content).toMatch(/^Revoked 0\/5 users\./);
     expect(r.content).not.toContain('Revoked for:');
   });
 
   test('zero-attempt format: "Revoked 0/0" omits the already-opened note', () => {
-    const r = renderRevokeMsg('send-4', [], 0, false);
+    const r = renderRevokeContent('send-4', [], 0, false);
     expect(r.content).not.toContain('already-opened');
   });
 
   test('singular "user" when total === 1', () => {
-    const r = renderRevokeMsg('send-5', ['alice'], 1, false);
+    const r = renderRevokeContent('send-5', ['alice'], 1, false);
     expect(r.content).toMatch(/^Revoked 1\/1 user\./);
     expect(r.content).not.toMatch(/^Revoked 1\/1 users\./);
   });
 
   test('large lists overflow to file attachment instead of inline truncation', () => {
     const names = Array.from({ length: 200 }, (_, i) => `verylongusername${String(i).padStart(4, '0')}`);
-    const r = renderRevokeMsg('send-6', names, names.length, true);
+    const r = renderRevokeContent('send-6', names, names.length, true);
     expect(r.content.length).toBeLessThanOrEqual(2000);
     expect(r.content).toContain('(see attached)');
     expect(r.attachmentText).not.toBeNull();

--- a/e2e/tests/qurl-send-revoke.smoke.test.ts
+++ b/e2e/tests/qurl-send-revoke.smoke.test.ts
@@ -1,18 +1,7 @@
 /**
- * Smoke contract for the post-revoke confirmation message format
- * (`/qurl send` → click Revoke → bot edits the ephemeral confirmation).
- *
- * Imports `renderRevokeContent` from `apps/discord/src/revoke-render.js`
- * — a pure-string module with no `discord.js` / store / config / logger
- * dependencies. Importing from `apps/discord/src/commands.js` directly
- * would drag in those transitive runtime deps and fail to load in the
- * smoke runner (which only installs `e2e/` deps; `apps/discord/
- * node_modules` isn't present in CI).
- *
- * The unit tests in apps/discord/tests/qurl-send-back-half.test.js
- * cover the same surface during the bot's own CI. This file's value
- * is at the post-deploy smoke layer — wording drift in the bot's
- * post-revoke message fails the smoke gate at deploy time.
+ * Wording-drift smoke for the post-revoke confirmation message.
+ * Imports the discord.js-free `revoke-render` module so the e2e
+ * runner can load it without `apps/discord/node_modules`.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -20,7 +9,7 @@ const { renderRevokeContent, REVOKE_TRUNC_LIMIT } = require('../../apps/discord/
 
 describe('qURL send revoke confirmation format (smoke)', () => {
   test('full-list format: "Revoked X/Y users" + "Revoked for: alice, bob"', () => {
-    const r = renderRevokeContent('send-1', ['alice', 'bob', 'carol'], 3, false);
+    const r = renderRevokeContent({ names: ['alice', 'bob', 'carol'], total: 3, showAll: false });
     expect(r.content).toMatch(/^Revoked 3\/3 users\./);
     expect(r.content).toContain('Revoked for: alice, bob, carol');
     expect(r.content).not.toMatch(/\+\d+ more/);
@@ -28,31 +17,31 @@ describe('qURL send revoke confirmation format (smoke)', () => {
 
   test(`truncated format: "+N more" when names exceed REVOKE_TRUNC_LIMIT (${REVOKE_TRUNC_LIMIT})`, () => {
     const names = Array.from({ length: REVOKE_TRUNC_LIMIT + 3 }, (_, i) => `u${i}`);
-    const r = renderRevokeContent('send-2', names, names.length, false);
+    const r = renderRevokeContent({ names, total: names.length, showAll: false });
     expect(r.content).toMatch(/\+3 more$/m);
     expect(r.needsExpand).toBe(true);
   });
 
   test('no-success format: "Revoked 0/N" omits "Revoked for:" line', () => {
-    const r = renderRevokeContent('send-3', [], 5, false);
+    const r = renderRevokeContent({ names: [], total: 5, showAll: false });
     expect(r.content).toMatch(/^Revoked 0\/5 users\./);
     expect(r.content).not.toContain('Revoked for:');
   });
 
   test('zero-attempt format: "Revoked 0/0" omits the already-opened note', () => {
-    const r = renderRevokeContent('send-4', [], 0, false);
+    const r = renderRevokeContent({ names: [], total: 0, showAll: false });
     expect(r.content).not.toContain('already-opened');
   });
 
   test('singular "user" when total === 1', () => {
-    const r = renderRevokeContent('send-5', ['alice'], 1, false);
+    const r = renderRevokeContent({ names: ['alice'], total: 1, showAll: false });
     expect(r.content).toMatch(/^Revoked 1\/1 user\./);
     expect(r.content).not.toMatch(/^Revoked 1\/1 users\./);
   });
 
   test('large lists overflow to file attachment instead of inline truncation', () => {
     const names = Array.from({ length: 200 }, (_, i) => `verylongusername${String(i).padStart(4, '0')}`);
-    const r = renderRevokeContent('send-6', names, names.length, true);
+    const r = renderRevokeContent({ names, total: names.length, showAll: true });
     expect(r.content.length).toBeLessThanOrEqual(2000);
     expect(r.content).toContain('(see attached)');
     expect(r.attachmentText).not.toBeNull();


### PR DESCRIPTION
## Summary

PR #198 added `e2e/tests/qurl-send-revoke.smoke.test.ts` to gate post-deploy on the post-revoke wording. It imported `apps/discord/src/commands.js` directly. After merge, the post-deploy smoke run on `4064e2f` failed:

```
FAIL tests/qurl-send-revoke.smoke.test.ts
  ● Test suite failed to run
    Cannot find module 'discord.js' from '../apps/discord/src/commands.js'
```

The e2e smoke runner installs only `e2e/` deps — `apps/discord/node_modules/discord.js` isn't present in CI, so `commands.js` fails to load when the smoke require()s it.

## Fix

Extract the pure-string wording layer into `apps/discord/src/revoke-render.js`:
- `renderRevokeContent(sendId, names, total, showAll, success)` — returns `{sendId, content, needsExpand, showAll, attachmentText}` (no discord.js components)
- `buildRevokeHeader`, `REVOKE_TRUNC_LIMIT`, `REVOKE_CONTENT_SAFE_MAX`

Only require is `./utils/sanitize` (also discord.js-free).

`commands.js`'s `renderRevokeMsg` is now a thin wrapper: calls `renderRevokeContent` for content + attachment, then builds the discord.js `ActionRowBuilder` Show All button from `needsExpand` / `showAll`. Existing bot-side unit tests against `_test.renderRevokeMsg` keep working.

The smoke test imports from `revoke-render` and loads cleanly under the e2e runner.

## Verification

- `apps/discord` — 934 tests + eslint --max-warnings 0 green
- `e2e` — smoke 6/6 pass locally without discord.js in node_modules
- Bot is already deployed (the merge run passed deploy; only the smoke gate failed). This PR restores the gate.

## Test plan
- [x] `cd apps/discord && npx jest --no-cache && npm run lint`
- [x] `cd e2e && npx jest --no-cache tests/qurl-send-revoke.smoke.test.ts`
- [ ] Post-merge: confirm `qurl-bot-discord: Build and Deploy` → `e2e-smoke / E2E Smoke Tests` reports success on the merge SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)