### PR TITLE
feat(discord): state-machine harness for flow_state DDB table

### DIFF
--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -268,7 +268,20 @@ const AUDIT_EVENTS = {
   //                   varies per flow type — revoke is shorter than
   //                   send). LOW-cardinality (boolean) — safe to
   //                   dimension on AND included in the materialized
-  //                   metric's dimension list above.
+  //                   metric's dimension list above. FORCED TO false
+  //                   on non-success results (not_found, conflict,
+  //                   error) — the transition didn't advance, so
+  //                   nothing terminal happened, so the audit is
+  //                   honest by construction. Consumers can still
+  //                   slice `count_by(terminal=true)` safely.
+  //   - `extended`:   bool. True if the transition extended/reset
+  //                   the row's expires_at (via the `set_expires_at`
+  //                   option). LOW-cardinality (boolean) — safe to
+  //                   dimension on. Forensic-only today; lets an
+  //                   incident query answer "did this transition
+  //                   bump the deadline?" without re-reading the
+  //                   row. Not currently used as a metric filter
+  //                   dimension.
   //   - `flow_id`:    HIGH-cardinality. Forensic-query ONLY — same
   //                   posture as FLOW_CREATED.
   FLOW_TRANSITION: 'flow_transition',

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -274,14 +274,21 @@ const AUDIT_EVENTS = {
   //                   nothing terminal happened, so the audit is
   //                   honest by construction. Consumers can still
   //                   slice `count_by(terminal=true)` safely.
-  //   - `extended`:   bool. True if the transition extended/reset
-  //                   the row's expires_at (via the `set_expires_at`
-  //                   option). LOW-cardinality (boolean) — safe to
-  //                   dimension on. Forensic-only today; lets an
-  //                   incident query answer "did this transition
-  //                   bump the deadline?" without re-reading the
-  //                   row. Not currently used as a metric filter
-  //                   dimension.
+  //   - `extended`:   bool. True iff the transition GENUINELY
+  //                   extended the row's expires_at (the new value
+  //                   is strictly greater than the prior). A
+  //                   set_expires_at that shortens, equals, or
+  //                   leaves the value untouched emits false —
+  //                   so `count_by(extended=true)` is a faithful
+  //                   "this transition bumped the deadline forward"
+  //                   count and not a "set_expires_at was passed"
+  //                   count. Also false on non-success transitions
+  //                   (nothing extended) and on rows whose prior
+  //                   expires_at was missing/corrupted (no honest
+  //                   baseline to extend FROM). LOW-cardinality
+  //                   (boolean) — safe to dimension on. Forensic-
+  //                   only today; not currently used as a metric
+  //                   filter dimension.
   //   - `version`:    integer. On success: the row's NEW version
   //                   after the OCC bump. On non-success (conflict,
   //                   not_found, error): the version the caller

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -282,6 +282,18 @@ const AUDIT_EVENTS = {
   //                   bump the deadline?" without re-reading the
   //                   row. Not currently used as a metric filter
   //                   dimension.
+  //   - `version`:    integer. On success: the row's NEW version
+  //                   after the OCC bump. On non-success (conflict,
+  //                   not_found, error): the version the caller
+  //                   expected (i.e., `expectedVersion`). Lets a
+  //                   forensic query correlate retries by attempt
+  //                   identity ("which attempt won version 5?")
+  //                   without needing the live row — important
+  //                   because already-deleted flows can't be
+  //                   JOINed against the live table. LOW-cardinality
+  //                   per-flow (bounded by transitions-per-flow,
+  //                   ~10 in practice); NOT a metric dimension —
+  //                   forensic-only field.
   //   - `flow_id`:    HIGH-cardinality. Forensic-query ONLY — same
   //                   posture as FLOW_CREATED.
   FLOW_TRANSITION: 'flow_transition',

--- a/apps/discord/src/flow-id.js
+++ b/apps/discord/src/flow-id.js
@@ -1,0 +1,74 @@
+// flow-id — canonical parse/build for the shard-aware composite key
+// used by `flow_state.flow_id` (see qurl-integrations-infra
+// modules/qurl-bot-ddb flow_state table).
+//
+// Format: `<shard_id>#<guild_id>#<channel_id>#<user_id>`
+//
+// Asymmetric separator rules — `shard_id` may contain `:` (the
+// canonical shard encoding is `k:n`, e.g. `0:1` for single-shard,
+// `3:8` for shard 3 of 8); `:` is therefore NOT used as the
+// flow_id-level separator. The flow-level separator is `#`, which
+// is FORBIDDEN inside every component (including shard_id). This
+// keeps split-on-first-`#` parseable AND lets shard_id retain its
+// natural `k:n` shape.
+//
+// Why centralize this in one module instead of inlining the join /
+// split at every callsite (handler, flow-state, future leader-
+// election lookup, audit-log forensic queries):
+//
+//   - A handler computing `flow_id = `${shard}#${guild}#${chan}#${user}``
+//     and a worker computing the same on its side will drift the
+//     first time someone changes the separator convention. The
+//     OCC-on-flow_id contract relies on byte-identical keys across
+//     both sides; the canonical build/parse pair removes the drift
+//     surface.
+//   - Validation lives in one place. A `guild_id` containing `#`
+//     (impossible per Discord's snowflake encoding today, but cheap
+//     to defend against if Discord ever ships a non-numeric guild
+//     identifier) would silently produce a malformed flow_id and a
+//     parseFlowId() at the other end would yield wrong fields. Reject
+//     at build time, not at deserialization time.
+
+const SEP = '#';
+
+// Snowflake-ish components MUST NOT contain `#`. We intentionally do
+// NOT check the colon — `:` is legal inside `shard_id` and irrelevant
+// for the other components.
+function assertNoSep(value, fieldName) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`flow-id: ${fieldName} must be a non-empty string (got ${typeof value === 'string' ? 'empty string' : typeof value})`);
+  }
+  if (value.includes(SEP)) {
+    throw new TypeError(`flow-id: ${fieldName} must not contain '${SEP}' (got ${JSON.stringify(value)}); the '#' character is reserved as the flow_id component separator`);
+  }
+}
+
+// Build a flow_id from its four components. Order is fixed:
+// shard → guild → channel → user. Callers should treat the returned
+// string as opaque; do not parse it inline — use parseFlowId().
+function buildFlowId({ shard_id, guild_id, channel_id, user_id }) {
+  assertNoSep(shard_id, 'shard_id');
+  assertNoSep(guild_id, 'guild_id');
+  assertNoSep(channel_id, 'channel_id');
+  assertNoSep(user_id, 'user_id');
+  return `${shard_id}${SEP}${guild_id}${SEP}${channel_id}${SEP}${user_id}`;
+}
+
+// Inverse of buildFlowId. Returns `null` for any malformed input
+// (wrong type, wrong shape, empty component) so callers can decide
+// whether to log + skip or throw. Throwing on a malformed flow_id
+// pulled from DDB would break the audit/forensic path — a
+// best-effort parse + null sentinel preserves that path.
+//
+// Split is exact: exactly 3 `#` separators produces 4 components.
+// More or fewer is rejected (returns null).
+function parseFlowId(flow_id) {
+  if (typeof flow_id !== 'string' || flow_id.length === 0) return null;
+  const parts = flow_id.split(SEP);
+  if (parts.length !== 4) return null;
+  const [shard_id, guild_id, channel_id, user_id] = parts;
+  if (!shard_id || !guild_id || !channel_id || !user_id) return null;
+  return { shard_id, guild_id, channel_id, user_id };
+}
+
+module.exports = { buildFlowId, parseFlowId };

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -101,6 +101,12 @@ if (!AWS_REGION) {
 
 const TABLE_NAME = `${TABLE_PREFIX}flow-state`;
 
+// Test escape hatch: `DDB_TEST_ENDPOINT=http://localhost:8000`
+// points the client at DynamoDB Local (or any HTTP-compatible
+// emulator). Not used in production. The unit tests in
+// `tests/flow-state.test.js` use `aws-sdk-client-mock` to
+// intercept at the SDK layer instead — this env var is for
+// integration tests against a real local DDB instance.
 const rawClient = new DynamoDBClient({
   region: AWS_REGION,
   ...(process.env.DDB_TEST_ENDPOINT ? { endpoint: process.env.DDB_TEST_ENDPOINT } : {}),
@@ -421,6 +427,13 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
   if (typeof terminal !== 'boolean') {
     throw new TypeError(`flow-state.transitionFlow: terminal must be a boolean (got ${typeof terminal})`);
   }
+  // "Strictly in the future" is enforced at call time, NOT at the
+  // DDB-write time. A caller passing `set_expires_at: now + 1` can
+  // validate clean, then have the row's expires_at land in the past
+  // by the time DDB sees the UpdateCommand (the pre-read network
+  // round-trip is between the two). Non-fatal — the row is just
+  // born expired, same shape as the createFlow foot-gun — but with
+  // sane TTLs (minutes-to-hours) the window is irrelevant.
   if (set_expires_at !== undefined) assertExpiresAt(set_expires_at);
 
   // Read stage_from for the audit emission. The Update below is
@@ -458,6 +471,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         result: 'not_found',
         terminal: false,
         extended,
+        version: expectedVersion,
       });
       return { result: 'not_found', version: null };
     }
@@ -471,6 +485,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       result: 'error',
       terminal: false,
       extended,
+      version: expectedVersion,
     });
     throw err;
   }
@@ -516,13 +531,17 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       result: 'success',
       terminal,
       extended,
+      version: newVersion,
     });
     return { result: 'success', version: newVersion };
   } catch (err) {
     if (isConditionalCheckFailed(err)) {
       // The OCC gate. Could be (a) row disappeared between pre-read
       // and Update (TTL reap or concurrent delete) → not_found, or
-      // (b) version mismatch (concurrent transition) → conflict.
+      // (b) row is logically expired but DDB hasn't reaped yet →
+      // not_found (same retry semantics as physical absence — a
+      // caller retrying conflict on an expired row is wasted work),
+      // or (c) version mismatch (concurrent transition) → conflict.
       // Distinguish with a second Get so the caller can pick the
       // right retry strategy.
       let result = 'conflict';
@@ -530,10 +549,20 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         const recheck = await ddb.send(new GetCommand({
           TableName: TABLE_NAME,
           Key: { flow_id },
-          ProjectionExpression: 'flow_id',
+          ProjectionExpression: 'flow_id, expires_at',
           ConsistentRead: true,
         }));
-        if (!recheck?.Item) result = 'not_found';
+        if (!recheck?.Item) {
+          result = 'not_found';
+        } else {
+          // Apply the same logical-expiry filter as loadFlow — a row
+          // present in DDB but already past expires_at should report
+          // not_found, not conflict. Symmetric with the reader.
+          const exp = recheck.Item.expires_at;
+          if (typeof exp === 'number' && Number.isFinite(exp) && Math.floor(exp) === exp && nowEpochSeconds() > exp) {
+            result = 'not_found';
+          }
+        }
       } catch (recheckErr) {
         // Recheck failure — stay conservative and report conflict
         // (the original Update failed due to a conditional check,
@@ -552,6 +581,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         result,
         terminal: false,
         extended,
+        version: expectedVersion,
       });
       return { result, version: null };
     }
@@ -563,6 +593,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       result: 'error',
       terminal: false,
       extended,
+      version: expectedVersion,
     });
     throw err;
   }

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -1,0 +1,459 @@
+// flow-state — DDB-backed state-machine harness.
+//
+// Single-purpose: create / load / transition / delete a flow row in
+// the `flow_state` DDB table provisioned by qurl-integrations-infra
+// modules/qurl-bot-ddb (PR #504). Standalone module — NOT a Store
+// contract method — because flow_state's lifecycle is tightly
+// coupled to the SQS event-shipper architecture and shouldn't be
+// reachable from code paths that legitimately depend on the Store
+// abstraction (those run identically against SQLite for local dev;
+// flow_state is DDB-only).
+//
+// Three correctness primitives:
+//
+//   1. OCC via `version` + `ConditionExpression: #v = :expected`.
+//      A worker advancing a flow MUST pass the version it loaded;
+//      a concurrent worker that already advanced the row will lose
+//      the conditional check and the caller can decide to retry,
+//      drop, or escalate. SQS at-least-once + the OCC gate gives
+//      the system exactly-once-application semantics without a
+//      FIFO queue.
+//
+//   2. TTL-driven cleanup. Every row has an `expires_at` Number
+//      (epoch-seconds — DDB TTL is asynchronous and only reaps
+//      Number-typed attributes; a string here would silently
+//      orphan the row in the table forever). Asynchronous reap
+//      delay can be up to ~48h, so the reader contract treats
+//      `now > expires_at` as absent — see `loadFlow` below.
+//
+//   3. Mandatory app-layer payload encryption via `encryptStrict`.
+//      The payload map transitively carries `attachment_url` and
+//      recipient lists; both are unacceptable in plaintext-at-rest.
+//      `encryptStrict` fails closed if `KEY_ENCRYPTION_KEY` is
+//      unset, so a misconfigured deploy can't silently persist
+//      plaintext.
+
+const {
+  DynamoDBClient,
+} = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  DeleteCommand,
+  UpdateCommand,
+} = require('@aws-sdk/lib-dynamodb');
+
+// `ConditionalCheckFailedException.name` is the stable identifier the
+// AWS v3 SDK sets on the error — the exception class itself is in
+// `@aws-sdk/client-dynamodb` and importing it here would couple this
+// module to two SDK packages for one error-discrimination check.
+// Matching on `.name` is what the rest of the codebase does
+// (see `store/ddb-store.js`) and what the SDK's own docs recommend.
+function isConditionalCheckFailed(err) {
+  return err?.name === 'ConditionalCheckFailedException';
+}
+
+const { encryptStrict, decrypt } = require('./utils/crypto');
+const logger = require('./logger');
+const { AUDIT_EVENTS } = require('./constants');
+
+// Module-load validations. Same fail-fast pattern as ddb-store.js
+// (DDB_TABLE_PREFIX + AWS_REGION). flow-state intentionally
+// duplicates the DDB-client setup rather than importing it from
+// ddb-store — flow-state is loaded on bot boot for ANY env that
+// runs the event-shipper architecture (incl. envs that may not
+// run STORE_TYPE=ddb), and tying it to ddb-store's module init
+// would couple two independent code paths. A future PR can extract
+// `src/store/ddb-client.js` once a third consumer appears.
+// TODO(PR 12): consolidate DDB client init into a shared module
+// when the gateway-tier RESUME table arrives — three consumers
+// is the right break-even point for the extraction.
+const TABLE_PREFIX = (process.env.DDB_TABLE_PREFIX ?? '').trim();
+if (!TABLE_PREFIX) {
+  throw new Error('DDB_TABLE_PREFIX is required to use the flow-state harness. Set it in the deployment template (e.g. `qurl-bot-discord-sandbox-`).');
+}
+if (!TABLE_PREFIX.endsWith('-')) {
+  throw new Error(`DDB_TABLE_PREFIX must end with '-' (got '${TABLE_PREFIX}'). flow-state concatenates it directly with 'flow-state'; a missing dash produces a malformed table name.`);
+}
+const AWS_REGION = (process.env.AWS_REGION ?? '').trim();
+if (!AWS_REGION) {
+  throw new Error('AWS_REGION is required to use the flow-state harness. Set it in the deployment template (e.g. `us-east-2`).');
+}
+
+const TABLE_NAME = `${TABLE_PREFIX}flow-state`;
+
+const rawClient = new DynamoDBClient({
+  region: AWS_REGION,
+  ...(process.env.DDB_TEST_ENDPOINT ? { endpoint: process.env.DDB_TEST_ENDPOINT } : {}),
+});
+const ddb = DynamoDBDocumentClient.from(rawClient, {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+// TTL writer contract enforcement. DDB silently keeps a row forever
+// if `expires_at` is anything other than a Number — string-typed
+// timestamps are the classic foot-gun (a `new Date().toISOString()`
+// looks correct but is type "S" and never reaps). Hard-fail here
+// rather than at GetItem-time when the orphan surfaces years later.
+function assertExpiresAt(expiresAt) {
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || Math.floor(expiresAt) !== expiresAt) {
+    throw new TypeError(`flow-state: expires_at must be a finite integer epoch-seconds Number (got ${typeof expiresAt}: ${JSON.stringify(expiresAt)}). DDB TTL only reaps Number-typed attributes; a string or float would silently orphan the row.`);
+  }
+}
+
+function nowEpochSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+// Encrypt the payload object as a JSON string. Decrypt is the
+// inverse. We encrypt the whole JSON blob rather than per-field
+// because the payload shape is intentionally freeform — different
+// flow types carry different keys, and a per-field allowlist would
+// either churn with every flow added or be too permissive to be
+// useful. Whole-blob encryption keeps the DDB attribute shape
+// predictable (always a single `payload` string column) regardless
+// of flow type.
+function encryptPayload(payload) {
+  if (payload == null) return null;
+  return encryptStrict(JSON.stringify(payload));
+}
+
+function decryptPayload(ciphertext) {
+  if (ciphertext == null) return null;
+  const plaintext = decrypt(ciphertext);
+  if (plaintext == null) return null;
+  try {
+    return JSON.parse(plaintext);
+  } catch (err) {
+    // A row with a malformed JSON payload is unrecoverable for
+    // anything except forensic inspection — emit and return null
+    // rather than throwing so a worker handling the row can decide
+    // to delete-and-move-on instead of crashing the consumer loop.
+    logger.error('flow-state: payload JSON.parse failed; row likely corrupted', {
+      reason: err && err.message,
+    });
+    return null;
+  }
+}
+
+// Create a new flow row. Idempotent on `flow_id` via
+// `attribute_not_exists` — a caller that re-emits the same
+// createFlow due to SQS at-least-once redelivery will get
+// `{ created: false }` and can short-circuit. Successful create
+// returns `{ created: true, version: 1 }`.
+//
+// Why caller-supplied `expires_at` rather than computing it here:
+// different flow types have different lifecycle bounds (a
+// `/qurl setup` modal has a 15-minute window; a `/qurl send`
+// confirmation can sit for hours). The caller knows; this module
+// just persists.
+async function createFlow({ flow_id, stage, payload, expires_at }) {
+  if (typeof flow_id !== 'string' || flow_id.length === 0) {
+    throw new TypeError('flow-state.createFlow: flow_id must be a non-empty string');
+  }
+  if (typeof stage !== 'string' || stage.length === 0) {
+    throw new TypeError('flow-state.createFlow: stage must be a non-empty string');
+  }
+  assertExpiresAt(expires_at);
+
+  const item = {
+    flow_id,
+    stage,
+    version: 1,
+    payload: encryptPayload(payload),
+    expires_at,
+    created_at: nowEpochSeconds(),
+    updated_at: nowEpochSeconds(),
+  };
+
+  try {
+    await ddb.send(new PutCommand({
+      TableName: TABLE_NAME,
+      Item: item,
+      ConditionExpression: 'attribute_not_exists(flow_id)',
+    }));
+  } catch (err) {
+    if (isConditionalCheckFailed(err)) {
+      // Existing row — idempotent no-op. Don't emit FLOW_CREATED;
+      // the SLI denominator counts new flows, not redeliveries.
+      return { created: false };
+    }
+    throw err;
+  }
+
+  logger.audit(AUDIT_EVENTS.FLOW_CREATED, {
+    flow_id,
+    stage,
+  });
+  return { created: true, version: 1 };
+}
+
+// Load a flow row by flow_id. Returns the row with the payload
+// decrypted, or `null` if the row is absent OR has logically
+// expired (now > expires_at). The DDB TTL reap is asynchronous —
+// up to ~48h delay between `now > expires_at` and the physical
+// row deletion — so a reader that returns the still-present row
+// would silently violate the "flow timed out" contract. Filter
+// at the reader.
+//
+// grace_seconds (default 0) lets callers tolerate a small clock-
+// skew window if they're reading on the back of a write they
+// just performed. Default 0 because the canonical use case is
+// "is this flow still alive?" and the answer should be honest.
+async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
+  if (typeof flow_id !== 'string' || flow_id.length === 0) {
+    throw new TypeError('flow-state.loadFlow: flow_id must be a non-empty string');
+  }
+  const res = await ddb.send(new GetCommand({
+    TableName: TABLE_NAME,
+    Key: { flow_id },
+    ConsistentRead: true,
+  }));
+  const item = res?.Item;
+  if (!item) return null;
+  const expires = item.expires_at;
+  if (typeof expires === 'number' && Number.isFinite(expires)) {
+    if (nowEpochSeconds() > expires + grace_seconds) {
+      // Logically expired but not yet reaped. Treat as absent.
+      return null;
+    }
+  } else {
+    // expires_at is present but not a finite Number — could be a
+    // corrupted row (manual console put, legacy writer regression,
+    // future schema mismatch). Fail-safe: treat as expired rather
+    // than returning a row that DDB TTL will never reap. Symmetric
+    // to the assertExpiresAt() guard on the writer side.
+    logger.warn('flow-state.loadFlow: row has missing or non-numeric expires_at; treating as expired', {
+      flow_id,
+      expires_at_type: typeof expires,
+    });
+    return null;
+  }
+  return {
+    flow_id: item.flow_id,
+    stage: item.stage,
+    version: item.version,
+    payload: decryptPayload(item.payload),
+    expires_at: item.expires_at,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+  };
+}
+
+// Advance a flow's stage under OCC. The caller passes the version
+// it loaded; this method only succeeds if the row's current version
+// still matches. Returns one of:
+//   { result: 'success',    version: <new_version> }
+//   { result: 'conflict',   version: null }   — OCC lost (concurrent advance)
+//   { result: 'not_found',  version: null }   — row absent
+//   { result: 'error',      version: null }   — unexpected DDB failure (rethrown after emit)
+//
+// `terminal` is caller-supplied because flow-state cannot know
+// which transitions end which flow types (the terminal set varies
+// per flow — revoke has fewer stages than send). When `terminal`
+// is true the next call should be deleteFlow.
+async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, terminal, extend_expires_at }) {
+  if (typeof flow_id !== 'string' || flow_id.length === 0) {
+    throw new TypeError('flow-state.transitionFlow: flow_id must be a non-empty string');
+  }
+  if (typeof expectedVersion !== 'number' || !Number.isInteger(expectedVersion) || expectedVersion < 1) {
+    throw new TypeError(`flow-state.transitionFlow: expectedVersion must be a positive integer (got ${expectedVersion})`);
+  }
+  if (typeof stage_to !== 'string' || stage_to.length === 0) {
+    throw new TypeError('flow-state.transitionFlow: stage_to must be a non-empty string');
+  }
+  if (typeof terminal !== 'boolean') {
+    throw new TypeError(`flow-state.transitionFlow: terminal must be a boolean (got ${typeof terminal})`);
+  }
+  if (extend_expires_at !== undefined) assertExpiresAt(extend_expires_at);
+
+  // Read stage_from for the audit emission. The Update below is
+  // the authoritative write — a concurrent transition between this
+  // Get and the Update is detected by OCC and reported as conflict;
+  // the stale stage_from in the audit emission is acceptable
+  // (forensic field, not used for SLI math).
+  let stage_from = null;
+  try {
+    const got = await ddb.send(new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { flow_id },
+      ProjectionExpression: 'stage',
+      ConsistentRead: true,
+    }));
+    if (!got?.Item) {
+      logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {
+        flow_id,
+        stage_from: null,
+        stage_to,
+        result: 'not_found',
+        terminal,
+      });
+      return { result: 'not_found', version: null };
+    }
+    stage_from = got.Item.stage ?? null;
+  } catch (err) {
+    logger.error('flow-state.transitionFlow: pre-read failed', { flow_id, reason: err && err.message });
+    logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id,
+      stage_from: null,
+      stage_to,
+      result: 'error',
+      terminal,
+    });
+    throw err;
+  }
+
+  const updateExprParts = ['#s = :stage_to', '#v = #v + :one', '#u = :updated_at'];
+  const exprNames = {
+    '#s': 'stage',
+    '#v': 'version',
+    '#u': 'updated_at',
+  };
+  const exprValues = {
+    ':stage_to': stage_to,
+    ':one': 1,
+    ':updated_at': nowEpochSeconds(),
+    ':expected': expectedVersion,
+  };
+  if (payload !== undefined) {
+    updateExprParts.push('#p = :payload');
+    exprNames['#p'] = 'payload';
+    exprValues[':payload'] = encryptPayload(payload);
+  }
+  if (extend_expires_at !== undefined) {
+    updateExprParts.push('#e = :expires_at');
+    exprNames['#e'] = 'expires_at';
+    exprValues[':expires_at'] = extend_expires_at;
+  }
+
+  try {
+    const res = await ddb.send(new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { flow_id },
+      UpdateExpression: `SET ${updateExprParts.join(', ')}`,
+      ConditionExpression: 'attribute_exists(flow_id) AND #v = :expected',
+      ExpressionAttributeNames: exprNames,
+      ExpressionAttributeValues: exprValues,
+      ReturnValues: 'UPDATED_NEW',
+    }));
+    const newVersion = res?.Attributes?.version ?? expectedVersion + 1;
+    logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id,
+      stage_from,
+      stage_to,
+      result: 'success',
+      terminal,
+    });
+    return { result: 'success', version: newVersion };
+  } catch (err) {
+    if (isConditionalCheckFailed(err)) {
+      // The OCC gate. Could be (a) row disappeared between pre-read
+      // and Update (TTL reap or concurrent delete) → not_found, or
+      // (b) version mismatch (concurrent transition) → conflict.
+      // Distinguish with a second Get so the caller can pick the
+      // right retry strategy.
+      let result = 'conflict';
+      try {
+        const recheck = await ddb.send(new GetCommand({
+          TableName: TABLE_NAME,
+          Key: { flow_id },
+          ProjectionExpression: 'flow_id',
+          ConsistentRead: true,
+        }));
+        if (!recheck?.Item) result = 'not_found';
+      } catch (_recheckErr) {
+        // Recheck failure — stay conservative and report conflict
+        // (the original Update failed due to a conditional check,
+        // not an availability issue).
+      }
+      logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {
+        flow_id,
+        stage_from,
+        stage_to,
+        result,
+        terminal,
+      });
+      return { result, version: null };
+    }
+    logger.error('flow-state.transitionFlow: update failed', { flow_id, reason: err && err.message });
+    logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id,
+      stage_from,
+      stage_to,
+      result: 'error',
+      terminal,
+    });
+    throw err;
+  }
+}
+
+// Explicit delete. Emits FLOW_DELETED (the SLI numerator) — TTL
+// reap deliberately does NOT emit this event so the
+// silently-dropped count surfaces in the difference. If a future
+// PR adds a TTL-driven sweeper it MUST emit a distinct event
+// (e.g. FLOW_REAPED) so the SLI math stays intact.
+//
+// `reason` is one of 'terminal' | 'abort' | 'admin_cleanup' per
+// the audit event's payload contract. Caller-supplied because
+// flow-state can't know whether a given delete is a clean
+// completion vs. a user abort.
+async function deleteFlow(flow_id, { stage, reason }) {
+  if (typeof flow_id !== 'string' || flow_id.length === 0) {
+    throw new TypeError('flow-state.deleteFlow: flow_id must be a non-empty string');
+  }
+  if (typeof stage !== 'string' || stage.length === 0) {
+    throw new TypeError('flow-state.deleteFlow: stage must be a non-empty string');
+  }
+  if (reason !== 'terminal' && reason !== 'abort' && reason !== 'admin_cleanup') {
+    throw new TypeError(`flow-state.deleteFlow: reason must be one of 'terminal'|'abort'|'admin_cleanup' (got ${JSON.stringify(reason)})`);
+  }
+
+  // Conditional Delete + emit-on-success. The SLI math
+  //   silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)
+  // requires at-most-once emission per logical flow on BOTH sides.
+  // CREATED is gated by `attribute_not_exists`; DELETED needs the
+  // mirror — `attribute_exists` — otherwise an SQS redelivery of an
+  // abort/admin_cleanup path (which have no version-checked
+  // predecessor to gate on) would Delete-success-idempotently a
+  // second time and double-emit FLOW_DELETED. Numerator inflates,
+  // signal lost.
+  //
+  // Returns `{ deleted: bool }` so callers can gate user-visible
+  // "flow completed" side effects on actual deletion (a false
+  // return means someone else already deleted, or the TTL reaped
+  // — either way, don't re-DM the user).
+  try {
+    await ddb.send(new DeleteCommand({
+      TableName: TABLE_NAME,
+      Key: { flow_id },
+      ConditionExpression: 'attribute_exists(flow_id)',
+    }));
+  } catch (err) {
+    if (isConditionalCheckFailed(err)) {
+      // Row was already gone (redelivery, TTL reap, or concurrent
+      // delete). No-op. Do NOT emit FLOW_DELETED — the SLI's
+      // count(FLOW_DELETED) must stay at-most-once per logical flow.
+      return { deleted: false };
+    }
+    throw err;
+  }
+
+  logger.audit(AUDIT_EVENTS.FLOW_DELETED, {
+    flow_id,
+    stage,
+    reason,
+  });
+  return { deleted: true };
+}
+
+module.exports = {
+  createFlow,
+  loadFlow,
+  transitionFlow,
+  deleteFlow,
+  // Exposed for tests + future modules that need the canonical
+  // table name (e.g. an admin CLI). Not for production code paths
+  // that should go through the four functions above.
+  __TABLE_NAME: TABLE_NAME,
+};

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -561,7 +561,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
     '#v': 'version',
     '#u': 'updated_at',
     // `#e` is in the names map unconditionally — the ConditionExpression
-    // below uses `#e > :now` to gate writes on logical aliveness.
+    // below uses `#e >= :now` to gate writes on logical aliveness.
     // `set_expires_at` may also reference `#e` to rewrite the value.
     '#e': 'expires_at',
   };
@@ -587,7 +587,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       TableName: TABLE_NAME,
       Key: { flow_id },
       UpdateExpression: `SET ${updateExprParts.join(', ')}`,
-      // `#e > :now` closes the silent-SLI-inflation hole where a
+      // `#e >= :now` closes the silent-SLI-inflation hole where a
       // logically-expired row (DDB TTL reap is async, ~48h lag)
       // could pass attribute_exists + version-match and have its
       // stage rewritten — even though loadFlow would then return

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -203,6 +203,13 @@ function decryptPayload(ciphertext) {
 // `{ created: false }` and can short-circuit. Successful create
 // returns `{ created: true, version: 1 }`.
 //
+// The `{ created: false }` return carries no `version`. A caller
+// that needs the existing row's version after a redelivery
+// short-circuit must follow up with `loadFlow(flow_id)` — the
+// version that would have been "1" for a fresh create is not
+// the version of the in-table row, which may have already
+// advanced via transitionFlow.
+//
 // Why caller-supplied `expires_at` rather than computing it here:
 // different flow types have different lifecycle bounds (a
 // `/qurl setup` modal has a 15-minute window; a `/qurl send`
@@ -549,7 +556,9 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         const recheck = await ddb.send(new GetCommand({
           TableName: TABLE_NAME,
           Key: { flow_id },
-          ProjectionExpression: 'flow_id, expires_at',
+          // Partition key is always returned by GetCommand, so we
+          // only project `expires_at` explicitly.
+          ProjectionExpression: 'expires_at',
           ConsistentRead: true,
         }));
         if (!recheck?.Item) {

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -32,6 +32,16 @@
 //      `encryptStrict` fails closed if `KEY_ENCRYPTION_KEY` is
 //      unset, so a misconfigured deploy can't silently persist
 //      plaintext.
+//
+// flow_id contract: must be a parseable shard-aware composite key
+// as produced by `buildFlowId` in `src/flow-id.js`. `createFlow`
+// validates structure at entry (parseFlowId returns non-null);
+// transition/load/delete trust the caller — a malformed flow_id
+// passed to those methods will simply hit not_found. Callers
+// SHOULD route every flow_id through buildFlowId() rather than
+// hand-rolling the join — drift on the separator convention
+// between handler and worker is exactly the foot-gun flow-id.js
+// exists to close.
 
 const {
   DynamoDBClient,
@@ -57,6 +67,7 @@ function isConditionalCheckFailed(err) {
 const { encryptStrict, decrypt } = require('./utils/crypto');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
+const { parseFlowId } = require('./flow-id');
 
 // Module-load validations. Same fail-fast pattern as ddb-store.js
 // (DDB_TABLE_PREFIX + AWS_REGION). flow-state intentionally
@@ -103,9 +114,21 @@ const ddb = DynamoDBDocumentClient.from(rawClient, {
 // timestamps are the classic foot-gun (a `new Date().toISOString()`
 // looks correct but is type "S" and never reaps). Hard-fail here
 // rather than at GetItem-time when the orphan surfaces years later.
+//
+// We ALSO reject `expires_at <= now` — a forgotten `+ ttl_seconds`
+// (a classic miscompute, e.g. `expiresAt = nowEpochSeconds()` with
+// the addition forgotten) writes a row that's instantly expired:
+//   1. passes type check, succeeds Put, fires FLOW_CREATED
+//   2. every loadFlow returns null (now > expires_at)
+//   3. caller can never advance to deleteFlow → SLI numerator drops
+// ⇒ guaranteed contributor to `silently_dropped_flows`. Reject at
+// write time instead so the bad call site is named in the throw.
 function assertExpiresAt(expiresAt) {
   if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || Math.floor(expiresAt) !== expiresAt) {
     throw new TypeError(`flow-state: expires_at must be a finite integer epoch-seconds Number (got ${typeof expiresAt}: ${JSON.stringify(expiresAt)}). DDB TTL only reaps Number-typed attributes; a string or float would silently orphan the row.`);
+  }
+  if (expiresAt <= nowEpochSeconds()) {
+    throw new RangeError(`flow-state: expires_at must be strictly in the future (got ${expiresAt}; now is ${nowEpochSeconds()}). A row whose TTL is in the past is born expired — it passes the Put, fires FLOW_CREATED, but loadFlow returns null forever after, silently inflating the SLI's silently_dropped numerator. Most often this is a forgotten '+ ttl_seconds' on the caller side.`);
   }
 }
 
@@ -122,12 +145,22 @@ function nowEpochSeconds() {
 // predictable (always a single `payload` string column) regardless
 // of flow type.
 function encryptPayload(payload) {
+  // Load-bearing null guard: without it, payload=null would
+  // encryptStrict(JSON.stringify(null)) = ciphertext-of-"null"
+  // (the 4-byte string), storing a non-null DDB attribute that
+  // decrypts to the string "null", which JSON.parse correctly
+  // reverses but at the cost of a wasted encrypt call AND an
+  // inconsistent DDB attribute shape (string sometimes, null
+  // sometimes). Pass null through unchanged so the column is
+  // either a real ciphertext or a DDB null — never both.
   if (payload == null) return null;
   return encryptStrict(JSON.stringify(payload));
 }
 
 function decryptPayload(ciphertext) {
-  if (ciphertext == null) return null;
+  // No upfront null guard — `decrypt` passes null/undefined through
+  // unchanged, and the `plaintext == null` check below catches it.
+  // A single guard is clearer than two redundant ones.
   const plaintext = decrypt(ciphertext);
   if (plaintext == null) return null;
   try {
@@ -169,19 +202,30 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.createFlow: flow_id must be a non-empty string');
   }
+  // Entry-point structure validation. Once a malformed flow_id is in
+  // the table its later operations would silently succeed (transitions
+  // and deletes only look up by the literal key), and the audit
+  // forensic path would fail at `parseFlowId` time with no signal —
+  // the silent-drop foot-gun the reviewer flagged as "aspirational
+  // coupling". Reject malformed keys at the only place a new row
+  // can enter the table.
+  if (parseFlowId(flow_id) === null) {
+    throw new TypeError(`flow-state.createFlow: flow_id ${JSON.stringify(flow_id)} is not a parseable shard-aware composite key. Use buildFlowId({ shard_id, guild_id, channel_id, user_id }) from src/flow-id.js to construct it.`);
+  }
   if (typeof stage !== 'string' || stage.length === 0) {
     throw new TypeError('flow-state.createFlow: stage must be a non-empty string');
   }
   assertExpiresAt(expires_at);
 
+  const now = nowEpochSeconds();
   const item = {
     flow_id,
     stage,
     version: 1,
     payload: encryptPayload(payload),
     expires_at,
-    created_at: nowEpochSeconds(),
-    updated_at: nowEpochSeconds(),
+    created_at: now,
+    updated_at: now,
   };
 
   try {
@@ -194,6 +238,16 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
     if (isConditionalCheckFailed(err)) {
       // Existing row — idempotent no-op. Don't emit FLOW_CREATED;
       // the SLI denominator counts new flows, not redeliveries.
+      //
+      // Note: a payload mutation in the redelivered call is DISCARDED
+      // silently. The contract is "create-once for this flow_id"; if
+      // the caller's payload genuinely needs to evolve, the right
+      // primitive is transitionFlow (which gives an OCC handle on
+      // mutation) rather than re-trying createFlow with a different
+      // payload. We do not warn-log on payload divergence today —
+      // there's no cheap way to compare encrypted payloads without
+      // decrypting both, and the legitimate case (SQS exact-duplicate)
+      // would generate spurious warns.
       return { created: false };
     }
     throw err;
@@ -221,9 +275,25 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
 // Negative grace values are accepted (skews "expired" earlier);
 // no use case yet but cheaper to leave permissive than to gate
 // on a corner case a future caller might legitimately want.
+//
+// ConsistentRead: the read is strongly consistent. Canonical use
+// case is "I just transitioned this flow and want to re-verify"
+// or "I'm about to transition and want the current version" —
+// both need strong consistency. Eventually-consistent reads
+// would also double RCU efficiency, but the harness today has
+// no orthogonal-read callers (admin tooling, audit forensics)
+// to justify a parameter. Add `consistent_read: false` here if
+// such a caller arrives.
 async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.loadFlow: flow_id must be a non-empty string');
+  }
+  // Type-check grace_seconds. Without this, `grace_seconds:
+  // 'forever'` would evaluate `expires + 'forever'` → string
+  // concat → NaN → `now > NaN` is false → expired-as-alive. A
+  // caller passing untrusted config could surface stale flows.
+  if (typeof grace_seconds !== 'number' || !Number.isFinite(grace_seconds)) {
+    throw new TypeError(`flow-state.loadFlow: grace_seconds must be a finite number (got ${typeof grace_seconds}: ${JSON.stringify(grace_seconds)})`);
   }
   const res = await ddb.send(new GetCommand({
     TableName: TABLE_NAME,
@@ -289,6 +359,25 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
 // per flow — revoke has fewer stages than send). When `terminal`
 // is true the next call should be deleteFlow.
 //
+// **`terminal` is forced to `false` on non-success results.** If
+// the transition didn't actually advance the row (not_found,
+// conflict, error), then nothing terminal happened — emitting
+// the caller's `terminal: true` would let a forensic query like
+// `count_by(terminal=true)` over-count by including failed
+// transitions. The SLI math is unaffected (it splits on `result`
+// + `terminal`, never `terminal` alone), but the audit shape
+// should be honest.
+//
+// `set_expires_at` (optional): replaces the row's expires_at to
+// the given value. **Named "set", not "extend"** because the
+// harness does NOT enforce monotonicity — a caller passing a
+// value earlier than the row's current expires_at will shorten
+// the lifetime, not extend it. Callers wanting monotonic-only
+// extension should compare against `loadFlow().expires_at`
+// first; the harness can't enforce it without an extra Read or
+// a stricter ConditionExpression (which would complicate the
+// not_found/conflict discrimination).
+//
 // **Audit-emit-on-rethrow contract.** On `result: 'error'` paths
 // the FLOW_TRANSITION audit fires BEFORE the rethrow. A caller
 // that retries a transient `NetworkingError` will produce N
@@ -297,7 +386,7 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
 // retry storm should be visible in the metric), and the SLI math
 // `silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)`
 // is unaffected because it doesn't read the `error` bucket.
-async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, terminal, extend_expires_at }) {
+async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, terminal, set_expires_at }) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.transitionFlow: flow_id must be a non-empty string');
   }
@@ -310,7 +399,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
   if (typeof terminal !== 'boolean') {
     throw new TypeError(`flow-state.transitionFlow: terminal must be a boolean (got ${typeof terminal})`);
   }
-  if (extend_expires_at !== undefined) assertExpiresAt(extend_expires_at);
+  if (set_expires_at !== undefined) assertExpiresAt(set_expires_at);
 
   // Read stage_from for the audit emission. The Update below is
   // the authoritative write — a concurrent transition between this
@@ -318,6 +407,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
   // the stale stage_from in the audit emission is acceptable
   // (forensic field, not used for SLI math).
   let stage_from = null;
+  const extended = set_expires_at !== undefined;
   try {
     const got = await ddb.send(new GetCommand({
       TableName: TABLE_NAME,
@@ -331,7 +421,8 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         stage_from: null,
         stage_to,
         result: 'not_found',
-        terminal,
+        terminal: false,
+        extended,
       });
       return { result: 'not_found', version: null };
     }
@@ -343,7 +434,8 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       stage_from: null,
       stage_to,
       result: 'error',
-      terminal,
+      terminal: false,
+      extended,
     });
     throw err;
   }
@@ -365,10 +457,10 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
     exprNames['#p'] = 'payload';
     exprValues[':payload'] = encryptPayload(payload);
   }
-  if (extend_expires_at !== undefined) {
+  if (set_expires_at !== undefined) {
     updateExprParts.push('#e = :expires_at');
     exprNames['#e'] = 'expires_at';
-    exprValues[':expires_at'] = extend_expires_at;
+    exprValues[':expires_at'] = set_expires_at;
   }
 
   try {
@@ -388,6 +480,7 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       stage_to,
       result: 'success',
       terminal,
+      extended,
     });
     return { result: 'success', version: newVersion };
   } catch (err) {
@@ -422,7 +515,8 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         stage_from,
         stage_to,
         result,
-        terminal,
+        terminal: false,
+        extended,
       });
       return { result, version: null };
     }
@@ -432,7 +526,8 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       stage_from,
       stage_to,
       result: 'error',
-      terminal,
+      terminal: false,
+      extended,
     });
     throw err;
   }

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -444,6 +444,16 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
 // retry storm should be visible in the metric), and the SLI math
 // `silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)`
 // is unaffected because it doesn't read the `error` bucket.
+//
+// On `result: 'error'` and `result: 'not_found'`, the `version`
+// field in the audit is the caller's `expectedVersion` — what
+// they INTENDED to advance from — not anything observed on the
+// row. Forensic queries correlating retries by attempt identity
+// should treat error/not_found `version` as intent, not
+// observation. (On `result: 'success'`, it's the post-bump
+// observed value; on `result: 'conflict'`, the caller's intent
+// is still the relevant correlator because the observed value
+// is what beat them.)
 async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, terminal, set_expires_at }) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.transitionFlow: flow_id must be a non-empty string');
@@ -619,8 +629,11 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         const recheck = await ddb.send(new GetCommand({
           TableName: TABLE_NAME,
           Key: { flow_id },
-          // Partition key is always returned by GetCommand, so we
-          // only project `expires_at` explicitly.
+          // We only need expires_at — `flow_id` is the lookup key
+          // and we never read it back from the recheck result.
+          // (Note: with ProjectionExpression set, the v3 SDK does
+          // NOT auto-include the partition key, contrary to a
+          // common assumption.)
           ProjectionExpression: 'expires_at',
           ConsistentRead: true,
         }));

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -69,6 +69,13 @@ const { AUDIT_EVENTS } = require('./constants');
 // TODO(PR 12): consolidate DDB client init into a shared module
 // when the gateway-tier RESUME table arrives — three consumers
 // is the right break-even point for the extraction.
+//
+// Test authoring note: these throws fire at `require()` time, so a
+// new test file importing flow-state MUST set DDB_TABLE_PREFIX and
+// AWS_REGION on `process.env` BEFORE the require — see
+// tests/flow-state.test.js for the canonical pattern. Forgetting
+// gives a confusing module-load stack trace rather than a clean
+// test-setup error.
 const TABLE_PREFIX = (process.env.DDB_TABLE_PREFIX ?? '').trim();
 if (!TABLE_PREFIX) {
   throw new Error('DDB_TABLE_PREFIX is required to use the flow-state harness. Set it in the deployment template (e.g. `qurl-bot-discord-sandbox-`).');
@@ -148,6 +155,16 @@ function decryptPayload(ciphertext) {
 // `/qurl setup` modal has a 15-minute window; a `/qurl send`
 // confirmation can sit for hours). The caller knows; this module
 // just persists.
+//
+// Payload semantics: `null` and `undefined` both persist as a null
+// DDB attribute. This is symmetric with createFlow but ASYMMETRIC
+// with `transitionFlow` — there, `payload: undefined` means "leave
+// existing payload untouched" (no `#p = :payload` in the Update),
+// while `payload: null` means "clear the existing payload". On
+// create the row has no existing payload so the distinction is
+// moot, but callers porting code from create-then-transition
+// should be aware that the same value carries different meaning
+// across the two methods.
 async function createFlow({ flow_id, stage, payload, expires_at }) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.createFlow: flow_id must be a non-empty string');
@@ -201,6 +218,9 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
 // skew window if they're reading on the back of a write they
 // just performed. Default 0 because the canonical use case is
 // "is this flow still alive?" and the answer should be honest.
+// Negative grace values are accepted (skews "expired" earlier);
+// no use case yet but cheaper to leave permissive than to gate
+// on a corner case a future caller might legitimately want.
 async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.loadFlow: flow_id must be a non-empty string');
@@ -213,7 +233,13 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
   const item = res?.Item;
   if (!item) return null;
   const expires = item.expires_at;
-  if (typeof expires === 'number' && Number.isFinite(expires)) {
+  // Reader strictness must MATCH the writer's assertExpiresAt() —
+  // a row whose expires_at is a non-integer float would otherwise
+  // round-trip undetected (writer rejects, but a regression or
+  // manual console put could still produce one). Same set: finite
+  // integer Number. Anything else falls through to the warn+null
+  // branch below.
+  if (typeof expires === 'number' && Number.isFinite(expires) && Math.floor(expires) === expires) {
     if (nowEpochSeconds() > expires + grace_seconds) {
       // Logically expired but not yet reaped. Treat as absent.
       return null;
@@ -249,10 +275,28 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
 //   { result: 'not_found',  version: null }   — row absent
 //   { result: 'error',      version: null }   — unexpected DDB failure (rethrown after emit)
 //
+// **OCC gates on `version` only, not `stage`.** A caller passing
+// `expectedVersion: 5, stage_to: 'B'` succeeds if the row's current
+// version is 5, even if its current stage isn't what the caller
+// expected. This module is a generic harness — state-machine
+// semantics (which `stage_from` is a legal precursor to `stage_to`)
+// are the caller's responsibility. Callers wanting strict stage
+// transitions should assert `stage_from` against expectations
+// after a success result, or pre-check before calling.
+//
 // `terminal` is caller-supplied because flow-state cannot know
 // which transitions end which flow types (the terminal set varies
 // per flow — revoke has fewer stages than send). When `terminal`
 // is true the next call should be deleteFlow.
+//
+// **Audit-emit-on-rethrow contract.** On `result: 'error'` paths
+// the FLOW_TRANSITION audit fires BEFORE the rethrow. A caller
+// that retries a transient `NetworkingError` will produce N
+// `result: 'error'` events for one logical attempt — this is
+// intentional. The error count is interesting per-attempt (a
+// retry storm should be visible in the metric), and the SLI math
+// `silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)`
+// is unaffected because it doesn't read the `error` bucket.
 async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, terminal, extend_expires_at }) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.transitionFlow: flow_id must be a non-empty string');
@@ -362,10 +406,16 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
           ConsistentRead: true,
         }));
         if (!recheck?.Item) result = 'not_found';
-      } catch (_recheckErr) {
+      } catch (recheckErr) {
         // Recheck failure — stay conservative and report conflict
         // (the original Update failed due to a conditional check,
-        // not an availability issue).
+        // not an availability issue). Warn so a DDB availability
+        // blip masked by the conservative fallback still surfaces
+        // in CloudWatch — silent fallback would hide a real signal.
+        logger.warn('flow-state.transitionFlow: post-CCFE recheck failed; defaulting to result=conflict', {
+          flow_id,
+          reason: recheckErr && recheckErr.message,
+        });
       }
       logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {
         flow_id,

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -127,8 +127,12 @@ function assertExpiresAt(expiresAt) {
   if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || Math.floor(expiresAt) !== expiresAt) {
     throw new TypeError(`flow-state: expires_at must be a finite integer epoch-seconds Number (got ${typeof expiresAt}: ${JSON.stringify(expiresAt)}). DDB TTL only reaps Number-typed attributes; a string or float would silently orphan the row.`);
   }
-  if (expiresAt <= nowEpochSeconds()) {
-    throw new RangeError(`flow-state: expires_at must be strictly in the future (got ${expiresAt}; now is ${nowEpochSeconds()}). A row whose TTL is in the past is born expired — it passes the Put, fires FLOW_CREATED, but loadFlow returns null forever after, silently inflating the SLI's silently_dropped numerator. Most often this is a forgotten '+ ttl_seconds' on the caller side.`);
+  // Cache the `now` read so the comparison and the error message
+  // can't straddle a second boundary and produce a `now` in the
+  // message that contradicts the failed comparison.
+  const now = nowEpochSeconds();
+  if (expiresAt <= now) {
+    throw new RangeError(`flow-state: expires_at must be strictly in the future (got ${expiresAt}; now is ${now}). A row whose TTL is in the past is born expired — it passes the Put, fires FLOW_CREATED, but loadFlow returns null forever after, silently inflating the SLI's silently_dropped numerator. Most often this is a forgotten '+ ttl_seconds' on the caller side.`);
   }
 }
 
@@ -161,6 +165,16 @@ function decryptPayload(ciphertext) {
   // No upfront null guard — `decrypt` passes null/undefined through
   // unchanged, and the `plaintext == null` check below catches it.
   // A single guard is clearer than two redundant ones.
+  //
+  // Decrypt-side throws (e.g. KEY_ENCRYPTION_KEY unset on a row
+  // written by a configured env, KEK rotation without the migration
+  // path in crypto.js) propagate intentionally — fail-loud on a
+  // KEK misconfig is the right shape. Do NOT add a try/catch here:
+  // it would silently degrade a config bug into payload: null and
+  // the caller would treat the flow as "no payload" rather than
+  // "we can't read the payload". The corruption path (JSON.parse
+  // failure) below is correctly soft — that's a row-level issue,
+  // not a deployment-wide one.
   const plaintext = decrypt(ciphertext);
   if (plaintext == null) return null;
   try {
@@ -248,6 +262,14 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
       // there's no cheap way to compare encrypted payloads without
       // decrypting both, and the legitimate case (SQS exact-duplicate)
       // would generate spurious warns.
+      //
+      // Debug log (not warn) on the redelivery branch so a "why is
+      // the user seeing stale data" triage has a breadcrumb at the
+      // first place a mutation would silently disappear. Debug level
+      // keeps it out of normal logs (the legitimate-redelivery rate
+      // would otherwise be noise) but surfaces under LOG_LEVEL=debug
+      // when an operator is actively investigating.
+      logger.debug('flow-state.createFlow: idempotent redelivery (row already exists)', { flow_id });
       return { created: false };
     }
     throw err;
@@ -406,6 +428,19 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
   // Get and the Update is detected by OCC and reported as conflict;
   // the stale stage_from in the audit emission is acceptable
   // (forensic field, not used for SLI math).
+  //
+  // TODO(#253): collapse this pre-read into the UpdateCommand via
+  // `ReturnValues: 'ALL_OLD'` (and `ReturnValuesOnConditionCheckFailure:
+  // 'ALL_OLD'` on the CCFE branch) to drop from 2 DDB calls → 1 on
+  // the happy path and 3 → 1 on the conflict path. Deliberately
+  // deferred from the harness's first ship — performance-only refactor,
+  // the simpler 2-call shape is correct and the optimization is the
+  // right scope for a focused follow-up.
+  //
+  // ConsistentRead doubles the RCU cost vs eventually-consistent,
+  // accepted here because a worker that just transitioned and is
+  // re-checking needs strong consistency. Same rationale as
+  // loadFlow's ConsistentRead choice.
   let stage_from = null;
   const extended = set_expires_at !== undefined;
   try {

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -137,6 +137,15 @@ function assertExpiresAt(expiresAt) {
   // can't straddle a second boundary and produce a `now` in the
   // message that contradicts the failed comparison.
   const now = nowEpochSeconds();
+  // Note on `==` boundary: this writer rejects `expires_at == now`
+  // (strict `<=`), while loadFlow and the transitionFlow recheck
+  // treat `expires_at == now` as alive (their `now > exp` checks
+  // are strict, and the Update condition is `#e >= :now`). The
+  // writer is intentionally STRICTER — a row whose TTL is exactly
+  // now would race the next-second boundary into expired territory
+  // before the first loadFlow could hit it. A future reader who
+  // tries to "fix" this asymmetry by relaxing the writer side
+  // would re-open the foot-gun.
   if (expiresAt <= now) {
     throw new RangeError(`flow-state: expires_at must be strictly in the future (got ${expiresAt}; now is ${now}). A row whose TTL is in the past is born expired — it passes the Put, fires FLOW_CREATED, but loadFlow returns null forever after, silently inflating the SLI's silently_dropped numerator. Most often this is a forgotten '+ ttl_seconds' on the caller side.`);
   }
@@ -415,6 +424,18 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
 // a stricter ConditionExpression (which would complicate the
 // not_found/conflict discrimination).
 //
+// **`set_expires_at` cannot revive an expired row.** The
+// `ConditionExpression: #e >= :now` guard means a row whose
+// `expires_at` already slipped into the past will fail the
+// transition with `result: 'not_found'` — even if the caller
+// passes a fresh `set_expires_at` deep into the future.
+// Intentional: a logically-expired row should be treated as
+// dropped, not resurrected (otherwise the SLI's `silently_dropped`
+// math would inflate on every "we noticed it expired, let's
+// extend it" save). Callers that legitimately need to start
+// a fresh lifecycle after expiry should `createFlow` again with
+// a new (or fresh-TTL'd) flow_id.
+//
 // **Audit-emit-on-rethrow contract.** On `result: 'error'` paths
 // the FLOW_TRANSITION audit fires BEFORE the rethrow. A caller
 // that retries a transient `NetworkingError` will produce N
@@ -464,12 +485,19 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
   // re-checking needs strong consistency. Same rationale as
   // loadFlow's ConsistentRead choice.
   let stage_from = null;
-  const extended = set_expires_at !== undefined;
+  // `extended` is computed against the row's PRIOR `expires_at`, not
+  // just "did the caller pass `set_expires_at`". The name reads as
+  // "the deadline was extended", and a forensic `count_by(extended=
+  // true)` should answer that question honestly — a caller passing
+  // a value EARLIER than the current expires_at (shortening the
+  // row's lifetime) must NOT count as extended. The pre-read
+  // projects `stage, expires_at` to give us the prior value.
+  let extended = false;
   try {
     const got = await ddb.send(new GetCommand({
       TableName: TABLE_NAME,
       Key: { flow_id },
-      ProjectionExpression: 'stage',
+      ProjectionExpression: 'stage, expires_at',
       ConsistentRead: true,
     }));
     if (!got?.Item) {
@@ -479,12 +507,25 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
         stage_to,
         result: 'not_found',
         terminal: false,
-        extended,
+        // `extended` is meaningless when there's no row to extend.
+        // Stay false (the boolean default) rather than emitting a
+        // mixed-type `null` for a dimensionable-style field.
+        extended: false,
         version: expectedVersion,
       });
       return { result: 'not_found', version: null };
     }
     stage_from = got.Item.stage ?? null;
+    if (set_expires_at !== undefined) {
+      const priorExpires = got.Item.expires_at;
+      // Strict comparison `>`: set_expires_at == priorExpires is a
+      // no-op rewrite, not an extension. Corrupted/missing prior
+      // expires_at can't be compared meaningfully — emit
+      // extended=false (a row with a missing expires_at can't be
+      // "extended" in any honest sense; downstream forensic queries
+      // would surface the corruption via the recheck warn anyway).
+      extended = typeof priorExpires === 'number' && Number.isFinite(priorExpires) && set_expires_at > priorExpires;
+    }
   } catch (err) {
     logger.error('flow-state.transitionFlow: pre-read failed', { flow_id, reason: err && err.message });
     logger.audit(AUDIT_EVENTS.FLOW_TRANSITION, {

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -307,9 +307,9 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
 // skew window if they're reading on the back of a write they
 // just performed. Default 0 because the canonical use case is
 // "is this flow still alive?" and the answer should be honest.
-// Negative grace values are accepted (skews "expired" earlier);
-// no use case yet but cheaper to leave permissive than to gate
-// on a corner case a future caller might legitimately want.
+// Must be >= 0 — the rest of the module is uncompromising about
+// input types, and a negative `grace_seconds: -3600` typo would
+// silently shorten flow lifetimes by an hour. Tight by symmetry.
 //
 // ConsistentRead: the read is strongly consistent. Canonical use
 // case is "I just transitioned this flow and want to re-verify"
@@ -327,8 +327,10 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
   // 'forever'` would evaluate `expires + 'forever'` → string
   // concat → NaN → `now > NaN` is false → expired-as-alive. A
   // caller passing untrusted config could surface stale flows.
-  if (typeof grace_seconds !== 'number' || !Number.isFinite(grace_seconds)) {
-    throw new TypeError(`flow-state.loadFlow: grace_seconds must be a finite number (got ${typeof grace_seconds}: ${JSON.stringify(grace_seconds)})`);
+  // Reject negatives too — a typo (`-3600` instead of `3600`)
+  // would silently shorten flow lifetimes by an hour.
+  if (typeof grace_seconds !== 'number' || !Number.isFinite(grace_seconds) || grace_seconds < 0) {
+    throw new TypeError(`flow-state.loadFlow: grace_seconds must be a non-negative finite number (got ${typeof grace_seconds}: ${JSON.stringify(grace_seconds)})`);
   }
   const res = await ddb.send(new GetCommand({
     TableName: TABLE_NAME,
@@ -497,17 +499,27 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
     throw err;
   }
 
+  // Cache `now` once: the same value gates the condition AND lands
+  // in `:updated_at`. Reading `nowEpochSeconds()` separately for
+  // each would let them straddle a second boundary.
+  const updateNow = nowEpochSeconds();
+
   const updateExprParts = ['#s = :stage_to', '#v = #v + :one', '#u = :updated_at'];
   const exprNames = {
     '#s': 'stage',
     '#v': 'version',
     '#u': 'updated_at',
+    // `#e` is in the names map unconditionally — the ConditionExpression
+    // below uses `#e > :now` to gate writes on logical aliveness.
+    // `set_expires_at` may also reference `#e` to rewrite the value.
+    '#e': 'expires_at',
   };
   const exprValues = {
     ':stage_to': stage_to,
     ':one': 1,
-    ':updated_at': nowEpochSeconds(),
+    ':updated_at': updateNow,
     ':expected': expectedVersion,
+    ':now': updateNow,
   };
   if (payload !== undefined) {
     updateExprParts.push('#p = :payload');
@@ -516,7 +528,6 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
   }
   if (set_expires_at !== undefined) {
     updateExprParts.push('#e = :expires_at');
-    exprNames['#e'] = 'expires_at';
     exprValues[':expires_at'] = set_expires_at;
   }
 
@@ -525,7 +536,18 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
       TableName: TABLE_NAME,
       Key: { flow_id },
       UpdateExpression: `SET ${updateExprParts.join(', ')}`,
-      ConditionExpression: 'attribute_exists(flow_id) AND #v = :expected',
+      // `#e > :now` closes the silent-SLI-inflation hole where a
+      // logically-expired row (DDB TTL reap is async, ~48h lag)
+      // could pass attribute_exists + version-match and have its
+      // stage rewritten — even though loadFlow would then return
+      // null for it. The next FLOW_DELETED would never fire and
+      // `silently_dropped = created - deleted` would inflate. The
+      // condition fires CCFE on expired rows, and the post-CCFE
+      // recheck below maps that to result='not_found' (symmetric
+      // with loadFlow's own expiry filter). A missing or non-
+      // numeric `expires_at` (corrupted row) also fails the
+      // comparison — fail-safe, matching loadFlow's treatment.
+      ConditionExpression: 'attribute_exists(flow_id) AND #v = :expected AND #e >= :now',
       ExpressionAttributeNames: exprNames,
       ExpressionAttributeValues: exprValues,
       ReturnValues: 'UPDATED_NEW',
@@ -567,8 +589,19 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
           // Apply the same logical-expiry filter as loadFlow — a row
           // present in DDB but already past expires_at should report
           // not_found, not conflict. Symmetric with the reader.
+          // Also treats missing/non-numeric `expires_at` as expired
+          // (the corrupted-row fail-safe — same posture as loadFlow).
           const exp = recheck.Item.expires_at;
-          if (typeof exp === 'number' && Number.isFinite(exp) && Math.floor(exp) === exp && nowEpochSeconds() > exp) {
+          const isValidExpires = typeof exp === 'number' && Number.isFinite(exp) && Math.floor(exp) === exp;
+          if (!isValidExpires) {
+            // Symmetric with loadFlow's warn — a corrupted row should
+            // be grepable from both the read and the transition path.
+            logger.warn('flow-state.transitionFlow: row has missing or non-numeric expires_at on recheck; treating as expired', {
+              flow_id,
+              expires_at_type: typeof exp,
+            });
+            result = 'not_found';
+          } else if (exp < nowEpochSeconds()) {
             result = 'not_found';
           }
         }
@@ -672,8 +705,11 @@ module.exports = {
   loadFlow,
   transitionFlow,
   deleteFlow,
-  // Exposed for tests + future modules that need the canonical
-  // table name (e.g. an admin CLI). Not for production code paths
-  // that should go through the four functions above.
+  // Test-only escape hatch (the `__` prefix signals: not part of
+  // the public API). Production code paths must go through the
+  // four functions above. A future admin CLI or third consumer
+  // should get its own real export when it arrives — the shape
+  // of "what does the API surface to non-test callers look like"
+  // is easier to design once that caller actually exists.
   __TABLE_NAME: TABLE_NAME,
 };

--- a/apps/discord/tests/flow-id.test.js
+++ b/apps/discord/tests/flow-id.test.js
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for src/flow-id.js — the canonical parse/build pair
+ * for the shard-aware flow_state.flow_id composite key.
+ *
+ * Roundtrip and validation surface. Same-format parity is enforced
+ * here so a handler producing flow_ids and a worker consuming them
+ * can't silently drift on the separator convention.
+ */
+const { buildFlowId, parseFlowId } = require('../src/flow-id');
+
+describe('flow-id', () => {
+  describe('buildFlowId', () => {
+    test('joins components with # in canonical order', () => {
+      expect(buildFlowId({
+        shard_id: '0:1',
+        guild_id: 'g',
+        channel_id: 'c',
+        user_id: 'u',
+      })).toBe('0:1#g#c#u');
+    });
+
+    test('allows ":" inside shard_id (canonical k:n shape)', () => {
+      expect(buildFlowId({
+        shard_id: '3:8',
+        guild_id: '1234',
+        channel_id: '5678',
+        user_id: '9012',
+      })).toBe('3:8#1234#5678#9012');
+    });
+
+    test('rejects "#" inside shard_id', () => {
+      expect(() => buildFlowId({
+        shard_id: '0#1',
+        guild_id: 'g',
+        channel_id: 'c',
+        user_id: 'u',
+      })).toThrow(/shard_id must not contain '#'/);
+    });
+
+    test('rejects "#" inside guild_id', () => {
+      expect(() => buildFlowId({
+        shard_id: '0:1',
+        guild_id: 'evil#guild',
+        channel_id: 'c',
+        user_id: 'u',
+      })).toThrow(/guild_id must not contain '#'/);
+    });
+
+    test('rejects "#" inside channel_id', () => {
+      expect(() => buildFlowId({
+        shard_id: '0:1',
+        guild_id: 'g',
+        channel_id: 'evil#chan',
+        user_id: 'u',
+      })).toThrow(/channel_id must not contain '#'/);
+    });
+
+    test('rejects "#" inside user_id', () => {
+      expect(() => buildFlowId({
+        shard_id: '0:1',
+        guild_id: 'g',
+        channel_id: 'c',
+        user_id: 'evil#user',
+      })).toThrow(/user_id must not contain '#'/);
+    });
+
+    test.each([
+      ['shard_id', { shard_id: '', guild_id: 'g', channel_id: 'c', user_id: 'u' }],
+      ['guild_id', { shard_id: '0:1', guild_id: '', channel_id: 'c', user_id: 'u' }],
+      ['channel_id', { shard_id: '0:1', guild_id: 'g', channel_id: '', user_id: 'u' }],
+      ['user_id', { shard_id: '0:1', guild_id: 'g', channel_id: 'c', user_id: '' }],
+    ])('rejects empty %s', (field, args) => {
+      expect(() => buildFlowId(args)).toThrow(new RegExp(`${field} must be a non-empty string`));
+    });
+
+    test.each([
+      ['shard_id', { shard_id: undefined, guild_id: 'g', channel_id: 'c', user_id: 'u' }],
+      ['guild_id', { shard_id: '0:1', guild_id: null, channel_id: 'c', user_id: 'u' }],
+      ['channel_id', { shard_id: '0:1', guild_id: 'g', channel_id: 123, user_id: 'u' }],
+    ])('rejects non-string %s', (field, args) => {
+      expect(() => buildFlowId(args)).toThrow(new RegExp(`${field} must be a non-empty string`));
+    });
+  });
+
+  describe('parseFlowId', () => {
+    test('inverts buildFlowId for the canonical case', () => {
+      const built = buildFlowId({
+        shard_id: '0:1',
+        guild_id: '1234',
+        channel_id: '5678',
+        user_id: '9012',
+      });
+      expect(parseFlowId(built)).toEqual({
+        shard_id: '0:1',
+        guild_id: '1234',
+        channel_id: '5678',
+        user_id: '9012',
+      });
+    });
+
+    test('preserves ":" inside shard_id on parse', () => {
+      expect(parseFlowId('3:8#g#c#u')).toEqual({
+        shard_id: '3:8',
+        guild_id: 'g',
+        channel_id: 'c',
+        user_id: 'u',
+      });
+    });
+
+    test('returns null for too few separators', () => {
+      expect(parseFlowId('0:1#g#c')).toBeNull();
+    });
+
+    test('returns null for too many separators', () => {
+      expect(parseFlowId('0:1#g#c#u#extra')).toBeNull();
+    });
+
+    test('returns null for empty component (leading sep)', () => {
+      expect(parseFlowId('#g#c#u')).toBeNull();
+    });
+
+    test('returns null for empty component (trailing sep)', () => {
+      expect(parseFlowId('0:1#g#c#')).toBeNull();
+    });
+
+    test('returns null for empty component (mid)', () => {
+      expect(parseFlowId('0:1##c#u')).toBeNull();
+    });
+
+    test.each([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+      ['number', 12345],
+      ['object', {}],
+    ])('returns null for non-string input: %s', (_label, input) => {
+      expect(parseFlowId(input)).toBeNull();
+    });
+  });
+
+  describe('roundtrip property', () => {
+    // Sample of realistic-shape inputs — the assertion is that
+    // parseFlowId(buildFlowId(x)) deep-equals x for every legal x.
+    const cases = [
+      { shard_id: '0:1', guild_id: '1', channel_id: '2', user_id: '3' },
+      { shard_id: '0:1', guild_id: '111111111111111111', channel_id: '222222222222222222', user_id: '333333333333333333' },
+      { shard_id: '7:16', guild_id: 'g', channel_id: 'c', user_id: 'u' },
+    ];
+    test.each(cases)('roundtrips %o', (input) => {
+      expect(parseFlowId(buildFlowId(input))).toEqual(input);
+    });
+  });
+});

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -532,10 +532,11 @@ describe('flow-state.transitionFlow', () => {
     expect(upd.args[0].input.UpdateExpression).not.toMatch(/payload/);
   });
 
-  test('set_expires_at writes the new expiry, is type-checked, and emits extended=true', async () => {
-    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+  test('set_expires_at writes new expiry; extended=true when new > prior', async () => {
+    const priorExpires = futureExpiry(600);
+    const newExpiry = futureExpiry(1800);
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a', expires_at: priorExpires } });
     ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
-    const newExpiry = futureExpiry(1200);
 
     await flowState.transitionFlow('id', 1, {
       stage_to: 'b',
@@ -554,6 +555,72 @@ describe('flow-state.transitionFlow', () => {
       extended: true,
       version: 2,
     });
+  });
+
+  test('set_expires_at that SHORTENS the lifetime emits extended=false (honest forensics)', async () => {
+    // The audit field name reads as "the deadline was extended" —
+    // a caller passing a value EARLIER than the current expires_at
+    // is shortening, not extending. Forensic queries like
+    // `count_by(extended=true)` must not over-count.
+    const priorExpires = futureExpiry(3600);
+    const shorterExpiry = futureExpiry(600);
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a', expires_at: priorExpires } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+      set_expires_at: shorterExpiry,
+    });
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'success',
+      terminal: false,
+      extended: false,
+      version: 2,
+    });
+  });
+
+  test('set_expires_at equal to prior emits extended=false (strict > semantics)', async () => {
+    // Reading `extended: true` should mean "the deadline genuinely
+    // moved forward". A no-op rewrite (same value) isn't an
+    // extension and shouldn't trip the forensic flag.
+    const sameExpiry = futureExpiry(600);
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a', expires_at: sameExpiry } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+      set_expires_at: sameExpiry,
+    });
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION,
+      expect.objectContaining({ extended: false }),
+    );
+  });
+
+  test('set_expires_at on a row with missing prior expires_at emits extended=false (no honest baseline)', async () => {
+    // A corrupted row with no prior expires_at can't be "extended"
+    // in any meaningful sense (there's no prior baseline to extend
+    // FROM). Emit false rather than true-by-default — downstream
+    // forensic queries will pick up the corruption signal via the
+    // recheck warn path anyway.
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+      set_expires_at: futureExpiry(600),
+    });
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION,
+      expect.objectContaining({ extended: false }),
+    );
   });
 
   test('set_expires_at rejects non-integer', async () => {

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -277,6 +277,23 @@ describe('flow-state.loadFlow', () => {
     );
   });
 
+  test('returns null and warns when expires_at is a non-integer float (writer/reader symmetry)', async () => {
+    // Writer's assertExpiresAt rejects floats (`Math.floor(x) !== x`);
+    // reader must match — a regression writer that puts a float
+    // should not round-trip undetected.
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        payload: null,
+        expires_at: 1234567890.5,
+      },
+    });
+    expect(await flowState.loadFlow('id')).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
   test('returns null and warns when expires_at is a string (legacy/corrupt writer)', async () => {
     ddbMock.on(GetCommand).resolves({
       Item: {
@@ -405,12 +422,19 @@ describe('flow-state.transitionFlow', () => {
     // First GetCommand: pre-read sees the row.
     // Update fails (row reaped between pre-read and Update).
     // Second GetCommand (recheck): row gone.
-    let getCalls = 0;
-    ddbMock.on(GetCommand).callsFake(() => {
-      getCalls += 1;
-      if (getCalls === 1) return { Item: { stage: 'a' } };
-      return {};
-    });
+    //
+    // `getCalls` is intentionally scoped to this test — a previous
+    // pattern used a describe-block-local closure which would have
+    // bled state between tests. Test-local scope keeps the call
+    // counter trivially reset on each run.
+    {
+      let getCalls = 0;
+      ddbMock.on(GetCommand).callsFake(() => {
+        getCalls += 1;
+        if (getCalls === 1) return { Item: { stage: 'a' } };
+        return {};
+      });
+    }
     ddbMock.on(UpdateCommand).rejects(ccfe());
 
     const res = await flowState.transitionFlow('id', 1, {
@@ -425,6 +449,31 @@ describe('flow-state.transitionFlow', () => {
       result: 'not_found',
       terminal: false,
     });
+  });
+
+  test('post-CCFE recheck failure warns and conservatively reports conflict', async () => {
+    // Pre-read sees the row, Update fails OCC, recheck-Get itself
+    // throws (DDB availability blip). The harness must NOT silently
+    // swallow the recheck error — a warn keeps the signal visible
+    // in CloudWatch while still defaulting to the conservative
+    // result=conflict bucket.
+    let getCalls = 0;
+    ddbMock.on(GetCommand).callsFake(() => {
+      getCalls += 1;
+      if (getCalls === 1) return { Item: { stage: 'a' } };
+      throw new Error('NetworkingError');
+    });
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    const res = await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+    expect(res).toEqual({ result: 'conflict', version: null });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/post-CCFE recheck failed/),
+      expect.objectContaining({ flow_id: 'id' }),
+    );
   });
 
   test('result=error emits and rethrows on non-conditional Update failure', async () => {

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -421,7 +421,52 @@ describe('flow-state.transitionFlow', () => {
       result: 'success',
       terminal: true,
       extended: false,
+      version: 5,
     });
+  });
+
+  test('success with terminal: false stays false (negative-control vs forced-false)', async () => {
+    // Companion to the terminal-force-to-false tests on non-success
+    // paths: confirm that a legitimate terminal=false on a SUCCESSFUL
+    // transition is preserved, not overwritten. Pins symmetry.
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 3 } });
+
+    await flowState.transitionFlow('id', 2, {
+      stage_to: 'b',
+      terminal: false,
+    });
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'success',
+      terminal: false,
+      extended: false,
+      version: 3,
+    });
+  });
+
+  test('payload: null clears existing payload (asymmetric with createFlow)', async () => {
+    // Documented in the module docstring — `payload: undefined`
+    // preserves existing, `payload: null` clears. This test locks
+    // in the asymmetry so a future refactor doesn't accidentally
+    // collapse them.
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      payload: null,
+      terminal: false,
+    });
+
+    const upd = ddbMock.commandCalls(UpdateCommand)[0];
+    // The clause IS present (vs undefined, which omits it)…
+    expect(upd.args[0].input.UpdateExpression).toMatch(/#p = :payload/);
+    // …and writes null to clear the existing payload.
+    expect(upd.args[0].input.ExpressionAttributeValues[':payload']).toBeNull();
   });
 
   test('skips payload encrypt when payload is omitted', async () => {
@@ -458,6 +503,7 @@ describe('flow-state.transitionFlow', () => {
       result: 'success',
       terminal: false,
       extended: true,
+      version: 2,
     });
   });
 
@@ -495,6 +541,7 @@ describe('flow-state.transitionFlow', () => {
       result: 'not_found',
       terminal: false,
       extended: false,
+      version: 1,
     });
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
   });
@@ -517,6 +564,7 @@ describe('flow-state.transitionFlow', () => {
       result: 'conflict',
       terminal: false,
       extended: false,
+      version: 1,
     });
   });
 
@@ -544,6 +592,39 @@ describe('flow-state.transitionFlow', () => {
       result: 'not_found',
       terminal: false,
       extended: false,
+      version: 1,
+    });
+  });
+
+  test('post-CCFE recheck reports not_found when row is present but logically expired', async () => {
+    // A row whose expires_at slipped into the past between pre-read
+    // and Update will still be returned by GetCommand (DDB TTL reap
+    // is async, up to ~48h delay). The recheck must apply the same
+    // logical-expiry filter as loadFlow — otherwise the caller gets
+    // result=conflict on an expired row and wastes a retry.
+    const pastExpiry = Math.floor(Date.now() / 1000) - 30;
+    let getCalls = 0;
+    ddbMock.on(GetCommand).callsFake(() => {
+      getCalls += 1;
+      if (getCalls === 1) return { Item: { stage: 'a' } };
+      // Recheck returns the row but it's logically expired.
+      return { Item: { flow_id: 'id', expires_at: pastExpiry } };
+    });
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    const res = await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+    expect(res).toEqual({ result: 'not_found', version: null });
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'not_found',
+      terminal: false,
+      extended: false,
+      version: 1,
     });
   });
 
@@ -588,6 +669,7 @@ describe('flow-state.transitionFlow', () => {
       result: 'error',
       terminal: false,
       extended: false,
+      version: 1,
     });
   });
 
@@ -606,6 +688,7 @@ describe('flow-state.transitionFlow', () => {
       result: 'error',
       terminal: false,
       extended: false,
+      version: 1,
     });
   });
 

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -262,14 +262,14 @@ describe('flow-state.createFlow', () => {
 
 describe('flow-state.loadFlow', () => {
   test('returns the row with payload decrypted on happy path', async () => {
-    const futureExpiry = Math.floor(Date.now() / 1000) + 600;
+    const expiresAt = futureExpiry();
     ddbMock.on(GetCommand).resolves({
       Item: {
         flow_id: 'id',
         stage: 's',
         version: 3,
         payload: `enc:v1:IV:TAG:${Buffer.from('{"k":"v"}').toString('hex')}`,
-        expires_at: futureExpiry,
+        expires_at: expiresAt,
         created_at: 1000,
         updated_at: 1100,
       },
@@ -281,7 +281,7 @@ describe('flow-state.loadFlow', () => {
       stage: 's',
       version: 3,
       payload: { k: 'v' },
-      expires_at: futureExpiry,
+      expires_at: expiresAt,
       created_at: 1000,
       updated_at: 1100,
     });
@@ -467,6 +467,24 @@ describe('flow-state.transitionFlow', () => {
     expect(upd.args[0].input.UpdateExpression).toMatch(/#p = :payload/);
     // …and writes null to clear the existing payload.
     expect(upd.args[0].input.ExpressionAttributeValues[':payload']).toBeNull();
+  });
+
+  test('created_at is never written by transitionFlow (preserves row birth time)', async () => {
+    // Regression guard: DDB preserves attributes not mentioned in
+    // UpdateExpression. If a future refactor accidentally added
+    // `#c = :created_at` to the SET list, the row would lose its
+    // original birth time on every transition. Lock it down.
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+
+    const upd = ddbMock.commandCalls(UpdateCommand)[0];
+    expect(upd.args[0].input.UpdateExpression).not.toMatch(/created_at/);
+    expect(upd.args[0].input.ExpressionAttributeNames).not.toMatchObject({ '#c': 'created_at' });
   });
 
   test('skips payload encrypt when payload is omitted', async () => {

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -438,8 +438,13 @@ describe('flow-state.transitionFlow', () => {
     expect(updCall.args[0].input.TableName).toBe(EXPECTED_TABLE);
     expect(updCall.args[0].input.ConditionExpression).toBe('attribute_exists(flow_id) AND #v = :expected AND #e >= :now');
     // `:now` is set by the harness at write time and passed alongside
-    // the rest of the expression values.
+    // the rest of the expression values. Pin `:now === :updated_at`
+    // as a regression guard for the cached `updateNow` — without
+    // the cache, a second-boundary straddle between the two reads
+    // would silently desync the condition and the SET clause.
     expect(typeof updCall.args[0].input.ExpressionAttributeValues[':now']).toBe('number');
+    expect(updCall.args[0].input.ExpressionAttributeValues[':now'])
+      .toBe(updCall.args[0].input.ExpressionAttributeValues[':updated_at']);
     expect(updCall.args[0].input.ExpressionAttributeValues[':expected']).toBe(4);
     expect(updCall.args[0].input.ExpressionAttributeValues[':stage_to']).toBe('stage_b');
     // Payload was encrypted via encryptStrict

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -1,0 +1,569 @@
+/**
+ * Unit tests for src/flow-state.js — the DDB-backed state-machine
+ * harness.
+ *
+ * Uses `aws-sdk-client-mock` (same pattern as ddb-store.test.js) to
+ * intercept DocumentClient commands without hitting AWS. Covers:
+ *   - createFlow happy path + idempotent re-create (OCC conflict)
+ *   - loadFlow happy path + missing row + logically expired row
+ *   - transitionFlow happy path + OCC conflict + not_found + error
+ *   - deleteFlow happy path
+ *   - TTL-type guards (expires_at must be a finite integer)
+ *   - Payload encryption is mandatory and roundtrips
+ *   - Audit events emit with the right shape (FLOW_CREATED,
+ *     FLOW_TRANSITION with terminal, FLOW_DELETED with reason)
+ */
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+// Crypto mock: pass-through encryption that wraps + unwraps without
+// touching the real KEK. The crypto module itself is tested
+// elsewhere (crypto.test.js); here we just need to verify the
+// harness routes payload through encryptStrict / decrypt.
+jest.mock('../src/utils/crypto', () => ({
+  encryptStrict: jest.fn((v) => (v == null ? v : `enc:v1:IV:TAG:${Buffer.from(String(v)).toString('hex')}`)),
+  decrypt: jest.fn((v) => {
+    if (v == null || typeof v !== 'string') return v;
+    if (!v.startsWith('enc:v1:')) return v;
+    const parts = v.split(':');
+    return Buffer.from(parts[4], 'hex').toString();
+  }),
+}));
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  DeleteCommand,
+  UpdateCommand,
+} = require('@aws-sdk/lib-dynamodb');
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+process.env.DDB_TABLE_PREFIX = 'test-prefix-';
+process.env.AWS_REGION = 'us-east-2';
+
+const flowState = require('../src/flow-state');
+const logger = require('../src/logger');
+const { encryptStrict, decrypt } = require('../src/utils/crypto');
+const { AUDIT_EVENTS } = require('../src/constants');
+
+const EXPECTED_TABLE = 'test-prefix-flow-state';
+
+// Build a synthetic ConditionalCheckFailedException — the v3 SDK's
+// real exception class has a constructor signature that's awkward
+// to invoke from a test. Matching by `.name` is what the harness
+// does in practice.
+function ccfe() {
+  const e = new Error('The conditional request failed');
+  e.name = 'ConditionalCheckFailedException';
+  return e;
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  logger.audit.mockReset();
+  logger.error.mockReset();
+  logger.warn.mockReset();
+  encryptStrict.mockClear();
+  decrypt.mockClear();
+});
+
+describe('flow-state — module sanity', () => {
+  test('exposes the four lifecycle methods', () => {
+    expect(typeof flowState.createFlow).toBe('function');
+    expect(typeof flowState.loadFlow).toBe('function');
+    expect(typeof flowState.transitionFlow).toBe('function');
+    expect(typeof flowState.deleteFlow).toBe('function');
+  });
+
+  test('computes the canonical table name from DDB_TABLE_PREFIX', () => {
+    expect(flowState.__TABLE_NAME).toBe(EXPECTED_TABLE);
+  });
+});
+
+describe('flow-state.createFlow', () => {
+  test('writes the row with version=1, encrypts payload, emits FLOW_CREATED', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const expiresAt = Math.floor(Date.now() / 1000) + 600;
+
+    const res = await flowState.createFlow({
+      flow_id: '0:1#g#c#u',
+      stage: 'awaiting_button',
+      payload: { foo: 'bar' },
+      expires_at: expiresAt,
+    });
+
+    expect(res).toEqual({ created: true, version: 1 });
+
+    const call = ddbMock.commandCalls(PutCommand)[0];
+    expect(call.args[0].input.TableName).toBe(EXPECTED_TABLE);
+    expect(call.args[0].input.ConditionExpression).toBe('attribute_not_exists(flow_id)');
+    const item = call.args[0].input.Item;
+    expect(item.flow_id).toBe('0:1#g#c#u');
+    expect(item.stage).toBe('awaiting_button');
+    expect(item.version).toBe(1);
+    expect(item.expires_at).toBe(expiresAt);
+    expect(typeof item.created_at).toBe('number');
+    expect(typeof item.updated_at).toBe('number');
+    // Payload was encrypted (mock wraps in enc:v1:...)
+    expect(typeof item.payload).toBe('string');
+    expect(item.payload.startsWith('enc:v1:')).toBe(true);
+    // The encrypted blob is the JSON-serialized payload.
+    expect(decrypt(item.payload)).toBe('{"foo":"bar"}');
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_CREATED, {
+      flow_id: '0:1#g#c#u',
+      stage: 'awaiting_button',
+    });
+  });
+
+  test('null payload persists as null (not encrypted, not silently coerced)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await flowState.createFlow({
+      flow_id: '0:1#g#c#u',
+      stage: 's',
+      payload: null,
+      expires_at: 1000,
+    });
+    const call = ddbMock.commandCalls(PutCommand)[0];
+    expect(call.args[0].input.Item.payload).toBeNull();
+    expect(encryptStrict).not.toHaveBeenCalled();
+  });
+
+  test('returns { created: false } and skips FLOW_CREATED when row exists (OCC)', async () => {
+    ddbMock.on(PutCommand).rejects(ccfe());
+
+    const res = await flowState.createFlow({
+      flow_id: 'id',
+      stage: 's',
+      expires_at: 1000,
+    });
+
+    expect(res).toEqual({ created: false });
+    expect(logger.audit).not.toHaveBeenCalled();
+  });
+
+  test('rethrows unexpected DDB errors', async () => {
+    ddbMock.on(PutCommand).rejects(new Error('AccessDenied'));
+    await expect(flowState.createFlow({
+      flow_id: 'id',
+      stage: 's',
+      expires_at: 1000,
+    })).rejects.toThrow('AccessDenied');
+  });
+
+  test.each([
+    ['string', 'not-a-number'],
+    ['float', 1.5],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['undefined', undefined],
+  ])('rejects expires_at that is not a finite integer: %s', async (_label, badValue) => {
+    await expect(flowState.createFlow({
+      flow_id: 'id',
+      stage: 's',
+      expires_at: badValue,
+    })).rejects.toThrow(/expires_at must be a finite integer/);
+  });
+
+  test('rejects empty flow_id', async () => {
+    await expect(flowState.createFlow({
+      flow_id: '',
+      stage: 's',
+      expires_at: 1000,
+    })).rejects.toThrow(/flow_id must be a non-empty string/);
+  });
+
+  test('rejects empty stage', async () => {
+    await expect(flowState.createFlow({
+      flow_id: 'id',
+      stage: '',
+      expires_at: 1000,
+    })).rejects.toThrow(/stage must be a non-empty string/);
+  });
+});
+
+describe('flow-state.loadFlow', () => {
+  test('returns the row with payload decrypted on happy path', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 600;
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 3,
+        payload: `enc:v1:IV:TAG:${Buffer.from('{"k":"v"}').toString('hex')}`,
+        expires_at: futureExpiry,
+        created_at: 1000,
+        updated_at: 1100,
+      },
+    });
+
+    const res = await flowState.loadFlow('id');
+    expect(res).toEqual({
+      flow_id: 'id',
+      stage: 's',
+      version: 3,
+      payload: { k: 'v' },
+      expires_at: futureExpiry,
+      created_at: 1000,
+      updated_at: 1100,
+    });
+
+    const call = ddbMock.commandCalls(GetCommand)[0];
+    expect(call.args[0].input.TableName).toBe(EXPECTED_TABLE);
+    expect(call.args[0].input.ConsistentRead).toBe(true);
+  });
+
+  test('returns null when row is absent', async () => {
+    ddbMock.on(GetCommand).resolves({});
+    expect(await flowState.loadFlow('id')).toBeNull();
+  });
+
+  test('returns null when now > expires_at (logically expired but not yet reaped)', async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 60;
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        payload: null,
+        expires_at: pastExpiry,
+      },
+    });
+    expect(await flowState.loadFlow('id')).toBeNull();
+  });
+
+  test('grace_seconds tolerates a small clock-skew window', async () => {
+    const recentExpiry = Math.floor(Date.now() / 1000) - 5;
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        payload: null,
+        expires_at: recentExpiry,
+      },
+    });
+    // Default grace=0 → null
+    expect(await flowState.loadFlow('id')).toBeNull();
+    // grace=60 → still alive
+    const withGrace = await flowState.loadFlow('id', { grace_seconds: 60 });
+    expect(withGrace).not.toBeNull();
+    expect(withGrace.flow_id).toBe('id');
+  });
+
+  test('returns null and warns when expires_at is missing (fail-safe vs corrupted row)', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        payload: null,
+        // expires_at intentionally absent
+      },
+    });
+    expect(await flowState.loadFlow('id')).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/missing or non-numeric expires_at/),
+      expect.any(Object),
+    );
+  });
+
+  test('returns null and warns when expires_at is a string (legacy/corrupt writer)', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        payload: null,
+        expires_at: '2026-05-11T00:00:00Z',
+      },
+    });
+    expect(await flowState.loadFlow('id')).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('rejects empty flow_id', async () => {
+    await expect(flowState.loadFlow('')).rejects.toThrow(/flow_id must be a non-empty string/);
+  });
+});
+
+describe('flow-state.transitionFlow', () => {
+  test('happy path: emits FLOW_TRANSITION with terminal=true and bumps version', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'stage_a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 5 } });
+
+    const res = await flowState.transitionFlow('id', 4, {
+      stage_to: 'stage_b',
+      payload: { next: 1 },
+      terminal: true,
+    });
+
+    expect(res).toEqual({ result: 'success', version: 5 });
+
+    const updCall = ddbMock.commandCalls(UpdateCommand)[0];
+    expect(updCall.args[0].input.TableName).toBe(EXPECTED_TABLE);
+    expect(updCall.args[0].input.ConditionExpression).toBe('attribute_exists(flow_id) AND #v = :expected');
+    expect(updCall.args[0].input.ExpressionAttributeValues[':expected']).toBe(4);
+    expect(updCall.args[0].input.ExpressionAttributeValues[':stage_to']).toBe('stage_b');
+    // Payload was encrypted via encryptStrict
+    expect(updCall.args[0].input.ExpressionAttributeValues[':payload'].startsWith('enc:v1:')).toBe(true);
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'stage_a',
+      stage_to: 'stage_b',
+      result: 'success',
+      terminal: true,
+    });
+  });
+
+  test('skips payload encrypt when payload is omitted', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+
+    const upd = ddbMock.commandCalls(UpdateCommand)[0];
+    expect(upd.args[0].input.ExpressionAttributeValues[':payload']).toBeUndefined();
+    expect(upd.args[0].input.UpdateExpression).not.toMatch(/payload/);
+  });
+
+  test('extend_expires_at writes the new expiry and is type-checked', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+
+    await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+      extend_expires_at: 9999,
+    });
+
+    const upd = ddbMock.commandCalls(UpdateCommand)[0];
+    expect(upd.args[0].input.ExpressionAttributeValues[':expires_at']).toBe(9999);
+  });
+
+  test('extend_expires_at rejects non-integer', async () => {
+    await expect(flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+      extend_expires_at: 9999.5,
+    })).rejects.toThrow(/expires_at must be a finite integer/);
+  });
+
+  test('returns not_found when pre-read finds no row', async () => {
+    ddbMock.on(GetCommand).resolves({});
+
+    const res = await flowState.transitionFlow('id', 1, {
+      stage_to: 's',
+      terminal: false,
+    });
+    expect(res).toEqual({ result: 'not_found', version: null });
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: null,
+      stage_to: 's',
+      result: 'not_found',
+      terminal: false,
+    });
+    // No Update should be attempted when pre-read says not_found.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  test('returns conflict when Update fails OCC and row still exists', async () => {
+    // First GetCommand call (pre-read): returns the row.
+    // Second GetCommand call (post-failure recheck): also returns the row.
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a', flow_id: 'id' } });
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    const res = await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+    expect(res).toEqual({ result: 'conflict', version: null });
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'conflict',
+      terminal: false,
+    });
+  });
+
+  test('returns not_found when Update fails OCC and row disappeared (TTL race)', async () => {
+    // First GetCommand: pre-read sees the row.
+    // Update fails (row reaped between pre-read and Update).
+    // Second GetCommand (recheck): row gone.
+    let getCalls = 0;
+    ddbMock.on(GetCommand).callsFake(() => {
+      getCalls += 1;
+      if (getCalls === 1) return { Item: { stage: 'a' } };
+      return {};
+    });
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    const res = await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+    expect(res).toEqual({ result: 'not_found', version: null });
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'not_found',
+      terminal: false,
+    });
+  });
+
+  test('result=error emits and rethrows on non-conditional Update failure', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
+    ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceeded'));
+
+    await expect(flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    })).rejects.toThrow('ProvisionedThroughputExceeded');
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'error',
+      terminal: false,
+    });
+  });
+
+  test('result=error emits and rethrows when pre-read fails', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('NetworkingError'));
+
+    await expect(flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    })).rejects.toThrow('NetworkingError');
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: null,
+      stage_to: 'b',
+      result: 'error',
+      terminal: false,
+    });
+  });
+
+  test('rejects non-positive-integer expectedVersion', async () => {
+    await expect(flowState.transitionFlow('id', 0, { stage_to: 's', terminal: false }))
+      .rejects.toThrow(/expectedVersion must be a positive integer/);
+    await expect(flowState.transitionFlow('id', 1.5, { stage_to: 's', terminal: false }))
+      .rejects.toThrow(/expectedVersion must be a positive integer/);
+    await expect(flowState.transitionFlow('id', -1, { stage_to: 's', terminal: false }))
+      .rejects.toThrow(/expectedVersion must be a positive integer/);
+  });
+
+  test('rejects non-boolean terminal', async () => {
+    await expect(flowState.transitionFlow('id', 1, { stage_to: 's', terminal: 'yes' }))
+      .rejects.toThrow(/terminal must be a boolean/);
+    await expect(flowState.transitionFlow('id', 1, { stage_to: 's', terminal: 1 }))
+      .rejects.toThrow(/terminal must be a boolean/);
+  });
+
+  test('rejects empty stage_to', async () => {
+    await expect(flowState.transitionFlow('id', 1, { stage_to: '', terminal: false }))
+      .rejects.toThrow(/stage_to must be a non-empty string/);
+  });
+});
+
+describe('flow-state.deleteFlow', () => {
+  test('issues a conditional DeleteCommand, emits FLOW_DELETED, returns deleted:true', async () => {
+    ddbMock.on(DeleteCommand).resolves({});
+
+    const res = await flowState.deleteFlow('id', { stage: 'completed', reason: 'terminal' });
+
+    expect(res).toEqual({ deleted: true });
+    const call = ddbMock.commandCalls(DeleteCommand)[0];
+    expect(call.args[0].input.TableName).toBe(EXPECTED_TABLE);
+    expect(call.args[0].input.Key).toEqual({ flow_id: 'id' });
+    expect(call.args[0].input.ConditionExpression).toBe('attribute_exists(flow_id)');
+
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_DELETED, {
+      flow_id: 'id',
+      stage: 'completed',
+      reason: 'terminal',
+    });
+  });
+
+  test('returns deleted:false and does NOT emit when row was already absent (redelivery / TTL reap)', async () => {
+    // The SLI math requires at-most-once FLOW_DELETED per logical flow.
+    // A second delete on an already-gone row must not emit again.
+    ddbMock.on(DeleteCommand).rejects(ccfe());
+
+    const res = await flowState.deleteFlow('id', { stage: 's', reason: 'abort' });
+    expect(res).toEqual({ deleted: false });
+    expect(logger.audit).not.toHaveBeenCalled();
+  });
+
+  test('rethrows unexpected DDB errors', async () => {
+    ddbMock.on(DeleteCommand).rejects(new Error('AccessDenied'));
+    await expect(flowState.deleteFlow('id', { stage: 's', reason: 'terminal' }))
+      .rejects.toThrow('AccessDenied');
+  });
+
+  test.each(['terminal', 'abort', 'admin_cleanup'])('accepts reason=%s', async (reason) => {
+    ddbMock.on(DeleteCommand).resolves({});
+    await flowState.deleteFlow('id', { stage: 's', reason });
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_DELETED, {
+      flow_id: 'id',
+      stage: 's',
+      reason,
+    });
+  });
+
+  test('rejects invalid reason', async () => {
+    await expect(flowState.deleteFlow('id', { stage: 's', reason: 'bogus' }))
+      .rejects.toThrow(/reason must be one of/);
+  });
+
+  test('rejects empty flow_id and empty stage', async () => {
+    await expect(flowState.deleteFlow('', { stage: 's', reason: 'terminal' }))
+      .rejects.toThrow(/flow_id must be a non-empty string/);
+    await expect(flowState.deleteFlow('id', { stage: '', reason: 'terminal' }))
+      .rejects.toThrow(/stage must be a non-empty string/);
+  });
+});
+
+describe('flow-state — payload corruption resilience', () => {
+  test('loadFlow returns payload=null and logs error when payload JSON is corrupt', async () => {
+    // Decrypt yields a non-JSON string → JSON.parse throws → row
+    // surfaces with payload=null rather than blowing up the caller.
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        // The mock decrypt strips the enc:v1: prefix and returns the
+        // hex-decoded payload. Use a string that decodes to invalid JSON.
+        payload: `enc:v1:IV:TAG:${Buffer.from('not-valid-json{').toString('hex')}`,
+        expires_at: Math.floor(Date.now() / 1000) + 600,
+      },
+    });
+
+    const res = await flowState.loadFlow('id');
+    expect(res).not.toBeNull();
+    expect(res.payload).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/payload JSON\.parse failed/),
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -135,6 +135,24 @@ describe('flow-state.createFlow', () => {
     });
   });
 
+  test('undefined payload persists as null (symmetric with explicit null)', async () => {
+    // Reviewer-flagged gap: the documented "null and undefined both
+    // persist as null DDB attribute" semantic is exercised
+    // transitively by other tests but never pinned for `undefined`
+    // explicitly. Lock it in so a future refactor doesn't quietly
+    // change the persisted shape for callers omitting the field.
+    ddbMock.on(PutCommand).resolves({});
+    await flowState.createFlow({
+      flow_id: FLOW_ID,
+      stage: 's',
+      // payload intentionally omitted
+      expires_at: futureExpiry(),
+    });
+    const call = ddbMock.commandCalls(PutCommand)[0];
+    expect(call.args[0].input.Item.payload).toBeNull();
+    expect(encryptStrict).not.toHaveBeenCalled();
+  });
+
   test('null payload persists as null (not encrypted, not silently coerced)', async () => {
     ddbMock.on(PutCommand).resolves({});
     await flowState.createFlow({
@@ -389,7 +407,17 @@ describe('flow-state.loadFlow', () => {
     ['object', {}],
   ])('rejects non-finite-number grace_seconds: %s', async (_label, badValue) => {
     await expect(flowState.loadFlow('id', { grace_seconds: badValue }))
-      .rejects.toThrow(/grace_seconds must be a finite number/);
+      .rejects.toThrow(/grace_seconds must be a non-negative finite number/);
+  });
+
+  test('rejects negative grace_seconds (typo guard)', async () => {
+    // A `-3600` typo (instead of `3600`) would silently shorten flow
+    // lifetimes by an hour. Reject — symmetric with the rest of the
+    // module's type-check-tight posture.
+    await expect(flowState.loadFlow('id', { grace_seconds: -1 }))
+      .rejects.toThrow(/grace_seconds must be a non-negative finite number/);
+    await expect(flowState.loadFlow('id', { grace_seconds: -3600 }))
+      .rejects.toThrow(/grace_seconds must be a non-negative finite number/);
   });
 });
 
@@ -408,7 +436,10 @@ describe('flow-state.transitionFlow', () => {
 
     const updCall = ddbMock.commandCalls(UpdateCommand)[0];
     expect(updCall.args[0].input.TableName).toBe(EXPECTED_TABLE);
-    expect(updCall.args[0].input.ConditionExpression).toBe('attribute_exists(flow_id) AND #v = :expected');
+    expect(updCall.args[0].input.ConditionExpression).toBe('attribute_exists(flow_id) AND #v = :expected AND #e >= :now');
+    // `:now` is set by the harness at write time and passed alongside
+    // the rest of the expression values.
+    expect(typeof updCall.args[0].input.ExpressionAttributeValues[':now']).toBe('number');
     expect(updCall.args[0].input.ExpressionAttributeValues[':expected']).toBe(4);
     expect(updCall.args[0].input.ExpressionAttributeValues[':stage_to']).toBe('stage_b');
     // Payload was encrypted via encryptStrict
@@ -567,7 +598,12 @@ describe('flow-state.transitionFlow', () => {
   test('returns conflict when Update fails OCC and row still exists (forces terminal=false)', async () => {
     // Same terminal=true override semantics as the not_found case
     // above: a transition that didn't advance isn't terminal.
-    ddbMock.on(GetCommand).resolves({ Item: { stage: 'a', flow_id: 'id' } });
+    // Recheck must see a row that is still LOGICALLY ALIVE to
+    // distinguish conflict from not_found — include a future
+    // expires_at on the mocked item.
+    ddbMock.on(GetCommand).resolves({
+      Item: { stage: 'a', flow_id: 'id', expires_at: futureExpiry() },
+    });
     ddbMock.on(UpdateCommand).rejects(ccfe());
 
     const res = await flowState.transitionFlow('id', 1, {
@@ -644,6 +680,30 @@ describe('flow-state.transitionFlow', () => {
       extended: false,
       version: 1,
     });
+  });
+
+  test('post-CCFE recheck warns when row has corrupted expires_at and reports not_found', async () => {
+    // Symmetric with loadFlow's corruption-as-expired fail-safe.
+    // An operator greppping for "row has missing or non-numeric
+    // expires_at" should find the signal from both the read and
+    // the transition recheck paths.
+    let getCalls = 0;
+    ddbMock.on(GetCommand).callsFake(() => {
+      getCalls += 1;
+      if (getCalls === 1) return { Item: { stage: 'a' } };
+      return { Item: { flow_id: 'id', expires_at: 'not-a-number' } };
+    });
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    const res = await flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+    });
+    expect(res).toEqual({ result: 'not_found', version: null });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/row has missing or non-numeric expires_at on recheck/),
+      expect.objectContaining({ flow_id: 'id' }),
+    );
   });
 
   test('post-CCFE recheck failure warns and conservatively reports conflict', async () => {

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -81,6 +81,7 @@ beforeEach(() => {
   logger.audit.mockReset();
   logger.error.mockReset();
   logger.warn.mockReset();
+  logger.debug.mockReset();
   encryptStrict.mockClear();
   decrypt.mockClear();
 });
@@ -169,6 +170,24 @@ describe('flow-state.createFlow', () => {
 
     expect(res).toEqual({ created: false });
     expect(logger.audit).not.toHaveBeenCalled();
+  });
+
+  test('redelivery emits a debug breadcrumb for triage', async () => {
+    // The legitimate-redelivery rate would be noise at warn level,
+    // but a debug breadcrumb gives an operator something to grep
+    // for when investigating "why is the user seeing stale data".
+    ddbMock.on(PutCommand).rejects(ccfe());
+
+    await flowState.createFlow({
+      flow_id: FLOW_ID,
+      stage: 's',
+      expires_at: futureExpiry(),
+    });
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/idempotent redelivery/),
+      expect.objectContaining({ flow_id: FLOW_ID }),
+    );
   });
 
   test('rethrows unexpected DDB errors', async () => {
@@ -671,6 +690,28 @@ describe('flow-state.deleteFlow', () => {
 });
 
 describe('flow-state — payload corruption resilience', () => {
+  test('loadFlow propagates decrypt-side throws (fail-loud on KEK misconfig)', async () => {
+    // A KEK-unset / KEK-rotated misconfig must fail loudly rather
+    // than silently degrade to payload=null — otherwise a config
+    // bug looks like "no payload" and the caller proceeds with
+    // wrong-shaped data. Symmetric to the harness's broader
+    // fail-closed posture on encryptStrict.
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 's',
+        version: 1,
+        payload: 'enc:v1:IV:TAG:cafef00d',
+        expires_at: Math.floor(Date.now() / 1000) + 600,
+      },
+    });
+    decrypt.mockImplementationOnce(() => {
+      throw new Error('KEY_ENCRYPTION_KEY is required to decrypt');
+    });
+
+    await expect(flowState.loadFlow('id')).rejects.toThrow(/KEY_ENCRYPTION_KEY is required/);
+  });
+
   test('loadFlow returns payload=null and logs error when payload JSON is corrupt', async () => {
     // Decrypt yields a non-JSON string → JSON.parse throws → row
     // surfaces with payload=null rather than blowing up the caller.

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -422,19 +422,12 @@ describe('flow-state.transitionFlow', () => {
     // First GetCommand: pre-read sees the row.
     // Update fails (row reaped between pre-read and Update).
     // Second GetCommand (recheck): row gone.
-    //
-    // `getCalls` is intentionally scoped to this test — a previous
-    // pattern used a describe-block-local closure which would have
-    // bled state between tests. Test-local scope keeps the call
-    // counter trivially reset on each run.
-    {
-      let getCalls = 0;
-      ddbMock.on(GetCommand).callsFake(() => {
-        getCalls += 1;
-        if (getCalls === 1) return { Item: { stage: 'a' } };
-        return {};
-      });
-    }
+    let getCalls = 0;
+    ddbMock.on(GetCommand).callsFake(() => {
+      getCalls += 1;
+      if (getCalls === 1) return { Item: { stage: 'a' } };
+      return {};
+    });
     ddbMock.on(UpdateCommand).rejects(ccfe());
 
     const res = await flowState.transitionFlow('id', 1, {

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -56,6 +56,15 @@ const { encryptStrict, decrypt } = require('../src/utils/crypto');
 const { AUDIT_EVENTS } = require('../src/constants');
 
 const EXPECTED_TABLE = 'test-prefix-flow-state';
+// Canonical test fixtures. `FLOW_ID` is a real parseable shard-aware
+// composite key (matches what `buildFlowId({...})` would emit) so it
+// passes createFlow's entry-point parseFlowId validation. A future-
+// dated expiry is computed at-test-time so it stays strictly in the
+// future across `assertExpiresAt`'s `> nowEpochSeconds()` guard.
+const FLOW_ID = '0:1#g#c#u';
+function futureExpiry(offset_seconds = 600) {
+  return Math.floor(Date.now() / 1000) + offset_seconds;
+}
 
 // Build a synthetic ConditionalCheckFailedException — the v3 SDK's
 // real exception class has a constructor signature that's awkward
@@ -92,10 +101,10 @@ describe('flow-state — module sanity', () => {
 describe('flow-state.createFlow', () => {
   test('writes the row with version=1, encrypts payload, emits FLOW_CREATED', async () => {
     ddbMock.on(PutCommand).resolves({});
-    const expiresAt = Math.floor(Date.now() / 1000) + 600;
+    const expiresAt = futureExpiry();
 
     const res = await flowState.createFlow({
-      flow_id: '0:1#g#c#u',
+      flow_id: FLOW_ID,
       stage: 'awaiting_button',
       payload: { foo: 'bar' },
       expires_at: expiresAt,
@@ -107,7 +116,7 @@ describe('flow-state.createFlow', () => {
     expect(call.args[0].input.TableName).toBe(EXPECTED_TABLE);
     expect(call.args[0].input.ConditionExpression).toBe('attribute_not_exists(flow_id)');
     const item = call.args[0].input.Item;
-    expect(item.flow_id).toBe('0:1#g#c#u');
+    expect(item.flow_id).toBe(FLOW_ID);
     expect(item.stage).toBe('awaiting_button');
     expect(item.version).toBe(1);
     expect(item.expires_at).toBe(expiresAt);
@@ -120,7 +129,7 @@ describe('flow-state.createFlow', () => {
     expect(decrypt(item.payload)).toBe('{"foo":"bar"}');
 
     expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_CREATED, {
-      flow_id: '0:1#g#c#u',
+      flow_id: FLOW_ID,
       stage: 'awaiting_button',
     });
   });
@@ -128,23 +137,34 @@ describe('flow-state.createFlow', () => {
   test('null payload persists as null (not encrypted, not silently coerced)', async () => {
     ddbMock.on(PutCommand).resolves({});
     await flowState.createFlow({
-      flow_id: '0:1#g#c#u',
+      flow_id: FLOW_ID,
       stage: 's',
       payload: null,
-      expires_at: 1000,
+      expires_at: futureExpiry(),
     });
     const call = ddbMock.commandCalls(PutCommand)[0];
     expect(call.args[0].input.Item.payload).toBeNull();
     expect(encryptStrict).not.toHaveBeenCalled();
   });
 
+  test('created_at and updated_at are equal on row birth (single now() call)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await flowState.createFlow({
+      flow_id: FLOW_ID,
+      stage: 's',
+      expires_at: futureExpiry(),
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item.created_at).toBe(item.updated_at);
+  });
+
   test('returns { created: false } and skips FLOW_CREATED when row exists (OCC)', async () => {
     ddbMock.on(PutCommand).rejects(ccfe());
 
     const res = await flowState.createFlow({
-      flow_id: 'id',
+      flow_id: FLOW_ID,
       stage: 's',
-      expires_at: 1000,
+      expires_at: futureExpiry(),
     });
 
     expect(res).toEqual({ created: false });
@@ -154,9 +174,9 @@ describe('flow-state.createFlow', () => {
   test('rethrows unexpected DDB errors', async () => {
     ddbMock.on(PutCommand).rejects(new Error('AccessDenied'));
     await expect(flowState.createFlow({
-      flow_id: 'id',
+      flow_id: FLOW_ID,
       stage: 's',
-      expires_at: 1000,
+      expires_at: futureExpiry(),
     })).rejects.toThrow('AccessDenied');
   });
 
@@ -168,25 +188,55 @@ describe('flow-state.createFlow', () => {
     ['undefined', undefined],
   ])('rejects expires_at that is not a finite integer: %s', async (_label, badValue) => {
     await expect(flowState.createFlow({
-      flow_id: 'id',
+      flow_id: FLOW_ID,
       stage: 's',
       expires_at: badValue,
     })).rejects.toThrow(/expires_at must be a finite integer/);
+  });
+
+  test('rejects expires_at in the past (silent-SLI-inflation foot-gun)', async () => {
+    // A row whose TTL is already-past at create time is born expired:
+    // FLOW_CREATED fires, but loadFlow returns null forever after,
+    // and the SLI's silently_dropped numerator inflates.
+    await expect(flowState.createFlow({
+      flow_id: FLOW_ID,
+      stage: 's',
+      expires_at: Math.floor(Date.now() / 1000) - 1,
+    })).rejects.toThrow(/must be strictly in the future/);
+  });
+
+  test('rejects expires_at equal to now', async () => {
+    await expect(flowState.createFlow({
+      flow_id: FLOW_ID,
+      stage: 's',
+      expires_at: Math.floor(Date.now() / 1000),
+    })).rejects.toThrow(/must be strictly in the future/);
+  });
+
+  test('rejects malformed flow_id (parseFlowId returns null)', async () => {
+    // Entry-point validation closes the silent-drop foot-gun where a
+    // handler builds a malformed key and flow-state accepts it,
+    // leaving forensic queries broken downstream.
+    await expect(flowState.createFlow({
+      flow_id: 'not-a-shard-aware-key',
+      stage: 's',
+      expires_at: futureExpiry(),
+    })).rejects.toThrow(/is not a parseable shard-aware composite key/);
   });
 
   test('rejects empty flow_id', async () => {
     await expect(flowState.createFlow({
       flow_id: '',
       stage: 's',
-      expires_at: 1000,
+      expires_at: futureExpiry(),
     })).rejects.toThrow(/flow_id must be a non-empty string/);
   });
 
   test('rejects empty stage', async () => {
     await expect(flowState.createFlow({
-      flow_id: 'id',
+      flow_id: FLOW_ID,
       stage: '',
-      expires_at: 1000,
+      expires_at: futureExpiry(),
     })).rejects.toThrow(/stage must be a non-empty string/);
   });
 });
@@ -311,6 +361,17 @@ describe('flow-state.loadFlow', () => {
   test('rejects empty flow_id', async () => {
     await expect(flowState.loadFlow('')).rejects.toThrow(/flow_id must be a non-empty string/);
   });
+
+  test.each([
+    ['string', 'forever'],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['null', null],
+    ['object', {}],
+  ])('rejects non-finite-number grace_seconds: %s', async (_label, badValue) => {
+    await expect(flowState.loadFlow('id', { grace_seconds: badValue }))
+      .rejects.toThrow(/grace_seconds must be a finite number/);
+  });
 });
 
 describe('flow-state.transitionFlow', () => {
@@ -340,6 +401,7 @@ describe('flow-state.transitionFlow', () => {
       stage_to: 'stage_b',
       result: 'success',
       terminal: true,
+      extended: false,
     });
   });
 
@@ -357,34 +419,54 @@ describe('flow-state.transitionFlow', () => {
     expect(upd.args[0].input.UpdateExpression).not.toMatch(/payload/);
   });
 
-  test('extend_expires_at writes the new expiry and is type-checked', async () => {
+  test('set_expires_at writes the new expiry, is type-checked, and emits extended=true', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
     ddbMock.on(UpdateCommand).resolves({ Attributes: { version: 2 } });
+    const newExpiry = futureExpiry(1200);
 
     await flowState.transitionFlow('id', 1, {
       stage_to: 'b',
       terminal: false,
-      extend_expires_at: 9999,
+      set_expires_at: newExpiry,
     });
 
     const upd = ddbMock.commandCalls(UpdateCommand)[0];
-    expect(upd.args[0].input.ExpressionAttributeValues[':expires_at']).toBe(9999);
+    expect(upd.args[0].input.ExpressionAttributeValues[':expires_at']).toBe(newExpiry);
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
+      flow_id: 'id',
+      stage_from: 'a',
+      stage_to: 'b',
+      result: 'success',
+      terminal: false,
+      extended: true,
+    });
   });
 
-  test('extend_expires_at rejects non-integer', async () => {
+  test('set_expires_at rejects non-integer', async () => {
     await expect(flowState.transitionFlow('id', 1, {
       stage_to: 'b',
       terminal: false,
-      extend_expires_at: 9999.5,
+      set_expires_at: futureExpiry() + 0.5,
     })).rejects.toThrow(/expires_at must be a finite integer/);
   });
 
-  test('returns not_found when pre-read finds no row', async () => {
+  test('set_expires_at rejects values in the past (writer guard)', async () => {
+    await expect(flowState.transitionFlow('id', 1, {
+      stage_to: 'b',
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) - 100,
+    })).rejects.toThrow(/must be strictly in the future/);
+  });
+
+  test('returns not_found when pre-read finds no row (forces terminal=false in audit)', async () => {
     ddbMock.on(GetCommand).resolves({});
 
+    // Caller passes terminal: true but the transition didn't actually
+    // advance the row — the audit MUST emit terminal=false so a
+    // forensic `count_by(terminal=true)` doesn't over-count.
     const res = await flowState.transitionFlow('id', 1, {
       stage_to: 's',
-      terminal: false,
+      terminal: true,
     });
     expect(res).toEqual({ result: 'not_found', version: null });
     expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
@@ -393,20 +475,20 @@ describe('flow-state.transitionFlow', () => {
       stage_to: 's',
       result: 'not_found',
       terminal: false,
+      extended: false,
     });
-    // No Update should be attempted when pre-read says not_found.
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
   });
 
-  test('returns conflict when Update fails OCC and row still exists', async () => {
-    // First GetCommand call (pre-read): returns the row.
-    // Second GetCommand call (post-failure recheck): also returns the row.
+  test('returns conflict when Update fails OCC and row still exists (forces terminal=false)', async () => {
+    // Same terminal=true override semantics as the not_found case
+    // above: a transition that didn't advance isn't terminal.
     ddbMock.on(GetCommand).resolves({ Item: { stage: 'a', flow_id: 'id' } });
     ddbMock.on(UpdateCommand).rejects(ccfe());
 
     const res = await flowState.transitionFlow('id', 1, {
       stage_to: 'b',
-      terminal: false,
+      terminal: true,
     });
     expect(res).toEqual({ result: 'conflict', version: null });
     expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
@@ -415,6 +497,7 @@ describe('flow-state.transitionFlow', () => {
       stage_to: 'b',
       result: 'conflict',
       terminal: false,
+      extended: false,
     });
   });
 
@@ -441,6 +524,7 @@ describe('flow-state.transitionFlow', () => {
       stage_to: 'b',
       result: 'not_found',
       terminal: false,
+      extended: false,
     });
   });
 
@@ -469,13 +553,13 @@ describe('flow-state.transitionFlow', () => {
     );
   });
 
-  test('result=error emits and rethrows on non-conditional Update failure', async () => {
+  test('result=error emits and rethrows on non-conditional Update failure (forces terminal=false)', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { stage: 'a' } });
     ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceeded'));
 
     await expect(flowState.transitionFlow('id', 1, {
       stage_to: 'b',
-      terminal: false,
+      terminal: true,  // caller's terminal claim must be overridden
     })).rejects.toThrow('ProvisionedThroughputExceeded');
 
     expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_TRANSITION, {
@@ -484,6 +568,7 @@ describe('flow-state.transitionFlow', () => {
       stage_to: 'b',
       result: 'error',
       terminal: false,
+      extended: false,
     });
   });
 
@@ -501,6 +586,7 @@ describe('flow-state.transitionFlow', () => {
       stage_to: 'b',
       result: 'error',
       terminal: false,
+      extended: false,
     });
   });
 


### PR DESCRIPTION
## Summary

Wire the four lifecycle methods the event-shipper architecture needs to drive multi-step flows across gateway handoffs and SQS-worker redeliveries — `createFlow` / `loadFlow` / `transitionFlow` / `deleteFlow` — backed by the `flow_state` DDB table.

This is **PR 4 of the zero-downtime upgrade rollout**. PRs 5–9 will convert `/qurl revoke`, `/qurl setup`, and `/qurl send` from in-memory `await*` interactions to flow_state, so a deploy mid-flow no longer drops the user.

## Why now

Today every multi-step Discord interaction ("click this button" → "fill out this modal" → "confirm send") is held in the gateway process's memory via `client.awaitMessageComponent`/`awaitModalSubmit`. A rolling deploy that swaps the WebSocket tier mid-flow drops that state, the bot stops responding, and the user is left staring at a button that no longer works.

The harness here gives us a durable substrate so the next deploy can stop, restart, and resume without losing in-flight interactions.

## Correctness primitives

| Primitive | Mechanism |
|-----------|-----------|
| Exactly-once advancement under SQS at-least-once | OCC: `version + 1` write gated by `ConditionExpression: #v = :expected` |
| Block transitions on logically-expired rows (SLI-honesty guard) | `ConditionExpression: #e >= :now` on Update — CCFE maps to `result: 'not_found'` via the recheck logic |
| No silent TTL orphans | Writer asserts `expires_at` is a finite-integer Number, strictly in the future; DDB TTL only reaps Number-typed attributes |
| Honest "is this flow alive?" | Reader returns `null` for `now > expires_at` even before async reap (~48h lag) |
| Fail-safe on corrupted rows | Reader returns `null` + warns for missing/non-numeric `expires_at` (vs. silently returning an immortal row). Recheck path has symmetric warn |
| SLI math integrity | `silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)` — DELETE is conditional on `attribute_exists`, so redelivery doesn't double-emit FLOW_DELETED and inflate the numerator |
| Mandatory payload encryption | `encryptStrict(JSON.stringify(payload))` — fails closed if `KEY_ENCRYPTION_KEY` is unset (payload transitively carries `attachment_url` + recipient lists) |
| No flow_id drift | Canonical `parseFlowId`/`buildFlowId` in `src/flow-id.js` locks the mixed-separator format (`:` allowed in `shard_id`, `#` forbidden everywhere); `createFlow` validates structure at entry |
| Audit-shape honesty | `terminal` forced to `false` on non-success transitions; `extended` true iff the new `expires_at` is strictly greater than the prior (genuine extension, not shortening) |

## What does NOT change

- No callers wired yet — flows still go through `await*` in this PR. PRs 5–9 do the conversions one flow at a time.
- No new audit event names — `FLOW_CREATED` / `FLOW_TRANSITION` (with `terminal`, `extended`, `version`) / `FLOW_DELETED` (with `reason`) landed in #245.
- No new infra — `flow_state` table is provisioned by qurl-integrations-infra #504.
- No new IAM — the bot's task role already covers data-plane DDB verbs for every table in the module.

## Deferred / explicit follow-up

- **DDB client setup is duplicated** from `src/store/ddb-store.js` rather than extracted. Marked `TODO(PR 12)`: consolidate once a third consumer (the gateway-tier RESUME table) arrives.
- **2 DDB calls per transition on the happy path** (pre-read for `stage_from` + Update). Tracked as #253 — collapse to a single call via `ReturnValues: 'ALL_OLD'` + `ReturnValuesOnConditionCheckFailure: 'ALL_OLD'` (also eliminates the recheck-Get).
- **No integration test** against a real DDB table — that lands with the first caller conversion (PR 5) where we can exercise the actual flow end-to-end.

## Test plan

- [x] `flow-id.test.js`: 28 tests covering roundtrip, every rejection surface (empty / non-string / contains `#`), and `:` preservation inside `shard_id`
- [x] `flow-state.test.js`: 65 tests covering: happy path, idempotent recreate (OCC conflict on Put), OCC conflict-vs-not-found discrimination on transition (via post-failure recheck), TTL writer guard (string / float / NaN / Infinity / past / equal-to-now rejected), TTL reader contract (logical expiry + grace), fail-safe on missing/non-numeric `expires_at` on both read and recheck paths, payload encryption shape (including null/undefined asymmetry between create and transition), at-most-once `FLOW_DELETED` emission on redelivery, payload corruption resilience in `loadFlow`, decrypt-throws propagation (fail-loud on KEK misconfig), `terminal` forced to false on non-success result paths, `extended` true only when `new > prior` (shortening, equal, and missing-prior all emit false), and entry-point `parseFlowId` rejection on createFlow
- [x] Full Jest suite: **1113 passing** (~89 new tests across the two suites; 24 net-new beyond the original `flow-state` plan after 9 rounds of code review)
- [ ] First caller wiring (PR 5) will exercise this against a real sandbox DDB table

🤖 Generated with [Claude Code](https://claude.com/claude-code)