### PR TITLE
refactor(discord): defensive recipients gates on executeSendPipeline

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -971,7 +971,10 @@ async function executeSendPipeline(interaction, {
   // `personalMessage` shape gate. The DM-embed renderer expects
   // null OR string. A non-string object would silently stringify
   // to `[object Object]` in the recipient's DM — exact silent-
-  // regression shape the other gates fence.
+  // regression shape the other gates fence. Intentionally renders
+  // only `typeof`, NOT the value (no truncForLog), since a string
+  // here would be user-authored DM prose; we don't want even a
+  // truncated 64-char prefix of that landing in prod logs.
   if (personalMessage !== null && typeof personalMessage !== 'string') {
     clearCooldown(interaction.user.id);
     cancelEdit();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -850,19 +850,11 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 // early-exit `return interaction.editReply(...)` paths discard
 // observable result; the function exists for its user-visible
 // side-effects (editReply + DM fan-out + channel-announce).
-// Shared throw-message renderer for the entry-gate family. Bounds the
-// stringified value at 64 code points and appends `…` when truncation
-// happened, so a prod-log reader can tell "the caller passed exactly
-// these 64 chars" from "the value was longer and we cut it." The
-// String() coercion may itself throw on a pathological value with a
-// throwing Symbol.toPrimitive / toString — fall back to a sentinel so
-// the gate's intended throw isn't itself replaced by an opaque error
-// from the renderer.
-//
-// Slice on code points (via the string iterator), NOT code units, so
-// the 64th character can't land on a high surrogate and produce a
-// malformed UTF-16 pair before the `…`. Cosmetic for log readability
-// but matches "do the boring thing right" for the gate family.
+// Bounded value-renderer for entry-gate throw messages. `String()` is
+// wrapped because a hostile @@toPrimitive / toString would otherwise
+// replace the gate's intended TypeError with the renderer's opaque
+// throw. Code-point (not code-unit) slicing avoids splitting a
+// surrogate pair across the `…` boundary.
 function truncForLog(v) {
   let s;
   try {
@@ -870,14 +862,11 @@ function truncForLog(v) {
   } catch {
     return '<unrepresentable>';
   }
-  // Bound the spread cost. A 1MB input would otherwise materialize a
-  // 1M-entry code-point array just to take the first 64. 128 code
-  // units is a safe over-budget that covers any 64-code-point prefix
-  // even if every code point uses a surrogate pair (each pair = 2
-  // code units). `truncated` is the authoritative truncation signal
-  // because a string of exactly 65 surrogate pairs (130 code units)
-  // has head-cps.length === 64 — relying on cps.length alone would
-  // silently drop the `…` marker on that shape.
+  // Pre-slice bounds the [...head] spread cost on pathological inputs
+  // (1MB string → 128-element array, not 1M). `truncated` is the
+  // authoritative truncation signal because 65 surrogate pairs (130
+  // code units) yields head-cps.length === 64 — relying on cps.length
+  // alone would silently drop the `…` on that shape.
   const truncated = s.length > 128;
   const head = truncated ? s.slice(0, 128) : s;
   const cps = [...head];

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -851,13 +851,18 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 // observable result; the function exists for its user-visible
 // side-effects (editReply + DM fan-out + channel-announce).
 // Shared throw-message renderer for the entry-gate family. Bounds the
-// stringified value at 64 chars and appends `…` when truncation
+// stringified value at 64 code points and appends `…` when truncation
 // happened, so a prod-log reader can tell "the caller passed exactly
 // these 64 chars" from "the value was longer and we cut it." The
 // String() coercion may itself throw on a pathological value with a
 // throwing Symbol.toPrimitive / toString — fall back to a sentinel so
 // the gate's intended throw isn't itself replaced by an opaque error
 // from the renderer.
+//
+// Slice on code points (via the string iterator), NOT code units, so
+// the 64th character can't land on a high surrogate and produce a
+// malformed UTF-16 pair before the `…`. Cosmetic for log readability
+// but matches "do the boring thing right" for the gate family.
 function truncForLog(v) {
   let s;
   try {
@@ -865,7 +870,8 @@ function truncForLog(v) {
   } catch {
     return '<unrepresentable>';
   }
-  return s.length > 64 ? `${s.slice(0, 64)}…` : s;
+  const cps = [...s];
+  return cps.length > 64 ? `${cps.slice(0, 64).join('')}…` : s;
 }
 
 async function executeSendPipeline(interaction, {
@@ -928,7 +934,7 @@ async function executeSendPipeline(interaction, {
   if (target !== 'user' && target !== 'channel') {
     clearCooldown(interaction.user.id);
     cancelEdit();
-    throw new TypeError(`executeSendPipeline: target must be 'user' or 'channel' (got ${String(target)})`);
+    throw new TypeError(`executeSendPipeline: target must be 'user' or 'channel' (got ${truncForLog(target)})`);
   }
 
   // Defense-in-depth SSRF re-check. handleSend's Step-2 validates
@@ -959,7 +965,7 @@ async function executeSendPipeline(interaction, {
   if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
     clearCooldown(interaction.user.id);
     cancelEdit();
-    throw new TypeError(`executeSendPipeline: expiresIn must be one of ${Object.keys(EXPIRY_LABELS).join('|')} (got ${String(expiresIn)})`);
+    throw new TypeError(`executeSendPipeline: expiresIn must be one of ${Object.keys(EXPIRY_LABELS).join('|')} (got ${truncForLog(expiresIn)})`);
   }
 
   // `personalMessage` shape gate. The DM-embed renderer expects
@@ -985,14 +991,9 @@ async function executeSendPipeline(interaction, {
   if (!Array.isArray(recipients) || recipients.length === 0) {
     clearCooldown(interaction.user.id);
     cancelEdit();
-    // For the non-array branch, render `typeof=` + `value=` separately
-    // — same disambiguation the isVoiceContext gate uses for the
-    // `typeof null === 'object'` foot-gun. A prod-log reader can tell
-    // `null` from `{}` from `undefined` from `'u1'`. For the
-    // empty-array branch, the value adds nothing (`[]` is the
-    // observable shape), so render just "empty array".
-    // Same rendering rationale as the isVoiceContext gate above
-    // (typeof + truncated value with `…` marker on truncation).
+    // Same `typeof=` + `value=` rendering as the isVoiceContext gate
+    // above. Empty-array branch collapses to just "empty array"
+    // since `[]` is the only observable shape there.
     const detail = Array.isArray(recipients)
       ? 'empty array'
       : `typeof=${typeof recipients}, value=${truncForLog(recipients)}`;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -789,8 +789,10 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 //     when `resourceType === RESOURCE_TYPES.FILE`.
 //   - `expiresIn` must be a key of `EXPIRY_LABELS`.
 //   - `personalMessage` must be `null` or `string`.
-//   - `recipients` must be a non-empty array of length
-//     ≤ `config.QURL_SEND_MAX_RECIPIENTS`.
+//   - `recipients` must be a non-empty array (element shape is
+//     `{ id: <discord-user-id>, username: <string> }`; the gate
+//     does NOT validate elements — only the array's outer shape +
+//     length ≤ `config.QURL_SEND_MAX_RECIPIENTS`).
 // Each gate clears the caller's stale ephemeral with a cancel-
 // edit then throws — the user still sees the outer catch's
 // generic followUp, but the gate's specific cancel replaces
@@ -961,7 +963,16 @@ async function executeSendPipeline(interaction, {
   if (!Array.isArray(recipients) || recipients.length === 0) {
     clearCooldown(interaction.user.id);
     cancelEdit();
-    throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${Array.isArray(recipients) ? 'empty array' : `typeof=${typeof recipients}`})`);
+    // For the non-array branch, render `typeof=` + `value=` separately
+    // — same disambiguation the isVoiceContext gate uses for the
+    // `typeof null === 'object'` foot-gun. A prod-log reader can tell
+    // `null` from `{}` from `undefined` from `'u1'`. For the
+    // empty-array branch, the value adds nothing (`[]` is the
+    // observable shape), so render just "empty array".
+    const detail = Array.isArray(recipients)
+      ? 'empty array'
+      : `typeof=${typeof recipients}, value=${String(recipients)}`;
+    throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${detail})`);
   }
   if (recipients.length > config.QURL_SEND_MAX_RECIPIENTS) {
     clearCooldown(interaction.user.id);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -870,8 +870,21 @@ function truncForLog(v) {
   } catch {
     return '<unrepresentable>';
   }
-  const cps = [...s];
-  return cps.length > 64 ? `${cps.slice(0, 64).join('')}…` : s;
+  // Bound the spread cost. A 1MB input would otherwise materialize a
+  // 1M-entry code-point array just to take the first 64. 128 code
+  // units is a safe over-budget that covers any 64-code-point prefix
+  // even if every code point uses a surrogate pair (each pair = 2
+  // code units). `truncated` is the authoritative truncation signal
+  // because a string of exactly 65 surrogate pairs (130 code units)
+  // has head-cps.length === 64 — relying on cps.length alone would
+  // silently drop the `…` marker on that shape.
+  const truncated = s.length > 128;
+  const head = truncated ? s.slice(0, 128) : s;
+  const cps = [...head];
+  if (truncated || cps.length > 64) {
+    return `${cps.slice(0, 64).join('')}…`;
+  }
+  return s;
 }
 
 async function executeSendPipeline(interaction, {
@@ -987,18 +1000,20 @@ async function executeSendPipeline(interaction, {
   // (deserialized payload, programmatic retry, admin tool) that
   // skips those checks. Trips here would otherwise surface deep
   // inside mintLinksInBatches as "Failed to create any links" with
-  // no caller-side breadcrumb. The non-empty check ALSO fences
-  // the `recipients.length` read on the editReply below — a non-
-  // array reaching that line would crash on `.length` lookup
-  // against undefined.
+  // no caller-side breadcrumb. The non-empty check ALSO fences the
+  // chain of `recipients.length` reads that follow (the cap check
+  // below, then the editReply) — a non-array reaching either site
+  // would crash on `.length` lookup against undefined.
   if (!Array.isArray(recipients) || recipients.length === 0) {
     clearCooldown(interaction.user.id);
     cancelEdit();
-    // Same `typeof=` + `value=` rendering as the isVoiceContext gate
-    // above. Empty-array branch collapses to just "empty array"
-    // since `[]` is the only observable shape there.
+    // Same canonical `typeof=`, `value=` rendering as the
+    // isVoiceContext gate above. Empty-array case renders the literal
+    // `<empty array>` sentinel (truncForLog on `[]` would `String()`
+    // to the empty string, which a prod-log reader couldn't
+    // distinguish from a missing value-field).
     const detail = Array.isArray(recipients)
-      ? 'empty array'
+      ? 'typeof=object, value=<empty array>'
       : `typeof=${typeof recipients}, value=${truncForLog(recipients)}`;
     throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${detail})`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -896,7 +896,9 @@ async function executeSendPipeline(interaction, {
     // a single-field "(got object: null)" rendering. `String()`
     // keeps `undefined` visible (JSON.stringify drops it) and
     // avoids the JSON.stringify-throws-on-BigInt edge case.
-    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${String(isVoiceContext)})`);
+    // Slice keeps the message bounded if a future caller hands
+    // a pathological value (1MB string, etc.).
+    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${String(isVoiceContext).slice(0, 64)})`);
   }
 
   // `target` allowed-set gate. Same silent-mis-render shape: an
@@ -969,9 +971,12 @@ async function executeSendPipeline(interaction, {
     // `null` from `{}` from `undefined` from `'u1'`. For the
     // empty-array branch, the value adds nothing (`[]` is the
     // observable shape), so render just "empty array".
+    // Slice the rendered value to 64 chars so a future caller
+    // that hands a pathological argument (1MB string, etc.)
+    // doesn't dump the whole blob into the rejection message.
     const detail = Array.isArray(recipients)
       ? 'empty array'
-      : `typeof=${typeof recipients}, value=${String(recipients)}`;
+      : `typeof=${typeof recipients}, value=${String(recipients).slice(0, 64)}`;
     throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${detail})`);
   }
   if (recipients.length > config.QURL_SEND_MAX_RECIPIENTS) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -955,8 +955,9 @@ async function executeSendPipeline(interaction, {
   // skips those checks. Trips here would otherwise surface deep
   // inside mintLinksInBatches as "Failed to create any links" with
   // no caller-side breadcrumb. The non-empty check ALSO fences
-  // line 948's `recipients.length` read — a non-array reaching
-  // that line would crash on `.length` lookup against undefined.
+  // the `recipients.length` read on the editReply below — a non-
+  // array reaching that line would crash on `.length` lookup
+  // against undefined.
   if (!Array.isArray(recipients) || recipients.length === 0) {
     clearCooldown(interaction.user.id);
     cancelEdit();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -789,6 +789,8 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 //     when `resourceType === RESOURCE_TYPES.FILE`.
 //   - `expiresIn` must be a key of `EXPIRY_LABELS`.
 //   - `personalMessage` must be `null` or `string`.
+//   - `recipients` must be a non-empty array of length
+//     ≤ `config.QURL_SEND_MAX_RECIPIENTS`.
 // Each gate clears the caller's stale ephemeral with a cancel-
 // edit then throws — the user still sees the outer catch's
 // generic followUp, but the gate's specific cancel replaces
@@ -945,6 +947,27 @@ async function executeSendPipeline(interaction, {
     cancelEdit();
     throw new TypeError(`executeSendPipeline: personalMessage must be null or string (got typeof=${typeof personalMessage})`);
   }
+
+  // `recipients` shape + cap gates. The docstring's "non-empty,
+  // ≤ QURL_SEND_MAX_RECIPIENTS" contract is enforced by handleSend's
+  // front-half today; this is defense-in-depth for a future caller
+  // (deserialized payload, programmatic retry, admin tool) that
+  // skips those checks. Trips here would otherwise surface deep
+  // inside mintLinksInBatches as "Failed to create any links" with
+  // no caller-side breadcrumb. The non-empty check ALSO fences
+  // line 948's `recipients.length` read — a non-array reaching
+  // that line would crash on `.length` lookup against undefined.
+  if (!Array.isArray(recipients) || recipients.length === 0) {
+    clearCooldown(interaction.user.id);
+    cancelEdit();
+    throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${Array.isArray(recipients) ? 'empty array' : `typeof=${typeof recipients}`})`);
+  }
+  if (recipients.length > config.QURL_SEND_MAX_RECIPIENTS) {
+    clearCooldown(interaction.user.id);
+    cancelEdit();
+    throw new RangeError(`executeSendPipeline: recipients.length (${recipients.length}) exceeds QURL_SEND_MAX_RECIPIENTS (${config.QURL_SEND_MAX_RECIPIENTS})`);
+  }
+
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
 
   const sendId = crypto.randomUUID();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -850,6 +850,24 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 // early-exit `return interaction.editReply(...)` paths discard
 // observable result; the function exists for its user-visible
 // side-effects (editReply + DM fan-out + channel-announce).
+// Shared throw-message renderer for the entry-gate family. Bounds the
+// stringified value at 64 chars and appends `…` when truncation
+// happened, so a prod-log reader can tell "the caller passed exactly
+// these 64 chars" from "the value was longer and we cut it." The
+// String() coercion may itself throw on a pathological value with a
+// throwing Symbol.toPrimitive / toString — fall back to a sentinel so
+// the gate's intended throw isn't itself replaced by an opaque error
+// from the renderer.
+function truncForLog(v) {
+  let s;
+  try {
+    s = String(v);
+  } catch {
+    return '<unrepresentable>';
+  }
+  return s.length > 64 ? `${s.slice(0, 64)}…` : s;
+}
+
 async function executeSendPipeline(interaction, {
   apiKey,
   resourceType,
@@ -897,8 +915,10 @@ async function executeSendPipeline(interaction, {
     // keeps `undefined` visible (JSON.stringify drops it) and
     // avoids the JSON.stringify-throws-on-BigInt edge case.
     // Slice keeps the message bounded if a future caller hands
-    // a pathological value (1MB string, etc.).
-    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${String(isVoiceContext).slice(0, 64)})`);
+    // a pathological value (1MB string, etc.). The `…` marker
+    // signals truncation to a prod-log reader so they don't
+    // assume the rendered value was the full payload.
+    throw new TypeError(`executeSendPipeline: isVoiceContext must be a boolean (got typeof=${typeof isVoiceContext}, value=${truncForLog(isVoiceContext)})`);
   }
 
   // `target` allowed-set gate. Same silent-mis-render shape: an
@@ -971,12 +991,11 @@ async function executeSendPipeline(interaction, {
     // `null` from `{}` from `undefined` from `'u1'`. For the
     // empty-array branch, the value adds nothing (`[]` is the
     // observable shape), so render just "empty array".
-    // Slice the rendered value to 64 chars so a future caller
-    // that hands a pathological argument (1MB string, etc.)
-    // doesn't dump the whole blob into the rejection message.
+    // Same rendering rationale as the isVoiceContext gate above
+    // (typeof + truncated value with `…` marker on truncation).
     const detail = Array.isArray(recipients)
       ? 'empty array'
-      : `typeof=${typeof recipients}, value=${String(recipients).slice(0, 64)}`;
+      : `typeof=${typeof recipients}, value=${truncForLog(recipients)}`;
     throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${detail})`);
   }
   if (recipients.length > config.QURL_SEND_MAX_RECIPIENTS) {

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1734,8 +1734,7 @@ describe('executeSendPipeline — personalMessage shape gate', () => {
 describe('executeSendPipeline — recipients shape + cap gates', () => {
   // Read the cap once from the same config module the gate consults
   // so the tests don't drift if the cap is bumped. Hoisting out of
-  // the individual tests (round-6 cr nit) keeps the `require` cost
-  // off the per-test path and centralizes the drift-anchor.
+  // the individual tests centralizes the drift-anchor.
   const { QURL_SEND_MAX_RECIPIENTS: RECIPIENT_CAP } = require('../src/config');
 
   function makePipelineParams(recipients) {
@@ -1782,21 +1781,21 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     ['plain object', {}, /typeof=object/],
     ['empty array', [], /typeof=object, value=<empty array>/],
   ])('rejection message distinguishes %s in the value-detail field', async (_label, recipients, detailRe) => {
-    // Round-2 cr nit: rendering both `null` and `{}` as
-    // `typeof=object` would force a prod-log reader to guess
-    // which one tripped the gate. Pin that the value-detail
-    // field disambiguates the realistic miscoding shapes.
+    // Rendering both `null` and `{}` as `typeof=object` would
+    // force a prod-log reader to guess which one tripped the
+    // gate. Pin that the value-detail field disambiguates the
+    // realistic miscoding shapes.
     const interaction = makeInteraction();
     await expect(executeSendPipeline(interaction, makePipelineParams(recipients)))
       .rejects.toThrow(detailRe);
   });
 
   test('rejection message truncates pathological values with `…` marker', async () => {
-    // Round-4 cr nit: a future caller handing a 1MB string would
-    // otherwise dump the whole blob into the rejection message
-    // AND into the prod logger.error. truncForLog slices at 64
-    // chars and appends `…` so a reader can tell "the caller
-    // passed exactly these 64 chars" from "we cut a longer value."
+    // A future caller handing a 1MB string would otherwise dump
+    // the whole blob into the rejection message AND into the
+    // prod logger.error. truncForLog slices at 64 chars and
+    // appends `…` so a reader can tell "the caller passed
+    // exactly these 64 chars" from "we cut a longer value."
     const interaction = makeInteraction();
     const oneKB = 'x'.repeat(1024);
     await expect(executeSendPipeline(interaction, makePipelineParams(oneKB)))
@@ -1815,12 +1814,12 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     // "Cannot convert object to primitive value" — the exact
     // worse-than-original-error shape the gate exists to prevent.
     ['throws on toString', { toString() { throw new Error('nope'); } }],
-    // Round-7 cr nit: Object.create(null) is the more realistic
-    // miscoding shape — a deserialized payload with prototype
-    // detached has no @@toPrimitive / toString, so `String(v)`
-    // throws "Cannot convert object to primitive value". Pin that
-    // the catch branch handles this shape too, not just the
-    // explicitly-hostile toString case.
+    // Object.create(null) is the realistic miscoding shape — a
+    // deserialized payload with prototype detached has no
+    // @@toPrimitive / toString, so `String(v)` throws "Cannot
+    // convert object to primitive value". Pin that the catch
+    // branch handles this shape too, not just the explicitly-
+    // hostile toString case.
     ['null-prototype object', Object.create(null)],
   ])('rejection message falls back to <unrepresentable> when String() throws (%s)', async (_label, value) => {
     const interaction = makeInteraction();
@@ -1829,14 +1828,14 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
   });
 
   test('truncation slices on code points, not UTF-16 code units (astral-char safety)', async () => {
-    // Round-5 cr nit: `slice(0, 64)` on code units would split a
-    // high-surrogate at position 63 from its low-surrogate at 64,
-    // producing a malformed UTF-16 pair before the `…`. Iterating
-    // via [...s] (the string iterator) operates on code points,
-    // so an emoji at the boundary stays intact. Build a string
-    // with 64 emoji (each 2 code units) — under code-unit slicing
-    // this would surface as 32 intact emoji + a lone high-surrogate;
-    // under code-point slicing it surfaces as 64 intact emoji.
+    // `slice(0, 64)` on code units would split a high-surrogate
+    // at position 63 from its low-surrogate at 64, producing a
+    // malformed UTF-16 pair before the `…`. Iterating via [...s]
+    // (the string iterator) operates on code points, so an emoji
+    // at the boundary stays intact. Build a string with 64 emoji
+    // (each 2 code units) — under code-unit slicing this would
+    // surface as 32 intact emoji + a lone high-surrogate; under
+    // code-point slicing it surfaces as 64 intact emoji.
     const interaction = makeInteraction();
     const sixtyFourEmoji = '🚀'.repeat(64);
     await expect(executeSendPipeline(interaction, makePipelineParams(sixtyFourEmoji)))

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1732,6 +1732,12 @@ describe('executeSendPipeline — personalMessage shape gate', () => {
 // trip would surface deep inside mintLinksInBatches as "Failed
 // to create any links" with no caller-side breadcrumb.
 describe('executeSendPipeline — recipients shape + cap gates', () => {
+  // Read the cap once from the same config module the gate consults
+  // so the tests don't drift if the cap is bumped. Hoisting out of
+  // the individual tests (round-6 cr nit) keeps the `require` cost
+  // off the per-test path and centralizes the drift-anchor.
+  const { QURL_SEND_MAX_RECIPIENTS: RECIPIENT_CAP } = require('../src/config');
+
   function makePipelineParams(recipients) {
     return {
       apiKey: 'apikey',
@@ -1835,11 +1841,7 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
   });
 
   test('throws RangeError when recipients.length exceeds QURL_SEND_MAX_RECIPIENTS', async () => {
-    // Read the cap via the same config module the gate consults so
-    // the test doesn't drift if the cap is bumped.
-    const cfg = require('../src/config');
-    const cap = cfg.QURL_SEND_MAX_RECIPIENTS;
-    const oversized = Array.from({ length: cap + 1 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }));
+    const oversized = Array.from({ length: RECIPIENT_CAP + 1 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }));
     const interaction = makeInteraction();
     await expect(executeSendPipeline(interaction, makePipelineParams(oversized)))
       .rejects.toThrow(/recipients\.length .* exceeds QURL_SEND_MAX_RECIPIENTS/);
@@ -1872,8 +1874,7 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     // calls is caught by exactly one test failing.
     const interaction = makeInteraction();
     const { setCooldown, isOnCooldown } = _test;
-    const cfg = require('../src/config');
-    const oversized = Array.from({ length: cfg.QURL_SEND_MAX_RECIPIENTS + 1 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }));
+    const oversized = Array.from({ length: RECIPIENT_CAP + 1 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }));
     interaction.user = { id: 'recipients-oversized-test-user', username: 'test' };
     setCooldown(interaction.user.id);
     expect(isOnCooldown(interaction.user.id)).toBe(true);
@@ -1889,9 +1890,8 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     // Boundary case: pin that `length === cap` is accepted (the
     // gate uses `>`, not `>=`). A future typo flipping `>` to
     // `>=` would otherwise only show up if a real send happened
-    // to hit exactly the cap. Compute the cap-sized array via
-    // the same config the gate reads, so a cap bump doesn't drift.
-    ['exactly at the cap', Array.from({ length: require('../src/config').QURL_SEND_MAX_RECIPIENTS }, (_, i) => ({ id: `u${i}`, username: `u${i}` }))],
+    // to hit exactly the cap.
+    ['exactly at the cap', Array.from({ length: RECIPIENT_CAP }, (_, i) => ({ id: `u${i}`, username: `u${i}` }))],
   ])('accepts the allowed shape: %s', async (_label, recipients) => {
     // Same shape as the other accept-path tests in this file:
     // assert the gate didn't reject. The pipeline mocks aren't

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1753,7 +1753,8 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     ['empty array', []],
     ['null', null],
     ['undefined', undefined],
-    ['plain object (not array-like)', {}],
+    ['plain object', {}],
+    ['array-like object', { 0: 'u1', length: 1 }],  // pins Array.isArray-strict (not duck-typed)
     ['string (not array)', 'u1'],
     ['number', 42],
   ])('throws TypeError on non-array-or-empty recipients (%s)', async (_label, recipients) => {
@@ -1836,6 +1837,12 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
   test.each([
     ['one recipient', [{ id: 'u1', username: 'u1' }]],
     ['several recipients', Array.from({ length: 5 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }))],
+    // Boundary case: pin that `length === cap` is accepted (the
+    // gate uses `>`, not `>=`). A future typo flipping `>` to
+    // `>=` would otherwise only show up if a real send happened
+    // to hit exactly the cap. Compute the cap-sized array via
+    // the same config the gate reads, so a cap bump doesn't drift.
+    ['exactly at the cap', Array.from({ length: require('../src/config').QURL_SEND_MAX_RECIPIENTS }, (_, i) => ({ id: `u${i}`, username: `u${i}` }))],
   ])('accepts the allowed shape: %s', async (_label, recipients) => {
     // Same shape as the other accept-path tests in this file:
     // assert the gate didn't reject. The pipeline mocks aren't
@@ -1843,7 +1850,7 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     // either throws downstream with a different message, or
     // resolves cleanly if the mock chain happens to line up.
     // The shared vacuous-pass concern across all four accept-
-    // path tests in this file is tracked separately.
+    // path tests in this file is tracked in #291.
     const interaction = makeInteraction();
     try {
       await executeSendPipeline(interaction, makePipelineParams(recipients));

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1769,6 +1769,21 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     );
   });
 
+  test.each([
+    ['null', null, /typeof=object, value=null/],
+    ['undefined', undefined, /typeof=undefined, value=undefined/],
+    ['plain object', {}, /typeof=object/],
+    ['empty array', [], /empty array/],
+  ])('rejection message distinguishes %s in the value-detail field', async (_label, recipients, detailRe) => {
+    // Round-2 cr nit: rendering both `null` and `{}` as
+    // `typeof=object` would force a prod-log reader to guess
+    // which one tripped the gate. Pin that the value-detail
+    // field disambiguates the realistic miscoding shapes.
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(recipients)))
+      .rejects.toThrow(detailRe);
+  });
+
   test('throws RangeError when recipients.length exceeds QURL_SEND_MAX_RECIPIENTS', async () => {
     // Read the cap via the same config module the gate consults so
     // the test doesn't drift if the cap is bumped.
@@ -1796,6 +1811,25 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
       .rejects.toThrow(TypeError);
     // The gate's own clearCooldown call IS the cleanup; the
     // post-throw isOnCooldown assertion is what verifies it.
+    expect(isOnCooldown(interaction.user.id)).toBe(false);
+  });
+
+  test('clears cooldown on the recipients-oversized path (RangeError branch)', async () => {
+    // The empty-array test above pins clearCooldown on the
+    // TypeError branch; the oversized-array (RangeError) branch
+    // has its own clearCooldown call. Pin it separately so a
+    // future refactor that drops one of the two clearCooldown
+    // calls is caught by exactly one test failing.
+    const interaction = makeInteraction();
+    const { setCooldown, isOnCooldown } = _test;
+    const cfg = require('../src/config');
+    const oversized = Array.from({ length: cfg.QURL_SEND_MAX_RECIPIENTS + 1 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }));
+    interaction.user = { id: 'recipients-oversized-test-user', username: 'test' };
+    setCooldown(interaction.user.id);
+    expect(isOnCooldown(interaction.user.id)).toBe(true);
+
+    await expect(executeSendPipeline(interaction, makePipelineParams(oversized)))
+      .rejects.toThrow(RangeError);
     expect(isOnCooldown(interaction.user.id)).toBe(false);
   });
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1785,6 +1785,36 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
       .rejects.toThrow(detailRe);
   });
 
+  test('rejection message truncates pathological values with `…` marker', async () => {
+    // Round-4 cr nit: a future caller handing a 1MB string would
+    // otherwise dump the whole blob into the rejection message
+    // AND into the prod logger.error. truncForLog slices at 64
+    // chars and appends `…` so a reader can tell "the caller
+    // passed exactly these 64 chars" from "we cut a longer value."
+    const interaction = makeInteraction();
+    const oneKB = 'x'.repeat(1024);
+    await expect(executeSendPipeline(interaction, makePipelineParams(oneKB)))
+      .rejects.toThrow(/value=x{64}…/);
+    // Negative pin: a 64-char value should NOT have the marker
+    // (otherwise we can't distinguish exact-fit from truncated).
+    const exact64 = 'y'.repeat(64);
+    await expect(executeSendPipeline(interaction, makePipelineParams(exact64)))
+      .rejects.toThrow(/value=y{64}\)/);
+  });
+
+  test('rejection message falls back to <unrepresentable> if String() throws', async () => {
+    // Pathological caller-shape protection. Without the try/catch
+    // in truncForLog, the throw-message renderer would itself
+    // throw, replacing the gate's TypeError with an opaque
+    // "Cannot convert object to primitive value" — the exact
+    // worse-than-the-original-error shape the gate exists to
+    // prevent. Realistically unreachable from any honest caller.
+    const interaction = makeInteraction();
+    const hostile = { toString() { throw new Error('nope'); } };
+    await expect(executeSendPipeline(interaction, makePipelineParams(hostile)))
+      .rejects.toThrow(/value=<unrepresentable>/);
+  });
+
   test('throws RangeError when recipients.length exceeds QURL_SEND_MAX_RECIPIENTS', async () => {
     // Read the cap via the same config module the gate consults so
     // the test doesn't drift if the cap is bumped.

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1917,10 +1917,11 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
   });
 });
 
-// Pin that truncForLog applies to ALL value-rendering gates in
-// the entry-gate family, not just the two introduced in round 4.
-// A future caller handing a 1MB string as `target` or `expiresIn`
-// would otherwise dump the whole blob into the rejection message.
+// Pin that truncForLog applies to ALL value-rendering gates in the
+// entry-gate family, not just the recipients gate that introduces
+// it. A future caller handing a 1MB string as `isVoiceContext`,
+// `target`, or `expiresIn` would otherwise dump the whole blob
+// into the rejection message.
 describe('executeSendPipeline — truncForLog applies to all value-rendering gates', () => {
   function makeParams(overrides) {
     return {
@@ -1939,6 +1940,13 @@ describe('executeSendPipeline — truncForLog applies to all value-rendering gat
       ...overrides,
     };
   }
+
+  test('isVoiceContext rejection message is bounded with `…` on oversized input', async () => {
+    const interaction = makeInteraction();
+    const huge = 'w'.repeat(1024);
+    await expect(executeSendPipeline(interaction, makeParams({ isVoiceContext: huge })))
+      .rejects.toThrow(/isVoiceContext must be a boolean .* value=w{64}…\)/);
+  });
 
   test('target rejection message is bounded with `…` on oversized input', async () => {
     const interaction = makeInteraction();

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1724,3 +1724,99 @@ describe('executeSendPipeline — personalMessage shape gate', () => {
   });
 });
 
+// Defensive guards for the `recipients` invariants — non-empty and
+// ≤ config.QURL_SEND_MAX_RECIPIENTS. handleSend's front-half
+// already enforces these before the pipeline call; the gates are
+// defense-in-depth for a future caller (deserialized payload,
+// programmatic retry) that skips those checks. Without them, a
+// trip would surface deep inside mintLinksInBatches as "Failed
+// to create any links" with no caller-side breadcrumb.
+describe('executeSendPipeline — recipients shape + cap gates', () => {
+  function makePipelineParams(recipients) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: { url: 'https://cdn.discordapp.com/x', name: 'x.png', contentType: 'image/png' },
+      locationUrl: null,
+      locationName: null,
+      recipients,
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+    };
+  }
+
+  test.each([
+    ['empty array', []],
+    ['null', null],
+    ['undefined', undefined],
+    ['plain object (not array-like)', {}],
+    ['string (not array)', 'u1'],
+    ['number', 42],
+  ])('throws TypeError on non-array-or-empty recipients (%s)', async (_label, recipients) => {
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(recipients)))
+      .rejects.toThrow(/recipients must be a non-empty array/);
+    // Cancel-edit fires before the throw — same shape as the other
+    // entry gates.
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+      }),
+    );
+  });
+
+  test('throws RangeError when recipients.length exceeds QURL_SEND_MAX_RECIPIENTS', async () => {
+    // Read the cap via the same config module the gate consults so
+    // the test doesn't drift if the cap is bumped.
+    const cfg = require('../src/config');
+    const cap = cfg.QURL_SEND_MAX_RECIPIENTS;
+    const oversized = Array.from({ length: cap + 1 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }));
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams(oversized)))
+      .rejects.toThrow(/recipients\.length .* exceeds QURL_SEND_MAX_RECIPIENTS/);
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/Internal error — send cancelled/),
+      }),
+    );
+  });
+
+  test('clears cooldown on the recipients-empty path (same convention as other gates)', async () => {
+    const interaction = makeInteraction();
+    const { setCooldown, isOnCooldown, clearCooldown } = _test;
+    interaction.user = { id: 'recipients-empty-test-user', username: 'test' };
+    setCooldown(interaction.user.id);
+    expect(isOnCooldown(interaction.user.id)).toBe(true);
+
+    await expect(executeSendPipeline(interaction, makePipelineParams([])))
+      .rejects.toThrow(TypeError);
+    expect(isOnCooldown(interaction.user.id)).toBe(false);
+
+    if (typeof clearCooldown === 'function') {
+      clearCooldown(interaction.user.id);
+    }
+  });
+
+  test.each([
+    ['one recipient', [{ id: 'u1', username: 'u1' }]],
+    ['several recipients', Array.from({ length: 5 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }))],
+  ])('accepts the allowed shape: %s', async (_label, recipients) => {
+    // Same shape as the other accept-path tests: assert the gate
+    // didn't reject. The pipeline mocks aren't fully wired here,
+    // so anything past the gate is fine (it'll fail downstream
+    // with a different message).
+    const interaction = makeInteraction();
+    try {
+      await executeSendPipeline(interaction, makePipelineParams(recipients));
+    } catch (err) {
+      expect(err.message).not.toMatch(/recipients must be a non-empty array/);
+      expect(err.message).not.toMatch(/exceeds QURL_SEND_MAX_RECIPIENTS/);
+      return;
+    }
+  });
+});
+

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1780,7 +1780,7 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
     ['null', null, /typeof=object, value=null/],
     ['undefined', undefined, /typeof=undefined, value=undefined/],
     ['plain object', {}, /typeof=object/],
-    ['empty array', [], /empty array/],
+    ['empty array', [], /typeof=object, value=<empty array>/],
   ])('rejection message distinguishes %s in the value-detail field', async (_label, recipients, detailRe) => {
     // Round-2 cr nit: rendering both `null` and `{}` as
     // `typeof=object` would force a prod-log reader to guess
@@ -1808,16 +1808,23 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
       .rejects.toThrow(/value=y{64}\)/);
   });
 
-  test('rejection message falls back to <unrepresentable> if String() throws', async () => {
-    // Pathological caller-shape protection. Without the try/catch
-    // in truncForLog, the throw-message renderer would itself
-    // throw, replacing the gate's TypeError with an opaque
+  test.each([
+    // Hostile-toString: the obvious adversarial shape. Without the
+    // try/catch in truncForLog, the throw-message renderer would
+    // itself throw, replacing the gate's TypeError with an opaque
     // "Cannot convert object to primitive value" — the exact
-    // worse-than-the-original-error shape the gate exists to
-    // prevent. Realistically unreachable from any honest caller.
+    // worse-than-original-error shape the gate exists to prevent.
+    ['throws on toString', { toString() { throw new Error('nope'); } }],
+    // Round-7 cr nit: Object.create(null) is the more realistic
+    // miscoding shape — a deserialized payload with prototype
+    // detached has no @@toPrimitive / toString, so `String(v)`
+    // throws "Cannot convert object to primitive value". Pin that
+    // the catch branch handles this shape too, not just the
+    // explicitly-hostile toString case.
+    ['null-prototype object', Object.create(null)],
+  ])('rejection message falls back to <unrepresentable> when String() throws (%s)', async (_label, value) => {
     const interaction = makeInteraction();
-    const hostile = { toString() { throw new Error('nope'); } };
-    await expect(executeSendPipeline(interaction, makePipelineParams(hostile)))
+    await expect(executeSendPipeline(interaction, makePipelineParams(value)))
       .rejects.toThrow(/value=<unrepresentable>/);
   });
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1815,6 +1815,25 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
       .rejects.toThrow(/value=<unrepresentable>/);
   });
 
+  test('truncation slices on code points, not UTF-16 code units (astral-char safety)', async () => {
+    // Round-5 cr nit: `slice(0, 64)` on code units would split a
+    // high-surrogate at position 63 from its low-surrogate at 64,
+    // producing a malformed UTF-16 pair before the `…`. Iterating
+    // via [...s] (the string iterator) operates on code points,
+    // so an emoji at the boundary stays intact. Build a string
+    // with 64 emoji (each 2 code units) — under code-unit slicing
+    // this would surface as 32 intact emoji + a lone high-surrogate;
+    // under code-point slicing it surfaces as 64 intact emoji.
+    const interaction = makeInteraction();
+    const sixtyFourEmoji = '🚀'.repeat(64);
+    await expect(executeSendPipeline(interaction, makePipelineParams(sixtyFourEmoji)))
+      .rejects.toThrow(/value=(?:🚀){64}\)/u);
+    // 65 emoji → 64 in the rendering + `…` marker.
+    const sixtyFiveEmoji = '🚀'.repeat(65);
+    await expect(executeSendPipeline(interaction, makePipelineParams(sixtyFiveEmoji)))
+      .rejects.toThrow(/value=(?:🚀){64}…/u);
+  });
+
   test('throws RangeError when recipients.length exceeds QURL_SEND_MAX_RECIPIENTS', async () => {
     // Read the cap via the same config module the gate consults so
     // the test doesn't drift if the cap is bumped.
@@ -1889,6 +1908,44 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
       expect(err.message).not.toMatch(/exceeds QURL_SEND_MAX_RECIPIENTS/);
       return;
     }
+  });
+});
+
+// Pin that truncForLog applies to ALL value-rendering gates in
+// the entry-gate family, not just the two introduced in round 4.
+// A future caller handing a 1MB string as `target` or `expiresIn`
+// would otherwise dump the whole blob into the rejection message.
+describe('executeSendPipeline — truncForLog applies to all value-rendering gates', () => {
+  function makeParams(overrides) {
+    return {
+      apiKey: 'apikey',
+      resourceType: 'file',
+      attachment: { url: 'https://cdn.discordapp.com/x', name: 'x.png', contentType: 'image/png' },
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: 'u1', username: 'u1' }],
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      sendNonce: 'nonce',
+      ...overrides,
+    };
+  }
+
+  test('target rejection message is bounded with `…` on oversized input', async () => {
+    const interaction = makeInteraction();
+    const huge = 'x'.repeat(1024);
+    await expect(executeSendPipeline(interaction, makeParams({ target: huge })))
+      .rejects.toThrow(/target must be 'user' or 'channel' \(got x{64}…\)/);
+  });
+
+  test('expiresIn rejection message is bounded with `…` on oversized input', async () => {
+    const interaction = makeInteraction();
+    const huge = 'y'.repeat(1024);
+    await expect(executeSendPipeline(interaction, makeParams({ expiresIn: huge })))
+      .rejects.toThrow(/expiresIn must be one of .* \(got y{64}…\)/);
   });
 });
 

--- a/apps/discord/tests/qurl-send-back-half.test.js
+++ b/apps/discord/tests/qurl-send-back-half.test.js
@@ -1787,28 +1787,29 @@ describe('executeSendPipeline — recipients shape + cap gates', () => {
 
   test('clears cooldown on the recipients-empty path (same convention as other gates)', async () => {
     const interaction = makeInteraction();
-    const { setCooldown, isOnCooldown, clearCooldown } = _test;
+    const { setCooldown, isOnCooldown } = _test;
     interaction.user = { id: 'recipients-empty-test-user', username: 'test' };
     setCooldown(interaction.user.id);
     expect(isOnCooldown(interaction.user.id)).toBe(true);
 
     await expect(executeSendPipeline(interaction, makePipelineParams([])))
       .rejects.toThrow(TypeError);
+    // The gate's own clearCooldown call IS the cleanup; the
+    // post-throw isOnCooldown assertion is what verifies it.
     expect(isOnCooldown(interaction.user.id)).toBe(false);
-
-    if (typeof clearCooldown === 'function') {
-      clearCooldown(interaction.user.id);
-    }
   });
 
   test.each([
     ['one recipient', [{ id: 'u1', username: 'u1' }]],
     ['several recipients', Array.from({ length: 5 }, (_, i) => ({ id: `u${i}`, username: `u${i}` }))],
   ])('accepts the allowed shape: %s', async (_label, recipients) => {
-    // Same shape as the other accept-path tests: assert the gate
-    // didn't reject. The pipeline mocks aren't fully wired here,
-    // so anything past the gate is fine (it'll fail downstream
-    // with a different message).
+    // Same shape as the other accept-path tests in this file:
+    // assert the gate didn't reject. The pipeline mocks aren't
+    // fully wired here, so anything past the gate is fine — it
+    // either throws downstream with a different message, or
+    // resolves cleanly if the mock chain happens to line up.
+    // The shared vacuous-pass concern across all four accept-
+    // path tests in this file is tracked separately.
     const interaction = makeInteraction();
     try {
       await executeSendPipeline(interaction, makePipelineParams(recipients));


### PR DESCRIPTION
## Summary

Closes #280. Adds the two `recipients`-invariant gates that the cr review on #277 flagged as the strongest non-blocking concern — landing them as a focused follow-up before PR 7b's `handleSendFormSend` becomes the second caller.

## What's in this PR

Two entry gates at `executeSendPipeline`, sharing the existing strict-input pattern (`cancelEdit` + `clearCooldown` + `throw`):

```js
if (!Array.isArray(recipients) || recipients.length === 0) {
  throw new TypeError(`executeSendPipeline: recipients must be a non-empty array (got ${...})`);
}
if (recipients.length > config.QURL_SEND_MAX_RECIPIENTS) {
  throw new RangeError(`executeSendPipeline: recipients.length (${recipients.length}) exceeds QURL_SEND_MAX_RECIPIENTS (${config.QURL_SEND_MAX_RECIPIENTS})`);
}
```

Seven entry gates now (was five): `isVoiceContext`, `target`, `attachment.url` SSRF, `expiresIn`, `personalMessage`, `recipients` non-empty, `recipients` ≤ cap.

## Why now (not in #277)

#277 was scoped as a focused refactor. Each gate added there was defensible inline, but bundling a sixth + seventh would have started pushing the "pure refactor" framing. Landing as its own tiny PR before PR 7b means:

- PR 7b's `handleSendFormSend` reconstructing from a decrypted `flow_state` payload inherits the guards by default
- A future cr cycle on PR 7b doesn't re-litigate the gate shape (already pinned here)
- The `recipients` non-empty gate also fences the `recipients.length` read on the very next line — a non-array reaching that line would crash with a less actionable "Cannot read properties of null" message

## What's NOT in this PR

- Drop of the matching pre-call checks in `handleSend` — they're idiomatic UX (polite editReply, no throw) and stay as belt-and-suspenders. The gates here are defense-in-depth for callers that skip those checks.

## Test plan

- [x] 1231 → 1241 (+10 new gate cases): non-array-or-empty (empty array, null, undefined, plain object, string, number), oversized (cap+1 trips the RangeError), cooldown cleanup on the rejection path, accept-set (one + several recipients).
- [x] All existing 1231 tests pass unchanged — today's callers thread valid recipients.
- [x] `npm run lint` clean (`--max-warnings 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)