### PR TITLE
feat(discord): convert /qurl setup legacy modal-paste to flow_state

### DIFF
--- a/apps/discord/docs/zero-downtime-design.md
+++ b/apps/discord/docs/zero-downtime-design.md
@@ -143,7 +143,7 @@ makes blocking the wrong call:
 | Command | Behavior on existing flow | Rationale |
 |---|---|---|
 | `/qurl revoke` | **Supersede** (admin_cleanup + recreate) | The menu is a stateless listing of recent sends; an admin who can't remember whether they cancelled the prior dropdown shouldn't be told "finish your existing dropdown first." Re-running shows a fresh menu and the orphan menu's selection lands on `loadFlow → null → "superseded"`. |
-| `/qurl setup` | Block (default) | Multi-step OAuth / API-key paste flow with in-progress state; the user should finish or cancel the active step. |
+| `/qurl setup` | **Supersede if pre-modal, block if mid-modal** | Two-stage flow (`awaiting_setup_button` → `awaiting_setup_modal`). The supersede call passes `stage: 'awaiting_setup_button'` to `deleteFlow`; the harness's stage gate succeeds when the prior flow is still on the button (admin walked away — give them a fresh one) and fails when the prior flow has advanced to `awaiting_setup_modal` (admin is actively pasting a key — don't yank their modal). The retry `createFlow` then returns `created: false` on the mid-modal case and the user sees "you already have a modal open — finish it." The OAuth path is unchanged — it has no `await*` to convert, so it doesn't enter the flow_state ledger at all. |
 | `/qurl send` | Block (default) | Multi-step send flow (recipient picker, attachment capture, confirm); abandoning mid-flow because a duplicate `/qurl send` slipped through would lose user input. |
 
 The supersede semantics are **enforced at the harness level** by `deleteFlow`'s

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2896,9 +2896,45 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     .setPlaceholder('lv_live_your_key_here')
     .setStyle(TextInputStyle.Short)
     .setRequired(true)
-    .setMinLength(28);
+    .setMinLength(28)
+    // Defense-in-depth ceiling. The regex below is open-ended on
+    // the high side and Discord's default is 4000 chars; a stricter
+    // client-side cap clips pathological pastes before they hit
+    // the network. A real qURL API key is well under 64 chars.
+    .setMaxLength(64);
   modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
-  await interaction.showModal(modal);
+
+  // Roll back the OCC transition if showModal throws. The
+  // transitionFlow committed the row to `awaiting_setup_modal`,
+  // but the modal never opened — leaving the row in that stage
+  // would mean the admin sees Discord's "interaction failed"
+  // notice and then, on rerun of /qurl setup, the supersede path
+  // refuses to admin_cleanup an awaiting_setup_modal row (its
+  // stage gate is awaiting_setup_button) and the loadFlow peek
+  // tells them "you already have a modal open" — but they don't.
+  // The admin would have to wait out the full SETUP_MODAL_TTL_SECONDS
+  // before recovering. Delete the row instead so the next /qurl
+  // setup runs cleanly. Best-effort reply — the interaction token
+  // may itself be in the failed state that just took down showModal.
+  try {
+    await interaction.showModal(modal);
+  } catch (err) {
+    logger.error('handleSetupButton: showModal failed after transitionFlow committed', {
+      flow_id, error: err && err.message,
+    });
+    await deleteFlow(flow_id, {
+      stage: SETUP_STAGE_AWAITING_MODAL,
+      reason: 'abort',
+    }).catch((rollbackErr) => {
+      logger.error('handleSetupButton: rollback deleteFlow failed', {
+        flow_id, error: rollbackErr && rollbackErr.message,
+      });
+    });
+    await interaction.reply({
+      content: 'Could not open the configuration form — please run `/qurl setup` again.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
 }
 
 // Modal-submit handler. Routed by flow-dispatch when the admin

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2837,12 +2837,15 @@ const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
 async function handleSetupButton(interaction, { flow_id, row }) {
   // `row.version` is the OCC handle the dispatcher already loaded.
   // The dispatcher's invariant (flow-dispatch.js — handleFlowInteraction)
-  // guarantees `row` is non-null with a numeric `version` field when
-  // the handler runs. A defensive check here would only fire if that
+  // guarantees `row` is non-null with an integer `version` when the
+  // handler runs. A defensive check here would only fire if that
   // invariant drifted; preferring an explicit failure over a
   // confusing TypeError-on-undefined deep inside transitionFlow.
-  if (typeof row?.version !== 'number') {
-    throw new TypeError('handleSetupButton: dispatcher contract violated — row.version must be numeric');
+  // Mirror transitionFlow's own validation (`Number.isInteger`) so a
+  // NaN-from-bad-parseInt-upstream is caught at the dispatcher
+  // boundary, not inside the OCC primitive.
+  if (!Number.isInteger(row?.version)) {
+    throw new TypeError('handleSetupButton: dispatcher contract violated — row.version must be an integer');
   }
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SETUP_STAGE_AWAITING_MODAL,
@@ -2916,6 +2919,14 @@ async function handleSetupButton(interaction, { flow_id, row }) {
   // before recovering. Delete the row instead so the next /qurl
   // setup runs cleanly. Best-effort reply — the interaction token
   // may itself be in the failed state that just took down showModal.
+  //
+  // Trapped-state recovery: if BOTH showModal AND the rollback
+  // deleteFlow fail (e.g. DDB region outage that killed both calls),
+  // the row stays at awaiting_setup_modal until TTL reap. The
+  // admin's only recovery is to wait out the SETUP_MODAL_TTL_SECONDS
+  // (5 min). Both errors are logged at error-level so a support
+  // ticket like "I can't run /qurl setup, it says I have a modal
+  // open but I don't" maps cleanly to this branch in CloudWatch.
   try {
     await interaction.showModal(modal);
   } catch (err) {
@@ -2955,8 +2966,13 @@ async function handleSetupModal(interaction, { flow_id }) {
     reason: 'terminal',
   });
   if (!deleted) {
+    // `deleted: false` collapses three real causes: TTL'd between
+    // modal open and submit, concurrent admin_cleanup, and a duplicate
+    // submit from Discord retry. The TTL case is the most plausible
+    // (admin walks away mid-paste past the 300 s budget), so the
+    // wording covers both "expired" and "already processed."
     return interaction.reply({
-      content: 'This setup was already processed.',
+      content: 'This setup session has expired or was already processed — run `/qurl setup` again.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
@@ -2984,7 +3000,7 @@ async function handleSetupModal(interaction, { flow_id }) {
   if (!SETUP_API_KEY_REGEX.test(submittedKey)) {
     logger.warn('validate-key rejected (bad format)', logFields);
     return interaction.reply({
-      content: 'Invalid API key format. Keys start with `lv_live_` or `lv_test_` and are at least 28 characters.',
+      content: 'Invalid API key format. Keys start with `lv_live_` or `lv_test_` and are at least 28 characters. Run `/qurl setup` again to retry.',
       ephemeral: true,
     });
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2862,12 +2862,11 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  if (result.result === 'error') {
-    return interaction.reply({
-      content: 'Could not start the setup modal — please try again in a moment.',
-      ephemeral: true,
-    }).catch(logIgnoredDiscordErr);
-  }
+  // Note: transitionFlow throws on non-CCFE failures (DDB outage,
+  // pre-read errors). Those propagate to the dispatcher's universal
+  // safety net, which replies with the generic "Something went wrong
+  // — please run the command again." The result discriminator only
+  // surfaces success | conflict | not_found.
 
   // Success — show the modal. It becomes the interaction's ACK.
   const modal = new ModalBuilder()
@@ -2908,10 +2907,28 @@ async function handleSetupModal(interaction, { flow_id }) {
     }).catch(logIgnoredDiscordErr);
   }
 
+  // Structured-log fields shared across every validation failure
+  // branch. A guild that hits "Invalid API key" 50 times in a row
+  // (admin keeps re-pasting the wrong key, or a credential rotation
+  // broke them) needs to surface in ops dashboards — that's only
+  // possible if every failure logs guild_id + configured_by.
+  // Bare reply paths (no .catch on the user-facing editReply) below
+  // are intentional: the flow row is already deleted by this point,
+  // so a Discord throw propagates to the dispatcher's safety net
+  // which replies "run again" — which IS the correct UX for these
+  // branches (admin really should rerun). Contrast the success-
+  // path .catch a few lines down, where "run again" would mislead
+  // because the key was already persisted.
+  const logFields = {
+    guild_id: interaction.guildId,
+    configured_by: interaction.user.id,
+  };
+
   const submittedKey = interaction.fields
     .getTextInputValue(SETUP_MODAL_FIELD_API_KEY)
     .trim();
   if (!SETUP_API_KEY_REGEX.test(submittedKey)) {
+    logger.warn('validate-key rejected (bad format)', logFields);
     return interaction.reply({
       content: 'Invalid API key format. Keys start with `lv_live_` or `lv_test_` and are at least 28 characters.',
       ephemeral: true,
@@ -2925,9 +2942,11 @@ async function handleSetupModal(interaction, { flow_id }) {
       signal: AbortSignal.timeout(10000),
     });
     if (resp.status === 401 || resp.status === 403) {
+      logger.warn('validate-key rejected by qURL API', { ...logFields, status: resp.status });
       return interaction.editReply({ content: '❌ **Invalid API key.** Double-check your key at **https://layerv.ai**.' });
     }
     if (!resp.ok) {
+      logger.warn('validate-key non-2xx from qURL API', { ...logFields, status: resp.status });
       return interaction.editReply({ content: `❌ **qURL API error** (${resp.status}). Try again later.` });
     }
   } catch (err) {
@@ -2935,7 +2954,7 @@ async function handleSetupModal(interaction, { flow_id }) {
     // contain internal hostnames/IPs (e.g. "connect ECONNREFUSED
     // 10.0.0.5:8080") that should not leak to a guild admin's
     // screen. Same redaction shape as the pre-conversion code.
-    logger.error('validate-key request failed', { error: err.message });
+    logger.error('validate-key request failed', { ...logFields, error: err.message });
     return interaction.editReply({
       content: '❌ **Could not validate key.** Please try again in a moment.',
     });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3050,17 +3050,16 @@ async function handleSetupModal(interaction, { flow_id }) {
     configured_by: interaction.user.id,
   };
 
-  // Defensive coalesce + stringify in case a Discord SDK contract
-  // change ever returns null/undefined/non-string from
-  // getTextInputValue. The `?? ''` runs first so String(null) →
-  // 'null' / String(undefined) → 'undefined' can't slip through as
-  // valid-looking key strings; the outer String(...) catches any
-  // remaining non-string return shape. The flow row is already
-  // deleted by this point, so an uncaught throw here would surface
-  // as the dispatcher's "Something went wrong" AFTER the row is
-  // gone — asymmetrically expensive vs. this two-token defense.
+  // `String(...)` coerces any non-string return shape (a hypothetical
+  // Discord SDK contract change) into a string before .trim(). A
+  // null/undefined coerces to 'null'/'undefined', which the regex
+  // format check below cleanly rejects as malformed — the defense's
+  // job is just to keep .trim() from throwing, not to validate.
+  // The flow row is already deleted by this point, so an uncaught
+  // throw here would surface as "Something went wrong" AFTER the
+  // row is gone — asymmetrically expensive vs. this one-token wrap.
   const submittedKey = String(
-    interaction.fields.getTextInputValue(SETUP_MODAL_FIELD_API_KEY) ?? '',
+    interaction.fields.getTextInputValue(SETUP_MODAL_FIELD_API_KEY),
   ).trim();
   if (!SETUP_API_KEY_REGEX.test(submittedKey)) {
     logger.warn('validate-key rejected (bad format)', logFields);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3034,6 +3034,12 @@ async function handleSetupModal(interaction, { flow_id }) {
   // branches (admin really should rerun). Contrast the success-
   // path .catch a few lines down, where "run again" would mislead
   // because the key was already persisted.
+  //
+  // Exception: the `!deleted` early-return above DOES .catch — the
+  // dedup-loser path means another worker already replied to the
+  // user, and a second "run again" from the safety net would
+  // visually duplicate. The bare-reply rule applies only to the
+  // post-deleteFlow validation branches.
   const logFields = {
     guild_id: interaction.guildId,
     configured_by: interaction.user.id,
@@ -4033,7 +4039,17 @@ const commands = [
             logger.warn('handleSetup: createFlow racy after admin_cleanup', {
               flow_id: setupFlowId,
             });
-            const surviving = await loadFlow(setupFlowId).catch(() => null);
+            const surviving = await loadFlow(setupFlowId).catch((err) => {
+              // Preserve observability — a DDB outage here silently
+              // degrades the user-visible wording from actionable
+              // ("you have a /qurl revoke menu open") to generic
+              // ("try again"). Without this warn, an intermittent
+              // read-side regression would be invisible to ops.
+              logger.warn('handleSetup: loadFlow peek failed (post-supersede disambiguation)', {
+                flow_id: setupFlowId, error: err && err.message,
+              });
+              return null;
+            });
             if (surviving?.stage === SETUP_STAGE_AWAITING_MODAL) {
               return interaction.editReply({
                 content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2808,12 +2808,13 @@ const SETUP_BUTTON_CUSTOM_ID = 'qurl_setup_button';
 const SETUP_MODAL_CUSTOM_ID = 'qurl_setup_modal';
 const SETUP_MODAL_FIELD_API_KEY = 'api_key';
 
-// Two-stage TTL budget. The button-stage window is short because an
-// admin who runs `/qurl setup` should click the button within
-// seconds; if they walk away, supersede semantics let them rerun
-// without confusion. The modal-stage window is the real budget for
-// finding and pasting the key.
-const SETUP_BUTTON_TTL_SECONDS = 60;
+// Two-stage TTL budget. The button-stage window covers "click the
+// button" — short enough that an abandoned button is naturally
+// superseded, long enough that a mobile admin who app-switches to
+// a password manager doesn't come back to an expired button. The
+// modal-stage window is the real budget for finding and pasting
+// the key.
+const SETUP_BUTTON_TTL_SECONDS = 120;
 const SETUP_MODAL_TTL_SECONDS = 300;
 
 const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
@@ -2872,18 +2873,14 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     // transitionFlow Update (TTL reap or a concurrent
     // admin_cleanup). Tell the user to rerun.
     return interaction.reply({
-      content: 'This setup session expired — please run `/qurl setup` again.',
+      content: 'This setup session expired or was replaced — please run `/qurl setup` again.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
 
-  // Note: transitionFlow throws on non-CCFE failures (DDB outage,
-  // pre-read errors). Those propagate to the dispatcher's universal
-  // safety net, which replies with the generic "Something went wrong
-  // — please run the command again." The result discriminator only
-  // surfaces success | conflict | not_found.
-
   // Success — show the modal. It becomes the interaction's ACK.
+  // (Non-CCFE transitionFlow failures throw and propagate to the
+  // dispatcher's safety net; see flow-state.js for the contract.)
   const modal = new ModalBuilder()
     .setCustomId(SETUP_MODAL_CUSTOM_ID)
     .setTitle('Configure qURL');
@@ -2897,7 +2894,9 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     // Defense-in-depth ceiling. The regex below is open-ended on
     // the high side and Discord's default is 4000 chars; a stricter
     // client-side cap clips pathological pastes before they hit
-    // the network. A real qURL API key is well under 64 chars.
+    // the network. A real qURL API key is well under 64 chars
+    // today — align with upstream qurl-service key-format spec if
+    // longer formats (e.g. JWT-shaped) ever ship.
     .setMaxLength(64);
   modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3061,6 +3061,19 @@ async function handleSetupModal(interaction, { flow_id }) {
   const submittedKey = String(
     interaction.fields.getTextInputValue(SETUP_MODAL_FIELD_API_KEY),
   ).trim();
+  // Probable client-side truncation: the key landed exactly at the
+  // setMaxLength ceiling. The regex check below will likely reject
+  // (current `lv_*` keys are well under 64 chars), but if it ever
+  // accepts a 64-char value the warn surfaces the truncation
+  // candidate to ops — an upstream key-format change that exceeds
+  // the cap would otherwise look like a guild-side "Invalid API
+  // key format" loop with no trail back to this constant.
+  if (submittedKey.length === SETUP_API_KEY_MAX_LENGTH) {
+    logger.warn('validate-key probable truncation (key landed at SETUP_API_KEY_MAX_LENGTH)', {
+      ...logFields,
+      key_length: submittedKey.length,
+    });
+  }
   if (!SETUP_API_KEY_REGEX.test(submittedKey)) {
     logger.warn('validate-key rejected (bad format)', logFields);
     return interaction.reply({
@@ -3996,9 +4009,12 @@ const commands = [
           // Within the supersede branch, deleteFlow + retry createFlow
           // share one try-envelope so a DDB throttle / IAM blip on
           // either gets the recoverable "could not start" message.
-          // The FIRST createFlow above is NOT wrapped — its throw
-          // bubbles to handleCommand's outer envelope (covered by
-          // test "propagates the throw when the first createFlow fails").
+          // The FIRST createFlow above is intentionally NOT wrapped —
+          // its throw bubbles to handleCommand's outer envelope.
+          // Pinned by:
+          //   - "propagates the throw when the first createFlow fails"
+          //   - "handleCommand wraps the createFlow throw into a generic
+          //      user-visible reply"
           //
           // Race-edge #272: two same-user supersede calls from
           // different clients within the deleteFlow round-trip can

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2840,27 +2840,15 @@ const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
 // trip the `extended: true` audit flag on the FLOW_TRANSITION event
 // — correct: the deadline really was extended.
 async function handleSetupButton(interaction, { flow_id, row }) {
-  // `row.version` is the OCC handle the dispatcher already loaded
-  // (flow-dispatch.js — handleFlowInteraction). transitionFlow
-  // validates it via `Number.isInteger` at the OCC primitive
-  // boundary, so a defensive guard here would re-validate something
-  // already-validated downstream — exactly the scenario CLAUDE.md
-  // calls out as "validation for scenarios that can't happen."
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SETUP_STAGE_AWAITING_MODAL,
     terminal: false,
     set_expires_at: Math.floor(Date.now() / 1000) + SETUP_MODAL_TTL_SECONDS,
   });
 
-  // Both early-return branches use `interaction.reply` directly,
-  // not flow-dispatch's `safeReply`. Two reasons: (a) the button
-  // click cannot be deferReply'd ahead of time (showModal must be
-  // the first response, and we don't know yet whether we'll get
-  // there), so `interaction.replied/deferred` are guaranteed false
-  // when we arrive here — safeReply's followUp branch would never
-  // be taken. (b) The shape matches handleRevokeSelect's OCC-loser
-  // path, keeping the dispatcher-side handler convention consistent
-  // across commands.
+  // Early-return branches below use `interaction.reply` directly
+  // (not safeReply): we haven't deferReply'd, so replied/deferred
+  // are false on entry. Matches handleRevokeSelect's shape.
   if (result.result === 'conflict') {
     // Two concurrent button clicks. The OCC loser must NOT call
     // showModal — the winner will (or already did), and a duplicate
@@ -2912,7 +2900,7 @@ async function handleSetupButton(interaction, { flow_id, row }) {
   // log at error-level — admin recovery is the SETUP_MODAL_TTL_SECONDS
   // (5 min) wait.
   //
-  // TODO(supersede-race): the rollback delete uses
+  // TODO(supersede-race) #272: the rollback delete uses
   // stage='awaiting_setup_modal' (matching the just-committed
   // transition). A concurrent /qurl setup rerun whose loadFlow
   // peek lands in the narrow window AFTER the transition committed
@@ -3958,14 +3946,13 @@ const commands = [
           // bubbles to handleCommand's outer envelope (covered by
           // test "propagates the throw when the first createFlow fails").
           //
-          // Race-edge: two same-user supersede calls from different
-          // clients within the deleteFlow round-trip can have the
-          // second deleteFlow stomp the first retry's fresh row
-          // (no OCC on deleteFlow). Worst case is "admin reruns,"
-          // and /qurl setup is admin-only + same-user so the window
-          // is vanishingly small — not worth an OCC primitive yet,
-          // but documented here so the next reader doesn't try to
-          // close it without weighing the cost.
+          // Race-edge #272: two same-user supersede calls from
+          // different clients within the deleteFlow round-trip can
+          // have the second deleteFlow stomp the first retry's
+          // fresh row (no OCC on deleteFlow). Worst case is "admin
+          // reruns," and /qurl setup is admin-only + same-user so
+          // the window is vanishingly small — not worth an OCC
+          // primitive yet, tracked in #272 if/when it bites.
           let setupRetry;
           try {
             await deleteFlow(setupFlowId, {
@@ -4008,6 +3995,17 @@ const commands = [
             if (surviving?.stage === SETUP_STAGE_AWAITING_MODAL) {
               return interaction.editReply({
                 content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
+              });
+            }
+            // Discriminate known sibling flows so the admin gets
+            // actionable guidance instead of "try again" — a sibling
+            // flow won't clear until ITS owner finishes or its TTL
+            // fires, so a blind retry of /qurl setup would loop
+            // forever. Map each sibling stage to the command the
+            // admin should finish/cancel first.
+            if (surviving?.stage === REVOKE_STAGE_AWAITING_SELECT) {
+              return interaction.editReply({
+                content: 'You have a `/qurl revoke` menu open in this channel — finish or cancel it first.',
               });
             }
             return interaction.editReply({
@@ -4482,6 +4480,11 @@ module.exports = {
       // alarm — table-driven tests pin every shape so a silent regex
       // breakage can't slip through.
       isAckTimeoutError,
+      // Setup-flow TTL constants — exposed so tests assert against
+      // the production values, not stale duplicates that would
+      // silently pass when the constants are tuned.
+      SETUP_BUTTON_TTL_SECONDS,
+      SETUP_MODAL_TTL_SECONDS,
     },
   }),
 };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -32,7 +32,7 @@ const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 const { createFlow, deleteFlow, transitionFlow, loadFlow } = require('./flow-state');
-const { flowIdForInteraction, registerFlow } = require('./flow-dispatch');
+const { flowIdForInteraction, registerFlow, safeReply } = require('./flow-dispatch');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
@@ -2920,6 +2920,11 @@ async function handleSetupButton(interaction, { flow_id, row }) {
   // "you already have a modal open" message. Window is bounded by
   // a single DDB round-trip; not worth closing with an additional
   // OCC primitive yet, but greppable for future readers.
+  //
+  // No spurious error log if a concurrent supersede ALSO cleared
+  // this row first — CCFE in deleteFlow returns `{deleted: false}`
+  // rather than throwing (flow-state.js), so the .catch below never
+  // fires on that path.
   try {
     await interaction.showModal(modal);
   } catch (err) {
@@ -2949,10 +2954,16 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     // (the .catch swallows it), and the wait-vs-retry distinction
     // is marginal UX in an already-rare error path; keep the
     // simpler wording.
-    await interaction.reply({
-      content: 'Could not open the configuration form — please run `/qurl setup` again.',
-      ephemeral: true,
-    }).catch(logIgnoredDiscordErr);
+    //
+    // Use safeReply (followUp vs reply based on interaction state)
+    // rather than a bare .reply.catch — showModal may have partially
+    // acked before throwing, leaving interaction.replied=true; a
+    // bare .reply would then throw InteractionAlreadyReplied and
+    // silently swallow, leaving the admin with no feedback.
+    await safeReply(
+      interaction,
+      'Could not open the configuration form — please run `/qurl setup` again.',
+    );
   }
 }
 
@@ -3940,11 +3951,12 @@ const commands = [
           expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
         });
         if (!setupCreated.created) {
-          // Both deleteFlow and the retry createFlow run under a
-          // single try-envelope so a DDB throttle / IAM blip on
-          // either gets the recoverable "could not start" message
-          // instead of falling through to handleCommand's generic
-          // "error executing this command" wording.
+          // Within the supersede branch, deleteFlow + retry createFlow
+          // share one try-envelope so a DDB throttle / IAM blip on
+          // either gets the recoverable "could not start" message.
+          // The FIRST createFlow above is NOT wrapped — its throw
+          // bubbles to handleCommand's outer envelope (covered by
+          // test "propagates the throw when the first createFlow fails").
           //
           // Race-edge: two same-user supersede calls from different
           // clients within the deleteFlow round-trip can have the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -31,7 +31,7 @@ const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
-const { createFlow, deleteFlow, transitionFlow } = require('./flow-state');
+const { createFlow, deleteFlow, transitionFlow, loadFlow } = require('./flow-state');
 const { flowIdForInteraction, registerFlow } = require('./flow-dispatch');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
@@ -2835,12 +2835,30 @@ const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
 // trip the `extended: true` audit flag on the FLOW_TRANSITION event
 // — correct: the deadline really was extended.
 async function handleSetupButton(interaction, { flow_id, row }) {
+  // `row.version` is the OCC handle the dispatcher already loaded.
+  // The dispatcher's invariant (flow-dispatch.js — handleFlowInteraction)
+  // guarantees `row` is non-null with a numeric `version` field when
+  // the handler runs. A defensive check here would only fire if that
+  // invariant drifted; preferring an explicit failure over a
+  // confusing TypeError-on-undefined deep inside transitionFlow.
+  if (typeof row?.version !== 'number') {
+    throw new TypeError('handleSetupButton: dispatcher contract violated — row.version must be numeric');
+  }
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SETUP_STAGE_AWAITING_MODAL,
     terminal: false,
     set_expires_at: Math.floor(Date.now() / 1000) + SETUP_MODAL_TTL_SECONDS,
   });
 
+  // Both early-return branches use `interaction.reply` directly,
+  // not flow-dispatch's `safeReply`. Two reasons: (a) the button
+  // click cannot be deferReply'd ahead of time (showModal must be
+  // the first response, and we don't know yet whether we'll get
+  // there), so `interaction.replied/deferred` are guaranteed false
+  // when we arrive here — safeReply's followUp branch would never
+  // be taken. (b) The shape matches handleRevokeSelect's OCC-loser
+  // path, keeping the dispatcher-side handler convention consistent
+  // across commands.
   if (result.result === 'conflict') {
     // Two concurrent button clicks. The OCC loser must NOT call
     // showModal — the winner will (or already did), and a duplicate
@@ -2961,10 +2979,7 @@ async function handleSetupModal(interaction, { flow_id }) {
   }
 
   await db.setGuildApiKey(interaction.guildId, submittedKey, interaction.user.id);
-  logger.info('Guild API key configured', {
-    guild_id: interaction.guildId,
-    configured_by: interaction.user.id,
-  });
+  logger.info('Guild API key configured', logFields);
   // Swallow Discord errors on the post-persist editReply. If the
   // editReply throws AFTER setGuildApiKey commits, letting it
   // propagate would fire the dispatcher's universal safety-net
@@ -3857,12 +3872,11 @@ const commands = [
         // supersede + recreate gives them a fresh button.
         await interaction.deferReply({ ephemeral: true });
         const setupFlowId = flowIdForInteraction(interaction);
-        const setupExpiresAt = Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS;
         const setupCreated = await createFlow({
           flow_id: setupFlowId,
           stage: SETUP_STAGE_AWAITING_BUTTON,
           payload: null,
-          expires_at: setupExpiresAt,
+          expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
         });
         if (!setupCreated.created) {
           await deleteFlow(setupFlowId, {
@@ -3875,7 +3889,10 @@ const commands = [
               flow_id: setupFlowId,
               stage: SETUP_STAGE_AWAITING_BUTTON,
               payload: null,
-              expires_at: setupExpiresAt,
+              // Recompute expires_at after the deleteFlow round-trip
+              // so the retried row gets a full SETUP_BUTTON_TTL_SECONDS
+              // budget, not a sub-second-truncated one.
+              expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
             });
           } catch (err) {
             logger.warn('handleSetup: createFlow retry threw after admin_cleanup', {
@@ -3886,11 +3903,28 @@ const commands = [
             });
           }
           if (!setupRetry.created) {
-            // Prior flow is mid-modal (stage gate refused the
-            // admin_cleanup) or two races in a row. Tell the admin
-            // to finish the existing modal.
+            // Retry create can fail for three distinct reasons:
+            //   (a) stage gate refused admin_cleanup because the
+            //       prior row is mid-modal → tell admin to finish
+            //       their existing modal.
+            //   (b) sibling flow type lives at this flow_id (e.g.
+            //       in-flight revoke) → don't claim a modal is
+            //       open; use the generic "could not start" wording.
+            //   (c) two races in a row → also generic wording.
+            // Disambiguate with a loadFlow peek. Adds one DDB read
+            // on a rare error path; cheap relative to telling the
+            // user about a modal that doesn't exist.
+            logger.warn('handleSetup: createFlow racy after admin_cleanup', {
+              flow_id: setupFlowId,
+            });
+            const surviving = await loadFlow(setupFlowId).catch(() => null);
+            if (surviving?.stage === SETUP_STAGE_AWAITING_MODAL) {
+              return interaction.editReply({
+                content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
+              });
+            }
             return interaction.editReply({
-              content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
+              content: 'Could not start a setup session — please try again.',
             });
           }
         }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2867,7 +2867,7 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     // showModal on the same parent interaction surfaces as a
     // confusing Discord error.
     return interaction.reply({
-      content: 'Another setup attempt is in progress — please use the existing modal.',
+      content: 'Another setup attempt is in progress — finish or close it, then retry.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
@@ -2911,10 +2911,24 @@ async function handleSetupButton(interaction, { flow_id, row }) {
   // rollback itself also fails (DDB region outage), both errors
   // log at error-level — admin recovery is the SETUP_MODAL_TTL_SECONDS
   // (5 min) wait.
+  //
+  // TODO(supersede-race): the rollback delete uses
+  // stage='awaiting_setup_modal' (matching the just-committed
+  // transition). A concurrent /qurl setup rerun whose loadFlow
+  // peek lands in the narrow window AFTER the transition committed
+  // but BEFORE this rollback fires will surface the misleading
+  // "you already have a modal open" message. Window is bounded by
+  // a single DDB round-trip; not worth closing with an additional
+  // OCC primitive yet, but greppable for future readers.
   try {
     await interaction.showModal(modal);
   } catch (err) {
-    logger.error('handleSetupButton: showModal failed after transitionFlow committed', {
+    // warn-level: the dominant cause is Discord token expiry /
+    // transient REST blips that are fully recoverable by user
+    // rerun. error-level is reserved for the rollback-also-failed
+    // branch below, which is the genuine "this admin is stuck for
+    // up to SETUP_MODAL_TTL_SECONDS" condition that warrants paging.
+    logger.warn('handleSetupButton: showModal failed after transitionFlow committed', {
       flow_id, error: err && err.message,
     });
     await deleteFlow(flow_id, {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -31,7 +31,7 @@ const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
-const { createFlow, deleteFlow } = require('./flow-state');
+const { createFlow, deleteFlow, transitionFlow } = require('./flow-state');
 const { flowIdForInteraction, registerFlow } = require('./flow-dispatch');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
@@ -2789,6 +2789,177 @@ async function handleRevokeSelect(interaction, { flow_id }) {
   });
 }
 
+// /qurl setup — legacy modal-paste path conversion. See
+// docs/zero-downtime-design.md Pillar 1 for the two-stage shape:
+//
+//   /qurl setup (slash)          createFlow(awaiting_setup_button)
+//       → reply with [Configure qURL] button
+//   button click (dispatcher)    transitionFlow → awaiting_setup_modal
+//       → showModal()                              (set_expires_at extends TTL)
+//   modal submit (dispatcher)    validate + persist + deleteFlow(terminal)
+//       → editReply(success)
+//
+// The OAuth path (when AUTH0_* is configured) is NOT flow-state-
+// backed — its persistence is the signed state token + pending_links
+// SQLite table, and there's no `await*` in process to convert.
+const SETUP_STAGE_AWAITING_BUTTON = 'awaiting_setup_button';
+const SETUP_STAGE_AWAITING_MODAL = 'awaiting_setup_modal';
+const SETUP_BUTTON_CUSTOM_ID = 'qurl_setup_button';
+const SETUP_MODAL_CUSTOM_ID = 'qurl_setup_modal';
+const SETUP_MODAL_FIELD_API_KEY = 'api_key';
+
+// Two-stage TTL budget. The button-stage window is short because an
+// admin who runs `/qurl setup` should click the button within
+// seconds; if they walk away, supersede semantics let them rerun
+// without confusion. The modal-stage window is the real budget for
+// finding and pasting the key.
+const SETUP_BUTTON_TTL_SECONDS = 60;
+const SETUP_MODAL_TTL_SECONDS = 300;
+
+const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
+
+// Button-stage handler. Routed by flow-dispatch when the admin
+// clicks the [Configure qURL] button rendered by handleSetup.
+//
+// Sequence: transitionFlow first (it's the OCC primitive that
+// rejects concurrent button clicks), then showModal as the ACK on
+// the success branch. `showModal` MUST be the interaction's first
+// response — we cannot deferReply ahead of it — so the DDB round-
+// trip happens inside Discord's 3 s ACK window. UpdateItem latency
+// is typically 50–200 ms; if a DDB outage pushes it close to the
+// wall, the user sees Discord's "interaction failed" notice and
+// can re-click. Acceptable tradeoff vs. losing OCC dedup.
+//
+// `set_expires_at` resets the TTL window so the admin has a fresh
+// 5 minutes to paste from the moment the modal opens. This will
+// trip the `extended: true` audit flag on the FLOW_TRANSITION event
+// — correct: the deadline really was extended.
+async function handleSetupButton(interaction, { flow_id, row }) {
+  const result = await transitionFlow(flow_id, row.version, {
+    stage_to: SETUP_STAGE_AWAITING_MODAL,
+    terminal: false,
+    set_expires_at: Math.floor(Date.now() / 1000) + SETUP_MODAL_TTL_SECONDS,
+  });
+
+  if (result.result === 'conflict') {
+    // Two concurrent button clicks. The OCC loser must NOT call
+    // showModal — the winner will (or already did), and a duplicate
+    // showModal on the same parent interaction surfaces as a
+    // confusing Discord error.
+    return interaction.reply({
+      content: 'Another setup attempt is in progress — please use the existing modal.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  if (result.result === 'not_found') {
+    // Flow row vanished between the dispatcher's loadFlow and the
+    // transitionFlow Update (TTL reap or a concurrent
+    // admin_cleanup). Tell the user to rerun.
+    return interaction.reply({
+      content: 'This setup session expired — please run `/qurl setup` again.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  if (result.result === 'error') {
+    return interaction.reply({
+      content: 'Could not start the setup modal — please try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  // Success — show the modal. It becomes the interaction's ACK.
+  const modal = new ModalBuilder()
+    .setCustomId(SETUP_MODAL_CUSTOM_ID)
+    .setTitle('Configure qURL');
+  const keyInput = new TextInputBuilder()
+    .setCustomId(SETUP_MODAL_FIELD_API_KEY)
+    .setLabel('qURL API Key')
+    .setPlaceholder('lv_live_your_key_here')
+    .setStyle(TextInputStyle.Short)
+    .setRequired(true)
+    .setMinLength(28);
+  modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
+  await interaction.showModal(modal);
+}
+
+// Modal-submit handler. Routed by flow-dispatch when the admin
+// submits the modal opened by handleSetupButton. The flow row's
+// stage is already validated (`awaiting_setup_modal`) by the
+// dispatcher.
+//
+// `deleteFlow` runs BEFORE the qURL API validation so the dedup
+// gate fires on the OCC primitive — a duplicate modal submit
+// (Discord retry, double-click) sees `deleted: false` and exits
+// without burning a qURL API key validation call. Same ordering
+// rationale as handleRevokeSelect.
+async function handleSetupModal(interaction, { flow_id }) {
+  // Modal-stage flow_state delete is terminal — the user committed
+  // the form, the flow has lifecycled out.
+  const { deleted } = await deleteFlow(flow_id, {
+    stage: SETUP_STAGE_AWAITING_MODAL,
+    reason: 'terminal',
+  });
+  if (!deleted) {
+    return interaction.reply({
+      content: 'This setup was already processed.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  const submittedKey = interaction.fields
+    .getTextInputValue(SETUP_MODAL_FIELD_API_KEY)
+    .trim();
+  if (!SETUP_API_KEY_REGEX.test(submittedKey)) {
+    return interaction.reply({
+      content: 'Invalid API key format. Keys start with `lv_live_` or `lv_test_` and are at least 28 characters.',
+      ephemeral: true,
+    });
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+  try {
+    const resp = await fetch(`${config.QURL_ENDPOINT}/v1/qurls?limit=1`, {
+      headers: { 'Authorization': `Bearer ${submittedKey}`, 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (resp.status === 401 || resp.status === 403) {
+      return interaction.editReply({ content: '❌ **Invalid API key.** Double-check your key at **https://layerv.ai**.' });
+    }
+    if (!resp.ok) {
+      return interaction.editReply({ content: `❌ **qURL API error** (${resp.status}). Try again later.` });
+    }
+  } catch (err) {
+    // Don't reflect err.message to Discord — network errors can
+    // contain internal hostnames/IPs (e.g. "connect ECONNREFUSED
+    // 10.0.0.5:8080") that should not leak to a guild admin's
+    // screen. Same redaction shape as the pre-conversion code.
+    logger.error('validate-key request failed', { error: err.message });
+    return interaction.editReply({
+      content: '❌ **Could not validate key.** Please try again in a moment.',
+    });
+  }
+
+  await db.setGuildApiKey(interaction.guildId, submittedKey, interaction.user.id);
+  logger.info('Guild API key configured', {
+    guild_id: interaction.guildId,
+    configured_by: interaction.user.id,
+  });
+  // Swallow Discord errors on the post-persist editReply. If the
+  // editReply throws AFTER setGuildApiKey commits, letting it
+  // propagate would fire the dispatcher's universal safety-net
+  // reply ("Something went wrong — please run the command again"),
+  // which is actively wrong: the key IS saved. Admin can confirm
+  // with /qurl status; the saved-but-no-confirmation case is rare
+  // and recoverable, the misleading-error case is not.
+  return interaction.editReply({
+    content: '✅ **qURL is now configured for this server!**\n\n' +
+      'Your team can use `/qurl send` to share files and locations securely.\n' +
+      'All qURL usage will be billed to your API key.',
+  }).catch(logIgnoredDiscordErr);
+}
+
 // Pure rendering / wording logic lives in `./revoke-render` so the
 // e2e smoke test can require it without pulling in `discord.js`.
 const {
@@ -3650,67 +3821,69 @@ const commands = [
             ephemeral: true,
           });
         }
-        // Use a modal to collect the API key — modal inputs are NOT recorded in Discord audit logs
-        // Nonce the customId so two concurrent /qurl setup flows don't consume each other's submissions.
-        const setupNonce = crypto.randomBytes(8).toString('hex');
-        const setupModalId = `qurl_setup_modal_${setupNonce}`;
-        const modal = new ModalBuilder()
-          .setCustomId(setupModalId)
-          .setTitle('Configure qURL');
-        const keyInput = new TextInputBuilder()
-          .setCustomId('api_key')
-          .setLabel('qURL API Key')
-          .setPlaceholder('lv_live_your_key_here')
-          .setStyle(TextInputStyle.Short)
-          .setRequired(true)
-          .setMinLength(28);
-        modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
-        await interaction.showModal(modal);
 
-        let modalSubmit;
-        try {
-          modalSubmit = await interaction.awaitModalSubmit({ filter: (i) => i.customId === setupModalId && i.user.id === interaction.user.id, time: 120000 });
-        } catch {
-          return; // Modal dismissed or timed out
-        }
-        const submittedKey = modalSubmit.fields.getTextInputValue('api_key').trim();
-        if (!/^lv_(live|test)_[A-Za-z0-9_-]{20,}$/.test(submittedKey)) {
-          return modalSubmit.reply({
-            content: 'Invalid API key format. Keys start with `lv_live_` or `lv_test_` and are at least 28 characters.',
-            ephemeral: true,
+        // Open the flow row + render the button. The actual modal is
+        // shown on button-click by handleSetupButton (see
+        // dispatcher-side handlers above), which lets a deploy
+        // between command and modal still resume cleanly — the
+        // button is a persistent message component, not an
+        // in-process Promise.
+        //
+        // Supersede semantics: deleteFlow's stage gate makes a
+        // second /qurl setup a no-op when the prior flow is already
+        // mid-modal (the deleteFlow returns deleted:false on the
+        // stage mismatch and the retry createFlow then also fails,
+        // surfacing "could not start"). When the prior flow is
+        // pre-modal — i.e. the admin walked away from the button —
+        // supersede + recreate gives them a fresh button.
+        await interaction.deferReply({ ephemeral: true });
+        const setupFlowId = flowIdForInteraction(interaction);
+        const setupExpiresAt = Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS;
+        const setupCreated = await createFlow({
+          flow_id: setupFlowId,
+          stage: SETUP_STAGE_AWAITING_BUTTON,
+          payload: null,
+          expires_at: setupExpiresAt,
+        });
+        if (!setupCreated.created) {
+          await deleteFlow(setupFlowId, {
+            stage: SETUP_STAGE_AWAITING_BUTTON,
+            reason: 'admin_cleanup',
           });
-        }
-        // Validate key by making a lightweight GET — no resource creation
-        await modalSubmit.deferReply({ ephemeral: true });
-        try {
-          const resp = await fetch(`${config.QURL_ENDPOINT}/v1/qurls?limit=1`, {
-            headers: { 'Authorization': `Bearer ${submittedKey}`, 'Accept': 'application/json' },
-            signal: AbortSignal.timeout(10000),
-          });
-          if (resp.status === 401 || resp.status === 403) {
-            return modalSubmit.editReply({ content: '❌ **Invalid API key.** Double-check your key at **https://layerv.ai**.' });
+          let setupRetry;
+          try {
+            setupRetry = await createFlow({
+              flow_id: setupFlowId,
+              stage: SETUP_STAGE_AWAITING_BUTTON,
+              payload: null,
+              expires_at: setupExpiresAt,
+            });
+          } catch (err) {
+            logger.warn('handleSetup: createFlow retry threw after admin_cleanup', {
+              flow_id: setupFlowId, error: err && err.message,
+            });
+            return interaction.editReply({
+              content: 'Could not start a setup session — please try again.',
+            });
           }
-          if (!resp.ok) {
-            return modalSubmit.editReply({ content: `❌ **qURL API error** (${resp.status}). Try again later.` });
+          if (!setupRetry.created) {
+            // Prior flow is mid-modal (stage gate refused the
+            // admin_cleanup) or two races in a row. Tell the admin
+            // to finish the existing modal.
+            return interaction.editReply({
+              content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
+            });
           }
-        } catch (err) {
-          // Don't reflect err.message to Discord — network errors can contain
-          // internal hostnames/IPs (e.g. "connect ECONNREFUSED 10.0.0.5:8080")
-          // that should not leak to a guild admin's screen.
-          logger.error('validate-key request failed', { error: err.message });
-          return modalSubmit.editReply({
-            content: '❌ **Could not validate key.** Please try again in a moment.',
-          });
         }
 
-        const guildId = interaction.guildId;
-        await db.setGuildApiKey(guildId, submittedKey, interaction.user.id);
-        logger.info('Guild API key configured', { guild_id: guildId, configured_by: interaction.user.id });
-        return modalSubmit.editReply({
-          content: '✅ **qURL is now configured for this server!**\n\n' +
-            'Your team can use `/qurl send` to share files and locations securely.\n' +
-            'All qURL usage will be billed to your API key.',
-          ephemeral: true,
+        const setupButton = new ButtonBuilder()
+          .setCustomId(SETUP_BUTTON_CUSTOM_ID)
+          .setLabel('Configure qURL')
+          .setStyle(ButtonStyle.Primary);
+        return interaction.editReply({
+          content: '🔐 **Connect qURL to this server**\n\n'
+            + 'Click below to open the API-key form. Inputs are NOT recorded in Discord audit logs.',
+          components: [new ActionRowBuilder().addComponents(setupButton)],
         });
       }
 
@@ -4105,14 +4278,24 @@ registerFlow(REVOKE_SELECT_CUSTOM_ID, {
   expectedStage: REVOKE_STAGE_AWAITING_SELECT,
   handler: handleRevokeSelect,
 });
+registerFlow(SETUP_BUTTON_CUSTOM_ID, {
+  expectedStage: SETUP_STAGE_AWAITING_BUTTON,
+  handler: handleSetupButton,
+});
+registerFlow(SETUP_MODAL_CUSTOM_ID, {
+  expectedStage: SETUP_STAGE_AWAITING_MODAL,
+  handler: handleSetupModal,
+});
 
 module.exports = {
   commands,
   registerCommands,
   handleCommand,
   // Exported for the dispatcher's unit tests. Production code reaches
-  // it via flow-dispatch's registry, not this export.
+  // these via flow-dispatch's registry, not these exports.
   handleRevokeSelect,
+  handleSetupButton,
+  handleSetupModal,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2822,6 +2822,39 @@ const SETUP_MODAL_TTL_SECONDS = 300;
 // JWT-shaped key format must update both in lockstep — grep with
 // `git grep TODO(upstream-rebrand)` lands every mirroring site.
 const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
+// Hard ceiling for the modal's TextInput, paired with
+// SETUP_API_KEY_REGEX above. Both must move in lockstep — a future
+// JWT-shaped key format that exceeds this would silently truncate at
+// the modal and surface as a misleading "Invalid API key format"
+// reply. Keeping the constant adjacent to the regex makes the pair
+// impossible to update independently.
+const SETUP_API_KEY_MAX_LENGTH = 64;
+
+// User-visible success message on successful setup. Exported via
+// _test so test assertions read the production string instead of
+// hardcoding a copy that drifts.
+const SETUP_SUCCESS_MSG =
+  '✅ **qURL is now configured for this server!**\n\n'
+  + 'Your team can use `/qurl send` to share files and locations securely.\n'
+  + 'All qURL usage will be billed to your API key.';
+
+// Sibling-flow → message map for the post-supersede-retry-failure
+// disambiguation in handleSetup. Each entry says: "if the surviving
+// row at this flow_id is at THIS stage, tell the admin what to do
+// about it." The forgot-to-add-an-entry footgun is real once more
+// flows land — the dispatcher-side test in
+// commands-comprehensive.test.js pins both the known-stage and
+// generic-fallback branches.
+//
+// Future PRs (e.g. /qurl send) should add their awaiting_* entry
+// here as they ship.
+const SIBLING_FLOW_MESSAGES = {
+  [REVOKE_STAGE_AWAITING_SELECT]:
+    'You have a `/qurl revoke` menu open in this channel — finish or cancel it first.',
+};
+function siblingMessageForStage(stage) {
+  return SIBLING_FLOW_MESSAGES[stage] ?? null;
+}
 
 // Button-stage handler. Routed by flow-dispatch when the admin
 // clicks the [Configure qURL] button rendered by handleSetup.
@@ -2835,10 +2868,12 @@ const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
 // wall, the user sees Discord's "interaction failed" notice and
 // can re-click. Acceptable tradeoff vs. losing OCC dedup.
 //
-// `set_expires_at` resets the TTL window so the admin has a fresh
-// 5 minutes to paste from the moment the modal opens. This will
-// trip the `extended: true` audit flag on the FLOW_TRANSITION event
-// — correct: the deadline really was extended.
+// `set_expires_at` extends the row's TTL from the 120s button window
+// (SETUP_BUTTON_TTL_SECONDS) to the 300s modal window
+// (SETUP_MODAL_TTL_SECONDS), giving the admin a fresh budget from
+// the moment the modal opens. This trips the `extended: true` audit
+// flag on the FLOW_TRANSITION event — correct: the deadline really
+// was extended.
 async function handleSetupButton(interaction, { flow_id, row }) {
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SETUP_STAGE_AWAITING_MODAL,
@@ -2883,13 +2918,10 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     .setStyle(TextInputStyle.Short)
     .setRequired(true)
     .setMinLength(28)
-    // TODO(upstream-rebrand): 64 mirrors upstream qurl-service's
-    // current key-format ceiling (see SETUP_API_KEY_REGEX above).
-    // Discord's default is 4000 chars; a stricter client-side cap
-    // clips pathological pastes before they hit the regex/network.
-    // A future JWT-shaped key format must update this in lockstep
-    // with the regex.
-    .setMaxLength(64);
+    // TODO(upstream-rebrand): mirrors upstream qurl-service's
+    // key-format ceiling. Constant lives next to SETUP_API_KEY_REGEX
+    // so the lockstep pair is impossible to update independently.
+    .setMaxLength(SETUP_API_KEY_MAX_LENGTH);
   modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
 
   // Roll back the OCC transition if showModal throws. Without the
@@ -2928,8 +2960,13 @@ async function handleSetupButton(interaction, { flow_id, row }) {
       stage: SETUP_STAGE_AWAITING_MODAL,
       reason: 'abort',
     }).catch((rollbackErr) => {
+      // `metric: 'setup_rollback_failed'` is the stable selector
+      // for the CloudWatch alarm filter. Keying on the message
+      // string instead would break the moment a copy tweak lands.
       logger.error('handleSetupButton: rollback deleteFlow failed', {
-        flow_id, error: rollbackErr && rollbackErr.message,
+        flow_id,
+        error: rollbackErr && rollbackErr.message,
+        metric: 'setup_rollback_failed',
       });
     });
     // The "run /qurl setup again" guidance is accurate when the
@@ -3002,9 +3039,16 @@ async function handleSetupModal(interaction, { flow_id }) {
     configured_by: interaction.user.id,
   };
 
-  const submittedKey = interaction.fields
-    .getTextInputValue(SETUP_MODAL_FIELD_API_KEY)
-    .trim();
+  // Defensive String() wrap insulates against a Discord SDK contract
+  // change that returns a non-string from getTextInputValue. The flow
+  // row is already deleted by this point, so an unexpected throw
+  // here would surface as the dispatcher's "Something went wrong"
+  // reply AFTER the row is gone — admin reruns and it works, but
+  // the cost of an uncaught throw is asymmetrically high relative
+  // to a `String(...) ?? ''` defense.
+  const submittedKey = String(
+    interaction.fields.getTextInputValue(SETUP_MODAL_FIELD_API_KEY) ?? '',
+  ).trim();
   if (!SETUP_API_KEY_REGEX.test(submittedKey)) {
     logger.warn('validate-key rejected (bad format)', logFields);
     return interaction.reply({
@@ -3048,9 +3092,7 @@ async function handleSetupModal(interaction, { flow_id }) {
   // with /qurl status; the saved-but-no-confirmation case is rare
   // and recoverable, the misleading-error case is not.
   return interaction.editReply({
-    content: '✅ **qURL is now configured for this server!**\n\n' +
-      'Your team can use `/qurl send` to share files and locations securely.\n' +
-      'All qURL usage will be billed to your API key.',
+    content: SETUP_SUCCESS_MSG,
   }).catch(logIgnoredDiscordErr);
 }
 
@@ -3997,16 +4039,14 @@ const commands = [
                 content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
               });
             }
-            // Discriminate known sibling flows so the admin gets
-            // actionable guidance instead of "try again" — a sibling
-            // flow won't clear until ITS owner finishes or its TTL
-            // fires, so a blind retry of /qurl setup would loop
-            // forever. Map each sibling stage to the command the
-            // admin should finish/cancel first.
-            if (surviving?.stage === REVOKE_STAGE_AWAITING_SELECT) {
-              return interaction.editReply({
-                content: 'You have a `/qurl revoke` menu open in this channel — finish or cancel it first.',
-              });
+            // Sibling-flow message lookup. A known sibling stage
+            // (revoke today, send/etc tomorrow) gets actionable
+            // wording naming the command the admin should finish
+            // or cancel first; an unknown stage / row-vanished
+            // case falls through to the generic "try again."
+            const siblingMsg = siblingMessageForStage(surviving?.stage);
+            if (siblingMsg) {
+              return interaction.editReply({ content: siblingMsg });
             }
             return interaction.editReply({
               content: 'Could not start a setup session — please try again.',
@@ -4480,11 +4520,16 @@ module.exports = {
       // alarm — table-driven tests pin every shape so a silent regex
       // breakage can't slip through.
       isAckTimeoutError,
-      // Setup-flow TTL constants — exposed so tests assert against
-      // the production values, not stale duplicates that would
-      // silently pass when the constants are tuned.
+      // Setup-flow constants — exposed so tests assert against
+      // production values, not stale duplicates that would silently
+      // pass when the constants are tuned. The regex export lets
+      // future tests assert format shape directly rather than via
+      // VALID_KEY round-tripping.
       SETUP_BUTTON_TTL_SECONDS,
       SETUP_MODAL_TTL_SECONDS,
+      SETUP_API_KEY_REGEX,
+      SETUP_API_KEY_MAX_LENGTH,
+      SETUP_SUCCESS_MSG,
     },
   }),
 };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2822,12 +2822,17 @@ const SETUP_MODAL_TTL_SECONDS = 300;
 // JWT-shaped key format must update both in lockstep — grep with
 // `git grep TODO(upstream-rebrand)` lands every mirroring site.
 const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
-// Hard ceiling for the modal's TextInput, paired with
-// SETUP_API_KEY_REGEX above. Both must move in lockstep — a future
-// JWT-shaped key format that exceeds this would silently truncate at
-// the modal and surface as a misleading "Invalid API key format"
-// reply. Keeping the constant adjacent to the regex makes the pair
-// impossible to update independently.
+// Length floor + ceiling for the modal's TextInput, paired with
+// SETUP_API_KEY_REGEX above. The floor (28) derives from
+// `lv_live_`-prefix (8 chars) + the regex suffix floor of 20 chars;
+// the ceiling (64) is a defense-in-depth cap for pathological
+// pastes (Discord's default is 4000). Every member of the trio
+// must move in lockstep — a future JWT-shaped key format that
+// exceeds the ceiling would silently truncate at the modal and
+// surface as a misleading "Invalid API key format" reply. Keeping
+// the constants adjacent makes the lockstep impossible to update
+// independently.
+const SETUP_API_KEY_MIN_LENGTH = 28;
 const SETUP_API_KEY_MAX_LENGTH = 64;
 
 // User-visible success message on successful setup. Exported via
@@ -2917,10 +2922,10 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     .setPlaceholder('lv_live_your_key_here')
     .setStyle(TextInputStyle.Short)
     .setRequired(true)
-    .setMinLength(28)
-    // TODO(upstream-rebrand): mirrors upstream qurl-service's
-    // key-format ceiling. Constant lives next to SETUP_API_KEY_REGEX
-    // so the lockstep pair is impossible to update independently.
+    // TODO(upstream-rebrand): min+max mirror upstream qurl-service's
+    // key-format bounds. Both constants live next to SETUP_API_KEY_REGEX
+    // so the lockstep trio is impossible to update independently.
+    .setMinLength(SETUP_API_KEY_MIN_LENGTH)
     .setMaxLength(SETUP_API_KEY_MAX_LENGTH);
   modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
 
@@ -3045,13 +3050,15 @@ async function handleSetupModal(interaction, { flow_id }) {
     configured_by: interaction.user.id,
   };
 
-  // Defensive String() wrap insulates against a Discord SDK contract
-  // change that returns a non-string from getTextInputValue. The flow
-  // row is already deleted by this point, so an unexpected throw
-  // here would surface as the dispatcher's "Something went wrong"
-  // reply AFTER the row is gone — admin reruns and it works, but
-  // the cost of an uncaught throw is asymmetrically high relative
-  // to a `String(...) ?? ''` defense.
+  // Defensive coalesce + stringify in case a Discord SDK contract
+  // change ever returns null/undefined/non-string from
+  // getTextInputValue. The `?? ''` runs first so String(null) →
+  // 'null' / String(undefined) → 'undefined' can't slip through as
+  // valid-looking key strings; the outer String(...) catches any
+  // remaining non-string return shape. The flow row is already
+  // deleted by this point, so an uncaught throw here would surface
+  // as the dispatcher's "Something went wrong" AFTER the row is
+  // gone — asymmetrically expensive vs. this two-token defense.
   const submittedKey = String(
     interaction.fields.getTextInputValue(SETUP_MODAL_FIELD_API_KEY) ?? '',
   ).trim();
@@ -4039,6 +4046,17 @@ const commands = [
             logger.warn('handleSetup: createFlow racy after admin_cleanup', {
               flow_id: setupFlowId,
             });
+            // TODO(stuck-orphan-#273): loadFlow filters logically-
+            // expired rows to null. If the orphan row is past its
+            // logical TTL but not yet physically reaped (DDB reap
+            // is async, minutes-to-hours), the peek returns null
+            // and we fall through to the generic "could not start"
+            // message — leaving the admin stuck until physical
+            // reap. /qurl revoke doesn't hit this because its
+            // supersede stage gate matches the orphan's own stage.
+            // Tracked in #273; mitigation likely a
+            // loadFlow({include_expired: true}) opt-in plus a
+            // matching deleteFlow against the expired stage.
             const surviving = await loadFlow(setupFlowId).catch((err) => {
               // Preserve observability — a DDB outage here silently
               // degrades the user-visible wording from actionable
@@ -4544,6 +4562,7 @@ module.exports = {
       SETUP_BUTTON_TTL_SECONDS,
       SETUP_MODAL_TTL_SECONDS,
       SETUP_API_KEY_REGEX,
+      SETUP_API_KEY_MIN_LENGTH,
       SETUP_API_KEY_MAX_LENGTH,
       SETUP_SUCCESS_MSG,
     },

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2817,6 +2817,10 @@ const SETUP_MODAL_FIELD_API_KEY = 'api_key';
 const SETUP_BUTTON_TTL_SECONDS = 120;
 const SETUP_MODAL_TTL_SECONDS = 300;
 
+// TODO(upstream-rebrand): regex + setMaxLength below mirror the
+// upstream qurl-service key-format spec. A future rebrand or
+// JWT-shaped key format must update both in lockstep — grep with
+// `git grep TODO(upstream-rebrand)` lands every mirroring site.
 const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
 
 // Button-stage handler. Routed by flow-dispatch when the admin
@@ -2891,12 +2895,12 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     .setStyle(TextInputStyle.Short)
     .setRequired(true)
     .setMinLength(28)
-    // Defense-in-depth ceiling. The regex below is open-ended on
-    // the high side and Discord's default is 4000 chars; a stricter
-    // client-side cap clips pathological pastes before they hit
-    // the network. A real qURL API key is well under 64 chars
-    // today — align with upstream qurl-service key-format spec if
-    // longer formats (e.g. JWT-shaped) ever ship.
+    // TODO(upstream-rebrand): 64 mirrors upstream qurl-service's
+    // current key-format ceiling (see SETUP_API_KEY_REGEX above).
+    // Discord's default is 4000 chars; a stricter client-side cap
+    // clips pathological pastes before they hit the regex/network.
+    // A future JWT-shaped key format must update this in lockstep
+    // with the regex.
     .setMaxLength(64);
   modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
 
@@ -2921,6 +2925,16 @@ async function handleSetupButton(interaction, { flow_id, row }) {
         flow_id, error: rollbackErr && rollbackErr.message,
       });
     });
+    // The "run /qurl setup again" guidance is accurate when the
+    // rollback succeeded (clean state, rerun works). If the rollback
+    // ALSO failed (rare double-DDB-failure logged just above), the
+    // rerun will hit the "you already have a modal open" branch
+    // until SETUP_MODAL_TTL_SECONDS elapses — the admin's recovery
+    // is just to wait. Distinguishing the two cases in the message
+    // would require reading the rollback outcome into a variable
+    // (the .catch swallows it), and the wait-vs-retry distinction
+    // is marginal UX in an already-rare error path; keep the
+    // simpler wording.
     await interaction.reply({
       content: 'Could not open the configuration form — please run `/qurl setup` again.',
       ephemeral: true,
@@ -3917,6 +3931,15 @@ const commands = [
           // either gets the recoverable "could not start" message
           // instead of falling through to handleCommand's generic
           // "error executing this command" wording.
+          //
+          // Race-edge: two same-user supersede calls from different
+          // clients within the deleteFlow round-trip can have the
+          // second deleteFlow stomp the first retry's fresh row
+          // (no OCC on deleteFlow). Worst case is "admin reruns,"
+          // and /qurl setup is admin-only + same-user so the window
+          // is vanishingly small — not worth an OCC primitive yet,
+          // but documented here so the next reader doesn't try to
+          // close it without weighing the cost.
           let setupRetry;
           try {
             await deleteFlow(setupFlowId, {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2835,18 +2835,12 @@ const SETUP_API_KEY_REGEX = /^lv_(live|test)_[A-Za-z0-9_-]{20,}$/;
 // trip the `extended: true` audit flag on the FLOW_TRANSITION event
 // — correct: the deadline really was extended.
 async function handleSetupButton(interaction, { flow_id, row }) {
-  // `row.version` is the OCC handle the dispatcher already loaded.
-  // The dispatcher's invariant (flow-dispatch.js — handleFlowInteraction)
-  // guarantees `row` is non-null with an integer `version` when the
-  // handler runs. A defensive check here would only fire if that
-  // invariant drifted; preferring an explicit failure over a
-  // confusing TypeError-on-undefined deep inside transitionFlow.
-  // Mirror transitionFlow's own validation (`Number.isInteger`) so a
-  // NaN-from-bad-parseInt-upstream is caught at the dispatcher
-  // boundary, not inside the OCC primitive.
-  if (!Number.isInteger(row?.version)) {
-    throw new TypeError('handleSetupButton: dispatcher contract violated — row.version must be an integer');
-  }
+  // `row.version` is the OCC handle the dispatcher already loaded
+  // (flow-dispatch.js — handleFlowInteraction). transitionFlow
+  // validates it via `Number.isInteger` at the OCC primitive
+  // boundary, so a defensive guard here would re-validate something
+  // already-validated downstream — exactly the scenario CLAUDE.md
+  // calls out as "validation for scenarios that can't happen."
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SETUP_STAGE_AWAITING_MODAL,
     terminal: false,
@@ -2907,26 +2901,13 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     .setMaxLength(64);
   modal.addComponents(new ActionRowBuilder().addComponents(keyInput));
 
-  // Roll back the OCC transition if showModal throws. The
-  // transitionFlow committed the row to `awaiting_setup_modal`,
-  // but the modal never opened — leaving the row in that stage
-  // would mean the admin sees Discord's "interaction failed"
-  // notice and then, on rerun of /qurl setup, the supersede path
-  // refuses to admin_cleanup an awaiting_setup_modal row (its
-  // stage gate is awaiting_setup_button) and the loadFlow peek
-  // tells them "you already have a modal open" — but they don't.
-  // The admin would have to wait out the full SETUP_MODAL_TTL_SECONDS
-  // before recovering. Delete the row instead so the next /qurl
-  // setup runs cleanly. Best-effort reply — the interaction token
-  // may itself be in the failed state that just took down showModal.
-  //
-  // Trapped-state recovery: if BOTH showModal AND the rollback
-  // deleteFlow fail (e.g. DDB region outage that killed both calls),
-  // the row stays at awaiting_setup_modal until TTL reap. The
-  // admin's only recovery is to wait out the SETUP_MODAL_TTL_SECONDS
-  // (5 min). Both errors are logged at error-level so a support
-  // ticket like "I can't run /qurl setup, it says I have a modal
-  // open but I don't" maps cleanly to this branch in CloudWatch.
+  // Roll back the OCC transition if showModal throws. Without the
+  // delete, the row sits at awaiting_setup_modal until TTL and the
+  // admin's /qurl setup rerun trips the loadFlow-peek into the
+  // misleading "you already have a modal open" branch. If the
+  // rollback itself also fails (DDB region outage), both errors
+  // log at error-level — admin recovery is the SETUP_MODAL_TTL_SECONDS
+  // (5 min) wait.
   try {
     await interaction.showModal(modal);
   } catch (err) {
@@ -2982,7 +2963,8 @@ async function handleSetupModal(interaction, { flow_id }) {
   // (admin keeps re-pasting the wrong key, or a credential rotation
   // broke them) needs to surface in ops dashboards — that's only
   // possible if every failure logs guild_id + configured_by.
-  // Bare reply paths (no .catch on the user-facing editReply) below
+  // Bare reply paths (no .catch on the malformed-key `interaction.reply`
+  // and the validation-failure `interaction.editReply` branches below)
   // are intentional: the flow row is already deleted by this point,
   // so a Discord throw propagates to the dispatcher's safety net
   // which replies "run again" — which IS the correct UX for these
@@ -3931,12 +3913,17 @@ const commands = [
           expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
         });
         if (!setupCreated.created) {
-          await deleteFlow(setupFlowId, {
-            stage: SETUP_STAGE_AWAITING_BUTTON,
-            reason: 'admin_cleanup',
-          });
+          // Both deleteFlow and the retry createFlow run under a
+          // single try-envelope so a DDB throttle / IAM blip on
+          // either gets the recoverable "could not start" message
+          // instead of falling through to handleCommand's generic
+          // "error executing this command" wording.
           let setupRetry;
           try {
+            await deleteFlow(setupFlowId, {
+              stage: SETUP_STAGE_AWAITING_BUTTON,
+              reason: 'admin_cleanup',
+            });
             setupRetry = await createFlow({
               flow_id: setupFlowId,
               stage: SETUP_STAGE_AWAITING_BUTTON,
@@ -3947,7 +3934,7 @@ const commands = [
               expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
             });
           } catch (err) {
-            logger.warn('handleSetup: createFlow retry threw after admin_cleanup', {
+            logger.warn('handleSetup: supersede deleteFlow+createFlow threw', {
               flow_id: setupFlowId, error: err && err.message,
             });
             return interaction.editReply({

--- a/apps/discord/src/flow-dispatch.js
+++ b/apps/discord/src/flow-dispatch.js
@@ -205,10 +205,13 @@ module.exports = {
   registerFlow,
   flowIdForInteraction,
   // Best-effort reply helper that picks followUp vs reply based on
-  // interaction.replied/deferred state. Exported so handlers reaching
-  // a reply point with ambiguous ack state (e.g. showModal that may
-  // have partially acked before throwing) can use it instead of
-  // re-implementing the branch.
+  // interaction.replied/deferred state. Part of the handler-author
+  // contract (not just dispatch-internal): handlers reaching a reply
+  // point with ambiguous ack state — e.g. `showModal` that may have
+  // partially acked before throwing — should call safeReply instead
+  // of `interaction.reply().catch(...)` to avoid silently swallowing
+  // an InteractionAlreadyReplied. See handleSetupButton's rollback
+  // path for the canonical consumer.
   safeReply,
   handleFlowInteraction,
   // Exported for tests so they can assert the supersede wording

--- a/apps/discord/src/flow-dispatch.js
+++ b/apps/discord/src/flow-dispatch.js
@@ -204,6 +204,12 @@ async function safeReply(interaction, content) {
 module.exports = {
   registerFlow,
   flowIdForInteraction,
+  // Best-effort reply helper that picks followUp vs reply based on
+  // interaction.replied/deferred state. Exported so handlers reaching
+  // a reply point with ambiguous ack state (e.g. showModal that may
+  // have partially acked before throwing) can use it instead of
+  // re-implementing the branch.
+  safeReply,
   handleFlowInteraction,
   // Exported for tests so they can assert the supersede wording
   // without duplicating the string.

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1655,6 +1655,12 @@ describe('handleSetupButton (dispatcher path)', () => {
     expect(transitionArgs[2].stage_to).toBe('awaiting_setup_modal');
     expect(transitionArgs[2].terminal).toBe(false);
     expect(transitionArgs[2].set_expires_at).toEqual(expect.any(Number));
+    // Pin: button-stage transition must NOT write a payload. The
+    // setup flow carries no encrypted state — the key itself
+    // arrives in interaction.fields on the modal submit, not in
+    // flow_state. A future refactor that accidentally persists
+    // anything sensitive here would trip this assertion.
+    expect(transitionArgs[2].payload).toBeUndefined();
 
     expect(interaction.showModal).toHaveBeenCalledTimes(1);
     expect(interaction.reply).not.toHaveBeenCalled();
@@ -1712,6 +1718,38 @@ describe('handleSetupButton (dispatcher path)', () => {
 
     expect(interaction.showModal).not.toHaveBeenCalled();
     expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the flow row when showModal throws after transitionFlow committed', async () => {
+    // The transitionFlow commits the row to `awaiting_setup_modal`
+    // before showModal fires. If showModal throws (Discord token
+    // expiry, REST blip), leaving the row in that stage would force
+    // the admin to wait out the full TTL — `/qurl setup` rerun
+    // would see the loadFlow peek find awaiting_setup_modal and
+    // surface the misleading "you already have a modal open"
+    // wording. Recovery requires the handler to delete the row.
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'success', version: 2 });
+    const showModalErr = new Error('Unknown interaction (token expired during ACK)');
+    const interaction = makeButtonInteraction({
+      showModal: jest.fn().mockRejectedValue(showModalErr),
+    });
+
+    await handleSetupButton(interaction, {
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      row: { stage: 'awaiting_setup_button', version: 1 },
+    });
+
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlow).toHaveBeenCalledWith(
+      '0:1#guild-1#ch-1#user-1',
+      { stage: 'awaiting_setup_modal', reason: 'abort' },
+    );
+    // Best-effort reply attempted (may fail itself; that's logged).
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('please run `/qurl setup` again'),
+      }),
+    );
   });
 });
 
@@ -1803,6 +1841,14 @@ describe('handleSetupModal (dispatcher path)', () => {
     await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
 
     expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
+    // Pin the 401-specific phrasing — the format-rejection branch
+    // also includes "Invalid API key", so a substring-only match
+    // could silently route through the wrong branch if VALID_KEY
+    // ever drifts. `Double-check your key` is unique to the 401
+    // path's blurb.
+    const replyArg = interaction.editReply.mock.calls.at(-1)[0];
+    expect(replyArg.content).toContain('Double-check your key');
+    expect(replyArg.content).not.toMatch(/format/);
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('Invalid API key'),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1829,6 +1829,45 @@ describe('handleSetupButton (dispatcher path)', () => {
   });
 });
 
+// Direct shape coverage of SETUP_API_KEY_REGEX. Round-tripping
+// through the handler (via VALID_KEY / 'short-bad-key') exercises
+// the format-rejection PATH; this pins the format itself, so adding
+// a new prefix family (lv_sandbox_, lv_internal_, etc.) requires a
+// deliberate test update rather than silently passing the existing
+// handler-level coverage.
+describe('SETUP_API_KEY_REGEX shape', () => {
+  const { SETUP_API_KEY_REGEX, SETUP_API_KEY_MAX_LENGTH } = _test;
+
+  test.each([
+    'lv_live_abcdefghijklmnopqrstuvwxyz12',
+    'lv_test_abcdefghijklmnopqrstuvwxyz12',
+    'lv_live_aaaaaaaaaaaaaaaaaaaa',                          // exactly 20 chars in suffix
+    'lv_test_AaBbCcDdEeFfGgHh-1234_5',                       // mixed-case + - + _
+  ])('accepts %s', (key) => {
+    expect(SETUP_API_KEY_REGEX.test(key)).toBe(true);
+  });
+
+  test.each([
+    '',
+    'live_abcdefghijklmnopqrstuvwxyz12',                     // missing lv_ prefix
+    'lv_sandbox_abcdefghijklmnopqrstuvwxyz12',               // unknown family
+    'lv_live_short',                                          // < 20-char suffix
+    'lv_live_abcdefghijklmnopqrst!!!!!',                     // disallowed char
+    'lv_live_abcdefghijklmnopqrstuvwxyz12 ',                 // trailing whitespace
+    'LV_LIVE_abcdefghijklmnopqrstuvwxyz12',                  // wrong case on prefix
+  ])('rejects %s', (key) => {
+    expect(SETUP_API_KEY_REGEX.test(key)).toBe(false);
+  });
+
+  it('declares a max length that exceeds the regex minimum', () => {
+    // 28 = 8 (lv_live_) + 20 (suffix floor). 64 leaves comfortable
+    // room above the floor; the constant itself is what the modal's
+    // setMaxLength uses, so a regression that drops it below the
+    // floor would surface as legitimate keys getting truncated.
+    expect(SETUP_API_KEY_MAX_LENGTH).toBeGreaterThan(28);
+  });
+});
+
 describe('handleSetupModal (dispatcher path)', () => {
   const { handleSetupModal } = require('../src/commands');
   const VALID_KEY = 'lv_live_abcdefghijklmnopqrstuvwxyz12';
@@ -1982,8 +2021,10 @@ describe('handleSetupModal (dispatcher path)', () => {
     // Identify the success-path editReply by exact match against
     // the production constant — no string drift on copy polish.
     const { SETUP_SUCCESS_MSG } = _test;
+    let successBranchInvoked = false;
     interaction.editReply = jest.fn().mockImplementation(async (arg) => {
       if (arg?.content === SETUP_SUCCESS_MSG) {
+        successBranchInvoked = true;
         throw new Error('Unknown interaction (token expired)');
       }
       return undefined;
@@ -1995,6 +2036,15 @@ describe('handleSetupModal (dispatcher path)', () => {
 
     // setGuildApiKey did commit before the editReply threw.
     expect(mockDb.setGuildApiKey).toHaveBeenCalled();
+    // Guard against a future refactor that augments the success
+    // editReply with extra fields (components, embeds, etc.) — the
+    // strict `arg.content === SETUP_SUCCESS_MSG` mock would silently
+    // miss the new shape and the test would pass green without
+    // exercising the swallow logic. Pin: the throw branch DID fire.
+    expect(successBranchInvoked).toBe(true);
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: SETUP_SUCCESS_MSG }),
+    );
   });
 
   it('propagates deferReply throw after deleteFlow (flow row already gone, key never persisted)', async () => {

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1813,12 +1813,14 @@ describe('handleSetupModal (dispatcher path)', () => {
     expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.stringContaining('already processed'),
+        // Covers both TTL'd and already-processed cases (deleted:false
+        // collapses both into the same branch).
+        content: expect.stringMatching(/expired or was already processed/),
       }),
     );
   });
 
-  it('rejects malformed API key', async () => {
+  it('rejects malformed API key with rerun hint', async () => {
     const interaction = makeModalInteraction({
       fields: { getTextInputValue: jest.fn(() => 'short-bad-key') },
     });
@@ -1827,11 +1829,12 @@ describe('handleSetupModal (dispatcher path)', () => {
 
     expect(global.fetch).not.toHaveBeenCalled();
     expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: expect.stringContaining('Invalid API key format'),
-      }),
-    );
+    const replyArg = interaction.reply.mock.calls.at(-1)[0];
+    expect(replyArg.content).toContain('Invalid API key format');
+    // The rerun hint is what closes the UX loop — the admin's flow
+    // row was already deleted by deleteFlow, so without this hint
+    // they'd be stuck without a path forward.
+    expect(replyArg.content).toContain('Run `/qurl setup` again');
   });
 
   it('surfaces 401 from qURL API as invalid-key message', async () => {

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1836,7 +1836,7 @@ describe('handleSetupButton (dispatcher path)', () => {
 // deliberate test update rather than silently passing the existing
 // handler-level coverage.
 describe('SETUP_API_KEY_REGEX shape', () => {
-  const { SETUP_API_KEY_REGEX, SETUP_API_KEY_MAX_LENGTH } = _test;
+  const { SETUP_API_KEY_REGEX, SETUP_API_KEY_MIN_LENGTH, SETUP_API_KEY_MAX_LENGTH } = _test;
 
   test.each([
     'lv_live_abcdefghijklmnopqrstuvwxyz12',
@@ -1859,12 +1859,17 @@ describe('SETUP_API_KEY_REGEX shape', () => {
     expect(SETUP_API_KEY_REGEX.test(key)).toBe(false);
   });
 
-  it('declares a max length that exceeds the regex minimum', () => {
-    // 28 = 8 (lv_live_) + 20 (suffix floor). 64 leaves comfortable
-    // room above the floor; the constant itself is what the modal's
-    // setMaxLength uses, so a regression that drops it below the
-    // floor would surface as legitimate keys getting truncated.
-    expect(SETUP_API_KEY_MAX_LENGTH).toBeGreaterThan(28);
+  it('min/max length constants form a coherent lockstep with the regex', () => {
+    // MIN = 28 = 8 (lv_live_/lv_test_) + 20 (regex suffix floor).
+    // MAX = 64 — defense-in-depth cap, well above MIN. Adding a
+    // new prefix family that changes the prefix length would have
+    // to bump MIN to stay coherent.
+    expect(SETUP_API_KEY_MIN_LENGTH).toBe(28);
+    expect(SETUP_API_KEY_MAX_LENGTH).toBeGreaterThan(SETUP_API_KEY_MIN_LENGTH);
+    // The regex itself accepts strings at the MIN boundary.
+    const atFloor = 'lv_live_' + 'a'.repeat(SETUP_API_KEY_MIN_LENGTH - 'lv_live_'.length);
+    expect(atFloor.length).toBe(SETUP_API_KEY_MIN_LENGTH);
+    expect(SETUP_API_KEY_REGEX.test(atFloor)).toBe(true);
   });
 });
 

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -132,6 +132,7 @@ jest.mock('discord.js', () => ({
     setPlaceholder: jest.fn().mockReturnThis(),
     setStyle: jest.fn().mockReturnThis(),
     setMaxLength: jest.fn().mockReturnThis(),
+    setMinLength: jest.fn().mockReturnThis(),
     setRequired: jest.fn().mockReturnThis(),
   })),
   TextInputStyle: { Short: 1, Paragraph: 2 },
@@ -157,6 +158,8 @@ const mockDb = {
   // gates fall through to config.QURL_API_KEY (which is set in
   // the config mock at the top of this file).
   getGuildApiKey: jest.fn().mockResolvedValue(null),
+  setGuildApiKey: jest.fn().mockResolvedValue(undefined),
+  getGuildConfig: jest.fn().mockResolvedValue(null),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   getSendItems: jest.fn(() => []),
@@ -1419,6 +1422,362 @@ describe('handleRevokeSelect (dispatcher path)', () => {
 
     expect(interaction.update).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('1/2') }),
+    );
+  });
+});
+
+// /qurl setup post-conversion (PR 6): legacy modal-paste path is now
+// button-first. The slash command writes a flow row + replies with a
+// button; clicking the button (dispatcher path) transitions the flow
+// and shows the modal; submitting the modal (dispatcher path)
+// validates the key + persists + deletes the flow.
+describe('/qurl setup subcommand (legacy modal-paste path)', () => {
+  const originalKEK = process.env.KEY_ENCRYPTION_KEY;
+  const originalAuthDomain = process.env.AUTH0_DOMAIN;
+  beforeAll(() => {
+    process.env.KEY_ENCRYPTION_KEY = '0'.repeat(64);
+    // Force the legacy path by clearing any Auth0 hints. The config
+    // mock at the top of this file doesn't define AUTH0_* and we
+    // rely on `config.isQurlOAuthConfigured` being falsy.
+    delete process.env.AUTH0_DOMAIN;
+  });
+  afterAll(() => {
+    if (originalKEK === undefined) delete process.env.KEY_ENCRYPTION_KEY;
+    else process.env.KEY_ENCRYPTION_KEY = originalKEK;
+    if (originalAuthDomain === undefined) delete process.env.AUTH0_DOMAIN;
+    else process.env.AUTH0_DOMAIN = originalAuthDomain;
+  });
+  beforeEach(() => {
+    mockCreateFlow.mockResolvedValue({ created: true, version: 1 });
+    mockDeleteFlow.mockResolvedValue({ deleted: true });
+  });
+
+  function makeSetupInteraction() {
+    return makeInteraction({
+      commandName: 'qurl',
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'setup'),
+      },
+    });
+  }
+
+  it('opens a flow row + renders the configure button', async () => {
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+
+    await cmd.execute(interaction);
+
+    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+    const createArgs = mockCreateFlow.mock.calls[0][0];
+    expect(createArgs.stage).toBe('awaiting_setup_button');
+    expect(createArgs.payload).toBeNull();
+    expect(createArgs.flow_id).toBe('0:1#guild-1#ch-1#user-1');
+
+    const buttonCall = interaction.editReply.mock.calls.find(
+      (c) => c[0]?.components?.length > 0,
+    );
+    expect(buttonCall).toBeDefined();
+    expect(buttonCall[0].content).toMatch(/Connect qURL to this server/);
+  });
+
+  it('refuses if KEK is not set', async () => {
+    const savedKEK = process.env.KEY_ENCRYPTION_KEY;
+    delete process.env.KEY_ENCRYPTION_KEY;
+    try {
+      const cmd = commands.find(c => c.data.name === 'qurl');
+      const interaction = makeSetupInteraction();
+      await cmd.execute(interaction);
+
+      expect(mockCreateFlow).not.toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('KEY_ENCRYPTION_KEY'),
+        }),
+      );
+    } finally {
+      process.env.KEY_ENCRYPTION_KEY = savedKEK;
+    }
+  });
+
+  it('refuses in DM context', async () => {
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    interaction.guildId = null;
+
+    await cmd.execute(interaction);
+
+    expect(mockCreateFlow).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('server, not in DMs'),
+      }),
+    );
+  });
+
+  it('refuses for non-admin users', async () => {
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    interaction.memberPermissions = { has: jest.fn().mockReturnValue(false) };
+
+    await cmd.execute(interaction);
+
+    expect(mockCreateFlow).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('administrators'),
+      }),
+    );
+  });
+
+  it('supersedes a stale pre-modal flow', async () => {
+    mockCreateFlow
+      .mockResolvedValueOnce({ created: false })
+      .mockResolvedValueOnce({ created: true, version: 1 });
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    await cmd.execute(interaction);
+
+    expect(mockDeleteFlow).toHaveBeenCalledWith(
+      '0:1#guild-1#ch-1#user-1',
+      { stage: 'awaiting_setup_button', reason: 'admin_cleanup' },
+    );
+    expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+    const buttonCall = interaction.editReply.mock.calls.find(
+      (c) => c[0]?.components?.length > 0,
+    );
+    expect(buttonCall).toBeDefined();
+  });
+
+  it('blocks when a mid-modal flow is in progress (supersede fails on stage gate)', async () => {
+    // Harness-level guarantee: deleteFlow with stage='awaiting_setup_button'
+    // returns deleted:false when the row is actually in
+    // 'awaiting_setup_modal'. The retry createFlow then conflicts on
+    // the existing row.
+    mockCreateFlow
+      .mockResolvedValueOnce({ created: false })
+      .mockResolvedValueOnce({ created: false });
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    await cmd.execute(interaction);
+
+    const blockedCall = interaction.editReply.mock.calls.find(
+      (c) => /modal open/.test(c[0]?.content || ''),
+    );
+    expect(blockedCall).toBeDefined();
+  });
+});
+
+describe('handleSetupButton (dispatcher path)', () => {
+  const { handleSetupButton } = require('../src/commands');
+
+  function makeButtonInteraction(overrides = {}) {
+    return {
+      user: { id: 'user-1' },
+      guildId: 'guild-1',
+      channelId: 'ch-1',
+      showModal: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  it('transitions flow to awaiting_setup_modal + shows modal on success', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'success', version: 2 });
+    const interaction = makeButtonInteraction();
+
+    await handleSetupButton(interaction, {
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      row: { stage: 'awaiting_setup_button', version: 1 },
+    });
+
+    const transitionArgs = mockTransitionFlow.mock.calls[0];
+    expect(transitionArgs[0]).toBe('0:1#guild-1#ch-1#user-1');
+    expect(transitionArgs[1]).toBe(1); // version
+    expect(transitionArgs[2].stage_to).toBe('awaiting_setup_modal');
+    expect(transitionArgs[2].terminal).toBe(false);
+    expect(transitionArgs[2].set_expires_at).toEqual(expect.any(Number));
+
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('replies (no modal) on OCC conflict', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict', version: null });
+    const interaction = makeButtonInteraction();
+
+    await handleSetupButton(interaction, {
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      row: { stage: 'awaiting_setup_button', version: 1 },
+    });
+
+    expect(interaction.showModal).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Another setup attempt'),
+      }),
+    );
+  });
+
+  it('replies on not_found (TTL race)', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found', version: null });
+    const interaction = makeButtonInteraction();
+
+    await handleSetupButton(interaction, {
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      row: { stage: 'awaiting_setup_button', version: 1 },
+    });
+
+    expect(interaction.showModal).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('expired'),
+      }),
+    );
+  });
+
+  it('replies on transition error', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'error', version: null });
+    const interaction = makeButtonInteraction();
+
+    await handleSetupButton(interaction, {
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      row: { stage: 'awaiting_setup_button', version: 1 },
+    });
+
+    expect(interaction.showModal).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalled();
+  });
+});
+
+describe('handleSetupModal (dispatcher path)', () => {
+  const { handleSetupModal } = require('../src/commands');
+  const VALID_KEY = 'lv_live_abcdefghijklmnopqrstuvwxyz12';
+
+  function makeModalInteraction(overrides = {}) {
+    return {
+      user: { id: 'user-1' },
+      guildId: 'guild-1',
+      channelId: 'ch-1',
+      fields: {
+        getTextInputValue: jest.fn(() => VALID_KEY),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  let originalFetch;
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+  beforeEach(() => {
+    mockDeleteFlow.mockResolvedValue({ deleted: true });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+  });
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('validates key + persists + replies success', async () => {
+    const interaction = makeModalInteraction();
+    await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(mockDeleteFlow).toHaveBeenCalledWith(
+      '0:1#guild-1#ch-1#user-1',
+      { stage: 'awaiting_setup_modal', reason: 'terminal' },
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockDb.setGuildApiKey).toHaveBeenCalledWith(
+      'guild-1', VALID_KEY, 'user-1',
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('qURL is now configured'),
+      }),
+    );
+  });
+
+  it('skips work when deleteFlow loses dedup race', async () => {
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const interaction = makeModalInteraction();
+
+    await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('already processed'),
+      }),
+    );
+  });
+
+  it('rejects malformed API key', async () => {
+    const interaction = makeModalInteraction({
+      fields: { getTextInputValue: jest.fn(() => 'short-bad-key') },
+    });
+
+    await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Invalid API key format'),
+      }),
+    );
+  });
+
+  it('surfaces 401 from qURL API as invalid-key message', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const interaction = makeModalInteraction();
+
+    await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Invalid API key'),
+      }),
+    );
+  });
+
+  it('redacts network-error details from user-facing reply', async () => {
+    // Internal hostnames or IPs in err.message must NOT leak to
+    // Discord. The pre-conversion code carried this guarantee and
+    // the dispatcher path preserves it.
+    global.fetch = jest.fn().mockRejectedValue(
+      new Error('connect ECONNREFUSED 10.0.0.5:8080'),
+    );
+    const interaction = makeModalInteraction();
+
+    await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
+    const replyContent = interaction.editReply.mock.calls.at(-1)[0].content;
+    expect(replyContent).not.toMatch(/10\.0\.0\.5/);
+    expect(replyContent).not.toMatch(/ECONNREFUSED/);
+    expect(replyContent).toContain('Could not validate key');
+  });
+
+  it('surfaces non-2xx non-401 as generic API error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+    const interaction = makeModalInteraction();
+
+    await handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' });
+
+    expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('503'),
+      }),
     );
   });
 });

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1979,14 +1979,11 @@ describe('handleSetupModal (dispatcher path)', () => {
     // swallows it. Use mockImplementation rather than mockRejected
     // so the prior editReply assertions on other tests aren't
     // disturbed.
-    // Substring `'configured for this server'` is the stable token
-    // — it's the load-bearing UX phrase ("qURL is now configured
-    // for this server") that survives copy tweaks. Matching on the
-    // leading "✅" emoji or full sentence would break the moment
-    // someone polishes the wording; matching on this phrase pins
-    // the throw to the persist-success branch specifically.
+    // Identify the success-path editReply by exact match against
+    // the production constant — no string drift on copy polish.
+    const { SETUP_SUCCESS_MSG } = _test;
     interaction.editReply = jest.fn().mockImplementation(async (arg) => {
-      if (typeof arg?.content === 'string' && arg.content.includes('configured for this server')) {
+      if (arg?.content === SETUP_SUCCESS_MSG) {
         throw new Error('Unknown interaction (token expired)');
       }
       return undefined;

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1706,6 +1706,17 @@ describe('handleSetupButton (dispatcher path)', () => {
 
     expect(interaction.showModal).toHaveBeenCalledTimes(1);
     expect(interaction.reply).not.toHaveBeenCalled();
+
+    // Pin the API-key TextInput length bounds. The 28-char floor
+    // matches the regex's minimum (8-char prefix + 20-char suffix);
+    // the 64-char ceiling carries the TODO(upstream-rebrand) lockstep
+    // marker. A regression that drops either bound — exactly the
+    // risk the marker is meant to surface — would now trip this
+    // assertion instead of sliding through green.
+    const { TextInputBuilder } = require('discord.js');
+    const lastInputBuilder = TextInputBuilder.mock.results.at(-1).value;
+    expect(lastInputBuilder.setMinLength).toHaveBeenCalledWith(28);
+    expect(lastInputBuilder.setMaxLength).toHaveBeenCalledWith(64);
   });
 
   it('replies (no modal) on OCC conflict', async () => {

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1578,20 +1578,48 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     expect(blockedCall).toBeDefined();
   });
 
-  it('uses generic wording when retry fails for a sibling-flow / race (not mid-modal)', async () => {
-    // The post-failure loadFlow peek discriminates: if the surviving
-    // row at flow_id is NOT awaiting_setup_modal, the user sees the
-    // generic "could not start" message instead of the misleading
-    // "modal open" wording.
+  it('names the sibling revoke flow when retry fails because revoke is in-flight', async () => {
+    // The post-failure loadFlow peek discriminates known sibling
+    // stages: if the surviving row is awaiting_revoke_select, the
+    // user sees actionable wording telling them to finish/cancel
+    // their revoke first — instead of "try again" which would loop
+    // forever until the revoke's TTL fires.
     mockCreateFlow
       .mockResolvedValueOnce({ created: false })
       .mockResolvedValueOnce({ created: false });
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     mockLoadFlow.mockResolvedValueOnce({
       flow_id: '0:1#guild-1#ch-1#user-1',
-      stage: 'awaiting_revoke_select', // sibling flow type
+      stage: 'awaiting_revoke_select',
       version: 1,
     });
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    await cmd.execute(interaction);
+
+    const revokeMentionCall = interaction.editReply.mock.calls.find(
+      (c) => /\/qurl revoke.*menu open/.test(c[0]?.content || ''),
+    );
+    expect(revokeMentionCall).toBeDefined();
+    const modalMsgCall = interaction.editReply.mock.calls.find(
+      (c) => /modal open/.test(c[0]?.content || ''),
+    );
+    expect(modalMsgCall).toBeUndefined();
+  });
+
+  it('falls back to generic wording for an unknown sibling stage / two-races-in-a-row', async () => {
+    // If the surviving row is at a stage the dispatcher doesn't
+    // recognize as a known sibling (e.g. an in-flight flow type
+    // added in a future PR before its stage gets a sibling-message
+    // entry, OR the row vanished entirely between the retry and
+    // the peek), the user gets the generic "could not start"
+    // wording. Better than naming a flow that doesn't fit.
+    mockCreateFlow
+      .mockResolvedValueOnce({ created: false })
+      .mockResolvedValueOnce({ created: false });
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    mockLoadFlow.mockResolvedValueOnce(null); // row vanished
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeSetupInteraction();
@@ -1601,10 +1629,6 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
       (c) => /Could not start a setup session/.test(c[0]?.content || ''),
     );
     expect(genericCall).toBeDefined();
-    const modalMsgCall = interaction.editReply.mock.calls.find(
-      (c) => /modal open/.test(c[0]?.content || ''),
-    );
-    expect(modalMsgCall).toBeUndefined();
   });
 
   it('propagates the throw when the first createFlow fails (caught by handleCommand)', async () => {
@@ -1679,23 +1703,22 @@ describe('handleSetupButton (dispatcher path)', () => {
     expect(transitionArgs[1]).toBe(1); // version
     expect(transitionArgs[2].stage_to).toBe('awaiting_setup_modal');
     expect(transitionArgs[2].terminal).toBe(false);
-    // Pin the modal-stage TTL (300s), not just "some number" —
-    // a refactor that accidentally re-used SETUP_BUTTON_TTL_SECONDS
-    // here would pass an `any(Number)` assertion. Lower bound is
-    // `now + 250` (allows ~50s of clock drift / test execution time);
-    // upper bound is `now + 350`.
+    // Pin the modal-stage TTL window against the production constant
+    // (NOT a duplicated local literal — if the constant is tuned, a
+    // stale local would silently pass).
+    const { SETUP_BUTTON_TTL_SECONDS, SETUP_MODAL_TTL_SECONDS } = _test;
     const nowSec = Math.floor(Date.now() / 1000);
-    expect(transitionArgs[2].set_expires_at).toBeGreaterThan(nowSec + 250);
-    expect(transitionArgs[2].set_expires_at).toBeLessThanOrEqual(nowSec + 350);
+    // Lower bound allows ~50s of clock drift / test execution time;
+    // upper bound is the modal TTL itself.
+    expect(transitionArgs[2].set_expires_at).toBeGreaterThan(nowSec + SETUP_MODAL_TTL_SECONDS - 50);
+    expect(transitionArgs[2].set_expires_at).toBeLessThanOrEqual(nowSec + SETUP_MODAL_TTL_SECONDS);
     // `extended: true` audit-flag pin: the new expires_at must
     // exceed the original button-stage TTL window. flow-state.js
     // computes `extended = set_expires_at > priorExpires`; the
     // prior expires_at on a fresh row is at most
     // `now + SETUP_BUTTON_TTL_SECONDS`, so any value strictly
     // greater than that guarantees extended=true at the audit
-    // emission. Pins the "button → modal transitions extend the
-    // TTL" contract that's documented in the handler comment.
-    const SETUP_BUTTON_TTL_SECONDS = 120;
+    // emission.
     expect(transitionArgs[2].set_expires_at).toBeGreaterThan(nowSec + SETUP_BUTTON_TTL_SECONDS);
     // Pin: button-stage transition must NOT write a payload. The
     // setup flow carries no encrypted state — the key itself

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1624,6 +1624,31 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     await expect(cmd.execute(interaction)).rejects.toThrow('DDB region timeout');
     expect(mockDeleteFlow).not.toHaveBeenCalled();
   });
+
+  it('handleCommand wraps the createFlow throw into a generic user-visible reply', async () => {
+    // Integration-style pin: drive the same throw THROUGH handleCommand
+    // (not just cmd.execute) and assert the outer try/catch in
+    // handleCommand surfaces the recoverable "There was an error"
+    // message. Closes the gap between "cmd.execute throws" and
+    // "user sees an error" — a future refactor that swallows the
+    // envelope reply would break user-visible UX without tripping
+    // the bare cmd.execute test above.
+    mockCreateFlow.mockRejectedValueOnce(new Error('DDB region timeout'));
+
+    const interaction = makeSetupInteraction();
+    await handleCommand(interaction);
+
+    // handleCommand uses followUp when interaction is deferred/replied
+    // (deferReply fired inside the setup branch before the throw).
+    const replyCalls = [
+      ...interaction.followUp.mock.calls,
+      ...interaction.reply.mock.calls,
+    ];
+    const errorReply = replyCalls.find(
+      (c) => /There was an error executing this command/.test(c[0]?.content || ''),
+    );
+    expect(errorReply).toBeDefined();
+  });
 });
 
 describe('handleSetupButton (dispatcher path)', () => {
@@ -1654,7 +1679,14 @@ describe('handleSetupButton (dispatcher path)', () => {
     expect(transitionArgs[1]).toBe(1); // version
     expect(transitionArgs[2].stage_to).toBe('awaiting_setup_modal');
     expect(transitionArgs[2].terminal).toBe(false);
-    expect(transitionArgs[2].set_expires_at).toEqual(expect.any(Number));
+    // Pin the modal-stage TTL (300s), not just "some number" —
+    // a refactor that accidentally re-used SETUP_BUTTON_TTL_SECONDS
+    // here would pass an `any(Number)` assertion. Lower bound is
+    // `now + 250` (allows ~50s of clock drift / test execution time);
+    // upper bound is `now + 350`.
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(transitionArgs[2].set_expires_at).toBeGreaterThan(nowSec + 250);
+    expect(transitionArgs[2].set_expires_at).toBeLessThanOrEqual(nowSec + 350);
     // Pin: button-stage transition must NOT write a payload. The
     // setup flow carries no encrypted state — the key itself
     // arrives in interaction.fields on the modal submit, not in

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1554,20 +1554,75 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     // Harness-level guarantee: deleteFlow with stage='awaiting_setup_button'
     // returns deleted:false when the row is actually in
     // 'awaiting_setup_modal'. The retry createFlow then conflicts on
-    // the existing row.
+    // the existing row, and the loadFlow peek confirms the prior
+    // flow is mid-modal so the user-visible message names the modal.
     mockCreateFlow
       .mockResolvedValueOnce({ created: false })
       .mockResolvedValueOnce({ created: false });
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    mockLoadFlow.mockResolvedValueOnce({
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      stage: 'awaiting_setup_modal',
+      version: 2,
+    });
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeSetupInteraction();
     await cmd.execute(interaction);
 
+    // Pin the slash-path block message specifically — not the
+    // button-handler conflict message which also contains "modal".
     const blockedCall = interaction.editReply.mock.calls.find(
-      (c) => /modal open/.test(c[0]?.content || ''),
+      (c) => /already have a `\/qurl setup` modal open/.test(c[0]?.content || ''),
     );
     expect(blockedCall).toBeDefined();
+  });
+
+  it('uses generic wording when retry fails for a sibling-flow / race (not mid-modal)', async () => {
+    // The post-failure loadFlow peek discriminates: if the surviving
+    // row at flow_id is NOT awaiting_setup_modal, the user sees the
+    // generic "could not start" message instead of the misleading
+    // "modal open" wording.
+    mockCreateFlow
+      .mockResolvedValueOnce({ created: false })
+      .mockResolvedValueOnce({ created: false });
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    mockLoadFlow.mockResolvedValueOnce({
+      flow_id: '0:1#guild-1#ch-1#user-1',
+      stage: 'awaiting_revoke_select', // sibling flow type
+      version: 1,
+    });
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    await cmd.execute(interaction);
+
+    const genericCall = interaction.editReply.mock.calls.find(
+      (c) => /Could not start a setup session/.test(c[0]?.content || ''),
+    );
+    expect(genericCall).toBeDefined();
+    const modalMsgCall = interaction.editReply.mock.calls.find(
+      (c) => /modal open/.test(c[0]?.content || ''),
+    );
+    expect(modalMsgCall).toBeUndefined();
+  });
+
+  it('propagates the throw when the first createFlow fails (caught by handleCommand)', async () => {
+    // The slash-path's first createFlow has no try/catch — a throw
+    // there propagates to handleCommand's outer error envelope
+    // (commands.js handleCommand try/catch), which replies the
+    // generic "There was an error executing this command." Pin
+    // here that cmd.execute lets the throw bubble; if a future
+    // refactor adds a try/catch around the first createFlow and
+    // accidentally swallows it (no user-visible error), this test
+    // trips instead of regressing silently.
+    mockCreateFlow.mockRejectedValueOnce(new Error('DDB region timeout'));
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+
+    await expect(cmd.execute(interaction)).rejects.toThrow('DDB region timeout');
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1687,6 +1687,16 @@ describe('handleSetupButton (dispatcher path)', () => {
     const nowSec = Math.floor(Date.now() / 1000);
     expect(transitionArgs[2].set_expires_at).toBeGreaterThan(nowSec + 250);
     expect(transitionArgs[2].set_expires_at).toBeLessThanOrEqual(nowSec + 350);
+    // `extended: true` audit-flag pin: the new expires_at must
+    // exceed the original button-stage TTL window. flow-state.js
+    // computes `extended = set_expires_at > priorExpires`; the
+    // prior expires_at on a fresh row is at most
+    // `now + SETUP_BUTTON_TTL_SECONDS`, so any value strictly
+    // greater than that guarantees extended=true at the audit
+    // emission. Pins the "button → modal transitions extend the
+    // TTL" contract that's documented in the handler comment.
+    const SETUP_BUTTON_TTL_SECONDS = 120;
+    expect(transitionArgs[2].set_expires_at).toBeGreaterThan(nowSec + SETUP_BUTTON_TTL_SECONDS);
     // Pin: button-stage transition must NOT write a payload. The
     // setup flow carries no encrypted state — the key itself
     // arrives in interaction.fields on the modal submit, not in

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1903,10 +1903,12 @@ describe('handleSetupModal (dispatcher path)', () => {
     // swallows it. Use mockImplementation rather than mockRejected
     // so the prior editReply assertions on other tests aren't
     // disturbed.
-    // Match on a stable substring shared by every success-blurb
-    // revision rather than the full copy — so a future tweak of
-    // the success message doesn't silently stop this test
-    // asserting at the throw site.
+    // Substring `'configured for this server'` is the stable token
+    // — it's the load-bearing UX phrase ("qURL is now configured
+    // for this server") that survives copy tweaks. Matching on the
+    // leading "✅" emoji or full sentence would break the moment
+    // someone polishes the wording; matching on this phrase pins
+    // the throw to the persist-success branch specifically.
     interaction.editReply = jest.fn().mockImplementation(async (arg) => {
       if (typeof arg?.content === 'string' && arg.content.includes('configured for this server')) {
         throw new Error('Unknown interaction (token expired)');
@@ -1920,6 +1922,32 @@ describe('handleSetupModal (dispatcher path)', () => {
 
     // setGuildApiKey did commit before the editReply threw.
     expect(mockDb.setGuildApiKey).toHaveBeenCalled();
+  });
+
+  it('propagates deferReply throw after deleteFlow (flow row already gone, key never persisted)', async () => {
+    // Pin the post-deleteFlow / pre-deferReply window. If
+    // deferReply throws (token expired during the DDB round-trip),
+    // the flow row is already gone but the qURL API call never
+    // fires and setGuildApiKey never runs. Admin sees Discord's
+    // generic "interaction failed" and reruns /qurl setup; the
+    // supersede path finds no row (deleted) so a fresh button
+    // renders cleanly. The throw itself propagates to the
+    // dispatcher's safety net.
+    const deferErr = new Error('Unknown interaction (token expired)');
+    const interaction = makeModalInteraction({
+      deferReply: jest.fn().mockRejectedValue(deferErr),
+    });
+
+    await expect(
+      handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' })
+    ).rejects.toThrow('Unknown interaction');
+
+    expect(mockDeleteFlow).toHaveBeenCalledWith(
+      '0:1#guild-1#ch-1#user-1',
+      { stage: 'awaiting_setup_modal', reason: 'terminal' },
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockDb.setGuildApiKey).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -159,7 +159,6 @@ const mockDb = {
   // the config mock at the top of this file).
   getGuildApiKey: jest.fn().mockResolvedValue(null),
   setGuildApiKey: jest.fn().mockResolvedValue(undefined),
-  getGuildConfig: jest.fn().mockResolvedValue(null),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   getSendItems: jest.fn(() => []),
@@ -1640,17 +1639,24 @@ describe('handleSetupButton (dispatcher path)', () => {
     );
   });
 
-  it('replies on transition error', async () => {
-    mockTransitionFlow.mockResolvedValueOnce({ result: 'error', version: null });
+  it('propagates throws from transitionFlow (caught by dispatcher safety net)', async () => {
+    // transitionFlow throws on non-CCFE failures (DDB outage, pre-
+    // read errors); it does not synthesize a `result: 'error'`
+    // return value. The handler must let the throw propagate so the
+    // dispatcher's universal safety net catches it — wrapping it
+    // here would swallow the audit signal flow-state already
+    // emitted for the failure.
+    const ddbErr = new Error('DDB region timeout');
+    mockTransitionFlow.mockRejectedValueOnce(ddbErr);
     const interaction = makeButtonInteraction();
 
-    await handleSetupButton(interaction, {
+    await expect(handleSetupButton(interaction, {
       flow_id: '0:1#guild-1#ch-1#user-1',
       row: { stage: 'awaiting_setup_button', version: 1 },
-    });
+    })).rejects.toThrow('DDB region timeout');
 
     expect(interaction.showModal).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalled();
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 });
 
@@ -1779,6 +1785,37 @@ describe('handleSetupModal (dispatcher path)', () => {
         content: expect.stringContaining('503'),
       }),
     );
+  });
+
+  it('swallows Discord errors on the post-persist success reply', async () => {
+    // The key is already saved by the time the success editReply
+    // fires. If editReply throws (Discord interaction-token expiry,
+    // transient API blip), the throw must NOT propagate to the
+    // dispatcher's universal safety net — that net replies "run
+    // the command again", which would be misleading after a
+    // successful persist. Admin can confirm via /qurl status.
+    const interaction = makeModalInteraction();
+    // First editReply (success path) throws; verify the handler
+    // swallows it. Use mockImplementation rather than mockRejected
+    // so the prior editReply assertions on other tests aren't
+    // disturbed.
+    // Match on a stable substring shared by every success-blurb
+    // revision rather than the full copy — so a future tweak of
+    // the success message doesn't silently stop this test
+    // asserting at the throw site.
+    interaction.editReply = jest.fn().mockImplementation(async (arg) => {
+      if (typeof arg?.content === 'string' && arg.content.includes('configured for this server')) {
+        throw new Error('Unknown interaction (token expired)');
+      }
+      return undefined;
+    });
+
+    await expect(
+      handleSetupModal(interaction, { flow_id: '0:1#guild-1#ch-1#user-1' })
+    ).resolves.not.toThrow();
+
+    // setGuildApiKey did commit before the editReply threw.
+    expect(mockDb.setGuildApiKey).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Second slash command converted off in-memory `await*` (after `/qurl revoke` in #256). The legacy `/qurl setup` modal-paste fallback used `interaction.awaitModalSubmit({ time: 120000 })` — an in-process Promise that a deploy mid-paste would drop, forcing the admin to rerun from scratch.

## Business context

`/qurl setup` is the first contact point for every new server admin: they install the bot, run `/qurl setup`, paste their qURL API key. Today, a rolling deploy in the middle of that paste silently loses the modal and surfaces nothing — the admin assumes the bot is broken and bounces. With this PR, the button + modal are persistent message components backed by DDB, so any process can pick up the modal-submit event.

## Two-stage flow

```
/qurl setup (slash)         createFlow(awaiting_setup_button, TTL 120s)
    → editReply with [Configure qURL] button
button click (dispatcher)   transitionFlow → awaiting_setup_modal
    → showModal()              (set_expires_at extends TTL to 300s)
modal submit (dispatcher)   deleteFlow(terminal) → validate key →
    → editReply success         setGuildApiKey → reply
```

The button-stage TTL is intentionally short (120s — admins should click promptly); the modal stage gets the real 5-minute window for finding and pasting.

## Supersede / block matrix

Falls out for free from the stage-gated `deleteFlow` shipped in #256's review fixes:

- Admin clicked `/qurl setup`, walked away, comes back, reruns → supersede succeeds (stage gate matches `awaiting_setup_button`), fresh button shown.
- Admin is actively typing in the modal, opens another `/qurl setup` from a different client → supersede fails (stage gate refuses to admin_cleanup `awaiting_setup_modal`), admin sees "you already have a modal open."

Documented in `docs/zero-downtime-design.md` per-command override table.

## OAuth path untouched

OAuth (when `AUTH0_*` is configured) has no `await*` in process — its persistence is the signed state token + `pending_links` SQLite row. It doesn't enter the flow_state ledger and was not refactored.

## Test plan

- [x] `/qurl setup` slash-command path: opens flow + renders button; refuses without KEK / in DM / for non-admins; supersedes stale pre-modal flow; blocks on mid-modal flow (4 cases)
- [x] `handleSetupButton` dispatcher path: transitions flow + shows modal on success; replies (no modal) on OCC conflict / not_found / error (4 cases)
- [x] `handleSetupModal` dispatcher path: validates key + persists + replies success; dedup-loser short-circuits; rejects malformed key format; 401 from qURL API; redacts network errors; non-2xx generic error (6 cases)
- [x] All 1150 tests pass, lint clean
- [x] Coverage 83.05 / 75.66 / 82.2 / 84.69 (above 78/68/78/78 floor)

## Known follow-ups

- The supersede-and-retry block at `commands.js` is now duplicated at 2 callsites (revoke + setup). Will be at 3+ after PR 7. Extract to a `supersedeOrCreate(flow_id, opts)` primitive in `flow-state.js` before PR 7 lands — track on #261 or a new issue.
- The `INTERACTION_HANDLED` audit gap (deferred from #256 review) — now a clearer picture with two dispatcher consumers; pick this up before PR 7 so the alarm-side metric filter knows about component/modal handler timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
