### PR TITLE
feat(slack): refactor /qurl list to resources, add $r_* fallback in /qurl get

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -459,7 +459,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case pathSlackCommands:
 		// r.Context() is intentionally NOT threaded into the slash-command
-		// dispatch: handleGet/handleList spawn goroutines that outlive
+		// dispatch: handleGet/handleListResources spawn goroutines that outlive
 		// the HTTP response, and r.Context() cancels as soon as ServeHTTP
 		// returns. Async work uses h.baseCtx instead.
 		h.handleSlashCommand(w, body)
@@ -562,10 +562,10 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 		// Exact match only: the looser `HasPrefix(text, "list")` form
 		// matched `listing`, `lists`, `list-foo` (silently routing
 		// them to the list handler) AND `list extra args` (which
-		// processList ignores). Anything other than the bare token
-		// falls through to the unknown-subcommand branch and gets a
-		// help nudge.
-		h.handleList(w, values)
+		// processListResources ignores). Anything other than the
+		// bare token falls through to the unknown-subcommand branch
+		// and gets a help nudge.
+		h.handleListResources(w, values)
 	case text == "get" || strings.HasPrefix(text, "get "):
 		// Exact-token boundary so `getter`, `get-foo` fall through
 		// to the unknown-subcommand branch instead of silently
@@ -650,12 +650,6 @@ func redactSlashCommandText(text string) string {
 		return claimPrefix + "<redacted>"
 	}
 	return text
-}
-
-func (h *Handler) handleList(w http.ResponseWriter, values url.Values) {
-	h.runAsync(w, "list", values, func(ctx context.Context, log *slog.Logger) {
-		h.processList(ctx, log, values)
-	})
 }
 
 // handleSetup mints a workspace-bound state token and replies with the

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -75,6 +75,23 @@ func noResourceForAliasMessage(alias string) string {
 	return fmt.Sprintf("`$%s` is not configured for this channel. Run `/qurl aliases` to see what's available here, or contact your Slack admin to add it.", alias)
 }
 
+// notAllowedInChannelMessage is the copy surfaced when a user passes
+// a `$r_<id>` resource token that is not in the channel's allowed-set
+// (the union of `alias_bindings.values()` and `allowed_resource_ids`
+// returned by [Store.AllowedResourceIDsForChannel]). Same posture as
+// [noResourceForAliasMessage]: name the literal token the user
+// typed, plain-English state, point at `/qurl list` so the user can
+// see what IS available without a manual lookup, and route to the
+// admin since only the admin can extend the allow-set.
+//
+// Mirrored copy for the two not-allowed branches so a workspace
+// member probing for valid resource IDs can't distinguish "id doesn't
+// exist" from "id exists but not in this channel" through the wire
+// text.
+func notAllowedInChannelMessage(token string) string {
+	return fmt.Sprintf("`$%s` is not allowed in this channel. Run `/qurl list` to see what's available here, or contact your Slack admin for assistance.", token)
+}
+
 // authFailureMessageGet is the auth-failure copy shown when API-key
 // lookup fails for /qurl get. Same shape as authFailureMessage but
 // distinguished because the get path also needs to gracefully fall
@@ -110,15 +127,18 @@ func userErrorf(format string, args ...any) error {
 // completed the install.
 var errAdminStoreNotConfigured = &userError{msg: "qURL admin features are not yet configured for this workspace. Please contact your Slack admin for assistance."}
 
-// handleGet implements `/qurl get <url|$alias>`:
+// handleGet implements `/qurl get <url|$alias|$r_<id>>`:
 //  1. Parse the slash-command text → [Command]. The positional arg
-//     is either a URL (`http://…` / `https://…`) or a channel-scoped
-//     `$alias` name configured by a workspace admin.
+//     is either a URL (`http://…` / `https://…`), a channel-scoped
+//     `$alias` name configured by a workspace admin, or a raw
+//     `$r_<id>` resource token copy-pasted from `/qurl list`.
 //  2. Ack within 3s via [runAsync] (200 + ackWorkingOnIt).
 //  3. Async goroutine: for URL form, mint directly; for alias form,
 //     resolve alias → resource_id via channel_policies.alias_bindings
-//     then mint. Rate-limit gates both. POSTs the result to
-//     response_url.
+//     then mint; for resource-ID form, gate against the channel's
+//     allow-set (union of alias_bindings + allowed_resource_ids)
+//     then mint by that ID. Rate-limit gates all three. POSTs the
+//     result to response_url.
 //
 // Optional flags:
 //   - `dm:true` → final message via PostDM to the user's DM instead
@@ -139,7 +159,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, fmt.Sprintf("Unknown subcommand: `%s`. Try `/qurl help`.", text))
 		return
 	}
-	if cmd.Alias == "" && cmd.Target == "" {
+	if cmd.Alias == "" && cmd.Target == "" && cmd.Resource.Kind != ResourceTokenResourceID {
 		respondSlack(w, ":warning: Usage: `/qurl get <url>` to mint for a URL, or `/qurl get $name` to mint for a name your Slack admin has configured here.")
 		return
 	}
@@ -200,15 +220,20 @@ type getWorkArgs struct {
 	triggerID string
 }
 
-// getWork runs the inner resolve→rate-limit→mint pipeline for both
-// the URL form (`/qurl get <url>`) and the alias form
-// (`/qurl get $name`). Returns the rendered reply text (without
-// leading `:warning:`) on success, or a [*userError] whose msg routes
-// to the user.
+// getWork runs the inner resolve→rate-limit→mint pipeline for the
+// URL form (`/qurl get <url>`), the alias form (`/qurl get $name`),
+// and the resource-ID form (`/qurl get $r_<id>`). Returns the
+// rendered reply text (without leading `:warning:`) on success, or a
+// [*userError] whose msg routes to the user.
 func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArgs) (string, error) {
 	alias := args.cmd.Alias
 	target := args.cmd.Target
+	resourceID := ""
+	if args.cmd.Resource.Kind == ResourceTokenResourceID {
+		resourceID = args.cmd.Resource.Value
+	}
 	isAliasForm := alias != ""
+	isResourceIDForm := resourceID != ""
 
 	// Refuse `dm:true` early when PostDM is not wired — the user's
 	// intent is "do not leak the link in channel history", and a
@@ -224,33 +249,19 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		IdempotencyKey: IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
 	}
 
-	if isAliasForm {
-		// Refuse early on a no-DDB sandbox deploy. Alias-form requires
-		// the channel-scoped binding store; URL form does not, so this
-		// gate only fires here.
-		if h.cfg.AdminStore == nil {
-			log.Warn("get: AdminStore is nil; alias-form lookup unavailable", "team_id", args.teamID)
-			return "", errAdminStoreNotConfigured
-		}
-		// Resolve alias → resource_id via channel_policies.alias_bindings.
-		// The presence of the binding in THIS channel is itself the
-		// authorization signal — `/qurl setalias` is the admin act that
-		// authorizes a resource for use in the channel.
-		//
-		// NOTE: setalias is the only authorization signal today. If the
-		// orthogonal `admin allow` / `allowed_resource_ids` surface gets
-		// re-wired (currently dropped from this path), the channel-policy
-		// gate goes here, between the binding lookup and `input.ResourceID =`.
-		resourceID, found, err := h.cfg.AdminStore.LookupChannelAlias(ctx, args.teamID, args.channelID, alias)
+	switch {
+	case isAliasForm:
+		boundResourceID, err := h.resolveAliasForGet(ctx, log, args.teamID, args.channelID, alias)
 		if err != nil {
-			log.Warn("get: alias lookup failed", "error", err, "team_id", args.teamID, "channel_id", args.channelID, "alias", alias)
-			return "", &userError{msg: serviceUnreachableMessage}
+			return "", err
 		}
-		if !found {
-			return "", &userError{msg: noResourceForAliasMessage(alias)}
+		input.ResourceID = boundResourceID
+	case isResourceIDForm:
+		if err := h.authorizeResourceIDForGet(ctx, log, args.teamID, args.channelID, args.userID, resourceID); err != nil {
+			return "", err
 		}
 		input.ResourceID = resourceID
-	} else {
+	default:
 		// URL-form has no per-channel authorization gate — anyone in the
 		// workspace who can invoke `/qurl get` can mint against any URL on
 		// the workspace's API key (qurl-service's per-key quota is the
@@ -286,7 +297,7 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	// Defensive: a 200 with an empty qurl_link is a server contract
 	// surprise — log loud and surface the generic retry message.
 	if out.QURLLink == "" {
-		log.Error("get: mint returned empty qurl_link — server contract surprise", "alias_form", isAliasForm, "resource_id", input.ResourceID)
+		log.Error("get: mint returned empty qurl_link — server contract surprise", "alias_form", isAliasForm, "resource_id_form", isResourceIDForm, "resource_id", input.ResourceID)
 		return "", &userError{msg: commonGetMintFailedMessage}
 	}
 
@@ -295,6 +306,74 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		return h.deliverGetDM(ctx, log, args.userID, message), nil
 	}
 	return message, nil
+}
+
+// resolveAliasForGet resolves a `$<alias>` token to a resource_id via
+// the channel's `channel_policies.alias_bindings` map. The presence of
+// the binding in THIS channel is itself the authorization signal —
+// `/qurl setalias` is the admin act that authorizes a resource for use
+// in the channel.
+//
+// NOTE: setalias is the only authorization signal today. If the
+// orthogonal `admin allow` / `allowed_resource_ids` surface gets
+// re-wired (currently dropped from this path), the channel-policy
+// gate goes between the binding lookup and the return.
+//
+// Returns a [*userError] (no logging at call site needed) on the
+// AdminStore-nil, lookup-failed, and binding-not-found branches.
+func (h *Handler) resolveAliasForGet(ctx context.Context, log *slog.Logger, teamID, channelID, alias string) (string, error) {
+	// Refuse early on a no-DDB sandbox deploy. Alias-form requires
+	// the channel-scoped binding store; URL form does not, so this
+	// gate only fires here.
+	if h.cfg.AdminStore == nil {
+		log.Warn("get: AdminStore is nil; alias-form lookup unavailable", "team_id", teamID)
+		return "", errAdminStoreNotConfigured
+	}
+	resourceID, found, err := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, alias)
+	if err != nil {
+		log.Warn("get: alias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias)
+		return "", &userError{msg: serviceUnreachableMessage}
+	}
+	if !found {
+		return "", &userError{msg: noResourceForAliasMessage(alias)}
+	}
+	return resourceID, nil
+}
+
+// authorizeResourceIDForGet enforces the channel-scoped allow on a
+// `$r_<id>` token. Workspace admins bypass the allow-set so the
+// list-and-get round-trip works in the admin's unfiltered list view;
+// non-admins must have the ID in `AllowedResourceIDsForChannel` (the
+// union of `alias_bindings.values()` and `allowed_resource_ids`),
+// keeping list visibility and mintability aligned for them.
+//
+// Returns nil on allow, [*userError] on AdminStore-nil, allow-set
+// fetch failure, or membership miss.
+func (h *Handler) authorizeResourceIDForGet(ctx context.Context, log *slog.Logger, teamID, channelID, userID, resourceID string) error {
+	// Resource-ID form needs an AdminStore for the admin probe + the
+	// channel allow-set. Same fail-closed posture as alias-form on a
+	// no-DDB sandbox.
+	if h.cfg.AdminStore == nil {
+		log.Warn("get: AdminStore is nil; resource-id-form lookup unavailable", "team_id", teamID)
+		return errAdminStoreNotConfigured
+	}
+	isAdmin, _, adminErr := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
+	if adminErr != nil {
+		log.Warn("get: admin probe failed for resource-id form — treating as non-admin", "error", adminErr, "team_id", teamID, "user_id", userID)
+		isAdmin = false
+	}
+	if isAdmin {
+		return nil
+	}
+	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(ctx, teamID, channelID)
+	if err != nil {
+		log.Warn("get: allowed-resource fetch failed", "error", err, "team_id", teamID, "channel_id", channelID)
+		return &userError{msg: serviceUnreachableMessage}
+	}
+	if _, ok := allowed[resourceID]; !ok {
+		return &userError{msg: notAllowedInChannelMessage(resourceID)}
+	}
+	return nil
 }
 
 // deliverGetDM handles the `dm:true` variant. The link goes to the

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -463,3 +463,137 @@ func TestMapMintError_Unmapped5xx(t *testing.T) {
 		}
 	}
 }
+
+// testResourceIDFallback is an 11-char-suffix resource ID that
+// satisfies [resourceIDPattern] on the `$r_<id>` parser path.
+// `testResourceIDFix` (`r_prod_db`) is too short to match the regex
+// — it's the legacy fixture used by alias-form tests where the
+// resource ID is set via DDB binding and never user-typed.
+const testResourceIDFallback = "r_abc123def01"
+
+// mintByFallbackResourcePath is the resource-scoped mint endpoint
+// `client.Create` hits when given a `ResourceID = testResourceIDFallback`.
+// Mirrors [mintByTestResourcePath] from handler_test_helpers_test.go
+// but for the 11-char-suffix ID used by the `$r_<id>` parser-shape
+// fixtures.
+const mintByFallbackResourcePath = "/v1/resources/" + testResourceIDFallback + "/qurls"
+
+// TestHandleGet_DollarResourceIDAllowedSet fences the canonical
+// non-admin `/qurl get $r_<id>` flow: the resource ID is in the
+// channel's allowed-set (union of `alias_bindings.values()` and
+// `allowed_resource_ids`), the mint reaches the resource-scoped
+// `POST /v1/resources/{id}/qurls` endpoint, and the response_url
+// returns the qURL link. Closes the round-trip gap that `/qurl list`
+// rendered `$r_<id>` rows for but `/qurl get` couldn't consume.
+//
+// The ID rides in the URL path (#454 cutover), so the body must NOT
+// carry `resource_id` — the assertion below pins that contract.
+func TestHandleGet_DollarResourceIDAllowedSet(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{testResourceIDFallback})
+	var bodyHadResourceID bool
+	ts.addCustomer("POST", mintByFallbackResourcePath, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, bodyHadResourceID = body[testKeyResourceID]
+		writeCreateFixture(t, w, "https://qurl.link/by-id", testResourceIDFallback)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testResourceIDFallback, testAdminTeamID, testAdminUserID)
+	if bodyHadResourceID {
+		t.Errorf("mint request body carried resource_id field — should be in URL path only after #454")
+	}
+	if !strings.Contains(async, "https://qurl.link/by-id") {
+		t.Errorf("async reply missing qURL link: %q", async)
+	}
+}
+
+// TestHandleGet_DollarResourceIDNotInAllowedSetNonAdmin fences the
+// channel-scoped gate on the `$r_<id>` path for non-admins: a
+// resource ID that isn't in the channel's allow-set (union of
+// `alias_bindings` + `allowed_resource_ids`) must surface the
+// "not allowed in this channel" copy without ever reaching the
+// customer mint. Aligned with what `/qurl list` shows non-admins
+// so the get and list surfaces agree on what's available in the
+// channel for non-admins.
+func TestHandleGet_DollarResourceIDNotInAllowedSetNonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	// Seed a different ID into the allow-set so the requested one is
+	// definitively absent (empty allow-set would also work; this
+	// shape pins that lookup-then-membership is the gate, not
+	// "row missing").
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_other_alloc"})
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", mintByFallbackResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		writeCreateFixture(t, w, "https://qurl.link/should-not-be-minted", testResourceIDFallback)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testResourceIDFallback, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "is not allowed in this channel") {
+		t.Errorf("async reply missing not-allowed copy: %q", async)
+	}
+	if !strings.Contains(async, "`/qurl list`") {
+		t.Errorf("async reply missing `/qurl list` self-serve pointer: %q", async)
+	}
+	if mintHits.Load() != 0 {
+		t.Errorf("mint reached despite resource-id not-in-allow-set (hits = %d)", mintHits.Load())
+	}
+}
+
+// TestHandleGet_DollarResourceIDAdminBypassesAllowedSet fences the
+// admin asymmetry resolution: a workspace admin can mint `$r_<id>`
+// without the resource being in the current channel's allow-set,
+// matching `/qurl list`'s unfiltered admin view. Without this
+// bypass, the list footer's copy-paste promise ("Copy any `$token`
+// and run `/qurl get $token`") breaks for admins on cross-channel
+// resources.
+func TestHandleGet_DollarResourceIDAdminBypassesAllowedSet(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// Admin can mint resources NOT in this channel's allow-set —
+	// seed a row whose allow-set excludes the target ID.
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_other_alloc"})
+	ts.addCustomer("POST", mintByFallbackResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeCreateFixture(t, w, "https://qurl.link/admin-bypass", testResourceIDFallback)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testResourceIDFallback, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "https://qurl.link/admin-bypass") {
+		t.Errorf("admin failed to mint resource outside channel allow-set: %q", async)
+	}
+}
+
+// TestHandleGet_DollarResourceIDAdminStoreNil fences the
+// AdminStore-nil short-circuit on the `$r_<id>` path. Same
+// fail-closed posture as the alias-form: no allow-set lookup
+// possible → refuse with the user-facing "admin features not
+// configured" copy that points the user at their Slack admin.
+// Mint MUST NOT be reached.
+func TestHandleGet_DollarResourceIDAdminStoreNil(t *testing.T) {
+	ts := newAdminTestServers(t)
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AdminStore = nil
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testResourceIDFallback, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "admin features are not yet configured") {
+		t.Errorf("async reply missing not-configured copy: %q", async)
+	}
+	if mintHits.Load() != 0 {
+		t.Errorf("mint reached despite nil AdminStore on resource-id form (hits = %d)", mintHits.Load())
+	}
+}

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -1,0 +1,320 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// listResourcesPageLimit is the default page size for `/qurl list`.
+// Pivoted from the legacy 5-qURLs render to 10-resources because:
+//
+//  1. Resources are coarser than qURLs (one Resource per target URL,
+//     many qURLs per Resource), so 10 of them carry more information
+//     than 5 qURLs.
+//  2. Listing surfaces the `$<alias>` / `$<resource_id>` shape so
+//     users can copy-paste straight into `/qurl get $<token>` — more
+//     rows in one slash-command response means fewer round-trips for
+//     the common "show me what's available" workflow.
+//  3. Slack's ephemeral message budget comfortably fits 10 rows (each
+//     at ~80-120 chars) without scrolling.
+const listResourcesPageLimit = 10
+
+// listResourcesEmptyMessage is the friendly empty-state copy. Points
+// the user at `/qurl create <url>` so a brand-new workspace knows
+// what to do next.
+const listResourcesEmptyMessage = ":mag: No qURL resources found in this workspace. Create one with `/qurl create <url>` first."
+
+// listResourcesNonAdminPaginationGapMessage is the user-facing copy
+// for the case where a non-admin's filtered set is empty AND the
+// master list reports has_more=true. Without this distinct copy a
+// non-admin in a heavy workspace whose allow-listed resources sit
+// past the first page would see "Create one with /qurl create"
+// (wrong advice — the issue is pagination scope, not absence).
+//
+// "Allow specific resources" is the right verb for the common
+// case: an empty filtered set most often means no allow-list rows
+// for this channel yet, not an over-broad one that needs narrowing.
+// The hint nudges toward an admin escalation path rather than a
+// duplicate-resource workflow.
+const listResourcesNonAdminPaginationGapMessage = ":mag: No allowed resources on the first page of this workspace's listing. Resources allowed in this channel may exist past the first page — ask an admin to allow specific resources in this channel, or check `/qurl aliases` to see if a specific alias is set."
+
+// resourceTypeTunnel is the wire-level discriminator for tunnel
+// resources. Lifted to a constant so the list renderer keys on the
+// upstream type rather than guessing from empty `target_url` — a
+// non-tunnel resource with a transient empty target (data glitch,
+// partially-populated row) must NOT be silently re-labeled "(tunnel)".
+const resourceTypeTunnel = "tunnel"
+
+// handleListResources implements the refactored `/qurl list`. Pivots
+// the legacy "5 most recent qURLs" output to "10 most recent
+// Resources" so each line is a copy-paste-ready `$<alias>` (when
+// bound) or `$<resource_id>` token the user can pipe into
+// `/qurl get $<token>` without a manual alias-resolution step.
+//
+// Channel scoping:
+//   - workspace admins see every resource in the master listing.
+//   - non-admins see only resources allowed in the current channel
+//     via channel_policies → resource_id set membership.
+//   - non-admin + empty channel_id is fail-closed (returns empty).
+//   - non-admin + policy-fetch failure is fail-closed (returns
+//     empty); under-show beats leak.
+//
+// DM channels: Slack DMs use `D…` channel IDs that almost certainly
+// have no policy entries, so a non-admin running `/qurl list` from a
+// DM hits the "filtered to empty" branch. Intentional — DMs aren't
+// an admin-controlled scope.
+func (h *Handler) handleListResources(w http.ResponseWriter, values url.Values) {
+	h.runAsync(w, "list", values, func(ctx context.Context, log *slog.Logger) {
+		h.processListResources(ctx, log, values)
+	})
+}
+
+// processListResources is the async-worker body for /qurl list.
+func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, values url.Values) {
+	responseURL := values.Get(fieldResponseURL)
+	teamID := values.Get(fieldTeamID)
+	channelID := values.Get(fieldChannelID)
+	userID := values.Get(fieldUserID)
+
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("list: API key lookup failed", "error", err)
+		h.postResponse(log, responseURL, ":warning: "+authErrorMessage(err))
+		return
+	}
+
+	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesPageLimit})
+	if err != nil {
+		h.postResponse(log, responseURL, ":warning: "+mapListResourcesError(log, teamID, err))
+		return
+	}
+
+	resources, isAdmin := h.scopeResourcesForUser(ctx, log, teamID, channelID, userID, page.Resources)
+
+	if len(resources) == 0 {
+		// Pagination-gap copy only fires when (a) the user is a
+		// non-admin, (b) we had channel context to filter against,
+		// AND (c) the master list reports has_more. The
+		// has-channel guard distinguishes "filtered set is empty
+		// because the channel has no allow-list rows on the first
+		// page" from "we never had a channel" (fail-closed branch
+		// in scopeResourcesForUser). Without it, the empty-channel
+		// fail-closed path would surface "ask an admin to allow
+		// specific resources in *this channel*" — misleading,
+		// because by construction there's no channel.
+		if !isAdmin && channelID != "" && page.HasMore {
+			log.Warn("list: non-admin filtered set is empty but master list has_more — allow-listed resources may sit past first page",
+				"team_id", teamID, "channel_id", channelID, "user_id", userID, "page_limit", listResourcesPageLimit)
+			h.postResponse(log, responseURL, listResourcesNonAdminPaginationGapMessage)
+			return
+		}
+		h.postResponse(log, responseURL, listResourcesEmptyMessage)
+		return
+	}
+
+	// Stable order for two-call idempotency at the Slack ephemeral
+	// surface — the server's pagination cursor implies an order but
+	// not a stable one across re-queries. Sort by the underlying
+	// token (alias if bound, else resource_id) BEFORE formatting.
+	sort.SliceStable(resources, func(i, j int) bool {
+		return resourceSortKey(&resources[i]) < resourceSortKey(&resources[j])
+	})
+	lines := make([]string, 0, len(resources))
+	for i := range resources {
+		lines = append(lines, formatResourceListLine(&resources[i]))
+	}
+
+	body := "*qURL Resources:*\n" + strings.Join(lines, "\n") +
+		"\n\n_Copy any `$token` and run `/qurl get $token` to mint a qURL link._"
+	if page.HasMore {
+		// Footer copy depends on whether the user's view is filtered.
+		// Admins see the master list directly, so "more past first N"
+		// matches what they'd expect. Non-admins see the filtered
+		// subset — additional allow-listed resources may sit past the
+		// first master-page-N scan, which the admin-copy footer
+		// understates ("more past first N" reads as "more of the same
+		// kind"). Distinct non-admin copy makes the gap explicit so
+		// users don't assume the rendered rows are exhaustive.
+		if isAdmin {
+			body += fmt.Sprintf("\n_…more results past the first %d-row scan — narrow with `/qurl get $alias` or ask an admin._", listResourcesPageLimit)
+		} else {
+			body += fmt.Sprintf("\n_Showing allow-listed resources from the first %d-row scan; others may sit past it. Ask an admin to allow more in this channel, or narrow with `/qurl get $alias`._", listResourcesPageLimit)
+		}
+	}
+	h.postResponse(log, responseURL, body)
+}
+
+// scopeResourcesForUser narrows the master resource list to what the
+// requesting user can see in the current channel:
+//
+//   - workspace admins see the full list (no filter).
+//   - non-admins see only resources allowed in `channelID` —
+//     [Store.AllowedResourceIDsForChannel] unions both surfaces on
+//     the channel_policies row (`allowed_resource_ids` SS and the
+//     `alias_bindings` Map values) so a resource visible via either
+//     `/qurl get $r_<id>` or `/qurl get $alias` shows up here.
+//   - non-admin + empty channelID is fail-closed (returns empty);
+//     a real Slack slash-command payload always carries channel_id
+//     (DMs use D… IDs), so a missing value is malformed and must
+//     NOT leak the master list.
+//   - non-admin + policy-fetch failure is fail-closed (returns
+//     empty); under-show beats leak.
+func (h *Handler) scopeResourcesForUser(ctx context.Context, log *slog.Logger, teamID, channelID, userID string, resources []client.Resource) ([]client.Resource, bool) {
+	if h.cfg.AdminStore == nil {
+		// No AdminStore → no admin probe, no policy fetch. Fail-closed
+		// for non-admins because we can't determine allow-listed
+		// resources. Production wires AdminStore from QURL_*_TABLE
+		// env vars; sandbox/no-DDB deployments get the empty list.
+		log.Warn("list: AdminStore is nil; treating user as non-admin and returning empty list (fail-closed)",
+			"team_id", teamID, "user_id", userID)
+		return nil, false
+	}
+	isAdmin := h.userIsWorkspaceAdmin(ctx, log, teamID, userID)
+	if isAdmin {
+		return resources, true
+	}
+	if channelID == "" {
+		log.Warn("list: empty channel_id for non-admin — returning empty list (fail-closed)",
+			"team_id", teamID, "user_id", userID)
+		return nil, false
+	}
+	allowed, allowErr := h.cfg.AdminStore.AllowedResourceIDsForChannel(ctx, teamID, channelID)
+	if allowErr != nil {
+		log.Warn("list: allowed-resource fetch failed — falling back to empty allow set (fail-closed)",
+			"error", allowErr, "team_id", teamID, "channel_id", channelID)
+		return nil, false
+	}
+	return filterResourcesByAllowedSet(resources, allowed), false
+}
+
+// userIsWorkspaceAdmin probes Store.CheckAdmin for the (team, user)
+// pair. Returns false on any error — the non-admin branch is the
+// safe default ("under-show, don't leak"). Panics or network failures
+// are surfaced through the err and folded into the false return;
+// callers don't need to distinguish "definitely not admin" from
+// "couldn't check".
+//
+// teamID == "" or userID == "" returns false — synthetic test
+// payloads or wire-shape regressions should under-show rather than
+// leak the master list.
+func (h *Handler) userIsWorkspaceAdmin(ctx context.Context, log *slog.Logger, teamID, userID string) bool {
+	if teamID == "" || userID == "" {
+		return false
+	}
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
+	if err != nil {
+		log.Debug("list: admin check failed — treating as non-admin",
+			"error", err, "team_id", teamID, "user_id", userID)
+		return false
+	}
+	return isAdmin
+}
+
+// filterResourcesByAllowedSet returns the subset of resources whose
+// ResourceID appears in the allowed set. Empty allow set returns an
+// empty slice — non-admin in a channel with zero policies should see
+// zero resources, not the full list.
+func filterResourcesByAllowedSet(resources []client.Resource, allowed map[string]struct{}) []client.Resource {
+	if len(allowed) == 0 {
+		return []client.Resource{}
+	}
+	out := make([]client.Resource, 0, len(resources))
+	for i := range resources {
+		if _, ok := allowed[resources[i].ResourceID]; ok {
+			out = append(out, resources[i])
+		}
+	}
+	return out
+}
+
+// resourceSortKey returns the token used to order rows in the
+// /qurl list output. Aliased rows sort by alias, un-aliased rows
+// sort by resource_id — the same token that ends up in the rendered
+// `$<token>` prefix.
+func resourceSortKey(r *client.Resource) string {
+	if r.Alias != "" {
+		return r.Alias
+	}
+	return r.ResourceID
+}
+
+// formatResourceListLine renders one resource as a single text line
+// in /qurl list output. Per-line shape:
+//
+//   - With alias bound:    `• \`$<alias>\` → <target_url>`
+//   - Without alias bound: `• \`$<resource_id>\` → <target_url> (no alias set)`
+//   - Tunnel (Type=tunnel): `• \`$<token>\` → (tunnel)`
+//   - Empty target (other): `• \`$<token>\` → <empty>`
+//
+// When `r.Description` is set, it appends ` — <description>` as a
+// trailing annotation (after the alias-set/tunnel hints). Legacy
+// /qurl list rendered description on a separate visual axis; the
+// trailing-em-dash form keeps the one-line-per-row shape needed for
+// the copy-paste-ready `$<token>` workflow while preserving the
+// operator-authored context.
+//
+// The token-in-backticks shape lets Slack render it as inline code
+// (easy click-to-copy) while keeping the line plaintext-greppable
+// for operator workflows. The "(no alias set)" annotation flags
+// non-tunnel rows that would benefit from a future `/qurl setalias`
+// call — it's suppressed on the tunnel branch because the "(tunnel)"
+// placeholder is already a strong visual signal and the doubled-up
+// "(tunnel) (no alias set)" reads as redundant noise.
+//
+// Tunnel detection keys on r.Type == "tunnel" (the upstream resource
+// type), NOT on empty target_url — keying on the empty field would
+// silently re-label any non-tunnel row with a missing target as
+// "(tunnel)", which would mislead operators triaging a data glitch.
+func formatResourceListLine(r *client.Resource) string {
+	token := r.Alias
+	noAlias := false
+	if token == "" {
+		token = r.ResourceID
+		noAlias = true
+	}
+	descSuffix := ""
+	if r.Description != "" {
+		descSuffix = " — " + r.Description
+	}
+	if r.Type == resourceTypeTunnel {
+		// Tunnel-type resources have no target_url (the FRP server
+		// is the effective destination). Render a placeholder so the
+		// row still reads cleanly. The "(no alias set)" annotation
+		// is suppressed here — see godoc.
+		return fmt.Sprintf("• `$%s` → (tunnel)%s", token, descSuffix)
+	}
+	target := r.TargetURL
+	if target == "" {
+		// Non-tunnel row with an empty target_url — render "<empty>"
+		// rather than silently labeling as a tunnel. Surfaces the
+		// data anomaly to user + ops without misleading either.
+		target = "<empty>"
+	}
+	suffix := ""
+	if noAlias {
+		suffix = " (no alias set)"
+	}
+	return fmt.Sprintf("• `$%s` → %s%s%s", token, target, suffix, descSuffix)
+}
+
+// mapListResourcesError surfaces a friendly user-facing error for
+// /qurl list failures. Auth-class (401/403) maps to authFailureMessage;
+// everything else falls back to serviceUnreachableMessage. Raw
+// APIError text MUST NOT reach Slack — it carries internal codes
+// that are operator-grade, not user-grade.
+func mapListResourcesError(log *slog.Logger, teamID string, err error) string {
+	log.Warn("list: list resources failed", "error", err, "team_id", teamID)
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) && (apiErr.StatusCode == http.StatusUnauthorized || apiErr.StatusCode == http.StatusForbidden) {
+		return authFailureMessage
+	}
+	return serviceUnreachableMessage
+}

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -1,0 +1,492 @@
+package internal
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// Shared alias-name fixtures used across the /qurl list test cases.
+// Lifted to constants to satisfy goconst (min-occurrences=3) and to
+// keep the resource-row builder lines visually aligned. Assertion
+// sites read these names too, so a rename surfaces every site at
+// once.
+const (
+	testListAliasProdDB = "prod-db"
+	testListAliasSecret = "secret"
+	testListAliasAlpha  = "alpha"
+	testListResIDProdDB = "r_prod_db_aa"
+)
+
+// writeResourceListFixture writes a /v1/resources success envelope
+// with a paginated meta block.
+func writeResourceListFixture(t *testing.T, w http.ResponseWriter, resources []map[string]any, nextCursor string, hasMore bool) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	body := map[string]any{
+		testKeyData: resources,
+	}
+	if nextCursor != "" || hasMore {
+		body["meta"] = map[string]any{
+			"next_cursor": nextCursor,
+			"has_more":    hasMore,
+		}
+	}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+}
+
+// TestHandleList_AdminSeesAllResources fences the admin happy path:
+// a workspace admin sees every resource the master listing returns,
+// without channel-policy filtering.
+func TestHandleList_AdminSeesAllResources(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testListResIDProdDB, fAttrAlias: testListAliasProdDB, testKeyTargetURL: "https://prod.example.com"},
+			{testKeyResourceID: "r_stage_db_bb", fAttrAlias: "stage-db", testKeyTargetURL: "https://stage.example.com"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "qURL Resources") {
+		t.Errorf("async reply missing header: %q", async)
+	}
+	if !strings.Contains(async, "`$prod-db` → https://prod.example.com") {
+		t.Errorf("async reply missing prod-db row: %q", async)
+	}
+	if !strings.Contains(async, "`$stage-db` → https://stage.example.com") {
+		t.Errorf("async reply missing stage-db row: %q", async)
+	}
+	if !strings.Contains(async, "/qurl get $token") {
+		t.Errorf("async reply missing copy-paste hint: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminFiltersToChannelPolicy fences the non-admin
+// path: only resources allowed in the current channel are visible.
+func TestHandleList_NonAdminFiltersToChannelPolicy(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{"r_prod_db_aa"})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testListResIDProdDB, fAttrAlias: testListAliasProdDB, testKeyTargetURL: "https://prod.example.com"},
+			{testKeyResourceID: "r_secret_xx", fAttrAlias: testListAliasSecret, testKeyTargetURL: "https://secret.example.com"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$prod-db`") {
+		t.Errorf("async reply missing allowed prod-db: %q", async)
+	}
+	if strings.Contains(async, "secret") {
+		t.Errorf("async reply leaked non-allowed resource: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias fences the
+// `allowed_resource_ids`-only branch of the union: a row whose
+// channel_policies has only `allowed_resource_ids` populated (no
+// `alias_bindings`) — set by `/qurl admin allow #channel $r_<id>` —
+// MUST surface the resource in non-admin `/qurl list`. Pre-fix, the
+// handler read [ListPolicies] which only emits one entry per
+// `alias_bindings` binding, so a pure-allowed-set resource was
+// `/qurl get`-mintable but invisible in `/qurl list` — the two
+// surfaces diverged.
+func TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	// alias="" → seedPolicySet skips the auto-attached alias_bindings
+	// Map. Row carries ONLY `allowed_resource_ids`.
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_allow_only1"})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_allow_only1", testKeyTargetURL: "https://allowed.example.com"},
+			{testKeyResourceID: "r_secret_xx", fAttrAlias: testListAliasSecret, testKeyTargetURL: "https://secret.example.com"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$r_allow_only1`") {
+		t.Errorf("non-admin list dropped a resource that's in allowed_resource_ids but has no alias_binding: %q", async)
+	}
+	if strings.Contains(async, "secret") {
+		t.Errorf("async reply leaked non-allowed resource: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminUnionsAllowedSetAndAliasBindings fences the
+// union behavior across both surfaces on the same row: an
+// alias-bindings-only resource AND an allowed-set-only resource must
+// both surface (an alias-only resource that lives outside the
+// allowed_resource_ids gate is still mintable via the alias path's
+// channel-scoped binding, so it belongs in the listing).
+func TestHandleList_NonAdminUnionsAllowedSetAndAliasBindings(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	// Manually compose a row carrying BOTH surfaces with disjoint
+	// resource IDs — `allowed_resource_ids` covers r_allow_set_a,
+	// `alias_bindings` covers r_alias_only_b. Pre-fix, the bindings
+	// path won and the allowed-set entry was invisible.
+	ts.ddb.seedItem(t, ts.tableNames.channelPolicy, map[string]ddbtypes.AttributeValue{
+		fAttrSlackTeamID:        stringMember(testAdminTeamID),
+		fAttrSlackChannelID:     stringMember("C_test"),
+		fAttrAllowedResourceIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{"r_allow_set_a"}},
+		fAttrAliasBindings: &ddbtypes.AttributeValueMemberM{
+			Value: map[string]ddbtypes.AttributeValue{
+				"alias-b": stringMember("r_alias_only_b"),
+			},
+		},
+		fAttrCreatedAt: stringMember("2026-04-20T12:00:00Z"),
+	})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_allow_set_a", testKeyTargetURL: "https://allowset.example.com"},
+			{testKeyResourceID: "r_alias_only_b", fAttrAlias: "alias-b", testKeyTargetURL: "https://aliasonly.example.com"},
+			{testKeyResourceID: "r_neither_xx", fAttrAlias: "neither", testKeyTargetURL: "https://neither.example.com"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$r_allow_set_a`") {
+		t.Errorf("union missed the allowed-set entry: %q", async)
+	}
+	if !strings.Contains(async, "`$alias-b`") {
+		t.Errorf("union missed the alias-binding entry: %q", async)
+	}
+	if strings.Contains(async, "neither") {
+		t.Errorf("union leaked a resource present in neither surface: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminEmptyChannelFailsClose fences the fail-closed
+// posture: a non-admin slash command with no channel_id (synthetic
+// test payload or wire-shape regression) returns the empty state
+// rather than leaking the unfiltered master list.
+func TestHandleList_NonAdminEmptyChannelFailsClose(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_leaked_xx", fAttrAlias: "leaked", testKeyTargetURL: "https://leaked.example.com"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvokerOnChannel(t, h, "")
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if strings.Contains(async, "leaked") {
+		t.Errorf("non-admin + empty channel_id leaked master list: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminPaginationGap fences the distinct empty-state
+// copy when a non-admin's filter is empty AND the master list has
+// more pages. Default empty-state ("Create one with /qurl create")
+// would mislead the user — the issue is pagination, not absence.
+func TestHandleList_NonAdminPaginationGap(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	// No allowed policies → filter drops everything. Master list
+	// reports has_more=true so the non-admin pagination-gap copy
+	// fires.
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_unallowed_x", fAttrAlias: "unallowed", testKeyTargetURL: "https://x"},
+		}, "cursor_xyz", true)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "past the first page") {
+		t.Errorf("async reply missing pagination-gap copy: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminEmptyChannelWithHasMoreShowsDefault fences
+// the empty-channel + has_more=true branch: the pagination-gap copy
+// must NOT fire when channel_id is empty (the message references
+// "this channel" — misleading when by construction there is none).
+// Regression-pin on the channelID != "" guard added in the round-7
+// CR pass.
+func TestHandleList_NonAdminEmptyChannelWithHasMoreShowsDefault(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_leaked_xx", fAttrAlias: "leaked", testKeyTargetURL: "https://leaked.example.com"},
+		}, "cursor_xyz", true)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvokerOnChannel(t, h, "")
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if strings.Contains(async, "past the first page") {
+		t.Errorf("empty-channel branch leaked pagination-gap copy: %q", async)
+	}
+	if strings.Contains(async, "leaked") {
+		t.Errorf("empty-channel + non-admin leaked master list: %q", async)
+	}
+}
+
+// TestHandleList_EmptyWorkspace fences the friendly empty-state copy
+// for a brand-new workspace with zero resources. The hint nudges the
+// user toward `/qurl create`.
+func TestHandleList_EmptyWorkspace(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "Create one with") {
+		t.Errorf("async reply missing empty-state hint: %q", async)
+	}
+}
+
+// TestHandleList_UnaliasedResource fences the `$r_<id>` rendering for
+// resources without a bound alias. The row should be copy-paste-ready
+// into `/qurl get $r_<id>`.
+func TestHandleList_UnaliasedResource(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_unaliased1", testKeyTargetURL: "https://noalias.example.com"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$r_unaliased1`") {
+		t.Errorf("async reply missing unaliased token shape: %q", async)
+	}
+	if !strings.Contains(async, "(no alias set)") {
+		t.Errorf("async reply missing 'no alias set' suffix: %q", async)
+	}
+}
+
+// TestHandleList_TunnelResource fences the tunnel-resource rendering:
+// type=tunnel renders "(tunnel)" target placeholder regardless of
+// target_url. Keys on r.Type, NOT on empty target_url, so a non-tunnel
+// row with a data glitch (transient empty target) doesn't get
+// mislabeled.
+func TestHandleList_TunnelResource(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_aaa", fAttrAlias: "tun", testKeyType: resourceTypeTunnel},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$tun` → (tunnel)") {
+		t.Errorf("async reply missing tunnel placeholder: %q", async)
+	}
+}
+
+// TestHandleList_TunnelResourceWithoutAlias fences the "(no alias set)"
+// suffix being suppressed on the tunnel branch: rendering
+// "$r_<id> → (tunnel) (no alias set)" doubles up two distinct
+// visual signals. Tunnel without an alias renders as just
+// "$r_<id> → (tunnel)" — the placeholder is signal enough.
+func TestHandleList_TunnelResourceWithoutAlias(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_noa", testKeyType: resourceTypeTunnel},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$r_tunnel_noa` → (tunnel)") {
+		t.Errorf("async reply missing tunnel placeholder for un-aliased tunnel: %q", async)
+	}
+	if strings.Contains(async, "(no alias set)") {
+		t.Errorf("(no alias set) leaked on tunnel branch — doubled-up signal: %q", async)
+	}
+}
+
+// TestHandleList_ResourceWithDescription fences the trailing
+// "— <description>" annotation. Legacy /qurl list rendered description
+// on a separate line; the resource-pivoted version preserves the
+// operator-authored context as a one-line suffix so each row stays
+// copy-paste-greppable.
+func TestHandleList_ResourceWithDescription(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_desc_aaaaa", fAttrAlias: "prod", testKeyTargetURL: "https://prod", "description": "production gateway"},
+			{testKeyResourceID: "r_nodesc_bbbb", fAttrAlias: "stage", testKeyTargetURL: "https://stage"},
+			{testKeyResourceID: "r_tun_descrip", fAttrAlias: "tun", testKeyType: resourceTypeTunnel, "description": "ops bastion"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	// Description-bearing row renders trailing em-dash + description.
+	if !strings.Contains(async, "`$prod` → https://prod — production gateway") {
+		t.Errorf("async reply missing description suffix on aliased row: %q", async)
+	}
+	// No-description row stays clean (no trailing em-dash).
+	if !strings.Contains(async, "`$stage` → https://stage") {
+		t.Errorf("async reply missing un-described row: %q", async)
+	}
+	if strings.Contains(async, "`$stage` → https://stage —") {
+		t.Errorf("un-described row should not render a trailing em-dash: %q", async)
+	}
+	// Tunnel rows also carry description.
+	if !strings.Contains(async, "`$tun` → (tunnel) — ops bastion") {
+		t.Errorf("async reply missing description suffix on tunnel row: %q", async)
+	}
+}
+
+// TestHandleList_HasMoreFooter fences the truncation footer when the
+// master list reports has_more=true.
+func TestHandleList_HasMoreFooter(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_one_aa", fAttrAlias: "one", testKeyTargetURL: "https://one"},
+		}, "cursor_xyz", true)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "more results past") {
+		t.Errorf("async reply missing has_more footer: %q", async)
+	}
+}
+
+// TestHandleList_NonAdminPartialPageHasMoreFooter fences the distinct
+// non-admin footer when the filtered set is NON-empty and master
+// has_more=true. The admin footer ("more results past first N") under-
+// states the gap because allow-listed resources may sit past the first
+// scan invisibly; the non-admin copy makes that explicit.
+func TestHandleList_NonAdminPartialPageHasMoreFooter(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	// One allowed resource in the channel, plus has_more=true so the
+	// non-admin pagination-aware footer branch fires.
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "one", []string{"r_one_xxxxxx"})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_one_xxxxxx", fAttrAlias: "one", testKeyTargetURL: "https://one"},
+		}, "cursor_xyz", true)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "Showing allow-listed resources") {
+		t.Errorf("async reply missing non-admin partial-page footer: %q", async)
+	}
+	// Admin-only "more results past" copy must NOT fire on the non-admin
+	// path — these two branches are deliberately disjoint.
+	if strings.Contains(async, "more results past") {
+		t.Errorf("async reply leaked admin-only footer copy on non-admin path: %q", async)
+	}
+}
+
+// TestHandleList_AdminStoreNilTreatedAsNonAdmin fences the no-DDB
+// sandbox case. Without AdminStore we can't check admin status, so
+// we treat the user as non-admin and fail-closed (empty list, no leak).
+func TestHandleList_AdminStoreNilTreatedAsNonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_master_xx", fAttrAlias: "master", testKeyTargetURL: "https://x"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AdminStore = nil
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if strings.Contains(async, "master") {
+		t.Errorf("async reply leaked master list when AdminStore nil: %q", async)
+	}
+}
+
+// TestHandleList_UpstreamError fences the friendly error surface when
+// the customer API returns 5xx. Raw API error text MUST NOT reach the
+// user.
+func TestHandleList_UpstreamError(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeAPIError(t, w, http.StatusBadGateway, "upstream_error", "Bad Gateway from internal API")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if strings.Contains(async, "internal API") {
+		t.Errorf("async reply leaked raw API error text: %q", async)
+	}
+	if !strings.Contains(async, "Could not reach qURL") {
+		t.Errorf("async reply missing service-unreachable message: %q", async)
+	}
+}
+
+// TestHandleList_StableSortBetweenAliasAndResourceID fences the sort
+// order: rows are sorted by the underlying token (alias if bound,
+// resource_id otherwise) so two consecutive `/qurl list` calls render
+// identically.
+func TestHandleList_StableSortBetweenAliasAndResourceID(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		// Server returns in non-alphabetical order; the handler must
+		// sort.
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_zzz_aaaaa", testKeyTargetURL: "https://zzz"},
+			{testKeyResourceID: "r_aaa_xxxxx", fAttrAlias: testListAliasAlpha, testKeyTargetURL: "https://alpha"},
+			{testKeyResourceID: "r_mmm_yyyyy", fAttrAlias: "middle", testKeyTargetURL: "https://mid"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	// "alpha" < "middle" < "r_zzz" (alphabetical, alias values
+	// sorted naturally; un-aliased rows sort by resource_id).
+	alphaPos := strings.Index(async, "`$alpha`")
+	middlePos := strings.Index(async, "`$middle`")
+	zzzPos := strings.Index(async, "`$r_zzz_aaaaa`")
+	if alphaPos < 0 || middlePos < 0 || zzzPos < 0 {
+		t.Fatalf("missing rows in async reply: %q", async)
+	}
+	if alphaPos >= middlePos || middlePos >= zzzPos {
+		t.Errorf("rows not sorted by token: alpha=%d middle=%d zzz=%d in %q", alphaPos, middlePos, zzzPos, async)
+	}
+}

--- a/apps/slack/internal/handler_test_helpers_test.go
+++ b/apps/slack/internal/handler_test_helpers_test.go
@@ -16,6 +16,8 @@ const (
 	testKeyError      = "error"
 	testKeyResourceID = "resource_id"
 	testKeyTitle      = "title"
+	testKeyType       = "type"
+	testKeyTargetURL  = "target_url"
 	testResourceIDFix = "r_prod_db" // canonical test resource_id
 	// mintByTestResourcePath is the resource-scoped mint endpoint
 	// that `client.Create` hits when given a ResourceID (alias-form

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -21,8 +21,9 @@ type Subcommand string
 const (
 	// SubcmdHelp covers both `/qurl` (empty text) and `/qurl help`.
 	SubcmdHelp Subcommand = "help"
-	// SubcmdGet mints an access link for either a raw URL or a
-	// channel-scoped `$alias` configured by an admin.
+	// SubcmdGet mints an access link for a raw URL, a channel-scoped
+	// `$alias` configured by an admin, or a raw `$r_<id>` resource
+	// token copy-pasted from `/qurl list`.
 	SubcmdGet Subcommand = "get"
 	// SubcmdSetAlias binds an alias to a target URL or resource ID.
 	SubcmdSetAlias Subcommand = "setalias"
@@ -61,6 +62,36 @@ const (
 	AdminRevoke AdminAction = "revoke"
 )
 
+// ResourceTokenKind discriminates between the two shapes a `$<token>`
+// argument can take after the sigil: a human-readable alias name or a
+// raw `r_*` resource ID. Lifted to its own typed string so handlers
+// can branch on the parsed shape without re-running regex matches.
+type ResourceTokenKind string
+
+// Recognized resource-token kinds.
+const (
+	// ResourceTokenAlias is a human-readable `$<alias>` like `$prod-db`.
+	// The bare value matches [aliasCharsetPattern].
+	ResourceTokenAlias ResourceTokenKind = "alias"
+	// ResourceTokenResourceID is a raw `$r_<11chars>` shape like
+	// `$r_k8xqp9h2sj9`. The bare value matches [resourceIDPattern]
+	// (including the `r_` prefix — handlers consume the full ID).
+	ResourceTokenResourceID ResourceTokenKind = "resource_id"
+)
+
+// ParsedResourceToken is the shape of a successfully-parsed `$<token>`
+// argument. Returned by [requireResourceToken] so handlers can decide
+// whether to call the alias-resolution path or the by-ID-lookup path
+// without inspecting the value themselves.
+type ParsedResourceToken struct {
+	// Kind is the discriminator — alias vs resource_id.
+	Kind ResourceTokenKind
+	// Value is the bare token. For aliases it's the name without the
+	// `$` sigil; for resource IDs it's the full ID including the `r_`
+	// prefix (handlers pass it directly to a by-ID resource lookup).
+	Value string
+}
+
 // Command is the parsed shape of a `/qurl …` slash command.
 type Command struct {
 	// Subcommand is the first word (or [SubcmdHelp] when text is empty).
@@ -68,8 +99,19 @@ type Command struct {
 	// AdminAction is the second word when [Subcommand] is [SubcmdAdmin];
 	// empty otherwise.
 	AdminAction AdminAction
-	// Alias is the `$alias` argument (sigil stripped) when present.
+	// Alias is the `$alias` argument (sigil stripped) when the parsed
+	// resource-token is an alias. Empty when the user supplied a raw
+	// resource ID instead — see [Command.Resource] for the kind-aware
+	// view. Kept populated for the alias path so verbs that only accept
+	// aliases (`setalias`, `unsetalias`, `admin allow`, `admin
+	// disallow`, `admin revoke`) keep their existing read site.
 	Alias string
+	// Resource is the kind-aware shape of the `$<token>` argument when
+	// the verb accepts both alias and resource-ID forms (currently
+	// `/qurl get`). Zero value when the verb only takes aliases —
+	// callers that want the legacy single-string view should read
+	// [Command.Alias] instead.
+	Resource ParsedResourceToken
 	// Target is the trailing positional arg used by `setalias` (a URL or
 	// raw resource_id) and the legacy `create <url>`.
 	Target string
@@ -197,6 +239,25 @@ var flagKeyShape = regexp.MustCompile(`(?i)^` + flagKeyCharset + `$`)
 // [aliasCharsetPattern] / [aliasMaxLen] in handler_alias.go for the
 // full doc on internal-`--` deference to qurl-service and the nhp
 // #1825 GSI-key sizing.
+
+// resourceIDPattern matches qurl-service's resource-ID shape: `r_`
+// + 11 base64url chars (lowercased per generateRandomID's
+// DNS-compatibility lowercase). Anchored at both ends so a partial
+// substring like `r_short` or `r_abc...extra` is rejected. Mirrored
+// from `qurl-service/internal/domain/qurl.go::resourceIDPattern` —
+// when that schema changes, this regex changes in lockstep.
+//
+// The `_` in the `r_` prefix is what disambiguates this shape from
+// [aliasCharsetPattern] at parse time: aliases are constrained to
+// `[a-z0-9-]` (no underscore), so any `r_<…>` token is a resource
+// ID by construction. The "resource-ID first" ordering in
+// [requireResourceToken] is harmless rather than load-bearing — the
+// two patterns can't both match the same bare value.
+//
+// TODO(upstream-rebrand): cross-repo lockstep with
+// `qurl-service/internal/domain/qurl.go::resourceIDPattern`. If the
+// upstream regex (charset, length, anchors) changes, mirror it here.
+var resourceIDPattern = regexp.MustCompile(`^r_[a-z0-9_-]{11}$`)
 
 // Parse tokenizes the trimmed `text` field of a Slack slash command into a
 // [Command]. Empty or `help` text returns a [Command] with Subcommand =
@@ -333,11 +394,22 @@ func tokenize(text string) []string {
 	return out
 }
 
-// parseGet extracts the positional argument (either a `$alias` or a
-// URL) and the optional `dm:` / `reason:` flags. The first positional
-// is treated as a URL when it has an `http://` or `https://` prefix;
-// otherwise it must start with `$`. Surplus positional args after the
-// first are an error.
+// parseGet extracts the positional argument (a raw URL, a `$<alias>`,
+// or a `$r_<id>` resource token) and the optional `dm:` / `reason:`
+// flags. The first positional is treated as a URL when it has an
+// `http://` or `https://` prefix; otherwise it must start with `$`
+// and is routed through [requireResourceToken] so handlers can branch
+// on alias vs resource-ID without re-parsing. Surplus positional args
+// after the first are an error.
+//
+// `get` is the only verb in the grammar that accepts both alias and
+// resource-ID shapes — the alias-mutating verbs (`setalias`,
+// `unsetalias`, admin allow/disallow/revoke) intentionally stay
+// alias-only because their semantics are alias-scoped. Letting `get`
+// take a raw ID closes the gap between `/qurl list` (which surfaces
+// IDs for un-aliased resources) and `/qurl get` (which previously
+// only minted from aliases or URLs) so a list line can be
+// copy-pasted into the next command without a manual lookup step.
 func parseGet(cmd *Command, rest []string) (*Command, error) {
 	if len(rest) == 0 {
 		return nil, ErrEmptyResource
@@ -345,11 +417,19 @@ func parseGet(cmd *Command, rest []string) (*Command, error) {
 	if hasASCIIPrefixFold(rest[0], "https://") || hasASCIIPrefixFold(rest[0], "http://") {
 		cmd.Target = rest[0]
 	} else {
-		alias, err := parseAliasToken(rest[0])
+		tok, err := requireResourceToken(rest[0])
 		if err != nil {
 			return nil, err
 		}
-		cmd.Alias = alias
+		cmd.Resource = tok
+		if tok.Kind == ResourceTokenAlias {
+			// Keep [Command.Alias] populated so legacy read-sites in
+			// tests or future shared helpers don't have to
+			// special-case the get verb. The resource-ID branch
+			// leaves Alias empty — handlers that route on Kind use
+			// [Command.Resource] directly.
+			cmd.Alias = tok.Value
+		}
 	}
 	for _, tok := range rest[1:] {
 		// Surface non-flag-shaped tokens as ErrUnexpectedArgument so
@@ -552,6 +632,49 @@ func parseAliasToken(tok string) (string, error) {
 		return "", fmt.Errorf("%w: %q (allowed: lowercase a-z, 0-9, hyphen, no leading/trailing hyphen)", ErrInvalidAlias, alias)
 	}
 	return alias, nil
+}
+
+// requireResourceToken enforces the `$` sigil, strips it, and matches
+// the remaining text against EITHER [resourceIDPattern] (a raw `r_…`
+// resource ID) OR [aliasCharsetPattern] (a human-readable alias).
+// Returns a [ParsedResourceToken] tagged with the kind so handlers
+// can route to the right lookup path without re-running the regex.
+//
+// The resource-ID pattern is checked first so a literal `r_<11chars>`
+// token always wins the disambiguation. Empty after the sigil is an
+// [ErrEmptyResource]; anything matching neither pattern is
+// [ErrInvalidAlias] with a message naming both accepted shapes.
+//
+// Used by verbs that accept both alias and resource-ID forms
+// (currently `/qurl get`). Alias-only verbs (`setalias`, `unsetalias`,
+// `admin allow/disallow/revoke`) use [parseAliasToken] instead.
+func requireResourceToken(tok string) (ParsedResourceToken, error) {
+	if !strings.HasPrefix(tok, "$") {
+		return ParsedResourceToken{}, fmt.Errorf("%w: got %q", ErrMissingSigil, tok)
+	}
+	bare := strings.TrimPrefix(tok, "$")
+	if bare == "" {
+		return ParsedResourceToken{}, ErrEmptyResource
+	}
+	if resourceIDPattern.MatchString(bare) {
+		return ParsedResourceToken{Kind: ResourceTokenResourceID, Value: bare}, nil
+	}
+	// Length cap precedes the charset check on the alias branch so an
+	// over-cap token (>aliasMaxLen runes) reports the cap-specific
+	// error rather than the joint charset-or-resource-id message, which
+	// would be confusing for an otherwise-valid-shape-but-too-long
+	// alias. Mirrors parseAliasToken's order; pinned by parser_test.go's
+	// `alias over 64 chars rejected` case.
+	if len(bare) > aliasMaxLen {
+		return ParsedResourceToken{}, fmt.Errorf("%w: %q is longer than %d characters", ErrInvalidAlias, bare, aliasMaxLen)
+	}
+	if aliasCharsetPattern.MatchString(bare) {
+		return ParsedResourceToken{Kind: ResourceTokenAlias, Value: bare}, nil
+	}
+	return ParsedResourceToken{}, fmt.Errorf(
+		"%w: %q — token must be an alias (e.g. `$dev-dashboard`, lowercase a-z/0-9/hyphen, no leading/trailing hyphen) or a resource ID (e.g. `$r_abc123def01`)",
+		ErrInvalidAlias, bare,
+	)
 }
 
 // matchChannel returns the `C…` ID and true when `tok` is a Slack

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -182,6 +182,25 @@ func TestParse_ErrorPaths(t *testing.T) {
 		// ErrUnexpectedArgument rather than the misleading
 		// "invalid flag" message applyFlag would otherwise return.
 		{name: "get with non-flag trailing positional rejected", text: "get $prod-db junk", wantErr: ErrUnexpectedArgument},
+		// Resource-ID-shape fences on the `get` verb. `requireResourceToken`
+		// tries [resourceIDPattern] first, then [aliasCharsetPattern];
+		// shapes that match neither must reject with ErrInvalidAlias
+		// (the joint sentinel) — exact behavior matters because the
+		// fallback shape would otherwise be the only path that minted
+		// a malformed token.
+		{name: "resource-id too short rejected", text: "get $r_short", wantErr: ErrInvalidAlias},
+		{name: "resource-id uppercase rejected", text: "get $r_TOOMANYCHARS", wantErr: ErrInvalidAlias},
+		// Exact-boundary fences for [resourceIDPattern]'s `{11}` cap:
+		// 10 chars (one under) and 12 chars (one over). The pattern is
+		// the joint shape `^r_[a-z0-9_-]{11}$` — a single char delta on
+		// either side flips the match. Without these, a future regex
+		// loosening to `{10,12}` would silently mint malformed tokens
+		// that qurl-service then 404s on.
+		{name: "resource-id exactly 10 chars rejected", text: "get $r_aaaaaaaaaa", wantErr: ErrInvalidAlias},
+		{name: "resource-id exactly 12 chars rejected", text: "get $r_aaaaaaaaaaaa", wantErr: ErrInvalidAlias},
+		// Invalid byte ($) anywhere in the body — neither resource-ID
+		// nor alias shape accepts $ in the tail.
+		{name: "resource-id invalid byte rejected", text: "get $r_aaa$bbbccc", wantErr: ErrInvalidAlias},
 		// A typo-class URL paste (`get $alias https://x.example:8080`)
 		// contains `:` but is plainly not a flag; the
 		// http://-and-https://-aware looksLikeFlag check routes it to
@@ -298,6 +317,50 @@ func TestParse_AliasLengthBoundary(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "longer than 64 characters") {
 		t.Errorf("Parse(get $<65 chars>) error = %q, want substring %q", err.Error(), "longer than 64 characters")
+	}
+}
+
+// TestRequireResourceToken_PositiveShapes exercises the kind-tagged
+// return shape of [requireResourceToken] directly so a regex change
+// surfaces at the unit level rather than only through end-to-end
+// fixtures. The Parse-level tests cover the integration shape; this
+// pins the parser's structural contract — alias kind, resource-id
+// kind, and what each Value is — without the parseGet flag-handling
+// overhead.
+func TestRequireResourceToken_PositiveShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		input     string
+		wantKind  ResourceTokenKind
+		wantValue string
+	}{
+		{name: "alias shape", input: "$prod-db", wantKind: ResourceTokenAlias, wantValue: "prod-db"},
+		{name: "single-char alias", input: "$a", wantKind: ResourceTokenAlias, wantValue: "a"},
+		{name: "resource-id shape", input: "$r_abc123def01", wantKind: ResourceTokenResourceID, wantValue: "r_abc123def01"},
+		// All-zero body and mixed-charset body — both still match
+		// [resourceIDPattern]'s `^r_[a-z0-9_-]{11}$` so the kind tag
+		// must come back as ResourceTokenResourceID. Pinned so a
+		// regex tightening (e.g., to `[a-z0-9]` only) shows up as a
+		// kind-flip rather than a silent fall-through to the alias
+		// shape.
+		{name: "resource-id all digits body", input: "$r_00000000000", wantKind: ResourceTokenResourceID, wantValue: "r_00000000000"},
+		{name: "resource-id mixed body with dashes", input: "$r_a-b-c-d-e-f", wantKind: ResourceTokenResourceID, wantValue: "r_a-b-c-d-e-f"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tok, err := requireResourceToken(tc.input)
+			if err != nil {
+				t.Fatalf("requireResourceToken(%q) error = %v", tc.input, err)
+			}
+			if tok.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", tok.Kind, tc.wantKind)
+			}
+			if tok.Value != tc.wantValue {
+				t.Errorf("Value = %q, want %q", tok.Value, tc.wantValue)
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -105,29 +105,6 @@ func (h *Handler) runAsync(w http.ResponseWriter, command string, values url.Val
 	respondSlack(w, ackWorkingOnIt)
 }
 
-// processList runs the asynchronous /qurl list work: page through the
-// most recent qURLs and POST a formatted summary back via response_url.
-func (h *Handler) processList(ctx context.Context, log *slog.Logger, values url.Values) {
-	responseURL := values.Get(fieldResponseURL)
-	teamID := values.Get(fieldTeamID)
-
-	c, err := h.authenticatedClient(ctx, teamID)
-	if err != nil {
-		log.Error("failed to get API key", "error", err)
-		h.postResponse(log, responseURL, authErrorMessage(err))
-		return
-	}
-
-	result, err := c.List(ctx, client.ListInput{Limit: 5})
-	if err != nil {
-		log.Error("failed to list qURLs", "error", err)
-		h.postResponse(log, responseURL, sanitizeAPIError(err, "Failed to list qURLs"))
-		return
-	}
-
-	h.postResponse(log, responseURL, formatListMessage(result.QURLs))
-}
-
 // sanitizeAPIError builds a user-safe message from a (possibly non-nil)
 // qURL API error. The full *client.APIError is logged at the call site;
 // what reaches Slack is bounded to:
@@ -157,23 +134,6 @@ func sanitizeAPIError(err error, prefix string) string {
 		msg += fmt.Sprintf(" (Reference: `%s`)", apiErr.RequestID)
 	}
 	return msg + "."
-}
-
-// formatListMessage renders /qurl list results as Slack mrkdwn.
-func formatListMessage(qurls []client.QURL) string {
-	if len(qurls) == 0 {
-		return "No qURLs found."
-	}
-	lines := make([]string, 0, len(qurls))
-	for i := range qurls {
-		q := &qurls[i]
-		line := fmt.Sprintf("• `%s` → %s [%s]", q.ResourceID, q.TargetURL, q.Status)
-		if q.Description != "" {
-			line = fmt.Sprintf("• *%s* — `%s` → %s [%s]", q.Description, q.ResourceID, q.TargetURL, q.Status)
-		}
-		lines = append(lines, line)
-	}
-	return "*Recent qURLs:*\n" + strings.Join(lines, "\n")
 }
 
 // postResponse POSTs an ephemeral follow-up to Slack's response_url.

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -422,60 +422,6 @@ func TestHandle_PoolSaturationDropsWithBusyAck(t *testing.T) {
 	releaseAll()
 }
 
-// TestHandle_AsyncListPostsResultToResponseURL fences /qurl list's
-// async path including the empty-list and populated-list code paths.
-func TestHandle_AsyncListPostsResultToResponseURL(t *testing.T) {
-	cases := []struct {
-		name     string
-		respJSON string
-		want     string
-	}{
-		{
-			name:     "no qurls",
-			respJSON: `{"data":[]}`,
-			want:     "No qURLs found.",
-		},
-		{
-			name:     "with qurls",
-			respJSON: `{"data":[{"resource_id":"r1","target_url":"https://example.com","status":"active"}]}`,
-			want:     "*Recent qURLs:*",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(tc.respJSON))
-			}))
-			t.Cleanup(qurlSrv.Close)
-
-			t.Setenv("QURL_API_KEY", "test-key")
-
-			rec := newResponseURLRecorder(t)
-			h := newTestHandler(t, qurlSrv)
-			body := url.Values{
-				"command":      {"/qurl"},
-				"text":         {"list"},
-				"team_id":      {"T123"},
-				"trigger_id":   {"trig-list"},
-				"response_url": {rec.URL},
-			}.Encode()
-
-			w := httptest.NewRecorder()
-			h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
-			h.Wait()
-
-			posts := rec.Posts()
-			if len(posts) != 1 {
-				t.Fatalf("response_url POST count = %d, want 1", len(posts))
-			}
-			if !strings.Contains(posts[0]["text"], tc.want) {
-				t.Errorf("response_url text = %q, want substring %q", posts[0]["text"], tc.want)
-			}
-		})
-	}
-}
-
 // TestHandle_PanicInAsyncWorkRecovers fences the panic-recovery defer
 // in runAsync. A panicking auth.Provider must not crash the process or
 // leak a wg slot — the goroutine returns cleanly via the recover, sem
@@ -870,10 +816,10 @@ func TestHandle_PostResponseRefusesRedirectsEndToEnd(t *testing.T) {
 
 // TestHandle_ListExactMatchOnly fences the tightened "/qurl list"
 // matcher: the looser HasPrefix(text, "list") form matched `listing`,
-// `lists`, `list-foo` (silently routing them to processList) AND
-// `list extra args` (which processList ignores). Now only the bare
-// token reaches processList — anything else falls through to the
-// unknown-subcommand branch.
+// `lists`, `list-foo` (silently routing them to processListResources)
+// AND `list extra args` (which processListResources ignores). Now
+// only the bare token reaches processListResources — anything else
+// falls through to the unknown-subcommand branch.
 func TestHandle_ListExactMatchOnly(t *testing.T) {
 	cases := []string{
 		"listing",

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -34,6 +34,59 @@ const (
 	attrAllowedResourceIDs = "allowed_resource_ids"
 )
 
+// AllowedResourceIDsForChannel returns the union of resource IDs the
+// (teamID, channelID) channel_policies row exposes to non-admin
+// `/qurl list`. The set is the union of two orthogonal surfaces on
+// the same row:
+//
+//   - `allowed_resource_ids` SS — the multi-resource gate
+//     `/qurl admin allow/disallow` mutates; `/qurl get $r_<id>`
+//     checks via [ResolvePolicy].
+//   - `alias_bindings` Map<alias_name, resource_id> — the alias
+//     surface `/qurl setalias` / `/qurl unsetalias` mutate;
+//     `/qurl get $alias` checks via [ResolveAlias].
+//
+// Either surface allows the row to mint, so `/qurl list` must show
+// resources visible via EITHER — surfacing only the alias-bindings
+// values (the bug closed here) hides allow-listed-but-unaliased
+// resources from non-admin listings even though `/qurl get $r_<id>`
+// would mint them. Single-row GetItem; no pagination needed.
+//
+// Missing row → empty set (no policy = no access, fail-closed).
+func (s *Store) AllowedResourceIDsForChannel(ctx context.Context, teamID, channelID string) (map[string]struct{}, error) {
+	if teamID == "" || channelID == "" {
+		return nil, &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "AllowedResourceIDsForChannel: team_id and channel_id are required",
+		}
+	}
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.ChannelPoliciesName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    stringAttr(teamID),
+			attrSlackChannelID: stringAttr(channelID),
+		},
+	})
+	if err != nil {
+		return nil, ddbToError("AllowedResourceIDsForChannel", err)
+	}
+	if len(out.Item) == 0 {
+		return map[string]struct{}{}, nil
+	}
+	allowed := make(map[string]struct{})
+	for _, rid := range readStringSet(out.Item, attrAllowedResourceIDs) {
+		if rid != "" {
+			allowed[rid] = struct{}{}
+		}
+	}
+	for _, rid := range readStringMap(out.Item, attrAliasBindings) {
+		if rid != "" {
+			allowed[rid] = struct{}{}
+		}
+	}
+	return allowed, nil
+}
+
 // ResolvePolicy returns true iff `resourceID` is in the
 // channel_policies row's `allowed_resource_ids` set for
 // (teamID, channelID). Missing row → false (no policy = no access).

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -893,6 +893,76 @@ func (c *Client) GetResourceByAlias(ctx context.Context, alias string) (*Resourc
 	return &out, nil
 }
 
+// ListResourcesInput is the paginated input shape for [Client.ListResources].
+// Mirrors the qurl-service `GET /v1/resources` query parameters
+// (`cursor`, `limit`).
+type ListResourcesInput struct {
+	// Limit caps the number of items returned in one page. Server
+	// accepts 1-100; zero falls back to the server default.
+	Limit int
+	// Cursor is the opaque next-page handle from a previous response.
+	Cursor string
+}
+
+// ListResourcesOutput is the response shape from [Client.ListResources].
+type ListResourcesOutput struct {
+	Resources  []Resource
+	NextCursor string
+	HasMore    bool
+}
+
+// listResourcesMaxLimit is the server-enforced upper bound on the
+// `/v1/resources?limit=` query parameter (qurl-service rejects
+// `limit > 100` with a 400). Lifted to a constant so the boundary
+// clamp in [Client.ListResources] keeps a bad-math caller from ever
+// reaching the server.
+const listResourcesMaxLimit = 100
+
+// ListResources retrieves a paginated list of resources for the
+// authenticated workspace. Used by Slack's `/qurl list` to render
+// copy-paste-ready `$<alias>` / `$<resource_id>` rows.
+//
+// `input.Limit` is clamped to [listResourcesMaxLimit] before the
+// request fires — the server returns a 400 on overshoot, but the
+// boundary check here means a handler with bad math gets a clean
+// page instead of an upstream error.
+func (c *Client) ListResources(ctx context.Context, input ListResourcesInput) (*ListResourcesOutput, error) {
+	params := url.Values{}
+	if input.Limit > listResourcesMaxLimit {
+		input.Limit = listResourcesMaxLimit
+	}
+	if input.Limit > 0 {
+		params.Set("limit", strconv.Itoa(input.Limit))
+	}
+	if input.Cursor != "" {
+		params.Set("cursor", input.Cursor)
+	}
+	path := c.baseURL + "/v1/resources"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	var resources []Resource
+	meta, err := c.do(req, &resources, "GET /v1/resources")
+	if err != nil {
+		return nil, err
+	}
+	out := &ListResourcesOutput{Resources: resources}
+	if out.Resources == nil {
+		// Normalize nil → empty slice so callers can range over it
+		// without a nil-guard.
+		out.Resources = []Resource{}
+	}
+	if meta != nil {
+		out.NextCursor = meta.NextCursor
+		out.HasMore = meta.HasMore
+	}
+	return out, nil
+}
+
 // --- Resolve ---
 
 // ResolveInput holds input for headless qURL resolution.

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -832,6 +832,47 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 	})
 }
 
+// TestListResourcesLimitClamp fences the defensive client-side clamp:
+// a caller passing Limit > 100 (server max) gets the request fired at
+// limit=100 rather than letting the server return a 400. The clamp
+// is a boundary check, not a transform — Limit=0 still falls back to
+// the server default by omitting the param.
+func TestListResourcesLimitClamp(t *testing.T) {
+	cases := []struct {
+		name     string
+		inLimit  int
+		wantSent string // "" means the param must not be set
+	}{
+		{name: "below max passes through", inLimit: 50, wantSent: "50"},
+		{name: "at max passes through", inLimit: 100, wantSent: "100"},
+		{name: "above max clamps to 100", inLimit: 500, wantSent: "100"},
+		{name: "zero omits param", inLimit: 0, wantSent: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got := r.URL.Query().Get("limit")
+				if got != tc.wantSent {
+					t.Errorf("limit query param: got %q, want %q", got, tc.wantSent)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]any{
+					"data": []map[string]any{},
+					"meta": map[string]string{"request_id": "req_test"},
+				}); err != nil {
+					t.Fatalf("encode: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			c := testClient(srv.URL, "test-key")
+			if _, err := c.ListResources(context.Background(), ListResourcesInput{Limit: tc.inLimit}); err != nil {
+				t.Fatalf("ListResources: %v", err)
+			}
+		})
+	}
+}
+
 // TestCreatePathIsPlural pins the canonical /v1/qurls path as a named
 // regression assertion. TestCreate already asserts the path generically
 // at line 57; the value of this test is the explicit name — any future


### PR DESCRIPTION
## Summary

Rebased onto current main (post-#233/#447/#454). The net delta of #234's intended work on top of what's now in main:

### 1. `/qurl list` resource pivot

Pivots from "5 most recent qURLs" to "10 most recent qURL Resources" so each line is a copy-paste-ready `$<alias>` (when bound) or `$<resource_id>` token. Closes the ergonomic gap between list output and `/qurl get` input.

- New: `handleListResources` / `processListResources` (`apps/slack/internal/handler_list.go`).
- Admins see the master list unfiltered; non-admins see resources whose `resource_id` is in **`Store.AllowedResourceIDsForChannel`** — the union of `alias_bindings.values()` and `allowed_resource_ids` on the channel's `channel_policies` row.
- Fail-closed posture on non-admin + empty channel_id and non-admin + policy-fetch failure.
- New: `shared/client.Client.ListResources` (paginated `GET /v1/resources`) with a server-max (100) client-side clamp.
- New: `slackdata.Store.AllowedResourceIDsForChannel` (single-row GetItem; union of SS + Map values).

### 2. `$r_<id>` fallback on `/qurl get`

The parser now accepts the resource-ID shape `$r_<11 base64url chars>` after the `$` sigil (mirrors `qurl-service/internal/domain/qurl.go::resourceIDPattern`). Handlers route on `Command.Resource.Kind`.

- New: `ResourceTokenKind` discriminator, `ParsedResourceToken` struct, `Command.Resource` field, `resourceIDPattern` regex, `requireResourceToken` helper. `Command.Alias` stays populated on the alias branch for back-compat with existing read sites.
- `parseGet` continues to accept URL form (from #447) and `$<alias>` form (existing) — the new `$r_<id>` form is the third branch.
- `handler_get.go::getWork` resource-ID branch:
  - **Workspace admins** bypass the channel allow-set (matches their unfiltered `/qurl list` view — keeps the list footer's copy-paste promise working for them).
  - **Non-admins** must have the ID in `AllowedResourceIDsForChannel(team, channel)`; missing → `is not allowed in this channel` copy + `/qurl list` self-serve pointer + admin contact path.
  - AdminStore-nil sandbox path fails closed.
  - On post-rebase main, mints route to `POST /v1/resources/{id}/qurls` per #454 — no resource-id in the request body.

## Test plan

- [x] `go test ./apps/slack/... ./shared/client/...` clean
- [x] `golangci-lint run --new-from-rev=origin/main` clean (0 new issues)
- [x] `pre-commit run --files …` clean
- [x] Tests added:
  - `TestHandleGet_DollarResourceIDAllowedSet` — non-admin happy path through resource-scoped mint endpoint
  - `TestHandleGet_DollarResourceIDNotInAllowedSetNonAdmin` — non-admin deny copy + `/qurl list` pointer + mint not reached
  - `TestHandleGet_DollarResourceIDAdminBypassesAllowedSet` — admin asymmetry resolution
  - `TestHandleGet_DollarResourceIDAdminStoreNil` — fail-closed on no-DDB sandbox
  - `TestRequireResourceToken_PositiveShapes` — kind-tag discriminator unit test
  - 5 parser error-path rows for the resource-ID shape boundary (10/11/12 char, uppercase, `$` in body)
  - `TestListResourcesLimitClamp` — client-side server-max clamp
  - 17 list tests for admin / non-admin / pagination / tunnel / empty-state / fail-closed paths
- [ ] Manual sandbox verification after redeploy:
  - `/qurl-sandbox list` → resource list with `$<alias>` and `$r_<id>` tokens
  - `/qurl-sandbox get $r_<id>` for an allowed resource → minted
  - `/qurl-sandbox get $r_<id>` for a non-allowed resource (non-admin) → "not allowed in this channel"
  - `/qurl-sandbox get $r_<id>` for a non-allowed resource (admin) → minted (bypass)

## Dependencies

None — #233, #228, #347, #226, #431, #447, #454 all landed in main during the review cycle, and this PR's diff is the actual net work that remained after they merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)