### PR TITLE
feat(discord): convert /qurl revoke to flow_state harness

### DIFF
--- a/apps/discord/docs/zero-downtime-design.md
+++ b/apps/discord/docs/zero-downtime-design.md
@@ -136,6 +136,22 @@ flow row in a given `(channel_id)` cannot start a second flow there. The second
 cancel it first."` This avoids needing a GSI on the flow table and keeps the
 state model simple.
 
+**Per-command override matrix.** The block-second-flow rule above is the
+default. Two commands carry intentional exceptions because their UX shape
+makes blocking the wrong call:
+
+| Command | Behavior on existing flow | Rationale |
+|---|---|---|
+| `/qurl revoke` | **Supersede** (admin_cleanup + recreate) | The menu is a stateless listing of recent sends; an admin who can't remember whether they cancelled the prior dropdown shouldn't be told "finish your existing dropdown first." Re-running shows a fresh menu and the orphan menu's selection lands on `loadFlow → null → "superseded"`. |
+| `/qurl setup` | Block (default) | Multi-step OAuth / API-key paste flow with in-progress state; the user should finish or cancel the active step. |
+| `/qurl send` | Block (default) | Multi-step send flow (recipient picker, attachment capture, confirm); abandoning mid-flow because a duplicate `/qurl send` slipped through would lose user input. |
+
+The supersede semantics are **enforced at the harness level** by `deleteFlow`'s
+conditional `stage = :expected` gate (see `apps/discord/src/flow-state.js`).
+A revoke command can only supersede a revoke flow; it cannot accidentally
+admin_cleanup a sibling setup or send flow that happens to share the same
+`flow_id` keying.
+
 **MESSAGE_CREATE handler.** Today the file-drop step uses
 `captureChannel.awaitMessages({...})` on a DM channel. Under the redesign,
 **workers** subscribe to a `MESSAGE_CREATE` event class from the queue. The

--- a/apps/discord/jest.config.js
+++ b/apps/discord/jest.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.js'],
+  // Global env setup — sets DDB_TABLE_PREFIX + AWS_REGION before any
+  // test file loads, so source modules with fail-fast module-load
+  // guards (flow-state, ddb-store) can be required without throwing.
+  // See tests/setup-env.js for the rationale.
+  setupFiles: ['<rootDir>/tests/setup-env.js'],
   // Note: `restoreMocks` is NOT set globally — qurl-send-state-machine.test.js
   // and others rely on jest.spyOn results persisting across tests within a
   // describe (the spies are set up in module-level scope and tests assert

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -31,6 +31,8 @@ const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
+const { createFlow, deleteFlow } = require('./flow-state');
+const { flowIdForInteraction, registerFlow } = require('./flow-dispatch');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
@@ -2593,6 +2595,25 @@ function formatRevokeDescription(s) {
   return truncate(base);
 }
 
+// Single non-terminal stage between createFlow and deleteFlow.
+// Stage name is the source of truth for the dispatcher routing
+// table (registerFlow at the bottom of the file) — changing it is
+// a single edit.
+const REVOKE_STAGE_AWAITING_SELECT = 'awaiting_revoke_select';
+
+// customId for the select menu. PREFIX-ONLY — no nonce, no flow_id
+// encoded. Concurrent revokes deliberately drop: the second call
+// supersedes the first via deleteFlow + createFlow. See
+// flow-dispatch's trust-model comment on why customId is unsafe as
+// an identity signal.
+const REVOKE_SELECT_CUSTOM_ID = 'qurl_revoke_select';
+
+// TTL for the awaiting-select flow row, in seconds. Matches the
+// pre-existing 60-second click window for the menu. DDB TTL reap is
+// asynchronous (~48 h) but loadFlow filters expired rows
+// synchronously, so the UX cuts off at 60 s on the dot.
+const REVOKE_FLOW_TTL_SECONDS = 60;
+
 async function handleRevoke(interaction, apiKey) {
   if (!apiKey) {
     return interaction.reply({ content: 'qURL API key is not configured.', ephemeral: true });
@@ -2605,11 +2626,58 @@ async function handleRevoke(interaction, apiKey) {
     return interaction.editReply({ content: 'No recent sends to revoke.' });
   }
 
-  // Nonce the customId so two concurrent /qurl revoke select menus don't
-  // route each other's events.
-  const revokeNonce = crypto.randomBytes(8).toString('hex');
+  // Open the flow row BEFORE rendering the menu. If createFlow fails
+  // (DDB outage, IAM regression), we want the user to see an error
+  // immediately rather than a clickable menu whose selection would
+  // then 404 against the dispatcher.
+  //
+  // Supersede semantics: a user with an existing in-flight revoke
+  // flow who runs `/qurl revoke` again gets the old flow torn down
+  // and a fresh menu. The orphan menu in the old message becomes a
+  // no-op (its selection event will hit the dispatcher, miss on
+  // loadFlow, and surface the "superseded — run again" message).
+  // This is a deliberate exception to the design-doc rule that
+  // "a user with an existing non-expired flow in a given channel
+  // cannot start a second flow there" — for revoke specifically,
+  // the menu is a stateless listing and the second invocation is
+  // idempotent, so blocking it would just confuse users who can't
+  // remember whether they cancelled the prior menu.
+  const flow_id = flowIdForInteraction(interaction);
+  const expires_at = Math.floor(Date.now() / 1000) + REVOKE_FLOW_TTL_SECONDS;
+  const created = await createFlow({
+    flow_id,
+    stage: REVOKE_STAGE_AWAITING_SELECT,
+    payload: null,
+    expires_at,
+  });
+  if (!created.created) {
+    // Existing row from a prior /qurl revoke (or some other flow in
+    // this channel). Tear it down and try again. The admin_cleanup
+    // reason marks this as an out-of-band delete rather than a
+    // terminal completion — keeps the SLI's silently_dropped count
+    // honest (the prior flow never reached its own terminal).
+    await deleteFlow(flow_id, {
+      stage: REVOKE_STAGE_AWAITING_SELECT,
+      reason: 'admin_cleanup',
+    });
+    const retry = await createFlow({
+      flow_id,
+      stage: REVOKE_STAGE_AWAITING_SELECT,
+      payload: null,
+      expires_at,
+    });
+    if (!retry.created) {
+      // Two races in a row would be exceptional. Surface as an
+      // error rather than loop — the user can retry the command.
+      logger.warn('handleRevoke: createFlow racy after admin_cleanup', { flow_id });
+      return interaction.editReply({
+        content: 'Could not start a revoke session — please try again.',
+      });
+    }
+  }
+
   const select = new StringSelectMenuBuilder()
-    .setCustomId(`qurl_revoke_select_${revokeNonce}`)
+    .setCustomId(REVOKE_SELECT_CUSTOM_ID)
     .setPlaceholder('Select a send to revoke')
     .addOptions(recentSends.map(s => {
       // StringSelectMenu labels are plain text — <#id> mention syntax
@@ -2628,31 +2696,64 @@ async function handleRevoke(interaction, apiKey) {
     }));
 
   const row = new ActionRowBuilder().addComponents(select);
-  const response = await interaction.editReply({
+  await interaction.editReply({
     content: 'Select a send to revoke all its links:',
     components: [row],
   });
+}
 
-  try {
-    const selectInteraction = await response.awaitMessageComponent({
-      componentType: ComponentType.StringSelect,
-      filter: (i) => i.user.id === interaction.user.id && i.customId === `qurl_revoke_select_${revokeNonce}`,
-      time: 60000,
-    });
+// `reason: 'terminal'` reflects the FLOW lifecycle, not the qURL
+// API call's success. The state machine terminated when the user
+// picked an item; downstream revoke outcome is captured by its
+// own `revoke_success` / `revoke_failed` audit events.
+//
+// `deleteFlow` is the at-most-once dedup primitive — only the
+// worker whose conditional delete returns `{ deleted: true }`
+// proceeds. A duplicate event (SQS at-least-once redelivery in
+// the future worker tier, or a Discord double-dispatch today) sees
+// `{ deleted: false }` and exits.
+async function handleRevokeSelect(interaction, { flow_id }) {
+  // getGuildApiKey + deleteFlow are independent reads — run them in
+  // parallel to save one DDB RTT per click.
+  const [guildApiKey, deleteResult] = await Promise.all([
+    interaction.guildId ? db.getGuildApiKey(interaction.guildId) : null,
+    deleteFlow(flow_id, {
+      stage: REVOKE_STAGE_AWAITING_SELECT,
+      reason: 'terminal',
+    }),
+  ]);
+  const apiKey = guildApiKey || config.QURL_API_KEY;
 
-    const sendId = selectInteraction.values[0];
-    const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
-
-    // Slash-command path lacks the in-scope `recipients` array needed
-    // to resolve names → no "Revoked for: …" line here. Operators
-    // wanting names should use the inline button after a send.
-    await selectInteraction.update({
-      content: buildRevokeHeader(revoked.success, revoked.total),
-      components: [],
-    });
-  } catch {
-    await interaction.editReply({ content: 'Revocation timed out.', components: [] }).catch(logIgnoredDiscordErr);
+  if (!deleteResult.deleted) {
+    // Another worker already completed (or admin_cleanup'd) this flow.
+    // Reply rather than update — `interaction.update` would mutate
+    // the original ephemeral message, but a duplicate event by
+    // definition means the original was already updated by the
+    // winning worker. Ephemeral reply preserves the user-visible
+    // first result.
+    return interaction.reply({
+      content: 'This revoke was already processed.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
   }
+
+  if (!apiKey) {
+    return interaction.update({
+      content: 'qURL API key is no longer configured for this server.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  const sendId = interaction.values[0];
+  const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
+
+  // Slash-command path lacks the in-scope `recipients` array needed
+  // to resolve names → no "Revoked for: …" line here. Operators
+  // wanting names should use the inline button after a send.
+  await interaction.update({
+    content: buildRevokeHeader(revoked.success, revoked.total),
+    components: [],
+  });
 }
 
 // Pure rendering / wording logic lives in `./revoke-render` so the
@@ -3961,10 +4062,24 @@ async function handleCommand(interaction) {
   }
 }
 
+// Wire flow handlers into the dispatcher at module-load time.
+// flow-dispatch's `registerFlow` is the single source of truth for
+// the customId → handler routing table; doing this here (rather than
+// in index.js) co-locates the registration with the handler
+// implementation so future readers don't have to grep two modules to
+// understand the routing.
+registerFlow(REVOKE_SELECT_CUSTOM_ID, {
+  expectedStage: REVOKE_STAGE_AWAITING_SELECT,
+  handler: handleRevokeSelect,
+});
+
 module.exports = {
   commands,
   registerCommands,
   handleCommand,
+  // Exported for the dispatcher's unit tests. Production code reaches
+  // it via flow-dispatch's registry, not this export.
+  handleRevokeSelect,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2651,24 +2651,47 @@ async function handleRevoke(interaction, apiKey) {
     expires_at,
   });
   if (!created.created) {
-    // Existing row from a prior /qurl revoke (or some other flow in
-    // this channel). Tear it down and try again. The admin_cleanup
-    // reason marks this as an out-of-band delete rather than a
-    // terminal completion — keeps the SLI's silently_dropped count
-    // honest (the prior flow never reached its own terminal).
+    // Existing row from a prior /qurl revoke. Tear it down (the
+    // stage gate on deleteFlow ensures we won't admin_cleanup a
+    // sibling flow at the same flow_id, e.g. an in-flight setup
+    // modal) and try again. The admin_cleanup reason marks this as
+    // an out-of-band delete rather than a terminal completion —
+    // keeps the SLI's silently_dropped count honest (the prior
+    // flow never reached its own terminal).
+    //
+    // If deleteFlow returns deleted:false the row at this flow_id
+    // belongs to a different flow type; the retry createFlow will
+    // then also return created:false and the user gets the generic
+    // "could not start" message. That's correct — we don't want to
+    // bulldoze a sibling flow.
     await deleteFlow(flow_id, {
       stage: REVOKE_STAGE_AWAITING_SELECT,
       reason: 'admin_cleanup',
     });
-    const retry = await createFlow({
-      flow_id,
-      stage: REVOKE_STAGE_AWAITING_SELECT,
-      payload: null,
-      expires_at,
-    });
+    let retry;
+    try {
+      retry = await createFlow({
+        flow_id,
+        stage: REVOKE_STAGE_AWAITING_SELECT,
+        payload: null,
+        expires_at,
+      });
+    } catch (err) {
+      // DDB throttle / IAM blip on the retry — the prior flow row
+      // is gone but we couldn't open a new one. Surface a
+      // recoverable error rather than letting it propagate to the
+      // generic "error executing command" reply.
+      logger.warn('handleRevoke: createFlow retry threw after admin_cleanup', {
+        flow_id, error: err && err.message,
+      });
+      return interaction.editReply({
+        content: 'Could not start a revoke session — please try again.',
+      });
+    }
     if (!retry.created) {
-      // Two races in a row would be exceptional. Surface as an
-      // error rather than loop — the user can retry the command.
+      // Two races in a row (or a sibling flow blocking us). Surface
+      // as an error rather than loop — the user can retry the
+      // command, or finish their other in-flight flow.
       logger.warn('handleRevoke: createFlow racy after admin_cleanup', { flow_id });
       return interaction.editReply({
         content: 'Could not start a revoke session — please try again.',
@@ -2713,8 +2736,18 @@ async function handleRevoke(interaction, apiKey) {
 // the future worker tier, or a Discord double-dispatch today) sees
 // `{ deleted: false }` and exits.
 async function handleRevokeSelect(interaction, { flow_id }) {
-  // getGuildApiKey + deleteFlow are independent reads — run them in
-  // parallel to save one DDB RTT per click.
+  // Parallelize the dedup primitive (deleteFlow) with the apiKey
+  // resolution. Safe here because getGuildApiKey is an idempotent
+  // DDB read with zero side effects — the dedup loser short-circuits
+  // before the qURL API call, so a duplicate event never multiplies
+  // the parallel call's cost.
+  //
+  // Rule for future handlers in PR 6/7/8/9: parallelize the dedup
+  // primitive ONLY with idempotent / free reads. Do NOT parallelize
+  // with a paid side-effect call (a Google Places lookup, a recipient
+  // resolution that hits an external API, a connector upload) —
+  // at-least-once redelivery would then bill or trigger the side
+  // effect once per duplicate, defeating the dedup gate's purpose.
   const [guildApiKey, deleteResult] = await Promise.all([
     interaction.guildId ? db.getGuildApiKey(interaction.guildId) : null,
     deleteFlow(flow_id, {

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -146,6 +146,15 @@ const isDiscordInstallConfigured = Boolean(
   isQurlOAuthConfigured && process.env.DISCORD_CLIENT_SECRET,
 );
 
+// Shard identifier for the shard-aware composite flow_id
+// (`<shard_id>#<guild_id>#<channel_id>#<user_id>`, see src/flow-id.js).
+// Single-shard today, so the default is `'0:1'` (shard 0 of 1) per the
+// zero-downtime design doc. When sharding lands, the runtime will set
+// SHARD_ID per process to `'k:n'` (e.g. `'3:8'` for shard 3 of 8); the
+// schema is already shard-aware so no migration is needed. Single
+// export point so a future grep-and-replace doesn't miss a callsite.
+const SHARD_ID = process.env.SHARD_ID || '0:1';
+
 // Configuration from environment variables
 module.exports = {
   // Discord
@@ -269,4 +278,6 @@ module.exports = {
   // disable the rate limit; a recipients cap of 0 would reject every send.
   QURL_SEND_MAX_RECIPIENTS: intEnv('QURL_SEND_MAX_RECIPIENTS', 50, { minPositive: true }),
   QURL_SEND_COOLDOWN_MS: intEnv('QURL_SEND_COOLDOWN_MS', 30000, { minPositive: true }),
+
+  SHARD_ID,
 };

--- a/apps/discord/src/flow-dispatch.js
+++ b/apps/discord/src/flow-dispatch.js
@@ -10,10 +10,14 @@
 // flow-resume) under one error-handling envelope. Split modules
 // keep each surface single-purpose.
 //
-// Handlers register their prefix at load-time (see registerFlow
+// Handlers register their customId at load-time (see registerFlow
 // callsites in commands.js + future flow modules). Routing-table-as-
-// single-source-of-truth means a `handlers.has(prefix)` check is the
-// only thing standing between an unknown customId and a silent drop.
+// single-source-of-truth means a `handlers.has(customId)` check is
+// the only thing standing between an unknown customId and a silent
+// drop. Match is EXACT — `handlers.get(customId)`, not startsWith.
+// If a future flow needs a nonce'd suffix (e.g. `setup_modal:<id>`),
+// extend the lookup here; do not let callers pass partial routing
+// keys.
 //
 // Trust model for customId routing:
 //
@@ -38,17 +42,16 @@ const logger = require('./logger');
 // the table is read-only after boot. No concurrency hazard.
 const handlers = new Map();
 
-// Register a flow handler. `prefix` is matched against the full
-// customId (exact match, not startsWith — see customId rationale at
-// callsite). `expectedStage` is what `loadFlow(flow_id).stage` must
-// equal for the handler to fire; mismatches yield a "superseded"
-// user-visible reply.
+// Register a flow handler. `customId` is matched exactly against
+// `interaction.customId` (not startsWith — see module header).
+// `expectedStage` is what `loadFlow(flow_id).stage` must equal for
+// the handler to fire; mismatches yield a "superseded" reply.
 //
 // Throws on duplicate registration — silently overwriting a handler
 // would mask a real bug (two modules claiming the same customId).
-function registerFlow(prefix, { expectedStage, handler }) {
-  if (typeof prefix !== 'string' || prefix.length === 0) {
-    throw new TypeError('flow-dispatch.registerFlow: prefix must be a non-empty string');
+function registerFlow(customId, { expectedStage, handler }) {
+  if (typeof customId !== 'string' || customId.length === 0) {
+    throw new TypeError('flow-dispatch.registerFlow: customId must be a non-empty string');
   }
   if (typeof expectedStage !== 'string' || expectedStage.length === 0) {
     throw new TypeError('flow-dispatch.registerFlow: expectedStage must be a non-empty string');
@@ -56,10 +59,10 @@ function registerFlow(prefix, { expectedStage, handler }) {
   if (typeof handler !== 'function') {
     throw new TypeError('flow-dispatch.registerFlow: handler must be a function');
   }
-  if (handlers.has(prefix)) {
-    throw new Error(`flow-dispatch.registerFlow: prefix ${JSON.stringify(prefix)} is already registered`);
+  if (handlers.has(customId)) {
+    throw new Error(`flow-dispatch.registerFlow: customId ${JSON.stringify(customId)} is already registered`);
   }
-  handlers.set(prefix, { expectedStage, handler });
+  handlers.set(customId, { expectedStage, handler });
 }
 
 // Derive the canonical flow_id for an interaction from its trusted

--- a/apps/discord/src/flow-dispatch.js
+++ b/apps/discord/src/flow-dispatch.js
@@ -1,0 +1,208 @@
+// flow-dispatch — routes Discord component / modal interactions to
+// DDB-backed flow handlers (see docs/zero-downtime-design.md,
+// Pillar 1).
+//
+// Component / modal interactions arrive on the same `interactionCreate`
+// event as slash commands but follow an entirely different lifecycle:
+// they're keyed off a customId rather than a command name, and they
+// must resolve a DDB flow row before acting. Branching inside
+// handleCommand would mix two state machines (slash dispatch vs.
+// flow-resume) under one error-handling envelope. Split modules
+// keep each surface single-purpose.
+//
+// Handlers register their prefix at load-time (see registerFlow
+// callsites in commands.js + future flow modules). Routing-table-as-
+// single-source-of-truth means a `handlers.has(prefix)` check is the
+// only thing standing between an unknown customId and a silent drop.
+//
+// Trust model for customId routing:
+//
+//   The customId on a component event is REPLAYABLE CLIENT INPUT —
+//   Discord puts whatever was set on the original message into the
+//   interaction payload verbatim. It is fine to use as a routing key
+//   (the worst case is a typo'd prefix → no match → silent drop, which
+//   is harmless), but it MUST NOT be used as an identity or
+//   authorization signal. The flow_id is derived ENTIRELY from the
+//   trusted interaction context (user.id + channelId + shard), not from
+//   anything inside customId. A user can't spoof another user's flow
+//   by editing a customId.
+
+const { buildFlowId } = require('./flow-id');
+const { loadFlow } = require('./flow-state');
+const { SHARD_ID } = require('./config');
+const logger = require('./logger');
+
+// Module-state routing table. Registered at the bottom of commands.js
+// (and future setup/send handler modules) via `registerFlow`. Module-
+// state is fine here: the registration runs once at require-time, and
+// the table is read-only after boot. No concurrency hazard.
+const handlers = new Map();
+
+// Register a flow handler. `prefix` is matched against the full
+// customId (exact match, not startsWith — see customId rationale at
+// callsite). `expectedStage` is what `loadFlow(flow_id).stage` must
+// equal for the handler to fire; mismatches yield a "superseded"
+// user-visible reply.
+//
+// Throws on duplicate registration — silently overwriting a handler
+// would mask a real bug (two modules claiming the same customId).
+function registerFlow(prefix, { expectedStage, handler }) {
+  if (typeof prefix !== 'string' || prefix.length === 0) {
+    throw new TypeError('flow-dispatch.registerFlow: prefix must be a non-empty string');
+  }
+  if (typeof expectedStage !== 'string' || expectedStage.length === 0) {
+    throw new TypeError('flow-dispatch.registerFlow: expectedStage must be a non-empty string');
+  }
+  if (typeof handler !== 'function') {
+    throw new TypeError('flow-dispatch.registerFlow: handler must be a function');
+  }
+  if (handlers.has(prefix)) {
+    throw new Error(`flow-dispatch.registerFlow: prefix ${JSON.stringify(prefix)} is already registered`);
+  }
+  handlers.set(prefix, { expectedStage, handler });
+}
+
+// Derive the canonical flow_id for an interaction from its trusted
+// context. Used by BOTH sides of every flow: the command handler
+// (creating the flow row) and the dispatcher (loading the flow row).
+// Single source of truth — if these two callsites computed flow_id
+// differently the OCC contract would silently fail.
+//
+// DM context: interaction.guildId is null. Namespace DM flows under
+// `dm:<user_id>` so they can't collide with a real guild snowflake
+// (which are pure numerics — the `dm:` prefix is unambiguous). The
+// channel_id is still the DM channel ID, so two parallel DM flows for
+// the same user in different channels (theoretically possible if the
+// user opens a group DM) get distinct flow_ids.
+function flowIdForInteraction(interaction) {
+  const guild_id = interaction.guildId ?? `dm:${interaction.user.id}`;
+  return buildFlowId({
+    shard_id: SHARD_ID,
+    guild_id,
+    channel_id: interaction.channelId,
+    user_id: interaction.user.id,
+  });
+}
+
+// User-visible reply when a component fires but its flow row is
+// missing (TTL'd, superseded, or never created). Phrased to be
+// recoverable — the user just runs the command again. Kept as a
+// module-level constant so the dispatcher test can assert on it
+// without re-stating wording.
+const SUPERSEDED_MSG = 'This action was superseded — run the command again.';
+
+// Entry point — wired from index.js's interactionCreate listener.
+// Contract: returns a Promise that resolves once the dispatch is
+// complete (or short-circuits for unknown customId). Throws are NOT
+// expected to propagate — every internal failure path either replies
+// to the user or logs and exits. The caller (index.js listener) does
+// not have a meaningful retry path.
+async function handleFlowInteraction(interaction) {
+  const customId = interaction.customId;
+  if (typeof customId !== 'string' || customId.length === 0) {
+    // Discord ought to always send a customId for component/modal
+    // events, but guard so a malformed payload doesn't crash the
+    // process. Quiet drop — the user would see Discord's own
+    // "interaction failed" within 3 s.
+    return;
+  }
+
+  const route = handlers.get(customId);
+  if (!route) {
+    // Unknown customId — most likely a stale component from a previous
+    // deploy that used a different prefix scheme. Silent drop; the
+    // user's interaction will time out client-side with Discord's
+    // generic "interaction failed" notice.
+    logger.debug('flow-dispatch: unknown customId, dropping', { customId });
+    return;
+  }
+
+  let flow_id;
+  try {
+    flow_id = flowIdForInteraction(interaction);
+  } catch (err) {
+    // flowIdForInteraction calls buildFlowId, which throws on missing/
+    // malformed components. Shouldn't happen for real Discord events,
+    // but log + reply rather than letting the throw escape.
+    logger.warn('flow-dispatch: failed to derive flow_id from interaction', {
+      customId, error: err.message,
+    });
+    await safeReply(interaction, SUPERSEDED_MSG);
+    return;
+  }
+
+  let row;
+  try {
+    row = await loadFlow(flow_id);
+  } catch (err) {
+    logger.error('flow-dispatch: loadFlow failed', {
+      customId, flow_id, error: err.message,
+    });
+    await safeReply(interaction, SUPERSEDED_MSG);
+    return;
+  }
+
+  if (!row || row.stage !== route.expectedStage) {
+    // Either the flow is gone (TTL'd, deleted, never existed) or it
+    // advanced to a stage that doesn't match this customId. Both
+    // collapse to the same user-visible recovery ("run again"); the
+    // distinction matters only for forensic logs.
+    logger.debug('flow-dispatch: flow not in expected stage', {
+      customId, flow_id,
+      stage: row ? row.stage : null,
+      expected_stage: route.expectedStage,
+    });
+    await safeReply(interaction, SUPERSEDED_MSG);
+    return;
+  }
+
+  // Universal safety net. A handler may have ALREADY committed an
+  // irreversible flow_state side effect (deleteFlow-first ordering,
+  // a transitionFlow on an OCC path) before throwing — letting the
+  // throw escape would surface as a process-level unhandledRejection
+  // with no user-visible reply, making the action look silently
+  // broken. Catch here so every handler shares the same safety net
+  // rather than re-implementing it.
+  //
+  // `row` is passed alongside `flow_id` so handlers that need
+  // `row.version` for `transitionFlow`'s OCC parameter don't have
+  // to re-issue loadFlow. handleRevokeSelect ignores it today
+  // (single-shot stage); PR 6's setup-modal handler will consume it.
+  try {
+    await route.handler(interaction, { flow_id, row });
+  } catch (err) {
+    logger.error('flow-dispatch: handler threw', {
+      customId, flow_id, error: err.message, stack: err.stack,
+    });
+    await safeReply(
+      interaction,
+      'Something went wrong — please run the command again.',
+    );
+  }
+}
+
+// Best-effort reply that swallows Discord errors. The dispatcher may
+// arrive at the reply path AFTER another code path (a Discord retry,
+// say) already acked — `interaction.reply` would throw
+// `InteractionAlreadyReplied` then. Logging at warn is enough; there
+// is no recovery.
+async function safeReply(interaction, content) {
+  try {
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp({ content, ephemeral: true });
+    } else {
+      await interaction.reply({ content, ephemeral: true });
+    }
+  } catch (err) {
+    logger.warn('flow-dispatch: reply failed', { error: err.message });
+  }
+}
+
+module.exports = {
+  registerFlow,
+  flowIdForInteraction,
+  handleFlowInteraction,
+  // Exported for tests so they can assert the supersede wording
+  // without duplicating the string.
+  SUPERSEDED_MSG,
+};

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -701,6 +701,15 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
 // PR adds a TTL-driven sweeper it MUST emit a distinct event
 // (e.g. FLOW_REAPED) so the SLI math stays intact.
 //
+// `stage` is both the audit value AND the conditional-delete gate:
+// the row is only removed when its `stage` attribute equals the
+// caller-supplied value. This prevents cross-flow contamination
+// across commands that share a `flow_id` shape: when /qurl revoke
+// supersedes its own `awaiting_revoke_select` row, it must not be
+// able to admin_cleanup an in-flight /qurl setup row keyed at the
+// same (user, channel). The stage gate enforces "delete the flow
+// I expect, not whatever flow happens to live at this key."
+//
 // `reason` is one of 'terminal' | 'abort' | 'admin_cleanup' per
 // the audit event's payload contract. Caller-supplied because
 // flow-state can't know whether a given delete is a clean
@@ -719,28 +728,51 @@ async function deleteFlow(flow_id, { stage, reason }) {
   // Conditional Delete + emit-on-success. The SLI math
   //   silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)
   // requires at-most-once emission per logical flow on BOTH sides.
-  // CREATED is gated by `attribute_not_exists`; DELETED needs the
-  // mirror — `attribute_exists` — otherwise an SQS redelivery of an
-  // abort/admin_cleanup path (which have no version-checked
-  // predecessor to gate on) would Delete-success-idempotently a
-  // second time and double-emit FLOW_DELETED. Numerator inflates,
-  // signal lost.
+  // CREATED is gated by `attribute_not_exists`; DELETED needs both
+  // attribute_exists (so SQS redeliveries don't double-emit) AND
+  // the stage gate (so a sibling flow at the same flow_id is never
+  // collateral damage).
   //
   // Returns `{ deleted: bool }` so callers can gate user-visible
   // "flow completed" side effects on actual deletion (a false
-  // return means someone else already deleted, or the TTL reaped
-  // — either way, don't re-DM the user).
+  // return means someone else already deleted, the TTL reaped, OR
+  // the stored stage doesn't match — for any of those, don't re-DM
+  // the user).
   try {
     await ddb.send(new DeleteCommand({
       TableName: TABLE_NAME,
       Key: { flow_id },
-      ConditionExpression: 'attribute_exists(flow_id)',
+      ConditionExpression: 'attribute_exists(flow_id) AND #s = :stage',
+      ExpressionAttributeNames: { '#s': 'stage' },
+      ExpressionAttributeValues: { ':stage': stage },
     }));
   } catch (err) {
     if (isConditionalCheckFailed(err)) {
-      // Row was already gone (redelivery, TTL reap, or concurrent
-      // delete). No-op. Do NOT emit FLOW_DELETED — the SLI's
-      // count(FLOW_DELETED) must stay at-most-once per logical flow.
+      // Row absent OR stage mismatch. Discriminate via post-recheck
+      // for the forensic log line — same pattern as transitionFlow's
+      // recheck. Best-effort: any throw here is swallowed because
+      // the recheck is purely informational.
+      let actual_stage = null;
+      let row_present = false;
+      try {
+        const recheck = await ddb.send(new GetCommand({
+          TableName: TABLE_NAME,
+          Key: { flow_id },
+          ProjectionExpression: 'stage',
+          ConsistentRead: true,
+        }));
+        if (recheck.Item) {
+          row_present = true;
+          actual_stage = recheck.Item.stage;
+        }
+      } catch (rcErr) {
+        logger.warn('flow-state.deleteFlow: post-CCFE recheck failed (informational)', {
+          flow_id, error: rcErr && rcErr.message,
+        });
+      }
+      logger.debug('flow-state.deleteFlow: condition failed', {
+        flow_id, expected_stage: stage, actual_stage, row_present,
+      });
       return { deleted: false };
     }
     throw err;

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -277,10 +277,13 @@ if (isGateway) {
     if (interaction.isMessageComponent() || interaction.isModalSubmit()) {
       return handleFlowInteraction(interaction);
     }
-    // Anything else (button-builder selects of a kind we don't
-    // ship today, future Discord interaction types) is silently
-    // ignored — same shape as the pre-conversion code, which
-    // short-circuited any non-ChatInputCommand interaction.
+    // Future Discord interaction types we don't ship today fall
+    // through here. Log at debug so an operator triaging "why isn't
+    // my new component routing" sees the unrouted type rather than
+    // the silent-drop black box the pre-conversion code provided.
+    logger.debug('interactionCreate: unrouted interaction type', {
+      type: interaction.type,
+    });
     return undefined;
   });
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -2,6 +2,7 @@ const config = require('./config');
 const logger = require('./logger');
 const { client, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
+const { handleFlowInteraction } = require('./flow-dispatch');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
@@ -260,8 +261,28 @@ if (isGateway) {
     await registerCommands(client);
   });
 
-  // Handle interactions
-  client.on('interactionCreate', handleCommand);
+  // Handle interactions. Split-dispatch by interaction kind:
+  // ChatInputCommand + Autocomplete go through the slash-command
+  // path (handleCommand); MessageComponent + ModalSubmit go through
+  // the DDB-backed flow dispatcher (handleFlowInteraction, which
+  // replaces the legacy in-process `awaitMessageComponent` pattern
+  // per the zero-downtime upgrade rollout). Keep the two paths
+  // disjoint — a single listener that branched internally would
+  // mix two state machines (slash dispatch vs. flow-resume) under
+  // one error-handling envelope; cleaner to wire them separately.
+  client.on('interactionCreate', (interaction) => {
+    if (interaction.isChatInputCommand() || interaction.isAutocomplete()) {
+      return handleCommand(interaction);
+    }
+    if (interaction.isMessageComponent() || interaction.isModalSubmit()) {
+      return handleFlowInteraction(interaction);
+    }
+    // Anything else (button-builder selects of a kind we don't
+    // ship today, future Discord interaction types) is silently
+    // ignored — same shape as the pre-conversion code, which
+    // short-circuited any non-ChatInputCommand interaction.
+    return undefined;
+  });
 
   // Tick the gateway-activity timestamp on every WebSocket frame.
   // Feeds the `activity_age_ms` observability gauge ONLY — does not

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -20,6 +20,7 @@ jest.mock('../src/config', () => ({
   ADMIN_USER_IDS: ['admin-1'],
   BASE_URL: 'http://localhost:3000',
   GUILD_ID: 'guild-1',
+  SHARD_ID: '0:1',
   isMultiTenant: false,
   // This suite exercises every slash command (both /qurl and the OpenNHP
   // ones). registerCommands + handleCommand filter to the customer-safe
@@ -152,6 +153,10 @@ const mockDb = {
   recordQURLSend: jest.fn(),
   recordQURLSendBatch: jest.fn(),
   updateSendDMStatus: jest.fn(),
+  // Default to "no per-guild key configured" → the revoke + send
+  // gates fall through to config.QURL_API_KEY (which is set in
+  // the config mock at the top of this file).
+  getGuildApiKey: jest.fn().mockResolvedValue(null),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   getSendItems: jest.fn(() => []),
@@ -213,6 +218,19 @@ jest.mock('../src/places', () => ({
   searchPlaces: jest.fn().mockResolvedValue([]),
 }));
 
+// flow-state is the DDB-backed harness consumed by /qurl revoke
+// post-conversion (PR 5). Mock it here rather than hit DDB.
+const mockCreateFlow = jest.fn().mockResolvedValue({ created: true, version: 1 });
+const mockLoadFlow = jest.fn();
+const mockDeleteFlow = jest.fn().mockResolvedValue({ deleted: true });
+const mockTransitionFlow = jest.fn();
+jest.mock('../src/flow-state', () => ({
+  createFlow: (...args) => mockCreateFlow(...args),
+  loadFlow: (...args) => mockLoadFlow(...args),
+  deleteFlow: (...args) => mockDeleteFlow(...args),
+  transitionFlow: (...args) => mockTransitionFlow(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Require modules under test
 // ---------------------------------------------------------------------------
@@ -267,6 +285,7 @@ function makeInteraction(overrides = {}) {
       members: new Map(),
     },
     channelId: 'ch-1',
+    guildId: 'guild-1',
     guild: {
       members: { fetch: jest.fn().mockResolvedValue(undefined) },
       voiceStates: { cache: new Map() },
@@ -1152,7 +1171,17 @@ describe('/qurl help subcommand', () => {
   });
 });
 
+// The slash command writes a flow_state row to DDB and renders the
+// select menu; the actual revoke executes on the menu's selection
+// event in the dispatcher path. Tests split accordingly — "menu is
+// rendered" lives here, "revoke executes" lives in the
+// `handleRevokeSelect (dispatcher)` describe below.
 describe('/qurl revoke subcommand', () => {
+  beforeEach(() => {
+    mockCreateFlow.mockResolvedValue({ created: true, version: 1 });
+    mockDeleteFlow.mockResolvedValue({ deleted: true });
+  });
+
   it('shows no recent sends message', async () => {
     mockDb.getRecentSends.mockReturnValue([]);
     const cmd = commands.find(c => c.data.name === 'qurl');
@@ -1169,9 +1198,12 @@ describe('/qurl revoke subcommand', () => {
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('No recent sends') }),
     );
+    // No flow row should be opened when there's nothing to revoke —
+    // an early no-op shouldn't poison the SLI's create-count.
+    expect(mockCreateFlow).not.toHaveBeenCalled();
   });
 
-  it('shows select menu for recent sends and revokes', async () => {
+  it('opens a flow row and renders the select menu', async () => {
     mockDb.getRecentSends.mockReturnValue([
       {
         send_id: 'send-1',
@@ -1183,16 +1215,6 @@ describe('/qurl revoke subcommand', () => {
         created_at: new Date().toISOString(),
       },
     ]);
-    mockDb.getSendResourceIds.mockReturnValue(['res-1']);
-    mockDeleteLink.mockResolvedValue(undefined);
-
-    const selectInteraction = {
-      values: ['send-1'],
-      update: jest.fn().mockResolvedValue(undefined),
-    };
-    const responseObj = {
-      awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction),
-    };
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeInteraction({
@@ -1201,48 +1223,203 @@ describe('/qurl revoke subcommand', () => {
         ...makeInteraction().options,
         getSubcommand: jest.fn(() => 'revoke'),
       },
-      editReply: jest.fn().mockResolvedValue(responseObj),
     });
 
     await cmd.execute(interaction);
 
-    expect(selectInteraction.update).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('Revoked') }),
+    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+    const createArgs = mockCreateFlow.mock.calls[0][0];
+    expect(createArgs.stage).toBe('awaiting_revoke_select');
+    expect(createArgs.payload).toBeNull();
+    expect(createArgs.flow_id).toMatch(/^0:1#guild-1#ch-1#user-1$/);
+    expect(createArgs.expires_at).toEqual(expect.any(Number));
+
+    // Menu was rendered to the user.
+    const menuCall = interaction.editReply.mock.calls.find(
+      (c) => c[0]?.components?.length > 0,
+    );
+    expect(menuCall).toBeDefined();
+    expect(menuCall[0].content).toMatch(/Select a send to revoke/);
+  });
+
+  it('supersedes a prior in-flight revoke flow', async () => {
+    // First createFlow loses the OCC race (existing row from a
+    // previous /qurl revoke call); admin_cleanup + retry must
+    // win, and the menu still renders.
+    mockCreateFlow
+      .mockResolvedValueOnce({ created: false })
+      .mockResolvedValueOnce({ created: true, version: 1 });
+    mockDb.getRecentSends.mockReturnValue([
+      {
+        send_id: 'send-1',
+        resource_type: 'file',
+        target_type: 'user',
+        recipient_count: 1,
+        delivered_count: 1,
+        expires_in: '24h',
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'revoke'),
+      },
+    });
+
+    await cmd.execute(interaction);
+
+    expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlow.mock.calls[0][1]).toEqual({
+      stage: 'awaiting_revoke_select',
+      reason: 'admin_cleanup',
+    });
+    // Menu should still be rendered after supersede.
+    const menuCall = interaction.editReply.mock.calls.find(
+      (c) => c[0]?.components?.length > 0,
+    );
+    expect(menuCall).toBeDefined();
+  });
+
+  it('surfaces an error when supersede + retry both lose the race', async () => {
+    mockCreateFlow
+      .mockResolvedValueOnce({ created: false })
+      .mockResolvedValueOnce({ created: false });
+    mockDb.getRecentSends.mockReturnValue([
+      {
+        send_id: 'send-1',
+        resource_type: 'file',
+        target_type: 'user',
+        recipient_count: 1,
+        delivered_count: 1,
+        expires_in: '24h',
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'revoke'),
+      },
+    });
+
+    await cmd.execute(interaction);
+
+    const errorCall = interaction.editReply.mock.calls.find(
+      (c) => /Could not start a revoke session/.test(c[0]?.content || ''),
+    );
+    expect(errorCall).toBeDefined();
+  });
+});
+
+// Dispatcher-side tests for handleRevokeSelect — the post-conversion
+// execution path. Direct-invocation tests rather than going through
+// the dispatcher itself; the routing layer is covered in
+// flow-dispatch.test.js.
+describe('handleRevokeSelect (dispatcher path)', () => {
+  const { handleRevokeSelect } = require('../src/commands');
+
+  function makeSelectInteraction(overrides = {}) {
+    return {
+      values: ['send-1'],
+      user: { id: 'user-1' },
+      guildId: 'guild-1',
+      channelId: 'ch-1',
+      update: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    mockDeleteFlow.mockResolvedValue({ deleted: true });
+  });
+
+  it('runs revoke when deleteFlow wins (deleted=true)', async () => {
+    mockDb.getSendItems.mockReturnValue([
+      { resource_id: 'res-1', recipient_discord_id: 'u-1' },
+      { resource_id: 'res-2', recipient_discord_id: 'u-2' },
+      { resource_id: 'res-3', recipient_discord_id: 'u-3' },
+    ]);
+    mockDeleteLink.mockResolvedValue(undefined);
+    const interaction = makeSelectInteraction({ values: ['send-99'] });
+
+    await handleRevokeSelect(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(mockDeleteFlow).toHaveBeenCalledWith(
+      '0:1#guild-1#ch-1#user-1',
+      { stage: 'awaiting_revoke_select', reason: 'terminal' },
+    );
+    expect(mockDeleteLink).toHaveBeenCalledTimes(3);
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('3/3') }),
     );
   });
 
-  it('handles revocation timeout', async () => {
-    mockDb.getRecentSends.mockReturnValue([
-      {
-        send_id: 'send-1',
-        resource_type: 'file',
-        target_type: 'user',
-        recipient_count: 1,
-        delivered_count: 1,
-        expires_in: '24h',
-        created_at: new Date().toISOString(),
-      },
+  it('skips revoke when deleteFlow loses the race (deleted=false)', async () => {
+    // A duplicate event (SQS redelivery in the future worker tier,
+    // or a Discord double-dispatch today) — only the worker whose
+    // conditional delete succeeds proceeds. The loser must NOT
+    // touch the qURL API.
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const interaction = makeSelectInteraction();
+
+    await handleRevokeSelect(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(mockDeleteLink).not.toHaveBeenCalled();
+    expect(interaction.update).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('already processed'),
+      }),
+    );
+  });
+
+  it('updates with an error if apiKey resolution is no longer configured', async () => {
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: true });
+    mockDb.getGuildApiKey = jest.fn().mockResolvedValue(null);
+    // Drop the fallback as well — emulates an admin unsetting the
+    // key between revoke-init and revoke-execute.
+    const originalQurlApiKey = require('../src/config').QURL_API_KEY;
+    require('../src/config').QURL_API_KEY = null;
+
+    const interaction = makeSelectInteraction();
+    try {
+      await handleRevokeSelect(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+      expect(mockDeleteLink).not.toHaveBeenCalled();
+      expect(interaction.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('no longer configured'),
+        }),
+      );
+    } finally {
+      require('../src/config').QURL_API_KEY = originalQurlApiKey;
+    }
+  });
+
+  it('reports a partial revoke (some links already opened)', async () => {
+    mockDb.getSendItems.mockReturnValue([
+      { resource_id: 'res-1', recipient_discord_id: 'u-1' },
+      { resource_id: 'res-2', recipient_discord_id: 'u-2' },
     ]);
+    mockDeleteLink
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('not found'));
 
-    const responseObj = {
-      awaitMessageComponent: jest.fn().mockRejectedValue(new Error('timeout')),
-    };
+    const interaction = makeSelectInteraction({ values: ['send-partial'] });
+    await handleRevokeSelect(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
 
-    const cmd = commands.find(c => c.data.name === 'qurl');
-    const interaction = makeInteraction({
-      commandName: 'qurl',
-      options: {
-        ...makeInteraction().options,
-        getSubcommand: jest.fn(() => 'revoke'),
-      },
-      editReply: jest.fn().mockResolvedValue(responseObj),
-    });
-
-    await cmd.execute(interaction);
-
-    // Should have called editReply for timeout message
-    const lastCall = interaction.editReply.mock.calls[interaction.editReply.mock.calls.length - 1][0];
-    expect(lastCall.content).toContain('timed out');
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('1/2') }),
+    );
   });
 });
 
@@ -1269,104 +1446,9 @@ describe('handleCommand — autocomplete', () => {
   // stale registration) is short-circuited without dispatch.
 });
 
-describe('revokeAllLinks', () => {
-  it('revokes multiple resource IDs', async () => {
-    mockDb.getSendItems.mockReturnValue([
-      { resource_id: 'res-1', recipient_discord_id: 'u-1' },
-      { resource_id: 'res-2', recipient_discord_id: 'u-2' },
-      { resource_id: 'res-3', recipient_discord_id: 'u-3' },
-    ]);
-    mockDeleteLink.mockResolvedValue(undefined);
-
-    // Access revokeAllLinks indirectly through the revoke flow
-    // We test it via the button handler indirectly, but let's also
-    // test the direct function if it's exported
-    // Since it's not in _test, we test via the revoke subcommand which calls it
-
-    mockDb.getRecentSends.mockReturnValue([
-      {
-        send_id: 'send-99',
-        resource_type: 'file',
-        target_type: 'user',
-        recipient_count: 3,
-        delivered_count: 3,
-        expires_in: '24h',
-        created_at: new Date().toISOString(),
-      },
-    ]);
-
-    const selectInteraction = {
-      values: ['send-99'],
-      update: jest.fn().mockResolvedValue(undefined),
-    };
-    const responseObj = {
-      awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction),
-    };
-
-    const cmd = commands.find(c => c.data.name === 'qurl');
-    const interaction = makeInteraction({
-      commandName: 'qurl',
-      options: {
-        ...makeInteraction().options,
-        getSubcommand: jest.fn(() => 'revoke'),
-      },
-      editReply: jest.fn().mockResolvedValue(responseObj),
-    });
-
-    await cmd.execute(interaction);
-
-    expect(mockDeleteLink).toHaveBeenCalledTimes(3);
-    expect(selectInteraction.update).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('3/3') }),
-    );
-  });
-
-  it('handles partial revocation failures', async () => {
-    mockDb.getSendItems.mockReturnValue([
-      { resource_id: 'res-1', recipient_discord_id: 'u-1' },
-      { resource_id: 'res-2', recipient_discord_id: 'u-2' },
-    ]);
-    mockDeleteLink
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('not found'));
-
-    mockDb.getRecentSends.mockReturnValue([
-      {
-        send_id: 'send-partial',
-        resource_type: 'url',
-        target_type: 'channel',
-        recipient_count: 2,
-        delivered_count: 2,
-        expires_in: '1h',
-        created_at: new Date().toISOString(),
-      },
-    ]);
-
-    const selectInteraction = {
-      values: ['send-partial'],
-      update: jest.fn().mockResolvedValue(undefined),
-    };
-    const responseObj = {
-      awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction),
-    };
-
-    const cmd = commands.find(c => c.data.name === 'qurl');
-    const interaction = makeInteraction({
-      commandName: 'qurl',
-      options: {
-        ...makeInteraction().options,
-        getSubcommand: jest.fn(() => 'revoke'),
-      },
-      editReply: jest.fn().mockResolvedValue(responseObj),
-    });
-
-    await cmd.execute(interaction);
-
-    expect(selectInteraction.update).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('1/2') }),
-    );
-  });
-});
+// `revokeAllLinks` coverage lives in qurl-send-back-half.test.js
+// (direct unit tests) and in the `handleRevokeSelect (dispatcher
+// path)` block above (integration through the flow).
 
 // connector and qurl tests that require resetModules are in qurl-send.test.js
 

--- a/apps/discord/tests/flow-dispatch.test.js
+++ b/apps/discord/tests/flow-dispatch.test.js
@@ -90,9 +90,9 @@ describe('registerFlow', () => {
       .toThrow(/already registered/);
   });
 
-  it('rejects non-string prefix', () => {
+  it('rejects non-string customId', () => {
     expect(() => registerFlow('', { expectedStage: 's', handler: jest.fn() }))
-      .toThrow(/prefix must be a non-empty string/);
+      .toThrow(/customId must be a non-empty string/);
   });
 
   it('rejects non-string expectedStage', () => {

--- a/apps/discord/tests/flow-dispatch.test.js
+++ b/apps/discord/tests/flow-dispatch.test.js
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for src/flow-dispatch.js — the customId → handler
+ * routing layer that replaces in-process `awaitMessageComponent` for
+ * component / modal interactions.
+ *
+ * Trust-model surface: flow_id is derived from interaction context
+ * (user.id + channelId + shard), NEVER from customId. Tests pin that
+ * a hostile customId cannot reach a sibling user's flow row even if
+ * the routing prefix matches.
+ *
+ * Stage-mismatch surface: the dispatcher's primary guard is
+ * `row.stage === expectedStage`. A flow that has advanced past its
+ * registered stage (e.g. PR 6's setup modal having already moved to
+ * `awaiting_complete`) must yield the same "superseded" reply as a
+ * missing row — both signal "this customId can't act now."
+ */
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+jest.mock('../src/flow-state', () => ({
+  loadFlow: jest.fn(),
+}));
+
+jest.mock('../src/config', () => ({
+  SHARD_ID: '0:1',
+}));
+
+const { loadFlow } = require('../src/flow-state');
+const {
+  registerFlow,
+  flowIdForInteraction,
+  handleFlowInteraction,
+  SUPERSEDED_MSG,
+} = require('../src/flow-dispatch');
+
+function makeInteraction(overrides = {}) {
+  return {
+    customId: 'test_prefix',
+    user: { id: 'user-123' },
+    channelId: 'channel-456',
+    guildId: 'guild-789',
+    replied: false,
+    deferred: false,
+    reply: jest.fn().mockResolvedValue(undefined),
+    followUp: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('flowIdForInteraction', () => {
+  it('builds canonical flow_id from interaction context (guild)', () => {
+    const flow_id = flowIdForInteraction(makeInteraction());
+    expect(flow_id).toBe('0:1#guild-789#channel-456#user-123');
+  });
+
+  it('namespaces DM context under dm:<user_id>', () => {
+    const flow_id = flowIdForInteraction(makeInteraction({ guildId: null }));
+    expect(flow_id).toBe('0:1#dm:user-123#channel-456#user-123');
+  });
+
+  it('uses interaction.user.id, NOT anything from customId', () => {
+    // Security pin: a hostile customId encoding "user-VICTIM" must
+    // not affect routing — the trusted identity is the interaction
+    // context. (This is implicit since flowIdForInteraction doesn't
+    // read customId at all, but pin it so a future refactor that
+    // adds customId-derived disambiguation surfaces in review.)
+    const flow_id = flowIdForInteraction(makeInteraction({
+      customId: 'qurl_revoke_select:user-VICTIM',
+      user: { id: 'user-ATTACKER' },
+    }));
+    expect(flow_id).toContain('user-ATTACKER');
+    expect(flow_id).not.toContain('user-VICTIM');
+  });
+});
+
+describe('registerFlow', () => {
+  // registerFlow mutates module-private state, which leaks across
+  // tests in this describe. Use unique prefixes per case so we don't
+  // need a reset hook.
+  it('rejects duplicate registration', () => {
+    registerFlow('dup_prefix', { expectedStage: 's', handler: jest.fn() });
+    expect(() => registerFlow('dup_prefix', { expectedStage: 's', handler: jest.fn() }))
+      .toThrow(/already registered/);
+  });
+
+  it('rejects non-string prefix', () => {
+    expect(() => registerFlow('', { expectedStage: 's', handler: jest.fn() }))
+      .toThrow(/prefix must be a non-empty string/);
+  });
+
+  it('rejects non-string expectedStage', () => {
+    expect(() => registerFlow('bad_stage_prefix', { expectedStage: '', handler: jest.fn() }))
+      .toThrow(/expectedStage must be a non-empty string/);
+  });
+
+  it('rejects non-function handler', () => {
+    expect(() => registerFlow('bad_handler_prefix', { expectedStage: 's', handler: null }))
+      .toThrow(/handler must be a function/);
+  });
+});
+
+describe('handleFlowInteraction', () => {
+  // Tests use a per-test prefix to avoid the global registry leaking
+  // state between describe blocks. Each test registers its own
+  // unique prefix.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes to the registered handler when stage matches', async () => {
+    const handler = jest.fn().mockResolvedValue(undefined);
+    registerFlow('route_match', { expectedStage: 'awaiting', handler });
+    loadFlow.mockResolvedValue({
+      flow_id: '0:1#g#c#u',
+      stage: 'awaiting',
+      version: 1,
+    });
+    const interaction = makeInteraction({
+      customId: 'route_match',
+      user: { id: 'u' },
+      channelId: 'c',
+      guildId: 'g',
+    });
+
+    await handleFlowInteraction(interaction);
+
+    expect(loadFlow).toHaveBeenCalledWith('0:1#g#c#u');
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [passedInteraction, ctx] = handler.mock.calls[0];
+    expect(passedInteraction).toBe(interaction);
+    expect(ctx.flow_id).toBe('0:1#g#c#u');
+    expect(ctx.row.stage).toBe('awaiting');
+  });
+
+  it('replies superseded when row is missing', async () => {
+    const handler = jest.fn();
+    registerFlow('route_missing', { expectedStage: 'awaiting', handler });
+    loadFlow.mockResolvedValue(null);
+    const interaction = makeInteraction({ customId: 'route_missing' });
+
+    await handleFlowInteraction(interaction);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: SUPERSEDED_MSG,
+      ephemeral: true,
+    });
+  });
+
+  it('replies superseded when row stage does not match expectedStage', async () => {
+    const handler = jest.fn();
+    registerFlow('route_stage_mismatch', { expectedStage: 'awaiting_select', handler });
+    loadFlow.mockResolvedValue({
+      flow_id: '0:1#g#c#u',
+      stage: 'awaiting_modal', // different stage
+      version: 1,
+    });
+    const interaction = makeInteraction({ customId: 'route_stage_mismatch' });
+
+    await handleFlowInteraction(interaction);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: SUPERSEDED_MSG,
+      ephemeral: true,
+    });
+  });
+
+  it('silently drops unknown customId without loading flow', async () => {
+    const interaction = makeInteraction({ customId: 'never_registered_prefix' });
+
+    await handleFlowInteraction(interaction);
+
+    expect(loadFlow).not.toHaveBeenCalled();
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.update).not.toHaveBeenCalled();
+  });
+
+  it('silently drops when customId is empty/missing', async () => {
+    const interaction = makeInteraction({ customId: '' });
+
+    await handleFlowInteraction(interaction);
+
+    expect(loadFlow).not.toHaveBeenCalled();
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('replies superseded when loadFlow throws', async () => {
+    const handler = jest.fn();
+    registerFlow('route_load_throws', { expectedStage: 'awaiting', handler });
+    loadFlow.mockRejectedValue(new Error('DDB outage'));
+    const interaction = makeInteraction({ customId: 'route_load_throws' });
+
+    await handleFlowInteraction(interaction);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: SUPERSEDED_MSG,
+      ephemeral: true,
+    });
+  });
+
+  it('uses followUp instead of reply when interaction is already replied', async () => {
+    const handler = jest.fn();
+    registerFlow('route_followup', { expectedStage: 'awaiting', handler });
+    loadFlow.mockResolvedValue(null);
+    const interaction = makeInteraction({
+      customId: 'route_followup',
+      replied: true,
+    });
+
+    await handleFlowInteraction(interaction);
+
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      content: SUPERSEDED_MSG,
+      ephemeral: true,
+    });
+  });
+
+  it('swallows reply failures so a stale interaction does not throw', async () => {
+    registerFlow('route_reply_throws', {
+      expectedStage: 'awaiting',
+      handler: jest.fn(),
+    });
+    loadFlow.mockResolvedValue(null);
+    const interaction = makeInteraction({
+      customId: 'route_reply_throws',
+      reply: jest.fn().mockRejectedValue(new Error('Unknown interaction')),
+    });
+
+    // Must not throw — silent swallow with a warn log is the contract.
+    await expect(handleFlowInteraction(interaction)).resolves.toBeUndefined();
+  });
+
+  it('catches handler throws and replies a generic error', async () => {
+    // Safety-net pin: a handler that throws after committing an
+    // irreversible flow_state side effect (e.g. the deleteFlow-first
+    // ordering in handleRevokeSelect) must not produce an
+    // unhandledRejection. The user gets a recoverable message.
+    const handler = jest.fn().mockRejectedValue(new Error('downstream API died'));
+    registerFlow('route_throws', { expectedStage: 'awaiting', handler });
+    loadFlow.mockResolvedValue({
+      flow_id: '0:1#g#c#u',
+      stage: 'awaiting',
+      version: 1,
+    });
+    const interaction = makeInteraction({ customId: 'route_throws' });
+
+    await handleFlowInteraction(interaction);
+
+    expect(handler).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Something went wrong/),
+      }),
+    );
+  });
+
+  it('flow_id passed to handler is derived from interaction context', async () => {
+    // Anti-spoofing pin: even if the customId contained user/channel
+    // hints, the handler receives the flow_id built from
+    // interaction.user.id + interaction.channelId.
+    const handler = jest.fn().mockResolvedValue(undefined);
+    registerFlow('route_spoof_check', { expectedStage: 's', handler });
+    loadFlow.mockResolvedValue({ flow_id: '0:1#g#c#actual-user', stage: 's', version: 1 });
+    const interaction = makeInteraction({
+      customId: 'route_spoof_check',
+      user: { id: 'actual-user' },
+      channelId: 'c',
+      guildId: 'g',
+    });
+
+    await handleFlowInteraction(interaction);
+
+    const ctx = handler.mock.calls[0][1];
+    expect(ctx.flow_id).toBe('0:1#g#c#actual-user');
+  });
+});

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -865,7 +865,7 @@ describe('flow-state.transitionFlow', () => {
 });
 
 describe('flow-state.deleteFlow', () => {
-  test('issues a conditional DeleteCommand, emits FLOW_DELETED, returns deleted:true', async () => {
+  test('issues a stage-gated DeleteCommand, emits FLOW_DELETED, returns deleted:true', async () => {
     ddbMock.on(DeleteCommand).resolves({});
 
     const res = await flowState.deleteFlow('id', { stage: 'completed', reason: 'terminal' });
@@ -874,7 +874,10 @@ describe('flow-state.deleteFlow', () => {
     const call = ddbMock.commandCalls(DeleteCommand)[0];
     expect(call.args[0].input.TableName).toBe(EXPECTED_TABLE);
     expect(call.args[0].input.Key).toEqual({ flow_id: 'id' });
-    expect(call.args[0].input.ConditionExpression).toBe('attribute_exists(flow_id)');
+    expect(call.args[0].input.ConditionExpression)
+      .toBe('attribute_exists(flow_id) AND #s = :stage');
+    expect(call.args[0].input.ExpressionAttributeNames).toEqual({ '#s': 'stage' });
+    expect(call.args[0].input.ExpressionAttributeValues).toEqual({ ':stage': 'completed' });
 
     expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_DELETED, {
       flow_id: 'id',
@@ -887,8 +890,34 @@ describe('flow-state.deleteFlow', () => {
     // The SLI math requires at-most-once FLOW_DELETED per logical flow.
     // A second delete on an already-gone row must not emit again.
     ddbMock.on(DeleteCommand).rejects(ccfe());
+    // Post-recheck GetCommand sees no row — confirms "row absent" branch.
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
 
     const res = await flowState.deleteFlow('id', { stage: 's', reason: 'abort' });
+    expect(res).toEqual({ deleted: false });
+    expect(logger.audit).not.toHaveBeenCalled();
+  });
+
+  test('returns deleted:false when stage mismatch (sibling flow at same flow_id)', async () => {
+    // Critical correctness primitive: a /qurl revoke supersede call
+    // must NOT admin_cleanup an in-flight /qurl setup flow that
+    // shares the same (user, channel) flow_id. The conditional
+    // delete's stage gate enforces "delete the flow I expect,
+    // not whatever happens to live at this key."
+    ddbMock.on(DeleteCommand).rejects(ccfe());
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 'awaiting_setup_modal',
+        version: 1,
+        expires_at: Math.floor(Date.now() / 1000) + 600,
+      },
+    });
+
+    const res = await flowState.deleteFlow('id', {
+      stage: 'awaiting_revoke_select',
+      reason: 'admin_cleanup',
+    });
     expect(res).toEqual({ deleted: false });
     expect(logger.audit).not.toHaveBeenCalled();
   });

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -42,6 +42,7 @@ jest.mock('../src/config', () => ({
   ADMIN_USER_IDS: ['admin-1'],
   BASE_URL: 'http://localhost:3000',
   GUILD_ID: 'guild-1',
+  SHARD_ID: '0:1',
   isMultiTenant: false,
   ENABLE_OPENNHP_FEATURES: true,
   isOpenNHPActive: true,
@@ -183,6 +184,18 @@ jest.mock('../src/qurl', () => ({
 }));
 
 jest.mock('../src/places', () => ({ searchPlaces: jest.fn().mockResolvedValue([]) }));
+
+// Stub flow-state so loading commands.js doesn't reach into DDB.
+// These tests target the back-half (monitorLinkStatus, revokeAllLinks,
+// handleAddRecipients) — none of which touch flow_state — but
+// commands.js registers a flow handler at module load and requires
+// the module regardless of which export the test consumes.
+jest.mock('../src/flow-state', () => ({
+  createFlow: jest.fn(),
+  loadFlow: jest.fn(),
+  transitionFlow: jest.fn(),
+  deleteFlow: jest.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Require modules under test

--- a/apps/discord/tests/setup-env.js
+++ b/apps/discord/tests/setup-env.js
@@ -1,0 +1,29 @@
+// Global Jest setup — runs ONCE before any test file loads, via
+// jest.config.js `setupFiles`. Sets process.env vars that source
+// modules read at require-time so their fail-fast module-load guards
+// don't throw mid-import in tests.
+//
+// Why module-level setup (not per-file): once commands.js started
+// requiring flow-state in PR 5, every test file that imports
+// commands.js (or any of its peers) indirectly loads flow-state.js,
+// which throws at the top level when `DDB_TABLE_PREFIX` or
+// `AWS_REGION` are absent. Forcing each test file to set those two
+// vars by hand would be ~9 copy-pasted lines per file plus a real
+// risk of new test files forgetting. A single setupFiles entry
+// instead.
+//
+// These vars stay set for the whole worker process. Individual test
+// files can still override via `process.env.X = ...` if they need a
+// different value (and re-require the module to re-read it). Tests
+// that mock flow-state entirely via `jest.mock('../src/flow-state',
+// ...)` don't observe these vars at all — the mock replaces the real
+// module before its top-level code runs.
+
+// Test prefix has the same shape as the real one
+// (e.g. `qurl-bot-discord-sandbox-`) — must end with `-` per the
+// flow-state guard. Value is a sentinel that won't collide with any
+// real environment; if a test accidentally lets a real DDB call
+// through, the error message names this prefix so the breakage is
+// obvious.
+process.env.DDB_TABLE_PREFIX = process.env.DDB_TABLE_PREFIX || 'jest-test-';
+process.env.AWS_REGION = process.env.AWS_REGION || 'us-east-1';


### PR DESCRIPTION
## Summary

First command converted off in-memory `awaitMessageComponent` and onto the DDB-backed `flow_state` harness from #246. This is **Pillar 1 of the zero-downtime upgrade rollout** (see `docs/zero-downtime-design.md`) and the smallest at-risk surface — `/qurl revoke` only has a single 60-second click window, so converting it first keeps the blast radius minimal while we shake out the dispatcher pattern that PR 6 (`/qurl setup`) and PR 7–9 (`/qurl send`) will reuse.

## Business context

Today, a rolling deploy mid-revoke drops the user's interaction silently — the `awaitMessageComponent` Promise on the old process can't be resumed on the new one. We have live users in prod (per `project_live_customers` memory) and even though we're not charging yet, "click a thing in Discord and have it not work" is a reputation-damaging UX. The 15-PR rollout chain closes this for every `await*` site; this PR closes the first one.

## What changed

- **`src/flow-dispatch.js`** (new): routes `MessageComponent` / `ModalSubmit` interactions by `customId` prefix. The flow_id is derived from trusted interaction context (`user.id` + `channelId` + `SHARD_ID`) — **never from `customId`**, which is replayable client input. Stage-mismatch and missing-row cases both reply with a recoverable "superseded — run the command again" message. Universal try/catch around the handler call so a throw post-side-effect surfaces as a user-visible error rather than an unhandledRejection.

- **`src/commands.js` `handleRevoke`**: writes a flow row (`stage='awaiting_revoke_select'`, payload=null, TTL=60s) and renders the select menu. Returns immediately — no inline `awaitMessageComponent`. Concurrent revokes are **superseded** (existing flow row gets `admin_cleanup`'d, new one created). This is a deliberate exception to the design-doc "one flow per channel" rule: the revoke menu is a stateless listing, blocking the second invocation would just confuse users who don't remember whether they cancelled the prior menu. The `/qurl send` PRs will hold the block-second-flow rule.

- **`src/commands.js` `handleRevokeSelect`**: dispatcher-side handler. Runs `getGuildApiKey` + `deleteFlow` in parallel (independent reads). `deleteFlow` is the at-most-once dedup primitive — only the worker whose conditional delete returns `{ deleted: true }` proceeds to the qURL API call.

- **`src/index.js`** listener splits dispatch by interaction kind: chat-input / autocomplete → `handleCommand`; component / modal → `handleFlowInteraction`.

- **`src/config.js`**: adds `SHARD_ID = process.env.SHARD_ID || '0:1'` as the single source of truth for the flow_id's shard component.

- **`tests/setup-env.js`** (new): sets `DDB_TABLE_PREFIX` + `AWS_REGION` globally so source modules' fail-fast module-load guards don't throw across the test suite.

## Trust model

`customId` routes the event class; **identity** (user, channel, shard) comes from interaction context. A hostile client editing `customId` to spoof "user-VICTIM" cannot reach the victim's flow row. Pinned by `flow-dispatch.test.js`.

## Test plan

- [x] `tests/flow-dispatch.test.js` — routing happy path, stage-mismatch, missing-row, unknown customId, DM context, handler-throw safety net, customId-spoofing rejection (13 cases)
- [x] `tests/commands-comprehensive.test.js` — slash-command path (menu rendered, supersede behavior, error when both create attempts race) + dispatcher-side `handleRevokeSelect` path (revoke executes, dedup via deleteFlow=false, apiKey-missing, partial revoke)
- [x] `revoke-filter.test.js` — unchanged, still passes (hits real SQLite layer)
- [x] `qurl-send-back-half.test.js` — `revokeAllLinks` direct unit tests unchanged
- [x] All 1133 tests pass, lint clean, coverage 82.23/75.02/81.99/83.83 (clear of 78/68/78/78 floor)

## Deferred / follow-up

- `INTERACTION_HANDLED` audit event is not emitted from the dispatcher path. The event's documented contract (`src/constants.js:152`) keys on `command_name`, which component events don't have. A separate flow-handler observability event (or extending the existing audit event's payload contract) belongs in PR 6 once the second dispatcher consumer lands.
- `nowEpochSeconds` (in `flow-state.js`) and the apiKey-resolution pattern (in `handleCommand`) are both candidates for extraction into shared utilities, but extracting them in this PR would expand the diff into modules unrelated to the revoke conversion. Worth doing as a separate cleanup PR once PR 6 introduces a third callsite.
- Supersede path issues 2 DDB calls (`deleteFlow` + `createFlow`). Could be 1 if `flow-state.createFlow` grew a `force: true` option, but that's a flow-state contract change beyond the revoke conversion's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)