### PR TITLE
feat(discord): /canary/exec endpoint (NHP-knock auth, no app-layer) — supersedes #139 + #215

### DIFF
--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -265,6 +265,19 @@ module.exports = {
   // Google Maps (location autocomplete)
   GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,
 
+  // Comma-separated allowlist of Discord user-IDs the canary's
+  // differentiated path may DM. Defense-in-depth: if the NHP
+  // network-layer auth is ever bypassed, an attacker could
+  // otherwise force the bot to DM arbitrary user-IDs they supply.
+  // Mirrors the recipient list terraform passes into the canary
+  // Lambda's RECIPIENT_USER_IDS_JSON env. Empty allowlist disables
+  // the differentiated path (route returns 503
+  // canary_recipients_unconfigured).
+  CANARY_RECIPIENT_USER_IDS: (process.env.CANARY_RECIPIENT_USER_IDS || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean),
+
   // /qurl send limits — both must be > 0. A cooldown of 0 would silently
   // disable the rate limit; a recipients cap of 0 would reject every send.
   QURL_SEND_MAX_RECIPIENTS: intEnv('QURL_SEND_MAX_RECIPIENTS', 50, { minPositive: true }),

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -269,14 +269,20 @@ module.exports = {
   // differentiated path may DM. Defense-in-depth: if the NHP
   // network-layer auth is ever bypassed, an attacker could
   // otherwise force the bot to DM arbitrary user-IDs they supply.
-  // Mirrors the recipient list terraform passes into the canary
-  // Lambda's RECIPIENT_USER_IDS_JSON env. Empty allowlist disables
-  // the differentiated path (route returns 503
-  // canary_recipients_unconfigured).
+  // Mirrors ADMIN_USER_IDS' filter+warn shape so a typo like
+  // "1234,abc,5678" doesn't pass the non-empty boot warn and
+  // silently keep the route "configured" with one usable ID.
   CANARY_RECIPIENT_USER_IDS: (process.env.CANARY_RECIPIENT_USER_IDS || '')
     .split(',')
     .map(s => s.trim())
-    .filter(Boolean),
+    .filter(s => {
+      if (!s) return false;
+      if (!/^\d{17,20}$/.test(s)) {
+        console.warn(`[config] Dropping malformed CANARY_RECIPIENT_USER_IDS entry (not a Discord snowflake): ${JSON.stringify(s)}`);
+        return false;
+      }
+      return true;
+    }),
 
   // /qurl send limits — both must be > 0. A cooldown of 0 would silently
   // disable the rate limit; a recipients cap of 0 would reject every send.

--- a/apps/discord/src/routes/canary.js
+++ b/apps/discord/src/routes/canary.js
@@ -32,11 +32,17 @@ const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
 // is gated to non-production). Embed shape doesn't need to match
 // `/qurl send` — recipients know this is a probe.
 function buildCanaryDmPayload({ test, qurlLink, resourceId, expiresAt }) {
-  const expiresUnix = Math.floor(new Date(expiresAt).getTime() / 1000);
+  // Guard against `expiresAt` being undefined/garbage from a future
+  // caller-shape change — `Math.floor(NaN)` would render `<t:NaN:R>`
+  // in the embed otherwise. `null` makes Discord drop the relative
+  // timestamp gracefully.
+  const t = new Date(expiresAt).getTime();
+  const expiresUnix = Number.isFinite(t) ? Math.floor(t / 1000) : null;
+  const expiresFragment = expiresUnix === null ? '' : `, expires <t:${expiresUnix}:R>`;
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
     .setTitle(`[Canary probe] ${test}`)
-    .setDescription(`Synthetic test from the canary-exec probe — confirms the qURL pipeline (connector upload → mint → DM) is healthy.\n\n[qURL link](${qurlLink}) (resource_id: \`${resourceId}\`, expires <t:${expiresUnix}:R>)`)
+    .setDescription(`Synthetic test from the canary-exec probe — confirms the qURL pipeline (connector upload → mint → DM) is healthy.\n\n[qURL link](${qurlLink}) (resource_id: \`${resourceId}\`${expiresFragment})`)
     .setTimestamp();
   return { embeds: [embed] };
 }
@@ -68,9 +74,10 @@ async function runScenario({ test, recipientUserId, apiKey }) {
       // Explicit default catches the "added to VALID_TESTS, forgot
       // to wire runScenario" refactor — fail fast with a named
       // error instead of silently falling through to the location
-      // path.
+      // path. step: null because no upload was attempted — keeps
+      // the Lambda's per-step metric attribution honest.
       return {
-        ok: false, step: 'upload', error: 'unhandled_test',
+        ok: false, step: null, error: 'unhandled_test',
         latency_ms: Date.now() - startedAt,
       };
     }

--- a/apps/discord/src/routes/canary.js
+++ b/apps/discord/src/routes/canary.js
@@ -1,0 +1,262 @@
+// Canary exec endpoint — synthetic-monitor probe driven by the
+// EventBridge Lambda in qurl-integrations-infra. Auth is the NHP
+// knock at the network layer (Lambda calls /nhp/internal/knock
+// directly; AC opens iptables hole for the Lambda's egress IP
+// within OpenTime). No HMAC or timestamp check at this layer —
+// NHP's per-knock OpenTime window subsumes replay defense.
+
+const express = require('express');
+const { EmbedBuilder } = require('discord.js');
+const config = require('../config');
+const logger = require('../logger');
+const { reUploadBuffer, uploadJsonToConnector, mintLinks } = require('../connector');
+const { sendDM } = require('../discord');
+const { COLORS } = require('../constants');
+
+const router = express.Router();
+
+const VALID_TESTS = new Set(['send_file', 'send_location']);
+const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
+
+// Standalone embed (not commands.js's `buildDeliveryPayload`, which
+// is gated to non-production). Embed shape doesn't need to match
+// `/qurl send` — recipients know this is a probe.
+function buildCanaryDmPayload({ test, qurlLink, resourceId, expiresAt }) {
+  const expiresUnix = Math.floor(new Date(expiresAt).getTime() / 1000);
+  const embed = new EmbedBuilder()
+    .setColor(COLORS.QURL_BRAND)
+    .setTitle(`[Canary probe] ${test}`)
+    .setDescription(`Synthetic test from the canary-exec probe — confirms the qURL pipeline (connector upload → mint → DM) is healthy.\n\n[qURL link](${qurlLink}) (resource_id: \`${resourceId}\`, expires <t:${expiresUnix}:R>)`)
+    .setTimestamp();
+  return { embeds: [embed] };
+}
+
+// Run a single canary scenario end-to-end. Returns { ok, step, ... }
+// where `step` names the failure point (upload | mint | dm) so the
+// Lambda's metric attribution is specific.
+async function runScenario({ test, recipientUserId, apiKey }) {
+  const startedAt = Date.now();
+
+  // Synthetic resource — shape differs by test so each scenario
+  // exercises a slightly different connector code path. send_file
+  // uses reUploadBuffer (raw bytes via multipart); send_location
+  // uses uploadJsonToConnector (JSON body, location-specific path).
+  let upload;
+  try {
+    if (test === 'send_file') {
+      const fileBuffer = Buffer.from(`canary probe @ ${new Date().toISOString()}\n`, 'utf8');
+      upload = await reUploadBuffer(fileBuffer, 'canary-probe.txt', 'text/plain', apiKey);
+    } else {
+      // send_location
+      const probePayload = {
+        type: 'google-map',
+        url: 'https://maps.app.goo.gl/canary-probe',
+        name: 'canary',
+      };
+      upload = await uploadJsonToConnector(probePayload, 'canary-location.json', apiKey);
+    }
+  } catch (err) {
+    return {
+      ok: false, step: 'upload', error: 'upload_threw',
+      reason: err?.message, apiCode: err?.apiCode,
+      latency_ms: Date.now() - startedAt,
+    };
+  }
+  // Unreachable today — connector.js throws on missing resource_id.
+  // Kept against a future refactor to a return-shape contract.
+  if (!upload?.resource_id) {
+    return {
+      ok: false, step: 'upload', error: 'upload_no_resource_id',
+      latency_ms: Date.now() - startedAt,
+    };
+  }
+
+  // 60-second TTL on canary links — short window keeps the qURL
+  // backend's bookkeeping costs negligible.
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  let minted;
+  try {
+    minted = await mintLinks(upload.resource_id, expiresAt, 1, apiKey);
+  } catch (err) {
+    return {
+      ok: false, step: 'mint', error: 'mint_threw',
+      reason: err?.message, apiCode: err?.apiCode,
+      latency_ms: Date.now() - startedAt,
+      resource_id: upload.resource_id,
+    };
+  }
+  const link = minted?.[0]?.qurl_link;
+  if (!link) {
+    return {
+      ok: false, step: 'mint', error: 'no_link_in_mint_response',
+      latency_ms: Date.now() - startedAt,
+      resource_id: upload.resource_id,
+    };
+  }
+
+  // DM the recipient. sendDM swallows + logs internally and returns
+  // boolean — propagate that so the Lambda metric attributes a DM
+  // delivery regression to the dm step specifically.
+  const dmOk = await sendDM(recipientUserId, buildCanaryDmPayload({
+    test, qurlLink: link, resourceId: upload.resource_id, expiresAt,
+  }));
+
+  let linkHost;
+  try { linkHost = new URL(link).host; } catch { linkHost = 'invalid-url'; }
+
+  if (!dmOk) {
+    return {
+      ok: false, step: 'dm', error: 'dm_failed',
+      latency_ms: Date.now() - startedAt,
+      resource_id: upload.resource_id,
+      link_host: linkHost,
+    };
+  }
+
+  return {
+    ok: true, step: null,
+    latency_ms: Date.now() - startedAt,
+    resource_id: upload.resource_id,
+    link_host: linkHost,
+    dm_status: 'sent',
+  };
+}
+
+router.post('/exec', async (req, res) => {
+  const startedAt = Date.now();
+  const apiKey = config.QURL_API_KEY;
+  if (!apiKey) {
+    // Multi-tenant deployments don't set a global QURL_API_KEY — the
+    // canary is meaningful only on single-tenant prod where the bot
+    // has its own key. Fail closed.
+    return res.status(503).json({ ok: false, error: 'no_api_key', latency_ms: Date.now() - startedAt });
+  }
+
+  // Body is JSON-parsed by express.json() in server.js. req.body is
+  // {} when the request body is empty or non-JSON.
+  const body = req.body || {};
+  const test = typeof body.test === 'string' ? body.test : null;
+  const recipientUserId = typeof body.recipient_user_id === 'string' ? body.recipient_user_id : null;
+
+  // Differentiated path: scenario + recipient → upload → mint → DM.
+  if (test || recipientUserId) {
+    if (!test || !VALID_TESTS.has(test)) {
+      return res.status(400).json({
+        ok: false, error: 'invalid_test',
+        valid: Array.from(VALID_TESTS),
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+    if (!recipientUserId || !SNOWFLAKE_RE.test(recipientUserId)) {
+      return res.status(400).json({
+        ok: false, error: 'invalid_recipient_user_id',
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+    // Allowlist is the last DM-blast defense if the qURL/NHP gate
+    // is ever bypassed. Empty list → 503 (server config); mismatch
+    // → 403 (auth OK, principal not authorized).
+    const allowlist = config.CANARY_RECIPIENT_USER_IDS;
+    if (!Array.isArray(allowlist) || allowlist.length === 0) {
+      return res.status(503).json({
+        ok: false, error: 'canary_recipients_unconfigured',
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+    if (!allowlist.includes(recipientUserId)) {
+      return res.status(403).json({
+        ok: false, error: 'recipient_not_allowed',
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+
+    try {
+      const result = await runScenario({ test, recipientUserId, apiKey });
+      // Step-level metrics emit even when runScenario doesn't throw —
+      // log so on-call has a correlatable entry per CloudWatch alarm.
+      if (!result.ok) {
+        logger.warn('Canary scenario failed', {
+          test, recipient_user_id: recipientUserId,
+          step: result.step, error: result.error,
+          reason: result.reason, apiCode: result.apiCode,
+          latency_ms: result.latency_ms,
+        });
+      }
+      const status = result.ok ? 200 : 500;
+      return res.status(status).json({ ...result, test, recipient_user_id: recipientUserId });
+    } catch (err) {
+      logger.warn('Canary scenario threw', {
+        test, recipient_user_id: recipientUserId,
+        error: err?.message,
+        latency_ms: Date.now() - startedAt,
+      });
+      return res.status(500).json({
+        ok: false, step: null, error: 'scenario_threw',
+        reason: err?.message,
+        latency_ms: Date.now() - startedAt,
+        test, recipient_user_id: recipientUserId,
+      });
+    }
+  }
+
+  // Legacy empty-body path — connector + mint, no DM. Pre-extension
+  // Lambdas still hit this; drop once every fielded Lambda sends the
+  // differentiated body. Location payload (not file) keeps this off
+  // the Discord CDN download path so the canary isolates the
+  // bot↔qURL hop.
+  const probePayload = {
+    type: 'google-map',
+    url: 'https://maps.app.goo.gl/canary-probe',
+    name: 'canary',
+  };
+
+  try {
+    const upload = await uploadJsonToConnector(probePayload, 'canary.json', apiKey);
+    if (!upload?.resource_id) {
+      return res.status(500).json({
+        ok: false, error: 'upload_no_resource_id',
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+
+    // 60-second TTL on the canary link.
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    const minted = await mintLinks(upload.resource_id, expiresAt, 1, apiKey);
+
+    const link = minted?.[0]?.qurl_link;
+    if (!link) {
+      return res.status(500).json({
+        ok: false, error: 'no_link_in_mint_response',
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+
+    let linkHost;
+    try { linkHost = new URL(link).host; } catch { linkHost = 'invalid-url'; }
+
+    return res.json({
+      ok: true,
+      latency_ms: Date.now() - startedAt,
+      // Single-use credential — host only, never the full link.
+      link_host: linkHost,
+      resource_id: upload.resource_id,
+    });
+  } catch (err) {
+    // warn not error — expected during outages; don't pollute the
+    // error log alongside whatever's already firing.
+    logger.warn('Canary exec failed', {
+      error: err?.message,
+      apiCode: err?.apiCode,
+      latency_ms: Date.now() - startedAt,
+    });
+    return res.status(500).json({
+      ok: false,
+      error: 'exec_failed',
+      reason: err?.message,
+      apiCode: err?.apiCode,
+      latency_ms: Date.now() - startedAt,
+    });
+  }
+});
+
+module.exports = router;

--- a/apps/discord/src/routes/canary.js
+++ b/apps/discord/src/routes/canary.js
@@ -1,9 +1,19 @@
 // Canary exec endpoint — synthetic-monitor probe driven by the
-// EventBridge Lambda in qurl-integrations-infra. Auth is the NHP
-// knock at the network layer (Lambda calls /nhp/internal/knock
+// EventBridge Lambda in qurl-integrations-infra#493. Auth is the
+// NHP knock at the network layer (Lambda calls /nhp/internal/knock
 // directly; AC opens iptables hole for the Lambda's egress IP
-// within OpenTime). No HMAC or timestamp check at this layer —
-// NHP's per-knock OpenTime window subsumes replay defense.
+// within OpenTime). No HMAC or timestamp at this layer — NHP's
+// per-knock OpenTime subsumes replay defense.
+//
+// Body shape: `{test, recipient_user_id}` required. Upload → mint
+// → DM the recipient with a "[Canary probe]" embed. Step-level
+// status returned so the Lambda's per-test metric attributes
+// failures to the right subsystem (upload | mint | dm).
+//
+// Upstream error detail (reason, apiCode) stays in logs only —
+// never echoed in HTTP responses, since reflecting upstream
+// internals to an arbitrary caller would leak connector internals
+// if NHP ever fails open.
 
 const express = require('express');
 const { EmbedBuilder } = require('discord.js');
@@ -126,135 +136,73 @@ router.post('/exec', async (req, res) => {
   const startedAt = Date.now();
   const apiKey = config.QURL_API_KEY;
   if (!apiKey) {
-    // Multi-tenant deployments don't set a global QURL_API_KEY — the
-    // canary is meaningful only on single-tenant prod where the bot
-    // has its own key. Fail closed.
+    // Multi-tenant deployments don't set a global QURL_API_KEY —
+    // canary is single-tenant-prod-only. Fail closed.
     return res.status(503).json({ ok: false, error: 'no_api_key', latency_ms: Date.now() - startedAt });
   }
 
-  // Body is JSON-parsed by express.json() in server.js. req.body is
-  // {} when the request body is empty or non-JSON.
   const body = req.body || {};
   const test = typeof body.test === 'string' ? body.test : null;
   const recipientUserId = typeof body.recipient_user_id === 'string' ? body.recipient_user_id : null;
 
-  // Differentiated path: scenario + recipient → upload → mint → DM.
-  if (test || recipientUserId) {
-    if (!test || !VALID_TESTS.has(test)) {
-      return res.status(400).json({
-        ok: false, error: 'invalid_test',
-        valid: Array.from(VALID_TESTS),
-        latency_ms: Date.now() - startedAt,
-      });
-    }
-    if (!recipientUserId || !SNOWFLAKE_RE.test(recipientUserId)) {
-      return res.status(400).json({
-        ok: false, error: 'invalid_recipient_user_id',
-        latency_ms: Date.now() - startedAt,
-      });
-    }
-    // Allowlist is the last DM-blast defense if the qURL/NHP gate
-    // is ever bypassed. Empty list → 503 (server config); mismatch
-    // → 403 (auth OK, principal not authorized).
-    const allowlist = config.CANARY_RECIPIENT_USER_IDS;
-    if (!Array.isArray(allowlist) || allowlist.length === 0) {
-      return res.status(503).json({
-        ok: false, error: 'canary_recipients_unconfigured',
-        latency_ms: Date.now() - startedAt,
-      });
-    }
-    if (!allowlist.includes(recipientUserId)) {
-      return res.status(403).json({
-        ok: false, error: 'recipient_not_allowed',
-        latency_ms: Date.now() - startedAt,
-      });
-    }
-
-    try {
-      const result = await runScenario({ test, recipientUserId, apiKey });
-      // Step-level metrics emit even when runScenario doesn't throw —
-      // log so on-call has a correlatable entry per CloudWatch alarm.
-      if (!result.ok) {
-        logger.warn('Canary scenario failed', {
-          test, recipient_user_id: recipientUserId,
-          step: result.step, error: result.error,
-          reason: result.reason, apiCode: result.apiCode,
-          latency_ms: result.latency_ms,
-        });
-      }
-      const status = result.ok ? 200 : 500;
-      return res.status(status).json({ ...result, test, recipient_user_id: recipientUserId });
-    } catch (err) {
-      logger.warn('Canary scenario threw', {
-        test, recipient_user_id: recipientUserId,
-        error: err?.message,
-        latency_ms: Date.now() - startedAt,
-      });
-      return res.status(500).json({
-        ok: false, step: null, error: 'scenario_threw',
-        reason: err?.message,
-        latency_ms: Date.now() - startedAt,
-        test, recipient_user_id: recipientUserId,
-      });
-    }
+  if (!test || !VALID_TESTS.has(test)) {
+    return res.status(400).json({
+      ok: false, error: 'invalid_test',
+      valid: Array.from(VALID_TESTS),
+      latency_ms: Date.now() - startedAt,
+    });
+  }
+  if (!recipientUserId || !SNOWFLAKE_RE.test(recipientUserId)) {
+    return res.status(400).json({
+      ok: false, error: 'invalid_recipient_user_id',
+      latency_ms: Date.now() - startedAt,
+    });
+  }
+  // Allowlist is the last DM-blast defense if the NHP gate is ever
+  // bypassed. Empty list → 503 (server config); mismatch → 403.
+  const allowlist = config.CANARY_RECIPIENT_USER_IDS;
+  if (!Array.isArray(allowlist) || allowlist.length === 0) {
+    return res.status(503).json({
+      ok: false, error: 'canary_recipients_unconfigured',
+      latency_ms: Date.now() - startedAt,
+    });
+  }
+  if (!allowlist.includes(recipientUserId)) {
+    return res.status(403).json({
+      ok: false, error: 'recipient_not_allowed',
+      latency_ms: Date.now() - startedAt,
+    });
   }
 
-  // Legacy empty-body path — connector + mint, no DM. Pre-extension
-  // Lambdas still hit this; drop once every fielded Lambda sends the
-  // differentiated body. Location payload (not file) keeps this off
-  // the Discord CDN download path so the canary isolates the
-  // bot↔qURL hop.
-  const probePayload = {
-    type: 'google-map',
-    url: 'https://maps.app.goo.gl/canary-probe',
-    name: 'canary',
-  };
-
   try {
-    const upload = await uploadJsonToConnector(probePayload, 'canary.json', apiKey);
-    if (!upload?.resource_id) {
-      return res.status(500).json({
-        ok: false, error: 'upload_no_resource_id',
-        latency_ms: Date.now() - startedAt,
+    const result = await runScenario({ test, recipientUserId, apiKey });
+    if (!result.ok) {
+      // Upstream reason + apiCode go to logs only — never echoed in
+      // the response body. The Lambda is internal, but if NHP ever
+      // fails open, reflecting upstream error detail to an arbitrary
+      // caller would leak connector internals.
+      logger.warn('Canary scenario failed', {
+        test, recipient_user_id: recipientUserId,
+        step: result.step, error: result.error,
+        reason: result.reason, apiCode: result.apiCode,
+        latency_ms: result.latency_ms,
       });
     }
-
-    // 60-second TTL on the canary link.
-    const expiresAt = new Date(Date.now() + 60_000).toISOString();
-    const minted = await mintLinks(upload.resource_id, expiresAt, 1, apiKey);
-
-    const link = minted?.[0]?.qurl_link;
-    if (!link) {
-      return res.status(500).json({
-        ok: false, error: 'no_link_in_mint_response',
-        latency_ms: Date.now() - startedAt,
-      });
-    }
-
-    let linkHost;
-    try { linkHost = new URL(link).host; } catch { linkHost = 'invalid-url'; }
-
-    return res.json({
-      ok: true,
-      latency_ms: Date.now() - startedAt,
-      // Single-use credential — host only, never the full link.
-      link_host: linkHost,
-      resource_id: upload.resource_id,
-    });
+    // Strip reason + apiCode before responding — same rationale.
+    const { reason: _r, apiCode: _a, ...safe } = result;
+    void _r; void _a;
+    const status = result.ok ? 200 : 500;
+    return res.status(status).json({ ...safe, test, recipient_user_id: recipientUserId });
   } catch (err) {
-    // warn not error — expected during outages; don't pollute the
-    // error log alongside whatever's already firing.
-    logger.warn('Canary exec failed', {
+    logger.warn('Canary scenario threw', {
+      test, recipient_user_id: recipientUserId,
       error: err?.message,
-      apiCode: err?.apiCode,
       latency_ms: Date.now() - startedAt,
     });
     return res.status(500).json({
-      ok: false,
-      error: 'exec_failed',
-      reason: err?.message,
-      apiCode: err?.apiCode,
+      ok: false, step: null, error: 'scenario_threw',
       latency_ms: Date.now() - startedAt,
+      test, recipient_user_id: recipientUserId,
     });
   }
 });

--- a/apps/discord/src/routes/canary.js
+++ b/apps/discord/src/routes/canary.js
@@ -32,10 +32,7 @@ const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
 // is gated to non-production). Embed shape doesn't need to match
 // `/qurl send` — recipients know this is a probe.
 function buildCanaryDmPayload({ test, qurlLink, resourceId, expiresAt }) {
-  // Guard against `expiresAt` being undefined/garbage from a future
-  // caller-shape change — `Math.floor(NaN)` would render `<t:NaN:R>`
-  // in the embed otherwise. `null` makes Discord drop the relative
-  // timestamp gracefully.
+  // Guard non-finite expiresAt; otherwise embed renders `<t:NaN:R>`.
   const t = new Date(expiresAt).getTime();
   const expiresUnix = Number.isFinite(t) ? Math.floor(t / 1000) : null;
   const expiresFragment = expiresUnix === null ? '' : `, expires <t:${expiresUnix}:R>`;
@@ -47,9 +44,8 @@ function buildCanaryDmPayload({ test, qurlLink, resourceId, expiresAt }) {
   return { embeds: [embed] };
 }
 
-// Run a single canary scenario end-to-end. Returns { ok, step, ... }
-// where `step` names the failure point (upload | mint | dm) so the
-// Lambda's metric attribution is specific.
+// Returns { ok, step, ... } — step names the failure point
+// (upload | mint | dm | null) for Lambda metric attribution.
 async function runScenario({ test, recipientUserId, apiKey }) {
   const startedAt = Date.now();
 
@@ -70,12 +66,10 @@ async function runScenario({ test, recipientUserId, apiKey }) {
       };
       upload = await uploadJsonToConnector(probePayload, 'canary-location.json', apiKey);
     } else {
-      // Defense in depth: VALID_TESTS upstream already gates this.
-      // Explicit default catches the "added to VALID_TESTS, forgot
-      // to wire runScenario" refactor — fail fast with a named
-      // error instead of silently falling through to the location
-      // path. step: null because no upload was attempted — keeps
-      // the Lambda's per-step metric attribution honest.
+      // Refactor-safety guard: VALID_TESTS already filters upstream,
+      // but a new test added to that set without a runScenario branch
+      // would silently route to the location path. step:null because
+      // no upload happened.
       return {
         ok: false, step: null, error: 'unhandled_test',
         latency_ms: Date.now() - startedAt,

--- a/apps/discord/src/routes/canary.js
+++ b/apps/discord/src/routes/canary.js
@@ -56,14 +56,23 @@ async function runScenario({ test, recipientUserId, apiKey }) {
     if (test === 'send_file') {
       const fileBuffer = Buffer.from(`canary probe @ ${new Date().toISOString()}\n`, 'utf8');
       upload = await reUploadBuffer(fileBuffer, 'canary-probe.txt', 'text/plain', apiKey);
-    } else {
-      // send_location
+    } else if (test === 'send_location') {
       const probePayload = {
         type: 'google-map',
         url: 'https://maps.app.goo.gl/canary-probe',
         name: 'canary',
       };
       upload = await uploadJsonToConnector(probePayload, 'canary-location.json', apiKey);
+    } else {
+      // Defense in depth: VALID_TESTS upstream already gates this.
+      // Explicit default catches the "added to VALID_TESTS, forgot
+      // to wire runScenario" refactor — fail fast with a named
+      // error instead of silently falling through to the location
+      // path.
+      return {
+        ok: false, step: 'upload', error: 'unhandled_test',
+        latency_ms: Date.now() - startedAt,
+      };
     }
   } catch (err) {
     return {
@@ -189,8 +198,8 @@ router.post('/exec', async (req, res) => {
       });
     }
     // Strip reason + apiCode before responding — same rationale.
-    const { reason: _r, apiCode: _a, ...safe } = result;
-    void _r; void _a;
+    // eslint-disable-next-line no-unused-vars
+    const { reason, apiCode, ...safe } = result;
     const status = result.ok ? 200 : 500;
     return res.status(status).json({ ...safe, test, recipient_user_id: recipientUserId });
   } catch (err) {

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -87,12 +87,15 @@ if (config.isOpenNHPActive) {
   }));
 }
 
-// Canary parser cap — 4 KB matches the route body shape (small JSON
-// with test + recipient_user_id). MUST be registered before the
-// global express.json() below so /canary inherits the tight cap.
-// Single constant shared with the router mount further down so a
-// future refactor touching one gate doesn't silently revert the
-// other to the 1 MB global parser.
+// Canary mount — parser, scoped error handler, router, and boot
+// warns colocated. MUST be registered before the global
+// express.json() below so /canary inherits the 4 KB cap (route
+// body shape is small JSON; 1 MB would silently widen the surface).
+// LOAD-BEARING: canaryEnabled (= config.isOpenNHPActive) trusts
+// that NHP is actually fronting the process at the network layer —
+// the route does no app-layer auth (NHP's per-knock OpenTime IS
+// the auth). If a future env flips this flag without NHP in front
+// of the listener, /canary/exec is unauthenticated. Tracked in #216.
 const canaryEnabled = config.isOpenNHPActive;
 
 if (canaryEnabled) {
@@ -111,6 +114,14 @@ if (canaryEnabled) {
     }
     return next(err);
   });
+  app.use('/canary', canaryRouter);
+  logger.info('Canary endpoint mounted at /canary/exec (NHP-knock authenticated)');
+  if (!config.QURL_API_KEY) {
+    logger.warn('Canary endpoint mounted but QURL_API_KEY is unset — every request will return 503 no_api_key until QURL_API_KEY is set.');
+  }
+  if (!Array.isArray(config.CANARY_RECIPIENT_USER_IDS) || config.CANARY_RECIPIENT_USER_IDS.length === 0) {
+    logger.warn('Canary endpoint mounted but CANARY_RECIPIENT_USER_IDS is empty — all requests will return 503 canary_recipients_unconfigured.');
+  }
 }
 
 app.use(express.json({ limit: '1mb' }));
@@ -260,22 +271,6 @@ if (!config.isQurlOAuthConfigured) {
 app.use('/oauth/discord', noStoreHeaders, discordInstallRouter);
 if (!config.isDiscordInstallConfigured) {
   logger.info('Discord install callback mounted in not-configured mode (DISCORD_CLIENT_SECRET or AUTH0_* env vars unset).');
-}
-
-// LOAD-BEARING: canaryEnabled (= config.isOpenNHPActive) trusts that
-// NHP is actually fronting the process at the network layer — the
-// route does no app-layer auth (NHP's per-knock OpenTime IS the
-// auth). If a future env enables the flag without NHP in front of
-// the listener, /canary/exec is unauthenticated. Tracked in #216.
-if (canaryEnabled) {
-  app.use('/canary', canaryRouter);
-  logger.info('Canary endpoint mounted at /canary/exec (NHP-knock authenticated)');
-  if (!config.QURL_API_KEY) {
-    logger.warn('Canary endpoint mounted but QURL_API_KEY is unset — every request will return 503 no_api_key until QURL_API_KEY is set.');
-  }
-  if (!Array.isArray(config.CANARY_RECIPIENT_USER_IDS) || config.CANARY_RECIPIENT_USER_IDS.length === 0) {
-    logger.warn('Canary endpoint mounted but CANARY_RECIPIENT_USER_IDS is empty — all requests will return 503 canary_recipients_unconfigured.');
-  }
 }
 
 // Error handler (Express requires the 4-arg signature; `next` unused)

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -10,6 +10,7 @@ const oauthRouter = require('./routes/oauth');
 const qurlOAuthRouter = require('./routes/qurl-oauth');
 const discordInstallRouter = require('./routes/discord-install');
 const webhooksRouter = require('./routes/webhooks');
+const canaryRouter = require('./routes/canary');
 
 const app = express();
 
@@ -84,6 +85,18 @@ if (config.isOpenNHPActive) {
       req.rawBody = buf;
     }
   }));
+}
+
+// Canary parser cap — 4 KB matches the route body shape (small JSON
+// with test + recipient_user_id). MUST be registered before the
+// global express.json() below so /canary inherits the tight cap.
+// Single constant shared with the router mount further down so a
+// future refactor touching one gate doesn't silently revert the
+// other to the 1 MB global parser.
+const canaryEnabled = config.isOpenNHPActive;
+
+if (canaryEnabled) {
+  app.use('/canary', express.json({ limit: '4kb' }));
 }
 
 app.use(express.json({ limit: '1mb' }));
@@ -233,6 +246,22 @@ if (!config.isQurlOAuthConfigured) {
 app.use('/oauth/discord', noStoreHeaders, discordInstallRouter);
 if (!config.isDiscordInstallConfigured) {
   logger.info('Discord install callback mounted in not-configured mode (DISCORD_CLIENT_SECRET or AUTH0_* env vars unset).');
+}
+
+// LOAD-BEARING: canaryEnabled (= config.isOpenNHPActive) trusts that
+// NHP is actually fronting the process at the network layer — the
+// route does no app-layer auth (NHP's per-knock OpenTime IS the
+// auth). If a future env enables the flag without NHP in front of
+// the listener, /canary/exec is unauthenticated. Tracked in #216.
+if (canaryEnabled) {
+  app.use('/canary', canaryRouter);
+  logger.info('Canary endpoint mounted at /canary/exec (NHP-knock authenticated)');
+  if (!config.QURL_API_KEY) {
+    logger.warn('Canary endpoint mounted but QURL_API_KEY is unset — every request will return 503 no_api_key until QURL_API_KEY is set.');
+  }
+  if (!Array.isArray(config.CANARY_RECIPIENT_USER_IDS) || config.CANARY_RECIPIENT_USER_IDS.length === 0) {
+    logger.warn('Canary endpoint mounted but CANARY_RECIPIENT_USER_IDS is empty — differentiated-path requests will return 503 canary_recipients_unconfigured. Legacy empty-body path still works.');
+  }
 }
 
 // Error handler (Express requires the 4-arg signature; `next` unused)

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -274,7 +274,7 @@ if (canaryEnabled) {
     logger.warn('Canary endpoint mounted but QURL_API_KEY is unset — every request will return 503 no_api_key until QURL_API_KEY is set.');
   }
   if (!Array.isArray(config.CANARY_RECIPIENT_USER_IDS) || config.CANARY_RECIPIENT_USER_IDS.length === 0) {
-    logger.warn('Canary endpoint mounted but CANARY_RECIPIENT_USER_IDS is empty — differentiated-path requests will return 503 canary_recipients_unconfigured. Legacy empty-body path still works.');
+    logger.warn('Canary endpoint mounted but CANARY_RECIPIENT_USER_IDS is empty — all requests will return 503 canary_recipients_unconfigured.');
   }
 }
 

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -97,6 +97,20 @@ const canaryEnabled = config.isOpenNHPActive;
 
 if (canaryEnabled) {
   app.use('/canary', express.json({ limit: '4kb' }));
+  // Scoped parser-error handler: parse failures + oversized bodies
+  // return JSON in the route's canonical envelope, not the HTML
+  // error page from the global 4-arg handler at the bottom of this
+  // file. Keeps the canary's response contract uniform for the
+  // Lambda's CloudWatch parser.
+  app.use('/canary', (err, req, res, next) => {
+    if (err && err.type === 'entity.parse.failed') {
+      return res.status(400).json({ ok: false, error: 'invalid_json' });
+    }
+    if (err && err.type === 'entity.too.large') {
+      return res.status(413).json({ ok: false, error: 'body_too_large' });
+    }
+    return next(err);
+  });
 }
 
 app.use(express.json({ limit: '1mb' }));

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -1,0 +1,349 @@
+// Tests for the /canary/exec endpoint. Mounts the router on a test
+// express app with the same 4 KB JSON middleware that server.js uses,
+// then exercises every dispatch branch via supertest. Connector + qURL
+// clients are mocked so the tests don't hit a real network.
+//
+// Auth model: NHP knock at the network layer. The Lambda calls
+// /nhp/internal/knock directly; AC opens the iptables hole for the
+// Lambda's egress IP within OpenTime. The route does no app-layer
+// auth — reaching it means the AC already authorized the caller.
+
+// --- mocks must be set up BEFORE requiring the router ---
+
+const mockUploadJsonToConnector = jest.fn();
+const mockMintLinks = jest.fn();
+const mockReUploadBuffer = jest.fn();
+jest.mock('../src/connector', () => ({
+  uploadJsonToConnector: mockUploadJsonToConnector,
+  mintLinks: mockMintLinks,
+  reUploadBuffer: mockReUploadBuffer,
+}));
+
+const mockSendDM = jest.fn();
+jest.mock('../src/discord', () => ({
+  sendDM: mockSendDM,
+}));
+
+// EmbedBuilder is the only discord.js export the canary route uses.
+// Keep the mock minimal — the canary's purpose is exercising the
+// connector → mint → DM call chain, not asserting on embed shape.
+jest.mock('discord.js', () => ({
+  EmbedBuilder: jest.fn().mockImplementation(() => {
+    const embed = {
+      setColor: jest.fn().mockReturnThis(),
+      setTitle: jest.fn().mockReturnThis(),
+      setDescription: jest.fn().mockReturnThis(),
+      setTimestamp: jest.fn().mockReturnThis(),
+    };
+    return embed;
+  }),
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+// config is consumed via require-time imports inside the router. Provide
+// a mutable mock so individual tests can override QURL_API_KEY or the
+// allowlist without re-requiring the module.
+const mockConfig = {
+  QURL_API_KEY: undefined,
+  // Allowlist gates the differentiated path. Suite-default contains
+  // the canonical test user-ID used across the differentiated-path
+  // tests below; allowlist-specific tests override per-case.
+  CANARY_RECIPIENT_USER_IDS: ['1483661063835750551'],
+};
+jest.mock('../src/config', () => mockConfig);
+
+const express = require('express');
+const request = require('supertest');
+const canaryRouter = require('../src/routes/canary');
+
+// Mirror server.js's mount: 4 KB JSON parser. No raw-body capture
+// needed (NHP gates at the network layer; no app-layer signature
+// or timestamp).
+function makeApp() {
+  const app = express();
+  app.use('/canary', express.json({ limit: '4kb' }));
+  app.use('/canary', canaryRouter);
+  return app;
+}
+
+// Empty body — the legacy back-end-only path, mirrors what an
+// operator would post (or a pre-extension Lambda). Differentiated-
+// path tests use their own scenario-shaped bodies.
+const VALID_BODY = {};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConfig.QURL_API_KEY = 'test-api-key';
+  // Reset allowlist to suite default — individual tests override
+  // (e.g. empty for "unconfigured" case, mismatched for "not allowed").
+  mockConfig.CANARY_RECIPIENT_USER_IDS = ['1483661063835750551'];
+  mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'res-canary-1' });
+  mockReUploadBuffer.mockResolvedValue({ resource_id: 'res-canary-file-1' });
+  mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/canary-token-abc' }]);
+  mockSendDM.mockResolvedValue(true);
+});
+
+describe('/canary/exec — dispatch', () => {
+  it('returns 503 no_api_key when QURL_API_KEY is unset', async () => {
+    mockConfig.QURL_API_KEY = undefined;
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.status).toBe(503);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('no_api_key');
+    expect(typeof res.body.latency_ms).toBe('number');
+    expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 ok with link_host on the happy path', async () => {
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.link_host).toBe('q.test');
+    expect(res.body.resource_id).toBe('res-canary-1');
+    expect(typeof res.body.latency_ms).toBe('number');
+    // Did NOT echo the actual link in the response — link is single-use
+    // and mustn't end up in CloudWatch logs.
+    expect(JSON.stringify(res.body)).not.toContain('canary-token-abc');
+  });
+
+  it('passes a synthetic location payload + 60s expiry to the connector + mintLinks', async () => {
+    await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'google-map',
+        url: expect.stringContaining('canary'),
+        name: 'canary',
+      }),
+      'canary.json',
+      'test-api-key',
+    );
+    expect(mockMintLinks).toHaveBeenCalledWith(
+      'res-canary-1',
+      expect.any(String),
+      1,
+      'test-api-key',
+    );
+    // expiresAt is ~60s in the future — verify it's an ISO date within
+    // a generous window (the network call shape is what matters).
+    const expiresAt = new Date(mockMintLinks.mock.calls[0][1]);
+    const drift = expiresAt.getTime() - Date.now();
+    expect(drift).toBeGreaterThan(30_000);
+    expect(drift).toBeLessThanOrEqual(60_000);
+  });
+
+  it('returns 500 upload_no_resource_id when uploadJsonToConnector resolves without resource_id', async () => {
+    mockUploadJsonToConnector.mockResolvedValueOnce({ /* no resource_id */ });
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('upload_no_resource_id');
+    expect(mockMintLinks).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 no_link_in_mint_response when mintLinks returns an empty array', async () => {
+    mockMintLinks.mockResolvedValueOnce([]);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('no_link_in_mint_response');
+  });
+
+  it('returns 500 exec_failed with the upstream reason when uploadJsonToConnector throws', async () => {
+    const err = Object.assign(new Error('connector down'), { apiCode: 'connector_unreachable' });
+    mockUploadJsonToConnector.mockRejectedValueOnce(err);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('exec_failed');
+    expect(res.body.reason).toBe('connector down');
+    expect(res.body.apiCode).toBe('connector_unreachable');
+  });
+
+  it('returns 500 exec_failed when mintLinks throws (e.g., qURL API down)', async () => {
+    mockMintLinks.mockRejectedValueOnce(new Error('mint API 503'));
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('exec_failed');
+    expect(res.body.reason).toBe('mint API 503');
+  });
+
+  it('exec_failed responses include latency_ms (operators triage by it)', async () => {
+    mockUploadJsonToConnector.mockRejectedValueOnce(new Error('network slow'));
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(VALID_BODY);
+    expect(res.body.latency_ms).toBeDefined();
+    expect(typeof res.body.latency_ms).toBe('number');
+    expect(res.body.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// Differentiated path — Lambda canary sends {test, recipient_user_id}
+// in the body. Each test = upload (file or location) → mint → DM.
+describe('/canary/exec — differentiated scenario path', () => {
+  const VALID_USER_ID = '1483661063835750551';
+  const SEND_FILE_BODY      = { test: 'send_file',     recipient_user_id: VALID_USER_ID };
+  const SEND_LOCATION_BODY  = { test: 'send_location', recipient_user_id: VALID_USER_ID };
+
+  it('returns 400 invalid_test for an unrecognized test value', async () => {
+    const body = { test: 'send_carrier_pigeon', recipient_user_id: VALID_USER_ID };
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_test');
+    expect(res.body.valid).toEqual(expect.arrayContaining(['send_file', 'send_location']));
+  });
+
+  it('returns 400 invalid_recipient_user_id for a non-snowflake recipient', async () => {
+    const body = { test: 'send_file', recipient_user_id: 'not-a-snowflake' };
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_recipient_user_id');
+  });
+
+  it('returns 400 invalid_test when only recipient_user_id is supplied (partial body)', async () => {
+    // Either both or neither — partial body is rejected to catch
+    // Lambda misconfig early.
+    const body = { recipient_user_id: VALID_USER_ID };
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_test');
+  });
+
+  it('send_file: uploads via reUploadBuffer (NOT uploadJsonToConnector), mints, DMs', async () => {
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.test).toBe('send_file');
+    expect(res.body.recipient_user_id).toBe(VALID_USER_ID);
+    expect(res.body.dm_status).toBe('sent');
+    expect(mockReUploadBuffer).toHaveBeenCalledTimes(1);
+    expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockSendDM).toHaveBeenCalledWith(VALID_USER_ID, expect.objectContaining({ embeds: expect.any(Array) }));
+  });
+
+  it('send_location: uploads via uploadJsonToConnector (NOT reUploadBuffer), mints, DMs', async () => {
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_LOCATION_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.test).toBe('send_location');
+    expect(res.body.dm_status).toBe('sent');
+    expect(mockUploadJsonToConnector).toHaveBeenCalledTimes(1);
+    expect(mockReUploadBuffer).not.toHaveBeenCalled();
+    expect(mockSendDM).toHaveBeenCalledWith(VALID_USER_ID, expect.objectContaining({ embeds: expect.any(Array) }));
+  });
+
+  it('attributes failure to step="upload" when reUploadBuffer rejects', async () => {
+    mockReUploadBuffer.mockRejectedValueOnce(new Error('connector 502'));
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.step).toBe('upload');
+    expect(res.body.error).toBe('upload_threw');
+    // Mint + DM never run when upload fails — pin the early-return.
+    expect(mockMintLinks).not.toHaveBeenCalled();
+    expect(mockSendDM).not.toHaveBeenCalled();
+  });
+
+  it('attributes failure to step="mint" when mintLinks returns no link', async () => {
+    mockMintLinks.mockResolvedValueOnce([]);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_LOCATION_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.step).toBe('mint');
+    expect(res.body.error).toBe('no_link_in_mint_response');
+    expect(mockSendDM).not.toHaveBeenCalled();
+  });
+
+  it('attributes failure to step="dm" when sendDM returns false', async () => {
+    mockSendDM.mockResolvedValueOnce(false);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.step).toBe('dm');
+    expect(res.body.error).toBe('dm_failed');
+    // Upload + mint succeeded — confirm the link_host is still echoed
+    // so the failure log lands on the right qURL pool.
+    expect(res.body.link_host).toBeDefined();
+  });
+
+  it('echoes test + recipient_user_id back to the Lambda for unambiguous metric attribution', async () => {
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.body.test).toBe('send_file');
+    expect(res.body.recipient_user_id).toBe(VALID_USER_ID);
+  });
+
+  it('returns 503 canary_recipients_unconfigured when allowlist is empty (server-config state)', async () => {
+    mockConfig.CANARY_RECIPIENT_USER_IDS = [];
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('canary_recipients_unconfigured');
+    // No connector / DM side-effect when the allowlist gate fires
+    expect(mockReUploadBuffer).not.toHaveBeenCalled();
+    expect(mockSendDM).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 recipient_not_allowed when recipient is not in the allowlist (textbook 403)', async () => {
+    mockConfig.CANARY_RECIPIENT_USER_IDS = ['9999999999999999999'];
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('recipient_not_allowed');
+    expect(mockSendDM).not.toHaveBeenCalled();
+  });
+
+  it('logs a structured warn when a scenario step fails (so on-call has a correlatable log)', async () => {
+    const logger = require('../src/logger');
+    mockSendDM.mockResolvedValueOnce(false);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.step).toBe('dm');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Canary scenario failed',
+      expect.objectContaining({
+        test: 'send_file',
+        recipient_user_id: VALID_USER_ID,
+        step: 'dm',
+        error: 'dm_failed',
+      })
+    );
+  });
+});

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -117,6 +117,18 @@ describe('/canary/exec — early gates', () => {
     expect(mockReUploadBuffer).not.toHaveBeenCalled();
   });
 
+  it('returns 413 body_too_large at the 4 KB boundary (5 KB body — just over cap)', async () => {
+    // Pins the actual 4 KB cap. The 100 KB test below catches
+    // mount-order regressions; this one catches "cap silently raised
+    // to e.g. 64 KB" refactors that the larger body wouldn't surface.
+    const justOverCap = { test: 'send_file', recipient_user_id: VALID_USER_ID, _pad: 'x'.repeat(5000) };
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(justOverCap);
+    expect(res.status).toBe(413);
+    expect(res.body.error).toBe('body_too_large');
+  });
+
   it('returns 413 body_too_large when body exceeds the 4 KB cap (well above, locks mount-order)', async () => {
     // 100 KB body — well above the 4 KB cap but below the global
     // 1 MB parser. A future refactor that moves the global parser
@@ -350,6 +362,22 @@ describe('/canary/exec — differentiated scenario path', () => {
         error: 'discord client crash',
       })
     );
+  });
+
+  it('returns step="upload" / upload_no_resource_id when reUploadBuffer resolves without a resource_id', async () => {
+    // Pins the defensive guard at canary.js:69-74. Unreachable
+    // today (connector.js throws on missing resource_id), but
+    // exercising it locks the return-shape contract — a future
+    // connector refactor that returns null instead of throwing
+    // would silently break failure attribution without this test.
+    mockReUploadBuffer.mockResolvedValueOnce({});
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.step).toBe('upload');
+    expect(res.body.error).toBe('upload_no_resource_id');
+    expect(mockMintLinks).not.toHaveBeenCalled();
   });
 
   it('falls back to link_host="invalid-url" when mintLinks returns a non-URL string', async () => {

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -62,12 +62,20 @@ const express = require('express');
 const request = require('supertest');
 const canaryRouter = require('../src/routes/canary');
 
-// Mirror server.js's mount: 4 KB JSON parser. No raw-body capture
-// needed (NHP gates at the network layer; no app-layer signature
-// or timestamp).
+// Mirror server.js's mount: 4 KB JSON parser + scoped parse-error
+// handler that returns JSON instead of the global HTML error page.
 function makeApp() {
   const app = express();
   app.use('/canary', express.json({ limit: '4kb' }));
+  app.use('/canary', (err, req, res, next) => {
+    if (err && err.type === 'entity.parse.failed') {
+      return res.status(400).json({ ok: false, error: 'invalid_json' });
+    }
+    if (err && err.type === 'entity.too.large') {
+      return res.status(413).json({ ok: false, error: 'body_too_large' });
+    }
+    return next(err);
+  });
   app.use('/canary', canaryRouter);
   return app;
 }
@@ -94,8 +102,7 @@ beforeEach(() => {
 });
 
 // Early gates — config-level rejections that run before any
-// upload/mint/dm work. Body shape is the same as the differentiated
-// path below.
+// upload/mint/dm work, plus the scoped body-parser failure shapes.
 describe('/canary/exec — early gates', () => {
   it('returns 503 no_api_key when QURL_API_KEY is unset', async () => {
     mockConfig.QURL_API_KEY = undefined;
@@ -108,6 +115,32 @@ describe('/canary/exec — early gates', () => {
     expect(typeof res.body.latency_ms).toBe('number');
     expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
     expect(mockReUploadBuffer).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 body_too_large when body exceeds the 4 KB cap', async () => {
+    // Pins the cap that the route comment marks load-bearing — a
+    // future refactor reordering mounts back to the 1 MB global
+    // parser would silently widen the surface.
+    const oversized = { test: 'send_file', recipient_user_id: VALID_USER_ID, _pad: 'x'.repeat(5000) };
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(oversized);
+    expect(res.status).toBe(413);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('body_too_large');
+  });
+
+  it('returns 400 invalid_json on malformed body (instead of the global HTML error page)', async () => {
+    // Scoped parser-error handler keeps the canary response shape
+    // uniform for the Lambda's CloudWatch parser — without it,
+    // express.json() failures fall to the 4-arg HTML error handler.
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .set('Content-Type', 'application/json')
+      .send('not-json{');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('invalid_json');
   });
 });
 

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -352,6 +352,20 @@ describe('/canary/exec — differentiated scenario path', () => {
     );
   });
 
+  it('falls back to link_host="invalid-url" when mintLinks returns a non-URL string', async () => {
+    // Pins the `try { new URL(link).host } catch { 'invalid-url' }`
+    // fallback in canary.js. Without this test, an upstream contract
+    // regression that returned a malformed link would dump garbage
+    // into the metric label silently — covered today by the catch
+    // but not exercised.
+    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'not a url' }]);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body.link_host).toBe('invalid-url');
+  });
+
   it('returns 400 invalid_recipient_user_id when only `test` is supplied (no recipient)', async () => {
     // Symmetric to the only-recipient case above. Pins that the
     // route validates both fields independently — a refactor that

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -72,10 +72,14 @@ function makeApp() {
   return app;
 }
 
-// Empty body — the legacy back-end-only path, mirrors what an
-// operator would post (or a pre-extension Lambda). Differentiated-
-// path tests use their own scenario-shaped bodies.
-const VALID_BODY = {};
+// Every request must carry both `test` and `recipient_user_id` —
+// the legacy empty-body path was dropped before this PR landed
+// (consolidation PR for the canary surface). Tests use these two
+// shared bodies for the happy paths; failure-mode tests build
+// their own.
+const VALID_USER_ID = '1483661063835750551';
+const SEND_FILE_BODY     = { test: 'send_file',     recipient_user_id: VALID_USER_ID };
+const SEND_LOCATION_BODY = { test: 'send_location', recipient_user_id: VALID_USER_ID };
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -89,119 +93,27 @@ beforeEach(() => {
   mockSendDM.mockResolvedValue(true);
 });
 
-describe('/canary/exec — dispatch', () => {
+// Early gates — config-level rejections that run before any
+// upload/mint/dm work. Body shape is the same as the differentiated
+// path below.
+describe('/canary/exec — early gates', () => {
   it('returns 503 no_api_key when QURL_API_KEY is unset', async () => {
     mockConfig.QURL_API_KEY = undefined;
     const res = await request(makeApp())
       .post('/canary/exec')
-      .send(VALID_BODY);
+      .send(SEND_FILE_BODY);
     expect(res.status).toBe(503);
     expect(res.body.ok).toBe(false);
     expect(res.body.error).toBe('no_api_key');
     expect(typeof res.body.latency_ms).toBe('number');
     expect(mockUploadJsonToConnector).not.toHaveBeenCalled();
-  });
-
-  it('returns 200 ok with link_host on the happy path', async () => {
-    const res = await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
-    expect(res.body.link_host).toBe('q.test');
-    expect(res.body.resource_id).toBe('res-canary-1');
-    expect(typeof res.body.latency_ms).toBe('number');
-    // Did NOT echo the actual link in the response — link is single-use
-    // and mustn't end up in CloudWatch logs.
-    expect(JSON.stringify(res.body)).not.toContain('canary-token-abc');
-  });
-
-  it('passes a synthetic location payload + 60s expiry to the connector + mintLinks', async () => {
-    await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'google-map',
-        url: expect.stringContaining('canary'),
-        name: 'canary',
-      }),
-      'canary.json',
-      'test-api-key',
-    );
-    expect(mockMintLinks).toHaveBeenCalledWith(
-      'res-canary-1',
-      expect.any(String),
-      1,
-      'test-api-key',
-    );
-    // expiresAt is ~60s in the future — verify it's an ISO date within
-    // a generous window (the network call shape is what matters).
-    const expiresAt = new Date(mockMintLinks.mock.calls[0][1]);
-    const drift = expiresAt.getTime() - Date.now();
-    expect(drift).toBeGreaterThan(30_000);
-    expect(drift).toBeLessThanOrEqual(60_000);
-  });
-
-  it('returns 500 upload_no_resource_id when uploadJsonToConnector resolves without resource_id', async () => {
-    mockUploadJsonToConnector.mockResolvedValueOnce({ /* no resource_id */ });
-    const res = await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(res.status).toBe(500);
-    expect(res.body.error).toBe('upload_no_resource_id');
-    expect(mockMintLinks).not.toHaveBeenCalled();
-  });
-
-  it('returns 500 no_link_in_mint_response when mintLinks returns an empty array', async () => {
-    mockMintLinks.mockResolvedValueOnce([]);
-    const res = await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(res.status).toBe(500);
-    expect(res.body.error).toBe('no_link_in_mint_response');
-  });
-
-  it('returns 500 exec_failed with the upstream reason when uploadJsonToConnector throws', async () => {
-    const err = Object.assign(new Error('connector down'), { apiCode: 'connector_unreachable' });
-    mockUploadJsonToConnector.mockRejectedValueOnce(err);
-    const res = await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(res.status).toBe(500);
-    expect(res.body.error).toBe('exec_failed');
-    expect(res.body.reason).toBe('connector down');
-    expect(res.body.apiCode).toBe('connector_unreachable');
-  });
-
-  it('returns 500 exec_failed when mintLinks throws (e.g., qURL API down)', async () => {
-    mockMintLinks.mockRejectedValueOnce(new Error('mint API 503'));
-    const res = await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(res.status).toBe(500);
-    expect(res.body.error).toBe('exec_failed');
-    expect(res.body.reason).toBe('mint API 503');
-  });
-
-  it('exec_failed responses include latency_ms (operators triage by it)', async () => {
-    mockUploadJsonToConnector.mockRejectedValueOnce(new Error('network slow'));
-    const res = await request(makeApp())
-      .post('/canary/exec')
-      .send(VALID_BODY);
-    expect(res.body.latency_ms).toBeDefined();
-    expect(typeof res.body.latency_ms).toBe('number');
-    expect(res.body.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(mockReUploadBuffer).not.toHaveBeenCalled();
   });
 });
 
 // Differentiated path — Lambda canary sends {test, recipient_user_id}
 // in the body. Each test = upload (file or location) → mint → DM.
 describe('/canary/exec — differentiated scenario path', () => {
-  const VALID_USER_ID = '1483661063835750551';
-  const SEND_FILE_BODY      = { test: 'send_file',     recipient_user_id: VALID_USER_ID };
-  const SEND_LOCATION_BODY  = { test: 'send_location', recipient_user_id: VALID_USER_ID };
-
   it('returns 400 invalid_test for an unrecognized test value', async () => {
     const body = { test: 'send_carrier_pigeon', recipient_user_id: VALID_USER_ID };
     const res = await request(makeApp())
@@ -345,5 +257,75 @@ describe('/canary/exec — differentiated scenario path', () => {
         error: 'dm_failed',
       })
     );
+  });
+
+  it('attributes failure to step="mint" with apiCode propagated to logs when mintLinks rejects', async () => {
+    // Differentiated-path mint-threw branch (canary.js:81-87) —
+    // covers the apiCode-propagation contract on-call relies on for
+    // alarm attribution. Symmetric to the upload-threw test above
+    // which asserts the same on the upload step.
+    const logger = require('../src/logger');
+    const err = Object.assign(new Error('mint API 503'), { apiCode: 'qurl_unreachable' });
+    mockMintLinks.mockRejectedValueOnce(err);
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.step).toBe('mint');
+    expect(res.body.error).toBe('mint_threw');
+    // reason + apiCode MUST NOT appear in the response body — they
+    // live in logs only. The route strips them via destructuring;
+    // pin the contract here.
+    expect(res.body.reason).toBeUndefined();
+    expect(res.body.apiCode).toBeUndefined();
+    // … but they MUST appear in the structured log so on-call can
+    // attribute alarms to a specific upstream failure mode.
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Canary scenario failed',
+      expect.objectContaining({
+        step: 'mint',
+        error: 'mint_threw',
+        reason: 'mint API 503',
+        apiCode: 'qurl_unreachable',
+      })
+    );
+  });
+
+  it('returns 500 scenario_threw when runScenario itself throws (sendDM rejects)', async () => {
+    // The outer try/catch in canary.js:69-79 catches throws that
+    // escape runScenario's inner per-step catches. sendDM swallows
+    // its own errors and returns boolean today; a future refactor
+    // that bubbles a throw must not silently break the synthesized-
+    // failure path. Pin the contract.
+    const logger = require('../src/logger');
+    mockSendDM.mockRejectedValueOnce(new Error('discord client crash'));
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('scenario_threw');
+    expect(res.body.step).toBeNull();
+    expect(res.body.reason).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Canary scenario threw',
+      expect.objectContaining({
+        test: 'send_file',
+        recipient_user_id: VALID_USER_ID,
+        error: 'discord client crash',
+      })
+    );
+  });
+
+  it('returns 400 invalid_recipient_user_id when only `test` is supplied (no recipient)', async () => {
+    // Symmetric to the only-recipient case above. Pins that the
+    // route validates both fields independently — a refactor that
+    // collapses the checks into a single combined-presence guard
+    // would regress this.
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send({ test: 'send_file' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_recipient_user_id');
   });
 });

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -117,11 +117,13 @@ describe('/canary/exec — early gates', () => {
     expect(mockReUploadBuffer).not.toHaveBeenCalled();
   });
 
-  it('returns 413 body_too_large when body exceeds the 4 KB cap', async () => {
-    // Pins the cap that the route comment marks load-bearing — a
-    // future refactor reordering mounts back to the 1 MB global
-    // parser would silently widen the surface.
-    const oversized = { test: 'send_file', recipient_user_id: VALID_USER_ID, _pad: 'x'.repeat(5000) };
+  it('returns 413 body_too_large when body exceeds the 4 KB cap (well above, locks mount-order)', async () => {
+    // 100 KB body — well above the 4 KB cap but below the global
+    // 1 MB parser. A future refactor that moves the global parser
+    // ahead of the /canary mount would still 200/400 this (the
+    // global parser would accept it). Pinning at this size catches
+    // mount-order regressions independent of which parser fires.
+    const oversized = { test: 'send_file', recipient_user_id: VALID_USER_ID, _pad: 'x'.repeat(100_000) };
     const res = await request(makeApp())
       .post('/canary/exec')
       .send(oversized);

--- a/apps/discord/tests/canary-route.test.js
+++ b/apps/discord/tests/canary-route.test.js
@@ -191,6 +191,20 @@ describe('/canary/exec — differentiated scenario path', () => {
     expect(res.body.error).toBe('invalid_test');
   });
 
+  it('happy-path response does NOT carry reason/apiCode (redaction contract holds on success)', async () => {
+    // Today `runScenario` doesn't attach reason/apiCode on success,
+    // so this is vacuous now — but pins the contract against a
+    // refactor that started attaching upstream metadata to the ok
+    // path. Keeps the redaction story symmetric with the failure
+    // tests above.
+    const res = await request(makeApp())
+      .post('/canary/exec')
+      .send(SEND_FILE_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('reason');
+    expect(res.body).not.toHaveProperty('apiCode');
+  });
+
   it('send_file: uploads via reUploadBuffer (NOT uploadJsonToConnector), mints, DMs', async () => {
     const res = await request(makeApp())
       .post('/canary/exec')


### PR DESCRIPTION
## Why

Consolidates the bot-side canary endpoint work. Replaces the two-PR chain layervai/qurl-integrations#139 (add endpoint w/ HMAC) → layervai/qurl-integrations#215 (drop HMAC, drop ts/replay) with a single PR that lands the endpoint with the NHP-direct auth model from the start.

Justin's layervai/qurl-integrations#456 review redirected the canary's auth model from HMAC-over-public-HTTP to NHP-direct knock (no app-layer auth — the AC's per-knock `OpenTime` IS the auth). Rather than landing HMAC code that's immediately removed in layervai/qurl-integrations#215 and leaving that history in git blame, this PR lands the end-state directly.

## What's in this PR

- **`src/routes/canary.js`** (new) — `POST /canary/exec` handler. **Single path** (no legacy empty-body branch): the body must carry both `test` and `recipient_user_id`. Upload → mint → DM the recipient with a "[Canary probe]" embed. `test` must be in `VALID_TESTS = {send_file, send_location}`; `recipient_user_id` must be a Discord snowflake AND in `CANARY_RECIPIENT_USER_IDS`. 4 KB body cap, 60s qURL TTL. Upstream error detail (`reason`, `apiCode`) stays in `logger.warn` only — never echoed in HTTP responses.
- **`src/server.js`** — mount router + scoped JSON parser + scoped parse/oversize error handler under `/canary`, gated on `isOpenNHPActive`. Boot warns surface unconfigured `QURL_API_KEY` + empty `CANARY_RECIPIENT_USER_IDS` before the first canary fire.
- **`src/config.js`** — `CANARY_RECIPIENT_USER_IDS` env (comma-separated Discord snowflakes; per-entry validated with `^\d{17,20}$` and a config-load warn on malformed entries, mirroring `ADMIN_USER_IDS`).
- **`tests/canary-route.test.js`** — 18 tests covering early gates (no API key, body too large, malformed JSON), validation (invalid test, invalid recipient, partial body), the full upload → mint → DM happy path for both scenarios, every step-attributed failure mode (upload, mint, DM), the outer scenario_threw catch, log-shape contracts, `reason`/`apiCode` redaction from responses, and allowlist empty / mismatch / member.

## Auth model

NHP-direct knock at the network layer:

1. Canary Lambda (qurl-integrations-infra#493) calls `POST /nhp/internal/knock` directly with `X-Nhp-Auth` HMAC.
2. AC opens the iptables hole for the Lambda's egress IP within `OpenTime` seconds.
3. Lambda POSTs canary body to `${BOT_URL}/canary/exec`.
4. The route does **no app-layer auth** — reaching it means the AC already authorized the caller. Replay protection is the per-knock `OpenTime` window.

## What this PR does NOT do

- Doesn't put the bot ALB behind the AC. Still pending (qurl-integrations-infra#495 ALB-internal flip + nhp#1864 AC resource registration).
- Doesn't enable the canary in any env. `canaryEnabled = config.isOpenNHPActive`; envs without OpenNHP still don't mount the route.

## Supersedes

- **#139** — "add /canary/exec w/ HMAC verifier (piece 1/6)" — closed.
- **#215** — "drop HMAC verifier on /canary/exec" — closed.

Both closed PRs' approvals/reviews are preserved as history but the actual landing is this PR.

## Test plan

- [x] `npx jest tests/canary-route.test.js` — 18/18 pass locally.
- [x] Lint pass — pre-commit hooks run on each commit.
- [ ] CI green.
- [ ] End-to-end: blocked on platform PRs (#495 ALB-internal + #1864 AC resource registration).

## Related PRs

- qurl-integrations-infra#493 — Lambda + TF NHP-direct (paired)
- qurl-integrations-infra#495 — bot ALB internal=true behind AC SG
- nhp#1864 — AC resource registration (partial; AC routing pending Justin's input)