### PR TITLE
refactor(discord): extract executeSendPipeline from handleSend

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -840,8 +840,13 @@ async function executeSendPipeline(interaction, {
   attachment,
   locationUrl,
   locationName,
+  // MUTATES: the Add Recipients post-send branch dedupe-pushes into
+  // this array (see docstring's "transferred ownership" note).
   recipients,
   target,
+  // Defaults to text-channel wording on a missing/undefined value;
+  // PR 7b should validate at the flow_state-payload schema layer to
+  // catch a voice-context send that lost this signal in serialization.
   isVoiceContext = false,
   expiresIn,
   selfDestructSeconds,
@@ -978,7 +983,10 @@ async function executeSendPipeline(interaction, {
   } catch (error) {
     logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
     clearCooldown(interaction.user.id); // allow retry on failure
-    releaseSlot();
+    // Slot release lives in the `finally` block below — it ALWAYS runs
+    // after a return-from-catch, and `releaseSlot` is idempotent via
+    // the `fileSendSlotClaimed` flag. Dropping the duplicate call here
+    // keeps the single-release-path invariant visible at a glance.
     // Surface a specific message for known upstream failure codes so the
     // user knows what to do (re-upload to refresh the per-resource quota)
     // instead of seeing a generic "try again" that won't help.
@@ -2313,9 +2321,12 @@ async function handleSend(interaction, apiKey) {
 
   // --- Step 4: Process and send (back-half — extracted to executeSendPipeline). ---
   // `return await` (not bare `await`) so the docstring's "Resolved value"
-  // contract matches the call shape — and the tail call propagates a
-  // throw with one less microtask hop than a bare-await + implicit
-  // undefined return.
+  // contract matches the call shape. `return await` keeps the async
+  // frame on the stack until the awaited promise settles, which
+  // preserves the executeSendPipeline frame in rejection traces —
+  // `return promise` (no await) would detach it, costing forensic
+  // signal. There's a ~1-microtask perf cost vs the no-await form;
+  // negligible at this scale, worth the better traces.
   return await executeSendPipeline(interaction, {
     apiKey,
     resourceType,
@@ -4576,6 +4587,12 @@ module.exports = {
       REVOKE_TRUNC_LIMIT,
       mintLinksInBatches,
       activeMonitors,
+      // The top-level back-half driver. Exported here so PR 7b's
+      // tests (and the follow-up direct unit spec in #278) can pin
+      // its contract against a constructed param object — without
+      // re-driving handleSend's Step-1-through-Step-3 wizard or the
+      // future flow_state-backed form-fill.
+      executeSendPipeline,
       // Test-only file-concurrency hooks. The slot counter is module-
       // private (live state) and exposing a setter lets the cap branch
       // be tested without a parallel-send harness.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -865,7 +865,17 @@ async function executeSendPipeline(interaction, {
   // a wrong value here surfaces only as a subtle copy mismatch in
   // a non-ephemeral channel post — exactly the silent-regression
   // shape the round-4 cr review flagged.
+  //
+  // Clear cooldown BEFORE the throw so the caller's setCooldown-
+  // in-flight doesn't lock the user out for the cooldown window
+  // (~30s) with no user-visible feedback. clearCooldown is a no-op
+  // when no cooldown is set, so this is safe for callers that
+  // haven't reached the cooldown branch yet — and it matches
+  // handleSend's existing convention of clearing on every error
+  // path. Today's caller never reaches the throw; the cleanup
+  // exists for PR 7b's handleSendFormSend.
   if (typeof isVoiceContext !== 'boolean') {
+    clearCooldown(interaction.user.id);
     throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got ${typeof isVoiceContext}: ${JSON.stringify(isVoiceContext)})`);
   }
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -782,13 +782,24 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 // notes below capture only non-obvious contract guarantees that a
 // reader couldn't infer from the call sites alone.
 //
+// Entry gates (fire-and-forget cancel-edit + throw):
+//   - `isVoiceContext` must be a strict boolean.
+//   - `target` must be `'user'` or `'channel'`.
+//   - `attachment.url` re-validated against `isAllowedSourceUrl`
+//     when `resourceType === RESOURCE_TYPES.FILE`.
+// Each gate clears the caller's stale ephemeral with a cancel-
+// edit then throws — the user still sees the outer catch's
+// generic followUp, but the gate's specific cancel replaces
+// the stale "Preparing send..." rather than co-existing with it.
+//
 // Caller contract (non-obvious bits — what the signature can't say):
 //
-//   - `attachment.url` is assumed PRE-VALIDATED against
-//     `isAllowedSourceUrl`. The pipeline does NOT re-check; an
-//     attacker-controlled URL reaching `downloadAndUpload` here
-//     would bypass the SSRF defense. Callers reconstructing this
-//     from a persisted source MUST re-validate before invoking.
+//   - `attachment.url` re-validated at entry against
+//     `isAllowedSourceUrl` — defense-in-depth, but callers
+//     SHOULD still validate at their boundary (the entry gate
+//     is the second line, not the first). A tampered persisted
+//     payload reaching the gate produces a generic "Internal
+//     error" cancel without leaking the SSRF detail.
 //
 //   - `recipients` is MUTATED in-place on the Add Recipients post-
 //     send branch (deduped push of new IDs). Treat as transferred
@@ -869,20 +880,22 @@ async function executeSendPipeline(interaction, {
   // handleSend's existing convention of clearing on every error
   // path. Today's caller never reaches the throw; the cleanup
   // exists for PR 7b's handleSendFormSend.
+  // Shared cancel-edit shape for all three entry gates. Fire-and-
+  // forget so a failed edit doesn't become the observable outcome —
+  // the throw is the load-bearing signal (test pins + logger.error
+  // in handleCommand's outer catch). The outer catch will still
+  // append a generic "There was an error" followUp; this edit
+  // replaces the caller's stale ephemeral so the user sees a
+  // specific cancel alongside the generic followUp, not a stale
+  // "Preparing send..." alongside it.
+  const cancelEdit = () => interaction.editReply({
+    content: '❌ Internal error — send cancelled. Please rerun the command.',
+    components: [],
+  }).catch(logIgnoredDiscordErr);
+
   if (typeof isVoiceContext !== 'boolean') {
     clearCooldown(interaction.user.id);
-    // Clear whatever stale ephemeral the caller's button handler
-    // left on screen ("Preparing send…" is the canonical case)
-    // BEFORE throwing. Fire-and-forget — the throw is the
-    // load-bearing signal (test pins + logger.error in
-    // handleCommand's outer catch), so a failed editReply here
-    // must not become the observable outcome. Without this, the
-    // user sees a persistent stale message alongside the generic
-    // "There was an error" followUp the outer catch will add.
-    interaction.editReply({
-      content: '❌ Internal error — send cancelled. Please rerun the command.',
-      components: [],
-    }).catch(logIgnoredDiscordErr);
+    cancelEdit();
     // Render `typeof=` + `value=` separately so a prod-log reader
     // doesn't have to disambiguate `(got object: null)` (where
     // "object" describes the typeof and "null" is the value — a
@@ -891,6 +904,38 @@ async function executeSendPipeline(interaction, {
     // drops it) and avoids the JSON.stringify-throws-on-BigInt
     // edge case.
     throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${String(isVoiceContext)})`);
+  }
+  // `target` allowed-set gate. Same silent-mis-render shape as
+  // isVoiceContext: an unrecognized value (e.g. `'voice'`) would
+  // silently suppress the channel-announce (the announce site's
+  // gate is strict equality on `'channel'`). The gate makes the
+  // failure mode loud at the boundary.
+  if (target !== 'user' && target !== 'channel') {
+    clearCooldown(interaction.user.id);
+    cancelEdit();
+    throw new TypeError(`executeSendPipeline: target must be 'user' or 'channel' (got ${String(target)})`);
+  }
+  // SSRF re-validation gate. Parallels the `isVoiceContext` gate
+  // but the failure mode is a security boundary, not a copy
+  // mismatch: a tampered DDB payload row could redirect
+  // downloadAndUpload to an internal target if no caller along
+  // the path re-checks. Today handleSend's Step-2 validates
+  // BEFORE calling the pipeline — this defense-in-depth gate
+  // catches a future caller that forgets. RESOURCE_TYPES.FILE-
+  // only because location sends don't carry an attacker-
+  // controlled URL (the locationUrl is built from sanitized
+  // user-text via google.com/maps/search).
+  if (resourceType === RESOURCE_TYPES.FILE) {
+    if (!attachment || typeof attachment.url !== 'string' || !isAllowedSourceUrl(attachment.url)) {
+      clearCooldown(interaction.user.id);
+      cancelEdit();
+      logger.warn('executeSendPipeline: attachment.url failed isAllowedSourceUrl gate', {
+        user_id: interaction.user.id,
+        send_nonce: sendNonce,
+        host: attachment?.url && safeUrlHost(attachment.url),
+      });
+      throw new Error(`executeSendPipeline: attachment.url failed SSRF re-validation (resourceType=${String(resourceType)})`);
+    }
   }
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -777,116 +777,62 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
   return allLinks;
 }
 
-// executeSendPipeline — back-half of the /qurl send lifecycle, extracted
-// from handleSend during PR 7a. Pure refactor: every behavior pinned by
-// qurl-send.test.js, qurl-send-state-machine.test.js,
-// qurl-send-back-half.test.js, and commands-comprehensive.test.js
-// passes unchanged. The closure-captured state from the legacy
-// handleSend's Step-3 form-fill becomes explicit destructured params
-// here so PR 7b's flow_state-backed form can be the second caller (its
-// handleSendFormSend will construct the params object from the
-// flow_state row's decrypted payload and invoke this function).
+// executeSendPipeline — back-half of the /qurl send lifecycle. The
+// destructure signature is the authoritative param surface; the
+// notes below capture only non-obvious contract guarantees that a
+// reader couldn't infer from the call sites alone.
 //
-// Caller contract — full param surface (the destructure list is the
-// authoritative signature; this prose calls out the non-obvious bits):
+// Caller contract (non-obvious bits — what the signature can't say):
 //
-//   - `apiKey` — resolved guild API key (or env fallback).
-//   - `resourceType` — `RESOURCE_TYPES.FILE` or location kind; branches
-//     the upload path and lands in DB rows + audit events.
-//   - `attachment` — non-null when `resourceType === RESOURCE_TYPES.FILE`;
-//     carries `{ url, name, contentType }`. The Discord CDN URL is
-//     leak-equivalent-to-the-file; encrypt before persisting.
-//     **SSRF: `attachment.url` is assumed pre-validated** against
-//     `isAllowedSourceUrl` (today: handleSend's Step-2 file-acceptance
-//     gate before reaching this pipeline). A PR 7b caller that
-//     reconstructs `attachment` from a `flow_state` payload row MUST
-//     re-validate before invoking — otherwise an attacker who edited
-//     the DDB row between create and execute could redirect the
-//     `downloadAndUpload` call to an internal target. The pipeline
-//     itself does not re-check.
-//   - `locationUrl` / `locationName` — non-null on a location send;
-//     forwarded as a `google-map` JSON payload to the connector.
-//   - `recipients` — resolved final list, filtered (sender + bots
-//     excluded), capped at `config.QURL_SEND_MAX_RECIPIENTS`. **The
-//     pipeline MUTATES this array** on the Add Recipients post-send
-//     branch (deduped push). Callers reconstructing the list from a
-//     persisted source (flow_state payload, retry, etc.) should treat
-//     it as transferred ownership for the lifetime of the call, not as
-//     a snapshot.
-//   - `target` — `'user' | 'channel'`; gates the channel-announce
-//     message and lands as `targetType` in the DB row. The voice-vs-
-//     text-channel discrimination is on `isVoiceContext`, NOT on
-//     `target` (a voice-context send still has `target: 'channel'`).
-//     Setting `target: 'voice'` would silently suppress the channel-
-//     announce because the gate at the announce site is strict
-//     equality on `'channel'`.
-//   - `isVoiceContext` — REQUIRED boolean; selects the voice-flavored
-//     wording in the channel-announce blurb. Strictly validated at
-//     entry — a caller that omits it (or passes a non-boolean) throws
-//     a `TypeError` rather than silently landing on the text-channel
-//     branch. This is the strongest forcing function against the
-//     silent-wrong-branch failure mode: a voice-context send that
-//     loses this signal in serialization (e.g. PR 7b's flow_state
-//     payload schema dropping it) fails loudly at the boundary
-//     instead of mis-rendering the channel announce.
-//   - `expiresIn` — canonical expiry token ('1h' / '24h' / '7d' / etc.);
-//     fed through `expiryToISO` and `expiryToMs`.
-//   - `selfDestructSeconds` — `null` for no timer, otherwise a positive
-//     finite integer matching one of `SELF_DESTRUCT_PRESETS.seconds`.
-//     Threaded to every (re)upload so Add Recipients honors the same TTL.
-//   - `personalMessage` — sanitized note (or null) embedded in each
-//     recipient's DM.
-//   - `sendNonce` — logging-breadcrumb only; keeps continuity with the
-//     caller's earlier log lines on the same flow.
+//   - `attachment.url` is assumed PRE-VALIDATED against
+//     `isAllowedSourceUrl`. The pipeline does NOT re-check; an
+//     attacker-controlled URL reaching `downloadAndUpload` here
+//     would bypass the SSRF defense. Callers reconstructing this
+//     from a persisted source MUST re-validate before invoking.
 //
-// Resolved value: the function awaits to completion and returns
-// `undefined`. The early-exit `return interaction.editReply(...)` paths
-// resolve to the editReply Promise's value, but no caller inspects it
-// (handleSend's `return executeSendPipeline(...)` discards it, and
-// `execute()` in turn ignores handleSend's resolved value). A future
-// caller that needs a structured result (e.g. for a programmatic retry)
-// would have to extend this contract.
+//   - `recipients` is MUTATED in-place on the Add Recipients post-
+//     send branch (deduped push of new IDs). Treat as transferred
+//     ownership for the lifetime of the call, not as a snapshot.
+//     A caller that reuses the same array across retries will see
+//     silent double-adds.
 //
-// Required `interaction` shape: the pipeline reads these fields and
-// expects them to be valid. A synthetic interaction missing any of
-// these will fail loudly at the corresponding call site:
-//   - `interaction.user.id`          — sender's discord ID; lands as
-//                                       `senderDiscordId` on every
-//                                       qurl_sends row + audit event,
-//                                       and as the cooldown bucket key.
-//   - `interaction.channelId`        — written to `qurl_sends.channel_id`
-//                                       on every row. A flow_state-backed
-//                                       caller that drops this lands
-//                                       null channel_ids in DDB that
-//                                       won't show up in audit queries.
-//   - `interaction.channel`          — read for the non-ephemeral
-//                                       channel-announce on `target ===
-//                                       'channel'`. Already null-guarded
-//                                       — a missing channel object just
-//                                       drops the announce, doesn't
-//                                       throw.
-//   - `interaction.member?.displayName` (+ `user.username` fallback) —
-//                                       resolved via `resolveSenderAlias`
-//                                       into the DM embed AND the
-//                                       channel-announce blurb.
-//   - `interaction.guild?.members?.fetch` — optionally consumed by the
-//                                       recipient-alias resolver for
-//                                       members that aren't already
-//                                       in cache. Best-effort.
-//   - `interaction.editReply`        — every user-visible status update
-//                                       on the pipeline's primary
-//                                       message goes through this.
-//                                       Must be a Promise-returning
-//                                       function.
-//   - `interaction.channel.send`     — only invoked on `target ===
-//                                       'channel' && delivered > 0`.
-//                                       Logged-and-swallowed on failure
-//                                       — a missing "Send Messages"
-//                                       perm doesn't fail the send.
-// Same forcing-function rationale as the `isVoiceContext` boolean gate:
-// PR 7b's `handleSendFormSend` will reconstruct an interaction surface
-// from a Discord component-event payload and a decrypted flow_state
-// row; whatever fields it omits will silently regress in production.
+//   - `target` is `'user' | 'channel'` ONLY — voice/text channel
+//     discrimination is on `isVoiceContext`, NOT on `target`.
+//     Setting `target: 'voice'` would silently suppress the
+//     channel-announce (the gate at the announce site is strict
+//     equality on `'channel'`).
+//
+//   - `isVoiceContext` is REQUIRED and strictly validated as a
+//     boolean (see entry-point assertion). A silent default would
+//     mis-render the channel-announce blurb for a voice-context
+//     send whose flag got dropped in serialization — exactly the
+//     silent-regression shape every other param avoids by landing
+//     in a grep-discoverable DB column or failing loudly inside
+//     the upload/mint stack.
+//
+// Required `interaction` surface (fail loudly at the corresponding
+// call site if missing):
+//
+//   - `interaction.user.id`            (cooldown key + senderDiscordId
+//                                       on every DB row + audit event)
+//   - `interaction.channelId`          (qurl_sends.channel_id)
+//   - `interaction.channel`            (null-guarded; nullable just
+//                                       drops the channel-announce)
+//   - `interaction.member?.displayName` + `user.username` fallback
+//                                      (resolveSenderAlias → DM embed
+//                                       + channel-announce wording)
+//   - `interaction.guild?.members?.fetch` (best-effort, recipient-
+//                                       alias resolution for cold cache)
+//   - `interaction.editReply`          (every user-visible status
+//                                       update on the primary message)
+//   - `interaction.channel.send`       (only on `target === 'channel'
+//                                       && delivered > 0`; logged-
+//                                       and-swallowed on failure)
+//
+// Resolved value is unused — both terminal completion and the
+// early-exit `return interaction.editReply(...)` paths discard
+// observable result; the function exists for its user-visible
+// side-effects (editReply + DM fan-out + channel-announce).
 async function executeSendPipeline(interaction, {
   apiKey,
   resourceType,
@@ -925,6 +871,18 @@ async function executeSendPipeline(interaction, {
   // exists for PR 7b's handleSendFormSend.
   if (typeof isVoiceContext !== 'boolean') {
     clearCooldown(interaction.user.id);
+    // Clear whatever stale ephemeral the caller's button handler
+    // left on screen ("Preparing send…" is the canonical case)
+    // BEFORE throwing. Fire-and-forget — the throw is the
+    // load-bearing signal (test pins + logger.error in
+    // handleCommand's outer catch), so a failed editReply here
+    // must not become the observable outcome. Without this, the
+    // user sees a persistent stale message alongside the generic
+    // "There was an error" followUp the outer catch will add.
+    interaction.editReply({
+      content: '❌ Internal error — send cancelled. Please rerun the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
     // Render `typeof=` + `value=` separately so a prod-log reader
     // doesn't have to disambiguate `(got object: null)` (where
     // "object" describes the typeof and "null" is the value — a

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -805,10 +805,18 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 //     persisted source (flow_state payload, retry, etc.) should treat
 //     it as transferred ownership for the lifetime of the call, not as
 //     a snapshot.
-//   - `target` — `'user' | 'channel' | 'voice'`; gates the channel-
-//     announce message and lands as `targetType` in the DB row.
+//   - `target` — `'user' | 'channel'`; gates the channel-announce
+//     message and lands as `targetType` in the DB row. The voice-vs-
+//     text-channel discrimination is on `isVoiceContext`, NOT on
+//     `target` (a voice-context send still has `target: 'channel'`).
+//     Setting `target: 'voice'` would silently suppress the channel-
+//     announce because the gate at the announce site is strict
+//     equality on `'channel'`.
 //   - `isVoiceContext` — boolean; selects the voice-flavored wording in
-//     the channel-announce blurb.
+//     the channel-announce blurb. Defaults to `false` in the destructure
+//     so a caller that omits it (e.g. PR 7b reconstructing from a
+//     flow_state payload) lands on the text-channel wording rather
+//     than `undefined ? ... : ...` returning the false branch silently.
 //   - `expiresIn` — canonical expiry token ('1h' / '24h' / '7d' / etc.);
 //     fed through `expiryToISO` and `expiryToMs`.
 //   - `selfDestructSeconds` — `null` for no timer, otherwise a positive
@@ -834,7 +842,7 @@ async function executeSendPipeline(interaction, {
   locationName,
   recipients,
   target,
-  isVoiceContext,
+  isVoiceContext = false,
   expiresIn,
   selfDestructSeconds,
   personalMessage,
@@ -2304,7 +2312,11 @@ async function handleSend(interaction, apiKey) {
   }
 
   // --- Step 4: Process and send (back-half — extracted to executeSendPipeline). ---
-  await executeSendPipeline(interaction, {
+  // `return await` (not bare `await`) so the docstring's "Resolved value"
+  // contract matches the call shape — and the tail call propagates a
+  // throw with one less microtask hop than a bare-await + implicit
+  // undefined return.
+  return await executeSendPipeline(interaction, {
     apiKey,
     resourceType,
     attachment,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -838,6 +838,47 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 // `execute()` in turn ignores handleSend's resolved value). A future
 // caller that needs a structured result (e.g. for a programmatic retry)
 // would have to extend this contract.
+//
+// Required `interaction` shape: the pipeline reads these fields and
+// expects them to be valid. A synthetic interaction missing any of
+// these will fail loudly at the corresponding call site:
+//   - `interaction.user.id`          — sender's discord ID; lands as
+//                                       `senderDiscordId` on every
+//                                       qurl_sends row + audit event,
+//                                       and as the cooldown bucket key.
+//   - `interaction.channelId`        — written to `qurl_sends.channel_id`
+//                                       on every row. A flow_state-backed
+//                                       caller that drops this lands
+//                                       null channel_ids in DDB that
+//                                       won't show up in audit queries.
+//   - `interaction.channel`          — read for the non-ephemeral
+//                                       channel-announce on `target ===
+//                                       'channel'`. Already null-guarded
+//                                       — a missing channel object just
+//                                       drops the announce, doesn't
+//                                       throw.
+//   - `interaction.member?.displayName` (+ `user.username` fallback) —
+//                                       resolved via `resolveSenderAlias`
+//                                       into the DM embed AND the
+//                                       channel-announce blurb.
+//   - `interaction.guild?.members?.fetch` — optionally consumed by the
+//                                       recipient-alias resolver for
+//                                       members that aren't already
+//                                       in cache. Best-effort.
+//   - `interaction.editReply`        — every user-visible status update
+//                                       on the pipeline's primary
+//                                       message goes through this.
+//                                       Must be a Promise-returning
+//                                       function.
+//   - `interaction.channel.send`     — only invoked on `target ===
+//                                       'channel' && delivered > 0`.
+//                                       Logged-and-swallowed on failure
+//                                       — a missing "Send Messages"
+//                                       perm doesn't fail the send.
+// Same forcing-function rationale as the `isVoiceContext` boolean gate:
+// PR 7b's `handleSendFormSend` will reconstruct an interaction surface
+// from a Discord component-event payload and a decrypted flow_state
+// row; whatever fields it omits will silently regress in production.
 async function executeSendPipeline(interaction, {
   apiKey,
   resourceType,
@@ -876,7 +917,12 @@ async function executeSendPipeline(interaction, {
   // exists for PR 7b's handleSendFormSend.
   if (typeof isVoiceContext !== 'boolean') {
     clearCooldown(interaction.user.id);
-    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got ${typeof isVoiceContext}: ${JSON.stringify(isVoiceContext)})`);
+    // `String(undefined)` → "undefined" (not stringified `undefined`
+    // which JSON.stringify drops entirely, producing the awkward
+    // "got undefined: undefined" rendering the round-7 cr flagged).
+    // For non-serializable values String() also avoids the
+    // JSON.stringify-throws-on-BigInt edge case.
+    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got ${typeof isVoiceContext}: ${String(isVoiceContext)})`);
   }
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -787,6 +787,8 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 //   - `target` must be `'user'` or `'channel'`.
 //   - `attachment.url` re-validated against `isAllowedSourceUrl`
 //     when `resourceType === RESOURCE_TYPES.FILE`.
+//   - `expiresIn` must be a key of `EXPIRY_LABELS`.
+//   - `personalMessage` must be `null` or `string`.
 // Each gate clears the caller's stale ephemeral with a cancel-
 // edit then throws — the user still sees the outer catch's
 // generic followUp, but the gate's specific cancel replaces
@@ -863,68 +865,52 @@ async function executeSendPipeline(interaction, {
   personalMessage,
   sendNonce,
 }) {
-  // Strict input gate on the one param whose silent default would
-  // misrender the channel-announce blurb. Other params either land
-  // in DB rows where corruption is grep-discoverable (resourceType,
-  // target, expiresIn) or fail loudly inside the upload/mint
-  // pipeline (attachment, locationUrl). isVoiceContext is unique:
-  // a wrong value here surfaces only as a subtle copy mismatch in
-  // a non-ephemeral channel post — exactly the silent-regression
-  // shape the round-4 cr review flagged.
-  //
-  // Clear cooldown BEFORE the throw so the caller's setCooldown-
-  // in-flight doesn't lock the user out for the cooldown window
-  // (~30s) with no user-visible feedback. clearCooldown is a no-op
-  // when no cooldown is set, so this is safe for callers that
-  // haven't reached the cooldown branch yet — and it matches
-  // handleSend's existing convention of clearing on every error
-  // path. Today's caller never reaches the throw; the cleanup
-  // exists for PR 7b's handleSendFormSend.
-  // Shared cancel-edit shape for all three entry gates. Fire-and-
-  // forget so a failed edit doesn't become the observable outcome —
-  // the throw is the load-bearing signal (test pins + logger.error
-  // in handleCommand's outer catch). The outer catch will still
-  // append a generic "There was an error" followUp; this edit
-  // replaces the caller's stale ephemeral so the user sees a
-  // specific cancel alongside the generic followUp, not a stale
-  // "Preparing send..." alongside it.
+  // Shared cancel-edit for every entry gate. Fire-and-forget — the
+  // throw is the load-bearing signal (test pins + logger.error in
+  // handleCommand's outer catch). The outer catch will still append
+  // a generic followUp; this edit replaces the caller's stale
+  // ephemeral so the user sees a specific cancel alongside the
+  // generic followUp, not a stale "Preparing send..." alongside it.
   const cancelEdit = () => interaction.editReply({
     content: '❌ Internal error — send cancelled. Please rerun the command.',
     components: [],
   }).catch(logIgnoredDiscordErr);
 
+  // `isVoiceContext` strict-boolean gate. Unique among the params
+  // because a wrong value surfaces only as a subtle copy mismatch
+  // in the non-ephemeral channel-announce — the silent-regression
+  // shape every other input either lands in a grep-discoverable
+  // DB column or fails loudly inside the upload/mint stack. The
+  // clearCooldown ahead of the throw matches handleSend's "clear
+  // on every error path" convention so a caller that hit the
+  // gate doesn't strand the user in a cooldown window.
   if (typeof isVoiceContext !== 'boolean') {
     clearCooldown(interaction.user.id);
     cancelEdit();
-    // Render `typeof=` + `value=` separately so a prod-log reader
-    // doesn't have to disambiguate `(got object: null)` (where
-    // "object" describes the typeof and "null" is the value — a
-    // common foot-gun since `typeof null === 'object'`). The
-    // String() call keeps `undefined` visible (JSON.stringify
-    // drops it) and avoids the JSON.stringify-throws-on-BigInt
-    // edge case.
+    // `typeof=` + `value=` rendered separately because
+    // `typeof null === 'object'` is a classic foot-gun in
+    // a single-field "(got object: null)" rendering. `String()`
+    // keeps `undefined` visible (JSON.stringify drops it) and
+    // avoids the JSON.stringify-throws-on-BigInt edge case.
     throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${String(isVoiceContext)})`);
   }
-  // `target` allowed-set gate. Same silent-mis-render shape as
-  // isVoiceContext: an unrecognized value (e.g. `'voice'`) would
-  // silently suppress the channel-announce (the announce site's
-  // gate is strict equality on `'channel'`). The gate makes the
-  // failure mode loud at the boundary.
+
+  // `target` allowed-set gate. Same silent-mis-render shape: an
+  // unrecognized value (e.g. `'voice'`) would silently suppress
+  // the channel-announce — the announce site gates on strict
+  // equality with `'channel'`.
   if (target !== 'user' && target !== 'channel') {
     clearCooldown(interaction.user.id);
     cancelEdit();
     throw new TypeError(`executeSendPipeline: target must be 'user' or 'channel' (got ${String(target)})`);
   }
-  // SSRF re-validation gate. Parallels the `isVoiceContext` gate
-  // but the failure mode is a security boundary, not a copy
-  // mismatch: a tampered DDB payload row could redirect
-  // downloadAndUpload to an internal target if no caller along
-  // the path re-checks. Today handleSend's Step-2 validates
-  // BEFORE calling the pipeline — this defense-in-depth gate
-  // catches a future caller that forgets. RESOURCE_TYPES.FILE-
-  // only because location sends don't carry an attacker-
-  // controlled URL (the locationUrl is built from sanitized
-  // user-text via google.com/maps/search).
+
+  // Defense-in-depth SSRF re-check. handleSend's Step-2 validates
+  // attachment.url against isAllowedSourceUrl BEFORE calling the
+  // pipeline; this gate catches a future caller that forgets.
+  // FILE-only because location sends carry no attacker-controlled
+  // URL (locationUrl is built from sanitized user-text via
+  // google.com/maps/search).
   if (resourceType === RESOURCE_TYPES.FILE) {
     if (!attachment || typeof attachment.url !== 'string' || !isAllowedSourceUrl(attachment.url)) {
       clearCooldown(interaction.user.id);
@@ -936,6 +922,28 @@ async function executeSendPipeline(interaction, {
       });
       throw new Error(`executeSendPipeline: attachment.url failed SSRF re-validation (resourceType=${String(resourceType)})`);
     }
+  }
+
+  // `expiresIn` allowed-set gate. Today only handleSend's
+  // expiry-select dropdown can supply it, so the set is closed.
+  // A future caller reconstructing from a persisted payload could
+  // ship an off-set value (`'25h'`, `'bogus'`) that lands in the
+  // DB and trips downstream when `expiryToISO` / `expiryToMs`
+  // hit it. Validate at the boundary instead.
+  if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
+    clearCooldown(interaction.user.id);
+    cancelEdit();
+    throw new TypeError(`executeSendPipeline: expiresIn must be one of ${Object.keys(EXPIRY_LABELS).join('|')} (got ${String(expiresIn)})`);
+  }
+
+  // `personalMessage` shape gate. The DM-embed renderer expects
+  // null OR string. A non-string object would silently stringify
+  // to `[object Object]` in the recipient's DM — exact silent-
+  // regression shape the other gates fence.
+  if (personalMessage !== null && typeof personalMessage !== 'string') {
+    clearCooldown(interaction.user.id);
+    cancelEdit();
+    throw new TypeError(`executeSendPipeline: personalMessage must be null or string (got typeof=${typeof personalMessage})`);
   }
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -777,6 +777,637 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
   return allLinks;
 }
 
+// executeSendPipeline — back-half of the /qurl send lifecycle, extracted
+// from handleSend during PR 7a. Pure refactor: every behavior pinned by
+// qurl-send.test.js, qurl-send-state-machine.test.js,
+// qurl-send-back-half.test.js, and commands-comprehensive.test.js
+// passes unchanged. The closure-captured state from the legacy
+// handleSend's Step-3 form-fill becomes explicit destructured params
+// here so PR 7b's flow_state-backed form can be the second caller (its
+// handleSendFormSend will construct the params object from the
+// flow_state row's decrypted payload and invoke this function).
+//
+// Caller contract:
+//   - `apiKey` is the resolved guild API key (or env fallback).
+//   - `attachment` is non-null when `resourceType === RESOURCE_TYPES.FILE`
+//     and carries the Discord CDN URL + filename + contentType.
+//   - `locationUrl`/`locationName` are non-null when `resourceType` is
+//     a location kind; the back-half forwards `locationUrl` as a
+//     `google-map` JSON payload to the connector.
+//   - `recipients` is the resolved final list (filtered: sender + bots
+//     excluded, capped at config.QURL_SEND_MAX_RECIPIENTS). The
+//     back-half defends-in-depth with its own length checks but
+//     assumes the caller has done the cap math.
+//   - `sendNonce` is logging-breadcrumb only — keeps continuity with
+//     the caller's earlier log lines on the same flow.
+async function executeSendPipeline(interaction, {
+  apiKey,
+  resourceType,
+  attachment,
+  locationUrl,
+  locationName,
+  recipients,
+  target,
+  isVoiceContext,
+  expiresIn,
+  selfDestructSeconds,
+  personalMessage,
+  sendNonce,
+}) {
+  await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
+
+  const sendId = crypto.randomUUID();
+  let qurlLinks = [];
+  let connectorResourceId = null;
+
+  // Track whether this send has claimed the file-concurrency slot so the
+  // outer finally can release it exactly once even if we hit an error path.
+  let fileSendSlotClaimed = false;
+  // Safety watchdog: if an upload hangs past the deadline (network stuck,
+  // misbehaving upstream AbortSignal), forcibly release the slot so a bad
+  // upload can never permanently consume one of the MAX_CONCURRENT_FILE_SENDS
+  // slots. 5 min is generous — every internal fetch already has its own
+  // shorter AbortSignal timeout, so this fires only on truly stuck flows.
+  let slotWatchdog = null;
+  const releaseSlot = () => {
+    if (fileSendSlotClaimed) {
+      activeFileSends--;
+      fileSendSlotClaimed = false;
+    }
+    if (slotWatchdog) { clearTimeout(slotWatchdog); slotWatchdog = null; }
+  };
+  try {
+    if (resourceType === RESOURCE_TYPES.FILE) {
+      // Atomic claim. The earlier cap-check at file acceptance is UX-only
+      // (told the user upfront the system was busy); five users could each
+      // pass that check while activeFileSends == 0, then all sit in the
+      // 3-min Step-3 form loop, then all increment here past the cap. Re-
+      // check at the increment point to keep the cap honest.
+      if (activeFileSends >= MAX_CONCURRENT_FILE_SENDS) {
+        clearCooldown(interaction.user.id);
+        logger.warn('File send rejected at slot-claim: concurrency cap reached', {
+          activeFileSends, sendId, sendNonce, userId: interaction.user.id,
+        });
+        return interaction.editReply({
+          content: 'The bot is processing too many file sends right now. Please try again in a moment.',
+          components: [],
+        });
+      }
+      activeFileSends++;
+      fileSendSlotClaimed = true;
+      slotWatchdog = setTimeout(() => {
+        if (fileSendSlotClaimed) {
+          logger.error('activeFileSends slot watchdog fired — slot force-released', { sendId, sendNonce, userId: interaction.user.id });
+          activeFileSends--;
+          fileSendSlotClaimed = false;
+        }
+      }, 5 * 60 * 1000);
+      slotWatchdog.unref();
+      const filename = sanitizeFilename(attachment.name);
+      const expiresAt = expiryToISO(expiresIn);
+
+      // Download once, cache the buffer for re-uploads.
+      // selfDestructSeconds threads through both initial upload AND every
+      // re-upload, so the bot's "Add Recipients" mints the same TTL on
+      // each new resource that gets registered (TOKENS_PER_RESOURCE
+      // exhaustion → re-upload → new connector resource).
+      const firstUpload = await downloadAndUpload(attachment.url, filename, attachment.contentType, apiKey, selfDestructSeconds);
+      connectorResourceId = firstUpload.resource_id;
+      // Use a holder so we can null out the reference after all re-uploads
+      // finish — the subsequent link-monitor closure would otherwise pin up
+      // to 25MB in memory for up to an hour per concurrent send.
+      const bufHolder = { buf: firstUpload.fileBuffer };
+
+      // try/finally around mintLinksInBatches so a throw inside batching
+      // still releases the 25 MB buffer — otherwise the reuploadFn closure
+      // would pin it on the activeMonitors set / pending error handler for
+      // up to an hour per concurrent send under GC pressure.
+      let allLinks;
+      try {
+        allLinks = await mintLinksInBatches({
+          initialResourceId: firstUpload.resource_id,
+          reuploadFn: () => reUploadBuffer(bufHolder.buf, filename, attachment.contentType, apiKey, selfDestructSeconds),
+          expiresAt,
+          recipientCount: recipients.length,
+          apiKey,
+        });
+      } finally {
+        bufHolder.buf = null;
+      }
+
+      if (allLinks.length < recipients.length) {
+        logger.error('mintLinks returned fewer links than expected', { expected: recipients.length, got: allLinks.length });
+        clearCooldown(interaction.user.id);
+        return interaction.editReply({ content: `Only ${allLinks.length} of ${recipients.length} links could be created. Please try again.` });
+      }
+
+      qurlLinks = recipients.map((r, i) => ({
+        recipientId: r.id,
+        qurlLink: allLinks[i].qurl_link,
+        resourceId: allLinks[i].resourceId,
+      }));
+      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
+    } else {
+      // Location send — upload JSON payload to connector, then mint in batches
+      // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
+      const locPayload = { type: 'google-map', url: locationUrl, name: locationName || locationUrl };
+      // Note: google-map JSON resources hit the connector's render
+      // carve-out (mapEmbedTmpl/mapFallbackTmpl don't honor
+      // expire_after at view time — qurl-integrations-infra#480).
+      // We still forward selfDestructSeconds so behavior matches the
+      // contract once the carve-out is removed; today it's a no-op.
+      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds);
+      connectorResourceId = firstUpload.resource_id;
+
+      const expiresAt = expiryToISO(expiresIn);
+      const allLinks = await mintLinksInBatches({
+        initialResourceId: firstUpload.resource_id,
+        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds),
+        expiresAt,
+        recipientCount: recipients.length,
+        apiKey,
+      });
+
+      if (allLinks.length < recipients.length) {
+        logger.error('mintLinks returned fewer links than expected for location', { expected: recipients.length, got: allLinks.length });
+        clearCooldown(interaction.user.id);
+        return interaction.editReply({ content: `Only ${allLinks.length} of ${recipients.length} links could be created. Please try again.` });
+      }
+
+      qurlLinks = recipients.map((r, i) => ({
+        recipientId: r.id,
+        qurlLink: allLinks[i].qurl_link,
+        resourceId: allLinks[i].resourceId,
+      }));
+      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
+    }
+  } catch (error) {
+    logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
+    clearCooldown(interaction.user.id); // allow retry on failure
+    releaseSlot();
+    // Surface a specific message for known upstream failure codes so the
+    // user knows what to do (re-upload to refresh the per-resource quota)
+    // instead of seeing a generic "try again" that won't help.
+    if (error.apiCode === 'quota_exceeded') {
+      const isFile = resourceType === RESOURCE_TYPES.FILE;
+      const verb = isFile ? 're-upload the file' : 'edit the location query and resend';
+      return interaction.editReply({
+        content: `Couldn't create more links — this ${isFile ? 'file' : 'location'} has hit its share limit (${TOKENS_PER_RESOURCE} per upload). To send to more recipients, ${verb}.`,
+      });
+    }
+    return interaction.editReply({ content: 'Failed to create links. Please try again.' });
+  } finally {
+    // Release the file-concurrency slot as soon as the mint+batch phase is
+    // done — we no longer hold the 25 MB buffer past this point.
+    releaseSlot();
+  }
+
+  if (qurlLinks.length === 0) {
+    clearCooldown(interaction.user.id);
+    return interaction.editReply({ content: 'Failed to create any links. Please try again.' });
+  }
+
+  // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
+  // still exist on the QURL side but there's no local record to revoke them
+  // later — abort the send and surface the error instead of continuing to DMs.
+  try {
+    await db.recordQURLSendBatch(qurlLinks.map(link => ({
+      sendId, senderDiscordId: interaction.user.id, recipientDiscordId: link.recipientId,
+      resourceId: link.resourceId, resourceType, qurlLink: link.qurlLink,
+      expiresIn, channelId: interaction.channelId, targetType: target,
+    })));
+  } catch (err) {
+    // Log the orphaned QURL resources at error level so an operator can
+    // manually revoke them — they exist on the QURL side with no local row.
+    logger.error('recordQURLSendBatch failed; aborting send to keep state consistent', {
+      sendId, error: err.message, linkCount: qurlLinks.length,
+      orphanedResources: qurlLinks.map(l => ({ resourceId: l.resourceId, qurlLink: l.qurlLink })),
+    });
+    clearCooldown(interaction.user.id);
+    return interaction.editReply({
+      content: 'Failed to save link records. Links were not sent. Please try again.',
+    });
+  }
+
+  // Send DMs
+  let delivered = 0;
+  let failed = 0;
+  const failedUsers = [];
+  const recipientMap = new Map(recipients.map(r => [r.id, r]));
+
+  // Compute the absolute expiry instant once for this dispatch (Unix
+  // seconds — Discord's <t:N:R> format requires seconds, not millis).
+  // Using send-time + duration rather than reading from the API mint
+  // response since `mintLinks` doesn't currently surface `expires_at`.
+  // Drift between this clock and the API's enforcement clock is bounded
+  // by the time between this line and the mint call (sub-second on
+  // handleSend; can be a few seconds on handleAddRecipients which
+  // re-downloads + re-uploads + re-mints first). Negligible at the
+  // 30m–7d horizon — recipients see "in 24 hours" instead of
+  // "in 23h 59m 56s" on the worst-case path.
+  const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
+
+  const dmResults = await batchSettled(qurlLinks, async (link) => {
+    const recipient = recipientMap.get(link.recipientId);
+    // Audit in `finally` so the metric fires for every recipient regardless
+    // of where the dispatch fails — sendDM resolving to false, sendDM
+    // throwing (against contract — see apps/discord/src/discord.js), OR
+    // buildDeliveryPayload throwing (e.g. on a pathological personalMessage).
+    // Audit fires BEFORE the DB write so a DDB-layer throw can't suppress
+    // it either — that's the failure mode the audit metric exists to
+    // measure. Coverage spans the entire dispatch attempt, not just the
+    // network leg.
+    let sent = false;
+    try {
+      const dmPayload = buildDeliveryPayload({
+        // member.displayName resolves to nickname || globalName || username,
+        // so it works whether the sender has a per-guild nickname, only a
+        // global display name, or just the legacy @-handle.
+        senderAlias: resolveSenderAlias(interaction),
+        qurlLink: link.qurlLink,
+        expiresAt,
+        personalMessage,
+      });
+      sent = await sendDM(link.recipientId, dmPayload);
+    } finally {
+      logger.audit(sent === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+    }
+    await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
+    return { recipientId: link.recipientId, username: recipient?.username, sent };
+  }, 5);
+
+  for (const r of dmResults) {
+    if (r.status === 'fulfilled' && r.value.sent) {
+      delivered++;
+    } else {
+      failed++;
+      if (r.status === 'fulfilled') {
+        failedUsers.push({ id: r.value.recipientId, username: r.value.username });
+      } else {
+        failedUsers.push({ id: null, username: 'unknown' });
+      }
+    }
+  }
+
+  // Save send config for "Add Recipients" reuse. For file sends, also stash
+  // the Discord CDN URL + content type so we can re-download + re-upload when
+  // adding recipients (the original resource's 10-token pool may be drained).
+  // Logged-and-swallowed: a failure here doesn't block DM delivery (already
+  // done above) but it disables future Add Recipients / revoke-via-ui for
+  // this send. The per-link rows in qurl_sends persisted above, so /qurl
+  // revoke by sendId still works even if this row is missing.
+  try {
+    await db.saveSendConfig({
+      sendId, senderDiscordId: interaction.user.id, resourceType, connectorResourceId,
+      actualUrl: locationUrl || null, expiresIn, personalMessage, locationName,
+      attachmentName: attachment?.name || null,
+      attachmentContentType: attachment?.contentType || null,
+      attachmentUrl: attachment?.url || null,
+      selfDestructSeconds,
+    });
+  } catch (err) {
+    logger.error('saveSendConfig failed; Add Recipients will be unavailable for this send', {
+      sendId, error: err.message,
+    });
+  }
+
+  // Ephemeral confirmation with Add Recipients + Revoke buttons.
+  // Match on the Discord id (snowflake, globally unique) rather than the
+  // display username — usernames can collide within a guild.
+  // Shares REVOKE_TRUNC_LIMIT (module scope) so the send-confirmation
+  // "Recipients: …" line and the post-revoke "Revoked for: …" line
+  // truncate at the same threshold.
+  const failedUserIds = new Set(failedUsers.map(u => u.id || u));
+  const successNames = recipients.filter(r => !failedUserIds.has(r.id)).map(r => resolveRecipientAlias(r, interaction));
+
+  // Plain-form failed names (sanitizeDisplayNamePlain is already
+  // applied inside resolveRecipientAlias). Used for the attachment
+  // file; message-content rendering escapes per name.
+  const failedNamesPlain = failedUsers.map(u => resolveRecipientAlias(u, interaction));
+  const buildConfirmMsg = (showAll) => renderSendConfirm({
+    delivered, expiresIn,
+    failedNamesPlain, successNames, showAll,
+  });
+
+  const confirmRendered = buildConfirmMsg(false);
+  let confirmMsg = confirmRendered.content;
+  // In attachment mode the file IS the full list, so suppress the
+  // Show All toggle — the same shape the post-revoke flow uses.
+  const needsExpand = confirmRendered.needsExpand;
+
+  const buttonRow = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`qurl_add_${sendId}`)
+      .setLabel('Add Recipients')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`qurl_revoke_${sendId}`)
+      .setLabel('Revoke All')
+      .setStyle(ButtonStyle.Danger),
+  );
+  if (needsExpand) {
+    buttonRow.addComponents(
+      new ButtonBuilder()
+        .setCustomId(`qurl_expand_${sendId}`)
+        .setLabel('Show All')
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+
+  // When successNames + failedNames overflow Discord's 2000-char content
+  // cap, attach the full lists as `recipients.txt` on this initial
+  // editReply. Subsequent monitor ticks / Add Recipients edits don't
+  // pass `files`, so Discord keeps the existing attachment without
+  // re-uploading. Add Recipients does NOT regenerate the attachment;
+  // the newly-added users surface in the post-revoke "Revoked for: …"
+  // list (with its own overflow path) and in monitor link-status
+  // updates.
+  const initialPayload = {
+    content: confirmMsg,
+    components: delivered > 0 ? [buttonRow] : [],
+  };
+  if (confirmRendered.attachmentText) {
+    initialPayload.files = [
+      new AttachmentBuilder(Buffer.from(confirmRendered.attachmentText, 'utf8'), { name: 'recipients.txt' }),
+    ];
+  }
+  const response = await interaction.editReply(initialPayload);
+
+  // Non-ephemeral channel notification when sending to "Everyone" (channel
+  // target) or "Voice users" (voice target). The sender's ephemeral reply
+  // confirms the send to THEM; this message is what recipients see in the
+  // channel so they know to look for the Qurl Bot DM. Without this, a
+  // passive channel member who missed the DM ping has no signal that a
+  // send happened. Logged-and-swallowed on failure — a missing
+  // "Send Messages" permission in a customer server shouldn't fail the
+  // whole send (DMs already went out successfully).
+  //
+  // Guard on `interaction.channel` being present: for a slash command
+  // invoked in a guild channel this is always set, but in edge cases
+  // (partial-cache on a fresh gateway connect, thread that got
+  // archived mid-send, DM-channel dispatch) the channel object can be
+  // null — and `.send()` on null throws synchronously, before the
+  // try/catch can see it.
+  if (interaction.channel && target === 'channel' && delivered > 0) {
+    // Same sanitizer the DM embed uses (sanitizeDisplayName: NFKC + bidi/
+    // zero-width/control strip + markdown escape + 64-char cap + 'Someone'
+    // fallback). Channel-post is a wider blast radius than DM, so applying
+    // the same spoof defense here is critical — without it a display name
+    // with a leading U+202E flips text direction in the public announcement.
+    const safeName = sanitizeDisplayName(resolveSenderAlias(interaction));
+    const notifyMsg = isVoiceContext
+      ? `📩 **${safeName}** has shared something with users currently connected to this voice channel via **qURL Bot** — check your DMs from qURL Bot.`
+      : `📩 **${safeName}** has shared something with all members of this channel via **qURL Bot** — check your DMs from qURL Bot.`;
+    try {
+      await interaction.channel.send({ content: notifyMsg });
+    } catch (err) {
+      logger.warn('Failed to send channel notification', { error: err.message });
+    }
+  }
+
+  logger.info('/qurl send completed', {
+    sender: interaction.user.id, sendId, target, resourceType, delivered, failed, expiresIn,
+  });
+
+  // Collector handles multiple button clicks (Add Recipients can be clicked multiple times)
+  let monitor = null;
+  if (delivered > 0) {
+    let addRecipientsCount = 0; // Track cumulative adds for cap enforcement
+    // Single source of truth for the "adding recipients" lock: the global
+    // addRecipientsLocks Set keyed by sendId. Acquire at the top of the
+    // collect handler, release in a single outer finally{} so any throw
+    // between acquire and the previous dual-flag release paths can't
+    // permanently block subsequent button clicks.
+
+    // Create the collector FIRST — if collector setup throws, we return
+    // without ever having started the monitor, so no setInterval leaks
+    // interaction/recipients/buttonRow/file data in a closure for up to
+    // an hour. Only after the collector is established do we kick the
+    // monitor setInterval.
+    let collector;
+    try {
+      collector = response.createMessageComponentCollector({
+        filter: (i) => i.user.id === interaction.user.id,
+        time: TIMEOUTS.QURL_REVOKE_WINDOW,
+      });
+    } catch (err) {
+      logger.error('Failed to create button collector', { sendId, error: err.message });
+      return;
+    }
+    monitor = monitorLinkStatus(sendId, interaction, qurlLinks, recipients, expiresIn, confirmMsg, buttonRow, delivered, apiKey);
+
+    let showAllRecipients = false;
+
+    // `revokeInFlight` dedups concurrent Revoke clicks. `revokeSucceeded`
+    // guards the on('end') re-render so a Failed message isn't overwritten
+    // by a stale "Revoked 0/0".
+    let revokeResultUserNames = [];
+    let revokeResultTotal = 0;
+    // Authoritative DDB strict-success count. Tracked separately from
+    // `revokeResultUserNames.length` so the header stays correct even
+    // if a successful recipient_id can't be name-resolved against
+    // `recipients[]`.
+    let revokeResultSuccess = 0;
+    let revokeShowAll = false;
+    let revokeInFlight = false;
+    let revokeSucceeded = false;
+
+    collector.on('collect', async (btnInteraction) => {
+      if (btnInteraction.customId === `qurl_expand_${sendId}`) {
+        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
+        showAllRecipients = !showAllRecipients;
+        // buildConfirmMsg now returns {content, attachmentText, needsExpand};
+        // extract content for the monitor + editReply (string-only).
+        confirmMsg = buildConfirmMsg(showAllRecipients).content;
+        monitor.updateBaseMsg(confirmMsg);
+        const fullMsg = monitor.getFullMsg();
+        const updatedRow = new ActionRowBuilder().addComponents(
+          new ButtonBuilder().setCustomId(`qurl_add_${sendId}`).setLabel('Add Recipients').setStyle(ButtonStyle.Primary),
+          new ButtonBuilder().setCustomId(`qurl_revoke_${sendId}`).setLabel('Revoke All').setStyle(ButtonStyle.Danger),
+          new ButtonBuilder().setCustomId(`qurl_expand_${sendId}`).setLabel(showAllRecipients ? 'Show Less' : 'Show All').setStyle(ButtonStyle.Secondary),
+        );
+        await interaction.editReply({ content: fullMsg, components: [updatedRow] }).catch(logIgnoredDiscordErr);
+        return;
+      }
+
+      if (btnInteraction.customId === `qurl_revoke_expand_${sendId}`) {
+        // Toggle Show All / Show Less on the post-revoke recipient list.
+        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
+        revokeShowAll = !revokeShowAll;
+        const updated = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, revokeShowAll, revokeResultSuccess);
+        await interaction.editReply(revokeReplyPayload(updated)).catch(logIgnoredDiscordErr);
+        return;
+      }
+
+      if (btnInteraction.customId === `qurl_revoke_${sendId}`) {
+        // Sync dedup before any await (Node single-threaded).
+        if (revokeInFlight) return btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
+        revokeInFlight = true;
+        // Stop monitor BEFORE any editReply — its setInterval can
+        // overwrite the revoke-result message otherwise.
+        if (monitor) monitor.stop();
+        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
+        await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
+        try {
+          const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
+          // Iterate `recipients` (canonical send-confirmation order)
+          // and filter by membership — `successUserIds` walks Set
+          // insertion order from resource-grouped iteration, which
+          // doesn't match what the user saw on "Recipients: …".
+          const successSet = new Set(revoked.successUserIds);
+          revokeResultUserNames = recipients
+            .filter(r => successSet.has(r.id))
+            .map(r => resolveRecipientAlias(r, interaction));
+          revokeResultTotal = revoked.total;
+          revokeResultSuccess = revoked.success;
+          revokeShowAll = false;
+          const initial = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, false, revokeResultSuccess);
+          await interaction.editReply(revokeReplyPayload(initial)).catch(logIgnoredDiscordErr);
+          revokeSucceeded = true;
+        } catch (err) {
+          logger.error('Revoke failed', { sendId, error: err.message });
+          await interaction.editReply({
+            content: 'Failed to revoke links. Try `/qurl revoke` instead.',
+            components: [],
+          }).catch(logIgnoredDiscordErr);
+          // Reset so the dedup flag isn't sticky if the failure UI
+          // ever changes to retain the Revoke button.
+          revokeInFlight = false;
+        }
+        // Collector keeps running for the post-revoke expand toggle;
+        // its `time:` window auto-expires.
+
+      } else if (btnInteraction.customId === `qurl_add_${sendId}`) {
+        // =====================================================================
+        // CRITICAL SECTION — do NOT add any `await` between the three lines
+        // below and the next `return` path. Node.js is single-threaded: if
+        // check+set+cooldown all happen synchronously, a second button click
+        // dispatched to the same handler cannot observe the unlocked state.
+        // The `await` in the rejection branches is fine because we've already
+        // committed to rejecting at that point.
+        // =====================================================================
+        // Check-and-claim are now adjacent: if the flag is unset, grab it
+        // FIRST (before any cap check), then verify remaining capacity and
+        // release on rejection. That way a future refactor that adds an
+        // `await` in the remaining check can't reopen a racy window.
+        if (addRecipientsLocks.has(sendId)) {
+          await btnInteraction.reply({ content: 'Already processing an "Add Recipients" action.', ephemeral: true }).catch(logIgnoredDiscordErr);
+          return;
+        }
+        addRecipientsLocks.add(sendId);
+        // Single outer try/finally guarantees the lock is released on every
+        // exit path — even if a synchronous throw happens between acquire
+        // and any early return. The old dual-flag pattern had multiple
+        // release sites and risked permanent lock-out on a missed release.
+        try {
+          const remaining = config.QURL_SEND_MAX_RECIPIENTS - delivered - addRecipientsCount;
+          if (remaining <= 0) {
+            await btnInteraction.reply({
+              content: `Recipient limit reached (${config.QURL_SEND_MAX_RECIPIENTS} max).`,
+              ephemeral: true,
+            });
+            return;
+          }
+          if (isOnCooldown(interaction.user.id)) {
+            await btnInteraction.reply({ content: 'Please wait before adding more recipients.', ephemeral: true }).catch(logIgnoredDiscordErr);
+            return;
+          }
+          setCooldown(interaction.user.id);
+
+          // Show user select menu — collect the response on the REPLY message
+          const maxSelect = Math.min(USER_SELECT_PER_PICK_CAP, remaining);
+          const userSelectRow = new ActionRowBuilder().addComponents(
+            new UserSelectMenuBuilder()
+              .setCustomId(`qurl_addusers_${sendId}`)
+              .setPlaceholder('Select users to send to')
+              .setMinValues(1)
+              .setMaxValues(maxSelect)
+          );
+          const selectReply = await btnInteraction.reply({
+            content: 'Select additional recipients:',
+            components: [userSelectRow],
+            ephemeral: true,
+            fetchReply: true,
+          });
+
+          try {
+            const selectInteraction = await selectReply.awaitMessageComponent({
+              componentType: ComponentType.UserSelect,
+              time: 60000,
+            });
+
+            await selectInteraction.deferUpdate();
+            const addResult = await handleAddRecipients(
+              sendId, selectInteraction.users, interaction, apiKey,
+            );
+
+            // Extend recipients[] for the post-revoke names line.
+            // Dedupe by id — re-Add of an already-included user.
+            if (addResult.newRecipients?.length) {
+              const existingIds = new Set(recipients.map(r => r.id));
+              for (const r of addResult.newRecipients) {
+                if (!existingIds.has(r.id)) recipients.push(r);
+              }
+            }
+
+            if (addResult.delivered > 0) {
+              addRecipientsCount += addResult.delivered;
+              // Tell the monitor to track the new links (including new resource IDs for location sends)
+              monitor.addRecipients(addResult.delivered, addResult.newResourceIds);
+              const totalSent = delivered + addRecipientsCount;
+              confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | One-time links`;
+              if (failed > 0) confirmMsg += `\n${failed} could not be reached`;
+              monitor.updateBaseMsg(confirmMsg);
+              await interaction.editReply({ content: monitor.getFullMsg(), components: [buttonRow] });
+            }
+
+            await selectInteraction.editReply({ content: addResult.msg, components: [] });
+          } catch (err) {
+            const isTimeout = err?.code === 'InteractionCollectorError' || err?.message?.includes('time');
+            // Generic user-facing message; real details only land in logs.
+            const msg = isTimeout ? 'Selection timed out.' : 'Failed to add recipients. Please try again.';
+            // Drop to warn for routine user-timeouts; keep error for real failures.
+            const log = isTimeout ? logger.warn : logger.error;
+            log('Add recipients failed', { sendId, error: err.message, isTimeout });
+            await btnInteraction.editReply({ content: msg, components: [] }).catch(logIgnoredDiscordErr);
+          }
+        } finally {
+          addRecipientsLocks.delete(sendId);
+        }
+      }
+    });
+
+    collector.on('end', (_, reason) => {
+      // Stop monitor polling when collector ends for any reason
+      if (monitor) monitor.stop();
+      if (reason === 'time') {
+        // After a SUCCESSFUL revoke, re-render the revoke result
+        // instead of the pre-revoke confirmMsg + Management-window
+        // banner — otherwise the user's "Revoked X/Y links" view
+        // gets clobbered when the collector window ends. Gate on
+        // `revokeSucceeded` (not `revokeInFlight`) so a failure
+        // message ("Failed to revoke links…") isn't overwritten with
+        // a stale "Revoked 0/0 links" line.
+        if (revokeSucceeded) {
+          // Terminal state: re-render content (Show All may have
+          // toggled), strip components. Omit `files`/`attachments`
+          // so Discord keeps the existing revoked-users.txt without
+          // re-uploading the same blob 15min later.
+          const final = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, revokeShowAll, revokeResultSuccess);
+          interaction.editReply({ content: final.content, components: [] }).catch(logIgnoredDiscordErr);
+          return;
+        }
+        // Revoke attempted but failed — leave the failure message.
+        if (revokeInFlight) return;
+        interaction.editReply({
+          content: (monitor ? monitor.getFullMsg() : confirmMsg) + '\n\n⏰ **Management window closed** — use `/qurl revoke` to revoke later.',
+          components: [],
+        }).catch(logIgnoredDiscordErr);
+      }
+    });
+  }
+}
+
 async function handleSend(interaction, apiKey) {
   // awaitMessageComponent below requires a channel handle
   if (!interaction.channel) {
@@ -1646,600 +2277,21 @@ async function handleSend(interaction, apiKey) {
     });
   }
 
-  // --- Step 4: Process and send (back-half — preserved unchanged) ---
-  await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
-
-  const sendId = crypto.randomUUID();
-  let qurlLinks = [];
-  let connectorResourceId = null;
-
-  // Track whether this send has claimed the file-concurrency slot so the
-  // outer finally can release it exactly once even if we hit an error path.
-  let fileSendSlotClaimed = false;
-  // Safety watchdog: if an upload hangs past the deadline (network stuck,
-  // misbehaving upstream AbortSignal), forcibly release the slot so a bad
-  // upload can never permanently consume one of the MAX_CONCURRENT_FILE_SENDS
-  // slots. 5 min is generous — every internal fetch already has its own
-  // shorter AbortSignal timeout, so this fires only on truly stuck flows.
-  let slotWatchdog = null;
-  const releaseSlot = () => {
-    if (fileSendSlotClaimed) {
-      activeFileSends--;
-      fileSendSlotClaimed = false;
-    }
-    if (slotWatchdog) { clearTimeout(slotWatchdog); slotWatchdog = null; }
-  };
-  try {
-    if (resourceType === RESOURCE_TYPES.FILE) {
-      // Atomic claim. The earlier cap-check at file acceptance is UX-only
-      // (told the user upfront the system was busy); five users could each
-      // pass that check while activeFileSends == 0, then all sit in the
-      // 3-min Step-3 form loop, then all increment here past the cap. Re-
-      // check at the increment point to keep the cap honest.
-      if (activeFileSends >= MAX_CONCURRENT_FILE_SENDS) {
-        clearCooldown(interaction.user.id);
-        logger.warn('File send rejected at slot-claim: concurrency cap reached', {
-          activeFileSends, sendId, sendNonce, userId: interaction.user.id,
-        });
-        return interaction.editReply({
-          content: 'The bot is processing too many file sends right now. Please try again in a moment.',
-          components: [],
-        });
-      }
-      activeFileSends++;
-      fileSendSlotClaimed = true;
-      slotWatchdog = setTimeout(() => {
-        if (fileSendSlotClaimed) {
-          logger.error('activeFileSends slot watchdog fired — slot force-released', { sendId, sendNonce, userId: interaction.user.id });
-          activeFileSends--;
-          fileSendSlotClaimed = false;
-        }
-      }, 5 * 60 * 1000);
-      slotWatchdog.unref();
-      const filename = sanitizeFilename(attachment.name);
-      const expiresAt = expiryToISO(expiresIn);
-
-      // Download once, cache the buffer for re-uploads.
-      // selfDestructSeconds threads through both initial upload AND every
-      // re-upload, so the bot's "Add Recipients" mints the same TTL on
-      // each new resource that gets registered (TOKENS_PER_RESOURCE
-      // exhaustion → re-upload → new connector resource).
-      const firstUpload = await downloadAndUpload(attachment.url, filename, attachment.contentType, apiKey, selfDestructSeconds);
-      connectorResourceId = firstUpload.resource_id;
-      // Use a holder so we can null out the reference after all re-uploads
-      // finish — the subsequent link-monitor closure would otherwise pin up
-      // to 25MB in memory for up to an hour per concurrent send.
-      const bufHolder = { buf: firstUpload.fileBuffer };
-
-      // try/finally around mintLinksInBatches so a throw inside batching
-      // still releases the 25 MB buffer — otherwise the reuploadFn closure
-      // would pin it on the activeMonitors set / pending error handler for
-      // up to an hour per concurrent send under GC pressure.
-      let allLinks;
-      try {
-        allLinks = await mintLinksInBatches({
-          initialResourceId: firstUpload.resource_id,
-          reuploadFn: () => reUploadBuffer(bufHolder.buf, filename, attachment.contentType, apiKey, selfDestructSeconds),
-          expiresAt,
-          recipientCount: recipients.length,
-          apiKey,
-        });
-      } finally {
-        bufHolder.buf = null;
-      }
-
-      if (allLinks.length < recipients.length) {
-        logger.error('mintLinks returned fewer links than expected', { expected: recipients.length, got: allLinks.length });
-        clearCooldown(interaction.user.id);
-        return interaction.editReply({ content: `Only ${allLinks.length} of ${recipients.length} links could be created. Please try again.` });
-      }
-
-      qurlLinks = recipients.map((r, i) => ({
-        recipientId: r.id,
-        qurlLink: allLinks[i].qurl_link,
-        resourceId: allLinks[i].resourceId,
-      }));
-      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
-    } else {
-      // Location send — upload JSON payload to connector, then mint in batches
-      // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
-      const locPayload = { type: 'google-map', url: locationUrl, name: locationName || locationUrl };
-      // Note: google-map JSON resources hit the connector's render
-      // carve-out (mapEmbedTmpl/mapFallbackTmpl don't honor
-      // expire_after at view time — qurl-integrations-infra#480).
-      // We still forward selfDestructSeconds so behavior matches the
-      // contract once the carve-out is removed; today it's a no-op.
-      const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds);
-      connectorResourceId = firstUpload.resource_id;
-
-      const expiresAt = expiryToISO(expiresIn);
-      const allLinks = await mintLinksInBatches({
-        initialResourceId: firstUpload.resource_id,
-        reuploadFn: () => uploadJsonToConnector(locPayload, 'location.json', apiKey, selfDestructSeconds),
-        expiresAt,
-        recipientCount: recipients.length,
-        apiKey,
-      });
-
-      if (allLinks.length < recipients.length) {
-        logger.error('mintLinks returned fewer links than expected for location', { expected: recipients.length, got: allLinks.length });
-        clearCooldown(interaction.user.id);
-        return interaction.editReply({ content: `Only ${allLinks.length} of ${recipients.length} links could be created. Please try again.` });
-      }
-
-      qurlLinks = recipients.map((r, i) => ({
-        recipientId: r.id,
-        qurlLink: allLinks[i].qurl_link,
-        resourceId: allLinks[i].resourceId,
-      }));
-      logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
-    }
-  } catch (error) {
-    logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
-    clearCooldown(interaction.user.id); // allow retry on failure
-    releaseSlot();
-    // Surface a specific message for known upstream failure codes so the
-    // user knows what to do (re-upload to refresh the per-resource quota)
-    // instead of seeing a generic "try again" that won't help.
-    if (error.apiCode === 'quota_exceeded') {
-      const isFile = resourceType === RESOURCE_TYPES.FILE;
-      const verb = isFile ? 're-upload the file' : 'edit the location query and resend';
-      return interaction.editReply({
-        content: `Couldn't create more links — this ${isFile ? 'file' : 'location'} has hit its share limit (${TOKENS_PER_RESOURCE} per upload). To send to more recipients, ${verb}.`,
-      });
-    }
-    return interaction.editReply({ content: 'Failed to create links. Please try again.' });
-  } finally {
-    // Release the file-concurrency slot as soon as the mint+batch phase is
-    // done — we no longer hold the 25 MB buffer past this point.
-    releaseSlot();
-  }
-
-  if (qurlLinks.length === 0) {
-    clearCooldown(interaction.user.id);
-    return interaction.editReply({ content: 'Failed to create any links. Please try again.' });
-  }
-
-  // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
-  // still exist on the QURL side but there's no local record to revoke them
-  // later — abort the send and surface the error instead of continuing to DMs.
-  try {
-    await db.recordQURLSendBatch(qurlLinks.map(link => ({
-      sendId, senderDiscordId: interaction.user.id, recipientDiscordId: link.recipientId,
-      resourceId: link.resourceId, resourceType, qurlLink: link.qurlLink,
-      expiresIn, channelId: interaction.channelId, targetType: target,
-    })));
-  } catch (err) {
-    // Log the orphaned QURL resources at error level so an operator can
-    // manually revoke them — they exist on the QURL side with no local row.
-    logger.error('recordQURLSendBatch failed; aborting send to keep state consistent', {
-      sendId, error: err.message, linkCount: qurlLinks.length,
-      orphanedResources: qurlLinks.map(l => ({ resourceId: l.resourceId, qurlLink: l.qurlLink })),
-    });
-    clearCooldown(interaction.user.id);
-    return interaction.editReply({
-      content: 'Failed to save link records. Links were not sent. Please try again.',
-    });
-  }
-
-  // Send DMs
-  let delivered = 0;
-  let failed = 0;
-  const failedUsers = [];
-  const recipientMap = new Map(recipients.map(r => [r.id, r]));
-
-  // Compute the absolute expiry instant once for this dispatch (Unix
-  // seconds — Discord's <t:N:R> format requires seconds, not millis).
-  // Using send-time + duration rather than reading from the API mint
-  // response since `mintLinks` doesn't currently surface `expires_at`.
-  // Drift between this clock and the API's enforcement clock is bounded
-  // by the time between this line and the mint call (sub-second on
-  // handleSend; can be a few seconds on handleAddRecipients which
-  // re-downloads + re-uploads + re-mints first). Negligible at the
-  // 30m–7d horizon — recipients see "in 24 hours" instead of
-  // "in 23h 59m 56s" on the worst-case path.
-  const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
-
-  const dmResults = await batchSettled(qurlLinks, async (link) => {
-    const recipient = recipientMap.get(link.recipientId);
-    // Audit in `finally` so the metric fires for every recipient regardless
-    // of where the dispatch fails — sendDM resolving to false, sendDM
-    // throwing (against contract — see apps/discord/src/discord.js), OR
-    // buildDeliveryPayload throwing (e.g. on a pathological personalMessage).
-    // Audit fires BEFORE the DB write so a DDB-layer throw can't suppress
-    // it either — that's the failure mode the audit metric exists to
-    // measure. Coverage spans the entire dispatch attempt, not just the
-    // network leg.
-    let sent = false;
-    try {
-      const dmPayload = buildDeliveryPayload({
-        // member.displayName resolves to nickname || globalName || username,
-        // so it works whether the sender has a per-guild nickname, only a
-        // global display name, or just the legacy @-handle.
-        senderAlias: resolveSenderAlias(interaction),
-        qurlLink: link.qurlLink,
-        expiresAt,
-        personalMessage,
-      });
-      sent = await sendDM(link.recipientId, dmPayload);
-    } finally {
-      logger.audit(sent === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
-    }
-    await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    return { recipientId: link.recipientId, username: recipient?.username, sent };
-  }, 5);
-
-  for (const r of dmResults) {
-    if (r.status === 'fulfilled' && r.value.sent) {
-      delivered++;
-    } else {
-      failed++;
-      if (r.status === 'fulfilled') {
-        failedUsers.push({ id: r.value.recipientId, username: r.value.username });
-      } else {
-        failedUsers.push({ id: null, username: 'unknown' });
-      }
-    }
-  }
-
-  // Save send config for "Add Recipients" reuse. For file sends, also stash
-  // the Discord CDN URL + content type so we can re-download + re-upload when
-  // adding recipients (the original resource's 10-token pool may be drained).
-  // Logged-and-swallowed: a failure here doesn't block DM delivery (already
-  // done above) but it disables future Add Recipients / revoke-via-ui for
-  // this send. The per-link rows in qurl_sends persisted above, so /qurl
-  // revoke by sendId still works even if this row is missing.
-  try {
-    await db.saveSendConfig({
-      sendId, senderDiscordId: interaction.user.id, resourceType, connectorResourceId,
-      actualUrl: locationUrl || null, expiresIn, personalMessage, locationName,
-      attachmentName: attachment?.name || null,
-      attachmentContentType: attachment?.contentType || null,
-      attachmentUrl: attachment?.url || null,
-      selfDestructSeconds,
-    });
-  } catch (err) {
-    logger.error('saveSendConfig failed; Add Recipients will be unavailable for this send', {
-      sendId, error: err.message,
-    });
-  }
-
-  // Ephemeral confirmation with Add Recipients + Revoke buttons.
-  // Match on the Discord id (snowflake, globally unique) rather than the
-  // display username — usernames can collide within a guild.
-  // Shares REVOKE_TRUNC_LIMIT (module scope) so the send-confirmation
-  // "Recipients: …" line and the post-revoke "Revoked for: …" line
-  // truncate at the same threshold.
-  const failedUserIds = new Set(failedUsers.map(u => u.id || u));
-  const successNames = recipients.filter(r => !failedUserIds.has(r.id)).map(r => resolveRecipientAlias(r, interaction));
-
-  // Plain-form failed names (sanitizeDisplayNamePlain is already
-  // applied inside resolveRecipientAlias). Used for the attachment
-  // file; message-content rendering escapes per name.
-  const failedNamesPlain = failedUsers.map(u => resolveRecipientAlias(u, interaction));
-  const buildConfirmMsg = (showAll) => renderSendConfirm({
-    delivered, expiresIn,
-    failedNamesPlain, successNames, showAll,
+  // --- Step 4: Process and send (back-half — extracted to executeSendPipeline). ---
+  await executeSendPipeline(interaction, {
+    apiKey,
+    resourceType,
+    attachment,
+    locationUrl,
+    locationName,
+    recipients,
+    target,
+    isVoiceContext,
+    expiresIn,
+    selfDestructSeconds,
+    personalMessage,
+    sendNonce,
   });
-
-  const confirmRendered = buildConfirmMsg(false);
-  let confirmMsg = confirmRendered.content;
-  // In attachment mode the file IS the full list, so suppress the
-  // Show All toggle — the same shape the post-revoke flow uses.
-  const needsExpand = confirmRendered.needsExpand;
-
-  const buttonRow = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId(`qurl_add_${sendId}`)
-      .setLabel('Add Recipients')
-      .setStyle(ButtonStyle.Primary),
-    new ButtonBuilder()
-      .setCustomId(`qurl_revoke_${sendId}`)
-      .setLabel('Revoke All')
-      .setStyle(ButtonStyle.Danger),
-  );
-  if (needsExpand) {
-    buttonRow.addComponents(
-      new ButtonBuilder()
-        .setCustomId(`qurl_expand_${sendId}`)
-        .setLabel('Show All')
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-
-  // When successNames + failedNames overflow Discord's 2000-char content
-  // cap, attach the full lists as `recipients.txt` on this initial
-  // editReply. Subsequent monitor ticks / Add Recipients edits don't
-  // pass `files`, so Discord keeps the existing attachment without
-  // re-uploading. Add Recipients does NOT regenerate the attachment;
-  // the newly-added users surface in the post-revoke "Revoked for: …"
-  // list (with its own overflow path) and in monitor link-status
-  // updates.
-  const initialPayload = {
-    content: confirmMsg,
-    components: delivered > 0 ? [buttonRow] : [],
-  };
-  if (confirmRendered.attachmentText) {
-    initialPayload.files = [
-      new AttachmentBuilder(Buffer.from(confirmRendered.attachmentText, 'utf8'), { name: 'recipients.txt' }),
-    ];
-  }
-  const response = await interaction.editReply(initialPayload);
-
-  // Non-ephemeral channel notification when sending to "Everyone" (channel
-  // target) or "Voice users" (voice target). The sender's ephemeral reply
-  // confirms the send to THEM; this message is what recipients see in the
-  // channel so they know to look for the Qurl Bot DM. Without this, a
-  // passive channel member who missed the DM ping has no signal that a
-  // send happened. Logged-and-swallowed on failure — a missing
-  // "Send Messages" permission in a customer server shouldn't fail the
-  // whole send (DMs already went out successfully).
-  //
-  // Guard on `interaction.channel` being present: for a slash command
-  // invoked in a guild channel this is always set, but in edge cases
-  // (partial-cache on a fresh gateway connect, thread that got
-  // archived mid-send, DM-channel dispatch) the channel object can be
-  // null — and `.send()` on null throws synchronously, before the
-  // try/catch can see it.
-  if (interaction.channel && target === 'channel' && delivered > 0) {
-    // Same sanitizer the DM embed uses (sanitizeDisplayName: NFKC + bidi/
-    // zero-width/control strip + markdown escape + 64-char cap + 'Someone'
-    // fallback). Channel-post is a wider blast radius than DM, so applying
-    // the same spoof defense here is critical — without it a display name
-    // with a leading U+202E flips text direction in the public announcement.
-    const safeName = sanitizeDisplayName(resolveSenderAlias(interaction));
-    const notifyMsg = isVoiceContext
-      ? `📩 **${safeName}** has shared something with users currently connected to this voice channel via **qURL Bot** — check your DMs from qURL Bot.`
-      : `📩 **${safeName}** has shared something with all members of this channel via **qURL Bot** — check your DMs from qURL Bot.`;
-    try {
-      await interaction.channel.send({ content: notifyMsg });
-    } catch (err) {
-      logger.warn('Failed to send channel notification', { error: err.message });
-    }
-  }
-
-  logger.info('/qurl send completed', {
-    sender: interaction.user.id, sendId, target, resourceType, delivered, failed, expiresIn,
-  });
-
-  // Collector handles multiple button clicks (Add Recipients can be clicked multiple times)
-  let monitor = null;
-  if (delivered > 0) {
-    let addRecipientsCount = 0; // Track cumulative adds for cap enforcement
-    // Single source of truth for the "adding recipients" lock: the global
-    // addRecipientsLocks Set keyed by sendId. Acquire at the top of the
-    // collect handler, release in a single outer finally{} so any throw
-    // between acquire and the previous dual-flag release paths can't
-    // permanently block subsequent button clicks.
-
-    // Create the collector FIRST — if collector setup throws, we return
-    // without ever having started the monitor, so no setInterval leaks
-    // interaction/recipients/buttonRow/file data in a closure for up to
-    // an hour. Only after the collector is established do we kick the
-    // monitor setInterval.
-    let collector;
-    try {
-      collector = response.createMessageComponentCollector({
-        filter: (i) => i.user.id === interaction.user.id,
-        time: TIMEOUTS.QURL_REVOKE_WINDOW,
-      });
-    } catch (err) {
-      logger.error('Failed to create button collector', { sendId, error: err.message });
-      return;
-    }
-    monitor = monitorLinkStatus(sendId, interaction, qurlLinks, recipients, expiresIn, confirmMsg, buttonRow, delivered, apiKey);
-
-    let showAllRecipients = false;
-
-    // `revokeInFlight` dedups concurrent Revoke clicks. `revokeSucceeded`
-    // guards the on('end') re-render so a Failed message isn't overwritten
-    // by a stale "Revoked 0/0".
-    let revokeResultUserNames = [];
-    let revokeResultTotal = 0;
-    // Authoritative DDB strict-success count. Tracked separately from
-    // `revokeResultUserNames.length` so the header stays correct even
-    // if a successful recipient_id can't be name-resolved against
-    // `recipients[]`.
-    let revokeResultSuccess = 0;
-    let revokeShowAll = false;
-    let revokeInFlight = false;
-    let revokeSucceeded = false;
-
-    collector.on('collect', async (btnInteraction) => {
-      if (btnInteraction.customId === `qurl_expand_${sendId}`) {
-        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
-        showAllRecipients = !showAllRecipients;
-        // buildConfirmMsg now returns {content, attachmentText, needsExpand};
-        // extract content for the monitor + editReply (string-only).
-        confirmMsg = buildConfirmMsg(showAllRecipients).content;
-        monitor.updateBaseMsg(confirmMsg);
-        const fullMsg = monitor.getFullMsg();
-        const updatedRow = new ActionRowBuilder().addComponents(
-          new ButtonBuilder().setCustomId(`qurl_add_${sendId}`).setLabel('Add Recipients').setStyle(ButtonStyle.Primary),
-          new ButtonBuilder().setCustomId(`qurl_revoke_${sendId}`).setLabel('Revoke All').setStyle(ButtonStyle.Danger),
-          new ButtonBuilder().setCustomId(`qurl_expand_${sendId}`).setLabel(showAllRecipients ? 'Show Less' : 'Show All').setStyle(ButtonStyle.Secondary),
-        );
-        await interaction.editReply({ content: fullMsg, components: [updatedRow] }).catch(logIgnoredDiscordErr);
-        return;
-      }
-
-      if (btnInteraction.customId === `qurl_revoke_expand_${sendId}`) {
-        // Toggle Show All / Show Less on the post-revoke recipient list.
-        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
-        revokeShowAll = !revokeShowAll;
-        const updated = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, revokeShowAll, revokeResultSuccess);
-        await interaction.editReply(revokeReplyPayload(updated)).catch(logIgnoredDiscordErr);
-        return;
-      }
-
-      if (btnInteraction.customId === `qurl_revoke_${sendId}`) {
-        // Sync dedup before any await (Node single-threaded).
-        if (revokeInFlight) return btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
-        revokeInFlight = true;
-        // Stop monitor BEFORE any editReply — its setInterval can
-        // overwrite the revoke-result message otherwise.
-        if (monitor) monitor.stop();
-        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
-        await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
-        try {
-          const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
-          // Iterate `recipients` (canonical send-confirmation order)
-          // and filter by membership — `successUserIds` walks Set
-          // insertion order from resource-grouped iteration, which
-          // doesn't match what the user saw on "Recipients: …".
-          const successSet = new Set(revoked.successUserIds);
-          revokeResultUserNames = recipients
-            .filter(r => successSet.has(r.id))
-            .map(r => resolveRecipientAlias(r, interaction));
-          revokeResultTotal = revoked.total;
-          revokeResultSuccess = revoked.success;
-          revokeShowAll = false;
-          const initial = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, false, revokeResultSuccess);
-          await interaction.editReply(revokeReplyPayload(initial)).catch(logIgnoredDiscordErr);
-          revokeSucceeded = true;
-        } catch (err) {
-          logger.error('Revoke failed', { sendId, error: err.message });
-          await interaction.editReply({
-            content: 'Failed to revoke links. Try `/qurl revoke` instead.',
-            components: [],
-          }).catch(logIgnoredDiscordErr);
-          // Reset so the dedup flag isn't sticky if the failure UI
-          // ever changes to retain the Revoke button.
-          revokeInFlight = false;
-        }
-        // Collector keeps running for the post-revoke expand toggle;
-        // its `time:` window auto-expires.
-
-      } else if (btnInteraction.customId === `qurl_add_${sendId}`) {
-        // =====================================================================
-        // CRITICAL SECTION — do NOT add any `await` between the three lines
-        // below and the next `return` path. Node.js is single-threaded: if
-        // check+set+cooldown all happen synchronously, a second button click
-        // dispatched to the same handler cannot observe the unlocked state.
-        // The `await` in the rejection branches is fine because we've already
-        // committed to rejecting at that point.
-        // =====================================================================
-        // Check-and-claim are now adjacent: if the flag is unset, grab it
-        // FIRST (before any cap check), then verify remaining capacity and
-        // release on rejection. That way a future refactor that adds an
-        // `await` in the remaining check can't reopen a racy window.
-        if (addRecipientsLocks.has(sendId)) {
-          await btnInteraction.reply({ content: 'Already processing an "Add Recipients" action.', ephemeral: true }).catch(logIgnoredDiscordErr);
-          return;
-        }
-        addRecipientsLocks.add(sendId);
-        // Single outer try/finally guarantees the lock is released on every
-        // exit path — even if a synchronous throw happens between acquire
-        // and any early return. The old dual-flag pattern had multiple
-        // release sites and risked permanent lock-out on a missed release.
-        try {
-          const remaining = config.QURL_SEND_MAX_RECIPIENTS - delivered - addRecipientsCount;
-          if (remaining <= 0) {
-            await btnInteraction.reply({
-              content: `Recipient limit reached (${config.QURL_SEND_MAX_RECIPIENTS} max).`,
-              ephemeral: true,
-            });
-            return;
-          }
-          if (isOnCooldown(interaction.user.id)) {
-            await btnInteraction.reply({ content: 'Please wait before adding more recipients.', ephemeral: true }).catch(logIgnoredDiscordErr);
-            return;
-          }
-          setCooldown(interaction.user.id);
-
-          // Show user select menu — collect the response on the REPLY message
-          const maxSelect = Math.min(USER_SELECT_PER_PICK_CAP, remaining);
-          const userSelectRow = new ActionRowBuilder().addComponents(
-            new UserSelectMenuBuilder()
-              .setCustomId(`qurl_addusers_${sendId}`)
-              .setPlaceholder('Select users to send to')
-              .setMinValues(1)
-              .setMaxValues(maxSelect)
-          );
-          const selectReply = await btnInteraction.reply({
-            content: 'Select additional recipients:',
-            components: [userSelectRow],
-            ephemeral: true,
-            fetchReply: true,
-          });
-
-          try {
-            const selectInteraction = await selectReply.awaitMessageComponent({
-              componentType: ComponentType.UserSelect,
-              time: 60000,
-            });
-
-            await selectInteraction.deferUpdate();
-            const addResult = await handleAddRecipients(
-              sendId, selectInteraction.users, interaction, apiKey,
-            );
-
-            // Extend recipients[] for the post-revoke names line.
-            // Dedupe by id — re-Add of an already-included user.
-            if (addResult.newRecipients?.length) {
-              const existingIds = new Set(recipients.map(r => r.id));
-              for (const r of addResult.newRecipients) {
-                if (!existingIds.has(r.id)) recipients.push(r);
-              }
-            }
-
-            if (addResult.delivered > 0) {
-              addRecipientsCount += addResult.delivered;
-              // Tell the monitor to track the new links (including new resource IDs for location sends)
-              monitor.addRecipients(addResult.delivered, addResult.newResourceIds);
-              const totalSent = delivered + addRecipientsCount;
-              confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | One-time links`;
-              if (failed > 0) confirmMsg += `\n${failed} could not be reached`;
-              monitor.updateBaseMsg(confirmMsg);
-              await interaction.editReply({ content: monitor.getFullMsg(), components: [buttonRow] });
-            }
-
-            await selectInteraction.editReply({ content: addResult.msg, components: [] });
-          } catch (err) {
-            const isTimeout = err?.code === 'InteractionCollectorError' || err?.message?.includes('time');
-            // Generic user-facing message; real details only land in logs.
-            const msg = isTimeout ? 'Selection timed out.' : 'Failed to add recipients. Please try again.';
-            // Drop to warn for routine user-timeouts; keep error for real failures.
-            const log = isTimeout ? logger.warn : logger.error;
-            log('Add recipients failed', { sendId, error: err.message, isTimeout });
-            await btnInteraction.editReply({ content: msg, components: [] }).catch(logIgnoredDiscordErr);
-          }
-        } finally {
-          addRecipientsLocks.delete(sendId);
-        }
-      }
-    });
-
-    collector.on('end', (_, reason) => {
-      // Stop monitor polling when collector ends for any reason
-      if (monitor) monitor.stop();
-      if (reason === 'time') {
-        // After a SUCCESSFUL revoke, re-render the revoke result
-        // instead of the pre-revoke confirmMsg + Management-window
-        // banner — otherwise the user's "Revoked X/Y links" view
-        // gets clobbered when the collector window ends. Gate on
-        // `revokeSucceeded` (not `revokeInFlight`) so a failure
-        // message ("Failed to revoke links…") isn't overwritten with
-        // a stale "Revoked 0/0 links" line.
-        if (revokeSucceeded) {
-          // Terminal state: re-render content (Show All may have
-          // toggled), strip components. Omit `files`/`attachments`
-          // so Discord keeps the existing revoked-users.txt without
-          // re-uploading the same blob 15min later.
-          const final = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, revokeShowAll, revokeResultSuccess);
-          interaction.editReply({ content: final.content, components: [] }).catch(logIgnoredDiscordErr);
-          return;
-        }
-        // Revoke attempted but failed — leave the failure message.
-        if (revokeInFlight) return;
-        interaction.editReply({
-          content: (monitor ? monitor.getFullMsg() : confirmMsg) + '\n\n\u23f0 **Management window closed** — use `/qurl revoke` to revoke later.',
-          components: [],
-        }).catch(logIgnoredDiscordErr);
-      }
-    });
-  }
-
 }
 
 // Handle adding new recipients to an existing send. senderDiscordId is

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -796,6 +796,14 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 //   - `attachment` — non-null when `resourceType === RESOURCE_TYPES.FILE`;
 //     carries `{ url, name, contentType }`. The Discord CDN URL is
 //     leak-equivalent-to-the-file; encrypt before persisting.
+//     **SSRF: `attachment.url` is assumed pre-validated** against
+//     `isAllowedSourceUrl` (today: handleSend's Step-2 file-acceptance
+//     gate before reaching this pipeline). A PR 7b caller that
+//     reconstructs `attachment` from a `flow_state` payload row MUST
+//     re-validate before invoking — otherwise an attacker who edited
+//     the DDB row between create and execute could redirect the
+//     `downloadAndUpload` call to an internal target. The pipeline
+//     itself does not re-check.
 //   - `locationUrl` / `locationName` — non-null on a location send;
 //     forwarded as a `google-map` JSON payload to the connector.
 //   - `recipients` — resolved final list, filtered (sender + bots
@@ -917,12 +925,14 @@ async function executeSendPipeline(interaction, {
   // exists for PR 7b's handleSendFormSend.
   if (typeof isVoiceContext !== 'boolean') {
     clearCooldown(interaction.user.id);
-    // `String(undefined)` → "undefined" (not stringified `undefined`
-    // which JSON.stringify drops entirely, producing the awkward
-    // "got undefined: undefined" rendering the round-7 cr flagged).
-    // For non-serializable values String() also avoids the
-    // JSON.stringify-throws-on-BigInt edge case.
-    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got ${typeof isVoiceContext}: ${String(isVoiceContext)})`);
+    // Render `typeof=` + `value=` separately so a prod-log reader
+    // doesn't have to disambiguate `(got object: null)` (where
+    // "object" describes the typeof and "null" is the value — a
+    // common foot-gun since `typeof null === 'object'`). The
+    // String() call keeps `undefined` visible (JSON.stringify
+    // drops it) and avoids the JSON.stringify-throws-on-BigInt
+    // edge case.
+    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${String(isVoiceContext)})`);
   }
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
 
@@ -4637,6 +4647,7 @@ module.exports = {
       isAllowedFileType,
       isOnCooldown,
       setCooldown,
+      clearCooldown,
       batchSettled,
       expiryToISO,
       sendCooldowns,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -812,11 +812,15 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 //     Setting `target: 'voice'` would silently suppress the channel-
 //     announce because the gate at the announce site is strict
 //     equality on `'channel'`.
-//   - `isVoiceContext` — boolean; selects the voice-flavored wording in
-//     the channel-announce blurb. Defaults to `false` in the destructure
-//     so a caller that omits it (e.g. PR 7b reconstructing from a
-//     flow_state payload) lands on the text-channel wording rather
-//     than `undefined ? ... : ...` returning the false branch silently.
+//   - `isVoiceContext` — REQUIRED boolean; selects the voice-flavored
+//     wording in the channel-announce blurb. Strictly validated at
+//     entry — a caller that omits it (or passes a non-boolean) throws
+//     a `TypeError` rather than silently landing on the text-channel
+//     branch. This is the strongest forcing function against the
+//     silent-wrong-branch failure mode: a voice-context send that
+//     loses this signal in serialization (e.g. PR 7b's flow_state
+//     payload schema dropping it) fails loudly at the boundary
+//     instead of mis-rendering the channel announce.
 //   - `expiresIn` — canonical expiry token ('1h' / '24h' / '7d' / etc.);
 //     fed through `expiryToISO` and `expiryToMs`.
 //   - `selfDestructSeconds` — `null` for no timer, otherwise a positive
@@ -844,15 +848,26 @@ async function executeSendPipeline(interaction, {
   // this array (see docstring's "transferred ownership" note).
   recipients,
   target,
-  // Defaults to text-channel wording on a missing/undefined value;
-  // PR 7b should validate at the flow_state-payload schema layer to
-  // catch a voice-context send that lost this signal in serialization.
-  isVoiceContext = false,
+  // REQUIRED — validated at entry (see assertion below). NO default
+  // value: an omitted-or-non-boolean caller fails loudly instead of
+  // silently landing on text-channel wording for a voice-context send.
+  isVoiceContext,
   expiresIn,
   selfDestructSeconds,
   personalMessage,
   sendNonce,
 }) {
+  // Strict input gate on the one param whose silent default would
+  // misrender the channel-announce blurb. Other params either land
+  // in DB rows where corruption is grep-discoverable (resourceType,
+  // target, expiresIn) or fail loudly inside the upload/mint
+  // pipeline (attachment, locationUrl). isVoiceContext is unique:
+  // a wrong value here surfaces only as a subtle copy mismatch in
+  // a non-ephemeral channel post — exactly the silent-regression
+  // shape the round-4 cr review flagged.
+  if (typeof isVoiceContext !== 'boolean') {
+    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got ${typeof isVoiceContext}: ${JSON.stringify(isVoiceContext)})`);
+  }
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
 
   const sendId = crypto.randomUUID();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -787,19 +787,45 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 // handleSendFormSend will construct the params object from the
 // flow_state row's decrypted payload and invoke this function).
 //
-// Caller contract:
-//   - `apiKey` is the resolved guild API key (or env fallback).
-//   - `attachment` is non-null when `resourceType === RESOURCE_TYPES.FILE`
-//     and carries the Discord CDN URL + filename + contentType.
-//   - `locationUrl`/`locationName` are non-null when `resourceType` is
-//     a location kind; the back-half forwards `locationUrl` as a
-//     `google-map` JSON payload to the connector.
-//   - `recipients` is the resolved final list (filtered: sender + bots
-//     excluded, capped at config.QURL_SEND_MAX_RECIPIENTS). The
-//     back-half defends-in-depth with its own length checks but
-//     assumes the caller has done the cap math.
-//   - `sendNonce` is logging-breadcrumb only — keeps continuity with
-//     the caller's earlier log lines on the same flow.
+// Caller contract — full param surface (the destructure list is the
+// authoritative signature; this prose calls out the non-obvious bits):
+//
+//   - `apiKey` — resolved guild API key (or env fallback).
+//   - `resourceType` — `RESOURCE_TYPES.FILE` or location kind; branches
+//     the upload path and lands in DB rows + audit events.
+//   - `attachment` — non-null when `resourceType === RESOURCE_TYPES.FILE`;
+//     carries `{ url, name, contentType }`. The Discord CDN URL is
+//     leak-equivalent-to-the-file; encrypt before persisting.
+//   - `locationUrl` / `locationName` — non-null on a location send;
+//     forwarded as a `google-map` JSON payload to the connector.
+//   - `recipients` — resolved final list, filtered (sender + bots
+//     excluded), capped at `config.QURL_SEND_MAX_RECIPIENTS`. **The
+//     pipeline MUTATES this array** on the Add Recipients post-send
+//     branch (deduped push). Callers reconstructing the list from a
+//     persisted source (flow_state payload, retry, etc.) should treat
+//     it as transferred ownership for the lifetime of the call, not as
+//     a snapshot.
+//   - `target` — `'user' | 'channel' | 'voice'`; gates the channel-
+//     announce message and lands as `targetType` in the DB row.
+//   - `isVoiceContext` — boolean; selects the voice-flavored wording in
+//     the channel-announce blurb.
+//   - `expiresIn` — canonical expiry token ('1h' / '24h' / '7d' / etc.);
+//     fed through `expiryToISO` and `expiryToMs`.
+//   - `selfDestructSeconds` — `null` for no timer, otherwise a positive
+//     finite integer matching one of `SELF_DESTRUCT_PRESETS.seconds`.
+//     Threaded to every (re)upload so Add Recipients honors the same TTL.
+//   - `personalMessage` — sanitized note (or null) embedded in each
+//     recipient's DM.
+//   - `sendNonce` — logging-breadcrumb only; keeps continuity with the
+//     caller's earlier log lines on the same flow.
+//
+// Resolved value: the function awaits to completion and returns
+// `undefined`. The early-exit `return interaction.editReply(...)` paths
+// resolve to the editReply Promise's value, but no caller inspects it
+// (handleSend's `return executeSendPipeline(...)` discards it, and
+// `execute()` in turn ignores handleSend's resolved value). A future
+// caller that needs a structured result (e.g. for a programmatic retry)
+// would have to extend this contract.
 async function executeSendPipeline(interaction, {
   apiKey,
   resourceType,

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -212,6 +212,7 @@ const {
   handleAddRecipients,
   mintLinksInBatches,
   activeMonitors,
+  executeSendPipeline,
 } = _test;
 
 // ---------------------------------------------------------------------------
@@ -1363,3 +1364,61 @@ describe('mintLinksInBatches', () => {
     expect(mockMintLinks).not.toHaveBeenCalled();
   });
 });
+
+// Strict input gate added in PR #277 (round-4 cr fix). isVoiceContext
+// is the one param whose silent default would mis-render the channel-
+// announce blurb — every other param either lands in DB rows where
+// corruption is grep-discoverable, or fails loudly inside the upload/
+// mint pipeline. Pin the gate here so PR 7b's flow_state-payload
+// schema can't drop the boolean in serialization and silently land
+// a voice-context send on text-channel wording.
+describe('executeSendPipeline — isVoiceContext strict gate', () => {
+  // Minimal params object that would otherwise satisfy the destructure
+  // — only isVoiceContext varies per case. The pipeline never reaches
+  // any downstream call because the gate is at function entry, so the
+  // mocks below don't need to be configured.
+  function makePipelineParams(isVoiceContext) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: { url: 'https://cdn.discordapp.com/x', name: 'x.png', contentType: 'image/png' },
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target: 'user',
+      isVoiceContext,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+    };
+  }
+
+  test('throws TypeError when isVoiceContext is undefined (missing-flag case PR 7b might hit)', async () => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(undefined)))
+      .rejects.toThrow(TypeError);
+    await expect(executeSendPipeline(interaction, makePipelineParams(undefined)))
+      .rejects.toThrow(/isVoiceContext must be a boolean/);
+    // Gate fires BEFORE the "Preparing links..." editReply that would
+    // otherwise be the first user-visible signal — confirm no editReply.
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  test('throws TypeError when isVoiceContext is a string (most-likely miscoding shape)', async () => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams('true')))
+      .rejects.toThrow(/isVoiceContext must be a boolean/);
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  test('throws TypeError for null isVoiceContext (typeof null === "object" foot-gun)', async () => {
+    // `typeof null === 'object'`, NOT 'boolean' — pin that null is
+    // rejected. A flow_state payload that serialized `false` as
+    // missing-vs-null could hit this without the test.
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(null)))
+      .rejects.toThrow(/isVoiceContext must be a boolean/);
+  });
+});
+

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1419,16 +1419,33 @@ describe('executeSendPipeline — isVoiceContext strict gate', () => {
     const rejection = executeSendPipeline(interaction, makePipelineParams(undefined));
     await expect(rejection).rejects.toThrow(TypeError);
     await expect(rejection).rejects.toThrow(/isVoiceContext must be a boolean/);
-    // Gate fires BEFORE the "Preparing links..." editReply that would
-    // otherwise be the first user-visible signal — confirm no editReply.
-    expect(interaction.editReply).not.toHaveBeenCalled();
+    // Gate clears the caller's stale ephemeral with an explicit error
+    // ephemeral BEFORE throwing. Pin the call — without it the user
+    // would see the caller's stale "Preparing send..." alongside the
+    // top-level catch's generic "There was an error" followUp.
+    // The "Preparing links..." editReply that lives later in the
+    // pipeline still never fires (the gate throws before reaching it),
+    // so any failed regression test that DOES see two editReplies is
+    // also caught: the cancellation edit is the only legitimate call.
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+        components: [],
+      }),
+    );
   });
 
   test('throws TypeError when isVoiceContext is a string (most-likely miscoding shape)', async () => {
     const interaction = makeInteraction();
     await expect(executeSendPipeline(interaction, makePipelineParams('true')))
       .rejects.toThrow(/isVoiceContext must be a boolean/);
-    expect(interaction.editReply).not.toHaveBeenCalled();
+    // Same user-facing cancellation behavior as the undefined case.
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+      }),
+    );
   });
 
   test('throws TypeError for null isVoiceContext (typeof null === "object" foot-gun)', async () => {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1634,3 +1634,93 @@ describe('executeSendPipeline — attachment.url SSRF re-validation gate', () =>
   });
 });
 
+describe('executeSendPipeline — expiresIn allowed-set gate', () => {
+  function makePipelineParams(expiresIn) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: { url: 'https://cdn.discordapp.com/x', name: 'x.png', contentType: 'image/png' },
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn,
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+    };
+  }
+
+  test.each([
+    ['off-set numeric-style', '25h'],
+    ['totally bogus', 'never'],
+    ['empty string', ''],
+    ['undefined', undefined],
+    ['number (not string)', 24],
+  ])('throws on expiresIn=%s', async (_label, expiresIn) => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(expiresIn)))
+      .rejects.toThrow(/expiresIn must be one of/);
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+      }),
+    );
+  });
+
+  test.each(['30m', '1h', '6h', '24h', '7d'])('accepts the allowed value: %s', async (expiresIn) => {
+    const interaction = makeInteraction();
+    try {
+      await executeSendPipeline(interaction, makePipelineParams(expiresIn));
+    } catch (err) {
+      expect(err.message).not.toMatch(/expiresIn must be one of/);
+      return;
+    }
+  });
+});
+
+describe('executeSendPipeline — personalMessage shape gate', () => {
+  function makePipelineParams(personalMessage) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: { url: 'https://cdn.discordapp.com/x', name: 'x.png', contentType: 'image/png' },
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage,
+      sendNonce: 'nonce',
+    };
+  }
+
+  test.each([
+    ['object', { text: 'oops' }],
+    ['array', ['oops']],
+    ['number', 42],
+    ['boolean', true],
+  ])('throws on non-string non-null personalMessage (%s) — would render [object Object] in DM otherwise', async (_label, personalMessage) => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(personalMessage)))
+      .rejects.toThrow(/personalMessage must be null or string/);
+  });
+
+  test.each([
+    ['null', null],
+    ['empty string', ''],
+    ['short note', 'See you at 5pm.'],
+  ])('accepts the allowed shape: %s', async (_label, personalMessage) => {
+    const interaction = makeInteraction();
+    try {
+      await executeSendPipeline(interaction, makePipelineParams(personalMessage));
+    } catch (err) {
+      expect(err.message).not.toMatch(/personalMessage must be null or string/);
+      return;
+    }
+  });
+});
+

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1373,6 +1373,20 @@ describe('mintLinksInBatches', () => {
 // schema can't drop the boolean in serialization and silently land
 // a voice-context send on text-channel wording.
 describe('executeSendPipeline — isVoiceContext strict gate', () => {
+  // sendCooldowns is module-private state; the cooldown-cleanup test
+  // sets it for a unique user id and relies on the gate's
+  // clearCooldown call to undo. If a future edit moves the throw
+  // ahead of clearCooldown (the exact regression that test pins),
+  // the unique-id strategy would still let other tests pass — but
+  // the residual entry would leak across describes. Explicit
+  // afterEach reset closes that hatch.
+  afterEach(() => {
+    const { clearCooldown } = _test;
+    if (typeof clearCooldown === 'function') {
+      clearCooldown('cooldown-gate-test-user');
+    }
+  });
+
   // Minimal params object that would otherwise satisfy the destructure
   // — only isVoiceContext varies per case. The pipeline never reaches
   // any downstream call because the gate is at function entry, so the

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1396,10 +1396,15 @@ describe('executeSendPipeline — isVoiceContext strict gate', () => {
 
   test('throws TypeError when isVoiceContext is undefined (missing-flag case PR 7b might hit)', async () => {
     const interaction = makeInteraction();
-    await expect(executeSendPipeline(interaction, makePipelineParams(undefined)))
-      .rejects.toThrow(TypeError);
-    await expect(executeSendPipeline(interaction, makePipelineParams(undefined)))
-      .rejects.toThrow(/isVoiceContext must be a boolean/);
+    // Single invocation captured into a promise so both the type + the
+    // message assertion observe the SAME rejection. The previous pattern
+    // (two await-expects, two pipeline invocations) is harmless today —
+    // the gate is idempotent — but would surface a double-fire bug if a
+    // future change adds side effects (audit emission, etc.) ahead of
+    // the throw.
+    const rejection = executeSendPipeline(interaction, makePipelineParams(undefined));
+    await expect(rejection).rejects.toThrow(TypeError);
+    await expect(rejection).rejects.toThrow(/isVoiceContext must be a boolean/);
     // Gate fires BEFORE the "Preparing links..." editReply that would
     // otherwise be the first user-visible signal — confirm no editReply.
     expect(interaction.editReply).not.toHaveBeenCalled();

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1507,3 +1507,130 @@ describe('executeSendPipeline — isVoiceContext strict gate', () => {
   });
 });
 
+// Symmetric to the isVoiceContext gate — pins target and
+// attachment.url at entry so a tampered persisted payload or a
+// future caller mis-coding cannot reach the upload/announce path.
+describe('executeSendPipeline — target allowed-set gate', () => {
+  function makePipelineParams(target) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: { url: 'https://cdn.discordapp.com/x', name: 'x.png', contentType: 'image/png' },
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target,
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+    };
+  }
+
+  test.each([
+    ['voice (silent-suppress shape — docstring warns about this)', 'voice'],
+    ['empty string', ''],
+    ['unknown future value', 'group'],
+  ])('throws TypeError for target=%s', async (_label, target) => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(target)))
+      .rejects.toThrow(/target must be 'user' or 'channel'/);
+    // Cancel-edit fires before the throw — same shape as the
+    // isVoiceContext gate.
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+      }),
+    );
+  });
+
+  test('throws TypeError for non-string target (undefined / null)', async () => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(undefined)))
+      .rejects.toThrow(/target must be 'user' or 'channel'/);
+  });
+
+  test.each(['user', 'channel'])('accepts the allowed value: %s', async (target) => {
+    // The downstream upload mocks aren't configured here, so accept-
+    // case observability is: did the gate let us PAST it? We rely on
+    // the rejection message NOT matching 'target must be' — anything
+    // else (e.g. downstream mint failures) is a different concern.
+    const interaction = makeInteraction();
+    try {
+      await executeSendPipeline(interaction, makePipelineParams(target));
+    } catch (err) {
+      expect(err.message).not.toMatch(/target must be/);
+      return;
+    }
+    // If the call resolved without throwing (mock-chain lined up
+    // perfectly somehow), that's also acceptable — the gate let us
+    // through, which is what this test checks.
+  });
+});
+
+describe('executeSendPipeline — attachment.url SSRF re-validation gate', () => {
+  function makePipelineParams(attachmentOverrides) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: attachmentOverrides,
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+    };
+  }
+
+  test.each([
+    ['null attachment', null],
+    ['attachment with no url field', { name: 'x.png', contentType: 'image/png' }],
+    ['attachment with non-string url', { url: 12345, name: 'x.png' }],
+    ['internal localhost URL (SSRF target)', { url: 'http://localhost/internal', name: 'x.png' }],
+    ['internal 127.0.0.1 URL', { url: 'http://127.0.0.1:8080/api', name: 'x.png' }],
+    ['internal AWS metadata endpoint', { url: 'http://169.254.169.254/latest/meta-data/', name: 'x.png' }],
+  ])('throws on %s when resourceType=file', async (_label, attachment) => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(attachment)))
+      .rejects.toThrow(/attachment\.url failed SSRF re-validation/);
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+      }),
+    );
+  });
+
+  test('SSRF gate is skipped when resourceType is NOT file (location sends carry no user URL)', async () => {
+    const interaction = makeInteraction();
+    // Bogus attachment.url that WOULD fail isAllowedSourceUrl — but
+    // resourceType is 'location' so the gate is bypassed. The pipeline
+    // will fail later downstream (mocks aren't configured for the
+    // location path), but NOT with the SSRF gate message.
+    const params = {
+      apiKey: 'apikey',
+      resourceType: 'location',
+      attachment: { url: 'http://localhost/whatever', name: 'x.png' },
+      locationUrl: 'https://google.com/maps/search/x',
+      locationName: 'X',
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+    };
+    try {
+      await executeSendPipeline(interaction, params);
+    } catch (err) {
+      expect(err.message).not.toMatch(/SSRF re-validation/);
+      return;
+    }
+  });
+});
+

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1420,5 +1420,54 @@ describe('executeSendPipeline — isVoiceContext strict gate', () => {
     await expect(executeSendPipeline(interaction, makePipelineParams(null)))
       .rejects.toThrow(/isVoiceContext must be a boolean/);
   });
+
+  test.each([0, 1])('throws TypeError for numeric %s (JS-y caller miscoding)', async (n) => {
+    // A caller writing `isVoiceContext: channel.type === 2 ? 1 : 0`
+    // (treating it as a truthy flag rather than a strict boolean)
+    // hits this branch. Pin both 0 and 1 — `Number(true) === 1`
+    // looks deceptively boolean-compatible but trips the typeof
+    // check.
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(n)))
+      .rejects.toThrow(/isVoiceContext must be a boolean/);
+  });
+
+  // eslint-disable-next-line no-new-wrappers
+  test('throws TypeError for Boolean wrapper object (typeof is "object", not "boolean")', async () => {
+    // `new Boolean(true)` is `typeof === 'object'` per JS spec —
+    // would silently coerce to truthy in a `?:` ternary while
+    // failing the strict gate. Worth pinning so a future reader
+    // debugging the gate doesn't get confused by the wrapper
+    // edge case.
+    const interaction = makeInteraction();
+    // eslint-disable-next-line no-new-wrappers
+    const wrapperTrue = new Boolean(true);
+    await expect(executeSendPipeline(interaction, makePipelineParams(wrapperTrue)))
+      .rejects.toThrow(/isVoiceContext must be a boolean/);
+  });
+
+  test('clears cooldown before throwing so caller is not locked out', async () => {
+    // Caller-side convention (see handleSend): setCooldown fires
+    // before the pipeline call so a rapid second invocation gets
+    // a "wait" reply. If the pipeline throws BEFORE clearing the
+    // cooldown, the user is locked out for the full window with
+    // no feedback — exactly the silent-failure shape the gate
+    // is meant to avoid amplifying. The post-throw isOnCooldown
+    // assertion below leaves no stray state for adjacent tests:
+    // the gate's clearCooldown call IS the cleanup.
+    const interaction = makeInteraction();
+    const { setCooldown, isOnCooldown } = _test;
+    // Use a unique sender id so a parallel test's cooldown state
+    // can't leak into this assertion. sendCooldowns is a module-
+    // private Map so the read/write surface is exposed only via
+    // the helpers above.
+    interaction.user = { id: 'cooldown-gate-test-user', username: 'test' };
+    setCooldown(interaction.user.id);
+    expect(isOnCooldown(interaction.user.id)).toBe(true);
+
+    await expect(executeSendPipeline(interaction, makePipelineParams(undefined)))
+      .rejects.toThrow(TypeError);
+    expect(isOnCooldown(interaction.user.id)).toBe(false);
+  });
 });
 


### PR DESCRIPTION
## Summary

Refactor — extract the back-half of `handleSend` into a standalone `executeSendPipeline(interaction, params)` function so PR 7b's `handleSendFormSend` can be the second caller. **1231 tests pass; lint clean.** (1194 pre-refactor + 37 new across multiple rounds for the five strict-input entry gates.)

The closure-captured state from `handleSend`'s Step-3 form-fill becomes explicit destructured params: `apiKey`, `resourceType`, `attachment`, `locationUrl`, `locationName`, `recipients`, `target`, `isVoiceContext`, `expiresIn`, `selfDestructSeconds`, `personalMessage`, `sendNonce`.

`handleSend` retains its front-half (file/location chooser, recipient/expiry/note form-loop). Step 4 — the line range already demarcated by the comment `// --- Step 4: Process and send ---` — is now a single `return await executeSendPipeline(...)` call.

## Scope honesty: behaviorally equivalent on every existing call path

Original framing said "byte-identical to the pre-refactor." It isn't — the additions are:

1. **Five strict-input entry gates** (none reachable by today's caller; the gates are forcing functions for PR 7b's flow_state-deserialized caller):
   - `isVoiceContext` must be a strict boolean.
   - `target` must be `'user' | 'channel'`.
   - `attachment.url` re-validated against `isAllowedSourceUrl` (defense-in-depth SSRF; `RESOURCE_TYPES.FILE`-only).
   - `expiresIn` must be a key of `EXPIRY_LABELS`.
   - `personalMessage` must be `null` or `string`.
   Each gate shares the same `cancelEdit()` + `clearCooldown()` + `throw` pattern. The cancel-edit replaces the caller's stale "Preparing send..." ephemeral with a specific cancel; the outer `handleCommand` catch still appends a generic followUp.
2. **Removed the duplicate `releaseSlot()` from the catch block.** The `finally` always runs after a return-from-catch and `releaseSlot` is idempotent via `fileSendSlotClaimed` — the catch-branch call was dead code that obscured the single-release-path invariant.

## Why now

PR 7b will replace `/qurl send`'s bouncy file-via-DM UX with new `/qurl file` and `/qurl map` slash commands, both flow_state-backed and fully in-channel. The terminal handler in that PR (`handleSendFormSend`) needs to invoke the same back-half pipeline that `handleSend` uses today. Extracting it as a focused refactor first means PR 7b's review can focus on the new front-half shape — not on whether the back-half extraction is faithful.

## What's NOT in this PR

- **Direct happy-path unit tests for `executeSendPipeline`** beyond the gate-rejection cases. The existing suite (`qurl-send.test.js`, `qurl-send-state-machine.test.js`, `qurl-send-back-half.test.js`, `commands-comprehensive.test.js`) pins end-to-end behavior via `handleSend`. Direct param-object tests will land in PR 7b alongside the second caller — tracked in #278.
- **`/qurl file` / `/qurl map`** — that's PR 7b.
- **Defensive guards on `recipients` shape/cap** — #280.
- **`recipients` mutation cleanup (clone-on-mutate)** — #281.
- **`QURL` → `qURL` prose-message brand sweep** (pre-existing drift in two moved strings) — #279.
- **`AUDIT_EVENTS.PERSIST_FAILED` on `recordQURLSendBatch` failure** — #284.
- **Split `executeSendPipeline` into mint / persist / dispatch phases** — #285.
- **Gate-error aggregation + `_test` export-bag split** — two new follow-ups filed from round 12.

## Diff shape

`apps/discord/src/commands.js` + new tests in `qurl-send-back-half.test.js`. The bulk of the commands.js diff is the function being moved (insertion at line ~803, deletion from former lines 1650–2241). Net adds include the new function header + destructure + docstring + 5 strict-input gates + 1 cleanup + the call-site object.

## Test plan

- [x] **1231 unit tests pass** (1194 pre-existing + 37 new across 5 new `describe` blocks: `isVoiceContext` gate, `target` gate, SSRF gate, `expiresIn` gate, `personalMessage` gate). Test count delta breakdown across review rounds: round 5 +3 (isVoiceContext base), round 6 +4 (numeric/wrapper/cooldown), round 10 +13 (target + SSRF), round 11 +17 (expiresIn + personalMessage).
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] Function structure inspection: `executeSendPipeline` at line ~803, `handleSend` at line ~1414, all other top-level functions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)