### PR TITLE
feat(discord): add recipient-parser module for /qurl file + /qurl map (7b.1)

### DIFF
--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -95,11 +95,12 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 // before the API ceiling. 7b.2 should narrow the option's
 // max_length to ≤4000 so this cap becomes defense-in-depth rather
 // than the user-visible truncation point.
-// KEEP IN SYNC with the slash-option `max_length` in 7b.2's
-// builder. If 7b.2 narrows the option's max_length to ≤ 4000,
-// this cap becomes defense-in-depth; if it doesn't, this is the
-// user-visible truncation point (and the partial-mention trim
-// below becomes lossy on legitimate over-cap content).
+// TODO(7b.2): KEEP IN SYNC with the slash-option `max_length` in
+// 7b.2's builder. If 7b.2 narrows the option's max_length to
+// ≤ 4000, this cap becomes defense-in-depth; if it doesn't, this
+// is the user-visible truncation point (and the partial-mention
+// trim below becomes lossy on legitimate over-cap content).
+// Grep `TODO(7b.2)` to find the 7b.1 → 7b.2 coordination markers.
 const MAX_INPUT_LENGTH = 4000;
 
 // Per-token cap on entries in `invalidTokens`. Discord's embed total
@@ -339,7 +340,7 @@ function parseRecipientMentions(raw, interaction) {
       ? logger.warn
       : logger.debug;
     logFn('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
-      unique_count: seen.size, cap, capped_count: cappedCount,
+      uniqueCount: seen.size, cap, cappedCount,
     });
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -13,9 +13,11 @@
 //   - User mentions:  <@123456> or <@!123456>   → user ID 123456
 //   - Role mentions:  <@&987654>                → expand to current
 //                                                 guild members of that role
-//   - Whitespace, commas, semicolons, pipes, and slashes as
-//     separators (lenient — covers free-form paste from contact
-//     lists / CSV-ish formats)
+// Mention extraction is regex-based — separators don't matter for
+// the mentions themselves (`<@111><@222>` matches both). The
+// separator class only affects the residue/invalid-token strip
+// pass: whitespace, commas, semicolons, pipes, and slashes (lenient
+// — covers free-form paste from contact lists / CSV-ish formats).
 //
 // What we reject (returned in `invalidTokens`):
 //   - Channel mentions <#...>
@@ -46,12 +48,18 @@
 // same per-send cap the in-channel form enforces), and excludes the
 // invoking user + bots (matches the form's self-send + bot rejection).
 //
-// Role expansion uses interaction.guild.members.cache. If the cache is
-// cold (DM context, bot just restarted) the role expansion silently
-// resolves to no members for that role — the role mention lands in
-// `invalidTokens` so the caller can surface "couldn't expand @team-blue,
-// pick users from the menu instead." This matches the existing form's
-// posture (fall through to the picker rather than 404 a slash command).
+// Role expansion uses interaction.guild.members.cache via discord.js's
+// `Role.members` getter, which filters the guild's member cache for
+// the role. PARTIAL-CACHE BLIND SPOT: in large guilds running without
+// `GUILD_MEMBERS` intent (or before chunking), `role.members.size`
+// reflects only the currently-cached subset, not the role's true
+// population. We cannot distinguish "small role" from "large role,
+// partial cache." Cold-cache / DM-context degrades safely (token
+// lands in `invalidTokens`), but a partial-cache silent under-resolve
+// is harder to surface — 7b.2 should consider logging `role.memberCount`
+// vs `role.members.size` when they diverge, and the user-facing copy
+// should say "expanded N members" so users notice if a role appears
+// to expand to far fewer recipients than they expect.
 
 const config = require('./config');
 const logger = require('./logger');
@@ -65,9 +73,13 @@ const USER_MENTION_RE = /<@!?(\d+)>/g;
 const ROLE_MENTION_RE = /<@&(\d+)>/g;
 
 // Hard cap on input length so an adversarial regex-blowup attack
-// (10MB of `<@1>` repetitions) doesn't tie up the worker. The form's
-// 200-char descriptions and Discord's natural 2000-char message cap
-// make 4000 chars more than enough headroom for legitimate use.
+// (10MB of `<@1>` repetitions) doesn't tie up the worker. Discord's
+// slash-command STRING option max is 6000 chars (when not narrowed
+// via setMaxLength); 4000 is a conservative budget that comfortably
+// fits any legitimate recipient-list paste while leaving headroom
+// before the API ceiling. 7b.2 should narrow the option's
+// max_length to ≤4000 so this cap becomes defense-in-depth rather
+// than the user-visible truncation point.
 const MAX_INPUT_LENGTH = 4000;
 
 // Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / etc.) to
@@ -122,14 +134,13 @@ function parseRecipientMentions(raw, interaction) {
   const guild = interaction.guild;
   const cap = config.QURL_SEND_MAX_RECIPIENTS;
 
-  // Mark an ID as considered. Returns true if it's net-new to the
-  // candidate set (caller uses this to drive "role contributed
-  // anything" detection).
+  // Mark an ID as considered: dedupe via `seen`, add to `ids` only
+  // while under cap. Role-contribution detection lives in the role
+  // loop's `usable` counter — see comment there.
   function consider(id) {
-    if (seen.has(id)) return false;
+    if (seen.has(id)) return;
     seen.add(id);
     if (ids.size < cap) ids.add(id);
-    return true;
   }
 
   for (const m of input.matchAll(USER_MENTION_RE)) {

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -285,6 +285,7 @@ function parseRecipientMentions(raw, interaction) {
     .replace(USER_MENTION_RE, ' ')
     .replace(ROLE_MENTION_RE, ' ');
   const leftover = stripped.split(/[\s,;|/]+/).filter(Boolean);
+  const residueSeen = new Set();
   for (const tok of leftover) {
     // Pre-escape `@everyone` / `@here` so a caller interpolating
     // `invalidTokens` into a user-visible message can't accidentally
@@ -307,6 +308,12 @@ function parseRecipientMentions(raw, interaction) {
     if (escaped.length > MAX_INVALID_TOKEN_LENGTH) {
       escaped = `${escaped.slice(0, MAX_INVALID_TOKEN_LENGTH)}\u2026`;
     }
+    // Dedupe residue tokens by the post-escape rendered form so
+    // `<#456> <#456>` or `alice alice` produces ONE entry, not two.
+    // Symmetric with the role-error dedup path (pushRoleErrorIfNew
+    // above) \u2014 a caller's "couldn't parse: X, X" embed is hostile.
+    if (residueSeen.has(escaped)) continue;
+    residueSeen.add(escaped);
     invalidTokens.push(escaped);
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -72,12 +72,15 @@ function parseRecipientMentions(raw, interaction) {
   }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
-  // pathological repetitions still allocate per-match strings. If the
-  // cut lands inside a `<...>` token, drop the trailing partial so the
-  // strip-pass doesn't surface a manufactured "invalid token" the user
-  // didn't actually type wrong.
-  let input = raw.length > MAX_INPUT_LENGTH ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
-  if (input.length === MAX_INPUT_LENGTH) {
+  // pathological repetitions still allocate per-match strings.
+  const truncated = raw.length > MAX_INPUT_LENGTH;
+  let input = truncated ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
+  // If the cut lands inside a `<...>` token, drop the trailing partial
+  // so the strip-pass doesn't surface a manufactured "invalid token"
+  // the user didn't actually mistype. Gate strictly on `truncated` —
+  // a naturally-MAX-length input with a stray `<` mid-string is
+  // legitimate content that the strip-pass should surface as-is.
+  if (truncated) {
     const lastOpen = input.lastIndexOf('<');
     const lastClose = input.lastIndexOf('>');
     if (lastOpen > lastClose) {
@@ -158,7 +161,12 @@ function parseRecipientMentions(raw, interaction) {
   const cap = config.QURL_SEND_MAX_RECIPIENTS;
   let finalIds = [...ids];
   if (finalIds.length > cap) {
-    logger.debug('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
+    // Massive over-cap (>2× the limit) signals user confusion —
+    // probably pasted a list they didn't trim. Surface at warn so
+    // oncall sees the pattern. Modest overshoot is normal-ish
+    // (typed too many) and stays at debug.
+    const logFn = finalIds.length > cap * 2 ? logger.warn : logger.debug;
+    logFn('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
       raw_count: finalIds.length, cap,
     });
     finalIds = finalIds.slice(0, cap);

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -146,10 +146,13 @@ function parseRecipientMentions(raw, interaction) {
   for (const m of input.matchAll(USER_MENTION_RE)) {
     const id = m[1];
     if (id === senderId) continue;
-    // Bot filter — best-effort via cache. A cache miss leaves the bot
-    // in the result; downstream send-pipeline has its own bot check
-    // (see existing form's `Cannot send to a bot` warning path) so
-    // this layer being lossy is acceptable.
+    // Bot filter — best-effort via cache. A cache miss (cold cache,
+    // partial cache without GUILD_MEMBERS intent, or DM-context with
+    // `guild === undefined`) leaves the bot in the result; downstream
+    // send-pipeline has its own bot check (see existing form's
+    // `Cannot send to a bot` warning path) so this layer being lossy
+    // is acceptable. 7b.2 wiring should NOT assume the parser
+    // filtered bots.
     const member = guild?.members?.cache?.get(id);
     if (member?.user?.bot) continue;
     consider(id);
@@ -158,19 +161,33 @@ function parseRecipientMentions(raw, interaction) {
   // Role expansion: missing role / empty role / DM-context guild lands
   // the raw role token in `invalidTokens` so the caller can surface
   // "couldn't resolve @role" rather than silently produce a smaller
-  // recipient list.
+  // recipient list. NOTE on perf: discord.js's `Role.members` getter
+  // filters the full guild member cache per call, so N role mentions
+  // = N O(guild_size) scans. Bounded by the 4000-char input cap and
+  // by Discord's slash-option max — worth knowing for 7b.2 wiring
+  // in large guilds but not a hot-path concern today.
+  const invalidRoleIds = new Set();
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
     const roleId = m[1];
+    // Dedupe role-error pushes by role ID so `<@&999> <@&999>` against
+    // an unknown role yields one invalidTokens entry, not two. The
+    // strip-pass's residue-tokens already dedupe naturally via input
+    // grouping; this set restores the same property for role errors.
+    const pushIfNew = () => {
+      if (invalidRoleIds.has(roleId)) return;
+      invalidRoleIds.add(roleId);
+      invalidTokens.push(m[0]);
+    };
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
-      invalidTokens.push(m[0]);
+      pushIfNew();
       continue;
     }
     // role.members is a Collection<Snowflake, GuildMember>. Empty for
     // a role with no current members in the cache; same treatment.
     const members = role.members;
     if (!members || members.size === 0) {
-      invalidTokens.push(m[0]);
+      pushIfNew();
       continue;
     }
     // `usable` counts post-filter members the role exposed (whether
@@ -188,7 +205,7 @@ function parseRecipientMentions(raw, interaction) {
       // Role had members but they were all filtered (sender + bots).
       // Surface as "no usable members" rather than silently no-op so
       // the caller can tell the user "the role only contains you / bots."
-      invalidTokens.push(m[0]);
+      pushIfNew();
     }
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -110,10 +110,27 @@ function parseRecipientMentions(raw, interaction) {
     return { ids: [], invalidTokens: [], cappedCount: 0 };
   }
 
+  // `seen` is the canonical post-filter unique-candidate set (every
+  // ID we considered, regardless of cap). `ids` is the cap-bounded
+  // subset returned to the caller. `cappedCount` is computed post-hoc
+  // as `seen.size - ids.size` — accurate even when role expansion is
+  // the source of the overflow.
+  const seen = new Set();
   const ids = new Set();
   const invalidTokens = [];
   const senderId = interaction.user?.id;
   const guild = interaction.guild;
+  const cap = config.QURL_SEND_MAX_RECIPIENTS;
+
+  // Mark an ID as considered. Returns true if it's net-new to the
+  // candidate set (caller uses this to drive "role contributed
+  // anything" detection).
+  function consider(id) {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    if (ids.size < cap) ids.add(id);
+    return true;
+  }
 
   for (const m of input.matchAll(USER_MENTION_RE)) {
     const id = m[1];
@@ -124,20 +141,14 @@ function parseRecipientMentions(raw, interaction) {
     // this layer being lossy is acceptable.
     const member = guild?.members?.cache?.get(id);
     if (member?.user?.bot) continue;
-    ids.add(id);
+    consider(id);
   }
 
   // Role expansion: missing role / empty role / DM-context guild lands
   // the raw role token in `invalidTokens` so the caller can surface
   // "couldn't resolve @role" rather than silently produce a smaller
   // recipient list.
-  const cap = config.QURL_SEND_MAX_RECIPIENTS;
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
-    // Short-circuit if we're already at/past the cap. The trim happens
-    // later, but iterating a 5000-member role here just to throw them
-    // away wastes worker time on the request path. Direct mentions
-    // already ran (pass 1), so this only skips role-expansion work.
-    if (ids.size >= cap) break;
     const roleId = m[1];
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
@@ -151,24 +162,18 @@ function parseRecipientMentions(raw, interaction) {
       invalidTokens.push(m[0]);
       continue;
     }
-    // `added` counts loop iterations that passed the sender + bot
-    // filters, NOT net-new additions to `ids` (a member already added
-    // by a direct mention will still count here). Used only to drive
-    // the "no usable members" branch — what we want there is "did the
-    // role contribute anything," and prior dedupe is a contribution.
-    let added = 0;
+    // `usable` counts post-filter members the role exposed (whether
+    // or not they were new to `seen`). Used to detect "all filtered"
+    // vs "role contributed but we'd already counted them" — dedupe
+    // is still a contribution.
+    let usable = 0;
     for (const [memberId, member] of members) {
-      // Inner break: a single role with 50k members would otherwise
-      // run 50k Set.add calls before the post-loop slice trims them
-      // back to the cap. Re-check on every iteration so a fat-roled
-      // input bails as soon as we've collected enough.
-      if (ids.size >= cap) break;
       if (memberId === senderId) continue;
       if (member?.user?.bot) continue;
-      ids.add(memberId);
-      added++;
+      usable++;
+      consider(memberId);
     }
-    if (added === 0) {
+    if (usable === 0) {
       // Role had members but they were all filtered (sender + bots).
       // Surface as "no usable members" rather than silently no-op so
       // the caller can tell the user "the role only contains you / bots."
@@ -203,24 +208,22 @@ function parseRecipientMentions(raw, interaction) {
     invalidTokens.push(tok.replace(/@(everyone|here)/g, '@\u200b$1'));
   }
 
-  // Apply the per-send recipient cap. The cap is enforced by the
-  // back-half too, but we want the user-visible feedback to say
-  // "I capped at N" before they hit Send — not as a back-half error.
-  // Config validates QURL_SEND_MAX_RECIPIENTS via intEnv minPositive
-  // (see src/config.js), so trust the invariant — no paranoid guards.
-  let finalIds = [...ids];
-  let cappedCount = 0;
-  if (finalIds.length > cap) {
-    cappedCount = finalIds.length - cap;
+  // Cap was enforced inline during the two passes (`ids` never
+  // exceeds `cap`; over-cap candidates live in `seen` but not `ids`).
+  // The back-half re-enforces the cap too; surfacing `cappedCount`
+  // here lets the caller say "I kept N of M — drop these or split"
+  // before they hit Send rather than waiting for the back-half error.
+  const finalIds = [...ids];
+  const cappedCount = seen.size - ids.size;
+  if (cappedCount > 0) {
     // Massive over-cap (>2× the limit) signals user confusion —
     // probably pasted a list they didn't trim. Surface at warn so
     // oncall sees the pattern. Modest overshoot is normal-ish
     // (typed too many) and stays at debug.
-    const logFn = finalIds.length > cap * 2 ? logger.warn : logger.debug;
+    const logFn = seen.size > cap * 2 ? logger.warn : logger.debug;
     logFn('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
-      raw_count: finalIds.length, cap,
+      raw_count: seen.size, cap,
     });
-    finalIds = finalIds.slice(0, cap);
   }
 
   return { ids: finalIds, invalidTokens, cappedCount };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -99,6 +99,14 @@ function parseRecipientMentions(raw, interaction) {
   if (raw == null || typeof raw !== 'string') {
     return { ids: [], invalidTokens: [], cappedCount: 0 };
   }
+  // Mirror the `raw` guard for `interaction` so a null/undefined
+  // caller-bug surfaces as an empty result instead of a TypeError
+  // at the `interaction.user?.id` deref below. The back-half has
+  // a clearer crash site for "no caller context"; the parser
+  // doesn't gain anything by failing here.
+  if (interaction == null) {
+    return { ids: [], invalidTokens: [], cappedCount: 0 };
+  }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
   // pathological repetitions still allocate per-match strings. This
@@ -166,28 +174,28 @@ function parseRecipientMentions(raw, interaction) {
   // = N O(guild_size) scans. Bounded by the 4000-char input cap and
   // by Discord's slash-option max — worth knowing for 7b.2 wiring
   // in large guilds but not a hot-path concern today.
+  // Dedupe role-error pushes by role ID so `<@&999> <@&999>` against
+  // an unknown role yields one invalidTokens entry, not two. The
+  // strip-pass's residue-tokens already dedupe naturally via input
+  // grouping; this set restores the same property for role errors.
   const invalidRoleIds = new Set();
+  function pushRoleErrorIfNew(roleId, rawToken) {
+    if (invalidRoleIds.has(roleId)) return;
+    invalidRoleIds.add(roleId);
+    invalidTokens.push(rawToken);
+  }
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
     const roleId = m[1];
-    // Dedupe role-error pushes by role ID so `<@&999> <@&999>` against
-    // an unknown role yields one invalidTokens entry, not two. The
-    // strip-pass's residue-tokens already dedupe naturally via input
-    // grouping; this set restores the same property for role errors.
-    const pushIfNew = () => {
-      if (invalidRoleIds.has(roleId)) return;
-      invalidRoleIds.add(roleId);
-      invalidTokens.push(m[0]);
-    };
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
-      pushIfNew();
+      pushRoleErrorIfNew(roleId, m[0]);
       continue;
     }
     // role.members is a Collection<Snowflake, GuildMember>. Empty for
     // a role with no current members in the cache; same treatment.
     const members = role.members;
     if (!members || members.size === 0) {
-      pushIfNew();
+      pushRoleErrorIfNew(roleId, m[0]);
       continue;
     }
     // `usable` counts post-filter members the role exposed (whether
@@ -205,7 +213,7 @@ function parseRecipientMentions(raw, interaction) {
       // Role had members but they were all filtered (sender + bots).
       // Surface as "no usable members" rather than silently no-op so
       // the caller can tell the user "the role only contains you / bots."
-      pushIfNew();
+      pushRoleErrorIfNew(roleId, m[0]);
     }
   }
 
@@ -250,7 +258,7 @@ function parseRecipientMentions(raw, interaction) {
     // (typed too many) and stays at debug.
     const logFn = seen.size > cap * 2 ? logger.warn : logger.debug;
     logFn('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
-      raw_count: seen.size, cap,
+      unique_count: seen.size, cap,
     });
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -26,7 +26,7 @@
 //     to resolve "alice" to a user ID without an autocomplete round-trip,
 //     and silently dropping it would mask user typos.
 //
-// `invalidTokens` are PRE-ESCAPED at the parser boundary:
+// SECURITY: `invalidTokens` are PRE-ESCAPED at the parser boundary:
 //   - `@everyone` / `@here` are rewritten by inserting a zero-width
 //     space (U+200B) after the `@` — visually identical but Discord's
 //     tokenizer no longer recognizes the mass-mention shape. A caller
@@ -36,7 +36,7 @@
 //     that Discord would ping (`<@id>`, `<@&id>`) can't reach this
 //     slot because they parse as valid mentions in the passes above.
 //
-// `invalidTokens` ARE NOT escaped against Discord markdown — a pasted
+// SECURITY: `invalidTokens` ARE NOT escaped against Discord markdown — a pasted
 // `[link](https://evil)`, `||spoiler||`, or backtick-fenced content
 // will render with full markdown semantics if a caller interpolates
 // the token bare into a message. The caller (7b.2's error renderer)
@@ -101,6 +101,15 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 // user-visible truncation point (and the partial-mention trim
 // below becomes lossy on legitimate over-cap content).
 const MAX_INPUT_LENGTH = 4000;
+
+// Per-token cap on entries in `invalidTokens`. Discord's embed total
+// is 4096 chars; a single ~4000-char garbage token (one giant string
+// with no separators) would blow that budget. Truncating at the
+// parser boundary means the caller's error renderer can interpolate
+// `invalidTokens` without further trimming. Applied to residue
+// tokens only — `<@&id>` role tokens are bounded by Discord ID
+// width and don't need it.
+const MAX_INVALID_TOKEN_LENGTH = 256;
 
 // Cap-overshoot logging threshold: above this multiple of the cap,
 // escalate the log level from `debug` to `warn`. The signal is "user
@@ -293,7 +302,12 @@ function parseRecipientMentions(raw, interaction) {
     // already inert. Widening would needlessly mangle legitimate
     // `@Everyone` paste artifacts. The `@Everyone-not-escaped`
     // test pins this invariant.
-    invalidTokens.push(tok.replace(/@(everyone|here)/g, '@\u200b$1'));
+    let escaped = tok.replace(/@(everyone|here)/g, '@\u200b$1');
+    // Per-token length cap (see MAX_INVALID_TOKEN_LENGTH doc above).
+    if (escaped.length > MAX_INVALID_TOKEN_LENGTH) {
+      escaped = `${escaped.slice(0, MAX_INVALID_TOKEN_LENGTH)}\u2026`;
+    }
+    invalidTokens.push(escaped);
   }
 
   // Cap was enforced inline during the two passes (`ids` never

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -95,6 +95,11 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 // before the API ceiling. 7b.2 should narrow the option's
 // max_length to ≤4000 so this cap becomes defense-in-depth rather
 // than the user-visible truncation point.
+// KEEP IN SYNC with the slash-option `max_length` in 7b.2's
+// builder. If 7b.2 narrows the option's max_length to ≤ 4000,
+// this cap becomes defense-in-depth; if it doesn't, this is the
+// user-visible truncation point (and the partial-mention trim
+// below becomes lossy on legitimate over-cap content).
 const MAX_INPUT_LENGTH = 4000;
 
 // Cap-overshoot logging threshold: above this multiple of the cap,
@@ -170,6 +175,9 @@ function parseRecipientMentions(raw, interaction) {
   const invalidTokens = [];
   const senderId = interaction.user?.id;
   const guild = interaction.guild;
+  // `cap > 0` is guaranteed by intEnv's `minPositive: true` validator
+  // at config.js:279 — if the env override ever flipped to ≤ 0, that
+  // validator would crash boot, not silently produce an empty result here.
   const cap = config.QURL_SEND_MAX_RECIPIENTS;
 
   // Mark an ID as considered: dedupe via `seen`, add to `ids` only

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -332,4 +332,5 @@ function parseRecipientMentions(raw, interaction) {
 module.exports = {
   parseRecipientMentions,
   MAX_INPUT_LENGTH,
+  MAX_INVALID_TOKEN_LENGTH,
 };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -184,9 +184,10 @@ function parseRecipientMentions(raw, interaction) {
   const invalidTokens = [];
   const senderId = interaction.user?.id;
   const guild = interaction.guild;
-  // `cap > 0` is guaranteed by intEnv's `minPositive: true` validator
-  // at config.js:279 — if the env override ever flipped to ≤ 0, that
-  // validator would crash boot, not silently produce an empty result here.
+  // `cap > 0` is guaranteed by the `intEnv(..., { minPositive: true })`
+  // validator on QURL_SEND_MAX_RECIPIENTS in config.js — if the env
+  // override ever flipped to ≤ 0, that validator would crash boot,
+  // not silently produce an empty result here.
   const cap = config.QURL_SEND_MAX_RECIPIENTS;
 
   // Mark an ID as considered: dedupe via `seen`, add to `ids` only
@@ -253,10 +254,14 @@ function parseRecipientMentions(raw, interaction) {
       pushRoleErrorIfNew(roleId, m[0]);
       continue;
     }
-    // `usable` counts post-filter members the role exposed (whether
-    // or not they were new to `seen`). Used to detect "all filtered"
-    // vs "role contributed but we'd already counted them" — dedupe
-    // is still a contribution.
+    // `usable` counts members that passed the sender/bot filter,
+    // INCLUDING ones already in `seen` (i.e. a role whose every
+    // member was already direct-mentioned still contributes — dedupe
+    // counts). Drives ONLY the "no usable members" → invalidTokens
+    // branch below: empty role / sender-only role / bots-only role.
+    // Critically, `usable++` runs BEFORE the seen-check inside
+    // `consider`, so the "fully-duplicate role isn't useless" test
+    // catches a future refactor reversing that order.
     let usable = 0;
     for (const [memberId, roleMember] of members) {
       if (memberId === senderId) continue;
@@ -305,8 +310,13 @@ function parseRecipientMentions(raw, interaction) {
     // test pins this invariant.
     let escaped = tok.replace(/@(everyone|here)/g, '@\u200b$1');
     // Per-token length cap (see MAX_INVALID_TOKEN_LENGTH doc above).
+    // Truncation runs AFTER the escape; defense-in-depth re-escape
+    // below catches the edge case where the cut leaves an `@everyone`
+    // suffix-fragment that's somehow still parseable (e.g. if the
+    // escape ever changes to a positional pattern). Cheap pass.
     if (escaped.length > MAX_INVALID_TOKEN_LENGTH) {
       escaped = `${escaped.slice(0, MAX_INVALID_TOKEN_LENGTH)}\u2026`;
+      escaped = escaped.replace(/@(everyone|here)/g, '@\u200b$1');
     }
     // Dedupe residue tokens by the post-escape rendered form so
     // `<#456> <#456>` or `alice alice` produces ONE entry, not two.

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -36,6 +36,16 @@
 //     that Discord would ping (`<@id>`, `<@&id>`) can't reach this
 //     slot because they parse as valid mentions in the passes above.
 //
+// `invalidTokens` ARE NOT escaped against Discord markdown — a pasted
+// `[link](https://evil)`, `||spoiler||`, or backtick-fenced content
+// will render with full markdown semantics if a caller interpolates
+// the token bare into a message. The caller (7b.2's error renderer)
+// MUST wrap `invalidTokens` in a code block, or escape `[`, `]`,
+// `` ` ``, `|`, `*`, `_` before display. The mass-mention escape is
+// special-cased because it's the only shape with off-channel side
+// effects (a real ping to thousands of users); other markdown is
+// "ugly rendering" not "security."
+//
 // Output shape:
 //   {
 //     ids:           [<user_id>, ...],        // deduped, cap-applied
@@ -186,14 +196,20 @@ function parseRecipientMentions(raw, interaction) {
     consider(id);
   }
 
-  // Role expansion: missing role / empty role / DM-context guild lands
-  // the raw role token in `invalidTokens` so the caller can surface
-  // "couldn't resolve @role" rather than silently produce a smaller
-  // recipient list. NOTE on perf: discord.js's `Role.members` getter
-  // filters the full guild member cache per call, so N role mentions
-  // = N O(guild_size) scans. Bounded by the 4000-char input cap and
-  // by Discord's slash-option max — worth knowing for 7b.2 wiring
-  // in large guilds but not a hot-path concern today.
+  // Role expansion: missing role / empty role / DM-context guild
+  // / all-members-filtered all land the raw role token in
+  // `invalidTokens` so the caller can surface "couldn't resolve
+  // @role" rather than silently produce a smaller recipient list.
+  // NOTE: these three states are CONFLATED in the current shape —
+  // 7b.2 may want to distinguish "role doesn't exist" / "role has
+  // no members" / "all members are you+bots" via separate fields
+  // (e.g. `emptyRoles`, or check `role.memberCount > 0 && members.size
+  // === 0` for the partial-cache case). For now, conflation is
+  // acceptable because the user-visible copy ("couldn't expand @role")
+  // works for all three. NOTE on perf: discord.js's `Role.members`
+  // getter filters the full guild member cache per call, so N role
+  // mentions = N O(guild_size) scans. Bounded by the 4000-char input
+  // cap and Discord's slash-option max.
   // Dedupe role-error pushes by role ID so `<@&999> <@&999>` against
   // an unknown role yields one invalidTokens entry, not two. The
   // strip-pass's residue-tokens already dedupe naturally via input
@@ -225,9 +241,9 @@ function parseRecipientMentions(raw, interaction) {
     // vs "role contributed but we'd already counted them" — dedupe
     // is still a contribution.
     let usable = 0;
-    for (const [memberId, member] of members) {
+    for (const [memberId, roleMember] of members) {
       if (memberId === senderId) continue;
-      if (member?.user?.bot) continue;
+      if (roleMember?.user?.bot) continue;
       usable++;
       consider(memberId);
     }

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -15,7 +15,7 @@
 //                                                 guild members of that role
 //   - Whitespace + commas as separators (lenient — the user typed it)
 //
-// What we reject (returned in `invalid_tokens`):
+// What we reject (returned in `invalidTokens`):
 //   - Channel mentions <#...>
 //   - Custom emoji <:name:id>
 //   - Bare plaintext (no `<@...>` wrapping) — there's no reliable way
@@ -23,7 +23,7 @@
 //     and silently dropping it would mask user typos.
 //
 // Output shape:
-//   { ids: [<user_id>, ...], invalid_tokens: [<raw_token>, ...] }
+//   { ids: [<user_id>, ...], invalidTokens: [<raw_token>, ...] }
 //
 // `ids` is deduped, capped at `config.QURL_SEND_MAX_RECIPIENTS` (the
 // same per-send cap the in-channel form enforces), and excludes the
@@ -32,7 +32,7 @@
 // Role expansion uses interaction.guild.members.cache. If the cache is
 // cold (DM context, bot just restarted) the role expansion silently
 // resolves to no members for that role — the role mention lands in
-// `invalid_tokens` so the caller can surface "couldn't expand @team-blue,
+// `invalidTokens` so the caller can surface "couldn't expand @team-blue,
 // pick users from the menu instead." This matches the existing form's
 // posture (fall through to the picker rather than 404 a slash command).
 
@@ -55,8 +55,8 @@ const MAX_INPUT_LENGTH = 4000;
 
 // Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / etc.) to
 // a flat user-ID list with the cap + self/bot filters applied. Returns
-// `{ ids, invalid_tokens }`; never throws on parse errors — invalid
-// tokens always land in `invalid_tokens` for caller-side surfacing.
+// `{ ids, invalidTokens }`; never throws on parse errors — invalid
+// tokens always land in `invalidTokens` for caller-side surfacing.
 //
 // `interaction` is the slash-command interaction; we need it for:
 //   - interaction.user.id  → exclude the sender from recipients
@@ -68,23 +68,31 @@ function parseRecipientMentions(raw, interaction) {
   // an empty result rather than throwing. Caller branches on
   // `ids.length === 0` to decide whether to render the recipient picker.
   if (raw == null || typeof raw !== 'string') {
-    return { ids: [], invalid_tokens: [] };
+    return { ids: [], invalidTokens: [] };
   }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
-  // pathological repetitions still allocate per-match strings.
-  const input = raw.length > MAX_INPUT_LENGTH ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
+  // pathological repetitions still allocate per-match strings. If the
+  // cut lands inside a `<...>` token, drop the trailing partial so the
+  // strip-pass doesn't surface a manufactured "invalid token" the user
+  // didn't actually type wrong.
+  let input = raw.length > MAX_INPUT_LENGTH ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
+  if (input.length === MAX_INPUT_LENGTH) {
+    const lastOpen = input.lastIndexOf('<');
+    const lastClose = input.lastIndexOf('>');
+    if (lastOpen > lastClose) {
+      input = input.slice(0, lastOpen);
+    }
+  }
   if (input.length === 0) {
-    return { ids: [], invalid_tokens: [] };
+    return { ids: [], invalidTokens: [] };
   }
 
   const ids = new Set();
-  const invalid_tokens = [];
+  const invalidTokens = [];
   const senderId = interaction.user?.id;
   const guild = interaction.guild;
 
-  // Pass 1: direct user mentions. Use `matchAll` (not `match`) so we
-  // get capture groups for every hit, not just a flat string list.
   for (const m of input.matchAll(USER_MENTION_RE)) {
     const id = m[1];
     if (id === senderId) continue;
@@ -97,23 +105,22 @@ function parseRecipientMentions(raw, interaction) {
     ids.add(id);
   }
 
-  // Pass 2: role mentions. Expand each role to its current member set
-  // and merge. A missing role / empty role / DM-context guild lands
-  // the raw role token in `invalid_tokens` so the caller can surface
+  // Role expansion: missing role / empty role / DM-context guild lands
+  // the raw role token in `invalidTokens` so the caller can surface
   // "couldn't resolve @role" rather than silently produce a smaller
   // recipient list.
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
     const roleId = m[1];
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
-      invalid_tokens.push(m[0]);
+      invalidTokens.push(m[0]);
       continue;
     }
     // role.members is a Collection<Snowflake, GuildMember>. Empty for
     // a role with no current members in the cache; same treatment.
     const members = role.members;
     if (!members || members.size === 0) {
-      invalid_tokens.push(m[0]);
+      invalidTokens.push(m[0]);
       continue;
     }
     let added = 0;
@@ -127,43 +134,40 @@ function parseRecipientMentions(raw, interaction) {
       // Role had members but they were all filtered (sender + bots).
       // Surface as "no usable members" rather than silently no-op so
       // the caller can tell the user "the role only contains you / bots."
-      invalid_tokens.push(m[0]);
+      invalidTokens.push(m[0]);
     }
   }
 
-  // Pass 3: detect non-mention tokens the user typed but we can't act
-  // on (channel mentions, custom emoji, bare names). Stripping the
-  // valid mentions and checking what's left lets us emit one invalid
-  // entry per stray token. Intentionally lossy on subtle parsing —
-  // the goal is "tell the user we didn't understand THIS bit", not
-  // a perfect tokenizer.
+  // Detect non-mention residue (channel mentions, custom emoji, bare
+  // names) by stripping valid mentions and surfacing what's left.
+  // Intentionally lossy on subtle parsing — the goal is "tell the user
+  // we didn't understand THIS bit", not a perfect tokenizer.
   const stripped = input
     .replace(USER_MENTION_RE, ' ')
     .replace(ROLE_MENTION_RE, ' ');
-  // Split on whitespace + commas; keep non-empty residue.
   const leftover = stripped.split(/[\s,]+/).filter(Boolean);
   for (const tok of leftover) {
-    invalid_tokens.push(tok);
+    invalidTokens.push(tok);
   }
 
   // Apply the per-send recipient cap. The cap is enforced by the
   // back-half too, but we want the user-visible feedback to say
   // "I capped at N" before they hit Send — not as a back-half error.
+  // Config validates QURL_SEND_MAX_RECIPIENTS via intEnv minPositive
+  // (see src/config.js), so trust the invariant — no paranoid guards.
   const cap = config.QURL_SEND_MAX_RECIPIENTS;
-  let final_ids = [...ids];
-  if (typeof cap === 'number' && Number.isFinite(cap) && cap > 0 && final_ids.length > cap) {
+  let finalIds = [...ids];
+  if (finalIds.length > cap) {
     logger.debug('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
-      raw_count: final_ids.length, cap,
+      raw_count: finalIds.length, cap,
     });
-    final_ids = final_ids.slice(0, cap);
+    finalIds = finalIds.slice(0, cap);
   }
 
-  return { ids: final_ids, invalid_tokens };
+  return { ids: finalIds, invalidTokens };
 }
 
 module.exports = {
   parseRecipientMentions,
-  // Exported for tests so they can assert the cap behavior without
-  // mutating config. Not intended for production callers.
-  __MAX_INPUT_LENGTH: MAX_INPUT_LENGTH,
+  MAX_INPUT_LENGTH,
 };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -69,6 +69,11 @@ const logger = require('./logger');
 // 1+ digit run) so a future ID-width change doesn't silently drop
 // real IDs. The format-validation that matters is "is this actually
 // a user/role Discord knows about" — fetched lazily on resolution.
+// Module-scope `/g` regexes are safe to share across calls: `matchAll`
+// clones the regex per-iteration, and `String.prototype.replace`
+// doesn't mutate `lastIndex`. (The `lastIndex` footgun applies only
+// to `RegExp.prototype.exec` / `RegExp.prototype.test` on the same
+// regex instance.)
 const USER_MENTION_RE = /<@!?(\d+)>/g;
 const ROLE_MENTION_RE = /<@&(\d+)>/g;
 
@@ -126,6 +131,14 @@ function parseRecipientMentions(raw, interaction) {
   // the user didn't actually mistype. Gate strictly on `truncated` —
   // a naturally-MAX-length input with a stray `<` mid-string is
   // legitimate content that the strip-pass should surface as-is.
+  //
+  // The `lastOpen > lastClose` heuristic is intentionally one-sided:
+  // false-positive-resistant on residue (won't manufacture a fake
+  // token from a clean cut), lossy by design on legitimate content
+  // past the cut (e.g. `<literal>` in a paste). Acceptable since
+  // truncation only fires past MAX, and 7b.2 should narrow the
+  // slash-option's max_length so this branch is defense-in-depth
+  // rather than a user-visible loss.
   if (truncated) {
     const lastOpen = input.lastIndexOf('<');
     const lastClose = input.lastIndexOf('>');
@@ -250,6 +263,12 @@ function parseRecipientMentions(raw, interaction) {
     // the strip pass (residue split class doesn't include
     // punctuation) and would otherwise slip through. Replace all
     // occurrences so a token like `here@everyone` is fully fenced.
+    //
+    // INTENTIONALLY case-sensitive (no `/i` flag) \u2014 Discord's mass-
+    // mention parser is itself lowercase-only, so `@Everyone` is
+    // already inert. Widening would needlessly mangle legitimate
+    // `@Everyone` paste artifacts. The `@Everyone-not-escaped`
+    // test pins this invariant.
     invalidTokens.push(tok.replace(/@(everyone|here)/g, '@\u200b$1'));
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -22,8 +22,23 @@
 //     to resolve "alice" to a user ID without an autocomplete round-trip,
 //     and silently dropping it would mask user typos.
 //
+// `invalidTokens` are PRE-ESCAPED at the parser boundary:
+//   - `@everyone` / `@here` are rewritten by inserting a zero-width
+//     space (U+200B) after the `@` — visually identical but Discord's
+//     tokenizer no longer recognizes the mass-mention shape. A caller
+//     naively interpolating an invalid token into a user-visible
+//     message (`` `Couldn't parse: ${invalidTokens.join(', ')}` ``)
+//     cannot accidentally fan-out-ping the channel. Other shapes
+//     that Discord would ping (`<@id>`, `<@&id>`) can't reach this
+//     slot because they parse as valid mentions in the passes above.
+//
 // Output shape:
-//   { ids: [<user_id>, ...], invalidTokens: [<raw_token>, ...] }
+//   {
+//     ids:           [<user_id>, ...],        // deduped, cap-applied
+//     invalidTokens: [<raw_token>, ...],      // pre-escaped (see above)
+//     cappedCount:   <number>,                // 0 if not capped; else
+//                                             // `total_pre_cap - cap`
+//   }
 //
 // `ids` is deduped, capped at `config.QURL_SEND_MAX_RECIPIENTS` (the
 // same per-send cap the in-channel form enforces), and excludes the
@@ -68,11 +83,13 @@ function parseRecipientMentions(raw, interaction) {
   // an empty result rather than throwing. Caller branches on
   // `ids.length === 0` to decide whether to render the recipient picker.
   if (raw == null || typeof raw !== 'string') {
-    return { ids: [], invalidTokens: [] };
+    return { ids: [], invalidTokens: [], cappedCount: 0 };
   }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
-  // pathological repetitions still allocate per-match strings.
+  // pathological repetitions still allocate per-match strings. This
+  // cap MUST precede `matchAll` — a refactor that flipped to
+  // "validate then truncate" would silently regress the ReDoS guard.
   const truncated = raw.length > MAX_INPUT_LENGTH;
   let input = truncated ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
   // If the cut lands inside a `<...>` token, drop the trailing partial
@@ -88,7 +105,7 @@ function parseRecipientMentions(raw, interaction) {
     }
   }
   if (input.length === 0) {
-    return { ids: [], invalidTokens: [] };
+    return { ids: [], invalidTokens: [], cappedCount: 0 };
   }
 
   const ids = new Set();
@@ -112,7 +129,13 @@ function parseRecipientMentions(raw, interaction) {
   // the raw role token in `invalidTokens` so the caller can surface
   // "couldn't resolve @role" rather than silently produce a smaller
   // recipient list.
+  const cap = config.QURL_SEND_MAX_RECIPIENTS;
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
+    // Short-circuit if we're already at/past the cap. The trim happens
+    // later, but iterating a 5000-member role here just to throw them
+    // away wastes worker time on the request path. Direct mentions
+    // already ran (pass 1), so this only skips role-expansion work.
+    if (ids.size >= cap) break;
     const roleId = m[1];
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
@@ -126,6 +149,11 @@ function parseRecipientMentions(raw, interaction) {
       invalidTokens.push(m[0]);
       continue;
     }
+    // `added` counts loop iterations that passed the sender + bot
+    // filters, NOT net-new additions to `ids` (a member already added
+    // by a direct mention will still count here). Used only to drive
+    // the "no usable members" branch — what we want there is "did the
+    // role contribute anything," and prior dedupe is a contribution.
     let added = 0;
     for (const [memberId, member] of members) {
       if (memberId === senderId) continue;
@@ -145,12 +173,26 @@ function parseRecipientMentions(raw, interaction) {
   // names) by stripping valid mentions and surfacing what's left.
   // Intentionally lossy on subtle parsing — the goal is "tell the user
   // we didn't understand THIS bit", not a perfect tokenizer.
+  //
+  // Separator class includes `;`, `|`, `/` in addition to whitespace
+  // and `,` — these are common when pasting from contact lists or
+  // CSV-ish formats. Without them the user gets `;` and `|` echoed
+  // back as "invalid tokens."
   const stripped = input
     .replace(USER_MENTION_RE, ' ')
     .replace(ROLE_MENTION_RE, ' ');
-  const leftover = stripped.split(/[\s,]+/).filter(Boolean);
+  const leftover = stripped.split(/[\s,;|/]+/).filter(Boolean);
   for (const tok of leftover) {
-    invalidTokens.push(tok);
+    // Pre-escape `@everyone` / `@here` so a caller interpolating
+    // `invalidTokens` into a user-visible message can't accidentally
+    // fan-out-ping the channel. Insert a zero-width-space after `@`
+    // — the rendered glyph is identical, but Discord's tokenizer
+    // sees a different word and won't trigger the mass mention.
+    if (tok === '@everyone' || tok === '@here') {
+      invalidTokens.push(`@\u200b${tok.slice(1)}`);
+    } else {
+      invalidTokens.push(tok);
+    }
   }
 
   // Apply the per-send recipient cap. The cap is enforced by the
@@ -158,9 +200,10 @@ function parseRecipientMentions(raw, interaction) {
   // "I capped at N" before they hit Send — not as a back-half error.
   // Config validates QURL_SEND_MAX_RECIPIENTS via intEnv minPositive
   // (see src/config.js), so trust the invariant — no paranoid guards.
-  const cap = config.QURL_SEND_MAX_RECIPIENTS;
   let finalIds = [...ids];
+  let cappedCount = 0;
   if (finalIds.length > cap) {
+    cappedCount = finalIds.length - cap;
     // Massive over-cap (>2× the limit) signals user confusion —
     // probably pasted a list they didn't trim. Surface at warn so
     // oncall sees the pattern. Modest overshoot is normal-ish
@@ -172,7 +215,7 @@ function parseRecipientMentions(raw, interaction) {
     finalIds = finalIds.slice(0, cap);
   }
 
-  return { ids: finalIds, invalidTokens };
+  return { ids: finalIds, invalidTokens, cappedCount };
 }
 
 module.exports = {

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -1,0 +1,169 @@
+// recipient-parser — extracts user/role mentions from the `recipients:`
+// slash-command option string and resolves them to a flat user-ID list.
+//
+// `/qurl file` and `/qurl map` expose `recipients:` as a STRING option
+// rather than a list of mentionables because Discord's slash-command
+// `mentionable` option type is single-value — a power-user one-shot
+// path needs a free-form text that can carry many mentions, role
+// mentions, or a mix. The same string also has to survive the round-
+// trip through interaction.options.getString (no parsing — Discord
+// hands us the raw "<@123> <@456> <@&789>" text).
+//
+// What we accept:
+//   - User mentions:  <@123456> or <@!123456>   → user ID 123456
+//   - Role mentions:  <@&987654>                → expand to current
+//                                                 guild members of that role
+//   - Whitespace + commas as separators (lenient — the user typed it)
+//
+// What we reject (returned in `invalid_tokens`):
+//   - Channel mentions <#...>
+//   - Custom emoji <:name:id>
+//   - Bare plaintext (no `<@...>` wrapping) — there's no reliable way
+//     to resolve "alice" to a user ID without an autocomplete round-trip,
+//     and silently dropping it would mask user typos.
+//
+// Output shape:
+//   { ids: [<user_id>, ...], invalid_tokens: [<raw_token>, ...] }
+//
+// `ids` is deduped, capped at `config.QURL_SEND_MAX_RECIPIENTS` (the
+// same per-send cap the in-channel form enforces), and excludes the
+// invoking user + bots (matches the form's self-send + bot rejection).
+//
+// Role expansion uses interaction.guild.members.cache. If the cache is
+// cold (DM context, bot just restarted) the role expansion silently
+// resolves to no members for that role — the role mention lands in
+// `invalid_tokens` so the caller can surface "couldn't expand @team-blue,
+// pick users from the menu instead." This matches the existing form's
+// posture (fall through to the picker rather than 404 a slash command).
+
+const config = require('./config');
+const logger = require('./logger');
+
+// Capture group is the snowflake ID. Discord IDs are 17-20 digit
+// integers; the regex is intentionally loose on length (matches any
+// 1+ digit run) so a future ID-width change doesn't silently drop
+// real IDs. The format-validation that matters is "is this actually
+// a user/role Discord knows about" — fetched lazily on resolution.
+const USER_MENTION_RE = /<@!?(\d+)>/g;
+const ROLE_MENTION_RE = /<@&(\d+)>/g;
+
+// Hard cap on input length so an adversarial regex-blowup attack
+// (10MB of `<@1>` repetitions) doesn't tie up the worker. The form's
+// 200-char descriptions and Discord's natural 2000-char message cap
+// make 4000 chars more than enough headroom for legitimate use.
+const MAX_INPUT_LENGTH = 4000;
+
+// Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / etc.) to
+// a flat user-ID list with the cap + self/bot filters applied. Returns
+// `{ ids, invalid_tokens }`; never throws on parse errors — invalid
+// tokens always land in `invalid_tokens` for caller-side surfacing.
+//
+// `interaction` is the slash-command interaction; we need it for:
+//   - interaction.user.id  → exclude the sender from recipients
+//   - interaction.guild    → role-mention expansion via members.cache
+//   - interaction.guild.members.cache.get(id).user.bot → bot filter
+function parseRecipientMentions(raw, interaction) {
+  // Defensive normalization: getString can return null when the option
+  // is omitted, and the empty-string path is the same shape — return
+  // an empty result rather than throwing. Caller branches on
+  // `ids.length === 0` to decide whether to render the recipient picker.
+  if (raw == null || typeof raw !== 'string') {
+    return { ids: [], invalid_tokens: [] };
+  }
+  // Length-cap BEFORE regex matching to keep the global-flag iteration
+  // bounded under adversarial input. The /g flag scans linearly but
+  // pathological repetitions still allocate per-match strings.
+  const input = raw.length > MAX_INPUT_LENGTH ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
+  if (input.length === 0) {
+    return { ids: [], invalid_tokens: [] };
+  }
+
+  const ids = new Set();
+  const invalid_tokens = [];
+  const senderId = interaction.user?.id;
+  const guild = interaction.guild;
+
+  // Pass 1: direct user mentions. Use `matchAll` (not `match`) so we
+  // get capture groups for every hit, not just a flat string list.
+  for (const m of input.matchAll(USER_MENTION_RE)) {
+    const id = m[1];
+    if (id === senderId) continue;
+    // Bot filter — best-effort via cache. A cache miss leaves the bot
+    // in the result; downstream send-pipeline has its own bot check
+    // (see existing form's `Cannot send to a bot` warning path) so
+    // this layer being lossy is acceptable.
+    const member = guild?.members?.cache?.get(id);
+    if (member?.user?.bot) continue;
+    ids.add(id);
+  }
+
+  // Pass 2: role mentions. Expand each role to its current member set
+  // and merge. A missing role / empty role / DM-context guild lands
+  // the raw role token in `invalid_tokens` so the caller can surface
+  // "couldn't resolve @role" rather than silently produce a smaller
+  // recipient list.
+  for (const m of input.matchAll(ROLE_MENTION_RE)) {
+    const roleId = m[1];
+    const role = guild?.roles?.cache?.get(roleId);
+    if (!role) {
+      invalid_tokens.push(m[0]);
+      continue;
+    }
+    // role.members is a Collection<Snowflake, GuildMember>. Empty for
+    // a role with no current members in the cache; same treatment.
+    const members = role.members;
+    if (!members || members.size === 0) {
+      invalid_tokens.push(m[0]);
+      continue;
+    }
+    let added = 0;
+    for (const [memberId, member] of members) {
+      if (memberId === senderId) continue;
+      if (member?.user?.bot) continue;
+      ids.add(memberId);
+      added++;
+    }
+    if (added === 0) {
+      // Role had members but they were all filtered (sender + bots).
+      // Surface as "no usable members" rather than silently no-op so
+      // the caller can tell the user "the role only contains you / bots."
+      invalid_tokens.push(m[0]);
+    }
+  }
+
+  // Pass 3: detect non-mention tokens the user typed but we can't act
+  // on (channel mentions, custom emoji, bare names). Stripping the
+  // valid mentions and checking what's left lets us emit one invalid
+  // entry per stray token. Intentionally lossy on subtle parsing —
+  // the goal is "tell the user we didn't understand THIS bit", not
+  // a perfect tokenizer.
+  const stripped = input
+    .replace(USER_MENTION_RE, ' ')
+    .replace(ROLE_MENTION_RE, ' ');
+  // Split on whitespace + commas; keep non-empty residue.
+  const leftover = stripped.split(/[\s,]+/).filter(Boolean);
+  for (const tok of leftover) {
+    invalid_tokens.push(tok);
+  }
+
+  // Apply the per-send recipient cap. The cap is enforced by the
+  // back-half too, but we want the user-visible feedback to say
+  // "I capped at N" before they hit Send — not as a back-half error.
+  const cap = config.QURL_SEND_MAX_RECIPIENTS;
+  let final_ids = [...ids];
+  if (typeof cap === 'number' && Number.isFinite(cap) && cap > 0 && final_ids.length > cap) {
+    logger.debug('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
+      raw_count: final_ids.length, cap,
+    });
+    final_ids = final_ids.slice(0, cap);
+  }
+
+  return { ids: final_ids, invalid_tokens };
+}
+
+module.exports = {
+  parseRecipientMentions,
+  // Exported for tests so they can assert the cap behavior without
+  // mutating config. Not intended for production callers.
+  __MAX_INPUT_LENGTH: MAX_INPUT_LENGTH,
+};

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -82,10 +82,17 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 // than the user-visible truncation point.
 const MAX_INPUT_LENGTH = 4000;
 
+// Cap-overshoot logging threshold: above this multiple of the cap,
+// escalate the log level from `debug` to `warn`. The signal is "user
+// pasted an untrimmed list" (vs the more common "typed too many"),
+// which oncall benefits from seeing as a pattern.
+const MASSIVE_OVERSHOOT_MULTIPLIER = 2;
+
 // Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / etc.) to
 // a flat user-ID list with the cap + self/bot filters applied. Returns
-// `{ ids, invalidTokens }`; never throws on parse errors — invalid
-// tokens always land in `invalidTokens` for caller-side surfacing.
+// `{ ids, invalidTokens, cappedCount }`; never throws on parse errors —
+// invalid tokens always land in `invalidTokens` for caller-side
+// surfacing.
 //
 // `interaction` is the slash-command interaction; we need it for:
 //   - interaction.user.id  → exclude the sender from recipients
@@ -192,7 +199,9 @@ function parseRecipientMentions(raw, interaction) {
       continue;
     }
     // role.members is a Collection<Snowflake, GuildMember>. Empty for
-    // a role with no current members in the cache; same treatment.
+    // a role with no current members in the cache; treated like an
+    // unknown role (lands in invalidTokens so the caller can surface
+    // "couldn't expand @role").
     const members = role.members;
     if (!members || members.size === 0) {
       pushRoleErrorIfNew(roleId, m[0]);
@@ -252,13 +261,11 @@ function parseRecipientMentions(raw, interaction) {
   const finalIds = [...ids];
   const cappedCount = seen.size - ids.size;
   if (cappedCount > 0) {
-    // Massive over-cap (>2× the limit) signals user confusion —
-    // probably pasted a list they didn't trim. Surface at warn so
-    // oncall sees the pattern. Modest overshoot is normal-ish
-    // (typed too many) and stays at debug.
-    const logFn = seen.size > cap * 2 ? logger.warn : logger.debug;
+    const logFn = seen.size > cap * MASSIVE_OVERSHOOT_MULTIPLIER
+      ? logger.warn
+      : logger.debug;
     logFn('recipient-parser: capping recipient list at QURL_SEND_MAX_RECIPIENTS', {
-      unique_count: seen.size, cap,
+      unique_count: seen.size, cap, capped_count: cappedCount,
     });
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -13,7 +13,9 @@
 //   - User mentions:  <@123456> or <@!123456>   → user ID 123456
 //   - Role mentions:  <@&987654>                → expand to current
 //                                                 guild members of that role
-//   - Whitespace + commas as separators (lenient — the user typed it)
+//   - Whitespace, commas, semicolons, pipes, and slashes as
+//     separators (lenient — covers free-form paste from contact
+//     lists / CSV-ish formats)
 //
 // What we reject (returned in `invalidTokens`):
 //   - Channel mentions <#...>
@@ -156,6 +158,11 @@ function parseRecipientMentions(raw, interaction) {
     // role contribute anything," and prior dedupe is a contribution.
     let added = 0;
     for (const [memberId, member] of members) {
+      // Inner break: a single role with 50k members would otherwise
+      // run 50k Set.add calls before the post-loop slice trims them
+      // back to the cap. Re-check on every iteration so a fat-roled
+      // input bails as soon as we've collected enough.
+      if (ids.size >= cap) break;
       if (memberId === senderId) continue;
       if (member?.user?.bot) continue;
       ids.add(memberId);
@@ -188,11 +195,12 @@ function parseRecipientMentions(raw, interaction) {
     // fan-out-ping the channel. Insert a zero-width-space after `@`
     // — the rendered glyph is identical, but Discord's tokenizer
     // sees a different word and won't trigger the mass mention.
-    if (tok === '@everyone' || tok === '@here') {
-      invalidTokens.push(`@\u200b${tok.slice(1)}`);
-    } else {
-      invalidTokens.push(tok);
-    }
+    // Use a regex (not exact-match) because `@everyone!`,
+    // `@everyone:`, `@everyone.fix` etc. are single tokens after
+    // the strip pass (residue split class doesn't include
+    // punctuation) and would otherwise slip through. Replace all
+    // occurrences so a token like `here@everyone` is fully fenced.
+    invalidTokens.push(tok.replace(/@(everyone|here)/g, '@\u200b$1'));
   }
 
   // Apply the per-send recipient cap. The cap is enforced by the

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -578,6 +578,22 @@ describe('parseRecipientMentions — cap + length safety', () => {
     );
     expect(logger.warn).not.toHaveBeenCalled();
 
+    // 50 unique = exactly 2× cap (the boundary) → debug.
+    // Pin the strict-greater direction: `seen.size > cap *
+    // MASSIVE_OVERSHOOT_MULTIPLIER` means EXACTLY 2× stays at debug.
+    // A future refactor flipping `>` to `>=` would surface here.
+    for (let i = 26; i < 50; i++) {
+      const id = `${6000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    int = makeInteraction({ users });
+    logger.debug.mockClear();
+    logger.warn.mockClear();
+    parseRecipientMentions(mentions.join(' '), int);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+
     // 51 unique = 2× cap + 1 = massive overshoot → warn
     for (let i = 26; i < 51; i++) {
       const id = `${6000000000 + i}`;

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -259,6 +259,24 @@ describe('parseRecipientMentions — invalid tokens', () => {
       .toEqual({ ids: ['111'], invalidTokens: ['@\u200bhere'], cappedCount: 0 });
   });
 
+  test('@everyone with trailing punctuation is also escaped (single-token residue)', () => {
+    // The strip-pass split class `[\s,;|/]+` does NOT include `.`,
+    // `:`, `!`, `?`, `-`, so `@everyone!` and `@everyone.fix` survive
+    // as single tokens. Exact-match escape would slip these past the
+    // guard. Pin that the regex-based escape catches them.
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('@everyone! <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@​everyone!'], cappedCount: 0 });
+    expect(parseRecipientMentions('@everyone.fix <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@​everyone.fix'], cappedCount: 0 });
+    expect(parseRecipientMentions('@here: <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@​here:'], cappedCount: 0 });
+    // Embedded mid-token (paste artifact). Regex replaces ALL
+    // occurrences so no `@everyone` / `@here` substring escapes.
+    expect(parseRecipientMentions('here@everyone <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['here@​everyone'], cappedCount: 0 });
+  });
+
   test('newline characters separate tokens (split regex includes \\n)', () => {
     // Discord slash-command option strings can contain literal
     // newlines (paste-from-multi-line). Pin that the split regex
@@ -318,6 +336,31 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(input).toHaveLength(MAX_INPUT_LENGTH);
     const int = makeInteraction({ users: { '777': {} } });
     expect(parseRecipientMentions(input, int).ids).toEqual(['777']);
+  });
+
+  test('cappedCount reflects POST-dedupe count, not raw mention count', () => {
+    // Cap fires AFTER dedupe (`finalIds = [...ids]`). Pin the order
+    // so a future refactor that swapped cap-before-dedupe would
+    // surface: paste 60 mentions with heavy duplicates that
+    // dedupe to 28 unique → cappedCount should be 3 (= 28 - 25),
+    // NOT 35 (= 60 - 25).
+    const users = {};
+    const mentions = [];
+    for (let i = 0; i < 28; i++) {
+      const id = `${2000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    // Duplicate every mention to push raw count to 56, which still
+    // dedupes to 28 unique. Then add 4 more dupes of the first to
+    // push the raw count even higher without growing the unique set.
+    const dupedInput = mentions.concat(mentions).concat([
+      `<@${2000000000}>`, `<@${2000000000}>`, `<@${2000000000}>`, `<@${2000000000}>`,
+    ]).join(' ');
+    const int = makeInteraction({ users });
+    const res = parseRecipientMentions(dupedInput, int);
+    expect(res.ids).toHaveLength(25);
+    expect(res.cappedCount).toBe(3);  // 28 unique - 25 cap
   });
 
   test('cap and invalidTokens are populated independently in the same call', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -23,6 +23,7 @@ jest.mock('../src/config', () => ({
 }));
 
 const { parseRecipientMentions, MAX_INPUT_LENGTH } = require('../src/recipient-parser');
+const logger = require('../src/logger');
 
 // Build a synthetic interaction with the cache shape the parser reads.
 // Pass `users` as { id → { bot } } and `roles` as
@@ -197,6 +198,48 @@ describe('parseRecipientMentions — role mentions', () => {
       .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
+  test('repeated invalid role mention dedupes in invalidTokens', () => {
+    // `<@&999> <@&999>` against a guild missing role 999 must yield
+    // ONE invalidTokens entry, not two. Without the role-id dedupe,
+    // matchAll iterates each input occurrence and pushes the raw
+    // token each time — a caller's "couldn't parse: X, X" embed is
+    // user-hostile. The residue strip pass already dedupes naturally
+    // via input grouping; this test pins the same property for the
+    // role-error path.
+    const int = makeInteraction({});  // no role 999
+    expect(parseRecipientMentions('<@&999> <@&999> <@&999>', int))
+      .toEqual({ ids: [], invalidTokens: ['<@&999>'], cappedCount: 0 });
+  });
+
+  test('direct mentions always win the cap over role-expansion members', () => {
+    // Pass 1 (user mentions) runs before pass 2 (role expansion), so
+    // direct mentions are inserted into `ids` first and survive the
+    // cap. A future refactor that swapped pass order — or interleaved
+    // mention/role parsing — could silently displace direct mentions
+    // by large role expansions. Pin the invariant.
+    const roleMembers = [];
+    const users = {};
+    // 5 direct-mention users (distinct snowflake range so we can
+    // assert presence without ambiguity).
+    const directIds = ['8000000001', '8000000002', '8000000003', '8000000004', '8000000005'];
+    for (const id of directIds) users[id] = {};
+    for (let i = 0; i < 50; i++) {
+      const id = `${5000000000 + i}`;
+      users[id] = {};
+      roleMembers.push(id);
+    }
+    const int = makeInteraction({ users, roles: { '7000': roleMembers } });
+    // Role mention FIRST in input order; direct mentions follow.
+    // With cap=25, the 5 direct mentions must all survive — the
+    // role's overflow goes to cappedCount, not the direct slots.
+    const directMentions = directIds.map(id => `<@${id}>`).join(' ');
+    const res = parseRecipientMentions(`<@&7000> ${directMentions}`, int);
+    expect(res.ids).toHaveLength(25);
+    expect(res.ids).toEqual(expect.arrayContaining(directIds));
+    // 55 unique candidates - 25 cap = 30 dropped.
+    expect(res.cappedCount).toBe(30);
+  });
+
   test('user listed BOTH directly AND via a role mention appears once in ids', () => {
     // The "merges role expansion with direct user mentions" test
     // above exercises this implicitly (user 101 is in role 7000 AND
@@ -293,8 +336,8 @@ describe('parseRecipientMentions — invalid tokens', () => {
   test('newline characters separate tokens (split regex includes \\n)', () => {
     // Discord slash-command option strings can contain literal
     // newlines (paste-from-multi-line). Pin that the split regex
-    // `/[\s,]+/` includes \n — a regression that switched to
-    // `/[ \t,]+/` would silently merge "alice\nbob" into one
+    // `/[\s,;|/]+/` includes \n — a regression that switched to
+    // `/[ \t,;|/]+/` would silently merge "alice\nbob" into one
     // bare-name token.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111>\n<#456>\n\nstray', int))
@@ -442,5 +485,41 @@ describe('parseRecipientMentions — cap + length safety', () => {
     // surfaces as one invalid token after the strip. The KEY
     // assertion is the partial-mention residue isn't ALSO there.
     expect(res.invalidTokens.every(t => !t.startsWith('<@'))).toBe(true);
+  });
+
+  test('cap-overshoot logging escalates to warn past 2x the cap', () => {
+    // Modest overshoot (≤ 2× cap) signals "user typed too many" and
+    // stays at debug; massive overshoot signals "user pasted an
+    // untrimmed list" and surfaces at warn so oncall sees the pattern.
+    // Pin the threshold so a future refactor that flipped the
+    // comparison or moved the multiplier silently regresses the
+    // oncall signal.
+    const users = {};
+    const mentions = [];
+    // 26 unique = cap+1 = modest overshoot → debug
+    for (let i = 0; i < 26; i++) {
+      const id = `${6000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    let int = makeInteraction({ users });
+    logger.debug.mockClear();
+    logger.warn.mockClear();
+    parseRecipientMentions(mentions.join(' '), int);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    // 51 unique = 2× cap + 1 = massive overshoot → warn
+    for (let i = 26; i < 51; i++) {
+      const id = `${6000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    int = makeInteraction({ users });
+    logger.debug.mockClear();
+    logger.warn.mockClear();
+    parseRecipientMentions(mentions.join(' '), int);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.debug).not.toHaveBeenCalled();
   });
 });

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -16,13 +16,13 @@ jest.mock('../src/logger', () => ({
 }));
 
 // Mock cap chosen for test convenience (prod default is 50 — see
-// src/config.js:279). Tests pin the cap behavior at 25 so the
-// boundary cases stay small + readable.
+// QURL_SEND_MAX_RECIPIENTS in src/config.js). Tests pin the cap
+// behavior at 25 so the boundary cases stay small + readable.
 jest.mock('../src/config', () => ({
   QURL_SEND_MAX_RECIPIENTS: 25,
 }));
 
-const { parseRecipientMentions, MAX_INPUT_LENGTH } = require('../src/recipient-parser');
+const { parseRecipientMentions, MAX_INPUT_LENGTH, MAX_INVALID_TOKEN_LENGTH } = require('../src/recipient-parser');
 const logger = require('../src/logger');
 
 // Build a synthetic interaction with the cache shape the parser reads.
@@ -579,7 +579,8 @@ describe('parseRecipientMentions — cap + length safety', () => {
     const res = parseRecipientMentions(longToken, int);
     expect(res.invalidTokens).toHaveLength(1);
     // 256 chars + the ellipsis marker.
-    expect(res.invalidTokens[0]).toHaveLength(257);
+    // length = cap + 1 (the ellipsis).
+    expect(res.invalidTokens[0]).toHaveLength(MAX_INVALID_TOKEN_LENGTH + 1);
     expect(res.invalidTokens[0].endsWith('…')).toBe(true);
 
     // Under-cap token is unchanged.

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -61,23 +61,23 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
 describe('parseRecipientMentions — basic shape', () => {
   test('returns empty result for null/undefined/empty input', () => {
     const int = makeInteraction();
-    expect(parseRecipientMentions(null, int)).toEqual({ ids: [], invalidTokens: [] });
-    expect(parseRecipientMentions(undefined, int)).toEqual({ ids: [], invalidTokens: [] });
-    expect(parseRecipientMentions('', int)).toEqual({ ids: [], invalidTokens: [] });
-    expect(parseRecipientMentions('   \t\n', int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions(null, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions(undefined, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions('', int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions('   \t\n', int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
   });
 
   test('returns empty result when raw is a non-string (defense vs caller bugs)', () => {
     const int = makeInteraction();
-    expect(parseRecipientMentions(42, int)).toEqual({ ids: [], invalidTokens: [] });
-    expect(parseRecipientMentions({}, int)).toEqual({ ids: [], invalidTokens: [] });
-    expect(parseRecipientMentions([], int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions(42, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions({}, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions([], int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
   });
 
   test('extracts a single user mention', () => {
     const int = makeInteraction({ users: { '111111111111111111': {} } });
     expect(parseRecipientMentions('<@111111111111111111>', int))
-      .toEqual({ ids: ['111111111111111111'], invalidTokens: [] });
+      .toEqual({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('accepts both <@id> and <@!id> forms (legacy nickname mention)', () => {
@@ -85,13 +85,13 @@ describe('parseRecipientMentions — basic shape', () => {
       users: { '111111111111111111': {}, '222222222222222222': {} },
     });
     expect(parseRecipientMentions('<@111111111111111111> <@!222222222222222222>', int))
-      .toEqual({ ids: ['111111111111111111', '222222222222222222'], invalidTokens: [] });
+      .toEqual({ ids: ['111111111111111111', '222222222222222222'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('dedupes repeated mentions', () => {
     const int = makeInteraction({ users: { '111111111111111111': {} } });
     expect(parseRecipientMentions('<@111111111111111111> <@111111111111111111> <@!111111111111111111>', int))
-      .toEqual({ ids: ['111111111111111111'], invalidTokens: [] });
+      .toEqual({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('handles whitespace + comma + mixed separators', () => {
@@ -110,7 +110,7 @@ describe('parseRecipientMentions — filtering', () => {
       users: { '900000000000000001': {}, '222222222222222222': {} },
     });
     expect(parseRecipientMentions('<@900000000000000001> <@222222222222222222>', int))
-      .toEqual({ ids: ['222222222222222222'], invalidTokens: [] });
+      .toEqual({ ids: ['222222222222222222'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('excludes bots flagged in the member cache', () => {
@@ -118,7 +118,7 @@ describe('parseRecipientMentions — filtering', () => {
       users: { '111': { bot: true }, '222': {} },
     });
     expect(parseRecipientMentions('<@111> <@222>', int))
-      .toEqual({ ids: ['222'], invalidTokens: [] });
+      .toEqual({ ids: ['222'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('best-effort bot filter: cache miss leaves the ID in (back-half re-checks)', () => {
@@ -128,7 +128,7 @@ describe('parseRecipientMentions — filtering', () => {
     // check (existing form's "Cannot send to a bot" path) catch it.
     const int = makeInteraction({});  // empty cache
     expect(parseRecipientMentions('<@555>', int))
-      .toEqual({ ids: ['555'], invalidTokens: [] });
+      .toEqual({ ids: ['555'], invalidTokens: [], cappedCount: 0 });
   });
 });
 
@@ -139,7 +139,7 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['101', '102', '103'] },
     });
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['101', '102', '103'], invalidTokens: [] });
+      .toEqual({ ids: ['101', '102', '103'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('merges role expansion with direct user mentions, deduped', () => {
@@ -158,13 +158,13 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['900', '801', '101'] },
     });
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['101'], invalidTokens: [] });
+      .toEqual({ ids: ['101'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('role unknown to the guild lands in invalidTokens', () => {
     const int = makeInteraction({});
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalidTokens: ['<@&7000>'] });
+      .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
   test('role with no usable members (all sender/bots) lands in invalidTokens', () => {
@@ -181,7 +181,22 @@ describe('parseRecipientMentions — role mentions', () => {
   test('DM context (guild=undefined) treats role mentions as invalid', () => {
     const int = { user: { id: '900' }, guild: undefined };
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalidTokens: ['<@&7000>'] });
+      .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
+  });
+
+  test('user listed BOTH directly AND via a role mention appears once in ids', () => {
+    // The "merges role expansion with direct user mentions" test
+    // above exercises this implicitly (user 101 is in role 7000 AND
+    // mentioned directly), but a fixture that EXPLICITLY overlaps
+    // makes the dedupe invariant non-incidental — a regression that
+    // re-added role members without the Set guard would surface
+    // here as ids.length === 2 instead of 1.
+    const int = makeInteraction({
+      users: { '101': {} },
+      roles: { '7000': ['101'] },
+    });
+    expect(parseRecipientMentions('<@101> <@&7000>', int))
+      .toEqual({ ids: ['101'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('role mention repeated in input expands once (no double-counting)', () => {
@@ -204,19 +219,19 @@ describe('parseRecipientMentions — invalid tokens', () => {
   test('channel mentions land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <#456>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<#456>'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
   });
 
   test('custom emoji land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <:smile:789>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<:smile:789>'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['<:smile:789>'], cappedCount: 0 });
   });
 
   test('bare plaintext usernames land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('alice <@111> bob', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['alice', 'bob'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['alice', 'bob'], cappedCount: 0 });
   });
 
   test('mention with missing closer (truncated input) is treated as invalid', () => {
@@ -228,20 +243,20 @@ describe('parseRecipientMentions — invalid tokens', () => {
     expect(res.invalidTokens.length).toBeGreaterThan(0);
   });
 
-  test('@everyone / @here land in invalidTokens (no fan-out shortcut)', () => {
+  test('@everyone / @here are pre-escaped with zero-width-space in invalidTokens', () => {
     // Discord's @everyone / @here are NOT `<@id>` mentions — they're
-    // bare tokens that the API expands at message-send time. The
-    // parser must surface them as invalid so a power-user typing
-    // `recipients:@everyone` doesn't get silent zero-recipient
-    // behavior (or, worse, the back-half hands the literal `@everyone`
-    // to mintLinksInBatches). Callers that render `invalidTokens`
-    // for the user MUST escape these the same way commands.js does
-    // (zero-width-space insertion) to avoid sending a stray ping.
+    // bare tokens that the API expands at message-send time. A caller
+    // naively interpolating `invalidTokens` into a user-visible
+    // message (`` `Couldn't parse: ${invalidTokens.join(', ')}` ``)
+    // would fan-out-ping the channel. To make the boundary safe by
+    // default, the parser inserts a zero-width space (U+200B) after
+    // the `@` — visually identical, but Discord's tokenizer no longer
+    // recognizes the mass-mention shape.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('@everyone <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@everyone'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['@\u200beveryone'], cappedCount: 0 });
     expect(parseRecipientMentions('@here <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@here'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['@\u200bhere'], cappedCount: 0 });
   });
 
   test('newline characters separate tokens (split regex includes \\n)', () => {
@@ -252,12 +267,12 @@ describe('parseRecipientMentions — invalid tokens', () => {
     // bare-name token.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111>\n<#456>\n\nstray', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<#456>', 'stray'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['<#456>', 'stray'], cappedCount: 0 });
   });
 });
 
 describe('parseRecipientMentions — cap + length safety', () => {
-  test('caps the result at QURL_SEND_MAX_RECIPIENTS', () => {
+  test('caps the result at QURL_SEND_MAX_RECIPIENTS + reports cappedCount', () => {
     // Build 30 user mentions; cap is 25 (set in the jest.mock above).
     // IDs are numeric to match the real Discord-mention format the
     // parser regex requires.
@@ -276,6 +291,9 @@ describe('parseRecipientMentions — cap + length safety', () => {
     // can reorder their mentions to influence the kept set.
     expect(res.ids[0]).toBe('1000000000');
     expect(res.ids[24]).toBe('1000000024');
+    // cappedCount lets the caller surface "I kept 25 of 30" without
+    // re-parsing or re-counting input.
+    expect(res.cappedCount).toBe(5);
   });
 
   test('truncates input above MAX_INPUT_LENGTH before scanning (ReDoS guard)', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -15,11 +15,14 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
+// Mock cap chosen for test convenience (prod default is 50 — see
+// src/config.js:279). Tests pin the cap behavior at 25 so the
+// boundary cases stay small + readable.
 jest.mock('../src/config', () => ({
   QURL_SEND_MAX_RECIPIENTS: 25,
 }));
 
-const { parseRecipientMentions, __MAX_INPUT_LENGTH } = require('../src/recipient-parser');
+const { parseRecipientMentions, MAX_INPUT_LENGTH } = require('../src/recipient-parser');
 
 // Build a synthetic interaction with the cache shape the parser reads.
 // Pass `users` as { id → { bot } } and `roles` as
@@ -58,23 +61,23 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
 describe('parseRecipientMentions — basic shape', () => {
   test('returns empty result for null/undefined/empty input', () => {
     const int = makeInteraction();
-    expect(parseRecipientMentions(null, int)).toEqual({ ids: [], invalid_tokens: [] });
-    expect(parseRecipientMentions(undefined, int)).toEqual({ ids: [], invalid_tokens: [] });
-    expect(parseRecipientMentions('', int)).toEqual({ ids: [], invalid_tokens: [] });
-    expect(parseRecipientMentions('   \t\n', int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions(null, int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions(undefined, int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions('', int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions('   \t\n', int)).toEqual({ ids: [], invalidTokens: [] });
   });
 
   test('returns empty result when raw is a non-string (defense vs caller bugs)', () => {
     const int = makeInteraction();
-    expect(parseRecipientMentions(42, int)).toEqual({ ids: [], invalid_tokens: [] });
-    expect(parseRecipientMentions({}, int)).toEqual({ ids: [], invalid_tokens: [] });
-    expect(parseRecipientMentions([], int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions(42, int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions({}, int)).toEqual({ ids: [], invalidTokens: [] });
+    expect(parseRecipientMentions([], int)).toEqual({ ids: [], invalidTokens: [] });
   });
 
   test('extracts a single user mention', () => {
     const int = makeInteraction({ users: { '111111111111111111': {} } });
     expect(parseRecipientMentions('<@111111111111111111>', int))
-      .toEqual({ ids: ['111111111111111111'], invalid_tokens: [] });
+      .toEqual({ ids: ['111111111111111111'], invalidTokens: [] });
   });
 
   test('accepts both <@id> and <@!id> forms (legacy nickname mention)', () => {
@@ -82,13 +85,13 @@ describe('parseRecipientMentions — basic shape', () => {
       users: { '111111111111111111': {}, '222222222222222222': {} },
     });
     expect(parseRecipientMentions('<@111111111111111111> <@!222222222222222222>', int))
-      .toEqual({ ids: ['111111111111111111', '222222222222222222'], invalid_tokens: [] });
+      .toEqual({ ids: ['111111111111111111', '222222222222222222'], invalidTokens: [] });
   });
 
   test('dedupes repeated mentions', () => {
     const int = makeInteraction({ users: { '111111111111111111': {} } });
     expect(parseRecipientMentions('<@111111111111111111> <@111111111111111111> <@!111111111111111111>', int))
-      .toEqual({ ids: ['111111111111111111'], invalid_tokens: [] });
+      .toEqual({ ids: ['111111111111111111'], invalidTokens: [] });
   });
 
   test('handles whitespace + comma + mixed separators', () => {
@@ -107,7 +110,7 @@ describe('parseRecipientMentions — filtering', () => {
       users: { '900000000000000001': {}, '222222222222222222': {} },
     });
     expect(parseRecipientMentions('<@900000000000000001> <@222222222222222222>', int))
-      .toEqual({ ids: ['222222222222222222'], invalid_tokens: [] });
+      .toEqual({ ids: ['222222222222222222'], invalidTokens: [] });
   });
 
   test('excludes bots flagged in the member cache', () => {
@@ -115,7 +118,7 @@ describe('parseRecipientMentions — filtering', () => {
       users: { '111': { bot: true }, '222': {} },
     });
     expect(parseRecipientMentions('<@111> <@222>', int))
-      .toEqual({ ids: ['222'], invalid_tokens: [] });
+      .toEqual({ ids: ['222'], invalidTokens: [] });
   });
 
   test('best-effort bot filter: cache miss leaves the ID in (back-half re-checks)', () => {
@@ -125,7 +128,7 @@ describe('parseRecipientMentions — filtering', () => {
     // check (existing form's "Cannot send to a bot" path) catch it.
     const int = makeInteraction({});  // empty cache
     expect(parseRecipientMentions('<@555>', int))
-      .toEqual({ ids: ['555'], invalid_tokens: [] });
+      .toEqual({ ids: ['555'], invalidTokens: [] });
   });
 });
 
@@ -136,7 +139,7 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['101', '102', '103'] },
     });
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['101', '102', '103'], invalid_tokens: [] });
+      .toEqual({ ids: ['101', '102', '103'], invalidTokens: [] });
   });
 
   test('merges role expansion with direct user mentions, deduped', () => {
@@ -155,16 +158,16 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['900', '801', '101'] },
     });
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['101'], invalid_tokens: [] });
+      .toEqual({ ids: ['101'], invalidTokens: [] });
   });
 
-  test('role unknown to the guild lands in invalid_tokens', () => {
+  test('role unknown to the guild lands in invalidTokens', () => {
     const int = makeInteraction({});
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalid_tokens: ['<@&7000>'] });
+      .toEqual({ ids: [], invalidTokens: ['<@&7000>'] });
   });
 
-  test('role with no usable members (all sender/bots) lands in invalid_tokens', () => {
+  test('role with no usable members (all sender/bots) lands in invalidTokens', () => {
     const int = makeInteraction({
       senderId: '900',
       users: { '900': {}, '801': { bot: true } },
@@ -172,33 +175,48 @@ describe('parseRecipientMentions — role mentions', () => {
     });
     const res = parseRecipientMentions('<@&7000>', int);
     expect(res.ids).toEqual([]);
-    expect(res.invalid_tokens).toEqual(['<@&7000>']);
+    expect(res.invalidTokens).toEqual(['<@&7000>']);
   });
 
   test('DM context (guild=undefined) treats role mentions as invalid', () => {
     const int = { user: { id: '900' }, guild: undefined };
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalid_tokens: ['<@&7000>'] });
+      .toEqual({ ids: [], invalidTokens: ['<@&7000>'] });
+  });
+
+  test('role mention repeated in input expands once (no double-counting)', () => {
+    // matchAll iterates every regex hit, so a repeated `<@&id>` would
+    // re-enter the expansion loop and re-add the same members. ids is
+    // a Set so they dedupe; pin that AND that invalidTokens stays empty
+    // (the second hit shouldn't trip the "no usable members" path on a
+    // role whose members were already added).
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+      roles: { '7000': ['101', '102'] },
+    });
+    const res = parseRecipientMentions('<@&7000> <@&7000> <@&7000>', int);
+    expect(res.ids.sort()).toEqual(['101', '102']);
+    expect(res.invalidTokens).toEqual([]);
   });
 });
 
 describe('parseRecipientMentions — invalid tokens', () => {
-  test('channel mentions land in invalid_tokens', () => {
+  test('channel mentions land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <#456>', int))
-      .toEqual({ ids: ['111'], invalid_tokens: ['<#456>'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['<#456>'] });
   });
 
-  test('custom emoji land in invalid_tokens', () => {
+  test('custom emoji land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <:smile:789>', int))
-      .toEqual({ ids: ['111'], invalid_tokens: ['<:smile:789>'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['<:smile:789>'] });
   });
 
-  test('bare plaintext usernames land in invalid_tokens', () => {
+  test('bare plaintext usernames land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('alice <@111> bob', int))
-      .toEqual({ ids: ['111'], invalid_tokens: ['alice', 'bob'] });
+      .toEqual({ ids: ['111'], invalidTokens: ['alice', 'bob'] });
   });
 
   test('mention with missing closer (truncated input) is treated as invalid', () => {
@@ -207,7 +225,7 @@ describe('parseRecipientMentions — invalid tokens', () => {
     // The truncated `<@111` cannot match the user-mention regex
     // (requires `>`), so it falls into the residual-token bucket.
     expect(res.ids).toEqual([]);
-    expect(res.invalid_tokens.length).toBeGreaterThan(0);
+    expect(res.invalidTokens.length).toBeGreaterThan(0);
   });
 });
 
@@ -238,9 +256,39 @@ describe('parseRecipientMentions — cap + length safety', () => {
     // at the END — the parser should NOT find it after truncation. If
     // a future regression dropped the length cap, this mention would
     // surface and the test would flip.
-    const padding = 'x'.repeat(__MAX_INPUT_LENGTH + 100);
+    const padding = 'x'.repeat(MAX_INPUT_LENGTH + 100);
     const int = makeInteraction({ users: { '999': {} } });
     const res = parseRecipientMentions(padding + ' <@999>', int);
     expect(res.ids).toEqual([]);
+  });
+
+  test('input of exactly MAX_INPUT_LENGTH is NOT truncated (boundary check)', () => {
+    // Pin the inequality direction. The cap fires on `raw.length > MAX_INPUT_LENGTH`,
+    // not >=, so an exactly-MAX-length input should be processed in
+    // full. Build a string of exactly MAX_INPUT_LENGTH that contains
+    // a real mention near the start so the rest is harmless padding.
+    const mention = '<@777>';
+    const padding = 'x'.repeat(MAX_INPUT_LENGTH - mention.length);
+    const input = mention + padding;
+    expect(input).toHaveLength(MAX_INPUT_LENGTH);
+    const int = makeInteraction({ users: { '777': {} } });
+    expect(parseRecipientMentions(input, int).ids).toEqual(['777']);
+  });
+
+  test('truncation that lands inside `<...>` drops the partial (no manufactured invalid token)', () => {
+    // If the slice cuts inside an open mention like `<@123`, a naive
+    // strip+split would surface `<@123` as an invalid token the user
+    // didn't actually mistype. Pin that we trim back to the last `<`
+    // before scanning, so the residual-token bucket stays clean.
+    const padding = 'x'.repeat(MAX_INPUT_LENGTH - 5);  // leaves room for partial mention at the end
+    const input = padding + '<@123456789';  // open `<@…` with no closing `>`, will land past MAX
+    expect(input.length).toBeGreaterThan(MAX_INPUT_LENGTH);
+    const int = makeInteraction({ users: { '123456789': {} } });
+    const res = parseRecipientMentions(input, int);
+    expect(res.ids).toEqual([]);
+    // padding is one big run of `x`s with no separators, so it
+    // surfaces as one invalid token after the strip. The KEY
+    // assertion is the partial-mention residue isn't ALSO there.
+    expect(res.invalidTokens.every(t => !t.startsWith('<@'))).toBe(true);
   });
 });

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -121,6 +121,19 @@ describe('parseRecipientMentions — filtering', () => {
       .toEqual({ ids: ['222'], invalidTokens: [], cappedCount: 0 });
   });
 
+  test('missing interaction.user falls through (sender-exclusion no-ops, no throw)', () => {
+    // Defensive precondition: `interaction.user?.id` is the sender
+    // exclusion anchor. If a caller passes `interaction = { guild }`
+    // (no user — bot misuse, not user input), the optional chain
+    // makes `senderId === undefined` so sender exclusion silently
+    // no-ops. Pin that the parser doesn't throw — the caller bug
+    // surfaces downstream via the back-half's interaction.user.id
+    // read, which is a clearer crash site than a parse-time TypeError.
+    const interaction = { guild: { members: { cache: new Map([['111', { user: { id: '111', bot: false } }]]) }, roles: { cache: new Map() } } };
+    expect(parseRecipientMentions('<@111>', interaction))
+      .toEqual({ ids: ['111'], invalidTokens: [], cappedCount: 0 });
+  });
+
   test('best-effort bot filter: cache miss leaves the ID in (back-half re-checks)', () => {
     // Bot filter relies on member.cache; a cache miss (e.g. cold cache
     // or member not yet fetched) cannot tell us "is this a bot." The

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -325,10 +325,15 @@ describe('parseRecipientMentions — invalid tokens', () => {
       .toEqual({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
   });
 
-  test('custom emoji land in invalidTokens', () => {
+  test('custom emoji (static and animated) land in invalidTokens', () => {
+    // Both `<:name:id>` (static) and `<a:name:id>` (animated) hit
+    // the residue path — neither matches the USER_MENTION_RE
+    // (`<@!?(\d+)>`) or ROLE_MENTION_RE (`<@&(\d+)>`) shapes.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <:smile:789>', int))
       .toEqual({ ids: ['111'], invalidTokens: ['<:smile:789>'], cappedCount: 0 });
+    expect(parseRecipientMentions('<@111> <a:dance:790>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['<a:dance:790>'], cappedCount: 0 });
   });
 
   test('bare plaintext usernames land in invalidTokens', () => {
@@ -635,7 +640,7 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(logger.debug).toHaveBeenCalledTimes(1);
     expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('capping recipient list'),
-      expect.objectContaining({ unique_count: 26, cap: 25, capped_count: 1 }),
+      expect.objectContaining({ uniqueCount: 26, cap: 25, cappedCount: 1 }),
     );
     expect(logger.warn).not.toHaveBeenCalled();
 
@@ -668,7 +673,7 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('capping recipient list'),
-      expect.objectContaining({ unique_count: 51, cap: 25, capped_count: 26 }),
+      expect.objectContaining({ uniqueCount: 51, cap: 25, cappedCount: 26 }),
     );
     expect(logger.debug).not.toHaveBeenCalled();
   });

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -322,15 +322,15 @@ describe('parseRecipientMentions — invalid tokens', () => {
     // guard. Pin that the regex-based escape catches them.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('@everyone! <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@​everyone!'], cappedCount: 0 });
+      .toEqual({ ids: ['111'], invalidTokens: ['@\u200beveryone!'], cappedCount: 0 });
     expect(parseRecipientMentions('@everyone.fix <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@​everyone.fix'], cappedCount: 0 });
+      .toEqual({ ids: ['111'], invalidTokens: ['@\u200beveryone.fix'], cappedCount: 0 });
     expect(parseRecipientMentions('@here: <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@​here:'], cappedCount: 0 });
+      .toEqual({ ids: ['111'], invalidTokens: ['@\u200bhere:'], cappedCount: 0 });
     // Embedded mid-token (paste artifact). Regex replaces ALL
     // occurrences so no `@everyone` / `@here` substring escapes.
     expect(parseRecipientMentions('here@everyone <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['here@​everyone'], cappedCount: 0 });
+      .toEqual({ ids: ['111'], invalidTokens: ['here@\u200beveryone'], cappedCount: 0 });
   });
 
   test('newline characters separate tokens (split regex includes \\n)', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -232,14 +232,23 @@ describe('parseRecipientMentions — role mentions', () => {
       .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
+  test('repeated residue tokens dedupe in invalidTokens (symmetric with role-error dedup)', () => {
+    // `<#456> <#456>` previously surfaced two entries; now dedupes
+    // via `residueSeen` (parallel to the role-error path's
+    // `invalidRoleIds`). Caller's "couldn't parse: X, X" embed
+    // isn't user-hostile.
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('<@111> <#456> <#456>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
+    expect(parseRecipientMentions('<@111> alice alice bob alice', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['alice', 'bob'], cappedCount: 0 });
+  });
+
   test('repeated invalid role mention dedupes in invalidTokens', () => {
     // `<@&999> <@&999>` against a guild missing role 999 must yield
     // ONE invalidTokens entry, not two. Without the role-id dedupe,
     // matchAll iterates each input occurrence and pushes the raw
-    // token each time — a caller's "couldn't parse: X, X" embed is
-    // user-hostile. The residue strip pass already dedupes naturally
-    // via input grouping; this test pins the same property for the
-    // role-error path.
+    // token each time. Symmetric with the residue dedupe above.
     const int = makeInteraction({});  // no role 999
     expect(parseRecipientMentions('<@&999> <@&999> <@&999>', int))
       .toEqual({ ids: [], invalidTokens: ['<@&999>'], cappedCount: 0 });

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -134,6 +134,17 @@ describe('parseRecipientMentions — filtering', () => {
       .toEqual({ ids: ['222'], invalidTokens: [], cappedCount: 0 });
   });
 
+  test('completely empty interaction ({}) does not throw, returns empty result', () => {
+    // The `interaction == null` early-return handles null/undefined,
+    // but a truthy empty object still has to walk the optional chains
+    // (`interaction.user?.id`, `interaction.guild?.roles?.cache`)
+    // without crashing. Pin that an `interaction = {}` is tolerated
+    // — a future refactor that switched `.guild?.x` to `.guild.x?` on
+    // the assumption "we've already null-checked" would surface here.
+    expect(parseRecipientMentions('<@111>', {}))
+      .toEqual({ ids: ['111'], invalidTokens: [], cappedCount: 0 });
+  });
+
   test('missing interaction.user falls through (sender-exclusion no-ops, no throw)', () => {
     // Defensive precondition: `interaction.user?.id` is the sender
     // exclusion anchor. If a caller passes `interaction = { guild }`
@@ -526,6 +537,27 @@ describe('parseRecipientMentions — cap + length safety', () => {
     // surfaces as one invalid token after the strip. The KEY
     // assertion is the partial-mention residue isn't ALSO there.
     expect(res.invalidTokens.every(t => !t.startsWith('<@'))).toBe(true);
+  });
+
+  test('invalidTokens entries are capped at MAX_INVALID_TOKEN_LENGTH', () => {
+    // A single ~4000-char garbage token (one long string with no
+    // separators) would otherwise blow Discord's 4096-char embed
+    // budget if the caller interpolated it verbatim. Parser caps
+    // each token at MAX_INVALID_TOKEN_LENGTH chars and appends `…`.
+    // Pin both branches: under-cap stays untrimmed; over-cap gets
+    // the marker.
+    const int = makeInteraction({});
+    const longToken = 'x'.repeat(500);
+    const res = parseRecipientMentions(longToken, int);
+    expect(res.invalidTokens).toHaveLength(1);
+    // 256 chars + the ellipsis marker.
+    expect(res.invalidTokens[0]).toHaveLength(257);
+    expect(res.invalidTokens[0].endsWith('…')).toBe(true);
+
+    // Under-cap token is unchanged.
+    const shortToken = 'y'.repeat(100);
+    const res2 = parseRecipientMentions(shortToken, int);
+    expect(res2.invalidTokens).toEqual([shortToken]);
   });
 
   test('exactly-cap unique candidates: no cap fires, no log call', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -227,6 +227,33 @@ describe('parseRecipientMentions — invalid tokens', () => {
     expect(res.ids).toEqual([]);
     expect(res.invalidTokens.length).toBeGreaterThan(0);
   });
+
+  test('@everyone / @here land in invalidTokens (no fan-out shortcut)', () => {
+    // Discord's @everyone / @here are NOT `<@id>` mentions — they're
+    // bare tokens that the API expands at message-send time. The
+    // parser must surface them as invalid so a power-user typing
+    // `recipients:@everyone` doesn't get silent zero-recipient
+    // behavior (or, worse, the back-half hands the literal `@everyone`
+    // to mintLinksInBatches). Callers that render `invalidTokens`
+    // for the user MUST escape these the same way commands.js does
+    // (zero-width-space insertion) to avoid sending a stray ping.
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('@everyone <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@everyone'] });
+    expect(parseRecipientMentions('@here <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@here'] });
+  });
+
+  test('newline characters separate tokens (split regex includes \\n)', () => {
+    // Discord slash-command option strings can contain literal
+    // newlines (paste-from-multi-line). Pin that the split regex
+    // `/[\s,]+/` includes \n — a regression that switched to
+    // `/[ \t,]+/` would silently merge "alice\nbob" into one
+    // bare-name token.
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('<@111>\n<#456>\n\nstray', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['<#456>', 'stray'] });
+  });
 });
 
 describe('parseRecipientMentions — cap + length safety', () => {
@@ -273,6 +300,26 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(input).toHaveLength(MAX_INPUT_LENGTH);
     const int = makeInteraction({ users: { '777': {} } });
     expect(parseRecipientMentions(input, int).ids).toEqual(['777']);
+  });
+
+  test('cap and invalidTokens are populated independently in the same call', () => {
+    // The cap test above exercises 30 valid → 25 ids. The invalid-
+    // tokens tests exercise typos in isolation. Pin the cross-cut:
+    // 30 valid mentions PLUS a channel-mention typo should produce
+    // 25 ids AND keep the typo in invalidTokens. A future bug where
+    // the cap pass also accidentally truncated invalidTokens would
+    // silently hide user-visible error feedback.
+    const users = {};
+    const mentions = [];
+    for (let i = 0; i < 30; i++) {
+      const id = `${1000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    const int = makeInteraction({ users });
+    const res = parseRecipientMentions(`${mentions.join(' ')} <#456>`, int);
+    expect(res.ids).toHaveLength(25);
+    expect(res.invalidTokens).toEqual(['<#456>']);
   });
 
   test('truncation that lands inside `<...>` drops the partial (no manufactured invalid token)', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -539,6 +539,25 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(res.invalidTokens.every(t => !t.startsWith('<@'))).toBe(true);
   });
 
+  test('mass-mention escape runs BEFORE per-token truncation', () => {
+    // Critical ordering. If truncate ran first and the slice fell
+    // before the escape pass, a token like `@everyone` near the
+    // start of an oversized residue would land in invalidTokens
+    // un-escaped after truncation. Pin: with `@everyone` at the
+    // start of a 300-char token, the rendered output starts with
+    // the ZWS-escaped form (`@\u200beveryone`) AND ends in the
+    // truncation marker. A future refactor flipping to truncate-
+    // then-escape would lose the ZWS and fail this test.
+    const int = makeInteraction({});
+    const overCap = `@everyone${'x'.repeat(300)}`;  // 309 chars total
+    const res = parseRecipientMentions(overCap, int);
+    expect(res.invalidTokens).toHaveLength(1);
+    const rendered = res.invalidTokens[0];
+    expect(rendered.endsWith('…')).toBe(true);
+    expect(rendered.startsWith('@\u200beveryone')).toBe(true);  // ZWS form
+    expect(rendered.startsWith('@e')).toBe(false);  // raw form absent
+  });
+
   test('invalidTokens entries are capped at MAX_INVALID_TOKEN_LENGTH', () => {
     // A single ~4000-char garbage token (one long string with no
     // separators) would otherwise blow Discord's 4096-char embed

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -210,6 +210,17 @@ describe('parseRecipientMentions — role mentions', () => {
       .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
+  test('DM context (guild=null) also treats role mentions as invalid', () => {
+    // discord.js returns `null` (not `undefined`) for DM-context
+    // guilds. Optional chaining handles both, but pin the runtime
+    // shape explicitly so a future refactor that switched
+    // `guild?.roles?.cache` to `guild.roles?.cache` would surface
+    // on this test, not in prod.
+    const int = { user: { id: '900' }, guild: null };
+    expect(parseRecipientMentions('<@&7000>', int))
+      .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
+  });
+
   test('repeated invalid role mention dedupes in invalidTokens', () => {
     // `<@&999> <@&999>` against a guild missing role 999 must yield
     // ONE invalidTokens entry, not two. Without the role-id dedupe,
@@ -252,13 +263,17 @@ describe('parseRecipientMentions — role mentions', () => {
     expect(res.cappedCount).toBe(30);
   });
 
-  test('user listed BOTH directly AND via a role mention appears once in ids', () => {
+  test('user listed BOTH directly AND via a role mention appears once in ids, role is not flagged useless', () => {
     // The "merges role expansion with direct user mentions" test
     // above exercises this implicitly (user 101 is in role 7000 AND
     // mentioned directly), but a fixture that EXPLICITLY overlaps
-    // makes the dedupe invariant non-incidental — a regression that
-    // re-added role members without the Set guard would surface
-    // here as ids.length === 2 instead of 1.
+    // makes two invariants non-incidental:
+    // (a) ids.length === 1 (Set dedup — a regression re-adding role
+    //     members without the dedupe guard surfaces here);
+    // (b) invalidTokens === [] (the role contributed via dedupe so
+    //     `usable++` fires before the seen-check — a refactor
+    //     swapping `usable++` to AFTER `seen.has` would flag this
+    //     role as useless and push the token to invalidTokens).
     const int = makeInteraction({
       users: { '101': {} },
       roles: { '7000': ['101'] },
@@ -513,13 +528,37 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(res.invalidTokens.every(t => !t.startsWith('<@'))).toBe(true);
   });
 
+  test('exactly-cap unique candidates: no cap fires, no log call', () => {
+    // Boundary on the OTHER side of the cap. The cap fires when
+    // `cappedCount > 0` (i.e. seen.size > ids.size); at exactly
+    // `cap` unique inputs, ids absorbs all of them and cappedCount
+    // stays 0. Pin that this branch doesn't log — the cap-overshoot
+    // signal should ONLY surface when something was actually dropped.
+    const users = {};
+    const mentions = [];
+    for (let i = 0; i < 25; i++) {
+      const id = `${7000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    const int = makeInteraction({ users });
+    logger.debug.mockClear();
+    logger.warn.mockClear();
+    const res = parseRecipientMentions(mentions.join(' '), int);
+    expect(res.ids).toHaveLength(25);
+    expect(res.cappedCount).toBe(0);
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   test('cap-overshoot logging escalates to warn past 2x the cap', () => {
     // Modest overshoot (≤ 2× cap) signals "user typed too many" and
     // stays at debug; massive overshoot signals "user pasted an
     // untrimmed list" and surfaces at warn so oncall sees the pattern.
     // Pin the threshold so a future refactor that flipped the
     // comparison or moved the multiplier silently regresses the
-    // oncall signal.
+    // oncall signal. Also pins the meta payload shape so a future
+    // field rename in the log fires this test, not the prod logs.
     const users = {};
     const mentions = [];
     // 26 unique = cap+1 = modest overshoot → debug
@@ -533,6 +572,10 @@ describe('parseRecipientMentions — cap + length safety', () => {
     logger.warn.mockClear();
     parseRecipientMentions(mentions.join(' '), int);
     expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('capping recipient list'),
+      expect.objectContaining({ unique_count: 26, cap: 25, capped_count: 1 }),
+    );
     expect(logger.warn).not.toHaveBeenCalled();
 
     // 51 unique = 2× cap + 1 = massive overshoot → warn
@@ -546,6 +589,10 @@ describe('parseRecipientMentions — cap + length safety', () => {
     logger.warn.mockClear();
     parseRecipientMentions(mentions.join(' '), int);
     expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('capping recipient list'),
+      expect.objectContaining({ unique_count: 51, cap: 25, capped_count: 26 }),
+    );
     expect(logger.debug).not.toHaveBeenCalled();
   });
 });

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -363,6 +363,37 @@ describe('parseRecipientMentions — cap + length safety', () => {
     expect(res.cappedCount).toBe(3);  // 28 unique - 25 cap
   });
 
+  test('cappedCount accounts for role-expansion overflow (not just direct mentions)', () => {
+    // Round-5 cr regression test: a `<@&role1> <@&role2>` where role1
+    // fills the cap and role2 has more usable members must NOT
+    // silently truncate. Both roles' members count toward
+    // `cappedCount`, even though the inner loop short-circuits Set
+    // insertions past cap. Without this, callers can't tell users
+    // "we kept 25 of N" when the overflow source is role expansion.
+    const role1Members = [];
+    const role2Members = [];
+    const users = {};
+    for (let i = 0; i < 50; i++) {
+      const id = `${3000000000 + i}`;
+      users[id] = {};
+      role1Members.push(id);
+    }
+    for (let i = 0; i < 20; i++) {
+      const id = `${4000000000 + i}`;
+      users[id] = {};
+      role2Members.push(id);
+    }
+    const int = makeInteraction({
+      users,
+      roles: { '7000': role1Members, '7001': role2Members },
+    });
+    const res = parseRecipientMentions('<@&7000> <@&7001>', int);
+    expect(res.ids).toHaveLength(25);
+    // 50 (role1) + 20 (role2) = 70 unique candidates; 25 kept; 45 dropped.
+    expect(res.cappedCount).toBe(45);
+    expect(res.invalidTokens).toEqual([]);
+  });
+
   test('cap and invalidTokens are populated independently in the same call', () => {
     // The cap test above exercises 30 valid → 25 ids. The invalid-
     // tokens tests exercise typos in isolation. Pin the cross-cut:

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -1,0 +1,246 @@
+/**
+ * Unit tests for src/recipient-parser.js — the `recipients:` slash-
+ * option mention parser used by /qurl file and /qurl map.
+ *
+ * Mocks config (just QURL_SEND_MAX_RECIPIENTS) and uses synthetic
+ * `interaction` objects with the guild.members.cache / guild.roles.cache
+ * shape discord.js produces. No real Discord API.
+ */
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+jest.mock('../src/config', () => ({
+  QURL_SEND_MAX_RECIPIENTS: 25,
+}));
+
+const { parseRecipientMentions, __MAX_INPUT_LENGTH } = require('../src/recipient-parser');
+
+// Build a synthetic interaction with the cache shape the parser reads.
+// Pass `users` as { id → { bot } } and `roles` as
+// { id → [member_id, member_id, ...] }. Sender defaults to '900000000000000001'.
+// IDs are all-numeric to match real Discord snowflakes — the parser's
+// regex is `/<@!?(\d+)>/` so letter-prefixed test fixtures would silently
+// drop every mention, masking real coverage.
+function makeInteraction({ senderId = '900000000000000001', users = {}, roles = {} } = {}) {
+  const memberCache = new Map();
+  for (const [id, attrs] of Object.entries(users)) {
+    memberCache.set(id, { user: { id, bot: !!attrs.bot } });
+  }
+  // Discord's role.members is a Collection<id, GuildMember>. We
+  // simulate with a Map; the parser iterates with for-of which both
+  // honor. Add the member to the cache when it's listed under a role
+  // so the bot filter has something to look up.
+  const roleCache = new Map();
+  for (const [roleId, memberIds] of Object.entries(roles)) {
+    const roleMembers = new Map();
+    for (const mid of memberIds) {
+      const existing = memberCache.get(mid) ?? { user: { id: mid, bot: false } };
+      memberCache.set(mid, existing);
+      roleMembers.set(mid, existing);
+    }
+    roleCache.set(roleId, { members: roleMembers });
+  }
+  return {
+    user: { id: senderId },
+    guild: {
+      members: { cache: memberCache },
+      roles: { cache: roleCache },
+    },
+  };
+}
+
+describe('parseRecipientMentions — basic shape', () => {
+  test('returns empty result for null/undefined/empty input', () => {
+    const int = makeInteraction();
+    expect(parseRecipientMentions(null, int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions(undefined, int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions('', int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions('   \t\n', int)).toEqual({ ids: [], invalid_tokens: [] });
+  });
+
+  test('returns empty result when raw is a non-string (defense vs caller bugs)', () => {
+    const int = makeInteraction();
+    expect(parseRecipientMentions(42, int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions({}, int)).toEqual({ ids: [], invalid_tokens: [] });
+    expect(parseRecipientMentions([], int)).toEqual({ ids: [], invalid_tokens: [] });
+  });
+
+  test('extracts a single user mention', () => {
+    const int = makeInteraction({ users: { '111111111111111111': {} } });
+    expect(parseRecipientMentions('<@111111111111111111>', int))
+      .toEqual({ ids: ['111111111111111111'], invalid_tokens: [] });
+  });
+
+  test('accepts both <@id> and <@!id> forms (legacy nickname mention)', () => {
+    const int = makeInteraction({
+      users: { '111111111111111111': {}, '222222222222222222': {} },
+    });
+    expect(parseRecipientMentions('<@111111111111111111> <@!222222222222222222>', int))
+      .toEqual({ ids: ['111111111111111111', '222222222222222222'], invalid_tokens: [] });
+  });
+
+  test('dedupes repeated mentions', () => {
+    const int = makeInteraction({ users: { '111111111111111111': {} } });
+    expect(parseRecipientMentions('<@111111111111111111> <@111111111111111111> <@!111111111111111111>', int))
+      .toEqual({ ids: ['111111111111111111'], invalid_tokens: [] });
+  });
+
+  test('handles whitespace + comma + mixed separators', () => {
+    const int = makeInteraction({
+      users: { '111': {}, '222': {}, '333': {} },
+    });
+    expect(parseRecipientMentions('<@111>,<@222>  <@333>', int).ids)
+      .toEqual(['111', '222', '333']);
+  });
+});
+
+describe('parseRecipientMentions — filtering', () => {
+  test('excludes the sender (no self-sends)', () => {
+    const int = makeInteraction({
+      senderId: '900000000000000001',
+      users: { '900000000000000001': {}, '222222222222222222': {} },
+    });
+    expect(parseRecipientMentions('<@900000000000000001> <@222222222222222222>', int))
+      .toEqual({ ids: ['222222222222222222'], invalid_tokens: [] });
+  });
+
+  test('excludes bots flagged in the member cache', () => {
+    const int = makeInteraction({
+      users: { '111': { bot: true }, '222': {} },
+    });
+    expect(parseRecipientMentions('<@111> <@222>', int))
+      .toEqual({ ids: ['222'], invalid_tokens: [] });
+  });
+
+  test('best-effort bot filter: cache miss leaves the ID in (back-half re-checks)', () => {
+    // Bot filter relies on member.cache; a cache miss (e.g. cold cache
+    // or member not yet fetched) cannot tell us "is this a bot." The
+    // parser keeps the ID and lets the downstream send-pipeline's bot
+    // check (existing form's "Cannot send to a bot" path) catch it.
+    const int = makeInteraction({});  // empty cache
+    expect(parseRecipientMentions('<@555>', int))
+      .toEqual({ ids: ['555'], invalid_tokens: [] });
+  });
+});
+
+describe('parseRecipientMentions — role mentions', () => {
+  test('expands a role to its current members', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {}, '103': {} },
+      roles: { '7000': ['101', '102', '103'] },
+    });
+    expect(parseRecipientMentions('<@&7000>', int))
+      .toEqual({ ids: ['101', '102', '103'], invalid_tokens: [] });
+  });
+
+  test('merges role expansion with direct user mentions, deduped', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {}, '103': {} },
+      roles: { '7000': ['101', '102'] },
+    });
+    expect(parseRecipientMentions('<@103> <@&7000> <@101>', int).ids.sort())
+      .toEqual(['101', '102', '103']);
+  });
+
+  test('role expansion excludes sender and bots', () => {
+    const int = makeInteraction({
+      senderId: '900',
+      users: { '900': {}, '801': { bot: true }, '101': {} },
+      roles: { '7000': ['900', '801', '101'] },
+    });
+    expect(parseRecipientMentions('<@&7000>', int))
+      .toEqual({ ids: ['101'], invalid_tokens: [] });
+  });
+
+  test('role unknown to the guild lands in invalid_tokens', () => {
+    const int = makeInteraction({});
+    expect(parseRecipientMentions('<@&7000>', int))
+      .toEqual({ ids: [], invalid_tokens: ['<@&7000>'] });
+  });
+
+  test('role with no usable members (all sender/bots) lands in invalid_tokens', () => {
+    const int = makeInteraction({
+      senderId: '900',
+      users: { '900': {}, '801': { bot: true } },
+      roles: { '7000': ['900', '801'] },
+    });
+    const res = parseRecipientMentions('<@&7000>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalid_tokens).toEqual(['<@&7000>']);
+  });
+
+  test('DM context (guild=undefined) treats role mentions as invalid', () => {
+    const int = { user: { id: '900' }, guild: undefined };
+    expect(parseRecipientMentions('<@&7000>', int))
+      .toEqual({ ids: [], invalid_tokens: ['<@&7000>'] });
+  });
+});
+
+describe('parseRecipientMentions — invalid tokens', () => {
+  test('channel mentions land in invalid_tokens', () => {
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('<@111> <#456>', int))
+      .toEqual({ ids: ['111'], invalid_tokens: ['<#456>'] });
+  });
+
+  test('custom emoji land in invalid_tokens', () => {
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('<@111> <:smile:789>', int))
+      .toEqual({ ids: ['111'], invalid_tokens: ['<:smile:789>'] });
+  });
+
+  test('bare plaintext usernames land in invalid_tokens', () => {
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('alice <@111> bob', int))
+      .toEqual({ ids: ['111'], invalid_tokens: ['alice', 'bob'] });
+  });
+
+  test('mention with missing closer (truncated input) is treated as invalid', () => {
+    const int = makeInteraction({ users: { '111': {} } });
+    const res = parseRecipientMentions('<@111 incomplete', int);
+    // The truncated `<@111` cannot match the user-mention regex
+    // (requires `>`), so it falls into the residual-token bucket.
+    expect(res.ids).toEqual([]);
+    expect(res.invalid_tokens.length).toBeGreaterThan(0);
+  });
+});
+
+describe('parseRecipientMentions — cap + length safety', () => {
+  test('caps the result at QURL_SEND_MAX_RECIPIENTS', () => {
+    // Build 30 user mentions; cap is 25 (set in the jest.mock above).
+    // IDs are numeric to match the real Discord-mention format the
+    // parser regex requires.
+    const users = {};
+    const mentions = [];
+    for (let i = 0; i < 30; i++) {
+      const id = `${1000000000 + i}`;
+      users[id] = {};
+      mentions.push(`<@${id}>`);
+    }
+    const int = makeInteraction({ users });
+    const res = parseRecipientMentions(mentions.join(' '), int);
+    expect(res.ids).toHaveLength(25);
+    // First-N ordering (set insertion is preserved). Pin that the
+    // cap takes the first 25 — keeping order stable means a user
+    // can reorder their mentions to influence the kept set.
+    expect(res.ids[0]).toBe('1000000000');
+    expect(res.ids[24]).toBe('1000000024');
+  });
+
+  test('truncates input above MAX_INPUT_LENGTH before scanning (ReDoS guard)', () => {
+    // Build a string longer than MAX_INPUT_LENGTH with a real mention
+    // at the END — the parser should NOT find it after truncation. If
+    // a future regression dropped the length cap, this mention would
+    // surface and the test would flip.
+    const padding = 'x'.repeat(__MAX_INPUT_LENGTH + 100);
+    const int = makeInteraction({ users: { '999': {} } });
+    const res = parseRecipientMentions(padding + ' <@999>', int);
+    expect(res.ids).toEqual([]);
+  });
+});

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -327,6 +327,20 @@ describe('parseRecipientMentions — invalid tokens', () => {
       .toEqual({ ids: ['111'], invalidTokens: ['@\u200bhere'], cappedCount: 0 });
   });
 
+  test('@Everyone / @Here (capitalized) are NOT escaped — Discord parser is lowercase-only', () => {
+    // Discord's mass-mention tokenizer is itself case-sensitive
+    // (lowercase only). The parser's escape regex is `/@(everyone|here)/g`
+    // — INTENTIONALLY no `/i` flag. Widening to case-insensitive
+    // would needlessly mangle legitimate `@Everyone` paste artifacts.
+    // Pin the invariant so a future "defensive hardening" PR can't
+    // silently widen the regex without flipping this test.
+    const int = makeInteraction({ users: { '111': {} } });
+    expect(parseRecipientMentions('@Everyone <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@Everyone'], cappedCount: 0 });
+    expect(parseRecipientMentions('@Here <@111>', int))
+      .toEqual({ ids: ['111'], invalidTokens: ['@Here'], cappedCount: 0 });
+  });
+
   test('@everyone with trailing punctuation is also escaped (single-token residue)', () => {
     // The strip-pass split class `[\s,;|/]+` does NOT include `.`,
     // `:`, `!`, `?`, `-`, so `@everyone!` and `@everyone.fix` survive

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -95,6 +95,18 @@ describe('parseRecipientMentions — basic shape', () => {
       .toEqual({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
   });
 
+  test('cappedCount is 0 when input has no mentions (no false-positive cap signal)', () => {
+    // Empty-input tests above pin null/undefined/'' paths; this pins
+    // the "input had content but no mentions" case explicitly so a
+    // future caller reading `cappedCount > 0` to infer "user pasted
+    // too many" can't accidentally fire on plain bare-name input.
+    const int = makeInteraction();
+    const res = parseRecipientMentions('alice bob carol', int);
+    expect(res.ids).toEqual([]);
+    expect(res.cappedCount).toBe(0);
+    expect(res.invalidTokens).toEqual(['alice', 'bob', 'carol']);
+  });
+
   test('handles whitespace + comma + mixed separators', () => {
     const int = makeInteraction({
       users: { '111': {}, '222': {}, '333': {} },


### PR DESCRIPTION
## Summary
**PR 7b.1 of 3** in the rollout to replace `/qurl send`'s bouncy-DM front-half with `/qurl file` + `/qurl map`. Pure-additive piece — lands the mention-parsing module that 7b.2 will wire into the new slash commands' `recipients:` option. **No existing code paths touched**; the module is unused until 7b.2.

## Business context
User feedback on `/qurl send`: the current UX bounces users into DMs to choose recipients after picking a file — confusing and adds friction. The 7b rollout splits this into two purpose-specific commands (`/qurl file`, `/qurl map`) with the recipient picker living in-channel, backed by `flow_state` (the harness landed in PR #275).

For power users, the new commands expose a `recipients:` slash-command option that takes free-form mentions: `/qurl file recipients:<@alice> <@bob> <@&team>`. **That's the option this PR parses.**

## What this module does
- Parses Discord mention syntax: `<@123>` / `<@!123>` users, `<@&id>` roles (expanded via guild member cache).
- Filters: dedupe via `seen` Set, sender exclusion, best-effort bot filter.
- Two-set cap design (`seen` + `ids`): `cappedCount = seen.size - ids.size` is accurate whether overflow source is direct mentions or role expansion.
- Returns `{ ids, invalidTokens, cappedCount }` — never throws.
- **Mass-mention safety:** `@everyone` / `@here` (lowercase only, matching Discord's case-sensitive tokenizer) are pre-escaped with U+200B via regex — handles `@everyone!`, `@here:`, embedded `here@everyone`. Belt-and-suspenders re-escape after per-token truncation. Naive caller interpolation can't fan-out-ping.
- **Per-token cap:** `invalidTokens` entries capped at 256 chars + ellipsis, protecting Discord's 4096-char embed budget.
- **ReDoS guard:** input length-capped at 4000 chars before regex scan.
- **Logger escalation:** at `MASSIVE_OVERSHOOT_MULTIPLIER × cap`, log level promotes from `debug` to `warn` for oncall pattern visibility.

## Why a STRING option (not Discord's `mentionable` type)
Discord's `mentionable` slash-command option type is **single-value**. The power-user path needs many mentions / role mentions / a mix in one shot. A free-form string is the only Discord shape that carries that.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx jest tests/recipient-parser.test.js` — **43 / 43 pass**
- [x] `npx jest` — **1299 / 1299 pass** (was 1256; +43 new)
- [x] Coverage: 5 describe blocks — basic shape, filtering (incl. malformed-interaction precondition, empty-object tolerance), role mentions (incl. cross-role overflow, explicit direct+role dedupe, repeated-invalid-role dedupe), invalid tokens (incl. `@everyone`/`@here` escape with punctuation residue, `@Everyone` case-sensitivity, animated emoji, residue dedupe), cap + ReDoS safety (incl. cappedCount accurate across direct + role overflow, dedupe-then-cap ordering, log threshold escalation at exactly-2× boundary, MAX_INPUT_LENGTH boundary, truncation-inside-token guard, per-token cap, escape-before-truncate ordering)

## Final diff
- `apps/discord/src/recipient-parser.js`: **new file, 354 lines** (heavy WHY comments — option semantics, regex tradeoffs, two-set cap design, mass-mention escape case-sensitivity, markdown-injection caller-responsibility, partial-cache caveat, shared-regex safety, TODO(7b.2) coordination markers)
- `apps/discord/tests/recipient-parser.test.js`: **new file, 680 lines** (43 tests)

## Rollout sequence
- **7b.1 (this PR):** parser module + tests, no wiring
- 7b.2: add `/qurl file` + `/qurl map` slash commands (flow_state-backed in-channel form, wires this parser into the `recipients:` option; narrows the option's `max_length` ≤ MAX_INPUT_LENGTH; surfaces `role.memberCount` vs `role.members.size` divergence; user-visible cappedCount copy; wraps `invalidTokens` in code block when rendering)
- 7b.3: hard-remove `/qurl send` (no grace period, no compat shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)