### PR TITLE
fix(discord): decouple gateway health from event-dispatch activity (revert #208 detection signal)

### DIFF
--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -175,11 +175,12 @@ const AUDIT_EVENTS = {
   GATEWAY_HEARTBEAT: 'gateway_heartbeat_healthy',
 
   // Negative-signal heartbeat. Emitted every 30 s when the composite
-  // readiness check FAILS — pairs with the healthy event so the
-  // unhealthy snapshot is observable as a metric (carries activity_age_ms
-  // unbounded, where the healthy emission caps at <60s by definition).
-  // The 5/8 zombie-WS incident showed an alarm on Max(activity_age_ms)
-  // is the right shape; that needs unhealthy emissions to fire on.
+  // readiness check FAILS (post-#210: !is_ready || ping_ms <= 0 ||
+  // ack_age_ms >= 60_000). Pairs with the healthy event so a real WS
+  // wedge surfaces as a metric. `activity_age_ms` rides along on both
+  // emissions for dashboarding only — it is NOT part of the gating
+  // predicate (#210 backed out the false-positive on idle bots). Don't
+  // alarm on activity_age_ms; alarm on missing healthy emissions.
   GATEWAY_HEARTBEAT_UNHEALTHY: 'gateway_heartbeat_unhealthy',
 
   // Bot added/removed from a guild. Single emission on the

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -11,9 +11,13 @@
  *      client.guilds.cache.size.
  *
  * Health is gated on heartbeat ACK age only. activity_age_ms is
- * reported as a metric for observability but does NOT gate health —
- * see the PR description for #210 for why (idle ≠ zombie at this
- * signal level).
+ * reported as a metric for observability but does NOT gate health.
+ * Why: discord.js's `client.on('raw', ...)` fires on op-0 dispatched
+ * events only — HEARTBEAT_ACK and other control packets never trigger
+ * it. So an idle bot (no chat traffic) and a wedged bot (no ACKs)
+ * look identical at this signal level. Gating health on
+ * activity_age_ms therefore false-positives on quiet workspaces;
+ * gating on ACK age catches the real WS-wedge case.
  */
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');

--- a/apps/discord/src/gateway-metrics.js
+++ b/apps/discord/src/gateway-metrics.js
@@ -5,23 +5,16 @@
  *   1. Heartbeat (30 s) — dual-emission. Healthy ticks emit
  *      gateway_heartbeat_healthy (paired with the missing-data
  *      `gateway_heartbeat_silence` alarm); unhealthy ticks emit
- *      gateway_heartbeat_unhealthy carrying activity_age_ms (paired
- *      with the Max-on-value `gateway_activity_age_ms_high` alarm in
- *      qurl-integrations-infra #446). Two metrics catch two failure
- *      shapes: total silence (process-level wedge) vs. flapping
- *      dispatch wedge (5/8 zombie-WS — heartbeat-ACKs land but event
- *      frames don't, so silence alarm misses it).
+ *      gateway_heartbeat_unhealthy carrying activity_age_ms for
+ *      observability.
  *   2. Active-guild gauge (60 s) — emits active_guild_count carrying
- *      client.guilds.cache.size. Used for install/uninstall trend
- *      detection and as a sanity check on guild-scoped features.
+ *      client.guilds.cache.size.
  *
- * Composite readiness threshold (60 s ack age) lines up with the alarm
- * window: silence alarm fires after 60 s of missing heartbeats.
- * Client-side threshold one heartbeat-interval (~41 s) plus one
- * buffer cycle. Unhealthy ticks ALSO trigger auto-recovery via
- * maybeAutoRecoverZombieWS at activity_age_ms > 120 s.
+ * Health is gated on heartbeat ACK age only. activity_age_ms is
+ * reported as a metric for observability but does NOT gate health —
+ * see the PR description for #210 for why (idle ≠ zombie at this
+ * signal level).
  */
-const { WebSocketShardDestroyRecovery } = require('discord.js');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
 
@@ -29,189 +22,21 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 const ACTIVE_GUILD_INTERVAL_MS = 60_000;
 const HEARTBEAT_ACK_AGE_THRESHOLD_MS = 60_000;
 
-// Auto-recovery thresholds for the zombie-WS pattern observed
-// 2026-05-08 (sandbox + prod): bot's `activity_age_ms` climbed past
-// 60s while heartbeat ACKs kept landing — Discord stopped pushing
-// events but discord.js didn't detect the dead session. Both bots
-// hit it simultaneously when their gateway pod blipped. Fix: when
-// activity is stale past `RECOVERY_ACTIVITY_THRESHOLD_MS` AND the
-// client thinks it's ready (so this isn't a normal boot/disconnect
-// flap), terminate every shard's WebSocket so the manager
-// reconnects fresh. `RECOVERY_COOLDOWN_MS` prevents a reconnect
-// storm if termination doesn't immediately restore activity.
-const RECOVERY_ACTIVITY_THRESHOLD_MS = 120_000;
-const RECOVERY_COOLDOWN_MS = 10 * 60_000;
-// Short cooldown stamped only when every shard's destroy() sync-threw
-// (every call rejected before the async body ran — pathological, e.g.
-// an @discordjs/ws bump that breaks the option shape). Bounds warn-log
-// volume in CloudWatch Logs without locking recovery out for the full
-// 10 min; activity-age alarm pages on-call regardless.
-const RECOVERY_RATE_LIMIT_COOLDOWN_MS = 60_000;
-let lastRecoveryAttemptAt = 0;
-let lastRecoveryRateLimitAt = 0;
-
-// Composite-readiness gateway-activity signal. client.isReady() alone
-// misses event-loop wedges (DB pool exhaustion, qurl-service stalls,
-// Auth0 refresh hangs) — the WebSocket stays connected but the raw
-// handler stops firing.
-//
-// Threshold = 60 s matches the heartbeat-ack threshold. discord.js
-// emits a heartbeat every ~41 s and the bot's `client.on('raw', ...)`
-// handler updates this timestamp on every WebSocket frame including
-// heartbeats — so an idle gateway still ticks. A wedge at the event-
-// loop level prevents the raw handler from running, the timestamp
-// goes stale, and the composite goes unhealthy.
-const GATEWAY_ACTIVITY_THRESHOLD_MS = 60_000;
+// Time-since-last-dispatch gauge. discord.js's `client.on('raw', ...)`
+// fires on dispatched gateway events (op 0) only — control packets like
+// HEARTBEAT_ACK do NOT trigger it. So this is a "time since last Discord
+// event" signal, not a "time since last frame" signal. Useful as an
+// observability gauge, NOT as a health predicate (an idle bot with a
+// healthy WebSocket has the same shape as a wedged bot).
 let lastGatewayActivityAt = 0;
 
-/**
- * Note that the gateway just received a frame. Called from the
- * `client.on('raw', ...)` hook in index.js (gateway-only path —
- * never invoked from the HTTP role; if `readGatewayHealth` is ever
- * called from HTTP, it'll always report unhealthy because this
- * timestamp stays at 0). Cheap — just a timestamp update — so it's
- * safe to fire on every frame including heartbeats.
- *
- * Defensive arg shape: discord.js's `raw` event hands the listener
- * a packet object as the first argument, NOT a clock function. The
- * `typeof maybeNow === 'function'` check lets the same function
- * be passed directly to `client.on('raw', noteGatewayActivity)`
- * (saves a closure allocation per frame) AND still accept a custom
- * clock from tests via `noteGatewayActivity(() => fakeNow)`.
- *
- * @param {(() => number) | unknown} [maybeNow] — optional clock fn
- *   for tests; any non-function argument falls back to Date.now.
- */
 function noteGatewayActivity(maybeNow) {
   const now = typeof maybeNow === 'function' ? maybeNow : Date.now;
   lastGatewayActivityAt = now();
 }
 
-/**
- * Test-only reset for the module-level activity timestamp. NOT
- * exported in the public API — accessed via `_test` for jest.
- */
 function _resetGatewayActivity() {
   lastGatewayActivityAt = 0;
-}
-
-/**
- * Test-only reset for the recovery cooldown clock.
- */
-function _resetRecoveryClock() {
-  lastRecoveryAttemptAt = 0;
-  lastRecoveryRateLimitAt = 0;
-}
-
-/**
- * Detect the zombie-WS pattern (heartbeats land but Discord events
- * don't) and force a fresh session. Returns the action taken so
- * callers can log + test the decision.
- *
- * Decision tree:
- *  - is_ready=false → boot/reconnect already in flight, skip
- *  - activity_age_ms < RECOVERY_ACTIVITY_THRESHOLD_MS → not zombie
- *  - within RECOVERY_COOLDOWN_MS of last attempt → debounce
- *  - else → terminate every shard via shard.destroy() so the manager
- *    re-IDENTIFYs cleanly. Per-shard so a future multi-shard config
- *    only restarts the wedged shard, not the whole client.
- *
- * @returns {{ triggered: boolean, reason: string, shardsTerminated?: number }}
- */
-function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
-  if (!snapshot.is_ready) return { triggered: false, reason: 'not_ready' };
-  if (snapshot.activity_age_ms === null) return { triggered: false, reason: 'no_activity_baseline' };
-  if (snapshot.activity_age_ms < RECOVERY_ACTIVITY_THRESHOLD_MS) {
-    return { triggered: false, reason: 'within_threshold' };
-  }
-  const t = now();
-  if (t - lastRecoveryAttemptAt < RECOVERY_COOLDOWN_MS) {
-    return { triggered: false, reason: 'cooldown' };
-  }
-  if (t - lastRecoveryRateLimitAt < RECOVERY_RATE_LIMIT_COOLDOWN_MS) {
-    return { triggered: false, reason: 'cooldown' };
-  }
-
-  // Per-shard destroy so a future multi-shard config (see the
-  // multi-shard TODO in readGatewayHealth above) only resets the
-  // wedged shard. discord.js shard.destroy is async and only
-  // re-IDENTIFYs when `recover` is set — without it, the shard
-  // transitions to Idle and stays there. `code` (NOT closeCode —
-  // different field name) 4000 = re-establishable. Fire-and-catch:
-  // tick() is sync but destroy awaits internals (updateSessionInfo,
-  // ws onclose race, internalConnect). Letting that promise reject
-  // would surface as an unhandledRejection that crashes the process
-  // on Node 16+.
-  //
-  // Cooldown choice: stamped optimistically as soon as destroy() is
-  // dispatched (line below), NOT on resolved-success. Rationale: if
-  // every shard's destroy rejects asynchronously, we'd be locked out
-  // for 10 min — but the bot is still emitting unhealthy heartbeats,
-  // and the activity_age_ms alarm (qurl-integrations-infra #446)
-  // will page on-call within ~2 min. Async rejections are rare and
-  // operator-handled; the optimistic stamp prevents a reconnect
-  // storm in the common case where destroy() succeeds.
-  let shardsAttempted = 0;
-  let shardsTerminated = 0;
-  if (client.ws?.shards && typeof client.ws.shards.values === 'function') {
-    for (const shard of client.ws.shards.values()) {
-      if (typeof shard?.destroy !== 'function') continue;
-      shardsAttempted++;
-      try {
-        const result = shard.destroy({
-          code: 4000,
-          reason: 'auto-recovery: zombie ws (activity stale)',
-          recover: WebSocketShardDestroyRecovery.Reconnect,
-        });
-        if (result && typeof result.catch === 'function') {
-          result.catch((err) => {
-            logger.warn('Shard destroy promise rejected during auto-recovery', { error: err?.message });
-          });
-        }
-        shardsTerminated++;
-      } catch (err) {
-        // Sync throw = bad-args / TypeError before the async body
-        // runs. Already-Idle shards return synchronously without
-        // throwing, so this branch is for genuinely unexpected
-        // shapes; log and keep going so a single broken shard
-        // doesn't block the others.
-        logger.warn('Shard destroy threw synchronously during auto-recovery', { error: err?.message });
-      }
-    }
-  }
-
-  // Two distinct empty-result branches:
-  //   - shardsAttempted === 0: client.ws.shards missing/empty. Pathological
-  //     in steady state (is_ready=true contradicts no shards); retry on
-  //     the next tick without consuming any cooldown.
-  //   - shardsAttempted > 0 && shardsTerminated === 0: shards exist but
-  //     every destroy() sync-threw. Stamp the short rate-limit cooldown
-  //     so the warn-log volume is bounded; recovery still retries inside
-  //     the 10-min main cooldown window.
-  if (shardsAttempted === 0) {
-    return { triggered: false, reason: 'no_shards' };
-  }
-  if (shardsTerminated === 0) {
-    lastRecoveryRateLimitAt = t;
-    return { triggered: false, reason: 'all_destroys_threw' };
-  }
-  // TODO(multi-shard): pairs with the multi-shard TODO in
-  // readGatewayHealth above. When sharding flips on, the actually-
-  // wedged shard could be the one that sync-throws while a healthy
-  // shard's destroy succeeds — locking recovery out for 10 min while
-  // the stuck shard stays stuck. Move to a per-shard cooldown map
-  // (lastRecoveryAttemptAt[shardId]) at that point.
-  lastRecoveryAttemptAt = t;
-  // Reset the activity baseline so subsequent ticks read
-  // `activity_age_ms: null` until the reconnected WebSocket's first
-  // raw frame re-baselines via noteGatewayActivity(). Without this,
-  // a tick between is_ready flipping back to true and the first
-  // post-reconnect frame would observe the pre-destroy stale value
-  // still climbing — harmless under the 10 min main cooldown today,
-  // but a flap source if cooldown ever shrinks (e.g. per-shard
-  // cooldown for the multi-shard TODO above).
-  _resetGatewayActivity();
-  return { triggered: true, reason: 'zombie_ws', shardsTerminated };
 }
 
 /**
@@ -220,56 +45,34 @@ function maybeAutoRecoverZombieWS(client, snapshot, now = Date.now) {
  *
  * @param {import('discord.js').Client} client
  * @param {() => number} now - Injected for testability.
- * @returns {{ healthy: boolean, ping_ms: number, ack_age_ms: number|null, is_ready: boolean }}
+ * @returns {{ healthy: boolean, ping_ms: number, ack_age_ms: number|null, activity_age_ms: number|null, is_ready: boolean }}
  */
 function readGatewayHealth(client, now = Date.now) {
-  // Single point-in-time read so ack_age_ms and activity_age_ms are
-  // computed against the same `t`. Practically irrelevant (microseconds
-  // of drift between two now() calls), but useful for tests injecting
-  // a non-monotonic now and for keeping the snapshot semantically
-  // atomic.
   const t = now();
   const isReady = typeof client.isReady === 'function' ? client.isReady() : false;
   const ping = client.ws?.ping;
   const ping_ms = typeof ping === 'number' ? ping : -1;
 
-  // discord.js v14 exposes the most recent heartbeat-round-trip
-  // timestamp on each WebSocketShard as `lastPingTimestamp` (set in
-  // WebSocketManager.js on every HEARTBEAT_ACK; initialized to -1
-  // pre-first-ack per WebSocketShard.js:54). NOT `lastHeartbeatAcked`
-  // — that field doesn't exist in v14. Iterate shards.values() so a
-  // future sharding flip is automatic; the oldest timestamp across
-  // shards is the worst-case heartbeat age and the right number to
-  // alarm on.
+  // discord.js v14 stores the most recent HEARTBEAT_ACK timestamp on
+  // each WebSocketShard as `lastPingTimestamp` (-1 pre-first-ack).
+  // Iterate so a future sharding flip is automatic; oldest across
+  // shards is the worst-case heartbeat age.
   let oldestAck = null;
   if (client.ws?.shards && typeof client.ws.shards.values === 'function') {
     for (const shard of client.ws.shards.values()) {
       const acked = shard?.lastPingTimestamp;
-      // > 0 rejects both the -1 sentinel (pre-first-ack) and any
-      // future change to 0 / null without falsely emitting "healthy"
-      // before the first heartbeat round-trip completes.
-      // TODO(multi-shard): if shard 0 ack'd recently and shard 1 has
-      // never ack'd (-1), this loop reports healthy from shard 0
-      // alone — a stuck-since-boot shard wouldn't move the needle.
-      // Single-shard today so unobservable, but when sharding flips
-      // on, treat a -1 sentinel as itself unhealthy after a settle
-      // window (e.g. >2× heartbeat interval since process start).
+      // > 0 rejects both the -1 sentinel and any future change to
+      // 0 / null without falsely emitting "healthy" before the first
+      // heartbeat round-trip.
       if (typeof acked === 'number' && acked > 0) {
         if (oldestAck === null || acked < oldestAck) oldestAck = acked;
       }
     }
   }
   // Math.max(0, ...) guards against an NTP step backward producing a
-  // negative age that would otherwise satisfy `< 60_000` and falsely
-  // mark the gateway healthy. Date.now() is wall-clock, not monotonic;
-  // Fargate hosts get periodic NTP corrections.
+  // negative age that would otherwise satisfy `< 60_000`.
   const ack_age_ms = oldestAck === null ? null : Math.max(0, t - oldestAck);
 
-  // Activity check (Justin #193 §2 — dispatch-wedge / event-loop
-  // saturation). lastGatewayActivityAt = 0 means we've never seen a
-  // frame, so the bot can't be healthy yet (boot window). Same NTP
-  // clamp logic as ack_age — a backward step shouldn't paper over a
-  // stale timestamp.
   const activity_age_ms = lastGatewayActivityAt === 0
     ? null
     : Math.max(0, t - lastGatewayActivityAt);
@@ -278,9 +81,7 @@ function readGatewayHealth(client, now = Date.now) {
     isReady &&
     ping_ms > 0 &&
     ack_age_ms !== null &&
-    ack_age_ms < HEARTBEAT_ACK_AGE_THRESHOLD_MS &&
-    activity_age_ms !== null &&
-    activity_age_ms < GATEWAY_ACTIVITY_THRESHOLD_MS;
+    ack_age_ms < HEARTBEAT_ACK_AGE_THRESHOLD_MS;
 
   return {
     healthy,
@@ -295,14 +96,6 @@ function readGatewayHealth(client, now = Date.now) {
  * Start the heartbeat timer. Returns the timer handle so callers
  * (gracefulShutdown) can clear it.
  *
- * Dual-emission: healthy ticks emit gateway_heartbeat_healthy (paired
- * with the silence/missing-data alarm — one shape of wedge: total
- * silence). Unhealthy ticks emit gateway_heartbeat_unhealthy carrying
- * activity_age_ms (paired with the Max-on-value alarm — second shape
- * of wedge: flapping dispatch where intermittent healthy ticks keep
- * the silence alarm quiet). Unhealthy ticks also trigger
- * maybeAutoRecoverZombieWS for self-heal at activity_age_ms >= 120 s.
- *
  * @param {import('discord.js').Client} client
  * @param {{ intervalMs?: number, now?: () => number }} [opts]
  */
@@ -311,9 +104,9 @@ function startGatewayHeartbeat(client, opts = {}) {
   const now = opts.now ?? Date.now;
 
   // Per-timer transition memory so we log a single warn at the
-  // healthy → unhealthy edge and a single info at the recovery edge,
-  // not every 30 s of cadence. Initial null = first observation is
-  // silent (boot window can flap freely without log spam).
+  // healthy → unhealthy edge and a single info at recovery, not every
+  // 30 s of cadence. Initial null = first observation is silent (boot
+  // window can flap freely without log spam).
   let prevHealthy = null;
 
   function tick() {
@@ -326,13 +119,6 @@ function startGatewayHeartbeat(client, opts = {}) {
           activity_age_ms: snapshot.activity_age_ms,
         });
       } else {
-        // Pair-event for the healthy heartbeat so activity_age_ms is
-        // observable as a metric on EVERY tick. Without this, the
-        // healthy emission caps activity_age_ms at <60s by definition
-        // and a Max(activity_age_ms) > 60s alarm would never fire — yet
-        // 60s+ is exactly the zombie-WS signal we need to alarm on
-        // (5/8 incident). null-safe payload: ack_age_ms is null pre-
-        // first-ack, ping_ms is -1 pre-first-ws.
         logger.audit(AUDIT_EVENTS.GATEWAY_HEARTBEAT_UNHEALTHY, {
           ping_ms: snapshot.ping_ms,
           ack_age_ms: snapshot.ack_age_ms,
@@ -340,9 +126,6 @@ function startGatewayHeartbeat(client, opts = {}) {
           is_ready: snapshot.is_ready,
         });
       }
-      // Edge-triggered logs so on-call can distinguish "wedged for
-      // 5 min" (one warn at t=0, then silence on the metric side) from
-      // "metric pipeline broken" (zero log lines + zero metric).
       if (prevHealthy === true && !snapshot.healthy) {
         logger.warn('Gateway heartbeat: healthy → unhealthy', {
           is_ready: snapshot.is_ready,
@@ -350,20 +133,6 @@ function startGatewayHeartbeat(client, opts = {}) {
           ack_age_ms: snapshot.ack_age_ms,
           activity_age_ms: snapshot.activity_age_ms,
         });
-      }
-      // Zombie-WS recovery runs on every unhealthy tick (not just
-      // the edge) — debounced by RECOVERY_COOLDOWN_MS internally.
-      // Edge-only would miss the case where the bot was already
-      // unhealthy at boot and stayed there.
-      if (!snapshot.healthy) {
-        const recovery = maybeAutoRecoverZombieWS(client, snapshot, now);
-        if (recovery.triggered) {
-          logger.warn('Gateway auto-recovery: forcing reconnect (zombie WS)', {
-            activity_age_ms: snapshot.activity_age_ms,
-            ack_age_ms: snapshot.ack_age_ms,
-            shards_terminated: recovery.shardsTerminated,
-          });
-        }
       }
       if (prevHealthy === false && snapshot.healthy) {
         logger.info('Gateway heartbeat: unhealthy → healthy', {
@@ -383,24 +152,16 @@ function startGatewayHeartbeat(client, opts = {}) {
   // Run once immediately so the first metric datapoint lands inside
   // the alarm's 60s evaluation window. Without this, setInterval
   // doesn't fire until t+30s and the alarm transitions
-  // INSUFFICIENT_DATA → ALARM during steady-state boot. Note: the
-  // 30s interval × 2 fits inside the 60s alarm window so a single
-  // missed sample doesn't trip the alarm — only sustained absence
-  // does. If you ever drop the alarm threshold to 30s, also drop the
-  // sampling interval to avoid flap.
+  // INSUFFICIENT_DATA → ALARM during steady-state boot.
   tick();
 
   const timer = setInterval(tick, intervalMs);
-
-  // .unref() so the timer doesn't keep the event loop alive at shutdown.
   if (typeof timer.unref === 'function') timer.unref();
-
   return timer;
 }
 
 /**
- * Start the active-guild-count gauge. Same shape as heartbeat, lower
- * cadence — guild membership doesn't change often.
+ * Start the active-guild-count gauge.
  *
  * @param {import('discord.js').Client} client
  * @param {{ intervalMs?: number }} [opts]
@@ -419,26 +180,16 @@ function startActiveGuildCount(client, opts = {}) {
     }
   }
 
-  // Symmetric with startGatewayHeartbeat — runOnce so the first
-  // datapoint lands inside any future alarm window without waiting
-  // for the first interval. Today this metric is gauge-only on the
-  // dashboard, so the immediate emit is just consistency, but it
-  // keeps both timers behaving the same way.
-  //
-  // Caveat (#196): index.js calls startActiveGuildCount() right
-  // after client.login() resolves, which is BEFORE the gateway READY
-  // event populates client.guilds.cache. The first datapoint here
-  // can be 0 while the bot is actually in N guilds — an artifact of
-  // the cache hydrating asynchronously. The 60s interval makes this
-  // self-correcting within one window. Phase 2 alarm-wiring on this
-  // metric must reference #196 and decide on a fix (defer first
-  // emit until ready, OR alarm-side ignore-the-boot-window).
+  // Caveat (#196): index.js calls startActiveGuildCount() right after
+  // client.login() resolves, which is BEFORE the gateway READY event
+  // populates client.guilds.cache. The first datapoint here can be 0
+  // while the bot is actually in N guilds — an artifact of the cache
+  // hydrating asynchronously. The 60s interval makes this self-
+  // correcting within one window.
   tick();
 
   const timer = setInterval(tick, intervalMs);
-
   if (typeof timer.unref === 'function') timer.unref();
-
   return timer;
 }
 
@@ -447,22 +198,10 @@ module.exports = {
   startActiveGuildCount,
   readGatewayHealth,
   noteGatewayActivity,
-  maybeAutoRecoverZombieWS,
   HEARTBEAT_INTERVAL_MS,
   ACTIVE_GUILD_INTERVAL_MS,
   HEARTBEAT_ACK_AGE_THRESHOLD_MS,
-  GATEWAY_ACTIVITY_THRESHOLD_MS,
-  RECOVERY_ACTIVITY_THRESHOLD_MS,
-  RECOVERY_COOLDOWN_MS,
-  RECOVERY_RATE_LIMIT_COOLDOWN_MS,
-  // Test-only exports (NODE_ENV-gated to keep live state out of prod
-  // consumers, mirroring the commands.js _test pattern).
-  // _test gated on NODE_ENV === 'test' (NOT !== 'production') so
-  // a misconfigured prod task with NODE_ENV unset doesn't ship the
-  // internal handles. jest sets NODE_ENV='test' automatically; if
-  // local-dev workflows need access, set NODE_ENV=test for that
-  // shell.
   ...(process.env.NODE_ENV === 'test' && {
-    _test: { _resetGatewayActivity, _resetRecoveryClock },
+    _test: { _resetGatewayActivity },
   }),
 };

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -264,10 +264,13 @@ if (isGateway) {
   client.on('interactionCreate', handleCommand);
 
   // Tick the gateway-activity timestamp on every WebSocket frame.
-  // Catches event-loop saturation: if the loop is saturated, raw events
-  // queue up and the timestamp goes stale, flipping the heartbeat
-  // composite to unhealthy. Pass the function directly (not wrapped) so
-  // v8 keeps a single shape and avoids per-frame closure allocation.
+  // Feeds the `activity_age_ms` observability gauge ONLY — does not
+  // gate gateway health (post-#210). The signal can't distinguish "no
+  // traffic because idle" from "no traffic because wedged", so an
+  // alarm on it would false-positive on quiet bots; real zombie-WS
+  // detection lives elsewhere (see PR description on #210). Pass the
+  // function directly (not wrapped) so v8 keeps a single shape and
+  // avoids per-frame closure allocation.
   client.on('raw', noteGatewayActivity);
 
   // Error handling

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -143,6 +143,11 @@ describe('readGatewayHealth', () => {
     noteGatewayActivity(() => Date.now() + 10_000);
     const snap = readGatewayHealth(fakeClient({ ackedAgo: 5_000 }));
     expect(snap.activity_age_ms).toBe(0);
+    // Parity with the ack_age_ms NTP test: clamp must not flip
+    // healthy. activity_age_ms doesn't gate health post-#210, but
+    // pinning it here prevents a future regression where clamp +
+    // gating drift apart.
+    expect(snap.healthy).toBe(true);
   });
 
   test('noteGatewayActivity treats non-function arg as Date.now (production caller shape)', () => {
@@ -274,12 +279,16 @@ describe('startGatewayHeartbeat', () => {
     );
   });
 
-  test('idle bot stays healthy across many ticks (regression: pre-#210 false-positive)', () => {
+  test('idle bot stays healthy when activity_age_ms exceeds the legacy 60s threshold (regression: pre-#210 false-positive)', () => {
     // Pin the #210 fix: with no dispatched events for a long stretch
     // (idle sandbox / low-traffic prod), the bot must remain healthy
     // as long as heartbeat ACKs keep landing. The pre-#210 design
     // gated health on activity_age_ms < 60s, which silently failed
-    // every idle environment.
+    // every idle environment. We seed activity 10 minutes in the past
+    // (well past the 60s threshold) and freeze ack_age at 5s — the
+    // assertion is that healthy still holds. (Mock has a frozen
+    // lastPingTimestamp by design; pushing the test window past 60s
+    // would trip ack_age itself and fail for the wrong reason.)
     gatewayMetricsTest._resetGatewayActivity();
     noteGatewayActivity(() => Date.now() - 10 * 60_000); // 10 min idle
     const client = {

--- a/apps/discord/tests/gateway-metrics.test.js
+++ b/apps/discord/tests/gateway-metrics.test.js
@@ -1,22 +1,12 @@
 /**
  * Tests for the Phase 1 gateway-side periodic metric emitters.
- *
- * Coverage focuses on the readiness composite (the only non-trivial
- * logic) and the audit-event shape the terraform metric filters rely
- * on. The setInterval timers are exercised via jest fake timers so
- * each test can advance time deterministically.
  */
-const { WebSocketShardDestroyRecovery } = require('discord.js');
 const logger = require('../src/logger');
 const {
   startGatewayHeartbeat,
   startActiveGuildCount,
   readGatewayHealth,
   noteGatewayActivity,
-  maybeAutoRecoverZombieWS,
-  RECOVERY_ACTIVITY_THRESHOLD_MS,
-  RECOVERY_COOLDOWN_MS,
-  RECOVERY_RATE_LIMIT_COOLDOWN_MS,
   _test: gatewayMetricsTest,
 } = require('../src/gateway-metrics');
 const { AUDIT_EVENTS } = require('../src/constants');
@@ -31,9 +21,7 @@ jest.mock('../src/logger', () => ({
 
 function fakeClient({ isReady = true, ping = 42, ackedAgo = 5_000, guildCount = 3 } = {}) {
   // Mirror discord.js v14 shape: WebSocketShard.lastPingTimestamp is
-  // a numeric ms epoch (-1 pre-first-ack). Tests use null to indicate
-  // "no shards have an ack at all" (whole shards Map empty / each
-  // shard pre-first-ack).
+  // a numeric ms epoch (-1 pre-first-ack).
   const lastPingTimestamp = ackedAgo === null ? -1 : Date.now() - ackedAgo;
   const shards = new Map([[0, { lastPingTimestamp }]]);
   return {
@@ -43,11 +31,6 @@ function fakeClient({ isReady = true, ping = 42, ackedAgo = 5_000, guildCount = 
   };
 }
 
-// Most readGatewayHealth tests want a "recent activity" baseline so
-// the activity-gate (Justin #193 §2) doesn't make every test report
-// unhealthy. Reset + tick at the start of each test that exercises
-// the composite. Tests for the pre-first-frame ("no activity yet")
-// path explicitly skip this.
 beforeEach(() => {
   if (gatewayMetricsTest && typeof gatewayMetricsTest._resetGatewayActivity === 'function') {
     gatewayMetricsTest._resetGatewayActivity();
@@ -98,8 +81,6 @@ describe('readGatewayHealth', () => {
   });
 
   test('unhealthy when shard reports lastPingTimestamp = 0 (legacy/null shape)', () => {
-    // Future-proof: if a future discord.js version flips the
-    // pre-first-ack sentinel to 0, the > 0 guard still catches it.
     const client = {
       isReady: () => true,
       ws: { ping: 42, shards: new Map([[0, { lastPingTimestamp: 0 }]]) },
@@ -133,59 +114,48 @@ describe('readGatewayHealth', () => {
     expect(snap.ack_age_ms).toBe(null);
   });
 
-  test('unhealthy before the first gateway frame (lastGatewayActivityAt = 0 sentinel)', () => {
-    // Justin #193 §2: dispatch wedge / event-loop saturation case.
-    // At fresh-boot, before client.on('raw') has fired even once,
-    // lastGatewayActivityAt = 0 so activity_age_ms is null and
-    // composite must report unhealthy regardless of other signals.
+  test('activity_age_ms reports null before the first gateway frame', () => {
+    // Pre-first-frame: lastGatewayActivityAt = 0 sentinel. The metric
+    // payload must be null (not 0 or a giant number from the epoch),
+    // so dashboards don't render a misleading value.
     gatewayMetricsTest._resetGatewayActivity();
     const snap = readGatewayHealth(fakeClient({ ackedAgo: 5_000 }));
-    expect(snap.healthy).toBe(false);
     expect(snap.activity_age_ms).toBe(null);
-    expect(snap.is_ready).toBe(true); // ready, but never tick'd → still unhealthy
+    // Health is gated only on ack_age_ms, so a fresh boot with a recent
+    // ack and no dispatched event yet is still healthy.
+    expect(snap.healthy).toBe(true);
   });
 
-  test('unhealthy when activity is stale (>60s — event-loop saturation)', () => {
+  test('healthy regardless of activity_age_ms (idle bot is healthy)', () => {
+    // The pre-#210 design required activity_age_ms < 60s for healthy,
+    // which false-positived in idle environments where dispatched
+    // events (interactions, messages) don't arrive for long stretches.
+    // Health now depends only on ack_age_ms; activity is metric-only.
     gatewayMetricsTest._resetGatewayActivity();
-    // Simulate a tick 90 s ago by calling noteGatewayActivity() with a
-    // back-dated `now` injection.
-    noteGatewayActivity(() => Date.now() - 90_000);
-    const snap = readGatewayHealth(fakeClient({ ackedAgo: 5_000 }));
-    expect(snap.healthy).toBe(false);
-    expect(snap.activity_age_ms).toBeGreaterThanOrEqual(60_000);
-  });
-
-  test('healthy when activity is recent and other signals OK', () => {
-    gatewayMetricsTest._resetGatewayActivity();
-    noteGatewayActivity();
+    noteGatewayActivity(() => Date.now() - 5 * 60_000); // 5 min idle
     const snap = readGatewayHealth(fakeClient({ ackedAgo: 5_000 }));
     expect(snap.healthy).toBe(true);
-    expect(snap.activity_age_ms).toBeLessThan(60_000);
+    expect(snap.activity_age_ms).toBeGreaterThanOrEqual(5 * 60_000);
   });
 
   test('NTP step-backward clamps activity_age_ms to 0', () => {
     gatewayMetricsTest._resetGatewayActivity();
-    // Simulate a tick "in the future" (clock just stepped backward).
     noteGatewayActivity(() => Date.now() + 10_000);
     const snap = readGatewayHealth(fakeClient({ ackedAgo: 5_000 }));
     expect(snap.activity_age_ms).toBe(0);
-    expect(snap.healthy).toBe(true);
   });
 
   test('noteGatewayActivity treats non-function arg as Date.now (production caller shape)', () => {
     // discord.js's `raw` event passes a packet object as the first
     // arg, not a clock function. The defensive `typeof === 'function'`
-    // fallback must keep the timestamp updating in that case. Without
-    // this test, a future refactor that drops the typeof check would
-    // pass tests that only exercise the clock-fn injection form.
+    // fallback must keep the timestamp updating in that case.
     gatewayMetricsTest._resetGatewayActivity();
-    const fakePacket = { op: 11, t: null, s: null, d: null }; // discord.js raw shape
+    const fakePacket = { op: 0, t: 'INTERACTION_CREATE', s: 1, d: {} };
     const before = Date.now();
     noteGatewayActivity(fakePacket);
     const snap = readGatewayHealth(fakeClient({ ackedAgo: 5_000 }));
     expect(snap.activity_age_ms).toBeGreaterThanOrEqual(0);
     expect(snap.activity_age_ms).toBeLessThan(Date.now() - before + 100);
-    expect(snap.healthy).toBe(true);
   });
 });
 
@@ -193,20 +163,8 @@ describe('startGatewayHeartbeat', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    // Reset + tick activity AFTER useFakeTimers so the timestamp uses
-    // the same fake-clock source as the readGatewayHealth comparisons.
-    // Without this, the outer beforeEach() ticks with real Date.now(),
-    // then advanceTimersByTime drifts the fake clock — Math.max(0,…)
-    // papers over the negative diff so tests pass, but the activity
-    // gate isn't actually being exercised in these tests.
-    //
-    // Reset the recovery cooldown too: a previous test in this block
-    // may have stamped lastRecoveryAttemptAt, which would silently
-    // make a downstream test that expects a triggered recovery
-    // pass-as-cooldown'd instead.
     if (gatewayMetricsTest && typeof gatewayMetricsTest._resetGatewayActivity === 'function') {
       gatewayMetricsTest._resetGatewayActivity();
-      gatewayMetricsTest._resetRecoveryClock();
     }
     noteGatewayActivity();
   });
@@ -235,11 +193,10 @@ describe('startGatewayHeartbeat', () => {
     );
   });
 
-  test('emits gateway_heartbeat_unhealthy carrying activity_age_ms when unhealthy (Max-on-activity_age_ms alarm source)', () => {
+  test('emits gateway_heartbeat_unhealthy carrying activity_age_ms when unhealthy', () => {
     // Pin the contract that the unhealthy companion event always
     // carries activity_age_ms — terraform's metric filter extracts
-    // that field directly. A future refactor that drops it from the
-    // payload would silently break the alarm.
+    // that field directly.
     const client = fakeClient({ isReady: false });
     startGatewayHeartbeat(client, { intervalMs: 1_000 });
     jest.advanceTimersByTime(1_000);
@@ -287,10 +244,6 @@ describe('startGatewayHeartbeat', () => {
   });
 
   test('logs healthy → unhealthy transition exactly once (edge-triggered, not per-tick)', () => {
-    // Start healthy, run two healthy ticks, then flip the client to
-    // unhealthy and run two more ticks. Expect exactly ONE warn at
-    // the edge — NOT one per unhealthy tick. Pin the broken contract
-    // ("warn fires every interval while wedged") that would spam logs.
     let isReady = true;
     const client = {
       isReady: () => isReady,
@@ -298,7 +251,6 @@ describe('startGatewayHeartbeat', () => {
       guilds: { cache: { size: 1 } },
     };
     startGatewayHeartbeat(client, { intervalMs: 1_000 });
-    // Initial runOnce + 1 tick = 2 healthy samples
     jest.advanceTimersByTime(1_000);
     expect(logger.warn).not.toHaveBeenCalled();
 
@@ -311,7 +263,6 @@ describe('startGatewayHeartbeat', () => {
       expect.objectContaining({ is_ready: false }),
     );
 
-    // Recovery → exactly one info, not one per healthy tick
     isReady = true;
     logger.info.mockClear();
     jest.advanceTimersByTime(1_000); // recovery → info
@@ -323,43 +274,31 @@ describe('startGatewayHeartbeat', () => {
     );
   });
 
-  test('tick() invokes auto-recovery when activity is stale past threshold (integration: pin the wiring)', () => {
-    // Without this test, deleting the maybeAutoRecoverZombieWS call
-    // from tick() — or flipping its guard from `!healthy` to
-    // `healthy` — would pass every other test in this file. Pin the
-    // wire so a regression has to break this assertion to land.
-    if (gatewayMetricsTest && typeof gatewayMetricsTest._resetGatewayActivity === 'function') {
-      gatewayMetricsTest._resetGatewayActivity();
-      gatewayMetricsTest._resetRecoveryClock();
-    }
-    // Back-date activity by 200s so the snapshot will be unhealthy
-    // AND past RECOVERY_ACTIVITY_THRESHOLD_MS (120s).
-    noteGatewayActivity(() => Date.now() - 200_000);
-    const shard = { destroy: jest.fn(() => Promise.resolve()) };
+  test('idle bot stays healthy across many ticks (regression: pre-#210 false-positive)', () => {
+    // Pin the #210 fix: with no dispatched events for a long stretch
+    // (idle sandbox / low-traffic prod), the bot must remain healthy
+    // as long as heartbeat ACKs keep landing. The pre-#210 design
+    // gated health on activity_age_ms < 60s, which silently failed
+    // every idle environment.
+    gatewayMetricsTest._resetGatewayActivity();
+    noteGatewayActivity(() => Date.now() - 10 * 60_000); // 10 min idle
     const client = {
       isReady: () => true,
-      ws: { ping: 42, shards: new Map([[0, shard]]) },
+      ws: { ping: 42, shards: new Map([[0, { lastPingTimestamp: Date.now() - 5_000 }]]) },
       guilds: { cache: { size: 1 } },
     };
-    startGatewayHeartbeat(client, { intervalMs: 60_000 });
-    // runOnce already fired — no advanceTimers needed.
-    expect(shard.destroy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        code: 4000,
-        recover: WebSocketShardDestroyRecovery.Reconnect,
-      }),
-    );
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Gateway auto-recovery: forcing reconnect (zombie WS)',
-      expect.objectContaining({ shards_terminated: 1 }),
+    startGatewayHeartbeat(client, { intervalMs: 1_000 });
+    jest.advanceTimersByTime(5_000);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.audit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.GATEWAY_HEARTBEAT,
+      expect.any(Object),
     );
   });
 
   test('runs once immediately so the first datapoint lands inside the boot alarm window', () => {
     const client = fakeClient({ ackedAgo: 5_000 });
     startGatewayHeartbeat(client, { intervalMs: 60_000 });
-    // No timer advance — just invocation. The runOnce should already
-    // have emitted a heartbeat without waiting for the first interval.
     expect(logger.audit).toHaveBeenCalledTimes(1);
     expect(logger.audit).toHaveBeenCalledWith(
       AUDIT_EVENTS.GATEWAY_HEARTBEAT,
@@ -368,7 +307,7 @@ describe('startGatewayHeartbeat', () => {
   });
 
   test('Math.max(0, …) guards against negative ack_age_ms from NTP step backward', () => {
-    const future = Date.now() + 10_000; // simulate clock that jumped backward
+    const future = Date.now() + 10_000;
     const shards = new Map([[0, { lastPingTimestamp: future }]]);
     const client = {
       isReady: () => true,
@@ -377,9 +316,6 @@ describe('startGatewayHeartbeat', () => {
     };
     const snap = readGatewayHealth(client);
     expect(snap.ack_age_ms).toBe(0);
-    // healthy still requires ack_age_ms < 60_000 — clamp keeps the
-    // signal correct: a backward clock step now produces "very recent
-    // ack" which is the right semantic, not "stale by Number.MIN".
     expect(snap.healthy).toBe(true);
   });
 });
@@ -388,8 +324,6 @@ describe('startActiveGuildCount', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    // See startGatewayHeartbeat beforeEach for why activity reset
-    // happens AFTER useFakeTimers (clock-source consistency).
     if (gatewayMetricsTest && typeof gatewayMetricsTest._resetGatewayActivity === 'function') {
       gatewayMetricsTest._resetGatewayActivity();
     }
@@ -415,13 +349,8 @@ describe('startActiveGuildCount', () => {
   });
 
   test('runs once immediately so the first gauge sample lands without waiting for the interval', () => {
-    // Symmetric with the startGatewayHeartbeat runOnce test. Pins the
-    // round-3 addition: a future refactor that drops the immediate
-    // tick() would otherwise pass CI silently because the existing
-    // tests advance fake timers before asserting.
     const client = fakeClient({ guildCount: 5 });
     startActiveGuildCount(client, { intervalMs: 60_000 });
-    // No timer advance — runOnce should already have emitted.
     expect(logger.audit).toHaveBeenCalledTimes(1);
     expect(logger.audit).toHaveBeenCalledWith(
       AUDIT_EVENTS.ACTIVE_GUILD_COUNT,
@@ -437,320 +366,5 @@ describe('startActiveGuildCount', () => {
     jest.advanceTimersByTime(1_000);
     expect(logger.audit).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
-  });
-});
-
-describe('maybeAutoRecoverZombieWS', () => {
-  // Default destroy returns a resolved promise — discord.js's destroy
-  // is async, and we test that the fire-and-forget caller handles
-  // both success and rejection without breaking the tick loop.
-  function shardClient({ destroyImpl } = {}) {
-    const shard = { destroy: destroyImpl ?? jest.fn(() => Promise.resolve()) };
-    return {
-      client: { ws: { shards: new Map([[0, shard]]) } },
-      shard,
-    };
-  }
-
-  beforeEach(() => {
-    if (gatewayMetricsTest && typeof gatewayMetricsTest._resetRecoveryClock === 'function') {
-      gatewayMetricsTest._resetRecoveryClock();
-    }
-    jest.clearAllMocks();
-  });
-
-  test('skips when client is not ready (boot/reconnect already running)', () => {
-    const { client, shard } = shardClient();
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: false, activity_age_ms: 999_999 },
-    );
-    expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('not_ready');
-    expect(shard.destroy).not.toHaveBeenCalled();
-  });
-
-  test('skips when activity baseline is null (pre-first-frame)', () => {
-    const { client, shard } = shardClient();
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: null },
-    );
-    expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('no_activity_baseline');
-    expect(shard.destroy).not.toHaveBeenCalled();
-  });
-
-  test('skips when activity is below threshold', () => {
-    const { client, shard } = shardClient();
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS - 1 },
-    );
-    expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('within_threshold');
-    expect(shard.destroy).not.toHaveBeenCalled();
-  });
-
-  test('triggers shard.destroy when activity is past threshold', () => {
-    const { client, shard } = shardClient();
-    const t = 1_000_000;
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    expect(result.triggered).toBe(true);
-    expect(result.reason).toBe('zombie_ws');
-    expect(result.shardsTerminated).toBe(1);
-    // `code` (NOT closeCode) — different field; closeCode would be
-    // silently ignored. `recover` MUST be set or the shard goes Idle
-    // and never reconnects (defeats the whole point of this code path).
-    expect(shard.destroy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        code: 4000,
-        recover: WebSocketShardDestroyRecovery.Reconnect,
-      }),
-    );
-  });
-
-  test('debounces a second attempt inside the cooldown window', () => {
-    const { client, shard } = shardClient();
-    const t0 = 1_000_000;
-    const first = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t0,
-    );
-    expect(first.triggered).toBe(true);
-    shard.destroy.mockClear();
-
-    const second = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 5_000 },
-      () => t0 + RECOVERY_COOLDOWN_MS - 1,
-    );
-    expect(second.triggered).toBe(false);
-    expect(second.reason).toBe('cooldown');
-    expect(shard.destroy).not.toHaveBeenCalled();
-  });
-
-  test('allows a second attempt after the cooldown elapses', () => {
-    const { client, shard } = shardClient();
-    const t0 = 1_000_000;
-    maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t0,
-    );
-    shard.destroy.mockClear();
-
-    const second = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t0 + RECOVERY_COOLDOWN_MS + 1,
-    );
-    expect(second.triggered).toBe(true);
-    expect(shard.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  test('all shards sync-throw → all_destroys_threw + short rate-limit cooldown', () => {
-    const { client, shard } = shardClient({
-      destroyImpl: jest.fn(() => { throw new Error('bad-args'); }),
-    });
-    const t = 1_000_000;
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    // Shards exist, every destroy() sync-threw — distinct from
-    // the empty/missing-shards branch (which retries next tick).
-    expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('all_destroys_threw');
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Shard destroy threw synchronously during auto-recovery',
-      expect.objectContaining({ error: 'bad-args' }),
-    );
-    expect(shard.destroy).toHaveBeenCalled();
-
-    // Within the rate-limit cooldown window, recovery is gated to
-    // bound warn-log volume — the warn block doesn't re-fire.
-    const second = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t + 1_000,
-    );
-    expect(second.reason).toBe('cooldown');
-  });
-
-  test('all_destroys_threw rate-limit cooldown elapses → recovery retries', () => {
-    const { client, shard } = shardClient({
-      destroyImpl: jest.fn(() => { throw new Error('bad-args'); }),
-    });
-    const t0 = 1_000_000;
-    maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t0,
-    );
-    shard.destroy.mockClear();
-
-    // Past the rate-limit cooldown but still inside the 10-min main
-    // cooldown — recovery should retry (the main cooldown is only
-    // stamped on successful termination, which never happened here).
-    const second = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t0 + RECOVERY_RATE_LIMIT_COOLDOWN_MS + 1,
-    );
-    expect(second.reason).toBe('all_destroys_threw');
-    expect(shard.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  test('successful recovery resets activity baseline (next snapshot reads null until first post-reconnect frame)', () => {
-    const { client } = shardClient({
-      destroyImpl: jest.fn(),
-    });
-    const t = 2_000_000;
-    // Pre-condition: activity baseline is set (the beforeEach
-    // noteGatewayActivity() seeded it). Confirm a snapshot has a
-    // numeric activity_age_ms before we trigger recovery.
-    const preSnap = readGatewayHealth(client);
-    expect(typeof preSnap.activity_age_ms).toBe('number');
-
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    expect(result.triggered).toBe(true);
-
-    // After successful destroy, the baseline is cleared. A snapshot
-    // taken before the new WebSocket's first raw frame reports null
-    // — readGatewayHealth treats lastGatewayActivityAt === 0 as the
-    // pre-first-frame sentinel. This prevents a tick between
-    // is_ready flipping back true and the first post-reconnect raw
-    // frame from observing the pre-destroy stale value still climbing.
-    const postSnap = readGatewayHealth(client);
-    expect(postSnap.activity_age_ms).toBeNull();
-
-    // First post-reconnect raw frame re-baselines.
-    noteGatewayActivity();
-    const postNoteSnap = readGatewayHealth(client);
-    expect(typeof postNoteSnap.activity_age_ms).toBe('number');
-    expect(postNoteSnap.activity_age_ms).toBeLessThan(1_000);
-  });
-
-  test('handles destroy() promise rejection without crashing the process', async () => {
-    const destroyImpl = jest.fn(() => Promise.reject(new Error('async-destroy-failed')));
-    const { client, shard } = shardClient({ destroyImpl });
-    const t = 1_000_000;
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    // Sync result still triggered — we count the destroy as fired.
-    expect(result.triggered).toBe(true);
-    expect(result.shardsTerminated).toBe(1);
-    // Wait one microtask tick for the rejection handler.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Shard destroy promise rejected during auto-recovery',
-      expect.objectContaining({ error: 'async-destroy-failed' }),
-    );
-    expect(shard.destroy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        code: 4000,
-        recover: WebSocketShardDestroyRecovery.Reconnect,
-      }),
-    );
-  });
-
-  test('returns no_shards (does NOT consume cooldown) when client.ws.shards is missing', () => {
-    const t = 1_000_000;
-    const result = maybeAutoRecoverZombieWS(
-      { ws: {} },
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    // No shards to terminate => not triggered, no cooldown stamp,
-    // next tick retries. (If is_ready=true while shards is missing,
-    // the bot is in a pathological state — locking out for 10min
-    // serves no one.)
-    expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('no_shards');
-
-    // Same-tick second call confirms the cooldown was NOT stamped.
-    const second = maybeAutoRecoverZombieWS(
-      { ws: {} },
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t + 100,
-    );
-    expect(second.reason).toBe('no_shards');
-  });
-
-  test('returns no_shards when client.ws itself is undefined', () => {
-    const t = 1_000_000;
-    const result = maybeAutoRecoverZombieWS(
-      {},
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    expect(result.triggered).toBe(false);
-    expect(result.reason).toBe('no_shards');
-  });
-
-  test('triggers across multiple shards (happy path) — pin shardsTerminated count', () => {
-    const shardA = { destroy: jest.fn(() => Promise.resolve()) };
-    const shardB = { destroy: jest.fn(() => Promise.resolve()) };
-    const client = { ws: { shards: new Map([[0, shardA], [1, shardB]]) } };
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => 1_000_000,
-    );
-    expect(result.triggered).toBe(true);
-    expect(result.shardsTerminated).toBe(2);
-    expect(shardA.destroy).toHaveBeenCalledTimes(1);
-    expect(shardB.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  test('partial-failure: one shard sync-throws, other succeeds — cooldown still stamped', () => {
-    const shardA = { destroy: jest.fn(() => { throw new Error('borked'); }) };
-    const shardB = { destroy: jest.fn(() => Promise.resolve()) };
-    const client = { ws: { shards: new Map([[0, shardA], [1, shardB]]) } };
-    const t = 1_000_000;
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t,
-    );
-    expect(result.triggered).toBe(true);
-    expect(result.shardsTerminated).toBe(1); // B succeeded; A threw
-    // Cooldown WAS stamped (>=1 success), so an immediate retry debounces.
-    const second = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS + 1 },
-      () => t + 1_000,
-    );
-    expect(second.reason).toBe('cooldown');
-  });
-
-  test('boundary: activity_age_ms === RECOVERY_ACTIVITY_THRESHOLD_MS triggers (>= semantic)', () => {
-    // Code uses `< THRESHOLD` to gate, so equality falls THROUGH to
-    // the recovery path. Pin the boundary so a future refactor to
-    // `<=` (which would silently delay recovery by one tick) breaks
-    // this test instead of getting silently merged.
-    const { client, shard } = shardClient();
-    const result = maybeAutoRecoverZombieWS(
-      client,
-      { is_ready: true, activity_age_ms: RECOVERY_ACTIVITY_THRESHOLD_MS },
-      () => 1_000_000,
-    );
-    expect(result.triggered).toBe(true);
-    expect(shard.destroy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

PR #208's auto-recovery fires off a flawed detection signal. Reverting the detection design while keeping `activity_age_ms` as an observability gauge.

## Root cause

PR #208 gated heartbeat health on `activity_age_ms < 60s` and added `maybeAutoRecoverZombieWS` to force-reconnect on staleness. The premise:

> Reuses the existing composite-readiness signal: `activity_age_ms` (last `client.on('raw', ...)` frame, set on every WebSocket frame including heartbeats).

That last claim is wrong in discord.js v14. `client.on('raw', ...)` only fires on **dispatched** gateway events (op 0 — `INTERACTION_CREATE`, `MESSAGE_CREATE`, `READY`, etc.). Control-plane packets (HEARTBEAT_ACK, op 11) do **not** trigger it. So `activity_age_ms` measures "time since last Discord event," not "time since last frame."

In any idle period (no real Discord events), `activity_age_ms` climbs indefinitely while the WebSocket stays perfectly healthy. Both sandbox and prod (no real users currently) trip the alarm whenever traffic dries up.

## Evidence — live audit logs from 2026-05-09 00:14-00:21 UTC

Vikram triggered `/qurl send` at 00:14:56 UTC. Reset → climb → flip → reset → climb pattern is the smoking gun:

| Time | activity_age_ms | State |
|------|-----------------|-------|
| 00:14:56 | **230ms** | `/qurl send` arrived (raw frame fired) |
| 00:15:26 | 7,397ms | Recent — last frame ~7s ago |
| 00:15:56 | 37,408ms | +30s (one heartbeat-sampler tick) — climbing |
| 00:16:26 | **6,971ms** | Another raw event reset it |
| 00:17:26 | 66,977ms | Crossed 60s → unhealthy |
| 00:18:26 | **16,837ms** | Another event reset → healthy |
| 00:19:26 | 76,840ms | Idle again, crossed 60s → unhealthy |
| 00:20:26 | 136,845ms | Past 120s recovery threshold — but `maybeAutoRecoverZombieWS` never fired (separate latent bug) |
| 00:21:26 | 196,849ms | Still climbing in idle |

If `raw` fired on heartbeats too, `activity_age_ms` would never exceed ~30s. It climbs by exactly 30s per sampler tick whenever no events arrive — confirming the dispatch-only behavior.

## Operational impact (alarm history)

The `qurl-bot-discord-gateway-heartbeat-silence` alarm has bounced OK ↔ ALARM **48+ times in the last ~72 hours** in sandbox alone. Each ALARM stretch coincides with a quiet period; each clear coincides with someone (or some test) interacting with the bot. The alarm is currently stuck in ALARM since 2026-05-09 00:26 UTC because no interactions happened in the test guild for ~5h.

## Fix

`readGatewayHealth`:

- **Drop** `activity_age_ms < GATEWAY_ACTIVITY_THRESHOLD_MS` from the `healthy` predicate. Health = `is_ready && ping_ms > 0 && ack_age_ms < 60s`. ACK age is the real WebSocket-health signal; it grows when heartbeats stop landing, which is the genuine wedge case.
- **Keep** `activity_age_ms` in the audit-event payload as an observability gauge. Dashboards and ad-hoc queries can still see "time since last dispatched event" — just don't gate alarms on it.
- **Remove** `maybeAutoRecoverZombieWS` entirely along with the `RECOVERY_*` constants. Detection signal can't distinguish idle from zombie at the gateway level (idle and wedged both have high `activity_age_ms` and healthy ACKs). Separately, the recovery never fired in the wild despite `activity_age_ms` crossing the 120s threshold many times — likely a `client.ws.shards` shape mismatch in `@discordjs/ws@^1.2.3`. Both are moot now.

## What zombie-WS detection should look like (follow-up, NOT in this PR)

The original `5/8` zombie incident PR #208 was written for is real. Catching it requires a signal that distinguishes "events should be flowing but aren't" from "no events are expected." Options:

1. **Active probe**: bot sends itself a synthetic interaction (or modifies its own presence) every 5 min and watches for the round-trip. End-to-end coverage of the dispatch path.
2. **`shardError` / `shardDisconnect` listeners**: cheaper but only catches some failure modes.
3. **External health probe**: HTTP service pings the bot via Discord's REST API and watches for ack via gateway. Cleanest separation but most infra.

I'll file an issue to design and pick one once this revert lands.

## Companion changes needed

`qurl-integrations-infra`'s `gateway_activity_age_ms_high` alarm (added in #446) becomes redundant with `gateway-heartbeat-silence` since `gateway_heartbeat_unhealthy` events now only fire on real WS issues. Follow-up infra PR will drop it. Keeping for now is harmless: post-merge the metric only emits during actual WS wedges, where both alarms would correctly fire.

## Test plan

- [x] Full discord test suite: `npx jest --no-cache` — 923/923 pass
- [x] New regression test pinning the fix: `'idle bot stays healthy across many ticks (regression: pre-#210 false-positive)'`
- [x] All readGatewayHealth tests updated to reflect activity-not-gating-health semantics
- [x] Removed entire `maybeAutoRecoverZombieWS` describe block (function is gone)
- [ ] Sandbox deploy: confirm `gateway-heartbeat-silence` clears within ~2 min of the new task taking over and stays clear during idle
- [ ] Sandbox deploy: confirm `gateway_heartbeat_healthy` events emit continuously during idle (no more false-unhealthy emissions)

## Deploy chain note

This PR's deploy is currently blocked on issue #454 (`GRAFANA_AUTH` secret missing on `qurl-integrations-infra`). Same blocker for PR #209 and any other queued change. Once Justin provisions the secret, both fixes ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)