### PR TITLE
chore: bump Go from 1.26.2 to 1.26.3

### DIFF
--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -4,7 +4,7 @@
 # ignore list (default frontend reads only `<context>/.dockerignore`,
 # which is the wrong place for a multi-app monorepo).
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layervai/qurl-integrations
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## Why

Two Go stdlib vulnerability advisories landed today and `govulncheck` is now flagging this repo on every PR run, even on PRs that don't touch Go source. Bumping the `go` directive in `go.mod` (and the matching Dockerfile base image) clears both.

| Advisory | Reachable call site | Fix |
|---|---|---|
| [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971) — Panic in `net.Dial` / `LookupPort` on Windows NUL bytes | `shared/client/client.go:577` (via `http.Client.Do`); `apps/slack/cmd/main.go:163` (via `net.ListenConfig.Listen`) | `net@go1.26.3` |
| [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918) — HTTP/2 transport infinite loop on bad `SETTINGS_MAX_FRAME_SIZE` | `shared/client/client.go:577` | `net/http@go1.26.3` |

## What

- `go.mod`: `go 1.26.2` → `go 1.26.3`. Single-line diff.
- `apps/slack/Dockerfile`: `golang:1.26.2-alpine@sha256:f85330846…` → `golang:1.26.3-alpine@sha256:91eda9776…`. Required because the build container otherwise fails `go mod download` with `go.mod requires go >= 1.26.3 (running go 1.26.2; GOTOOLCHAIN=local)`.
- Other workflows already reference `go-version-file: go.mod`, so they pick the new toolchain up automatically.

## What is unchanged

- `go.sum` — `go mod tidy` is clean.

## Verification

- [x] Local `~/go/bin/govulncheck ./...` after the `go.mod` bump → `No vulnerabilities found.`
- [x] `go mod tidy` produces no `go.sum` changes.
- [ ] After merge: confirm `Vulnerability Scan` goes green on subsequent PRs (e.g., #213).

## Bypass rationale

The new `golang:1.26.3-alpine` pin was published `2026-05-07` — 2 days old vs the docker age-check's 14-day quarantine. Applying the `age-check-bypass` label since the bump is **verified-CVE-driven** (GO-2026-4971 + GO-2026-4918, both reachable in this repo's call graph), which is exactly the bypass policy's intended scope.

Bypass is limited to this PR. Neither the consumer rollout PRs (#213 et al) nor any future PR re-trigger it.