### PR TITLE
chore(ci): page on main-branch CI failure + module-load smoke test

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -70,45 +70,45 @@ jobs:
         working-directory: apps/discord
         run: docker build -t discord-bot-test .
 
-  # Pages on post-merge CI failures so a stale-merge-ref bug (or any
-  # other class of regression that slipped past PR-time CI) surfaces
-  # immediately as an actionable issue, instead of staying silent
-  # behind a `trigger-deploy: skipped` like #202 did. The repo doesn't
-  # have a Slack webhook secret wired up, so we file a GitHub issue
-  # via the built-in token — same triaging surface, no secret deps.
+  # Pages on post-merge CI failures via Slack #all-layerv so a stale-
+  # merge-ref bug (or any other class of regression that slipped past
+  # PR-time CI) surfaces immediately, instead of staying silent behind
+  # a `trigger-deploy: skipped` like #202 did.
+  #
+  # Routes through SLACK_WEBHOOK_URL repo secret — the team already
+  # uses Slack for prod alerting and has no GitHub-issue alerting
+  # attached, so an issue would have been silent. Webhook posts to
+  # #all-layerv (the channel the secret is bound to).
   notify-on-main-failure:
     needs: [build-and-test, docker-check]
     if: failure() && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
-      - name: File regression-tracking issue
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+      - name: Notify #all-layerv on Slack
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          script: |
-            const sha = context.sha;
-            const shortSha = sha.slice(0, 7);
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const title = `CI regression: discord build-and-test failed on main (${shortSha})`;
-            const body = [
-              `**Workflow run**: ${runUrl}`,
-              `**Commit**: ${sha}`,
-              ``,
-              `\`build-and-test\` and/or \`docker-check\` failed on main after merge. Until this is fixed:`,
-              `- \`trigger-deploy\` was skipped → no new image pushed to ECR.`,
-              `- The discord bot in sandbox is running the prior image.`,
-              `- \`promote-bot-discord-to-prod.yml\` will refuse at the sandbox-status-check gate.`,
-              ``,
-              `Open a hotfix PR against this SHA. See [#204](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/204) for the pattern (the regression that motivated this guard).`,
-            ].join('\n');
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['ci-regression', 'discord'],
-            });
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":rotating_light: discord CI failed on main \u2014 `${{ github.sha }}`",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*:rotating_light: discord CI regression on main*\n`build-and-test` and/or `docker-check` failed after merge. `trigger-deploy` is *skipped* \u2192 no new image in ECR; sandbox bot is on the prior image; `promote-bot-discord-to-prod.yml` will refuse at the sandbox-status-check gate. Open a hotfix PR against this SHA. See <https://github.com/${{ github.repository }}/pull/204|#204> for the pattern."
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Commit*\n`${{ github.sha }}`" },
+                    { "type": "mrkdwn", "text": "*Run*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>" }
+                  ]
+                }
+              ]
+            }
 
   trigger-deploy:
     needs: [build-and-test, docker-check]

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -70,6 +70,46 @@ jobs:
         working-directory: apps/discord
         run: docker build -t discord-bot-test .
 
+  # Pages on post-merge CI failures so a stale-merge-ref bug (or any
+  # other class of regression that slipped past PR-time CI) surfaces
+  # immediately as an actionable issue, instead of staying silent
+  # behind a `trigger-deploy: skipped` like #202 did. The repo doesn't
+  # have a Slack webhook secret wired up, so we file a GitHub issue
+  # via the built-in token — same triaging surface, no secret deps.
+  notify-on-main-failure:
+    needs: [build-and-test, docker-check]
+    if: failure() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File regression-tracking issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const sha = context.sha;
+            const shortSha = sha.slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = `CI regression: discord build-and-test failed on main (${shortSha})`;
+            const body = [
+              `**Workflow run**: ${runUrl}`,
+              `**Commit**: ${sha}`,
+              ``,
+              `\`build-and-test\` and/or \`docker-check\` failed on main after merge. Until this is fixed:`,
+              `- \`trigger-deploy\` was skipped → no new image pushed to ECR.`,
+              `- The discord bot in sandbox is running the prior image.`,
+              `- \`promote-bot-discord-to-prod.yml\` will refuse at the sandbox-status-check gate.`,
+              ``,
+              `Open a hotfix PR against this SHA. See [#204](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/204) for the pattern (the regression that motivated this guard).`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['ci-regression', 'discord'],
+            });
+
   trigger-deploy:
     needs: [build-and-test, docker-check]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/apps/discord/tests/module-load.test.js
+++ b/apps/discord/tests/module-load.test.js
@@ -1,0 +1,21 @@
+// Module-load smoke test — fails fast if any source module has an
+// undefined identifier (no-undef) or a missing require/import. ESLint's
+// `no-undef` rule covers most cases statically, but a CI run on a
+// stale merge-ref can pass lint while the actually-merged code fails
+// (see #204 / #202 for the regression that motivated this). Loading
+// the modules at jest time gives us a runtime cross-check that
+// doesn't depend on ESLint having seen the post-merge state.
+
+describe('module load smoke', () => {
+  // Discord-side require()s are heavy (discord.js, jose, AWS SDK) but
+  // jest already imports a similar surface via the existing test files,
+  // so the marginal cost here is negligible.
+  test.each([
+    ['../src/commands'],
+    ['../src/qurl'],
+    ['../src/connector'],
+    ['../src/revoke-render'],
+  ])('%s loads without ReferenceError', (modulePath) => {
+    expect(() => require(modulePath)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Implements items #2 and #3 from the post-mortem comment on #204 — defense-in-depth for the stale-merge-ref regression class.

Item #1 from that comment ("Require branches to be up to date before merging" branch protection) is the actual root-cause fix and is a repo-settings flip — needs admin action separately.

## Changes

### 1. \`notify-on-main-failure\` job in \`.github/workflows/discord.yml\`

- Runs **only** when \`build-and-test\` or \`docker-check\` fail AND we're on \`main\` from a push event. PR runs are out of scope (PR author already sees their own red checks).
- Posts to Slack **#all-layerv** via \`slackapi/slack-github-action\` with the \`SLACK_WEBHOOK_URL\` repo secret. Block-Kit payload includes commit SHA, run URL, and a hotfix-pattern pointer to #204.
- Slack-not-issue because the team has no alerting attached to GitHub issues — an issue would sit unread. Slack to #all-layerv is the canonical alert channel for this class of regression.

**Pre-merge action item**: ensure the \`SLACK_WEBHOOK_URL\` secret on \`layervai/qurl-integrations\` repo points at the #all-layerv incoming webhook. (If the secret doesn't exist, the step posts nothing — a silent no-op rather than a CI failure, but defeats the purpose.)

### 2. \`apps/discord/tests/module-load.test.js\`

- 4-row \`test.each\` — each of \`commands.js\`, \`qurl.js\`, \`connector.js\`, \`revoke-render.js\` must load without \`ReferenceError\`.
- ESLint's \`no-undef\` rule covers most cases statically, but a CI run on a stale merge-ref can pass lint while the actually-merged code fails — the runtime require gives an independent cross-check that doesn't depend on ESLint having seen the post-merge state.

## Type of Change

- [ ] Bug fix
- [x] CI/CD improvement
- [ ] New feature

## Testing

- [x] \`npm run lint\` clean
- [x] \`npx jest --no-cache --testPathIgnorePatterns=e2e\` — 950 tests pass (was 946, +4 from \`module-load.test.js\`)
- [x] Workflow YAML validated with \`yaml.safe_load\`

## Why this is safe

- Workflow change is additive — new job depends on \`[build-and-test, docker-check]\` and the existing \`trigger-deploy\` job's behavior is untouched.
- New job only fires on \`failure() && main && push\` — a green run won't open noise issues.
- Test file is read-only — uses \`require()\`, doesn't run any side-effecting code beyond what's already in module-init.

## Out of scope

- Branch protection ("Require branches to be up to date before merging") — repo-admin setting flip. The actual root-cause fix; this PR is belt-and-suspenders.
- Slack notification — needs \`SLACK_WEBHOOK_URL\` secret on the repo first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
