### PR TITLE
docs: trim stale and derivable content from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,22 @@
 # CLAUDE.md — qurl-integrations
 
-## CRITICAL RULES - NEVER VIOLATE
+## Constraints
 
-> **NEVER push directly to `main` branch.** All changes MUST go through a Pull Request, no exceptions. Create a branch, open a PR, and let CI run.
+- **Never push directly to `main`.** Branch protection enforces PRs.
+- **All commits must be GPG/SSH signed.** Unsigned commits are rejected.
+- **`golangci-lint` must pass clean.** Config is strict by design (see `.golangci.yml`); fix the code, not the rules.
 
-> **All commits must be GPG/SSH signed.** Unsigned commits will be rejected by GitHub branch protection rules.
+## Layout
 
-> **All code must pass `golangci-lint` with zero issues.** The linter config is strict by design — fix the code, don't weaken the rules.
+Polyglot monorepo for qURL integrations. SDKs live in separate repos: [qurl-python](https://github.com/layervai/qurl-python), [qurl-typescript](https://github.com/layervai/qurl-typescript).
 
-## Code Change Workflow
+- `apps/slack/`, `apps/teams/`, `apps/cli/`, `apps/zapier/` — Go (`cmd/` + `internal/`)
+- `apps/discord/` — Node.js / TypeScript
+- `shared/` — Go packages consumed by every Go app; changes here affect all of them
+- `e2e/` — TypeScript end-to-end tests
+- Per-app release tracks via Release Please monorepo mode (`release-please-config.json`)
 
-1. `git checkout main && git pull origin main`
-2. `git checkout -b <type>/<short-description>`
-3. Make changes
-4. `make check` (runs fmt, vet, lint, tests)
-5. `git push -u origin <branch>`
-6. `gh pr create --title "<type>(scope): description" --body "..."`
-7. Address code review feedback, then push fixes
-
-## Project Overview
-
-Go monorepo for qURL integrations (Slack, Teams, Discord, CLI, Zapier, etc.).
-Each integration lives in `apps/{name}/` with independent release tracks.
-Shared code lives in `shared/`.
-
-SDKs live in separate repos: [qurl-python](https://github.com/layervai/qurl-python), [qurl-typescript](https://github.com/layervai/qurl-typescript).
-
-## Commit Format
+## Commit format
 
 ```
 <type>(<scope>): <description>
@@ -35,26 +25,9 @@ type:  feat | fix | chore | docs | test | refactor | ci
 scope: slack | teams | discord | cli | zapier | shared | ci
 ```
 
-Examples:
-- `feat(slack): add slash command handler`
-- `fix(shared): retry on 429 in API client`
-- `ci(slack): add deploy step to workflow`
+> Keep this scope list aligned with the Component dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`. Convention only (not CI-enforced); add a new scope to both places in the same PR. The dropdown's `other` option is a reporter-UX escape hatch — do NOT add it here (not a valid commit scope).
 
-> Keep this scope list aligned with the Component dropdown in
-> `.github/ISSUE_TEMPLATE/bug_report.yml`. Convention only (not CI-
-> enforced in this repo); add a new scope to both places in the same
-> PR. The dropdown's `other` option is a reporter-UX escape hatch —
-> do NOT add it here (it's not a valid commit scope).
-
-## Code Conventions
-
-- **Language:** Go
-- **Module:** `github.com/layervai/qurl-integrations`
-- **App entry points:** `apps/{name}/cmd/main.go`
-- **App-private code:** `apps/{name}/internal/`
-- **Shared code:** `shared/{package}/` — changes here affect ALL apps
-
-### Brand spelling
+## Brand spelling
 
 The product brand is **`qURL`** (case-sensitive: lowercase `q`, uppercase `URL`). Use `qURL` in user-visible prose, log/error messages, doc comments, README content, and anything a human reads.
 
@@ -69,74 +42,3 @@ The following stay literal — don't "finish" the rebrand:
 - Man-page section titles (`QURL(1)` — system-reference convention)
 
 When upstream qurl-service rebrands its API error strings, the test fixtures in this repo that mirror them (`"QURL not found"`, `"QURL API error (...)"`, `"token limit per QURL reached"` etc.) need to update in lockstep — `git grep TODO(upstream-rebrand)` finds the doc-comment markers.
-
-## Linting
-
-This repo uses `golangci-lint` v2.10.1 with 28+ linters enabled (see `.golangci.yml`). Key rules:
-
-- All errors must be checked (`errcheck`)
-- Use `errors.Is`/`errors.As`, not type assertions (`errorlint`)
-- No naked returns (`nakedret`)
-- Max cognitive complexity 30 / cyclomatic complexity 20
-- No code duplication over 150 tokens (`dupl`)
-- Repeated strings (3+ occurrences) must be constants (`goconst`)
-- All exported types/functions need comments (`revive`)
-- `nolint` directives require explanation and specific linter name (`nolintlint`)
-- Security scanning via `gosec`
-- Performance-aware formatting (`perfsprint`)
-
-## Pre-commit Hooks
-
-```bash
-# Install (one-time)
-pip install pre-commit && pre-commit install
-
-# Run manually
-pre-commit run --all-files
-```
-
-Hooks: trailing whitespace, EOF fixer, YAML/JSON validation, large file check, private key detection, merge conflict check, `gofmt`, `go mod tidy`, `golangci-lint`.
-
-## Common Commands
-
-```bash
-make check          # Full CI parity: fmt + vet + lint + test
-make lint           # golangci-lint only
-make test           # go test (no race)
-make test-race      # go test -race
-make build-slack    # Build Slack bot binary (also bundled into apps/slack/Dockerfile)
-make security       # govulncheck
-make fmt            # gofmt + goimports
-```
-
-## Testing
-
-```bash
-go test ./...                      # All tests
-go test ./apps/slack/...           # Single app
-go test ./shared/...               # Shared only
-go test -count=1 ./...             # Skip cache
-```
-
-## Build
-
-Production builds target `linux/arm64` (Graviton on Fargate). The
-canonical build path is the per-app Dockerfile (e.g. `apps/slack/Dockerfile`):
-
-```bash
-docker buildx build --platform linux/arm64 \
-  -f apps/slack/Dockerfile -t qurl-bot-slack:dev .
-```
-
-For a local Go binary outside Docker (development, debugging) — `make build-slack` is the supported path:
-```bash
-make build-slack
-# binary lands at release/slack/qurl-bot-slack (gitignored)
-```
-
-## Key Architecture Decisions
-
-- **Auth:** Start with workspace API keys (qurl-api-keys table exists). Per-user OAuth later.
-- **Runtime (Slack):** AWS Fargate (arm64, distroless container) behind an ALB. Always-on; the steady enterprise workload makes Lambda cold starts the wrong shape.
-- **Shared client:** `shared/client/` wraps the qURL API. Not a standalone module yet.
-- **Release:** Release Please monorepo mode with per-app version tracks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,11 @@
 
 Polyglot monorepo for qURL integrations. SDKs live in separate repos: [qurl-python](https://github.com/layervai/qurl-python), [qurl-typescript](https://github.com/layervai/qurl-typescript).
 
-- `apps/slack/`, `apps/teams/`, `apps/cli/`, `apps/zapier/` — Go (`cmd/` + `internal/`)
-- `apps/discord/` — Node.js / TypeScript
+- `apps/slack/`, `apps/cli/` — Go (`cmd/` + `internal/`)
+- `apps/discord/` — Node.js (CommonJS, `src/*.js`)
+- `apps/teams/`, `apps/zapier/` — placeholder dirs, no implementation yet
 - `shared/` — Go packages consumed by every Go app; changes here affect all of them
-- `e2e/` — TypeScript end-to-end tests
+- `e2e/` — TypeScript end-to-end tests (Jest)
 - Per-app release tracks via Release Please monorepo mode (`release-please-config.json`)
 
 ## Commit format


### PR DESCRIPTION
## Summary

CLAUDE.md had drifted into a Makefile mirror plus roadmap status notes. Strip what an agent can already read from the repo itself, and keep only the non-obvious guidance.

**Removed (derivable or stale):**
- *Code Change Workflow* — standard branch/PR/`make check` loop agents already know
- *Code Conventions* — module name (in `go.mod`), `cmd/`/`internal/` layout (visible in tree)
- *Linting* — pinned `golangci-lint v2.10.1`, hand-maintained "28+ linters" list, individual rule summaries; all in `.golangci.yml`
- *Pre-commit Hooks* — in `.pre-commit-config.yaml` + `Makefile` (`pre-commit-install`, `pre-commit-run`)
- *Common Commands* / *Testing* / *Build* — in `Makefile` and per-app Dockerfiles; the listed binary path was also wrong
- *Key Architecture Decisions* — "auth: workspace keys today, OAuth later," "shared client: not a standalone module yet," Slack Fargate-vs-Lambda rationale (in `apps/slack/README.md`)

**Kept (genuinely non-obvious):**
- Signed-commit and no-main-push constraints (branch-protection gotchas)
- Polyglot layout note (Discord is Node.js, not Go like the others)
- Per-app Release Please monorepo tracks
- Commit-scope list + the alignment rule with the Component dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`
- qURL brand-spelling rules (which casings stay literal, and the `TODO(upstream-rebrand)` marker for in-lockstep error-string updates)

Net: 142 → 44 lines.

## Test plan

- [ ] CI passes (no code changes; doc-only)
- [ ] Spot-check that retained references still resolve: `.golangci.yml`, `release-please-config.json`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `git grep TODO(upstream-rebrand)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)