### PR TITLE
feat(discord): trim /qurl send DM embed copy

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -308,13 +308,12 @@ function resolveRecipientAlias(r, interaction) {
 
 // --- Shared DM delivery payload builder ---
 // Builds the {embeds, components} payload for a per-recipient DM. The
-// embed copy is intentionally evocative ("opened a door", "Portal closes",
-// "what's on the other side is invisible to … scanners, bots, crawlers,
-// strangers") rather than literal ("shared a file with you") — the brand
-// goal is to convey the qURL hidden-layer model, not just announce a
-// file transfer. The qURL link is rendered as a `🔗 Step Through` Link
-// button rather than a bare URL field; recipients click the button to
-// open the link in their default browser.
+// embed copy is intentionally evocative ("opened a door", "Door closes")
+// rather than literal ("shared a file with you") — the brand goal is to
+// convey the qURL hidden-layer model, not just announce a file transfer.
+// The qURL link is rendered as a `🔗 Step Through` Link button rather
+// than a bare URL field; recipients click the button to open the link
+// in their default browser.
 //
 // `senderAlias` is the sender's friendly display name (Discord nickname
 // > globalName > username) — same source resolveSenderAlias used at the
@@ -336,11 +335,7 @@ function resolveRecipientAlias(r, interaction) {
 //     │                                                             │
 //     │  > "Quarterly numbers — for your eyes only."                │  (optional personal message — italic blockquote)
 //     │                                                             │
-//     │  This link is your portal — what's on the other side is    │  (fixed body copy)
-//     │  invisible to everyone else on the internet: scanners,     │
-//     │  bots, crawlers, strangers.                                │
-//     │                                                             │
-//     │  🕐 Portal closes in 24 hours                               │  (Discord <t:N:R> — auto-updates client-side
+//     │  🕐 Door closes in 1 day                                    │  (Discord <t:N:R> — auto-updates client-side
 //     │                                                             │   to "in 16 hours" / "in 1 hour" / "1 hour ago")
 //     │                                                             │
 //     │  Quantum URL (qURL) · The internet has a hidden layer.     │  (final embed field;
@@ -394,22 +389,18 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     // does not span newlines, so a multi-line message would render with
     // only the first line styled. Flatten newlines to a space so the
     // recipient sees one tidy quote — matches the design mockup which
-    // shows the message as a single-line styled box. 450-char cap keeps
-    // the body paragraph visible without scroll.
-    const capped = personalMessage.substring(0, 450).replace(/[\r\n]+/g, ' ').trim();
+    // shows the message as a single-line styled box. 280-char cap keeps
+    // the embed visually compact now that the fixed body copy is gone.
+    const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
     embed.addFields({ name: '\u200B', value: `> *"${capped}"*` });
   }
 
   embed.addFields(
     {
-      name: '\u200B',
-      value: "This link is your portal — what's on the other side is invisible to everyone else on the internet: scanners, bots, crawlers, strangers.",
-    },
-    {
       // Discord's native relative-time markdown: <t:UNIX:R> renders
       // CLIENT-SIDE based on the viewer's current time, so the recipient
-      // sees "in 24 hours" at send time and "in 16 hours" 8 hours later
-      // (and "1 hour ago" once the link has expired). No bot-side editing
+      // sees "in 1 day" at send time, "in 16 hours" 8 hours later, and
+      // "1 hour ago" once the link has expired. No bot-side editing
       // needed — Discord handles the live update.
       //
       // Fail-loud on a missing/invalid expiresAt rather than rendering
@@ -421,7 +412,7 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
         if (!Number.isFinite(expiresAt)) {
           throw new Error(`buildDeliveryPayload: expiresAt must be a finite Unix-seconds number (got ${expiresAt})`);
         }
-        return `\ud83d\udd50 Portal closes <t:${expiresAt}:R>`;
+        return `\ud83d\udd50 Door closes <t:${expiresAt}:R>`;
       })(),
     },
     {
@@ -1516,7 +1507,7 @@ async function handleSend(interaction, apiKey) {
           .setCustomId(messageInputId)
           .setLabel('Optional note (leave blank to clear)')
           .setStyle(TextInputStyle.Paragraph)
-          .setMaxLength(450)
+          .setMaxLength(280)
           .setRequired(false)
           .setValue(personalMessage || '')
       ));

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -215,20 +215,20 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(desc).not.toMatch(/\uD83C(?![\uDC00-\uDFFF])/);
   });
 
-  // Regression net for the live-countdown design: the Portal-closes line
+  // Regression net for the live-countdown design: the Door-closes line
   // must render Discord's <t:N:R> relative-time markdown so the recipient
   // sees "in 24 hours" → "in 16 hours" → "1 hour ago" as time passes.
   // A future refactor that goes back to baking a static label into the
-  // embed ("Portal closes in **24 hours**" forever) would silently
+  // embed ("Door closes in **24 hours**" forever) would silently
   // regress this UX — the assertion below catches it.
-  it('renders Discord native relative-time <t:N:R> for the Portal-closes line', () => {
+  it('renders Discord native relative-time <t:N:R> for the Door-closes line', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
     const fields = capturedEmbeds[0].addFields.mock.calls.flatMap(call => call);
-    const portalField = fields.find(f => typeof f.value === 'string' && f.value.includes('Portal closes'));
-    expect(portalField).toBeDefined();
-    expect(portalField.value).toBe('\ud83d\udd50 Portal closes <t:1735689600:R>');
+    const doorField = fields.find(f => typeof f.value === 'string' && f.value.includes('Door closes'));
+    expect(doorField).toBeDefined();
+    expect(doorField.value).toBe('\ud83d\udd50 Door closes <t:1735689600:R>');
     // Locks against accidental reversion to a static label
-    expect(portalField.value).not.toMatch(/Portal closes in \*\*\d/);
+    expect(doorField.value).not.toMatch(/Door closes in \*\*\d/);
   });
 
   // Defensive guard: a future caller that drops `expiresAt` (or passes


### PR DESCRIPTION
## Summary

Recipient DM gets two cuts:

- **Drop the body-copy field** ("This link is your portal — what's on the other side is invisible to everyone else on the internet: scanners, bots, crawlers, strangers."). Description ("X opened a door for you.") + door-closes timer + brand line carry the same intent without the verbose middle paragraph.
- **Rename "Portal closes" → "Door closes"** to match the opening line ("opened a door for you."). Discord's `<t:N:R>` renders the relative time client-side ("in 1 day" / "in 16 hours" / "1 hour ago"); only the static prefix changes.

Personal-message cap: 450 → 280. The embed has more visual room now that the body copy is gone, so the input modal can be tighter without forcing scroll on the recipient side.

## Before / After

**Before**:
```
Vik opened a door for you.

> "Quarterly numbers — for your eyes only."

This link is your portal — what's on the other side is
invisible to everyone else on the internet: scanners,
bots, crawlers, strangers.

🕐 Portal closes in 24 hours

Quantum URL (qURL) · The internet has a hidden layer.
This is how you enter.
```

**After**:
```
Vik opened a door for you.

> "Quarterly numbers — for your eyes only."

🕐 Door closes in 1 day

Quantum URL (qURL) · The internet has a hidden layer.
This is how you enter.
```

## Test plan

- [x] `npx jest --no-cache` — 963 tests pass (refreshed `Door-closes` regression test in `build-delivery-embed.test.js`)
- [x] ASCII layout comment + brand-goal doc comment updated
- [x] Sandbox sanity check via `/qurl send` — confirm DM renders with door verbiage and the personal-message modal caps at 280

🤖 Generated with [Claude Code](https://claude.com/claude-code)