### PR TITLE
fix(discord): repair Step-3 user-select test mocks after #212

### DIFF
--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -918,7 +918,7 @@ describe('handleSend — Step 3: final form', () => {
     // last argument.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const destructPick = makeCompInt(ids.selfDestructSelect, { values: ['30'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -941,7 +941,7 @@ describe('handleSend — Step 3: final form', () => {
     // echo of their choice (parity with the personal-message preview).
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const destructPick = makeCompInt(ids.selfDestructSelect, { values: ['30'] });
     const cancel = makeCompInt(ids.cancelBtn);
@@ -977,7 +977,7 @@ describe('handleSend — Step 3: final form', () => {
       sendCooldowns.clear();
       const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
       const userSelect = makeCompInt(ids.userSelect, {
-        users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+        users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
       });
       const destructPick = makeCompInt(ids.selfDestructSelect, { values: [value] });
       const sendBtn = makeCompInt(ids.sendBtn);
@@ -1001,7 +1001,7 @@ describe('handleSend — Step 3: final form', () => {
     // initial state.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const destructSet = makeCompInt(ids.selfDestructSelect, { values: ['30'] });
     const destructClear = makeCompInt(ids.selfDestructSelect, { values: ['no-timer'] });
@@ -1045,7 +1045,7 @@ describe('handleSend — Step 3: final form', () => {
   ])('self-destruct dropdown: %s falls back to no-timer (defense)', async (_label, valuesField) => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const destructEmpty = makeCompInt(ids.selfDestructSelect, { values: valuesField });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1068,7 +1068,7 @@ describe('handleSend — Step 3: final form', () => {
     // safe default ("no timer") wins over a half-set state.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const destructForged = makeCompInt(ids.selfDestructSelect, { values: ['7200'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1479,7 +1479,7 @@ describe('handleSend — end-to-end happy paths', () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })) },
+      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
     });
     const destructPick = makeCompInt(ids.selfDestructSelect, { values: ['300'] });
     const sendBtn = makeCompInt(ids.sendBtn);

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -238,6 +238,11 @@ function makeCompInt(customId, overrides = {}) {
   };
 }
 
+// Discord's `compInt.users` is a Collection (Map subclass); production
+// reads `users.values()`. The returned iterator matches the spread
+// contract `[...users.values()]`.
+const mockUsers = (...users) => ({ values: jest.fn(() => users[Symbol.iterator]()) });
+
 // Module-scoped so both the location-path describe AND the final-form
 // describe (self-destruct modal tests) can build modal-submit fixtures
 // without per-describe re-declaration.
@@ -918,7 +923,7 @@ describe('handleSend — Step 3: final form', () => {
     // last argument.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const destructPick = makeCompInt(ids.selfDestructSelect, { values: ['30'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -941,7 +946,7 @@ describe('handleSend — Step 3: final form', () => {
     // echo of their choice (parity with the personal-message preview).
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const destructPick = makeCompInt(ids.selfDestructSelect, { values: ['30'] });
     const cancel = makeCompInt(ids.cancelBtn);
@@ -977,7 +982,7 @@ describe('handleSend — Step 3: final form', () => {
       sendCooldowns.clear();
       const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
       const userSelect = makeCompInt(ids.userSelect, {
-        users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+        users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
       });
       const destructPick = makeCompInt(ids.selfDestructSelect, { values: [value] });
       const sendBtn = makeCompInt(ids.sendBtn);
@@ -1001,7 +1006,7 @@ describe('handleSend — Step 3: final form', () => {
     // initial state.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const destructSet = makeCompInt(ids.selfDestructSelect, { values: ['30'] });
     const destructClear = makeCompInt(ids.selfDestructSelect, { values: ['no-timer'] });
@@ -1045,7 +1050,7 @@ describe('handleSend — Step 3: final form', () => {
   ])('self-destruct dropdown: %s falls back to no-timer (defense)', async (_label, valuesField) => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const destructEmpty = makeCompInt(ids.selfDestructSelect, { values: valuesField });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1068,7 +1073,7 @@ describe('handleSend — Step 3: final form', () => {
     // safe default ("no timer") wins over a half-set state.
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const destructForged = makeCompInt(ids.selfDestructSelect, { values: ['7200'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1093,12 +1098,6 @@ describe('handleSend — Step 3: final form', () => {
     }));
     expect(sendCooldowns.has('user-1')).toBe(false);
   });
-
-  // Helper for the multi-pick mock — Discord's `compInt.users` is a
-  // Collection (Map subclass), so the route reads `users.values()`.
-  // Returning an array of users from .values() matches the iterator
-  // contract close enough for the spread `[...users.values()]`.
-  const mockUsers = (...users) => ({ values: jest.fn(() => users[Symbol.iterator]()) });
 
   it('target=user picks a single recipient, send button completes flow', async () => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
@@ -1450,7 +1449,7 @@ describe('handleSend — end-to-end happy paths', () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -1479,7 +1478,7 @@ describe('handleSend — end-to-end happy paths', () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const destructPick = makeCompInt(ids.selfDestructSelect, { values: ['300'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1506,7 +1505,7 @@ describe('handleSend — end-to-end happy paths', () => {
     });
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const interaction = makeInteraction({
@@ -1639,7 +1638,7 @@ describe('handleSend — audit emission', () => {
     const fileInit = makeCompInt(ids.initFile);
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -1866,7 +1865,7 @@ describe('handleSend — additional branch coverage', () => {
     const fileInit = fileInitBtn();
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelect = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
@@ -1950,12 +1949,12 @@ describe('handleSend — additional branch coverage', () => {
     mockGetChannelMembers.mockReturnValue([{ id: 'u3', username: 'Channeler' }]);
     const target1 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const target2 = makeCompInt(ids.targetSelect, { values: ['channel'] });
     const target3 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick2 = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-7', bot: false, username: 'Carol' })), values: jest.fn(() => [{ id: 'user-7', bot: false, username: 'Carol' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-7', bot: false, username: 'Carol' }),
     });
     const sendBtn = makeCompInt(ids.sendBtn);
     const interaction = makeInteraction({
@@ -1972,7 +1971,7 @@ describe('handleSend — additional branch coverage', () => {
   it('user re-select preserves the picked recipient (no recipients reset)', async () => {
     const target1 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userPick = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => ({ id: 'user-2', bot: false, username: 'Bob' })), values: jest.fn(() => [{ id: 'user-2', bot: false, username: 'Bob' }][Symbol.iterator]()) },
+      users: mockUsers({ id: 'user-2', bot: false, username: 'Bob' }),
     });
     const target2 = makeCompInt(ids.targetSelect, { values: ['user'] });
     const sendBtn = makeCompInt(ids.sendBtn);
@@ -1990,7 +1989,7 @@ describe('handleSend — additional branch coverage', () => {
   it('defers and continues when UserSelect resolves with no user', async () => {
     const targetUser = makeCompInt(ids.targetSelect, { values: ['user'] });
     const userSelectEmpty = makeCompInt(ids.userSelect, {
-      users: { first: jest.fn(() => null), values: jest.fn(() => [][Symbol.iterator]()) },
+      users: mockUsers(),
     });
     const cancel = makeCompInt(ids.cancelBtn);
     const interaction = makeInteraction({


### PR DESCRIPTION
## Why

\`main\` has been red on \`build-and-test\` since #212 merged. The PR switched production code to \`compInt.users.values()\` for multi-pick support but didn't update 14 test sites that still mocked the old single-pick shape, producing:

\`\`\`
TypeError: compInt.users.values is not a function or its return value is not iterable
\`\`\`

at every Step-3 test exercising the user-select path (failing run: [25647481492](https://github.com/layervai/qurl-integrations/actions/runs/25647481492)).

## What

\`apps/discord/tests/qurl-send-state-machine.test.js\` — every \`users: { first: jest.fn(...) }\` mock now also exposes \`.values()\` returning a single-element iterator. Production code unchanged.

## Test plan

- [x] \`npx jest tests/qurl-send-state-machine.test.js\` — 84 / 84 pass
- [x] \`npx jest\` (full discord suite) — 1015 / 1015 across 42 suites

## Blast radius

Tests only. No code or runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)