### PR TITLE
ci: bump ops-routines-workflows shims to v0.6.1 + enable PR comments

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -34,9 +34,16 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       min_age_days: 7
+      # Post a sticky PR comment when an age-check fails, listing each
+      # pin with its eligible-after date and days remaining. The PR
+      # author / reviewer sees the retry-after date inline on the PR
+      # instead of having to click into the run log to find it. Sticky
+      # comment is updated in place on re-runs and deleted on a clean
+      # pass; soft-fails to a `::notice` if the token can't write.
+      comment_on_failure: true
     # Forwards OPS_ROUTINES_APP_ID / OPS_ROUTINES_APP_PRIVATE_KEY (org-
     # level secrets) to the reusable workflow, which declares them
     # required. Without this line GH rejects the reusable call at
@@ -45,3 +52,8 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+      # Required for `comment_on_failure: true` to actually post.
+      # Dependabot PRs default to read-only and need this grant
+      # explicitly. Without it, the workflow still fails the age check
+      # correctly — only the inline comment is suppressed.
+      pull-requests: write

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -34,7 +34,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       # Container images get 14 days (vs 7 for source-package
       # ecosystems) — base-image vendors typically take longer to
@@ -42,7 +42,19 @@ jobs:
       # reusable's default; set explicitly here so the policy is
       # visible per-repo.
       min_age_days: 14
+      # Post a sticky PR comment when an age-check fails, listing each
+      # pin with its eligible-after date and days remaining. The PR
+      # author / reviewer sees the retry-after date inline on the PR
+      # instead of having to click into the run log to find it. Sticky
+      # comment is updated in place on re-runs and deleted on a clean
+      # pass; soft-fails to a `::notice` if the token can't write.
+      comment_on_failure: true
     # See dependency-age-check-actions.yml for rationale on secrets: inherit.
     secrets: inherit
     permissions:
       contents: read
+      # Required for `comment_on_failure: true` to actually post.
+      # Dependabot PRs default to read-only and need this grant
+      # explicitly. Without it, the workflow still fails the age check
+      # correctly — only the inline comment is suppressed.
+      pull-requests: write

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -36,10 +36,22 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       min_age_days: 7
+      # Post a sticky PR comment when an age-check fails, listing each
+      # pin with its eligible-after date and days remaining. The PR
+      # author / reviewer sees the retry-after date inline on the PR
+      # instead of having to click into the run log to find it. Sticky
+      # comment is updated in place on re-runs and deleted on a clean
+      # pass; soft-fails to a `::notice` if the token can't write.
+      comment_on_failure: true
     # See dependency-age-check-actions.yml for rationale on secrets: inherit.
     secrets: inherit
     permissions:
       contents: read
+      # Required for `comment_on_failure: true` to actually post.
+      # Dependabot PRs default to read-only and need this grant
+      # explicitly. Without it, the workflow still fails the age check
+      # correctly — only the inline comment is suppressed.
+      pull-requests: write

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -33,9 +33,16 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       min_age_days: 7
+      # Post a sticky PR comment when an age-check fails, listing each
+      # pin with its eligible-after date and days remaining. The PR
+      # author / reviewer sees the retry-after date inline on the PR
+      # instead of having to click into the run log to find it. Sticky
+      # comment is updated in place on re-runs and deleted on a clean
+      # pass; soft-fails to a `::notice` if the token can't write.
+      comment_on_failure: true
       # Scoped to apps/discord — the only Python app in this Go
       # monorepo today. Add a second shim (different working_directory)
       # if more Python apps land.
@@ -44,3 +51,8 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+      # Required for `comment_on_failure: true` to actually post.
+      # Dependabot PRs default to read-only and need this grant
+      # explicitly. Without it, the workflow still fails the age check
+      # correctly — only the inline comment is suppressed.
+      pull-requests: write

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -116,7 +116,7 @@ jobs:
     # The reusable authenticates via App secrets; the caller's GITHUB_TOKEN
     # isn't read by any step, so deny everything.
     permissions: {}
-    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
+    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       target_repo: qurl-integrations-infra
       # `event_type` must match the receiver's `repository_dispatch.types` at

--- a/.github/workflows/issue-priority.yml
+++ b/.github/workflows/issue-priority.yml
@@ -48,6 +48,6 @@ jobs:
     # reusable's own `sender.type != 'Bot'` check short-circuits them
     # before setFailed — net effect is a near-instant no-op run.
     if: ${{ github.actor != 'github-actions[bot]' }}
-    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
+    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     permissions:
       issues: write

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -119,7 +119,7 @@ jobs:
     # The reusable authenticates via App secrets; the caller's GITHUB_TOKEN
     # isn't read by any step, so deny everything.
     permissions: {}
-    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@86d4de84b95cf923bfdd11e3384a1f0deecfbef0 # v0.5.0
+    uses: layervai/ops-routines-workflows/.github/workflows/dispatch-deploy.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       target_repo: qurl-integrations-infra
       # An off-allowlist value hard-fails in the reusable; an allowlisted

--- a/.github/workflows/validate-issue-templates.yml
+++ b/.github/workflows/validate-issue-templates.yml
@@ -35,4 +35,4 @@ permissions:
 
 jobs:
   validate-templates:
-    uses: layervai/ops-routines-workflows/.github/workflows/validate-issue-templates.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0
+    uses: layervai/ops-routines-workflows/.github/workflows/validate-issue-templates.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1


### PR DESCRIPTION
## Why

When dependabot bumps a recently-released action / Go module / docker base image / npm or pip package, the age-check workflow correctly blocks merge until the pin clears the quarantine. Until v0.6.1 the eligible-after date was only in the run log; now it lands as a sticky comment on the PR itself — one row per too-new pin (id, age, eligible date, days remaining).

## What

For each age-check shim (`.github/workflows/dependency-age-check-*.yml`):
1. Bump pinned reusable to **v0.6.1** (`4edea7408d64f424780e08f68a54000308817a08`).
2. Set `comment_on_failure: true`.
3. Grant `pull-requests: write` at the calling job. **This is what makes the comment actually post on Dependabot PRs** (Dependabot's token defaults to read-only; without the grant the post-step soft-fails to a `::notice` and the comment is suppressed — the check itself still runs and blocks merge correctly).

For non-age-check shims (issue-priority / validate-issue-templates / dispatch-deploy if present): pin bump only. v0.6.1's dist for those reusables is byte-identical to earlier versions; the bump is purely version-alignment.

## What is unchanged

- The age-check logic itself (still blocks new pins under the configured `min_age_days`).
- The `age-check-bypass` label still works.
- The required-check job names are unchanged in v0.6.1, so branch protection will not trip.
- No behavior change for non-failing PRs.

## Refs

- v0.6.1 release: https://github.com/layervai/ops-routines-workflows/releases/tag/v0.6.1
