### PR TITLE
fix(discord): opt into connector per-recipient vid path (qurl-integrations-infra#525)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -745,16 +745,31 @@ async function fetchGuildMembers(guild) {
  * and handleAddRecipients (file/location). Centralizing this means a fix to
  * the re-upload / batching / quota logic lands in one place.
  *
+ * `expiresIn` (optional duration string like "1h", "168h") opts into the
+ * connector's per-recipient vid path (qurl-integrations-infra#525). Each
+ * minted link becomes its own one-time-use qURL with a unique vid in
+ * target_url, so refresh after the viewer self-destruct fires returns 410
+ * for that specific recipient. Omitting it keeps the legacy shape (1 qURL
+ * + N tokens, shared target_url, no server-side refresh enforcement).
+ *
+ * Per-recipient resource_id: when the connector takes the per-vid path,
+ * each link comes back with its own fresh resource_id; we honor that
+ * (link.resource_id) for downstream tracking. The legacy path returns the
+ * shared resource_id; fallback to the currentResourceId we drove the
+ * batch with preserves the existing contract.
+ *
  * @param {object} opts
  * @param {string} opts.initialResourceId — resource_id from the first upload
  * @param {() => Promise<{resource_id: string}>} opts.reuploadFn — called when
  *   the current resource's token pool is drained. Must return a fresh resource.
  * @param {string} opts.expiresAt — ISO string; forwarded to mintLinks.
+ * @param {string} [opts.expiresIn] — duration string ("1h", "168h"); when
+ *   set, opts into per-recipient vid enforcement on the connector side.
  * @param {number} opts.recipientCount — number of tokens to mint in total.
  * @param {string} opts.apiKey — QURL API key.
  * @returns {Array<{qurl_link: string, resourceId: string}>}
  */
-async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey }) {
+async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, expiresIn, recipientCount, apiKey }) {
   const allLinks = [];
   let currentResourceId = initialResourceId;
   let tokensUsed = 0;
@@ -766,9 +781,12 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       tokensUsed = 0;
     }
     const batchSize = Math.min(TOKENS_PER_RESOURCE, recipientCount - i);
-    const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey);
+    const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey, expiresIn);
     for (const link of minted) {
-      allLinks.push({ qurl_link: link.qurl_link, resourceId: currentResourceId });
+      // Per-vid path returns per-mint resource_id. Legacy path returns
+      // the shared one (or nothing, on a pre-#525 connector). Fall back
+      // so this stays compatible with both shapes.
+      allLinks.push({ qurl_link: link.qurl_link, resourceId: link.resource_id || currentResourceId });
     }
     tokensUsed += batchSize;
   }
@@ -1719,6 +1737,10 @@ async function handleSend(interaction, apiKey) {
           initialResourceId: firstUpload.resource_id,
           reuploadFn: () => reUploadBuffer(bufHolder.buf, filename, attachment.contentType, apiKey, selfDestructSeconds),
           expiresAt,
+          // Opt into the connector's per-recipient vid path so refresh
+          // after self-destruct returns 410 per recipient
+          // (qurl-integrations-infra#525).
+          expiresIn,
           recipientCount: recipients.length,
           apiKey,
         });
@@ -1755,6 +1777,11 @@ async function handleSend(interaction, apiKey) {
         initialResourceId: firstUpload.resource_id,
         reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds),
         expiresAt,
+        // Per-recipient vid path (qurl-integrations-infra#525). Note:
+        // google-map JSON resources hit the connector's render
+        // carve-out today (#480) so vid is provisioned but inert
+        // until the carve-out is removed.
+        expiresIn,
         recipientCount: recipients.length,
         apiKey,
       });
@@ -2335,6 +2362,10 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           initialResourceId: first.resource_id,
           reuploadFn: () => reUploadBuffer(fileBuffer, filename, contentType, apiKey, inheritedDestruct),
           expiresAt,
+          // Per-recipient vid path on the connector
+          // (qurl-integrations-infra#525) — same opt-in as the
+          // original send.
+          expiresIn: sendConfig.expires_in,
           recipientCount: newRecipients.length,
           apiKey,
         });
@@ -2379,6 +2410,10 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         initialResourceId: firstUpload.resource_id,
         reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestruct),
         expiresAt,
+        // Per-recipient vid path (qurl-integrations-infra#525). Inert
+        // for google-map JSON today per the #480 carve-out — still
+        // forwarded so behavior matches once the carve-out is removed.
+        expiresIn: sendConfig.expires_in,
         recipientCount: newRecipients.length,
         apiKey,
       });

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -322,8 +322,16 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * field applies PER minted link: `n` recipients get `n` independent
  * one-time tokens, so one recipient opening their link doesn't
  * invalidate anyone else's.
+ *
+ * `expiresIn` (optional duration string like `1h`, `168h`) opts the
+ * caller into the connector's per-recipient `vid` path
+ * (qurl-integrations-infra#525): each mint becomes its own
+ * one-time-use qURL with a unique vid baked into target_url, so the
+ * server-side viewer enforcement keys per-recipient. Omitting it
+ * keeps the legacy shape (one qURL, N tokens, shared target_url) —
+ * no per-recipient refresh-bypass enforcement.
  */
-async function mintLinks(resourceId, expiresAt, n, apiKey) {
+async function mintLinks(resourceId, expiresAt, n, apiKey, expiresIn) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);
@@ -335,10 +343,14 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
   if (!Number.isInteger(n) || n < 1 || n > 100) {
     throw new Error(`Invalid link count (n must be integer 1..100): ${n}`);
   }
+  const body = { expires_at: expiresAt, n, one_time_use: true };
+  if (expiresIn) {
+    body.expires_in = expiresIn;
+  }
   const response = await fetch(`${config.CONNECTOR_URL}/api/mint_link/${resourceId}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...connectorAuthHeaders(apiKey) },
-    body: JSON.stringify({ expires_at: expiresAt, n, one_time_use: true }),
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(30000),
   });
 
@@ -354,7 +366,7 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
     throw new Error('Connector mint_link returned no links array');
   }
 
-  logger.info('Minted links', { resource_id: resourceId, count: result.links.length });
+  logger.info('Minted links', { resource_id: resourceId, count: result.links.length, per_vid: Boolean(expiresIn) });
   return result.links;
 }
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1555,7 +1555,7 @@ describe('handleAddRecipients', () => {
       null,
     );
     // mintLinks is called against the NEW resource (conn-res-43)
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key', expect.any(String));
     // createOneTimeLink should NOT have been called
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     // DMs should have been sent
@@ -1632,7 +1632,7 @@ describe('handleAddRecipients', () => {
       'location.json', 'test-api-key',
       null,
     );
-    expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', expect.any(String), 1, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', expect.any(String), 1, 'test-api-key', expect.any(String));
     expect(mockSendDM).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch.mock.calls[0][0]).toHaveLength(1);
@@ -1701,7 +1701,7 @@ describe('handleAddRecipients', () => {
       'location.json', 'test-api-key',
       null,
     );
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', expect.any(String), 1, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', expect.any(String), 1, 'test-api-key', expect.any(String));
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     expect(result.msg).toMatch(/Added 1 recipient/);
   });
@@ -1791,7 +1791,7 @@ describe('handleAddRecipients', () => {
     // Only Alice and Bob should get DMs (bot and sender excluded)
     expect(mockSendDM).toHaveBeenCalledTimes(2);
     expect(mockUploadJsonToConnector).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', expect.any(String), 2, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', expect.any(String), 2, 'test-api-key', expect.any(String));
     expect(result.msg).toMatch(/Added 2 recipients/);
   });
 
@@ -1856,8 +1856,8 @@ describe('handleAddRecipients', () => {
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockReUploadBuffer).toHaveBeenCalledTimes(1);
     expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', expect.any(String), 10, 'test-api-key');
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', expect.any(String), 2, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', expect.any(String), 10, 'test-api-key', expect.any(String));
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', expect.any(String), 2, 'test-api-key', expect.any(String));
     expect(result.msg).toMatch(/Added 12 recipients/);
   });
 
@@ -1889,7 +1889,7 @@ describe('handleAddRecipients', () => {
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockMintLinks).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', expect.any(String), 8, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', expect.any(String), 8, 'test-api-key', expect.any(String));
     expect(mockSendDM).toHaveBeenCalledTimes(8);
     expect(result.msg).toMatch(/Added 8 recipients/);
   });

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1554,16 +1554,72 @@ describe('handleAddRecipients', () => {
       // sendConfig has no self_destruct_seconds → null inherits through.
       null,
     );
-    // mintLinks is called against the NEW resource (conn-res-43)
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key', expect.any(String));
+    // mintLinks is called against the NEW resource (conn-res-43).
+    // 5th arg is expires_in from sendConfig — pinned to the literal
+    // '6h' (not just any-string) so a future bug that swaps the
+    // expires_at ISO into this slot fails CI.
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key', '6h');
     // createOneTimeLink should NOT have been called
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
+    // Both recipients' qURL records share the batch resource_id —
+    // the mock returns no per-link resource_id, exercising the
+    // legacy/cold-start fallback (link.resource_id || currentResourceId).
+    expect(mockDb.recordQURLSendBatch.mock.calls[0][0][0].resourceId).toBe('conn-res-43');
+    expect(mockDb.recordQURLSendBatch.mock.calls[0][0][1].resourceId).toBe('conn-res-43');
     // DMs should have been sent
     expect(mockSendDM).toHaveBeenCalledTimes(2);
     // DB should record the new sends
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch.mock.calls[0][0]).toHaveLength(2);
     expect(result.msg).toMatch(/Added 2 recipients/);
+  });
+
+  it('file send: per-vid response shape — uses per-link resource_id from connector', async () => {
+    // Connector PR #526's per-recipient vid path returns a distinct
+    // resource_id per minted link. The bot must honor that
+    // (link.resource_id) instead of falling back to the batch's
+    // currentResourceId — otherwise downstream revoke would target
+    // the original qURL rather than the fresh per-recipient ones.
+    // Regression fence for the mintLinksInBatches branch:
+    //   resourceId: link.resource_id || currentResourceId
+    mockDb.getSendConfig.mockReturnValue({
+      resource_type: 'file',
+      connector_resource_id: 'conn-res-old',
+      actual_url: null,
+      expires_in: '1h',
+      personal_message: null,
+      location_name: null,
+      attachment_name: 'report.pdf',
+      attachment_content_type: 'application/pdf',
+      attachment_url: 'https://cdn.discordapp.com/attachments/1/2/report.pdf',
+      self_destruct_seconds: 30,
+    });
+    mockDownloadAndUpload.mockResolvedValue({
+      resource_id: 'conn-res-batch',
+      fileBuffer: new ArrayBuffer(8),
+    });
+    // Connector's per-vid path returns a fresh resource_id per link.
+    mockMintLinks.mockResolvedValue([
+      { qurl_link: 'https://q.test/per-vid-1', resource_id: 'per-vid-rid-1' },
+      { qurl_link: 'https://q.test/per-vid-2', resource_id: 'per-vid-rid-2' },
+    ]);
+    mockSendDM.mockResolvedValue(true);
+
+    const users = makeUsersCollection([
+      { id: 'rcpt-pv-1', bot: false, username: 'Pat' },
+      { id: 'rcpt-pv-2', bot: false, username: 'Quinn' },
+    ]);
+
+    await handleAddRecipients('send-pv-1', users, mockOriginalInteraction, 'test-api-key');
+
+    // 5th arg (expires_in) opts the connector into per-vid path.
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-batch', expect.any(String), 2, 'test-api-key', '1h');
+    // Each recipient's stored resourceId is its own per-vid id —
+    // NOT the batch's currentResourceId. This is the fence: drop
+    // `link.resource_id || ...` from mintLinksInBatches and these
+    // two assertions break.
+    expect(mockDb.recordQURLSendBatch.mock.calls[0][0][0].resourceId).toBe('per-vid-rid-1');
+    expect(mockDb.recordQURLSendBatch.mock.calls[0][0][1].resourceId).toBe('per-vid-rid-2');
   });
 
   it('file send: inherits the original send\'s self-destruct timer into the re-upload', async () => {


### PR DESCRIPTION
## Closes refresh-bypass on self-destruct (bot half)

Companion to **qurl-integrations-infra#526**, which adds the server-side enforcement primitive. This PR makes the Discord bot opt into the new per-recipient vid path so the connector actually generates per-mint vids on \`/qurl send\`.

Without this PR, the connector's enforcement code is dormant — the legacy mint_link path (1 qURL + N tokens, shared target_url) keeps shipping and refresh-bypass stays open.

## What changes

\`apps/discord/src/connector.js\` — \`mintLinks\` gains an optional 5th argument \`expiresIn\` (duration string like \`1h\`, \`168h\`). When set, included in the connector's mint_link request body, which is the connector's signal to take the per-vid path (N × \`CreateOneTimeQURL\`). Backward-compat: 4-arg legacy callers continue to work unchanged.

\`apps/discord/src/commands.js\` — \`mintLinksInBatches\` accepts \`expiresIn\` in opts and forwards it to \`mintLinks\`. Also reads \`link.resource_id\` from the connector response (per-vid path returns per-mint resource_id) with a fallback to the batch's \`currentResourceId\` for legacy responses + cold-start pre-#525 connectors. Four call sites updated:

- \`handleSend\` file send
- \`handleSend\` location send (no-op today per the #480 carve-out; provisioned for when it's removed)
- \`handleAddRecipients\` file
- \`handleAddRecipients\` location (same carve-out note)

All four pass the user-chosen send TTL (\`expiresIn\` from \`sendConfig.expires_in\`) so the per-recipient qURLs honor the sender's choice.

## Backward compat

| Connector | Bot side | Result |
|---|---|---|
| Pre-#526 | Pre-this-PR | Legacy mint_link, no enforcement. Status quo. |
| **Post-#526 (merged)** | Pre-this-PR | Legacy mint_link path on connector (bot omits expires_in) — enforcement dormant. Safe to merge connector first. |
| Pre-#526 | This PR (deployed early) | Bot sends \`expires_in\`; old connector ignores it; legacy mint_link. No regression. |
| Post-#526 | This PR | **Per-recipient vid enforcement live.** Refresh after self-destruct = 410. |

Deploy order: connector first, then bot. Both PRs are independently safe.

## Tests

- \`tests/qurl-send.test.js\` — 7 \`mockMintLinks.toHaveBeenCalledWith\` assertions updated to expect the 5th \`expires_in\` arg.
- All 1113 bot tests green.

## Test plan

- [x] \`npx jest\` — 1113 passed, 0 failed
- [x] Lint clean (\`npm run lint\` if configured; pre-commit hooks)
- [x] Diff confined to mintLinks signature + 4 call sites + 7 test assertions
- [ ] After connector PR #526 lands in sandbox: deploy bot here, set self-destruct=30s, view from one recipient, wait 30s, refresh → expect 410 \"Content expired\"
- [ ] Multi-recipient: with 3 recipients sharing a batch, recipient B opening at T=45s (past A's 30s window) should STILL see the content fresh for their own 30s window (per-recipient vid means B has their own clock)

## Pairs with

- **qurl-integrations-infra#526** — connector server-side enforcement (must ship first for this PR's effect to be observable; safe to merge in either order)
- Tracking issue: qurl-integrations-infra#525

🤖 Generated with [Claude Code](https://claude.com/claude-code)