### PR TITLE
fix(discord)!: require per-guild API key for /qurl send + revoke in multi-tenant mode

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3678,8 +3678,8 @@ const commands = [
             ? '❌ **qURL is not configured for this server.**\n\n' +
               'A server admin needs to run `/qurl setup` first and sign in with a layerv account.\n' +
               'Sign up at **https://layerv.ai** if you don\'t have an account yet.'
-            : '❌ **qURL `/' + sub + '` is only available inside a server.**\n\n' +
-              'Run this command in a Discord server where qURL has been set up via `/qurl setup`.';
+            : `❌ **qURL \`/qurl ${sub}\` is only available inside a server.**\n\n`
+              + 'Run this command in a Discord server where qURL has been set up via `/qurl setup`.';
           return interaction.reply({
             content: refusalCopy,
             ephemeral: true,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3659,14 +3659,9 @@ const commands = [
         });
       }
 
-      // Gate: require per-guild API key for send/revoke. In multi-tenant
-      // mode the global config.QURL_API_KEY is NEVER a valid fallback —
-      // it points at the layerv-internal bootstrap customer, and a
-      // guild that hasn't completed /qurl setup must NOT silently ride
-      // that account (audit attribution, quota burn, billing). The
-      // fallback is honored only in single-guild mode where the bot
-      // operator IS the owner of the global key (their bot, their
-      // account).
+      // Multi-tenant gate: global QURL_API_KEY is NEVER a valid fallback —
+      // it would silently attribute every unconfigured guild's mints to
+      // the bootstrap customer. Honor it only in single-guild mode.
       let resolvedApiKey = null;
       if (sub === 'send' || sub === 'revoke') {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3659,7 +3659,7 @@ const commands = [
         });
       }
 
-      // Gate: require guild API key for send/revoke. In multi-tenant
+      // Gate: require per-guild API key for send/revoke. In multi-tenant
       // mode the global config.QURL_API_KEY is NEVER a valid fallback —
       // it points at the layerv-internal bootstrap customer, and a
       // guild that hasn't completed /qurl setup must NOT silently ride
@@ -3670,16 +3670,26 @@ const commands = [
       let resolvedApiKey = null;
       if (sub === 'send' || sub === 'revoke') {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;
-        const fallbackAllowed = !config.isMultiTenant;
-        if (!guildApiKey && !(fallbackAllowed && config.QURL_API_KEY)) {
-          return interaction.reply({
-            content: '❌ **qURL is not configured for this server.**\n\n' +
+        const operatorOwnsGlobalKey = !config.isMultiTenant;
+        if (!guildApiKey && !(operatorOwnsGlobalKey && config.QURL_API_KEY)) {
+          logger.warn('qurl gate refused: no per-guild API key in multi-tenant mode', {
+            sub,
+            guildId: interaction.guildId || null,
+            multiTenant: config.isMultiTenant,
+            hasGlobalKey: !!config.QURL_API_KEY,
+          });
+          const refusalCopy = interaction.guildId
+            ? '❌ **qURL is not configured for this server.**\n\n' +
               'A server admin needs to run `/qurl setup` first and sign in with a layerv account.\n' +
-              'Sign up at **https://layerv.ai** if you don\'t have an account yet.',
+              'Sign up at **https://layerv.ai** if you don\'t have an account yet.'
+            : '❌ **qURL `/' + sub + '` is only available inside a server.**\n\n' +
+              'Run this command in a Discord server where qURL has been set up via `/qurl setup`.';
+          return interaction.reply({
+            content: refusalCopy,
             ephemeral: true,
           });
         }
-        resolvedApiKey = guildApiKey || (fallbackAllowed ? config.QURL_API_KEY : null);
+        resolvedApiKey = guildApiKey || (operatorOwnsGlobalKey ? config.QURL_API_KEY : null);
       }
 
       // Pass API key as an explicit parameter rather than monkey-patching

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3659,19 +3659,27 @@ const commands = [
         });
       }
 
-      // Gate: require guild API key for send/revoke
+      // Gate: require guild API key for send/revoke. In multi-tenant
+      // mode the global config.QURL_API_KEY is NEVER a valid fallback —
+      // it points at the layerv-internal bootstrap customer, and a
+      // guild that hasn't completed /qurl setup must NOT silently ride
+      // that account (audit attribution, quota burn, billing). The
+      // fallback is honored only in single-guild mode where the bot
+      // operator IS the owner of the global key (their bot, their
+      // account).
       let resolvedApiKey = null;
       if (sub === 'send' || sub === 'revoke') {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;
-        if (!guildApiKey && !config.QURL_API_KEY) {
+        const fallbackAllowed = !config.isMultiTenant;
+        if (!guildApiKey && !(fallbackAllowed && config.QURL_API_KEY)) {
           return interaction.reply({
             content: '❌ **qURL is not configured for this server.**\n\n' +
-              'A server admin needs to run `/qurl setup` first.\n' +
-              'Sign up at **https://layerv.ai** to get your API key.',
+              'A server admin needs to run `/qurl setup` first and sign in with a layerv account.\n' +
+              'Sign up at **https://layerv.ai** if you don\'t have an account yet.',
             ephemeral: true,
           });
         }
-        resolvedApiKey = guildApiKey || config.QURL_API_KEY;
+        resolvedApiKey = guildApiKey || (fallbackAllowed ? config.QURL_API_KEY : null);
       }
 
       // Pass API key as an explicit parameter rather than monkey-patching

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3667,9 +3667,10 @@ const commands = [
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;
         const operatorOwnsGlobalKey = !config.isMultiTenant;
         if (!guildApiKey && !(operatorOwnsGlobalKey && config.QURL_API_KEY)) {
-          logger.warn('qurl gate refused: no per-guild API key in multi-tenant mode', {
+          logger.warn('qurl gate refused: no usable API key', {
             sub,
             guildId: interaction.guildId || null,
+            userId: interaction.user.id,
             multiTenant: config.isMultiTenant,
             hasGlobalKey: !!config.QURL_API_KEY,
           });

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -146,6 +146,8 @@ function isAllowedSourceUrl(sourceUrl) {
 /**
  * Build auth headers for connector requests.
  * Uses the provided API key, or falls back to the global config key.
+ * Multi-tenant safety is enforced by requireApiKey() at each public
+ * entry point — connectorAuthHeaders is internal and trusts callers.
  */
 function connectorAuthHeaders(apiKey) {
   const key = apiKey || config.QURL_API_KEY;
@@ -154,6 +156,19 @@ function connectorAuthHeaders(apiKey) {
     headers['Authorization'] = `Bearer ${key}`;
   }
   return headers;
+}
+
+// Defense-in-depth at the network boundary (#259). PR #257 closes the
+// attribution leak at the slash-command gate, but each public connector
+// entry point also refuses the multi-tenant bootstrap fallback so a new
+// caller bypassing the gate can't silently re-open the leak.
+function requireApiKey(apiKey) {
+  if (!apiKey && config.isMultiTenant) {
+    throw new Error('Refusing to use global QURL_API_KEY in multi-tenant mode — caller must thread a per-guild key');
+  }
+  if (!apiKey && !config.QURL_API_KEY) {
+    throw new Error('QURL_API_KEY is not configured');
+  }
 }
 
 // Append `viewer_ttl_seconds` to the multipart form when a positive value
@@ -182,7 +197,7 @@ function appendViewerTtl(form, viewerTtlSeconds) {
  */
 async function uploadToConnector(sourceUrl, filename, contentType, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
-  if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
+  requireApiKey(apiKey);
   if (!isAllowedSourceUrl(sourceUrl)) {
     throw new Error('Source URL is not a valid Discord CDN URL');
   }
@@ -248,7 +263,7 @@ async function uploadToConnector(sourceUrl, filename, contentType, apiKey, viewe
  */
 async function reUploadBuffer(fileBuffer, filename, contentType, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
-  if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
+  requireApiKey(apiKey);
 
   const blob = new Blob([fileBuffer], { type: contentType || 'application/octet-stream' });
   const form = new FormData();
@@ -324,7 +339,7 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * invalidate anyone else's.
  */
 async function mintLinks(resourceId, expiresAt, n, apiKey) {
-  if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
+  requireApiKey(apiKey);
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);
   }
@@ -364,7 +379,7 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
  */
 async function uploadJsonToConnector(jsonPayload, filename, apiKey, viewerTtlSeconds) {
   filename = sanitizeFilename(filename);
-  if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
+  requireApiKey(apiKey);
 
   const blob = new Blob([JSON.stringify(jsonPayload)], { type: 'application/json' });
   const form = new FormData();

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -13,11 +13,22 @@ const dns = require('dns').promises;
 // auth/validation failures and retrying won't help.
 const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 
-async function qurlFetch(method, path, body, apiKey) {
-  const key = apiKey || config.QURL_API_KEY;
-  if (!key) {
+// Defense-in-depth at the network boundary (#259). PR #257's slash-
+// command gate is the primary line of defense; this refuses the
+// bootstrap fallback at qurl-service's edge too so a new caller
+// bypassing the gate can't silently re-open the attribution leak.
+function requireApiKey(apiKey) {
+  if (!apiKey && config.isMultiTenant) {
+    throw new Error('Refusing to use global QURL_API_KEY in multi-tenant mode — caller must thread a per-guild key');
+  }
+  if (!apiKey && !config.QURL_API_KEY) {
     throw new Error('QURL_API_KEY is not configured');
   }
+}
+
+async function qurlFetch(method, path, body, apiKey) {
+  requireApiKey(apiKey);
+  const key = apiKey || config.QURL_API_KEY;
   const url = `${config.QURL_ENDPOINT}/v1${path}`;
   const baseOpts = {
     method,

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -532,3 +532,35 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     assertNoFullHashLeaked();
   });
 });
+
+// Defense-in-depth at the network boundary: connectorAuthHeaders
+// refuses to fall back to config.QURL_API_KEY in multi-tenant mode
+// even though the slash-command gate (PR #257) is the primary line of
+// defense. Pins issue #259.
+describe('Connector client — multi-tenant fallback refusal at network boundary', () => {
+  let connector;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('../src/config', () => ({
+      CONNECTOR_URL: 'https://connector.test.local',
+      QURL_API_KEY: 'lv_live_bootstrapxxxxxxxxxxxxxxxxxxx',
+      isMultiTenant: true,
+    }));
+    jest.mock('../src/logger', () => ({
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
+    }));
+    connector = require('../src/connector');
+  });
+
+  it('uploadToConnector throws when called without apiKey in multi-tenant mode', async () => {
+    await expect(connector.uploadToConnector(
+      'https://cdn.discordapp.com/file.pdf', 'file.pdf', 'application/pdf',
+    )).rejects.toThrow(/Refusing to use global QURL_API_KEY in multi-tenant mode/);
+  });
+
+  it('mintLinks throws when called without apiKey in multi-tenant mode', async () => {
+    await expect(connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1))
+      .rejects.toThrow(/Refusing to use global QURL_API_KEY in multi-tenant mode/);
+  });
+});

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -271,3 +271,58 @@ describe('qURL client — createOneTimeLink happy path', () => {
       .rejects.toThrow(/resolved/);
   });
 });
+
+// Defense-in-depth at the network boundary: even if a future caller
+// bypasses the slash-command gate (PR #257), qurlFetch refuses to fall
+// back to config.QURL_API_KEY in multi-tenant mode. Pins issue #259.
+describe('qURL client — multi-tenant fallback refusal at network boundary', () => {
+  let qurl;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.doMock('../src/config', () => ({
+      QURL_API_KEY: 'lv_live_bootstrapxxxxxxxxxxxxxxxxxxx',
+      QURL_ENDPOINT: 'https://api.test.local',
+      isMultiTenant: true,
+    }));
+    jest.doMock('../src/logger', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn() }));
+    qurl = require('../src/qurl');
+  });
+
+  it('throws when called without apiKey in multi-tenant mode even though QURL_API_KEY is set', async () => {
+    await expect(qurl.getResourceStatus('res-1', null))
+      .rejects.toThrow(/Refusing to use global QURL_API_KEY in multi-tenant mode/);
+  });
+
+  it('accepts an explicit per-guild apiKey in multi-tenant mode (positive path)', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => ({ data: { id: 'r1', status: 'active' } }),
+    });
+    await expect(qurl.getResourceStatus('res-1', 'lv_live_perguildxxxxxxxxxxxxxxxxxxx'))
+      .resolves.toBeDefined();
+  });
+});
+
+// Single-guild mode (isMultiTenant: false) MUST still allow the global
+// fallback — that's the legacy operator-owned deployment shape.
+describe('qURL client — single-guild fallback preserved', () => {
+  it('uses config.QURL_API_KEY when apiKey is null in single-guild mode', async () => {
+    jest.resetModules();
+    jest.doMock('../src/config', () => ({
+      QURL_API_KEY: 'lv_live_operatorxxxxxxxxxxxxxxxxxxx',
+      QURL_ENDPOINT: 'https://api.test.local',
+      isMultiTenant: false,
+    }));
+    jest.doMock('../src/logger', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn() }));
+    const q = require('../src/qurl');
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => ({ data: { id: 'r1', status: 'active' } }),
+    });
+    await expect(q.getResourceStatus('res-1', null)).resolves.toBeDefined();
+    // Confirm the global key was actually used (in Authorization header).
+    const callArgs = globalThis.fetch.mock.calls[0][1];
+    expect(callArgs.headers['Authorization']).toBe('Bearer lv_live_operatorxxxxxxxxxxxxxxxxxxx');
+  });
+});

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -560,6 +560,10 @@ describe('handleSend — pre-flight guards', () => {
     const refusalReply = replyCalls.find(c => typeof c === 'string' && c.includes('only available'));
     expect(refusalReply).toBeDefined();
     expect(refusalReply).not.toMatch(/server admin/);
+    // The refusal must point users at the real command `/qurl send`,
+    // not the bare `/send` Discord has no command for. Catches the
+    // `'/' + sub` interpolation bug that shipped the wrong slash.
+    expect(refusalReply).toContain('`/qurl send`');
     jest.dontMock('../src/config');
     jest.dontMock('../src/store');
   });

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -352,6 +352,20 @@ describe('handleSend — pre-flight guards', () => {
 
   it('rejects when QURL_API_KEY is not configured', async () => {
     jest.resetModules();
+    jest.doMock('../src/store', () => ({
+      getGuildApiKey: jest.fn().mockResolvedValue(null),
+      setGuildApiKey: jest.fn(),
+      getGuildConfig: jest.fn().mockResolvedValue(null),
+      getPendingLink: jest.fn(),
+      consumePendingLink: jest.fn(),
+      recordQURLSendBatch: jest.fn(),
+      updateSendDMStatus: jest.fn(),
+      getRecentSends: jest.fn().mockResolvedValue([]),
+      getSendResourceIds: jest.fn().mockResolvedValue([]),
+      markSendRevoked: jest.fn(),
+      getSendConfig: jest.fn(),
+      saveSendConfig: jest.fn(),
+    }));
     jest.doMock('../src/config', () => ({
       ...jest.requireActual('./helpers/buildConfigMock').buildConfigMock({ guildId: 'guild-1' }),
       QURL_API_KEY: '',
@@ -371,11 +385,16 @@ describe('handleSend — pre-flight guards', () => {
     const { commands: cmds } = require('../src/commands');
     const localCmd = cmds.find((c) => c.data.name === 'qurl');
     const interaction = makeInteraction();
+    // Single-guild deployment + invoked inside a guild: the gate should
+    // refuse with the guild-context copy ("not configured for this
+    // server") because the global QURL_API_KEY is empty.
+    interaction.guildId = 'guild-1';
     await localCmd.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining('not configured for this server'),
     }));
     jest.dontMock('../src/config');
+    jest.dontMock('../src/store');
   });
 
   // CRITICAL regression guard. Before this gate, a guild that hadn't
@@ -386,10 +405,136 @@ describe('handleSend — pre-flight guards', () => {
   // collapsed onto one row. This test fires on every build to make
   // sure multi-tenant mode ALWAYS requires a per-guild key from
   // /qurl setup and never silently rides the global fallback.
-  it('multi-tenant: refuses /qurl send even when QURL_API_KEY is set (no global fallback)', async () => {
+  // Parameterized over both subcommands that consume the API key. Both
+  // hit the same gate (`sub === 'send' || sub === 'revoke'`) in
+  // commands.js; pinning revoke too prevents a future edit from
+  // narrowing the gate to send-only and reintroducing the leak via the
+  // revoke path.
+  it.each(['send', 'revoke'])(
+    'multi-tenant: refuses /qurl %s even when QURL_API_KEY is set (no global fallback)',
+    async (subName) => {
+      jest.resetModules();
+      // Mock the store with getGuildApiKey returning null — that's the
+      // "no per-guild key" shape the unconfigured-guild leak relied on.
+      jest.doMock('../src/store', () => ({
+        getGuildApiKey: jest.fn().mockResolvedValue(null),
+        setGuildApiKey: jest.fn(),
+        getGuildConfig: jest.fn().mockResolvedValue(null),
+        getPendingLink: jest.fn(),
+        consumePendingLink: jest.fn(),
+        recordQURLSendBatch: jest.fn(),
+        updateSendDMStatus: jest.fn(),
+        getRecentSends: jest.fn().mockResolvedValue([]),
+        getSendResourceIds: jest.fn().mockResolvedValue([]),
+        markSendRevoked: jest.fn(),
+        getSendConfig: jest.fn(),
+        saveSendConfig: jest.fn(),
+      }));
+      const loggerMock = {
+        info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
+      };
+      jest.doMock('../src/logger', () => loggerMock);
+      jest.doMock('../src/config', () => ({
+        ...jest.requireActual('./helpers/buildConfigMock').buildConfigMock({ guildId: null }),
+        QURL_API_KEY: 'lv_live_bootstrapxxxxxxxxxxxxxxxxxxx',
+        QURL_ENDPOINT: 'https://api.test.local',
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_SEND_COOLDOWN_MS: 30000,
+        QURL_SEND_MAX_RECIPIENTS: 50,
+        DATABASE_PATH: ':memory:',
+        ADMIN_USER_IDS: [],
+        BASE_URL: 'http://localhost:3000',
+        STAR_MILESTONES: [10],
+        CONTRIBUTOR_ROLE_NAME: 'Contributor',
+        ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
+        CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',
+        CHAMPION_ROLE_NAME: 'Champion',
+      }));
+      const { commands: cmds } = require('../src/commands');
+      const localCmd = cmds.find((c) => c.data.name === 'qurl');
+      const interaction = makeInteraction();
+      interaction.options.getSubcommand = jest.fn(() => subName);
+      // guildId present — mirrors the leak shape: real server, real
+      // guildId, just no per-guild key from /qurl setup.
+      interaction.guildId = 'guild-unconfigured';
+      await localCmd.execute(interaction);
+      expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringContaining('not configured for this server'),
+      }));
+      expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringContaining('/qurl setup'),
+      }));
+      // Observability: the gate must emit a warn so an operator can see
+      // how often it fires (signals "users hitting a bot that hasn't
+      // been set up" → growth funnel, not just an error).
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.stringContaining('gate refused'),
+        expect.objectContaining({ sub: subName, multiTenant: true }),
+      );
+      jest.dontMock('../src/config');
+      jest.dontMock('../src/store');
+      jest.dontMock('../src/logger');
+    }
+  );
+
+  // Positive case: multi-tenant mode with a per-guild key DOES proceed
+  // past the gate and does NOT touch config.QURL_API_KEY. Pins the
+  // happy path so a future refactor can't silently revert to "always
+  // use global".
+  it('multi-tenant: with per-guild key, proceeds past gate without consulting QURL_API_KEY', async () => {
     jest.resetModules();
-    // Mock the store with getGuildApiKey returning null — that's the
-    // "no per-guild key" shape the unconfigured-guild leak relied on.
+    const guildKeyMock = jest.fn().mockResolvedValue('lv_live_perguildxxxxxxxxxxxxxxxxxxx');
+    jest.doMock('../src/store', () => ({
+      getGuildApiKey: guildKeyMock,
+      setGuildApiKey: jest.fn(),
+      getGuildConfig: jest.fn().mockResolvedValue(null),
+      getPendingLink: jest.fn(),
+      consumePendingLink: jest.fn(),
+      recordQURLSendBatch: jest.fn(),
+      updateSendDMStatus: jest.fn(),
+      getRecentSends: jest.fn().mockResolvedValue([]),
+      getSendResourceIds: jest.fn().mockResolvedValue([]),
+      markSendRevoked: jest.fn(),
+      getSendConfig: jest.fn(),
+      saveSendConfig: jest.fn(),
+    }));
+    jest.doMock('../src/config', () => ({
+      ...jest.requireActual('./helpers/buildConfigMock').buildConfigMock({ guildId: null }),
+      QURL_API_KEY: 'lv_live_bootstrapxxxxxxxxxxxxxxxxxxx',
+      QURL_ENDPOINT: 'https://api.test.local',
+      CONNECTOR_URL: 'https://connector.test.local',
+      QURL_SEND_COOLDOWN_MS: 30000,
+      QURL_SEND_MAX_RECIPIENTS: 50,
+      DATABASE_PATH: ':memory:',
+      ADMIN_USER_IDS: [],
+      BASE_URL: 'http://localhost:3000',
+      STAR_MILESTONES: [10],
+      CONTRIBUTOR_ROLE_NAME: 'Contributor',
+      ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
+      CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',
+      CHAMPION_ROLE_NAME: 'Champion',
+    }));
+    const { commands: cmds } = require('../src/commands');
+    const localCmd = cmds.find((c) => c.data.name === 'qurl');
+    const interaction = makeInteraction();
+    interaction.guildId = 'guild-configured';
+    await localCmd.execute(interaction);
+    expect(guildKeyMock).toHaveBeenCalledWith('guild-configured');
+    // Should NOT see the gate-refusal copy — the per-guild key satisfies
+    // the gate even though the global QURL_API_KEY is also set.
+    expect(interaction.reply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('not configured for this server'),
+    }));
+    jest.dontMock('../src/config');
+    jest.dontMock('../src/store');
+  });
+
+  // DM context: /qurl send is reachable in DMs (no setDMPermission(false)
+  // on the command). The gate refuses (no guildId → no per-guild key
+  // possible), but the refusal copy MUST NOT instruct the user to ask a
+  // "server admin" — there's no server. Pins the DM-aware copy branch.
+  it('multi-tenant: /qurl send in a DM refuses with DM-aware copy (no "server admin" reference)', async () => {
+    jest.resetModules();
     jest.doMock('../src/store', () => ({
       getGuildApiKey: jest.fn().mockResolvedValue(null),
       setGuildApiKey: jest.fn(),
@@ -423,13 +568,12 @@ describe('handleSend — pre-flight guards', () => {
     const { commands: cmds } = require('../src/commands');
     const localCmd = cmds.find((c) => c.data.name === 'qurl');
     const interaction = makeInteraction();
+    interaction.guildId = null;
     await localCmd.execute(interaction);
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining('not configured for this server'),
-    }));
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining('/qurl setup'),
-    }));
+    const replyCalls = interaction.reply.mock.calls.map(c => c[0]?.content || '');
+    const refusalReply = replyCalls.find(c => typeof c === 'string' && c.includes('only available'));
+    expect(refusalReply).toBeDefined();
+    expect(refusalReply).not.toMatch(/server admin/);
     jest.dontMock('../src/config');
     jest.dontMock('../src/store');
   });

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -397,19 +397,9 @@ describe('handleSend — pre-flight guards', () => {
     jest.dontMock('../src/store');
   });
 
-  // CRITICAL regression guard. Before this gate, a guild that hadn't
-  // run /qurl setup would silently fall back to config.QURL_API_KEY
-  // (= the layerv-internal bootstrap customer's key in prod). Every
-  // qURL minted by every unconfigured server was attributed to that
-  // single account — audit, quota, and (eventually) billing all
-  // collapsed onto one row. This test fires on every build to make
-  // sure multi-tenant mode ALWAYS requires a per-guild key from
-  // /qurl setup and never silently rides the global fallback.
-  // Parameterized over both subcommands that consume the API key. Both
-  // hit the same gate (`sub === 'send' || sub === 'revoke'`) in
-  // commands.js; pinning revoke too prevents a future edit from
-  // narrowing the gate to send-only and reintroducing the leak via the
-  // revoke path.
+  // Regression guard for the bootstrap-fallback leak (see PR #257).
+  // Parameterized over both subcommands sharing the gate to prevent a
+  // future edit from narrowing it to send-only.
   it.each(['send', 'revoke'])(
     'multi-tenant: refuses /qurl %s even when QURL_API_KEY is set (no global fallback)',
     async (subName) => {
@@ -477,10 +467,8 @@ describe('handleSend — pre-flight guards', () => {
     }
   );
 
-  // Positive case: multi-tenant mode with a per-guild key DOES proceed
-  // past the gate and does NOT touch config.QURL_API_KEY. Pins the
-  // happy path so a future refactor can't silently revert to "always
-  // use global".
+  // Pins the multi-tenant happy path so a future refactor can't
+  // silently revert to "always use global".
   it('multi-tenant: with per-guild key, proceeds past gate without consulting QURL_API_KEY', async () => {
     jest.resetModules();
     const guildKeyMock = jest.fn().mockResolvedValue('lv_live_perguildxxxxxxxxxxxxxxxxxxx');
@@ -529,10 +517,8 @@ describe('handleSend — pre-flight guards', () => {
     jest.dontMock('../src/store');
   });
 
-  // DM context: /qurl send is reachable in DMs (no setDMPermission(false)
-  // on the command). The gate refuses (no guildId → no per-guild key
-  // possible), but the refusal copy MUST NOT instruct the user to ask a
-  // "server admin" — there's no server. Pins the DM-aware copy branch.
+  // /qurl send has no setDMPermission(false), so DMs reach this gate.
+  // Pin the DM-aware refusal copy — must not reference "server admin".
   it('multi-tenant: /qurl send in a DM refuses with DM-aware copy (no "server admin" reference)', async () => {
     jest.resetModules();
     jest.doMock('../src/store', () => ({

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -378,6 +378,107 @@ describe('handleSend — pre-flight guards', () => {
     jest.dontMock('../src/config');
   });
 
+  // CRITICAL regression guard. Before this gate, a guild that hadn't
+  // run /qurl setup would silently fall back to config.QURL_API_KEY
+  // (= the layerv-internal bootstrap customer's key in prod). Every
+  // qURL minted by every unconfigured server was attributed to that
+  // single account — audit, quota, and (eventually) billing all
+  // collapsed onto one row. This test fires on every build to make
+  // sure multi-tenant mode ALWAYS requires a per-guild key from
+  // /qurl setup and never silently rides the global fallback.
+  it('multi-tenant: refuses /qurl send even when QURL_API_KEY is set (no global fallback)', async () => {
+    jest.resetModules();
+    // Mock the store with getGuildApiKey returning null — that's the
+    // "no per-guild key" shape the unconfigured-guild leak relied on.
+    jest.doMock('../src/store', () => ({
+      getGuildApiKey: jest.fn().mockResolvedValue(null),
+      setGuildApiKey: jest.fn(),
+      getGuildConfig: jest.fn().mockResolvedValue(null),
+      getPendingLink: jest.fn(),
+      consumePendingLink: jest.fn(),
+      recordQURLSendBatch: jest.fn(),
+      updateSendDMStatus: jest.fn(),
+      getRecentSends: jest.fn().mockResolvedValue([]),
+      getSendResourceIds: jest.fn().mockResolvedValue([]),
+      markSendRevoked: jest.fn(),
+      getSendConfig: jest.fn(),
+      saveSendConfig: jest.fn(),
+    }));
+    jest.doMock('../src/config', () => ({
+      ...jest.requireActual('./helpers/buildConfigMock').buildConfigMock({ guildId: null }),
+      QURL_API_KEY: 'lv_live_bootstrapxxxxxxxxxxxxxxxxxxx',
+      QURL_ENDPOINT: 'https://api.test.local',
+      CONNECTOR_URL: 'https://connector.test.local',
+      QURL_SEND_COOLDOWN_MS: 30000,
+      QURL_SEND_MAX_RECIPIENTS: 50,
+      DATABASE_PATH: ':memory:',
+      ADMIN_USER_IDS: [],
+      BASE_URL: 'http://localhost:3000',
+      STAR_MILESTONES: [10],
+      CONTRIBUTOR_ROLE_NAME: 'Contributor',
+      ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
+      CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',
+      CHAMPION_ROLE_NAME: 'Champion',
+    }));
+    const { commands: cmds } = require('../src/commands');
+    const localCmd = cmds.find((c) => c.data.name === 'qurl');
+    const interaction = makeInteraction();
+    await localCmd.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('not configured for this server'),
+    }));
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('/qurl setup'),
+    }));
+    jest.dontMock('../src/config');
+    jest.dontMock('../src/store');
+  });
+
+  it('single-guild: still falls back to QURL_API_KEY when guild has no per-guild key (legacy preserved)', async () => {
+    jest.resetModules();
+    jest.doMock('../src/store', () => ({
+      getGuildApiKey: jest.fn().mockResolvedValue(null),
+      setGuildApiKey: jest.fn(),
+      getGuildConfig: jest.fn().mockResolvedValue(null),
+      getPendingLink: jest.fn(),
+      consumePendingLink: jest.fn(),
+      recordQURLSendBatch: jest.fn(),
+      updateSendDMStatus: jest.fn(),
+      getRecentSends: jest.fn().mockResolvedValue([]),
+      getSendResourceIds: jest.fn().mockResolvedValue([]),
+      markSendRevoked: jest.fn(),
+      getSendConfig: jest.fn(),
+      saveSendConfig: jest.fn(),
+    }));
+    jest.doMock('../src/config', () => ({
+      ...jest.requireActual('./helpers/buildConfigMock').buildConfigMock({ guildId: 'guild-1' }),
+      QURL_API_KEY: 'lv_live_singleguildxxxxxxxxxxxxxxxxxxx',
+      QURL_ENDPOINT: 'https://api.test.local',
+      CONNECTOR_URL: 'https://connector.test.local',
+      QURL_SEND_COOLDOWN_MS: 30000,
+      QURL_SEND_MAX_RECIPIENTS: 50,
+      DATABASE_PATH: ':memory:',
+      ADMIN_USER_IDS: [],
+      BASE_URL: 'http://localhost:3000',
+      STAR_MILESTONES: [10],
+      CONTRIBUTOR_ROLE_NAME: 'Contributor',
+      ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
+      CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',
+      CHAMPION_ROLE_NAME: 'Champion',
+    }));
+    const { commands: cmds } = require('../src/commands');
+    const localCmd = cmds.find((c) => c.data.name === 'qurl');
+    const interaction = makeInteraction();
+    await localCmd.execute(interaction);
+    // Should NOT see "not configured" — the global fallback is honored
+    // in single-guild mode because the bot operator owns the global key.
+    expect(interaction.reply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('not configured for this server'),
+    }));
+    jest.dontMock('../src/config');
+    jest.dontMock('../src/store');
+  });
+
   it('rejects when user is on cooldown', async () => {
     setCooldown('user-1');
     const interaction = makeInteraction();


### PR DESCRIPTION
> 🚨 **SECURITY / BREAKING.** Every prod guild that hasn't run \`/qurl setup\` will start seeing a "not configured" error on next \`/qurl send\`. They previously rode the layerv-internal bootstrap customer's API key silently — that's the defect being closed.

## What broke

Found 2026-05-12. In multi-tenant prod, \`/qurl send\` and \`/qurl revoke\` silently fell back to \`config.QURL_API_KEY\` when a guild hadn't run \`/qurl setup\`. The prod global key is owned by the layerv-internal \`bootstrap@layerv.ai\` system customer:

| SSM | API key | Owner | Customer |
|---|---|---|---|
| \`/qurl-bot-discord/QURL_API_KEY\` | \`lv_live_Jfjm…\` (\`key_g09i8b3HBZu2\`) | \`auth0\|69adc6edc33d5b7a60a7710c\` | \`bootstrap@layerv.ai\` (tier=\`system\`, spending_cap_cents=0, unit_price_cents=0) |

Every qURL minted by an unconfigured guild was attributed to that single account. At time of catch: \`current_period_usage=311\` on bootstrap customer, audit-log rows accumulating with foreign Discord IDs all attributed to one owner. A real server owner installed the bot, never got prompted to sign up, and qurls just worked — paid for by a single internal row.

## Fix

\`apps/discord/src/commands.js:3673\` — gate \`/qurl send\` and \`/qurl revoke\`:

\`\`\`js
const fallbackAllowed = !config.isMultiTenant;
if (!guildApiKey && !(fallbackAllowed && config.QURL_API_KEY)) {
  return interaction.reply({ content: '❌ qURL is not configured for this server. A server admin needs to run /qurl setup first and sign in with a layerv account.', ephemeral: true });
}
resolvedApiKey = guildApiKey || (fallbackAllowed ? config.QURL_API_KEY : null);
\`\`\`

| Mode | Guild has per-guild key | Behavior |
|---|---|---|
| Multi-tenant | ✅ Yes | Works normally |
| Multi-tenant | ❌ No | **Refuses with setup prompt** (new) |
| Single-guild | ✅ Yes | Works normally |
| Single-guild | ❌ No | Falls back to \`QURL_API_KEY\` (legacy preserved — operator owns the global key) |

## Tests — every-build regression guard

Two new cases in \`tests/qurl-send-state-machine.test.js\`, running in the standard \`build-and-test\` suite that fires on every PR + every main push:

1. \`multi-tenant: refuses /qurl send even when QURL_API_KEY is set\` — pins the new gate. \`isMultiTenant=true\` + \`QURL_API_KEY\` set + \`getGuildApiKey→null\` must produce the "not configured" + "/qurl setup" rejection.
2. \`single-guild: still falls back to QURL_API_KEY\` — pins legacy single-guild dev/sandbox path doesn't regress.

\`npx jest\`: **1115 / 1115 across 44 suites.**

## Operator impact (read before merge)

On deploy, every multi-tenant guild WITHOUT a completed \`/qurl setup\` will see:

> ❌ **qURL is not configured for this server.**
>
> A server admin needs to run \`/qurl setup\` first and sign in with a layerv account.
> Sign up at **https://layerv.ai** if you don't have an account yet.

Server admins run \`/qurl setup\` → OAuth flow (Discord → Auth0 → qurl-service) → guild gets its own \`lv_live_…\` API key in DDB → \`/qurl send\` works against THEIR account from then on.

The bootstrap customer's \`current_period_usage\` counter stops growing the moment the bot rolls. Existing audit-log rows attributed to bootstrap are historical leakage — a backfill / re-attribution is a separate cleanup.

## Why \`!\` in the title

Behavior change for existing prod guilds. Setup-incomplete guilds were unintentionally working; they will appear "broken" until admins complete setup. Communications to existing installs should go out alongside or before this merges — they're not going to know what changed unless told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)