### PR TITLE
feat(shared): add resource methods + ResourceID on CreateInput, regression-pin /v1/qurls path

### DIFF
--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -556,12 +556,17 @@ type Resource struct {
 	// ResourceData schema (qurl-service/api/openapi.yaml:2546). Tag
 	// matches QURL.Status.
 	Status string `json:"status"`
-	// CreatedAt has no `omitempty` because encoding/json's omitempty does
-	// not honor the time.Time zero value (it would still serialize as
-	// "0001-01-01T00:00:00Z"). Matches the QURL type's `created_at` tag.
-	// Once the repo is on Go 1.24+, switching to `omitzero` would honor it.
-	CreatedAt    time.Time     `json:"created_at"`
-	UpdatedAt    *time.Time    `json:"updated_at,omitempty"`
+	// CreatedAt uses `omitzero` (Go 1.24+) — it honors the time.Time
+	// zero value, eliding "0001-01-01T00:00:00Z" from the wire when
+	// the field is unset on a response. (QURL.CreatedAt still uses
+	// `json:"created_at"` without omitzero — that's a separate
+	// migration tracked outside this PR.)
+	CreatedAt time.Time `json:"created_at,omitzero"`
+	// UpdatedAt is also a time.Time + omitzero now that we're on
+	// Go 1.24+. The pre-1.24 *time.Time idiom is no longer needed —
+	// keeping it as a value avoids the nil-vs-zero ambiguity for a
+	// field that's structurally just "missing on the wire".
+	UpdatedAt    time.Time     `json:"updated_at,omitzero"`
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }
 

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -88,6 +88,13 @@ var ErrCreateResourceNilInput = errors.New("client: CreateResource input is nil"
 // compute the `(owner_id, target_url_hash)` idempotency key.
 var ErrCreateResourceRequiresTargetURL = errors.New("client: CreateResource requires TargetURL")
 
+// ErrCreateResourceTunnelRejectsTargetURL is returned by CreateResource
+// when Type is "tunnel" but TargetURL is non-empty. The server ignores
+// TargetURL on tunnel creates, but a non-empty value is almost always
+// a stale field from copy-pasted CreateResourceInput literals — fail
+// fast for a clearer error than a silent server discard.
+var ErrCreateResourceTunnelRejectsTargetURL = errors.New("client: CreateResource Type=tunnel must not set TargetURL (server ignores it)")
+
 // ErrUpdateResourceEmptyID is returned by UpdateResource when resourceID
 // is the empty string.
 var ErrUpdateResourceEmptyID = errors.New("client: UpdateResource resourceID is empty")
@@ -641,13 +648,23 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 	if input == nil {
 		return nil, ErrCreateResourceNilInput
 	}
-	// TargetURL is required for type=url (the default and the field used
-	// to compute the server's `(owner_id, target_url_hash)` idempotency
-	// key). For type=tunnel the server ignores TargetURL — don't reject
-	// the request just because it's empty. Server returns 400 either way
-	// for the type=url branch; failing fast saves a round-trip.
-	if input.Type != ResourceTypeTunnel && input.TargetURL == "" {
-		return nil, ErrCreateResourceRequiresTargetURL
+	// TargetURL handling by Type:
+	//   - "" / [ResourceTypeURL] — TargetURL required (uniquely
+	//     identifies the resource on `(owner_id, target_url_hash)`).
+	//   - [ResourceTypeTunnel]   — TargetURL must be empty (server
+	//     ignores it; a stale value usually indicates copy-pasted
+	//     literals).
+	// Server returns 400 either way; failing fast saves a round-trip
+	// and yields a typed Go error.
+	switch input.Type {
+	case "", ResourceTypeURL:
+		if input.TargetURL == "" {
+			return nil, ErrCreateResourceRequiresTargetURL
+		}
+	case ResourceTypeTunnel:
+		if input.TargetURL != "" {
+			return nil, ErrCreateResourceTunnelRejectsTargetURL
+		}
 	}
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -684,11 +701,16 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 	if !input.hasAnyFieldSet() {
 		return nil, ErrUpdateResourceNoFieldsSet
 	}
-	if input.Alias != nil && *input.Alias == "" {
-		return nil, ErrUpdateResourceAliasEmpty
-	}
+	// Order: the exclusivity check runs before the empty-pointer
+	// footgun guard. A caller passing both `Alias: &""` and
+	// `ClearAlias: true` learns about the structural conflict first
+	// (the actionable fix is "pick one"); the empty-pointer error
+	// is the footgun guard for the single-field case.
 	if input.Alias != nil && input.ClearAlias {
 		return nil, ErrUpdateResourceAliasClearExclusive
+	}
+	if input.Alias != nil && *input.Alias == "" {
+		return nil, ErrUpdateResourceAliasEmpty
 	}
 	body, err := json.Marshal(input)
 	if err != nil {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -736,10 +736,12 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // access policy, etc.). resourceID must be a `r_…` ID; alias-keyed updates
 // must first resolve via GetResourceByAlias.
 //
-// Validation order (first match wins): empty resourceID → nil input →
-// no-fields-set → Alias/ClearAlias exclusivity → empty-Alias-pointer
-// guard. The exclusivity-before-empty-pointer leg is pinned by
-// TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst.
+// Validation order (first match wins): trim resourceID → empty
+// resourceID → nil input → no-fields-set → trim Alias → exclusivity
+// → empty-Alias-pointer. The exclusivity-before-empty-pointer leg is
+// pinned by TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst;
+// the alias-trim leg is pinned by TestUpdateResourceTrimsAliasPointer
+// and TestUpdateResourceWhitespaceOnlyAliasRejected.
 //
 // Retry semantics: do() retries 5xx/429 with the buffered body, so a
 // successfully-applied PATCH that returns 502 will be re-applied on retry.
@@ -768,10 +770,15 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 		return nil, ErrUpdateResourceNoFieldsSet
 	}
 	// Trim *input.Alias for symmetry with the resourceID and
-	// GetResourceByAlias trim contracts. Make a defensive copy of
-	// input so the trim doesn't mutate the caller's struct, then
-	// re-point Alias at the trimmed value. The trimmed string is what
-	// hits the wire and what the empty-pointer guard below sees.
+	// GetResourceByAlias trim contracts. Shallow-copy input so the
+	// trim doesn't mutate the caller's struct, then re-point Alias at
+	// the trimmed value. The trimmed string is what hits the wire and
+	// what the empty-pointer guard below sees.
+	//
+	// Note: this is a shallow copy — pointer fields like AccessPolicy
+	// still alias the caller's data. Today only Alias gets retargeted;
+	// adding more normalization (e.g. trimming Description/CustomDomain)
+	// would need either a deeper copy or per-field copy-on-mutate.
 	if input.Alias != nil {
 		trimmed := strings.TrimSpace(*input.Alias)
 		copyInput := *input

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -185,8 +185,20 @@ type AccessPolicy struct {
 }
 
 // CreateInput is the input for creating a qURL.
+//
+// Either TargetURL or ResourceID must be supplied — never both. Server-side
+// validation enforces a `mutually_exclusive_fields` rule (per Phase 3a.3:
+// `resource_id` is mutually exclusive with `target_url` and explicit `type`).
+// The `,omitempty` JSON tag on TargetURL is load-bearing: it lets the
+// ResourceID-only flow ship a request body that omits `target_url` entirely
+// rather than serializing the zero value `""`, which would otherwise trip the
+// server's exclusivity check.
 type CreateInput struct {
-	TargetURL    string        `json:"target_url"`
+	TargetURL string `json:"target_url,omitempty"`
+	// ResourceID, when set, mints a qURL bound to an existing resource
+	// (e.g. a tunnel resource resolved via GetResourceByAlias). Mutually
+	// exclusive with TargetURL on the wire.
+	ResourceID   string        `json:"resource_id,omitempty"`
 	Description  string        `json:"description,omitempty"`
 	ExpiresIn    string        `json:"expires_in,omitempty"`
 	OneTimeUse   bool          `json:"one_time_use,omitempty"`
@@ -243,7 +255,14 @@ func validateIdempotencyKey(key string) error {
 
 // Create creates a new qURL.
 //
-//nolint:gocritic // hugeParam: CreateInput is 88 bytes; *CreateInput migration tracked at #146.
+// Either input.TargetURL or input.ResourceID must be set, never both — see
+// [CreateInput] for the rationale. The function does not enforce the
+// exclusivity itself; the server returns 400 `mutually_exclusive_fields`
+// if both are populated. The client only ensures that empty fields elide
+// from the wire payload (via `omitempty`) so a ResourceID-only call
+// doesn't accidentally trip the rule.
+//
+//nolint:gocritic // hugeParam: CreateInput is 104 bytes; *CreateInput migration tracked at #146.
 func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	if err := validateIdempotencyKey(input.IdempotencyKey); err != nil {
 		return nil, err
@@ -413,6 +432,133 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 
 	var out MintOutput
 	if _, err := c.do(req, &out, "POST /v1/qurls/:id/mint_link"); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// --- Resources ---
+//
+// These methods target the post-PR-3a.2 surface in qurl-service: alias
+// fields on `Resource`, the `GET /v1/resources/by-alias/{alias}` endpoint,
+// and `clear_alias` on `PATCH /v1/resources/{id}`. The OpenAPI schema for
+// PR-3a.2 has not shipped at the time this client method set lands — they
+// are added here so the Slack `setalias`/`get` flows in PR-3c.3+ have a
+// stable Go surface to call against. Until PR-3a.2 ships in qurl-service,
+// these methods will return 404/400 from the API.
+
+// Resource represents a qURL resource (the durable object behind a qURL link).
+//
+// Field shapes mirror the `ResourceData` schema in `qurl-service/api/openapi.yaml`
+// post-PR-3a.2; consumers should treat unknown fields as best-effort.
+type Resource struct {
+	ResourceID   string        `json:"resource_id"`
+	OwnerID      string        `json:"owner_id,omitempty"`
+	TargetURL    string        `json:"target_url,omitempty"`
+	Type         string        `json:"type,omitempty"`
+	Alias        string        `json:"alias,omitempty"`
+	CustomDomain string        `json:"custom_domain,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	CreatedAt    time.Time     `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time    `json:"updated_at,omitempty"`
+	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+}
+
+// CreateResourceInput is the input for `POST /v1/resources`. Idempotent on
+// `(owner_id, target_url_hash)` — repeat calls with the same target return
+// the existing resource. Per the PR-3a.2 contract, supplying `Alias` here
+// when a matching resource exists *without* an alias yields 409
+// `alias_in_use`; callers must use UpdateResource to set alias on an
+// already-existing resource.
+type CreateResourceInput struct {
+	TargetURL    string        `json:"target_url,omitempty"`
+	Type         string        `json:"type,omitempty"`
+	Alias        string        `json:"alias,omitempty"`
+	CustomDomain string        `json:"custom_domain,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+}
+
+// UpdateResourceInput is the input for `PATCH /v1/resources/{id}`.
+//
+// Pointer fields distinguish "field absent" (caller didn't provide it,
+// server keeps existing value) from "field present with zero value"
+// (server should accept the zero). For Alias specifically: a non-nil
+// non-empty pointer sets the alias, ClearAlias=true clears it. Setting
+// both is invalid; the server returns 400.
+type UpdateResourceInput struct {
+	Description  *string       `json:"description,omitempty"`
+	Alias        *string       `json:"alias,omitempty"`
+	ClearAlias   bool          `json:"clear_alias,omitempty"`
+	CustomDomain *string       `json:"custom_domain,omitempty"`
+	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+}
+
+// CreateResource creates a (or returns the existing) qURL resource.
+func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput) (*Resource, error) {
+	if input == nil {
+		return nil, errors.New("client: CreateResource input is nil")
+	}
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create resource input: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/resources", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var out Resource
+	if _, err := c.do(req, &out, "POST /v1/resources"); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateResource updates a resource's mutable properties (alias, description,
+// access policy, etc.). resourceID must be a `r_…` ID; alias-keyed updates
+// must first resolve via GetResourceByAlias.
+func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
+	if resourceID == "" {
+		return nil, errors.New("client: UpdateResource resourceID is empty")
+	}
+	if input == nil {
+		return nil, errors.New("client: UpdateResource input is nil")
+	}
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update resource input: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.baseURL+"/v1/resources/"+url.PathEscape(resourceID), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var out Resource
+	if _, err := c.do(req, &out, "PATCH /v1/resources/:id"); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetResourceByAlias resolves an alias to its underlying resource.
+//
+// alias must NOT include the leading `$` sigil used in Slack/Discord
+// surfaces — pass the bare alias string. Returns a typed APIError with
+// 404 status if the alias is not registered for the caller's owner.
+func (c *Client) GetResourceByAlias(ctx context.Context, alias string) (*Resource, error) {
+	if alias == "" {
+		return nil, errors.New("client: GetResourceByAlias alias is empty")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/resources/by-alias/"+url.PathEscape(alias), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var out Resource
+	if _, err := c.do(req, &out, "GET /v1/resources/by-alias/:alias"); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -639,7 +639,9 @@ type CreateResourceInput struct {
 type UpdateResourceInput struct {
 	// Description: pass `&""` to clear the field server-side (no
 	// `ClearDescription` sentinel — the empty string is the clear
-	// semantic). Pass nil to leave unchanged.
+	// semantic). Pass nil to leave unchanged. NOT trimmed by the
+	// client — surrounding whitespace round-trips verbatim; callers
+	// who care should pre-trim.
 	Description *string `json:"description,omitempty"`
 	// Alias sets the resource's alias when non-nil. Must NOT be a pointer
 	// to the empty string — use ClearAlias=true to clear. The empty-string
@@ -654,7 +656,8 @@ type UpdateResourceInput struct {
 	// validators accept the empty string as a clear signal.
 	ClearAlias bool `json:"clear_alias,omitempty"`
 	// CustomDomain: pass `&""` to clear the custom domain mapping (same
-	// convention as Description). Pass nil to leave unchanged.
+	// convention as Description). Pass nil to leave unchanged. NOT
+	// trimmed by the client (consistent with Description).
 	CustomDomain *string `json:"custom_domain,omitempty"`
 	// AccessPolicy: pass a non-nil pointer to update the policy in
 	// place. The server treats `&AccessPolicy{}` (all zero subfields)

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -73,55 +73,55 @@ var ErrIdempotencyKeyInvalid = errors.New("idempotency key contains invalid byte
 
 // ErrCreateRequiresTarget is returned by Create when both TargetURL and
 // ResourceID are empty — the qURL has no target to bind to.
-var ErrCreateRequiresTarget = errors.New("Create requires TargetURL or ResourceID")
+var ErrCreateRequiresTarget = errors.New("create: target_url or resource_id required")
 
 // ErrCreateTargetResourceExclusive is returned by Create when both TargetURL
 // and ResourceID are populated. The server-side `mutually_exclusive_fields`
 // rule rejects this combination; the client fails fast for a typed error.
-var ErrCreateTargetResourceExclusive = errors.New("Create TargetURL and ResourceID are mutually exclusive")
+var ErrCreateTargetResourceExclusive = errors.New("create: target_url and resource_id are mutually exclusive")
 
 // ErrCreateResourceNilInput is returned by CreateResource when input is nil.
-var ErrCreateResourceNilInput = errors.New("CreateResource input is nil")
+var ErrCreateResourceNilInput = errors.New("create resource: input is nil")
 
 // ErrCreateResourceRequiresTargetURL is returned by CreateResource when
 // CreateResourceInput.TargetURL is empty — without it the server can't
 // compute the `(owner_id, target_url_hash)` idempotency key.
-var ErrCreateResourceRequiresTargetURL = errors.New("CreateResource requires TargetURL")
+var ErrCreateResourceRequiresTargetURL = errors.New("create resource: target_url required")
 
 // ErrCreateResourceTunnelRejectsTargetURL is returned by CreateResource
 // when Type is "tunnel" but TargetURL is non-empty. The server ignores
 // TargetURL on tunnel creates, but a non-empty value is almost always
 // a stale field from copy-pasted CreateResourceInput literals — fail
 // fast for a clearer error than a silent server discard.
-var ErrCreateResourceTunnelRejectsTargetURL = errors.New("CreateResource Type=tunnel must not set TargetURL (server ignores it)")
+var ErrCreateResourceTunnelRejectsTargetURL = errors.New("create resource: type=tunnel must not set target_url (server ignores it)")
 
 // ErrUpdateResourceEmptyID is returned by UpdateResource when resourceID
 // is the empty string.
-var ErrUpdateResourceEmptyID = errors.New("UpdateResource resourceID is empty")
+var ErrUpdateResourceEmptyID = errors.New("update resource: resource_id is empty")
 
 // ErrUpdateResourceNilInput is returned by UpdateResource when input is nil.
-var ErrUpdateResourceNilInput = errors.New("UpdateResource input is nil")
+var ErrUpdateResourceNilInput = errors.New("update resource: input is nil")
 
 // ErrUpdateResourceAliasEmpty is returned by UpdateResource when
 // UpdateResourceInput.Alias is a pointer to the empty string. The empty
 // string is reserved as a footgun guard — the server's
 // `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` regex rejects it; use ClearAlias=true.
-var ErrUpdateResourceAliasEmpty = errors.New("UpdateResource Alias must not be a pointer to empty string; use ClearAlias=true to clear")
+var ErrUpdateResourceAliasEmpty = errors.New("update resource: alias must not be a pointer to empty string; use ClearAlias=true to clear")
 
 // ErrUpdateResourceAliasClearExclusive is returned by UpdateResource when
 // both Alias != nil and ClearAlias=true. Server-side returns 400; client
 // fails fast for a typed error.
-var ErrUpdateResourceAliasClearExclusive = errors.New("UpdateResource Alias and ClearAlias are mutually exclusive")
+var ErrUpdateResourceAliasClearExclusive = errors.New("update resource: alias and clear_alias are mutually exclusive")
 
 // ErrUpdateResourceNoFieldsSet is returned by UpdateResource when input
 // is non-nil but has no fields populated — the request would PATCH `{}`
 // and either no-op or 400 server-side. Symmetric with the no-target
 // guard on Create.
-var ErrUpdateResourceNoFieldsSet = errors.New("UpdateResource input has no fields set")
+var ErrUpdateResourceNoFieldsSet = errors.New("update resource: input has no fields set")
 
 // ErrGetResourceByAliasEmpty is returned by GetResourceByAlias when alias
 // is the empty string.
-var ErrGetResourceByAliasEmpty = errors.New("GetResourceByAlias alias is empty")
+var ErrGetResourceByAliasEmpty = errors.New("get resource by alias: alias is empty")
 
 // StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
@@ -540,8 +540,9 @@ type Resource struct {
 	Alias        string `json:"alias,omitempty"`
 	CustomDomain string `json:"custom_domain,omitempty"`
 	Description  string `json:"description,omitempty"`
-	// Status is one of "active" or "revoked" per the live ResourceData
-	// schema (qurl-service/api/openapi.yaml:2546). Tag matches QURL.Status.
+	// Status is one of [StatusActive] or [StatusRevoked] per the live
+	// ResourceData schema (qurl-service/api/openapi.yaml:2546). Tag
+	// matches QURL.Status.
 	Status string `json:"status"`
 	// CreatedAt has no `omitempty` because encoding/json's omitempty does
 	// not honor the time.Time zero value (it would still serialize as
@@ -568,7 +569,13 @@ type CreateResourceInput struct {
 	// or "tunnel". When type=tunnel, TargetURL is ignored server-side.
 	// Mirrors the `ResourceType` enum at
 	// qurl-service/api/openapi.yaml:2468-2474.
-	Type         string        `json:"type,omitempty"`
+	Type string `json:"type,omitempty"`
+	// Alias: empty string elides via `omitempty` and yields a resource
+	// with no alias. Server validates non-empty values against
+	// `^[a-z][a-z0-9-]{1,62}[a-z0-9]$`. If a caller passes an empty
+	// string from upstream input intending an alias, they'll silently
+	// get a no-alias create — pre-validate at the caller if that's a
+	// concern.
 	Alias        string        `json:"alias,omitempty"`
 	CustomDomain string        `json:"custom_domain,omitempty"`
 	Description  string        `json:"description,omitempty"`
@@ -688,10 +695,14 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // access policy, etc.). resourceID must be a `r_…` ID; alias-keyed updates
 // must first resolve via GetResourceByAlias.
 //
-// Idempotency-Key plumbing for resource mutations is tracked at #148 — until
-// it lands, callers needing at-least-once retry safety should dedupe on the
-// server's `(owner_id, resource_id)` model and accept that PATCH retries
-// re-execute on the server.
+// Retry semantics: do() retries 5xx/429 with the buffered body, so a
+// successfully-applied PATCH that returns 502 will be re-applied on retry.
+// All currently-supported PATCH fields (alias, description, custom_domain,
+// access_policy) are field-idempotent — the second apply is a no-op.
+// Adding a non-idempotent field (a counter, an append, etc.) would break
+// this contract; callers should plumb Idempotency-Key (tracked at #148)
+// before that happens. Until #148 lands, callers needing at-least-once
+// retry safety should dedupe on `(owner_id, resource_id)` server-side.
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
 	if resourceID == "" {
 		return nil, ErrUpdateResourceEmptyID

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -633,6 +634,11 @@ type UpdateResourceInput struct {
 // hasAnyFieldSet reports whether the input has at least one mutable
 // field populated. Used by UpdateResource to fail fast on the no-op
 // PATCH `{}` case.
+//
+// Keep in sync with [UpdateResourceInput] fields — adding a new
+// mutable field without updating this method silently allows a no-op
+// PATCH that exercises only the new field. (No reflection: the
+// 5-field surface doesn't justify it.)
 func (in *UpdateResourceInput) hasAnyFieldSet() bool {
 	return in.Description != nil ||
 		in.Alias != nil ||
@@ -707,7 +713,10 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // TODO(#148): plumb Idempotency-Key on this method before any
 // non-idempotent PATCH field lands.
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
-	if resourceID == "" {
+	// TrimSpace catches whitespace-only inputs that would otherwise hit
+	// the wire as `/v1/resources/%20%20` and 400 server-side; the
+	// client error stays actionable.
+	if strings.TrimSpace(resourceID) == "" {
 		return nil, ErrUpdateResourceEmptyID
 	}
 	if input == nil {
@@ -750,7 +759,9 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 // surfaces — pass the bare alias string. Returns a typed APIError with
 // 404 status if the alias is not registered for the caller's owner.
 func (c *Client) GetResourceByAlias(ctx context.Context, alias string) (*Resource, error) {
-	if alias == "" {
+	// TrimSpace catches whitespace-only inputs that would otherwise
+	// hit the wire and 400; client error stays actionable.
+	if strings.TrimSpace(alias) == "" {
 		return nil, ErrGetResourceByAliasEmpty
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/resources/by-alias/"+url.PathEscape(alias), http.NoBody)

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -255,15 +255,18 @@ func validateIdempotencyKey(key string) error {
 
 // Create creates a new qURL.
 //
-// Either input.TargetURL or input.ResourceID must be set, never both — see
-// [CreateInput] for the rationale. The function does not enforce the
-// exclusivity itself; the server returns 400 `mutually_exclusive_fields`
-// if both are populated. The client only ensures that empty fields elide
-// from the wire payload (via `omitempty`) so a ResourceID-only call
-// doesn't accidentally trip the rule.
+// Exactly one of input.TargetURL or input.ResourceID must be set. The client
+// fails fast on the both-populated case (saves a round-trip and yields a
+// Go-typed error rather than a deserialized *APIError); the server-side
+// `mutually_exclusive_fields` rule is the enforcement of last resort. Empty
+// fields elide from the wire payload via `omitempty`, so a ResourceID-only
+// call doesn't accidentally trip the rule.
 //
 //nolint:gocritic // hugeParam: CreateInput is 104 bytes; *CreateInput migration tracked at #146.
 func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
+	if input.TargetURL != "" && input.ResourceID != "" {
+		return nil, errors.New("client: Create TargetURL and ResourceID are mutually exclusive")
+	}
 	if err := validateIdempotencyKey(input.IdempotencyKey); err != nil {
 		return nil, err
 	}
@@ -457,13 +460,17 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 // the live ResourceData schema doesn't expose it (it's derived from auth);
 // add it here only if/when the server starts returning it.
 type Resource struct {
-	ResourceID   string        `json:"resource_id"`
-	TargetURL    string        `json:"target_url,omitempty"`
-	Type         string        `json:"type,omitempty"`
-	Alias        string        `json:"alias,omitempty"`
-	CustomDomain string        `json:"custom_domain,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	CreatedAt    time.Time     `json:"created_at,omitempty"`
+	ResourceID   string `json:"resource_id"`
+	TargetURL    string `json:"target_url,omitempty"`
+	Type         string `json:"type,omitempty"`
+	Alias        string `json:"alias,omitempty"`
+	CustomDomain string `json:"custom_domain,omitempty"`
+	Description  string `json:"description,omitempty"`
+	// CreatedAt has no `omitempty` because encoding/json's omitempty does
+	// not honor the time.Time zero value (it would still serialize as
+	// "0001-01-01T00:00:00Z"). Matches the QURL type's `created_at` tag.
+	// Once the repo is on Go 1.24+, switching to `omitzero` would honor it.
+	CreatedAt    time.Time     `json:"created_at"`
 	UpdatedAt    *time.Time    `json:"updated_at,omitempty"`
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -245,6 +245,12 @@ type QURL struct {
 }
 
 // AccessPolicy defines access restrictions for a qURL.
+//
+// All subfields MUST keep `omitempty` — `&AccessPolicy{}` is the
+// documented "clear policy" signal in [UpdateResourceInput], and that
+// contract relies on every field eliding from the JSON payload when
+// zero. Adding a non-omitempty field (or one that doesn't elide on
+// zero, like a non-pointer time) silently breaks the clear convention.
 type AccessPolicy struct {
 	IPAllowlist  []string `json:"ip_allowlist,omitempty"`
 	IPDenylist   []string `json:"ip_denylist,omitempty"`
@@ -576,7 +582,11 @@ type CreateResourceInput struct {
 	// `^[a-z][a-z0-9-]{1,62}[a-z0-9]$`. If a caller passes an empty
 	// string from upstream input intending an alias, they'll silently
 	// get a no-alias create — pre-validate at the caller if that's a
-	// concern.
+	// concern. (Note the asymmetry with [UpdateResourceInput.Alias],
+	// which is `*string` and rejects `&""` client-side: a `string`
+	// can't distinguish "unset" from "empty" without an extra sentinel,
+	// and the create surface accepts the silent-no-alias semantic so
+	// callers can pass an optional alias literal.)
 	Alias        string        `json:"alias,omitempty"`
 	CustomDomain string        `json:"custom_domain,omitempty"`
 	Description  string        `json:"description,omitempty"`
@@ -605,6 +615,16 @@ type CreateResourceInput struct {
 // empty input (no fields populated) is also rejected
 // ([ErrUpdateResourceNoFieldsSet]) — symmetric with Create's
 // no-target guard.
+//
+// Retry-safety invariant: every field on this struct MUST be
+// field-idempotent until Idempotency-Key plumbing lands (#148).
+// do() retries 5xx/429 with the buffered body, so a successfully-
+// applied PATCH that returns 502 will be re-applied on retry — that's
+// safe iff a second apply is a no-op (which is true for setting alias
+// to a value, clearing alias, setting description, etc., but NOT for
+// counters, appends, or audit-log-per-call semantics). Adding a
+// non-idempotent field requires #148 first; the [Client.UpdateResource]
+// doc-comment carries a TODO marker.
 type UpdateResourceInput struct {
 	// Description: pass `&""` to clear the field server-side (no
 	// `ClearDescription` sentinel — the empty string is the clear
@@ -667,7 +687,11 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 	//   - default                — unknown type; pass through and let
 	//     the server be the authority. This keeps the client
 	//     forward-compatible with future ResourceType values without
-	//     a release dependency.
+	//     a release dependency. The trade-off is that a typo (e.g.
+	//     "urll") skips the TargetURL validator and the caller learns
+	//     about it from a server 400 instead of a Go-typed error;
+	//     forward-compat won out here because the server's enum
+	//     enforcement is authoritative anyway.
 	// For known types: server returns 400 either way; failing fast
 	// saves a round-trip and yields a typed Go error.
 	switch input.Type {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -703,6 +703,9 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // this contract; callers should plumb Idempotency-Key (tracked at #148)
 // before that happens. Until #148 lands, callers needing at-least-once
 // retry safety should dedupe on `(owner_id, resource_id)` server-side.
+//
+// TODO(#148): plumb Idempotency-Key on this method before any
+// non-idempotent PATCH field lands.
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
 	if resourceID == "" {
 		return nil, ErrUpdateResourceEmptyID

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -73,55 +73,55 @@ var ErrIdempotencyKeyInvalid = errors.New("idempotency key contains invalid byte
 
 // ErrCreateRequiresTarget is returned by Create when both TargetURL and
 // ResourceID are empty — the qURL has no target to bind to.
-var ErrCreateRequiresTarget = errors.New("client: Create requires TargetURL or ResourceID")
+var ErrCreateRequiresTarget = errors.New("Create requires TargetURL or ResourceID")
 
 // ErrCreateTargetResourceExclusive is returned by Create when both TargetURL
 // and ResourceID are populated. The server-side `mutually_exclusive_fields`
 // rule rejects this combination; the client fails fast for a typed error.
-var ErrCreateTargetResourceExclusive = errors.New("client: Create TargetURL and ResourceID are mutually exclusive")
+var ErrCreateTargetResourceExclusive = errors.New("Create TargetURL and ResourceID are mutually exclusive")
 
 // ErrCreateResourceNilInput is returned by CreateResource when input is nil.
-var ErrCreateResourceNilInput = errors.New("client: CreateResource input is nil")
+var ErrCreateResourceNilInput = errors.New("CreateResource input is nil")
 
 // ErrCreateResourceRequiresTargetURL is returned by CreateResource when
 // CreateResourceInput.TargetURL is empty — without it the server can't
 // compute the `(owner_id, target_url_hash)` idempotency key.
-var ErrCreateResourceRequiresTargetURL = errors.New("client: CreateResource requires TargetURL")
+var ErrCreateResourceRequiresTargetURL = errors.New("CreateResource requires TargetURL")
 
 // ErrCreateResourceTunnelRejectsTargetURL is returned by CreateResource
 // when Type is "tunnel" but TargetURL is non-empty. The server ignores
 // TargetURL on tunnel creates, but a non-empty value is almost always
 // a stale field from copy-pasted CreateResourceInput literals — fail
 // fast for a clearer error than a silent server discard.
-var ErrCreateResourceTunnelRejectsTargetURL = errors.New("client: CreateResource Type=tunnel must not set TargetURL (server ignores it)")
+var ErrCreateResourceTunnelRejectsTargetURL = errors.New("CreateResource Type=tunnel must not set TargetURL (server ignores it)")
 
 // ErrUpdateResourceEmptyID is returned by UpdateResource when resourceID
 // is the empty string.
-var ErrUpdateResourceEmptyID = errors.New("client: UpdateResource resourceID is empty")
+var ErrUpdateResourceEmptyID = errors.New("UpdateResource resourceID is empty")
 
 // ErrUpdateResourceNilInput is returned by UpdateResource when input is nil.
-var ErrUpdateResourceNilInput = errors.New("client: UpdateResource input is nil")
+var ErrUpdateResourceNilInput = errors.New("UpdateResource input is nil")
 
 // ErrUpdateResourceAliasEmpty is returned by UpdateResource when
 // UpdateResourceInput.Alias is a pointer to the empty string. The empty
 // string is reserved as a footgun guard — the server's
 // `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` regex rejects it; use ClearAlias=true.
-var ErrUpdateResourceAliasEmpty = errors.New("client: UpdateResource Alias must not be a pointer to empty string; use ClearAlias=true to clear")
+var ErrUpdateResourceAliasEmpty = errors.New("UpdateResource Alias must not be a pointer to empty string; use ClearAlias=true to clear")
 
 // ErrUpdateResourceAliasClearExclusive is returned by UpdateResource when
 // both Alias != nil and ClearAlias=true. Server-side returns 400; client
 // fails fast for a typed error.
-var ErrUpdateResourceAliasClearExclusive = errors.New("client: UpdateResource Alias and ClearAlias are mutually exclusive")
+var ErrUpdateResourceAliasClearExclusive = errors.New("UpdateResource Alias and ClearAlias are mutually exclusive")
 
 // ErrUpdateResourceNoFieldsSet is returned by UpdateResource when input
 // is non-nil but has no fields populated — the request would PATCH `{}`
 // and either no-op or 400 server-side. Symmetric with the no-target
 // guard on Create.
-var ErrUpdateResourceNoFieldsSet = errors.New("client: UpdateResource input has no fields set")
+var ErrUpdateResourceNoFieldsSet = errors.New("UpdateResource input has no fields set")
 
 // ErrGetResourceByAliasEmpty is returned by GetResourceByAlias when alias
 // is the empty string.
-var ErrGetResourceByAliasEmpty = errors.New("client: GetResourceByAlias alias is empty")
+var ErrGetResourceByAliasEmpty = errors.New("GetResourceByAlias alias is empty")
 
 // StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
@@ -541,10 +541,7 @@ type Resource struct {
 	CustomDomain string `json:"custom_domain,omitempty"`
 	Description  string `json:"description,omitempty"`
 	// Status is one of "active" or "revoked" per the live ResourceData
-	// schema (qurl-service/api/openapi.yaml:2546). Mirrors QURL.Status
-	// — keeping the two types' status surface in sync. No `omitempty`
-	// because Status is a discriminator field; eliding it on a
-	// zero-value response would mask a malformed server response.
+	// schema (qurl-service/api/openapi.yaml:2546). Tag matches QURL.Status.
 	Status string `json:"status"`
 	// CreatedAt has no `omitempty` because encoding/json's omitempty does
 	// not honor the time.Time zero value (it would still serialize as
@@ -654,8 +651,12 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 	//   - [ResourceTypeTunnel]   — TargetURL must be empty (server
 	//     ignores it; a stale value usually indicates copy-pasted
 	//     literals).
-	// Server returns 400 either way; failing fast saves a round-trip
-	// and yields a typed Go error.
+	//   - default                — unknown type; pass through and let
+	//     the server be the authority. This keeps the client
+	//     forward-compatible with future ResourceType values without
+	//     a release dependency.
+	// For known types: server returns 400 either way; failing fast
+	// saves a round-trip and yields a typed Go error.
 	switch input.Type {
 	case "", ResourceTypeURL:
 		if input.TargetURL == "" {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -106,6 +106,12 @@ var ErrUpdateResourceAliasEmpty = errors.New("client: UpdateResource Alias must 
 // fails fast for a typed error.
 var ErrUpdateResourceAliasClearExclusive = errors.New("client: UpdateResource Alias and ClearAlias are mutually exclusive")
 
+// ErrUpdateResourceNoFieldsSet is returned by UpdateResource when input
+// is non-nil but has no fields populated — the request would PATCH `{}`
+// and either no-op or 400 server-side. Symmetric with the no-target
+// guard on Create.
+var ErrUpdateResourceNoFieldsSet = errors.New("client: UpdateResource input has no fields set")
+
 // ErrGetResourceByAliasEmpty is returned by GetResourceByAlias when alias
 // is the empty string.
 var ErrGetResourceByAliasEmpty = errors.New("client: GetResourceByAlias alias is empty")
@@ -529,8 +535,10 @@ type Resource struct {
 	Description  string `json:"description,omitempty"`
 	// Status is one of "active" or "revoked" per the live ResourceData
 	// schema (qurl-service/api/openapi.yaml:2546). Mirrors QURL.Status
-	// — keeping the two types' status surface in sync.
-	Status string `json:"status,omitempty"`
+	// — keeping the two types' status surface in sync. No `omitempty`
+	// because Status is a discriminator field; eliding it on a
+	// zero-value response would mask a malformed server response.
+	Status string `json:"status"`
 	// CreatedAt has no `omitempty` because encoding/json's omitempty does
 	// not honor the time.Time zero value (it would still serialize as
 	// "0001-01-01T00:00:00Z"). Matches the QURL type's `created_at` tag.
@@ -547,6 +555,10 @@ type Resource struct {
 // `alias_in_use`; callers must use UpdateResource to set alias on an
 // already-existing resource.
 type CreateResourceInput struct {
+	// TargetURL is required when Type is empty or "url"; the client
+	// fails fast with ErrCreateResourceRequiresTargetURL otherwise.
+	// `omitempty` is load-bearing for the type=tunnel branch where
+	// TargetURL is legitimately empty.
 	TargetURL string `json:"target_url,omitempty"`
 	// Type is one of "url" (default; required for target-URL proxies)
 	// or "tunnel". When type=tunnel, TargetURL is ignored server-side.
@@ -572,9 +584,15 @@ type CreateResourceInput struct {
 //     `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` rejects `""`, so the empty-string
 //     pointer is reserved as a footgun guard ([Client.UpdateResource]
 //     fails fast with [ErrUpdateResourceAliasEmpty]).
+//   - AccessPolicy — pass `&AccessPolicy{}` (all zero subfields) to
+//     clear; pass nil to leave unchanged. There is no sentinel-clear
+//     because AccessPolicy is a struct, not a scalar.
 //
 // Setting Alias and ClearAlias together is invalid and rejected
-// client-side ([ErrUpdateResourceAliasClearExclusive]).
+// client-side ([ErrUpdateResourceAliasClearExclusive]). An entirely
+// empty input (no fields populated) is also rejected
+// ([ErrUpdateResourceNoFieldsSet]) — symmetric with Create's
+// no-target guard.
 type UpdateResourceInput struct {
 	// Description: pass `&""` to clear the field server-side (no
 	// `ClearDescription` sentinel — the empty string is the clear
@@ -594,8 +612,22 @@ type UpdateResourceInput struct {
 	ClearAlias bool `json:"clear_alias,omitempty"`
 	// CustomDomain: pass `&""` to clear the custom domain mapping (same
 	// convention as Description). Pass nil to leave unchanged.
-	CustomDomain *string       `json:"custom_domain,omitempty"`
+	CustomDomain *string `json:"custom_domain,omitempty"`
+	// AccessPolicy: pass a non-nil pointer to update the policy in
+	// place. The server treats `&AccessPolicy{}` (all zero subfields)
+	// as a clear; pass nil to leave the existing policy unchanged.
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+}
+
+// hasAnyFieldSet reports whether the input has at least one mutable
+// field populated. Used by UpdateResource to fail fast on the no-op
+// PATCH `{}` case.
+func (in *UpdateResourceInput) hasAnyFieldSet() bool {
+	return in.Description != nil ||
+		in.Alias != nil ||
+		in.ClearAlias ||
+		in.CustomDomain != nil ||
+		in.AccessPolicy != nil
 }
 
 // CreateResource creates a (or returns the existing) qURL resource.
@@ -609,11 +641,12 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 	if input == nil {
 		return nil, ErrCreateResourceNilInput
 	}
-	// TargetURL is the field that uniquely identifies a resource on the
-	// server's `(owner_id, target_url_hash)` idempotency key — without it
-	// the request can't succeed. Server returns 400 either way; failing
-	// fast saves a round-trip on a programmer error.
-	if input.TargetURL == "" {
+	// TargetURL is required for type=url (the default and the field used
+	// to compute the server's `(owner_id, target_url_hash)` idempotency
+	// key). For type=tunnel the server ignores TargetURL — don't reject
+	// the request just because it's empty. Server returns 400 either way
+	// for the type=url branch; failing fast saves a round-trip.
+	if input.Type != ResourceTypeTunnel && input.TargetURL == "" {
 		return nil, ErrCreateResourceRequiresTargetURL
 	}
 	body, err := json.Marshal(input)
@@ -647,6 +680,9 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 	}
 	if input == nil {
 		return nil, ErrUpdateResourceNilInput
+	}
+	if !input.hasAnyFieldSet() {
+		return nil, ErrUpdateResourceNoFieldsSet
 	}
 	if input.Alias != nil && *input.Alias == "" {
 		return nil, ErrUpdateResourceAliasEmpty

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -65,6 +65,51 @@ var ErrIdempotencyKeyTooLong = errors.New("idempotency key exceeds 256 bytes")
 // typed sentinel.
 var ErrIdempotencyKeyInvalid = errors.New("idempotency key contains invalid bytes (CR/LF/NUL/control, non-ASCII, or leading/trailing whitespace)")
 
+// --- Input-validation sentinels for Create / *Resource methods.
+//
+// These are exported so callers can branch with `errors.Is(err, ErrFoo)`
+// rather than substring-matching the error text. Pattern matches the
+// existing ErrIdempotencyKey* sentinels above.
+
+// ErrCreateRequiresTarget is returned by Create when both TargetURL and
+// ResourceID are empty — the qURL has no target to bind to.
+var ErrCreateRequiresTarget = errors.New("client: Create requires TargetURL or ResourceID")
+
+// ErrCreateTargetResourceExclusive is returned by Create when both TargetURL
+// and ResourceID are populated. The server-side `mutually_exclusive_fields`
+// rule rejects this combination; the client fails fast for a typed error.
+var ErrCreateTargetResourceExclusive = errors.New("client: Create TargetURL and ResourceID are mutually exclusive")
+
+// ErrCreateResourceNilInput is returned by CreateResource when input is nil.
+var ErrCreateResourceNilInput = errors.New("client: CreateResource input is nil")
+
+// ErrCreateResourceRequiresTargetURL is returned by CreateResource when
+// CreateResourceInput.TargetURL is empty — without it the server can't
+// compute the `(owner_id, target_url_hash)` idempotency key.
+var ErrCreateResourceRequiresTargetURL = errors.New("client: CreateResource requires TargetURL")
+
+// ErrUpdateResourceEmptyID is returned by UpdateResource when resourceID
+// is the empty string.
+var ErrUpdateResourceEmptyID = errors.New("client: UpdateResource resourceID is empty")
+
+// ErrUpdateResourceNilInput is returned by UpdateResource when input is nil.
+var ErrUpdateResourceNilInput = errors.New("client: UpdateResource input is nil")
+
+// ErrUpdateResourceAliasEmpty is returned by UpdateResource when
+// UpdateResourceInput.Alias is a pointer to the empty string. The empty
+// string is reserved as a footgun guard — the server's
+// `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` regex rejects it; use ClearAlias=true.
+var ErrUpdateResourceAliasEmpty = errors.New("client: UpdateResource Alias must not be a pointer to empty string; use ClearAlias=true to clear")
+
+// ErrUpdateResourceAliasClearExclusive is returned by UpdateResource when
+// both Alias != nil and ClearAlias=true. Server-side returns 400; client
+// fails fast for a typed error.
+var ErrUpdateResourceAliasClearExclusive = errors.New("client: UpdateResource Alias and ClearAlias are mutually exclusive")
+
+// ErrGetResourceByAliasEmpty is returned by GetResourceByAlias when alias
+// is the empty string.
+var ErrGetResourceByAliasEmpty = errors.New("client: GetResourceByAlias alias is empty")
+
 // StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
 
@@ -76,6 +121,15 @@ const StatusRevoked = "revoked"
 
 // StatusConsumed indicates a one-time qURL has been used.
 const StatusConsumed = "consumed"
+
+// --- Resource type constants (mirrors `ResourceType` enum at
+// qurl-service/api/openapi.yaml:2468-2474).
+
+// ResourceTypeURL is the target-URL proxy type (default).
+const ResourceTypeURL = "url"
+
+// ResourceTypeTunnel is the FRP-backed reverse-tunnel type.
+const ResourceTypeTunnel = "tunnel"
 
 // Logger is an optional interface for debug logging.
 type Logger interface {
@@ -265,10 +319,10 @@ func validateIdempotencyKey(key string) error {
 //nolint:gocritic // hugeParam: CreateInput is 104 bytes; *CreateInput migration tracked at #146.
 func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	if input.TargetURL == "" && input.ResourceID == "" {
-		return nil, errors.New("client: Create requires TargetURL or ResourceID")
+		return nil, ErrCreateRequiresTarget
 	}
 	if input.TargetURL != "" && input.ResourceID != "" {
-		return nil, errors.New("client: Create TargetURL and ResourceID are mutually exclusive")
+		return nil, ErrCreateTargetResourceExclusive
 	}
 	if err := validateIdempotencyKey(input.IdempotencyKey); err != nil {
 		return nil, err
@@ -464,8 +518,11 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 // doesn't expose it (it's derived from auth); add it here only if/when the
 // server starts returning it.
 type Resource struct {
-	ResourceID   string `json:"resource_id"`
-	TargetURL    string `json:"target_url,omitempty"`
+	ResourceID string `json:"resource_id"`
+	TargetURL  string `json:"target_url,omitempty"`
+	// Type is one of "url" (target-URL proxy, default) or "tunnel"
+	// (FRP-backed reverse tunnel). Mirrors the `ResourceType` enum at
+	// qurl-service/api/openapi.yaml:2468-2474.
 	Type         string `json:"type,omitempty"`
 	Alias        string `json:"alias,omitempty"`
 	CustomDomain string `json:"custom_domain,omitempty"`
@@ -490,7 +547,11 @@ type Resource struct {
 // `alias_in_use`; callers must use UpdateResource to set alias on an
 // already-existing resource.
 type CreateResourceInput struct {
-	TargetURL    string        `json:"target_url,omitempty"`
+	TargetURL string `json:"target_url,omitempty"`
+	// Type is one of "url" (default; required for target-URL proxies)
+	// or "tunnel". When type=tunnel, TargetURL is ignored server-side.
+	// Mirrors the `ResourceType` enum at
+	// qurl-service/api/openapi.yaml:2468-2474.
 	Type         string        `json:"type,omitempty"`
 	Alias        string        `json:"alias,omitempty"`
 	CustomDomain string        `json:"custom_domain,omitempty"`
@@ -502,11 +563,18 @@ type CreateResourceInput struct {
 //
 // Pointer fields distinguish "field absent" (caller didn't provide it,
 // server keeps existing value) from "field present with zero value"
-// (server should accept the zero). For Alias specifically: a non-nil
-// non-empty pointer sets the alias, ClearAlias=true clears it. Setting
-// both is invalid and rejected client-side by [Client.UpdateResource];
-// passing a pointer to the empty string is also rejected (use
-// ClearAlias=true to clear).
+// (server should accept the zero).
+//
+// Clear semantics are asymmetric across fields by design:
+//   - Description, CustomDomain — pass `&""` to clear; the empty string
+//     is a valid wire value the server accepts as a clear signal.
+//   - Alias — has a sentinel `ClearAlias bool`. The server's regex
+//     `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` rejects `""`, so the empty-string
+//     pointer is reserved as a footgun guard ([Client.UpdateResource]
+//     fails fast with [ErrUpdateResourceAliasEmpty]).
+//
+// Setting Alias and ClearAlias together is invalid and rejected
+// client-side ([ErrUpdateResourceAliasClearExclusive]).
 type UpdateResourceInput struct {
 	// Description: pass `&""` to clear the field server-side (no
 	// `ClearDescription` sentinel — the empty string is the clear
@@ -539,14 +607,14 @@ type UpdateResourceInput struct {
 // #148 alongside the other write methods.
 func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput) (*Resource, error) {
 	if input == nil {
-		return nil, errors.New("client: CreateResource input is nil")
+		return nil, ErrCreateResourceNilInput
 	}
 	// TargetURL is the field that uniquely identifies a resource on the
 	// server's `(owner_id, target_url_hash)` idempotency key — without it
 	// the request can't succeed. Server returns 400 either way; failing
 	// fast saves a round-trip on a programmer error.
 	if input.TargetURL == "" {
-		return nil, errors.New("client: CreateResource requires TargetURL")
+		return nil, ErrCreateResourceRequiresTargetURL
 	}
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -575,16 +643,16 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // re-execute on the server.
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
 	if resourceID == "" {
-		return nil, errors.New("client: UpdateResource resourceID is empty")
+		return nil, ErrUpdateResourceEmptyID
 	}
 	if input == nil {
-		return nil, errors.New("client: UpdateResource input is nil")
+		return nil, ErrUpdateResourceNilInput
 	}
 	if input.Alias != nil && *input.Alias == "" {
-		return nil, errors.New("client: UpdateResource Alias must not be a pointer to empty string; use ClearAlias=true to clear")
+		return nil, ErrUpdateResourceAliasEmpty
 	}
 	if input.Alias != nil && input.ClearAlias {
-		return nil, errors.New("client: UpdateResource Alias and ClearAlias are mutually exclusive")
+		return nil, ErrUpdateResourceAliasClearExclusive
 	}
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -610,7 +678,7 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 // 404 status if the alias is not registered for the caller's owner.
 func (c *Client) GetResourceByAlias(ctx context.Context, alias string) (*Resource, error) {
 	if alias == "" {
-		return nil, errors.New("client: GetResourceByAlias alias is empty")
+		return nil, ErrGetResourceByAliasEmpty
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/resources/by-alias/"+url.PathEscape(alias), http.NoBody)
 	if err != nil {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -450,10 +450,14 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 // Resource represents a qURL resource (the durable object behind a qURL link).
 //
 // Field shapes mirror the `ResourceData` schema in `qurl-service/api/openapi.yaml`
-// post-PR-3a.2; consumers should treat unknown fields as best-effort.
+// post-PR-3a.2; consumers should treat unknown fields as best-effort. Fields
+// not yet on the OpenAPI surface (Alias, UpdatedAt, AccessPolicy) are added
+// in anticipation of the PR-3a.2 schema landing — until then they will be
+// the zero value on the wire. `owner_id` is intentionally omitted because
+// the live ResourceData schema doesn't expose it (it's derived from auth);
+// add it here only if/when the server starts returning it.
 type Resource struct {
 	ResourceID   string        `json:"resource_id"`
-	OwnerID      string        `json:"owner_id,omitempty"`
 	TargetURL    string        `json:"target_url,omitempty"`
 	Type         string        `json:"type,omitempty"`
 	Alias        string        `json:"alias,omitempty"`
@@ -485,16 +489,30 @@ type CreateResourceInput struct {
 // server keeps existing value) from "field present with zero value"
 // (server should accept the zero). For Alias specifically: a non-nil
 // non-empty pointer sets the alias, ClearAlias=true clears it. Setting
-// both is invalid; the server returns 400.
+// both is invalid and rejected client-side by [Client.UpdateResource];
+// passing a pointer to the empty string is also rejected (use
+// ClearAlias=true to clear).
 type UpdateResourceInput struct {
-	Description  *string       `json:"description,omitempty"`
-	Alias        *string       `json:"alias,omitempty"`
+	Description *string `json:"description,omitempty"`
+	// Alias sets the resource's alias when non-nil. Must NOT be a pointer
+	// to the empty string — use ClearAlias=true to clear. Server-side
+	// regex `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` would 400 on `""` anyway,
+	// but the client fails fast in UpdateResource for a clearer error.
+	Alias *string `json:"alias,omitempty"`
+	// ClearAlias=true sends `clear_alias: true` to the server, removing
+	// any existing alias. Mutually exclusive with a non-nil Alias.
 	ClearAlias   bool          `json:"clear_alias,omitempty"`
 	CustomDomain *string       `json:"custom_domain,omitempty"`
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }
 
 // CreateResource creates a (or returns the existing) qURL resource.
+//
+// CreateResource is server-side idempotent on `(owner_id, target_url_hash)`:
+// repeating the same body returns the existing resource. A caller-supplied
+// Idempotency-Key would still be useful for layered retry semantics on top
+// of side-effecting Slack/Discord triggers; that plumbing is tracked at
+// #148 alongside the other write methods.
 func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput) (*Resource, error) {
 	if input == nil {
 		return nil, errors.New("client: CreateResource input is nil")
@@ -519,12 +537,23 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // UpdateResource updates a resource's mutable properties (alias, description,
 // access policy, etc.). resourceID must be a `r_…` ID; alias-keyed updates
 // must first resolve via GetResourceByAlias.
+//
+// Idempotency-Key plumbing for resource mutations is tracked at #148 — until
+// it lands, callers needing at-least-once retry safety should dedupe on the
+// server's `(owner_id, resource_id)` model and accept that PATCH retries
+// re-execute on the server.
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
 	if resourceID == "" {
 		return nil, errors.New("client: UpdateResource resourceID is empty")
 	}
 	if input == nil {
 		return nil, errors.New("client: UpdateResource input is nil")
+	}
+	if input.Alias != nil && *input.Alias == "" {
+		return nil, errors.New("client: UpdateResource Alias must not be a pointer to empty string; use ClearAlias=true to clear")
+	}
+	if input.Alias != nil && input.ClearAlias {
+		return nil, errors.New("client: UpdateResource Alias and ClearAlias are mutually exclusive")
 	}
 	body, err := json.Marshal(input)
 	if err != nil {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -737,10 +737,12 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // TODO(#148): plumb Idempotency-Key on this method before any
 // non-idempotent PATCH field lands.
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *UpdateResourceInput) (*Resource, error) {
-	// TrimSpace catches whitespace-only inputs that would otherwise hit
-	// the wire as `/v1/resources/%20%20` and 400 server-side; the
-	// client error stays actionable.
-	if strings.TrimSpace(resourceID) == "" {
+	// Normalize then validate: surrounding whitespace is silently
+	// stripped so " r_existing01 " hits the wire as
+	// /v1/resources/r_existing01 (not /v1/resources/%20r_existing01%20),
+	// and a whitespace-only input is rejected as empty.
+	resourceID = strings.TrimSpace(resourceID)
+	if resourceID == "" {
 		return nil, ErrUpdateResourceEmptyID
 	}
 	if input == nil {
@@ -783,9 +785,11 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 // surfaces — pass the bare alias string. Returns a typed APIError with
 // 404 status if the alias is not registered for the caller's owner.
 func (c *Client) GetResourceByAlias(ctx context.Context, alias string) (*Resource, error) {
-	// TrimSpace catches whitespace-only inputs that would otherwise
-	// hit the wire and 400; client error stays actionable.
-	if strings.TrimSpace(alias) == "" {
+	// Normalize then validate (same posture as UpdateResource on
+	// resourceID) — strips surrounding whitespace so trimmed value
+	// is what hits the wire, and rejects whitespace-only as empty.
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
 		return nil, ErrGetResourceByAliasEmpty
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/resources/by-alias/"+url.PathEscape(alias), http.NoBody)

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -336,6 +336,11 @@ func validateIdempotencyKey(key string) error {
 // enforcement of last resort. Empty fields elide from the wire payload via
 // `omitempty`, so a ResourceID-only call doesn't accidentally trip the rule.
 //
+// Note: Create takes a value receiver for backward-compat with the existing
+// callers in apps/slack and apps/cli; the new methods ([Client.CreateResource],
+// [Client.UpdateResource]) take *Input pointers, which is the going-forward
+// idiom. Pointer migration tracked at #146.
+//
 //nolint:gocritic // hugeParam: CreateInput is 104 bytes; *CreateInput migration tracked at #146.
 func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	if input.TargetURL == "" && input.ResourceID == "" {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -256,14 +256,17 @@ func validateIdempotencyKey(key string) error {
 // Create creates a new qURL.
 //
 // Exactly one of input.TargetURL or input.ResourceID must be set. The client
-// fails fast on the both-populated case (saves a round-trip and yields a
-// Go-typed error rather than a deserialized *APIError); the server-side
-// `mutually_exclusive_fields` rule is the enforcement of last resort. Empty
-// fields elide from the wire payload via `omitempty`, so a ResourceID-only
-// call doesn't accidentally trip the rule.
+// fails fast on both the both-empty and both-populated cases (saves a
+// round-trip and yields a Go-typed error rather than a deserialized
+// *APIError); the server-side `mutually_exclusive_fields` rule is the
+// enforcement of last resort. Empty fields elide from the wire payload via
+// `omitempty`, so a ResourceID-only call doesn't accidentally trip the rule.
 //
 //nolint:gocritic // hugeParam: CreateInput is 104 bytes; *CreateInput migration tracked at #146.
 func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
+	if input.TargetURL == "" && input.ResourceID == "" {
+		return nil, errors.New("client: Create requires TargetURL or ResourceID")
+	}
 	if input.TargetURL != "" && input.ResourceID != "" {
 		return nil, errors.New("client: Create TargetURL and ResourceID are mutually exclusive")
 	}
@@ -452,13 +455,14 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 
 // Resource represents a qURL resource (the durable object behind a qURL link).
 //
-// Field shapes mirror the `ResourceData` schema in `qurl-service/api/openapi.yaml`
-// post-PR-3a.2; consumers should treat unknown fields as best-effort. Fields
-// not yet on the OpenAPI surface (Alias, UpdatedAt, AccessPolicy) are added
-// in anticipation of the PR-3a.2 schema landing — until then they will be
-// the zero value on the wire. `owner_id` is intentionally omitted because
-// the live ResourceData schema doesn't expose it (it's derived from auth);
-// add it here only if/when the server starts returning it.
+// Field shapes mirror the `ResourceData` schema in
+// `qurl-service/api/openapi.yaml` post-PR-3a.2; consumers should treat
+// unknown fields as best-effort. Fields not yet on the OpenAPI surface
+// (Alias, UpdatedAt, AccessPolicy) are added in anticipation of the PR-3a.2
+// schema landing — until then they will be the zero value on the wire.
+// `owner_id` is intentionally omitted because the live ResourceData schema
+// doesn't expose it (it's derived from auth); add it here only if/when the
+// server starts returning it.
 type Resource struct {
 	ResourceID   string `json:"resource_id"`
 	TargetURL    string `json:"target_url,omitempty"`
@@ -466,6 +470,10 @@ type Resource struct {
 	Alias        string `json:"alias,omitempty"`
 	CustomDomain string `json:"custom_domain,omitempty"`
 	Description  string `json:"description,omitempty"`
+	// Status is one of "active" or "revoked" per the live ResourceData
+	// schema (qurl-service/api/openapi.yaml:2546). Mirrors QURL.Status
+	// — keeping the two types' status surface in sync.
+	Status string `json:"status,omitempty"`
 	// CreatedAt has no `omitempty` because encoding/json's omitempty does
 	// not honor the time.Time zero value (it would still serialize as
 	// "0001-01-01T00:00:00Z"). Matches the QURL type's `created_at` tag.
@@ -500,15 +508,24 @@ type CreateResourceInput struct {
 // passing a pointer to the empty string is also rejected (use
 // ClearAlias=true to clear).
 type UpdateResourceInput struct {
+	// Description: pass `&""` to clear the field server-side (no
+	// `ClearDescription` sentinel — the empty string is the clear
+	// semantic). Pass nil to leave unchanged.
 	Description *string `json:"description,omitempty"`
 	// Alias sets the resource's alias when non-nil. Must NOT be a pointer
-	// to the empty string — use ClearAlias=true to clear. Server-side
-	// regex `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` would 400 on `""` anyway,
-	// but the client fails fast in UpdateResource for a clearer error.
+	// to the empty string — use ClearAlias=true to clear. The empty-string
+	// pointer is reserved as a fail-fast footgun guard because the server
+	// regex `^[a-z][a-z0-9-]{1,62}[a-z0-9]$` would 400 on `""` anyway —
+	// the client raises a clearer error than the server's generic message.
 	Alias *string `json:"alias,omitempty"`
 	// ClearAlias=true sends `clear_alias: true` to the server, removing
 	// any existing alias. Mutually exclusive with a non-nil Alias.
-	ClearAlias   bool          `json:"clear_alias,omitempty"`
+	// Alias is the only field with a sentinel-clear; Description and
+	// CustomDomain use the `&""` convention because their server-side
+	// validators accept the empty string as a clear signal.
+	ClearAlias bool `json:"clear_alias,omitempty"`
+	// CustomDomain: pass `&""` to clear the custom domain mapping (same
+	// convention as Description). Pass nil to leave unchanged.
 	CustomDomain *string       `json:"custom_domain,omitempty"`
 	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }
@@ -523,6 +540,13 @@ type UpdateResourceInput struct {
 func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput) (*Resource, error) {
 	if input == nil {
 		return nil, errors.New("client: CreateResource input is nil")
+	}
+	// TargetURL is the field that uniquely identifies a resource on the
+	// server's `(owner_id, target_url_hash)` idempotency key — without it
+	// the request can't succeed. Server returns 400 either way; failing
+	// fast saves a round-trip on a programmer error.
+	if input.TargetURL == "" {
+		return nil, errors.New("client: CreateResource requires TargetURL")
 	}
 	body, err := json.Marshal(input)
 	if err != nil {

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -136,8 +136,8 @@ const StatusRevoked = "revoked"
 // StatusConsumed indicates a one-time qURL has been used.
 const StatusConsumed = "consumed"
 
-// --- Resource type constants (mirrors `ResourceType` enum at
-// qurl-service/api/openapi.yaml:2468-2474).
+// --- Resource type constants (mirrors qurl-service/api/openapi.yaml
+// `ResourceType` enum).
 
 // ResourceTypeURL is the target-URL proxy type (default).
 const ResourceTypeURL = "url"
@@ -546,15 +546,17 @@ type Resource struct {
 	ResourceID string `json:"resource_id"`
 	TargetURL  string `json:"target_url,omitempty"`
 	// Type is one of "url" (target-URL proxy, default) or "tunnel"
-	// (FRP-backed reverse tunnel). Mirrors the `ResourceType` enum at
-	// qurl-service/api/openapi.yaml:2468-2474.
+	// (FRP-backed reverse tunnel). Mirrors the qurl-service
+	// `ResourceType` enum.
 	Type         string `json:"type,omitempty"`
 	Alias        string `json:"alias,omitempty"`
 	CustomDomain string `json:"custom_domain,omitempty"`
 	Description  string `json:"description,omitempty"`
-	// Status is one of [StatusActive] or [StatusRevoked] per the live
-	// ResourceData schema (qurl-service/api/openapi.yaml:2546). Tag
-	// matches QURL.Status.
+	// Status is one of [StatusActive] or [StatusRevoked] per the
+	// `ResourceData` schema in qurl-service/api/openapi.yaml. The
+	// QURL-only [StatusConsumed] / [StatusExpired] don't apply at the
+	// resource level — resource state is binary (live or revoked);
+	// per-qURL TTL/one-time semantics are tracked on QURL instead.
 	Status string `json:"status"`
 	// CreatedAt uses `omitzero` (Go 1.24+) — it honors the time.Time
 	// zero value, eliding "0001-01-01T00:00:00Z" from the wire when
@@ -584,8 +586,7 @@ type CreateResourceInput struct {
 	TargetURL string `json:"target_url,omitempty"`
 	// Type is one of "url" (default; required for target-URL proxies)
 	// or "tunnel". When type=tunnel, TargetURL is ignored server-side.
-	// Mirrors the `ResourceType` enum at
-	// qurl-service/api/openapi.yaml:2468-2474.
+	// Mirrors the qurl-service `ResourceType` enum.
 	Type string `json:"type,omitempty"`
 	// Alias: empty string elides via `omitempty` and yields a resource
 	// with no alias. Server validates non-empty values against
@@ -735,6 +736,11 @@ func (c *Client) CreateResource(ctx context.Context, input *CreateResourceInput)
 // access policy, etc.). resourceID must be a `r_…` ID; alias-keyed updates
 // must first resolve via GetResourceByAlias.
 //
+// Validation order (first match wins): empty resourceID → nil input →
+// no-fields-set → Alias/ClearAlias exclusivity → empty-Alias-pointer
+// guard. The exclusivity-before-empty-pointer leg is pinned by
+// TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst.
+//
 // Retry semantics: do() retries 5xx/429 with the buffered body, so a
 // successfully-applied PATCH that returns 502 will be re-applied on retry.
 // All currently-supported PATCH fields (alias, description, custom_domain,
@@ -760,6 +766,17 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 	}
 	if !input.hasAnyFieldSet() {
 		return nil, ErrUpdateResourceNoFieldsSet
+	}
+	// Trim *input.Alias for symmetry with the resourceID and
+	// GetResourceByAlias trim contracts. Make a defensive copy of
+	// input so the trim doesn't mutate the caller's struct, then
+	// re-point Alias at the trimmed value. The trimmed string is what
+	// hits the wire and what the empty-pointer guard below sees.
+	if input.Alias != nil {
+		trimmed := strings.TrimSpace(*input.Alias)
+		copyInput := *input
+		copyInput.Alias = &trimmed
+		input = &copyInput
 	}
 	// Order: the exclusivity check runs before the empty-pointer
 	// footgun guard. A caller passing both `Alias: &""` and

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -828,11 +828,12 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 	})
 }
 
-// TestCreatePathIsPlural pins the canonical /v1/qurls path. PR #176 fixed
-// the singular `/v1/qurl` regression in production; this assertion lives
-// here so any future "let me just rename it back" change fails CI loudly,
-// not silently like the original bug did (the previous test mocked the
-// wrong path so it passed against /v1/qurl too).
+// TestCreatePathIsPlural pins the canonical /v1/qurls path as a named
+// regression assertion. TestCreate already asserts the path generically
+// at line 57; the value of this test is the explicit name — any future
+// "let me just rename it back" change surfaces by the regression-pin
+// test name, not by an unrelated TestCreate failure. PR #176 fixed the
+// original singular `/v1/qurl` bug in production.
 func TestCreatePathIsPlural(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1051,6 +1052,11 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 	if got, ok := raw["clear_alias"]; !ok || got != true {
 		t.Errorf("clear_alias: want true, got %v (ok=%v); body=%s", got, ok, gotBody)
 	}
+	// Symmetric pin: clearing must NOT also send a stale `alias` key.
+	// Mirror of the assertion in TestUpdateResourceSetAlias.
+	if _, ok := raw["alias"]; ok {
+		t.Errorf("alias must elide when ClearAlias=true; body=%s", gotBody)
+	}
 }
 
 func TestUpdateResourceEmptyIDRejected(t *testing.T) {
@@ -1161,5 +1167,126 @@ func TestGetResourceByAliasNotFound(t *testing.T) {
 	}
 	if apiErr.Code != "alias_not_found" {
 		t.Errorf("got code %q, want alias_not_found", apiErr.Code)
+	}
+}
+
+// TestCreateResourceAliasInUse pins the typed *APIError shape on the
+// `alias_in_use` 409 path documented in CreateResourceInput's doc comment
+// (alias attempted on an already-existing resource missing an alias).
+// Symmetric with TestGetResourceByAliasNotFound — pins the error envelope
+// for the second new resource method.
+func TestCreateResourceAliasInUse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusConflict)
+		resp := map[string]any{
+			"error": map[string]any{
+				"title":  "Conflict",
+				"status": 409,
+				"detail": "alias already in use",
+				"code":   "alias_in_use",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	_, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		TargetURL: "https://internal.example.com",
+		Alias:     testAlias,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Errorf("got status %d, want 409", apiErr.StatusCode)
+	}
+	if apiErr.Code != "alias_in_use" {
+		t.Errorf("got code %q, want alias_in_use", apiErr.Code)
+	}
+}
+
+// TestUpdateResourceInvalidAlias pins the typed *APIError shape on a 400
+// `invalid_alias` path — symmetric coverage with the other two new methods.
+func TestUpdateResourceInvalidAlias(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusBadRequest)
+		resp := map[string]any{
+			"error": map[string]any{
+				"title":  "Bad Request",
+				"status": 400,
+				"detail": "alias must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
+				"code":   "invalid_alias",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	alias := "Bad-Alias!"
+	_, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+		Alias: &alias,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("got status %d, want 400", apiErr.StatusCode)
+	}
+	if apiErr.Code != "invalid_alias" {
+		t.Errorf("got code %q, want invalid_alias", apiErr.Code)
+	}
+}
+
+// TestUpdateResourceEmptyAliasPointerRejected pins the client-side
+// fail-fast for the "pointer to empty string" footgun documented on
+// UpdateResourceInput.Alias — the server's regex would 400 it anyway,
+// but the client's error message tells the caller exactly what to do
+// (use ClearAlias=true).
+func TestUpdateResourceEmptyAliasPointerRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	empty := ""
+	_, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+		Alias: &empty,
+	})
+	if err == nil {
+		t.Fatal("expected error on Alias=&\"\"")
+	}
+	if !strings.Contains(err.Error(), "ClearAlias") {
+		t.Errorf("error should mention ClearAlias remediation; got %q", err.Error())
+	}
+}
+
+// TestUpdateResourceAliasAndClearAliasMutuallyExclusive pins the
+// client-side rejection of the (Alias != nil, ClearAlias=true) combo
+// — the server returns 400 for this combination, and the client
+// fails fast to save the round-trip.
+func TestUpdateResourceAliasAndClearAliasMutuallyExclusive(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	alias := testAlias
+	_, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+		Alias:      &alias,
+		ClearAlias: true,
+	})
+	if err == nil {
+		t.Fatal("expected error when both Alias and ClearAlias are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusivity; got %q", err.Error())
 	}
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,11 +16,12 @@ import (
 )
 
 const (
-	testDescription = "updated"
-	testAlias       = "dev-dashboard"
-	testAliasAlt    = "prod-grafana"
-	testResourceID  = "r_existing01"
-	testTargetURL   = "https://internal.example.com"
+	testDescription   = "updated"
+	testAlias         = "dev-dashboard"
+	testAliasAlt      = "prod-grafana"
+	testResourceID    = "r_existing01"
+	testResourceIDAlt = "r_dev_dash01"
+	testTargetURL     = "https://internal.example.com"
 )
 
 // testClient creates a client with retries disabled for fast unit tests.
@@ -1010,7 +1012,7 @@ func TestCreateResource(t *testing.T) {
 			t.Errorf("got Alias %q, want %q", input.Alias, testAlias)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_dev_dash01",
+			"resource_id": testResourceIDAlt,
 			"target_url":  testTargetURL,
 			"alias":       testAlias,
 			"type":        ResourceTypeURL,
@@ -1028,7 +1030,7 @@ func TestCreateResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateResource: %v", err)
 	}
-	if got.ResourceID != "r_dev_dash01" {
+	if got.ResourceID != testResourceIDAlt {
 		t.Errorf("got ResourceID %q", got.ResourceID)
 	}
 	if got.Alias != testAlias {
@@ -1221,6 +1223,12 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 		if len(input.AccessPolicy.IPAllowlist) != 2 {
 			t.Errorf("IPAllowlist: got %v", input.AccessPolicy.IPAllowlist)
 		}
+		if len(input.AccessPolicy.IPDenylist) != 1 {
+			t.Errorf("IPDenylist: got %v", input.AccessPolicy.IPDenylist)
+		}
+		if len(input.AccessPolicy.GeoAllowlist) != 2 {
+			t.Errorf("GeoAllowlist: got %v", input.AccessPolicy.GeoAllowlist)
+		}
 		if len(input.AccessPolicy.GeoDenylist) != 1 {
 			t.Errorf("GeoDenylist: got %v", input.AccessPolicy.GeoDenylist)
 		}
@@ -1229,8 +1237,10 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 			"target_url":  testTargetURL,
 			"status":      StatusActive,
 			"access_policy": map[string]any{
-				"ip_allowlist": []string{"10.0.0.0/8", "192.168.0.0/16"},
-				"geo_denylist": []string{"CN"},
+				"ip_allowlist":  []string{"10.0.0.0/8", "192.168.0.0/16"},
+				"ip_denylist":   []string{"203.0.113.0/24"},
+				"geo_allowlist": []string{"US", "CA"},
+				"geo_denylist":  []string{"CN"},
 			},
 		})
 	}))
@@ -1240,8 +1250,10 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
 		TargetURL: testTargetURL,
 		AccessPolicy: &AccessPolicy{
-			IPAllowlist: []string{"10.0.0.0/8", "192.168.0.0/16"},
-			GeoDenylist: []string{"CN"},
+			IPAllowlist:  []string{"10.0.0.0/8", "192.168.0.0/16"},
+			IPDenylist:   []string{"203.0.113.0/24"},
+			GeoAllowlist: []string{"US", "CA"},
+			GeoDenylist:  []string{"CN"},
 		},
 	})
 	if err != nil {
@@ -1252,6 +1264,12 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 	}
 	if len(got.AccessPolicy.IPAllowlist) != 2 {
 		t.Errorf("response IPAllowlist: got %v", got.AccessPolicy.IPAllowlist)
+	}
+	if len(got.AccessPolicy.IPDenylist) != 1 {
+		t.Errorf("response IPDenylist: got %v", got.AccessPolicy.IPDenylist)
+	}
+	if len(got.AccessPolicy.GeoAllowlist) != 2 {
+		t.Errorf("response GeoAllowlist: got %v", got.AccessPolicy.GeoAllowlist)
 	}
 	if len(got.AccessPolicy.GeoDenylist) != 1 {
 		t.Errorf("response GeoDenylist: got %v", got.AccessPolicy.GeoDenylist)
@@ -1266,6 +1284,56 @@ func TestUpdateResourceNoFieldsSetRejected(t *testing.T) {
 	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{})
 	if !errors.Is(err, ErrUpdateResourceNoFieldsSet) {
 		t.Fatalf("expected ErrUpdateResourceNoFieldsSet, got %v", err)
+	}
+}
+
+// TestHasAnyFieldSetCoversAllFields walks UpdateResourceInput's struct
+// fields via reflection and asserts that setting *each one alone* makes
+// hasAnyFieldSet return true. Catches the failure mode where a future
+// contributor adds a new mutable field but forgets to update
+// hasAnyFieldSet — without this test, a no-op PATCH that exercises only
+// the new field would slip past the guard.
+//
+// The reflection walk is intentionally narrow: pointer fields get a
+// pointer to a zero value of the target type; bool fields flip to true.
+// Skip the test (with a t.Skip) for any field whose type isn't covered;
+// adding such a field here is a nudge to extend the helper. Today's
+// surface (5 fields: Description, Alias, ClearAlias, CustomDomain,
+// AccessPolicy) is fully covered.
+func TestHasAnyFieldSetCoversAllFields(t *testing.T) {
+	emptyStr := ""
+	cases := []struct {
+		name  string
+		input UpdateResourceInput
+	}{
+		{"Description", UpdateResourceInput{Description: &emptyStr}},
+		{"Alias", UpdateResourceInput{Alias: &emptyStr}},
+		{"ClearAlias", UpdateResourceInput{ClearAlias: true}},
+		{"CustomDomain", UpdateResourceInput{CustomDomain: &emptyStr}},
+		{"AccessPolicy", UpdateResourceInput{AccessPolicy: &AccessPolicy{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.input.hasAnyFieldSet() {
+				t.Errorf("hasAnyFieldSet should be true with %s set; got false", tc.name)
+			}
+		})
+	}
+
+	// Sanity check: empty struct returns false.
+	var empty UpdateResourceInput
+	if empty.hasAnyFieldSet() {
+		t.Error("hasAnyFieldSet on empty UpdateResourceInput should return false")
+	}
+
+	// Coverage tripwire: if a new field is added to UpdateResourceInput
+	// without updating both hasAnyFieldSet and the cases above, the
+	// reflect-based field count diverges from the case count.
+	got := reflect.TypeOf(UpdateResourceInput{}).NumField()
+	if got != len(cases) {
+		t.Errorf("UpdateResourceInput has %d fields but TestHasAnyFieldSetCoversAllFields covers %d — "+
+			"add the new field to both hasAnyFieldSet and this test's cases slice",
+			got, len(cases))
 	}
 }
 
@@ -1505,9 +1573,35 @@ func TestUpdateResourceWhitespaceIDRejected(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceTrimsSurroundingWhitespace pins the "trim then
+// validate AND send" contract — `" r_existing01 "` must hit the wire
+// as `/v1/resources/r_existing01`, NOT `/v1/resources/%20r_existing01%20`.
+// Catches the bug where TrimSpace validated one value but the
+// un-trimmed value went into the URL.
+func TestUpdateResourceTrimsSurroundingWhitespace(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	desc := testDescription
+	if _, err := c.UpdateResource(context.Background(), "  "+testResourceID+"  ", &UpdateResourceInput{
+		Description: &desc,
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+	wantPath := "/v1/resources/" + testResourceID
+	if gotPath != wantPath {
+		t.Errorf("trimmed value should hit the wire: got %q, want %q", gotPath, wantPath)
+	}
+}
+
 func TestUpdateResourceNilInputRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	_, err := c.UpdateResource(context.Background(), "r_x", nil)
+	_, err := c.UpdateResource(context.Background(), testResourceID, nil)
 	if !errors.Is(err, ErrUpdateResourceNilInput) {
 		t.Fatalf("expected ErrUpdateResourceNilInput, got %v", err)
 	}
@@ -1523,7 +1617,7 @@ func TestGetResourceByAlias(t *testing.T) {
 			t.Errorf("expected %s, got %s", wantPath, r.URL.Path)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_dev_dash01",
+			"resource_id": testResourceIDAlt,
 			"alias":       testAlias,
 			"target_url":  testTargetURL,
 			"type":        ResourceTypeURL,
@@ -1537,7 +1631,7 @@ func TestGetResourceByAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetResourceByAlias: %v", err)
 	}
-	if got.ResourceID != "r_dev_dash01" {
+	if got.ResourceID != testResourceIDAlt {
 		t.Errorf("got ResourceID %q", got.ResourceID)
 	}
 	if got.Alias != testAlias {
@@ -1565,7 +1659,7 @@ func TestGetResourceByAliasEscapesPathSegment(t *testing.T) {
 	var gotEscapedPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotEscapedPath = r.URL.EscapedPath()
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
 	}))
 	defer srv.Close()
 
@@ -1589,7 +1683,7 @@ func TestUpdateResourceEscapesIDPathSegment(t *testing.T) {
 	var gotEscapedPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotEscapedPath = r.URL.EscapedPath()
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
 	}))
 	defer srv.Close()
 
@@ -1623,6 +1717,27 @@ func TestGetResourceByAliasWhitespaceRejected(t *testing.T) {
 	_, err := c.GetResourceByAlias(context.Background(), "   ")
 	if !errors.Is(err, ErrGetResourceByAliasEmpty) {
 		t.Fatalf("expected ErrGetResourceByAliasEmpty on whitespace, got %v", err)
+	}
+}
+
+// TestGetResourceByAliasTrimsSurroundingWhitespace pins the
+// "trim then validate AND send" contract for the alias path
+// (mirror of TestUpdateResourceTrimsSurroundingWhitespace).
+func TestGetResourceByAliasTrimsSurroundingWhitespace(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.GetResourceByAlias(context.Background(), "  "+testAlias+"  "); err != nil {
+		t.Fatalf("GetResourceByAlias: %v", err)
+	}
+	wantPath := "/v1/resources/by-alias/" + testAlias
+	if gotPath != wantPath {
+		t.Errorf("trimmed value should hit the wire: got %q, want %q", gotPath, wantPath)
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -943,6 +943,21 @@ func TestCreateTargetURLAndResourceIDMutuallyExclusive(t *testing.T) {
 	}
 }
 
+// TestCreateNeitherTargetURLNorResourceIDRejected pins the client-side
+// fail-fast for the both-empty case (companion to the both-populated test).
+// Without a target on either field the server can't bind the qURL to
+// anything; failing fast saves a 400 round-trip.
+func TestCreateNeitherTargetURLNorResourceIDRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.Create(context.Background(), CreateInput{})
+	if err == nil {
+		t.Fatal("expected error when neither TargetURL nor ResourceID is set")
+	}
+	if !strings.Contains(err.Error(), "TargetURL or ResourceID") {
+		t.Errorf("error should mention TargetURL or ResourceID; got %q", err.Error())
+	}
+}
+
 // --- Resource methods ---
 
 func TestCreateResource(t *testing.T) {
@@ -968,6 +983,7 @@ func TestCreateResource(t *testing.T) {
 			"target_url":  "https://internal.example.com",
 			"alias":       testAlias,
 			"type":        "url",
+			"status":      StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -986,12 +1002,34 @@ func TestCreateResource(t *testing.T) {
 	if got.Alias != testAlias {
 		t.Errorf("got Alias %q, want %q", got.Alias, testAlias)
 	}
+	// Pin Status decoding — confirms the response shape from
+	// qurl-service/api/openapi.yaml ResourceData.status round-trips.
+	if got.Status != StatusActive {
+		t.Errorf("got Status %q, want %q", got.Status, StatusActive)
+	}
 }
 
 func TestCreateResourceNilInputRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	if _, err := c.CreateResource(context.Background(), nil); err == nil {
 		t.Fatal("expected error on nil input")
+	}
+}
+
+// TestCreateResourceEmptyTargetURLRejected pins the client-side fail-fast
+// when TargetURL is missing — without it the server can't compute the
+// `(owner_id, target_url_hash)` idempotency key. Companion to the nil-input
+// test.
+func TestCreateResourceEmptyTargetURLRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		Alias: testAlias,
+	})
+	if err == nil {
+		t.Fatal("expected error on empty TargetURL")
+	}
+	if !strings.Contains(err.Error(), "TargetURL") {
+		t.Errorf("error should mention TargetURL; got %q", err.Error())
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1380,21 +1380,35 @@ func TestHasAnyFieldSetCoversAllFields(t *testing.T) {
 
 	// Coverage tripwire: if a new mutable field is added to
 	// UpdateResourceInput without updating both hasAnyFieldSet and
-	// the cases above, the reflect-based field count diverges from
-	// the case count. Filters out fields with `json:"-"` so future
-	// request-decoration fields (e.g. IdempotencyKey per #148) don't
-	// trip the count.
-	mutableFields := 0
+	// the cases above, the reflect-based set-equality check fires.
+	// Set-equality (not just count) catches the duplicate-case copy-
+	// paste mistake too — two cases named "Alias" and a missing case
+	// for a new field would slip past a count-only check.
+	// Filters out fields with `json:"-"` so future request-decoration
+	// fields (e.g. IdempotencyKey per #148) don't trip the check.
+	expected := make(map[string]bool)
 	tt := reflect.TypeOf(UpdateResourceInput{})
-	for i := 0; i < tt.NumField(); i++ {
-		if tt.Field(i).Tag.Get("json") != "-" {
-			mutableFields++
+	for i := range tt.NumField() {
+		f := tt.Field(i)
+		if f.Tag.Get("json") != "-" {
+			expected[f.Name] = true
 		}
 	}
-	if mutableFields != len(cases) {
-		t.Errorf("UpdateResourceInput has %d mutable fields but TestHasAnyFieldSetCoversAllFields covers %d — "+
-			"add the new field to both hasAnyFieldSet and this test's cases slice",
-			mutableFields, len(cases))
+	got := make(map[string]bool)
+	for _, tc := range cases {
+		got[tc.name] = true
+	}
+	for name := range expected {
+		if !got[name] {
+			t.Errorf("UpdateResourceInput field %q has no test case in TestHasAnyFieldSetCoversAllFields — "+
+				"add it to the cases slice (and ensure hasAnyFieldSet covers it)", name)
+		}
+	}
+	for name := range got {
+		if !expected[name] {
+			t.Errorf("test case %q does not match any UpdateResourceInput field — "+
+				"likely a typo or stale rename", name)
+		}
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1326,14 +1326,23 @@ func TestHasAnyFieldSetCoversAllFields(t *testing.T) {
 		t.Error("hasAnyFieldSet on empty UpdateResourceInput should return false")
 	}
 
-	// Coverage tripwire: if a new field is added to UpdateResourceInput
-	// without updating both hasAnyFieldSet and the cases above, the
-	// reflect-based field count diverges from the case count.
-	got := reflect.TypeOf(UpdateResourceInput{}).NumField()
-	if got != len(cases) {
-		t.Errorf("UpdateResourceInput has %d fields but TestHasAnyFieldSetCoversAllFields covers %d — "+
+	// Coverage tripwire: if a new mutable field is added to
+	// UpdateResourceInput without updating both hasAnyFieldSet and
+	// the cases above, the reflect-based field count diverges from
+	// the case count. Filters out fields with `json:"-"` so future
+	// request-decoration fields (e.g. IdempotencyKey per #148) don't
+	// trip the count.
+	mutableFields := 0
+	tt := reflect.TypeOf(UpdateResourceInput{})
+	for i := 0; i < tt.NumField(); i++ {
+		if tt.Field(i).Tag.Get("json") != "-" {
+			mutableFields++
+		}
+	}
+	if mutableFields != len(cases) {
+		t.Errorf("UpdateResourceInput has %d mutable fields but TestHasAnyFieldSetCoversAllFields covers %d — "+
 			"add the new field to both hasAnyFieldSet and this test's cases slice",
-			got, len(cases))
+			mutableFields, len(cases))
 	}
 }
 
@@ -1428,6 +1437,56 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 	// Mirror of the assertion in TestUpdateResourceSetAlias.
 	if _, ok := raw["alias"]; ok {
 		t.Errorf("alias must elide when ClearAlias=true; body=%s", gotBody)
+	}
+}
+
+// TestUpdateResourceRetryPreservesBody pins the retry-safety contract
+// documented at [Client.UpdateResource]: do() retries 5xx with the
+// buffered body, so a successfully-applied PATCH that returns 502
+// will be re-applied with byte-identical request bytes. If a future
+// refactor breaks the body-buffering invariant, the per-attempt
+// payloads would diverge and this test catches it before any
+// non-idempotent PATCH field starts shipping.
+func TestUpdateResourceRetryPreservesBody(t *testing.T) {
+	var attempts atomic.Int32
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("attempt %d: read body: %v", n, err)
+		}
+		mu.Lock()
+		bodies = append(bodies, body)
+		mu.Unlock()
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-key",
+		WithRetry(3),
+		withDelaysForTest(),
+	)
+	alias := testAliasAlt
+	if _, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+		Alias: &alias,
+	}); err != nil {
+		t.Fatalf("UpdateResource after retries: %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts.Load())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 1; i < len(bodies); i++ {
+		if !bytes.Equal(bodies[0], bodies[i]) {
+			t.Errorf("attempt %d body diverged from attempt 1.\n#1: %s\n#%d: %s", i+1, bodies[0], i+1, bodies[i])
+		}
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -868,14 +868,14 @@ func TestCreateResourceIDFlow(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_existing",
+			"resource_id": testResourceID,
 			"qurl_link":   "https://qurl.link/at_existing",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.Create(context.Background(), CreateInput{ResourceID: "r_existing"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateInput{ResourceID: testResourceID}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -884,8 +884,8 @@ func TestCreateResourceIDFlow(t *testing.T) {
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v (body=%s)", err, gotBody)
 	}
-	if got := raw["resource_id"]; got != "r_existing" {
-		t.Errorf("resource_id: got %v, want \"r_existing\"", got)
+	if got := raw["resource_id"]; got != testResourceID {
+		t.Errorf("resource_id: got %v, want %q", got, testResourceID)
 	}
 	if _, hasTargetURL := raw["target_url"]; hasTargetURL {
 		t.Errorf("target_url must be omitted when empty (server-side mutually_exclusive_fields rule); body=%s", gotBody)
@@ -933,7 +933,7 @@ func TestCreateTargetURLAndResourceIDMutuallyExclusive(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.Create(context.Background(), CreateInput{
 		TargetURL:  "https://example.com",
-		ResourceID: "r_existing",
+		ResourceID: testResourceID,
 	})
 	if !errors.Is(err, ErrCreateTargetResourceExclusive) {
 		t.Fatalf("expected ErrCreateTargetResourceExclusive, got %v", err)
@@ -1025,6 +1025,107 @@ func TestCreateResourceEmptyTargetURLRejected(t *testing.T) {
 	}
 }
 
+// TestCreateResourceTunnelTypeAcceptsEmptyTargetURL pins the tunnel
+// branch of the TargetURL validator. The doc on
+// CreateResourceInput.Type says TargetURL is ignored when type=tunnel;
+// this test ensures the client doesn't reject the request before it
+// reaches the server.
+func TestCreateResourceTunnelTypeAcceptsEmptyTargetURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input CreateResourceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.Type != ResourceTypeTunnel {
+			t.Errorf("got Type %q, want %q", input.Type, ResourceTypeTunnel)
+		}
+		if input.TargetURL != "" {
+			t.Errorf("got TargetURL %q, want empty", input.TargetURL)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_tunnel01",
+			"type":        ResourceTypeTunnel,
+			"status":      StatusActive,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		Type: ResourceTypeTunnel,
+	})
+	if err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+	if got.Type != ResourceTypeTunnel {
+		t.Errorf("got Type %q, want %q", got.Type, ResourceTypeTunnel)
+	}
+}
+
+// TestCreateResourceAccessPolicyRoundTrip pins the AccessPolicy decoding
+// path — if the server schema renames a subfield (ip_allowlist →
+// ip_allow, etc.) the round-trip would silently drop it without this
+// test.
+func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input CreateResourceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.AccessPolicy == nil {
+			t.Fatal("AccessPolicy should not be nil on the wire")
+		}
+		if len(input.AccessPolicy.IPAllowlist) != 2 {
+			t.Errorf("IPAllowlist: got %v", input.AccessPolicy.IPAllowlist)
+		}
+		if len(input.AccessPolicy.GeoDenylist) != 1 {
+			t.Errorf("GeoDenylist: got %v", input.AccessPolicy.GeoDenylist)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_policy01",
+			"target_url":  "https://internal.example.com",
+			"status":      StatusActive,
+			"access_policy": map[string]any{
+				"ip_allowlist": []string{"10.0.0.0/8", "192.168.0.0/16"},
+				"geo_denylist": []string{"CN"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		TargetURL: "https://internal.example.com",
+		AccessPolicy: &AccessPolicy{
+			IPAllowlist: []string{"10.0.0.0/8", "192.168.0.0/16"},
+			GeoDenylist: []string{"CN"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+	if got.AccessPolicy == nil {
+		t.Fatal("response AccessPolicy should not be nil")
+	}
+	if len(got.AccessPolicy.IPAllowlist) != 2 {
+		t.Errorf("response IPAllowlist: got %v", got.AccessPolicy.IPAllowlist)
+	}
+	if len(got.AccessPolicy.GeoDenylist) != 1 {
+		t.Errorf("response GeoDenylist: got %v", got.AccessPolicy.GeoDenylist)
+	}
+}
+
+// TestUpdateResourceNoFieldsSetRejected pins the client-side fail-fast
+// for the all-nil-pointers, ClearAlias=false case. Symmetric with
+// Create's no-target guard — saves a round-trip on a no-op PATCH.
+func TestUpdateResourceNoFieldsSetRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{})
+	if !errors.Is(err, ErrUpdateResourceNoFieldsSet) {
+		t.Fatalf("expected ErrUpdateResourceNoFieldsSet, got %v", err)
+	}
+}
+
 func TestUpdateResourceSetAlias(t *testing.T) {
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1084,17 +1185,25 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
+		// Server responds with the cleared resource — alias absent on
+		// the wire, decoding to Resource.Alias == "".
 		apiEnvelope(t, w, map[string]any{
 			"resource_id": testResourceID,
+			"status":      StatusActive,
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+	got, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		ClearAlias: true,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("UpdateResource: %v", err)
+	}
+	// Confirm the cleared alias decodes correctly on the response side.
+	if got.Alias != "" {
+		t.Errorf("cleared alias should decode as empty string; got %q", got.Alias)
 	}
 
 	var raw map[string]any

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1275,6 +1275,44 @@ func TestUpdateResourceClearDescriptionByEmptyString(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceClearCustomDomainByEmptyString pins the same `&""`
+// clear convention on CustomDomain — symmetric with
+// TestUpdateResourceClearDescriptionByEmptyString. Both fields share
+// the convention but only one direction was pinned.
+func TestUpdateResourceClearCustomDomainByEmptyString(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": testResourceID,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	empty := ""
+	if _, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+		CustomDomain: &empty,
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	got, ok := raw["custom_domain"]
+	if !ok {
+		t.Fatalf("custom_domain must be present (the &\"\" clear semantic); body=%s", gotBody)
+	}
+	if got != "" {
+		t.Errorf("custom_domain: got %v, want \"\"", got)
+	}
+}
+
 func TestUpdateResourceEmptyIDRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.UpdateResource(context.Background(), "", &UpdateResourceInput{})

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1041,10 +1041,10 @@ func TestCreateResource(t *testing.T) {
 	if got.Status != StatusActive {
 		t.Errorf("got Status %q, want %q", got.Status, StatusActive)
 	}
-	// Pin UpdatedAt decoding — *time.Time round-trip with explicit
-	// timezone offset. nil-vs-zero distinction matters for "field
-	// present on response" semantics.
-	if got.UpdatedAt == nil {
+	// Pin UpdatedAt decoding — time.Time + omitzero round-trip. The
+	// non-zero check confirms the field decoded; year/month assertion
+	// catches a future timezone-parsing regression.
+	if got.UpdatedAt.IsZero() {
 		t.Fatal("UpdatedAt should be populated when present on the wire")
 	}
 	if got.UpdatedAt.Year() != 2026 || got.UpdatedAt.Month() != 5 {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1710,6 +1710,61 @@ func TestUpdateResourceTrimsSurroundingWhitespace(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceTrimsAliasPointer pins symmetry with the path-segment
+// trim contract — a caller passing `Alias: &" prod-grafana "` should
+// see the trimmed value on the wire (the server regex would 400 on
+// surrounding whitespace anyway). Also pins the defensive-copy posture:
+// the caller's input struct must NOT be mutated.
+func TestUpdateResourceTrimsAliasPointer(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	original := "  " + testAliasAlt + "  "
+	in := &UpdateResourceInput{Alias: &original}
+	if _, err := c.UpdateResource(context.Background(), testResourceID, in); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+
+	// Wire: alias is the trimmed value.
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got := raw["alias"]; got != testAliasAlt {
+		t.Errorf("alias on wire: got %v, want %q", got, testAliasAlt)
+	}
+
+	// Caller's struct: untouched. The defensive copy must not
+	// mutate the original *string.
+	if *in.Alias != original {
+		t.Errorf("caller's input.Alias was mutated; got %q, want %q", *in.Alias, original)
+	}
+}
+
+// TestUpdateResourceWhitespaceOnlyAliasRejected pins what happens when
+// an Alias-only payload trims to "": the empty-pointer footgun guard
+// should fire (use ClearAlias=true). Symmetric with the explicit
+// `Alias: &""` case but exercises the new trim path.
+func TestUpdateResourceWhitespaceOnlyAliasRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	whitespace := "   "
+	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+		Alias: &whitespace,
+	})
+	if !errors.Is(err, ErrUpdateResourceAliasEmpty) {
+		t.Fatalf("expected ErrUpdateResourceAliasEmpty on whitespace-only alias, got %v", err)
+	}
+}
+
 func TestUpdateResourceNilInputRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.UpdateResource(context.Background(), testResourceID, nil)

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -935,11 +935,8 @@ func TestCreateTargetURLAndResourceIDMutuallyExclusive(t *testing.T) {
 		TargetURL:  "https://example.com",
 		ResourceID: "r_existing",
 	})
-	if err == nil {
-		t.Fatal("expected error when both TargetURL and ResourceID are set")
-	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("error should mention mutual exclusivity; got %q", err.Error())
+	if !errors.Is(err, ErrCreateTargetResourceExclusive) {
+		t.Fatalf("expected ErrCreateTargetResourceExclusive, got %v", err)
 	}
 }
 
@@ -950,11 +947,8 @@ func TestCreateTargetURLAndResourceIDMutuallyExclusive(t *testing.T) {
 func TestCreateNeitherTargetURLNorResourceIDRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.Create(context.Background(), CreateInput{})
-	if err == nil {
-		t.Fatal("expected error when neither TargetURL nor ResourceID is set")
-	}
-	if !strings.Contains(err.Error(), "TargetURL or ResourceID") {
-		t.Errorf("error should mention TargetURL or ResourceID; got %q", err.Error())
+	if !errors.Is(err, ErrCreateRequiresTarget) {
+		t.Fatalf("expected ErrCreateRequiresTarget, got %v", err)
 	}
 }
 
@@ -1011,8 +1005,9 @@ func TestCreateResource(t *testing.T) {
 
 func TestCreateResourceNilInputRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	if _, err := c.CreateResource(context.Background(), nil); err == nil {
-		t.Fatal("expected error on nil input")
+	_, err := c.CreateResource(context.Background(), nil)
+	if !errors.Is(err, ErrCreateResourceNilInput) {
+		t.Fatalf("expected ErrCreateResourceNilInput, got %v", err)
 	}
 }
 
@@ -1025,11 +1020,8 @@ func TestCreateResourceEmptyTargetURLRejected(t *testing.T) {
 	_, err := c.CreateResource(context.Background(), &CreateResourceInput{
 		Alias: testAlias,
 	})
-	if err == nil {
-		t.Fatal("expected error on empty TargetURL")
-	}
-	if !strings.Contains(err.Error(), "TargetURL") {
-		t.Errorf("error should mention TargetURL; got %q", err.Error())
+	if !errors.Is(err, ErrCreateResourceRequiresTargetURL) {
+		t.Fatalf("expected ErrCreateResourceRequiresTargetURL, got %v", err)
 	}
 }
 
@@ -1119,17 +1111,58 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceClearDescriptionByEmptyString pins the documented
+// `&""` clear convention on Description (no sentinel-clear sibling). The
+// empty string must round-trip on the wire as `"description": ""` so the
+// server treats it as a clear; if a future contributor adds `omitempty` to
+// `Description` (echoing Alias), this test fails loudly.
+func TestUpdateResourceClearDescriptionByEmptyString(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": testResourceID,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	empty := ""
+	if _, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+		Description: &empty,
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	got, ok := raw["description"]
+	if !ok {
+		t.Fatalf("description must be present (the &\"\" clear semantic); body=%s", gotBody)
+	}
+	if got != "" {
+		t.Errorf("description: got %v, want \"\"", got)
+	}
+}
+
 func TestUpdateResourceEmptyIDRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	if _, err := c.UpdateResource(context.Background(), "", &UpdateResourceInput{}); err == nil {
-		t.Fatal("expected error on empty resourceID")
+	_, err := c.UpdateResource(context.Background(), "", &UpdateResourceInput{})
+	if !errors.Is(err, ErrUpdateResourceEmptyID) {
+		t.Fatalf("expected ErrUpdateResourceEmptyID, got %v", err)
 	}
 }
 
 func TestUpdateResourceNilInputRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	if _, err := c.UpdateResource(context.Background(), "r_x", nil); err == nil {
-		t.Fatal("expected error on nil input")
+	_, err := c.UpdateResource(context.Background(), "r_x", nil)
+	if !errors.Is(err, ErrUpdateResourceNilInput) {
+		t.Fatalf("expected ErrUpdateResourceNilInput, got %v", err)
 	}
 }
 
@@ -1190,8 +1223,9 @@ func TestGetResourceByAliasEscapesPathSegment(t *testing.T) {
 
 func TestGetResourceByAliasEmptyRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	if _, err := c.GetResourceByAlias(context.Background(), ""); err == nil {
-		t.Fatal("expected error on empty alias")
+	_, err := c.GetResourceByAlias(context.Background(), "")
+	if !errors.Is(err, ErrGetResourceByAliasEmpty) {
+		t.Fatalf("expected ErrGetResourceByAliasEmpty, got %v", err)
 	}
 }
 
@@ -1332,11 +1366,8 @@ func TestUpdateResourceEmptyAliasPointerRejected(t *testing.T) {
 	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		Alias: &empty,
 	})
-	if err == nil {
-		t.Fatal("expected error on Alias=&\"\"")
-	}
-	if !strings.Contains(err.Error(), "ClearAlias") {
-		t.Errorf("error should mention ClearAlias remediation; got %q", err.Error())
+	if !errors.Is(err, ErrUpdateResourceAliasEmpty) {
+		t.Fatalf("expected ErrUpdateResourceAliasEmpty, got %v", err)
 	}
 }
 
@@ -1351,10 +1382,7 @@ func TestUpdateResourceAliasAndClearAliasMutuallyExclusive(t *testing.T) {
 		Alias:      &alias,
 		ClearAlias: true,
 	})
-	if err == nil {
-		t.Fatal("expected error when both Alias and ClearAlias are set")
-	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("error should mention mutual exclusivity; got %q", err.Error())
+	if !errors.Is(err, ErrUpdateResourceAliasClearExclusive) {
+		t.Fatalf("expected ErrUpdateResourceAliasClearExclusive, got %v", err)
 	}
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -953,6 +953,25 @@ func TestCreateNeitherTargetURLNorResourceIDRejected(t *testing.T) {
 	}
 }
 
+// TestCreateNoTargetBeatsInvalidIdempotencyKey pins the validation
+// order in Create: target presence (a structural error) is checked
+// before the idempotency-key bytes (a request-decoration error). A
+// caller missing both should learn about the missing target first;
+// the error is the more actionable of the two. Symmetric with
+// TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst.
+func TestCreateNoTargetBeatsInvalidIdempotencyKey(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.Create(context.Background(), CreateInput{
+		// No TargetURL, no ResourceID, AND a key with a control byte
+		// (would also fail validateIdempotencyKey). Target check runs
+		// first.
+		IdempotencyKey: "bad\nkey",
+	})
+	if !errors.Is(err, ErrCreateRequiresTarget) {
+		t.Fatalf("expected ErrCreateRequiresTarget (target-presence beats idempotency), got %v", err)
+	}
+}
+
 // --- Resource methods ---
 
 func TestCreateResource(t *testing.T) {
@@ -1457,6 +1476,18 @@ func TestUpdateResourceEmptyIDRejected(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceWhitespaceIDRejected pins the strings.TrimSpace
+// guard — a whitespace-only resource ID would otherwise hit the wire
+// as `/v1/resources/%20%20` and 400 server-side. The client error
+// stays actionable.
+func TestUpdateResourceWhitespaceIDRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.UpdateResource(context.Background(), "   ", &UpdateResourceInput{})
+	if !errors.Is(err, ErrUpdateResourceEmptyID) {
+		t.Fatalf("expected ErrUpdateResourceEmptyID on whitespace ID, got %v", err)
+	}
+}
+
 func TestUpdateResourceNilInputRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.UpdateResource(context.Background(), "r_x", nil)
@@ -1520,11 +1551,50 @@ func TestGetResourceByAliasEscapesPathSegment(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceEscapesIDPathSegment is the symmetric path-escape
+// pin for UpdateResource (mirror of TestGetResourceByAliasEscapesPathSegment).
+// Server-side resource_id format is `^r_[a-z0-9_-]{11}$` so reserved
+// bytes won't reach this method via normal flows; the test is
+// defensive for direct programmatic callers and keeps a future
+// `url.PathEscape` removal from tripping silently.
+func TestUpdateResourceEscapesIDPathSegment(t *testing.T) {
+	var gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	desc := testDescription
+	if _, err := c.UpdateResource(context.Background(), "weird/id", &UpdateResourceInput{
+		Description: &desc,
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+	const want = "/v1/resources/weird%2Fid"
+	if gotEscapedPath != want {
+		t.Errorf("resourceID path-escape: got %q, want %q", gotEscapedPath, want)
+	}
+}
+
 func TestGetResourceByAliasEmptyRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.GetResourceByAlias(context.Background(), "")
 	if !errors.Is(err, ErrGetResourceByAliasEmpty) {
 		t.Fatalf("expected ErrGetResourceByAliasEmpty, got %v", err)
+	}
+}
+
+// TestGetResourceByAliasWhitespaceRejected pins the strings.TrimSpace
+// guard — a whitespace-only alias would hit the wire as
+// `/v1/resources/by-alias/%20%20` and 400 server-side. Companion to
+// TestGetResourceByAliasEmptyRejected.
+func TestGetResourceByAliasWhitespaceRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.GetResourceByAlias(context.Background(), "   ")
+	if !errors.Is(err, ErrGetResourceByAliasEmpty) {
+		t.Fatalf("expected ErrGetResourceByAliasEmpty on whitespace, got %v", err)
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -18,6 +18,7 @@ const (
 	testDescription = "updated"
 	testAlias       = "dev-dashboard"
 	testAliasAlt    = "prod-grafana"
+	testResourceID  = "r_existing01"
 )
 
 // testClient creates a client with retries disabled for fast unit tests.
@@ -922,6 +923,26 @@ func TestCreateTargetURLOnlyOmitsResourceID(t *testing.T) {
 	}
 }
 
+// TestCreateTargetURLAndResourceIDMutuallyExclusive pins the client-side
+// fail-fast for the both-populated case. Mirror of the symmetric guard in
+// UpdateResource for (Alias, ClearAlias). Closes the third leg of the
+// omitempty + exclusivity contract — the two valid shapes are pinned by
+// TestCreateResourceIDFlow / TestCreateTargetURLOnlyOmitsResourceID, and
+// this test pins the invalid combination.
+func TestCreateTargetURLAndResourceIDMutuallyExclusive(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.Create(context.Background(), CreateInput{
+		TargetURL:  "https://example.com",
+		ResourceID: "r_existing",
+	})
+	if err == nil {
+		t.Fatal("expected error when both TargetURL and ResourceID are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusivity; got %q", err.Error())
+	}
+}
+
 // --- Resource methods ---
 
 func TestCreateResource(t *testing.T) {
@@ -980,8 +1001,9 @@ func TestUpdateResourceSetAlias(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("expected PATCH, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1/resources/r_existing01" {
-			t.Errorf("expected /v1/resources/r_existing01, got %s", r.URL.Path)
+		wantPath := "/v1/resources/" + testResourceID
+		if r.URL.Path != wantPath {
+			t.Errorf("expected %s, got %s", wantPath, r.URL.Path)
 		}
 		var err error
 		gotBody, err = io.ReadAll(r.Body)
@@ -989,7 +1011,7 @@ func TestUpdateResourceSetAlias(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_existing01",
+			"resource_id": testResourceID,
 			"alias":       testAliasAlt,
 		})
 	}))
@@ -997,7 +1019,7 @@ func TestUpdateResourceSetAlias(t *testing.T) {
 
 	c := testClient(srv.URL, "test-key")
 	alias := testAliasAlt
-	got, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+	got, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		Alias: &alias,
 	})
 	if err != nil {
@@ -1033,13 +1055,13 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_existing01",
+			"resource_id": testResourceID,
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+	if _, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		ClearAlias: true,
 	}); err != nil {
 		t.Fatalf("UpdateResource: %v", err)
@@ -1215,6 +1237,8 @@ func TestCreateResourceAliasInUse(t *testing.T) {
 
 // TestUpdateResourceInvalidAlias pins the typed *APIError shape on a 400
 // `invalid_alias` path — symmetric coverage with the other two new methods.
+// Also pins the InvalidFields decoding so a regression in either parseError
+// or the test fixture would surface here.
 func TestUpdateResourceInvalidAlias(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/problem+json")
@@ -1225,6 +1249,9 @@ func TestUpdateResourceInvalidAlias(t *testing.T) {
 				"status": 400,
 				"detail": "alias must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
 				"code":   "invalid_alias",
+				"invalid_fields": map[string]string{
+					"alias": "must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
+				},
 			},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -1235,7 +1262,7 @@ func TestUpdateResourceInvalidAlias(t *testing.T) {
 
 	c := testClient(srv.URL, "test-key")
 	alias := "Bad-Alias!"
-	_, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		Alias: &alias,
 	})
 	if err == nil {
@@ -1251,6 +1278,9 @@ func TestUpdateResourceInvalidAlias(t *testing.T) {
 	if apiErr.Code != "invalid_alias" {
 		t.Errorf("got code %q, want invalid_alias", apiErr.Code)
 	}
+	if got, ok := apiErr.InvalidFields["alias"]; !ok || got == "" {
+		t.Errorf("InvalidFields[\"alias\"] should be populated; got %v (ok=%v)", got, ok)
+	}
 }
 
 // TestUpdateResourceEmptyAliasPointerRejected pins the client-side
@@ -1261,7 +1291,7 @@ func TestUpdateResourceInvalidAlias(t *testing.T) {
 func TestUpdateResourceEmptyAliasPointerRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	empty := ""
-	_, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		Alias: &empty,
 	})
 	if err == nil {
@@ -1279,7 +1309,7 @@ func TestUpdateResourceEmptyAliasPointerRejected(t *testing.T) {
 func TestUpdateResourceAliasAndClearAliasMutuallyExclusive(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	alias := testAlias
-	_, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
 		Alias:      &alias,
 		ClearAlias: true,
 	})

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1062,6 +1062,22 @@ func TestCreateResourceTunnelTypeAcceptsEmptyTargetURL(t *testing.T) {
 	}
 }
 
+// TestCreateResourceTunnelTypeRejectsTargetURL pins the inverse of
+// TestCreateResourceTunnelTypeAcceptsEmptyTargetURL — a tunnel resource
+// with a non-empty TargetURL is almost always a stale field from
+// copy-pasted literals; failing fast yields a clearer error than a
+// silent server-side discard.
+func TestCreateResourceTunnelTypeRejectsTargetURL(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		Type:      ResourceTypeTunnel,
+		TargetURL: "https://internal.example.com",
+	})
+	if !errors.Is(err, ErrCreateResourceTunnelRejectsTargetURL) {
+		t.Fatalf("expected ErrCreateResourceTunnelRejectsTargetURL, got %v", err)
+	}
+}
+
 // TestCreateResourceAccessPolicyRoundTrip pins the AccessPolicy decoding
 // path — if the server schema renames a subfield (ip_allowlist →
 // ip_allow, etc.) the round-trip would silently drop it without this
@@ -1493,5 +1509,22 @@ func TestUpdateResourceAliasAndClearAliasMutuallyExclusive(t *testing.T) {
 	})
 	if !errors.Is(err, ErrUpdateResourceAliasClearExclusive) {
 		t.Fatalf("expected ErrUpdateResourceAliasClearExclusive, got %v", err)
+	}
+}
+
+// TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst pins
+// the validation-order contract: when a caller passes both `Alias: &""`
+// AND `ClearAlias: true`, the structural conflict (mutual exclusion)
+// is the more actionable error and fires first. The empty-pointer
+// footgun guard fires only when Alias is the only field in conflict.
+func TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	empty := ""
+	_, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+		Alias:      &empty,
+		ClearAlias: true,
+	})
+	if !errors.Is(err, ErrUpdateResourceAliasClearExclusive) {
+		t.Fatalf("expected ErrUpdateResourceAliasClearExclusive (exclusivity beats empty-pointer), got %v", err)
 	}
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -19,6 +19,7 @@ const (
 	testAlias       = "dev-dashboard"
 	testAliasAlt    = "prod-grafana"
 	testResourceID  = "r_existing01"
+	testTargetURL   = "https://internal.example.com"
 )
 
 // testClient creates a client with retries disabled for fast unit tests.
@@ -966,7 +967,7 @@ func TestCreateResource(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if input.TargetURL != "https://internal.example.com" {
+		if input.TargetURL != testTargetURL {
 			t.Errorf("got TargetURL %q", input.TargetURL)
 		}
 		if input.Alias != testAlias {
@@ -974,17 +975,18 @@ func TestCreateResource(t *testing.T) {
 		}
 		apiEnvelope(t, w, map[string]any{
 			"resource_id": "r_dev_dash01",
-			"target_url":  "https://internal.example.com",
+			"target_url":  testTargetURL,
 			"alias":       testAlias,
-			"type":        "url",
+			"type":        ResourceTypeURL,
 			"status":      StatusActive,
+			"updated_at":  "2026-05-10T07:30:00Z",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
 	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
-		TargetURL: "https://internal.example.com",
+		TargetURL: testTargetURL,
 		Alias:     testAlias,
 	})
 	if err != nil {
@@ -1000,6 +1002,85 @@ func TestCreateResource(t *testing.T) {
 	// qurl-service/api/openapi.yaml ResourceData.status round-trips.
 	if got.Status != StatusActive {
 		t.Errorf("got Status %q, want %q", got.Status, StatusActive)
+	}
+	// Pin UpdatedAt decoding — *time.Time round-trip with explicit
+	// timezone offset. nil-vs-zero distinction matters for "field
+	// present on response" semantics.
+	if got.UpdatedAt == nil {
+		t.Fatal("UpdatedAt should be populated when present on the wire")
+	}
+	if got.UpdatedAt.Year() != 2026 || got.UpdatedAt.Month() != 5 {
+		t.Errorf("UpdatedAt: got %v, want 2026-05-...", got.UpdatedAt)
+	}
+}
+
+// TestCreateResourceURLTypeExplicit pins the explicit Type=ResourceTypeURL
+// branch of the validator switch. The empty-Type and Type=tunnel branches
+// have dedicated tests; this fills the middle case.
+func TestCreateResourceURLTypeExplicit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input CreateResourceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.Type != ResourceTypeURL {
+			t.Errorf("got Type %q, want %q", input.Type, ResourceTypeURL)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_url_explicit",
+			"target_url":  testTargetURL,
+			"type":        ResourceTypeURL,
+			"status":      StatusActive,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		Type:      ResourceTypeURL,
+		TargetURL: testTargetURL,
+	})
+	if err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+	if got.Type != ResourceTypeURL {
+		t.Errorf("got Type %q, want %q", got.Type, ResourceTypeURL)
+	}
+}
+
+// TestCreateResourceUnknownTypePassesThrough pins the forward-compat
+// default branch in the TargetURL validator: an unknown Type value
+// should pass through to the server, which is the authority on type
+// validation. Keeps the client release-independent of new ResourceType
+// values added to the qurl-service OpenAPI surface.
+func TestCreateResourceUnknownTypePassesThrough(t *testing.T) {
+	const futureType = "webhook"
+	var sawRequest bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		var input CreateResourceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.Type != futureType {
+			t.Errorf("got Type %q, want %q", input.Type, futureType)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_future",
+			"type":        futureType,
+			"status":      StatusActive,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		Type: futureType,
+	}); err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("server should have seen the request (unknown type must pass through)")
 	}
 }
 
@@ -1071,7 +1152,7 @@ func TestCreateResourceTunnelTypeRejectsTargetURL(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.CreateResource(context.Background(), &CreateResourceInput{
 		Type:      ResourceTypeTunnel,
-		TargetURL: "https://internal.example.com",
+		TargetURL: testTargetURL,
 	})
 	if !errors.Is(err, ErrCreateResourceTunnelRejectsTargetURL) {
 		t.Fatalf("expected ErrCreateResourceTunnelRejectsTargetURL, got %v", err)
@@ -1099,7 +1180,7 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 		}
 		apiEnvelope(t, w, map[string]any{
 			"resource_id": "r_policy01",
-			"target_url":  "https://internal.example.com",
+			"target_url":  testTargetURL,
 			"status":      StatusActive,
 			"access_policy": map[string]any{
 				"ip_allowlist": []string{"10.0.0.0/8", "192.168.0.0/16"},
@@ -1111,7 +1192,7 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 
 	c := testClient(srv.URL, "test-key")
 	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
-		TargetURL: "https://internal.example.com",
+		TargetURL: testTargetURL,
 		AccessPolicy: &AccessPolicy{
 			IPAllowlist: []string{"10.0.0.0/8", "192.168.0.0/16"},
 			GeoDenylist: []string{"CN"},
@@ -1341,7 +1422,7 @@ func TestGetResourceByAlias(t *testing.T) {
 		apiEnvelope(t, w, map[string]any{
 			"resource_id": "r_dev_dash01",
 			"alias":       testAlias,
-			"target_url":  "https://internal.example.com",
+			"target_url":  testTargetURL,
 		})
 	}))
 	defer srv.Close()
@@ -1452,7 +1533,7 @@ func TestCreateResourceAliasInUse(t *testing.T) {
 
 	c := testClient(srv.URL, "test-key")
 	_, err := c.CreateResource(context.Background(), &CreateResourceInput{
-		TargetURL: "https://internal.example.com",
+		TargetURL: testTargetURL,
 		Alias:     testAlias,
 	})
 	if err == nil {

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -972,6 +972,23 @@ func TestCreateNoTargetBeatsInvalidIdempotencyKey(t *testing.T) {
 	}
 }
 
+// TestCreateBothPopulatedBeatsInvalidIdempotencyKey is the both-populated
+// counterpart of the both-empty validation-order test. The exclusivity
+// error (a structural error) should fire before the idempotency-key
+// validation (a request-decoration error). Pinning both directions
+// ensures a future reorder of guards trips a test.
+func TestCreateBothPopulatedBeatsInvalidIdempotencyKey(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	_, err := c.Create(context.Background(), CreateInput{
+		TargetURL:      "https://example.com",
+		ResourceID:     testResourceID,
+		IdempotencyKey: "bad\nkey",
+	})
+	if !errors.Is(err, ErrCreateTargetResourceExclusive) {
+		t.Fatalf("expected ErrCreateTargetResourceExclusive (exclusivity beats idempotency), got %v", err)
+	}
+}
+
 // --- Resource methods ---
 
 func TestCreateResource(t *testing.T) {
@@ -1509,6 +1526,8 @@ func TestGetResourceByAlias(t *testing.T) {
 			"resource_id": "r_dev_dash01",
 			"alias":       testAlias,
 			"target_url":  testTargetURL,
+			"type":        ResourceTypeURL,
+			"status":      StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -1523,6 +1542,15 @@ func TestGetResourceByAlias(t *testing.T) {
 	}
 	if got.Alias != testAlias {
 		t.Errorf("got Alias %q, want %q", got.Alias, testAlias)
+	}
+	// Pin response-side decode of Type and Status — the schema is
+	// the contract, and round-tripping these fields catches future
+	// JSON-tag regressions on the response side.
+	if got.Type != ResourceTypeURL {
+		t.Errorf("got Type %q, want %q", got.Type, ResourceTypeURL)
+	}
+	if got.Status != StatusActive {
+		t.Errorf("got Status %q, want %q", got.Status, StatusActive)
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1112,16 +1112,12 @@ func TestCreateResourceEmptyTargetURLRejected(t *testing.T) {
 // this test ensures the client doesn't reject the request before it
 // reaches the server.
 func TestCreateResourceTunnelTypeAcceptsEmptyTargetURL(t *testing.T) {
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var input CreateResourceInput
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if input.Type != ResourceTypeTunnel {
-			t.Errorf("got Type %q, want %q", input.Type, ResourceTypeTunnel)
-		}
-		if input.TargetURL != "" {
-			t.Errorf("got TargetURL %q, want empty", input.TargetURL)
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
 			"resource_id": "r_tunnel01",
@@ -1140,6 +1136,20 @@ func TestCreateResourceTunnelTypeAcceptsEmptyTargetURL(t *testing.T) {
 	}
 	if got.Type != ResourceTypeTunnel {
 		t.Errorf("got Type %q, want %q", got.Type, ResourceTypeTunnel)
+	}
+	// Pin wire elision — `target_url` must be absent from the JSON
+	// payload entirely (not serialized as `""`). Mirrors the
+	// TestCreateResourceIDFlow pattern so a future `,omitempty`
+	// removal on TargetURL trips here.
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got := raw["type"]; got != ResourceTypeTunnel {
+		t.Errorf("type: got %v, want %q", got, ResourceTypeTunnel)
+	}
+	if _, ok := raw["target_url"]; ok {
+		t.Errorf("target_url must be omitted on tunnel creates; body=%s", gotBody)
 	}
 }
 
@@ -1391,6 +1401,51 @@ func TestUpdateResourceClearCustomDomainByEmptyString(t *testing.T) {
 	}
 	if got != "" {
 		t.Errorf("custom_domain: got %v, want \"\"", got)
+	}
+}
+
+// TestUpdateResourceClearAccessPolicyByEmptyStruct pins the documented
+// `&AccessPolicy{}` clear convention. AccessPolicy has no sentinel
+// because it's a struct (not a scalar), so passing an all-zero pointer
+// is the clear signal. The wire shape must round-trip as
+// `"access_policy": {}` — if a future contributor adds a non-omitempty
+// field to AccessPolicy, the empty literal would no longer marshal as
+// `{}` and the clear contract would silently break; this test catches
+// that.
+func TestUpdateResourceClearAccessPolicyByEmptyStruct(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": testResourceID,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.UpdateResource(context.Background(), testResourceID, &UpdateResourceInput{
+		AccessPolicy: &AccessPolicy{},
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	got, ok := raw["access_policy"]
+	if !ok {
+		t.Fatalf("access_policy must be present (the &AccessPolicy{} clear semantic); body=%s", gotBody)
+	}
+	policy, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("access_policy should decode as object; got %T (%v)", got, got)
+	}
+	if len(policy) != 0 {
+		t.Errorf("access_policy should marshal as `{}`; got %v", policy)
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -14,7 +14,11 @@ import (
 	"testing"
 )
 
-const testDescription = "updated"
+const (
+	testDescription = "updated"
+	testAlias       = "dev-dashboard"
+	testAliasAlt    = "prod-grafana"
+)
 
 // testClient creates a client with retries disabled for fast unit tests.
 func testClient(url, key string) *Client {
@@ -822,4 +826,340 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 			t.Errorf("header drift: got %q, want %q", gotKey, want)
 		}
 	})
+}
+
+// TestCreatePathIsPlural pins the canonical /v1/qurls path. PR #176 fixed
+// the singular `/v1/qurl` regression in production; this assertion lives
+// here so any future "let me just rename it back" change fails CI loudly,
+// not silently like the original bug did (the previous test mocked the
+// wrong path so it passed against /v1/qurl too).
+func TestCreatePathIsPlural(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_path_test",
+			"qurl_link":   "https://qurl.link/path",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if gotPath != "/v1/qurls" {
+		t.Errorf("expected /v1/qurls (plural), got %q", gotPath)
+	}
+}
+
+func TestCreateResourceIDFlow(t *testing.T) {
+	// When ResourceID is set and TargetURL is empty, the wire payload
+	// must contain `resource_id` and must NOT contain `target_url`.
+	// Server-side `mutually_exclusive_fields` rejects bodies that
+	// serialize an empty `target_url` alongside a `resource_id`.
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_existing",
+			"qurl_link":   "https://qurl.link/at_existing",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.Create(context.Background(), CreateInput{ResourceID: "r_existing"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Decode into a generic map so omitempty behavior is observable.
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v (body=%s)", err, gotBody)
+	}
+	if got := raw["resource_id"]; got != "r_existing" {
+		t.Errorf("resource_id: got %v, want \"r_existing\"", got)
+	}
+	if _, hasTargetURL := raw["target_url"]; hasTargetURL {
+		t.Errorf("target_url must be omitted when empty (server-side mutually_exclusive_fields rule); body=%s", gotBody)
+	}
+}
+
+func TestCreateTargetURLOnlyOmitsResourceID(t *testing.T) {
+	// Mirror of the ResourceID-only test: a TargetURL-only call must
+	// not emit `resource_id` on the wire. Pin the omitempty contract
+	// in both directions so a future `,omitempty` removal trips here.
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{"resource_id": "r_url_only"})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got, ok := raw["target_url"]; !ok || got != "https://example.com" {
+		t.Errorf("target_url should be present and set; got %v", got)
+	}
+	if _, ok := raw["resource_id"]; ok {
+		t.Errorf("resource_id must be omitted when empty; body=%s", gotBody)
+	}
+}
+
+// --- Resource methods ---
+
+func TestCreateResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/resources" {
+			t.Errorf("expected /v1/resources, got %s", r.URL.Path)
+		}
+		var input CreateResourceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.TargetURL != "https://internal.example.com" {
+			t.Errorf("got TargetURL %q", input.TargetURL)
+		}
+		if input.Alias != testAlias {
+			t.Errorf("got Alias %q, want %q", input.Alias, testAlias)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_dev_dash01",
+			"target_url":  "https://internal.example.com",
+			"alias":       testAlias,
+			"type":        "url",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		TargetURL: "https://internal.example.com",
+		Alias:     testAlias,
+	})
+	if err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+	if got.ResourceID != "r_dev_dash01" {
+		t.Errorf("got ResourceID %q", got.ResourceID)
+	}
+	if got.Alias != testAlias {
+		t.Errorf("got Alias %q, want %q", got.Alias, testAlias)
+	}
+}
+
+func TestCreateResourceNilInputRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	if _, err := c.CreateResource(context.Background(), nil); err == nil {
+		t.Fatal("expected error on nil input")
+	}
+}
+
+func TestUpdateResourceSetAlias(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/resources/r_existing01" {
+			t.Errorf("expected /v1/resources/r_existing01, got %s", r.URL.Path)
+		}
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_existing01",
+			"alias":       testAliasAlt,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	alias := testAliasAlt
+	got, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+		Alias: &alias,
+	})
+	if err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+	if got.Alias != testAliasAlt {
+		t.Errorf("got Alias %q, want %q", got.Alias, testAliasAlt)
+	}
+
+	// Pin the wire shape: alias serialized, clear_alias absent (false +
+	// omitempty), description / custom_domain absent.
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got := raw["alias"]; got != testAliasAlt {
+		t.Errorf("alias: got %v, want %q", got, testAliasAlt)
+	}
+	if _, ok := raw["clear_alias"]; ok {
+		t.Errorf("clear_alias must elide when false; body=%s", gotBody)
+	}
+	if _, ok := raw["description"]; ok {
+		t.Errorf("description must elide when nil pointer; body=%s", gotBody)
+	}
+}
+
+func TestUpdateResourceClearAlias(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_existing01",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.UpdateResource(context.Background(), "r_existing01", &UpdateResourceInput{
+		ClearAlias: true,
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got, ok := raw["clear_alias"]; !ok || got != true {
+		t.Errorf("clear_alias: want true, got %v (ok=%v); body=%s", got, ok, gotBody)
+	}
+}
+
+func TestUpdateResourceEmptyIDRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	if _, err := c.UpdateResource(context.Background(), "", &UpdateResourceInput{}); err == nil {
+		t.Fatal("expected error on empty resourceID")
+	}
+}
+
+func TestUpdateResourceNilInputRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	if _, err := c.UpdateResource(context.Background(), "r_x", nil); err == nil {
+		t.Fatal("expected error on nil input")
+	}
+}
+
+func TestGetResourceByAlias(t *testing.T) {
+	const wantPath = "/v1/resources/by-alias/" + testAlias
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != wantPath {
+			t.Errorf("expected %s, got %s", wantPath, r.URL.Path)
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": "r_dev_dash01",
+			"alias":       testAlias,
+			"target_url":  "https://internal.example.com",
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.GetResourceByAlias(context.Background(), testAlias)
+	if err != nil {
+		t.Fatalf("GetResourceByAlias: %v", err)
+	}
+	if got.ResourceID != "r_dev_dash01" {
+		t.Errorf("got ResourceID %q", got.ResourceID)
+	}
+	if got.Alias != testAlias {
+		t.Errorf("got Alias %q, want %q", got.Alias, testAlias)
+	}
+}
+
+func TestGetResourceByAliasEscapesPathSegment(t *testing.T) {
+	// Aliases are validated server-side as `^[a-z][a-z0-9-]{1,62}[a-z0-9]$`
+	// (no `/`, no `%`), so reserved bytes won't reach this method via the
+	// Slack/Discord parsers. But the client method should still escape its
+	// input — defensive for direct programmatic callers and to keep a future
+	// refactor that drops `url.PathEscape` from tripping silently.
+	// Inspect r.URL.EscapedPath() because net/http decodes `%2F` → `/`
+	// on r.URL.Path before the handler runs.
+	var gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.GetResourceByAlias(context.Background(), "weird/alias"); err != nil {
+		t.Fatalf("GetResourceByAlias: %v", err)
+	}
+	const want = "/v1/resources/by-alias/weird%2Falias"
+	if gotEscapedPath != want {
+		t.Errorf("alias path-escape: got %q, want %q", gotEscapedPath, want)
+	}
+}
+
+func TestGetResourceByAliasEmptyRejected(t *testing.T) {
+	c := testClient("http://example.invalid", "test-key")
+	if _, err := c.GetResourceByAlias(context.Background(), ""); err == nil {
+		t.Fatal("expected error on empty alias")
+	}
+}
+
+func TestGetResourceByAliasNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		resp := map[string]any{
+			"error": map[string]any{
+				"title":  "Not Found",
+				"status": 404,
+				"detail": "alias not found",
+				"code":   "alias_not_found",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	_, err := c.GetResourceByAlias(context.Background(), "missing-alias")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("got status %d, want 404", apiErr.StatusCode)
+	}
+	if apiErr.Code != "alias_not_found" {
+		t.Errorf("got code %q, want alias_not_found", apiErr.Code)
+	}
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1276,6 +1276,58 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 	}
 }
 
+// TestCreateResourceRetryPreservesBody pins the body-buffering invariant
+// on the CreateResource retry path, mirroring
+// TestUpdateResourceRetryPreservesBody. POST /v1/resources is server-side
+// idempotent on (owner_id, target_url_hash), but client-side body bytes
+// must stay byte-identical across attempts so the server's hash matches.
+func TestCreateResourceRetryPreservesBody(t *testing.T) {
+	var attempts atomic.Int32
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("attempt %d: read body: %v", n, err)
+		}
+		mu.Lock()
+		bodies = append(bodies, body)
+		mu.Unlock()
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": testResourceIDAlt,
+			"target_url":  testTargetURL,
+			"status":      StatusActive,
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-key",
+		WithRetry(3),
+		withDelaysForTest(),
+	)
+	if _, err := c.CreateResource(context.Background(), &CreateResourceInput{
+		TargetURL: testTargetURL,
+		Alias:     testAlias,
+	}); err != nil {
+		t.Fatalf("CreateResource after retries: %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts.Load())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 1; i < len(bodies); i++ {
+		if !bytes.Equal(bodies[0], bodies[i]) {
+			t.Errorf("attempt %d body diverged from attempt 1.\n#1: %s\n#%d: %s", i+1, bodies[0], i+1, bodies[i])
+		}
+	}
+}
+
 // TestUpdateResourceNoFieldsSetRejected pins the client-side fail-fast
 // for the all-nil-pointers, ClearAlias=false case. Symmetric with
 // Create's no-target guard — saves a round-trip on a no-op PATCH.


### PR DESCRIPTION
## Summary

Phase 3c.2 from the Slack-triggered qURL plan. Extends `shared/client` for
the alias / get flows that ship in PR-3c.3+.

- **Blocker #1 — `/v1/qurl` (singular) path bug.** Already fixed in #176;
  this PR adds `TestCreatePathIsPlural` as a *named regression pin* so a
  future "rename it back" change surfaces by an explicit test name, not
  by a generic `TestCreate` failure. (TestCreate already asserts the path
  generically; the value of the new test is the name.)
- **Blocker #2 — `target_url` empty-string vs `mutually_exclusive_fields`.**
  Add `ResourceID string` to `CreateInput` with `,omitempty`, and switch
  `TargetURL` to `,omitempty` so a ResourceID-only mint elides `target_url`
  from the wire payload entirely. Server-side PR-3a.3 enforces
  `mutually_exclusive_fields(resource_id, target_url, type)`; without the
  omitempty change, every ResourceID-only call would marshal `"target_url":""`
  and 400.
- **Idempotency-Key.** Already shipped via `CreateInput.IdempotencyKey` in
  #147 + #149 (validator + retry preservation tests already in tree). Plan
  asked for a variadic `WithIdempotencyKey(...)` option; deviated because
  switching to options-pattern would break the existing `Create` callers in
  `apps/slack/internal/process.go:121` and `apps/cli/cmd/create.go:47`,
  both of which are out of scope per the task constraints.
- **New resource methods** for the alias flow:
  - `CreateResource(ctx, *CreateResourceInput) (*Resource, error)` →
    `POST /v1/resources`
  - `UpdateResource(ctx, id, *UpdateResourceInput) (*Resource, error)` →
    `PATCH /v1/resources/{id}` (alias set + `clear_alias: true` paths
    both pinned in tests)
  - `GetResourceByAlias(ctx, alias) (*Resource, error)` →
    `GET /v1/resources/by-alias/{alias}`

  These target the **post-PR-3a.2** surface in qurl-service. PR-3a.2
  hasn't shipped, so callers will get 404/400 from the API until it
  does. Added here so the Slack flows in PR-3c.3+ have a stable Go
  surface to compile against.

## Choice on TargetURL handling

Kept `TargetURL string` and added `,omitempty` to the JSON tag (the
recommended option in the plan). The alternative was `*string`, which
would have been a breaking change for the existing `client.CreateInput{
TargetURL: someString }` literal at `apps/slack/internal/process.go:121`
and `apps/cli/cmd/create.go:39-45`. The constraint forbade touching
`apps/slack/`; `apps/cli/` could have been migrated but the symmetry
("string fields elide on zero, pointer fields elide on nil") wasn't
worth the API churn. The `omitempty` path is byte-equivalent for the
TargetURL-only happy path — `TestCreateBodyByteIdenticalWithAndWithoutIdempotencyKey`
still passes.

## References

- Plan: \`/Users/kevin/Downloads/slack-triggered-qurl-glistening-rain.md\`
  ("Review findings → Blockers" #1, #2; "Phase 3c → Shared client extensions";
  Phase 3c PR sequence step 3.)
- Independent of PR-3c.0 (Lambda → Fargate runtime swap) and PR-3c.1
  (parser); per the plan, this PR can land first.
- Server counterparts:
  - PR-3a.2 (qurl-service alias domain + by-alias endpoint) — not yet open
  - PR-3a.3 (`resource_id` on `POST /v1/qurls` with `mutually_exclusive_fields`) — not yet open

## Test plan

- [x] \`go test ./shared/client/...\` (12 new tests + 0 regressions; passes
      under \`-race\`)
- [x] \`golangci-lint run --timeout=5m ./shared/client/...\` clean
- [x] Wire-shape pinning: `TestCreateResourceIDFlow` confirms ResourceID-only
      payloads omit `target_url`; `TestCreateTargetURLOnlyOmitsResourceID`
      confirms TargetURL-only payloads omit `resource_id`.
- [x] `TestCreatePathIsPlural` regression-pins the canonical `/v1/qurls`
      path so the original singular-path bug can't silently re-ship.
- [x] One happy-path test per new resource method
      (`TestCreateResource`, `TestUpdateResourceSetAlias`,
      `TestUpdateResourceClearAlias`, `TestGetResourceByAlias`) plus
      input-validation guards (`TestCreateResourceNilInputRejected`,
      `TestUpdateResourceEmptyIDRejected`,
      `TestUpdateResourceNilInputRejected`,
      `TestGetResourceByAliasEmptyRejected`) and an error-path
      (`TestGetResourceByAliasNotFound` — 404 → typed `*APIError`).
- [x] `TestGetResourceByAliasEscapesPathSegment` pins `url.PathEscape` on
      the alias path segment (defensive — the server-side regex won't let
      `/` through, but a programmatic caller bypassing parser validation
      shouldn't accidentally split-route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)