### PR TITLE
feat(discord): self-destruct timer in /qurl send

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -19,7 +19,13 @@ const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
 const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, AUDIT_EVENTS } = require('./constants');
-const { expiryToISO, expiryToMs, parseSelfDestructSeconds } = require('./utils/time');
+const {
+  expiryToISO,
+  expiryToMs,
+  parseSelfDestructSeconds,
+  formatSelfDestructLabel,
+  SELF_DESTRUCT_OPTIONS_TEXT,
+} = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
@@ -55,20 +61,6 @@ let _warnedStateSecretFallback = false;
 // on every process start; tests that need a stable secret should set
 // OAUTH_STATE_SECRET explicitly in their own mocks.
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
-// formatSelfDestructLabel renders a seconds value as a compact button
-// label fragment — `0.5s`, `30s`, `1m`, `5m`, `1h`. Avoids `30 seconds`
-// because Discord buttons truncate aggressively and pixel budget on the
-// 2-button row is tight when paired with the personal-note button.
-function formatSelfDestructLabel(seconds) {
-  if (seconds < 60) return `${seconds}s`;
-  if (seconds < 3600) {
-    const m = seconds / 60;
-    return Number.isInteger(m) ? `${m}m` : `${m.toFixed(1)}m`;
-  }
-  const h = seconds / 3600;
-  return Number.isInteger(h) ? `${h}h` : `${h.toFixed(1)}h`;
-}
-
 function stateSecret() {
   // Prefer a dedicated OAUTH_STATE_SECRET so a compromised GITHUB_CLIENT_SECRET
   // can be rotated without also invalidating in-flight OAuth state tokens —
@@ -1267,8 +1259,9 @@ async function handleSend(interaction, apiKey) {
   let recipients = [];
   let personalMessage = null;
   let expiresIn = '24h';
-  // Self-destruct timer (seconds, 0.5–3600). null = no timer (default).
-  // Forwarded to the connector as `viewer_ttl_seconds` at upload time.
+  // Self-destruct timer — one of SELF_DESTRUCT_PRESETS in seconds, or null
+  // for no timer (default). Forwarded to the connector as
+  // `viewer_ttl_seconds` at upload time.
   let selfDestructSeconds = null;
 
   const formId = `qurl_form_${sendNonce}`;
@@ -1563,11 +1556,13 @@ async function handleSend(interaction, apiKey) {
     }
 
     if (compInt.customId === ids.selfDestructBtn) {
-      // Modal collects an optional self-destruct timer (seconds).
-      // Empty submit = no timer (also the way users clear an existing
-      // value). parseSelfDestructSeconds enforces 0.5–3600 mirror of
-      // the connector contract; on validation failure we re-render the
-      // form with an inline warning rather than rejecting the modal.
+      // Modal collects an optional self-destruct timer. Choices come from
+      // SELF_DESTRUCT_PRESETS — Discord modals are TextInput-only (no native
+      // dropdown nested in a modal), so the placeholder lists the 7 options
+      // and parseSelfDestructSeconds enforces preset membership. Empty
+      // submit = no timer (also the way users clear an existing value).
+      // On validation failure we re-render the form with an inline warning
+      // so the user keeps their other selections.
       const destructInputId = 'destruct_value';
       const destructModal = new ModalBuilder()
         .setCustomId(selfDestructModalId)
@@ -1575,12 +1570,12 @@ async function handleSend(interaction, apiKey) {
       destructModal.addComponents(new ActionRowBuilder().addComponents(
         new TextInputBuilder()
           .setCustomId(destructInputId)
-          .setLabel('Seconds before content vanishes (0.5–3600)')
-          .setPlaceholder('e.g. 30 (or leave blank for no timer)')
+          .setLabel('Pick a duration (blank = no timer)')
+          .setPlaceholder(SELF_DESTRUCT_OPTIONS_TEXT)
           .setStyle(TextInputStyle.Short)
           .setMaxLength(32)
           .setRequired(false)
-          .setValue(selfDestructSeconds ? String(selfDestructSeconds) : '')
+          .setValue(selfDestructSeconds ? formatSelfDestructLabel(selfDestructSeconds) : '')
       ));
       await compInt.showModal(destructModal).catch(logIgnoredDiscordErr);
 
@@ -1602,9 +1597,11 @@ async function handleSend(interaction, apiKey) {
       if (error) {
         // Inline warning on the form rather than killing the flow —
         // the user keeps their other selections and can correct the
-        // value with another click.
+        // value with another click. The parser error already carries
+        // the full option list; the modal label already advertises
+        // "blank = no timer", so no extra prompt is needed here.
         await destructSubmit.update({
-          content: formContent({ warning: `Self-destruct: ${error} Try again or leave the field blank to skip.` }),
+          content: formContent({ warning: `Self-destruct: ${error}` }),
           components: formRows(),
         }).catch(logIgnoredDiscordErr);
       } else {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1307,7 +1307,10 @@ async function handleSend(interaction, apiKey) {
       const preview = personalMessage.length > 80 ? personalMessage.slice(0, 80) + '…' : personalMessage;
       content += `\n\n_Personal message:_ "${preview}"`;
     }
-    if (selfDestructSeconds) {
+    // Same isFinite + > 0 invariant the modal prefill uses — a
+    // corrupted DDB row carrying Infinity is truthy and would otherwise
+    // surface as "_Self-destruct timer:_ (invalid)" in the form preview.
+    if (Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0) {
       content += `\n\n_Self-destruct timer:_ ${formatSelfDestructLabel(selfDestructSeconds)}`;
     }
     return content;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1307,6 +1307,9 @@ async function handleSend(interaction, apiKey) {
       const preview = personalMessage.length > 80 ? personalMessage.slice(0, 80) + '…' : personalMessage;
       content += `\n\n_Personal message:_ "${preview}"`;
     }
+    if (selfDestructSeconds) {
+      content += `\n\n_Self-destruct timer:_ ${formatSelfDestructLabel(selfDestructSeconds)}`;
+    }
     return content;
   };
 
@@ -1598,11 +1601,11 @@ async function handleSend(interaction, apiKey) {
       if (error) {
         // Inline warning on the form rather than killing the flow —
         // the user keeps their other selections and can correct the
-        // value with another click. The parser error already carries
-        // the full option list; the modal label already advertises
-        // "blank = no timer", so no extra prompt is needed here.
+        // value with another click. The parser error reads as a verb
+        // phrase ("must be one of: …") so the prefix here is just the
+        // field name, no colon-on-colon repetition.
         await destructSubmit.update({
-          content: formContent({ warning: `Self-destruct: ${error}` }),
+          content: formContent({ warning: `Self-destruct timer ${error}` }),
           components: formRows(),
         }).catch(logIgnoredDiscordErr);
       } else {
@@ -2282,6 +2285,13 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // qurl-integrations-infra#309). The collapsed event keeps UploadCount
   // = "number of fully-prepared sends" regardless of kind composition.
   const preparedKinds = [];
+  // Inherit the original send's self-destruct timer so additional
+  // recipients see the same vanish behavior. Persisted as a REAL/Number
+  // column; both stores return null when unset. Hoisted above the file/
+  // location branches because both pull the same value — the branches
+  // can both fire for a sendConfig that had both kinds, and a per-branch
+  // recompute would invite drift.
+  const inheritedDestruct = sendConfig.self_destruct_seconds ?? null;
   try {
     if (hasFile) {
       // Re-download from the stored Discord CDN URL, then upload a fresh
@@ -2315,10 +2325,6 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       let fileBuffer = null;
       const filename = sendConfig.attachment_name || 'file';
       const contentType = sendConfig.attachment_content_type || 'application/octet-stream';
-      // Inherit the original send's self-destruct timer so additional
-      // recipients see the same vanish behavior. Persisted as a REAL/
-      // Number column; sqlite returns null when unset, DDB likewise.
-      const inheritedDestruct = sendConfig.self_destruct_seconds ?? null;
 
       try {
         // Initial download+upload gives us the buffer for subsequent re-uploads.
@@ -2366,14 +2372,11 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
     if (hasLocation) {
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
-      // Same inheritance as the file branch above — keeps the timer
-      // contract uniform across resource types.
-      const inheritedDestructLoc = sendConfig.self_destruct_seconds ?? null;
-      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestructLoc);
+      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestruct);
       const expiresAt = expiryToISO(sendConfig.expires_in);
       const allLinks = await mintLinksInBatches({
         initialResourceId: firstUpload.resource_id,
-        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestructLoc),
+        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestruct),
         expiresAt,
         recipientCount: newRecipients.length,
         apiKey,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1354,7 +1354,11 @@ async function handleSend(interaction, apiKey) {
     // (the form is bumping against the 5-row max when target=user).
     // Labels are shorter than they were as solo-button rows so both
     // fit without truncation on standard widths.
-    const destructBtnLabel = selfDestructSeconds
+    // Same isFinite + > 0 invariant the modal prefill and form preview
+    // use — keeps all three render sites on a single predicate so a
+    // future caller piping a corrupted (Infinity / NaN) value through
+    // selfDestructSeconds can't render "💥 Self-destruct: (invalid) · edit".
+    const destructBtnLabel = Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0
       ? `\u{1F4A5} Self-destruct: ${formatSelfDestructLabel(selfDestructSeconds)} · edit`
       : '\u{1F4A5} Self-destruct timer (optional)';
     rows.push(new ActionRowBuilder().addComponents(

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -19,7 +19,7 @@ const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
 const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, AUDIT_EVENTS } = require('./constants');
-const { expiryToISO, expiryToMs } = require('./utils/time');
+const { expiryToISO, expiryToMs, parseSelfDestructSeconds } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
@@ -55,6 +55,20 @@ let _warnedStateSecretFallback = false;
 // on every process start; tests that need a stable secret should set
 // OAUTH_STATE_SECRET explicitly in their own mocks.
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
+// formatSelfDestructLabel renders a seconds value as a compact button
+// label fragment — `0.5s`, `30s`, `1m`, `5m`, `1h`. Avoids `30 seconds`
+// because Discord buttons truncate aggressively and pixel budget on the
+// 2-button row is tight when paired with the personal-note button.
+function formatSelfDestructLabel(seconds) {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) {
+    const m = seconds / 60;
+    return Number.isInteger(m) ? `${m}m` : `${m.toFixed(1)}m`;
+  }
+  const h = seconds / 3600;
+  return Number.isInteger(h) ? `${h}h` : `${h.toFixed(1)}h`;
+}
+
 function stateSecret() {
   // Prefer a dedicated OAUTH_STATE_SECRET so a compromised GITHUB_CLIENT_SECRET
   // can be rotated without also invalidating in-flight OAuth state tokens —
@@ -1253,6 +1267,9 @@ async function handleSend(interaction, apiKey) {
   let recipients = [];
   let personalMessage = null;
   let expiresIn = '24h';
+  // Self-destruct timer (seconds, 0.5–3600). null = no timer (default).
+  // Forwarded to the connector as `viewer_ttl_seconds` at upload time.
+  let selfDestructSeconds = null;
 
   const formId = `qurl_form_${sendNonce}`;
   // Component customIds for the form-loop filter. Every entry must be a
@@ -1264,14 +1281,16 @@ async function handleSend(interaction, apiKey) {
     targetSelect: `${formId}_target`,
     userSelect: `${formId}_user`,
     messageBtn: `${formId}_msg_btn`,
+    selfDestructBtn: `${formId}_destruct_btn`,
     expirySelect: `${formId}_expiry`,
     sendBtn: `${formId}_send`,
     cancelBtn: `${formId}_cancel`,
   };
-  // Modal customId — local to the messageBtn handler; never consumed by
-  // the form-loop filter, kept out of `ids` so Object.values(ids) doesn't
-  // grow noise.
+  // Modal customIds — local to their respective button handlers; never
+  // consumed by the form-loop filter, kept out of `ids` so
+  // Object.values(ids) doesn't grow noise.
   const messageModalId = `${formId}_msg_modal`;
+  const selfDestructModalId = `${formId}_destruct_modal`;
 
   // Sender's own filename in their own ephemeral form preview is low-blast,
   // but match the same defense the location path applies to locationName so
@@ -1330,14 +1349,22 @@ async function handleSend(interaction, apiKey) {
       ));
     }
 
+    // Two-button row: personal message + self-destruct timer. Discord
+    // allows up to 5 buttons per ActionRow; bundling these saves a row
+    // (the form is bumping against the 5-row max when target=user).
+    // Labels are shorter than they were as solo-button rows so both
+    // fit without truncation on standard widths.
+    const destructBtnLabel = selfDestructSeconds
+      ? `\u{1F4A5} Self-destruct: ${formatSelfDestructLabel(selfDestructSeconds)} · edit`
+      : '\u{1F4A5} Self-destruct timer (optional)';
     rows.push(new ActionRowBuilder().addComponents(
       new ButtonBuilder()
         .setCustomId(ids.messageBtn)
-        // Primary (blue) + a longer descriptive label so this button reads as
-        // a peer of the surrounding select dropdowns rather than a small
-        // grey afterthought. Discord doesn't let buttons match select-menu
-        // width, but a more present label closes most of the visual gap.
-        .setLabel(personalMessage ? '✏\u{FE0F} Edit personal message for recipients' : '✏\u{FE0F} Add a personal note for recipients (optional)')
+        .setLabel(personalMessage ? '✏\u{FE0F} Edit personal note' : '✏\u{FE0F} Add a personal note (optional)')
+        .setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId(ids.selfDestructBtn)
+        .setLabel(destructBtnLabel)
         .setStyle(ButtonStyle.Primary)
     ));
 
@@ -1535,6 +1562,58 @@ async function handleSend(interaction, apiKey) {
       continue;
     }
 
+    if (compInt.customId === ids.selfDestructBtn) {
+      // Modal collects an optional self-destruct timer (seconds).
+      // Empty submit = no timer (also the way users clear an existing
+      // value). parseSelfDestructSeconds enforces 0.5–3600 mirror of
+      // the connector contract; on validation failure we re-render the
+      // form with an inline warning rather than rejecting the modal.
+      const destructInputId = 'destruct_value';
+      const destructModal = new ModalBuilder()
+        .setCustomId(selfDestructModalId)
+        .setTitle('Self-destruct timer');
+      destructModal.addComponents(new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId(destructInputId)
+          .setLabel('Seconds before content vanishes (0.5–3600)')
+          .setPlaceholder('e.g. 30 (or leave blank for no timer)')
+          .setStyle(TextInputStyle.Short)
+          .setMaxLength(32)
+          .setRequired(false)
+          .setValue(selfDestructSeconds ? String(selfDestructSeconds) : '')
+      ));
+      await compInt.showModal(destructModal).catch(logIgnoredDiscordErr);
+
+      let destructSubmit;
+      try {
+        destructSubmit = await compInt.awaitModalSubmit({
+          filter: (i) => i.customId === selfDestructModalId && i.user.id === interaction.user.id,
+          time: 120000,
+        });
+      } catch {
+        // Modal timeout / close-without-submit — silent no-op (same
+        // posture as the messageBtn handler above). The form state is
+        // unchanged so re-rendering would redraw the same form.
+        continue;
+      }
+
+      const raw = destructSubmit.fields.getTextInputValue(destructInputId);
+      const { seconds, error } = parseSelfDestructSeconds(raw);
+      if (error) {
+        // Inline warning on the form rather than killing the flow —
+        // the user keeps their other selections and can correct the
+        // value with another click.
+        await destructSubmit.update({
+          content: formContent({ warning: `Self-destruct: ${error} Try again or leave the field blank to skip.` }),
+          components: formRows(),
+        }).catch(logIgnoredDiscordErr);
+      } else {
+        selfDestructSeconds = seconds; // null when raw is empty/whitespace
+        await destructSubmit.update({ content: formContent(), components: formRows() }).catch(logIgnoredDiscordErr);
+      }
+      continue;
+    }
+
     if (compInt.customId === ids.expirySelect) {
       expiresIn = compInt.values[0];
       await safeCompUpdate(compInt, { content: formContent(), components: formRows() });
@@ -1617,7 +1696,11 @@ async function handleSend(interaction, apiKey) {
       const expiresAt = expiryToISO(expiresIn);
 
       // Download once, cache the buffer for re-uploads.
-      const firstUpload = await downloadAndUpload(attachment.url, filename, attachment.contentType, apiKey);
+      // selfDestructSeconds threads through both initial upload AND every
+      // re-upload, so the bot's "Add Recipients" mints the same TTL on
+      // each new resource that gets registered (TOKENS_PER_RESOURCE
+      // exhaustion → re-upload → new connector resource).
+      const firstUpload = await downloadAndUpload(attachment.url, filename, attachment.contentType, apiKey, selfDestructSeconds);
       connectorResourceId = firstUpload.resource_id;
       // Use a holder so we can null out the reference after all re-uploads
       // finish — the subsequent link-monitor closure would otherwise pin up
@@ -1632,7 +1715,7 @@ async function handleSend(interaction, apiKey) {
       try {
         allLinks = await mintLinksInBatches({
           initialResourceId: firstUpload.resource_id,
-          reuploadFn: () => reUploadBuffer(bufHolder.buf, filename, attachment.contentType, apiKey),
+          reuploadFn: () => reUploadBuffer(bufHolder.buf, filename, attachment.contentType, apiKey, selfDestructSeconds),
           expiresAt,
           recipientCount: recipients.length,
           apiKey,
@@ -1657,13 +1740,18 @@ async function handleSend(interaction, apiKey) {
       // Location send — upload JSON payload to connector, then mint in batches
       // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
       const locPayload = { type: 'google-map', url: locationUrl, name: locationName || locationUrl };
-      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey);
+      // Note: google-map JSON resources hit the connector's render
+      // carve-out (mapEmbedTmpl/mapFallbackTmpl don't honor
+      // expire_after at view time — qurl-integrations-infra#480).
+      // We still forward selfDestructSeconds so behavior matches the
+      // contract once the carve-out is removed; today it's a no-op.
+      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds);
       connectorResourceId = firstUpload.resource_id;
 
       const expiresAt = expiryToISO(expiresIn);
       const allLinks = await mintLinksInBatches({
         initialResourceId: firstUpload.resource_id,
-        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey),
+        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds),
         expiresAt,
         recipientCount: recipients.length,
         apiKey,
@@ -1804,6 +1892,7 @@ async function handleSend(interaction, apiKey) {
       attachmentName: attachment?.name || null,
       attachmentContentType: attachment?.contentType || null,
       attachmentUrl: attachment?.url || null,
+      selfDestructSeconds,
     });
   } catch (err) {
     logger.error('saveSendConfig failed; Add Recipients will be unavailable for this send', {
@@ -2228,14 +2317,18 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       let fileBuffer = null;
       const filename = sendConfig.attachment_name || 'file';
       const contentType = sendConfig.attachment_content_type || 'application/octet-stream';
+      // Inherit the original send's self-destruct timer so additional
+      // recipients see the same vanish behavior. Persisted as a REAL/
+      // Number column; sqlite returns null when unset, DDB likewise.
+      const inheritedDestruct = sendConfig.self_destruct_seconds ?? null;
 
       try {
         // Initial download+upload gives us the buffer for subsequent re-uploads.
-        const first = await downloadAndUpload(sendConfig.attachment_url, filename, contentType, apiKey);
+        const first = await downloadAndUpload(sendConfig.attachment_url, filename, contentType, apiKey, inheritedDestruct);
         fileBuffer = first.fileBuffer;
         allLinks = await mintLinksInBatches({
           initialResourceId: first.resource_id,
-          reuploadFn: () => reUploadBuffer(fileBuffer, filename, contentType, apiKey),
+          reuploadFn: () => reUploadBuffer(fileBuffer, filename, contentType, apiKey, inheritedDestruct),
           expiresAt,
           recipientCount: newRecipients.length,
           apiKey,
@@ -2275,11 +2368,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
     if (hasLocation) {
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
-      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey);
+      // Same inheritance as the file branch above — keeps the timer
+      // contract uniform across resource types.
+      const inheritedDestructLoc = sendConfig.self_destruct_seconds ?? null;
+      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestructLoc);
       const expiresAt = expiryToISO(sendConfig.expires_in);
       const allLinks = await mintLinksInBatches({
         initialResourceId: firstUpload.resource_id,
-        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey),
+        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestructLoc),
         expiresAt,
         recipientCount: newRecipients.length,
         apiKey,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -25,6 +25,7 @@ const {
   parseSelfDestructSeconds,
   formatSelfDestructLabel,
   SELF_DESTRUCT_OPTIONS_TEXT,
+  SELF_DESTRUCT_INPUT_MAX_LENGTH,
 } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
@@ -1573,7 +1574,7 @@ async function handleSend(interaction, apiKey) {
           .setLabel('Pick a duration (blank = no timer)')
           .setPlaceholder(SELF_DESTRUCT_OPTIONS_TEXT)
           .setStyle(TextInputStyle.Short)
-          .setMaxLength(32)
+          .setMaxLength(SELF_DESTRUCT_INPUT_MAX_LENGTH)
           .setRequired(false)
           .setValue(selfDestructSeconds ? formatSelfDestructLabel(selfDestructSeconds) : '')
       ));

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1579,7 +1579,15 @@ async function handleSend(interaction, apiKey) {
           .setStyle(TextInputStyle.Short)
           .setMaxLength(SELF_DESTRUCT_INPUT_MAX_LENGTH)
           .setRequired(false)
-          .setValue(selfDestructSeconds ? formatSelfDestructLabel(selfDestructSeconds) : '')
+          // Number.isFinite + > 0 instead of truthy so a corrupted DDB row
+          // surfacing Infinity/-Infinity (truthy) doesn't prefill the
+          // modal with the literal "(invalid)" formatter fallback. Same
+          // invariant as appendViewerTtl on the connector boundary.
+          .setValue(
+            Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0
+              ? formatSelfDestructLabel(selfDestructSeconds)
+              : ''
+          )
       ));
       await compInt.showModal(destructModal).catch(logIgnoredDiscordErr);
 
@@ -1604,6 +1612,15 @@ async function handleSend(interaction, apiKey) {
         // value with another click. The parser error reads as a verb
         // phrase ("must be one of: …") so the prefix here is just the
         // field name, no colon-on-colon repetition.
+        //
+        // We deliberately DON'T stash the rejected raw input for the
+        // next modal open. Re-opening prefills from `selfDestructSeconds`
+        // (still null/previous), so the user retypes. Trade-off:
+        // preserving the raw would let them edit a typo without
+        // retyping, but it would also imply the bad value is "almost
+        // right" — when the warning explicitly says "must be one of:
+        // <list>", a clean prefill nudges the user to pick a preset
+        // exactly rather than tweak their previous wrong guess.
         await destructSubmit.update({
           content: formContent({ warning: `Self-destruct timer ${error}` }),
           components: formRows(),

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -162,7 +162,10 @@ function connectorAuthHeaders(apiKey) {
 // field name. The connector validates the value (PR #477); we forward
 // it as a string and let the connector own the contract.
 function appendViewerTtl(form, viewerTtlSeconds) {
-  if (typeof viewerTtlSeconds === 'number' && Number.isFinite(viewerTtlSeconds) && viewerTtlSeconds > 0) {
+  // Number.isFinite already filters non-numbers (Number.isFinite('30') is
+  // false), so the typeof guard would be redundant. Strict positive-finite
+  // is the same invariant the modal-prefill setValue uses.
+  if (Number.isFinite(viewerTtlSeconds) && viewerTtlSeconds > 0) {
     form.append('viewer_ttl_seconds', String(viewerTtlSeconds));
   }
 }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -147,6 +147,17 @@ function isAllowedSourceUrl(sourceUrl) {
  * Build auth headers for connector requests.
  * Uses the provided API key, or falls back to the global config key.
  */
+// Append `viewer_ttl_seconds` to the multipart form when a positive value
+// is provided. Centralized so all four upload paths (file initial,
+// re-upload, file via Discord CDN download, JSON) thread the same wire
+// field name. The connector validates the value (PR #477); we forward
+// it as a string and let the connector own the contract.
+function appendViewerTtl(form, viewerTtlSeconds) {
+  if (typeof viewerTtlSeconds === 'number' && Number.isFinite(viewerTtlSeconds) && viewerTtlSeconds > 0) {
+    form.append('viewer_ttl_seconds', String(viewerTtlSeconds));
+  }
+}
+
 function connectorAuthHeaders(apiKey) {
   const key = apiKey || config.QURL_API_KEY;
   const headers = {};
@@ -166,7 +177,7 @@ function connectorAuthHeaders(apiKey) {
  * tests/connector-coverage.test.js and tests/qurl-send.test.js, and those
  * cases would lose coverage if it were removed.
  */
-async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
+async function uploadToConnector(sourceUrl, filename, contentType, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!isAllowedSourceUrl(sourceUrl)) {
@@ -195,6 +206,7 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
 
   const form = new FormData();
   form.append('file', blob, filename);
+  appendViewerTtl(form, viewerTtlSeconds);
 
   const uploadResponse = await fetch(`${config.CONNECTOR_URL}/api/upload`, {
     method: 'POST',
@@ -231,13 +243,14 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey) {
  * re-downloading from Discord CDN. Used when the per-resource token
  * quota (10) is exhausted and more recipients need links.
  */
-async function reUploadBuffer(fileBuffer, filename, contentType, apiKey) {
+async function reUploadBuffer(fileBuffer, filename, contentType, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
 
   const blob = new Blob([fileBuffer], { type: contentType || 'application/octet-stream' });
   const form = new FormData();
   form.append('file', blob, filename);
+  appendViewerTtl(form, viewerTtlSeconds);
 
   const uploadResponse = await fetch(`${config.CONNECTOR_URL}/api/upload`, {
     method: 'POST',
@@ -270,7 +283,7 @@ async function reUploadBuffer(fileBuffer, filename, contentType, apiKey) {
  * Download a file from Discord CDN and return the buffer + upload result.
  * The buffer is cached so subsequent re-uploads don't re-download.
  */
-async function downloadAndUpload(sourceUrl, filename, contentType, apiKey) {
+async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
   if (!isAllowedSourceUrl(sourceUrl)) {
     throw new Error('Source URL is not a valid Discord CDN URL');
@@ -294,7 +307,7 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey) {
   }
 
   const fileBuffer = await readBodyWithCap(downloadResponse, MAX_FILE_SIZE);
-  const result = await reUploadBuffer(fileBuffer, filename, contentType, apiKey);
+  const result = await reUploadBuffer(fileBuffer, filename, contentType, apiKey, viewerTtlSeconds);
   return { ...result, fileBuffer };
 }
 
@@ -346,13 +359,14 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
  * Upload a JSON object to the connector as a file.
  * Used for structured payloads like location data.
  */
-async function uploadJsonToConnector(jsonPayload, filename, apiKey) {
+async function uploadJsonToConnector(jsonPayload, filename, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
 
   const blob = new Blob([JSON.stringify(jsonPayload)], { type: 'application/json' });
   const form = new FormData();
   form.append('file', blob, filename);
+  appendViewerTtl(form, viewerTtlSeconds);
 
   const uploadResponse = await fetch(`${config.CONNECTOR_URL}/api/upload`, {
     method: 'POST',

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -147,6 +147,15 @@ function isAllowedSourceUrl(sourceUrl) {
  * Build auth headers for connector requests.
  * Uses the provided API key, or falls back to the global config key.
  */
+function connectorAuthHeaders(apiKey) {
+  const key = apiKey || config.QURL_API_KEY;
+  const headers = {};
+  if (key) {
+    headers['Authorization'] = `Bearer ${key}`;
+  }
+  return headers;
+}
+
 // Append `viewer_ttl_seconds` to the multipart form when a positive value
 // is provided. Centralized so all four upload paths (file initial,
 // re-upload, file via Discord CDN download, JSON) thread the same wire
@@ -156,15 +165,6 @@ function appendViewerTtl(form, viewerTtlSeconds) {
   if (typeof viewerTtlSeconds === 'number' && Number.isFinite(viewerTtlSeconds) && viewerTtlSeconds > 0) {
     form.append('viewer_ttl_seconds', String(viewerTtlSeconds));
   }
-}
-
-function connectorAuthHeaders(apiKey) {
-  const key = apiKey || config.QURL_API_KEY;
-  const headers = {};
-  if (key) {
-    headers['Authorization'] = `Bearer ${key}`;
-  }
-  return headers;
 }
 
 /**

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -162,10 +162,12 @@ const SAFE_ALTERS = {
   // revocable. Used to hide already-revoked sends from the /qurl revoke
   // dropdown so users don't re-select a no-op and see "0/0 links revoked".
   revoked_at: 'ALTER TABLE qurl_send_configs ADD COLUMN revoked_at TEXT',
-  // Self-destruct timer (seconds, 0.5–3600) — forwarded to the connector
-  // as `viewer_ttl_seconds` so the rendered viewer page wipes content
-  // after N seconds. NULL ⇒ no timer (default). Persisted so the Add
-  // Recipients flow inherits the timer the original send chose.
+  // Self-destruct timer (seconds) — one of the SELF_DESTRUCT_PRESETS the
+  // user picked in the /qurl send modal, forwarded to the connector as
+  // `viewer_ttl_seconds` so the rendered viewer page wipes content after
+  // N seconds. REAL because the smallest preset is 0.5. NULL ⇒ no timer
+  // (default). Persisted so the Add Recipients flow inherits the timer
+  // the original send chose.
   self_destruct_seconds: 'ALTER TABLE qurl_send_configs ADD COLUMN self_destruct_seconds REAL',
 };
 for (const [col, sql] of Object.entries(SAFE_ALTERS)) {

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -124,6 +124,7 @@ db.exec(`
     attachment_name TEXT,
     attachment_content_type TEXT,
     attachment_url TEXT,
+    self_destruct_seconds REAL,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP
   );
 
@@ -161,6 +162,11 @@ const SAFE_ALTERS = {
   // revocable. Used to hide already-revoked sends from the /qurl revoke
   // dropdown so users don't re-select a no-op and see "0/0 links revoked".
   revoked_at: 'ALTER TABLE qurl_send_configs ADD COLUMN revoked_at TEXT',
+  // Self-destruct timer (seconds, 0.5–3600) — forwarded to the connector
+  // as `viewer_ttl_seconds` so the rendered viewer page wipes content
+  // after N seconds. NULL ⇒ no timer (default). Persisted so the Add
+  // Recipients flow inherits the timer the original send chose.
+  self_destruct_seconds: 'ALTER TABLE qurl_send_configs ADD COLUMN self_destruct_seconds REAL',
 };
 for (const [col, sql] of Object.entries(SAFE_ALTERS)) {
   try {
@@ -778,16 +784,16 @@ const dbModule = {
     insertStmt.run(sendId, senderDiscordId, legacy.resource_type, legacy.expires_in || '24h');
   },
 
-  saveSendConfig({ sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl, expiresIn, personalMessage, locationName, attachmentName, attachmentContentType, attachmentUrl }) {
+  saveSendConfig({ sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl, expiresIn, personalMessage, locationName, attachmentName, attachmentContentType, attachmentUrl, selfDestructSeconds }) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO qurl_send_configs (send_id, sender_discord_id, resource_type, connector_resource_id, actual_url, expires_in, personal_message, location_name, attachment_name, attachment_content_type, attachment_url)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO qurl_send_configs (send_id, sender_discord_id, resource_type, connector_resource_id, actual_url, expires_in, personal_message, location_name, attachment_name, attachment_content_type, attachment_url, self_destruct_seconds)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     // Encrypt the Discord CDN URL at rest for consistency with the other
     // secrets in this table. Discord signs these URLs with a short TTL, but
     // an EFS leak inside the window could still be used to re-fetch the file.
     const encryptedUrl = attachmentUrl ? encrypt(attachmentUrl) : null;
-    stmt.run(sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl, expiresIn, personalMessage, locationName, attachmentName, attachmentContentType ?? null, encryptedUrl);
+    stmt.run(sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl, expiresIn, personalMessage, locationName, attachmentName, attachmentContentType ?? null, encryptedUrl, selfDestructSeconds ?? null);
   },
 
   getSendConfig(sendId, senderDiscordId) {

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1245,7 +1245,7 @@ async function markSendRevoked(sendId, senderDiscordId) {
 async function saveSendConfig({
   sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl,
   expiresIn, personalMessage, locationName, attachmentName,
-  attachmentContentType, attachmentUrl,
+  attachmentContentType, attachmentUrl, selfDestructSeconds,
 }) {
   const encryptedUrl = attachmentUrl ? encrypt(attachmentUrl) : null;
   await ddb.send(new PutCommand({
@@ -1262,6 +1262,7 @@ async function saveSendConfig({
       attachment_name: attachmentName,
       attachment_content_type: attachmentContentType ?? null,
       attachment_url: encryptedUrl,
+      self_destruct_seconds: selfDestructSeconds ?? null,
       created_at: nowIso(),
     },
   }));

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -61,9 +61,12 @@ const SELF_DESTRUCT_INPUT_MAX_LENGTH = 32;
 
 // Strict decimal-seconds shape — gates the numeric branch of the parser
 // so hex (`0x1`, `0x1e`) and scientific notation (`5e-1`) can't coerce
-// through Number() into a preset value. Optional sign + digits + optional
-// fractional part. See parseSelfDestructSeconds for the rationale.
-const DECIMAL_SECONDS_RE = /^[+-]?\d+(\.\d+)?$/;
+// through Number() into a preset value. Bare digits + optional fractional
+// part. No leading sign: every preset is positive, the placeholder reads
+// "0.5" not "+0.5", and a "-" prefix is meaningfully an error (the user
+// asked for a negative duration). See parseSelfDestructSeconds for the
+// full rationale.
+const DECIMAL_SECONDS_RE = /^\d+(\.\d+)?$/;
 
 function canonicalize(s) {
   return String(s).toLowerCase().replace(/\s+/g, ' ').trim();

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -80,7 +80,10 @@ function findPresetByLabel(canonical) {
 }
 
 function findPresetBySeconds(n) {
-  if (!Number.isFinite(n)) return null;
+  // No explicit isFinite guard — NaN is never === anything, so the loop
+  // returns null naturally for it. ±Infinity also fails the equality
+  // check against every (finite) preset. formatSelfDestructLabel does
+  // its own non-finite handling for the "(invalid)" fallback.
   for (const preset of SELF_DESTRUCT_PRESETS) {
     if (n === preset.seconds) return preset;
   }

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -72,11 +72,14 @@ function canonicalize(s) {
   return String(s).toLowerCase().replace(/\s+/g, ' ').trim();
 }
 
+// Pre-canonicalized preset labels so findPresetByLabel doesn't re-canonicalize
+// constant strings on every parse. Same length and order as
+// SELF_DESTRUCT_PRESETS (parallel arrays).
+const SELF_DESTRUCT_CANONICAL_LABELS = SELF_DESTRUCT_PRESETS.map((p) => canonicalize(p.label));
+
 function findPresetByLabel(canonical) {
-  for (const preset of SELF_DESTRUCT_PRESETS) {
-    if (canonical === canonicalize(preset.label)) return preset;
-  }
-  return null;
+  const idx = SELF_DESTRUCT_CANONICAL_LABELS.indexOf(canonical);
+  return idx === -1 ? null : SELF_DESTRUCT_PRESETS[idx];
 }
 
 function findPresetBySeconds(n) {

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -29,4 +29,50 @@ function expiryToMs(expiresIn) {
   return ms === null ? DEFAULT_EXPIRY_MS : ms;
 }
 
-module.exports = { expiryToISO, expiryToMs };
+// Self-destruct timer parsing — bot-side validation that mirrors the
+// connector's `viewer_ttl_seconds` contract (qurl-s3-connector PR #477):
+// 0.5 to 3600 seconds, fractional accepted. Out-of-range / NaN / Inf /
+// non-numeric all map to a parse error so the caller can render an
+// inline modal validation message rather than silently dropping the value.
+//
+// Internally named "self-destruct" (matches the user-facing modal label).
+// The wire field forwarded to the connector is `viewer_ttl_seconds`.
+const SELF_DESTRUCT_MIN_SECONDS = 0.5;
+const SELF_DESTRUCT_MAX_SECONDS = 3600;
+
+function parseSelfDestructSeconds(raw) {
+  const trimmed = String(raw ?? '').trim();
+  if (trimmed === '') return { seconds: null, error: null };
+  // Length cap mirrors the connector — bounds CPU on hostile input
+  // before parseFloat. Max legal `"3600.0"` is 6 chars; 32 is generous.
+  if (trimmed.length > 32) {
+    return { seconds: null, error: 'Value is too long.' };
+  }
+  // strconv.ParseFloat accepts hex-float (`0x1p3`) per Go spec; the
+  // connector rejects it (PR #477). JS Number() does NOT accept hex
+  // floats, but reject the prefix explicitly so the bot's contract
+  // mirrors the connector's whether or not Number() is the parser.
+  const prefix = trimmed.replace(/^[+-]/, '');
+  if (/^0x/i.test(prefix)) {
+    return { seconds: null, error: 'Use a decimal number, not hex.' };
+  }
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0) {
+    return { seconds: null, error: 'Enter a positive number of seconds.' };
+  }
+  if (n < SELF_DESTRUCT_MIN_SECONDS) {
+    return { seconds: null, error: `Minimum is ${SELF_DESTRUCT_MIN_SECONDS} seconds.` };
+  }
+  // Above-max is intentionally clamped (matches connector's silent clamp).
+  // Returning the clamped value keeps the persisted state honest with
+  // what the renderer will actually enforce.
+  return { seconds: Math.min(n, SELF_DESTRUCT_MAX_SECONDS), error: null };
+}
+
+module.exports = {
+  expiryToISO,
+  expiryToMs,
+  parseSelfDestructSeconds,
+  SELF_DESTRUCT_MIN_SECONDS,
+  SELF_DESTRUCT_MAX_SECONDS,
+};

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -29,50 +29,106 @@ function expiryToMs(expiresIn) {
   return ms === null ? DEFAULT_EXPIRY_MS : ms;
 }
 
-// Self-destruct timer parsing — bot-side validation that mirrors the
-// connector's `viewer_ttl_seconds` contract (qurl-s3-connector PR #477):
-// 0.5 to 3600 seconds, fractional accepted. Out-of-range / NaN / Inf /
-// non-numeric all map to a parse error so the caller can render an
-// inline modal validation message rather than silently dropping the value.
+// Self-destruct timer presets — the 7 durations exposed in the /qurl send
+// modal. Discord modals are TextInput-only, so we surface the choices in
+// the placeholder and accept either the friendly label or the seconds
+// value below. The set is intentionally narrow so creators don't ship a
+// 0.7s viewer that hits the 500ms-floor edge case in the connector by
+// accident — every preset is a value we'd recommend out loud.
 //
-// Internally named "self-destruct" (matches the user-facing modal label).
-// The wire field forwarded to the connector is `viewer_ttl_seconds`.
-const SELF_DESTRUCT_MIN_SECONDS = 0.5;
-const SELF_DESTRUCT_MAX_SECONDS = 3600;
+// The wire field forwarded to the connector is `viewer_ttl_seconds`
+// (qurl-s3-connector PR #477). Connector contract is 0.5–3600 inclusive,
+// so every preset here is in range; clamping is unreachable.
+const SELF_DESTRUCT_PRESETS = Object.freeze([
+  Object.freeze({ seconds: 0.5, label: '1/2 second' }),
+  Object.freeze({ seconds: 1, label: '1 second' }),
+  Object.freeze({ seconds: 5, label: '5 seconds' }),
+  Object.freeze({ seconds: 30, label: '30 seconds' }),
+  Object.freeze({ seconds: 300, label: '5 minutes' }),
+  Object.freeze({ seconds: 1800, label: '30 minutes' }),
+  Object.freeze({ seconds: 3600, label: '1 hour' }),
+]);
 
+const SELF_DESTRUCT_MIN_SECONDS = SELF_DESTRUCT_PRESETS[0].seconds;
+const SELF_DESTRUCT_MAX_SECONDS = SELF_DESTRUCT_PRESETS[SELF_DESTRUCT_PRESETS.length - 1].seconds;
+
+const SELF_DESTRUCT_OPTIONS_TEXT = SELF_DESTRUCT_PRESETS.map((p) => p.label).join(', ');
+
+function canonicalize(s) {
+  return String(s).toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function findPresetByLabel(canonical) {
+  for (const preset of SELF_DESTRUCT_PRESETS) {
+    if (canonical === canonicalize(preset.label)) return preset;
+  }
+  return null;
+}
+
+function findPresetBySeconds(n) {
+  if (!Number.isFinite(n)) return null;
+  for (const preset of SELF_DESTRUCT_PRESETS) {
+    if (n === preset.seconds) return preset;
+  }
+  return null;
+}
+
+// parseSelfDestructSeconds — strict preset matcher used by the modal handler
+// in /qurl send. Empty / whitespace-only input means "no timer" (returns
+// {seconds: null, error: null}). Any other input that does not match one
+// of the 7 presets returns an error string with the full option list so
+// the modal handler renders an inline retry, not a hard rejection.
+//
+// Accepted forms (case-insensitive, internal whitespace tolerated):
+//   - the friendly label: "1/2 second", "5 minutes", "1 hour", ...
+//   - the raw seconds value: "0.5", "30", "300", ...
 function parseSelfDestructSeconds(raw) {
   const trimmed = String(raw ?? '').trim();
   if (trimmed === '') return { seconds: null, error: null };
-  // Length cap mirrors the connector — bounds CPU on hostile input
-  // before parseFloat. Max legal `"3600.0"` is 6 chars; 32 is generous.
+  // Length cap bounds CPU on hostile input before any parse.
+  // Longest legal label "30 minutes" + slack = 32 chars is plenty.
   if (trimmed.length > 32) {
     return { seconds: null, error: 'Value is too long.' };
   }
-  // strconv.ParseFloat accepts hex-float (`0x1p3`) per Go spec; the
-  // connector rejects it (PR #477). JS Number() does NOT accept hex
-  // floats, but reject the prefix explicitly so the bot's contract
-  // mirrors the connector's whether or not Number() is the parser.
-  const prefix = trimmed.replace(/^[+-]/, '');
-  if (/^0x/i.test(prefix)) {
-    return { seconds: null, error: 'Use a decimal number, not hex.' };
-  }
-  const n = Number(trimmed);
-  if (!Number.isFinite(n) || n <= 0) {
-    return { seconds: null, error: 'Enter a positive number of seconds.' };
-  }
-  if (n < SELF_DESTRUCT_MIN_SECONDS) {
-    return { seconds: null, error: `Minimum is ${SELF_DESTRUCT_MIN_SECONDS} seconds.` };
-  }
-  // Above-max is intentionally clamped (matches connector's silent clamp).
-  // Returning the clamped value keeps the persisted state honest with
-  // what the renderer will actually enforce.
-  return { seconds: Math.min(n, SELF_DESTRUCT_MAX_SECONDS), error: null };
+
+  const canonical = canonicalize(trimmed);
+
+  const labelMatch = findPresetByLabel(canonical);
+  if (labelMatch) return { seconds: labelMatch.seconds, error: null };
+
+  // Number() accepts whitespace and signs but not hex floats.
+  // No need to special-case hex: a hex literal like "0x1p3" would be
+  // rejected by both Number() AND the preset-membership check that
+  // follows — so the broad rejection error message covers it.
+  const n = Number(canonical);
+  const numericMatch = findPresetBySeconds(n);
+  if (numericMatch) return { seconds: numericMatch.seconds, error: null };
+
+  return {
+    seconds: null,
+    error: `Choose one of: ${SELF_DESTRUCT_OPTIONS_TEXT}.`,
+  };
+}
+
+// formatSelfDestructLabel — renders a stored seconds value as the matching
+// preset's friendly label (e.g., 0.5 → "1/2 second"). Used by the form to
+// echo what the user picked. Falls back to a compact "Ns" rendering for
+// any seconds value that isn't a known preset, which is unreachable today
+// but defends against a future caller (e.g., a backfilled config) feeding
+// in an off-preset value.
+function formatSelfDestructLabel(seconds) {
+  const match = findPresetBySeconds(seconds);
+  if (match) return match.label;
+  return `${seconds}s`;
 }
 
 module.exports = {
   expiryToISO,
   expiryToMs,
   parseSelfDestructSeconds,
+  formatSelfDestructLabel,
+  SELF_DESTRUCT_PRESETS,
   SELF_DESTRUCT_MIN_SECONDS,
   SELF_DESTRUCT_MAX_SECONDS,
+  SELF_DESTRUCT_OPTIONS_TEXT,
 };

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -59,6 +59,12 @@ const SELF_DESTRUCT_OPTIONS_TEXT = SELF_DESTRUCT_PRESETS.map((p) => p.label).joi
 // has to defend against strings the modal would have rejected.
 const SELF_DESTRUCT_INPUT_MAX_LENGTH = 32;
 
+// Strict decimal-seconds shape — gates the numeric branch of the parser
+// so hex (`0x1`, `0x1e`) and scientific notation (`5e-1`) can't coerce
+// through Number() into a preset value. Optional sign + digits + optional
+// fractional part. See parseSelfDestructSeconds for the rationale.
+const DECIMAL_SECONDS_RE = /^[+-]?\d+(\.\d+)?$/;
+
 function canonicalize(s) {
   return String(s).toLowerCase().replace(/\s+/g, ' ').trim();
 }
@@ -103,13 +109,15 @@ function parseSelfDestructSeconds(raw) {
   const labelMatch = findPresetByLabel(canonical);
   if (labelMatch) return { seconds: labelMatch.seconds, error: null };
 
-  // Number() accepts whitespace and signs but not hex floats.
-  // No need to special-case hex: a hex literal like "0x1p3" would be
-  // rejected by both Number() AND the preset-membership check that
-  // follows — so the broad rejection error message covers it.
-  const n = Number(canonical);
-  const numericMatch = findPresetBySeconds(n);
-  if (numericMatch) return { seconds: numericMatch.seconds, error: null };
+  // Strict decimal notation only — Number() also accepts hex integers
+  // (`0x1` → 1, `0x1e` → 30, `0x12c` → 300) and scientific notation
+  // (`5e-1` → 0.5), all of which would silently coerce into preset
+  // values and bypass the user-visible label set. The placeholder
+  // advertises decimal seconds; honor that exactly.
+  if (DECIMAL_SECONDS_RE.test(canonical)) {
+    const numericMatch = findPresetBySeconds(Number(canonical));
+    if (numericMatch) return { seconds: numericMatch.seconds, error: null };
+  }
 
   return {
     seconds: null,

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -54,6 +54,11 @@ const SELF_DESTRUCT_MAX_SECONDS = SELF_DESTRUCT_PRESETS[SELF_DESTRUCT_PRESETS.le
 
 const SELF_DESTRUCT_OPTIONS_TEXT = SELF_DESTRUCT_PRESETS.map((p) => p.label).join(', ');
 
+// Single source of truth for the modal's setMaxLength + the parser's
+// length cap — both bound the input the same way so the parser never
+// has to defend against strings the modal would have rejected.
+const SELF_DESTRUCT_INPUT_MAX_LENGTH = 32;
+
 function canonicalize(s) {
   return String(s).toLowerCase().replace(/\s+/g, ' ').trim();
 }
@@ -85,9 +90,11 @@ function findPresetBySeconds(n) {
 function parseSelfDestructSeconds(raw) {
   const trimmed = String(raw ?? '').trim();
   if (trimmed === '') return { seconds: null, error: null };
-  // Length cap bounds CPU on hostile input before any parse.
-  // Longest legal label "30 minutes" + slack = 32 chars is plenty.
-  if (trimmed.length > 32) {
+  // Length cap bounds CPU on hostile input before any parse. The modal
+  // already enforces SELF_DESTRUCT_INPUT_MAX_LENGTH via setMaxLength, so
+  // a string longer than this is either an upstream caller misuse or a
+  // forged interaction — fail loud.
+  if (trimmed.length > SELF_DESTRUCT_INPUT_MAX_LENGTH) {
     return { seconds: null, error: 'Value is too long.' };
   }
 
@@ -131,4 +138,5 @@ module.exports = {
   SELF_DESTRUCT_MIN_SECONDS,
   SELF_DESTRUCT_MAX_SECONDS,
   SELF_DESTRUCT_OPTIONS_TEXT,
+  SELF_DESTRUCT_INPUT_MAX_LENGTH,
 };

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -99,9 +99,13 @@ function parseSelfDestructSeconds(raw) {
   // Length cap bounds CPU on hostile input before any parse. The modal
   // already enforces SELF_DESTRUCT_INPUT_MAX_LENGTH via setMaxLength, so
   // a string longer than this is either an upstream caller misuse or a
-  // forged interaction — fail loud.
+  // forged interaction — fail loud, but include the limit so anyone
+  // looking at the rendered warning has the constraint in front of them.
   if (trimmed.length > SELF_DESTRUCT_INPUT_MAX_LENGTH) {
-    return { seconds: null, error: 'Value is too long.' };
+    return {
+      seconds: null,
+      error: `is too long (max ${SELF_DESTRUCT_INPUT_MAX_LENGTH} characters).`,
+    };
   }
 
   const canonical = canonicalize(trimmed);
@@ -121,19 +125,21 @@ function parseSelfDestructSeconds(raw) {
 
   return {
     seconds: null,
-    error: `Choose one of: ${SELF_DESTRUCT_OPTIONS_TEXT}.`,
+    error: `must be one of: ${SELF_DESTRUCT_OPTIONS_TEXT}.`,
   };
 }
 
 // formatSelfDestructLabel — renders a stored seconds value as the matching
 // preset's friendly label (e.g., 0.5 → "1/2 second"). Used by the form to
 // echo what the user picked. Falls back to a compact "Ns" rendering for
-// any seconds value that isn't a known preset, which is unreachable today
-// but defends against a future caller (e.g., a backfilled config) feeding
-// in an off-preset value.
+// any finite off-preset value (unreachable through the modal today but
+// defends against a backfilled config). Non-finite (NaN/Infinity) returns
+// "(invalid)" so a corrupted DB row doesn't surface as the literal string
+// "NaNs" / "Infinitys" in the button label or modal prefill.
 function formatSelfDestructLabel(seconds) {
   const match = findPresetBySeconds(seconds);
   if (match) return match.label;
+  if (!Number.isFinite(seconds)) return '(invalid)';
   return `${seconds}s`;
 }
 

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -113,6 +113,108 @@ describe('Connector client — coverage boost', () => {
     });
   });
 
+  describe('viewer_ttl_seconds field forwarding', () => {
+    // Each upload entry-point must thread viewerTtlSeconds onto the
+    // multipart body when the caller passes a positive number, and
+    // omit the field entirely otherwise. Pinning all four paths so a
+    // future entry-point that forgets `appendViewerTtl` gets caught.
+    function captureUploadFormFields() {
+      let formCaptured = null;
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({ // CDN download (only used by file paths)
+          ok: true,
+          headers: { get: jest.fn(() => '5') },
+          arrayBuffer: async () => new ArrayBuffer(5),
+        })
+        .mockResolvedValueOnce({ // connector /api/upload
+          ok: true,
+          json: async () => ({ success: true, hash: 'h1', resource_id: 'r1' }),
+        })
+        // Second fetch call for the no-CDN paths (re-upload, JSON) lands here.
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: 'h2', resource_id: 'r2' }),
+        });
+      // Hook the FormData append so we can see exactly what the helper sent.
+      const originalAppend = globalThis.FormData.prototype.append;
+      const appended = [];
+      globalThis.FormData.prototype.append = function (...args) {
+        appended.push({ name: args[0], valueType: typeof args[1], filename: args[2] });
+        return originalAppend.apply(this, args);
+      };
+      formCaptured = appended;
+      const restore = () => { globalThis.FormData.prototype.append = originalAppend; };
+      return { appended: formCaptured, restore };
+    }
+
+    it('uploadToConnector appends viewer_ttl_seconds when provided', async () => {
+      const { appended, restore } = captureUploadFormFields();
+      try {
+        await connector.uploadToConnector('https://cdn.discordapp.com/x.png', 'x.png', 'image/png', undefined, 30);
+      } finally { restore(); }
+      expect(appended.find(f => f.name === 'viewer_ttl_seconds')).toMatchObject({ name: 'viewer_ttl_seconds' });
+    });
+
+    it('uploadToConnector omits viewer_ttl_seconds when null/undefined', async () => {
+      const { appended, restore } = captureUploadFormFields();
+      try {
+        await connector.uploadToConnector('https://cdn.discordapp.com/x.png', 'x.png', 'image/png', undefined, null);
+      } finally { restore(); }
+      expect(appended.find(f => f.name === 'viewer_ttl_seconds')).toBeUndefined();
+    });
+
+    it('reUploadBuffer appends viewer_ttl_seconds when provided', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, hash: 'h', resource_id: 'r' }),
+      });
+      const originalAppend = globalThis.FormData.prototype.append;
+      const appended = [];
+      globalThis.FormData.prototype.append = function (...args) { appended.push({ name: args[0] }); return originalAppend.apply(this, args); };
+      try {
+        await connector.reUploadBuffer(Buffer.from('hi'), 'x.txt', 'text/plain', undefined, 0.5);
+      } finally { globalThis.FormData.prototype.append = originalAppend; }
+      expect(appended.find(f => f.name === 'viewer_ttl_seconds')).toBeDefined();
+    });
+
+    it('uploadJsonToConnector appends viewer_ttl_seconds when provided', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, hash: 'h', resource_id: 'r' }),
+      });
+      const originalAppend = globalThis.FormData.prototype.append;
+      const appended = [];
+      globalThis.FormData.prototype.append = function (...args) { appended.push({ name: args[0], value: args[1] }); return originalAppend.apply(this, args); };
+      try {
+        await connector.uploadJsonToConnector({ type: 'google-map' }, 'loc.json', undefined, 60);
+      } finally { globalThis.FormData.prototype.append = originalAppend; }
+      const ttlField = appended.find(f => f.name === 'viewer_ttl_seconds');
+      expect(ttlField).toBeDefined();
+      expect(ttlField.value).toBe('60');
+    });
+
+    it('omits viewer_ttl_seconds for non-positive / non-finite / wrong-type input', async () => {
+      // Defensive: an upstream caller passing 0, NaN, or a string by
+      // mistake shouldn't cause the field to land on the form. The
+      // parser layer (parseSelfDestructSeconds) is the contract; the
+      // append helper is belt-and-suspenders.
+      const cases = [0, -1, NaN, Infinity, '30', null, undefined, {}];
+      for (const v of cases) {
+        globalThis.fetch = jest.fn().mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: 'h', resource_id: 'r' }),
+        });
+        const originalAppend = globalThis.FormData.prototype.append;
+        const appended = [];
+        globalThis.FormData.prototype.append = function (...args) { appended.push({ name: args[0] }); return originalAppend.apply(this, args); };
+        try {
+          await connector.reUploadBuffer(Buffer.from('hi'), 'x.txt', 'text/plain', undefined, v);
+        } finally { globalThis.FormData.prototype.append = originalAppend; }
+        expect(appended.find(f => f.name === 'viewer_ttl_seconds')).toBeUndefined();
+      }
+    });
+  });
+
   describe('throwConnectorError — quota_exceeded tagging', () => {
     // The connector wraps upstream qURL API errors as
     //   { success: false, error: "QURL API error (403): quota exceeded: token limit per QURL reached (12/10)", links: [] }

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -119,7 +119,6 @@ describe('Connector client — coverage boost', () => {
     // omit the field entirely otherwise. Pinning all four paths so a
     // future entry-point that forgets `appendViewerTtl` gets caught.
     function captureUploadFormFields() {
-      let formCaptured = null;
       globalThis.fetch = jest.fn()
         .mockResolvedValueOnce({ // CDN download (only used by file paths)
           ok: true,
@@ -142,9 +141,8 @@ describe('Connector client — coverage boost', () => {
         appended.push({ name: args[0], valueType: typeof args[1], filename: args[2] });
         return originalAppend.apply(this, args);
       };
-      formCaptured = appended;
       const restore = () => { globalThis.FormData.prototype.append = originalAppend; };
-      return { appended: formCaptured, restore };
+      return { appended, restore };
     }
 
     it('uploadToConnector appends viewer_ttl_seconds when provided', async () => {

--- a/apps/discord/tests/database-module.test.js
+++ b/apps/discord/tests/database-module.test.js
@@ -300,6 +300,40 @@ describe('database module', () => {
     it('returns undefined for wrong sender', () => {
       expect(db.getSendConfig('sc1', 'wrong-sender')).toBeUndefined();
     });
+
+    it('roundtrips selfDestructSeconds (0.5–3600 range, optional)', () => {
+      // Persisted as REAL so sub-second values survive — the connector
+      // accepts fractional seconds (PR #477) and the bot must not
+      // truncate them at the storage layer. Pin both the round-trip
+      // shape AND the optional/null case so a future schema change
+      // can't silently drop the field.
+      db.saveSendConfig({
+        sendId: 'destruct-yes', senderDiscordId: 'sender1',
+        resourceType: 'file', connectorResourceId: 'conn-d1',
+        actualUrl: null, expiresIn: '1h', personalMessage: null,
+        locationName: null, attachmentName: 'snap.png',
+        selfDestructSeconds: 0.5,
+      });
+      expect(db.getSendConfig('destruct-yes', 'sender1').self_destruct_seconds).toBe(0.5);
+
+      db.saveSendConfig({
+        sendId: 'destruct-int', senderDiscordId: 'sender1',
+        resourceType: 'file', connectorResourceId: 'conn-d2',
+        actualUrl: null, expiresIn: '1h', personalMessage: null,
+        locationName: null, attachmentName: 'snap.png',
+        selfDestructSeconds: 30,
+      });
+      expect(db.getSendConfig('destruct-int', 'sender1').self_destruct_seconds).toBe(30);
+
+      db.saveSendConfig({
+        sendId: 'destruct-no', senderDiscordId: 'sender1',
+        resourceType: 'file', connectorResourceId: 'conn-d3',
+        actualUrl: null, expiresIn: '1h', personalMessage: null,
+        locationName: null, attachmentName: 'snap.png',
+        // selfDestructSeconds intentionally omitted
+      });
+      expect(db.getSendConfig('destruct-no', 'sender1').self_destruct_seconds).toBeNull();
+    });
   });
 
   describe('streak updates — consecutive months', () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -966,6 +966,27 @@ describe('qurl sends', () => {
     expect(item.attachment_name).toBe('doc.pdf');
   });
 
+  test('saveSendConfig: persists self_destruct_seconds across the preset range', async () => {
+    // Mirror of the sqlite roundtrip in database-module.test.js — pins
+    // the DDB writer for the same three cases (sub-second 0.5, integer
+    // 30, omitted-as-null) so a future refactor that drops the field
+    // from the Item silently regresses both stores in one signal.
+    ddbMock.on(PutCommand).resolves({});
+    const base = {
+      senderDiscordId: 'sender', resourceType: 'file',
+      connectorResourceId: 'conn', actualUrl: null,
+      expiresIn: '24h', personalMessage: null, locationName: null,
+      attachmentName: null, attachmentContentType: null, attachmentUrl: null,
+    };
+    await store.saveSendConfig({ ...base, sendId: 'destruct-half', selfDestructSeconds: 0.5 });
+    await store.saveSendConfig({ ...base, sendId: 'destruct-int', selfDestructSeconds: 30 });
+    await store.saveSendConfig({ ...base, sendId: 'destruct-none' /* omitted */ });
+    const items = ddbMock.commandCalls(PutCommand).map((c) => c.args[0].input.Item);
+    expect(items[0].self_destruct_seconds).toBe(0.5);
+    expect(items[1].self_destruct_seconds).toBe(30);
+    expect(items[2].self_destruct_seconds).toBeNull();
+  });
+
   test('getSendConfig: decrypts attachment_url + ownership check', async () => {
     const encryptedUrl = `enc:v1:IV:TAG:${Buffer.from('https://cdn.example/attachment').toString('hex')}`;
     ddbMock.on(GetCommand).resolves({

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -933,15 +933,16 @@ describe('handleSend — Step 3: final form', () => {
   });
 
   it('self-destruct modal: invalid value re-renders the form with a warning', async () => {
-    // "0.4" is sub-floor. The handler must NOT abort the flow; it
-    // re-renders the form with an inline warning so the user can
-    // correct the value or skip the timer entirely.
+    // "2" is not in the preset set. The handler must NOT abort the flow;
+    // it re-renders the form with an inline warning that lists the
+    // allowed options so the user can correct the value or skip the
+    // timer entirely.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
       users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
     });
     const destructBtn = makeCompInt(ids.selfDestructBtn, {
-      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('0.4')),
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('2')),
     });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({
@@ -950,10 +951,34 @@ describe('handleSend — Step 3: final form', () => {
     await cmd.execute(interaction);
     const submit = await destructBtn.awaitModalSubmit.mock.results[0].value;
     expect(submit.update).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/Self-destruct.*0\.5/),
+      content: expect.stringMatching(/Self-destruct.*1\/2 second/),
     }));
     // Subsequent cancel — back-half should not run.
     expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
+  });
+
+  it('self-destruct modal: friendly label "5 minutes" parses to 300s', async () => {
+    // The placeholder advertises the friendly label form; users typing
+    // the label exactly must be honored without falling through to the
+    // option-list error.
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('5 minutes')),
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')), targetUser, userSelect, destructBtn, sendBtn],
+    });
+    await cmd.execute(interaction);
+    expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google-map' }),
+      'location.json',
+      expect.any(String),
+      300,
+    );
   });
 
   it('self-destruct modal: empty value clears the timer (state stays null)', async () => {

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -1005,22 +1005,44 @@ describe('handleSend — Step 3: final form', () => {
     );
   });
 
-  it('self-destruct modal: empty value clears the timer (state stays null)', async () => {
-    // User clicks the button with a previously-set value, then submits
-    // empty to clear. The form re-renders with the timer button label
-    // returning to its unset state. Subsequent send carries selfDestruct=null.
+  it('self-destruct modal: empty submit AFTER a set value actually clears (not just stays null)', async () => {
+    // Two destruct-button clicks: first sets "30", second submits empty.
+    // The eventual upload call must carry null — proving the empty-submit
+    // path actively clears the previous value, rather than just being a
+    // no-op that happens to leave the trivially-already-null initial
+    // state intact.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
       users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
     });
-    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+    const destructBtnSet = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('30')),
+    });
+    const destructBtnClear = makeCompInt(ids.selfDestructBtn, {
       awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('')),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const interaction = makeInteraction({
-      awaitQueue: [locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')), targetUser, userSelect, destructBtn, sendBtn],
+      awaitQueue: [
+        locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')),
+        targetUser, userSelect,
+        destructBtnSet,
+        destructBtnClear,
+        sendBtn,
+      ],
     });
     await cmd.execute(interaction);
+    // Mid-flight: after the SET submit, the form preview reflects "30 seconds".
+    const setSubmit = await destructBtnSet.awaitModalSubmit.mock.results[0].value;
+    expect(setSubmit.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('_Self-destruct timer:_ 30 seconds'),
+    }));
+    // After the CLEAR submit, the preview line is gone.
+    const clearSubmit = await destructBtnClear.awaitModalSubmit.mock.results[0].value;
+    expect(clearSubmit.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.not.stringContaining('_Self-destruct timer:_'),
+    }));
+    // And the eventual upload carries null — the actual contract under test.
     expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'google-map' }),
       'location.json',

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -957,6 +957,30 @@ describe('handleSend — Step 3: final form', () => {
     expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
   });
 
+  it('self-destruct modal: setting a value re-renders the form with a visible preview line', async () => {
+    // After the user submits a valid duration, the form re-render must
+    // include "_Self-destruct timer:_ <preset label>" so the user has
+    // a visible echo of their choice (parity with the personal-message
+    // preview). Without this, the only state signal is the button label,
+    // which is harder to spot at a glance.
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('30 seconds')),
+    });
+    const cancel = makeCompInt(ids.cancelBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')), targetUser, userSelect, destructBtn, cancel],
+    });
+    await cmd.execute(interaction);
+    const submit = await destructBtn.awaitModalSubmit.mock.results[0].value;
+    expect(submit.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('_Self-destruct timer:_ 30 seconds'),
+    }));
+  });
+
   it('self-destruct modal: friendly label "5 minutes" parses to 300s', async () => {
     // The placeholder advertises the friendly label form; users typing
     // the label exactly must be honored without falling through to the

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -218,6 +218,8 @@ const ids = {
   userSelect: `qurl_form_${NONCE}_user`,
   msgBtn: `qurl_form_${NONCE}_msg_btn`,
   msgModal: `qurl_form_${NONCE}_msg_modal`,
+  selfDestructBtn: `qurl_form_${NONCE}_destruct_btn`,
+  selfDestructModal: `qurl_form_${NONCE}_destruct_modal`,
   expirySelect: `qurl_form_${NONCE}_expiry`,
   sendBtn: `qurl_form_${NONCE}_send`,
   cancelBtn: `qurl_form_${NONCE}_cancel`,
@@ -234,6 +236,17 @@ function makeCompInt(customId, overrides = {}) {
     values: [],
     users: { first: jest.fn(() => null) },
     ...overrides,
+  };
+}
+
+// Module-scoped so both the location-path describe AND the final-form
+// describe (self-destruct modal tests) can build modal-submit fixtures
+// without per-describe re-declaration.
+function makeModalSubmit(value) {
+  return {
+    fields: { getTextInputValue: jest.fn(() => value) },
+    deferUpdate: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -807,13 +820,8 @@ describe('handleSend — Step 2: location path', () => {
     });
   }
 
-  function makeModalSubmit(value) {
-    return {
-      fields: { getTextInputValue: jest.fn(() => value) },
-      deferUpdate: jest.fn().mockResolvedValue(undefined),
-      update: jest.fn().mockResolvedValue(undefined),
-    };
-  }
+  // makeModalSubmit is module-scoped (see top of file) so the
+  // self-destruct tests in Step 3 can reuse it.
 
   it('cancels when location modal times out', async () => {
     const interaction = makeInteraction({ awaitQueue: [locInitBtn(null)] });
@@ -892,6 +900,85 @@ describe('handleSend — Step 3: final form', () => {
       }),
     });
   }
+
+  // -------------------------------------------------------------------------
+  // Self-destruct timer (viewer_ttl_seconds bot-side capture)
+  // -------------------------------------------------------------------------
+
+  it('self-destruct modal: valid value persists into the upload call', async () => {
+    // Form-loop sequence: location-init → self-destruct button click
+    // (modal returns "30") → user-select → send. The handleSend
+    // back-half runs uploadJsonToConnector with selfDestructSeconds
+    // threaded as the last argument.
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('30')),
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')), targetUser, userSelect, destructBtn, sendBtn],
+    });
+    await cmd.execute(interaction);
+    expect(destructBtn.showModal).toHaveBeenCalled();
+    // uploadJsonToConnector signature: (payload, filename, apiKey, selfDestructSeconds)
+    expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google-map' }),
+      'location.json',
+      expect.any(String),
+      30,
+    );
+  });
+
+  it('self-destruct modal: invalid value re-renders the form with a warning', async () => {
+    // "0.4" is sub-floor. The handler must NOT abort the flow; it
+    // re-renders the form with an inline warning so the user can
+    // correct the value or skip the timer entirely.
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('0.4')),
+    });
+    const cancel = makeCompInt(ids.cancelBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')), targetUser, userSelect, destructBtn, cancel],
+    });
+    await cmd.execute(interaction);
+    const submit = await destructBtn.awaitModalSubmit.mock.results[0].value;
+    expect(submit.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Self-destruct.*0\.5/),
+    }));
+    // Subsequent cancel — back-half should not run.
+    expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
+  });
+
+  it('self-destruct modal: empty value clears the timer (state stays null)', async () => {
+    // User clicks the button with a previously-set value, then submits
+    // empty to clear. The form re-renders with the timer button label
+    // returning to its unset state. Subsequent send carries selfDestruct=null.
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('')),
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const interaction = makeInteraction({
+      awaitQueue: [locInitBtn(makeModalSubmit('https://maps.app.goo.gl/abc123')), targetUser, userSelect, destructBtn, sendBtn],
+    });
+    await cmd.execute(interaction);
+    expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google-map' }),
+      'location.json',
+      expect.any(String),
+      null,
+    );
+  });
 
   it('cancel button clears cooldown and exits', async () => {
     const cancel = makeCompInt(ids.cancelBtn);
@@ -1172,6 +1259,9 @@ describe('handleSend — end-to-end happy paths', () => {
     await cmd.execute(interaction);
     expect(mockDownloadAndUpload).toHaveBeenCalledWith(
       attachment.url, expect.any(String), attachment.contentType, expect.any(String),
+      // selfDestructSeconds — null when the form leaves the timer unset
+      // (the default for this happy-path test).
+      null,
     );
     expect(mockMintLinks).toHaveBeenCalled();
     expect(mockSendDM).toHaveBeenCalled();

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -1293,6 +1293,33 @@ describe('handleSend — end-to-end happy paths', () => {
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalled();
   });
 
+  it('file send: self-destruct timer threads from modal into downloadAndUpload', async () => {
+    // Symmetric with the location-path positive test above. The location
+    // path's self-destruct test pins uploadJsonToConnector — this one
+    // pins downloadAndUpload so a future refactor that drops the arg
+    // from one path but not the other gets caught by both branches.
+    const fileInit = makeCompInt(ids.initFile);
+    const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
+    const userSelect = makeCompInt(ids.userSelect, {
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+    });
+    const destructBtn = makeCompInt(ids.selfDestructBtn, {
+      awaitModalSubmit: jest.fn().mockResolvedValue(makeModalSubmit('5 minutes')),
+    });
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
+    const awaitMessages = jest.fn().mockResolvedValue(makeAttachmentMessage(attachment));
+    const interaction = makeInteraction({
+      awaitQueue: [fileInit, targetUser, userSelect, destructBtn, sendBtn],
+      awaitMessages,
+    });
+    await cmd.execute(interaction);
+    expect(mockDownloadAndUpload).toHaveBeenCalledWith(
+      attachment.url, expect.any(String), attachment.contentType, expect.any(String),
+      300,
+    );
+  });
+
   it('location send: full flow from init → uploadJsonToConnector → mintLinks → sendDM', async () => {
     const locInit = makeCompInt(ids.initLoc, {
       showModal: jest.fn().mockResolvedValue(undefined),

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1566,6 +1566,43 @@ describe('handleAddRecipients', () => {
     expect(result.msg).toMatch(/Added 2 recipients/);
   });
 
+  it('file send: inherits the original send\'s self-destruct timer into the re-upload', async () => {
+    // Pins the inheritance contract — when /qurl send recipients is run
+    // against an original send that had a timer set, the additional
+    // recipients' re-uploaded resource carries the same timer through to
+    // the connector. Without this, Add Recipients would silently strip
+    // the self-destruct semantic from the second batch.
+    mockDb.getSendConfig.mockReturnValue({
+      resource_type: 'file',
+      connector_resource_id: 'conn-res-42',
+      actual_url: null,
+      expires_in: '6h',
+      personal_message: null,
+      location_name: null,
+      attachment_name: 'report.pdf',
+      attachment_content_type: 'application/pdf',
+      attachment_url: 'https://cdn.discordapp.com/attachments/1/2/report.pdf',
+      self_destruct_seconds: 30,
+    });
+    mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-res-44', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/mint-3' }]);
+    mockSendDM.mockResolvedValue(true);
+
+    const users = makeUsersCollection([
+      { id: 'rcpt-3', bot: false, username: 'Carol' },
+    ]);
+
+    await handleAddRecipients('send-file-2', users, mockOriginalInteraction, 'test-api-key');
+
+    expect(mockDownloadAndUpload).toHaveBeenCalledWith(
+      'https://cdn.discordapp.com/attachments/1/2/report.pdf',
+      'report.pdf',
+      'application/pdf',
+      'test-api-key',
+      30,
+    );
+  });
+
   it('URL send: uploads location JSON and mints links', async () => {
     mockDb.getSendConfig.mockReturnValue({
       resource_type: 'url',
@@ -1600,6 +1637,37 @@ describe('handleAddRecipients', () => {
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch.mock.calls[0][0]).toHaveLength(1);
     expect(result.msg).toMatch(/Added 1 recipient/);
+  });
+
+  it('URL/maps send: inherits the original send\'s self-destruct timer into the re-upload', async () => {
+    // Symmetric with the file-path inheritance test — the location/url
+    // re-upload through uploadJsonToConnector must carry the timer too.
+    mockDb.getSendConfig.mockReturnValue({
+      resource_type: 'url',
+      connector_resource_id: null,
+      actual_url: 'https://example.com/doc',
+      expires_in: '24h',
+      personal_message: null,
+      location_name: null,
+      attachment_name: null,
+      self_destruct_seconds: 300,
+    });
+    mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'res-loc-2', hash: 'loc-hash' });
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/otl-2' }]);
+    mockSendDM.mockResolvedValue(true);
+
+    const users = makeUsersCollection([
+      { id: 'rcpt-2', bot: false, username: 'Dave' },
+    ]);
+
+    await handleAddRecipients('send-url-2', users, mockOriginalInteraction, 'test-api-key');
+
+    expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google-map', url: 'https://example.com/doc' }),
+      'location.json',
+      'test-api-key',
+      300,
+    );
   });
 
   it('maps send: uploads location JSON with location_name and mints links', async () => {

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1551,6 +1551,8 @@ describe('handleAddRecipients', () => {
       'report.pdf',
       'application/pdf',
       'test-api-key',
+      // sendConfig has no self_destruct_seconds → null inherits through.
+      null,
     );
     // mintLinks is called against the NEW resource (conn-res-43)
     expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key');
@@ -1591,6 +1593,7 @@ describe('handleAddRecipients', () => {
     expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'google-map', url: 'https://example.com/doc' }),
       'location.json', 'test-api-key',
+      null,
     );
     expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', expect.any(String), 1, 'test-api-key');
     expect(mockSendDM).toHaveBeenCalledTimes(1);
@@ -1628,6 +1631,7 @@ describe('handleAddRecipients', () => {
     expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'google-map', url: 'https://www.google.com/maps/place/Eiffel+Tower', name: 'Eiffel Tower' }),
       'location.json', 'test-api-key',
+      null,
     );
     expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', expect.any(String), 1, 'test-api-key');
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -149,11 +149,23 @@ describe('utils/time', () => {
       }
     });
 
-    it('rejects oversized input (DoS bound)', () => {
+    it('rejects oversized input (DoS bound) and surfaces the limit', () => {
       const huge = '9'.repeat(33);
       const r = parseSelfDestructSeconds(huge);
       expect(r.seconds).toBeNull();
-      expect(r.error).toMatch(/too long/i);
+      // The handler renders this as "Self-destruct timer ${error}" so the
+      // error reads as a verb phrase ("is too long (max N characters).").
+      expect(r.error).toMatch(/^is too long/);
+      expect(r.error).toContain('32 characters');
+    });
+
+    it('error message reads as a verb phrase ("must be one of …") so the handler can frame it cleanly', () => {
+      // Both the rejection and the length-cap errors are concatenated by
+      // the modal handler as "Self-destruct timer ${error}". Pinning the
+      // shape here so a parser change can't break the rendered warning.
+      expect(parseSelfDestructSeconds('999').error).toMatch(/^must be one of:/);
+      expect(parseSelfDestructSeconds('999').error).toContain('1/2 second');
+      expect(parseSelfDestructSeconds('999').error).toContain('1 hour');
     });
   });
 
@@ -172,12 +184,13 @@ describe('utils/time', () => {
       expect(formatSelfDestructLabel(0.75)).toBe('0.75s');
     });
 
-    it('falls back gracefully on non-finite stored values (corrupted DB row)', () => {
+    it('renders "(invalid)" for non-finite stored values (corrupted DB row)', () => {
       // Defense against findPresetBySeconds receiving NaN/Infinity from a
-      // backfilled row — the formatter must not throw or substitute a
-      // preset, just render the raw value compactly.
-      expect(formatSelfDestructLabel(NaN)).toBe('NaNs');
-      expect(formatSelfDestructLabel(Infinity)).toBe('Infinitys');
+      // backfilled row — never substitute a preset, never throw, never
+      // surface the literal "NaNs"/"Infinitys" strings to the user.
+      expect(formatSelfDestructLabel(NaN)).toBe('(invalid)');
+      expect(formatSelfDestructLabel(Infinity)).toBe('(invalid)');
+      expect(formatSelfDestructLabel(-Infinity)).toBe('(invalid)');
     });
   });
 

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -11,7 +11,13 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
-const { expiryToISO, expiryToMs } = require('../src/utils/time');
+const {
+  expiryToISO,
+  expiryToMs,
+  parseSelfDestructSeconds,
+  SELF_DESTRUCT_MIN_SECONDS,
+  SELF_DESTRUCT_MAX_SECONDS,
+} = require('../src/utils/time');
 
 describe('utils/time', () => {
   describe('expiryToMs', () => {
@@ -34,6 +40,81 @@ describe('utils/time', () => {
       expect(expiryToMs(null)).toBe(DEFAULT);
       expect(expiryToMs(undefined)).toBe(DEFAULT);
       expect(expiryToMs('0d')).toBe(DEFAULT); // zero-valued rejected
+    });
+  });
+
+  describe('parseSelfDestructSeconds', () => {
+    // Mirrors the connector's parseExpireAfterMs codomain (PR #477):
+    // 0.5–3600 inclusive accepted (above-max clamps), everything else
+    // returns an error string the modal handler renders inline.
+    it('treats absent / empty / whitespace as no-timer (no error)', () => {
+      for (const v of [undefined, null, '', ' ', '   ', '\t', ' \n\t ']) {
+        const r = parseSelfDestructSeconds(v);
+        expect(r).toEqual({ seconds: null, error: null });
+      }
+    });
+
+    it('accepts the floor exactly', () => {
+      expect(parseSelfDestructSeconds('0.5')).toEqual({ seconds: 0.5, error: null });
+    });
+
+    it('accepts integers and decimals in range', () => {
+      expect(parseSelfDestructSeconds('1')).toEqual({ seconds: 1, error: null });
+      expect(parseSelfDestructSeconds('30')).toEqual({ seconds: 30, error: null });
+      expect(parseSelfDestructSeconds('0.7')).toEqual({ seconds: 0.7, error: null });
+      expect(parseSelfDestructSeconds('3600')).toEqual({ seconds: 3600, error: null });
+    });
+
+    it('clamps above-max silently (matches connector)', () => {
+      expect(parseSelfDestructSeconds('3601')).toEqual({ seconds: 3600, error: null });
+      expect(parseSelfDestructSeconds('100000')).toEqual({ seconds: 3600, error: null });
+    });
+
+    it('rejects sub-floor with a floor-specific message', () => {
+      const r = parseSelfDestructSeconds('0.4');
+      expect(r.seconds).toBeNull();
+      expect(r.error).toMatch(/0\.5/);
+    });
+
+    it('rejects zero / negative as non-positive', () => {
+      for (const v of ['0', '-5', '-0.5']) {
+        const r = parseSelfDestructSeconds(v);
+        expect(r.seconds).toBeNull();
+        expect(r.error).toMatch(/positive/i);
+      }
+    });
+
+    it('rejects non-numeric / NaN / Infinity', () => {
+      for (const v of ['abc', 'NaN', 'Infinity', '-Infinity']) {
+        const r = parseSelfDestructSeconds(v);
+        expect(r.seconds).toBeNull();
+        // Different error text per class is fine — pin only the rejection.
+        expect(r.error).toBeTruthy();
+      }
+    });
+
+    it('rejects hex prefix even though Number() does not accept hex floats', () => {
+      // Symmetric with the connector's parseExpireAfterMs (Go strconv
+      // accepts `0x1p3`). The bot's contract should reject the same
+      // inputs even though JS Number() would already reject — pinned
+      // so a future swap to a different parser doesn't regress.
+      for (const v of ['0x1p3', '+0x1', '-0x1']) {
+        const r = parseSelfDestructSeconds(v);
+        expect(r.seconds).toBeNull();
+        expect(r.error).toMatch(/hex/i);
+      }
+    });
+
+    it('rejects oversized input (DoS bound)', () => {
+      const huge = '9'.repeat(33);
+      const r = parseSelfDestructSeconds(huge);
+      expect(r.seconds).toBeNull();
+      expect(r.error).toMatch(/too long/i);
+    });
+
+    it('exports MIN/MAX constants for callers building UI labels', () => {
+      expect(SELF_DESTRUCT_MIN_SECONDS).toBe(0.5);
+      expect(SELF_DESTRUCT_MAX_SECONDS).toBe(3600);
     });
   });
 

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -76,6 +76,14 @@ describe('utils/time', () => {
         '1/2 second, 1 second, 5 seconds, 30 seconds, 5 minutes, 30 minutes, 1 hour'
       );
     });
+
+    it('OPTIONS_TEXT fits inside Discord\'s 100-char setPlaceholder cap', () => {
+      // Future preset additions (e.g. "15 minutes") could push the
+      // joined string past Discord's 100-char placeholder limit and
+      // fail at runtime as a Discord API error. Guard at build time so
+      // the regression is caught here, not in the bot's logs.
+      expect(SELF_DESTRUCT_OPTIONS_TEXT.length).toBeLessThanOrEqual(100);
+    });
   });
 
   describe('parseSelfDestructSeconds', () => {
@@ -131,16 +139,22 @@ describe('utils/time', () => {
       }
     });
 
-    it('rejects non-numeric / NaN / Infinity / hex / scientific notation', () => {
+    it('rejects non-numeric / NaN / Infinity / hex / scientific notation / signed', () => {
       // Hex integers and scientific notation are accepted by Number() and
       // would otherwise coerce into preset values (Number("0x1") → 1,
       // Number("0x1e") → 30, Number("5e-1") → 0.5). The strict decimal
       // gate in the parser blocks them so the placeholder's "decimal
       // seconds" advertisement is the actual contract.
+      //
+      // Leading + and - are also rejected — every preset is positive,
+      // a "+30" wouldn't be a typo of any placeholder string, and "-30"
+      // is meaningfully an error. Net: regex matches "0.5" and "30",
+      // not "+0.5", "+30", "-0.5", "-30".
       const cases = [
         'abc', 'NaN', 'Infinity', '-Infinity',
         '0x1', '0x1e', '0x12c', '0x1p3', '+0x1', '-0x1',
         '5e-1', '3e2', '1e0', '0.5e0',
+        '+0.5', '+1', '+30', '+300',
       ];
       for (const v of cases) {
         const r = parseSelfDestructSeconds(v);

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -198,6 +198,22 @@ describe('utils/time', () => {
       expect(formatSelfDestructLabel(0.75)).toBe('0.75s');
     });
 
+    it('format → parse round-trips every preset (re-edit modal preserves the value)', () => {
+      // The modal's setValue prefill uses formatSelfDestructLabel(seconds)
+      // when re-opening to edit. Submitting that prefilled label without
+      // changing it must parse back to the same seconds — otherwise a
+      // user re-opening the modal and hitting submit would silently
+      // change the timer to something else (or clear it). Pin every
+      // preset.
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        const formatted = formatSelfDestructLabel(preset.seconds);
+        expect(parseSelfDestructSeconds(formatted)).toEqual({
+          seconds: preset.seconds,
+          error: null,
+        });
+      }
+    });
+
     it('renders "(invalid)" for non-finite stored values (corrupted DB row)', () => {
       // Defense against findPresetBySeconds receiving NaN/Infinity from a
       // backfilled row — never substitute a preset, never throw, never

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -131,8 +131,18 @@ describe('utils/time', () => {
       }
     });
 
-    it('rejects non-numeric / NaN / Infinity / hex', () => {
-      for (const v of ['abc', 'NaN', 'Infinity', '-Infinity', '0x1p3', '+0x1', '-0x1']) {
+    it('rejects non-numeric / NaN / Infinity / hex / scientific notation', () => {
+      // Hex integers and scientific notation are accepted by Number() and
+      // would otherwise coerce into preset values (Number("0x1") → 1,
+      // Number("0x1e") → 30, Number("5e-1") → 0.5). The strict decimal
+      // gate in the parser blocks them so the placeholder's "decimal
+      // seconds" advertisement is the actual contract.
+      const cases = [
+        'abc', 'NaN', 'Infinity', '-Infinity',
+        '0x1', '0x1e', '0x12c', '0x1p3', '+0x1', '-0x1',
+        '5e-1', '3e2', '1e0', '0.5e0',
+      ];
+      for (const v of cases) {
         const r = parseSelfDestructSeconds(v);
         expect(r.seconds).toBeNull();
         expect(r.error).toBeTruthy();
@@ -160,6 +170,14 @@ describe('utils/time', () => {
       // off-preset state — never silently substitute a different preset.
       expect(formatSelfDestructLabel(2)).toBe('2s');
       expect(formatSelfDestructLabel(0.75)).toBe('0.75s');
+    });
+
+    it('falls back gracefully on non-finite stored values (corrupted DB row)', () => {
+      // Defense against findPresetBySeconds receiving NaN/Infinity from a
+      // backfilled row — the formatter must not throw or substitute a
+      // preset, just render the raw value compactly.
+      expect(formatSelfDestructLabel(NaN)).toBe('NaNs');
+      expect(formatSelfDestructLabel(Infinity)).toBe('Infinitys');
     });
   });
 

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -15,8 +15,11 @@ const {
   expiryToISO,
   expiryToMs,
   parseSelfDestructSeconds,
+  formatSelfDestructLabel,
+  SELF_DESTRUCT_PRESETS,
   SELF_DESTRUCT_MIN_SECONDS,
   SELF_DESTRUCT_MAX_SECONDS,
+  SELF_DESTRUCT_OPTIONS_TEXT,
 } = require('../src/utils/time');
 
 describe('utils/time', () => {
@@ -43,10 +46,39 @@ describe('utils/time', () => {
     });
   });
 
+  describe('SELF_DESTRUCT_PRESETS', () => {
+    it('exposes the 7 user-specified durations in ascending order', () => {
+      const labels = SELF_DESTRUCT_PRESETS.map((p) => p.label);
+      expect(labels).toEqual([
+        '1/2 second',
+        '1 second',
+        '5 seconds',
+        '30 seconds',
+        '5 minutes',
+        '30 minutes',
+        '1 hour',
+      ]);
+      const seconds = SELF_DESTRUCT_PRESETS.map((p) => p.seconds);
+      expect(seconds).toEqual([0.5, 1, 5, 30, 300, 1800, 3600]);
+      // Ascending so the modal placeholder reads naturally short→long.
+      for (let i = 1; i < seconds.length; i++) {
+        expect(seconds[i]).toBeGreaterThan(seconds[i - 1]);
+      }
+    });
+
+    it('MIN/MAX track the first and last preset', () => {
+      expect(SELF_DESTRUCT_MIN_SECONDS).toBe(0.5);
+      expect(SELF_DESTRUCT_MAX_SECONDS).toBe(3600);
+    });
+
+    it('OPTIONS_TEXT is the comma-joined label list (used in the modal placeholder)', () => {
+      expect(SELF_DESTRUCT_OPTIONS_TEXT).toBe(
+        '1/2 second, 1 second, 5 seconds, 30 seconds, 5 minutes, 30 minutes, 1 hour'
+      );
+    });
+  });
+
   describe('parseSelfDestructSeconds', () => {
-    // Mirrors the connector's parseExpireAfterMs codomain (PR #477):
-    // 0.5–3600 inclusive accepted (above-max clamps), everything else
-    // returns an error string the modal handler renders inline.
     it('treats absent / empty / whitespace as no-timer (no error)', () => {
       for (const v of [undefined, null, '', ' ', '   ', '\t', ' \n\t ']) {
         const r = parseSelfDestructSeconds(v);
@@ -54,54 +86,56 @@ describe('utils/time', () => {
       }
     });
 
-    it('accepts the floor exactly', () => {
-      expect(parseSelfDestructSeconds('0.5')).toEqual({ seconds: 0.5, error: null });
-    });
-
-    it('accepts integers and decimals in range', () => {
-      expect(parseSelfDestructSeconds('1')).toEqual({ seconds: 1, error: null });
-      expect(parseSelfDestructSeconds('30')).toEqual({ seconds: 30, error: null });
-      expect(parseSelfDestructSeconds('0.7')).toEqual({ seconds: 0.7, error: null });
-      expect(parseSelfDestructSeconds('3600')).toEqual({ seconds: 3600, error: null });
-    });
-
-    it('clamps above-max silently (matches connector)', () => {
-      expect(parseSelfDestructSeconds('3601')).toEqual({ seconds: 3600, error: null });
-      expect(parseSelfDestructSeconds('100000')).toEqual({ seconds: 3600, error: null });
-    });
-
-    it('rejects sub-floor with a floor-specific message', () => {
-      const r = parseSelfDestructSeconds('0.4');
-      expect(r.seconds).toBeNull();
-      expect(r.error).toMatch(/0\.5/);
-    });
-
-    it('rejects zero / negative as non-positive', () => {
-      for (const v of ['0', '-5', '-0.5']) {
-        const r = parseSelfDestructSeconds(v);
-        expect(r.seconds).toBeNull();
-        expect(r.error).toMatch(/positive/i);
+    it('accepts every preset by its friendly label', () => {
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(parseSelfDestructSeconds(preset.label)).toEqual({
+          seconds: preset.seconds,
+          error: null,
+        });
       }
     });
 
-    it('rejects non-numeric / NaN / Infinity', () => {
-      for (const v of ['abc', 'NaN', 'Infinity', '-Infinity']) {
+    it('accepts every preset by its raw seconds value', () => {
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(parseSelfDestructSeconds(String(preset.seconds))).toEqual({
+          seconds: preset.seconds,
+          error: null,
+        });
+      }
+    });
+
+    it('is case- and whitespace-insensitive on labels', () => {
+      expect(parseSelfDestructSeconds('5 MINUTES').seconds).toBe(300);
+      expect(parseSelfDestructSeconds('  5   minutes  ').seconds).toBe(300);
+      expect(parseSelfDestructSeconds('1 Hour').seconds).toBe(3600);
+      expect(parseSelfDestructSeconds('1/2 SECOND').seconds).toBe(0.5);
+    });
+
+    it('rejects values outside the preset set with the option list', () => {
+      for (const v of ['2', '7', '60', '120', '0.7', '3600.5', '7200']) {
         const r = parseSelfDestructSeconds(v);
         expect(r.seconds).toBeNull();
-        // Different error text per class is fine — pin only the rejection.
+        expect(r.error).toContain('1/2 second');
+        expect(r.error).toContain('1 hour');
+      }
+    });
+
+    it('rejects non-preset friendly phrasings', () => {
+      // Plausible-looking inputs that aren't in the preset set must fail
+      // — the modal placeholder is the source of truth; partial matches
+      // would be misleading (e.g., "2 minutes" silently becoming 5).
+      for (const v of ['2 minutes', '10 seconds', '15 min', 'forever', '5 mins']) {
+        const r = parseSelfDestructSeconds(v);
+        expect(r.seconds).toBeNull();
         expect(r.error).toBeTruthy();
       }
     });
 
-    it('rejects hex prefix even though Number() does not accept hex floats', () => {
-      // Symmetric with the connector's parseExpireAfterMs (Go strconv
-      // accepts `0x1p3`). The bot's contract should reject the same
-      // inputs even though JS Number() would already reject — pinned
-      // so a future swap to a different parser doesn't regress.
-      for (const v of ['0x1p3', '+0x1', '-0x1']) {
+    it('rejects non-numeric / NaN / Infinity / hex', () => {
+      for (const v of ['abc', 'NaN', 'Infinity', '-Infinity', '0x1p3', '+0x1', '-0x1']) {
         const r = parseSelfDestructSeconds(v);
         expect(r.seconds).toBeNull();
-        expect(r.error).toMatch(/hex/i);
+        expect(r.error).toBeTruthy();
       }
     });
 
@@ -111,10 +145,21 @@ describe('utils/time', () => {
       expect(r.seconds).toBeNull();
       expect(r.error).toMatch(/too long/i);
     });
+  });
 
-    it('exports MIN/MAX constants for callers building UI labels', () => {
-      expect(SELF_DESTRUCT_MIN_SECONDS).toBe(0.5);
-      expect(SELF_DESTRUCT_MAX_SECONDS).toBe(3600);
+  describe('formatSelfDestructLabel', () => {
+    it('renders each preset seconds value as the matching label', () => {
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(formatSelfDestructLabel(preset.seconds)).toBe(preset.label);
+      }
+    });
+
+    it('falls back to a compact "Ns" rendering for off-preset values', () => {
+      // Unreachable through the modal today (the parser blocks off-preset
+      // input) but defends against a future caller feeding in stored
+      // off-preset state — never silently substitute a different preset.
+      expect(formatSelfDestructLabel(2)).toBe('2s');
+      expect(formatSelfDestructLabel(0.75)).toBe('0.75s');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds an optional self-destruct timer to the button-driven `/qurl send` flow. The timer is constrained to **7 user-curated presets** — 1/2 second, 1 second, 5 seconds, 30 seconds, 5 minutes, 30 minutes, 1 hour. Forwarded to qurl-s3-connector as `viewer_ttl_seconds` (the field accepted by the connector since [qurl-integrations-infra#477](https://github.com/layervai/qurl-integrations-infra/pull/477)) so the rendered viewer page wipes content after N seconds.

```
/qurl send
  → 📁 Send File / 🗺 Send Location
  → recipient · personal note (optional) · 💥 Self-destruct timer (optional) · expiry
  → Send
```

Customer-facing terminology is "Self-destruct timer" — TTL is jargon. Internal var name (`selfDestructSeconds`) matches the UX label; wire-name to the connector stays `viewer_ttl_seconds`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## UX

- New form button alongside the personal-note button — one ActionRow with two buttons (Discord allows up to 5/row), saving a row when target=user pushes the form to the 5-row limit.
- Modal label is "Pick a duration (blank = no timer)"; placeholder is the inline option list — `1/2 second, 1 second, 5 seconds, 30 seconds, 5 minutes, 30 minutes, 1 hour`. Discord modals are TextInput-only (no nested dropdown), and the form already saturates the 5-row max when target=user, so a `StringSelectMenu` row wasn't an option without relocating other controls.
- Parser accepts either the friendly label (`"5 minutes"`) OR the raw seconds value (`"300"`), case- and whitespace-insensitive. Anything outside the preset set renders an inline form warning that lists the allowed options, so the user can correct without losing other selections.
- Empty submit clears the timer.
- Button label reflects current state — "💥 Self-destruct timer (optional)" when unset, "💥 Self-destruct: 5 minutes · edit" when set.

## Why preset-only

The connector's contract is `0.5–3600` inclusive, but exposing the full range as free text would let creators ship values like `0.7s` that hit the 500ms-floor edge case where the page renders just long enough to show a flash of content before blanking. The 7 presets are values we'd recommend out loud — every one produces a useful UX.

## Plumbing

- **`SELF_DESTRUCT_PRESETS`** + **`parseSelfDestructSeconds`** (`utils/time.js`) — frozen preset table is the single source of truth for the modal placeholder, the parser's accept-set, and the formatter's label-rendering. Strict membership matching, no clamping.
- **All four connector upload paths** (`uploadToConnector`, `reUploadBuffer`, `downloadAndUpload`, `uploadJsonToConnector`) accept an optional `viewerTtlSeconds` and route through a new `appendViewerTtl` helper that only adds the form field when a positive finite number is passed — defensive against an upstream caller misrouting NaN/0/string values.
- **`handleSend`** threads `selfDestructSeconds` → `downloadAndUpload` (file) / `uploadJsonToConnector` (location) AND the corresponding `reuploadFn` closure, so a `TOKENS_PER_RESOURCE` refill registers the same timer on each new resource.
- **Persistence**: `qurl_send_configs.self_destruct_seconds` (REAL — sub-second `0.5` survives roundtrip). `ALTER TABLE` migration in `SAFE_ALTERS` for existing tables; `CREATE TABLE` for greenfield. DDB store mirrored.
- **`handleAddRecipients`** reads `sendConfig.self_destruct_seconds` and inherits it into both file and location re-upload paths so additional recipients see the same timer.

## Carve-out

Google-Maps JSON resources hit the connector's render-side carve-out ([qurl-integrations-infra#480](https://github.com/layervai/qurl-integrations-infra/issues/480)) — a TTL on a location upload is silently no-op at view time. The plumbing still forwards the value so behavior matches contract once the carve-out is removed; documented inline.

## Tests

989 tests pass, 100% coverage on `utils/time.js`.

- `parseSelfDestructSeconds` (`tests/time.test.js`): every preset accepted by both label and seconds form, case-/whitespace-insensitivity pinned, off-preset numeric values rejected (`'2'`, `'7'`, `'60'`, `'120'`, `'0.7'`, `'3600.5'`), non-preset friendly phrasings rejected (`'2 minutes'`, `'10 seconds'`, `'forever'`), NaN/Inf/hex/oversized rejected, MIN/MAX/OPTIONS_TEXT exports pinned.
- `formatSelfDestructLabel`: every preset round-trips to its label; off-preset values fall back to compact `"Ns"` rendering (defends against backfilled state).
- **All four connector upload helpers** (`tests/connector-coverage.test.js`): `viewer_ttl_seconds` appears on the multipart form when a positive number is passed; omitted for `null` / `undefined` / `0` / `NaN` / `Infinity` / string / object inputs.
- `saveSendConfig` roundtrip (`tests/database-module.test.js`): 0.5 sub-second persists as REAL, 30 integer persists, omitted defaults to NULL on read.
- `handleSend` self-destruct modal (`tests/qurl-send-state-machine.test.js`): valid preset (`30`) threads through to `uploadJsonToConnector`; friendly label (`"5 minutes"` → 300) threads through; invalid value (`'2'`) re-renders form with inline warning + back-half does not run; empty submit clears the timer.
- `handleSend` file path (`tests/qurl-send-state-machine.test.js`): self-destruct preset threads through to `downloadAndUpload` — symmetric with the location-path positive test so a future refactor that drops the arg from one path but not the other gets caught.
- `handleAddRecipients` inheritance (`tests/qurl-send.test.js`): both file and url/maps re-upload paths inherit `self_destruct_seconds` from the original `sendConfig` — pins the "additional recipients see the same timer" contract on the positive path.

## Security / privacy

- TTL is **not a security boundary** — devtools-strip and screenshots already defeat any client-side timer. Same threat model as PR #477's renderer side.
- The bot already passes `one_time_use: true` on every `mintLinks` call, so the Snapchat-style "no refresh to reset" semantic holds out of the box for the bot flow (direct `/api/upload` callers don't get this — see [qurl-integrations-infra#479](https://github.com/layervai/qurl-integrations-infra/issues/479) for the connector-side coupling follow-up).
- No new logged identifiers — the form-state changes don't add any md5/qurl_link references to log lines.

## Testing

- [x] `npx jest` — 989 tests pass
- [x] `npx eslint src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)