### PR TITLE
fix(discord): import REVOKE_CONTENT_SAFE_MAX in commands.js

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2570,6 +2570,7 @@ async function handleRevoke(interaction, apiKey) {
 // e2e smoke test can require it without pulling in `discord.js`.
 const {
   REVOKE_TRUNC_LIMIT,
+  REVOKE_CONTENT_SAFE_MAX,
   buildRevokeHeader,
   renderRevokeContent,
 } = require('./revoke-render');


### PR DESCRIPTION
## Summary

Hotfix for the broken post-merge build on PR #202 (\`d347566\`):

\`\`\`
apps/discord/src/commands.js:2624:77
error  'REVOKE_CONTENT_SAFE_MAX' is not defined  no-undef
\`\`\`

The constant has lived in \`./revoke-render\` (exported since #198), but the destructuring at \`commands.js:2571\` was missed when #202 added the new use site at line 2624. \`build-and-test\` failed → \`trigger-deploy\` skipped → no image in ECR → prod promote workflow's sandbox-status-check gate would refuse.

## Type of Change

- [x] Bug fix
- [ ] New feature

## Testing

- [x] \`npm run lint\` clean
- [x] \`npx jest --no-cache --testPathIgnorePatterns=e2e\` — 946 tests pass

## Why this is safe

- One-line addition to an existing destructure.
- The exported constant is what 3 test files have been asserting against since #198 — verified by grep.
- No behavior change.

## Follow-up

Once this merges and \`trigger-deploy\` is green, dispatch \`promote-bot-discord-to-prod.yml\` with the new merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)