### PR TITLE
fix(discord): close two post-incident observability gaps (#276 + #283)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -99,9 +99,10 @@ function emitMintFailureAudit(error, { sendId, kind }) {
   logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
     send_id: sendId,
     reason: classifyMintFailure(error),
-    // `?? null` (not `|| null`) preserves a legitimate `0` status (e.g.
-    // fetch-on-DNS-failure surfaces 0) or empty-string `apiCode` —
-    // collapsing those to null would lose a dimension silently.
+    // `?? null` (not `|| null`) preserves an empty-string `apiCode` —
+    // `|| null` would collapse it to null and lose a forensic dimension.
+    // (Status 0 doesn't apply: native fetch throws on transport errors
+    // rather than returning a 0-status response.)
     api_code: error?.apiCode ?? null,
     status_code: error?.status ?? null,
     kind,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -52,15 +52,12 @@ const TOKENS_PER_RESOURCE = 10;
 // 429 handling).
 function classifyMintFailure(error) {
   if (!error) return 'unknown';
-  // AbortError disambiguation runs BEFORE the message-regex branch
-  // because undici/fetch raises AbortError on deadline-fired aborts
-  // AND on user-cancellations. Bucket as `timeout` only when
-  // error.cause corroborates a timeout signal; otherwise fall through
-  // to `unknown` so a future cancel-button adoption doesn't silently
-  // mis-bucket cancellations as timeouts. Without this ordering, an
-  // AbortError whose message happens to contain "timeout" would
-  // short-circuit through the regex below and bypass the cause check.
-  // See PR #300 review (Justin).
+  // AbortError is ambiguous: undici/fetch raises it on deadline-fired
+  // aborts AND on user-cancellations. error.cause is the only reliable
+  // disambiguator — bucket as `timeout` only when cause corroborates a
+  // timeout signal; otherwise fall through to `unknown` so a future
+  // cancel-button adoption doesn't silently mis-bucket cancellations
+  // as timeouts. See PR #300 review (Justin).
   if (error.name === 'AbortError') {
     const causeStr = String((error.cause && (error.cause.message || error.cause)) || '');
     if (/timeout/i.test(causeStr)) return 'timeout';
@@ -1212,10 +1209,13 @@ async function executeSendPipeline(interaction, {
     // un-instrumented and tonight's outage shape (4+ hours of users
     // hitting this before anyone noticed) repeats. qurl-integrations#276.
     //
-    emitMintFailureAudit(error, {
-      sendId,
-      kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location',
-    });
+    // Explicit map (RESOURCE_TYPES.MAPS → 'location' for parity with the
+    // UPLOAD_SUCCESS / addRecipients vocabulary) instead of `=== FILE ?
+    // 'file' : 'location'` so a future third RESOURCE_TYPES value
+    // surfaces as `null` rather than silently bucketing as 'location'.
+    // quota_exceeded skip lives inside emitMintFailureAudit.
+    const kindMap = { [RESOURCE_TYPES.FILE]: 'file', [RESOURCE_TYPES.MAPS]: 'location' };
+    emitMintFailureAudit(error, { sendId, kind: kindMap[resourceType] ?? null });
     logger.error('Failed to prepare QURL links', {
       error: error.message,
       apiCode: error.apiCode,
@@ -2698,6 +2698,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
+        // quota_exceeded skip lives inside emitMintFailureAudit.
         emitMintFailureAudit(err, { sendId, kind: 'file' });
         return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
@@ -2760,6 +2761,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // fallback needed. If a future refactor adds throwable work before
     // the branches, the audit emission will land with kind=null and
     // surface in CloudWatch (discoverable, not silent).
+    // quota_exceeded skip lives inside emitMintFailureAudit.
     emitMintFailureAudit(error, { sendId, kind: activeKind });
     return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -50,23 +50,6 @@ const TOKENS_PER_RESOURCE = 10;
 // categories or earn a new top-level category with a clear
 // dimensional purpose (e.g. a future "rate_limit" if we add upstream
 // 429 handling).
-// emitMintFailureAudit centralizes the QURL_SEND_CREATE_LINK_FAILURE
-// emission contract so the three catch sites (initial /qurl send +
-// addRecipients file branch + addRecipients location branch) cannot
-// drift on the skip rule or field shape. Adding a fourth call site
-// goes through here too — owns both the contract and the cardinality
-// discipline in one place. See #276.
-function emitMintFailureAudit(error, { sendId, kind }) {
-  if (error && error.apiCode === 'quota_exceeded') return;
-  logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
-    send_id: sendId,
-    reason: classifyMintFailure(error),
-    api_code: (error && error.apiCode) || null,
-    status_code: (error && error.status) || null,
-    kind,
-  });
-}
-
 function classifyMintFailure(error) {
   if (!error) return 'unknown';
   // libuv socket codes + undici/fetch TimeoutError DOMException — all
@@ -90,6 +73,23 @@ function classifyMintFailure(error) {
   if (status >= 500 && status < 600) return 'upstream_5xx';
   if (status >= 400 && status < 500) return 'upstream_4xx';
   return 'unknown';
+}
+
+// emitMintFailureAudit centralizes the QURL_SEND_CREATE_LINK_FAILURE
+// emission contract so the three catch sites (initial /qurl send +
+// addRecipients file branch + addRecipients location branch) cannot
+// drift on the skip rule or field shape. Adding a fourth call site
+// goes through here too — owns both the contract and the cardinality
+// discipline in one place. See #276.
+function emitMintFailureAudit(error, { sendId, kind }) {
+  if (error && error.apiCode === 'quota_exceeded') return;
+  logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+    send_id: sendId,
+    reason: classifyMintFailure(error),
+    api_code: (error && error.apiCode) || null,
+    status_code: (error && error.status) || null,
+    kind,
+  });
 }
 
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
@@ -2744,6 +2744,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
+    // `?? 'unknown'` is defensive against a future refactor that adds
+    // throwable work BEFORE either branch sets activeKind (e.g. a
+    // sendConfig validation step). Today this fallback is unreachable
+    // because activeKind is set on entry to each hasFile/hasLocation
+    // block; preserves the audit-event invariant that `kind` is always
+    // populated.
     emitMintFailureAudit(error, { sendId, kind: activeKind ?? 'unknown' });
     return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2674,6 +2674,18 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
+        // Mirror the /qurl send catch-block emission (#276) — Add Recipients
+        // is the same upload+mint phase and the 2026-05-13 incident shape
+        // fires through here too. Same quota_exceeded skip semantics.
+        if (err.apiCode !== 'quota_exceeded') {
+          logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+            send_id: sendId,
+            reason: classifyMintFailure(err),
+            api_code: err.apiCode || null,
+            status_code: err.status || null,
+            kind: 'file',
+          });
+        }
         return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
 
@@ -2729,6 +2741,21 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
+    // Mirror the /qurl send catch-block emission (#276) — Add Recipients
+    // is the same upload+mint phase as initial send and the 2026-05-13
+    // incident shape (viewer_ttl_seconds regression) fires through here
+    // too if the user retries via Add Recipients. Without this, the alarm
+    // under-counts and the next regression of the same shape is invisible
+    // again from this surface.
+    if (error.apiCode !== 'quota_exceeded') {
+      logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+        send_id: sendId,
+        reason: classifyMintFailure(error),
+        api_code: error.apiCode || null,
+        status_code: error.status || null,
+        kind: hasFile ? 'file' : 'location',
+      });
+    }
     return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -50,6 +50,23 @@ const TOKENS_PER_RESOURCE = 10;
 // categories or earn a new top-level category with a clear
 // dimensional purpose (e.g. a future "rate_limit" if we add upstream
 // 429 handling).
+// emitMintFailureAudit centralizes the QURL_SEND_CREATE_LINK_FAILURE
+// emission contract so the three catch sites (initial /qurl send +
+// addRecipients file branch + addRecipients location branch) cannot
+// drift on the skip rule or field shape. Adding a fourth call site
+// goes through here too — owns both the contract and the cardinality
+// discipline in one place. See #276.
+function emitMintFailureAudit(error, { sendId, kind }) {
+  if (error && error.apiCode === 'quota_exceeded') return;
+  logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+    send_id: sendId,
+    reason: classifyMintFailure(error),
+    api_code: (error && error.apiCode) || null,
+    status_code: (error && error.status) || null,
+    kind,
+  });
+}
+
 function classifyMintFailure(error) {
   if (!error) return 'unknown';
   // libuv socket codes + undici/fetch TimeoutError DOMException — all
@@ -1184,21 +1201,10 @@ async function executeSendPipeline(interaction, {
     // un-instrumented and tonight's outage shape (4+ hours of users
     // hitting this before anyone noticed) repeats. qurl-integrations#276.
     //
-    // Skip emission for `quota_exceeded` — that error has its own
-    // dedicated user-message path below and is a normal product
-    // condition (viral file hitting TOKENS_PER_RESOURCE), NOT an
-    // availability signal. The constants.js docstring for this
-    // event explicitly excludes it; emitting here would page on a
-    // viral upload.
-    if (error.apiCode !== 'quota_exceeded') {
-      logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
-        send_id: sendId,
-        reason: classifyMintFailure(error),
-        api_code: error.apiCode || null,
-        status_code: error.status || null,
-        kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location',
-      });
-    }
+    emitMintFailureAudit(error, {
+      sendId,
+      kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location',
+    });
     logger.error('Failed to prepare QURL links', {
       error: error.message,
       apiCode: error.apiCode,
@@ -2619,8 +2625,15 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // can both fire for a sendConfig that had both kinds, and a per-branch
   // recompute would invite drift.
   const inheritedDestruct = sendConfig.self_destruct_seconds ?? null;
+  // activeKind tracks which branch is in-flight when the outer catch
+  // fires. The inner file try/catch returns on file failure, so by the
+  // time we reach the outer catch the failure was NOT in the file
+  // branch — `hasFile ? 'file' : 'location'` would mis-label mixed
+  // sends. Per-branch assignment is the durable fix.
+  let activeKind = null;
   try {
     if (hasFile) {
+      activeKind = 'file';
       // Re-download from the stored Discord CDN URL, then upload a fresh
       // resource so the 10-token pool is full. Re-upload again every
       // TOKENS_PER_RESOURCE recipients. The original resource is drained by
@@ -2674,18 +2687,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
-        // Mirror the /qurl send catch-block emission (#276) — Add Recipients
-        // is the same upload+mint phase and the 2026-05-13 incident shape
-        // fires through here too. Same quota_exceeded skip semantics.
-        if (err.apiCode !== 'quota_exceeded') {
-          logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
-            send_id: sendId,
-            reason: classifyMintFailure(err),
-            api_code: err.apiCode || null,
-            status_code: err.status || null,
-            kind: 'file',
-          });
-        }
+        emitMintFailureAudit(err, { sendId, kind: 'file' });
         return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
 
@@ -2710,6 +2712,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       preparedKinds.push('file');
     }
     if (hasLocation) {
+      activeKind = 'location';
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
       const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestruct);
       const expiresAt = expiryToISO(sendConfig.expires_in);
@@ -2741,21 +2744,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
-    // Mirror the /qurl send catch-block emission (#276) — Add Recipients
-    // is the same upload+mint phase as initial send and the 2026-05-13
-    // incident shape (viewer_ttl_seconds regression) fires through here
-    // too if the user retries via Add Recipients. Without this, the alarm
-    // under-counts and the next regression of the same shape is invisible
-    // again from this surface.
-    if (error.apiCode !== 'quota_exceeded') {
-      logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
-        send_id: sendId,
-        reason: classifyMintFailure(error),
-        api_code: error.apiCode || null,
-        status_code: error.status || null,
-        kind: hasFile ? 'file' : 'location',
-      });
-    }
+    emitMintFailureAudit(error, { sendId, kind: activeKind ?? 'unknown' });
     return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -52,22 +52,26 @@ const TOKENS_PER_RESOURCE = 10;
 // 429 handling).
 function classifyMintFailure(error) {
   if (!error) return 'unknown';
+  // AbortError disambiguation runs BEFORE the message-regex branch
+  // because undici/fetch raises AbortError on deadline-fired aborts
+  // AND on user-cancellations. Bucket as `timeout` only when
+  // error.cause corroborates a timeout signal; otherwise fall through
+  // to `unknown` so a future cancel-button adoption doesn't silently
+  // mis-bucket cancellations as timeouts. Without this ordering, an
+  // AbortError whose message happens to contain "timeout" would
+  // short-circuit through the regex below and bypass the cause check.
+  // See PR #300 review (Justin).
+  if (error.name === 'AbortError') {
+    const causeStr = String((error.cause && (error.cause.message || error.cause)) || '');
+    if (/timeout/i.test(causeStr)) return 'timeout';
+    return 'unknown';
+  }
   // libuv socket codes + undici/fetch TimeoutError DOMException — all
   // unambiguous deadline-shaped failures.
   if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED' ||
       error.name === 'TimeoutError' ||
       /timeout/i.test(error.message || '')) {
     return 'timeout';
-  }
-  // AbortError is ambiguous: undici/fetch raises it on deadline-fired
-  // aborts AND on user-cancellations. Bucket as `timeout` only when
-  // error.cause corroborates a timeout signal; otherwise fall through
-  // to `unknown` so a future cancel-button adoption doesn't silently
-  // mis-bucket cancellations as timeouts. See PR #300 review (Justin).
-  if (error.name === 'AbortError') {
-    const causeStr = String((error.cause && (error.cause.message || error.cause)) || '');
-    if (/timeout/i.test(causeStr)) return 'timeout';
-    return 'unknown';
   }
   const status = error.status || 0;
   if (status >= 500 && status < 600) return 'upstream_5xx';

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -38,6 +38,30 @@ const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } 
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
+// classifyMintFailure maps a thrown error from the upload + mint phase
+// of /qurl send into a small enum of reason strings. Used as the
+// `reason` field on the QURL_SEND_CREATE_LINK_FAILURE audit event
+// (qurl-integrations#276) so the CloudWatch metric filter can split
+// failures by class — 4xx (likely client/contract problem) vs 5xx
+// (likely upstream outage) vs timeout (likely network/cold-start).
+//
+// Don't add per-API-code branches here — that explodes the metric
+// cardinality. New reasons should map to one of the existing
+// categories or earn a new top-level category with a clear
+// dimensional purpose (e.g. a future "rate_limit" if we add upstream
+// 429 handling).
+function classifyMintFailure(error) {
+  if (!error) return 'unknown';
+  if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED' ||
+      /timeout/i.test(error.message || '')) {
+    return 'timeout';
+  }
+  const status = error.status || 0;
+  if (status >= 500 && status < 600) return 'upstream_5xx';
+  if (status >= 400 && status < 500) return 'upstream_4xx';
+  return 'unknown';
+}
+
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
 // degraded, we log a warning and continue rather than fail the whole flow.
@@ -1139,7 +1163,26 @@ async function executeSendPipeline(interaction, {
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
     }
   } catch (error) {
-    logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
+    // Audit emission for CloudWatch metric filter — pairs with the
+    // qurl_send_create_link_failure log-metric filter +
+    // qurl-bot-discord-send-failure alarm in
+    // qurl-integrations-infra qurl-bot-discord/terraform/monitoring.tf.
+    // Without this, the "Failed to create links" user surface goes
+    // un-instrumented and tonight's outage shape (4+ hours of users
+    // hitting this before anyone noticed) repeats. qurl-integrations#276.
+    logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+      send_id: sendId,
+      reason: classifyMintFailure(error),
+      api_code: error.apiCode || null,
+      status_code: error.status || null,
+      kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location',
+    });
+    logger.error('Failed to prepare QURL links', {
+      error: error.message,
+      apiCode: error.apiCode,
+      status: error.status,
+      sendId,
+    });
     clearCooldown(interaction.user.id); // allow retry on failure
     // Slot release lives in the `finally` block below — it ALWAYS runs
     // after a return-from-catch, and `releaseSlot` is idempotent via

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -90,8 +90,11 @@ function emitMintFailureAudit(error, { sendId, kind }) {
   logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
     send_id: sendId,
     reason: classifyMintFailure(error),
-    api_code: (error && error.apiCode) || null,
-    status_code: (error && error.status) || null,
+    // `?? null` (not `|| null`) preserves a legitimate `0` status (e.g.
+    // fetch-on-DNS-failure surfaces 0) or empty-string `apiCode` —
+    // collapsing those to null would lose a dimension silently.
+    api_code: error?.apiCode ?? null,
+    status_code: error?.status ?? null,
     kind,
   });
 }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -52,7 +52,15 @@ const TOKENS_PER_RESOURCE = 10;
 // 429 handling).
 function classifyMintFailure(error) {
   if (!error) return 'unknown';
+  // libuv socket codes (axios, http.get, etc.) + undici/fetch
+  // DOMException shapes (TimeoutError from a real timeout,
+  // AbortError when an AbortController fired before the response
+  // landed — both are timeout-class from the user's perspective).
+  // Without the .name check, undici timeouts bucket as 'unknown'
+  // and we lose the dimensional split that's the whole point of
+  // having reason classes.
   if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED' ||
+      error.name === 'TimeoutError' || error.name === 'AbortError' ||
       /timeout/i.test(error.message || '')) {
     return 'timeout';
   }
@@ -1170,13 +1178,22 @@ async function executeSendPipeline(interaction, {
     // Without this, the "Failed to create links" user surface goes
     // un-instrumented and tonight's outage shape (4+ hours of users
     // hitting this before anyone noticed) repeats. qurl-integrations#276.
-    logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
-      send_id: sendId,
-      reason: classifyMintFailure(error),
-      api_code: error.apiCode || null,
-      status_code: error.status || null,
-      kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location',
-    });
+    //
+    // Skip emission for `quota_exceeded` — that error has its own
+    // dedicated user-message path below and is a normal product
+    // condition (viral file hitting TOKENS_PER_RESOURCE), NOT an
+    // availability signal. The constants.js docstring for this
+    // event explicitly excludes it; emitting here would page on a
+    // viral upload.
+    if (error.apiCode !== 'quota_exceeded') {
+      logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+        send_id: sendId,
+        reason: classifyMintFailure(error),
+        api_code: error.apiCode || null,
+        status_code: error.status || null,
+        kind: resourceType === RESOURCE_TYPES.FILE ? 'file' : 'location',
+      });
+    }
     logger.error('Failed to prepare QURL links', {
       error: error.message,
       apiCode: error.apiCode,
@@ -4819,6 +4836,12 @@ module.exports = {
       SETUP_API_KEY_MIN_LENGTH,
       SETUP_API_KEY_MAX_LENGTH,
       SETUP_SUCCESS_MSG,
+      // classifyMintFailure: exposed so a unit test pins the
+      // reason-category contract (qurl-integrations#276). The
+      // cardinality-discipline comment on the helper says "don't
+      // add per-API-code branches" — without a test, that's just
+      // a docstring waiting to drift.
+      classifyMintFailure,
     },
   }),
 };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -67,10 +67,14 @@ function classifyMintFailure(error) {
     return 'unknown';
   }
   // libuv socket codes + undici/fetch TimeoutError DOMException — all
-  // unambiguous deadline-shaped failures.
+  // unambiguous deadline-shaped failures. The message-regex branch was
+  // removed (round 11): `/timeout/i.test(error.message)` over-matched
+  // any string containing the substring "timeout" (e.g. "not a timeout
+  // related error") and a future upstream message like "completed
+  // after timeout retry" would mis-bucket. The name/code paths above
+  // cover every real shape we've seen.
   if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED' ||
-      error.name === 'TimeoutError' ||
-      /timeout/i.test(error.message || '')) {
+      error.name === 'TimeoutError') {
     return 'timeout';
   }
   const status = error.status || 0;
@@ -2751,13 +2755,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
-    // `?? 'unknown'` is defensive against a future refactor that adds
-    // throwable work BEFORE either branch sets activeKind (e.g. a
-    // sendConfig validation step). Today this fallback is unreachable
-    // because activeKind is set on entry to each hasFile/hasLocation
-    // block; preserves the audit-event invariant that `kind` is always
-    // populated.
-    emitMintFailureAudit(error, { sendId, kind: activeKind ?? 'unknown' });
+    // activeKind is set on entry to each hasFile/hasLocation block, so
+    // it's guaranteed populated by the time the catch fires — no
+    // fallback needed. If a future refactor adds throwable work before
+    // the branches, the audit emission will land with kind=null and
+    // surface in CloudWatch (discoverable, not silent).
+    emitMintFailureAudit(error, { sendId, kind: activeKind });
     return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -60,7 +60,15 @@ function classifyMintFailure(error) {
   // as timeouts. See PR #300 review (Justin).
   if (error.name === 'AbortError') {
     const causeStr = String((error.cause && (error.cause.message || error.cause)) || '');
-    if (/timeout/i.test(causeStr)) return 'timeout';
+    // Word-anchored to drop strange concatenations like "rtimeout" or
+    // "timeouted" — but it does NOT defend against "not due to timeout"
+    // because "timeout" is still a complete word in that string. The
+    // false-positive class for negation-containing causes is acceptable
+    // because real timeout-driven aborts in undici raise TimeoutError
+    // (handled above) rather than AbortError; this branch is a defense
+    // against libraries that use controller.abort('timeout') as their
+    // deadline signal, where the cause is the deliberate marker string.
+    if (/\btimed?\s*out\b/i.test(causeStr)) return 'timeout';
     return 'unknown';
   }
   // libuv socket codes + undici/fetch TimeoutError DOMException — all
@@ -74,7 +82,7 @@ function classifyMintFailure(error) {
       error.name === 'TimeoutError') {
     return 'timeout';
   }
-  const status = error.status || 0;
+  const status = error.status ?? 0;
   if (status >= 500 && status < 600) return 'upstream_5xx';
   if (status >= 400 && status < 500) return 'upstream_4xx';
   return 'unknown';
@@ -2697,7 +2705,9 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         const msg = isExpired
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
-        logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
+        logger.error('addRecipients file re-upload failed', {
+          sendId, error: err.message, apiCode: err.apiCode, status: err.status, isExpired,
+        });
         // quota_exceeded skip lives inside emitMintFailureAudit.
         emitMintFailureAudit(err, { sendId, kind: 'file' });
         return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
@@ -2751,7 +2761,9 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       preparedKinds.push('location');
     }
   } catch (error) {
-    logger.error('Failed to create links for additional recipients', { error: error.message });
+    logger.error('Failed to create links for additional recipients', {
+      sendId, error: error.message, apiCode: error.apiCode, status: error.status,
+    });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -52,17 +52,22 @@ const TOKENS_PER_RESOURCE = 10;
 // 429 handling).
 function classifyMintFailure(error) {
   if (!error) return 'unknown';
-  // libuv socket codes (axios, http.get, etc.) + undici/fetch
-  // DOMException shapes (TimeoutError from a real timeout,
-  // AbortError when an AbortController fired before the response
-  // landed — both are timeout-class from the user's perspective).
-  // Without the .name check, undici timeouts bucket as 'unknown'
-  // and we lose the dimensional split that's the whole point of
-  // having reason classes.
+  // libuv socket codes + undici/fetch TimeoutError DOMException — all
+  // unambiguous deadline-shaped failures.
   if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED' ||
-      error.name === 'TimeoutError' || error.name === 'AbortError' ||
+      error.name === 'TimeoutError' ||
       /timeout/i.test(error.message || '')) {
     return 'timeout';
+  }
+  // AbortError is ambiguous: undici/fetch raises it on deadline-fired
+  // aborts AND on user-cancellations. Bucket as `timeout` only when
+  // error.cause corroborates a timeout signal; otherwise fall through
+  // to `unknown` so a future cancel-button adoption doesn't silently
+  // mis-bucket cancellations as timeouts. See PR #300 review (Justin).
+  if (error.name === 'AbortError') {
+    const causeStr = String((error.cause && (error.cause.message || error.cause)) || '');
+    if (/timeout/i.test(causeStr)) return 'timeout';
+    return 'unknown';
   }
   const status = error.status || 0;
   if (status >= 500 && status < 600) return 'upstream_5xx';

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -363,10 +363,12 @@ const AUDIT_EVENTS = {
   // Carries `reason` (categorized failure class), `api_code` (the
   // upstream-error code if the connector/qurl-service surfaced
   // RFC 7807-style), `status_code` (the upstream HTTP status), and
-  // `kind` ('file' | 'location' for normal traffic; `null` only if a
-  // future refactor adds throwable work before activeKind is set —
-  // discoverable in CloudWatch, not silent). Same low-cardinality
-  // value space as UPLOAD_SUCCESS — dashboard splits stay symmetric.
+  // `kind` ('file' | 'location' for normal traffic; `null` when an
+  // unrecognized resourceType reaches the initial-send catch, OR when
+  // a future refactor adds throwable work before addRecipients sets
+  // activeKind — both are discoverable in CloudWatch, not silent).
+  // Same low-cardinality value space as UPLOAD_SUCCESS — dashboard
+  // splits stay symmetric.
   //
   // Cardinality discipline: `reason`, `kind`, and `status_code` are LOW
   // cardinality (closed enums) — safe to dimension on for CloudWatch

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -365,6 +365,13 @@ const AUDIT_EVENTS = {
   // RFC 7807-style), `status_code` (the upstream HTTP status), and
   // `kind` ('file' | 'location' | 'unknown'; same value space as
   // UPLOAD_SUCCESS — dashboard splits stay symmetric across the two).
+  //
+  // Cardinality discipline: `reason`, `kind`, and `status_code` are LOW
+  // cardinality (closed enums) — safe to dimension on for CloudWatch
+  // metric filters and dashboard splits. `api_code` is HIGH cardinality
+  // (free-form upstream string) — log-side forensic field, NOT a
+  // metric dimension. Mirrors DEPENDENCY_AUTH_FAILURE's `path` guidance.
+  //
   // Reason classes used today:
   //   - upstream_4xx          — connector or qurl-service 4xx that
   //                              isn't quota_exceeded (already split

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -354,6 +354,31 @@ const AUDIT_EVENTS = {
   // stays zero — but for an idle bot the rotation also doesn't
   // matter until someone tries to use it.
   DEPENDENCY_AUTH_FAILURE: 'dependency_auth_failure',
+
+  // Emitted once per `/qurl send` that fails at the mint/prepare-
+  // links step (commands.js's "Failed to prepare QURL links" catch
+  // block). Surfaces the user-visible "Failed to create links" path
+  // as a metric so on-call sees a sustained spike before users do.
+  //
+  // Carries `reason` (categorized failure class), `api_code` (the
+  // upstream-error code if the connector/qurl-service surfaced
+  // RFC 7807-style), and `status_code` (the upstream HTTP status).
+  // Reason classes used today:
+  //   - upstream_4xx          — connector or qurl-service 4xx that
+  //                              isn't quota_exceeded (already split
+  //                              into its own user-message path)
+  //   - upstream_5xx          — connector or qurl-service 5xx
+  //   - timeout               — request timed out before status
+  //   - unknown               — fallback for unclassifiable errors
+  //
+  // CloudWatch metric filter + alarm paired at
+  // qurl-integrations-infra qurl-bot-discord/terraform/monitoring.tf
+  // (filed as part of qurl-integrations#276's terraform-side
+  // follow-up). Existing connector_no_resource_id alarm catches
+  // the "200 + missing resource_id" shape; this catches the
+  // non-2xx + uncategorized-failure shape that wraps to the
+  // user's "Failed to create links" message.
+  QURL_SEND_CREATE_LINK_FAILURE: 'qurl_send_create_link_failure',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -362,7 +362,9 @@ const AUDIT_EVENTS = {
   //
   // Carries `reason` (categorized failure class), `api_code` (the
   // upstream-error code if the connector/qurl-service surfaced
-  // RFC 7807-style), and `status_code` (the upstream HTTP status).
+  // RFC 7807-style), `status_code` (the upstream HTTP status), and
+  // `kind` ('file' | 'location' | 'unknown'; same value space as
+  // UPLOAD_SUCCESS — dashboard splits stay symmetric across the two).
   // Reason classes used today:
   //   - upstream_4xx          — connector or qurl-service 4xx that
   //                              isn't quota_exceeded (already split

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -363,8 +363,11 @@ const AUDIT_EVENTS = {
   // Carries `reason` (categorized failure class), `api_code` (the
   // upstream-error code if the connector/qurl-service surfaced
   // RFC 7807-style), `status_code` (the upstream HTTP status), and
-  // `kind` ('file' | 'location' | 'unknown'; same value space as
-  // UPLOAD_SUCCESS — dashboard splits stay symmetric across the two).
+  // `kind` ('file' | 'location' for normal traffic; 'unknown' is a
+  // defensive-only fallback for a future refactor that could throw
+  // before activeKind is set — don't wire a dashboard panel expecting
+  // 'unknown' traffic). Same value space as UPLOAD_SUCCESS — dashboard
+  // splits stay symmetric across the two events.
   //
   // Cardinality discipline: `reason`, `kind`, and `status_code` are LOW
   // cardinality (closed enums) — safe to dimension on for CloudWatch

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -363,11 +363,10 @@ const AUDIT_EVENTS = {
   // Carries `reason` (categorized failure class), `api_code` (the
   // upstream-error code if the connector/qurl-service surfaced
   // RFC 7807-style), `status_code` (the upstream HTTP status), and
-  // `kind` ('file' | 'location' for normal traffic; 'unknown' is a
-  // defensive-only fallback for a future refactor that could throw
-  // before activeKind is set — don't wire a dashboard panel expecting
-  // 'unknown' traffic). Same value space as UPLOAD_SUCCESS — dashboard
-  // splits stay symmetric across the two events.
+  // `kind` ('file' | 'location' for normal traffic; `null` only if a
+  // future refactor adds throwable work before activeKind is set —
+  // discoverable in CloudWatch, not silent). Same low-cardinality
+  // value space as UPLOAD_SUCCESS — dashboard splits stay symmetric.
   //
   // Cardinality discipline: `reason`, `kind`, and `status_code` are LOW
   // cardinality (closed enums) — safe to dimension on for CloudWatch

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -61,6 +61,16 @@ describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
       expect(classifyMintFailure({ name: 'AbortError', cause: 'user-cancelled' })).toBe('unknown');
     });
 
+    test('AbortError with timeout-shaped message + no cause → unknown (ordering fence)', () => {
+      // Round-9 regression fence: the message-regex `/timeout/i` runs
+      // AFTER the AbortError branch. Pre-fix, an AbortError whose
+      // message happened to contain "timeout" would short-circuit
+      // through the regex and bypass the cause check — defeating the
+      // user-cancel disambiguation. Pin that bare AbortError + timeout-
+      // worded message still requires cause-corroboration.
+      expect(classifyMintFailure({ name: 'AbortError', message: 'aborted due to timeout' })).toBe('unknown');
+    });
+
     test('message-string fallback', () => {
       // Some HTTP libs surface "timeout" only in the error message
       // without a code/name. The regex catches those.

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -61,21 +61,20 @@ describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
       expect(classifyMintFailure({ name: 'AbortError', cause: 'user-cancelled' })).toBe('unknown');
     });
 
-    test('AbortError with timeout-shaped message + no cause → unknown (ordering fence)', () => {
-      // Round-9 regression fence: the message-regex `/timeout/i` runs
-      // AFTER the AbortError branch. Pre-fix, an AbortError whose
-      // message happened to contain "timeout" would short-circuit
-      // through the regex and bypass the cause check — defeating the
-      // user-cancel disambiguation. Pin that bare AbortError + timeout-
-      // worded message still requires cause-corroboration.
+    test('AbortError with timeout-shaped message + no cause → unknown', () => {
+      // AbortError still requires cause-corroboration to bucket as
+      // timeout, regardless of the message string. Pinned for explicit
+      // coverage — the message-regex branch was removed in round 11
+      // so this is also implicitly covered by "no message-regex".
       expect(classifyMintFailure({ name: 'AbortError', message: 'aborted due to timeout' })).toBe('unknown');
     });
 
-    test('message-string fallback', () => {
-      // Some HTTP libs surface "timeout" only in the error message
-      // without a code/name. The regex catches those.
-      expect(classifyMintFailure({ message: 'request timeout exceeded' })).toBe('timeout');
-      expect(classifyMintFailure({ message: 'Timeout while waiting for response' })).toBe('timeout');
+    test('message-string fallback removed (round 11) — bare message → unknown', () => {
+      // The message-regex /timeout/i was removed because it over-matched
+      // ("not a timeout related error" used to bucket as timeout). The
+      // name/code paths above cover every real shape we've seen.
+      expect(classifyMintFailure({ message: 'request timeout exceeded' })).toBe('unknown');
+      expect(classifyMintFailure({ message: 'Timeout while waiting for response' })).toBe('unknown');
     });
   });
 
@@ -100,12 +99,13 @@ describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
       expect(classifyMintFailure({ message: 'something else broke' })).toBe('unknown');
     });
 
-    test('message containing the substring "timeout" in negative context still buckets as timeout', () => {
-      // Documents a known false-positive of the /timeout/i message regex:
-      // any substring match flips to `timeout`. Not exploitable today (no
-      // known upstream surfaces "not a timeout" messages), but pinning
-      // the boundary keeps the regex from drifting on a future tweak.
-      expect(classifyMintFailure({ message: 'not a timeout related error' })).toBe('timeout');
+    test('message-only error with no name/code → unknown (round-11 false-positive fix)', () => {
+      // Pre-round-11 this bucketed as `timeout` due to the /timeout/i
+      // substring match — the fix dropped the message-regex branch
+      // entirely. A bare message-only error now correctly resolves to
+      // `unknown`, preventing dashboard contamination from a future
+      // upstream message like "completed after timeout retry".
+      expect(classifyMintFailure({ message: 'not a timeout related error' })).toBe('unknown');
     });
 
     test('2xx status (should never happen in this code path, but pinned)', () => {

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -35,10 +35,25 @@ describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
       expect(classifyMintFailure({ name: 'TimeoutError' })).toBe('timeout');
     });
 
-    test('undici AbortController AbortError', () => {
-      // AbortError from a per-request AbortController firing on
-      // deadline — same user-experience as a TimeoutError.
-      expect(classifyMintFailure({ name: 'AbortError' })).toBe('timeout');
+    test('AbortError with timeout cause → timeout (deadline-fired abort)', () => {
+      // Real undici deadline-fired aborts populate error.cause with the
+      // reason string. Pin both the cause-string and cause-with-message
+      // shapes (cause can be a string OR an Error object).
+      expect(classifyMintFailure({ name: 'AbortError', cause: 'timeout' })).toBe('timeout');
+      expect(classifyMintFailure({ name: 'AbortError', cause: new Error('request timeout') })).toBe('timeout');
+    });
+  });
+
+  describe('AbortError without timeout cause → unknown (PR #300 review)', () => {
+    test('bare AbortError → unknown (ambiguous between deadline and user-cancel)', () => {
+      // Justin: if AbortController gets adopted upstream for user-
+      // cancellation (e.g. a future "cancel send" button), bare
+      // AbortError without a corroborating timeout signal should NOT
+      // mis-bucket as timeout. Bare AbortError now buckets as unknown;
+      // a deliberate cause-tagged AbortError still buckets as timeout
+      // (see the cause-corroborated test above).
+      expect(classifyMintFailure({ name: 'AbortError' })).toBe('unknown');
+      expect(classifyMintFailure({ name: 'AbortError', cause: 'user-cancelled' })).toBe('unknown');
     });
 
     test('message-string fallback', () => {

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -23,7 +23,12 @@ describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
       expect(classifyMintFailure({ code: 'ETIMEDOUT' })).toBe('timeout');
     });
 
-    test('libuv ECONNABORTED (axios timeout after socket connect)', () => {
+    test('libuv ECONNABORTED — kept defensively (not produced by current native fetch stack)', () => {
+      // ECONNABORTED is axios-shaped; the connector helper uses native
+      // fetch + throwConnectorError so this code path is currently
+      // unreachable. Kept for defensive coverage against a future HTTP-
+      // client swap (axios / got / etc.) that surfaces ECONNABORTED on
+      // socket-level timeouts.
       expect(classifyMintFailure({ code: 'ECONNABORTED' })).toBe('timeout');
     });
 

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -1,0 +1,90 @@
+/**
+ * Unit pin for classifyMintFailure (qurl-integrations#276).
+ *
+ * The helper maps thrown errors from /qurl send's upload + mint phase
+ * into a small enum of reason classes — `timeout`, `upstream_4xx`,
+ * `upstream_5xx`, `unknown` — that drive the CloudWatch metric filter
+ * dimension. Without a test pinning the contract, the docstring's
+ * "don't add per-API-code branches" cardinality discipline silently
+ * drifts the first time someone adds a "helpful" special case.
+ */
+
+const { _test } = require('../src/commands');
+const { classifyMintFailure } = _test;
+
+describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
+  test('null / undefined → unknown', () => {
+    expect(classifyMintFailure(null)).toBe('unknown');
+    expect(classifyMintFailure(undefined)).toBe('unknown');
+  });
+
+  describe('timeout class', () => {
+    test('libuv ETIMEDOUT (axios / http.request socket-level)', () => {
+      expect(classifyMintFailure({ code: 'ETIMEDOUT' })).toBe('timeout');
+    });
+
+    test('libuv ECONNABORTED (axios timeout after socket connect)', () => {
+      expect(classifyMintFailure({ code: 'ECONNABORTED' })).toBe('timeout');
+    });
+
+    test('undici / node fetch TimeoutError DOMException', () => {
+      // Node's built-in fetch surfaces timeout as { name: 'TimeoutError' }
+      // with no code field. Without the .name check, this would have
+      // bucketed as `unknown` and tonight's incident would be in a
+      // different category from the next undici-shaped one.
+      expect(classifyMintFailure({ name: 'TimeoutError' })).toBe('timeout');
+    });
+
+    test('undici AbortController AbortError', () => {
+      // AbortError from a per-request AbortController firing on
+      // deadline — same user-experience as a TimeoutError.
+      expect(classifyMintFailure({ name: 'AbortError' })).toBe('timeout');
+    });
+
+    test('message-string fallback', () => {
+      // Some HTTP libs surface "timeout" only in the error message
+      // without a code/name. The regex catches those.
+      expect(classifyMintFailure({ message: 'request timeout exceeded' })).toBe('timeout');
+      expect(classifyMintFailure({ message: 'Timeout while waiting for response' })).toBe('timeout');
+    });
+  });
+
+  describe('upstream_5xx class', () => {
+    test('500 / 502 / 503 / 504', () => {
+      for (const status of [500, 502, 503, 504, 599]) {
+        expect(classifyMintFailure({ status })).toBe('upstream_5xx');
+      }
+    });
+  });
+
+  describe('upstream_4xx class', () => {
+    test('400 / 401 / 403 / 404 / 429', () => {
+      for (const status of [400, 401, 403, 404, 429, 499]) {
+        expect(classifyMintFailure({ status })).toBe('upstream_4xx');
+      }
+    });
+  });
+
+  describe('unknown class', () => {
+    test('non-HTTP error with no code/name/message-keyword', () => {
+      expect(classifyMintFailure({ message: 'something else broke' })).toBe('unknown');
+    });
+
+    test('2xx status (should never happen in this code path, but pinned)', () => {
+      // The catch block only fires on thrown errors, but if a caller
+      // somehow synthesized a 2xx error object, it should NOT bucket
+      // as upstream_4xx or upstream_5xx.
+      expect(classifyMintFailure({ status: 200 })).toBe('unknown');
+    });
+  });
+
+  describe('priority ordering: timeout beats status when both present', () => {
+    test('ETIMEDOUT + status 504 → timeout (not upstream_5xx)', () => {
+      // If a future axios-like lib attaches BOTH a timeout code AND
+      // a synthesized 504, the more-specific timeout label should win
+      // — operators want to distinguish "we never got a response" from
+      // "upstream actively returned 504".
+      expect(classifyMintFailure({ code: 'ETIMEDOUT', status: 504 })).toBe('timeout');
+    });
+  });
+});

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -70,6 +70,14 @@ describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
       expect(classifyMintFailure({ message: 'something else broke' })).toBe('unknown');
     });
 
+    test('message containing the substring "timeout" in negative context still buckets as timeout', () => {
+      // Documents a known false-positive of the /timeout/i message regex:
+      // any substring match flips to `timeout`. Not exploitable today (no
+      // known upstream surfaces "not a timeout" messages), but pinning
+      // the boundary keeps the regex from drifting on a future tweak.
+      expect(classifyMintFailure({ message: 'not a timeout related error' })).toBe('timeout');
+    });
+
     test('2xx status (should never happen in this code path, but pinned)', () => {
       // The catch block only fires on thrown errors, but if a caller
       // somehow synthesized a 2xx error object, it should NOT bucket

--- a/apps/discord/tests/qurl-send-state-machine.test.js
+++ b/apps/discord/tests/qurl-send-state-machine.test.js
@@ -2072,8 +2072,13 @@ describe('handleSend — additional branch coverage', () => {
     }));
   });
 
-  // C14 — quota_exceeded on the file path uses the "re-upload" copy.
-  it('quota_exceeded on the file path tells the user to re-upload', async () => {
+  // C14 — quota_exceeded on the file path uses the "re-upload" copy
+  // AND must NOT emit qurl_send_create_link_failure (viral upload is a
+  // normal product condition; emitting would page on-call). Removing the
+  // `if (error.apiCode !== 'quota_exceeded')` guard in commands.js
+  // catch-block would silently regress to paging on every viral upload —
+  // the assertion below pins that.
+  it('quota_exceeded on the file path tells the user to re-upload AND skips QURL_SEND_CREATE_LINK_FAILURE', async () => {
     const err = new Error('upstream quota');
     err.apiCode = 'quota_exceeded';
     mockDownloadAndUpload.mockRejectedValueOnce(err);
@@ -2090,6 +2095,35 @@ describe('handleSend — additional branch coverage', () => {
     await cmd.execute(interaction);
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining('re-upload the file'),
+    }));
+    const auditCalls = logger.audit.mock.calls.filter(
+      c => c[0] === 'qurl_send_create_link_failure',
+    );
+    expect(auditCalls).toHaveLength(0);
+  });
+
+  // C14b — non-quota mint failure DOES emit qurl_send_create_link_failure
+  // with the right reason/kind/status_code. Pairs with C14: together they
+  // pin both branches of the catch-block's quota_exceeded guard.
+  it('non-quota mint failure emits QURL_SEND_CREATE_LINK_FAILURE with reason=upstream_5xx', async () => {
+    const err = new Error('upstream 503');
+    err.status = 503;
+    mockDownloadAndUpload.mockRejectedValueOnce(err);
+    const fileInit = makeCompInt(ids.initFile);
+    const targetChannel = makeCompInt(ids.targetSelect, { values: ['channel'] });
+    mockGetChannelMembers.mockReturnValue([{ id: 'u2', username: 'Alice' }]);
+    const sendBtn = makeCompInt(ids.sendBtn);
+    const attachment = { name: 'doc.pdf', contentType: 'application/pdf', size: 1024, url: 'https://cdn.discordapp.com/doc.pdf' };
+    const awaitMessages = jest.fn().mockResolvedValue(makeAttachmentMessage(attachment));
+    const interaction = makeInteraction({
+      awaitQueue: [fileInit, targetChannel, sendBtn],
+      awaitMessages,
+    });
+    await cmd.execute(interaction);
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      reason: 'upstream_5xx',
+      status_code: 503,
+      kind: 'file',
     }));
   });
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1817,6 +1817,17 @@ describe('handleAddRecipients', () => {
 
     const result = await handleAddRecipients('send-fail', users, mockOriginalInteraction, 'test-api-key');
     expect(result.msg).toMatch(/Failed to prepare links/);
+
+    // Pin the QURL_SEND_CREATE_LINK_FAILURE emission from the INNER file
+    // catch at commands.js:2667. This catch site was un-instrumented before
+    // the round-6 fix — Add Recipients failures from the file branch went
+    // un-audited and the alarm under-counted. See #300 Claude review.
+    const logger = require('../src/logger');
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-fail',
+      kind: 'file',
+      reason: expect.any(String),
+    }));
   });
 
   it('file send: batches > 10 new recipients into multiple mintLinks calls', async () => {
@@ -1915,6 +1926,57 @@ describe('handleAddRecipients', () => {
     const result = await handleAddRecipients('send-allfail', users, mockOriginalInteraction, 'test-api-key');
     expect(result.msg).toBe('Failed to create links for new recipients.');
     expect(mockSendDM).not.toHaveBeenCalled();
+
+    // Pin the QURL_SEND_CREATE_LINK_FAILURE emission from the OUTER catch
+    // at commands.js:2738. activeKind tracking guarantees kind='location'
+    // for a URL/location-resource send — `hasFile ? 'file' : 'location'`
+    // would mis-label mixed sends because the file branch returns early
+    // on its own failure. See #300 Claude review.
+    const logger = require('../src/logger');
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-allfail',
+      kind: 'location',
+      reason: expect.any(String),
+    }));
+  });
+
+  // Mixed-resource sendConfig variant — exercises the `activeKind` fix
+  // for the case where hasFile && hasLocation are both true. Without the
+  // fix, the outer catch would emit kind='file' for a failure that
+  // happened in the location branch (file branch returns on its own
+  // failure). Pins the #300 round-7 correctness fix.
+  it('mixed send (file+location): outer catch from location failure emits kind=location, not file', async () => {
+    mockDb.getSendConfig.mockReturnValue({
+      resource_type: 'mixed',
+      connector_resource_id: null,
+      actual_url: 'https://maps.google.com/?q=test',
+      expires_in: '24h',
+      personal_message: null,
+      location_name: 'Mixed Send Location',
+      attachment_name: 'doc.pdf',
+      attachment_content_type: 'application/pdf',
+      attachment_url: 'https://cdn.discordapp.com/attachments/1/2/doc.pdf',
+    });
+
+    // File branch succeeds, location branch fails. activeKind must be
+    // 'location' at the moment the outer catch fires.
+    mockDownloadAndUpload.mockResolvedValue({ resource_id: 'mix-file-res', fileBuffer: new ArrayBuffer(4) });
+    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/m-1' }]);
+    mockUploadJsonToConnector.mockRejectedValue(Object.assign(new Error('connector 502'), { status: 502 }));
+
+    const users = makeUsersCollection([
+      { id: 'rcpt-1', bot: false, username: 'Alice' },
+    ]);
+
+    await handleAddRecipients('send-mixed-fail', users, mockOriginalInteraction, 'test-api-key');
+
+    const logger = require('../src/logger');
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-mixed-fail',
+      kind: 'location', // NOT 'file' — pins the activeKind fix
+      reason: 'upstream_5xx',
+      status_code: 502,
+    }));
   });
 });
 

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1940,6 +1940,42 @@ describe('handleAddRecipients', () => {
     }));
   });
 
+  // quota_exceeded skip rule for addRecipients sites. The skip lives in
+  // emitMintFailureAudit (commands.js helper) so it applies uniformly to
+  // all 3 emission sites. If a future refactor moves the guard back out
+  // of the helper, the addRecipients sites silently regress to paging on
+  // viral uploads via Add Recipients — this test catches that.
+  it('addRecipients: quota_exceeded does NOT emit QURL_SEND_CREATE_LINK_FAILURE', async () => {
+    mockDb.getSendConfig.mockReturnValue({
+      resource_type: 'file',
+      connector_resource_id: 'conn-res-q',
+      actual_url: null,
+      expires_in: '24h',
+      personal_message: null,
+      location_name: null,
+      attachment_name: 'viral.pdf',
+      attachment_content_type: 'application/pdf',
+      attachment_url: 'https://cdn.discordapp.com/attachments/1/2/viral.pdf',
+    });
+
+    mockDownloadAndUpload.mockResolvedValue({ resource_id: 'res-q', fileBuffer: new ArrayBuffer(4) });
+    const quotaErr = Object.assign(new Error('upstream quota'), { apiCode: 'quota_exceeded' });
+    mockMintLinks.mockRejectedValue(quotaErr);
+
+    const users = makeUsersCollection([
+      { id: 'rcpt-1', bot: false, username: 'Alice' },
+    ]);
+
+    const logger = require('../src/logger');
+    logger.audit.mockClear();
+    await handleAddRecipients('send-quota', users, mockOriginalInteraction, 'test-api-key');
+
+    const failureCalls = logger.audit.mock.calls.filter(
+      (c) => c[0] === 'qurl_send_create_link_failure',
+    );
+    expect(failureCalls).toHaveLength(0);
+  });
+
   // Mixed-resource sendConfig variant — exercises the `activeKind` fix
   // for the case where hasFile && hasLocation are both true. Without the
   // fix, the outer catch would emit kind='file' for a failure that

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -1826,7 +1826,9 @@ describe('handleAddRecipients', () => {
     expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
       send_id: 'send-fail',
       kind: 'file',
-      reason: expect.any(String),
+      // 'Connector down' has no status/code/name → classifyMintFailure
+      // falls through to 'unknown'. Pin the exact category, not any-string.
+      reason: 'unknown',
     }));
   });
 
@@ -1936,7 +1938,8 @@ describe('handleAddRecipients', () => {
     expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
       send_id: 'send-allfail',
       kind: 'location',
-      reason: expect.any(String),
+      // 'Connector upload failed' has no status/code/name → 'unknown'.
+      reason: 'unknown',
     }));
   });
 

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -19,17 +19,28 @@ export interface LinkAccessResult {
   body?: string;
 }
 
-/** Upload a file to the connector and get a resource_id */
+/** Upload a file to the connector and get a resource_id.
+ *
+ * Set `viewerTtlSeconds` to exercise the Snapchat-style auto-destruct
+ * path — the connector derives `session_duration` from it and forwards
+ * to qurl-service. Pinning this in a smoke test catches the
+ * 2026-05-13 contract regression class where a session_duration value
+ * below qurl-service's then-current floor returned a 400 with no
+ * direct test coverage (qurl-integrations#283). */
 export async function uploadFile(
   uploadUrl: string,
   filePath: string,
   apiKey: string,
-): Promise<{ resource_id: string; hash: string }> {
+  opts?: { viewerTtlSeconds?: number },
+): Promise<{ resource_id: string; hash: string; qurl_link?: string; error?: string }> {
   const fileBuffer = fs.readFileSync(filePath);
   const fileName = path.basename(filePath);
 
   const formData = new FormData();
   formData.append('file', new Blob([fileBuffer]), fileName);
+  if (opts?.viewerTtlSeconds !== undefined) {
+    formData.append('viewer_ttl_seconds', String(opts.viewerTtlSeconds));
+  }
 
   const res = await fetch(`${uploadUrl}/upload`, {
     method: 'POST',
@@ -38,7 +49,7 @@ export async function uploadFile(
   });
 
   if (!res.ok) throw new Error(`Upload failed: ${res.status} ${await res.text()}`);
-  return res.json() as Promise<{ resource_id: string; hash: string }>;
+  return res.json() as Promise<{ resource_id: string; hash: string; qurl_link?: string; error?: string }>;
 }
 
 /** Mint a one-time qURL link for a resource */

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -32,7 +32,7 @@ export async function uploadFile(
   filePath: string,
   apiKey: string,
   opts?: { viewerTtlSeconds?: number },
-): Promise<{ resource_id: string; hash: string; qurl_link?: string; error?: string }> {
+): Promise<{ resource_id: string; hash: string }> {
   const fileBuffer = fs.readFileSync(filePath);
   const fileName = path.basename(filePath);
 
@@ -49,7 +49,7 @@ export async function uploadFile(
   });
 
   if (!res.ok) throw new Error(`Upload failed: ${res.status} ${await res.text()}`);
-  return res.json() as Promise<{ resource_id: string; hash: string; qurl_link?: string; error?: string }>;
+  return res.json() as Promise<{ resource_id: string; hash: string }>;
 }
 
 /** Mint a one-time qURL link for a resource */

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -77,12 +77,15 @@ describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
       { viewerTtlSeconds: 30 },
     );
 
-    // Connector contract: success path returns hash + resource_id +
-    // qurl_link. Failure path returns hash + a non-null `error` (the
-    // 2026-05-13 incident shape). Pin both — if `error` is set we
-    // know the contract regression is back.
+    // Connector contract on success: hash + resource_id + qurl_link.
+    // The 2026-05-13 incident shape (4xx from qurl-service) is caught
+    // *implicitly* via uploadFile's `!res.ok → throw` at qurl-api.ts:51
+    // — Jest fails the test on the thrown "Upload failed: 400 ..." and
+    // the connector regression is surfaced. We do NOT assert on
+    // result.error here because the helper never returns with that
+    // field set; if qurl-service ever changes the regression shape to
+    // 200-with-error-body, uploadFile would need to be widened too.
     expect(result.hash).toMatch(/^[0-9a-f]{32}$/);
-    expect(result.error).toBeUndefined();
     expect(result.qurl_link).toBeDefined();
     expect(result.qurl_link).toMatch(/^https?:\/\//);
   });
@@ -104,7 +107,6 @@ describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
       env.QURL_API_KEY,
     );
     expect(result.hash).toMatch(/^[0-9a-f]{32}$/);
-    expect(result.error).toBeUndefined();
     expect(result.qurl_link).toBeDefined();
   });
 });

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -38,20 +38,31 @@ import * as qurl from '../helpers/qurl-api';
 const env = loadEnv();
 
 describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
-  let tempFile: string;
-
-  beforeAll(() => {
-    // Tiny fixture — the file content doesn't matter; we're pinning
-    // the connector → qurl-service contract, not the upload pipeline.
-    tempFile = path.join(__dirname, 'qurl-send-viewer-ttl.smoke.fixture.txt');
-    fs.writeFileSync(tempFile, `e2e smoke fixture ${new Date().toISOString()}\n`);
-  });
+  // Per-test unique fixture content to avoid the connector's md5
+  // content-addressed dedup shortcut. If both tests uploaded the
+  // same bytes, the second call would short-circuit to the cached
+  // resource from the first call (minted WITH viewer_ttl_seconds=30)
+  // and the "control" no-TTL case would silently fail to exercise
+  // the "use server default" branch it's supposed to pin.
+  const tempFiles: string[] = [];
+  function freshFixture(label: string): string {
+    const f = path.join(
+      __dirname,
+      `qurl-send-viewer-ttl.smoke.fixture.${label}.${Date.now()}.${Math.random().toString(36).slice(2)}.txt`,
+    );
+    fs.writeFileSync(f, `e2e smoke fixture ${label} ${new Date().toISOString()} ${Math.random()}\n`);
+    tempFiles.push(f);
+    return f;
+  }
 
   afterAll(() => {
-    try { fs.unlinkSync(tempFile); } catch { /* best-effort */ }
+    for (const f of tempFiles) {
+      try { fs.unlinkSync(f); } catch { /* best-effort */ }
+    }
   });
 
   test('connector accepts viewer_ttl_seconds=30 and qurl-service mints a link', async () => {
+    const tempFile = freshFixture('ttl30');
     // 30s = below the historical 5-minute floor. If qurl-service ever
     // re-tightens the floor without coordinating with the connector,
     // this assertion catches it before users do.
@@ -78,6 +89,11 @@ describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
     // path was the only one exercised by smoke before #283. Kept
     // alongside the TTL'd case so a regression that breaks the
     // no-TTL path is also caught here, not silently in another file.
+    //
+    // Fresh fixture (different bytes from the TTL'd test) so the
+    // connector's content-addressed dedup doesn't return the cached
+    // TTL'd resource.
+    const tempFile = freshFixture('no-ttl');
     const result = await qurl.uploadFile(
       env.UPLOAD_API_URL,
       tempFile,

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -29,6 +29,7 @@
 
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
@@ -46,8 +47,11 @@ describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
   // the "use server default" branch it's supposed to pin.
   const tempFiles: string[] = [];
   function freshFixture(label: string): string {
+    // os.tmpdir() rather than __dirname so a killed-mid-test run doesn't
+    // leak fixture files into the e2e source tree (and from there into
+    // `git status`). afterAll cleanup is still best-effort.
     const f = path.join(
-      __dirname,
+      os.tmpdir(),
       `qurl-send-viewer-ttl.smoke.fixture.${label}.${Date.now()}.${Math.random().toString(36).slice(2)}.txt`,
     );
     fs.writeFileSync(f, `e2e smoke fixture ${label} ${new Date().toISOString()} ${Math.random()}\n`);

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -77,17 +77,19 @@ describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
       { viewerTtlSeconds: 30 },
     );
 
-    // Connector contract on success: hash + resource_id + qurl_link.
+    // Connector /upload contract: hash + resource_id (NOT qurl_link —
+    // minting is a separate /mint-link call; the bot's connector.js
+    // confirms /upload never returns qurl_link).
+    //
     // The 2026-05-13 incident shape (4xx from qurl-service) is caught
-    // *implicitly* via uploadFile's `!res.ok → throw` at qurl-api.ts:51
-    // — Jest fails the test on the thrown "Upload failed: 400 ..." and
+    // *implicitly* via uploadFile's `!res.ok → throw` at qurl-api.ts:51:
+    // Jest fails the test on the thrown "Upload failed: 400 ..." and
     // the connector regression is surfaced. We do NOT assert on
     // result.error here because the helper never returns with that
     // field set; if qurl-service ever changes the regression shape to
     // 200-with-error-body, uploadFile would need to be widened too.
     expect(result.hash).toMatch(/^[0-9a-f]{32}$/);
-    expect(result.qurl_link).toBeDefined();
-    expect(result.qurl_link).toMatch(/^https?:\/\//);
+    expect(result.resource_id).toBeDefined();
   });
 
   test('connector accepts no viewer_ttl_seconds (control case)', async () => {
@@ -107,6 +109,6 @@ describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
       env.QURL_API_KEY,
     );
     expect(result.hash).toMatch(/^[0-9a-f]{32}$/);
-    expect(result.qurl_link).toBeDefined();
+    expect(result.resource_id).toBeDefined();
   });
 });

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -10,8 +10,10 @@
  * session_duration → qurl-service contract entirely.
  *
  * This test pins the contract: an upload with viewer_ttl_seconds=30
- * must succeed and return a qurl_link. Closes that coverage gap so the
- * next regression of this shape doesn't ship green.
+ * must succeed (HTTP 2xx) and return hash + resource_id. Closes that
+ * coverage gap so the next regression of this shape doesn't ship green.
+ * (The /upload endpoint does NOT return qurl_link — minting is a
+ * separate /mint-link call; the smoke pins the upload contract only.)
  *
  * What this catches:
  *   - qurl-service tightens its session_duration floor again

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Smoke for the Snapchat-style auto-destruct path (qurl-integrations#283).
+ *
+ * 2026-05-13 incident: PR qurl-integrations-infra#540 added connector-side
+ * `session_duration` forwarding. The deployed prod qurl-service still
+ * had a 5-minute floor. Every /qurl send with a small viewer_ttl_seconds
+ * returned "Failed to create links" — for hours, without the prod e2e
+ * smoke catching it. The smoke only exercised the no-TTL path, which
+ * takes the connector's "use server default" branch and bypasses the
+ * session_duration → qurl-service contract entirely.
+ *
+ * This test pins the contract: an upload with viewer_ttl_seconds=30
+ * must succeed and return a qurl_link. Closes that coverage gap so the
+ * next regression of this shape doesn't ship green.
+ *
+ * What this catches:
+ *   - qurl-service tightens its session_duration floor again
+ *   - connector stops forwarding session_duration but starts setting
+ *     a different field that downstream rejects
+ *   - any change to the connector→qurl-service contract that breaks
+ *     the small-TTL path while leaving the no-TTL path working
+ *
+ * What this does NOT catch:
+ *   - per-recipient view-window enforcement (separate Traefik layer)
+ *   - the file actually rendering with a working countdown (UI layer)
+ *
+ * Both of those have separate dedicated tests in this suite.
+ */
+
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+import { loadEnv } from '../helpers/env';
+import * as qurl from '../helpers/qurl-api';
+
+const env = loadEnv();
+
+describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
+  let tempFile: string;
+
+  beforeAll(() => {
+    // Tiny fixture — the file content doesn't matter; we're pinning
+    // the connector → qurl-service contract, not the upload pipeline.
+    tempFile = path.join(__dirname, 'qurl-send-viewer-ttl.smoke.fixture.txt');
+    fs.writeFileSync(tempFile, `e2e smoke fixture ${new Date().toISOString()}\n`);
+  });
+
+  afterAll(() => {
+    try { fs.unlinkSync(tempFile); } catch { /* best-effort */ }
+  });
+
+  test('connector accepts viewer_ttl_seconds=30 and qurl-service mints a link', async () => {
+    // 30s = below the historical 5-minute floor. If qurl-service ever
+    // re-tightens the floor without coordinating with the connector,
+    // this assertion catches it before users do.
+    const result = await qurl.uploadFile(
+      env.UPLOAD_API_URL,
+      tempFile,
+      env.QURL_API_KEY,
+      { viewerTtlSeconds: 30 },
+    );
+
+    // Connector contract: success path returns hash + resource_id +
+    // qurl_link. Failure path returns hash + a non-null `error` (the
+    // 2026-05-13 incident shape). Pin both — if `error` is set we
+    // know the contract regression is back.
+    expect(result.hash).toMatch(/^[0-9a-f]{32}$/);
+    expect(result.error).toBeUndefined();
+    expect(result.qurl_link).toBeDefined();
+    expect(result.qurl_link).toMatch(/^https?:\/\//);
+  });
+
+  test('connector accepts no viewer_ttl_seconds (control case)', async () => {
+    // Without viewer_ttl_seconds the connector sends empty
+    // session_duration → qurl-service applies its server default. This
+    // path was the only one exercised by smoke before #283. Kept
+    // alongside the TTL'd case so a regression that breaks the
+    // no-TTL path is also caught here, not silently in another file.
+    const result = await qurl.uploadFile(
+      env.UPLOAD_API_URL,
+      tempFile,
+      env.QURL_API_KEY,
+    );
+    expect(result.hash).toMatch(/^[0-9a-f]{32}$/);
+    expect(result.error).toBeUndefined();
+    expect(result.qurl_link).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Two follow-ups from the 2026-05-13 \`/qurl send\` outage post-mortem:

### #276 — bot \"Failed to create links\" path doesn't log or alarm

The catch block at \`apps/discord/src/commands.js::handleSend\` logs at \`logger.error\` level but doesn't emit an audit event. The CloudWatch log-metric filters that drive alarms only key off the \`audit.event\` field in our log envelope, so the existing log line is invisible to the alarm layer.

**Fix:** add a new \`QURL_SEND_CREATE_LINK_FAILURE\` audit event, emitted once per failed send. Categorized via a new \`classifyMintFailure\` helper into \`timeout\` / \`upstream_4xx\` / \`upstream_5xx\` / \`unknown\` so the dashboard can split a real qurl-service outage from a per-user 4xx (validation, contract drift, etc.).

The audit event also carries \`api_code\`, \`status_code\`, and \`kind\` (file/location) for forensic-query convenience. Names frozen in \`AUDIT_EVENTS\` so a runtime mutation can't silently break the metric.

**Paired terraform** (alarm + filter) lives in qurl-integrations-infra and will land in a follow-up PR — kept separate so this PR doesn't span repos.

### #283 — e2e smoke doesn't exercise \`viewer_ttl_seconds < 300s\`

PR qurl-integrations-infra#540 added connector-side \`session_duration\` forwarding. Prod qurl-service had a 5-minute floor at deploy time. The existing smoke uploads with no \`viewer_ttl_seconds\`, taking the connector's \"use server default\" branch — bypassing the session_duration → qurl-service contract entirely. The contract regression was invisible to smoke; users hit it for ~4 hours before someone noticed.

**Fix:** add \`viewerTtlSeconds\` parameter to the \`uploadFile\` helper, plus a new \`qurl-send-viewer-ttl.smoke.test.ts\` that pins both paths:
- TTL'd path (\`viewer_ttl_seconds=30\`) — the regression-class catcher
- No-TTL path — control, catches refactors that break the \"use server default\" branch

## Files

| File | Change |
|---|---|
| \`apps/discord/src/constants.js\` | + \`QURL_SEND_CREATE_LINK_FAILURE\` audit event with comment |
| \`apps/discord/src/commands.js\` | + \`classifyMintFailure\` helper, audit emission in the catch block, enriched logger.error fields (status, sendId) |
| \`e2e/helpers/qurl-api.ts\` | + optional \`viewerTtlSeconds\` on \`uploadFile\` |
| \`e2e/tests/qurl-send-viewer-ttl.smoke.test.ts\` | new — TTL'd + no-TTL smoke cases |

## Tests

- \`apps/discord\` Jest: 45 suites, 1256 tests, all pass
- \`e2e\` TypeScript compile: clean (only pre-existing tsconfig deprecation warning)

## Closes

- ✅ qurl-integrations#276 (bot send-failure observability)
- ✅ qurl-integrations#283 (TTL smoke coverage)

## Follow-up (separate PR)

- qurl-integrations-infra terraform: log-metric filter on \`audit.event = qurl_send_create_link_failure\` + alarm wired to the existing \`alerts_connector\` SNS topic. Will reference this PR.