### PR TITLE
feat(discord): reserve flow_state audit events for event-shipper Pillar 1

### DIFF
--- a/apps/discord/docs/zero-downtime-design.md
+++ b/apps/discord/docs/zero-downtime-design.md
@@ -125,7 +125,10 @@ sharding lands later).
 The state-machine harness `apps/discord/src/flow-state.js` (PR 4) provides
 `createFlow`, `loadFlow`, `transitionFlow` (DDB conditional `UpdateItem` with
 `version = :expected` for OCC), and `deleteFlow`. Every transition emits a
-metric `qurl_bot_flow_transition_total{stage_from,stage_to,result}` (PR 3).
+metric `qurl_bot_flow_transition_total{stage_from,stage_to,result,terminal}`
+(materialized by the event-shipper observability Phase 1.0 PR's audit-event
+reservation plus the matching CloudWatch metric filter in
+`qurl-integrations-infra`).
 
 **Application-level concurrency rule:** a user with an existing non-expired
 flow row in a given `(channel_id)` cannot start a second flow there. The second
@@ -656,11 +659,12 @@ by design, because DDB TTL deletion is asynchronous and a synchronous
 captures every unclean drop: process crash mid-flow, worker hang, TTL reap
 of an abandoned flow.
 
-PR 3 (event-shipper observability, Phase 1.0) reserves the
+The event-shipper observability Phase 1.0 PR reserves the
 `FLOW_CREATED` / `FLOW_TRANSITION` / `FLOW_DELETED` audit-event names in
-`apps/discord/src/constants.js`. PR 4 wires the emissions in the
-state-machine harness. The paired CloudWatch metric filters land in
-`qurl-integrations-infra` once PR 4 is producing events in sandbox.
+`apps/discord/src/constants.js`. The state-machine harness PR wires the
+emissions. The paired CloudWatch metric filters land in
+`qurl-integrations-infra` once the harness is producing events in
+sandbox.
 
 If a future change adds a "delete-on-TTL-reap" sweeper, it MUST emit a
 distinct event (e.g. `FLOW_REAPED`) — not `FLOW_DELETED` — to preserve

--- a/apps/discord/docs/zero-downtime-design.md
+++ b/apps/discord/docs/zero-downtime-design.md
@@ -637,6 +637,35 @@ deploy story. It's not SLO'd because we don't control it (Discord does), but
 we alert if it drops below 99% over a 24 h window — that signals a Discord-side
 change or our session-state staleness, both of which need investigation.
 
+### Flow continuity — computation contract
+
+The `silently_dropped_flows` numerator is computed as a difference, not
+emitted as a direct event:
+
+```
+total_flows            = count(FLOW_CREATED)
+completed_flows        = count(FLOW_DELETED)
+silently_dropped_flows = total_flows - completed_flows
+```
+
+Every `createFlow()` emits `FLOW_CREATED`; every explicit `deleteFlow()`
+(terminal stage, abort, admin cleanup) emits `FLOW_DELETED`. TTL-reaped
+flows — the silent-drop case the SLI is designed to catch — emit no event
+by design, because DDB TTL deletion is asynchronous and a synchronous
+"reaped" signal would require a separate sweeper. Counting the difference
+captures every unclean drop: process crash mid-flow, worker hang, TTL reap
+of an abandoned flow.
+
+PR 3 (event-shipper observability, Phase 1.0) reserves the
+`FLOW_CREATED` / `FLOW_TRANSITION` / `FLOW_DELETED` audit-event names in
+`apps/discord/src/constants.js`. PR 4 wires the emissions in the
+state-machine harness. The paired CloudWatch metric filters land in
+`qurl-integrations-infra` once PR 4 is producing events in sandbox.
+
+If a future change adds a "delete-on-TTL-reap" sweeper, it MUST emit a
+distinct event (e.g. `FLOW_REAPED`) — not `FLOW_DELETED` — to preserve
+the asymmetry the SLI math relies on.
+
 ## Open questions, deliberately deferred
 
 These do not block the current design but should be revisited:

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -199,12 +199,13 @@ const AUDIT_EVENTS = {
 
   // ── Event-shipper Pillar 1: flow_state observability ──
   //
-  // Names reserved by this PR (event-shipper observability Phase 1.0);
-  // emissions wired by PR 4's state-machine harness in
+  // Names reserved by the event-shipper observability Phase 1.0 PR;
+  // emissions wired by the state-machine harness PR in
   // apps/discord/src/flow-state.js. The paired CloudWatch metric filters
-  // land in qurl-integrations-infra (separate PR) once PR 4 is producing
-  // events in sandbox. Three-stage rollout — names reserved → emissions
-  // wired → metric filters lit — keeps each layer reviewable in isolation.
+  // land in qurl-integrations-infra (separate PR) once the harness is
+  // producing events in sandbox. Three-stage rollout — names reserved →
+  // emissions wired → metric filters lit — keeps each layer reviewable
+  // in isolation.
   //
   // The "flow_state" table is created by qurl-integrations-infra#504; the
   // SLI these events feed is "Flow continuity" (design doc § SLI / SLO
@@ -243,8 +244,9 @@ const AUDIT_EVENTS = {
 
   // Emitted on every transitionFlow() call — the workhorse event for
   // the state machine's observability. The paired CloudWatch metric
-  // filter materializes `qurl_bot_flow_transition_total{stage_from,
-  // stage_to,result}` (design doc § Pillar 1).
+  // filter materializes
+  // `qurl_bot_flow_transition_total{stage_from,stage_to,result,terminal}`
+  // (design doc § Pillar 1).
   // Payload fields:
   //   - `stage_from`: stage the flow was in before the transition.
   //                   LOW-cardinality — safe to dimension on.
@@ -265,7 +267,8 @@ const AUDIT_EVENTS = {
   //                   terminal stage in the filter (terminal set
   //                   varies per flow type — revoke is shorter than
   //                   send). LOW-cardinality (boolean) — safe to
-  //                   dimension on.
+  //                   dimension on AND included in the materialized
+  //                   metric's dimension list above.
   //   - `flow_id`:    HIGH-cardinality. Forensic-query ONLY — same
   //                   posture as FLOW_CREATED.
   FLOW_TRANSITION: 'flow_transition',

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -197,6 +197,100 @@ const AUDIT_EVENTS = {
   // Periodic gauge of `client.guilds.cache.size`. Emitted every 60 s.
   ACTIVE_GUILD_COUNT: 'active_guild_count',
 
+  // ── Event-shipper Pillar 1: flow_state observability ──
+  //
+  // Names reserved by this PR (event-shipper observability Phase 1.0);
+  // emissions wired by PR 4's state-machine harness in
+  // apps/discord/src/flow-state.js. The paired CloudWatch metric filters
+  // land in qurl-integrations-infra (separate PR) once PR 4 is producing
+  // events in sandbox. Three-stage rollout — names reserved → emissions
+  // wired → metric filters lit — keeps each layer reviewable in isolation.
+  //
+  // The "flow_state" table is created by qurl-integrations-infra#504; the
+  // SLI these events feed is "Flow continuity" (design doc § SLI / SLO
+  // definitions, target 99.99% over 1-day windows).
+  //
+  // SLI computation contract:
+  //   total_flows           = count(FLOW_CREATED)
+  //   completed_flows       = count(FLOW_DELETED)
+  //   silently_dropped_flows = total_flows - completed_flows
+  //                          = count(FLOW_CREATED) - count(FLOW_DELETED)
+  // Every FLOW_CREATED MUST be followed by either an explicit FLOW_DELETED
+  // (terminal stage, abort, etc.) OR a TTL reap. The reap path emits no
+  // event by design (DDB TTL is asynchronous, so a "deleted by TTL"
+  // signal would itself require a separate sweeper). Computing
+  // silently_dropped via "created minus deleted" sidesteps the async-reap
+  // problem AND captures all unclean drops (crashes, hangs, partial
+  // process restart between transitions).
+
+  // Single emission per createFlow() call. Marks the start of a flow's
+  // lifecycle for the "Flow continuity" SLI's denominator.
+  // Payload fields:
+  //   - `stage`:    initial stage the flow enters at (e.g.
+  //                 'awaiting_button'). LOW-cardinality — safe to
+  //                 dimension on. Bounded by the state-machine's
+  //                 stage enum.
+  //   - `shard_id`: e.g. '0:1' (single-shard today); generalizes to
+  //                 'k:n' post-sharding. LOW-cardinality — safe to
+  //                 dimension on.
+  //   - `flow_id`:  HIGH-cardinality (composite encoding of shard /
+  //                 guild / channel / user). Forensic-query field
+  //                 ONLY — same trap as `guild_id` / `path` above:
+  //                 do NOT promote to a CloudWatch metric dimension
+  //                 at the terraform-filter layer. Use Logs Insights
+  //                 for per-flow drilldown during an incident.
+  FLOW_CREATED: 'flow_created',
+
+  // Emitted on every transitionFlow() call — the workhorse event for
+  // the state machine's observability. The paired CloudWatch metric
+  // filter materializes `qurl_bot_flow_transition_total{stage_from,
+  // stage_to,result}` (design doc § Pillar 1).
+  // Payload fields:
+  //   - `stage_from`: stage the flow was in before the transition.
+  //                   LOW-cardinality — safe to dimension on.
+  //   - `stage_to`:   stage the flow advances to. LOW-cardinality —
+  //                   safe to dimension on.
+  //   - `result`:     'success' | 'conflict' | 'not_found' | 'error'.
+  //                   LOW-cardinality — safe to dimension on. The
+  //                   conflict bucket counts OCC-loser races (DDB
+  //                   ConditionalCheckFailedException) — the
+  //                   correctness primitive that gates concurrent
+  //                   worker advances. SUSTAINED conflict > 0 indicates
+  //                   spurious dispatch; conflict at low rate is the
+  //                   expected at-least-once-delivery behavior.
+  //   - `terminal`:   bool. When true, this transition ends the flow
+  //                   (the next call will be deleteFlow). Lets the
+  //                   metric math identify clean completions vs.
+  //                   mid-flow transitions without enumerating every
+  //                   terminal stage in the filter (terminal set
+  //                   varies per flow type — revoke is shorter than
+  //                   send). LOW-cardinality (boolean) — safe to
+  //                   dimension on.
+  //   - `flow_id`:    HIGH-cardinality. Forensic-query ONLY — same
+  //                   posture as FLOW_CREATED.
+  FLOW_TRANSITION: 'flow_transition',
+
+  // Emitted on every explicit deleteFlow() call — flow numerator for
+  // the "Flow continuity" SLI (completed_flows). TTL-reaped flows do
+  // NOT emit this event; the SLI math relies on that asymmetry to
+  // identify silent drops (FLOW_CREATED count minus FLOW_DELETED
+  // count). If a future change adds a "delete-on-TTL-reap" sweeper,
+  // it MUST emit a distinct event (e.g. FLOW_REAPED) — not
+  // FLOW_DELETED — to preserve the SLI math.
+  // Payload fields:
+  //   - `stage`:  stage the flow was in at deletion. LOW-cardinality
+  //               — safe to dimension on. For terminal completions,
+  //               equals the terminal stage; for aborts, equals
+  //               whatever the flow was awaiting when aborted.
+  //   - `reason`: 'terminal' | 'abort' | 'admin_cleanup'.
+  //               LOW-cardinality — safe to dimension on. Splits
+  //               clean completions ('terminal') from user/operator
+  //               aborts ('abort') from operator-driven cleanup
+  //               ('admin_cleanup'). 'terminal' should dominate; a
+  //               sustained 'abort' rate indicates a UX problem.
+  //   - `flow_id`: HIGH-cardinality. Forensic-query ONLY.
+  FLOW_DELETED: 'flow_deleted',
+
   // Emitted when a request to a dependency returns 401 or 403 — catches
   // rotation drift (qurl-service API key, GitHub App token, etc.) that
   // client.isReady() can't see.

--- a/apps/discord/tests/constants-flow-state-events.test.js
+++ b/apps/discord/tests/constants-flow-state-events.test.js
@@ -1,0 +1,50 @@
+/**
+ * Contract test for the event-shipper Pillar 1 audit events.
+ *
+ * These three event names (FLOW_CREATED, FLOW_TRANSITION, FLOW_DELETED)
+ * are reserved by qurl-integrations-infra's matching CloudWatch metric
+ * filters (separate PR, paired with PR 4's emissions). The literal
+ * string values MUST stay stable — renaming any of them silently
+ * breaks the metric filters with no compile-time signal, because
+ * CloudWatch metric filters match log-line JSON against literal
+ * strings.
+ *
+ * Lock the values here so a casual edit to `constants.js` (typo,
+ * "let's snake-case this better", AI-suggested rename) fails the
+ * test instead of the filter.
+ */
+const { AUDIT_EVENTS } = require('../src/constants');
+
+describe('AUDIT_EVENTS — event-shipper Pillar 1 (flow_state)', () => {
+  test('FLOW_CREATED literal is "flow_created"', () => {
+    expect(AUDIT_EVENTS.FLOW_CREATED).toBe('flow_created');
+  });
+
+  test('FLOW_TRANSITION literal is "flow_transition"', () => {
+    expect(AUDIT_EVENTS.FLOW_TRANSITION).toBe('flow_transition');
+  });
+
+  test('FLOW_DELETED literal is "flow_deleted"', () => {
+    expect(AUDIT_EVENTS.FLOW_DELETED).toBe('flow_deleted');
+  });
+
+  test('AUDIT_EVENTS remains frozen', () => {
+    // The freeze is the second line of defense against a runtime
+    // mutation breaking metric filters. Pin it here so a future
+    // refactor that drops the Object.freeze() call gets caught.
+    expect(Object.isFrozen(AUDIT_EVENTS)).toBe(true);
+  });
+
+  test('FLOW_* literals match the snake_case-lower convention used by all other audit events', () => {
+    // Convention check: every audit event literal is lower_snake_case
+    // (no uppercase, no hyphens, no spaces). CloudWatch metric filter
+    // patterns happen to be case-sensitive AND the rest of the
+    // codebase's filters at qurl-integrations-infra assume
+    // lower_snake_case. A capital letter slipping into a new event
+    // name would silently miss every filter.
+    for (const key of ['FLOW_CREATED', 'FLOW_TRANSITION', 'FLOW_DELETED']) {
+      const literal = AUDIT_EVENTS[key];
+      expect(literal).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+});

--- a/apps/discord/tests/constants-flow-state-events.test.js
+++ b/apps/discord/tests/constants-flow-state-events.test.js
@@ -35,16 +35,28 @@ describe('AUDIT_EVENTS — event-shipper Pillar 1 (flow_state)', () => {
     expect(Object.isFrozen(AUDIT_EVENTS)).toBe(true);
   });
 
-  test('FLOW_* literals match the snake_case-lower convention used by all other audit events', () => {
-    // Convention check: every audit event literal is lower_snake_case
-    // (no uppercase, no hyphens, no spaces). CloudWatch metric filter
-    // patterns happen to be case-sensitive AND the rest of the
-    // codebase's filters at qurl-integrations-infra assume
-    // lower_snake_case. A capital letter slipping into a new event
-    // name would silently miss every filter.
-    for (const key of ['FLOW_CREATED', 'FLOW_TRANSITION', 'FLOW_DELETED']) {
-      const literal = AUDIT_EVENTS[key];
+  test('every AUDIT_EVENTS literal follows the lower_snake_case convention', () => {
+    // Convention check across the WHOLE object, not just the FLOW_*
+    // entries this PR adds — turns this test into a regression guard
+    // for every current and future event name. Convention: every
+    // audit event literal is lower_snake_case (no uppercase, no
+    // hyphens, no spaces). CloudWatch metric filter patterns are
+    // case-sensitive AND the rest of the codebase's filters at
+    // qurl-integrations-infra assume lower_snake_case. A capital
+    // letter slipping into any new event name would silently miss
+    // every filter that targets it.
+    for (const [key, literal] of Object.entries(AUDIT_EVENTS)) {
       expect(literal).toMatch(/^[a-z][a-z0-9_]*$/);
+      // Pin a sane upper bound on the literal length too — CloudWatch
+      // metric filter pattern length is bounded, and a runaway literal
+      // would silently misbehave at the filter layer. 80 chars is well
+      // above every current literal (longest today is
+      // `gateway_heartbeat_unhealthy` at 26).
+      expect(literal.length).toBeLessThanOrEqual(80);
+      // Sanity: key must be UPPER_SNAKE_CASE per file convention.
+      // Catches a future contributor adding `flowCreated: 'flow_created'`
+      // which would still pass the literal-shape check.
+      expect(key).toMatch(/^[A-Z][A-Z0-9_]*$/);
     }
   });
 });


### PR DESCRIPTION
## Why

This is **Phase 1.0** of the event-shipper redesign (`apps/discord/docs/zero-downtime-design.md`, merged in #240). Reserves the three audit-event names that PR 4's state-machine harness will emit, and documents the CloudWatch-side SLI computation contract those events feed.

**Why ship Phase 1.0 first**: every downstream event-shipper PR (PR 4 = state-machine harness, PRs 5/6/7-9 = per-command `await*` conversions, PR 10 = gateway producer, PR 11 = worker consumer) needs a stable observability surface to emit against. Locking the event names + meta schema in a single up-front PR prevents two classes of churn: AUDIT_EVENTS edits in every downstream PR, and CloudWatch metric-filter churn in `qurl-integrations-infra`.

## What's in this PR

Constants + docs + a contract test only. **No emissions are wired** (those land in PR 4); **no CloudWatch metric filters are created** (those land in `qurl-integrations-infra` once PR 4 is producing events in sandbox).

Three-stage rollout — **names reserved → emissions wired → filters lit** — keeps each layer reviewable in isolation. This is the same pattern the existing `AUDIT_EVENTS` entries follow: `GUILD_INSTALL` and `monitoring.tf`'s filter live together as a paired unit.

## Events reserved

| Constant | Literal | When emitted | Purpose |
|---|---|---|---|
| `FLOW_CREATED` | `flow_created` | `createFlow()` | SLI denominator (`total_flows`) |
| `FLOW_TRANSITION` | `flow_transition` | `transitionFlow()` | The canonical metric — `qurl_bot_flow_transition_total{stage_from,stage_to,result,terminal}` (design doc § Pillar 1) |
| `FLOW_DELETED` | `flow_deleted` | explicit `deleteFlow()` | SLI numerator (`completed_flows`). TTL-reaped flows deliberately do NOT emit |

Detailed comments in `constants.js` for each entry cover: when it fires, the meta schema (LOW-cardinality-safe-to-dimension vs HIGH-cardinality-forensic-only field distinction), and which SLI it feeds. Mirrors the existing comment discipline on `GUILD_INSTALL` / `INTERACTION_HANDLED` / `DEPENDENCY_AUTH_FAILURE`.

## SLI computation contract (new section in design doc)

The \"`silently_dropped_flows / total_flows`\" SLI from the design doc's existing table was previously underspecified — the doc named the numerator without saying how it's computed. Closed in this PR:

```
total_flows            = count(FLOW_CREATED)
completed_flows        = count(FLOW_DELETED)
silently_dropped_flows = total_flows - completed_flows
```

The \"computed as a difference\" framing intentionally sidesteps the async-TTL-reap problem (DDB TTL deletion is asynchronous, so a synchronous \"reaped\" signal would require a separate sweeper). It also captures every unclean-drop class — process crash mid-flow, worker hang, TTL reap of abandoned flow — under one metric, which is what the SLI is designed to measure.

**Asymmetry the SLI math relies on**: if a future change adds a \"delete-on-TTL-reap\" sweeper, it MUST emit a distinct event (e.g. `FLOW_REAPED`), not `FLOW_DELETED`. Pinned in both the inline `constants.js` comment AND the design-doc section so whoever writes that PR sees it.

## Tests

New `tests/constants-flow-state-events.test.js` (5 tests) locks:
- The three literal string values (CloudWatch metric filters match literals; a typo or rename silently breaks the filters with no compile-time signal).
- The `Object.freeze` guard remains in place.
- The lower_snake_case naming convention every new entry must follow.

Full suite still passes: **1020 / 1020 tests across 42 suites**.

## Explicitly out of scope

- **Queue / worker-dispatch / resume / clock-skew constants** — those land with PRs 10 / 11 / 13 respectively, paired with their own emissions. Reserving them now without consumers creates \"what is this?\" surface area without solving any actual churn problem.
- **Helper wrapper module** (e.g. `emitFlowTransition()`) — the existing pattern is direct `logger.audit(AUDIT_EVENTS.X, {...})` calls. Helper modules exist only where there's real auxiliary logic (`gateway-metrics.js` has `setInterval` timers, not just wrappers).
- **Terraform CloudWatch metric filters** — those live in `qurl-integrations-infra` and pair with PR 4's emissions, not this PR.

## Verification

- [x] `npx jest tests/constants-flow-state-events.test.js` — 5/5 pass
- [x] `npx jest` (full suite) — 1020/1020 pass across 42 suites
- [x] `npx eslint` clean on changed files
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)