### PR TITLE
chore(ci): bump ops-routines-workflows from v0.6.1 to v0.6.2

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -34,7 +34,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
     with:
       min_age_days: 7
       # Post a sticky PR comment when an age-check fails, listing each

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -34,7 +34,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-docker.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
     with:
       # Container images get 14 days (vs 7 for source-package
       # ecosystems) — base-image vendors typically take longer to

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -36,7 +36,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-go.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
     with:
       min_age_days: 7
       # Post a sticky PR comment when an age-check fails, listing each

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -33,7 +33,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-pip.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
     with:
       min_age_days: 7
       # Post a sticky PR comment when an age-check fails, listing each


### PR DESCRIPTION
## Why

Bumps the ops-routines-workflows age-check reusables from v0.6.1 to v0.6.2 across all four shims (actions, docker, go, pip).

In v0.6.0/v0.6.1, the sticky PR comment only fired when a pin failed for being **too new**. Transient upstream failures (gh api / docker registry / proxy.golang.org / pypi.org / npmjs unreachable) left PRs with a red required check and **no PR-level explanation** — the reviewer had to dig into the run log to learn whether to re-run the check or open an upstream issue.

v0.6.2 surfaces unverifiable failures with the same sticky-comment treatment as too-new pins, with **re-run guidance** instead of an eligible-after date. Two sections are rendered independently (suppressed when empty).

Hardening folded in alongside:
- `record_unverifiable` strips `\t\n|` from the `reason` arg so future callers forwarding upstream error text can't break the markdown table layout.
- Same pin landing as both kinds (mid-run flake across two changed files) is deduped — too-new wins because we have a valid age from at least one file.
- `awk` failure under `set -euo pipefail` no longer silently suppresses the comment — wrapped in `if !` with a fallback that dumps the deduped data into the too_new bucket.

Upstream: layervai/ops-routines-workflows@v0.6.2 (cut from layervai/ops-routines#64).

End-to-end proof of the unverifiable-comment path is live at layervai/log-service#23 (closed diagnostic PR).

## Test plan

- [ ] CI green on this PR (the age-check reusables are exercised on every PR; the bump is exercised by this PR's own run).
- [ ] If a future age-check failure surfaces, the sticky comment renders the appropriate section (too-new with eligible-after date, unverifiable with re-run guidance).