### PR TITLE
fix(discord): restore multi-user select on /qurl send "A specific user" target

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -365,6 +365,12 @@ const EXPIRY_LABELS = {
 
 const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ name, value }));
 
+// Per-pick cap on UserSelectMenuBuilder.setMaxValues. Discord's hard
+// limit is 25; capping at 10 bounds the UX. Both the initial user-
+// target select AND the channel-target's "Add more recipients" flow
+// use this — keep them in lockstep so a future bump doesn't drift.
+const USER_SELECT_PER_PICK_CAP = 10;
+
 function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
   // sanitizeDisplayName: NFKC + bidi/zero-width strip + markdown escape
   // + 64-char cap + 'Someone' fallback. Same helper used at the channel
@@ -1321,18 +1327,12 @@ async function handleSend(interaction, apiKey) {
     ));
 
     if (target === 'user') {
-      // Multi-user select. Per-pick cap mirrors the channel-target's
-      // "Add more recipients" flow (~line 2058) — Discord allows up
-      // to 25 in one user-select, but capping at 10 keeps the UX
-      // bounded and matches the existing add-more cadence. The
-      // per-send envelope cap (config.QURL_SEND_MAX_RECIPIENTS) is
-      // re-checked downstream alongside the channel-target path.
       rows.push(new ActionRowBuilder().addComponents(
         new UserSelectMenuBuilder()
           .setCustomId(ids.userSelect)
           .setPlaceholder('Pick one or more users')
           .setMinValues(1)
-          .setMaxValues(Math.min(10, config.QURL_SEND_MAX_RECIPIENTS))
+          .setMaxValues(Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS))
       ));
     }
 
@@ -1482,22 +1482,18 @@ async function handleSend(interaction, apiKey) {
     }
 
     if (compInt.customId === ids.userSelect) {
-      // Multi-select: read every picked user, validate each, and
-      // replace `recipients` with the full picked set on success.
-      // compInt.users is a discord.js Collection (Map subclass), so
-      // .values() yields every entry; spreading materializes the
-      // array. A previous single-pick build used .first() — that
-      // shape silently dropped extra picks when the dropdown was
-      // bumped to multi-select.
+      // REPLACE semantic (not append): Discord's user-select shows
+      // the previously-picked set as the default and the user edits
+      // it; un-picking Bob and adding Carol must yield [Carol], not
+      // [Bob, Carol]. Use the channel-target's "Add more recipients"
+      // button for the additive path.
       const selected = [...compInt.users.values()];
       if (selected.length === 0) {
         await safeCompDefer(compInt);
         continue;
       }
-      // Reject the whole selection if ANY entry is invalid (vs.
-      // silently dropping bad picks) — matches the prior single-pick
-      // "warn loud, don't accept partial" UX. Operator re-picks
-      // without the offender.
+      // Fail-loud over silent-drop — operator re-picks without the
+      // offender. Matches the prior single-pick UX.
       if (selected.some(u => u.bot)) {
         await safeCompUpdate(compInt, { content: formContent({ warning: 'Cannot send to a bot. Re-pick without any bot users.' }), components: formRows() });
         continue;
@@ -2072,7 +2068,7 @@ async function handleSend(interaction, apiKey) {
           setCooldown(interaction.user.id);
 
           // Show user select menu — collect the response on the REPLY message
-          const maxSelect = Math.min(10, remaining);
+          const maxSelect = Math.min(USER_SELECT_PER_PICK_CAP, remaining);
           const userSelectRow = new ActionRowBuilder().addComponents(
             new UserSelectMenuBuilder()
               .setCustomId(`qurl_addusers_${sendId}`)

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1315,18 +1315,24 @@ async function handleSend(interaction, apiKey) {
         .setCustomId(ids.targetSelect)
         .setPlaceholder('Recipient(s) — choose type')
         .addOptions(
-          { label: 'A specific user', value: 'user', description: 'Pick one user to send to', default: target === 'user' },
+          { label: 'A specific user', value: 'user', description: 'Pick one or more users to send to', default: target === 'user' },
           { label: channelOptionLabel, value: 'channel', description: channelOptionDescription, default: target === 'channel' },
         )
     ));
 
     if (target === 'user') {
+      // Multi-user select. Per-pick cap mirrors the channel-target's
+      // "Add more recipients" flow (~line 2058) — Discord allows up
+      // to 25 in one user-select, but capping at 10 keeps the UX
+      // bounded and matches the existing add-more cadence. The
+      // per-send envelope cap (config.QURL_SEND_MAX_RECIPIENTS) is
+      // re-checked downstream alongside the channel-target path.
       rows.push(new ActionRowBuilder().addComponents(
         new UserSelectMenuBuilder()
           .setCustomId(ids.userSelect)
-          .setPlaceholder('Pick a user')
+          .setPlaceholder('Pick one or more users')
           .setMinValues(1)
-          .setMaxValues(1)
+          .setMaxValues(Math.min(10, config.QURL_SEND_MAX_RECIPIENTS))
       ));
     }
 
@@ -1350,7 +1356,7 @@ async function handleSend(interaction, apiKey) {
         )
     ));
 
-    const recipientsResolved = (target === 'user' && recipients.length === 1)
+    const recipientsResolved = (target === 'user' && recipients.length >= 1)
       || (target === 'channel' && recipients.length > 0);
     rows.push(new ActionRowBuilder().addComponents(
       new ButtonBuilder()
@@ -1476,20 +1482,31 @@ async function handleSend(interaction, apiKey) {
     }
 
     if (compInt.customId === ids.userSelect) {
-      const selectedUser = compInt.users.first();
-      if (!selectedUser) {
+      // Multi-select: read every picked user, validate each, and
+      // replace `recipients` with the full picked set on success.
+      // compInt.users is a discord.js Collection (Map subclass), so
+      // .values() yields every entry; spreading materializes the
+      // array. A previous single-pick build used .first() — that
+      // shape silently dropped extra picks when the dropdown was
+      // bumped to multi-select.
+      const selected = [...compInt.users.values()];
+      if (selected.length === 0) {
         await safeCompDefer(compInt);
         continue;
       }
-      if (selectedUser.bot) {
-        await safeCompUpdate(compInt, { content: formContent({ warning: 'Cannot send to a bot. Pick a different user.' }), components: formRows() });
+      // Reject the whole selection if ANY entry is invalid (vs.
+      // silently dropping bad picks) — matches the prior single-pick
+      // "warn loud, don't accept partial" UX. Operator re-picks
+      // without the offender.
+      if (selected.some(u => u.bot)) {
+        await safeCompUpdate(compInt, { content: formContent({ warning: 'Cannot send to a bot. Re-pick without any bot users.' }), components: formRows() });
         continue;
       }
-      if (selectedUser.id === interaction.user.id) {
-        await safeCompUpdate(compInt, { content: formContent({ warning: 'Cannot send to yourself. Pick a different user.' }), components: formRows() });
+      if (selected.some(u => u.id === interaction.user.id)) {
+        await safeCompUpdate(compInt, { content: formContent({ warning: 'Cannot send to yourself. Re-pick without your own user.' }), components: formRows() });
         continue;
       }
-      recipients = [selectedUser];
+      recipients = selected;
       await safeCompUpdate(compInt, { content: formContent(), components: formRows() });
       continue;
     }

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -979,6 +979,60 @@ describe('handleSend — Step 3: final form', () => {
     }));
   });
 
+  it('target=user re-picking REPLACES the previous set (matches Discord user-select edit semantic)', async () => {
+    // Pin REPLACE-vs-APPEND. User picks Bob first, then re-opens the
+    // dropdown and picks Carol+Dave (without Bob). Final recipients
+    // must be [Carol, Dave], not [Bob, Carol, Dave]. Discord shows
+    // the previously-picked set as the default and the user edits it
+    // — un-picking Bob and adding the others is an explicit removal.
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/c' },
+      { qurl_link: 'https://q.test/d' },
+    ]);
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect1 = makeCompInt(ids.userSelect, {
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
+    });
+    const userSelect2 = makeCompInt(ids.userSelect, {
+      users: mockUsers(
+        { id: 'user-3', bot: false, username: 'Carol' },
+        { id: 'user-4', bot: false, username: 'Dave' },
+      ),
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), targetUser, userSelect1, userSelect2, sendBtn],
+    });
+    await cmd.execute(interaction);
+    // 2 DMs (Carol + Dave) — Bob from the first pick is gone.
+    expect(mockSendDM).toHaveBeenCalledTimes(2);
+    const recipientIds = mockSendDM.mock.calls.map(c => c[0]);
+    expect(recipientIds).toEqual(expect.arrayContaining(['user-3', 'user-4']));
+    expect(recipientIds).not.toContain('user-2');
+  });
+
+  it('target=user picks at the cap (10 users) — all delivered', async () => {
+    // Pin the boundary at Math.min(USER_SELECT_PER_PICK_CAP, ...).
+    // Discord won't let setMaxValues exceed 25; bumping our cap above
+    // 10 silently here would risk drift — the test fails loud if a
+    // future change drops a recipient at the boundary.
+    const cap = 10;
+    const tenUsers = Array.from({ length: cap }, (_, i) => ({
+      id: `user-${i + 2}`, bot: false, username: `User${i + 2}`,
+    }));
+    mockMintLinks.mockResolvedValueOnce(
+      tenUsers.map((_, i) => ({ qurl_link: `https://q.test/u${i}` })),
+    );
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, { users: mockUsers(...tenUsers) });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), targetUser, userSelect, sendBtn],
+    });
+    await cmd.execute(interaction);
+    expect(mockSendDM).toHaveBeenCalledTimes(cap);
+  });
+
   it('target=user rejects the whole selection if ANY pick is the sender', async () => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelectSelf = makeCompInt(ids.userSelect, {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -232,7 +232,7 @@ function makeCompInt(customId, overrides = {}) {
     showModal: jest.fn().mockResolvedValue(undefined),
     awaitModalSubmit: jest.fn().mockRejectedValue(new Error('timeout')),
     values: [],
-    users: { first: jest.fn(() => null) },
+    users: { first: jest.fn(() => null), values: jest.fn(() => [][Symbol.iterator]()) },
     ...overrides,
   };
 }
@@ -903,29 +903,71 @@ describe('handleSend — Step 3: final form', () => {
     expect(sendCooldowns.has('user-1')).toBe(false);
   });
 
-  it('target=user picks a recipient, send button completes flow', async () => {
+  // Helper for the multi-pick mock — Discord's `compInt.users` is a
+  // Collection (Map subclass), so the route reads `users.values()`.
+  // Returning an array of users from .values() matches the iterator
+  // contract close enough for the spread `[...users.values()]`.
+  const mockUsers = (...users) => ({ values: jest.fn(() => users[Symbol.iterator]()) });
+
+  it('target=user picks a single recipient, send button completes flow', async () => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const interaction = makeInteraction({
       awaitQueue: [locInitBtn(), targetUser, userSelect, sendBtn],
     });
     await cmd.execute(interaction);
-    // Send button update fires before the back-half kicks in.
     expect(sendBtn.update).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining('Preparing send'),
     }));
-    // Back-half ran: mintLinks + sendDM
     expect(mockMintLinks).toHaveBeenCalled();
     expect(mockSendDM).toHaveBeenCalled();
   });
 
-  it('target=user rejects selecting a bot', async () => {
+  it('target=user picks MULTIPLE recipients, send fan-outs to all of them', async () => {
+    // Pin the multi-select regression fix: a single user-select
+    // interaction yielding N picks must produce N DMs (not just 1).
+    // Previous single-pick handler (`.users.first()`) silently dropped
+    // every pick beyond the first.
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/a' },
+      { qurl_link: 'https://q.test/b' },
+      { qurl_link: 'https://q.test/c' },
+    ]);
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: mockUsers(
+        { id: 'user-2', bot: false, username: 'Bob' },
+        { id: 'user-3', bot: false, username: 'Carol' },
+        { id: 'user-4', bot: false, username: 'Dave' },
+      ),
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(), targetUser, userSelect, sendBtn],
+    });
+    await cmd.execute(interaction);
+    expect(sendBtn.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Preparing send'),
+    }));
+    // 3 picks → 3 DMs (one per recipient, each with their own qURL).
+    expect(mockSendDM).toHaveBeenCalledTimes(3);
+    expect(mockSendDM.mock.calls.map(c => c[0])).toEqual(
+      expect.arrayContaining(['user-2', 'user-3', 'user-4']),
+    );
+  });
+
+  it('target=user rejects the whole selection if ANY pick is a bot', async () => {
+    // Fail-loud over silent-drop — operator re-picks without the
+    // offender rather than the bot getting silently filtered out.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelectBot = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'bot-1', bot: true, username: 'Botty' })) },
+      users: mockUsers(
+        { id: 'user-2', bot: false, username: 'Bob' },
+        { id: 'bot-1',  bot: true,  username: 'Botty' },
+      ),
     });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
@@ -937,10 +979,13 @@ describe('handleSend — Step 3: final form', () => {
     }));
   });
 
-  it('target=user rejects selecting yourself', async () => {
+  it('target=user rejects the whole selection if ANY pick is the sender', async () => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelectSelf = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-1', bot: false, username: 'TestUser' })) },
+      users: mockUsers(
+        { id: 'user-2', bot: false, username: 'Bob' },
+        { id: 'user-1', bot: false, username: 'TestUser' }, // sender (interaction.user.id)
+      ),
     });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
@@ -1160,7 +1205,7 @@ describe('handleSend — end-to-end happy paths', () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -1188,7 +1233,7 @@ describe('handleSend — end-to-end happy paths', () => {
     });
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const interaction = makeInteraction({
@@ -1321,7 +1366,7 @@ describe('handleSend — audit emission', () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -1548,7 +1593,7 @@ describe('handleSend — additional branch coverage', () => {
     const fileInit = fileInitBtn();
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -1632,12 +1677,12 @@ describe('handleSend — additional branch coverage', () => {
     mockGetChannelMembers.mockReturnValue([{ id: 'u3', username: 'Channeler' }]);
     const target1 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const target2 = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const target3 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick2 = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-7', bot: false, username: 'Carol' })) },
+      users: { first: jest.fn(() => ({ id: 'user-7', bot: false, username: 'Carol' })), values: jest.fn(() => [{ id: 'user-7', bot: false, username: 'Carol' }][Symbol.iterator]()) },
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const interaction = makeInteraction({
@@ -1654,7 +1699,7 @@ describe('handleSend — additional branch coverage', () => {
   it('user re-select preserves the picked recipient (no recipients reset)', async () => {
     const target1 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const target2 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1672,7 +1717,7 @@ describe('handleSend — additional branch coverage', () => {
   it('defers and continues when UserSelect resolves with no user', async () => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelectEmpty = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => null) },
+      users: { first: jest.fn(() => null), values: jest.fn(() => [][Symbol.iterator]()) },
     });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({


### PR DESCRIPTION
## Summary

Regression fix: the user-select dropdown on `/qurl send`'s "A specific user" target hardcoded `setMaxValues(1)` — a recent change collapsed what used to be a checkbox-style multi-select. The "Add more recipients" button flow on the channel target still allowed up to 10 picks, so the regression only affected the user-target path.

## Affects both chat-server and voice-server

The same user-select component is shared between both contexts. The chat-vs-voice distinction lives in the *channel*-target branch's labels ("Everyone in this voice channel" / "Everyone in this channel"), not in the user-target branch. A single change fixes both server types.

## Changes (all in `apps/discord/src/commands.js`)

| Line | Change |
|---|---|
| 1318 | option description: "Pick one user to send to" → "Pick one or more users to send to" |
| 1325-1330 | `setMaxValues(1)` → `Math.min(10, config.QURL_SEND_MAX_RECIPIENTS)`; placeholder "Pick a user" → "Pick one or more users" |
| 1359 | send-button gate `recipients.length === 1` → `recipients.length >= 1` (user-target only) |
| 1485-1505 | handler reads `[...compInt.users.values()]` instead of `.users.first()`; bot/self validation applies across the full set, fail-loud if ANY pick is invalid |

`Math.min(10, QURL_SEND_MAX_RECIPIENTS)` mirrors the existing "Add more recipients" button flow's per-click cap (commands.js:2058) so behavior is consistent across both add-recipient surfaces.

## Test updates

- 3 existing `target=user` tests refactored to a new `mockUsers()` helper that provides both `.first()` and `.values()` Collection shapes (backwards-compat with any future code path that uses either).
- **New test**: `target=user picks MULTIPLE recipients, send fan-outs to all of them` — pins 3-pick → 3 DMs with correct recipient IDs. Catches future regressions back to single-pick.
- Reframed bot/self rejection tests as "rejects the whole selection if ANY pick is X" to document the fail-loud-don't-partial contract.

## Test plan

- [x] `npx jest --no-cache` — 928 pass (74 in `qurl-send-state-machine.test.js`, including the new multi-pick assertion)
- [ ] Manual sandbox test: invoke `/qurl send` from a text channel + voice channel, confirm the user-select dropdown allows multiple picks in both
- [ ] Verify each picked user receives a DM with their own qURL

## No overlap with in-flight PRs

- #455 (qurl-roundtrip canary) — workflow file only
- #456 (canary EventBridge) — terraform only
- #139 (bot canary route) — `apps/discord/src/routes/canary.js` + utils + tests
- #462 (grafana cross-account) — terraform only

This PR is the only one touching `apps/discord/src/commands.js` + `apps/discord/tests/qurl-send-state-machine.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)