### PR TITLE
feat(discord): auto-recover from zombie WebSocket

### DIFF
--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -4916,9 +4916,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -4927,7 +4927,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -8591,6 +8592,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -174,6 +174,14 @@ const AUDIT_EVENTS = {
   // ack_age_ms < 60000). Missing emissions = wedge.
   GATEWAY_HEARTBEAT: 'gateway_heartbeat_healthy',
 
+  // Negative-signal heartbeat. Emitted every 30 s when the composite
+  // readiness check FAILS — pairs with the healthy event so the
+  // unhealthy snapshot is observable as a metric (carries activity_age_ms
+  // unbounded, where the healthy emission caps at <60s by definition).
+  // The 5/8 zombie-WS incident showed an alarm on Max(activity_age_ms)
+  // is the right shape; that needs unhealthy emissions to fire on.
+  GATEWAY_HEARTBEAT_UNHEALTHY: 'gateway_heartbeat_unhealthy',
+
   // Bot added/removed from a guild. Single emission on the
   // guildCreate / guildDelete event. `guild_id` is in the payload
   // for log-grep / forensic queries; it MUST NOT be promoted to a

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -250,6 +250,20 @@ function startGatewayHeartbeat(client, opts = {}) {
           ack_age_ms: snapshot.ack_age_ms,
           activity_age_ms: snapshot.activity_age_ms,
         });
+      } else {
+        // Pair-event for the healthy heartbeat so activity_age_ms is
+        // observable as a metric on EVERY tick. Without this, the
+        // healthy emission caps activity_age_ms at <60s by definition
+        // and a Max(activity_age_ms) > 60s alarm would never fire — yet
+        // 60s+ is exactly the zombie-WS signal we need to alarm on
+        // (5/8 incident). null-safe payload: ack_age_ms is null pre-
+        // first-ack, ping_ms is -1 pre-first-ws.
+        logger.audit(AUDIT_EVENTS.GATEWAY_HEARTBEAT_UNHEALTHY, {
+          ping_ms: snapshot.ping_ms,
+          ack_age_ms: snapshot.ack_age_ms,
+          activity_age_ms: snapshot.activity_age_ms,
+          is_ready: snapshot.is_ready,
+        });
       }
       // Edge-triggered logs so on-call can distinguish "wedged for
       // 5 min" (one warn at t=0, then silence on the metric side) from

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -116,15 +116,25 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
     return { triggered: false, reason: 'cooldown' };
   }
 
-  // Per-shard destroy so a future multi-shard config (TODO at L107)
-  // only resets the wedged shard. discord.js shard.destroy is async
-  // and only re-IDENTIFYs when `recover` is set — without it, the
-  // shard transitions to Idle and stays there. `code` (NOT closeCode
-  // — different field name) 4000 = re-establishable. Fire-and-catch:
+  // Per-shard destroy so a future multi-shard config (see the
+  // multi-shard TODO in readGatewayHealth above) only resets the
+  // wedged shard. discord.js shard.destroy is async and only
+  // re-IDENTIFYs when `recover` is set — without it, the shard
+  // transitions to Idle and stays there. `code` (NOT closeCode —
+  // different field name) 4000 = re-establishable. Fire-and-catch:
   // tick() is sync but destroy awaits internals (updateSessionInfo,
   // ws onclose race, internalConnect). Letting that promise reject
   // would surface as an unhandledRejection that crashes the process
   // on Node 16+.
+  //
+  // Cooldown choice: stamped optimistically as soon as destroy() is
+  // dispatched (line below), NOT on resolved-success. Rationale: if
+  // every shard's destroy rejects asynchronously, we'd be locked out
+  // for 10 min — but the bot is still emitting unhealthy heartbeats,
+  // and the activity_age_ms alarm (qurl-integrations-infra #446)
+  // will page on-call within ~2 min. Async rejections are rare and
+  // operator-handled; the optimistic stamp prevents a reconnect
+  // storm in the common case where destroy() succeeds.
   let shardsTerminated = 0;
   if (client.ws?.shards && typeof client.ws.shards.values === 'function') {
     for (const shard of client.ws.shards.values()) {

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -16,6 +16,7 @@
  * window: alarm fires after 60 s of missing heartbeats. Client-side
  * threshold one heartbeat-interval (~41 s) plus one buffer cycle.
  */
+const { WebSocketShardDestroyRecovery } = require('discord.js');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
 
@@ -116,27 +117,47 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
   }
 
   // Per-shard destroy so a future multi-shard config (TODO at L107)
-  // only resets the wedged shard. discord.js v14 WebSocketShard.destroy
-  // closes the underlying ws, marks the shard for re-IDENTIFY, and
-  // the WebSocketManager runs the reconnect loop automatically.
+  // only resets the wedged shard. discord.js shard.destroy is async
+  // and only re-IDENTIFYs when `recover` is set — without it, the
+  // shard transitions to Idle and stays there. `code` (NOT closeCode
+  // — different field name) 4000 = re-establishable. Fire-and-catch:
+  // tick() is sync but destroy awaits internals (updateSessionInfo,
+  // ws onclose race, internalConnect). Letting that promise reject
+  // would surface as an unhandledRejection that crashes the process
+  // on Node 16+.
   let shardsTerminated = 0;
   if (client.ws?.shards && typeof client.ws.shards.values === 'function') {
     for (const shard of client.ws.shards.values()) {
+      if (typeof shard?.destroy !== 'function') continue;
       try {
-        if (typeof shard?.destroy === 'function') {
-          // closeCode 4000 = re-establishable. Reason string surfaces
-          // in CloudWatch via the manager's reconnect logs.
-          shard.destroy({ closeCode: 4000, reason: 'auto-recovery: zombie ws (activity stale)' });
-          shardsTerminated++;
+        const result = shard.destroy({
+          code: 4000,
+          reason: 'auto-recovery: zombie ws (activity stale)',
+          recover: WebSocketShardDestroyRecovery.Reconnect,
+        });
+        if (result && typeof result.catch === 'function') {
+          result.catch((err) => {
+            logger.warn('Shard destroy promise rejected during auto-recovery', { error: err?.message });
+          });
         }
+        shardsTerminated++;
       } catch (err) {
-        // A throw here means the shard's already torn down (race with
-        // an in-flight disconnect) — log and keep going. Don't gate
-        // the cooldown reset on success; we still consumed the
-        // recovery budget.
-        logger.warn('Shard destroy threw during auto-recovery', { error: err?.message });
+        // Sync throw = bad-args / TypeError before the async body
+        // runs. Already-Idle shards return synchronously without
+        // throwing, so this branch is for genuinely unexpected
+        // shapes; log and keep going so a single broken shard
+        // doesn't block the others.
+        logger.warn('Shard destroy threw synchronously during auto-recovery', { error: err?.message });
       }
     }
+  }
+
+  // Only stamp the cooldown when something actually got terminated.
+  // If client.ws.shards is missing/empty (rare — would mean is_ready
+  // is true while no shards exist, contradiction in steady state),
+  // retry on the next tick rather than locking out for 10 min.
+  if (shardsTerminated === 0) {
+    return { triggered: false, reason: 'no_shards' };
   }
   lastRecoveryAttemptAt = t;
   return { triggered: true, reason: 'zombie_ws', shardsTerminated };

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -169,6 +169,12 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
   if (shardsTerminated === 0) {
     return { triggered: false, reason: 'no_shards' };
   }
+  // TODO(multi-shard): pairs with the multi-shard TODO in
+  // readGatewayHealth above. When sharding flips on, the actually-
+  // wedged shard could be the one that sync-throws while a healthy
+  // shard's destroy succeeds — locking recovery out for 10 min while
+  // the stuck shard stays stuck. Move to a per-shard cooldown map
+  // (lastRecoveryAttemptAt[shardId]) at that point.
   lastRecoveryAttemptAt = t;
   return { triggered: true, reason: 'zombie_ws', shardsTerminated };
 }

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -2,19 +2,24 @@
  * Periodic gateway-side metric emitters for Phase 1 monitoring.
  *
  * Two timers, both run on the gateway-only ECS task:
- *   1. Positive-signal heartbeat (30 s) — emits gateway_heartbeat_healthy
- *      when discord.js reports a connected, ack'd, recently-active
- *      WebSocket. Missing emissions are the alarm condition (paired
- *      with treat_missing_data = breaching at the alarm side), which
- *      catches the wedge classes client.isReady() alone misses:
- *      heartbeat-zombie, dispatch-deadlock, event-loop saturation.
+ *   1. Heartbeat (30 s) — dual-emission. Healthy ticks emit
+ *      gateway_heartbeat_healthy (paired with the missing-data
+ *      `gateway_heartbeat_silence` alarm); unhealthy ticks emit
+ *      gateway_heartbeat_unhealthy carrying activity_age_ms (paired
+ *      with the Max-on-value `gateway_activity_age_ms_high` alarm in
+ *      qurl-integrations-infra #446). Two metrics catch two failure
+ *      shapes: total silence (process-level wedge) vs. flapping
+ *      dispatch wedge (5/8 zombie-WS — heartbeat-ACKs land but event
+ *      frames don't, so silence alarm misses it).
  *   2. Active-guild gauge (60 s) — emits active_guild_count carrying
  *      client.guilds.cache.size. Used for install/uninstall trend
  *      detection and as a sanity check on guild-scoped features.
  *
  * Composite readiness threshold (60 s ack age) lines up with the alarm
- * window: alarm fires after 60 s of missing heartbeats. Client-side
- * threshold one heartbeat-interval (~41 s) plus one buffer cycle.
+ * window: silence alarm fires after 60 s of missing heartbeats.
+ * Client-side threshold one heartbeat-interval (~41 s) plus one
+ * buffer cycle. Unhealthy ticks ALSO trigger auto-recovery via
+ * maybeAutoRecoverZombieWS at activity_age_ms > 120 s.
  */
 const { WebSocketShardDestroyRecovery } = require('discord.js');
 const logger = require('./logger');
@@ -257,13 +262,16 @@ function readGatewayHealth(client, now = Date.now) {
 }
 
 /**
- * Start the positive-signal heartbeat timer. Returns the timer handle
- * so callers (gracefulShutdown) can clear it.
+ * Start the heartbeat timer. Returns the timer handle so callers
+ * (gracefulShutdown) can clear it.
  *
- * Only emits on the healthy path — silence is the alarm condition.
- * Emitting an "unhealthy" event would create a second metric the
- * operator would have to remember to watch; the missing-data trick
- * collapses that into one alarm.
+ * Dual-emission: healthy ticks emit gateway_heartbeat_healthy (paired
+ * with the silence/missing-data alarm — one shape of wedge: total
+ * silence). Unhealthy ticks emit gateway_heartbeat_unhealthy carrying
+ * activity_age_ms (paired with the Max-on-value alarm — second shape
+ * of wedge: flapping dispatch where intermittent healthy ticks keep
+ * the silence alarm quiet). Unhealthy ticks also trigger
+ * maybeAutoRecoverZombieWS for self-heal at activity_age_ms > 120 s.
  *
  * @param {import('discord.js').Client} client
  * @param {{ intervalMs?: number, now?: () => number }} [opts]

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -108,7 +108,7 @@ function _resetRecoveryClock() {
  *    re-IDENTIFYs cleanly. Per-shard so a future multi-shard config
  *    only restarts the wedged shard, not the whole client.
  *
- * @returns {{ triggered: boolean, reason: string }}
+ * @returns {{ triggered: boolean, reason: string, shardsTerminated?: number }}
  */
 function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
   if (!snapshot.is_ready) return { triggered: false, reason: 'not_ready' };
@@ -271,7 +271,7 @@ function readGatewayHealth(client, now = Date.now) {
  * activity_age_ms (paired with the Max-on-value alarm — second shape
  * of wedge: flapping dispatch where intermittent healthy ticks keep
  * the silence alarm quiet). Unhealthy ticks also trigger
- * maybeAutoRecoverZombieWS for self-heal at activity_age_ms > 120 s.
+ * maybeAutoRecoverZombieWS for self-heal at activity_age_ms >= 120 s.
  *
  * @param {import('discord.js').Client} client
  * @param {{ intervalMs?: number, now?: () => number }} [opts]

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -41,7 +41,14 @@ const HEARTBEAT_ACK_AGE_THRESHOLD_MS = 60_000;
 // storm if termination doesn't immediately restore activity.
 const RECOVERY_ACTIVITY_THRESHOLD_MS = 120_000;
 const RECOVERY_COOLDOWN_MS = 10 * 60_000;
+// Short cooldown stamped only when every shard's destroy() sync-threw
+// (every call rejected before the async body ran — pathological, e.g.
+// an @discordjs/ws bump that breaks the option shape). Bounds warn-log
+// volume in CloudWatch Logs without locking recovery out for the full
+// 10 min; activity-age alarm pages on-call regardless.
+const RECOVERY_RATE_LIMIT_COOLDOWN_MS = 60_000;
 let lastRecoveryAttemptAt = 0;
+let lastRecoveryRateLimitAt = 0;
 
 // Composite-readiness gateway-activity signal. client.isReady() alone
 // misses event-loop wedges (DB pool exhaustion, qurl-service stalls,
@@ -93,6 +100,7 @@ function _resetGatewayActivity() {
  */
 function _resetRecoveryClock() {
   lastRecoveryAttemptAt = 0;
+  lastRecoveryRateLimitAt = 0;
 }
 
 /**
@@ -120,6 +128,9 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
   if (t - lastRecoveryAttemptAt < RECOVERY_COOLDOWN_MS) {
     return { triggered: false, reason: 'cooldown' };
   }
+  if (t - lastRecoveryRateLimitAt < RECOVERY_RATE_LIMIT_COOLDOWN_MS) {
+    return { triggered: false, reason: 'cooldown' };
+  }
 
   // Per-shard destroy so a future multi-shard config (see the
   // multi-shard TODO in readGatewayHealth above) only resets the
@@ -140,10 +151,12 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
   // will page on-call within ~2 min. Async rejections are rare and
   // operator-handled; the optimistic stamp prevents a reconnect
   // storm in the common case where destroy() succeeds.
+  let shardsAttempted = 0;
   let shardsTerminated = 0;
   if (client.ws?.shards && typeof client.ws.shards.values === 'function') {
     for (const shard of client.ws.shards.values()) {
       if (typeof shard?.destroy !== 'function') continue;
+      shardsAttempted++;
       try {
         const result = shard.destroy({
           code: 4000,
@@ -167,12 +180,20 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
     }
   }
 
-  // Only stamp the cooldown when something actually got terminated.
-  // If client.ws.shards is missing/empty (rare — would mean is_ready
-  // is true while no shards exist, contradiction in steady state),
-  // retry on the next tick rather than locking out for 10 min.
-  if (shardsTerminated === 0) {
+  // Two distinct empty-result branches:
+  //   - shardsAttempted === 0: client.ws.shards missing/empty. Pathological
+  //     in steady state (is_ready=true contradicts no shards); retry on
+  //     the next tick without consuming any cooldown.
+  //   - shardsAttempted > 0 && shardsTerminated === 0: shards exist but
+  //     every destroy() sync-threw. Stamp the short rate-limit cooldown
+  //     so the warn-log volume is bounded; recovery still retries inside
+  //     the 10-min main cooldown window.
+  if (shardsAttempted === 0) {
     return { triggered: false, reason: 'no_shards' };
+  }
+  if (shardsTerminated === 0) {
+    lastRecoveryRateLimitAt = t;
+    return { triggered: false, reason: 'all_destroys_threw' };
   }
   // TODO(multi-shard): pairs with the multi-shard TODO in
   // readGatewayHealth above. When sharding flips on, the actually-
@@ -181,6 +202,15 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
   // the stuck shard stays stuck. Move to a per-shard cooldown map
   // (lastRecoveryAttemptAt[shardId]) at that point.
   lastRecoveryAttemptAt = t;
+  // Reset the activity baseline so subsequent ticks read
+  // `activity_age_ms: null` until the reconnected WebSocket's first
+  // raw frame re-baselines via noteGatewayActivity(). Without this,
+  // a tick between is_ready flipping back to true and the first
+  // post-reconnect frame would observe the pre-destroy stale value
+  // still climbing — harmless under the 10 min main cooldown today,
+  // but a flap source if cooldown ever shrinks (e.g. per-shard
+  // cooldown for the multi-shard TODO above).
+  _resetGatewayActivity();
   return { triggered: true, reason: 'zombie_ws', shardsTerminated };
 }
 
@@ -424,6 +454,7 @@ module.exports = {
   GATEWAY_ACTIVITY_THRESHOLD_MS,
   RECOVERY_ACTIVITY_THRESHOLD_MS,
   RECOVERY_COOLDOWN_MS,
+  RECOVERY_RATE_LIMIT_COOLDOWN_MS,
   // Test-only exports (NODE_ENV-gated to keep live state out of prod
   // consumers, mirroring the commands.js _test pattern).
   // _test gated on NODE_ENV === 'test' (NOT !== 'production') so

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -23,6 +23,20 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 const ACTIVE_GUILD_INTERVAL_MS = 60_000;
 const HEARTBEAT_ACK_AGE_THRESHOLD_MS = 60_000;
 
+// Auto-recovery thresholds for the zombie-WS pattern observed
+// 2026-05-08 (sandbox + prod): bot's `activity_age_ms` climbed past
+// 60s while heartbeat ACKs kept landing — Discord stopped pushing
+// events but discord.js didn't detect the dead session. Both bots
+// hit it simultaneously when their gateway pod blipped. Fix: when
+// activity is stale past `RECOVERY_ACTIVITY_THRESHOLD_MS` AND the
+// client thinks it's ready (so this isn't a normal boot/disconnect
+// flap), terminate every shard's WebSocket so the manager
+// reconnects fresh. `RECOVERY_COOLDOWN_MS` prevents a reconnect
+// storm if termination doesn't immediately restore activity.
+const RECOVERY_ACTIVITY_THRESHOLD_MS = 120_000;
+const RECOVERY_COOLDOWN_MS = 10 * 60_000;
+let lastRecoveryAttemptAt = 0;
+
 // Composite-readiness gateway-activity signal. client.isReady() alone
 // misses event-loop wedges (DB pool exhaustion, qurl-service stalls,
 // Auth0 refresh hangs) — the WebSocket stays connected but the raw
@@ -66,6 +80,66 @@ function noteGatewayActivity(maybeNow) {
  */
 function _resetGatewayActivity() {
   lastGatewayActivityAt = 0;
+}
+
+/**
+ * Test-only reset for the recovery cooldown clock.
+ */
+function _resetRecoveryClock() {
+  lastRecoveryAttemptAt = 0;
+}
+
+/**
+ * Detect the zombie-WS pattern (heartbeats land but Discord events
+ * don't) and force a fresh session. Returns the action taken so
+ * callers can log + test the decision.
+ *
+ * Decision tree:
+ *  - is_ready=false → boot/reconnect already in flight, skip
+ *  - activity_age_ms < RECOVERY_ACTIVITY_THRESHOLD_MS → not zombie
+ *  - within RECOVERY_COOLDOWN_MS of last attempt → debounce
+ *  - else → terminate every shard via shard.destroy() so the manager
+ *    re-IDENTIFYs cleanly. Per-shard so a future multi-shard config
+ *    only restarts the wedged shard, not the whole client.
+ *
+ * @returns {{ triggered: boolean, reason: string }}
+ */
+function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
+  if (!snapshot.is_ready) return { triggered: false, reason: 'not_ready' };
+  if (snapshot.activity_age_ms === null) return { triggered: false, reason: 'no_activity_baseline' };
+  if (snapshot.activity_age_ms < RECOVERY_ACTIVITY_THRESHOLD_MS) {
+    return { triggered: false, reason: 'within_threshold' };
+  }
+  const t = now();
+  if (t - lastRecoveryAttemptAt < RECOVERY_COOLDOWN_MS) {
+    return { triggered: false, reason: 'cooldown' };
+  }
+
+  // Per-shard destroy so a future multi-shard config (TODO at L107)
+  // only resets the wedged shard. discord.js v14 WebSocketShard.destroy
+  // closes the underlying ws, marks the shard for re-IDENTIFY, and
+  // the WebSocketManager runs the reconnect loop automatically.
+  let shardsTerminated = 0;
+  if (client.ws?.shards && typeof client.ws.shards.values === 'function') {
+    for (const shard of client.ws.shards.values()) {
+      try {
+        if (typeof shard?.destroy === 'function') {
+          // closeCode 4000 = re-establishable. Reason string surfaces
+          // in CloudWatch via the manager's reconnect logs.
+          shard.destroy({ closeCode: 4000, reason: 'auto-recovery: zombie ws (activity stale)' });
+          shardsTerminated++;
+        }
+      } catch (err) {
+        // A throw here means the shard's already torn down (race with
+        // an in-flight disconnect) — log and keep going. Don't gate
+        // the cooldown reset on success; we still consumed the
+        // recovery budget.
+        logger.warn('Shard destroy threw during auto-recovery', { error: err?.message });
+      }
+    }
+  }
+  lastRecoveryAttemptAt = t;
+  return { triggered: true, reason: 'zombie_ws', shardsTerminated };
 }
 
 /**
@@ -187,7 +261,22 @@ function startGatewayHeartbeat(client, opts = {}) {
           ack_age_ms: snapshot.ack_age_ms,
           activity_age_ms: snapshot.activity_age_ms,
         });
-      } else if (prevHealthy === false && snapshot.healthy) {
+      }
+      // Zombie-WS recovery runs on every unhealthy tick (not just
+      // the edge) — debounced by RECOVERY_COOLDOWN_MS internally.
+      // Edge-only would miss the case where the bot was already
+      // unhealthy at boot and stayed there.
+      if (!snapshot.healthy) {
+        const recovery = maybeAutoRecoverZombieWS(client, snapshot, now);
+        if (recovery.triggered) {
+          logger.warn('Gateway auto-recovery: forcing reconnect (zombie WS)', {
+            activity_age_ms: snapshot.activity_age_ms,
+            ack_age_ms: snapshot.ack_age_ms,
+            shards_terminated: recovery.shardsTerminated,
+          });
+        }
+      }
+      if (prevHealthy === false && snapshot.healthy) {
         logger.info('Gateway heartbeat: unhealthy → healthy', {
           ping_ms: snapshot.ping_ms,
           ack_age_ms: snapshot.ack_age_ms,
@@ -269,10 +358,13 @@ module.exports = {
   startActiveGuildCount,
   readGatewayHealth,
   noteGatewayActivity,
+  maybeAutoRecoverZombieWS,
   HEARTBEAT_INTERVAL_MS,
   ACTIVE_GUILD_INTERVAL_MS,
   HEARTBEAT_ACK_AGE_THRESHOLD_MS,
   GATEWAY_ACTIVITY_THRESHOLD_MS,
+  RECOVERY_ACTIVITY_THRESHOLD_MS,
+  RECOVERY_COOLDOWN_MS,
   // Test-only exports (NODE_ENV-gated to keep live state out of prod
   // consumers, mirroring the commands.js _test pattern).
   // _test gated on NODE_ENV === 'test' (NOT !== 'production') so
@@ -281,6 +373,6 @@ module.exports = {
   // local-dev workflows need access, set NODE_ENV=test for that
   // shell.
   ...(process.env.NODE_ENV === 'test' && {
-    _test: { _resetGatewayActivity },
+    _test: { _resetGatewayActivity, _resetRecoveryClock },
   }),
 };

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -12,6 +12,9 @@ const {
   startActiveGuildCount,
   readGatewayHealth,
   noteGatewayActivity,
+  maybeAutoRecoverZombieWS,
+  RECOVERY_ACTIVITY_THRESHOLD_MS,
+  RECOVERY_COOLDOWN_MS,
   _test: gatewayMetricsTest,
 } = require('../src/gateway-metrics');
 const { AUDIT_EVENTS } = require('../src/constants');
@@ -370,5 +373,148 @@ describe('startActiveGuildCount', () => {
     jest.advanceTimersByTime(1_000);
     expect(logger.audit).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
+  });
+});
+
+describe('maybeAutoRecoverZombieWS', () => {
+  function shardClient({ destroyImpl } = {}) {
+    const shard = { destroy: destroyImpl ?? jest.fn() };
+    return {
+      client: { ws: { shards: new Map([[0, shard]]) } },
+      shard,
+    };
+  }
+
+  beforeEach(() => {
+    if (gatewayMetricsTest && typeof gatewayMetricsTest._resetRecoveryClock === 'function') {
+      gatewayMetricsTest._resetRecoveryClock();
+    }
+    jest.clearAllMocks();
+  });
+
+  test('skips when client is not ready (boot/reconnect already running)', () => {
+    const { client, shard } = shardClient();
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: false, activity_age_ms: 999_999 },
+    );
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('not_ready');
+    expect(shard.destroy).not.toHaveBeenCalled();
+  });
+
+  test('skips when activity baseline is null (pre-first-frame)', () => {
+    const { client, shard } = shardClient();
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: null },
+    );
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('no_activity_baseline');
+    expect(shard.destroy).not.toHaveBeenCalled();
+  });
+
+  test('skips when activity is below threshold', () => {
+    const { client, shard } = shardClient();
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS - 1 },
+    );
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('within_threshold');
+    expect(shard.destroy).not.toHaveBeenCalled();
+  });
+
+  test('triggers shard.destroy when activity is past threshold', () => {
+    const { client, shard } = shardClient();
+    const t = 1_000_000;
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.reason).toBe('zombie_ws');
+    expect(result.shardsTerminated).toBe(1);
+    expect(shard.destroy).toHaveBeenCalledWith(
+      expect.objectContaining({ closeCode: 4000 }),
+    );
+  });
+
+  test('debounces a second attempt inside the cooldown window', () => {
+    const { client, shard } = shardClient();
+    const t0 = 1_000_000;
+    const first = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t0,
+    );
+    expect(first.triggered).toBe(true);
+    shard.destroy.mockClear();
+
+    const second = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 5_000 },
+      () => t0 + RECOVERY_COOLDOWN_MS - 1,
+    );
+    expect(second.triggered).toBe(false);
+    expect(second.reason).toBe('cooldown');
+    expect(shard.destroy).not.toHaveBeenCalled();
+  });
+
+  test('allows a second attempt after the cooldown elapses', () => {
+    const { client, shard } = shardClient();
+    const t0 = 1_000_000;
+    maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t0,
+    );
+    shard.destroy.mockClear();
+
+    const second = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t0 + RECOVERY_COOLDOWN_MS + 1,
+    );
+    expect(second.triggered).toBe(true);
+    expect(shard.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('logs warn but still consumes recovery budget when shard.destroy throws', () => {
+    const { client, shard } = shardClient({
+      destroyImpl: jest.fn(() => { throw new Error('already destroyed'); }),
+    });
+    const t = 1_000_000;
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.shardsTerminated).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Shard destroy threw during auto-recovery',
+      expect.objectContaining({ error: 'already destroyed' }),
+    );
+    // Cooldown still consumed — the next call inside the window debounces.
+    const second = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t + 1_000,
+    );
+    expect(second.triggered).toBe(false);
+    expect(second.reason).toBe('cooldown');
+  });
+
+  test('safely no-ops when client.ws.shards is missing', () => {
+    const t = 1_000_000;
+    const result = maybeAutoRecoverZombieWS(
+      { ws: {} },
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.shardsTerminated).toBe(0);
   });
 });

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -16,6 +16,7 @@ const {
   maybeAutoRecoverZombieWS,
   RECOVERY_ACTIVITY_THRESHOLD_MS,
   RECOVERY_COOLDOWN_MS,
+  RECOVERY_RATE_LIMIT_COOLDOWN_MS,
   _test: gatewayMetricsTest,
 } = require('../src/gateway-metrics');
 const { AUDIT_EVENTS } = require('../src/constants');
@@ -553,7 +554,7 @@ describe('maybeAutoRecoverZombieWS', () => {
     expect(shard.destroy).toHaveBeenCalledTimes(1);
   });
 
-  test('catches sync throw from shard.destroy and keeps going', () => {
+  test('all shards sync-throw → all_destroys_threw + short rate-limit cooldown', () => {
     const { client, shard } = shardClient({
       destroyImpl: jest.fn(() => { throw new Error('bad-args'); }),
     });
@@ -563,23 +564,82 @@ describe('maybeAutoRecoverZombieWS', () => {
       { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
       () => t,
     );
-    // Sync throw => shardsTerminated stays 0 => returns no_shards
-    // and DOES NOT consume the cooldown. The next tick retries.
+    // Shards exist, every destroy() sync-threw — distinct from
+    // the empty/missing-shards branch (which retries next tick).
     expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('no_shards');
+    expect(result.reason).toBe('all_destroys_threw');
     expect(logger.warn).toHaveBeenCalledWith(
       'Shard destroy threw synchronously during auto-recovery',
       expect.objectContaining({ error: 'bad-args' }),
     );
     expect(shard.destroy).toHaveBeenCalled();
 
-    // Confirm cooldown was NOT stamped — second call same tick can fire.
+    // Within the rate-limit cooldown window, recovery is gated to
+    // bound warn-log volume — the warn block doesn't re-fire.
     const second = maybeAutoRecoverZombieWS(
       client,
       { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
       () => t + 1_000,
     );
-    expect(second.reason).toBe('no_shards'); // still failing the same way
+    expect(second.reason).toBe('cooldown');
+  });
+
+  test('all_destroys_threw rate-limit cooldown elapses → recovery retries', () => {
+    const { client, shard } = shardClient({
+      destroyImpl: jest.fn(() => { throw new Error('bad-args'); }),
+    });
+    const t0 = 1_000_000;
+    maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t0,
+    );
+    shard.destroy.mockClear();
+
+    // Past the rate-limit cooldown but still inside the 10-min main
+    // cooldown — recovery should retry (the main cooldown is only
+    // stamped on successful termination, which never happened here).
+    const second = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t0 + RECOVERY_RATE_LIMIT_COOLDOWN_MS + 1,
+    );
+    expect(second.reason).toBe('all_destroys_threw');
+    expect(shard.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('successful recovery resets activity baseline (next snapshot reads null until first post-reconnect frame)', () => {
+    const { client } = shardClient({
+      destroyImpl: jest.fn(),
+    });
+    const t = 2_000_000;
+    // Pre-condition: activity baseline is set (the beforeEach
+    // noteGatewayActivity() seeded it). Confirm a snapshot has a
+    // numeric activity_age_ms before we trigger recovery.
+    const preSnap = readGatewayHealth(client);
+    expect(typeof preSnap.activity_age_ms).toBe('number');
+
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    expect(result.triggered).toBe(true);
+
+    // After successful destroy, the baseline is cleared. A snapshot
+    // taken before the new WebSocket's first raw frame reports null
+    // — readGatewayHealth treats lastGatewayActivityAt === 0 as the
+    // pre-first-frame sentinel. This prevents a tick between
+    // is_ready flipping back true and the first post-reconnect raw
+    // frame from observing the pre-destroy stale value still climbing.
+    const postSnap = readGatewayHealth(client);
+    expect(postSnap.activity_age_ms).toBeNull();
+
+    // First post-reconnect raw frame re-baselines.
+    noteGatewayActivity();
+    const postNoteSnap = readGatewayHealth(client);
+    expect(typeof postNoteSnap.activity_age_ms).toBe('number');
+    expect(postNoteSnap.activity_age_ms).toBeLessThan(1_000);
   });
 
   test('handles destroy() promise rejection without crashing the process', async () => {

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -198,8 +198,14 @@ describe('startGatewayHeartbeat', () => {
     // then advanceTimersByTime drifts the fake clock — Math.max(0,…)
     // papers over the negative diff so tests pass, but the activity
     // gate isn't actually being exercised in these tests.
+    //
+    // Reset the recovery cooldown too: a previous test in this block
+    // may have stamped lastRecoveryAttemptAt, which would silently
+    // make a downstream test that expects a triggered recovery
+    // pass-as-cooldown'd instead.
     if (gatewayMetricsTest && typeof gatewayMetricsTest._resetGatewayActivity === 'function') {
       gatewayMetricsTest._resetGatewayActivity();
+      gatewayMetricsTest._resetRecoveryClock();
     }
     noteGatewayActivity();
   });

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -401,8 +401,11 @@ describe('startActiveGuildCount', () => {
 });
 
 describe('maybeAutoRecoverZombieWS', () => {
+  // Default destroy returns a resolved promise — discord.js's destroy
+  // is async, and we test that the fire-and-forget caller handles
+  // both success and rejection without breaking the tick loop.
   function shardClient({ destroyImpl } = {}) {
-    const shard = { destroy: destroyImpl ?? jest.fn() };
+    const shard = { destroy: destroyImpl ?? jest.fn(() => Promise.resolve()) };
     return {
       client: { ws: { shards: new Map([[0, shard]]) } },
       shard,
@@ -460,8 +463,14 @@ describe('maybeAutoRecoverZombieWS', () => {
     expect(result.triggered).toBe(true);
     expect(result.reason).toBe('zombie_ws');
     expect(result.shardsTerminated).toBe(1);
+    // `code` (NOT closeCode) — different field; closeCode would be
+    // silently ignored. `recover` MUST be set or the shard goes Idle
+    // and never reconnects (defeats the whole point of this code path).
     expect(shard.destroy).toHaveBeenCalledWith(
-      expect.objectContaining({ closeCode: 4000 }),
+      expect.objectContaining({
+        code: 4000,
+        recover: 0, // WebSocketShardDestroyRecovery.Reconnect
+      }),
     );
   });
 
@@ -505,9 +514,9 @@ describe('maybeAutoRecoverZombieWS', () => {
     expect(shard.destroy).toHaveBeenCalledTimes(1);
   });
 
-  test('logs warn but still consumes recovery budget when shard.destroy throws', () => {
+  test('catches sync throw from shard.destroy and keeps going', () => {
     const { client, shard } = shardClient({
-      destroyImpl: jest.fn(() => { throw new Error('already destroyed'); }),
+      destroyImpl: jest.fn(() => { throw new Error('bad-args'); }),
     });
     const t = 1_000_000;
     const result = maybeAutoRecoverZombieWS(
@@ -515,30 +524,80 @@ describe('maybeAutoRecoverZombieWS', () => {
       { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
       () => t,
     );
-    expect(result.triggered).toBe(true);
-    expect(result.shardsTerminated).toBe(0);
+    // Sync throw => shardsTerminated stays 0 => returns no_shards
+    // and DOES NOT consume the cooldown. The next tick retries.
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('no_shards');
     expect(logger.warn).toHaveBeenCalledWith(
-      'Shard destroy threw during auto-recovery',
-      expect.objectContaining({ error: 'already destroyed' }),
+      'Shard destroy threw synchronously during auto-recovery',
+      expect.objectContaining({ error: 'bad-args' }),
     );
-    // Cooldown still consumed — the next call inside the window debounces.
+    expect(shard.destroy).toHaveBeenCalled();
+
+    // Confirm cooldown was NOT stamped — second call same tick can fire.
     const second = maybeAutoRecoverZombieWS(
       client,
       { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
       () => t + 1_000,
     );
-    expect(second.triggered).toBe(false);
-    expect(second.reason).toBe('cooldown');
+    expect(second.reason).toBe('no_shards'); // still failing the same way
   });
 
-  test('safely no-ops when client.ws.shards is missing', () => {
+  test('handles destroy() promise rejection without crashing the process', async () => {
+    const destroyImpl = jest.fn(() => Promise.reject(new Error('async-destroy-failed')));
+    const { client, shard } = shardClient({ destroyImpl });
+    const t = 1_000_000;
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    // Sync result still triggered — we count the destroy as fired.
+    expect(result.triggered).toBe(true);
+    expect(result.shardsTerminated).toBe(1);
+    // Wait one microtask tick for the rejection handler.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Shard destroy promise rejected during auto-recovery',
+      expect.objectContaining({ error: 'async-destroy-failed' }),
+    );
+    expect(shard.destroy).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 4000, recover: 0 }),
+    );
+  });
+
+  test('returns no_shards (does NOT consume cooldown) when client.ws.shards is missing', () => {
     const t = 1_000_000;
     const result = maybeAutoRecoverZombieWS(
       { ws: {} },
       { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
       () => t,
     );
-    expect(result.triggered).toBe(true);
-    expect(result.shardsTerminated).toBe(0);
+    // No shards to terminate => not triggered, no cooldown stamp,
+    // next tick retries. (If is_ready=true while shards is missing,
+    // the bot is in a pathological state — locking out for 10min
+    // serves no one.)
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('no_shards');
+
+    // Same-tick second call confirms the cooldown was NOT stamped.
+    const second = maybeAutoRecoverZombieWS(
+      { ws: {} },
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t + 100,
+    );
+    expect(second.reason).toBe('no_shards');
+  });
+
+  test('returns no_shards when client.ws itself is undefined', () => {
+    const t = 1_000_000;
+    const result = maybeAutoRecoverZombieWS(
+      {},
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('no_shards');
   });
 });

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -217,11 +217,31 @@ describe('startGatewayHeartbeat', () => {
     );
   });
 
-  test('does NOT emit when unhealthy (silence is the alarm signal)', () => {
+  test('does NOT emit gateway_heartbeat_healthy when unhealthy (silence is the existing alarm signal)', () => {
     const client = fakeClient({ isReady: false });
     startGatewayHeartbeat(client, { intervalMs: 1_000 });
     jest.advanceTimersByTime(1_000);
-    expect(logger.audit).not.toHaveBeenCalled();
+    expect(logger.audit).not.toHaveBeenCalledWith(
+      AUDIT_EVENTS.GATEWAY_HEARTBEAT,
+      expect.any(Object),
+    );
+  });
+
+  test('emits gateway_heartbeat_unhealthy carrying activity_age_ms when unhealthy (Max-on-activity_age_ms alarm source)', () => {
+    // Pin the contract that the unhealthy companion event always
+    // carries activity_age_ms — terraform's metric filter extracts
+    // that field directly. A future refactor that drops it from the
+    // payload would silently break the alarm.
+    const client = fakeClient({ isReady: false });
+    startGatewayHeartbeat(client, { intervalMs: 1_000 });
+    jest.advanceTimersByTime(1_000);
+    expect(logger.audit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.GATEWAY_HEARTBEAT_UNHEALTHY,
+      expect.objectContaining({
+        activity_age_ms: expect.any(Number),
+        is_ready: false,
+      }),
+    );
   });
 
   test('emits on every interval tick when healthy', () => {
@@ -230,6 +250,10 @@ describe('startGatewayHeartbeat', () => {
     // 1 immediate runOnce + 3 interval ticks at t=1000/2000/3000 = 4
     jest.advanceTimersByTime(3_500);
     expect(logger.audit).toHaveBeenCalledTimes(4);
+    expect(logger.audit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.GATEWAY_HEARTBEAT,
+      expect.any(Object),
+    );
   });
 
   test('swallows sampler errors so a future API change does not wedge the bot', () => {

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -6,6 +6,7 @@
  * on. The setInterval timers are exercised via jest fake timers so
  * each test can advance time deterministically.
  */
+const { WebSocketShardDestroyRecovery } = require('discord.js');
 const logger = require('../src/logger');
 const {
   startGatewayHeartbeat,
@@ -469,7 +470,7 @@ describe('maybeAutoRecoverZombieWS', () => {
     expect(shard.destroy).toHaveBeenCalledWith(
       expect.objectContaining({
         code: 4000,
-        recover: 0, // WebSocketShardDestroyRecovery.Reconnect
+        recover: WebSocketShardDestroyRecovery.Reconnect,
       }),
     );
   });
@@ -563,7 +564,10 @@ describe('maybeAutoRecoverZombieWS', () => {
       expect.objectContaining({ error: 'async-destroy-failed' }),
     );
     expect(shard.destroy).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 4000, recover: 0 }),
+      expect.objectContaining({
+        code: 4000,
+        recover: WebSocketShardDestroyRecovery.Reconnect,
+      }),
     );
   });
 
@@ -599,5 +603,56 @@ describe('maybeAutoRecoverZombieWS', () => {
     );
     expect(result.triggered).toBe(false);
     expect(result.reason).toBe('no_shards');
+  });
+
+  test('triggers across multiple shards (happy path) — pin shardsTerminated count', () => {
+    const shardA = { destroy: jest.fn(() => Promise.resolve()) };
+    const shardB = { destroy: jest.fn(() => Promise.resolve()) };
+    const client = { ws: { shards: new Map([[0, shardA], [1, shardB]]) } };
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => 1_000_000,
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.shardsTerminated).toBe(2);
+    expect(shardA.destroy).toHaveBeenCalledTimes(1);
+    expect(shardB.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('partial-failure: one shard sync-throws, other succeeds — cooldown still stamped', () => {
+    const shardA = { destroy: jest.fn(() => { throw new Error('borked'); }) };
+    const shardB = { destroy: jest.fn(() => Promise.resolve()) };
+    const client = { ws: { shards: new Map([[0, shardA], [1, shardB]]) } };
+    const t = 1_000_000;
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t,
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.shardsTerminated).toBe(1); // B succeeded; A threw
+    // Cooldown WAS stamped (>=1 success), so an immediate retry debounces.
+    const second = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
+      () => t + 1_000,
+    );
+    expect(second.reason).toBe('cooldown');
+  });
+
+  test('boundary: activity_age_ms === RECOVERY_ACTIVITY_THRESHOLD_MS triggers (>= semantic)', () => {
+    // Code uses `< THRESHOLD` to gate, so equality falls THROUGH to
+    // the recovery path. Pin the boundary so a future refactor to
+    // `<=` (which would silently delay recovery by one tick) breaks
+    // this test instead of getting silently merged.
+    const { client, shard } = shardClient();
+    const result = maybeAutoRecoverZombieWS(
+      client,
+      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS },
+      () => 1_000_000,
+    );
+    expect(result.triggered).toBe(true);
+    expect(shard.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -316,6 +316,38 @@ describe('startGatewayHeartbeat', () => {
     );
   });
 
+  test('tick() invokes auto-recovery when activity is stale past threshold (integration: pin the wiring)', () => {
+    // Without this test, deleting the maybeAutoRecoverZombieWS call
+    // from tick() — or flipping its guard from `!healthy` to
+    // `healthy` — would pass every other test in this file. Pin the
+    // wire so a regression has to break this assertion to land.
+    if (gatewayMetricsTest && typeof gatewayMetricsTest._resetGatewayActivity === 'function') {
+      gatewayMetricsTest._resetGatewayActivity();
+      gatewayMetricsTest._resetRecoveryClock();
+    }
+    // Back-date activity by 200s so the snapshot will be unhealthy
+    // AND past RECOVERY_ACTIVITY_THRESHOLD_MS (120s).
+    noteGatewayActivity(() => Date.now() - 200_000);
+    const shard = { destroy: jest.fn(() => Promise.resolve()) };
+    const client = {
+      isReady: () => true,
+      ws: { ping: 42, shards: new Map([[0, shard]]) },
+      guilds: { cache: { size: 1 } },
+    };
+    startGatewayHeartbeat(client, { intervalMs: 60_000 });
+    // runOnce already fired — no advanceTimers needed.
+    expect(shard.destroy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 4000,
+        recover: WebSocketShardDestroyRecovery.Reconnect,
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Gateway auto-recovery: forcing reconnect (zombie WS)',
+      expect.objectContaining({ shards_terminated: 1 }),
+    );
+  });
+
   test('runs once immediately so the first datapoint lands inside the boot alarm window', () => {
     const client = fakeClient({ ackedAgo: 5_000 });
     startGatewayHeartbeat(client, { intervalMs: 60_000 });


### PR DESCRIPTION
## Summary

When the bot's gateway connection enters the zombie-WS state (heartbeats keep ACK'ing but Discord stops pushing event frames), force every shard to reconnect via `shard.destroy({ code: 4000, recover: WebSocketShardDestroyRecovery.Reconnect })`. The reconnect re-IDENTIFYs cleanly and resumes event delivery.

Hit both sandbox + prod **simultaneously** earlier today — `/qurl send` returned "The application did not respond" because the InteractionCreate events never reached the bot, even though `client.isReady() === true` and `client.ws.ping` was healthy. Manual fix was an ECS service restart on each. This automates that recovery.

## Why this matters: the zombie loop is structural, not an outage

The zombie mechanism is independent of any AWS outage — it's a structural Discord ↔ ECS interaction problem that compounds on itself once started:

1. The first task dies for some reason (health check, container crash, OOM, ECS circuit breaker reap, etc.).
2. ECS kills it with SIGKILL — no graceful shutdown handler runs, no Discord gateway "close" frame is sent.
3. Discord's gateway keeps the WebSocket session alive for ~5 minutes waiting for a heartbeat that never comes.
4. ECS spawns the replacement task immediately (`deployment_minimum_healthy_percent = 0`).
5. New task IDENTIFYs to Discord with the same bot token → Discord sees "another connection is using this token" → boots the new connection → container exits → ECS restarts → loop.
6. The loop self-perpetuates: each new task is killed before its WebSocket can take over the session, so the "previous" zombie keeps appearing fresh.

This PR breaks step 1's downstream: the bot self-detects a zombie WebSocket and gracefully tears down + reconnects in-process, before ECS gets involved. No ungraceful kill → no lingering session on Discord's side → next task (whether ECS-driven or in-process recovery) IDENTIFYs into a clean slate.

## Detection

Reuses the existing composite-readiness signal: `activity_age_ms` (last `client.on('raw', ...)` frame, set on every WebSocket frame including heartbeats). When activity is stale past **120s** while `is_ready=true`, every shard is destroyed and the WebSocketManager re-IDENTIFYs.

- Threshold: `RECOVERY_ACTIVITY_THRESHOLD_MS = 120_000` — 2× the existing 60s health threshold so the alarm fires first, recovery follows
- Cooldown: `RECOVERY_COOLDOWN_MS = 10 * 60_000` — prevents a reconnect storm if termination doesn't immediately restore activity
- Per-shard `destroy()` so a future multi-shard config only resets the wedged shard

## API correctness

The first cut passed `{ closeCode: 4000 }` — `@discordjs/ws` reads `code` (not `closeCode`), and the call only triggers a reconnect when `recover` is set. Without `recover`, the shard transitions to `Idle` and stays there. Final shape: `{ code: 4000, reason: '...', recover: WebSocketShardDestroyRecovery.Reconnect }`. Verified against `node_modules/@discordjs/ws/dist/index.js:705-764`.

The `destroy()` return value is awaited via `.catch()` so a rejection from internal teardown doesn't surface as `unhandledRejection` (process crash on Node 22).

## Companion

Pairs with PR #446 in qurl-integrations-infra: extracts `activity_age_ms` from the new `gateway_heartbeat_unhealthy` audit event into a CloudWatch metric, alarms when Max > 120s for 2 consecutive minutes (matches the auto-recovery threshold so alarm fires only when self-heal didn't clear it).

## Test plan

- [x] Unit tests: not-ready skip, no-baseline skip, within-threshold skip, threshold-boundary trigger, single-shard trigger, multi-shard trigger, partial sync-failure, async-rejection handling, no-shards/no-ws guards, cooldown debounce, post-cooldown re-trigger
- [x] All 957 discord tests pass
- [ ] Sandbox deploy + observe normal heartbeat cadence (no false-positive triggers)
- [ ] If next zombie-WS event hits, confirm CloudWatch shows the warn log + shard reconnect within 30s of the activity_age_ms breach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
