### PR TITLE
fix(discord): log md5_prefix instead of full MD5 on upload

### DIFF
--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -6,6 +6,18 @@ const { sanitizeFilename } = require('./utils/sanitize');
 const { MAX_FILE_SIZE } = require('./constants');
 const MAX_CDN_REDIRECTS = 3;
 
+// Truncate the connector's MD5 of an uploaded file for CloudWatch logging.
+// The full MD5 + WM_SECRET reconstructs a fileviewer URL (handler.go
+// validateWatermarkSig signs md5|wm|ts), so anyone with logs:GetLogEvents on
+// this CloudWatch group could exfiltrate user uploads. 8 hex chars (32 bits)
+// is enough for cross-system correlation; the connector itself still logs
+// the full hash to journald (SSM-only access). This helper is the single
+// chokepoint for that invariant — every upload-success log path goes through
+// it. Don't inline `result.hash` back into a log call.
+function md5Prefix(hash) {
+  return typeof hash === 'string' ? hash.slice(0, 8) : undefined;
+}
+
 // Fetch from a Discord CDN URL with manual redirect handling. `redirect:
 // 'error'` would refuse legitimate Discord redirects (cdn.discordapp.com
 // sometimes 302s to media.discordapp.net). This walks the redirect chain
@@ -207,13 +219,8 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
     throw new Error('Connector upload returned no resource_id');
   }
 
-  // md5_prefix (not full hash): full MD5 + WM_SECRET reconstructs a fileviewer
-  // URL (handler.go validateWatermarkSig signs md5|wm|ts), so anyone with
-  // logs:GetLogEvents on this CloudWatch group could exfiltrate user uploads.
-  // 8 hex chars (32 bits) is enough for cross-system correlation; the connector
-  // still logs the full hash to journald (SSM-only access).
   logger.info('Uploaded to connector', {
-    md5_prefix: result.hash?.slice(0, 8),
+    md5_prefix: md5Prefix(result.hash),
     resource_id: result.resource_id,
   });
 
@@ -254,7 +261,7 @@ async function reUploadBuffer(fileBuffer, filename, contentType, apiKey) {
   }
 
   logger.info('Re-uploaded to connector (new resource)', {
-    md5_prefix: result.hash?.slice(0, 8),
+    md5_prefix: md5Prefix(result.hash),
     resource_id: result.resource_id,
   });
 
@@ -369,7 +376,7 @@ async function uploadJsonToConnector(jsonPayload, filename, apiKey) {
   }
 
   logger.info('Uploaded JSON to connector', {
-    md5_prefix: result.hash?.slice(0, 8),
+    md5_prefix: md5Prefix(result.hash),
     resource_id: result.resource_id,
   });
 

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -6,14 +6,12 @@ const { sanitizeFilename } = require('./utils/sanitize');
 const { MAX_FILE_SIZE } = require('./constants');
 const MAX_CDN_REDIRECTS = 3;
 
-// Truncate the connector's MD5 of an uploaded file for CloudWatch logging.
-// The full MD5 + WM_SECRET reconstructs a fileviewer URL (handler.go
-// validateWatermarkSig signs md5|wm|ts), so anyone with logs:GetLogEvents on
-// this CloudWatch group could exfiltrate user uploads. 8 hex chars (32 bits)
-// is enough for cross-system correlation; the connector itself still logs
-// the full hash to journald (SSM-only access). This helper is the single
-// chokepoint for that invariant — every upload-success log path goes through
-// it. Don't inline `result.hash` back into a log call.
+// Truncate the connector's MD5 of an uploaded file before logging. The full
+// hash is treated as sensitive in our broader infrastructure; see internal
+// security docs for the threat model. 8 hex chars preserves cross-system
+// correlation. Single chokepoint — every upload-success log path goes through
+// this helper. The truncation is load-bearing; don't inline `result.hash`
+// back into a log call.
 function md5Prefix(hash) {
   return typeof hash === 'string' ? hash.slice(0, 8) : undefined;
 }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -208,7 +208,7 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
   }
 
   // md5_prefix (not full hash): full MD5 + WM_SECRET reconstructs a fileviewer
-  // viewer URL (handler.go validateWatermarkSig signs md5|wm|ts), so anyone with
+  // URL (handler.go validateWatermarkSig signs md5|wm|ts), so anyone with
   // logs:GetLogEvents on this CloudWatch group could exfiltrate user uploads.
   // 8 hex chars (32 bits) is enough for cross-system correlation; the connector
   // still logs the full hash to journald (SSM-only access).

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -207,8 +207,13 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
     throw new Error('Connector upload returned no resource_id');
   }
 
+  // md5_prefix (not full hash): full MD5 + WM_SECRET reconstructs a fileviewer
+  // viewer URL (handler.go validateWatermarkSig signs md5|wm|ts), so anyone with
+  // logs:GetLogEvents on this CloudWatch group could exfiltrate user uploads.
+  // 8 hex chars (32 bits) is enough for cross-system correlation; the connector
+  // still logs the full hash to journald (SSM-only access).
   logger.info('Uploaded to connector', {
-    hash: result.hash,
+    md5_prefix: result.hash?.slice(0, 8),
     resource_id: result.resource_id,
   });
 
@@ -249,7 +254,7 @@ async function reUploadBuffer(fileBuffer, filename, contentType, apiKey) {
   }
 
   logger.info('Re-uploaded to connector (new resource)', {
-    hash: result.hash,
+    md5_prefix: result.hash?.slice(0, 8),
     resource_id: result.resource_id,
   });
 
@@ -364,7 +369,7 @@ async function uploadJsonToConnector(jsonPayload, filename, apiKey) {
   }
 
   logger.info('Uploaded JSON to connector', {
-    hash: result.hash,
+    md5_prefix: result.hash?.slice(0, 8),
     resource_id: result.resource_id,
   });
 

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -280,10 +280,10 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
   });
 });
 
-// Full MD5 + WM_SECRET reconstructs a fileviewer URL (handler.go
-// validateWatermarkSig signs md5|wm|ts), so the bot must never log the full
-// value to its CloudWatch group. These tests guard against a future caller
-// reverting to `hash: result.hash` in any of the three upload paths.
+// Guard the truncation invariant from md5Prefix(): the bot must never log the
+// full hash. These tests pin all three upload paths to the helper so a future
+// caller can't quietly revert to `hash: result.hash`. See md5Prefix() in
+// connector.js for the "why."
 describe('Connector client — MD5 hash truncation in upload logs', () => {
   let connector;
   let logger;

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -397,6 +397,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       md5_prefix: undefined,
       resource_id: 'r4',
     });
+    assertNoFullHashLeaked();
   });
 
   // Pins the `typeof hash === 'string'` guard against future schema drift

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -280,7 +280,6 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
   });
 });
 
-// MD5 hash truncation in upload logs.
 // Full MD5 + WM_SECRET reconstructs a fileviewer URL (handler.go
 // validateWatermarkSig signs md5|wm|ts), so the bot must never log the full
 // value to its CloudWatch group. These tests guard against a future caller

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -279,3 +279,124 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
       .rejects.toThrow('QURL_API_KEY is not configured');
   });
 });
+
+// MD5 hash truncation in upload logs.
+// Full MD5 + WM_SECRET reconstructs a fileviewer URL (handler.go
+// validateWatermarkSig signs md5|wm|ts), so the bot must never log the full
+// value to its CloudWatch group. These tests guard against a future caller
+// reverting to `hash: result.hash` in any of the three upload paths.
+describe('Connector client — MD5 hash truncation in upload logs', () => {
+  let connector;
+  let logger;
+
+  // 32-char hex string. The first 8 chars are what the bot is allowed to log.
+  const FULL_MD5 = '5d41402abc4b2a76b9719d911017c592';
+  const MD5_PREFIX = '5d41402a';
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('../src/config', () => ({
+      CONNECTOR_URL: 'https://connector.test.local',
+      QURL_API_KEY: 'test-key',
+    }));
+    jest.mock('../src/logger', () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      audit: jest.fn(),
+    }));
+    connector = require('../src/connector');
+    logger = require('../src/logger');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function assertNoFullHashLeaked() {
+    for (const call of logger.info.mock.calls) {
+      const meta = call[1] ?? {};
+      expect(JSON.stringify(meta)).not.toContain(FULL_MD5);
+      expect(meta).not.toHaveProperty('hash');
+    }
+  }
+
+  it('uploadToConnector logs md5_prefix (8 chars), never the full hash', async () => {
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: jest.fn(() => '10') },
+        arrayBuffer: async () => new ArrayBuffer(10),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, hash: FULL_MD5, resource_id: 'r1' }),
+      });
+
+    await connector.uploadToConnector(
+      'https://cdn.discordapp.com/file.png', 'file.png', 'image/png',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith('Uploaded to connector', {
+      md5_prefix: MD5_PREFIX,
+      resource_id: 'r1',
+    });
+    assertNoFullHashLeaked();
+  });
+
+  it('reUploadBuffer logs md5_prefix (8 chars), never the full hash', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, hash: FULL_MD5, resource_id: 'r2' }),
+    });
+
+    await connector.reUploadBuffer(Buffer.from('payload'), 'file.png', 'image/png');
+
+    expect(logger.info).toHaveBeenCalledWith('Re-uploaded to connector (new resource)', {
+      md5_prefix: MD5_PREFIX,
+      resource_id: 'r2',
+    });
+    assertNoFullHashLeaked();
+  });
+
+  it('uploadJsonToConnector logs md5_prefix (8 chars), never the full hash', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, hash: FULL_MD5, resource_id: 'r3' }),
+    });
+
+    await connector.uploadJsonToConnector(
+      { type: 'google-map', url: 'https://maps.app.goo.gl/x' },
+      'location.json',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith('Uploaded JSON to connector', {
+      md5_prefix: MD5_PREFIX,
+      resource_id: 'r3',
+    });
+    assertNoFullHashLeaked();
+  });
+
+  it('md5_prefix is undefined (not crash) when connector returns no hash', async () => {
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: jest.fn(() => '10') },
+        arrayBuffer: async () => new ArrayBuffer(10),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, resource_id: 'r4' }),
+      });
+
+    await connector.uploadToConnector(
+      'https://cdn.discordapp.com/file.png', 'file.png', 'image/png',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith('Uploaded to connector', {
+      md5_prefix: undefined,
+      resource_id: 'r4',
+    });
+  });
+});

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -398,4 +398,35 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       resource_id: 'r4',
     });
   });
+
+  // Pins the `typeof hash === 'string'` guard against future schema drift
+  // where the connector returns a non-string non-undefined value (number,
+  // null, Buffer, ...). The guard must short-circuit to undefined; without
+  // it, `?.slice` on a Buffer would have produced a usable byte slice.
+  it.each([
+    ['null', null],
+    ['number', 12345],
+    ['object', { md5: 'embedded' }],
+  ])('md5_prefix is undefined when connector returns hash as %s', async (_label, hashValue) => {
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: jest.fn(() => '10') },
+        arrayBuffer: async () => new ArrayBuffer(10),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, hash: hashValue, resource_id: 'r5' }),
+      });
+
+    await connector.uploadToConnector(
+      'https://cdn.discordapp.com/file.png', 'file.png', 'image/png',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith('Uploaded to connector', {
+      md5_prefix: undefined,
+      resource_id: 'r5',
+    });
+    assertNoFullHashLeaked();
+  });
 });


### PR DESCRIPTION
## Summary

Truncate the MD5 hash of uploaded files to 8 hex chars before the bot logs it, and rename the log-meta field from `hash` to `md5_prefix` so the truncation is explicit at the reader. All three upload-success paths in `apps/discord/src/connector.js` (`uploadToConnector`, `reUploadBuffer`, `uploadJsonToConnector`) now go through a single `md5Prefix(hash)` helper that carries the rationale on its docstring.

## Why

The full MD5 of an uploaded file is content-derived and treated as sensitive in our broader infrastructure. The bot was emitting it on every upload-success line. Truncating to 8 hex chars (32 bits) preserves cross-system log correlation without the bot's log destination receiving a sensitive value. Detailed threat model lives in internal security docs.

## What changed

- New `md5Prefix(hash)` helper at the top of `connector.js`. Returns the first 8 hex chars or `undefined` for non-string input. Single chokepoint.
- Three call sites switched to `md5_prefix: md5Prefix(result.hash)`.
- Field rename `hash` → `md5_prefix` makes the truncation visible at the reader.
- 7 new unit tests in `apps/discord/tests/connector-coverage.test.js` (one each for the three upload paths, one for missing hash, three `it.each` cases for non-string schema drift).

## Test plan

- [x] `npx jest tests/connector-coverage.test.js` — 29/29 pass
- [x] `npm run lint` clean
- [x] CI green
- [x] Verified no infra-side metric filters / dashboards reference the old `hash` field
- [ ] After merge: confirm the bot's log destination no longer emits a `hash` field on upload-success lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)