### PR TITLE
refactor(discord): consolidate flow_state supersede primitive

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -31,8 +31,8 @@ const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
-const { createFlow, deleteFlow, transitionFlow, loadFlow } = require('./flow-state');
-const { flowIdForInteraction, registerFlow, safeReply } = require('./flow-dispatch');
+const { deleteFlow, transitionFlow, supersedeOrCreate } = require('./flow-state');
+const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } = require('./flow-dispatch');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
@@ -2626,10 +2626,10 @@ async function handleRevoke(interaction, apiKey) {
     return interaction.editReply({ content: 'No recent sends to revoke.' });
   }
 
-  // Open the flow row BEFORE rendering the menu. If createFlow fails
-  // (DDB outage, IAM regression), we want the user to see an error
-  // immediately rather than a clickable menu whose selection would
-  // then 404 against the dispatcher.
+  // Open the flow row BEFORE rendering the menu. If the harness
+  // fails (DDB outage, IAM regression), we want the user to see an
+  // error immediately rather than a clickable menu whose selection
+  // would then 404 against the dispatcher.
   //
   // Supersede semantics: a user with an existing in-flight revoke
   // flow who runs `/qurl revoke` again gets the old flow torn down
@@ -2642,61 +2642,50 @@ async function handleRevoke(interaction, apiKey) {
   // the menu is a stateless listing and the second invocation is
   // idempotent, so blocking it would just confuse users who can't
   // remember whether they cancelled the prior menu.
+  //
+  // supersedeOrCreate (flow-state.js) encapsulates the create →
+  // load → version-gated delete → retry sequence shared by all
+  // two-stage flows; the only flow-specific shape here is the
+  // sibling-flow disambiguation when a non-revoke row owns the
+  // flow_id.
   const flow_id = flowIdForInteraction(interaction);
-  const expires_at = Math.floor(Date.now() / 1000) + REVOKE_FLOW_TTL_SECONDS;
-  const created = await createFlow({
-    flow_id,
-    stage: REVOKE_STAGE_AWAITING_SELECT,
-    payload: null,
-    expires_at,
-  });
-  if (!created.created) {
-    // Existing row from a prior /qurl revoke. Tear it down (the
-    // stage gate on deleteFlow ensures we won't admin_cleanup a
-    // sibling flow at the same flow_id, e.g. an in-flight setup
-    // modal) and try again. The admin_cleanup reason marks this as
-    // an out-of-band delete rather than a terminal completion —
-    // keeps the SLI's silently_dropped count honest (the prior
-    // flow never reached its own terminal).
-    //
-    // If deleteFlow returns deleted:false the row at this flow_id
-    // belongs to a different flow type; the retry createFlow will
-    // then also return created:false and the user gets the generic
-    // "could not start" message. That's correct — we don't want to
-    // bulldoze a sibling flow.
-    await deleteFlow(flow_id, {
+  let supersede;
+  try {
+    supersede = await supersedeOrCreate({
+      flow_id,
       stage: REVOKE_STAGE_AWAITING_SELECT,
-      reason: 'admin_cleanup',
+      payload: null,
+      ttl_seconds: REVOKE_FLOW_TTL_SECONDS,
     });
-    let retry;
-    try {
-      retry = await createFlow({
-        flow_id,
-        stage: REVOKE_STAGE_AWAITING_SELECT,
-        payload: null,
-        expires_at,
-      });
-    } catch (err) {
-      // DDB throttle / IAM blip on the retry — the prior flow row
-      // is gone but we couldn't open a new one. Surface a
-      // recoverable error rather than letting it propagate to the
-      // generic "error executing command" reply.
-      logger.warn('handleRevoke: createFlow retry threw after admin_cleanup', {
-        flow_id, error: err && err.message,
-      });
-      return interaction.editReply({
-        content: 'Could not start a revoke session — please try again.',
-      });
+  } catch (err) {
+    // DDB throttle / IAM blip — surface as recoverable rather than
+    // letting it propagate to the generic "error executing command"
+    // reply. supersedeOrCreate internally already retried once, so
+    // throws here are real (not transient OCC churn).
+    logger.warn('handleRevoke: supersedeOrCreate threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.editReply({
+      content: 'Could not start a revoke session — please try again.',
+    });
+  }
+  if (!supersede.created) {
+    // A sibling flow owns this flow_id (or we lost two OCC races
+    // in a row). Look up the sibling-message via the dispatcher's
+    // registry — known sibling stage (setup-modal etc.) gets
+    // actionable wording naming the command the user should
+    // finish or cancel first; an unknown or vanished surviving
+    // row falls through to the generic "try again."
+    logger.warn('handleRevoke: supersedeOrCreate did not claim slot', {
+      flow_id, surviving_stage: supersede.surviving?.stage ?? null,
+    });
+    const siblingMsg = siblingMessageForStage(supersede.surviving?.stage);
+    if (siblingMsg) {
+      return interaction.editReply({ content: siblingMsg });
     }
-    if (!retry.created) {
-      // Two races in a row (or a sibling flow blocking us). Surface
-      // as an error rather than loop — the user can retry the
-      // command, or finish their other in-flight flow.
-      logger.warn('handleRevoke: createFlow racy after admin_cleanup', { flow_id });
-      return interaction.editReply({
-        content: 'Could not start a revoke session — please try again.',
-      });
-    }
+    return interaction.editReply({
+      content: 'Could not start a revoke session — please try again.',
+    });
   }
 
   const select = new StringSelectMenuBuilder()
@@ -2843,24 +2832,6 @@ const SETUP_SUCCESS_MSG =
   + 'Your team can use `/qurl send` to share files and locations securely.\n'
   + 'All qURL usage will be billed to your API key.';
 
-// Sibling-flow → message map for the post-supersede-retry-failure
-// disambiguation in handleSetup. Each entry says: "if the surviving
-// row at this flow_id is at THIS stage, tell the admin what to do
-// about it." The forgot-to-add-an-entry footgun is real once more
-// flows land — the dispatcher-side test in
-// commands-comprehensive.test.js pins both the known-stage and
-// generic-fallback branches.
-//
-// Future PRs (e.g. /qurl send) should add their awaiting_* entry
-// here as they ship.
-const SIBLING_FLOW_MESSAGES = {
-  [REVOKE_STAGE_AWAITING_SELECT]:
-    'You have a `/qurl revoke` menu open in this channel — finish or cancel it first.',
-};
-function siblingMessageForStage(stage) {
-  return SIBLING_FLOW_MESSAGES[stage] ?? null;
-}
-
 // Button-stage handler. Routed by flow-dispatch when the admin
 // clicks the [Configure qURL] button rendered by handleSetup.
 //
@@ -2931,20 +2902,19 @@ async function handleSetupButton(interaction, { flow_id, row }) {
 
   // Roll back the OCC transition if showModal throws. Without the
   // delete, the row sits at awaiting_setup_modal until TTL and the
-  // admin's /qurl setup rerun trips the loadFlow-peek into the
-  // misleading "you already have a modal open" branch. If the
-  // rollback itself also fails (DDB region outage), both errors
-  // log at error-level — admin recovery is the SETUP_MODAL_TTL_SECONDS
-  // (5 min) wait.
+  // admin's /qurl setup rerun trips the supersede peek into the
+  // "you already have a modal open" branch. If the rollback itself
+  // also fails (DDB region outage), the error logs at error-level
+  // — admin recovery is the SETUP_MODAL_TTL_SECONDS (5 min) wait.
   //
-  // TODO(supersede-race) #272: the rollback delete uses
-  // stage='awaiting_setup_modal' (matching the just-committed
-  // transition). A concurrent /qurl setup rerun whose loadFlow
-  // peek lands in the narrow window AFTER the transition committed
-  // but BEFORE this rollback fires will surface the misleading
-  // "you already have a modal open" message. Window is bounded by
-  // a single DDB round-trip; not worth closing with an additional
-  // OCC primitive yet, but greppable for future readers.
+  // expectedVersion gates the rollback delete on the exact version
+  // we just wrote. If a concurrent /qurl setup rerun's
+  // supersedeOrCreate ALSO observed this row and won the version
+  // race first, this delete fails (deleted:false) — correct: the
+  // row that exists at flow_id is now the new caller's, not ours
+  // to clean up. Without the version gate, two simultaneous
+  // rollbacks across two clients could each "succeed" against
+  // each other's rows.
   //
   // No spurious error log if a concurrent supersede ALSO cleared
   // this row first — CCFE in deleteFlow returns `{deleted: false}`
@@ -2964,6 +2934,11 @@ async function handleSetupButton(interaction, { flow_id, row }) {
     await deleteFlow(flow_id, {
       stage: SETUP_STAGE_AWAITING_MODAL,
       reason: 'abort',
+      // The version that landed after our successful transitionFlow
+      // — anything else means a concurrent supersede already
+      // advanced the row past us, in which case we don't own the
+      // rollback anymore.
+      expectedVersion: result.version,
     }).catch((rollbackErr) => {
       // `metric: 'setup_rollback_failed'` is the stable selector
       // for the CloudWatch alarm filter. Keying on the message
@@ -3990,117 +3965,53 @@ const commands = [
         // button is a persistent message component, not an
         // in-process Promise.
         //
-        // Supersede semantics: deleteFlow's stage gate makes a
-        // second /qurl setup a no-op when the prior flow is already
-        // mid-modal (the deleteFlow returns deleted:false on the
-        // stage mismatch and the retry createFlow then also fails,
-        // surfacing "could not start"). When the prior flow is
-        // pre-modal — i.e. the admin walked away from the button —
-        // supersede + recreate gives them a fresh button.
+        // Supersede semantics: supersedeOrCreate's version-gated
+        // deleteFlow makes a second /qurl setup a no-op when the
+        // prior flow is mid-modal (the surviving peek returns the
+        // awaiting_setup_modal row unchanged, and we surface the
+        // "modal already open" wording from its registered
+        // siblingMessage). When the prior flow is still pre-modal
+        // — i.e. the admin walked away from the button — the
+        // claim succeeds and they get a fresh button.
         await interaction.deferReply({ ephemeral: true });
         const setupFlowId = flowIdForInteraction(interaction);
-        const setupCreated = await createFlow({
-          flow_id: setupFlowId,
-          stage: SETUP_STAGE_AWAITING_BUTTON,
-          payload: null,
-          expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
-        });
-        if (!setupCreated.created) {
-          // Within the supersede branch, deleteFlow + retry createFlow
-          // share one try-envelope so a DDB throttle / IAM blip on
-          // either gets the recoverable "could not start" message.
-          // The FIRST createFlow above is intentionally NOT wrapped —
-          // its throw bubbles to handleCommand's outer envelope.
-          // Pinned by:
-          //   - "propagates the throw when the first createFlow fails"
-          //   - "handleCommand wraps the createFlow throw into a generic
-          //      user-visible reply"
-          //
-          // Race-edge #272: two same-user supersede calls from
-          // different clients within the deleteFlow round-trip can
-          // have the second deleteFlow stomp the first retry's
-          // fresh row (no OCC on deleteFlow). Worst case is "admin
-          // reruns," and /qurl setup is admin-only + same-user so
-          // the window is vanishingly small — not worth an OCC
-          // primitive yet, tracked in #272 if/when it bites.
-          let setupRetry;
-          try {
-            await deleteFlow(setupFlowId, {
-              stage: SETUP_STAGE_AWAITING_BUTTON,
-              reason: 'admin_cleanup',
-            });
-            setupRetry = await createFlow({
-              flow_id: setupFlowId,
-              stage: SETUP_STAGE_AWAITING_BUTTON,
-              payload: null,
-              // Recompute expires_at after the deleteFlow round-trip
-              // so the retried row gets a full SETUP_BUTTON_TTL_SECONDS
-              // budget, not a sub-second-truncated one.
-              expires_at: Math.floor(Date.now() / 1000) + SETUP_BUTTON_TTL_SECONDS,
-            });
-          } catch (err) {
-            logger.warn('handleSetup: supersede deleteFlow+createFlow threw', {
-              flow_id: setupFlowId, error: err && err.message,
-            });
-            return interaction.editReply({
-              content: 'Could not start a setup session — please try again.',
-            });
+        let setupSupersede;
+        try {
+          setupSupersede = await supersedeOrCreate({
+            flow_id: setupFlowId,
+            stage: SETUP_STAGE_AWAITING_BUTTON,
+            payload: null,
+            ttl_seconds: SETUP_BUTTON_TTL_SECONDS,
+          });
+        } catch (err) {
+          logger.warn('handleSetup: supersedeOrCreate threw', {
+            flow_id: setupFlowId, error: err && err.message,
+          });
+          return interaction.editReply({
+            content: 'Could not start a setup session — please try again.',
+          });
+        }
+        if (!setupSupersede.created) {
+          // Did not claim the slot. Three distinct branches:
+          //   (a) surviving.stage === awaiting_setup_modal → admin
+          //       has an in-flight modal; tell them to finish or
+          //       wait for it to expire.
+          //   (b) surviving is a sibling flow's row (e.g. revoke
+          //       menu open) → surface its registered sibling
+          //       message.
+          //   (c) surviving is null OR an unregistered stage →
+          //       generic "try again" fallback.
+          logger.warn('handleSetup: supersedeOrCreate did not claim slot', {
+            flow_id: setupFlowId,
+            surviving_stage: setupSupersede.surviving?.stage ?? null,
+          });
+          const siblingMsg = siblingMessageForStage(setupSupersede.surviving?.stage);
+          if (siblingMsg) {
+            return interaction.editReply({ content: siblingMsg });
           }
-          if (!setupRetry.created) {
-            // Retry create can fail for three distinct reasons:
-            //   (a) stage gate refused admin_cleanup because the
-            //       prior row is mid-modal → tell admin to finish
-            //       their existing modal.
-            //   (b) sibling flow type lives at this flow_id (e.g.
-            //       in-flight revoke) → don't claim a modal is
-            //       open; use the generic "could not start" wording.
-            //   (c) two races in a row → also generic wording.
-            // Disambiguate with a loadFlow peek. Adds one DDB read
-            // on a rare error path; cheap relative to telling the
-            // user about a modal that doesn't exist.
-            logger.warn('handleSetup: createFlow racy after admin_cleanup', {
-              flow_id: setupFlowId,
-            });
-            // TODO(stuck-orphan-#273): loadFlow filters logically-
-            // expired rows to null. If the orphan row is past its
-            // logical TTL but not yet physically reaped (DDB reap
-            // is async, minutes-to-hours), the peek returns null
-            // and we fall through to the generic "could not start"
-            // message — leaving the admin stuck until physical
-            // reap. /qurl revoke doesn't hit this because its
-            // supersede stage gate matches the orphan's own stage.
-            // Tracked in #273; mitigation likely a
-            // loadFlow({include_expired: true}) opt-in plus a
-            // matching deleteFlow against the expired stage.
-            const surviving = await loadFlow(setupFlowId).catch((err) => {
-              // Preserve observability — a DDB outage here silently
-              // degrades the user-visible wording from actionable
-              // ("you have a /qurl revoke menu open") to generic
-              // ("try again"). Without this warn, an intermittent
-              // read-side regression would be invisible to ops.
-              logger.warn('handleSetup: loadFlow peek failed (post-supersede disambiguation)', {
-                flow_id: setupFlowId, error: err && err.message,
-              });
-              return null;
-            });
-            if (surviving?.stage === SETUP_STAGE_AWAITING_MODAL) {
-              return interaction.editReply({
-                content: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
-              });
-            }
-            // Sibling-flow message lookup. A known sibling stage
-            // (revoke today, send/etc tomorrow) gets actionable
-            // wording naming the command the admin should finish
-            // or cancel first; an unknown stage / row-vanished
-            // case falls through to the generic "try again."
-            const siblingMsg = siblingMessageForStage(surviving?.stage);
-            if (siblingMsg) {
-              return interaction.editReply({ content: siblingMsg });
-            }
-            return interaction.editReply({
-              content: 'Could not start a setup session — please try again.',
-            });
-          }
+          return interaction.editReply({
+            content: 'Could not start a setup session — please try again.',
+          });
         }
 
         const setupButton = new ButtonBuilder()
@@ -4501,17 +4412,36 @@ async function handleCommand(interaction) {
 // in index.js) co-locates the registration with the handler
 // implementation so future readers don't have to grep two modules to
 // understand the routing.
+// Each registerFlow co-locates two things at the same site: the
+// customId → handler binding (for dispatch) and the stage →
+// siblingMessage binding (for cross-flow supersede disambiguation).
+// A future flow that adds a new awaiting_* stage SHOULD register
+// its siblingMessage here so peer flows' supersede peeks can
+// surface actionable wording instead of falling through to the
+// generic "try again." Stages without a registered message (e.g.
+// short-lived ones nobody else would race against) are fine to
+// omit — peers will fall through to the generic copy.
 registerFlow(REVOKE_SELECT_CUSTOM_ID, {
   expectedStage: REVOKE_STAGE_AWAITING_SELECT,
   handler: handleRevokeSelect,
+  siblingMessage: 'You have a `/qurl revoke` menu open in this channel — finish or cancel it first.',
 });
 registerFlow(SETUP_BUTTON_CUSTOM_ID, {
   expectedStage: SETUP_STAGE_AWAITING_BUTTON,
   handler: handleSetupButton,
+  // Cross-flow collision wording: a /qurl revoke supersede whose
+  // peek finds a row at awaiting_setup_button surfaces this — its
+  // surviving.stage !== awaiting_revoke_select so it doesn't claim,
+  // but a generic "try again" wouldn't tell the admin what to do.
+  // (A same-flow-type /qurl setup rerun never hits this path: its
+  // own supersedeOrCreate matches the button stage and version-
+  // gated-deletes the prior row in one round-trip.)
+  siblingMessage: 'You have a `/qurl setup` button waiting in this channel — click it or wait for it to expire.',
 });
 registerFlow(SETUP_MODAL_CUSTOM_ID, {
   expectedStage: SETUP_STAGE_AWAITING_MODAL,
   handler: handleSetupModal,
+  siblingMessage: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
 });
 
 module.exports = {

--- a/apps/discord/src/flow-dispatch.js
+++ b/apps/discord/src/flow-dispatch.js
@@ -42,14 +42,33 @@ const logger = require('./logger');
 // the table is read-only after boot. No concurrency hazard.
 const handlers = new Map();
 
+// stage → user-visible message map. Populated alongside the routing
+// table by `registerFlow`'s optional `siblingMessage`. Each entry
+// describes the REGISTERING handler's own stage — i.e. "if a caller
+// found a surviving row at this stage, here is the actionable thing
+// to tell the user." Co-locating this with the routing registration
+// closes the forgot-to-add-an-entry footgun that an external
+// SIBLING_FLOW_MESSAGES map (the pre-#274 shape) carried.
+const siblingMessages = new Map();
+
 // Register a flow handler. `customId` is matched exactly against
 // `interaction.customId` (not startsWith — see module header).
 // `expectedStage` is what `loadFlow(flow_id).stage` must equal for
 // the handler to fire; mismatches yield a "superseded" reply.
 //
+// `siblingMessage` (optional) is the user-visible string a DIFFERENT
+// flow's supersede peek should surface when it finds a surviving
+// row at THIS stage. Co-located with the routing registration so
+// adding a new two-stage flow doesn't require updating a parallel
+// map (the pre-#274 shape had that map in commands.js, easy to
+// miss when adding a new flow). When omitted, peers that find a
+// row at this stage fall through to their generic "could not start"
+// wording — appropriate for stages that are too short-lived or too
+// sibling-irrelevant to merit a dedicated message.
+//
 // Throws on duplicate registration — silently overwriting a handler
 // would mask a real bug (two modules claiming the same customId).
-function registerFlow(customId, { expectedStage, handler }) {
+function registerFlow(customId, { expectedStage, handler, siblingMessage }) {
   if (typeof customId !== 'string' || customId.length === 0) {
     throw new TypeError('flow-dispatch.registerFlow: customId must be a non-empty string');
   }
@@ -59,10 +78,40 @@ function registerFlow(customId, { expectedStage, handler }) {
   if (typeof handler !== 'function') {
     throw new TypeError('flow-dispatch.registerFlow: handler must be a function');
   }
+  if (siblingMessage !== undefined && (typeof siblingMessage !== 'string' || siblingMessage.length === 0)) {
+    throw new TypeError('flow-dispatch.registerFlow: siblingMessage must be a non-empty string when provided');
+  }
   if (handlers.has(customId)) {
     throw new Error(`flow-dispatch.registerFlow: customId ${JSON.stringify(customId)} is already registered`);
   }
   handlers.set(customId, { expectedStage, handler });
+  // The same `expectedStage` could be registered by multiple
+  // customIds (e.g. a flow with parallel input components both at
+  // the same stage). Last-wins is fine because the message
+  // describes the stage, not the customId — but a TYPE mismatch
+  // (one registration sets siblingMessage, another omits it)
+  // would silently flip the lookup behavior depending on
+  // registration order. Reject inconsistency upfront.
+  if (siblingMessage !== undefined) {
+    const existing = siblingMessages.get(expectedStage);
+    if (existing !== undefined && existing !== siblingMessage) {
+      throw new Error(`flow-dispatch.registerFlow: stage ${JSON.stringify(expectedStage)} already has a different siblingMessage registered`);
+    }
+    siblingMessages.set(expectedStage, siblingMessage);
+  }
+}
+
+// Look up the actionable user-visible message for a stage. Returns
+// null when no flow registered a siblingMessage for that stage —
+// the caller (a different flow's supersede peek) should then fall
+// through to generic "could not start" wording.
+//
+// Pure reverse-lookup over the registry — there is no module-level
+// state to maintain across registerFlow calls beyond what
+// registerFlow itself wrote.
+function siblingMessageForStage(stage) {
+  if (typeof stage !== 'string' || stage.length === 0) return null;
+  return siblingMessages.get(stage) ?? null;
 }
 
 // Derive the canonical flow_id for an interaction from its trusted
@@ -203,6 +252,7 @@ async function safeReply(interaction, content) {
 
 module.exports = {
   registerFlow,
+  siblingMessageForStage,
   flowIdForInteraction,
   // Best-effort reply helper that picks followUp vs reply based on
   // interaction.replied/deferred state. Part of the handler-author

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -320,6 +320,17 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
 // input types, and a negative `grace_seconds: -3600` typo would
 // silently shorten flow lifetimes by an hour. Tight by symmetry.
 //
+// include_expired (default false) is an opt-in escape hatch for
+// callers that legitimately need to observe a row past its logical
+// expiry — currently `supersedeOrCreate` uses it to peek at a
+// stuck-orphan row whose stage gate would otherwise be unreachable
+// (DDB physical reap is async, minutes-to-hours, and meanwhile the
+// row's stored stage is the only key that can unlock the matching
+// `deleteFlow`). The default stays `false` so existing callers
+// (the dispatcher, OCC pre-reads) keep the "logically expired ==
+// absent" contract — flipping the default would silently surface
+// stale rows to every reader.
+//
 // ConsistentRead: the read is strongly consistent. Canonical use
 // case is "I just transitioned this flow and want to re-verify"
 // or "I'm about to transition and want the current version" —
@@ -328,7 +339,7 @@ async function createFlow({ flow_id, stage, payload, expires_at }) {
 // no orthogonal-read callers (admin tooling, audit forensics)
 // to justify a parameter. Add `consistent_read: false` here if
 // such a caller arrives.
-async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
+async function loadFlow(flow_id, { grace_seconds = 0, include_expired = false } = {}) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.loadFlow: flow_id must be a non-empty string');
   }
@@ -340,6 +351,9 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
   // would silently shorten flow lifetimes by an hour.
   if (typeof grace_seconds !== 'number' || !Number.isFinite(grace_seconds) || grace_seconds < 0) {
     throw new TypeError(`flow-state.loadFlow: grace_seconds must be a non-negative finite number (got ${typeof grace_seconds}: ${JSON.stringify(grace_seconds)})`);
+  }
+  if (typeof include_expired !== 'boolean') {
+    throw new TypeError(`flow-state.loadFlow: include_expired must be a boolean (got ${typeof include_expired})`);
   }
   const res = await ddb.send(new GetCommand({
     TableName: TABLE_NAME,
@@ -354,9 +368,10 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
   // round-trip undetected (writer rejects, but a regression or
   // manual console put could still produce one). Same set: finite
   // integer Number. Anything else falls through to the warn+null
-  // branch below.
+  // branch below (even under include_expired — a corrupted row's
+  // stage isn't a safe key to act on).
   if (typeof expires === 'number' && Number.isFinite(expires) && Math.floor(expires) === expires) {
-    if (nowEpochSeconds() > expires + grace_seconds) {
+    if (!include_expired && nowEpochSeconds() > expires + grace_seconds) {
       // Logically expired but not yet reaped. Treat as absent.
       return null;
     }
@@ -365,7 +380,9 @@ async function loadFlow(flow_id, { grace_seconds = 0 } = {}) {
     // corrupted row (manual console put, legacy writer regression,
     // future schema mismatch). Fail-safe: treat as expired rather
     // than returning a row that DDB TTL will never reap. Symmetric
-    // to the assertExpiresAt() guard on the writer side.
+    // to the assertExpiresAt() guard on the writer side. We do
+    // NOT honor include_expired here — a corrupted row's stage is
+    // not a safe basis for any harness operation.
     logger.warn('flow-state.loadFlow: row has missing or non-numeric expires_at; treating as expired', {
       flow_id,
       expires_at_type: typeof expires,
@@ -714,7 +731,18 @@ async function transitionFlow(flow_id, expectedVersion, { stage_to, payload, ter
 // the audit event's payload contract. Caller-supplied because
 // flow-state can't know whether a given delete is a clean
 // completion vs. a user abort.
-async function deleteFlow(flow_id, { stage, reason }) {
+//
+// `expectedVersion` (optional): when passed, adds `AND #v =
+// :expected` to the ConditionExpression so the delete is atomic
+// against a concurrent transitionFlow. Used by `supersedeOrCreate`
+// to claim a specific row version it just observed — without it,
+// two concurrent supersedes could each see the same orphan,
+// agree on its stage, and have the second delete stomp the
+// first caller's freshly-created replacement. When undefined,
+// behavior is exactly the pre-existing stage-gate-only delete
+// (the only path used by terminal-flow callers, where there
+// is no concurrent advancement to race against).
+async function deleteFlow(flow_id, { stage, reason, expectedVersion } = {}) {
   if (typeof flow_id !== 'string' || flow_id.length === 0) {
     throw new TypeError('flow-state.deleteFlow: flow_id must be a non-empty string');
   }
@@ -724,6 +752,11 @@ async function deleteFlow(flow_id, { stage, reason }) {
   if (reason !== 'terminal' && reason !== 'abort' && reason !== 'admin_cleanup') {
     throw new TypeError(`flow-state.deleteFlow: reason must be one of 'terminal'|'abort'|'admin_cleanup' (got ${JSON.stringify(reason)})`);
   }
+  if (expectedVersion !== undefined) {
+    if (typeof expectedVersion !== 'number' || !Number.isInteger(expectedVersion) || expectedVersion < 1) {
+      throw new TypeError(`flow-state.deleteFlow: expectedVersion must be a positive integer when provided (got ${expectedVersion})`);
+    }
+  }
 
   // Conditional Delete + emit-on-success. The SLI math
   //   silently_dropped = count(FLOW_CREATED) - count(FLOW_DELETED)
@@ -731,39 +764,52 @@ async function deleteFlow(flow_id, { stage, reason }) {
   // CREATED is gated by `attribute_not_exists`; DELETED needs both
   // attribute_exists (so SQS redeliveries don't double-emit) AND
   // the stage gate (so a sibling flow at the same flow_id is never
-  // collateral damage).
+  // collateral damage). Optional version gate adds OCC for callers
+  // racing concurrent advancement.
   //
   // Returns `{ deleted: bool }` so callers can gate user-visible
   // "flow completed" side effects on actual deletion (a false
   // return means someone else already deleted, the TTL reaped, OR
   // the stored stage doesn't match — for any of those, don't re-DM
   // the user).
+  const conditionParts = ['attribute_exists(flow_id)', '#s = :stage'];
+  const exprNames = { '#s': 'stage' };
+  const exprValues = { ':stage': stage };
+  if (expectedVersion !== undefined) {
+    conditionParts.push('#v = :expected');
+    exprNames['#v'] = 'version';
+    exprValues[':expected'] = expectedVersion;
+  }
+
   try {
     await ddb.send(new DeleteCommand({
       TableName: TABLE_NAME,
       Key: { flow_id },
-      ConditionExpression: 'attribute_exists(flow_id) AND #s = :stage',
-      ExpressionAttributeNames: { '#s': 'stage' },
-      ExpressionAttributeValues: { ':stage': stage },
+      ConditionExpression: conditionParts.join(' AND '),
+      ExpressionAttributeNames: exprNames,
+      ExpressionAttributeValues: exprValues,
     }));
   } catch (err) {
     if (isConditionalCheckFailed(err)) {
-      // Row absent OR stage mismatch. Discriminate via post-recheck
-      // for the forensic log line — same pattern as transitionFlow's
+      // Row absent OR stage mismatch OR (when expectedVersion is
+      // gated) version mismatch. Discriminate via post-recheck for
+      // the forensic log line — same pattern as transitionFlow's
       // recheck. Best-effort: any throw here is swallowed because
       // the recheck is purely informational.
       let actual_stage = null;
+      let actual_version = null;
       let row_present = false;
       try {
         const recheck = await ddb.send(new GetCommand({
           TableName: TABLE_NAME,
           Key: { flow_id },
-          ProjectionExpression: 'stage',
+          ProjectionExpression: 'stage, version',
           ConsistentRead: true,
         }));
         if (recheck.Item) {
           row_present = true;
           actual_stage = recheck.Item.stage;
+          actual_version = recheck.Item.version ?? null;
         }
       } catch (rcErr) {
         logger.warn('flow-state.deleteFlow: post-CCFE recheck failed (informational)', {
@@ -771,7 +817,12 @@ async function deleteFlow(flow_id, { stage, reason }) {
         });
       }
       logger.debug('flow-state.deleteFlow: condition failed', {
-        flow_id, expected_stage: stage, actual_stage, row_present,
+        flow_id,
+        expected_stage: stage,
+        actual_stage,
+        expected_version: expectedVersion ?? null,
+        actual_version,
+        row_present,
       });
       return { deleted: false };
     }
@@ -786,16 +837,141 @@ async function deleteFlow(flow_id, { stage, reason }) {
   return { deleted: true };
 }
 
+// Open a fresh flow row, superseding a same-flow_id predecessor at
+// the SAME stage if one exists. The supersede-and-retry pattern was
+// duplicated across /qurl revoke and /qurl setup (and would have
+// re-emerged in /qurl send); extracting it here closes #272 (OCC on
+// deleteFlow against the prior version), #273 (include_expired so
+// a stuck-orphan past its logical TTL is still observable), and
+// #274 (the duplication itself).
+//
+// Returns one of:
+//   { created: true, version: 1 }
+//        — fresh row written; caller proceeds with the flow.
+//   { created: false, surviving: <row>|null }
+//        — caller did NOT win the supersede race or a sibling flow
+//          owns this flow_id. `surviving` is the post-failure peek
+//          (via loadFlow include_expired:true so stuck-orphans are
+//          observable) so the caller can disambiguate sibling-flow
+//          vs same-flow-different-stage vs vanished. May be null if
+//          the row evaporated between the second createFlow and
+//          the peek.
+//
+// Why not also return surviving on success: the caller already has
+// the version it needs (1, since createFlow just wrote it) and no
+// other useful state — a same-shape return on both branches would
+// just invite "surviving" reads on the success path that aren't
+// meaningful.
+//
+// Pure-harness contract: this function does not know about the
+// dispatcher's `siblingMessageForStage` registry. The caller looks
+// up the user-visible disambiguation message from the surviving
+// row's stage; the harness only delivers the row.
+//
+// Atomicity caveat: the implementation is a sequence of DDB
+// operations, NOT a TransactWriteItems batch. Between the
+// observed-version `loadFlow(include_expired:true)` and the
+// `deleteFlow(expectedVersion)`, a concurrent caller can advance
+// the row, causing our deleteFlow to fail-by-design (we wanted to
+// claim that specific version). This is the right shape: a
+// concurrent caller advanced the prior flow, so the right answer
+// for us is "the prior flow is still active, return surviving"
+// rather than "stomp it." TransactWriteItems would buy us the
+// ability to fail more cleanly but not a different correctness
+// shape.
+async function supersedeOrCreate({ flow_id, stage, payload, ttl_seconds }) {
+  if (typeof flow_id !== 'string' || flow_id.length === 0) {
+    throw new TypeError('flow-state.supersedeOrCreate: flow_id must be a non-empty string');
+  }
+  if (typeof stage !== 'string' || stage.length === 0) {
+    throw new TypeError('flow-state.supersedeOrCreate: stage must be a non-empty string');
+  }
+  if (typeof ttl_seconds !== 'number' || !Number.isInteger(ttl_seconds) || ttl_seconds < 1) {
+    throw new TypeError(`flow-state.supersedeOrCreate: ttl_seconds must be a positive integer (got ${ttl_seconds})`);
+  }
+
+  // First attempt — happy path. No row at flow_id ⇒ write straight
+  // through. createFlow does its own assertExpiresAt and structure
+  // validation; we just hand it a freshly computed expires_at.
+  const firstExpiresAt = nowEpochSeconds() + ttl_seconds;
+  const created = await createFlow({ flow_id, stage, payload, expires_at: firstExpiresAt });
+  if (created.created) {
+    return { created: true, version: created.version };
+  }
+
+  // Collision. Peek with include_expired:true so the supersede can
+  // act on a stuck-orphan whose logical TTL has passed but whose
+  // physical reap hasn't fired (#273). Without the opt-in, an
+  // orphan at the supersede-mismatch stage would be invisible
+  // here and the next deleteFlow would fail by stage gate.
+  let surviving = await loadFlow(flow_id, { include_expired: true });
+  if (!surviving) {
+    // Row vanished between createFlow conflict and the peek (TTL
+    // reap on a stuck-orphan, or a concurrent supersede won the
+    // delete). Retry the create — at this point we're racing as
+    // if we never saw a collision.
+    const retryExpiresAt = nowEpochSeconds() + ttl_seconds;
+    const retry = await createFlow({ flow_id, stage, payload, expires_at: retryExpiresAt });
+    if (retry.created) {
+      return { created: true, version: retry.version };
+    }
+    // Lost the race twice in a row — caller's branch is the same
+    // "couldn't claim it, here's what's there" with surviving:null
+    // letting the caller fall through to generic wording.
+    return { created: false, surviving: null };
+  }
+
+  // Same-stage predecessor: we can attempt to claim it via stage +
+  // version gate. A sibling flow (different stage) is unreachable
+  // by deleteFlow's stage check — return it unchanged so the caller
+  // can surface the sibling-flow message.
+  if (surviving.stage !== stage) {
+    return { created: false, surviving };
+  }
+
+  // Atomic claim: stage gate AND version gate. If a concurrent
+  // transitionFlow advanced the prior row between our peek and
+  // this delete, the version check fails and we leave the row
+  // alone — correct, since "concurrent advancement" means the
+  // prior flow is still active.
+  const claimed = await deleteFlow(flow_id, {
+    stage: surviving.stage,
+    reason: 'admin_cleanup',
+    expectedVersion: surviving.version,
+  });
+  if (!claimed.deleted) {
+    // Lost the OCC race or the row evaporated. Re-peek so the
+    // caller sees the current state (could be a sibling flow's
+    // fresh row, or another supersede's fresh same-stage row).
+    surviving = await loadFlow(flow_id, { include_expired: true });
+    return { created: false, surviving };
+  }
+
+  // Claimed the slot — retry create. Recompute expires_at so the
+  // new row gets a full TTL budget despite the deleteFlow RTT.
+  const retryExpiresAt = nowEpochSeconds() + ttl_seconds;
+  const retry = await createFlow({ flow_id, stage, payload, expires_at: retryExpiresAt });
+  if (retry.created) {
+    return { created: true, version: retry.version };
+  }
+  // Lost the create race to a third caller that slipped in
+  // between our delete and our retry. Same return shape — the
+  // surviving peek tells the caller what to do.
+  surviving = await loadFlow(flow_id, { include_expired: true });
+  return { created: false, surviving };
+}
+
 module.exports = {
   createFlow,
   loadFlow,
   transitionFlow,
   deleteFlow,
+  supersedeOrCreate,
   // Test-only escape hatch (the `__` prefix signals: not part of
   // the public API). Production code paths must go through the
-  // four functions above. A future admin CLI or third consumer
-  // should get its own real export when it arrives — the shape
-  // of "what does the API surface to non-test callers look like"
-  // is easier to design once that caller actually exists.
+  // five named functions above. A future admin CLI or third
+  // consumer should get its own real export when it arrives — the
+  // shape of "what does the API surface to non-test callers look
+  // like" is easier to design once that caller actually exists.
   __TABLE_NAME: TABLE_NAME,
 };

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -222,15 +222,24 @@ jest.mock('../src/places', () => ({
 
 // flow-state is the DDB-backed harness consumed by /qurl revoke
 // post-conversion (PR 5). Mock it here rather than hit DDB.
+//
+// `supersedeOrCreate` is the consolidated primitive (post-harness-PR)
+// used by slash-command paths to open a fresh row, claiming over a
+// stale predecessor at the same stage. The harness-internal
+// orchestration (createFlow → loadFlow → version-gated deleteFlow →
+// retry) is pinned by flow-state.test.js, not here; commands-side
+// tests just drive its public return shape.
 const mockCreateFlow = jest.fn().mockResolvedValue({ created: true, version: 1 });
 const mockLoadFlow = jest.fn();
 const mockDeleteFlow = jest.fn().mockResolvedValue({ deleted: true });
 const mockTransitionFlow = jest.fn();
+const mockSupersedeOrCreate = jest.fn().mockResolvedValue({ created: true, version: 1 });
 jest.mock('../src/flow-state', () => ({
   createFlow: (...args) => mockCreateFlow(...args),
   loadFlow: (...args) => mockLoadFlow(...args),
   deleteFlow: (...args) => mockDeleteFlow(...args),
   transitionFlow: (...args) => mockTransitionFlow(...args),
+  supersedeOrCreate: (...args) => mockSupersedeOrCreate(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1180,8 +1189,7 @@ describe('/qurl help subcommand', () => {
 // `handleRevokeSelect (dispatcher)` describe below.
 describe('/qurl revoke subcommand', () => {
   beforeEach(() => {
-    mockCreateFlow.mockResolvedValue({ created: true, version: 1 });
-    mockDeleteFlow.mockResolvedValue({ deleted: true });
+    mockSupersedeOrCreate.mockResolvedValue({ created: true, version: 1 });
   });
 
   it('shows no recent sends message', async () => {
@@ -1202,7 +1210,7 @@ describe('/qurl revoke subcommand', () => {
     );
     // No flow row should be opened when there's nothing to revoke —
     // an early no-op shouldn't poison the SLI's create-count.
-    expect(mockCreateFlow).not.toHaveBeenCalled();
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
   });
 
   it('opens a flow row and renders the select menu', async () => {
@@ -1229,12 +1237,12 @@ describe('/qurl revoke subcommand', () => {
 
     await cmd.execute(interaction);
 
-    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
-    const createArgs = mockCreateFlow.mock.calls[0][0];
-    expect(createArgs.stage).toBe('awaiting_revoke_select');
-    expect(createArgs.payload).toBeNull();
-    expect(createArgs.flow_id).toMatch(/^0:1#guild-1#ch-1#user-1$/);
-    expect(createArgs.expires_at).toEqual(expect.any(Number));
+    expect(mockSupersedeOrCreate).toHaveBeenCalledTimes(1);
+    const args = mockSupersedeOrCreate.mock.calls[0][0];
+    expect(args.stage).toBe('awaiting_revoke_select');
+    expect(args.payload).toBeNull();
+    expect(args.flow_id).toMatch(/^0:1#guild-1#ch-1#user-1$/);
+    expect(args.ttl_seconds).toEqual(expect.any(Number));
 
     // Menu was rendered to the user.
     const menuCall = interaction.editReply.mock.calls.find(
@@ -1244,13 +1252,13 @@ describe('/qurl revoke subcommand', () => {
     expect(menuCall[0].content).toMatch(/Select a send to revoke/);
   });
 
-  it('supersedes a prior in-flight revoke flow', async () => {
-    // First createFlow loses the OCC race (existing row from a
-    // previous /qurl revoke call); admin_cleanup + retry must
-    // win, and the menu still renders.
-    mockCreateFlow
-      .mockResolvedValueOnce({ created: false })
-      .mockResolvedValueOnce({ created: true, version: 1 });
+  it('renders the menu when supersedeOrCreate claims the slot from a stale predecessor', async () => {
+    // supersedeOrCreate encapsulates the create → load → delete →
+    // retry orchestration. From the caller's view, a successful
+    // claim looks identical to a fresh create — both return
+    // { created: true, version: ... }. The harness-internal
+    // orchestration is pinned by flow-state.test.js, not here.
+    mockSupersedeOrCreate.mockResolvedValueOnce({ created: true, version: 1 });
     mockDb.getRecentSends.mockReturnValue([
       {
         send_id: 'send-1',
@@ -1274,23 +1282,132 @@ describe('/qurl revoke subcommand', () => {
 
     await cmd.execute(interaction);
 
-    expect(mockCreateFlow).toHaveBeenCalledTimes(2);
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
-    expect(mockDeleteFlow.mock.calls[0][1]).toEqual({
-      stage: 'awaiting_revoke_select',
-      reason: 'admin_cleanup',
-    });
-    // Menu should still be rendered after supersede.
+    expect(mockSupersedeOrCreate).toHaveBeenCalledTimes(1);
+    // Menu rendered after supersede claim.
     const menuCall = interaction.editReply.mock.calls.find(
       (c) => c[0]?.components?.length > 0,
     );
     expect(menuCall).toBeDefined();
   });
 
-  it('surfaces an error when supersede + retry both lose the race', async () => {
-    mockCreateFlow
-      .mockResolvedValueOnce({ created: false })
-      .mockResolvedValueOnce({ created: false });
+  it('names a sibling setup-modal flow when revoke supersede cannot claim', async () => {
+    // supersedeOrCreate returns the surviving row when a non-revoke
+    // flow owns this flow_id. The handler resolves the user-visible
+    // wording via the dispatcher's siblingMessageForStage registry
+    // (populated at registerFlow time).
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: { stage: 'awaiting_setup_modal', version: 1 },
+    });
+    mockDb.getRecentSends.mockReturnValue([
+      {
+        send_id: 'send-1',
+        resource_type: 'file',
+        target_type: 'user',
+        recipient_count: 1,
+        delivered_count: 1,
+        expires_in: '24h',
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'revoke'),
+      },
+    });
+
+    await cmd.execute(interaction);
+
+    // Sibling-flow message names the in-flight setup modal — not
+    // a generic "could not start" fallback.
+    const siblingCall = interaction.editReply.mock.calls.find(
+      (c) => /qurl setup/.test(c[0]?.content || ''),
+    );
+    expect(siblingCall).toBeDefined();
+  });
+
+  it('names a sibling setup-button flow when revoke supersede finds one in the channel', async () => {
+    // Cross-flow collision: /qurl revoke colliding with an unclicked
+    // /qurl setup button at the same flow_id. The setup-button stage
+    // has its own registered siblingMessage (different from modal),
+    // so revoke sees the "click the button or wait" wording rather
+    // than the generic "try again."
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: { stage: 'awaiting_setup_button', version: 1 },
+    });
+    mockDb.getRecentSends.mockReturnValue([
+      {
+        send_id: 'send-1',
+        resource_type: 'file',
+        target_type: 'user',
+        recipient_count: 1,
+        delivered_count: 1,
+        expires_in: '24h',
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'revoke'),
+      },
+    });
+
+    await cmd.execute(interaction);
+
+    const siblingCall = interaction.editReply.mock.calls.find(
+      (c) => /qurl setup.*button/.test(c[0]?.content || ''),
+    );
+    expect(siblingCall).toBeDefined();
+  });
+
+  it('falls through to generic error when the surviving row is at an unregistered stage', async () => {
+    // No siblingMessage registered for this fictional stage — the
+    // handler should NOT invent wording, just fall through to the
+    // generic recoverable message.
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: { stage: 'unknown_future_stage', version: 1 },
+    });
+    mockDb.getRecentSends.mockReturnValue([
+      {
+        send_id: 'send-1',
+        resource_type: 'file',
+        target_type: 'user',
+        recipient_count: 1,
+        delivered_count: 1,
+        expires_in: '24h',
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'revoke'),
+      },
+    });
+
+    await cmd.execute(interaction);
+
+    const errorCall = interaction.editReply.mock.calls.find(
+      (c) => /Could not start a revoke session/.test(c[0]?.content || ''),
+    );
+    expect(errorCall).toBeDefined();
+  });
+
+  it('surfaces an error when supersedeOrCreate throws', async () => {
+    mockSupersedeOrCreate.mockRejectedValueOnce(new Error('DDB throttle'));
     mockDb.getRecentSends.mockReturnValue([
       {
         send_id: 'send-1',
@@ -1447,8 +1564,7 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     else process.env.AUTH0_DOMAIN = originalAuthDomain;
   });
   beforeEach(() => {
-    mockCreateFlow.mockResolvedValue({ created: true, version: 1 });
-    mockDeleteFlow.mockResolvedValue({ deleted: true });
+    mockSupersedeOrCreate.mockResolvedValue({ created: true, version: 1 });
   });
 
   function makeSetupInteraction() {
@@ -1468,11 +1584,12 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
 
     await cmd.execute(interaction);
 
-    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
-    const createArgs = mockCreateFlow.mock.calls[0][0];
-    expect(createArgs.stage).toBe('awaiting_setup_button');
-    expect(createArgs.payload).toBeNull();
-    expect(createArgs.flow_id).toBe('0:1#guild-1#ch-1#user-1');
+    expect(mockSupersedeOrCreate).toHaveBeenCalledTimes(1);
+    const args = mockSupersedeOrCreate.mock.calls[0][0];
+    expect(args.stage).toBe('awaiting_setup_button');
+    expect(args.payload).toBeNull();
+    expect(args.flow_id).toBe('0:1#guild-1#ch-1#user-1');
+    expect(args.ttl_seconds).toEqual(expect.any(Number));
 
     const buttonCall = interaction.editReply.mock.calls.find(
       (c) => c[0]?.components?.length > 0,
@@ -1489,7 +1606,7 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
       const interaction = makeSetupInteraction();
       await cmd.execute(interaction);
 
-      expect(mockCreateFlow).not.toHaveBeenCalled();
+      expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
       expect(interaction.reply).toHaveBeenCalledWith(
         expect.objectContaining({
           content: expect.stringContaining('KEY_ENCRYPTION_KEY'),
@@ -1507,7 +1624,7 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
 
     await cmd.execute(interaction);
 
-    expect(mockCreateFlow).not.toHaveBeenCalled();
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('server, not in DMs'),
@@ -1522,7 +1639,7 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
 
     await cmd.execute(interaction);
 
-    expect(mockCreateFlow).not.toHaveBeenCalled();
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('administrators'),
@@ -1530,68 +1647,61 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     );
   });
 
-  it('supersedes a stale pre-modal flow', async () => {
-    mockCreateFlow
-      .mockResolvedValueOnce({ created: false })
-      .mockResolvedValueOnce({ created: true, version: 1 });
+  it('renders the button when supersedeOrCreate claims the slot from a stale predecessor', async () => {
+    // supersedeOrCreate encapsulates the create → load →
+    // version-gated delete → retry orchestration. From the caller's
+    // view a successful claim is identical to a fresh create —
+    // { created: true, version: ... }. The internal orchestration
+    // is pinned by flow-state.test.js, not here.
+    mockSupersedeOrCreate.mockResolvedValueOnce({ created: true, version: 1 });
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeSetupInteraction();
     await cmd.execute(interaction);
 
-    expect(mockDeleteFlow).toHaveBeenCalledWith(
-      '0:1#guild-1#ch-1#user-1',
-      { stage: 'awaiting_setup_button', reason: 'admin_cleanup' },
-    );
-    expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+    expect(mockSupersedeOrCreate).toHaveBeenCalledTimes(1);
     const buttonCall = interaction.editReply.mock.calls.find(
       (c) => c[0]?.components?.length > 0,
     );
     expect(buttonCall).toBeDefined();
   });
 
-  it('blocks when a mid-modal flow is in progress (supersede fails on stage gate)', async () => {
-    // Harness-level guarantee: deleteFlow with stage='awaiting_setup_button'
-    // returns deleted:false when the row is actually in
-    // 'awaiting_setup_modal'. The retry createFlow then conflicts on
-    // the existing row, and the loadFlow peek confirms the prior
-    // flow is mid-modal so the user-visible message names the modal.
-    mockCreateFlow
-      .mockResolvedValueOnce({ created: false })
-      .mockResolvedValueOnce({ created: false });
-    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
-    mockLoadFlow.mockResolvedValueOnce({
-      flow_id: '0:1#guild-1#ch-1#user-1',
-      stage: 'awaiting_setup_modal',
-      version: 2,
+  it('blocks with the modal-open message when a mid-modal flow is in progress', async () => {
+    // supersedeOrCreate cannot claim because the surviving row is
+    // at awaiting_setup_modal (different stage). It returns the
+    // surviving row; the dispatcher's siblingMessageForStage
+    // registry resolves the modal-open wording. The registry is
+    // populated at registerFlow time — confirmed by this test.
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: {
+        flow_id: '0:1#guild-1#ch-1#user-1',
+        stage: 'awaiting_setup_modal',
+        version: 2,
+      },
     });
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeSetupInteraction();
     await cmd.execute(interaction);
 
-    // Pin the slash-path block message specifically — not the
-    // button-handler conflict message which also contains "modal".
     const blockedCall = interaction.editReply.mock.calls.find(
       (c) => /already have a `\/qurl setup` modal open/.test(c[0]?.content || ''),
     );
     expect(blockedCall).toBeDefined();
   });
 
-  it('names the sibling revoke flow when retry fails because revoke is in-flight', async () => {
-    // The post-failure loadFlow peek discriminates known sibling
-    // stages: if the surviving row is awaiting_revoke_select, the
-    // user sees actionable wording telling them to finish/cancel
-    // their revoke first — instead of "try again" which would loop
-    // forever until the revoke's TTL fires.
-    mockCreateFlow
-      .mockResolvedValueOnce({ created: false })
-      .mockResolvedValueOnce({ created: false });
-    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
-    mockLoadFlow.mockResolvedValueOnce({
-      flow_id: '0:1#guild-1#ch-1#user-1',
-      stage: 'awaiting_revoke_select',
-      version: 1,
+  it('names the sibling revoke flow when supersede surfaces an in-flight revoke menu', async () => {
+    // If the surviving row is awaiting_revoke_select the user sees
+    // actionable wording naming the revoke menu instead of generic
+    // "try again" which would loop until the revoke's TTL fires.
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: {
+        flow_id: '0:1#guild-1#ch-1#user-1',
+        stage: 'awaiting_revoke_select',
+        version: 1,
+      },
     });
 
     const cmd = commands.find(c => c.data.name === 'qurl');
@@ -1608,18 +1718,11 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     expect(modalMsgCall).toBeUndefined();
   });
 
-  it('falls back to generic wording for an unknown sibling stage / two-races-in-a-row', async () => {
-    // If the surviving row is at a stage the dispatcher doesn't
-    // recognize as a known sibling (e.g. an in-flight flow type
-    // added in a future PR before its stage gets a sibling-message
-    // entry, OR the row vanished entirely between the retry and
-    // the peek), the user gets the generic "could not start"
-    // wording. Better than naming a flow that doesn't fit.
-    mockCreateFlow
-      .mockResolvedValueOnce({ created: false })
-      .mockResolvedValueOnce({ created: false });
-    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
-    mockLoadFlow.mockResolvedValueOnce(null); // row vanished
+  it('falls back to generic wording when surviving is null (vanished between collide and peek)', async () => {
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: null,
+    });
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeSetupInteraction();
@@ -1631,47 +1734,45 @@ describe('/qurl setup subcommand (legacy modal-paste path)', () => {
     expect(genericCall).toBeDefined();
   });
 
-  it('propagates the throw when the first createFlow fails (caught by handleCommand)', async () => {
-    // The slash-path's first createFlow has no try/catch — a throw
-    // there propagates to handleCommand's outer error envelope
-    // (commands.js handleCommand try/catch), which replies the
-    // generic "There was an error executing this command." Pin
-    // here that cmd.execute lets the throw bubble; if a future
-    // refactor adds a try/catch around the first createFlow and
-    // accidentally swallows it (no user-visible error), this test
-    // trips instead of regressing silently.
-    mockCreateFlow.mockRejectedValueOnce(new Error('DDB region timeout'));
+  it('falls back to generic wording when surviving stage has no registered siblingMessage', async () => {
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: {
+        flow_id: '0:1#guild-1#ch-1#user-1',
+        stage: 'awaiting_future_unregistered_stage',
+        version: 1,
+      },
+    });
+
+    const cmd = commands.find(c => c.data.name === 'qurl');
+    const interaction = makeSetupInteraction();
+    await cmd.execute(interaction);
+
+    const genericCall = interaction.editReply.mock.calls.find(
+      (c) => /Could not start a setup session/.test(c[0]?.content || ''),
+    );
+    expect(genericCall).toBeDefined();
+  });
+
+  it('surfaces a recoverable error when supersedeOrCreate throws', async () => {
+    // supersedeOrCreate already retried internally — a thrown
+    // exception at this layer is a real DDB/IAM failure. The
+    // handler catches it (one shared try-envelope) and surfaces
+    // "could not start" rather than letting it propagate to
+    // handleCommand's generic envelope, so the user sees an
+    // actionable rerun hint instead of "an error executing this
+    // command."
+    mockSupersedeOrCreate.mockRejectedValueOnce(new Error('DDB region timeout'));
 
     const cmd = commands.find(c => c.data.name === 'qurl');
     const interaction = makeSetupInteraction();
 
-    await expect(cmd.execute(interaction)).rejects.toThrow('DDB region timeout');
-    expect(mockDeleteFlow).not.toHaveBeenCalled();
-  });
+    await cmd.execute(interaction);
 
-  it('handleCommand wraps the createFlow throw into a generic user-visible reply', async () => {
-    // Integration-style pin: drive the same throw THROUGH handleCommand
-    // (not just cmd.execute) and assert the outer try/catch in
-    // handleCommand surfaces the recoverable "There was an error"
-    // message. Closes the gap between "cmd.execute throws" and
-    // "user sees an error" — a future refactor that swallows the
-    // envelope reply would break user-visible UX without tripping
-    // the bare cmd.execute test above.
-    mockCreateFlow.mockRejectedValueOnce(new Error('DDB region timeout'));
-
-    const interaction = makeSetupInteraction();
-    await handleCommand(interaction);
-
-    // handleCommand uses followUp when interaction is deferred/replied
-    // (deferReply fired inside the setup branch before the throw).
-    const replyCalls = [
-      ...interaction.followUp.mock.calls,
-      ...interaction.reply.mock.calls,
-    ];
-    const errorReply = replyCalls.find(
-      (c) => /There was an error executing this command/.test(c[0]?.content || ''),
+    const genericCall = interaction.editReply.mock.calls.find(
+      (c) => /Could not start a setup session/.test(c[0]?.content || ''),
     );
-    expect(errorReply).toBeDefined();
+    expect(genericCall).toBeDefined();
   });
 });
 
@@ -1801,9 +1902,15 @@ describe('handleSetupButton (dispatcher path)', () => {
     // before showModal fires. If showModal throws (Discord token
     // expiry, REST blip), leaving the row in that stage would force
     // the admin to wait out the full TTL — `/qurl setup` rerun
-    // would see the loadFlow peek find awaiting_setup_modal and
+    // would see the supersede peek find awaiting_setup_modal and
     // surface the misleading "you already have a modal open"
     // wording. Recovery requires the handler to delete the row.
+    //
+    // expectedVersion gates the rollback on the specific version
+    // the transitionFlow just committed (post-bump = 2 from initial
+    // version=1). A concurrent supersede that advanced the row past
+    // version 2 would fail this delete by design — at that point
+    // the row at flow_id is no longer ours to clean up.
     mockTransitionFlow.mockResolvedValueOnce({ result: 'success', version: 2 });
     const showModalErr = new Error('Unknown interaction (token expired during ACK)');
     const interaction = makeButtonInteraction({
@@ -1818,7 +1925,11 @@ describe('handleSetupButton (dispatcher path)', () => {
     expect(interaction.showModal).toHaveBeenCalledTimes(1);
     expect(mockDeleteFlow).toHaveBeenCalledWith(
       '0:1#guild-1#ch-1#user-1',
-      { stage: 'awaiting_setup_modal', reason: 'abort' },
+      {
+        stage: 'awaiting_setup_modal',
+        reason: 'abort',
+        expectedVersion: 2,
+      },
     );
     // Best-effort reply attempted (may fail itself; that's logged).
     expect(interaction.reply).toHaveBeenCalledWith(

--- a/apps/discord/tests/flow-dispatch.test.js
+++ b/apps/discord/tests/flow-dispatch.test.js
@@ -34,6 +34,7 @@ jest.mock('../src/config', () => ({
 const { loadFlow } = require('../src/flow-state');
 const {
   registerFlow,
+  siblingMessageForStage,
   flowIdForInteraction,
   handleFlowInteraction,
   SUPERSEDED_MSG,
@@ -103,6 +104,67 @@ describe('registerFlow', () => {
   it('rejects non-function handler', () => {
     expect(() => registerFlow('bad_handler_prefix', { expectedStage: 's', handler: null }))
       .toThrow(/handler must be a function/);
+  });
+
+  it('rejects non-string siblingMessage when provided', () => {
+    expect(() => registerFlow('sm_bad_type', {
+      expectedStage: 's_bad_type', handler: jest.fn(), siblingMessage: 42,
+    })).toThrow(/siblingMessage must be a non-empty string when provided/);
+    expect(() => registerFlow('sm_bad_empty', {
+      expectedStage: 's_bad_empty', handler: jest.fn(), siblingMessage: '',
+    })).toThrow(/siblingMessage must be a non-empty string when provided/);
+  });
+
+  it('rejects re-registering a stage with a DIFFERENT siblingMessage', () => {
+    // Two customIds registering the same stage MUST agree on the
+    // sibling message — otherwise the lookup behavior would flip
+    // depending on registration order, which is registration-order
+    // dependent magic.
+    registerFlow('sm_first_prefix', {
+      expectedStage: 'sm_consistent_stage',
+      handler: jest.fn(),
+      siblingMessage: 'first message',
+    });
+    expect(() => registerFlow('sm_second_prefix', {
+      expectedStage: 'sm_consistent_stage',
+      handler: jest.fn(),
+      siblingMessage: 'second message',
+    })).toThrow(/already has a different siblingMessage/);
+  });
+
+  it('allows omitting siblingMessage entirely (no entry in the lookup)', () => {
+    registerFlow('sm_optional_prefix', {
+      expectedStage: 'sm_optional_stage',
+      handler: jest.fn(),
+    });
+    expect(siblingMessageForStage('sm_optional_stage')).toBeNull();
+  });
+});
+
+describe('siblingMessageForStage', () => {
+  it('returns the message registered alongside a customId for that stage', () => {
+    registerFlow('sm_lookup_prefix', {
+      expectedStage: 'sm_lookup_stage',
+      handler: jest.fn(),
+      siblingMessage: 'You have an X in progress — finish it first.',
+    });
+    expect(siblingMessageForStage('sm_lookup_stage'))
+      .toBe('You have an X in progress — finish it first.');
+  });
+
+  it('returns null for an unregistered stage', () => {
+    expect(siblingMessageForStage('never_registered_stage')).toBeNull();
+  });
+
+  it('returns null for non-string input (defensive against caller bugs)', () => {
+    // The caller's typical input is `surviving?.stage` where
+    // surviving may be null — guard against the resulting
+    // undefined / non-string defensively rather than relying on
+    // every caller to optional-chain.
+    expect(siblingMessageForStage(undefined)).toBeNull();
+    expect(siblingMessageForStage(null)).toBeNull();
+    expect(siblingMessageForStage(42)).toBeNull();
+    expect(siblingMessageForStage('')).toBeNull();
   });
 });
 

--- a/apps/discord/tests/flow-state.test.js
+++ b/apps/discord/tests/flow-state.test.js
@@ -87,11 +87,12 @@ beforeEach(() => {
 });
 
 describe('flow-state — module sanity', () => {
-  test('exposes the four lifecycle methods', () => {
+  test('exposes the five lifecycle methods', () => {
     expect(typeof flowState.createFlow).toBe('function');
     expect(typeof flowState.loadFlow).toBe('function');
     expect(typeof flowState.transitionFlow).toBe('function');
     expect(typeof flowState.deleteFlow).toBe('function');
+    expect(typeof flowState.supersedeOrCreate).toBe('function');
   });
 
   test('computes the canonical table name from DDB_TABLE_PREFIX', () => {
@@ -418,6 +419,60 @@ describe('flow-state.loadFlow', () => {
       .rejects.toThrow(/grace_seconds must be a non-negative finite number/);
     await expect(flowState.loadFlow('id', { grace_seconds: -3600 }))
       .rejects.toThrow(/grace_seconds must be a non-negative finite number/);
+  });
+
+  test('include_expired:true surfaces a logically-expired row (stuck-orphan recovery)', async () => {
+    // The supersede-and-retry path on two-stage flows needs to
+    // observe the orphan's stored stage to issue a matching
+    // deleteFlow — but DDB physical reap is async (~48h) and the
+    // default loadFlow filter would return null for any logically-
+    // expired row, leaving the supersede unable to recover.
+    // include_expired:true is the opt-in that unblocks the path.
+    const pastExpiry = Math.floor(Date.now() / 1000) - 60;
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        flow_id: 'id',
+        stage: 'awaiting_setup_modal',
+        version: 3,
+        payload: null,
+        expires_at: pastExpiry,
+        created_at: 100,
+        updated_at: 200,
+      },
+    });
+
+    // Default behavior unchanged: expired row → null.
+    expect(await flowState.loadFlow('id')).toBeNull();
+
+    // Opt-in: surfaces the row with its stored stage + version.
+    const row = await flowState.loadFlow('id', { include_expired: true });
+    expect(row).not.toBeNull();
+    expect(row.stage).toBe('awaiting_setup_modal');
+    expect(row.version).toBe(3);
+    expect(row.expires_at).toBe(pastExpiry);
+  });
+
+  test('include_expired:true STILL filters corrupted rows (missing expires_at)', async () => {
+    // A row with no expires_at cannot be safely surfaced even
+    // under include_expired — its stage isn't a trustworthy
+    // basis for any harness operation. Fail-safe wins over the
+    // opt-in here, matching the warn+null contract of the
+    // default path.
+    ddbMock.on(GetCommand).resolves({
+      Item: { flow_id: 'id', stage: 's', version: 1, payload: null },
+    });
+    expect(await flowState.loadFlow('id', { include_expired: true })).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/missing or non-numeric expires_at/),
+      expect.any(Object),
+    );
+  });
+
+  test('rejects non-boolean include_expired', async () => {
+    await expect(flowState.loadFlow('id', { include_expired: 'yes' }))
+      .rejects.toThrow(/include_expired must be a boolean/);
+    await expect(flowState.loadFlow('id', { include_expired: 1 }))
+      .rejects.toThrow(/include_expired must be a boolean/);
   });
 });
 
@@ -949,6 +1004,77 @@ describe('flow-state.deleteFlow', () => {
     await expect(flowState.deleteFlow('id', { stage: '', reason: 'terminal' }))
       .rejects.toThrow(/stage must be a non-empty string/);
   });
+
+  test('with expectedVersion: condition includes version gate', async () => {
+    // OCC opt-in. Without it, two concurrent supersedes could each
+    // delete-by-stage-only and stomp each other's freshly-created
+    // replacements. With it, only the caller that observed the
+    // specific version wins the claim.
+    ddbMock.on(DeleteCommand).resolves({});
+
+    const res = await flowState.deleteFlow('id', {
+      stage: 'awaiting_setup_button',
+      reason: 'admin_cleanup',
+      expectedVersion: 4,
+    });
+    expect(res).toEqual({ deleted: true });
+
+    const call = ddbMock.commandCalls(DeleteCommand)[0];
+    expect(call.args[0].input.ConditionExpression)
+      .toBe('attribute_exists(flow_id) AND #s = :stage AND #v = :expected');
+    expect(call.args[0].input.ExpressionAttributeNames).toEqual({
+      '#s': 'stage', '#v': 'version',
+    });
+    expect(call.args[0].input.ExpressionAttributeValues).toEqual({
+      ':stage': 'awaiting_setup_button', ':expected': 4,
+    });
+  });
+
+  test('with expectedVersion: returns deleted:false when version mismatch (concurrent advance)', async () => {
+    // A peer caller already advanced this row past our observed
+    // version. The right answer is "didn't claim it" — the prior
+    // flow is still active (just at a later version), so we leave
+    // it alone.
+    ddbMock.on(DeleteCommand).rejects(ccfe());
+    ddbMock.on(GetCommand).resolves({
+      Item: { flow_id: 'id', stage: 'awaiting_setup_button', version: 5 },
+    });
+
+    const res = await flowState.deleteFlow('id', {
+      stage: 'awaiting_setup_button',
+      reason: 'admin_cleanup',
+      expectedVersion: 4,
+    });
+    expect(res).toEqual({ deleted: false });
+    expect(logger.audit).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-integer expectedVersion when provided', async () => {
+    await expect(flowState.deleteFlow('id', {
+      stage: 's', reason: 'terminal', expectedVersion: 1.5,
+    })).rejects.toThrow(/expectedVersion must be a positive integer/);
+    await expect(flowState.deleteFlow('id', {
+      stage: 's', reason: 'terminal', expectedVersion: 0,
+    })).rejects.toThrow(/expectedVersion must be a positive integer/);
+    await expect(flowState.deleteFlow('id', {
+      stage: 's', reason: 'terminal', expectedVersion: '1',
+    })).rejects.toThrow(/expectedVersion must be a positive integer/);
+  });
+
+  test('omitting expectedVersion preserves the pre-existing stage-gate-only contract', async () => {
+    // Defensively pin the additive nature of the new parameter:
+    // existing terminal-delete callers (handleRevokeSelect,
+    // handleSetupModal) MUST observe the exact same DDB call
+    // shape as before — no #v in names, no :expected in values.
+    ddbMock.on(DeleteCommand).resolves({});
+    await flowState.deleteFlow('id', { stage: 's', reason: 'terminal' });
+
+    const call = ddbMock.commandCalls(DeleteCommand)[0];
+    expect(call.args[0].input.ConditionExpression)
+      .toBe('attribute_exists(flow_id) AND #s = :stage');
+    expect(call.args[0].input.ExpressionAttributeNames).toEqual({ '#s': 'stage' });
+    expect(call.args[0].input.ExpressionAttributeValues).toEqual({ ':stage': 's' });
+  });
 });
 
 describe('flow-state — payload corruption resilience', () => {
@@ -996,5 +1122,266 @@ describe('flow-state — payload corruption resilience', () => {
       expect.stringMatching(/payload JSON\.parse failed/),
       expect.any(Object),
     );
+  });
+});
+
+describe('flow-state.supersedeOrCreate', () => {
+  // The consolidated supersede-and-retry primitive. Tests pin the
+  // five distinct outcome shapes:
+  //   - first-try create succeeds (no predecessor)
+  //   - predecessor at SAME stage, same version → claim wins
+  //   - predecessor at DIFFERENT stage (sibling flow) → surfaced unchanged
+  //   - predecessor advanced between peek and delete → not claimed
+  //   - row vanishes between conflict and peek → retry create
+
+  test('first-try create succeeds when no row exists at flow_id', async () => {
+    // Happy path: no collision, single PutCommand to DDB.
+    ddbMock.on(PutCommand).resolves({});
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    expect(res).toEqual({ created: true, version: 1 });
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    // No supersede-side reads or deletes when there's nothing to supersede.
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.FLOW_CREATED, expect.objectContaining({
+      flow_id: FLOW_ID, stage: 'awaiting_setup_button',
+    }));
+  });
+
+  test('claims a same-stage predecessor via version-gated delete + retry create', async () => {
+    // 1) PutCommand #1 conflicts on the existing row.
+    // 2) GetCommand (loadFlow include_expired:true) returns the
+    //    predecessor with its stage + version.
+    // 3) DeleteCommand with both stage AND version gates wins.
+    // 4) PutCommand #2 succeeds for the fresh row.
+    const priorRow = {
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      version: 3,
+      payload: null,
+      expires_at: futureExpiry(),
+    };
+    ddbMock.on(PutCommand)
+      .rejectsOnce(ccfe())
+      .resolves({});
+    ddbMock.on(GetCommand).resolves({ Item: priorRow });
+    ddbMock.on(DeleteCommand).resolves({});
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    expect(res).toEqual({ created: true, version: 1 });
+
+    // The DeleteCommand must include the version gate.
+    const delCall = ddbMock.commandCalls(DeleteCommand)[0];
+    expect(delCall.args[0].input.ConditionExpression)
+      .toBe('attribute_exists(flow_id) AND #s = :stage AND #v = :expected');
+    expect(delCall.args[0].input.ExpressionAttributeValues[':expected']).toBe(3);
+    expect(delCall.args[0].input.ExpressionAttributeValues[':stage']).toBe('awaiting_setup_button');
+  });
+
+  test('returns surviving (no claim) when predecessor is at a DIFFERENT stage (sibling flow)', async () => {
+    // /qurl setup colliding with an in-flight /qurl revoke menu:
+    // the surviving row is at awaiting_revoke_select. We must NOT
+    // delete it (cross-flow safety) — return it unchanged so the
+    // caller can surface the sibling-message wording.
+    const siblingRow = {
+      flow_id: FLOW_ID,
+      stage: 'awaiting_revoke_select',
+      version: 1,
+      payload: null,
+      expires_at: futureExpiry(),
+    };
+    ddbMock.on(PutCommand).rejects(ccfe());
+    ddbMock.on(GetCommand).resolves({ Item: siblingRow });
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    expect(res.created).toBe(false);
+    expect(res.surviving.stage).toBe('awaiting_revoke_select');
+    expect(res.surviving.version).toBe(1);
+    // No delete attempted — the sibling flow stays untouched.
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(0);
+  });
+
+  test('uses include_expired:true on the peek so stuck-orphans (logically expired, not reaped) are observable', async () => {
+    // Without include_expired, the peek would return null for a
+    // row past its logical TTL but not yet physically reaped — and
+    // the caller would fall through to generic "try again" instead
+    // of recovering the orphan. Pin that the peek sees a past-
+    // expires_at row.
+    const pastExpiry = Math.floor(Date.now() / 1000) - 120;
+    const orphanRow = {
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_modal',
+      version: 2,
+      payload: null,
+      expires_at: pastExpiry,
+    };
+    ddbMock.on(PutCommand).rejects(ccfe());
+    ddbMock.on(GetCommand).resolves({ Item: orphanRow });
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    // Surfaced as surviving even though logically expired. The
+    // caller branches on .stage (sibling vs same-stage) before
+    // attempting any delete.
+    expect(res.created).toBe(false);
+    expect(res.surviving).not.toBeNull();
+    expect(res.surviving.stage).toBe('awaiting_setup_modal');
+    expect(res.surviving.expires_at).toBe(pastExpiry);
+  });
+
+  test('returns surviving (no claim) when predecessor advances between peek and delete (OCC race)', async () => {
+    // We observed version=3 but by the time our DeleteCommand
+    // fires, a concurrent transitionFlow has bumped to version=4.
+    // The version-gated delete fails by design. Re-peek surfaces
+    // the post-advance state for the caller.
+    const observedRow = {
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      version: 3,
+      payload: null,
+      expires_at: futureExpiry(),
+    };
+    const advancedRow = {
+      ...observedRow,
+      stage: 'awaiting_setup_modal',
+      version: 4,
+    };
+    ddbMock.on(PutCommand).rejects(ccfe());
+    // First Get: peek before delete — sees version=3.
+    // Second Get: post-CCFE recheck inside deleteFlow → sees
+    //   version=4 (project-only on stage/version, fine).
+    // Third Get: re-peek after delete failed → returns advanced row.
+    ddbMock.on(GetCommand)
+      .resolvesOnce({ Item: observedRow })
+      .resolvesOnce({ Item: { stage: 'awaiting_setup_modal', version: 4 } })
+      .resolves({ Item: advancedRow });
+    ddbMock.on(DeleteCommand).rejects(ccfe());
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    expect(res.created).toBe(false);
+    expect(res.surviving.version).toBe(4);
+    // Only one PutCommand — we did not attempt a retry create
+    // after losing the OCC race.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+
+  test('retries create when the row vanishes between conflict and peek (TTL reap or peer cleanup)', async () => {
+    // First Put conflicts (something exists), but by the time we
+    // peek, the row is gone — a parallel cleanup beat us to it.
+    // The right move is to retry the create as if we never saw a
+    // collision.
+    ddbMock.on(PutCommand)
+      .rejectsOnce(ccfe())
+      .resolves({});
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    expect(res).toEqual({ created: true, version: 1 });
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2);
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(0);
+  });
+
+  test('surfaces surviving:null when both attempts collide and the peek then sees nothing', async () => {
+    // Two collisions in a row + a final empty peek. Caller
+    // disambiguates "couldn't claim" vs "stuck-orphan" via
+    // .surviving (null here means "row evaporated").
+    ddbMock.on(PutCommand)
+      .rejectsOnce(ccfe()) // first create
+      .rejectsOnce(ccfe()); // retry create after vanished-peek
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const res = await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+
+    expect(res).toEqual({ created: false, surviving: null });
+  });
+
+  test('recomputes expires_at on the retry create (full TTL budget after deleteFlow RTT)', async () => {
+    // A subtle correctness property: if supersedeOrCreate reused
+    // the first attempt's expires_at, the retry row's lifetime
+    // would be sub-second-truncated by the deleteFlow round-trip.
+    // Pin that the second PutCommand's expires_at is independently
+    // computed from now+ttl_seconds.
+    const priorRow = {
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      version: 1,
+      payload: null,
+      expires_at: futureExpiry(),
+    };
+    ddbMock.on(PutCommand)
+      .rejectsOnce(ccfe())
+      .resolves({});
+    ddbMock.on(GetCommand).resolves({ Item: priorRow });
+    ddbMock.on(DeleteCommand).resolves({});
+
+    const beforeSec = Math.floor(Date.now() / 1000);
+    await flowState.supersedeOrCreate({
+      flow_id: FLOW_ID,
+      stage: 'awaiting_setup_button',
+      payload: null,
+      ttl_seconds: 120,
+    });
+    const afterSec = Math.floor(Date.now() / 1000);
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    const retryPut = putCalls[1].args[0].input.Item;
+    expect(retryPut.expires_at).toBeGreaterThanOrEqual(beforeSec + 120);
+    expect(retryPut.expires_at).toBeLessThanOrEqual(afterSec + 120);
+  });
+
+  test('rejects invalid arguments at entry', async () => {
+    await expect(flowState.supersedeOrCreate({
+      flow_id: '', stage: 's', payload: null, ttl_seconds: 60,
+    })).rejects.toThrow(/flow_id must be a non-empty string/);
+    await expect(flowState.supersedeOrCreate({
+      flow_id: FLOW_ID, stage: '', payload: null, ttl_seconds: 60,
+    })).rejects.toThrow(/stage must be a non-empty string/);
+    await expect(flowState.supersedeOrCreate({
+      flow_id: FLOW_ID, stage: 's', payload: null, ttl_seconds: 0,
+    })).rejects.toThrow(/ttl_seconds must be a positive integer/);
+    await expect(flowState.supersedeOrCreate({
+      flow_id: FLOW_ID, stage: 's', payload: null, ttl_seconds: 60.5,
+    })).rejects.toThrow(/ttl_seconds must be a positive integer/);
   });
 });


### PR DESCRIPTION
## Summary

Adds the `supersedeOrCreate` primitive to `flow-state.js` and rewires `/qurl revoke` and `/qurl setup`'s slash-command paths to consume it. Closes #272, #273, #274 in one focused harness PR before PR 7 (`/qurl send` flow_state conversion) lands a third caller.

The supersede-and-retry pattern was duplicated across `handleRevoke` and `handleSetup` (and would have re-emerged in `handleSend`). Three follow-up issues filed during PR #271's review all converge on this primitive — folding them together avoids carrying the duplication and the open issues through PR 7.

## What's in the harness now

All three harness changes are **additive** — defaults are unchanged for existing callers; opt-in only.

### `deleteFlow({..., expectedVersion})` — optional OCC (#272)

When provided, adds `AND #v = :expected` to the ConditionExpression. Closes the concurrent-supersede race where two callers could each see the same orphan, agree on its stage, and have the second `deleteFlow` stomp the first caller's freshly-created replacement.

### `loadFlow(id, { include_expired: true })` — opt-in expired-row visibility (#273)

When `true`, the reader returns rows past their logical TTL. Used by `supersedeOrCreate`'s post-conflict peek so a stuck-orphan (logically expired, not yet physically reaped — DDB TTL reap is async, minutes-to-hours) is observable instead of returning `null`. Corrupted rows (missing/non-numeric `expires_at`) are still filtered even under the opt-in — fail-safe wins for non-trustworthy state.

Default `false` so existing dispatcher and OCC pre-read callers see no change.

### `supersedeOrCreate({ flow_id, stage, payload, ttl_seconds })` — consolidated primitive (#274)

Returns:
- `{ created: true, version }` — fresh row written, caller proceeds.
- `{ created: false, surviving: <row>|null }` — caller did NOT win the supersede race or a sibling flow owns this `flow_id`. `surviving` is the post-failure peek (via `include_expired: true`) so the caller can disambiguate sibling-flow vs same-flow-different-stage vs vanished.

Pure-harness: the function does not know about the dispatcher's sibling-message registry. The caller looks up the user-visible wording from `surviving.stage`.

### Cross-flow sibling-message wiring moved into the dispatcher

`registerFlow(customId, { ..., siblingMessage })` co-locates the stage → user-visible message binding next to the customId → handler binding. The pre-PR `SIBLING_FLOW_MESSAGES` map in `commands.js` is gone — adding a new two-stage flow no longer requires updating a parallel registry, and inconsistent re-registration of the same stage now throws at module-load.

Sibling messages are registered for all three current stages, including the previously-missing `awaiting_setup_button` cross-flow gap (revoke colliding with an unclicked setup button now surfaces actionable wording instead of generic "try again").

## #272 race verification

The original sequence was:
- A: `createFlow` → conflict (existing row)
- B: `createFlow` → conflict; B's `deleteFlow + createFlow` win; row is now B's at version 1
- A: `deleteFlow(stage='awaiting_setup_button')` — without OCC, matches B's stage and stomps B's clean row

With this PR: both A and B observe the same pre-supersede row at version N. Both attempt `deleteFlow(expectedVersion: N)`. First-to-DDB wins; second's OCC fails. The OCC loser then takes the `surviving` branch (re-peeks and returns the winner's fresh row to the caller). The "returns surviving (no claim) when predecessor advances between peek and delete" test in `flow-state.test.js` pins this.

## Behavior change worth flagging

Unexpected harness throws in `/qurl revoke` and `/qurl setup`'s slash paths now surface **"Could not start a [revoke|setup] session — please try again"** rather than `handleCommand`'s generic **"There was an error executing this command."**

Why: `supersedeOrCreate` retries internally, so a thrown exception at the caller layer is a real DDB/IAM failure — not OCC churn. The new wording is actionable (admin reruns); the generic envelope was a leftover of the throw bubbling out. The deleted "propagates the throw when the first createFlow fails" test from #271 is the visible signal of this change; replaced by "surfaces a recoverable error when supersedeOrCreate throws."

## Out of scope

Cross-flow collision wording for stages that haven't been registered yet — future flows (PR 7+ `/qurl send`) should register a `siblingMessage` at their `registerFlow` callsite the same way revoke and setup do here.

## Test plan

- [x] Unit: `flow-state.test.js` — 8 new `supersedeOrCreate` cases (happy path, same-stage claim, sibling-flow no-claim, stuck-orphan visibility, OCC race, vanished row retry, double-collision surviving:null, TTL recomputation, arg validation) + `deleteFlow` `expectedVersion` cases + `loadFlow` `include_expired` cases.
- [x] Unit: `flow-dispatch.test.js` — `siblingMessage` validation, consistency-check, omission, and `siblingMessageForStage` lookup (registered/unregistered/null-safe).
- [x] Integration: `commands-comprehensive.test.js` — both slash paths drive `supersedeOrCreate`'s return shape (success, sibling, modal-block, vanished, unregistered-stage, throw); rollback `expectedVersion` pinned in `handleSetupButton`.
- [x] All 1194 tests pass; `npm run lint` clean (`--max-warnings 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)