### PR TITLE
feat(discord): logger-side redaction of 'hash' keys

### DIFF
--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -39,6 +39,9 @@ const REDACT_EXACT_KEYS = new Set([
   'content_hash', 'body_hash',
 ]);
 
+// Internal: callers must pass strings. Only invoked from Object.entries()
+// loops, which yield string keys. If this becomes externally-used, restore
+// a String() coercion or guard non-string inputs.
 function shouldRedact(key) {
   const k = key.toLowerCase();
   if (REDACT_EXACT_KEYS.has(k)) return true;
@@ -63,6 +66,7 @@ const AUDIT_SECRET_KEYS = new Set([
   'content_hash', 'body_hash',
 ]);
 
+// Internal: callers must pass strings (same contract as shouldRedact).
 function isAuditSecretKey(key) {
   return AUDIT_SECRET_KEYS.has(key.toLowerCase());
 }

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -109,11 +109,15 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
       // undefined) pass through — they can't carry a usable secret and
       // zero-string-replace would lose type info.
       //
-      // Note: the recursion uses isAuditSecretKey (exact-match), NOT the
-      // wider shouldRedact (substring) rule. An inner `myToken` would
-      // therefore SURVIVE here even though it'd be blanked by redact().
-      // Intentional — audit dimensions like `tokens_minted` must not be
-      // redacted via substring.
+      // Recursion uses isAuditSecretKey (exact-match), NOT the wider
+      // shouldRedact (substring) rule, so legit dimensions like
+      // `tokens_minted` survive in the audit pathway. The asymmetry is
+      // intentional and pinned by a dedicated test.
+      //
+      // Push outer key BEFORE recursing so secretKeys order is parent-first
+      // (intuitive: the warn line reads "hash, auth_token" not the post-
+      // order "auth_token, hash" for `{ hash: { auth_token: ... } }`).
+      if (!secretKeys.includes(k)) secretKeys.push(k);
       if (typeof v === 'string' && v.length > 0) {
         out[k] = '[REDACTED]';
       } else if (v != null && typeof v === 'object') {
@@ -121,7 +125,6 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
       } else {
         out[k] = v;
       }
-      if (!secretKeys.includes(k)) secretKeys.push(k);
     } else {
       out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
     }
@@ -141,9 +144,13 @@ function redact(value, depth = 0) {
       // examined. Other primitives pass through.
       // Asymmetry note: see redactAuditSecrets() — this recursion uses the
       // wider substring rule; the audit pathway uses exact-match.
-      if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
-      else if (v != null && typeof v === 'object') out[k] = redact(v, depth + 1);
-      else out[k] = v;
+      if (typeof v === 'string' && v.length > 0) {
+        out[k] = '[REDACTED]';
+      } else if (v != null && typeof v === 'object') {
+        out[k] = redact(v, depth + 1);
+      } else {
+        out[k] = v;
+      }
     } else {
       out[k] = redact(v, depth + 1);
     }

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -19,6 +19,7 @@ function formatTimestamp() {
 // Substrings that should never appear unredacted in logs. Matched case-
 // insensitively against the key name via includes(), so a future field
 // named refreshToken / bearerToken / apiSecret / myPassword is auto-caught.
+// See REDACT_EXACT_KEYS below for the exact-match alternative.
 const REDACT_SUBSTRINGS = [
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
 ];

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -48,11 +48,11 @@ const REDACT_EXACT_KEYS = new Set([
   'private_key',
 ]);
 
-// Internal: callers must pass strings. Only invoked from Object.entries()
-// loops, which yield string keys. If this becomes externally-used, restore
-// a String() coercion or guard non-string inputs.
+// `String(key)` coerces — Object.entries() yields strings today, but a
+// future caller (a different walker, a Map-like) might pass non-strings;
+// the coercion keeps the predicate safe for free.
 function shouldRedact(key) {
-  const k = key.toLowerCase();
+  const k = String(key).toLowerCase();
   if (REDACT_EXACT_KEYS.has(k)) return true;
   return REDACT_SUBSTRINGS.some(s => k.includes(s));
 }
@@ -75,9 +75,8 @@ const AUDIT_SECRET_KEYS = new Set([
   'content_hash', 'body_hash',
 ]);
 
-// Internal: callers must pass strings (same contract as shouldRedact).
 function isAuditSecretKey(key) {
-  return AUDIT_SECRET_KEYS.has(key.toLowerCase());
+  return AUDIT_SECRET_KEYS.has(String(key).toLowerCase());
 }
 
 // Returns a cloned meta value with any object key in AUDIT_SECRET_KEYS

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -99,12 +99,17 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
   const out = {};
   for (const [k, v] of Object.entries(value)) {
     if (isAuditSecretKey(k)) {
-      // Blank non-empty strings; recurse into non-null objects/arrays so
-      // a `{ auth_token: { value: 'real' } }` accident still has `value`
-      // examined by the inner pass (the inner `value` won't match itself,
-      // but a nested `auth_token` / `password` etc. would). Other primitives
-      // (numbers, null, undefined) pass through — they can't carry a usable
-      // secret and zero-string-replace would lose type info.
+      // Blank non-empty strings; recurse into non-null objects/arrays so a
+      // `{ auth_token: { ... nested auth_token ... } }` accident still has
+      // its inner sensitive keys examined. Other primitives (numbers, null,
+      // undefined) pass through — they can't carry a usable secret and
+      // zero-string-replace would lose type info.
+      //
+      // Note: the recursion uses isAuditSecretKey (exact-match), NOT the
+      // wider shouldRedact (substring) rule. An inner `myToken` would
+      // therefore SURVIVE here even though it'd be blanked by redact().
+      // Intentional — audit dimensions like `tokens_minted` must not be
+      // redacted via substring.
       if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
       else if (v != null && typeof v === 'object') out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
       else out[k] = v;
@@ -273,3 +278,7 @@ const logger = {
 };
 
 module.exports = logger;
+// Test-only: exposes the redact constants so a drift-guard test can iterate
+// the live set rather than duplicate it. Not part of the public API; do
+// not consume from production code.
+module.exports.__testExports = { REDACT_EXACT_KEYS, AUDIT_SECRET_KEYS };

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -24,11 +24,20 @@ const REDACT_SUBSTRINGS = [
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
 ];
 
-// Exact-match keys (not substring): `hash` is the connector's md5 of
-// uploaded content; per-call-site truncation goes through md5Prefix() in
-// connector.js. Exact-match so legitimate names like `commitHash` /
-// `webhookHash` don't trip.
-const REDACT_EXACT_KEYS = new Set(['hash']);
+// Exact-match keys (not substring): content-derived hash names that are
+// sensitive in our broader infrastructure. The connector's md5 of uploaded
+// content is the original motivator (per-call-site truncation goes through
+// md5Prefix() in connector.js); the rest are forward-looking guards so a
+// future caller using a different canonical name doesn't slip through.
+// Exact-match so legitimate names like `commitHash` / `commit_hash` /
+// `webhookHash` / `md5_prefix` don't trip. Mirrored in AUDIT_SECRET_KEYS
+// below — the two sets are kept in sync by hand today (see #221).
+const REDACT_EXACT_KEYS = new Set([
+  'hash',
+  'md5', 'sha1', 'sha256', 'sha512',
+  'digest', 'checksum',
+  'content_hash', 'body_hash',
+]);
 
 function shouldRedact(key) {
   const k = String(key).toLowerCase();
@@ -47,7 +56,11 @@ const AUDIT_SECRET_KEYS = new Set([
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
   'auth_token', 'access_token', 'refresh_token', 'bearer_token',
   'session_token', 'private_key', 'client_secret', 'webhook_secret',
-  'hash', // see REDACT_EXACT_KEYS above
+  // Content-derived hash names — see REDACT_EXACT_KEYS above for rationale.
+  // Kept in sync by hand today; consolidation tracked in #221.
+  'hash', 'md5', 'sha1', 'sha256', 'sha512',
+  'digest', 'checksum',
+  'content_hash', 'body_hash',
 ]);
 
 function isAuditSecretKey(key) {

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -40,7 +40,7 @@ const REDACT_EXACT_KEYS = new Set([
 ]);
 
 function shouldRedact(key) {
-  const k = String(key).toLowerCase();
+  const k = key.toLowerCase();
   if (REDACT_EXACT_KEYS.has(k)) return true;
   return REDACT_SUBSTRINGS.some(s => k.includes(s));
 }
@@ -64,7 +64,7 @@ const AUDIT_SECRET_KEYS = new Set([
 ]);
 
 function isAuditSecretKey(key) {
-  return AUDIT_SECRET_KEYS.has(String(key).toLowerCase());
+  return AUDIT_SECRET_KEYS.has(key.toLowerCase());
 }
 
 // Returns a cloned meta value with any object key in AUDIT_SECRET_KEYS

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -88,20 +88,11 @@ function isAuditSecretKey(key) {
 // the warn line — partial reporting would let a caller fix one key
 // and re-run only to discover another the next time.
 //
-// Note on the contract shift: the original audit() bypassed redact()
-// entirely because the legacy substring-match REDACT_SUBSTRINGS would
-// blank legitimate dimensions like `tokens_minted`. AUDIT_SECRET_KEYS
-// uses exact-match against a closed set of canonical secret names
-// (auth_token, api_key, password, ...), none of which collide with any
-// known legitimate audit dimension. So we can redact the value of an
-// offending key without risk of corrupting a metric — and that's
-// strictly safer than emitting the secret verbatim and relying on a
-// dashboard sweep to catch it.
-//
-// Recursion contract (added in #219): when a matched key's value is a
-// non-null object/array, we recurse so an `{ auth_token: { ... } }`
-// accident still has its inner sensitive keys examined. Inherits the
-// existing depth-5 cap.
+// Exact-match (not substring) so legitimate audit dimensions like
+// `tokens_minted` survive — these are the canonical secret-bearer names
+// (auth_token, api_key, password, ...) that are safe to redact-by-value
+// without corrupting metrics. Recurses into matched-key non-null
+// object/array values (depth-5 cap inherited from the function body).
 function redactAuditSecrets(value, depth = 0, secretKeys = []) {
   if (depth > 5 || value == null || typeof value !== 'object') {
     return { value, secretKeys };
@@ -148,11 +139,9 @@ function redact(value, depth = 0) {
     if (shouldRedact(k)) {
       // Blank non-empty strings; recurse into non-null objects/arrays so
       // a `{ hash: { token: 'real' } }` accident still has its inner keys
-      // examined. Other primitives (numbers, null, etc.) pass through.
-      // Note: this recursion uses shouldRedact (substring rule); the
-      // audit pathway recursion uses isAuditSecretKey (exact-match) so a
-      // `{ hash: { myToken: ... } }` blanks here but survives audit. See
-      // redactAuditSecrets() for the rationale.
+      // examined. Other primitives pass through.
+      // Asymmetry note: see redactAuditSecrets() — this recursion uses the
+      // wider substring rule; the audit pathway uses exact-match.
       if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
       else if (v != null && typeof v === 'object') out[k] = redact(v, depth + 1);
       else out[k] = v;
@@ -218,17 +207,10 @@ const logger = {
   // canonical: "discord" | "slack" | "teams" | "cli" | "web" | "api".
   //
   // Audit lines bypass currentLevel — they're observability, not
-  // debug noise. They also bypass the top-level redact() pass on
-  // `meta` because that pass matches on KEY-name SUBSTRING and would
-  // blank legitimate dimensions like `tokens_minted` or `token_count`.
-  // Instead, audit() runs redactAuditSecrets() — same shape but uses
-  // exact-match against a closed AUDIT_SECRET_KEYS set so only canonical
-  // secret-bearer names (auth_token, api_key, password, ...) are
-  // blanked. Callers SHOULD still avoid passing secrets in meta —
-  // the AUDIT_EVENTS allowlist in constants.js documents the small,
-  // pre-vetted vocabulary (send_id, kind, count, expires_in, success,
-  // total). The redaction here is belt-and-suspenders: an error log
-  // fires too so a misbehaving caller is catchable in dashboards.
+  // debug noise. They also bypass redact() (which uses substring) in
+  // favor of redactAuditSecrets() (exact-match) so legitimate dimensions
+  // like `tokens_minted` survive. The AUDIT_EVENTS allowlist in
+  // constants.js documents the canonical vocabulary.
   audit(event, meta = {}) {
     // Default param only fires for `undefined`. A caller passing `null`
     // (easy mistake from optional chaining: `someObj?.meta`) would

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -82,13 +82,15 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
   const out = {};
   for (const [k, v] of Object.entries(value)) {
     if (isAuditSecretKey(k)) {
-      // Match redact()'s shape: blank only non-empty strings; non-string
-      // values (numbers, null, etc.) survive — they can't carry a usable
-      // secret on their own and zero-string-replace would lose type info.
-      // TODO: nested objects/arrays under a matched key pass through verbatim
-      // — `{ hash: { token: ... } }` would NOT redact inner keys. Tighten
-      // by recursing on non-string matched values.
-      out[k] = typeof v === 'string' && v.length > 0 ? '[REDACTED]' : v;
+      // Blank non-empty strings; recurse into non-null objects/arrays so
+      // a `{ auth_token: { value: 'real' } }` accident still has `value`
+      // examined by the inner pass (the inner `value` won't match itself,
+      // but a nested `auth_token` / `password` etc. would). Other primitives
+      // (numbers, null, undefined) pass through — they can't carry a usable
+      // secret and zero-string-replace would lose type info.
+      if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
+      else if (v != null && typeof v === 'object') out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
+      else out[k] = v;
       if (!secretKeys.includes(k)) secretKeys.push(k);
     } else {
       out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
@@ -104,10 +106,12 @@ function redact(value, depth = 0) {
   const out = {};
   for (const [k, v] of Object.entries(value)) {
     if (shouldRedact(k)) {
-      // TODO: nested objects/arrays under a matched key pass through verbatim
-      // — `{ hash: { token: ... } }` would NOT redact inner keys. Tighten
-      // by recursing on non-string matched values.
-      out[k] = typeof v === 'string' && v.length > 0 ? '[REDACTED]' : v;
+      // Blank non-empty strings; recurse into non-null objects/arrays so
+      // a `{ hash: { token: 'real' } }` accident still has its inner keys
+      // examined. Other primitives (numbers, null, etc.) pass through.
+      if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
+      else if (v != null && typeof v === 'object') out[k] = redact(v, depth + 1);
+      else out[k] = v;
     } else {
       out[k] = redact(v, depth + 1);
     }

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -85,6 +85,9 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
       // Match redact()'s shape: blank only non-empty strings; non-string
       // values (numbers, null, etc.) survive — they can't carry a usable
       // secret on their own and zero-string-replace would lose type info.
+      // TODO: nested objects/arrays under a matched key pass through verbatim
+      // — `{ hash: { token: ... } }` would NOT redact inner keys. Tighten
+      // by recursing on non-string matched values.
       out[k] = typeof v === 'string' && v.length > 0 ? '[REDACTED]' : v;
       if (!secretKeys.includes(k)) secretKeys.push(k);
     } else {
@@ -101,6 +104,9 @@ function redact(value, depth = 0) {
   const out = {};
   for (const [k, v] of Object.entries(value)) {
     if (shouldRedact(k)) {
+      // TODO: nested objects/arrays under a matched key pass through verbatim
+      // — `{ hash: { token: ... } }` would NOT redact inner keys. Tighten
+      // by recursing on non-string matched values.
       out[k] = typeof v === 'string' && v.length > 0 ? '[REDACTED]' : v;
     } else {
       out[k] = redact(v, depth + 1);

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -24,20 +24,10 @@ const REDACT_SUBSTRINGS = [
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
 ];
 
-// Exact-match keys (not substring): names that need explicit coverage
-// because substring matching would either over-catch or under-catch them.
-// Two categories live here today:
-//   1. Content-derived hash names (`hash`, `md5`, `sha*`, `digest`,
-//      `checksum`, `content_hash`, `body_hash`). The connector's md5 of
-//      uploaded content is the original motivator (per-call-site
-//      truncation via md5Prefix() in connector.js); the rest are
-//      forward-looking guards. Substring on `hash` would blank
-//      `commitHash` / `webhookHash` / `md5_prefix`.
-//   2. Substring-uncovered audit-secret-key entries. `private_key` is
-//      in AUDIT_SECRET_KEYS but doesn't match any REDACT_SUBSTRINGS rule
-//      (no `private_` / `_key` substring is broad-safe). Pinned here so
-//      both pathways treat it identically.
-// Mirrored in AUDIT_SECRET_KEYS below — sets kept in sync by hand (#221).
+// Exact-match keys (not substring) — content-hash names where substring
+// would catch `commitHash` / `md5_prefix`, plus `private_key` which has
+// no broad-safe substring rule. Mirrored in AUDIT_SECRET_KEYS below;
+// drift-guarded by tests, consolidation tracked in #221.
 const REDACT_EXACT_KEYS = new Set([
   'hash',
   'md5', 'sha1', 'sha256', 'sha512',
@@ -104,19 +94,10 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
   for (const [k, v] of Object.entries(value)) {
     if (isAuditSecretKey(k)) {
       // Blank non-empty strings; recurse into non-null objects/arrays so a
-      // `{ auth_token: { ... nested auth_token ... } }` accident still has
-      // its inner sensitive keys examined. Other primitives (numbers, null,
-      // undefined) pass through — they can't carry a usable secret and
-      // zero-string-replace would lose type info.
-      //
-      // Recursion uses isAuditSecretKey (exact-match), NOT the wider
-      // shouldRedact (substring) rule, so legit dimensions like
-      // `tokens_minted` survive in the audit pathway. The asymmetry is
-      // intentional and pinned by a dedicated test.
-      //
-      // Push outer key BEFORE recursing so secretKeys order is parent-first
-      // (intuitive: the warn line reads "hash, auth_token" not the post-
-      // order "auth_token, hash" for `{ hash: { auth_token: ... } }`).
+      // `{ auth_token: { ... } }` accident still has its inner sensitive
+      // keys examined. Recursion uses exact-match — legit audit dimensions
+      // like `tokens_minted` survive (pinned by test). Push outer key
+      // BEFORE recursing for parent-first warn-line order.
       if (!secretKeys.includes(k)) secretKeys.push(k);
       if (typeof v === 'string' && v.length > 0) {
         out[k] = '[REDACTED]';

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -24,19 +24,26 @@ const REDACT_SUBSTRINGS = [
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
 ];
 
-// Exact-match keys (not substring): content-derived hash names that are
-// sensitive in our broader infrastructure. The connector's md5 of uploaded
-// content is the original motivator (per-call-site truncation goes through
-// md5Prefix() in connector.js); the rest are forward-looking guards so a
-// future caller using a different canonical name doesn't slip through.
-// Exact-match so legitimate names like `commitHash` / `commit_hash` /
-// `webhookHash` / `md5_prefix` don't trip. Mirrored in AUDIT_SECRET_KEYS
-// below — the two sets are kept in sync by hand today (see #221).
+// Exact-match keys (not substring): names that need explicit coverage
+// because substring matching would either over-catch or under-catch them.
+// Two categories live here today:
+//   1. Content-derived hash names (`hash`, `md5`, `sha*`, `digest`,
+//      `checksum`, `content_hash`, `body_hash`). The connector's md5 of
+//      uploaded content is the original motivator (per-call-site
+//      truncation via md5Prefix() in connector.js); the rest are
+//      forward-looking guards. Substring on `hash` would blank
+//      `commitHash` / `webhookHash` / `md5_prefix`.
+//   2. Substring-uncovered audit-secret-key entries. `private_key` is
+//      in AUDIT_SECRET_KEYS but doesn't match any REDACT_SUBSTRINGS rule
+//      (no `private_` / `_key` substring is broad-safe). Pinned here so
+//      both pathways treat it identically.
+// Mirrored in AUDIT_SECRET_KEYS below — sets kept in sync by hand (#221).
 const REDACT_EXACT_KEYS = new Set([
   'hash',
   'md5', 'sha1', 'sha256', 'sha512',
   'digest', 'checksum',
   'content_hash', 'body_hash',
+  'private_key',
 ]);
 
 // Internal: callers must pass strings. Only invoked from Object.entries()
@@ -280,5 +287,9 @@ const logger = {
 module.exports = logger;
 // Test-only: exposes the redact constants so a drift-guard test can iterate
 // the live set rather than duplicate it. Not part of the public API; do
-// not consume from production code.
-module.exports.__testExports = { REDACT_EXACT_KEYS, AUDIT_SECRET_KEYS };
+// not consume from production code. Defensive copies — a buggy test must
+// not be able to mutate the live Sets and corrupt subsequent log calls.
+module.exports.__testExports = {
+  REDACT_EXACT_KEYS: new Set(REDACT_EXACT_KEYS),
+  AUDIT_SECRET_KEYS: new Set(AUDIT_SECRET_KEYS),
+};

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -42,11 +42,8 @@ const REDACT_EXACT_KEYS = new Set([
   'hash',
   'md5', 'sha1', 'sha256', 'sha512',
   'digest', 'checksum',
-  // body_hash here means a content digest of a payload (informational
-  // identifier of body bytes). If a future caller introduces a
-  // body_hash field that's actually an HMAC/MAC of the body (true secret-
-  // bearer), the exact-match still catches it correctly — listed here
-  // because EITHER interpretation is sensitive-shaped enough to redact.
+  // body_hash covers both content-digest and HMAC interpretations;
+  // either is sensitive-shaped enough to redact.
   'content_hash', 'body_hash',
   'private_key',
 ]);
@@ -304,10 +301,13 @@ const logger = {
 
 module.exports = logger;
 // Test-only: exposes the redact constants so a drift-guard test can iterate
-// the live set rather than duplicate it. Not part of the public API; do
-// not consume from production code. Defensive copies — a buggy test must
-// not be able to mutate the live Sets and corrupt subsequent log calls.
-module.exports.__testExports = {
-  REDACT_EXACT_KEYS: new Set(REDACT_EXACT_KEYS),
-  AUDIT_SECRET_KEYS: new Set(AUDIT_SECRET_KEYS),
-};
+// the live set rather than duplicate it. Gated on NODE_ENV='test' so it's
+// absent from prod bundles entirely (Jest sets NODE_ENV=test by default).
+// Defensive copies so a buggy test can't mutate the live Sets and corrupt
+// subsequent log calls.
+if (process.env.NODE_ENV === 'test') {
+  module.exports.__testExports = {
+    REDACT_EXACT_KEYS: new Set(REDACT_EXACT_KEYS),
+    AUDIT_SECRET_KEYS: new Set(AUDIT_SECRET_KEYS),
+  };
+}

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -23,13 +23,10 @@ const REDACT_SUBSTRINGS = [
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
 ];
 
-// Exact-match key names (not substring) that always trigger redaction.
-// `hash` here is the connector's md5 of uploaded content — treated as
-// sensitive in our broader infrastructure (see internal security docs).
-// The per-call-site fix goes through connector.js's md5Prefix() helper;
-// this is the chokepoint that catches a future caller that bypasses it.
-// Kept separate from REDACT_SUBSTRINGS because legitimate names like
-// `commitHash` / `webhookHash` / `tokenHash` must NOT be blanked.
+// Exact-match keys (not substring): `hash` is the connector's md5 of
+// uploaded content; per-call-site truncation goes through md5Prefix() in
+// connector.js. Exact-match so legitimate names like `commitHash` /
+// `webhookHash` don't trip.
 const REDACT_EXACT_KEYS = new Set(['hash']);
 
 function shouldRedact(key) {
@@ -49,10 +46,7 @@ const AUDIT_SECRET_KEYS = new Set([
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
   'auth_token', 'access_token', 'refresh_token', 'bearer_token',
   'session_token', 'private_key', 'client_secret', 'webhook_secret',
-  // `hash` is the connector's md5 of uploaded content; same rationale
-  // as REDACT_EXACT_KEYS above. See md5Prefix() in connector.js for the
-  // intentional truncated form (`md5_prefix`) callers should use instead.
-  'hash',
+  'hash', // see REDACT_EXACT_KEYS above
 ]);
 
 function isAuditSecretKey(key) {

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -42,6 +42,11 @@ const REDACT_EXACT_KEYS = new Set([
   'hash',
   'md5', 'sha1', 'sha256', 'sha512',
   'digest', 'checksum',
+  // body_hash here means a content digest of a payload (informational
+  // identifier of body bytes). If a future caller introduces a
+  // body_hash field that's actually an HMAC/MAC of the body (true secret-
+  // bearer), the exact-match still catches it correctly — listed here
+  // because EITHER interpretation is sensitive-shaped enough to redact.
   'content_hash', 'body_hash',
   'private_key',
 ]);
@@ -95,6 +100,11 @@ function isAuditSecretKey(key) {
 // offending key without risk of corrupting a metric — and that's
 // strictly safer than emitting the secret verbatim and relying on a
 // dashboard sweep to catch it.
+//
+// Recursion contract (added in #219): when a matched key's value is a
+// non-null object/array, we recurse so an `{ auth_token: { ... } }`
+// accident still has its inner sensitive keys examined. Inherits the
+// existing depth-5 cap.
 function redactAuditSecrets(value, depth = 0, secretKeys = []) {
   if (depth > 5 || value == null || typeof value !== 'object') {
     return { value, secretKeys };
@@ -117,9 +127,13 @@ function redactAuditSecrets(value, depth = 0, secretKeys = []) {
       // therefore SURVIVE here even though it'd be blanked by redact().
       // Intentional — audit dimensions like `tokens_minted` must not be
       // redacted via substring.
-      if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
-      else if (v != null && typeof v === 'object') out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
-      else out[k] = v;
+      if (typeof v === 'string' && v.length > 0) {
+        out[k] = '[REDACTED]';
+      } else if (v != null && typeof v === 'object') {
+        out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;
+      } else {
+        out[k] = v;
+      }
       if (!secretKeys.includes(k)) secretKeys.push(k);
     } else {
       out[k] = redactAuditSecrets(v, depth + 1, secretKeys).value;

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -23,8 +23,18 @@ const REDACT_SUBSTRINGS = [
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
 ];
 
+// Exact-match key names (not substring) that always trigger redaction.
+// `hash` here is the connector's md5 of uploaded content — treated as
+// sensitive in our broader infrastructure (see internal security docs).
+// The per-call-site fix goes through connector.js's md5Prefix() helper;
+// this is the chokepoint that catches a future caller that bypasses it.
+// Kept separate from REDACT_SUBSTRINGS because legitimate names like
+// `commitHash` / `webhookHash` / `tokenHash` must NOT be blanked.
+const REDACT_EXACT_KEYS = new Set(['hash']);
+
 function shouldRedact(key) {
   const k = String(key).toLowerCase();
+  if (REDACT_EXACT_KEYS.has(k)) return true;
   return REDACT_SUBSTRINGS.some(s => k.includes(s));
 }
 
@@ -39,6 +49,10 @@ const AUDIT_SECRET_KEYS = new Set([
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
   'auth_token', 'access_token', 'refresh_token', 'bearer_token',
   'session_token', 'private_key', 'client_secret', 'webhook_secret',
+  // `hash` is the connector's md5 of uploaded content; same rationale
+  // as REDACT_EXACT_KEYS above. See md5Prefix() in connector.js for the
+  // intentional truncated form (`md5_prefix`) callers should use instead.
+  'hash',
 ]);
 
 function isAuditSecretKey(key) {

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -138,6 +138,10 @@ function redact(value, depth = 0) {
       // Blank non-empty strings; recurse into non-null objects/arrays so
       // a `{ hash: { token: 'real' } }` accident still has its inner keys
       // examined. Other primitives (numbers, null, etc.) pass through.
+      // Note: this recursion uses shouldRedact (substring rule); the
+      // audit pathway recursion uses isAuditSecretKey (exact-match) so a
+      // `{ hash: { myToken: ... } }` blanks here but survives audit. See
+      // redactAuditSecrets() for the rationale.
       if (typeof v === 'string' && v.length > 0) out[k] = '[REDACTED]';
       else if (v != null && typeof v === 'object') out[k] = redact(v, depth + 1);
       else out[k] = v;

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -383,23 +383,22 @@ describe('logger', () => {
     });
   });
 
-  // `hash` is exact-match-redacted at both the regular logger pathway
-  // (info/warn/error/debug via redact()) and the audit pathway
-  // (via redactAuditSecrets()). The intentional truncated form is
-  // `md5_prefix` (per md5Prefix() in connector.js); a future caller
-  // accidentally passing the full hash under the `hash` key gets
-  // caught here without needing per-call-site review.
+  // The intentional truncated form is `md5_prefix` (per md5Prefix() in
+  // connector.js); these tests pin both that `hash` is redacted and that
+  // `md5_prefix` survives.
   describe('hash key redaction', () => {
+    const FULL_MD5 = '5d41402abc4b2a76b9719d911017c592';
+
     it('redacts a top-level hash key on info()', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      logger.info('uploaded', { hash: '5d41402abc4b2a76b9719d911017c592', resource_id: 'r1' });
+      logger.info('uploaded', { hash: FULL_MD5, resource_id: 'r1' });
 
       expect(consoleSpy.log).toHaveBeenCalledTimes(1);
       const line = consoleSpy.log.mock.calls[0][0];
       expect(line).toContain('"hash":"[REDACTED]"');
-      expect(line).not.toContain('5d41402abc4b2a76b9719d911017c592');
+      expect(line).not.toContain(FULL_MD5);
       expect(line).toContain('"resource_id":"r1"');
     });
 
@@ -414,13 +413,10 @@ describe('logger', () => {
       expect(line).not.toContain('REDACTED');
     });
 
-    it('does NOT redact hash-substring keys like commitHash / tokenHash-of-non-secret', () => {
+    it('does NOT redact hash-substring keys like commitHash / webhookHash', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      // `commitHash` is a legitimate non-MD5 field. `webhookHash` likewise.
-      // (note: tokenHash WOULD be redacted via the existing `token`
-      // substring rule — that's correct; not re-asserting here.)
       logger.info('deploy', { commitHash: 'abc1234', webhookHash: 'def5678' });
 
       const line = consoleSpy.log.mock.calls[0][0];
@@ -433,23 +429,21 @@ describe('logger', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      logger.info('uploaded', { context: { hash: '5d41402abc4b2a76b9719d911017c592' } });
+      logger.info('uploaded', { context: { hash: FULL_MD5 } });
 
       const line = consoleSpy.log.mock.calls[0][0];
       expect(line).toContain('"hash":"[REDACTED]"');
-      expect(line).not.toContain('5d41402abc4b2a76b9719d911017c592');
+      expect(line).not.toContain(FULL_MD5);
     });
 
     it('redacts hash on audit() AND emits a warn line naming the key', () => {
       logger = require('../src/logger');
 
-      logger.audit('upload_success', { send_id: 's1', hash: '5d41402abc4b2a76b9719d911017c592' });
+      logger.audit('upload_success', { send_id: 's1', hash: FULL_MD5 });
 
-      // Warn line surfaces the offending key so a misbehaving caller is grep-able.
       expect(consoleSpy.error).toHaveBeenCalledTimes(1);
       expect(consoleSpy.error.mock.calls[0][0]).toContain('secret-shaped key');
       expect(consoleSpy.error.mock.calls[0][0]).toContain('hash');
-      // Value redacted in the emitted audit payload; sibling untouched.
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
       expect(parsed.audit.hash).toBe('[REDACTED]');
       expect(parsed.audit.send_id).toBe('s1');
@@ -464,14 +458,10 @@ describe('logger', () => {
       logger.info('uploaded', { hash: { nested: 'object' } });
 
       const lines = consoleSpy.log.mock.calls.map(c => c[0]);
-      // null serializes as `null`, not `"[REDACTED]"`.
       expect(lines[0]).toContain('"hash":null');
-      // Number passes through.
       expect(lines[1]).toContain('"hash":12345');
-      // Object recurses (the redact pass walks into it); the inner key
-      // `nested` is not in any redact set, so its value passes through.
+      // Object value recurses; inner `nested` key isn't in any redact set.
       expect(lines[2]).toContain('"nested":"object"');
-      // No false-positive REDACTED markers from non-string inputs.
       expect(lines.every(l => !l.includes('REDACTED'))).toBe(true);
     });
   });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -382,4 +382,97 @@ describe('logger', () => {
       expect(parsed.audit['1']).toBeUndefined();
     });
   });
+
+  // `hash` is exact-match-redacted at both the regular logger pathway
+  // (info/warn/error/debug via redact()) and the audit pathway
+  // (via redactAuditSecrets()). The intentional truncated form is
+  // `md5_prefix` (per md5Prefix() in connector.js); a future caller
+  // accidentally passing the full hash under the `hash` key gets
+  // caught here without needing per-call-site review.
+  describe('hash key redaction', () => {
+    it('redacts a top-level hash key on info()', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { hash: '5d41402abc4b2a76b9719d911017c592', resource_id: 'r1' });
+
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1);
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain('"hash":"[REDACTED]"');
+      expect(line).not.toContain('5d41402abc4b2a76b9719d911017c592');
+      expect(line).toContain('"resource_id":"r1"');
+    });
+
+    it('does NOT redact md5_prefix (the intentional truncated form)', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { md5_prefix: '5d41402a', resource_id: 'r1' });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain('"md5_prefix":"5d41402a"');
+      expect(line).not.toContain('REDACTED');
+    });
+
+    it('does NOT redact hash-substring keys like commitHash / tokenHash-of-non-secret', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      // `commitHash` is a legitimate non-MD5 field. `webhookHash` likewise.
+      // (note: tokenHash WOULD be redacted via the existing `token`
+      // substring rule — that's correct; not re-asserting here.)
+      logger.info('deploy', { commitHash: 'abc1234', webhookHash: 'def5678' });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain('"commitHash":"abc1234"');
+      expect(line).toContain('"webhookHash":"def5678"');
+      expect(line).not.toContain('REDACTED');
+    });
+
+    it('redacts nested hash key inside a meta object', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { context: { hash: '5d41402abc4b2a76b9719d911017c592' } });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain('"hash":"[REDACTED]"');
+      expect(line).not.toContain('5d41402abc4b2a76b9719d911017c592');
+    });
+
+    it('redacts hash on audit() AND emits a warn line naming the key', () => {
+      logger = require('../src/logger');
+
+      logger.audit('upload_success', { send_id: 's1', hash: '5d41402abc4b2a76b9719d911017c592' });
+
+      // Warn line surfaces the offending key so a misbehaving caller is grep-able.
+      expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('secret-shaped key');
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('hash');
+      // Value redacted in the emitted audit payload; sibling untouched.
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.hash).toBe('[REDACTED]');
+      expect(parsed.audit.send_id).toBe('s1');
+    });
+
+    it('non-string hash values pass through unchanged (number, null, object)', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { hash: null });
+      logger.info('uploaded', { hash: 12345 });
+      logger.info('uploaded', { hash: { nested: 'object' } });
+
+      const lines = consoleSpy.log.mock.calls.map(c => c[0]);
+      // null serializes as `null`, not `"[REDACTED]"`.
+      expect(lines[0]).toContain('"hash":null');
+      // Number passes through.
+      expect(lines[1]).toContain('"hash":12345');
+      // Object recurses (the redact pass walks into it); the inner key
+      // `nested` is not in any redact set, so its value passes through.
+      expect(lines[2]).toContain('"nested":"object"');
+      // No false-positive REDACTED markers from non-string inputs.
+      expect(lines.every(l => !l.includes('REDACTED'))).toBe(true);
+    });
+  });
 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -542,8 +542,11 @@ describe('logger', () => {
 
       const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
       expect(parsed.audit.hash.auth_token).toBe('[REDACTED]');
-      // Outer `hash` key still triggers the warn line so the caller is grep-able.
+      // Both outer (`hash`) and inner (`auth_token`) matches surface in the
+      // warn line — guards against a future refactor that returns early
+      // after finding the outer match.
       expect(consoleSpy.error.mock.calls[0][0]).toContain('hash');
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('auth_token');
     });
   });
 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -487,11 +487,14 @@ describe('logger', () => {
 
       logger.info('uploaded', { Hash: FULL_MD5, HASH: FULL_MD5, HaSh: FULL_MD5 });
 
+      // Assert each case variant maps to REDACTED specifically, rather than
+      // counting global occurrences — robust against a future change that
+      // adds an unrelated redacted field to this test's fixture.
       const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain('"Hash":"[REDACTED]"');
+      expect(line).toContain('"HASH":"[REDACTED]"');
+      expect(line).toContain('"HaSh":"[REDACTED]"');
       expect(line).not.toContain(FULL_MD5);
-      // Pin every case variant — guards a future refactor that drops the
-      // .toLowerCase() in shouldRedact().
-      expect((line.match(/\[REDACTED\]/g) || []).length).toBe(3);
     });
 
     it('redacts hash key inside an array element', () => {
@@ -536,16 +539,16 @@ describe('logger', () => {
     });
 
     // Drift guard: REDACT_EXACT_KEYS and AUDIT_SECRET_KEYS are kept in
-    // sync by hand today (see #221). This test fires if a future edit
-    // adds an exact-match key to one set without mirroring it to the
-    // other — same shape of regression that consolidation in #221 will
-    // ultimately remove the need for.
+    // sync by hand today (see #221). This test iterates the LIVE
+    // REDACT_EXACT_KEYS set (via __testExports) and fires if a future
+    // edit adds an exact-match key without mirroring it to AUDIT_SECRET_KEYS.
+    // Reverse-direction drift (audit-only key without redact mirror) is NOT
+    // covered here — also tracked in #221.
     it('every REDACT_EXACT_KEYS entry is also redacted by audit()', () => {
+      const { __testExports } = require('../src/logger');
       logger = require('../src/logger');
-      const exactKeys = ['hash', 'md5', 'sha1', 'sha256', 'sha512',
-        'digest', 'checksum', 'content_hash', 'body_hash'];
 
-      for (const k of exactKeys) {
+      for (const k of __testExports.REDACT_EXACT_KEYS) {
         consoleSpy.log.mockClear();
         consoleSpy.error.mockClear();
         logger.audit('upload_success', { send_id: 's1', [k]: FULL_MD5 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -449,6 +449,30 @@ describe('logger', () => {
       expect(parsed.audit.send_id).toBe('s1');
     });
 
+    it('mixed-case hash keys are still caught via .toLowerCase() lookup', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { Hash: FULL_MD5, HASH: FULL_MD5, HaSh: FULL_MD5 });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).not.toContain(FULL_MD5);
+      // Pin every case variant — guards a future refactor that drops the
+      // .toLowerCase() in shouldRedact().
+      expect((line.match(/\[REDACTED\]/g) || []).length).toBe(3);
+    });
+
+    it('redacts hash key inside an array element', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { items: [{ hash: FULL_MD5 }, { hash: FULL_MD5 }] });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).not.toContain(FULL_MD5);
+      expect((line.match(/"hash":"\[REDACTED\]"/g) || []).length).toBe(2);
+    });
+
     it('non-string hash values pass through unchanged (number, null, object)', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -591,11 +591,25 @@ describe('logger', () => {
         nested: { token: 'sensitive-1' },
         body: { hash: 'sensitive-2' },
       });
+      logger.audit('upload_success', {
+        send_id: 's1',
+        hash: FULL_MD5,
+        nested: { auth_token: 'sensitive-3' },
+      });
 
-      const line = consoleSpy.log.mock.calls[0][0];
-      expect(line).not.toContain(FULL_MD5);
-      expect(line).not.toContain('sensitive-1');
-      expect(line).not.toContain('sensitive-2');
+      // Sweep BOTH stdout (info/warn/error/debug + audit JSON) and stderr
+      // (audit warn line). The warn line names the offending key but must
+      // not echo the value.
+      const allLines = [
+        ...consoleSpy.log.mock.calls.map(c => c[0]),
+        ...consoleSpy.error.mock.calls.map(c => c[0]),
+      ];
+      for (const line of allLines) {
+        expect(line).not.toContain(FULL_MD5);
+        expect(line).not.toContain('sensitive-1');
+        expect(line).not.toContain('sensitive-2');
+        expect(line).not.toContain('sensitive-3');
+      }
     });
 
     // Reverse drift guard: every entry in AUDIT_SECRET_KEYS should also
@@ -611,6 +625,10 @@ describe('logger', () => {
 
       // currentLevel is captured at module load; LOG_LEVEL defaults to
       // 'info' which is what we want here, so no per-iteration env work.
+      // Assumption: redact() is stateless across calls. If a future change
+      // adds per-call state (rate limiter, sampling counter), iteration
+      // coupling would silently couple cases — switch to per-iteration
+      // jest.resetModules() at that point.
       for (const k of __testExports.AUDIT_SECRET_KEYS) {
         consoleSpy.log.mockClear();
         logger.info('uploaded', { [k]: 'real-secret-value' });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -460,7 +460,11 @@ describe('logger', () => {
       const lines = consoleSpy.log.mock.calls.map(c => c[0]);
       expect(lines[0]).toContain('"hash":null');
       expect(lines[1]).toContain('"hash":12345');
-      // Object value recurses; inner `nested` key isn't in any redact set.
+      // Non-string matched values pass through verbatim — redact() does
+      // NOT recurse into a value once its key matched. Inner `nested`
+      // survives because the whole object is copied as-is. (A future
+      // `{ hash: { token: ... } }` would NOT redact the inner `token` —
+      // tracked as a follow-up to tighten.)
       expect(lines[2]).toContain('"nested":"object"');
       expect(lines.every(l => !l.includes('REDACTED'))).toBe(true);
     });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -473,24 +473,45 @@ describe('logger', () => {
       expect((line.match(/"hash":"\[REDACTED\]"/g) || []).length).toBe(2);
     });
 
-    it('non-string hash values pass through unchanged (number, null, object)', () => {
+    it('primitive hash values (null, number, empty-string) pass through unchanged', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       logger.info('uploaded', { hash: null });
       logger.info('uploaded', { hash: 12345 });
-      logger.info('uploaded', { hash: { nested: 'object' } });
+      logger.info('uploaded', { hash: '' });
 
       const lines = consoleSpy.log.mock.calls.map(c => c[0]);
       expect(lines[0]).toContain('"hash":null');
       expect(lines[1]).toContain('"hash":12345');
-      // Non-string matched values pass through verbatim — redact() does
-      // NOT recurse into a value once its key matched. Inner `nested`
-      // survives because the whole object is copied as-is. (A future
-      // `{ hash: { token: ... } }` would NOT redact the inner `token` —
-      // tracked as a follow-up to tighten.)
-      expect(lines[2]).toContain('"nested":"object"');
+      expect(lines[2]).toContain('"hash":""');
       expect(lines.every(l => !l.includes('REDACTED'))).toBe(true);
+    });
+
+    it('recurses into matched-key objects so inner sensitive keys are redacted', () => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { hash: { token: 'real-secret', nested_hash: 'also-secret' } });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      // Inner `token` matches REDACT_SUBSTRINGS substring rule.
+      expect(line).toContain('"token":"[REDACTED]"');
+      // Inner `nested_hash` does NOT exact-match `hash` and doesn't
+      // substring-match any secret name, so it passes through.
+      expect(line).toContain('"nested_hash":"also-secret"');
+      expect(line).not.toContain('real-secret');
+    });
+
+    it('audit() recurses into matched-key objects', () => {
+      logger = require('../src/logger');
+
+      logger.audit('upload_success', { send_id: 's1', hash: { auth_token: 'real-secret' } });
+
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.hash.auth_token).toBe('[REDACTED]');
+      // Outer `hash` key still triggers the warn line so the caller is grep-able.
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('hash');
     });
   });
 });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -574,6 +574,27 @@ describe('logger', () => {
       }
     });
 
+    // Structural regression guard: the formatted log line never contains
+    // a sensitive value as a substring, regardless of where it sat in the
+    // meta. A future change that stringifies meta before redacting (or
+    // any other shape that bypasses the redact pass) would emit the value
+    // in the JSON serialization — key-targeted asserts alone might miss
+    // it; this catches the structural failure mode.
+    it('sensitive values never appear as substrings anywhere in the log line', () => {
+      logger = require('../src/logger');
+
+      logger.info('uploaded', {
+        hash: FULL_MD5,
+        nested: { token: 'sensitive-1' },
+        body: { hash: 'sensitive-2' },
+      });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).not.toContain(FULL_MD5);
+      expect(line).not.toContain('sensitive-1');
+      expect(line).not.toContain('sensitive-2');
+    });
+
     // Reverse drift guard: every entry in AUDIT_SECRET_KEYS should also
     // be redacted by the regular pathway — either via REDACT_EXACT_KEYS
     // exact-match OR via REDACT_SUBSTRINGS substring. Catches the case

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -425,6 +425,38 @@ describe('logger', () => {
       expect(line).not.toContain('REDACTED');
     });
 
+    // Other canonical content-hash names share `hash`'s exact-match treatment
+    // so a future caller using a different name doesn't slip through.
+    it.each([
+      'md5', 'sha1', 'sha256', 'sha512',
+      'digest', 'checksum',
+      'content_hash', 'body_hash',
+    ])('redacts content-hash key "%s" (exact-match)', (keyName) => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('uploaded', { [keyName]: FULL_MD5 });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain(`"${keyName}":"[REDACTED]"`);
+      expect(line).not.toContain(FULL_MD5);
+    });
+
+    // Adjacent names that look like content hashes but aren't on the
+    // exact-match list — they must survive (no over-redaction).
+    it.each([
+      'md5_prefix', 'sha256_prefix', 'commit_hash', 'fileHash',
+    ])('does NOT redact adjacent name "%s"', (keyName) => {
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.info('deploy', { [keyName]: 'value-survives' });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain(`"${keyName}":"value-survives"`);
+      expect(line).not.toContain('REDACTED');
+    });
+
     it('redacts nested hash key inside a meta object', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -558,6 +558,53 @@ describe('logger', () => {
       }
     });
 
+    // Reverse drift guard: every entry in AUDIT_SECRET_KEYS should also
+    // be redacted by the regular pathway — either via REDACT_EXACT_KEYS
+    // exact-match OR via REDACT_SUBSTRINGS substring. Catches the case
+    // where a future audit-only entry (e.g. `etag`) lands without either
+    // a redact mirror or a substring match. #221 will eliminate this risk
+    // via consolidation.
+    it('every AUDIT_SECRET_KEYS entry is also redacted by info()', () => {
+      const { __testExports } = require('../src/logger');
+      logger = require('../src/logger');
+
+      for (const k of __testExports.AUDIT_SECRET_KEYS) {
+        consoleSpy.log.mockClear();
+        process.env.LOG_LEVEL = 'info';
+        logger.info('uploaded', { [k]: 'real-secret-value' });
+        const line = consoleSpy.log.mock.calls[0][0];
+        expect(line).toContain(`"${k}":"[REDACTED]"`);
+      }
+    });
+
+    // Pin the asymmetry between redact() and redactAuditSecrets()
+    // recursion semantics: redact() uses substring (so `myToken` under
+    // a matched key gets blanked), audit() uses exact-match (so `myToken`
+    // SURVIVES). This is intentional — audit dimensions like `tokens_minted`
+    // / `token_count` must not be blanked. A future refactor that unifies
+    // the two functions and silently tightens audit semantics would break
+    // those dimensions in production dashboards; this test surfaces the
+    // change in CI instead.
+    it('redact() and audit() recursion semantics differ — substring vs exact-match', () => {
+      logger = require('../src/logger');
+
+      // audit() pathway: exact-match does NOT catch `myToken` under `hash`,
+      // so the inner value survives.
+      logger.audit('upload_success', { send_id: 's1', hash: { myToken: 'audit-survives' } });
+      const auditParsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(auditParsed.audit.hash.myToken).toBe('audit-survives');
+
+      consoleSpy.log.mockClear();
+
+      // redact() pathway: substring catches `myToken` (contains `token`),
+      // so the inner value is blanked.
+      process.env.LOG_LEVEL = 'info';
+      logger.info('uploaded', { hash: { myToken: 'redact-blanks' } });
+      const infoLine = consoleSpy.log.mock.calls[0][0];
+      expect(infoLine).toContain('"myToken":"[REDACTED]"');
+      expect(infoLine).not.toContain('redact-blanks');
+    });
+
     it('audit() recurses into matched-key objects', () => {
       logger = require('../src/logger');
 

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -535,6 +535,26 @@ describe('logger', () => {
       expect(line).not.toContain('real-secret');
     });
 
+    // Drift guard: REDACT_EXACT_KEYS and AUDIT_SECRET_KEYS are kept in
+    // sync by hand today (see #221). This test fires if a future edit
+    // adds an exact-match key to one set without mirroring it to the
+    // other — same shape of regression that consolidation in #221 will
+    // ultimately remove the need for.
+    it('every REDACT_EXACT_KEYS entry is also redacted by audit()', () => {
+      logger = require('../src/logger');
+      const exactKeys = ['hash', 'md5', 'sha1', 'sha256', 'sha512',
+        'digest', 'checksum', 'content_hash', 'body_hash'];
+
+      for (const k of exactKeys) {
+        consoleSpy.log.mockClear();
+        consoleSpy.error.mockClear();
+        logger.audit('upload_success', { send_id: 's1', [k]: FULL_MD5 });
+        const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+        expect(parsed.audit[k]).toBe('[REDACTED]');
+        expect(consoleSpy.error.mock.calls[0][0]).toContain(k);
+      }
+    });
+
     it('audit() recurses into matched-key objects', () => {
       logger = require('../src/logger');
 

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -442,6 +442,22 @@ describe('logger', () => {
       expect(line).not.toContain(FULL_MD5);
     });
 
+    // info()'s primitive-passthrough rule preserves legit-audit-dimension
+    // names (`tokens_minted`, `token_count`) when their values are numbers,
+    // even though the substring rule matches the keys. Pins the contract
+    // so a future change that always blanks matched keys regardless of
+    // value type would break this in CI rather than silently break dashboards.
+    it('info() preserves tokens_minted / token_count with primitive (number) values', () => {
+      logger = require('../src/logger');
+
+      logger.info('audit-event', { tokens_minted: 7, token_count: 3 });
+
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain('"tokens_minted":7');
+      expect(line).toContain('"token_count":3');
+      expect(line).not.toContain('REDACTED');
+    });
+
     // Adjacent names that look like content hashes but aren't on the
     // exact-match list — they must survive (no over-redaction).
     it.each([
@@ -568,9 +584,10 @@ describe('logger', () => {
       const { __testExports } = require('../src/logger');
       logger = require('../src/logger');
 
+      // currentLevel is captured at module load; LOG_LEVEL defaults to
+      // 'info' which is what we want here, so no per-iteration env work.
       for (const k of __testExports.AUDIT_SECRET_KEYS) {
         consoleSpy.log.mockClear();
-        process.env.LOG_LEVEL = 'info';
         logger.info('uploaded', { [k]: 'real-secret-value' });
         const line = consoleSpy.log.mock.calls[0][0];
         expect(line).toContain(`"${k}":"[REDACTED]"`);
@@ -598,7 +615,6 @@ describe('logger', () => {
 
       // redact() pathway: substring catches `myToken` (contains `token`),
       // so the inner value is blanked.
-      process.env.LOG_LEVEL = 'info';
       logger.info('uploaded', { hash: { myToken: 'redact-blanks' } });
       const infoLine = consoleSpy.log.mock.calls[0][0];
       expect(infoLine).toContain('"myToken":"[REDACTED]"');

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -386,7 +386,7 @@ describe('logger', () => {
   // The intentional truncated form is `md5_prefix` (per md5Prefix() in
   // connector.js); these tests pin both that `hash` is redacted and that
   // `md5_prefix` survives.
-  describe('hash key redaction', () => {
+  describe('hash-family redaction, drift guards, and recursion semantics', () => {
     const FULL_MD5 = '5d41402abc4b2a76b9719d911017c592';
 
     it('redacts a top-level hash key on info()', () => {
@@ -448,6 +448,7 @@ describe('logger', () => {
     // so a future change that always blanks matched keys regardless of
     // value type would break this in CI rather than silently break dashboards.
     it('info() preserves tokens_minted / token_count with primitive (number) values', () => {
+      process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       logger.info('audit-event', { tokens_minted: 7, token_count: 3 });
@@ -561,6 +562,7 @@ describe('logger', () => {
     // Reverse-direction drift (audit-only key without redact mirror) is NOT
     // covered here — also tracked in #221.
     it('every REDACT_EXACT_KEYS entry is also redacted by audit()', () => {
+      process.env.LOG_LEVEL = 'info';
       const { __testExports } = require('../src/logger');
       logger = require('../src/logger');
 
@@ -581,6 +583,7 @@ describe('logger', () => {
     // in the JSON serialization — key-targeted asserts alone might miss
     // it; this catches the structural failure mode.
     it('sensitive values never appear as substrings anywhere in the log line', () => {
+      process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       logger.info('uploaded', {
@@ -602,6 +605,7 @@ describe('logger', () => {
     // a redact mirror or a substring match. #221 will eliminate this risk
     // via consolidation.
     it('every AUDIT_SECRET_KEYS entry is also redacted by info()', () => {
+      process.env.LOG_LEVEL = 'info';
       const { __testExports } = require('../src/logger');
       logger = require('../src/logger');
 
@@ -624,6 +628,7 @@ describe('logger', () => {
     // those dimensions in production dashboards; this test surfaces the
     // change in CI instead.
     it('redact() and audit() recursion semantics differ — substring vs exact-match', () => {
+      process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       // audit() pathway: exact-match does NOT catch `myToken` under `hash`,
@@ -643,6 +648,7 @@ describe('logger', () => {
     });
 
     it('audit() recurses into matched-key objects', () => {
+      process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
       logger.audit('upload_success', { send_id: 's1', hash: { auth_token: 'real-secret' } });

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -525,19 +525,19 @@ describe('logger', () => {
       expect((line.match(/"hash":"\[REDACTED\]"/g) || []).length).toBe(2);
     });
 
-    it('primitive hash values (null, number, empty-string) pass through unchanged', () => {
+    it.each([
+      ['null', null, '"hash":null'],
+      ['number', 12345, '"hash":12345'],
+      ['empty-string', '', '"hash":""'],
+    ])('primitive hash value (%s) passes through unchanged', (_label, hashValue, expectedSubstring) => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
-      logger.info('uploaded', { hash: null });
-      logger.info('uploaded', { hash: 12345 });
-      logger.info('uploaded', { hash: '' });
+      logger.info('uploaded', { hash: hashValue });
 
-      const lines = consoleSpy.log.mock.calls.map(c => c[0]);
-      expect(lines[0]).toContain('"hash":null');
-      expect(lines[1]).toContain('"hash":12345');
-      expect(lines[2]).toContain('"hash":""');
-      expect(lines.every(l => !l.includes('REDACTED'))).toBe(true);
+      const line = consoleSpy.log.mock.calls[0][0];
+      expect(line).toContain(expectedSubstring);
+      expect(line).not.toContain('REDACTED');
     });
 
     it('recurses into matched-key objects so inner sensitive keys are redacted', () => {

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -582,7 +582,7 @@ describe('logger', () => {
     // any other shape that bypasses the redact pass) would emit the value
     // in the JSON serialization — key-targeted asserts alone might miss
     // it; this catches the structural failure mode.
-    it('sensitive values never appear as substrings anywhere in the log line', () => {
+    it('no sensitive value appears as a substring in the log line', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 
@@ -627,7 +627,7 @@ describe('logger', () => {
     // the two functions and silently tightens audit semantics would break
     // those dimensions in production dashboards; this test surfaces the
     // change in CI instead.
-    it('redact() and audit() recursion semantics differ — substring vs exact-match', () => {
+    it('recursion semantics: substring (redact) vs exact-match (audit)', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');
 


### PR DESCRIPTION
## Summary

Adds a defense-in-depth chokepoint in the bot's logger: any meta object passed to `logger.info / .warn / .error / .debug / .audit` with a content-hash key (`hash`, `md5`, `sha1`, `sha256`, `sha512`, `digest`, `checksum`, `content_hash`, `body_hash`) has its value blanked to `[REDACTED]` before serialization. Belt-and-suspenders for the per-call-site truncation that landed in #218. PR scope grew slightly during review — see "Behavior changes" below.

## Why

#218 truncated the connector's MD5 of uploaded content at three known call sites by routing them through `connector.js`'s `md5Prefix()` helper. The invariant only holds at those three sites — a future caller passing the full `result` object straight to `logger.info`, or using a different canonical hash name, would have shipped the full hash unchanged. This adds the same protection at the logger layer so a bypass becomes impossible without going around the logger entirely.

## Behavior changes

1. **Logger redaction triggers on a set of content-hash key names**, not just `hash`. New `REDACT_EXACT_KEYS` constant: `hash`, `md5`, `sha1`, `sha256`, `sha512`, `digest`, `checksum`, `content_hash`, `body_hash`. Exact-match (not substring) so legitimate names like `commitHash` / `webhookHash` / `md5_prefix` aren't blanked. Same set mirrored in `AUDIT_SECRET_KEYS` so the audit pathway gets the same treatment plus a `console.error` warn line naming the offending key. **No current bot log call uses any of these key names** (verified with grep), so this change emits no different bytes for any existing path.

2. **`redact()` and `redactAuditSecrets()` now recurse into non-null object/array values when a key matches** (commit 11279c7). Previously the matched-key branch shallow-copied the value, leaving a `{ hash: { token: '...' } }` accident path that emitted the inner `token` unredacted. The fix applies symmetrically — so this is a contract shift for **every** existing redacted key (`token`, `secret`, `password`, `authorization`, `apikey`, `api_key`, plus the new content-hash family), not just for `hash`. The recursion inherits the existing depth-5 cap. **No current caller exercises this contract** (no logger.* call passes nested objects under any matched key), so there's no observable byte-level change in production logs today — but the contract for future callers is tightened.

3. **Pre-existing `private_key` gap fixed.** `private_key` was in `AUDIT_SECRET_KEYS` (so audit emitted `[REDACTED]` for it) but was NOT caught by any `REDACT_SUBSTRINGS` rule (`private_` and `_key` are both too broad to add as substrings) and wasn't in `REDACT_EXACT_KEYS`. So before this PR, `logger.info('x', { private_key: 'real' })` shipped the value unredacted. Surfaced by the new reverse drift-guard test (`every AUDIT_SECRET_KEYS entry is also redacted by info()`) — `private_key` now sits in `REDACT_EXACT_KEYS` and is treated identically by both pathways. This is a real existing-behavior fix, not bookkeeping.

### Scope of the recursion fix — what it does and doesn't catch

The recursion catches **inner sensitive-named keys** under a matched outer key (e.g. `{ hash: { auth_token: 'real' } }` → inner `auth_token` blanked). It does **not** catch two related shapes — the value is non-primitive but the inner naming doesn't trigger redaction. Both are tracked in #222 for follow-up:

- Arrays of primitives: `{ hash: ['s1', 's2'] }` — array elements have no key name to match against, so primitives pass through.
- Objects with non-secret-named inner keys: `{ hash: { algorithm: 'md5', value: 'real-md5' } }` — `algorithm` and `value` aren't secret-shaped, so the inner `value` leaks.

So the framing is: this PR is **strictly safer than the previous shallow-copy behavior** for the nested-sensitive-named-key case, **but the protection is not complete** — the gaps above are documented and tracked. No current caller exercises any of the leaky shapes today.

## What changed

- New `REDACT_EXACT_KEYS` set in `apps/discord/src/logger.js` with two categories (content-hash + substring-uncovered audit secrets like `private_key`); mirrored in `AUDIT_SECRET_KEYS`.
- `shouldRedact()` checks the exact-match set before the substring-match set.
- Matched-key branch in both `redact()` and `redactAuditSecrets()` now recurses into non-null objects/arrays.
- Test-only `__testExports` exposes defensive `Set` copies of `REDACT_EXACT_KEYS` / `AUDIT_SECRET_KEYS` so drift-guard tests can iterate the live constants without risk of mutation.
- `apps/discord/tests/logger.test.js`: 14 new + modified `it(...)` blocks expanding to 24 distinct test cases via `it.each` parametrization. Coverage: top-level + nested redaction, `md5_prefix` survival, substring-near-miss survival (`commitHash` / `webhookHash`), audit-pathway warn signal naming both outer and inner matches, mixed-case via `.toLowerCase()` (asserts each variant individually), array-element recursion, primitive (null/number/empty-string) passthrough, recursion-into-matched-key-objects (both pathways), parametrized coverage of all 9 added content-hash + substring-uncovered key names, parametrized survival of 4 adjacent names, primitive-passthrough for legit-audit-dimension names (`tokens_minted` / `token_count`) on `info()`, redact-vs-audit recursion asymmetry pinned, forward + reverse drift-guard tests iterating the live `REDACT_EXACT_KEYS` / `AUDIT_SECRET_KEYS` sets.

## Filed as follow-ups

- #220 — Broaden audit warn-line wording when redaction key isn't credential-shaped (today's "secret-shaped" wording reads strangely for `hash`).
- #221 — Consolidate the two diverging exact-match sets (`REDACT_EXACT_KEYS` + `AUDIT_SECRET_KEYS`) into a single canonical structure; the function-pair (`redact()` / `redactAuditSecrets()`) likely collapses into one helper at the same time.
- #222 — Under-protection of values nested inside matched-key objects/arrays (arrays-of-primitives + objects with non-secret-named inner keys). Pre-existing for all matched keys.
- #223 — `Array.includes` dedup in `redactAuditSecrets` is O(n²); swap for a `Set`. Future-only concern; trivial for current shapes.

## Test plan

- [x] 50/50 logger tests pass (`npx jest tests/logger.test.js`)
- [x] `npm run lint` clean
- [x] /simplify ran across reuse / quality / efficiency reviewers; polish applied
- [x] CI green on each push
- [x] Verified no current bot log call uses any newly-redacted key name

🤖 Generated with [Claude Code](https://claude.com/claude-code)