### PR TITLE
feat(discord): add /qurl file + /qurl map slash commands (7b.2)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3882,6 +3882,14 @@ async function handleQurlSlashSend(interaction, params) {
   // that never produced a visible response. Every known failure
   // mode below has its own targeted clearCooldown + ephemeral
   // editReply; this catch is the safety net for everything else.
+  //
+  // Hoisted out of the try: `flow_id` (deterministic from the
+  // interaction id) and `orphanFlowCreated` (flipped true ONLY after
+  // supersedeOrCreate.created === true) so the catch can tell whether
+  // a throw between supersedeOrCreate success and the final editReply
+  // left an orphan DDB row that needs cleaning up.
+  let flow_id;
+  let orphanFlowCreated = false;
   try {
     await interaction.deferReply({ ephemeral: true });
 
@@ -3988,7 +3996,7 @@ async function handleQurlSlashSend(interaction, params) {
     // case — sibling-flow disambig surfaces a stage-specific message;
     // same-stage rerun atomically claims the slot. Mirrors /qurl
     // revoke's pattern.
-    const flow_id = flowIdForInteraction(interaction);
+    flow_id = flowIdForInteraction(interaction);
     const sendNonce = crypto.randomBytes(8).toString('hex');
     const payload = {
       resourceType: params.resourceType,
@@ -4026,6 +4034,10 @@ async function handleQurlSlashSend(interaction, params) {
         content: siblingMsg || '❌ Could not start a send — please try again.',
       });
     }
+    // We own the row from here on — a throw before the final editReply
+    // would orphan it. The catch below uses this flag to fire a
+    // best-effort version-checked deleteFlow.
+    orphanFlowCreated = true;
 
     const content = renderConfirmCardContent({
       resourceType: params.resourceType,
@@ -4042,7 +4054,12 @@ async function handleQurlSlashSend(interaction, params) {
       attachPicker: needsPicker,
       sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
     });
-    return interaction.editReply({ content, components: rows });
+    // `return await` (not bare `return`) is load-bearing: without it
+    // a Discord-side rejection on the confirm-card delivery would
+    // bypass the outer catch entirely, leaving the user with a set
+    // cooldown AND an orphan flow row from the supersedeOrCreate
+    // we just landed.
+    return await interaction.editReply({ content, components: rows });
   } catch (err) {
     // Unanticipated throw. Always clear cooldown — the user got no
     // visible response, so they must not be locked out for the full
@@ -4054,8 +4071,26 @@ async function handleQurlSlashSend(interaction, params) {
     // so they can retry.
     clearCooldown(interaction.user.id);
     logger.error('handleQurlSlashSend: unexpected throw', {
-      user_id: interaction.user.id, error: err && err.message, stack: err && err.stack,
+      user_id: interaction.user.id, flow_id, error: err && err.message, stack: err && err.stack,
     });
+    // Best-effort cleanup of any orphan flow row we created. Only
+    // fires when supersedeOrCreate succeeded and the throw happened
+    // between then and the final editReply — otherwise the row
+    // would sit in DDB until TTL eviction, blocking a fresh /qurl
+    // file or /qurl map invocation under the sibling-flow guard.
+    // Version-gated stage check keeps a concurrent confirm-click
+    // from racing the delete and removing a row that's already
+    // advanced past awaiting-confirm.
+    if (orphanFlowCreated) {
+      deleteFlow(flow_id, {
+        stage: SEND_STAGE_AWAITING_CONFIRM,
+        reason: 'terminal',
+      }).catch((cleanupErr) => {
+        logger.warn('handleQurlSlashSend: orphan-flow cleanup failed', {
+          flow_id, error: cleanupErr && cleanupErr.message,
+        });
+      });
+    }
     const errContent = '❌ Something went wrong — please try again.';
     return interaction.editReply({ content: errContent })
       .catch(() => interaction.reply({ content: errContent, ephemeral: true }).catch(logIgnoredDiscordErr));
@@ -4243,8 +4278,25 @@ async function handleQurlMap(interaction) {
   // Shared parser: see `parseLocationInput` near the top of this file.
   // `/qurl send`'s modal-driven location text calls it too — keep both
   // entry points in lockstep so they produce identical delivered URLs
-  // for the same input.
-  let { locationUrl, locationName } = parseLocationInput(locationValue);
+  // for the same input. Wrap in try/catch as a defensive symmetry with
+  // handleQurlFile's catches: a future regex change in parseLocationInput
+  // or a pathological input could throw synchronously before reaching
+  // handleQurlSlashSend's safety net, leaving cooldown set with no
+  // visible response.
+  let locationUrl;
+  let locationName;
+  try {
+    ({ locationUrl, locationName } = parseLocationInput(locationValue));
+  } catch (err) {
+    logger.error('handleQurlMap: parseLocationInput threw', {
+      user_id: interaction.user.id, error: err && err.message,
+    });
+    clearCooldown(interaction.user.id);
+    return interaction.reply({
+      content: '❌ Could not parse location — please re-run with a Google Maps URL or address.',
+      ephemeral: true,
+    });
+  }
   // Explicit location-name override wins over the URL-derived name.
   if (locationNameRaw && locationNameRaw.trim().length > 0) {
     locationName = locationNameRaw.trim();
@@ -4278,6 +4330,27 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // handleSendConfirmClick / handleSendCancelClick. All `update`
   // calls below become `editReply` (the interaction is now deferred).
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
+  // Validate payload.resourceType BEFORE renderConfirmCardContent
+  // would throw on it. A corrupt/stale DDB row (manual mutation,
+  // schema drift, etc.) with an unknown resourceType would otherwise
+  // throw TypeError from the renderer and surface the dispatcher's
+  // generic "superseded" copy — wrong, since nothing was superseded.
+  // Delete the corrupt row + surface actionable "re-run" copy.
+  const payloadResource = (row.payload || {}).resourceType;
+  if (payloadResource !== RESOURCE_TYPES.FILE && payloadResource !== RESOURCE_TYPES.MAPS) {
+    logger.error('handleSendUserSelect: corrupt flow payload (unknown resourceType)', {
+      flow_id, resource_type: payloadResource,
+    });
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch(logIgnoredDiscordErr);
+    return interaction.editReply({
+      content: '❌ Card data is corrupted — please re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
 
   // `interaction.users` is a discord.js Collection in production,
   // duck-typed as a Map in tests — both support `.values()` so the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -265,6 +265,22 @@ function clearCooldown(userId) {
   sendCooldowns.delete(userId);
 }
 
+// Soften an existing cooldown so `residualMs` remain. Monotonic SHRINK
+// — only reduces remaining time, never extends. Used by Cancel paths
+// so a legitimate "I changed my mind" doesn't lock the full window
+// out, but rapid /qurl file → Cancel → /qurl file → Cancel spam still
+// pays a small throttle on each iteration (preventing supersedeOrCreate
+// + interaction-reply abuse).
+function softenCooldown(userId, residualMs) {
+  if (!sendCooldowns.has(userId)) return;
+  const target = Date.now() - Math.max(0, config.QURL_SEND_COOLDOWN_MS - residualMs);
+  const existing = sendCooldowns.get(userId);
+  if (target < existing) {
+    sendCooldowns.delete(userId);
+    sendCooldowns.set(userId, target);
+  }
+}
+
 async function batchSettled(items, fn, batchSize = 5) {
   const results = [];
   for (let i = 0; i < items.length; i += batchSize) {
@@ -390,7 +406,12 @@ const USER_SELECT_PER_PICK_CAP = 10;
 const MAPS_URL_PATTERNS = [
   /https?:\/\/(?:www\.)?google\.com\/maps\/(?:place|search|dir|@)[\w/.,@?=&+%-]{1,500}/,
   /https?:\/\/(?:goo\.gl\/maps|maps\.app\.goo\.gl)\/[\w-]{1,100}/,
-  /https?:\/\/(?:www\.)?google\.com\/maps\/embed\/v1\/\w{1,32}\?[^\s]{1,500}/,
+  // Defense-in-depth: exclude `<>"'|\` from the embed-tail character
+  // class. `isGoogleMapsURL` re-validates host and downstream sanitizers
+  // escape rendering, so these chars aren't exploitable today — but
+  // narrowing the regex here makes the bound tighter against URL
+  // shapes that would never come from a legitimate maps embed link.
+  /https?:\/\/(?:www\.)?google\.com\/maps\/embed\/v1\/\w{1,32}\?[^\s<>"'|\\`]{1,500}/,
 ];
 
 // decodeURIComponent throws URIError on malformed %-encoding (e.g. %ZZ).
@@ -2097,9 +2118,11 @@ async function handleSend(interaction, apiKey) {
     await modalSubmit.deferUpdate();
 
     ({ locationUrl, locationName } = parseLocationInput(locationValue));
-    // Cap + escape markdown so a crafted place name can't inject
-    // **bold** / links / code / spoilers into the recipient embed.
-    if (locationName) locationName = escapeDiscordMarkdown(locationName.slice(0, 256));
+    // sanitizeContentLabel: NFKC + bidi/zero-width/control strip +
+    // codepoint-aware 256-cap + markdown-escape. Matches the
+    // /qurl map slash entry's defense at handleQurlMap so a U+202E
+    // RLO can't visually spoof a Maps URL via the modal path either.
+    if (locationName) locationName = sanitizeContentLabel(locationName);
   }
 
   // ── Step 3: Common final step ──
@@ -3719,6 +3742,15 @@ function formatPersonalMessagePreview(message) {
   // operates on UTF-16 code units, so a slice that lands mid-surrogate
   // emits a lone surrogate that Discord renders as tofu. Same defense
   // sanitize.js applies for display-name caps.
+  //
+  // Caveat: codepoint-aware ≠ grapheme-aware. ZWJ-joined emoji
+  // sequences (e.g. 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl, three
+  // codepoints + two joiners = 5 codepoints) can be sliced mid-cluster
+  // and render only the first segment. Acceptable: the preview is
+  // an 80-codepoint truncation indicator (followed by `…`), so a
+  // partial emoji renders as exactly that — a partial display, not
+  // garbled text. Full grapheme-segmentation would need Intl.Segmenter
+  // which isn't justified for a preview cap.
   const codepoints = Array.from(oneLine);
   if (codepoints.length <= 80) return `> ${oneLine}`;
   let cut = 80;
@@ -3790,13 +3822,10 @@ async function handleQurlSlashSend(interaction, params) {
       ephemeral: true,
     });
   }
-  if (isOnCooldown(interaction.user.id)) {
-    return interaction.reply({
-      content: 'Please wait before sending again.',
-      ephemeral: true,
-    });
-  }
-  setCooldown(interaction.user.id);
+  // Cooldown gate is owned by the front-half handlers (handleQurlFile /
+  // handleQurlMap) so invalid inputs are throttled too. By the time we
+  // get here the cooldown is already set; legitimate clearCooldown calls
+  // on individual error branches below still unlock retry.
 
   // Top-level try/catch fences unanticipated throws (a TypeError from
   // a malformed cached member, a future parser change, etc.) from
@@ -3958,6 +3987,21 @@ async function handleQurlSlashSend(interaction, params) {
 }
 
 async function handleQurlFile(interaction) {
+  // Cooldown gate at the EARLIEST entry point so invalid inputs
+  // (malformed attachment, SSRF host, wrong type, oversize) are
+  // throttled too — matches handleSend's pattern at commands.js:~1677.
+  // setCooldown is shared with /qurl send and /qurl map via the
+  // sendCooldowns Map; tests pin the cross-command contract.
+  if (interaction.guildId && interaction.guild) {
+    if (isOnCooldown(interaction.user.id)) {
+      return interaction.reply({
+        content: 'Please wait before sending again.',
+        ephemeral: true,
+      });
+    }
+    setCooldown(interaction.user.id);
+  }
+
   // UX fast-fail. The real concurrency-slot claim happens inside
   // executeSendPipeline (commands.js:~1043); this pre-check is best-
   // effort — by Send-click time the cap state can have shifted, in
@@ -4038,6 +4082,19 @@ async function handleQurlFile(interaction) {
 }
 
 async function handleQurlMap(interaction) {
+  // Cooldown gate at entry — same pattern handleQurlFile uses.
+  // Cross-command bucket (sendCooldowns) shared with /qurl send and
+  // /qurl file; tests pin the contract.
+  if (interaction.guildId && interaction.guild) {
+    if (isOnCooldown(interaction.user.id)) {
+      return interaction.reply({
+        content: 'Please wait before sending again.',
+        ephemeral: true,
+      });
+    }
+    setCooldown(interaction.user.id);
+  }
+
   // `getString('location', true)` throws on a missing option. Discord
   // enforces required server-side; only a forged interaction can hit
   // this. Targeted catch matches handleQurlFile's required-option
@@ -4157,6 +4214,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
   }).catch(logIgnoredDiscordErr);
   if (valid.length === 0) {
+    // No transitionFlow on the all-invalid branch — the card stays at
+    // the same flow_state version. Log for forensics so a sudden spike
+    // in invalid-pick churn surfaces in metrics without lowering log
+    // verbosity.
+    logger.debug('handleSendUserSelect: all-invalid pick', {
+      flow_id, dropped_bots: droppedBots, dropped_self: droppedSelf,
+    });
     return rejectPick('⚠\u{FE0F} ' + (droppedBots > 0 ? 'Cannot send to bots.' : 'Cannot send to yourself.')
       + ' Re-pick recipients below.\n\n');
   }
@@ -4414,7 +4478,10 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       parts.push(`${partialTransientCount} couldn't be looked up just now (rerun /qurl file to retry them)`);
     }
     await interaction.followUp({
-      content: `ℹ\u{FE0F} ${parts.join('; ')} — sending to the remaining ${valid.length}.`,
+      // "Attempting to" (not "sending to") so a downstream pipeline
+      // failure doesn't leave the user reading a confident "sending"
+      // message alongside a subsequent failure message.
+      content: `ℹ\u{FE0F} ${parts.join('; ')} — attempting to send to the remaining ${valid.length}.`,
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
@@ -4448,8 +4515,12 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
 //     surfaces that as the dedup-loser path (user re-clicks Cancel on
 //     the new row if they still want to abort).
 //
-// `clearCooldown` is gated on `deleted: true` so the cooldown stays
-// honored on the Cancel-loser branch.
+// On a successful Cancel, `softenCooldown` retains 5s of throttle
+// instead of fully clearing — a full clear would let a user spam
+// /qurl file → Cancel → /qurl file → Cancel and rack up
+// supersedeOrCreate DDB writes + Discord interactions with zero
+// throttle. The cooldown-loser branch leaves cooldown untouched
+// (Send is mid-fanout; bypassing is the abuse vector).
 async function handleSendCancelClick(interaction, { flow_id, row }) {
   // Defer-ack within the 3s window. The single deleteFlow call below
   // is fast in the happy path, but a DDB blip or slow region could
@@ -4479,12 +4550,17 @@ async function handleSendCancelClick(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
   if (!deleted) {
+    // Dedup-loser: either Send won the race (deletedFlow already, fan-out
+    // in progress) or a UserSelect transition advanced the row version.
+    // Distinct branches share the same recovery (re-check the card),
+    // but the wording avoids implying the flow was "processed" on the
+    // picker-race path where nothing actually committed.
     return interaction.followUp({
-      content: 'This send was already processed or the card moved — re-check it.',
+      content: 'The card moved — re-check it.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
-  clearCooldown(interaction.user.id);
+  softenCooldown(interaction.user.id, 5000);
   return interaction.editReply({
     content: 'Send cancelled.',
     components: [],
@@ -6041,6 +6117,9 @@ module.exports = {
       selfDestructOptionToSeconds,
       renderRecipientWarnings,
       renderConfirmCardContent,
+      parseLocationInput,
+      safeDecodeURIComponent,
+      softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
       SEND_USER_SELECT_CUSTOM_ID,
       SEND_CONFIRM_SEND_CUSTOM_ID,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -135,7 +135,7 @@ function isGoogleMapsURL(url) {
 
 
 
-const { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain } = require('./utils/sanitize');
+const { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel } = require('./utils/sanitize');
 
 // Best-effort host extraction for log lines. URL parsing throws on
 // pathological input (no scheme, embedded null, etc.) — swallow and
@@ -425,13 +425,6 @@ function parseLocationInput(rawInput) {
     else if (placeMatch) name = safeDecodeURIComponent(placeMatch[1].replace(/\+/g, ' '));
     return { locationUrl: detectedUrl, locationName: name };
   }
-  // Pre-extraction the legacy /qurl send handler had TWO separate
-  // branches here ("detectedUrl but not Google Maps" vs "no
-  // detectedUrl"), each producing the same synthesized-search URL +
-  // raw-input name. The consolidated single branch below is
-  // intentional, NOT dead code — both prior cases collapse to the
-  // same behavior, so a maintainer is welcome to leave the
-  // simplification as-is.
   return {
     locationUrl: `https://www.google.com/maps/search/${encodeURIComponent(rawInput)}`,
     locationName: rawInput,
@@ -3979,11 +3972,13 @@ async function handleQurlFile(interaction) {
     },
     locationUrl: null,
     locationName: null,
-    // 256-char cap mirrors the map-path `locationName` cap so a future
-    // upload-pipeline change that loosens Discord's filename ceiling
-    // can't bloat the confirm card. String() coerces in case a
-    // hypothetical future caller hands a non-string name.
-    resourceLabel: escapeDiscordMarkdown(String(attachment.name).slice(0, 256)),
+    // sanitizeContentLabel: NFKC + strip bidi/zero-width/control +
+    // codepoint-aware 256-cap + markdown-escape. The codepoint slice
+    // prevents UTF-16 surrogate splits at the 256 boundary; the bidi
+    // strip defends against U+202E spoofing in filenames (a crafted
+    // upload could otherwise visually fake a different filename in
+    // the confirm card).
+    resourceLabel: sanitizeContentLabel(attachment.name),
   });
 }
 
@@ -4021,7 +4016,14 @@ async function handleQurlMap(interaction) {
   if (locationNameRaw && locationNameRaw.trim().length > 0) {
     locationName = locationNameRaw.trim();
   }
-  if (locationName) locationName = escapeDiscordMarkdown(locationName.slice(0, 256));
+  // sanitizeContentLabel: NFKC + strip bidi/zero-width/control +
+  // codepoint-aware 256-cap + markdown-escape. The bidi strip is
+  // load-bearing here — /qurl map's slash option is a new
+  // attack surface (no modal friction) and a crafted U+202E in
+  // `location-name` would otherwise let the sender visually spoof
+  // a Maps URL inside the rendered confirm card. Also handles the
+  // UTF-16 surrogate-split risk at the 256 boundary.
+  if (locationName) locationName = sanitizeContentLabel(locationName);
 
   return handleQurlSlashSend(interaction, {
     resourceType: RESOURCE_TYPES.MAPS,
@@ -4037,10 +4039,25 @@ async function handleQurlMap(interaction) {
 // refreshes the TTL, so repeated picker churn doesn't expire the row
 // while the user is still deciding.
 async function handleSendUserSelect(interaction, { flow_id, row }) {
+  // `interaction.users` is a discord.js Collection in production,
+  // duck-typed as a Map in tests — both support `.values()` so the
+  // iteration here is interchangeable. A future test refactor that
+  // switches to Collection-only methods (`.first()`, `.filter()`)
+  // would break the test harness without breaking prod; keep the
+  // Map-compatible API surface.
   const selected = [...interaction.users.values()];
   if (selected.length === 0) {
     return interaction.deferUpdate().catch(logIgnoredDiscordErr);
   }
+  // `interaction.user.id` IS the original sender's ID — Discord
+  // enforces "only the user who triggered an ephemeral interaction
+  // can click its components" at the gateway level, so the clicker
+  // === the sender. This invariant is LOAD-BEARING: partitioning
+  // by clicker also drops the SENDER from the pick (droppedSelf),
+  // and a future refactor that flips the confirm card to
+  // non-ephemeral would need to thread the original sender ID
+  // through the flow payload + read it here instead.
+  //
   // No `resolveRecipientUsers` re-fetch here — Discord's
   // UserSelectMenu only surfaces users visible to the bot in this
   // guild, so picked User IDs are guild-bounded at the gateway-event
@@ -4317,11 +4334,28 @@ async function handleSendCancelClick(interaction, { flow_id, row }) {
   // still blow the budget. Same pattern handleSendConfirmClick uses
   // (deferUpdate at top, editReply / followUp downstream).
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
-  const { deleted } = await deleteFlow(flow_id, {
-    stage: SEND_STAGE_AWAITING_CONFIRM,
-    reason: 'terminal',
-    expectedVersion: row.version,
-  });
+  // Targeted catch around deleteFlow mirrors handleSendConfirmClick's
+  // guards on resolveRecipientUsers + getGuildApiKey. Without it, a
+  // DDB throw propagates to the dispatcher's outer catch which
+  // surfaces a generic "superseded" message — wrong for Cancel
+  // (the user wanted to abort; the flow row may still be alive
+  // and Send may still be in flight, so cooldown stays set).
+  let deleted;
+  try {
+    ({ deleted } = await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+      expectedVersion: row.version,
+    }));
+  } catch (err) {
+    logger.error('handleSendCancelClick: deleteFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not cancel right now — try clicking **Cancel** again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
   if (!deleted) {
     return interaction.followUp({
       content: 'This send was already processed or the card moved — re-check it.',

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4042,8 +4042,12 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // to fence (commands.js:~3196). `deleted: false` here now collapses
   // duplicate dispatch AND mid-flight picker mutation; both map to the
   // same user recovery ("the card moved under you, re-click Send").
+  // `interaction.guildId` is guaranteed non-null at this point —
+  // handleQurlSlashSend rejects DM invocations BEFORE the flow row
+  // is created, so a row at SEND_STAGE_AWAITING_CONFIRM only ever
+  // belongs to a guild interaction. No conditional fallback.
   const [guildApiKey, deleteResult] = await Promise.all([
-    interaction.guildId ? db.getGuildApiKey(interaction.guildId) : null,
+    db.getGuildApiKey(interaction.guildId),
     deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
@@ -5268,7 +5272,8 @@ const commands = [
             // matches the two-space indent below, but bypasses the list
             // auto-formatter.
             '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n' +
-            '  2. Optionally `recipients:@a @b @role` — leave blank to pick from a menu\n' +
+            '  2. Optionally `recipients:@a @b @role` (up to 25 users via @mentions or role expansion) — '
+              + 'leave blank to pick from a menu (up to 10 at a time)\n' +
             '  3. Confirm the card, then click **Send**\n' +
             '  4. Recipients get a one-time link by DM that self-destructs on first access (or when the expiry elapses)\n\n' +
             oauthSetupSection +

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -380,6 +380,61 @@ const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ n
 // use this — keep them in lockstep so a future bump doesn't drift.
 const USER_SELECT_PER_PICK_CAP = 10;
 
+// Shared Google Maps URL patterns. Both `/qurl send`'s modal-driven
+// location-text capture and `/qurl file`/`/qurl map`'s slash-option
+// `location:` consume these — extracted to a single source so a
+// future "new URL shape" tweak only happens here.
+//
+// Each pattern bounds character-class repetition (`{1,500}`, `{1,32}`,
+// etc.) to keep ReDoS-resistant against pathological inputs.
+const MAPS_URL_PATTERNS = [
+  /https?:\/\/(?:www\.)?google\.com\/maps\/(?:place|search|dir|@)[\w/.,@?=&+%-]{1,500}/,
+  /https?:\/\/(?:goo\.gl\/maps|maps\.app\.goo\.gl)\/[\w-]{1,100}/,
+  /https?:\/\/(?:www\.)?google\.com\/maps\/embed\/v1\/\w{1,32}\?[^\s]{1,500}/,
+];
+
+// decodeURIComponent throws URIError on malformed %-encoding (e.g. %ZZ).
+// Swallow + return the raw string — a garbled label is preferable to a
+// crashed command handler.
+function safeDecodeURIComponent(s) {
+  try { return decodeURIComponent(s); } catch { return s; }
+}
+
+// Parse a free-form `location:` input into `{ locationUrl, locationName }`.
+// Detection order:
+//   1. Google Maps URL embedded anywhere in the input → preserve URL,
+//      extract name from `?q=` or `/place/<name>`.
+//   2. Anything else → synthesize a `/maps/search/<input>` URL with the
+//      whole input as the name.
+//
+// Returns BOTH fields; caller is responsible for escaping the name
+// (markdown injection defense) and applying any cap. The two call
+// sites — `handleSend`'s modal branch and `handleQurlMap`'s slash
+// entry — share this so a pattern tweak lands in one place.
+function parseLocationInput(rawInput) {
+  let detectedUrl = null;
+  for (const pattern of MAPS_URL_PATTERNS) {
+    const match = rawInput.match(pattern);
+    if (match) { detectedUrl = match[0]; break; }
+  }
+  if (detectedUrl && isGoogleMapsURL(detectedUrl)) {
+    const queryMatch = detectedUrl.match(/[?&]q=([^&]+)/);
+    const placeMatch = detectedUrl.match(/\/place\/([^/@]+)/);
+    let name = null;
+    if (queryMatch) name = safeDecodeURIComponent(queryMatch[1].replace(/\+/g, ' '));
+    else if (placeMatch) name = safeDecodeURIComponent(placeMatch[1].replace(/\+/g, ' '));
+    return { locationUrl: detectedUrl, locationName: name };
+  }
+  // Either no Maps URL detected, OR a candidate URL failed
+  // `isGoogleMapsURL` re-validation (path/host check). Either way,
+  // wrap the raw input in a maps-search URL and use it as both URL
+  // and name.
+  return {
+    locationUrl: `https://www.google.com/maps/search/${encodeURIComponent(rawInput)}`,
+    locationName: rawInput,
+  };
+}
+
 function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
   // sanitizeDisplayName: NFKC + bidi/zero-width strip + markdown escape
   // + 64-char cap + 'Someone' fallback. Same helper used at the channel
@@ -2041,39 +2096,11 @@ async function handleSend(interaction, apiKey) {
 
     // Hard-cap input length BEFORE regex matching to prevent ReDoS on
     // pathological strings against the unbounded character classes
-    // below. Real Google Maps URLs peak around ~300 chars.
+    // inside MAPS_URL_PATTERNS. Real Google Maps URLs peak around ~300 chars.
     const locationValue = modalSubmit.fields.getTextInputValue('location_value').trim().slice(0, 2000);
     await modalSubmit.deferUpdate();
 
-    const mapsPatterns = [
-      /https?:\/\/(?:www\.)?google\.com\/maps\/(?:place|search|dir|@)[\w/.,@?=&+%-]{1,500}/,
-      /https?:\/\/(?:goo\.gl\/maps|maps\.app\.goo\.gl)\/[\w-]{1,100}/,
-      /https?:\/\/(?:www\.)?google\.com\/maps\/embed\/v1\/\w{1,32}\?[^\s]{1,500}/,
-    ];
-
-    let detectedUrl = null;
-    for (const pattern of mapsPatterns) {
-      const match = locationValue.match(pattern);
-      if (match) { detectedUrl = match[0]; break; }
-    }
-
-    if (detectedUrl && isGoogleMapsURL(detectedUrl)) {
-      locationUrl = detectedUrl;
-      const queryMatch = detectedUrl.match(/[?&]q=([^&]+)/);
-      const placeMatch = detectedUrl.match(/\/place\/([^/@]+)/);
-      // decodeURIComponent throws URIError on malformed %-encoding (e.g. %ZZ).
-      // Swallow and fall back to the raw string — a garbled label is better
-      // than a crashed command handler.
-      const safeDecode = (s) => { try { return decodeURIComponent(s); } catch { return s; } };
-      if (queryMatch) locationName = safeDecode(queryMatch[1].replace(/\+/g, ' '));
-      else if (placeMatch) locationName = safeDecode(placeMatch[1].replace(/\+/g, ' '));
-    } else if (detectedUrl) {
-      locationName = locationValue;
-      locationUrl = `https://www.google.com/maps/search/${encodeURIComponent(locationValue)}`;
-    } else {
-      locationName = locationValue;
-      locationUrl = `https://www.google.com/maps/search/${encodeURIComponent(locationValue)}`;
-    }
+    ({ locationUrl, locationName } = parseLocationInput(locationValue));
     // Cap + escape markdown so a crafted place name can't inject
     // **bold** / links / code / spoilers into the recipient embed.
     if (locationName) locationName = escapeDiscordMarkdown(locationName.slice(0, 256));
@@ -3355,6 +3382,677 @@ async function handleSetupModal(interaction, { flow_id }) {
   }).catch(logIgnoredDiscordErr);
 }
 
+// ─────────────────────────────────────────────────────────────
+// /qurl file + /qurl map — slash-driven sends.
+//
+// Two new subcommands replace `/qurl send`'s button-driven wizard
+// with all-options-up-front slash commands. The flow:
+//
+//   /qurl file recipients:<text> attachment:<file> [expires-in]
+//                                                  [self-destruct]
+//                                                  [personal-message]
+//   /qurl map  recipients:<text> location:<text>   [location-name]
+//                                                  [expires-in]
+//                                                  [self-destruct]
+//                                                  [personal-message]
+//
+// After parsing/validating the slash options, the bot renders an
+// in-channel ephemeral confirm card with the resolved recipient list
+// (or a UserSelectMenu when `recipients:` was omitted) plus Send /
+// Cancel buttons. The confirm card is flow_state-backed so the Send
+// dedup gate fires on `deleteFlow` (consistent with /qurl revoke,
+// /qurl setup).
+//
+// /qurl send stays in place until PR 7b.3 hard-removes it.
+// ─────────────────────────────────────────────────────────────
+
+const {
+  parseRecipientMentions,
+  MAX_INPUT_LENGTH: RECIPIENTS_MAX_INPUT_LENGTH,
+} = require('./recipient-parser');
+
+const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
+
+// CustomIds — PREFIX-ONLY (no nonce). flow-dispatch's loadFlow already
+// gates routing on stage + version; encoding identity into customId
+// would not add safety (the dispatcher's trust model treats customId
+// as a routing key, not an identity signal). Matches the convention
+// REVOKE_SELECT_CUSTOM_ID / SETUP_BUTTON_CUSTOM_ID use.
+const SEND_USER_SELECT_CUSTOM_ID = 'qurl_send_user_select';
+const SEND_CONFIRM_SEND_CUSTOM_ID = 'qurl_send_confirm_send';
+const SEND_CONFIRM_CANCEL_CUSTOM_ID = 'qurl_send_confirm_cancel';
+
+// 3-minute confirm-card window. Matches /qurl send's Step-3 form
+// timeout at line ~2293 so users have the same time-to-finish budget
+// whichever entry point they use.
+const SEND_FLOW_TTL_SECONDS = 180;
+
+// Slash-option choice arrays. Reuse the existing /qurl send wording
+// so users see the same labels in autocomplete as in the form's
+// dropdowns. EXPIRY_CHOICES already exists. SELF_DESTRUCT_CHOICES is
+// new here because /qurl send wires self-destruct via a StringSelect
+// post-invocation rather than a slash option.
+const SELF_DESTRUCT_NO_TIMER_CHOICE = 'none';
+const SELF_DESTRUCT_CHOICES = [
+  { name: 'No timer (default)', value: SELF_DESTRUCT_NO_TIMER_CHOICE },
+  ...SELF_DESTRUCT_PRESETS.map((p) => ({ name: p.label, value: String(p.seconds) })),
+];
+
+// Map the slash option's string value to a seconds integer or null.
+// Mirrors `selfDestructSelectValueToSeconds` in utils/time but for the
+// slash-option value space (which uses 'none' instead of the form's
+// SELF_DESTRUCT_NO_TIMER_VALUE). Wrong values fall back to null (no
+// timer) so a future option-list drift can't crash the handler.
+function selfDestructOptionToSeconds(value) {
+  if (!value || value === SELF_DESTRUCT_NO_TIMER_CHOICE) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.floor(n);
+}
+
+// Resolve a list of recipient IDs to User-shaped objects via the guild
+// member cache (with fallback fetch on miss). Returns
+// `{ users, unresolvedIds }` — callers surface unresolvedIds so a
+// user who left the guild between /qurl file invocation and Send
+// click sees a deterministic error rather than a silent drop in the
+// back-half.
+//
+// Discord API code 10007 ("Unknown Member") is the canonical
+// "left the guild" signal. Any other fetch error (rate limit,
+// gateway blip) is also treated as unresolved — degrading to the
+// resolvable subset is preferable to aborting the whole command.
+//
+// Fetches the cache-miss tail in parallel via `batchSettled` (the
+// same helper used by the DM fan-out path; honors Discord's per-route
+// rate-limit bucket by capping concurrent in-flight calls).
+async function resolveRecipientUsers(interaction, ids) {
+  if (!interaction.guild) {
+    return { users: [], unresolvedIds: [...ids] };
+  }
+  const users = [];
+  const missQueue = [];
+  for (const id of ids) {
+    const cached = interaction.guild.members.cache.get(id);
+    if (cached) users.push(cached.user);
+    else missQueue.push(id);
+  }
+  if (missQueue.length === 0) return { users, unresolvedIds: [] };
+
+  const unresolvedIds = [];
+  const results = await batchSettled(missQueue, async (id) => {
+    try {
+      const m = await interaction.guild.members.fetch(id);
+      return { id, user: m.user };
+    } catch (err) {
+      if (!err || (err.code !== 10007 && err.code !== '10007')) {
+        logger.warn('resolveRecipientUsers: members.fetch failed', {
+          recipient_id: id, error: err && err.message, code: err && err.code,
+        });
+      }
+      return { id, user: null };
+    }
+  });
+  for (const r of results) {
+    // batchSettled wraps each callback in Promise.allSettled — fulfilled
+    // results carry our `{id, user}` shape, rejected ones would carry an
+    // err. The callback never throws (try/catch above) so `rejected` is
+    // unreachable in practice; defend regardless.
+    if (r.status !== 'fulfilled' || !r.value || r.value.user == null) {
+      const id = r.value?.id ?? null;
+      if (id) unresolvedIds.push(id);
+      continue;
+    }
+    users.push(r.value.user);
+  }
+  return { users, unresolvedIds };
+}
+
+// Filter resolved Users: drop bots, drop the sender. Returns
+// `{ valid, droppedBots, droppedSelf }` so the caller can surface
+// "X bots / your-own-id were dropped" as a distinct error from
+// "no recipients at all".
+//
+// Known v1 cap-skew: parseRecipientMentions caps to QURL_SEND_MAX_RECIPIENTS
+// BEFORE knowing which IDs are bots. A mention list of
+// [bot1, bot2, ..., bot25, user1] with cap=25 yields ids=[bot1..bot25]
+// and post-filter valid=[]. The user sees "all recipients dropped" and
+// has to re-run with bots removed. Acceptable since (a) it requires a
+// pathological mention list to trip, (b) the failure mode is loud
+// rather than silent. A future refactor can resolve-then-cap if this
+// becomes a real complaint.
+function partitionRecipients(users, senderId) {
+  const valid = [];
+  let droppedBots = 0;
+  let droppedSelf = 0;
+  for (const u of users) {
+    if (u.bot) { droppedBots++; continue; }
+    if (u.id === senderId) { droppedSelf++; continue; }
+    valid.push(u);
+  }
+  return { valid, droppedBots, droppedSelf };
+}
+
+// Returns the empty string when nothing is worth surfacing — keeps
+// callers simple (`warningsBlock + content`) without a separate
+// "do I have any warnings" check.
+function renderRecipientWarnings({ invalidTokens, cappedCount, unresolvedIds, droppedBots, droppedSelf }) {
+  const lines = [];
+  if (cappedCount > 0) {
+    lines.push(`• Capped at ${config.QURL_SEND_MAX_RECIPIENTS} — ${cappedCount} recipient(s) past the cap were dropped.`);
+  }
+  if (invalidTokens.length > 0) {
+    // Code-fence the raw tokens so any residual markdown / mention
+    // shapes the parser couldn't fully neutralize render as literals.
+    // Cap the listed count at 10 so a pathological list doesn't blow
+    // the Discord content budget.
+    const shown = invalidTokens.slice(0, 10);
+    const more = invalidTokens.length > 10 ? ` (+${invalidTokens.length - 10} more)` : '';
+    lines.push('• Could not parse:\n```\n' + shown.join('\n') + '\n```' + more);
+  }
+  if (unresolvedIds.length > 0) {
+    lines.push(`• ${unresolvedIds.length} user(s) are no longer in this server and were dropped.`);
+  }
+  if (droppedBots > 0) {
+    lines.push(`• ${droppedBots} bot(s) cannot receive qURL links — skipped.`);
+  }
+  if (droppedSelf > 0) {
+    lines.push('• You cannot send a qURL to yourself — skipped.');
+  }
+  if (lines.length === 0) return '';
+  return '⚠\u{FE0F} **Some recipients were dropped:**\n' + lines.join('\n') + '\n\n';
+}
+
+// Build the confirm-card content string. Mirrors /qurl send's Step-3
+// content shape (formContent at ~line 2130) so users see consistent
+// wording across both entry points. Brand spelling is `qURL` per
+// CLAUDE.md — the user-visible copy here, the slash-command
+// descriptions, and any logger.audit user-facing fields all preserve
+// the case.
+function renderConfirmCardContent({
+  resourceType, resourceLabel, validRecipients,
+  expiresIn, selfDestructSeconds, personalMessage,
+  warningsBlock, needsPicker,
+}) {
+  let content = warningsBlock || '';
+  if (resourceType === RESOURCE_TYPES.FILE) {
+    content += `📁 **Sending file:** ${resourceLabel}\n`;
+  } else {
+    content += `🗺\u{FE0F} **Sending location:** ${resourceLabel}\n`;
+  }
+  if (needsPicker) {
+    content += '\n**Pick recipients below** (1–'
+      + String(Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS))
+      + ' users), then click **Send**.\n';
+  } else {
+    // First-N preview keeps the card scannable when a paste resolves
+    // to many users. Discord-name display via resolveRecipientAlias
+    // matches the post-send confirmation wording.
+    const PREVIEW = 5;
+    const previewNames = validRecipients.slice(0, PREVIEW)
+      .map((u) => escapeDiscordMarkdown(u.username))
+      .join(', ');
+    const more = validRecipients.length > PREVIEW ? `, +${validRecipients.length - PREVIEW} more` : '';
+    content += `\n**To:** ${validRecipients.length} user${validRecipients.length === 1 ? '' : 's'} (${previewNames}${more})\n`;
+  }
+  content += `**Expires:** ${EXPIRY_LABELS[expiresIn] || expiresIn}\n`;
+  if (Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0) {
+    content += `**Self-destruct:** ${formatSelfDestructLabel(selfDestructSeconds)}\n`;
+  }
+  if (personalMessage) {
+    const preview = personalMessage.length > 80 ? personalMessage.slice(0, 80) + '…' : personalMessage;
+    content += `**Note:** "${escapeDiscordMarkdown(preview)}"\n`;
+  }
+  content += '\nClick **Send** to deliver one-time qURL links, or **Cancel** to abort.';
+  return content;
+}
+
+// Build the ActionRow set for the confirm card. When `needsPicker`,
+// row 0 is a UserSelectMenu (recipients absent / post-filter empty);
+// otherwise no picker row. Send/Cancel always in the last row.
+function renderConfirmCardRows({ needsPicker, sendDisabled }) {
+  const rows = [];
+  if (needsPicker) {
+    const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
+    rows.push(new ActionRowBuilder().addComponents(
+      new UserSelectMenuBuilder()
+        .setCustomId(SEND_USER_SELECT_CUSTOM_ID)
+        .setPlaceholder(`Pick recipients (1–${maxValues})`)
+        .setMinValues(1)
+        .setMaxValues(maxValues)
+    ));
+  }
+  rows.push(new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(SEND_CONFIRM_SEND_CUSTOM_ID)
+      .setLabel('\u{1F4E4} Send')
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(sendDisabled),
+    new ButtonBuilder()
+      .setCustomId(SEND_CONFIRM_CANCEL_CUSTOM_ID)
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+  ));
+  return rows;
+}
+
+// Shared entry point — both `/qurl file` and `/qurl map` route here
+// after collecting their resource-specific options. `params` carries:
+//   resourceType: RESOURCE_TYPES.FILE | RESOURCE_TYPES.MAPS
+//   attachment:   {url, name, contentType, size} | null  (file path)
+//   locationUrl:  string | null                          (map path)
+//   locationName: string | null                          (map path)
+//   resourceLabel: string                                (rendered on card)
+async function _handleQurlSlashSend(interaction, apiKey, params) {
+  if (!interaction.guildId || !interaction.guild) {
+    return interaction.reply({
+      content: 'This command can only be used in a server, not in DMs.',
+      ephemeral: true,
+    });
+  }
+  if (isOnCooldown(interaction.user.id)) {
+    return interaction.reply({
+      content: 'Please wait before sending again.',
+      ephemeral: true,
+    });
+  }
+  setCooldown(interaction.user.id);
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const recipientsRaw = interaction.options.getString('recipients');
+  const expiresIn = interaction.options.getString('expires-in') || '24h';
+  const selfDestructValue = interaction.options.getString('self-destruct') || SELF_DESTRUCT_NO_TIMER_CHOICE;
+  const personalMessageRaw = interaction.options.getString('personal-message');
+
+  // Defense-in-depth: expiresIn comes from the slash command's choice
+  // list which Discord enforces server-side, but a forged interaction
+  // could carry an off-set value. EXPIRY_LABELS owns the closed set.
+  if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
+    clearCooldown(interaction.user.id);
+    return interaction.editReply({
+      content: '❌ Unrecognized expiry value. Re-run and pick from the list.',
+    });
+  }
+  const selfDestructSeconds = selfDestructOptionToSeconds(selfDestructValue);
+  const personalMessage = personalMessageRaw ? sanitizeMessage(personalMessageRaw) : null;
+
+  // Phase 1: parse the recipients string (no fetch yet).
+  const parsed = parseRecipientMentions(recipientsRaw, interaction);
+
+  // Phase 2: resolve IDs → Users via guild member cache + fallback fetch.
+  let resolved = { users: [], unresolvedIds: [] };
+  if (parsed.ids.length > 0) {
+    try {
+      resolved = await resolveRecipientUsers(interaction, parsed.ids);
+    } catch (err) {
+      clearCooldown(interaction.user.id);
+      logger.error('qurl file/map: resolveRecipientUsers threw', {
+        user_id: interaction.user.id, error: err && err.message,
+      });
+      return interaction.editReply({
+        content: '❌ Could not resolve recipients. Please try again.',
+      });
+    }
+  }
+
+  // Phase 3: drop bots + self.
+  const { valid, droppedBots, droppedSelf } = partitionRecipients(resolved.users, interaction.user.id);
+
+  // Phase 4: decide branch — confirm card straight through, or picker
+  // fallback. `needsPicker` is true when the user supplied no
+  // `recipients:` value at all. When they DID supply one but it
+  // post-filtered to empty, we hard-fail with a specific error so
+  // the user knows why (vs. silently dropping into the picker, which
+  // would mask the underlying mention-list problem).
+  const recipientsOmitted = recipientsRaw == null || recipientsRaw.trim().length === 0;
+  const warningsBlock = renderRecipientWarnings({
+    invalidTokens: parsed.invalidTokens,
+    cappedCount: parsed.cappedCount,
+    unresolvedIds: resolved.unresolvedIds,
+    droppedBots,
+    droppedSelf,
+  });
+  if (!recipientsOmitted && valid.length === 0) {
+    clearCooldown(interaction.user.id);
+    // Parser silently strips bots + the sender from `<@id>` mentions
+    // when the cache reports them (recipient-parser.js:205, 214) —
+    // those IDs never reach `partitionRecipients`. If post-parse `ids`
+    // is empty AND the user supplied non-empty `recipients`, surface
+    // a "nothing usable" message even when partition's breakdown is
+    // zero. This is what bot-only / self-only mention lists hit.
+    const breakdownEmpty = droppedBots === 0 && droppedSelf === 0
+      && resolved.unresolvedIds.length === 0
+      && parsed.invalidTokens.length === 0
+      && parsed.cappedCount === 0;
+    const detail = breakdownEmpty
+      ? '\n\nMake sure you @-mention real users (bots and your own user are skipped automatically).'
+      : '';
+    return interaction.editReply({
+      content: warningsBlock + '❌ **No valid recipients to send to.** Re-run with at least one valid user mention.' + detail,
+    });
+  }
+
+  const needsPicker = recipientsOmitted;
+  const recipientIds = valid.map((u) => u.id);
+
+  // Phase 5: open the flow row. supersedeOrCreate handles the
+  // "another /qurl file/map is open" case — sibling-flow disambig
+  // surfaces a stage-specific message; same-stage rerun atomically
+  // claims the slot. Mirrors /qurl revoke's pattern.
+  const flow_id = flowIdForInteraction(interaction);
+  const sendNonce = crypto.randomBytes(8).toString('hex');
+  const payload = {
+    resourceType: params.resourceType,
+    attachment: params.attachment,
+    locationUrl: params.locationUrl,
+    locationName: params.locationName,
+    resourceLabel: params.resourceLabel,
+    recipientIds,
+    expiresIn,
+    selfDestructSeconds,
+    personalMessage,
+    sendNonce,
+  };
+  let supersede;
+  try {
+    supersede = await supersedeOrCreate({
+      flow_id,
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      payload,
+      ttl_seconds: SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    clearCooldown(interaction.user.id);
+    logger.warn('handleQurlSlashSend: supersedeOrCreate threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.editReply({
+      content: '❌ Could not start a send — please try again.',
+    });
+  }
+  if (!supersede.created) {
+    clearCooldown(interaction.user.id);
+    const siblingMsg = siblingMessageForStage(supersede.surviving?.stage);
+    return interaction.editReply({
+      content: siblingMsg || '❌ Could not start a send — please try again.',
+    });
+  }
+
+  // Phase 6: render the confirm card.
+  const content = renderConfirmCardContent({
+    resourceType: params.resourceType,
+    resourceLabel: params.resourceLabel,
+    validRecipients: valid,
+    expiresIn,
+    selfDestructSeconds,
+    personalMessage,
+    warningsBlock,
+    needsPicker,
+  });
+  const rows = renderConfirmCardRows({
+    needsPicker,
+    sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
+  });
+  return interaction.editReply({ content, components: rows });
+}
+
+async function handleQurlFile(interaction, apiKey) {
+  // File concurrency-cap pre-check (UX fast-fail). Final claim happens
+  // inside executeSendPipeline. Surfacing the cap here lets us refuse
+  // the slash invocation before we render a confirm card the user
+  // would then never get past.
+  if (activeFileSends >= MAX_CONCURRENT_FILE_SENDS) {
+    return interaction.reply({
+      content: 'The bot is processing too many file sends right now. Please try again in a moment.',
+      ephemeral: true,
+    });
+  }
+
+  const attachment = interaction.options.getAttachment('attachment', true);
+  if (!attachment || typeof attachment.url !== 'string') {
+    return interaction.reply({
+      content: '❌ Attachment is missing or malformed.',
+      ephemeral: true,
+    });
+  }
+  if (!isAllowedSourceUrl(attachment.url)) {
+    logger.warn('handleQurlFile: attachment.url failed SSRF gate', {
+      user_id: interaction.user.id, host: safeUrlHost(attachment.url),
+    });
+    return interaction.reply({
+      content: '❌ Attachment source not allowed. Files must be uploaded via Discord, not linked from external URLs.',
+      ephemeral: true,
+    });
+  }
+  if (!isAllowedFileType(attachment.contentType)) {
+    return interaction.reply({
+      content: `❌ File type not allowed: \`${escapeDiscordMarkdown(String(attachment.contentType || 'unknown'))}\`.`,
+      ephemeral: true,
+    });
+  }
+  if (attachment.size > MAX_FILE_SIZE) {
+    return interaction.reply({
+      content: `❌ File too large: ${attachment.size} bytes (cap: ${MAX_FILE_SIZE}).`,
+      ephemeral: true,
+    });
+  }
+
+  return _handleQurlSlashSend(interaction, apiKey, {
+    resourceType: RESOURCE_TYPES.FILE,
+    attachment: {
+      url: attachment.url,
+      name: attachment.name,
+      contentType: attachment.contentType,
+      size: attachment.size,
+    },
+    locationUrl: null,
+    locationName: null,
+    resourceLabel: escapeDiscordMarkdown(attachment.name),
+  });
+}
+
+async function handleQurlMap(interaction, apiKey) {
+  const locationValue = interaction.options.getString('location', true).trim();
+  const locationNameRaw = interaction.options.getString('location-name');
+  if (locationValue.length === 0) {
+    return interaction.reply({
+      content: '❌ Location is empty.',
+      ephemeral: true,
+    });
+  }
+
+  // Shared parser: see `parseLocationInput` near the top of this file.
+  // `/qurl send`'s modal-driven location text calls it too — keep both
+  // entry points in lockstep so they produce identical delivered URLs
+  // for the same input.
+  let { locationUrl, locationName } = parseLocationInput(locationValue);
+  // Explicit location-name override wins over the URL-derived name.
+  if (locationNameRaw && locationNameRaw.trim().length > 0) {
+    locationName = locationNameRaw.trim();
+  }
+  if (locationName) locationName = escapeDiscordMarkdown(locationName.slice(0, 256));
+
+  return _handleQurlSlashSend(interaction, apiKey, {
+    resourceType: RESOURCE_TYPES.MAPS,
+    attachment: null,
+    locationUrl,
+    locationName,
+    resourceLabel: locationName || 'location',
+  });
+}
+
+// Stage stays at SEND_STAGE_AWAITING_CONFIRM — `transitionFlow` with
+// `stage_to` === current stage advances the version (OCC guard) and
+// refreshes the TTL, so repeated picker churn doesn't expire the row
+// while the user is still deciding.
+async function handleSendUserSelect(interaction, { flow_id, row }) {
+  const selected = [...interaction.users.values()];
+  if (selected.length === 0) {
+    return interaction.deferUpdate().catch(logIgnoredDiscordErr);
+  }
+  const { valid, droppedBots, droppedSelf } = partitionRecipients(selected, interaction.user.id);
+  if (valid.length === 0) {
+    return interaction.update({
+      content: '⚠\u{FE0F} ' + (droppedBots > 0 ? 'Cannot send to bots.' : 'Cannot send to yourself.')
+        + ' Re-pick recipients below.',
+      components: renderConfirmCardRows({ needsPicker: true, sendDisabled: true }),
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
+    return interaction.update({
+      content: `⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.`,
+      components: renderConfirmCardRows({ needsPicker: true, sendDisabled: true }),
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  const payload = row.payload || {};
+  const newPayload = { ...payload, recipientIds: valid.map((u) => u.id) };
+  const result = await transitionFlow(flow_id, row.version, {
+    stage_to: SEND_STAGE_AWAITING_CONFIRM,
+    payload: newPayload,
+    terminal: false,
+    set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+  });
+  if (result.result === 'conflict') {
+    return interaction.update({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.update({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  // Recompute warnings against the new pick (bots-on-pick is the only
+  // signal that can flip here; cappedCount / invalidTokens were string-
+  // path-only). droppedBots / droppedSelf above already short-circuited
+  // on zero-valid; if we got here, both are best-effort UI cues only.
+  const warningsBlock = renderRecipientWarnings({
+    invalidTokens: [],
+    cappedCount: 0,
+    unresolvedIds: [],
+    droppedBots,
+    droppedSelf,
+  });
+  const content = renderConfirmCardContent({
+    resourceType: payload.resourceType,
+    resourceLabel: payload.resourceLabel,
+    validRecipients: valid,
+    expiresIn: payload.expiresIn,
+    selfDestructSeconds: payload.selfDestructSeconds,
+    personalMessage: payload.personalMessage,
+    warningsBlock,
+    needsPicker: false,
+  });
+  return interaction.update({
+    content,
+    components: renderConfirmCardRows({ needsPicker: true, sendDisabled: false }),
+  }).catch(logIgnoredDiscordErr);
+}
+
+// Send button → fire executeSendPipeline. deleteFlow first as the
+// dedup primitive (duplicate dispatch under future SQS at-least-once
+// must not double-send). Mirrors handleRevokeSelect's ordering.
+async function handleSendConfirmClick(interaction, { flow_id, row }) {
+  const payload = row.payload || {};
+  // Re-fetch users at click time — defensive against members leaving
+  // the guild between confirm and Send. unresolvedIds at this point
+  // are no longer surface-able (we already committed past the warning
+  // step), so they're silently dropped with a debug log.
+  const { users, unresolvedIds } = await resolveRecipientUsers(interaction, payload.recipientIds || []);
+  if (unresolvedIds.length > 0) {
+    logger.debug('handleSendConfirmClick: dropping unresolved IDs at click time', {
+      flow_id, count: unresolvedIds.length,
+    });
+  }
+  const { valid } = partitionRecipients(users, interaction.user.id);
+  if (valid.length === 0) {
+    // Everyone left the guild between confirm and Send. Treat as a
+    // terminal failure of THIS attempt — delete the flow so a rerun
+    // claims a fresh slot.
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on empty failed', {
+      flow_id, error: err && err.message,
+    }));
+    return interaction.update({
+      content: '❌ Recipients are no longer available. Re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  // Resolve apiKey before dedup — getGuildApiKey is idempotent + free,
+  // so a duplicate dispatch's redundant call is harmless. Same
+  // safety rule handleRevokeSelect documents (parallelize ONLY with
+  // idempotent reads).
+  const [guildApiKey, deleteResult] = await Promise.all([
+    interaction.guildId ? db.getGuildApiKey(interaction.guildId) : null,
+    deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }),
+  ]);
+  if (!deleteResult.deleted) {
+    return interaction.reply({
+      content: 'This send was already processed.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  const apiKey = guildApiKey || config.QURL_API_KEY;
+  if (!apiKey) {
+    return interaction.update({
+      content: '❌ qURL is no longer configured for this server. Ask an admin to run `/qurl setup`.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  // Ack with a "Preparing send…" placeholder; executeSendPipeline
+  // takes over the editReply from here. Matches handleSend's hand-off
+  // shape at commands.js:~2307.
+  await interaction.update({ content: 'Preparing send…', components: [] }).catch(logIgnoredDiscordErr);
+
+  return executeSendPipeline(interaction, {
+    apiKey,
+    resourceType: payload.resourceType,
+    attachment: payload.attachment,
+    locationUrl: payload.locationUrl,
+    locationName: payload.locationName,
+    recipients: valid,
+    target: 'user',
+    isVoiceContext: false,
+    expiresIn: payload.expiresIn,
+    selfDestructSeconds: payload.selfDestructSeconds,
+    personalMessage: payload.personalMessage,
+    sendNonce: payload.sendNonce,
+  });
+}
+
+// Cancel button → deleteFlow + acknowledge. The cooldown was set on
+// invocation; clear it so a user who second-guesses isn't gated for
+// the full QURL_SEND_COOLDOWN_MS window.
+async function handleSendCancelClick(interaction, { flow_id }) {
+  const { deleted } = await deleteFlow(flow_id, {
+    stage: SEND_STAGE_AWAITING_CONFIRM,
+    reason: 'terminal',
+  });
+  clearCooldown(interaction.user.id);
+  if (!deleted) {
+    return interaction.reply({
+      content: 'This send was already processed.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  return interaction.update({
+    content: 'Send cancelled.',
+    components: [],
+  }).catch(logIgnoredDiscordErr);
+}
+
 // Pure rendering / wording logic lives in `./revoke-render` so the
 // e2e smoke test can require it without pulling in `discord.js`.
 const {
@@ -4136,6 +4834,84 @@ const commands = [
           // then converges on a shared final step that gathers
           // recipient(s), optional message, and expiry before
           // committing the send.
+          //
+          // PR 7b.3 hard-removes /qurl send in favor of /qurl file
+          // and /qurl map. The two new subcommands take all options
+          // up-front so power users can stay on the keyboard, and
+          // the in-channel confirm card is flow_state-backed.
+      )
+      .addSubcommand(sub =>
+        sub.setName('file')
+          .setDescription('Share a file via one-time qURL links')
+          .addAttachmentOption(opt =>
+            opt.setName('attachment')
+              .setDescription('The file to share')
+              .setRequired(true)
+          )
+          .addStringOption(opt =>
+            opt.setName('recipients')
+              .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
+              .setRequired(false)
+              .setMaxLength(RECIPIENTS_MAX_INPUT_LENGTH)
+          )
+          .addStringOption(opt =>
+            opt.setName('expires-in')
+              .setDescription('How long the qURL links stay valid (default: 24 hours)')
+              .setRequired(false)
+              .addChoices(...EXPIRY_CHOICES)
+          )
+          .addStringOption(opt =>
+            opt.setName('self-destruct')
+              .setDescription('Optional countdown after first open (default: no timer)')
+              .setRequired(false)
+              .addChoices(...SELF_DESTRUCT_CHOICES)
+          )
+          .addStringOption(opt =>
+            opt.setName('personal-message')
+              .setDescription('Optional note included in each recipient\'s DM')
+              .setRequired(false)
+              .setMaxLength(280)
+          )
+      )
+      .addSubcommand(sub =>
+        sub.setName('map')
+          .setDescription('Share a Google Maps location via one-time qURL links')
+          .addStringOption(opt =>
+            opt.setName('location')
+              .setDescription('Google Maps URL, or a place / address to search')
+              .setRequired(true)
+              .setMaxLength(500)
+          )
+          .addStringOption(opt =>
+            opt.setName('recipients')
+              .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
+              .setRequired(false)
+              .setMaxLength(RECIPIENTS_MAX_INPUT_LENGTH)
+          )
+          .addStringOption(opt =>
+            opt.setName('location-name')
+              .setDescription('Override the label shown to recipients (defaults to URL/address)')
+              .setRequired(false)
+              .setMaxLength(256)
+          )
+          .addStringOption(opt =>
+            opt.setName('expires-in')
+              .setDescription('How long the qURL links stay valid (default: 24 hours)')
+              .setRequired(false)
+              .addChoices(...EXPIRY_CHOICES)
+          )
+          .addStringOption(opt =>
+            opt.setName('self-destruct')
+              .setDescription('Optional countdown after first open (default: no timer)')
+              .setRequired(false)
+              .addChoices(...SELF_DESTRUCT_CHOICES)
+          )
+          .addStringOption(opt =>
+            opt.setName('personal-message')
+              .setDescription('Optional note included in each recipient\'s DM')
+              .setRequired(false)
+              .setMaxLength(280)
+          )
       )
       .addSubcommand(sub =>
         sub.setName('revoke')
@@ -4363,9 +5139,13 @@ const commands = [
         });
       }
 
-      // Gate: require guild API key for send/revoke
+      // Gate: require guild API key for send/file/map/revoke. The
+      // `Set.has` lookup keeps the gate's allowlist single-source —
+      // adding a new send-style subcommand in 7b.3+ only requires
+      // touching this set, not the dispatch fall-through below.
+      const SEND_LIKE_SUBCOMMANDS = new Set(['send', 'file', 'map', 'revoke']);
       let resolvedApiKey = null;
-      if (sub === 'send' || sub === 'revoke') {
+      if (SEND_LIKE_SUBCOMMANDS.has(sub)) {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;
         if (!guildApiKey && !config.QURL_API_KEY) {
           return interaction.reply({
@@ -4383,6 +5163,8 @@ const commands = [
       // sometimes clone/serialize interactions) and a security smell for
       // secret-bearing values.
       if (sub === 'send') return handleSend(interaction, resolvedApiKey);
+      if (sub === 'file') return handleQurlFile(interaction, resolvedApiKey);
+      if (sub === 'map') return handleQurlMap(interaction, resolvedApiKey);
       if (sub === 'revoke') return handleRevoke(interaction, resolvedApiKey);
       if (sub === 'help') {
         // Section order: user-facing flow first (Getting started → How it
@@ -4406,7 +5188,9 @@ const commands = [
         return interaction.reply({
           content: '**qURL Bot — Help**\n\n' +
             '**Getting started — Share resources securely via one-time links:**\n' +
-            '  `/qurl send` — send a file or location to users\n' +
+            '  `/qurl file` — share a file with users via one-time qURL links\n' +
+            '  `/qurl map` — share a Google Maps location via one-time qURL links\n' +
+            '  `/qurl send` — legacy button-driven flow (use `/qurl file` or `/qurl map` instead)\n' +
             '  `/qurl revoke` — revoke links from a previous send\n' +
             '  `/qurl help` — show this message\n\n' +
             '**How it works:**\n' +
@@ -4416,17 +5200,17 @@ const commands = [
             // misalign "1." with "2.", "3.", "4."). The tab indent now
             // matches the two-space indent below, but bypasses the list
             // auto-formatter.
-            '\t1. Run `/qurl send` and pick **Send File** or **Send Location**\n' +
-            '  2. (Files only) I\'ll DM you privately — attach the file there, not in the public channel\n' +
-            '  3. Choose recipient(s), expiry, and optionally a personal message — then click **Send**\n' +
+            '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n' +
+            '  2. Optionally `recipients:@a @b @role` — leave blank to pick from a menu\n' +
+            '  3. Confirm the card, then click **Send**\n' +
             '  4. Recipients get a one-time link by DM that self-destructs on first access (or when the expiry elapses)\n\n' +
             oauthSetupSection +
             '**Terms:** a *protected resource* is the file or location you\'re sharing. ' +
             'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
-            'You create a qurl for a protected resource each time you run `/qurl send`.\n\n' +
-            '**Large servers (~1000+ members):** when sending to **Everyone in this channel** ' +
-            'or **Everyone in your voice channel**, members who appear offline in Discord may be skipped. ' +
-            'If you need to reach a specific person for sure, pick **A specific user**.\n\n' +
+            'You create a qurl for a protected resource each time you run `/qurl file` or `/qurl map`.\n\n' +
+            '**Large servers (~1000+ members):** `/qurl send` with **Everyone in this channel** ' +
+            'or **Everyone in your voice channel** may skip members who appear offline in Discord. ' +
+            'If you need to reach a specific person for sure, prefer `/qurl file` or `/qurl map` with an explicit @mention.\n\n' +
             'Learn more at **https://layerv.ai**.',
           ephemeral: true,
         });
@@ -4703,6 +5487,26 @@ registerFlow(SETUP_MODAL_CUSTOM_ID, {
   siblingMessage: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
 });
 
+// /qurl file + /qurl map confirm-card components. All three customIds
+// share the same expectedStage — they're three component types
+// (button + user-select + button) attached to the same confirm-card
+// message, all routed by stage. siblingMessage is registered on the
+// FIRST customId only; flow-dispatch rejects mismatched re-registrations
+// of the same stage so we don't repeat it.
+registerFlow(SEND_USER_SELECT_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendUserSelect,
+  siblingMessage: 'You have a `/qurl file` or `/qurl map` confirm card open in this channel — finish or cancel it first.',
+});
+registerFlow(SEND_CONFIRM_SEND_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendConfirmClick,
+});
+registerFlow(SEND_CONFIRM_CANCEL_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendCancelClick,
+});
+
 module.exports = {
   commands,
   registerCommands,
@@ -4712,6 +5516,9 @@ module.exports = {
   handleRevokeSelect,
   handleSetupButton,
   handleSetupModal,
+  handleSendUserSelect,
+  handleSendConfirmClick,
+  handleSendCancelClick,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with
@@ -4776,6 +5583,22 @@ module.exports = {
       SETUP_API_KEY_MIN_LENGTH,
       SETUP_API_KEY_MAX_LENGTH,
       SETUP_SUCCESS_MSG,
+      // /qurl file + /qurl map handlers + flow constants. Tests pin
+      // against production values via these exports rather than
+      // re-stating the strings.
+      handleQurlFile,
+      handleQurlMap,
+      resolveRecipientUsers,
+      partitionRecipients,
+      selfDestructOptionToSeconds,
+      renderRecipientWarnings,
+      renderConfirmCardContent,
+      SEND_STAGE_AWAITING_CONFIRM,
+      SEND_USER_SELECT_CUSTOM_ID,
+      SEND_CONFIRM_SEND_CUSTOM_ID,
+      SEND_CONFIRM_CANCEL_CUSTOM_ID,
+      SEND_FLOW_TTL_SECONDS,
+      SELF_DESTRUCT_NO_TIMER_CHOICE,
     },
   }),
 };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4426,7 +4426,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // without committing the dedup deleteFlow.
   let resolved;
   try {
-    resolved = await resolveRecipientUsers(interaction, payload.recipientIds || []);
+    resolved = await resolveRecipientUsers(interaction, payload.recipientIds);
   } catch (err) {
     logger.error('handleSendConfirmClick: resolveRecipientUsers threw', {
       flow_id, error: err && err.message,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3862,8 +3862,10 @@ async function handleQurlFile(interaction, apiKey) {
     });
   }
   if (attachment.size > MAX_FILE_SIZE) {
+    // Match /qurl send's MB formatting at commands.js:~1994 so users
+    // see the same readable cap across all three entry points.
     return interaction.reply({
-      content: `❌ File too large: ${attachment.size} bytes (cap: ${MAX_FILE_SIZE}).`,
+      content: `❌ File too large (${Math.round(attachment.size / 1024 / 1024)}MB). Maximum is ${Math.round(MAX_FILE_SIZE / 1024 / 1024)}MB.`,
       ephemeral: true,
     });
   }
@@ -3933,6 +3935,11 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
       components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
     }).catch(logIgnoredDiscordErr);
   }
+  // Defense-in-depth — unreachable in production today: the picker's
+  // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,
+  // QURL_SEND_MAX_RECIPIENTS=25) = 10, so the user physically can't
+  // pick more than 25. Kept against a future bump to either constant
+  // (or a forged interaction) so the cap stays honored.
   if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
     return interaction.update({
       content: `⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.`,
@@ -4001,20 +4008,24 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 async function handleSendConfirmClick(interaction, { flow_id, row }) {
   const payload = row.payload || {};
   // Re-fetch users at click time — defensive against members leaving
-  // the guild between confirm and Send. unresolvedIds at this point
-  // are no longer surface-able (we already committed past the warning
-  // step), so they're silently dropped with a debug log.
+  // the guild between confirm and Send. `partialDropCount` carries
+  // unresolved IDs forward so the Send-success path can surface a
+  // followUp explaining why N recipients won't receive their DM.
+  // The forensic log escalates to info (not debug) — oncall benefits
+  // from grep-discoverable signal on guild churn mid-flow without
+  // having to lower log verbosity.
   const { users, unresolvedIds } = await resolveRecipientUsers(interaction, payload.recipientIds || []);
-  if (unresolvedIds.length > 0) {
-    logger.debug('handleSendConfirmClick: dropping unresolved IDs at click time', {
-      flow_id, count: unresolvedIds.length,
+  const partialDropCount = unresolvedIds.length;
+  if (partialDropCount > 0) {
+    logger.info('handleSendConfirmClick: dropping unresolved IDs at click time', {
+      flow_id, count: partialDropCount,
     });
   }
   const { valid } = partitionRecipients(users, interaction.user.id);
   if (valid.length === 0) {
-    // Everyone left the guild between confirm and Send. Treat as a
-    // terminal failure of THIS attempt — delete the flow so a rerun
-    // claims a fresh slot.
+    // Every recipient resolved at confirm time has since left the
+    // guild or become unreachable. Terminal for THIS attempt —
+    // delete the flow so a rerun claims a fresh slot.
     await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
@@ -4022,7 +4033,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       flow_id, error: err && err.message,
     }));
     return interaction.update({
-      content: '❌ Recipients are no longer available. Re-run the command.',
+      content: '❌ Recipients are no longer reachable (all left the server). Re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
@@ -4073,6 +4084,18 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // takes over the editReply from here. Matches handleSend's hand-off
   // shape at commands.js:~2307.
   await interaction.update({ content: 'Preparing send…', components: [] }).catch(logIgnoredDiscordErr);
+
+  // Surface the partial-drop (members who left the guild between
+  // confirm and Send) as a separate ephemeral followUp BEFORE the
+  // back-half takes over the main reply. Without this the user
+  // would see "Sent to N users" with no signal that N != the count
+  // shown on the card.
+  if (partialDropCount > 0) {
+    await interaction.followUp({
+      content: `ℹ\u{FE0F} ${partialDropCount} recipient${partialDropCount === 1 ? '' : 's'} had left the server between **Send** and now — sending to the remaining ${valid.length}.`,
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
 
   return executeSendPipeline(interaction, {
     apiKey,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3408,7 +3408,7 @@ async function handleSetupModal(interaction, { flow_id }) {
 
 const {
   parseRecipientMentions,
-  MAX_INPUT_LENGTH: RECIPIENTS_MAX_INPUT_LENGTH,
+  MAX_SLASH_OPTION_LENGTH: RECIPIENTS_SLASH_MAX_LENGTH,
 } = require('./recipient-parser');
 
 const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
@@ -3614,12 +3614,18 @@ function renderConfirmCardContent({
   return content;
 }
 
-// Build the ActionRow set for the confirm card. When `needsPicker`,
-// row 0 is a UserSelectMenu (recipients absent / post-filter empty);
-// otherwise no picker row. Send/Cancel always in the last row.
-function renderConfirmCardRows({ needsPicker, sendDisabled }) {
+// Build the ActionRow set for the confirm card. When `attachPicker`,
+// row 0 is a UserSelectMenu (recipients absent OR a prior pick is in
+// the payload and the user might want to re-pick); otherwise no
+// picker row. Send/Cancel always in the last row.
+//
+// Renamed from `needsPicker` so the content/rows divergence at the
+// post-pick call site (content rendered WITHOUT picker, rows rendered
+// WITH picker — to let the user re-pick) is impossible to silently
+// merge in a future refactor.
+function renderConfirmCardRows({ attachPicker, sendDisabled }) {
   const rows = [];
-  if (needsPicker) {
+  if (attachPicker) {
     const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
     rows.push(new ActionRowBuilder().addComponents(
       new UserSelectMenuBuilder()
@@ -3665,150 +3671,167 @@ async function handleQurlSlashSend(interaction, apiKey, params) {
   }
   setCooldown(interaction.user.id);
 
-  await interaction.deferReply({ ephemeral: true });
+  // Top-level try/catch fences unanticipated throws (a TypeError from
+  // a malformed cached member, a future parser change, etc.) from
+  // leaving the user stranded in a cooldown window for a failure
+  // that never produced a visible response. Every known failure
+  // mode below has its own targeted clearCooldown + ephemeral
+  // editReply; this catch is the safety net for everything else.
+  try {
+    await interaction.deferReply({ ephemeral: true });
 
-  const recipientsRaw = interaction.options.getString('recipients');
-  const expiresIn = interaction.options.getString('expires-in') || '24h';
-  const selfDestructValue = interaction.options.getString('self-destruct') || SELF_DESTRUCT_NO_TIMER_CHOICE;
-  const personalMessageRaw = interaction.options.getString('personal-message');
+    const recipientsRaw = interaction.options.getString('recipients');
+    const expiresIn = interaction.options.getString('expires-in') || '24h';
+    const selfDestructValue = interaction.options.getString('self-destruct') || SELF_DESTRUCT_NO_TIMER_CHOICE;
+    const personalMessageRaw = interaction.options.getString('personal-message');
 
-  // Defense-in-depth: expiresIn comes from the slash command's choice
-  // list which Discord enforces server-side, but a forged interaction
-  // could carry an off-set value. EXPIRY_LABELS owns the closed set.
-  if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
-    clearCooldown(interaction.user.id);
-    return interaction.editReply({
-      content: '❌ Unrecognized expiry value. Re-run and pick from the list.',
-    });
-  }
-  const selfDestructSeconds = selfDestructOptionToSeconds(selfDestructValue);
-  const personalMessage = personalMessageRaw ? sanitizeMessage(personalMessageRaw) : null;
-
-  // Phase 1: parse the recipients string (no fetch yet).
-  const parsed = parseRecipientMentions(recipientsRaw, interaction);
-
-  // Phase 2: resolve IDs → Users via guild member cache + fallback fetch.
-  let resolved = { users: [], unresolvedIds: [] };
-  if (parsed.ids.length > 0) {
-    try {
-      resolved = await resolveRecipientUsers(interaction, parsed.ids);
-    } catch (err) {
+    // Defense-in-depth: expiresIn comes from the slash command's choice
+    // list which Discord enforces server-side, but a forged interaction
+    // could carry an off-set value. EXPIRY_LABELS owns the closed set.
+    if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
       clearCooldown(interaction.user.id);
-      logger.error('qurl file/map: resolveRecipientUsers threw', {
-        user_id: interaction.user.id, error: err && err.message,
-      });
       return interaction.editReply({
-        content: '❌ Could not resolve recipients. Please try again.',
+        content: '❌ Unrecognized expiry value. Re-run and pick from the list.',
       });
     }
-  }
+    const selfDestructSeconds = selfDestructOptionToSeconds(selfDestructValue);
+    const personalMessage = personalMessageRaw ? sanitizeMessage(personalMessageRaw) : null;
 
-  // Phase 3: drop bots + self.
-  const { valid, droppedBots, droppedSelf } = partitionRecipients(resolved.users, interaction.user.id);
+    const parsed = parseRecipientMentions(recipientsRaw, interaction);
 
-  // Phase 4: decide branch — confirm card straight through, or picker
-  // fallback. `needsPicker` is true when the user supplied no
-  // `recipients:` value at all. When they DID supply one but it
-  // post-filtered to empty, we hard-fail with a specific error so
-  // the user knows why (vs. silently dropping into the picker, which
-  // would mask the underlying mention-list problem).
-  const recipientsOmitted = recipientsRaw == null || recipientsRaw.trim().length === 0;
-  const warningsBlock = renderRecipientWarnings({
-    invalidTokens: parsed.invalidTokens,
-    cappedCount: parsed.cappedCount,
-    unresolvedIds: resolved.unresolvedIds,
-    droppedBots,
-    droppedSelf,
-  });
-  if (!recipientsOmitted && valid.length === 0) {
-    clearCooldown(interaction.user.id);
-    // Parser silently strips bots + the sender from `<@id>` mentions
-    // when the cache reports them (recipient-parser.js:205, 214) —
-    // those IDs never reach `partitionRecipients`. If post-parse `ids`
-    // is empty AND the user supplied non-empty `recipients`, surface
-    // a "nothing usable" message even when partition's breakdown is
-    // zero. This is what bot-only / self-only mention lists hit.
-    const breakdownEmpty = droppedBots === 0 && droppedSelf === 0
-      && resolved.unresolvedIds.length === 0
-      && parsed.invalidTokens.length === 0
-      && parsed.cappedCount === 0;
-    const detail = breakdownEmpty
-      ? '\n\nMake sure you @-mention real users (bots and your own user are skipped automatically).'
-      : '';
-    return interaction.editReply({
-      content: warningsBlock + '❌ **No valid recipients to send to.** Re-run with at least one valid user mention.' + detail,
+    let resolved = { users: [], unresolvedIds: [] };
+    if (parsed.ids.length > 0) {
+      try {
+        resolved = await resolveRecipientUsers(interaction, parsed.ids);
+      } catch (err) {
+        clearCooldown(interaction.user.id);
+        logger.error('qurl file/map: resolveRecipientUsers threw', {
+          user_id: interaction.user.id, error: err && err.message,
+        });
+        return interaction.editReply({
+          content: '❌ Could not resolve recipients. Please try again.',
+        });
+      }
+    }
+
+    const { valid, droppedBots, droppedSelf } = partitionRecipients(resolved.users, interaction.user.id);
+
+    // `needsPicker` is true when the user supplied no `recipients:`
+    // value at all. When they DID supply one but it post-filtered to
+    // empty, hard-fail with a specific error so the user knows why
+    // (vs. silently dropping into the picker, which would mask the
+    // underlying mention-list problem).
+    const recipientsOmitted = recipientsRaw == null || recipientsRaw.trim().length === 0;
+    const warningsBlock = renderRecipientWarnings({
+      invalidTokens: parsed.invalidTokens,
+      cappedCount: parsed.cappedCount,
+      unresolvedIds: resolved.unresolvedIds,
+      droppedBots,
+      droppedSelf,
     });
-  }
+    if (!recipientsOmitted && valid.length === 0) {
+      clearCooldown(interaction.user.id);
+      // Parser silently strips bots + the sender from `<@id>` mentions
+      // when the cache reports them (recipient-parser.js:205, 214) —
+      // those IDs never reach `partitionRecipients`. If post-parse `ids`
+      // is empty AND the user supplied non-empty `recipients`, surface
+      // a "nothing usable" message even when partition's breakdown is
+      // zero. This is what bot-only / self-only mention lists hit.
+      const breakdownEmpty = droppedBots === 0 && droppedSelf === 0
+        && resolved.unresolvedIds.length === 0
+        && parsed.invalidTokens.length === 0
+        && parsed.cappedCount === 0;
+      const detail = breakdownEmpty
+        ? '\n\nMake sure you @-mention real users (bots and your own user are skipped automatically).'
+        : '';
+      return interaction.editReply({
+        content: warningsBlock + '❌ **No valid recipients to send to.** Re-run with at least one valid user mention.' + detail,
+      });
+    }
 
-  const needsPicker = recipientsOmitted;
-  const recipientIds = valid.map((u) => u.id);
+    const needsPicker = recipientsOmitted;
+    const recipientIds = valid.map((u) => u.id);
 
-  // Phase 5: open the flow row. supersedeOrCreate handles the
-  // "another /qurl file/map is open" case — sibling-flow disambig
-  // surfaces a stage-specific message; same-stage rerun atomically
-  // claims the slot. Mirrors /qurl revoke's pattern.
-  const flow_id = flowIdForInteraction(interaction);
-  const sendNonce = crypto.randomBytes(8).toString('hex');
-  const payload = {
-    resourceType: params.resourceType,
-    attachment: params.attachment,
-    locationUrl: params.locationUrl,
-    locationName: params.locationName,
-    resourceLabel: params.resourceLabel,
-    recipientIds,
-    expiresIn,
-    selfDestructSeconds,
-    personalMessage,
-    sendNonce,
-  };
-  let supersede;
-  try {
-    supersede = await supersedeOrCreate({
-      flow_id,
-      stage: SEND_STAGE_AWAITING_CONFIRM,
-      payload,
-      ttl_seconds: SEND_FLOW_TTL_SECONDS,
+    // supersedeOrCreate handles the "another /qurl file/map is open"
+    // case — sibling-flow disambig surfaces a stage-specific message;
+    // same-stage rerun atomically claims the slot. Mirrors /qurl
+    // revoke's pattern.
+    const flow_id = flowIdForInteraction(interaction);
+    const sendNonce = crypto.randomBytes(8).toString('hex');
+    const payload = {
+      resourceType: params.resourceType,
+      attachment: params.attachment,
+      locationUrl: params.locationUrl,
+      locationName: params.locationName,
+      resourceLabel: params.resourceLabel,
+      recipientIds,
+      expiresIn,
+      selfDestructSeconds,
+      personalMessage,
+      sendNonce,
+    };
+    let supersede;
+    try {
+      supersede = await supersedeOrCreate({
+        flow_id,
+        stage: SEND_STAGE_AWAITING_CONFIRM,
+        payload,
+        ttl_seconds: SEND_FLOW_TTL_SECONDS,
+      });
+    } catch (err) {
+      clearCooldown(interaction.user.id);
+      logger.warn('handleQurlSlashSend: supersedeOrCreate threw', {
+        flow_id, error: err && err.message,
+      });
+      return interaction.editReply({
+        content: '❌ Could not start a send — please try again.',
+      });
+    }
+    if (!supersede.created) {
+      clearCooldown(interaction.user.id);
+      const siblingMsg = siblingMessageForStage(supersede.surviving?.stage);
+      return interaction.editReply({
+        content: siblingMsg || '❌ Could not start a send — please try again.',
+      });
+    }
+
+    const content = renderConfirmCardContent({
+      resourceType: params.resourceType,
+      resourceLabel: params.resourceLabel,
+      validRecipients: valid,
+      expiresIn,
+      selfDestructSeconds,
+      personalMessage,
+      warningsBlock,
+      needsPicker,
     });
+    const rows = renderConfirmCardRows({
+      attachPicker: needsPicker,
+      sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
+    });
+    return interaction.editReply({ content, components: rows });
   } catch (err) {
+    // Unanticipated throw. Always clear cooldown — the user got no
+    // visible response, so they must not be locked out for the full
+    // cooldown window. Try to surface a generic error via the
+    // (already-deferred) reply; if the editReply ALSO throws (token
+    // expired, Discord blip), the safety-net catch in flow-dispatch's
+    // handleFlowInteraction handles the front-half error visibility.
     clearCooldown(interaction.user.id);
-    logger.warn('handleQurlSlashSend: supersedeOrCreate threw', {
-      flow_id, error: err && err.message,
+    logger.error('handleQurlSlashSend: unexpected throw', {
+      user_id: interaction.user.id, error: err && err.message, stack: err && err.stack,
     });
     return interaction.editReply({
-      content: '❌ Could not start a send — please try again.',
-    });
+      content: '❌ Something went wrong — please try again.',
+    }).catch(logIgnoredDiscordErr);
   }
-  if (!supersede.created) {
-    clearCooldown(interaction.user.id);
-    const siblingMsg = siblingMessageForStage(supersede.surviving?.stage);
-    return interaction.editReply({
-      content: siblingMsg || '❌ Could not start a send — please try again.',
-    });
-  }
-
-  // Phase 6: render the confirm card.
-  const content = renderConfirmCardContent({
-    resourceType: params.resourceType,
-    resourceLabel: params.resourceLabel,
-    validRecipients: valid,
-    expiresIn,
-    selfDestructSeconds,
-    personalMessage,
-    warningsBlock,
-    needsPicker,
-  });
-  const rows = renderConfirmCardRows({
-    needsPicker,
-    sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
-  });
-  return interaction.editReply({ content, components: rows });
 }
 
 async function handleQurlFile(interaction, apiKey) {
-  // File concurrency-cap pre-check (UX fast-fail). Final claim happens
-  // inside executeSendPipeline. Surfacing the cap here lets us refuse
-  // the slash invocation before we render a confirm card the user
-  // would then never get past.
+  // UX fast-fail. The real concurrency-slot claim happens inside
+  // executeSendPipeline (commands.js:~1043); this pre-check is best-
+  // effort — by Send-click time the cap state can have shifted, in
+  // which case the back-half's guard fires instead.
   if (activeFileSends >= MAX_CONCURRENT_FILE_SENDS) {
     return interaction.reply({
       content: 'The bot is processing too many file sends right now. Please try again in a moment.',
@@ -3855,7 +3878,11 @@ async function handleQurlFile(interaction, apiKey) {
     },
     locationUrl: null,
     locationName: null,
-    resourceLabel: escapeDiscordMarkdown(attachment.name),
+    // 256-char cap mirrors the map-path `locationName` cap so a future
+    // upload-pipeline change that loosens Discord's filename ceiling
+    // can't bloat the confirm card. String() coerces in case a
+    // hypothetical future caller hands a non-string name.
+    resourceLabel: escapeDiscordMarkdown(String(attachment.name).slice(0, 256)),
   });
 }
 
@@ -3903,13 +3930,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     return interaction.update({
       content: '⚠\u{FE0F} ' + (droppedBots > 0 ? 'Cannot send to bots.' : 'Cannot send to yourself.')
         + ' Re-pick recipients below.',
-      components: renderConfirmCardRows({ needsPicker: true, sendDisabled: true }),
+      components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
     }).catch(logIgnoredDiscordErr);
   }
   if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
     return interaction.update({
       content: `⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.`,
-      components: renderConfirmCardRows({ needsPicker: true, sendDisabled: true }),
+      components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
     }).catch(logIgnoredDiscordErr);
   }
 
@@ -3945,6 +3972,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     droppedBots,
     droppedSelf,
   });
+  // Intentional flag divergence: the CONTENT renders the resolved
+  // recipient summary ("**To:** N user(s)") — needsPicker:false —
+  // while the ROWS keep the UserSelectMenu attached so the user can
+  // re-pick. Send is enabled because we now have a valid recipient
+  // set. The two flags are deliberately fed opposite values; the
+  // rename from `needsPicker` to `attachPicker` on the rows side
+  // makes this asymmetry impossible to silently consolidate.
   const content = renderConfirmCardContent({
     resourceType: payload.resourceType,
     resourceLabel: payload.resourceLabel,
@@ -3957,7 +3991,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   });
   return interaction.update({
     content,
-    components: renderConfirmCardRows({ needsPicker: true, sendDisabled: false }),
+    components: renderConfirmCardRows({ attachPicker: true, sendDisabled: false }),
   }).catch(logIgnoredDiscordErr);
 }
 
@@ -4052,21 +4086,34 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   });
 }
 
-// Cancel button → deleteFlow + acknowledge. The cooldown was set on
-// invocation; clear it so a user who second-guesses isn't gated for
-// the full QURL_SEND_COOLDOWN_MS window.
-async function handleSendCancelClick(interaction, { flow_id }) {
+// Cancel button → version-gated deleteFlow + acknowledge.
+//
+// expectedVersion fences two distinct races, both serious:
+//  1. Cancel vs. Send: if Send is mid-dispatch (already deleted the
+//     flow), Cancel must NOT clear the cooldown — the first send is
+//     fanning out DMs and the user could otherwise immediately rerun
+//     and bypass the per-user cooldown window mid-send.
+//  2. Cancel vs. UserSelect: a Cancel click that lands while a
+//     UserSelectMenu transition is in flight would otherwise silently
+//     kill the row out from under the user's pick. The version gate
+//     surfaces that as the dedup-loser path (user re-clicks Cancel on
+//     the new row if they still want to abort).
+//
+// `clearCooldown` is gated on `deleted: true` so the cooldown stays
+// honored on the Cancel-loser branch.
+async function handleSendCancelClick(interaction, { flow_id, row }) {
   const { deleted } = await deleteFlow(flow_id, {
     stage: SEND_STAGE_AWAITING_CONFIRM,
     reason: 'terminal',
+    expectedVersion: row.version,
   });
-  clearCooldown(interaction.user.id);
   if (!deleted) {
     return interaction.reply({
-      content: 'This send was already processed.',
+      content: 'This send was already processed or the card moved — re-check it.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
+  clearCooldown(interaction.user.id);
   return interaction.update({
     content: 'Send cancelled.',
     components: [],
@@ -4872,7 +4919,7 @@ const commands = [
             opt.setName('recipients')
               .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
               .setRequired(false)
-              .setMaxLength(RECIPIENTS_MAX_INPUT_LENGTH)
+              .setMaxLength(RECIPIENTS_SLASH_MAX_LENGTH)
           )
           .addStringOption(opt =>
             opt.setName('expires-in')
@@ -4906,7 +4953,7 @@ const commands = [
             opt.setName('recipients')
               .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
               .setRequired(false)
-              .setMaxLength(RECIPIENTS_MAX_INPUT_LENGTH)
+              .setMaxLength(RECIPIENTS_SLASH_MAX_LENGTH)
           )
           .addStringOption(opt =>
             opt.setName('location-name')

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4086,11 +4086,13 @@ async function handleQurlFile(interaction) {
   // Required-option lookups via `getAttachment(..., true)` /
   // `getString(..., true)` throw on a missing option. Discord enforces
   // required server-side, so production interactions can't trip
-  // these; a forged interaction is the only way. The targeted catch
-  // produces an actionable ephemeral rather than letting the throw
-  // hit the dispatcher's generic safety net. Cooldown stays set —
-  // forged interactions are abuse-aligned, same shape as the SSRF
-  // gate below.
+  // these — BUT the more likely cause of a hit in production is a
+  // client/schema desync (gateway has the new command schema, bot
+  // has the old, or vice versa) during a redeploy window, not abuse.
+  // Clear the cooldown so the user can retry once the deploy
+  // stabilizes. SSRF gate below still preserves cooldown (probing
+  // the allow-list IS abuse-aligned and doesn't have a redeploy
+  // explanation).
   let attachment;
   try {
     attachment = interaction.options.getAttachment('attachment', true);
@@ -4098,15 +4100,15 @@ async function handleQurlFile(interaction) {
     logger.warn('handleQurlFile: required attachment option missing', {
       user_id: interaction.user.id, error: err && err.message,
     });
+    clearCooldown(interaction.user.id);
     return interaction.reply({
       content: '❌ The `attachment:` option is required. Re-run with a file attached.',
       ephemeral: true,
     });
   }
   if (!attachment || typeof attachment.url !== 'string') {
-    // Malformed attachment payload — Discord won't ship one, so this
-    // is forged-interaction territory. Cooldown stays set (abuse-
-    // aligned, same shape as SSRF).
+    // Same client/schema-desync rationale — clear cooldown for retry.
+    clearCooldown(interaction.user.id);
     return interaction.reply({
       content: '❌ Attachment is missing or malformed.',
       ephemeral: true,
@@ -4180,10 +4182,11 @@ async function handleQurlMap(interaction) {
   setCooldown(interaction.user.id);
 
   // `getString('location', true)` throws on a missing option. Discord
-  // enforces required server-side; only a forged interaction can hit
-  // this. Targeted catch matches handleQurlFile's required-option
-  // guard for symmetry + actionable user-visible copy. Cooldown stays
-  // set on the forged-interaction throw branch — abuse-aligned.
+  // enforces required server-side; the more likely cause in production
+  // is a client/schema desync (redeploy timing) than abuse. Clear
+  // cooldown on the throw catch so the user can retry once the deploy
+  // stabilizes — same rationale as handleQurlFile's required-option
+  // throw branch.
   let locationValue;
   try {
     // Defensive .slice mirrors the modal path's pattern at commands.js:~2096.
@@ -4196,6 +4199,7 @@ async function handleQurlMap(interaction) {
     logger.warn('handleQurlMap: required location option missing', {
       user_id: interaction.user.id, error: err && err.message,
     });
+    clearCooldown(interaction.user.id);
     return interaction.reply({
       content: '❌ The `location:` option is required. Re-run with a Google Maps URL or address.',
       ephemeral: true,
@@ -4502,19 +4506,28 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       flow_id, left: partialLeftCount, transient: partialTransientCount,
     });
   }
-  const { valid } = partitionRecipients(users, interaction.user.id);
+  const { valid, droppedBots, droppedSelf } = partitionRecipients(users, interaction.user.id);
   if (valid.length === 0) {
-    // Every recipient resolved at confirm time has since left the
-    // guild or become unreachable. Terminal for THIS attempt —
-    // delete the flow so a rerun claims a fresh slot.
+    // Distinguish the failure mode by what was dropped. The general
+    // case is "everyone left the guild between confirm and Send"
+    // (10007 / transient) — but a forged Send click with payload
+    // recipientIds containing only the sender or only bots would
+    // resolve fine and then partition would drop everything, hitting
+    // this branch with the WRONG copy ("they left the server"
+    // misdirects when nobody left — the recipient list was invalid).
+    // Terminal for THIS attempt either way: delete the flow so a
+    // rerun claims a fresh slot.
     await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
     }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on empty failed', {
       flow_id, error: err && err.message,
     }));
+    const wasInvalidList = droppedBots > 0 || droppedSelf > 0;
     return interaction.editReply({
-      content: '❌ Recipients are no longer reachable (all left the server). Re-run the command.',
+      content: wasInvalidList
+        ? '❌ Invalid recipient list — re-run the command with at least one real user.'
+        : '❌ Recipients are no longer reachable (all left the server). Re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3607,7 +3607,7 @@ function renderRecipientWarnings({
 function renderConfirmCardContent({
   resourceType, resourceLabel, validRecipients,
   expiresIn, selfDestructSeconds, personalMessage,
-  warningsBlock, needsPicker,
+  warningsBlock, needsPicker, interaction,
 }) {
   let content = warningsBlock || '';
   // Explicit branch per RESOURCE_TYPES value — a future resource
@@ -3628,11 +3628,14 @@ function renderConfirmCardContent({
       + ' users), then click **Send**.\n';
   } else {
     // First-N preview keeps the card scannable when a paste resolves
-    // to many users. Discord-name display via resolveRecipientAlias
-    // matches the post-send confirmation wording.
+    // to many users. resolveRecipientAlias prefers nickname > globalName >
+    // username (NFKC + bidi/zero-width strip baked in), matching the
+    // post-send confirmation wording exactly. The escapeDiscordMarkdown
+    // wrap is still required — resolveRecipientAlias returns the PLAIN
+    // form (its docstring at commands.js:~305 calls this out).
     const PREVIEW = 5;
     const previewNames = validRecipients.slice(0, PREVIEW)
-      .map((u) => escapeDiscordMarkdown(u.username))
+      .map((u) => escapeDiscordMarkdown(resolveRecipientAlias(u, interaction)))
       .join(', ');
     const more = validRecipients.length > PREVIEW ? `, +${validRecipients.length - PREVIEW} more` : '';
     content += `\n**To:** ${validRecipients.length} user${validRecipients.length === 1 ? '' : 's'} (${previewNames}${more})\n`;
@@ -3661,23 +3664,34 @@ function renderConfirmCardContent({
 
 // Truncate the pre-sanitized message to 80 chars MAX, then back off
 // to the last completed markdown-escape so a slice doesn't leave a
-// lone trailing `\`. The blockquote prefix (`> `) is rendered by
-// Discord as a left-bar offset.
+// lone trailing `\`. Embedded `\n` is collapsed to a single space —
+// Discord blockquotes are per-LINE (only the line starting with `> `
+// gets the left-bar), so a multi-line message would render with a
+// quoted first line and flush-left subsequent lines. The single-line
+// preview also keeps the card's vertical rhythm predictable.
 //
 // The "back off" handles the case where `sanitizeMessage` emitted a
 // `\` immediately before the slice boundary (e.g. `\*` becomes `\`
 // at index 79, `*` at index 80 — slicing at 80 leaves a dangling
 // `\` that Discord would render as a literal backslash). Trimming
 // to index 79 in that case is the conservative fix.
+// Newlines and Unicode line/paragraph separators (U+2028, U+2029) all
+// render as line breaks in Discord — collapse the lot to single spaces
+// so the blockquote preview stays a single rendered line. Built via
+// `new RegExp(...)` (instead of a literal) so the \uXXXX escapes go
+// through string parsing — keeps the source ASCII-only and avoids
+// editor/tool-chain confusion over raw line-separator codepoints in a
+// regex literal. Same pattern STRIP_RE in utils/sanitize.js uses.
+const NEWLINE_COLLAPSE_RE = new RegExp('[\\r\\n\\u2028\\u2029]+', 'g');
+
 function formatPersonalMessagePreview(message) {
-  if (message.length <= 80) return `> ${message}`;
+  const oneLine = message.replace(NEWLINE_COLLAPSE_RE, ' ');
+  if (oneLine.length <= 80) return `> ${oneLine}`;
   let cut = 80;
-  if (message[cut - 1] === '\\' && message[cut - 2] !== '\\') {
-    // The would-be cut sits ON an escape char. Back off so the
-    // truncation lands BEFORE the escape, not in the middle of it.
+  if (oneLine[cut - 1] === '\\' && oneLine[cut - 2] !== '\\') {
     cut -= 1;
   }
-  return `> ${message.slice(0, cut)}…`;
+  return `> ${oneLine.slice(0, cut)}…`;
 }
 
 // Build the ActionRow set for the confirm card. When `attachPicker`,
@@ -3879,6 +3893,7 @@ async function handleQurlSlashSend(interaction, params) {
       personalMessage,
       warningsBlock,
       needsPicker,
+      interaction,
     });
     const rows = renderConfirmCardRows({
       attachPicker: needsPicker,
@@ -4136,6 +4151,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     personalMessage: payload.personalMessage,
     warningsBlock,
     needsPicker: false,
+    interaction,
   });
   return interaction.update({
     content,
@@ -4162,6 +4178,24 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // deferred state and `.reply` would throw); main-message updates
   // switch from `interaction.update` to `interaction.editReply`.
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
+  // Bot-kicked-between-confirm-and-Send: `interaction.guild` is null.
+  // Without this guard the user sees "all recipients left the server"
+  // (the all-unresolved branch's copy below) — misleading, because
+  // the bot left, not the recipients. Delete the flow row so a
+  // future re-invite + rerun starts fresh.
+  if (!interaction.guild) {
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on bot-kicked failed', {
+      flow_id, error: err && err.message,
+    }));
+    return interaction.editReply({
+      content: '❌ qURL bot is no longer in this server. Re-invite the bot and re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
 
   const payload = row.payload || {};
   // Re-fetch users at click time — defensive against members leaving

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3452,22 +3452,24 @@ function selfDestructOptionToSeconds(value) {
 
 // Resolve a list of recipient IDs to User-shaped objects via the guild
 // member cache (with fallback fetch on miss). Returns
-// `{ users, unresolvedIds }` — callers surface unresolvedIds so a
-// user who left the guild between /qurl file invocation and Send
-// click sees a deterministic error rather than a silent drop in the
-// back-half.
+// `{ users, unresolvedIds, transientFailureIds }` — callers surface
+// each bucket with appropriate copy:
+//   * `unresolvedIds` — Discord API 10007 "Unknown Member". The
+//     canonical "user left the guild" signal. Stable / deterministic.
+//   * `transientFailureIds` — any other fetch error (rate limit
+//     surfacing past discord.js's retry, gateway blip, perms
+//     revoked mid-fetch). User-visible copy should encourage retry
+//     rather than imply the recipient is gone.
 //
-// Discord API code 10007 ("Unknown Member") is the canonical
-// "left the guild" signal. Any other fetch error (rate limit,
-// gateway blip) is also treated as unresolved — degrading to the
-// resolvable subset is preferable to aborting the whole command.
+// Splitting the buckets prevents the 429-rendered-as-"left the
+// server" misdirection cr round 4 flagged.
 //
 // Fetches the cache-miss tail in parallel via `batchSettled` (the
 // same helper used by the DM fan-out path; honors Discord's per-route
 // rate-limit bucket by capping concurrent in-flight calls).
 async function resolveRecipientUsers(interaction, ids) {
   if (!interaction.guild) {
-    return { users: [], unresolvedIds: [...ids] };
+    return { users: [], unresolvedIds: [...ids], transientFailureIds: [] };
   }
   const users = [];
   const missQueue = [];
@@ -3476,35 +3478,44 @@ async function resolveRecipientUsers(interaction, ids) {
     if (cached) users.push(cached.user);
     else missQueue.push(id);
   }
-  if (missQueue.length === 0) return { users, unresolvedIds: [] };
+  if (missQueue.length === 0) {
+    return { users, unresolvedIds: [], transientFailureIds: [] };
+  }
 
   const unresolvedIds = [];
+  const transientFailureIds = [];
   const results = await batchSettled(missQueue, async (id) => {
     try {
       const m = await interaction.guild.members.fetch(id);
-      return { id, user: m.user };
+      return { id, user: m.user, kind: 'ok' };
     } catch (err) {
-      if (!err || (err.code !== 10007 && err.code !== '10007')) {
-        logger.warn('resolveRecipientUsers: members.fetch failed', {
+      // Discord error 10007 is "Unknown Member" — recipient really
+      // left the guild. Anything else (429 rate-limit surfacing past
+      // discord.js's retry, 500-class, gateway disconnect, perms
+      // revoked) is transient and shouldn't read like "they're gone."
+      const is10007 = err && (err.code === 10007 || err.code === '10007');
+      if (!is10007) {
+        logger.warn('resolveRecipientUsers: members.fetch failed (transient)', {
           recipient_id: id, error: err && err.message, code: err && err.code,
         });
       }
-      return { id, user: null };
+      return { id, user: null, kind: is10007 ? 'unknown_member' : 'transient' };
     }
   });
   for (const r of results) {
     // batchSettled wraps each callback in Promise.allSettled — fulfilled
-    // results carry our `{id, user}` shape, rejected ones would carry an
-    // err. The callback never throws (try/catch above) so `rejected` is
-    // unreachable in practice; defend regardless.
-    if (r.status !== 'fulfilled' || !r.value || r.value.user == null) {
-      const id = r.value?.id ?? null;
-      if (id) unresolvedIds.push(id);
+    // results carry our `{id, user, kind}` shape. The callback never
+    // throws (try/catch above) so a `rejected` status is unreachable in
+    // practice; bucket as transient if it ever does fire.
+    if (r.status !== 'fulfilled' || !r.value) continue;
+    if (r.value.user != null) {
+      users.push(r.value.user);
       continue;
     }
-    users.push(r.value.user);
+    if (r.value.kind === 'transient') transientFailureIds.push(r.value.id);
+    else unresolvedIds.push(r.value.id);
   }
-  return { users, unresolvedIds };
+  return { users, unresolvedIds, transientFailureIds };
 }
 
 // Filter resolved Users: drop bots, drop the sender. Returns
@@ -3535,7 +3546,14 @@ function partitionRecipients(users, senderId) {
 // Returns the empty string when nothing is worth surfacing — keeps
 // callers simple (`warningsBlock + content`) without a separate
 // "do I have any warnings" check.
-function renderRecipientWarnings({ invalidTokens, cappedCount, unresolvedIds, droppedBots, droppedSelf }) {
+function renderRecipientWarnings({
+  invalidTokens = [],
+  cappedCount = 0,
+  unresolvedIds = [],
+  transientFailureIds = [],
+  droppedBots = 0,
+  droppedSelf = 0,
+} = {}) {
   const lines = [];
   if (cappedCount > 0) {
     lines.push(`• Capped at ${config.QURL_SEND_MAX_RECIPIENTS} — ${cappedCount} recipient(s) past the cap were dropped.`);
@@ -3554,6 +3572,12 @@ function renderRecipientWarnings({ invalidTokens, cappedCount, unresolvedIds, dr
   }
   if (unresolvedIds.length > 0) {
     lines.push(`• ${unresolvedIds.length} user(s) are no longer in this server and were dropped.`);
+  }
+  if (transientFailureIds.length > 0) {
+    // Distinct copy from unresolvedIds — transient failures (429,
+    // gateway blip) mislead the user if rendered as "they left the
+    // server." Encourage retry.
+    lines.push(`• ${transientFailureIds.length} user(s) couldn't be looked up right now — try again in a moment.`);
   }
   if (droppedBots > 0) {
     lines.push(`• ${droppedBots} bot(s) cannot receive qURL links — skipped.`);
@@ -3699,7 +3723,7 @@ async function handleQurlSlashSend(interaction, apiKey, params) {
 
     const parsed = parseRecipientMentions(recipientsRaw, interaction);
 
-    let resolved = { users: [], unresolvedIds: [] };
+    let resolved = { users: [], unresolvedIds: [], transientFailureIds: [] };
     if (parsed.ids.length > 0) {
       try {
         resolved = await resolveRecipientUsers(interaction, parsed.ids);
@@ -3726,6 +3750,7 @@ async function handleQurlSlashSend(interaction, apiKey, params) {
       invalidTokens: parsed.invalidTokens,
       cappedCount: parsed.cappedCount,
       unresolvedIds: resolved.unresolvedIds,
+      transientFailureIds: resolved.transientFailureIds,
       droppedBots,
       droppedSelf,
     });
@@ -3739,6 +3764,7 @@ async function handleQurlSlashSend(interaction, apiKey, params) {
       // zero. This is what bot-only / self-only mention lists hit.
       const breakdownEmpty = droppedBots === 0 && droppedSelf === 0
         && resolved.unresolvedIds.length === 0
+        && resolved.transientFailureIds.length === 0
         && parsed.invalidTokens.length === 0
         && parsed.cappedCount === 0;
       const detail = breakdownEmpty
@@ -3927,6 +3953,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   if (selected.length === 0) {
     return interaction.deferUpdate().catch(logIgnoredDiscordErr);
   }
+  // No `resolveRecipientUsers` re-fetch here — Discord's
+  // UserSelectMenu only surfaces users visible to the bot in this
+  // guild, so picked User IDs are guild-bounded at the gateway-event
+  // level. handleSendConfirmClick re-fetches at click time
+  // (partial-drop test pins this) as the actual guild-membership
+  // defense; adding it here would burn 10 members.fetch calls per
+  // picker tick without catching anything the Send-time check misses.
   const { valid, droppedBots, droppedSelf } = partitionRecipients(selected, interaction.user.id);
   if (valid.length === 0) {
     return interaction.update({

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3987,31 +3987,36 @@ async function handleQurlSlashSend(interaction, params) {
 }
 
 async function handleQurlFile(interaction) {
-  // Cooldown gate at the EARLIEST entry point so invalid inputs
-  // (malformed attachment, SSRF host, wrong type, oversize) are
-  // throttled too — matches handleSend's pattern at commands.js:~1677.
-  // setCooldown is shared with /qurl send and /qurl map via the
-  // sendCooldowns Map; tests pin the cross-command contract.
-  if (interaction.guildId && interaction.guild) {
-    if (isOnCooldown(interaction.user.id)) {
-      return interaction.reply({
-        content: 'Please wait before sending again.',
-        ephemeral: true,
-      });
-    }
-    setCooldown(interaction.user.id);
+  // DM rejection first — no cooldown burned on a guild-only invocation
+  // attempted from DMs.
+  if (!interaction.guildId || !interaction.guild) {
+    return interaction.reply({
+      content: 'This command can only be used in a server, not in DMs.',
+      ephemeral: true,
+    });
   }
 
-  // UX fast-fail. The real concurrency-slot claim happens inside
-  // executeSendPipeline (commands.js:~1043); this pre-check is best-
-  // effort — by Send-click time the cap state can have shifted, in
-  // which case the back-half's guard fires instead.
+  // UX fast-fail BEFORE setCooldown — "bot too busy" is server-side
+  // backpressure, not user fault; locking the user out for 30s on a
+  // capacity rejection would be punitive.
   if (activeFileSends >= MAX_CONCURRENT_FILE_SENDS) {
     return interaction.reply({
       content: 'The bot is processing too many file sends right now. Please try again in a moment.',
       ephemeral: true,
     });
   }
+
+  // Cooldown gate at entry — after capacity backpressure but BEFORE
+  // any input-validation so invalid inputs (malformed attachment,
+  // SSRF host, wrong type, oversize) still throttle. Matches the
+  // pattern at commands.js:~1677.
+  if (isOnCooldown(interaction.user.id)) {
+    return interaction.reply({
+      content: 'Please wait before sending again.',
+      ephemeral: true,
+    });
+  }
+  setCooldown(interaction.user.id);
 
   // Required-option lookups via `getAttachment(..., true)` /
   // `getString(..., true)` throw on a missing option. Discord enforces
@@ -4082,18 +4087,22 @@ async function handleQurlFile(interaction) {
 }
 
 async function handleQurlMap(interaction) {
-  // Cooldown gate at entry — same pattern handleQurlFile uses.
-  // Cross-command bucket (sendCooldowns) shared with /qurl send and
-  // /qurl file; tests pin the contract.
-  if (interaction.guildId && interaction.guild) {
-    if (isOnCooldown(interaction.user.id)) {
-      return interaction.reply({
-        content: 'Please wait before sending again.',
-        ephemeral: true,
-      });
-    }
-    setCooldown(interaction.user.id);
+  // DM rejection first — no cooldown burned on a DM invocation.
+  if (!interaction.guildId || !interaction.guild) {
+    return interaction.reply({
+      content: 'This command can only be used in a server, not in DMs.',
+      ephemeral: true,
+    });
   }
+  // Cooldown gate — cross-command bucket shared with /qurl send and
+  // /qurl file (sendCooldowns Map). Tests pin the contract.
+  if (isOnCooldown(interaction.user.id)) {
+    return interaction.reply({
+      content: 'Please wait before sending again.',
+      ephemeral: true,
+    });
+  }
+  setCooldown(interaction.user.id);
 
   // `getString('location', true)` throws on a missing option. Discord
   // enforces required server-side; only a forged interaction can hit
@@ -4323,6 +4332,9 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on bot-kicked failed', {
       flow_id, error: err && err.message,
     }));
+    // Zero side effects (no DMs sent, no API calls) — unlock retry
+    // immediately after re-invite without paying the cooldown window.
+    clearCooldown(interaction.user.id);
     return interaction.editReply({
       content: '❌ qURL bot is no longer in this server. Re-invite the bot and re-run the command.',
       components: [],
@@ -4368,6 +4380,9 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     logger.error('handleSendConfirmClick: resolveRecipientUsers threw', {
       flow_id, error: err && err.message,
     });
+    // Zero side effects — unlock retry so the user can re-click Send
+    // immediately after the transient blip clears.
+    clearCooldown(interaction.user.id);
     return interaction.followUp({
       content: '❌ Could not look up recipients right now. Try **Send** again in a moment.',
       ephemeral: true,
@@ -4431,6 +4446,9 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     logger.error('handleSendConfirmClick: getGuildApiKey threw', {
       flow_id, error: err && err.message,
     });
+    // Flow row stays alive; unlock retry so the user isn't stranded
+    // for 30s waiting for a DDB blip to clear.
+    clearCooldown(interaction.user.id);
     return interaction.followUp({
       content: '❌ Could not look up the qURL API key right now. Try **Send** again in a moment.',
       ephemeral: true,
@@ -4450,6 +4468,9 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
 
   const apiKey = guildApiKey || config.QURL_API_KEY;
   if (!apiKey) {
+    // Admin action required to recover (`/qurl setup`); unlock retry so
+    // the user isn't stranded for 30s after the admin completes setup.
+    clearCooldown(interaction.user.id);
     return interaction.editReply({
       content: '❌ qURL is no longer configured for this server. Ask an admin to run `/qurl setup`.',
       components: [],

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -182,6 +182,21 @@ function safeCodepointSlice(s, maxCodepoints) {
   return codepoints.slice(0, cut).join('');
 }
 
+/**
+ * Cap `s` to `maxCodepoints` codepoints and append `indicator` only
+ * when truncation actually occurred. Relies on `safeCodepointSlice`'s
+ * "return the input unchanged when below the cap" contract — reference
+ * equality (`=== s`) is the truncation sentinel, so both callers
+ * (`renderRecipientWarnings` per-token, `renderConfirmCardContent`
+ * total) can use the same shape without a separate length probe.
+ *
+ * Final output is at most `maxCodepoints + indicator.length` codepoints.
+ */
+function sliceWithEllipsis(s, maxCodepoints, indicator) {
+  const sliced = safeCodepointSlice(s, maxCodepoints);
+  return sliced === s ? s : sliced + indicator;
+}
+
 function sanitizeMessage(msg) {
   // Order matters:
   //  1. NFKC-normalize + strip bidi/zero-width/control codepoints first
@@ -3703,11 +3718,9 @@ function renderRecipientWarnings({
     // enough to spot the typo / paste error without rendering the
     // attacker's entire payload.
     const TOKEN_DISPLAY_MAX = 80;
-    const shown = invalidTokens.slice(0, 10).map((t) => {
-      const stripped = t.replace(/`/g, '');
-      const sliced = safeCodepointSlice(stripped, TOKEN_DISPLAY_MAX);
-      return sliced === stripped ? stripped : sliced + '…';
-    });
+    const shown = invalidTokens.slice(0, 10).map(
+      (t) => sliceWithEllipsis(t.replace(/`/g, ''), TOKEN_DISPLAY_MAX, '…'),
+    );
     const more = invalidTokens.length > 10 ? ` (+${invalidTokens.length - 10} more)` : '';
     lines.push('• Could not parse:\n```\n' + shown.join('\n') + '\n```' + more);
   }
@@ -3791,25 +3804,14 @@ function renderConfirmCardContent({
     content += `**Note:** ${formatPersonalMessagePreview(personalMessage)}\n`;
   }
   content += '\nClick **Send** to deliver one-time qURL links, or **Cancel** to abort.';
-  // Discord's message-content cap is 2000 chars. Adversarial inputs
-  // (10 × 80-char invalidTokens + 256-char resourceLabel + 5 ×
-  // post-escape display names + personalMessage preview) can plausibly
-  // approach this; without a cap, `editReply` would reject with a 400
-  // and the throw would orphan the flow row (cleaned up by the
-  // safety-net catch, but the user sees a confusing generic error
-  // instead of the confirm card). Truncate at 1988 codepoints so the
-  // appended '…(truncated)' marker (12 codepoints) keeps the total at
-  // ≤ 2000 for typical ASCII / BMP-only content. Surrogate-pair-heavy
-  // adversarial input could exceed 2000 UTF-16 units, but real inputs
-  // funnel through `sanitizeContentLabel` / `safeCodepointSlice` which
-  // bound each section's codepoint budget; the pre-render upstream caps
-  // make a surrogate-pair-stuffed payload that crosses the cap exotic.
-  const CONFIRM_CARD_MAX_CODEPOINTS = 1988;
-  const trimmed = safeCodepointSlice(content, CONFIRM_CARD_MAX_CODEPOINTS);
-  // Reference equality is the truncation sentinel: safeCodepointSlice
-  // returns the input unchanged when below the cap (post-fast-path),
-  // so a strict !== means a real truncation occurred.
-  return trimmed === content ? content : trimmed + '…(truncated)';
+  // Fail-safe cap below Discord's 2000-char content limit so adversarial
+  // inputs can't trip a 400 from editReply and orphan the flow row.
+  // Cap (1988) + '…(truncated)' indicator (12 codepoints) = 2000 max
+  // for ASCII / BMP content. Surrogate-pair-stuffed input could still
+  // exceed 2000 UTF-16 units, but every contributing field
+  // (`resourceLabel`, display-name aliases, personalMessage preview)
+  // is already codepoint-capped upstream, so that path is exotic.
+  return sliceWithEllipsis(content, 1988, '…(truncated)');
 }
 
 // Truncate the pre-sanitized message to 80 chars MAX, then back off

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4009,17 +4009,19 @@ async function handleQurlSlashSend(interaction, params) {
   } catch (err) {
     // Unanticipated throw. Always clear cooldown — the user got no
     // visible response, so they must not be locked out for the full
-    // cooldown window. Try to surface a generic error via the
-    // (already-deferred) reply; if the editReply ALSO throws (token
-    // expired, Discord blip), the safety-net catch in flow-dispatch's
-    // handleFlowInteraction handles the front-half error visibility.
+    // cooldown window. Try editReply first (interaction was deferred
+    // up-front); if it also throws (the deferReply ITSELF failed, so
+    // there's no deferred state to edit), fall back to reply() as
+    // ephemeral. The double .catch keeps a failed fallback silent —
+    // worst case the user sees nothing, but the cooldown is cleared
+    // so they can retry.
     clearCooldown(interaction.user.id);
     logger.error('handleQurlSlashSend: unexpected throw', {
       user_id: interaction.user.id, error: err && err.message, stack: err && err.stack,
     });
-    return interaction.editReply({
-      content: '❌ Something went wrong — please try again.',
-    }).catch(logIgnoredDiscordErr);
+    const errContent = '❌ Something went wrong — please try again.';
+    return interaction.editReply({ content: errContent })
+      .catch(() => interaction.reply({ content: errContent, ephemeral: true }).catch(logIgnoredDiscordErr));
   }
 }
 
@@ -4546,8 +4548,15 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
 
   const apiKey = guildApiKey || config.QURL_API_KEY;
   if (!apiKey) {
-    // Admin action required to recover (`/qurl setup`); unlock retry so
-    // the user isn't stranded for 30s after the admin completes setup.
+    // Flow row is INTENTIONALLY already deleted here — by the time the
+    // happy-path deleteFlow above succeeded, the user's send-intent has
+    // committed. If the API key vanished (admin ran `/qurl setup` and
+    // the new key didn't propagate, or the key was actively rotated
+    // between the dispatcher's pre-check and click time), the recovery
+    // path is `/qurl setup` followed by a NEW `/qurl file` / `/qurl
+    // map` invocation — NOT a re-click on the dead card. Cooldown
+    // clears so the user isn't stranded for 30s after the admin
+    // completes setup.
     clearCooldown(interaction.user.id);
     return interaction.editReply({
       content: '❌ qURL is no longer configured for this server. Ask an admin to run `/qurl setup`.',
@@ -4569,6 +4578,13 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // blipped" encourages a fresh rerun if they want to include the
   // missed recipients. The rerun hint names the actual subcommand
   // they invoked (resourceType drives /qurl file vs /qurl map).
+  //
+  // followUp (not edited into the "Preparing send…" editReply) is
+  // INTENTIONAL: executeSendPipeline will rewrite editReply to
+  // "Sent to N users" / failure copy as the send progresses, which
+  // would clobber the partial-drop banner if it lived in the same
+  // message. followUp is a separate ephemeral that persists past
+  // the back-half's editReply rewrites.
   if (partialLeftCount > 0 || partialTransientCount > 0) {
     const rerunCommand = payload.resourceType === RESOURCE_TYPES.MAPS ? '/qurl map' : '/qurl file';
     const parts = [];

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -166,6 +166,13 @@ function safeUrlHost(url) {
  * cap or a UI surface that distinguishes empty from truncated.
  */
 function safeCodepointSlice(s, maxCodepoints) {
+  // Fast path: UTF-16 code-unit count is an upper bound on codepoint
+  // count (every codepoint is 1 or 2 code units), so a string whose
+  // `.length` is below the cap CANNOT exceed the cap in codepoints.
+  // Skips the `Array.from` allocation on the common case where the
+  // input is already well under the cap (the confirm-card render
+  // path hits this branch for every typical-sized message).
+  if (s.length <= maxCodepoints) return s;
   const codepoints = Array.from(s);
   if (codepoints.length <= maxCodepoints) return s;
   let cut = maxCodepoints;
@@ -3688,7 +3695,19 @@ function renderRecipientWarnings({
     // ephemeral. Strip backticks from each token before joining;
     // also cap the listed count at 10 so a pathological list can't
     // blow the Discord content budget.
-    const shown = invalidTokens.slice(0, 10).map((t) => t.replace(/`/g, ''));
+    //
+    // Per-token codepoint cap (80) keeps the worst case bounded:
+    // recipient-parser.js caps each token at 256 chars, so 10 × 256
+    // = 2.5KB of code-fenced text would dwarf the rest of the card
+    // and risk crowding out the action prompt. 80 codepoints is
+    // enough to spot the typo / paste error without rendering the
+    // attacker's entire payload.
+    const TOKEN_DISPLAY_MAX = 80;
+    const shown = invalidTokens.slice(0, 10).map((t) => {
+      const stripped = t.replace(/`/g, '');
+      const sliced = safeCodepointSlice(stripped, TOKEN_DISPLAY_MAX);
+      return sliced === stripped ? stripped : sliced + '…';
+    });
     const more = invalidTokens.length > 10 ? ` (+${invalidTokens.length - 10} more)` : '';
     lines.push('• Could not parse:\n```\n' + shown.join('\n') + '\n```' + more);
   }
@@ -3772,7 +3791,25 @@ function renderConfirmCardContent({
     content += `**Note:** ${formatPersonalMessagePreview(personalMessage)}\n`;
   }
   content += '\nClick **Send** to deliver one-time qURL links, or **Cancel** to abort.';
-  return content;
+  // Discord's message-content cap is 2000 chars. Adversarial inputs
+  // (10 × 80-char invalidTokens + 256-char resourceLabel + 5 ×
+  // post-escape display names + personalMessage preview) can plausibly
+  // approach this; without a cap, `editReply` would reject with a 400
+  // and the throw would orphan the flow row (cleaned up by the
+  // safety-net catch, but the user sees a confusing generic error
+  // instead of the confirm card). Truncate at 1988 codepoints so the
+  // appended '…(truncated)' marker (12 codepoints) keeps the total at
+  // ≤ 2000 for typical ASCII / BMP-only content. Surrogate-pair-heavy
+  // adversarial input could exceed 2000 UTF-16 units, but real inputs
+  // funnel through `sanitizeContentLabel` / `safeCodepointSlice` which
+  // bound each section's codepoint budget; the pre-render upstream caps
+  // make a surrogate-pair-stuffed payload that crosses the cap exotic.
+  const CONFIRM_CARD_MAX_CODEPOINTS = 1988;
+  const trimmed = safeCodepointSlice(content, CONFIRM_CARD_MAX_CODEPOINTS);
+  // Reference equality is the truncation sentinel: safeCodepointSlice
+  // returns the input unchanged when below the cap (post-fast-path),
+  // so a strict !== means a real truncation occurred.
+  return trimmed === content ? content : trimmed + '…(truncated)';
 }
 
 // Truncate the pre-sanitized message to 80 chars MAX, then back off
@@ -4225,6 +4262,11 @@ async function handleQurlMap(interaction) {
       ephemeral: true,
     });
   }
+  // NOTE: No `activeFileSends` capacity gate here (unlike handleQurlFile).
+  // The capacity gate guards the connector upload path that file sends
+  // hit during back-half dispatch; map sends never touch that resource.
+  // Sharing the gate would punish maps for file-pipeline saturation.
+  //
   // Cooldown gate — cross-command bucket shared with /qurl send and
   // /qurl file (sendCooldowns Map). Tests pin the contract.
   if (isOnCooldown(interaction.user.id)) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3423,6 +3423,11 @@ const SEND_CONFIRM_CANCEL_CUSTOM_ID = 'qurl_send_confirm_cancel';
 // whichever entry point they use.
 const SEND_FLOW_TTL_SECONDS = 180;
 
+// Subcommands that require the guild API key resolution + cooldown gate.
+// Single-source allowlist: adding a new send-style subcommand only
+// requires touching this set, not the dispatcher fall-through.
+const SEND_LIKE_SUBCOMMANDS = new Set(['send', 'file', 'map', 'revoke']);
+
 // Slash-option choice arrays. Reuse the existing /qurl send wording
 // so users see the same labels in autocomplete as in the form's
 // dropdowns. EXPIRY_CHOICES already exists. SELF_DESTRUCT_CHOICES is
@@ -3450,9 +3455,15 @@ function selfDestructOptionToSeconds(value) {
   if (!value || value === SELF_DESTRUCT_NO_TIMER_CHOICE) return null;
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) return null;
-  const floored = Math.floor(n);
-  if (!SELF_DESTRUCT_PRESET_SECONDS.has(floored)) return null;
-  return floored;
+  // Match the parsed Number directly — SELF_DESTRUCT_PRESETS contains
+  // 0.5 (the "1/2 second" preset), so a Math.floor here would map 0.5
+  // → 0 (not in the set) and silently downgrade to "no timer." The
+  // form path (selfDestructSelectValueToSeconds in utils/time.js) uses
+  // strict string equality against `String(p.seconds)` and gets this
+  // right; matching the parsed numeric value against the Set keeps
+  // the two entry points consistent.
+  if (!SELF_DESTRUCT_PRESET_SECONDS.has(n)) return null;
+  return n;
 }
 
 // Resolve a list of recipient IDs to User-shaped objects via the guild
@@ -3558,9 +3569,21 @@ function partitionRecipients(users, senderId) {
   return { valid, droppedBots, droppedSelf };
 }
 
-// Returns the empty string when nothing is worth surfacing — keeps
-// callers simple (`warningsBlock + content`) without a separate
-// "do I have any warnings" check.
+/**
+ * Render a warnings block for the confirm card. Returns the empty
+ * string when nothing is worth surfacing — keeps callers simple
+ * (`warningsBlock + content`) without a separate "do I have any
+ * warnings" check.
+ *
+ * @param {{
+ *   invalidTokens?: string[],
+ *   cappedCount?: number,
+ *   unresolvedIds?: string[],
+ *   transientFailureIds?: string[],
+ *   droppedBots?: number,
+ *   droppedSelf?: number,
+ * }} [opts]
+ */
 function renderRecipientWarnings({
   invalidTokens = [],
   cappedCount = 0,
@@ -4021,7 +4044,12 @@ async function handleQurlMap(interaction) {
   // guard for symmetry + actionable user-visible copy.
   let locationValue;
   try {
-    locationValue = interaction.options.getString('location', true).trim();
+    // Defensive .slice mirrors the modal path's pattern at commands.js:~2096.
+    // The slash option's setMaxLength(500) enforces this server-side, so
+    // legitimate clients can't exceed it — the slice is forged-interaction
+    // defense (a fabricated interaction could pass an unbounded payload),
+    // matching the modal entry point one-for-one.
+    locationValue = interaction.options.getString('location', true).trim().slice(0, 500);
   } catch (err) {
     logger.warn('handleQurlMap: required location option missing', {
       user_id: interaction.user.id, error: err && err.message,
@@ -5553,11 +5581,8 @@ const commands = [
         });
       }
 
-      // Gate: require guild API key for send/file/map/revoke. The
-      // `Set.has` lookup keeps the gate's allowlist single-source —
-      // adding a new send-style subcommand in 7b.3+ only requires
-      // touching this set, not the dispatch fall-through below.
-      const SEND_LIKE_SUBCOMMANDS = new Set(['send', 'file', 'map', 'revoke']);
+      // Gate: require guild API key for send/file/map/revoke.
+      // SEND_LIKE_SUBCOMMANDS hoisted to module scope.
       let resolvedApiKey = null;
       if (SEND_LIKE_SUBCOMMANDS.has(sub)) {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -144,6 +144,31 @@ function safeUrlHost(url) {
   try { return new URL(url).host; } catch { return 'invalid-url'; }
 }
 
+/**
+ * Codepoint-aware truncation with an odd-backslash backoff. Two
+ * concerns this guards against:
+ *  1. Surrogate split — bare String.prototype.slice operates on UTF-16
+ *     code units, so cutting at a boundary that lands inside a
+ *     surrogate pair (e.g. \u{1F600}) emits a lone high surrogate
+ *     that Discord renders as tofu.
+ *  2. Dangling escape backslash — a markdown-escaped input may have
+ *     `\X` sequences. A slice that lands ON the `\` separates the
+ *     escape from its target. Count trailing `\` chars; odd count →
+ *     back off by 1 so the escape stays intact.
+ *
+ * Returns the truncated string (no ellipsis appended — callers add
+ * their own truncation indicator if desired).
+ */
+function safeCodepointSlice(s, maxCodepoints) {
+  const codepoints = Array.from(s);
+  if (codepoints.length <= maxCodepoints) return s;
+  let cut = maxCodepoints;
+  let bs = 0;
+  for (let i = cut - 1; i >= 0 && codepoints[i] === '\\'; i--) bs++;
+  if (bs % 2 === 1) cut -= 1;
+  return codepoints.slice(0, cut).join('');
+}
+
 function sanitizeMessage(msg) {
   // Order matters:
   //  1. NFKC-normalize + strip bidi/zero-width/control codepoints first
@@ -167,9 +192,14 @@ function sanitizeMessage(msg) {
   const stripped = stripBidiAndControls(msg)
     .replace(/@(everyone|here)/gi, '@\u200b$1')
     .replace(/<@[!&]?\d+>/g, MENTION_SENTINEL);
-  return escapeDiscordMarkdown(stripped)
-    .replaceAll(MENTION_SENTINEL, '[mention]')
-    .slice(0, 500);
+  const escaped = escapeDiscordMarkdown(stripped)
+    .replaceAll(MENTION_SENTINEL, '[mention]');
+  // safeCodepointSlice: codepoint-aware + odd-backslash backoff. Bare
+  // String.prototype.slice could split a surrogate pair (emoji) at the
+  // 500 boundary or leave a dangling `\` from a mid-cut markdown
+  // escape. The slash option's setMaxLength(280) usually keeps us
+  // well under 500, but this is defense-in-depth.
+  return safeCodepointSlice(escaped, 500);
 }
 
 const ALLOWED_FILE_TYPES = [
@@ -3758,10 +3788,9 @@ const NEWLINE_COLLAPSE_RE = new RegExp('[\\r\\n\\u2028\\u2029]+', 'g');
 
 function formatPersonalMessagePreview(message) {
   const oneLine = message.replace(NEWLINE_COLLAPSE_RE, ' ');
-  // Codepoint-aware view of the string — bare String.prototype.slice
-  // operates on UTF-16 code units, so a slice that lands mid-surrogate
-  // emits a lone surrogate that Discord renders as tofu. Same defense
-  // sanitize.js applies for display-name caps.
+  // safeCodepointSlice handles surrogate-safe truncation + odd-trailing-
+  // backslash backoff. The early-return at 80 codepoints avoids the
+  // `…` ellipsis when there's nothing to truncate.
   //
   // Caveat: codepoint-aware ≠ grapheme-aware. ZWJ-joined emoji
   // sequences (e.g. 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl, three
@@ -3771,19 +3800,8 @@ function formatPersonalMessagePreview(message) {
   // partial emoji renders as exactly that — a partial display, not
   // garbled text. Full grapheme-segmentation would need Intl.Segmenter
   // which isn't justified for a preview cap.
-  const codepoints = Array.from(oneLine);
-  if (codepoints.length <= 80) return `> ${oneLine}`;
-  let cut = 80;
-  // Count trailing backslashes just before `cut`. An ODD count means
-  // the last `\` is starting a markdown-escape sequence (`\X`) whose
-  // target lands at `cut` and would be sliced off — back off by 1.
-  // EVEN counts represent complete `\\` literal-backslash pairs and
-  // can be kept. Handles single (`\*`), triple (`\\\*`), etc. A `\` is
-  // one codepoint, so the count is the same in either view.
-  let bs = 0;
-  for (let i = cut - 1; i >= 0 && codepoints[i] === '\\'; i--) bs++;
-  if (bs % 2 === 1) cut -= 1;
-  return `> ${codepoints.slice(0, cut).join('')}…`;
+  if (Array.from(oneLine).length <= 80) return `> ${oneLine}`;
+  return `> ${safeCodepointSlice(oneLine, 80)}…`;
 }
 
 // Build the ActionRow set for the confirm card. When `attachPicker`,
@@ -3937,6 +3955,16 @@ async function handleQurlSlashSend(interaction, params) {
       const detail = breakdownEmpty
         ? '\n\nMake sure you @-mention real users (bots and your own user are skipped automatically).'
         : '';
+      // Metric signal for the v1 cap-skew tracked in #304: a
+      // mention-list that resolved to NOTHING (parser-stripped bots
+      // before partition saw them) is exactly the failure mode the v2
+      // resolve-then-cap refactor would fix. Log at INFO so #304's
+      // prioritization has data without dialing verbosity up.
+      if (breakdownEmpty && !recipientsOmitted) {
+        logger.info('handleQurlSlashSend: bot-only-or-self mention list', {
+          user_id: interaction.user.id, resource_type: params.resourceType,
+        });
+      }
       return interaction.editReply({
         content: warningsBlock + '❌ **No valid recipients to send to.** Re-run with at least one valid user mention.' + detail,
       });
@@ -4284,8 +4312,8 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     });
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
-    if (droppedSelf > 0) reasons.push('cannot send to yourself');
-    return rejectPick(`⚠\u{FE0F} ${reasons.join('; ')}. Re-pick recipients below.\n\n`);
+    if (droppedSelf > 0) reasons.push('Cannot send to yourself');
+    return rejectPick(`⚠\u{FE0F} ${reasons.join('. ')}. Re-pick recipients below.\n\n`);
   }
   // Defense-in-depth — unreachable in production today: the picker's
   // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3541,6 +3541,12 @@ async function resolveRecipientUsers(interaction, ids) {
 // budget that legitimate ops elsewhere could use. The durable fix is
 // the v2 resolve-then-cap refactor tracked in #304.
 function partitionRecipients(users, senderId) {
+  // Dedup contract is OWNED upstream: parseRecipientMentions dedupes
+  // via a Set (recipient-parser.js:197-198) and the UserSelectMenu
+  // gateway-event surfaces each picked user at most once. This loop
+  // therefore does NOT re-dedup; doing so would silently mask an
+  // upstream regression (parser dedup breakage) that should fail
+  // loudly via the recipient-count divergence test instead.
   const valid = [];
   let droppedBots = 0;
   let droppedSelf = 0;
@@ -3688,9 +3694,14 @@ function formatPersonalMessagePreview(message) {
   const oneLine = message.replace(NEWLINE_COLLAPSE_RE, ' ');
   if (oneLine.length <= 80) return `> ${oneLine}`;
   let cut = 80;
-  if (oneLine[cut - 1] === '\\' && oneLine[cut - 2] !== '\\') {
-    cut -= 1;
-  }
+  // Count trailing backslashes just before `cut`. An ODD count means
+  // the last `\` is starting a markdown-escape sequence (`\X`) whose
+  // target lands at `cut` and would be sliced off — back off by 1.
+  // EVEN counts represent complete `\\` literal-backslash pairs and
+  // can be kept. Handles single (`\*`), triple (`\\\*`), etc.
+  let bs = 0;
+  for (let i = cut - 1; i >= 0 && oneLine[i] === '\\'; i--) bs++;
+  if (bs % 2 === 1) cut -= 1;
   return `> ${oneLine.slice(0, cut)}…`;
 }
 
@@ -4080,13 +4091,32 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // (partial-drop test pins this) as the actual guild-membership
   // defense; adding it here would burn 10 members.fetch calls per
   // picker tick without catching anything the Send-time check misses.
+  const payload = row.payload || {};
   const { valid, droppedBots, droppedSelf } = partitionRecipients(selected, interaction.user.id);
+  // Both invalid-pick branches re-render the full confirm card with a
+  // warning banner prepended. Replacing card content with just the
+  // warning string strips the resource header ("Sending file:
+  // report.pdf / Expires: 24h / Self-destruct: …") that the user
+  // chose at /qurl file time — they shouldn't have to scroll back to
+  // remember what they're sending. needsPicker:true keeps the "Pick
+  // recipients below" prompt; sendDisabled:true keeps Send greyed.
+  const rejectPick = (warning) => interaction.update({
+    content: renderConfirmCardContent({
+      resourceType: payload.resourceType,
+      resourceLabel: payload.resourceLabel,
+      validRecipients: [],
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+      warningsBlock: warning,
+      needsPicker: true,
+      interaction,
+    }),
+    components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
+  }).catch(logIgnoredDiscordErr);
   if (valid.length === 0) {
-    return interaction.update({
-      content: '⚠\u{FE0F} ' + (droppedBots > 0 ? 'Cannot send to bots.' : 'Cannot send to yourself.')
-        + ' Re-pick recipients below.',
-      components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
-    }).catch(logIgnoredDiscordErr);
+    return rejectPick('⚠\u{FE0F} ' + (droppedBots > 0 ? 'Cannot send to bots.' : 'Cannot send to yourself.')
+      + ' Re-pick recipients below.\n\n');
   }
   // Defense-in-depth — unreachable in production today: the picker's
   // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,
@@ -4094,13 +4124,10 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // pick more than 25. Kept against a future bump to either constant
   // (or a forged interaction) so the cap stays honored.
   if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
-    return interaction.update({
-      content: `⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.`,
-      components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
-    }).catch(logIgnoredDiscordErr);
+    return rejectPick(`⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.\n\n`);
   }
 
-  const payload = row.payload || {};
+
   const newPayload = { ...payload, recipientIds: valid.map((u) => u.id) };
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SEND_STAGE_AWAITING_CONFIRM,
@@ -4198,6 +4225,26 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   }
 
   const payload = row.payload || {};
+  // Forged-interaction defense: a legitimate Send click can only land
+  // when the card has at least one recipient (Send is disabled while
+  // recipientIds is empty — both at confirm-card-render time and in
+  // the picker re-render after an empty pick). A click with empty
+  // recipientIds therefore implies a fabricated interaction. The
+  // "all left the server" copy below would be misleading for this
+  // path (nobody left, nobody was ever there); distinct copy + flow
+  // delete keeps the dispatcher's outer catch from masking the signal.
+  if (!Array.isArray(payload.recipientIds) || payload.recipientIds.length === 0) {
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on empty-recipients failed', {
+      flow_id, error: err && err.message,
+    }));
+    return interaction.editReply({
+      content: '❌ No recipients were selected — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
   // Re-fetch users at click time — defensive against members leaving
   // the guild between confirm and Send. Both unresolved buckets
   // (10007 + transient fetch failure) reduce the delivered count,
@@ -5230,6 +5277,10 @@ const commands = [
             opt.setName('location')
               .setDescription('Google Maps URL, or a place / address to search')
               .setRequired(true)
+              // 500 chars covers full Google Maps URLs (which can be
+              // 200-400 chars after place params + coordinates) plus
+              // headroom; not tied to the recipients-parser cap because
+              // location is a single URL/address, not a token list.
               .setMaxLength(500)
           )
           .addStringOption(opt =>

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3541,11 +3541,14 @@ function renderRecipientWarnings({ invalidTokens, cappedCount, unresolvedIds, dr
     lines.push(`• Capped at ${config.QURL_SEND_MAX_RECIPIENTS} — ${cappedCount} recipient(s) past the cap were dropped.`);
   }
   if (invalidTokens.length > 0) {
-    // Code-fence the raw tokens so any residual markdown / mention
-    // shapes the parser couldn't fully neutralize render as literals.
-    // Cap the listed count at 10 so a pathological list doesn't blow
-    // the Discord content budget.
-    const shown = invalidTokens.slice(0, 10);
+    // recipient-parser.js's docstring is explicit: invalidTokens are
+    // NOT markdown-escaped — callers wrap or escape. We code-fence
+    // for literal rendering, but a token containing ``` would close
+    // the fence early and inject markdown / masked-links into the
+    // ephemeral. Strip backticks from each token before joining;
+    // also cap the listed count at 10 so a pathological list can't
+    // blow the Discord content budget.
+    const shown = invalidTokens.slice(0, 10).map((t) => t.replace(/`/g, ''));
     const more = invalidTokens.length > 10 ? ` (+${invalidTokens.length - 10} more)` : '';
     lines.push('• Could not parse:\n```\n' + shown.join('\n') + '\n```' + more);
   }
@@ -3599,8 +3602,13 @@ function renderConfirmCardContent({
     content += `**Self-destruct:** ${formatSelfDestructLabel(selfDestructSeconds)}\n`;
   }
   if (personalMessage) {
+    // `personalMessage` is pre-sanitized: sanitizeMessage already
+    // ran markdown-escape + @-mention strip at the slash-option
+    // boundary. Re-escaping here would render `\*\*bold\*\*`
+    // literals on the card. Same shape /qurl send's Step-3
+    // formContent uses (commands.js:~2164).
     const preview = personalMessage.length > 80 ? personalMessage.slice(0, 80) + '…' : personalMessage;
-    content += `**Note:** "${escapeDiscordMarkdown(preview)}"\n`;
+    content += `**Note:** "${preview}"\n`;
   }
   content += '\nClick **Send** to deliver one-time qURL links, or **Cancel** to abort.';
   return content;
@@ -3642,7 +3650,7 @@ function renderConfirmCardRows({ needsPicker, sendDisabled }) {
 //   locationUrl:  string | null                          (map path)
 //   locationName: string | null                          (map path)
 //   resourceLabel: string                                (rendered on card)
-async function _handleQurlSlashSend(interaction, apiKey, params) {
+async function handleQurlSlashSend(interaction, apiKey, params) {
   if (!interaction.guildId || !interaction.guild) {
     return interaction.reply({
       content: 'This command can only be used in a server, not in DMs.',
@@ -3837,7 +3845,7 @@ async function handleQurlFile(interaction, apiKey) {
     });
   }
 
-  return _handleQurlSlashSend(interaction, apiKey, {
+  return handleQurlSlashSend(interaction, apiKey, {
     resourceType: RESOURCE_TYPES.FILE,
     attachment: {
       url: attachment.url,
@@ -3872,7 +3880,7 @@ async function handleQurlMap(interaction, apiKey) {
   }
   if (locationName) locationName = escapeDiscordMarkdown(locationName.slice(0, 256));
 
-  return _handleQurlSlashSend(interaction, apiKey, {
+  return handleQurlSlashSend(interaction, apiKey, {
     resourceType: RESOURCE_TYPES.MAPS,
     attachment: null,
     locationUrl,
@@ -3989,16 +3997,28 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // so a duplicate dispatch's redundant call is harmless. Same
   // safety rule handleRevokeSelect documents (parallelize ONLY with
   // idempotent reads).
+  //
+  // `expectedVersion: row.version` fences the picker-then-Send race:
+  // if a UserSelectMenu interaction landed and transitioned the flow
+  // between the dispatcher's loadFlow (which fed `row` here) and our
+  // deleteFlow, the version would have advanced. Without the version
+  // gate, we'd deleteFlow successfully and call executeSendPipeline
+  // with the STALE recipientIds captured in `payload` above — exactly
+  // the silent-divergence shape handleSetupButton uses expectedVersion
+  // to fence (commands.js:~3196). `deleted: false` here now collapses
+  // duplicate dispatch AND mid-flight picker mutation; both map to the
+  // same user recovery ("the card moved under you, re-click Send").
   const [guildApiKey, deleteResult] = await Promise.all([
     interaction.guildId ? db.getGuildApiKey(interaction.guildId) : null,
     deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
+      expectedVersion: row.version,
     }),
   ]);
   if (!deleteResult.deleted) {
     return interaction.reply({
-      content: 'This send was already processed.',
+      content: 'Recipients changed before Send fired — re-check the card and click Send again.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3469,7 +3469,7 @@ const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
 // Subcommands that require the guild API key resolution + cooldown gate.
 // Single-source allowlist: adding a new send-style subcommand only
 // requires touching this set, not the dispatcher fall-through.
-const SEND_LIKE_SUBCOMMANDS = new Set(['send', 'file', 'map', 'revoke']);
+const API_KEY_GATED_SUBCOMMANDS = new Set(['send', 'file', 'map', 'revoke']);
 
 // Slash-option choice arrays. Reuse the existing /qurl send wording
 // so users see the same labels in autocomplete as in the form's
@@ -3833,7 +3833,7 @@ function renderConfirmCardRows({ attachPicker, sendDisabled }) {
 // — the key may rotate during the confirm card's 3-min TTL, and the
 // dispatcher's gate at the slash-command entry point only proves the
 // key was present at that single moment. Re-fetching at click time
-// is the durable check. The dispatcher's gate (SEND_LIKE_SUBCOMMANDS
+// is the durable check. The dispatcher's gate (API_KEY_GATED_SUBCOMMANDS
 // set) still runs to fail fast on the no-key-at-all case.
 async function handleQurlSlashSend(interaction, params) {
   if (!interaction.guildId || !interaction.guild) {
@@ -4532,6 +4532,22 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
+  // Check the resolved key BEFORE deleteFlow. If both guildApiKey and
+  // config.QURL_API_KEY are null (rare: key rotation removed the key
+  // between dispatcher pre-check and Send click), there's nothing to
+  // send with — preserving the flow row lets the user retry after the
+  // admin re-runs `/qurl setup` without re-invoking the slash command.
+  // Cooldown clears so the user isn't stranded for the 30s window
+  // while waiting on the admin.
+  const apiKey = guildApiKey || config.QURL_API_KEY;
+  if (!apiKey) {
+    clearCooldown(interaction.user.id);
+    return interaction.editReply({
+      content: '❌ qURL is no longer configured for this server. Ask an admin to run `/qurl setup`.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
   const deleteResult = await deleteFlow(flow_id, {
     stage: SEND_STAGE_AWAITING_CONFIRM,
     reason: 'terminal',
@@ -4541,24 +4557,6 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     return interaction.followUp({
       content: 'Recipients changed before Send fired — re-check the card and click Send again.',
       ephemeral: true,
-    }).catch(logIgnoredDiscordErr);
-  }
-
-  const apiKey = guildApiKey || config.QURL_API_KEY;
-  if (!apiKey) {
-    // Flow row is INTENTIONALLY already deleted here — by the time the
-    // happy-path deleteFlow above succeeded, the user's send-intent has
-    // committed. If the API key vanished (admin ran `/qurl setup` and
-    // the new key didn't propagate, or the key was actively rotated
-    // between the dispatcher's pre-check and click time), the recovery
-    // path is `/qurl setup` followed by a NEW `/qurl file` / `/qurl
-    // map` invocation — NOT a re-click on the dead card. Cooldown
-    // clears so the user isn't stranded for 30s after the admin
-    // completes setup.
-    clearCooldown(interaction.user.id);
-    return interaction.editReply({
-      content: '❌ qURL is no longer configured for this server. Ask an admin to run `/qurl setup`.',
-      components: [],
     }).catch(logIgnoredDiscordErr);
   }
 
@@ -5764,7 +5762,7 @@ const commands = [
       }
 
       // Gate: require guild API key for send/file/map/revoke.
-      // SEND_LIKE_SUBCOMMANDS hoisted to module scope.
+      // API_KEY_GATED_SUBCOMMANDS hoisted to module scope.
       //
       // For /qurl file + /qurl map this read is a fail-fast presence
       // check — the resolved value is intentionally NOT threaded
@@ -5776,7 +5774,7 @@ const commands = [
       // re-introduce stale-key dispatches. The handleQurlSlashSend
       // docstring documents the contract explicitly.
       let resolvedApiKey = null;
-      if (SEND_LIKE_SUBCOMMANDS.has(sub)) {
+      if (API_KEY_GATED_SUBCOMMANDS.has(sub)) {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;
         if (!guildApiKey && !config.QURL_API_KEY) {
           return interaction.reply({
@@ -5797,7 +5795,7 @@ const commands = [
       // /qurl file and /qurl map deliberately don't accept the
       // dispatcher-resolved apiKey — handleSendConfirmClick re-fetches
       // at Send time so a mid-flow rotation still uses the live key.
-      // The dispatcher's SEND_LIKE_SUBCOMMANDS gate above is the
+      // The dispatcher's API_KEY_GATED_SUBCOMMANDS gate above is the
       // fail-fast presence check.
       if (sub === 'file') return handleQurlFile(interaction);
       if (sub === 'map') return handleQurlMap(interaction);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -135,7 +135,7 @@ function isGoogleMapsURL(url) {
 
 
 
-const { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel } = require('./utils/sanitize');
+const { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls } = require('./utils/sanitize');
 
 // Best-effort host extraction for log lines. URL parsing throws on
 // pathological input (no scheme, embedded null, etc.) — swallow and
@@ -145,17 +145,26 @@ function safeUrlHost(url) {
 }
 
 function sanitizeMessage(msg) {
-  // Order matters: strip @-mention abuse first (the closing `>` of `<@123>`
-  // would otherwise be escaped and the mention regex wouldn't match). Then
-  // escape Discord markdown so a crafted message like
-  // `[Free Prizes](https://phishing.com)` can't render as a masked link.
-  // The `[mention]` literal we insert below is re-applied post-escape as a
-  // plain substitution so the brackets stay visible to the user.
-  // Sentinel survives the markdown-escape pass unchanged: it contains no
-  // chars in the escape regex ([\*~`>|\[\]()\\_]). Suffix/prefix of random
-  // hex so it can't collide with anything a user would plausibly type.
+  // Order matters:
+  //  1. NFKC-normalize + strip bidi/zero-width/control codepoints first
+  //     (stripBidiAndControls) \u2014 defends against U+202E RLO spoofing in
+  //     the recipient's DM body AND the sender's confirm-card preview.
+  //     Without this, a crafted personal-message containing U+202E
+  //     flips text direction in the rendered embed/blockquote.
+  //  2. Strip @-mention abuse next (the closing `>` of `<@123>` would
+  //     otherwise be escaped by step 3 and the mention regex wouldn't
+  //     match).
+  //  3. Escape Discord markdown so a crafted message like
+  //     `[Free Prizes](https://phishing.com)` can't render as a masked
+  //     link.
+  // The `[mention]` literal is re-applied post-escape as a plain
+  // substitution so the brackets stay visible to the user.
+  // Sentinel survives the markdown-escape pass unchanged: it contains
+  // no chars in the escape regex ([\*~`>|\[\]()\\_]). Suffix/prefix of
+  // random hex so it can't collide with anything a user would
+  // plausibly type.
   const MENTION_SENTINEL = 'XMENTIONX74caf3b0e79aXMENTIONX';
-  const stripped = msg
+  const stripped = stripBidiAndControls(msg)
     .replace(/@(everyone|here)/gi, '@\u200b$1')
     .replace(/<@[!&]?\d+>/g, MENTION_SENTINEL);
   return escapeDiscordMarkdown(stripped)
@@ -4051,7 +4060,9 @@ async function handleQurlFile(interaction) {
   // required server-side, so production interactions can't trip
   // these; a forged interaction is the only way. The targeted catch
   // produces an actionable ephemeral rather than letting the throw
-  // hit the dispatcher's generic safety net.
+  // hit the dispatcher's generic safety net. Cooldown stays set —
+  // forged interactions are abuse-aligned, same shape as the SSRF
+  // gate below.
   let attachment;
   try {
     attachment = interaction.options.getAttachment('attachment', true);
@@ -4065,6 +4076,9 @@ async function handleQurlFile(interaction) {
     });
   }
   if (!attachment || typeof attachment.url !== 'string') {
+    // Malformed attachment payload — Discord won't ship one, so this
+    // is forged-interaction territory. Cooldown stays set (abuse-
+    // aligned, same shape as SSRF).
     return interaction.reply({
       content: '❌ Attachment is missing or malformed.',
       ephemeral: true,
@@ -4140,7 +4154,8 @@ async function handleQurlMap(interaction) {
   // `getString('location', true)` throws on a missing option. Discord
   // enforces required server-side; only a forged interaction can hit
   // this. Targeted catch matches handleQurlFile's required-option
-  // guard for symmetry + actionable user-visible copy.
+  // guard for symmetry + actionable user-visible copy. Cooldown stays
+  // set on the forged-interaction throw branch — abuse-aligned.
   let locationValue;
   try {
     // Defensive .slice mirrors the modal path's pattern at commands.js:~2096.
@@ -4160,6 +4175,10 @@ async function handleQurlMap(interaction) {
   }
   const locationNameRaw = interaction.options.getString('location-name');
   if (locationValue.length === 0) {
+    // Honest user error (pasted only whitespace, or empty string) —
+    // unlock retry. Same shape as the file-type / size cap branches
+    // in handleQurlFile.
+    clearCooldown(interaction.user.id);
     return interaction.reply({
       content: '❌ Location is empty.',
       ephemeral: true,
@@ -4376,6 +4395,14 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // (the all-unresolved branch's copy below) — misleading, because
   // the bot left, not the recipients. Delete the flow row so a
   // future re-invite + rerun starts fresh.
+  //
+  // No `expectedVersion` on this deleteFlow (unlike the happy-path /
+  // empty-recipients / all-unresolved branches): if the bot has been
+  // kicked, every subsequent interaction for this guild is dead
+  // (Discord won't deliver further events to this bot for this guild)
+  // — there's no concurrent path that could bump the version. The
+  // version-gate fences picker-vs-Send and Cancel-vs-Send races; both
+  // require an active gateway session that bot-kicked has terminated.
   if (!interaction.guild) {
     await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3467,7 +3467,7 @@ function selfDestructOptionToSeconds(value) {
 //     rather than imply the recipient is gone.
 //
 // Splitting the buckets prevents the 429-rendered-as-"left the
-// server" misdirection cr round 4 flagged.
+// server" misdirection.
 //
 // Fetches the cache-miss tail in parallel via `batchSettled` (the
 // same helper used by the DM fan-out path; honors Discord's per-route
@@ -3692,17 +3692,23 @@ const NEWLINE_COLLAPSE_RE = new RegExp('[\\r\\n\\u2028\\u2029]+', 'g');
 
 function formatPersonalMessagePreview(message) {
   const oneLine = message.replace(NEWLINE_COLLAPSE_RE, ' ');
-  if (oneLine.length <= 80) return `> ${oneLine}`;
+  // Codepoint-aware view of the string — bare String.prototype.slice
+  // operates on UTF-16 code units, so a slice that lands mid-surrogate
+  // emits a lone surrogate that Discord renders as tofu. Same defense
+  // sanitize.js applies for display-name caps.
+  const codepoints = Array.from(oneLine);
+  if (codepoints.length <= 80) return `> ${oneLine}`;
   let cut = 80;
   // Count trailing backslashes just before `cut`. An ODD count means
   // the last `\` is starting a markdown-escape sequence (`\X`) whose
   // target lands at `cut` and would be sliced off — back off by 1.
   // EVEN counts represent complete `\\` literal-backslash pairs and
-  // can be kept. Handles single (`\*`), triple (`\\\*`), etc.
+  // can be kept. Handles single (`\*`), triple (`\\\*`), etc. A `\` is
+  // one codepoint, so the count is the same in either view.
   let bs = 0;
-  for (let i = cut - 1; i >= 0 && oneLine[i] === '\\'; i--) bs++;
+  for (let i = cut - 1; i >= 0 && codepoints[i] === '\\'; i--) bs++;
   if (bs % 2 === 1) cut -= 1;
-  return `> ${oneLine.slice(0, cut)}…`;
+  return `> ${codepoints.slice(0, cut).join('')}…`;
 }
 
 // Build the ActionRow set for the confirm card. When `attachPicker`,
@@ -4065,6 +4071,13 @@ async function handleQurlMap(interaction) {
 // refreshes the TTL, so repeated picker churn doesn't expire the row
 // while the user is still deciding.
 async function handleSendUserSelect(interaction, { flow_id, row }) {
+  // `deferUpdate` first so the downstream `transitionFlow` (DDB OCC
+  // update) can take more than Discord's 3-second hard ack deadline
+  // without surfacing as an "interaction failed" toast. Mirrors
+  // handleSendConfirmClick / handleSendCancelClick. All `update`
+  // calls below become `editReply` (the interaction is now deferred).
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
   // `interaction.users` is a discord.js Collection in production,
   // duck-typed as a Map in tests — both support `.values()` so the
   // iteration here is interchangeable. A future test refactor that
@@ -4073,7 +4086,8 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // Map-compatible API surface.
   const selected = [...interaction.users.values()];
   if (selected.length === 0) {
-    return interaction.deferUpdate().catch(logIgnoredDiscordErr);
+    // Empty pick → already acked via deferUpdate above. Nothing to edit.
+    return undefined;
   }
   // `interaction.user.id` IS the original sender's ID — Discord
   // enforces "only the user who triggered an ephemeral interaction
@@ -4100,7 +4114,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // chose at /qurl file time — they shouldn't have to scroll back to
   // remember what they're sending. needsPicker:true keeps the "Pick
   // recipients below" prompt; sendDisabled:true keeps Send greyed.
-  const rejectPick = (warning) => interaction.update({
+  const rejectPick = (warning) => interaction.editReply({
     content: renderConfirmCardContent({
       resourceType: payload.resourceType,
       resourceLabel: payload.resourceLabel,
@@ -4127,7 +4141,6 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     return rejectPick(`⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.\n\n`);
   }
 
-
   const newPayload = { ...payload, recipientIds: valid.map((u) => u.id) };
   const result = await transitionFlow(flow_id, row.version, {
     stage_to: SEND_STAGE_AWAITING_CONFIRM,
@@ -4136,13 +4149,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
   });
   if (result.result === 'conflict') {
-    return interaction.update({
+    return interaction.editReply({
       content: 'Send was superseded — re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
   if (result.result === 'not_found') {
-    return interaction.update({
+    return interaction.editReply({
       content: 'This send expired — re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
@@ -4180,7 +4193,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     needsPicker: false,
     interaction,
   });
-  return interaction.update({
+  return interaction.editReply({
     content,
     components: renderConfirmCardRows({ attachPicker: true, sendDisabled: false }),
   }).catch(logIgnoredDiscordErr);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -276,6 +276,10 @@ function softenCooldown(userId, residualMs) {
   const target = Date.now() - Math.max(0, config.QURL_SEND_COOLDOWN_MS - residualMs);
   const existing = sendCooldowns.get(userId);
   if (target < existing) {
+    // delete-then-set re-inserts at the end of Map iteration order so
+    // the bulk eviction in setCooldown (line ~248) preserves active
+    // users. Matches the same LRU pattern setCooldown uses; a bare
+    // `set` on an existing key would NOT re-order.
     sendCooldowns.delete(userId);
     sendCooldowns.set(userId, target);
   }
@@ -3449,6 +3453,12 @@ const SEND_CONFIRM_CANCEL_CUSTOM_ID = 'qurl_send_confirm_cancel';
 // whichever entry point they use.
 const SEND_FLOW_TTL_SECONDS = 180;
 
+// On a successful Cancel, soften (don't clear) the cooldown so 5s of
+// throttle remain — defuses the rapid /qurl file → Cancel → /qurl file
+// → Cancel spam vector (which would otherwise rack up supersedeOrCreate
+// DDB writes with zero throttle).
+const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
+
 // Subcommands that require the guild API key resolution + cooldown gate.
 // Single-source allowlist: adding a new send-style subcommand only
 // requires touching this set, not the dispatcher fall-through.
@@ -4251,12 +4261,28 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   }
 
   const newPayload = { ...payload, recipientIds: valid.map((u) => u.id) };
-  const result = await transitionFlow(flow_id, row.version, {
-    stage_to: SEND_STAGE_AWAITING_CONFIRM,
-    payload: newPayload,
-    terminal: false,
-    set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
-  });
+  // Targeted catch around transitionFlow mirrors the same shape
+  // handleSendConfirmClick / handleSendCancelClick use around their
+  // DDB calls. A throw here would otherwise bubble to the dispatcher's
+  // outer catch which surfaces a generic "superseded" message —
+  // wrong, since nothing was actually superseded on a DDB blip.
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleSendUserSelect: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not save your pick right now. Try selecting recipients again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
   if (result.result === 'conflict') {
     return interaction.editReply({
       content: 'Send was superseded — re-run the command.',
@@ -4591,7 +4617,7 @@ async function handleSendCancelClick(interaction, { flow_id, row }) {
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
-  softenCooldown(interaction.user.id, 5000);
+  softenCooldown(interaction.user.id, CANCEL_SOFTEN_RESIDUAL_MS);
   return interaction.editReply({
     content: 'Send cancelled.',
     components: [],
@@ -5690,6 +5716,16 @@ const commands = [
 
       // Gate: require guild API key for send/file/map/revoke.
       // SEND_LIKE_SUBCOMMANDS hoisted to module scope.
+      //
+      // For /qurl file + /qurl map this read is a fail-fast presence
+      // check — the resolved value is intentionally NOT threaded
+      // through to the back-half. handleSendConfirmClick re-fetches at
+      // Send-click time so a key rotation during the 3-minute confirm-
+      // card window is honored. Threading resolvedApiKey through here
+      // would break that rotation-safety property: a future optimization
+      // pass that "saves the redundant DDB read" would silently
+      // re-introduce stale-key dispatches. The handleQurlSlashSend
+      // docstring documents the contract explicitly.
       let resolvedApiKey = null;
       if (SEND_LIKE_SUBCOMMANDS.has(sub)) {
         const guildApiKey = interaction.guildId ? await db.getGuildApiKey(interaction.guildId) : null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3541,8 +3541,12 @@ async function resolveRecipientUsers(interaction, ids) {
 // and post-filter valid=[]. The user sees "all recipients dropped" and
 // has to re-run with bots removed. Acceptable since (a) it requires a
 // pathological mention list to trip, (b) the failure mode is loud
-// rather than silent. A future refactor can resolve-then-cap if this
-// becomes a real complaint.
+// rather than silent. Cost dimension worth flagging: 25 cache-miss
+// bot mentions still hit `members.fetch` 25 times (via batchSettled's
+// 5-at-a-time fan-out, in 5 rate-limit-budget burns) before partition
+// drops them all — small absolute cost but burns per-guild rate-limit
+// budget that legitimate ops elsewhere could use. The durable fix is
+// the v2 resolve-then-cap refactor tracked in #304.
 function partitionRecipients(users, senderId) {
   const valid = [];
   let droppedBots = 0;
@@ -3613,10 +3617,17 @@ function renderConfirmCardContent({
   warningsBlock, needsPicker,
 }) {
   let content = warningsBlock || '';
+  // Explicit branch per RESOURCE_TYPES value — a future resource
+  // type (audio, contact card, etc.) MUST add its own branch here.
+  // Throwing on unknown beats silently rendering the new type as a
+  // location, which would propagate the misdirection into every
+  // confirm card the new type ever shows.
   if (resourceType === RESOURCE_TYPES.FILE) {
     content += `📁 **Sending file:** ${resourceLabel}\n`;
-  } else {
+  } else if (resourceType === RESOURCE_TYPES.MAPS) {
     content += `🗺\u{FE0F} **Sending location:** ${resourceLabel}\n`;
+  } else {
+    throw new TypeError(`renderConfirmCardContent: unknown resourceType ${JSON.stringify(resourceType)}`);
   }
   if (needsPicker) {
     content += '\n**Pick recipients below** (1–'
@@ -4119,6 +4130,22 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 // dedup primitive (duplicate dispatch under future SQS at-least-once
 // must not double-send). Mirrors handleRevokeSelect's ordering.
 async function handleSendConfirmClick(interaction, { flow_id, row }) {
+  // `deferUpdate` at the very top so the chain
+  // `resolveRecipientUsers → getGuildApiKey → deleteFlow → editReply`
+  // can take more than Discord's 3-second hard ack deadline without
+  // surfacing as an "interaction failed" toast to the user. Cold
+  // cache + 25 cache-miss `members.fetch` calls in `resolveRecipientUsers`
+  // alone can chew through the budget. The .catch swallows the
+  // (rare) race where Discord's gateway already acked the
+  // interaction; a duplicate defer there throws InteractionAlreadyReplied
+  // and the subsequent editReply still works.
+  //
+  // All ephemeral error-replies below switch from `interaction.reply`
+  // to `interaction.followUp` (the interaction is now in the
+  // deferred state and `.reply` would throw); main-message updates
+  // switch from `interaction.update` to `interaction.editReply`.
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
   const payload = row.payload || {};
   // Re-fetch users at click time — defensive against members leaving
   // the guild between confirm and Send. Both unresolved buckets
@@ -4138,12 +4165,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     logger.error('handleSendConfirmClick: resolveRecipientUsers threw', {
       flow_id, error: err && err.message,
     });
-    // `interaction.reply` (not safeReply / editReply) is intentional —
-    // this is a button-click dispatched by flow-dispatch, the
-    // interaction is in the unacked state at this point. A refactor
-    // that swaps in deferReply earlier in the handler would need to
-    // flip this to editReply too.
-    return interaction.reply({
+    return interaction.followUp({
       content: '❌ Could not look up recipients right now. Try **Send** again in a moment.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
@@ -4167,7 +4189,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on empty failed', {
       flow_id, error: err && err.message,
     }));
-    return interaction.update({
+    return interaction.editReply({
       content: '❌ Recipients are no longer reachable (all left the server). Re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
@@ -4206,7 +4228,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     logger.error('handleSendConfirmClick: getGuildApiKey threw', {
       flow_id, error: err && err.message,
     });
-    return interaction.reply({
+    return interaction.followUp({
       content: '❌ Could not look up the qURL API key right now. Try **Send** again in a moment.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
@@ -4217,7 +4239,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     expectedVersion: row.version,
   });
   if (!deleteResult.deleted) {
-    return interaction.reply({
+    return interaction.followUp({
       content: 'Recipients changed before Send fired — re-check the card and click Send again.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
@@ -4225,7 +4247,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
 
   const apiKey = guildApiKey || config.QURL_API_KEY;
   if (!apiKey) {
-    return interaction.update({
+    return interaction.editReply({
       content: '❌ qURL is no longer configured for this server. Ask an admin to run `/qurl setup`.',
       components: [],
     }).catch(logIgnoredDiscordErr);
@@ -4234,7 +4256,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // Ack with a "Preparing send…" placeholder; executeSendPipeline
   // takes over the editReply from here. Matches handleSend's hand-off
   // shape at commands.js:~2307.
-  await interaction.update({ content: 'Preparing send…', components: [] }).catch(logIgnoredDiscordErr);
+  await interaction.editReply({ content: 'Preparing send…', components: [] }).catch(logIgnoredDiscordErr);
 
   // Surface partial drops (members who left the guild between confirm
   // and Send, OR who failed lookup transiently) as a separate
@@ -4290,19 +4312,24 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
 // `clearCooldown` is gated on `deleted: true` so the cooldown stays
 // honored on the Cancel-loser branch.
 async function handleSendCancelClick(interaction, { flow_id, row }) {
+  // Defer-ack within the 3s window. The single deleteFlow call below
+  // is fast in the happy path, but a DDB blip or slow region could
+  // still blow the budget. Same pattern handleSendConfirmClick uses
+  // (deferUpdate at top, editReply / followUp downstream).
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const { deleted } = await deleteFlow(flow_id, {
     stage: SEND_STAGE_AWAITING_CONFIRM,
     reason: 'terminal',
     expectedVersion: row.version,
   });
   if (!deleted) {
-    return interaction.reply({
+    return interaction.followUp({
       content: 'This send was already processed or the card moved — re-check it.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
   clearCooldown(interaction.user.id);
-  return interaction.update({
+  return interaction.editReply({
     content: 'Send cancelled.',
     components: [],
   }).catch(logIgnoredDiscordErr);
@@ -5756,6 +5783,12 @@ registerFlow(SEND_USER_SELECT_CUSTOM_ID, {
   handler: handleSendUserSelect,
   siblingMessage: 'You have a `/qurl file` or `/qurl map` confirm card open in this channel — finish or cancel it first.',
 });
+// siblingMessage intentionally omitted on the SEND + CANCEL custom-
+// id registrations below — flow-dispatch's `siblingMessages` map is
+// keyed by stage (not by customId), so the message registered on
+// USER_SELECT above is reachable from any of the three customIds
+// at SEND_STAGE_AWAITING_CONFIRM. The "siblingMessage keyed by stage"
+// test in qurl-file-map.test.js pins this contract.
 registerFlow(SEND_CONFIRM_SEND_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleSendConfirmClick,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -158,6 +158,12 @@ function safeUrlHost(url) {
  *
  * Returns the truncated string (no ellipsis appended — callers add
  * their own truncation indicator if desired).
+ *
+ * Edge case: if `cut === 1` and the only char before it is `\`, the
+ * backoff sets `cut = 0` and the slice returns `''`. Safe failure
+ * mode for the 500-codepoint cap (callers don't depend on the result
+ * being non-empty), but worth knowing if you wire this into a smaller
+ * cap or a UI surface that distinguishes empty from truncated.
  */
 function safeCodepointSlice(s, maxCodepoints) {
   const codepoints = Array.from(s);
@@ -4194,6 +4200,15 @@ async function handleQurlMap(interaction) {
     // legitimate clients can't exceed it — the slice is forged-interaction
     // defense (a fabricated interaction could pass an unbounded payload),
     // matching the modal entry point one-for-one.
+    //
+    // Order matters: trim() FIRST, then slice. Trimming after slicing
+    // could let a forged 500+ chars-of-whitespace payload pass the
+    // length check below if trimming peeled fewer chars than the slice
+    // truncated (e.g. 510 spaces → slice(500) keeps 500 spaces → trim
+    // produces ''; the empty-location branch catches it). Reversing
+    // the order would NOT preserve the empty-after-trim semantics on
+    // a payload whose first 500 chars are non-whitespace + trailing
+    // whitespace.
     locationValue = interaction.options.getString('location', true).trim().slice(0, 500);
   } catch (err) {
     logger.warn('handleQurlMap: required location option missing', {
@@ -4472,23 +4487,24 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
-  // Re-fetch users at click time — defensive against members leaving
-  // the guild between confirm and Send. Both unresolved buckets
-  // (10007 + transient fetch failure) reduce the delivered count,
-  // so both are surfaced to the sender via followUp below — without
-  // the split, a 429 / gateway blip would silently shrink the
-  // delivered set with no signal.
+  // Re-fetch users + resolve apiKey IN PARALLEL at click time. Both
+  // are idempotent reads (rule from handleRevokeSelect: parallelize
+  // ONLY with idempotent reads), so the cold-cache happy path saves
+  // a DDB round-trip vs. running them sequentially. allSettled keeps
+  // each failure routable to its own user-actionable copy below; a
+  // rejection in one doesn't short-circuit the other.
   //
-  // resolveRecipientUsers is wrapped in try/catch because the dispatcher's
-  // outer catch only logs + replies generic-superseded; a click-time
-  // lookup throw should give the user a directly actionable message
-  // without committing the dedup deleteFlow.
-  let resolved;
-  try {
-    resolved = await resolveRecipientUsers(interaction, payload.recipientIds);
-  } catch (err) {
+  // Both unresolved buckets (10007 + transient fetch failure) reduce
+  // the delivered count, so both are surfaced to the sender via
+  // followUp below — without the split, a 429 / gateway blip would
+  // silently shrink the delivered set with no signal.
+  const [resolveResult, apiKeyResult] = await Promise.allSettled([
+    resolveRecipientUsers(interaction, payload.recipientIds),
+    db.getGuildApiKey(interaction.guildId),
+  ]);
+  if (resolveResult.status === 'rejected') {
     logger.error('handleSendConfirmClick: resolveRecipientUsers threw', {
-      flow_id, error: err && err.message,
+      flow_id, error: resolveResult.reason && resolveResult.reason.message,
     });
     // Zero side effects — unlock retry so the user can re-click Send
     // immediately after the transient blip clears.
@@ -4498,7 +4514,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
-  const { users, unresolvedIds, transientFailureIds } = resolved;
+  const { users, unresolvedIds, transientFailureIds } = resolveResult.value;
   const partialLeftCount = unresolvedIds.length;
   const partialTransientCount = transientFailureIds.length;
   if (partialLeftCount > 0 || partialTransientCount > 0) {
@@ -4532,38 +4548,32 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  // Resolve apiKey before dedup — getGuildApiKey is idempotent + free,
-  // so a duplicate dispatch's redundant call is harmless. Same
-  // safety rule handleRevokeSelect documents (parallelize ONLY with
-  // idempotent reads).
+  // apiKey was resolved in parallel with resolveRecipientUsers above.
+  // Check the rejection branch before consuming the value.
   //
-  // `expectedVersion: row.version` fences the picker-then-Send race:
-  // if a UserSelectMenu interaction landed and transitioned the flow
-  // between the dispatcher's loadFlow (which fed `row` here) and our
-  // deleteFlow, the version would have advanced. Without the version
-  // gate, we'd deleteFlow successfully and call executeSendPipeline
-  // with the STALE recipientIds captured in `payload` above — exactly
-  // the silent-divergence shape handleSetupButton uses expectedVersion
-  // to fence (commands.js:~3196). `deleted: false` here now collapses
-  // duplicate dispatch AND mid-flight picker mutation; both map to the
-  // same user recovery ("the card moved under you, re-click Send").
+  // `expectedVersion: row.version` (used below on deleteFlow) fences
+  // the picker-then-Send race: if a UserSelectMenu interaction landed
+  // and transitioned the flow between the dispatcher's loadFlow (which
+  // fed `row` here) and our deleteFlow, the version would have
+  // advanced. Without the version gate, we'd deleteFlow successfully
+  // and call executeSendPipeline with the STALE recipientIds captured
+  // in `payload` above. `deleted: false` collapses duplicate dispatch
+  // AND mid-flight picker mutation; both map to the same user
+  // recovery ("the card moved under you, re-click Send").
   // `interaction.guildId` is guaranteed non-null at this point —
   // handleQurlSlashSend rejects DM invocations BEFORE the flow row
   // is created, so a row at SEND_STAGE_AWAITING_CONFIRM only ever
-  // belongs to a guild interaction. No conditional fallback.
+  // belongs to a guild interaction.
   //
-  // Sequence: getGuildApiKey BEFORE deleteFlow. If the DDB read
-  // throws (rare — region outage, IAM revocation), the row stays
-  // alive and the user can re-click Send within the TTL once the
-  // blip clears. Burning the flow row first would strand the user
-  // on a dead card with the dispatcher's generic-superseded message
-  // and force a full /qurl file rerun.
-  let guildApiKey;
-  try {
-    guildApiKey = await db.getGuildApiKey(interaction.guildId);
-  } catch (err) {
+  // apiKey gate runs BEFORE deleteFlow: if both guildApiKey AND
+  // config.QURL_API_KEY are null (rare — key rotation removed the
+  // key), the flow row stays alive and the user can re-click Send
+  // within the TTL after the admin reruns `/qurl setup`. Burning the
+  // row before discovering there's no key to send with would strand
+  // the user on a dead card.
+  if (apiKeyResult.status === 'rejected') {
     logger.error('handleSendConfirmClick: getGuildApiKey threw', {
-      flow_id, error: err && err.message,
+      flow_id, error: apiKeyResult.reason && apiKeyResult.reason.message,
     });
     // Flow row stays alive; unlock retry so the user isn't stranded
     // for 30s waiting for a DDB blip to clear.
@@ -4573,6 +4583,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
+  const guildApiKey = apiKeyResult.value;
   // Check the resolved key BEFORE deleteFlow. If both guildApiKey and
   // config.QURL_API_KEY are null (rare: key rotation removed the key
   // between dispatcher pre-check and Send click), there's nothing to

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -286,6 +286,11 @@ function setCooldown(userId) {
   // LRU-ish behavior: delete first so set() re-inserts at the end of the
   // Map's insertion order. Combined with the bulk 10%-drop eviction below,
   // active users stay resident while stale entries roll out.
+  //
+  // CAUTION: softenCooldown (below) rides on the same insertion-order
+  // contract — if the eviction strategy ever changes (priority-based,
+  // TTL-based, etc.), softenCooldown's iteration-order test will fail
+  // loudly and both helpers will need rethinking together.
   sendCooldowns.delete(userId);
   sendCooldowns.set(userId, Date.now());
   if (sendCooldowns.size > 10000) {
@@ -4071,6 +4076,14 @@ async function handleQurlFile(interaction) {
   // backpressure, not user fault; locking the user out for 30s on a
   // capacity rejection would be punitive.
   if (activeFileSends >= MAX_CONCURRENT_FILE_SENDS) {
+    // Log at INFO so capacity-tuning has a trend signal — a sudden
+    // burst of these would indicate either MAX_CONCURRENT_FILE_SENDS
+    // is undersized or a downstream pipeline is stuck holding slots.
+    logger.info('handleQurlFile: capacity backpressure', {
+      user_id: interaction.user.id,
+      active_file_sends: activeFileSends,
+      max_concurrent: MAX_CONCURRENT_FILE_SENDS,
+    });
     return interaction.reply({
       content: 'The bot is processing too many file sends right now. Please try again in a moment.',
       ephemeral: true,
@@ -4198,17 +4211,12 @@ async function handleQurlMap(interaction) {
     // Defensive .slice mirrors the modal path's pattern at commands.js:~2096.
     // The slash option's setMaxLength(500) enforces this server-side, so
     // legitimate clients can't exceed it — the slice is forged-interaction
-    // defense (a fabricated interaction could pass an unbounded payload),
-    // matching the modal entry point one-for-one.
+    // defense.
     //
-    // Order matters: trim() FIRST, then slice. Trimming after slicing
-    // could let a forged 500+ chars-of-whitespace payload pass the
-    // length check below if trimming peeled fewer chars than the slice
-    // truncated (e.g. 510 spaces → slice(500) keeps 500 spaces → trim
-    // produces ''; the empty-location branch catches it). Reversing
-    // the order would NOT preserve the empty-after-trim semantics on
-    // a payload whose first 500 chars are non-whitespace + trailing
-    // whitespace.
+    // Order: trim() FIRST so the 500-char slice measures CONTENT, not
+    // whitespace. Slicing first would let a payload like
+    // `<100 leading spaces> + <450 chars of content>` lose 50 content
+    // chars to the cap; trimming first preserves the full content.
     locationValue = interaction.options.getString('location', true).trim().slice(0, 500);
   } catch (err) {
     logger.warn('handleQurlMap: required location option missing', {
@@ -4476,12 +4484,27 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // path (nobody left, nobody was ever there); distinct copy + flow
   // delete keeps the dispatcher's outer catch from masking the signal.
   if (!Array.isArray(payload.recipientIds) || payload.recipientIds.length === 0) {
-    await deleteFlow(flow_id, {
+    // Version-gate the delete: a concurrent UserSelect could have
+    // transitioned the row between the dispatcher's loadFlow (which
+    // fed our stale `payload` view) and this click. If `deleted:
+    // false`, the more-recent row is preserved and the user sees the
+    // "card moved" recovery copy instead of a silently wiped pick.
+    const deleteResult = await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
-    }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on empty-recipients failed', {
-      flow_id, error: err && err.message,
-    }));
+      expectedVersion: row.version,
+    }).catch((err) => {
+      logger.warn('handleSendConfirmClick: deleteFlow on empty-recipients failed', {
+        flow_id, error: err && err.message,
+      });
+      return { deleted: false };
+    });
+    if (!deleteResult.deleted) {
+      return interaction.followUp({
+        content: 'The card moved — re-check it and click Send again.',
+        ephemeral: true,
+      }).catch(logIgnoredDiscordErr);
+    }
     return interaction.editReply({
       content: '❌ No recipients were selected — re-run the command.',
       components: [],
@@ -4533,12 +4556,28 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     // misdirects when nobody left — the recipient list was invalid).
     // Terminal for THIS attempt either way: delete the flow so a
     // rerun claims a fresh slot.
-    await deleteFlow(flow_id, {
+    //
+    // Version-gate the delete (same shape as the happy-path Send and
+    // the empty-recipientIds branch): a concurrent UserSelect could
+    // have advanced the row between the dispatcher's loadFlow and
+    // this point. If `deleted: false`, the more-recent row is
+    // preserved and the user sees the "card moved" recovery copy.
+    const deleteResult = await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
-    }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on empty failed', {
-      flow_id, error: err && err.message,
-    }));
+      expectedVersion: row.version,
+    }).catch((err) => {
+      logger.warn('handleSendConfirmClick: deleteFlow on empty failed', {
+        flow_id, error: err && err.message,
+      });
+      return { deleted: false };
+    });
+    if (!deleteResult.deleted) {
+      return interaction.followUp({
+        content: 'The card moved — re-check it and click Send again.',
+        ephemeral: true,
+      }).catch(logIgnoredDiscordErr);
+    }
     const wasInvalidList = droppedBots > 0 || droppedSelf > 0;
     return interaction.editReply({
       content: wasInvalidList

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3444,13 +3444,22 @@ const SELF_DESTRUCT_CHOICES = [
 // Map the slash option's string value to a seconds integer or null.
 // Mirrors `selfDestructSelectValueToSeconds` in utils/time but for the
 // slash-option value space (which uses 'none' instead of the form's
-// SELF_DESTRUCT_NO_TIMER_VALUE). Wrong values fall back to null (no
-// timer) so a future option-list drift can't crash the handler.
+// SELF_DESTRUCT_NO_TIMER_VALUE).
+//
+// Defense-in-depth: validate against the SELF_DESTRUCT_PRESETS closed
+// set the same way handleQurlSlashSend validates `expiresIn` against
+// EXPIRY_LABELS. Discord enforces the choice set server-side, but a
+// forged interaction could pass `'999999999'` and that value would
+// otherwise land unchecked in the flow payload + connector upload.
+// Wrong values fall back to null (no timer) so the failure is safe.
+const SELF_DESTRUCT_PRESET_SECONDS = new Set(SELF_DESTRUCT_PRESETS.map((p) => p.seconds));
 function selfDestructOptionToSeconds(value) {
   if (!value || value === SELF_DESTRUCT_NO_TIMER_CHOICE) return null;
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) return null;
-  return Math.floor(n);
+  const floored = Math.floor(n);
+  if (!SELF_DESTRUCT_PRESET_SECONDS.has(floored)) return null;
+  return floored;
 }
 
 // Resolve a list of recipient IDs to User-shaped objects via the guild
@@ -3634,11 +3643,37 @@ function renderConfirmCardContent({
     // boundary. Re-escaping here would render `\*\*bold\*\*`
     // literals on the card. Same shape /qurl send's Step-3
     // formContent uses (commands.js:~2164).
-    const preview = personalMessage.length > 80 ? personalMessage.slice(0, 80) + '…' : personalMessage;
-    content += `**Note:** "${preview}"\n`;
+    //
+    // Quote-block syntax `> ` (instead of `"..."` wraps) avoids the
+    // ragged-look failure mode when the message itself contains a
+    // literal `"` character. Discord renders `> ` as a left-bar
+    // blockquote which visually offsets the preview from the rest
+    // of the card.
+    content += `**Note:** ${formatPersonalMessagePreview(personalMessage)}\n`;
   }
   content += '\nClick **Send** to deliver one-time qURL links, or **Cancel** to abort.';
   return content;
+}
+
+// Truncate the pre-sanitized message to 80 chars MAX, then back off
+// to the last completed markdown-escape so a slice doesn't leave a
+// lone trailing `\`. The blockquote prefix (`> `) is rendered by
+// Discord as a left-bar offset.
+//
+// The "back off" handles the case where `sanitizeMessage` emitted a
+// `\` immediately before the slice boundary (e.g. `\*` becomes `\`
+// at index 79, `*` at index 80 — slicing at 80 leaves a dangling
+// `\` that Discord would render as a literal backslash). Trimming
+// to index 79 in that case is the conservative fix.
+function formatPersonalMessagePreview(message) {
+  if (message.length <= 80) return `> ${message}`;
+  let cut = 80;
+  if (message[cut - 1] === '\\' && message[cut - 2] !== '\\') {
+    // The would-be cut sits ON an escape char. Back off so the
+    // truncation lands BEFORE the escape, not in the middle of it.
+    cut -= 1;
+  }
+  return `> ${message.slice(0, cut)}…`;
 }
 
 // Build the ActionRow set for the confirm card. When `attachPicker`,
@@ -3875,7 +3910,24 @@ async function handleQurlFile(interaction) {
     });
   }
 
-  const attachment = interaction.options.getAttachment('attachment', true);
+  // Required-option lookups via `getAttachment(..., true)` /
+  // `getString(..., true)` throw on a missing option. Discord enforces
+  // required server-side, so production interactions can't trip
+  // these; a forged interaction is the only way. The targeted catch
+  // produces an actionable ephemeral rather than letting the throw
+  // hit the dispatcher's generic safety net.
+  let attachment;
+  try {
+    attachment = interaction.options.getAttachment('attachment', true);
+  } catch (err) {
+    logger.warn('handleQurlFile: required attachment option missing', {
+      user_id: interaction.user.id, error: err && err.message,
+    });
+    return interaction.reply({
+      content: '❌ The `attachment:` option is required. Re-run with a file attached.',
+      ephemeral: true,
+    });
+  }
   if (!attachment || typeof attachment.url !== 'string') {
     return interaction.reply({
       content: '❌ Attachment is missing or malformed.',
@@ -3925,7 +3977,22 @@ async function handleQurlFile(interaction) {
 }
 
 async function handleQurlMap(interaction) {
-  const locationValue = interaction.options.getString('location', true).trim();
+  // `getString('location', true)` throws on a missing option. Discord
+  // enforces required server-side; only a forged interaction can hit
+  // this. Targeted catch matches handleQurlFile's required-option
+  // guard for symmetry + actionable user-visible copy.
+  let locationValue;
+  try {
+    locationValue = interaction.options.getString('location', true).trim();
+  } catch (err) {
+    logger.warn('handleQurlMap: required location option missing', {
+      user_id: interaction.user.id, error: err && err.message,
+    });
+    return interaction.reply({
+      content: '❌ The `location:` option is required. Re-run with a Google Maps URL or address.',
+      ephemeral: true,
+    });
+  }
   const locationNameRaw = interaction.options.getString('location-name');
   if (locationValue.length === 0) {
     return interaction.reply({
@@ -4125,14 +4192,30 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // handleQurlSlashSend rejects DM invocations BEFORE the flow row
   // is created, so a row at SEND_STAGE_AWAITING_CONFIRM only ever
   // belongs to a guild interaction. No conditional fallback.
-  const [guildApiKey, deleteResult] = await Promise.all([
-    db.getGuildApiKey(interaction.guildId),
-    deleteFlow(flow_id, {
-      stage: SEND_STAGE_AWAITING_CONFIRM,
-      reason: 'terminal',
-      expectedVersion: row.version,
-    }),
-  ]);
+  //
+  // Sequence: getGuildApiKey BEFORE deleteFlow. If the DDB read
+  // throws (rare — region outage, IAM revocation), the row stays
+  // alive and the user can re-click Send within the TTL once the
+  // blip clears. Burning the flow row first would strand the user
+  // on a dead card with the dispatcher's generic-superseded message
+  // and force a full /qurl file rerun.
+  let guildApiKey;
+  try {
+    guildApiKey = await db.getGuildApiKey(interaction.guildId);
+  } catch (err) {
+    logger.error('handleSendConfirmClick: getGuildApiKey threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.reply({
+      content: '❌ Could not look up the qURL API key right now. Try **Send** again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  const deleteResult = await deleteFlow(flow_id, {
+    stage: SEND_STAGE_AWAITING_CONFIRM,
+    reason: 'terminal',
+    expectedVersion: row.version,
+  });
   if (!deleteResult.deleted) {
     return interaction.reply({
       content: 'Recipients changed before Send fired — re-check the card and click Send again.',
@@ -5347,7 +5430,7 @@ const commands = [
         // Section order: user-facing flow first (Getting started → How it
         // works), then admin-only setup (now the OAuth-redirect flow per
         // PR #177), then glossary (Terms), then operational caveat
-        // (Large servers). The "Setting up" section pivots based on
+        // The "Setting up" section pivots based on
         // whether OAuth is configured — when it is, we describe the
         // /qurl setup OAuth flow + the "Add to Discord" install-flow
         // entry point. When unset (sandbox before Auth0 secrets land),
@@ -5386,9 +5469,6 @@ const commands = [
             '**Terms:** a *protected resource* is the file or location you\'re sharing. ' +
             'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
             'You create a qurl for a protected resource each time you run `/qurl file` or `/qurl map`.\n\n' +
-            '**Large servers (~1000+ members):** `/qurl send` with **Everyone in this channel** ' +
-            'or **Everyone in your voice channel** may skip members who appear offline in Discord. ' +
-            'If you need to reach a specific person for sure, prefer `/qurl file` or `/qurl map` with an explicit @mention.\n\n' +
             'Learn more at **https://layerv.ai**.',
           ephemeral: true,
         });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3437,8 +3437,6 @@ async function handleSetupModal(interaction, { flow_id }) {
 // Cancel buttons. The confirm card is flow_state-backed so the Send
 // dedup gate fires on `deleteFlow` (consistent with /qurl revoke,
 // /qurl setup).
-//
-// /qurl send stays in place until PR 7b.3 hard-removes it.
 // ─────────────────────────────────────────────────────────────
 
 const {
@@ -5453,23 +5451,14 @@ const commands = [
       .addSubcommand(sub =>
         sub.setName('send')
           .setDescription('Send a file or location to users via one-time secure link')
-          // No options — the redesigned flow is button-driven. Customer
-          // feedback (April 2026): the prior 4-option shape (target,
-          // expiry_optional, file_optional, message_optional) confused
-          // users at the slash-command-popup stage because they had to
-          // pre-decide file-vs-location AND fill in target before
-          // seeing the actual flow. New flow: `/qurl send` opens a
-          // 2-button reply (Send File / Send Location); each path
-          // collects its specific resource (drop-file in chat for
-          // file via awaitMessages, modal text input for location)
-          // then converges on a shared final step that gathers
-          // recipient(s), optional message, and expiry before
-          // committing the send.
-          //
-          // PR 7b.3 hard-removes /qurl send in favor of /qurl file
-          // and /qurl map. The two new subcommands take all options
-          // up-front so power users can stay on the keyboard, and
-          // the in-channel confirm card is flow_state-backed.
+          // No options — the redesigned flow is button-driven. The prior
+          // 4-option shape (target, expiry_optional, file_optional,
+          // message_optional) confused users at the slash-command-popup
+          // stage because they had to pre-decide file-vs-location AND
+          // fill in target before seeing the actual flow. Current flow:
+          // a 2-button reply opens, each path collects its specific
+          // resource (drop-file via awaitMessages, modal for location),
+          // then converges on the shared final step.
       )
       .addSubcommand(sub =>
         sub.setName('file')

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -425,10 +425,13 @@ function parseLocationInput(rawInput) {
     else if (placeMatch) name = safeDecodeURIComponent(placeMatch[1].replace(/\+/g, ' '));
     return { locationUrl: detectedUrl, locationName: name };
   }
-  // Either no Maps URL detected, OR a candidate URL failed
-  // `isGoogleMapsURL` re-validation (path/host check). Either way,
-  // wrap the raw input in a maps-search URL and use it as both URL
-  // and name.
+  // Pre-extraction the legacy /qurl send handler had TWO separate
+  // branches here ("detectedUrl but not Google Maps" vs "no
+  // detectedUrl"), each producing the same synthesized-search URL +
+  // raw-input name. The consolidated single branch below is
+  // intentional, NOT dead code — both prior cases collapse to the
+  // same behavior, so a maintainer is welcome to leave the
+  // simplification as-is.
   return {
     locationUrl: `https://www.google.com/maps/search/${encodeURIComponent(rawInput)}`,
     locationName: rawInput,
@@ -3680,7 +3683,14 @@ function renderConfirmCardRows({ attachPicker, sendDisabled }) {
 //   locationUrl:  string | null                          (map path)
 //   locationName: string | null                          (map path)
 //   resourceLabel: string                                (rendered on card)
-async function handleQurlSlashSend(interaction, apiKey, params) {
+// apiKey is INTENTIONALLY not threaded through the front-half.
+// handleSendConfirmClick re-fetches the guild API key at Send time
+// — the key may rotate during the confirm card's 3-min TTL, and the
+// dispatcher's gate at the slash-command entry point only proves the
+// key was present at that single moment. Re-fetching at click time
+// is the durable check. The dispatcher's gate (SEND_LIKE_SUBCOMMANDS
+// set) still runs to fail fast on the no-key-at-all case.
+async function handleQurlSlashSend(interaction, params) {
   if (!interaction.guildId || !interaction.guild) {
     return interaction.reply({
       content: 'This command can only be used in a server, not in DMs.',
@@ -3853,7 +3863,7 @@ async function handleQurlSlashSend(interaction, apiKey, params) {
   }
 }
 
-async function handleQurlFile(interaction, apiKey) {
+async function handleQurlFile(interaction) {
   // UX fast-fail. The real concurrency-slot claim happens inside
   // executeSendPipeline (commands.js:~1043); this pre-check is best-
   // effort — by Send-click time the cap state can have shifted, in
@@ -3896,7 +3906,7 @@ async function handleQurlFile(interaction, apiKey) {
     });
   }
 
-  return handleQurlSlashSend(interaction, apiKey, {
+  return handleQurlSlashSend(interaction, {
     resourceType: RESOURCE_TYPES.FILE,
     attachment: {
       url: attachment.url,
@@ -3914,7 +3924,7 @@ async function handleQurlFile(interaction, apiKey) {
   });
 }
 
-async function handleQurlMap(interaction, apiKey) {
+async function handleQurlMap(interaction) {
   const locationValue = interaction.options.getString('location', true).trim();
   const locationNameRaw = interaction.options.getString('location-name');
   if (locationValue.length === 0) {
@@ -3935,7 +3945,7 @@ async function handleQurlMap(interaction, apiKey) {
   }
   if (locationName) locationName = escapeDiscordMarkdown(locationName.slice(0, 256));
 
-  return handleQurlSlashSend(interaction, apiKey, {
+  return handleQurlSlashSend(interaction, {
     resourceType: RESOURCE_TYPES.MAPS,
     attachment: null,
     locationUrl,
@@ -4001,14 +4011,17 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  // Recompute warnings against the new pick (bots-on-pick is the only
-  // signal that can flip here; cappedCount / invalidTokens were string-
-  // path-only). droppedBots / droppedSelf above already short-circuited
-  // on zero-valid; if we got here, both are best-effort UI cues only.
+  // Recompute warnings against the new pick. `droppedBots` AND
+  // `droppedSelf` can flip here — Discord's UserSelectMenu doesn't
+  // exclude the invoker, so a user picking themselves bumps
+  // droppedSelf; bots present in the picker bump droppedBots.
+  // `cappedCount` / `invalidTokens` / unresolved / transient buckets
+  // are string-path-only (parser never ran on the picker selection),
+  // so they stay empty here. The earlier zero-valid short-circuit
+  // already handled the empty case; what's left below is the
+  // partial-pick UX where SOME picked users are valid but the
+  // warning still surfaces the dropped ones.
   const warningsBlock = renderRecipientWarnings({
-    invalidTokens: [],
-    cappedCount: 0,
-    unresolvedIds: [],
     droppedBots,
     droppedSelf,
   });
@@ -4041,17 +4054,39 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 async function handleSendConfirmClick(interaction, { flow_id, row }) {
   const payload = row.payload || {};
   // Re-fetch users at click time — defensive against members leaving
-  // the guild between confirm and Send. `partialDropCount` carries
-  // unresolved IDs forward so the Send-success path can surface a
-  // followUp explaining why N recipients won't receive their DM.
-  // The forensic log escalates to info (not debug) — oncall benefits
-  // from grep-discoverable signal on guild churn mid-flow without
-  // having to lower log verbosity.
-  const { users, unresolvedIds } = await resolveRecipientUsers(interaction, payload.recipientIds || []);
-  const partialDropCount = unresolvedIds.length;
-  if (partialDropCount > 0) {
-    logger.info('handleSendConfirmClick: dropping unresolved IDs at click time', {
-      flow_id, count: partialDropCount,
+  // the guild between confirm and Send. Both unresolved buckets
+  // (10007 + transient fetch failure) reduce the delivered count,
+  // so both are surfaced to the sender via followUp below — without
+  // the split, a 429 / gateway blip would silently shrink the
+  // delivered set with no signal.
+  //
+  // resolveRecipientUsers is wrapped in try/catch because the dispatcher's
+  // outer catch only logs + replies generic-superseded; a click-time
+  // lookup throw should give the user a directly actionable message
+  // without committing the dedup deleteFlow.
+  let resolved;
+  try {
+    resolved = await resolveRecipientUsers(interaction, payload.recipientIds || []);
+  } catch (err) {
+    logger.error('handleSendConfirmClick: resolveRecipientUsers threw', {
+      flow_id, error: err && err.message,
+    });
+    // `interaction.reply` (not safeReply / editReply) is intentional —
+    // this is a button-click dispatched by flow-dispatch, the
+    // interaction is in the unacked state at this point. A refactor
+    // that swaps in deferReply earlier in the handler would need to
+    // flip this to editReply too.
+    return interaction.reply({
+      content: '❌ Could not look up recipients right now. Try **Send** again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  const { users, unresolvedIds, transientFailureIds } = resolved;
+  const partialLeftCount = unresolvedIds.length;
+  const partialTransientCount = transientFailureIds.length;
+  if (partialLeftCount > 0 || partialTransientCount > 0) {
+    logger.info('handleSendConfirmClick: partial drop at click time', {
+      flow_id, left: partialLeftCount, transient: partialTransientCount,
     });
   }
   const { valid } = partitionRecipients(users, interaction.user.id);
@@ -4118,14 +4153,24 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // shape at commands.js:~2307.
   await interaction.update({ content: 'Preparing send…', components: [] }).catch(logIgnoredDiscordErr);
 
-  // Surface the partial-drop (members who left the guild between
-  // confirm and Send) as a separate ephemeral followUp BEFORE the
-  // back-half takes over the main reply. Without this the user
-  // would see "Sent to N users" with no signal that N != the count
-  // shown on the card.
-  if (partialDropCount > 0) {
+  // Surface partial drops (members who left the guild between confirm
+  // and Send, OR who failed lookup transiently) as a separate
+  // ephemeral followUp BEFORE the back-half takes over the main
+  // reply. Without this the user would see "Sent to N users" with no
+  // signal that N != the count shown on the card. Distinct wording
+  // for the two buckets — "left the server" is stable, "lookup
+  // blipped" encourages a fresh /qurl file rerun if they want to
+  // include the missed recipients.
+  if (partialLeftCount > 0 || partialTransientCount > 0) {
+    const parts = [];
+    if (partialLeftCount > 0) {
+      parts.push(`${partialLeftCount} recipient${partialLeftCount === 1 ? '' : 's'} had left the server`);
+    }
+    if (partialTransientCount > 0) {
+      parts.push(`${partialTransientCount} couldn't be looked up just now (rerun /qurl file to retry them)`);
+    }
     await interaction.followUp({
-      content: `ℹ\u{FE0F} ${partialDropCount} recipient${partialDropCount === 1 ? '' : 's'} had left the server between **Send** and now — sending to the remaining ${valid.length}.`,
+      content: `ℹ\u{FE0F} ${parts.join('; ')} — sending to the remaining ${valid.length}.`,
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
@@ -5290,8 +5335,13 @@ const commands = [
       // sometimes clone/serialize interactions) and a security smell for
       // secret-bearing values.
       if (sub === 'send') return handleSend(interaction, resolvedApiKey);
-      if (sub === 'file') return handleQurlFile(interaction, resolvedApiKey);
-      if (sub === 'map') return handleQurlMap(interaction, resolvedApiKey);
+      // /qurl file and /qurl map deliberately don't accept the
+      // dispatcher-resolved apiKey — handleSendConfirmClick re-fetches
+      // at Send time so a mid-flow rotation still uses the live key.
+      // The dispatcher's SEND_LIKE_SUBCOMMANDS gate above is the
+      // fail-fast presence check.
+      if (sub === 'file') return handleQurlFile(interaction);
+      if (sub === 'map') return handleQurlMap(interaction);
       if (sub === 'revoke') return handleRevoke(interaction, resolvedApiKey);
       if (sub === 'help') {
         // Section order: user-facing flow first (Getting started → How it

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -955,7 +955,10 @@ async function executeSendPipeline(interaction, {
   locationUrl,
   locationName,
   // MUTATES: the Add Recipients post-send branch dedupe-pushes into
-  // this array (see docstring's "transferred ownership" note).
+  // this array (see docstring's "transferred ownership" note). The
+  // initial `recipients` is already deduped + bot/sender-filtered by
+  // partitionRecipients (see contract pin at commands.js:~3552):
+  // upstream owns dedup, this function does NOT re-dedup the initial set.
   recipients,
   target,
   // REQUIRED — validated at entry (see assertion below). NO default
@@ -4052,14 +4055,19 @@ async function handleQurlFile(interaction) {
     });
   }
   if (!isAllowedFileType(attachment.contentType)) {
+    // Honest user error (picked the wrong file in the OS dialog); not
+    // an abuse signal. Unlock so retry with a valid file is immediate.
+    // SSRF rejection above stays throttled — probing the allow-list is
+    // an abuse signal, type/size rejections are not.
+    clearCooldown(interaction.user.id);
     return interaction.reply({
       content: `❌ File type not allowed: \`${escapeDiscordMarkdown(String(attachment.contentType || 'unknown'))}\`.`,
       ephemeral: true,
     });
   }
   if (attachment.size > MAX_FILE_SIZE) {
-    // Match /qurl send's MB formatting at commands.js:~1994 so users
-    // see the same readable cap across all three entry points.
+    // Same shape as the file-type rejection — honest user error.
+    clearCooldown(interaction.user.id);
     return interaction.reply({
       content: `❌ File too large (${Math.round(attachment.size / 1024 / 1024)}MB). Maximum is ${Math.round(MAX_FILE_SIZE / 1024 / 1024)}MB.`,
       ephemeral: true,
@@ -4488,15 +4496,17 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // reply. Without this the user would see "Sent to N users" with no
   // signal that N != the count shown on the card. Distinct wording
   // for the two buckets — "left the server" is stable, "lookup
-  // blipped" encourages a fresh /qurl file rerun if they want to
-  // include the missed recipients.
+  // blipped" encourages a fresh rerun if they want to include the
+  // missed recipients. The rerun hint names the actual subcommand
+  // they invoked (resourceType drives /qurl file vs /qurl map).
   if (partialLeftCount > 0 || partialTransientCount > 0) {
+    const rerunCommand = payload.resourceType === RESOURCE_TYPES.MAPS ? '/qurl map' : '/qurl file';
     const parts = [];
     if (partialLeftCount > 0) {
       parts.push(`${partialLeftCount} recipient${partialLeftCount === 1 ? '' : 's'} had left the server`);
     }
     if (partialTransientCount > 0) {
-      parts.push(`${partialTransientCount} couldn't be looked up just now (rerun /qurl file to retry them)`);
+      parts.push(`${partialTransientCount} couldn't be looked up just now (rerun ${rerunCommand} to retry them)`);
     }
     await interaction.followUp({
       // "Attempting to" (not "sending to") so a downstream pipeline
@@ -5750,6 +5760,9 @@ const commands = [
             '**Terms:** a *protected resource* is the file or location you\'re sharing. ' +
             'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
             'You create a qurl for a protected resource each time you run `/qurl file` or `/qurl map`.\n\n' +
+            '**Large servers (~1000+ members):** `/qurl send` with **Everyone in this channel** ' +
+            'or **Everyone in your voice channel** may skip members who appear offline in Discord. ' +
+            'If you need to reach a specific person for sure, prefer `/qurl file` or `/qurl map` with an explicit @mention.\n\n' +
             'Learn more at **https://layerv.ai**.',
           ephemeral: true,
         });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3901,6 +3901,21 @@ async function handleQurlSlashSend(interaction, params) {
     });
     if (!recipientsOmitted && valid.length === 0) {
       clearCooldown(interaction.user.id);
+      // Transient-only: every mentioned ID hit a 429 / gateway blip in
+      // members.fetch. Generic "no valid recipients" misleads — the
+      // user's mentions were valid, the lookup just failed. Encourage
+      // retry instead of asking them to re-pick.
+      const transientOnly = resolved.transientFailureIds.length > 0
+        && resolved.unresolvedIds.length === 0
+        && droppedBots === 0
+        && droppedSelf === 0
+        && parsed.invalidTokens.length === 0
+        && parsed.cappedCount === 0;
+      if (transientOnly) {
+        return interaction.editReply({
+          content: warningsBlock + '❌ **Could not look up recipients right now.** Try again in a moment.',
+        });
+      }
       // Parser silently strips bots + the sender from `<@id>` mentions
       // when the cache reports them (recipient-parser.js:205, 214) —
       // those IDs never reach `partitionRecipients`. If post-parse `ids`
@@ -4248,8 +4263,10 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     logger.debug('handleSendUserSelect: all-invalid pick', {
       flow_id, dropped_bots: droppedBots, dropped_self: droppedSelf,
     });
-    return rejectPick('⚠\u{FE0F} ' + (droppedBots > 0 ? 'Cannot send to bots.' : 'Cannot send to yourself.')
-      + ' Re-pick recipients below.\n\n');
+    const reasons = [];
+    if (droppedBots > 0) reasons.push('Cannot send to bots');
+    if (droppedSelf > 0) reasons.push('cannot send to yourself');
+    return rejectPick(`⚠\u{FE0F} ${reasons.join('; ')}. Re-pick recipients below.\n\n`);
   }
   // Defense-in-depth — unreachable in production today: the picker's
   // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -90,18 +90,27 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 // Hard cap on input length so an adversarial regex-blowup attack
 // (10MB of `<@1>` repetitions) doesn't tie up the worker. Discord's
 // slash-command STRING option max is 6000 chars (when not narrowed
-// via setMaxLength); 4000 is a conservative budget that comfortably
-// fits any legitimate recipient-list paste while leaving headroom
-// before the API ceiling. 7b.2 should narrow the option's
-// max_length to ≤4000 so this cap becomes defense-in-depth rather
-// than the user-visible truncation point.
-// TODO(7b.2): KEEP IN SYNC with the slash-option `max_length` in
-// 7b.2's builder. If 7b.2 narrows the option's max_length to
-// ≤ 4000, this cap becomes defense-in-depth; if it doesn't, this
-// is the user-visible truncation point (and the partial-mention
-// trim below becomes lossy on legitimate over-cap content).
-// Grep `TODO(7b.2)` to find the 7b.1 → 7b.2 coordination markers.
+// via setMaxLength).
+//
+// 7b.2 narrows the slash option to MAX_SLASH_OPTION_LENGTH (2000)
+// — well below this parser cap (4000) — so:
+//   * the parser cap is genuine defense-in-depth (only reachable
+//     via a forged interaction OR a future non-slash caller), and
+//   * the partial-mention trim below is unreachable from `/qurl
+//     file` / `/qurl map`'s slash path.
+// Legitimate recipient lists peak around 25 mentions × ~24 chars =
+// ~600 chars; 2000 leaves headroom for role-mention expansion and
+// pasted formatting without ever hitting the parser cap.
 const MAX_INPUT_LENGTH = 4000;
+
+// Max length applied to `/qurl file` / `/qurl map` `recipients:`
+// slash options. Discord enforces this server-side, so anything
+// past it never reaches the parser. Computed as half of
+// `MAX_INPUT_LENGTH` so the gap survives a future bump to either
+// constant — the relationship is code-enforced rather than a
+// hand-maintained literal. Both /qurl file and /qurl map builders
+// read this; 7b.3+ should continue to honor the gap.
+const MAX_SLASH_OPTION_LENGTH = Math.floor(MAX_INPUT_LENGTH / 2);
 
 // Per-token cap on entries in `invalidTokens`. Discord's embed total
 // is 4096 chars; a single ~4000-char garbage token (one giant string
@@ -351,4 +360,5 @@ module.exports = {
   parseRecipientMentions,
   MAX_INPUT_LENGTH,
   MAX_INVALID_TOKEN_LENGTH,
+  MAX_SLASH_OPTION_LENGTH,
 };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -104,13 +104,18 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 const MAX_INPUT_LENGTH = 4000;
 
 // Max length applied to `/qurl file` / `/qurl map` `recipients:`
-// slash options. Discord enforces this server-side, so anything
-// past it never reaches the parser. Computed as half of
-// `MAX_INPUT_LENGTH` so the gap survives a future bump to either
-// constant — the relationship is code-enforced rather than a
-// hand-maintained literal. Both /qurl file and /qurl map builders
-// read this; 7b.3+ should continue to honor the gap.
-const MAX_SLASH_OPTION_LENGTH = Math.floor(MAX_INPUT_LENGTH / 2);
+// slash options. Discord enforces this server-side, so anything past
+// it never reaches the parser — the parser's MAX_INPUT_LENGTH cap
+// (above) is genuine defense-in-depth, only reachable via a forged
+// interaction or a future non-slash caller.
+//
+// Picked at half of MAX_INPUT_LENGTH so the headroom relationship is
+// load-bearing: a future bump to MAX_INPUT_LENGTH (e.g. for a larger
+// guild's role-expansion needs) preserves the 2× gap automatically.
+// Both /qurl file and /qurl map builders read this; 7b.3+ should
+// continue to honor the gap.
+const SLASH_OPTION_HEADROOM_DIVISOR = 2;
+const MAX_SLASH_OPTION_LENGTH = Math.floor(MAX_INPUT_LENGTH / SLASH_OPTION_HEADROOM_DIVISOR);
 
 // Per-token cap on entries in `invalidTokens`. Discord's embed total
 // is 4096 chars; a single ~4000-char garbage token (one giant string

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -110,4 +110,21 @@ function sanitizeDisplayNamePlain(s) {
   return stripControlAndBidi(s);
 }
 
-module.exports = { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel };
+/**
+ * Strip bidi / zero-width / control / line-separator codepoints from
+ * a user-controlled message body without any length cap, NFKC pass,
+ * or markdown escape. Used by sanitizeMessage to layer the same RLO
+ * spoofing defense onto the personal-message surface that
+ * sanitizeContentLabel applies to labels — without disrupting
+ * sanitizeMessage's own slice / markdown-escape ordering.
+ *
+ * NFKC IS applied first because U+FEFF (BOM) and a few other strip
+ * codepoints are only matched against canonical forms after NFKC.
+ * No fallback string — empty input returns empty output (the
+ * sanitizeMessage caller has its own empty-message handling).
+ */
+function stripBidiAndControls(s) {
+  return String(s ?? '').normalize('NFKC').replace(STRIP_RE, '');
+}
+
+module.exports = { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls };

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -40,13 +40,39 @@ const STRIP_RE = new RegExp(
   'g',
 );
 
-function stripControlAndBidi(s) {
+// `maxCodepoints` defaults to 64 (display-name budget). Larger
+// surfaces (locationName, attachment.name → 256) pass their own
+// cap; the strip + NFKC + codepoint-slice contract is identical.
+// Empty / undefined input returns the 'Someone' fallback for the
+// display-name caller; surface-specific callers should branch on
+// the empty case themselves rather than render "Someone".
+function stripControlAndBidi(s, maxCodepoints = 64) {
   const cleaned = String(s ?? 'Someone').normalize('NFKC').replace(STRIP_RE, '');
   // Codepoint-aware slice. `String.prototype.slice` operates on UTF-16
-  // code units, so a 64-char cap on a name like `'A'.repeat(63) + emoji`
+  // code units, so a cap on a name like `'A'.repeat(63) + emoji`
   // would split a surrogate pair and Discord would render the lone high
   // surrogate as tofu. `Array.from(str)` iterates by codepoint.
-  return Array.from(cleaned).slice(0, 64).join('') || 'Someone';
+  return Array.from(cleaned).slice(0, maxCodepoints).join('') || 'Someone';
+}
+
+/**
+ * Sanitize a user-controlled label that lands inside Discord message
+ * content (NOT a display-name slot): strip bidi / zero-width / control
+ * chars (RLO spoofing defense), NFKC-normalize, codepoint-slice to
+ * `maxCodepoints`, then escape markdown so a crafted label can't
+ * inject `**bold**` / `[masked-link](https://evil)` / spoilers.
+ *
+ * Callers: /qurl map's `locationName`, /qurl file's
+ * `attachment.name`-derived `resourceLabel`. Returns '' on empty /
+ * all-strip-char input (NOT the 'Someone' display-name fallback) so
+ * the caller can render its own empty-state.
+ */
+function sanitizeContentLabel(s, maxCodepoints = 256) {
+  if (s == null || s === '') return '';
+  const cleaned = String(s).normalize('NFKC').replace(STRIP_RE, '');
+  if (!cleaned) return '';
+  const sliced = Array.from(cleaned).slice(0, maxCodepoints).join('');
+  return escapeDiscordMarkdown(sliced);
 }
 
 /**
@@ -84,4 +110,4 @@ function sanitizeDisplayNamePlain(s) {
   return stripControlAndBidi(s);
 }
 
-module.exports = { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain };
+module.exports = { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel };

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -69,18 +69,11 @@ const makeEmbed = () => {
 };
 
 jest.mock('discord.js', () => {
-  // Option-builder chainable. Each option type (string/attachment/etc.)
-  // exposes the same surface; the mock returns a single shape so a new
-  // method added at the discord.js layer only needs one update here.
-  const makeOptionBuilder = () => ({
-    setName: jest.fn().mockReturnThis(),
-    setDescription: jest.fn().mockReturnThis(),
-    setRequired: jest.fn().mockReturnThis(),
-    setMaxLength: jest.fn().mockReturnThis(),
-    setMinLength: jest.fn().mockReturnThis(),
-    addChoices: jest.fn().mockReturnThis(),
-    setAutocomplete: jest.fn().mockReturnThis(),
-  });
+  // Shared option-builder chainable. Centralized so a new chained
+  // method at the discord.js layer (setMaxLength, addChoices, etc.)
+  // touches one site for the whole test suite — PR #301 regression
+  // surfaced this exact gap when setMaxLength was added.
+  const { makeOptionBuilder } = require('./helpers/discord-mock');
   return {
   SlashCommandBuilder: jest.fn().mockImplementation(() => {
     const subBuilder = () => ({

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1183,10 +1183,10 @@ describe('/qurl help subcommand', () => {
     // (3) Terms block disambiguates "protected resource" from "qURL"
     expect(content).toContain('protected resource');
     expect(content).toContain('access link');
-    // (4) Help text doesn't leak internal jargon. The legacy
-    // "Large servers" copy described /qurl send's voice/channel
-    // fanout modes; removed in 7b.2 round 6 (cr-flagged) because
-    // /qurl file / /qurl map have no equivalent fanout target.
+    // (4) Help text doesn't leak internal jargon. The "Large servers"
+    // section explains the /qurl send fanout caveat to end-users
+    // without naming the underlying GUILD_PRESENCES intent. That
+    // section goes away when 7b.3 deletes /qurl send.
     expect(content).not.toContain('GUILD_PRESENCES');
   });
 });

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -1183,8 +1183,10 @@ describe('/qurl help subcommand', () => {
     // (3) Terms block disambiguates "protected resource" from "qURL"
     expect(content).toContain('protected resource');
     expect(content).toContain('access link');
-    // (4) Large-servers note uses plain language, not GUILD_PRESENCES jargon
-    expect(content).toContain('Large servers');
+    // (4) Help text doesn't leak internal jargon. The legacy
+    // "Large servers" copy described /qurl send's voice/channel
+    // fanout modes; removed in 7b.2 round 6 (cr-flagged) because
+    // /qurl file / /qurl map have no equivalent fanout target.
     expect(content).not.toContain('GUILD_PRESENCES');
   });
 });

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -68,24 +68,37 @@ const makeEmbed = () => {
   return embed;
 };
 
-jest.mock('discord.js', () => ({
+jest.mock('discord.js', () => {
+  // Option-builder chainable. Each option type (string/attachment/etc.)
+  // exposes the same surface; the mock returns a single shape so a new
+  // method added at the discord.js layer only needs one update here.
+  const makeOptionBuilder = () => ({
+    setName: jest.fn().mockReturnThis(),
+    setDescription: jest.fn().mockReturnThis(),
+    setRequired: jest.fn().mockReturnThis(),
+    setMaxLength: jest.fn().mockReturnThis(),
+    setMinLength: jest.fn().mockReturnThis(),
+    addChoices: jest.fn().mockReturnThis(),
+    setAutocomplete: jest.fn().mockReturnThis(),
+  });
+  return {
   SlashCommandBuilder: jest.fn().mockImplementation(() => {
     const subBuilder = () => ({
       setName: jest.fn().mockReturnThis(),
       setDescription: jest.fn().mockReturnThis(),
-      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis(), addChoices: jest.fn().mockReturnThis(), setAutocomplete: jest.fn().mockReturnThis() }); return this; }),
-      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return this; }),
-      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return this; }),
-      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return this; }),
+      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
     });
     const builder = {
       setName: jest.fn(function (n) { builder.name = n; return builder; }),
       setDescription: jest.fn().mockReturnThis(),
       addSubcommand: jest.fn(function (fn) { if (typeof fn === 'function') fn(subBuilder()); return builder; }),
-      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis(), addChoices: jest.fn().mockReturnThis(), setAutocomplete: jest.fn().mockReturnThis() }); return builder; }),
-      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return builder; }),
-      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return builder; }),
-      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return builder; }),
+      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
+      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
+      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
+      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
       setDefaultMemberPermissions: jest.fn().mockReturnThis(),
       toJSON: jest.fn().mockReturnValue({}),
     };
@@ -136,7 +149,8 @@ jest.mock('discord.js', () => ({
     setRequired: jest.fn().mockReturnThis(),
   })),
   TextInputStyle: { Short: 1, Paragraph: 2 },
-}));
+  };
+});
 
 const mockDb = {
   getLinkByDiscord: jest.fn(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -76,24 +76,37 @@ const makeEmbed = () => {
   return embed;
 };
 
-jest.mock('discord.js', () => ({
+jest.mock('discord.js', () => {
+  // Single option-builder chainable so any new chained method (e.g.
+  // setMaxLength added for 7b.2) only needs one update across this
+  // mock surface, not 8 inline copies.
+  const makeOptionBuilder = () => ({
+    setName: jest.fn().mockReturnThis(),
+    setDescription: jest.fn().mockReturnThis(),
+    setRequired: jest.fn().mockReturnThis(),
+    setMaxLength: jest.fn().mockReturnThis(),
+    setMinLength: jest.fn().mockReturnThis(),
+    addChoices: jest.fn().mockReturnThis(),
+    setAutocomplete: jest.fn().mockReturnThis(),
+  });
+  return {
   SlashCommandBuilder: jest.fn().mockImplementation(() => {
     const subBuilder = () => ({
       setName: jest.fn().mockReturnThis(),
       setDescription: jest.fn().mockReturnThis(),
-      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis(), addChoices: jest.fn().mockReturnThis(), setAutocomplete: jest.fn().mockReturnThis() }); return this; }),
-      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return this; }),
-      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return this; }),
-      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return this; }),
+      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
     });
     const builder = {
       setName: jest.fn(function (n) { builder.name = n; return builder; }),
       setDescription: jest.fn().mockReturnThis(),
       addSubcommand: jest.fn(function (fn) { if (typeof fn === 'function') fn(subBuilder()); return builder; }),
-      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis(), addChoices: jest.fn().mockReturnThis(), setAutocomplete: jest.fn().mockReturnThis() }); return builder; }),
-      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return builder; }),
-      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return builder; }),
-      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn({ setName: jest.fn().mockReturnThis(), setDescription: jest.fn().mockReturnThis(), setRequired: jest.fn().mockReturnThis() }); return builder; }),
+      addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
+      addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
+      addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
+      addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return builder; }),
       setDefaultMemberPermissions: jest.fn().mockReturnThis(),
       toJSON: jest.fn().mockReturnValue({}),
     };
@@ -143,7 +156,8 @@ jest.mock('discord.js', () => ({
     setRequired: jest.fn().mockReturnThis(),
   })),
   TextInputStyle: { Short: 1, Paragraph: 2 },
-}));
+  };
+});
 
 const mockDb = {
   getLinkByDiscord: jest.fn(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -77,18 +77,11 @@ const makeEmbed = () => {
 };
 
 jest.mock('discord.js', () => {
-  // Single option-builder chainable so any new chained method (e.g.
-  // setMaxLength added for 7b.2) only needs one update across this
-  // mock surface, not 8 inline copies.
-  const makeOptionBuilder = () => ({
-    setName: jest.fn().mockReturnThis(),
-    setDescription: jest.fn().mockReturnThis(),
-    setRequired: jest.fn().mockReturnThis(),
-    setMaxLength: jest.fn().mockReturnThis(),
-    setMinLength: jest.fn().mockReturnThis(),
-    addChoices: jest.fn().mockReturnThis(),
-    setAutocomplete: jest.fn().mockReturnThis(),
-  });
+  // Shared option-builder chainable from tests/helpers/discord-mock.
+  // Same instance used by commands-comprehensive.test.js so a new
+  // chained method (setMaxLength, addChoices, etc.) at the
+  // discord.js layer only touches one site.
+  const { makeOptionBuilder } = require('./helpers/discord-mock');
   return {
   SlashCommandBuilder: jest.fn().mockImplementation(() => {
     const subBuilder = () => ({

--- a/apps/discord/tests/helpers/discord-mock.js
+++ b/apps/discord/tests/helpers/discord-mock.js
@@ -1,0 +1,33 @@
+/**
+ * Shared discord.js mock factory helpers for jest tests.
+ *
+ * The SlashCommandBuilder + option-builder chainables are the dominant
+ * mock surface that grows whenever a new chained method appears at the
+ * discord.js layer (setMaxLength, addChoices, setAutocomplete, etc.).
+ * Without a shared factory, each test file that mocks discord.js had
+ * to be touched in lockstep — which silently breaks at module-load
+ * (e.g. commands-comprehensive + coverage-boost both regressed when
+ * PR #301 added setMaxLength).
+ *
+ * Tests opt in by importing these factories inside their own
+ * `jest.mock('discord.js', () => ({ ... }))` factory function.
+ */
+
+// Option-builder chainable used by addStringOption / addAttachmentOption
+// / addUserOption / addIntegerOption. Every chainable method returns
+// itself so the discord.js builder DSL works unchanged.
+function makeOptionBuilder() {
+  return {
+    setName: jest.fn().mockReturnThis(),
+    setDescription: jest.fn().mockReturnThis(),
+    setRequired: jest.fn().mockReturnThis(),
+    setMaxLength: jest.fn().mockReturnThis(),
+    setMinLength: jest.fn().mockReturnThis(),
+    addChoices: jest.fn().mockReturnThis(),
+    setAutocomplete: jest.fn().mockReturnThis(),
+  };
+}
+
+module.exports = {
+  makeOptionBuilder,
+};

--- a/apps/discord/tests/helpers/discord-mock.js
+++ b/apps/discord/tests/helpers/discord-mock.js
@@ -28,6 +28,40 @@ function makeOptionBuilder() {
   };
 }
 
+// Component-builder chainable — superset surface covering
+// ButtonBuilder, StringSelectMenuBuilder, UserSelectMenuBuilder,
+// ModalBuilder, TextInputBuilder. Each method returns `this` so the
+// discord.js builder DSL works unchanged. Unused methods on the
+// chainable are inert — tests can reuse this for any component
+// without per-component shaping.
+//
+// commands-comprehensive.test.js and coverage-boost.test.js still
+// inline narrower per-component shapes for historical reasons; they
+// can migrate to this superset whenever a discord.js change
+// surfaces a setMaxLength-style drift gap for components.
+function makeComponentChainable(extra = {}) {
+  return {
+    setCustomId: jest.fn().mockReturnThis(),
+    setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
+    setStyle: jest.fn().mockReturnThis(),
+    setURL: jest.fn().mockReturnThis(),
+    setTitle: jest.fn().mockReturnThis(),
+    setPlaceholder: jest.fn().mockReturnThis(),
+    addOptions: jest.fn().mockReturnThis(),
+    setMinValues: jest.fn().mockReturnThis(),
+    setMaxValues: jest.fn().mockReturnThis(),
+    addComponents: jest.fn().mockReturnThis(),
+    setDisabled: jest.fn().mockReturnThis(),
+    setValue: jest.fn().mockReturnThis(),
+    setMaxLength: jest.fn().mockReturnThis(),
+    setMinLength: jest.fn().mockReturnThis(),
+    setRequired: jest.fn().mockReturnThis(),
+    ...extra,
+  };
+}
+
 module.exports = {
   makeOptionBuilder,
+  makeComponentChainable,
 };

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -301,19 +301,32 @@ beforeEach(() => {
 // ──────────────────────────────────────────────────────────────
 
 describe('selfDestructOptionToSeconds', () => {
+  // SELF_DESTRUCT_PRESETS (utils/time.js): 0.5, 1, 5, 30, 300, 1800, 3600.
+  // Anything else falls back to null per the defense-in-depth gate
+  // added in round 6 (cr-flagged: forged interactions could otherwise
+  // smuggle '999999999' past Discord's server-side choice enforcement).
   test.each([
     ['none', null],
     [SELF_DESTRUCT_NO_TIMER_CHOICE, null],
     [null, null],
     [undefined, null],
     ['', null],
-    ['60', 60],
+    // Preset values pass through:
+    ['5', 5],
+    ['30', 30],
+    ['300', 300],
+    ['1800', 1800],
     ['3600', 3600],
+    // Off-set values fall back to null (defense-in-depth):
+    ['60', null],
+    ['7200', null],
+    ['999999999', null],
+    // Edge cases:
     ['0', null],
     ['-5', null],
     ['NaN', null],
     ['bogus', null],
-    ['1.5', 1],
+    ['1.5', 1],  // Math.floor(1.5)=1 IS a preset
   ])('value=%j → seconds=%j', (input, expected) => {
     expect(selfDestructOptionToSeconds(input)).toBe(expected);
   });
@@ -556,11 +569,31 @@ describe('renderConfirmCardContent', () => {
     expect(out).toMatch(/Self-destruct/);
   });
 
-  test('personal-message preview cap at 80 chars', () => {
+  test('personal-message preview cap at 80 chars, rendered as blockquote', () => {
     const long = 'x'.repeat(120);
     const out = renderConfirmCardContent({ ...baseProps, personalMessage: long });
-    // 80 chars of x + ellipsis
-    expect(out).toMatch(/x{80}…/);
+    // Round-6 (cr) switched from `"..."` to `> ` blockquote so literal
+    // `"` chars in the message can't make the rendering look ragged.
+    expect(out).toMatch(/> x{80}…/);
+    // The previous `"..."` wrap is gone.
+    expect(out).not.toMatch(/"x{80}…"/);
+  });
+
+  test('personal-message preview backs off the cut when it would land on a markdown escape', () => {
+    // sanitizeMessage emits `\*` etc. If a slice lands the cut at a
+    // boundary between `\` and `*`, the rendered preview shows a
+    // dangling `\`. Round-6 (cr) backs the cut off by 1 when the
+    // 80th char is a `\` not preceded by another `\`.
+    //
+    // Build a 90-char message where char[79] is '\\' and char[80] is '*'.
+    // Confirm the truncation drops the trailing `\` before the ellipsis.
+    const safePrefix = 'a'.repeat(79);  // 79 chars
+    const message = safePrefix + '\\*' + 'rest'.repeat(10);  // 79+2+40 = 121 chars
+    const out = renderConfirmCardContent({ ...baseProps, personalMessage: message });
+    // The truncated preview ends with 79 chars (no trailing `\`)
+    // followed by the ellipsis. Backed-off cut: index 79.
+    expect(out).toContain(`> ${safePrefix}…`);
+    expect(out).not.toMatch(/\\…/);
   });
 
   test('personal-message renders pre-sanitized input verbatim (no double-escape)', () => {
@@ -570,7 +603,7 @@ describe('renderConfirmCardContent', () => {
     // `\\\*\\\*bold\\\*\\\*`.
     const presanitized = '\\*\\*emphasis\\*\\*';
     const out = renderConfirmCardContent({ ...baseProps, personalMessage: presanitized });
-    expect(out).toContain(`"${presanitized}"`);
+    expect(out).toContain(`> ${presanitized}`);
     expect(out).not.toMatch(/\\\\\*/);
   });
 
@@ -581,9 +614,7 @@ describe('renderConfirmCardContent', () => {
     // must NOT themselves become `\\\\` in the card.
     const presanitized = '\\*\\*bold\\*\\* \\\\n \\[link\\]\\(https://evil\\)';
     const out = renderConfirmCardContent({ ...baseProps, personalMessage: presanitized });
-    // The substring renders exactly as supplied — no markdown-escape
-    // pass turns `\\` into `\\\\`.
-    expect(out).toContain(`"${presanitized}"`);
+    expect(out).toContain(`> ${presanitized}`);
     // Defense: no `\\\\` (four backslashes) appears — that'd be the
     // unambiguous double-escape regression signature.
     expect(out).not.toMatch(/\\\\\\\\/);
@@ -943,6 +974,29 @@ describe('handleQurlMap — slash entry', () => {
       content: expect.stringMatching(/in a server/),
     }));
   });
+
+  test('forged interaction missing required `location` → actionable ephemeral, no flow row', async () => {
+    // Discord enforces required options server-side; only a forged
+    // interaction can hit the `getString('location', true)` throw.
+    // Round-6 (cr) added a targeted catch so the user sees an
+    // actionable message instead of the dispatcher's generic safety
+    // net.
+    const int = makeInteraction({ options: {} });
+    int.options.getString = jest.fn((name, required) => {
+      if (name === 'location' && required) {
+        const err = new Error('CommandInteractionOptionNotFound');
+        err.code = 'CommandInteractionOptionNotFound';
+        throw err;
+      }
+      return null;
+    });
+    await handleQurlMap(int);
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/`location:` option is required/),
+      ephemeral: true,
+    }));
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -1097,6 +1151,24 @@ describe('handleSendConfirmClick', () => {
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringMatching(/partial drop at click time/),
       expect.objectContaining({ left: 0, transient: 1 }),
+    );
+  });
+
+  test('getGuildApiKey throw at click time → ephemeral retry, NO deleteFlow (row stays alive)', async () => {
+    // Round-6 (cr) reordering: getGuildApiKey runs BEFORE deleteFlow
+    // so a DDB blip doesn't burn the flow row. User can re-click
+    // Send within the 3-min TTL once the blip clears.
+    mockDb.getGuildApiKey.mockRejectedValueOnce(new Error('ddb gone'));
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not look up the qURL API key/),
+      ephemeral: true,
+    }));
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/getGuildApiKey threw/),
+      expect.objectContaining({ flow_id: 'fid' }),
     );
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -643,6 +643,40 @@ describe('renderConfirmCardContent', () => {
     expect(out).not.toMatch(/\*\*bob\*\*/);
     expect(out).toMatch(/\\\*\\\*bob\\\*\\\*/);
   });
+
+  test('preview prefers guild member displayName over username when interaction is supplied', () => {
+    // cr round 9: a previous round's comment claimed
+    // resolveRecipientAlias was used, but the code path was raw
+    // `u.username`. Pin the alias path so a future refactor can't
+    // silently drift back to username-only.
+    const u = makeUser('100000000000000001', { username: 'alice' });
+    const int = {
+      guild: {
+        members: {
+          cache: new Map([[u.id, { displayName: 'Alice in Wonderland', user: u }]]),
+        },
+      },
+    };
+    const out = renderConfirmCardContent({ ...baseProps, validRecipients: [u], interaction: int });
+    expect(out).toMatch(/Alice in Wonderland/);
+    expect(out).not.toMatch(/\balice\b/);
+  });
+
+  test('personal-message blockquote collapses embedded newlines + unicode line/paragraph separators to spaces', () => {
+    // cr round 9: Discord blockquotes are per-LINE — only the line
+    // starting with `> ` gets the left-bar. A multi-line message
+    // would render with a quoted first line and flush-left subsequent
+    // lines. formatPersonalMessagePreview collapses `\n` / `\r\n` /
+    // U+2028 (line sep) / U+2029 (paragraph sep) into single spaces
+    // so the preview is a clean one-liner. The Unicode separators
+    // matter because Discord renders them as line breaks too (per
+    // simplify round 10 review).
+    const out = renderConfirmCardContent({
+      ...baseProps,
+      personalMessage: 'first line\nsecond\r\nthird fourth fifth',
+    });
+    expect(out).toContain('> first line second third fourth fifth\n');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -1247,10 +1281,11 @@ describe('handleSendConfirmClick', () => {
     int.guild.members.fetch = jest.fn().mockRejectedValue(new Error('catastrophic'));
     // Need to bypass batchSettled's swallow path: rejection inside the
     // callback is caught by Promise.allSettled, then resolveRecipientUsers's
-    // own try/catch handles it. A real throw from BEFORE the try (e.g.
-    // guild === null) is what we want here. Simulate by deleting guild.
-    // Actually simpler — make the entire interaction.guild throw on read.
-    Object.defineProperty(int, 'guild', {
+    // own try/catch handles it. Simulate a synchronous blow-up inside
+    // resolveRecipientUsers by making `interaction.guild.members`
+    // throw on read — that lands *after* handleSendConfirmClick's
+    // bot-kicked guard (which only checks `interaction.guild`).
+    Object.defineProperty(int.guild, 'members', {
       get() { throw new Error('cache exploded'); },
     });
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: { ...validPayload, recipientIds: [u1] }, version: 1 } });
@@ -1263,6 +1298,30 @@ describe('handleSendConfirmClick', () => {
       expect.stringMatching(/resolveRecipientUsers threw/),
       expect.objectContaining({ flow_id: 'fid' }),
     );
+  });
+
+  test('bot kicked between confirm and Send → distinct ephemeral, flow row deleted', async () => {
+    // cr round 9: when the bot is removed from the guild between
+    // confirm and Send, `interaction.guild` is null. Without an
+    // explicit guard, resolveRecipientUsers returns every recipientId
+    // in unresolvedIds and the user sees "recipients left the server"
+    // — misleading. Pin the dedicated copy + deleteFlow so the flow
+    // row doesn't linger.
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    int.guild = null;
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/bot is no longer in this server/i),
+      components: [],
+    }));
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }));
+    // The misleading "left the server" copy must NOT fire here.
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/no longer reachable/i),
+    }));
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -189,6 +189,8 @@ const {
   clearCooldown,
   sendCooldowns,
   executeSendPipeline,
+  getActiveFileSends,
+  setActiveFileSends,
 } = _test;
 
 // Flow-dispatch handlers live at module top-level (consumed by
@@ -901,6 +903,31 @@ describe('handleQurlFile — slash entry', () => {
       content: expect.stringMatching(/in a server/),
       ephemeral: true,
     }));
+  });
+
+  test('rejects when activeFileSends is at cap (UX fast-fail) — cooldown NOT burned (server-side backpressure)', async () => {
+    // activeFileSends ≥ MAX_CONCURRENT_FILE_SENDS short-circuits at slash
+    // entry with a "bot too busy" reply. The actual concurrency-slot
+    // claim happens inside executeSendPipeline; this entry-time check
+    // is a UX fast-fail. Server-side backpressure is not user fault →
+    // cooldown is intentionally NOT set so the user can retry as soon
+    // as a slot frees.
+    const originalActive = getActiveFileSends();
+    try {
+      setActiveFileSends(99);  // any value ≥ MAX_CONCURRENT_FILE_SENDS
+      const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+      await handleQurlFile(int);
+      expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringMatching(/too many file sends/i),
+        ephemeral: true,
+      }));
+      // No cooldown set on this branch.
+      expect(isOnCooldown(SENDER_ID)).toBe(false);
+      // And no flow row created.
+      expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    } finally {
+      setActiveFileSends(originalActive);
+    }
   });
 
   test('rejects when attachment.url is not Discord CDN (SSRF gate) — cooldown PRESERVED (probing defense)', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1258,7 +1258,7 @@ describe('handleQurlMap — slash entry', () => {
     expect(payload.locationName).toBe('Custom Label');
   });
 
-  test('empty location string → ephemeral error', async () => {
+  test('empty location string → ephemeral error, cooldown CLEARED (honest user error)', async () => {
     const int = makeInteraction({
       options: { location: '   ', recipients: '<@100000000000000001>' },
     });
@@ -1266,6 +1266,10 @@ describe('handleQurlMap — slash entry', () => {
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/empty/),
     }));
+    // Honest user error (whitespace-only paste) — don't strand them
+    // for 30s. Same shape as the file-type / size-cap branches in
+    // handleQurlFile.
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
   test('rejects in DM context', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -160,8 +160,10 @@ jest.mock('../src/flow-state', () => ({
   supersedeOrCreate: (...a) => mockSupersedeOrCreate(...a),
 }));
 
-// flow-dispatch is a real module — we want registerFlow's
-// idempotent-failure guard to fire on test re-loads.
+// flow-dispatch (registerFlow + customId routing) is loaded for real —
+// only flow-state's DDB-backed primitives are mocked above. Loading
+// the real registerFlow lets the idempotent-failure guard fire on
+// test re-loads and pins the customId → handler contract.
 const commands = require('../src/commands');
 const { _test } = commands;
 const logger = require('../src/logger');
@@ -303,8 +305,8 @@ beforeEach(() => {
 describe('selfDestructOptionToSeconds', () => {
   // SELF_DESTRUCT_PRESETS (utils/time.js): 0.5, 1, 5, 30, 300, 1800, 3600.
   // Anything else falls back to null per the defense-in-depth gate
-  // added in round 6 (cr-flagged: forged interactions could otherwise
-  // smuggle '999999999' past Discord's server-side choice enforcement).
+  // against forged interactions that could otherwise smuggle
+  // '999999999' past Discord's server-side choice enforcement.
   test.each([
     ['none', null],
     [SELF_DESTRUCT_NO_TIMER_CHOICE, null],
@@ -365,7 +367,7 @@ describe('partitionRecipients', () => {
   });
 
   test('contract: does NOT re-dedup — dedup is upstream (parseRecipientMentions Set + Discord picker gateway-event)', () => {
-    // cr round 10 audit: confirm that duplicates passed in are preserved
+    // Confirm duplicates passed in are preserved verbatim:
     // verbatim. parseRecipientMentions already dedupes via Set
     // (recipient-parser.js:197-198) and Discord's UserSelectMenu
     // gateway-event surfaces each picked user at most once. If a future
@@ -515,7 +517,7 @@ describe('renderRecipientWarnings', () => {
   test('transientFailureIds rendered with neutral copy (not "left the server")', () => {
     // Rate-limit / gateway-blip 429s land in transientFailureIds, NOT
     // unresolvedIds — so the message must encourage retry, not imply
-    // the recipient is gone. cr round 4 caught this misdirection.
+    // the recipient is gone — distinct copy avoids misdirection.
     const out = renderRecipientWarnings({
       transientFailureIds: ['100000000000000001', '100000000000000002'],
     });
@@ -563,9 +565,8 @@ describe('renderConfirmCardContent', () => {
   });
 
   test('unknown resourceType throws — forces an explicit branch for future types', () => {
-    // Round-7 (cr) added an explicit else-throw so a future resource
-    // type (audio, contact card, etc.) can't silently render as a
-    // location. Pins the contract.
+    // Explicit else-throw so a future resource type (audio, contact
+    // card, etc.) can't silently render as a location.
     expect(() => renderConfirmCardContent({
       ...baseProps,
       resourceType: 'audio',
@@ -595,8 +596,8 @@ describe('renderConfirmCardContent', () => {
   test('personal-message preview cap at 80 chars, rendered as blockquote', () => {
     const long = 'x'.repeat(120);
     const out = renderConfirmCardContent({ ...baseProps, personalMessage: long });
-    // Round-6 (cr) switched from `"..."` to `> ` blockquote so literal
-    // `"` chars in the message can't make the rendering look ragged.
+    // Blockquote form (`> `) instead of `"..."` wrap so literal `"`
+    // chars in the message can't make the rendering look ragged.
     expect(out).toMatch(/> x{80}…/);
     // The previous `"..."` wrap is gone.
     expect(out).not.toMatch(/"x{80}…"/);
@@ -605,8 +606,8 @@ describe('renderConfirmCardContent', () => {
   test('personal-message preview backs off the cut when it would land on a markdown escape', () => {
     // sanitizeMessage emits `\*` etc. If a slice lands the cut at a
     // boundary between `\` and `*`, the rendered preview shows a
-    // dangling `\`. Round-6 (cr) backs the cut off by 1 when the
-    // 80th char is a `\` not preceded by another `\`.
+    // dangling `\`. The slice backs off by 1 when the 80th char
+    // is a `\` not preceded by another `\`.
     //
     // Build a 90-char message where char[79] is '\\' and char[80] is '*'.
     // Confirm the truncation drops the trailing `\` before the ellipsis.
@@ -619,9 +620,21 @@ describe('renderConfirmCardContent', () => {
     expect(out).not.toMatch(/\\…/);
   });
 
+  test('personal-message preview slices by codepoint, not UTF-16 code units (surrogate-pair safe)', () => {
+    // Bare String.prototype.slice operates on UTF-16 code units, so a
+    // slice that lands mid-surrogate emits a lone surrogate that
+    // Discord renders as tofu. Build a message where the 80th
+    // codepoint is an emoji (surrogate pair) and verify the rendered
+    // preview contains no lone surrogate.
+    const message = 'a'.repeat(79) + '\u{1F600}' + 'rest'.repeat(20);
+    const out = renderConfirmCardContent({ ...baseProps, personalMessage: message });
+    const lone = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(out).not.toMatch(lone);
+  });
+
   test('personal-message preview back-off handles odd-count multi-backslash boundary', () => {
-    // cr round 10: the previous heuristic only checked the last two
-    // chars (`\` at cut-1 + non-`\` at cut-2). With THREE consecutive
+    // The previous single-backslash heuristic only checked the last
+    // two chars (`\` at cut-1 + non-`\` at cut-2). With THREE consecutive
     // `\` at cut-3..cut-1, the last one starts a fresh escape sequence
     // but cut-2 also `\` would fool the old check into NOT backing off.
     // The fix counts trailing `\` and backs off when the count is odd.
@@ -681,10 +694,10 @@ describe('renderConfirmCardContent', () => {
   });
 
   test('preview prefers guild member displayName over username when interaction is supplied', () => {
-    // cr round 9: a previous round's comment claimed
-    // resolveRecipientAlias was used, but the code path was raw
-    // `u.username`. Pin the alias path so a future refactor can't
-    // silently drift back to username-only.
+    // Pin the resolveRecipientAlias path so a future refactor can't
+    // silently drift back to raw `u.username` (which skips the
+    // nickname/globalName resolution and would diverge from the
+    // post-send confirmation wording).
     const u = makeUser('100000000000000001', { username: 'alice' });
     const int = {
       guild: {
@@ -699,14 +712,13 @@ describe('renderConfirmCardContent', () => {
   });
 
   test('personal-message blockquote collapses embedded newlines + unicode line/paragraph separators to spaces', () => {
-    // cr round 9: Discord blockquotes are per-LINE — only the line
-    // starting with `> ` gets the left-bar. A multi-line message
-    // would render with a quoted first line and flush-left subsequent
-    // lines. formatPersonalMessagePreview collapses `\n` / `\r\n` /
-    // U+2028 (line sep) / U+2029 (paragraph sep) into single spaces
-    // so the preview is a clean one-liner. The Unicode separators
-    // matter because Discord renders them as line breaks too (per
-    // simplify round 10 review).
+    // Discord blockquotes are per-LINE — only the line starting with
+    // `> ` gets the left-bar. A multi-line message would render with
+    // a quoted first line and flush-left subsequent lines.
+    // formatPersonalMessagePreview collapses `\n` / `\r\n` / U+2028
+    // (line sep) / U+2029 (paragraph sep) into single spaces so the
+    // preview is a clean one-liner. The Unicode separators matter
+    // because Discord renders them as line breaks too.
     const out = renderConfirmCardContent({
       ...baseProps,
       personalMessage: 'first line\nsecond\r\nthird fourth fifth',
@@ -1056,7 +1068,7 @@ describe('handleQurlMap — slash entry', () => {
   });
 
   test('locationName strips bidi/zero-width control chars (RLO spoof defense)', async () => {
-    // Round-8 (cr): /qurl map's slash option is a new attack surface
+    // /qurl map's slash option is a new attack surface
     // that bypasses the modal's natural friction. A crafted U+202E
     // (RLO) in `location-name` would otherwise flip text direction
     // in the rendered confirm card. sanitizeContentLabel strips it
@@ -1102,7 +1114,7 @@ describe('handleQurlMap — slash entry', () => {
   test('forged interaction missing required `location` → actionable ephemeral, no flow row', async () => {
     // Discord enforces required options server-side; only a forged
     // interaction can hit the `getString('location', true)` throw.
-    // Round-6 (cr) added a targeted catch so the user sees an
+    // Targeted catch so the user sees an
     // actionable message instead of the dispatcher's generic safety
     // net.
     const int = makeInteraction({ options: {} });
@@ -1146,9 +1158,9 @@ describe('handleSendConfirmClick', () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
-    // Defer-ack within the 3s window before any awaits — round-7 (cr)
-    // added this so resolveRecipientUsers + getGuildApiKey + deleteFlow
-    // can't blow Discord's hard ack deadline on a cold cache.
+    // Defer-ack within the 3s window before any awaits — without this,
+    // resolveRecipientUsers + getGuildApiKey + deleteFlow can blow
+    // Discord's hard ack deadline on a cold cache.
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM, reason: 'terminal',
@@ -1247,9 +1259,8 @@ describe('handleSendConfirmClick', () => {
       content: expect.stringMatching(/1 recipient had left the server/),
       ephemeral: true,
     }));
-    // Forensic log at INFO (escalated from debug per cr round 3) —
-    // oncall can grep for mid-flight guild churn without dialing
-    // verbosity up. Round 5 split the bucket so the log fields
+    // Forensic log at INFO so oncall can grep for mid-flight guild
+    // churn without dialing verbosity up. Split bucket: log fields
     // distinguish left-the-server (10007) from transient.
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringMatching(/partial drop at click time/),
@@ -1258,10 +1269,9 @@ describe('handleSendConfirmClick', () => {
   });
 
   test('partial transient lookup at Send click — Send proceeds with remaining, transient drop surfaced with retry copy', async () => {
-    // cr round 5: transientFailureIds were previously dropped silently
-    // at click time. They must be surfaced with retry-encouraging
-    // copy (NOT "left the server" wording) — the buckets are now
-    // split + threaded.
+    // transientFailureIds must be surfaced with retry-encouraging
+    // copy (NOT "left the server" wording) — the buckets are split
+    // + threaded so a 429/gateway blip doesn't read as "they're gone".
     const flaky = '100000000000000099';
     const payloadWithFlaky = { ...validPayload, recipientIds: [u1, flaky] };
     const int = makeInteraction({
@@ -1285,9 +1295,9 @@ describe('handleSendConfirmClick', () => {
   });
 
   test('getGuildApiKey throw at click time → ephemeral retry, NO deleteFlow (row stays alive)', async () => {
-    // Round-6 (cr) reordering: getGuildApiKey runs BEFORE deleteFlow
-    // so a DDB blip doesn't burn the flow row. User can re-click
-    // Send within the 3-min TTL once the blip clears.
+    // getGuildApiKey runs BEFORE deleteFlow so a DDB blip doesn't
+    // burn the flow row. User can re-click Send within the 3-min TTL
+    // once the blip clears.
     mockDb.getGuildApiKey.mockRejectedValueOnce(new Error('ddb gone'));
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
@@ -1303,12 +1313,11 @@ describe('handleSendConfirmClick', () => {
   });
 
   test('resolveRecipientUsers throw at click time → ephemeral retry message, NO deleteFlow', async () => {
-    // cr round 5: handleSendConfirmClick previously had no try/catch
-    // around the click-time resolution. A throw would propagate to the
-    // dispatcher's outer catch and leave the user staring at the
-    // unchanged card. Targeted catch now surfaces a recoverable
-    // ephemeral reply and DOES NOT commit the dedup deleteFlow so the
-    // card stays alive for the 3-min TTL.
+    // Targeted catch on resolveRecipientUsers surfaces a recoverable
+    // ephemeral reply and does NOT commit the dedup deleteFlow, so
+    // the card stays alive for the 3-min TTL. Without it the throw
+    // would hit the dispatcher's outer catch and leave the user
+    // staring at an unchanged card.
     const int = makeInteraction({
       guildMembers: {},
       // Force a throw out of `members.fetch` (not a return-value error,
@@ -1337,12 +1346,11 @@ describe('handleSendConfirmClick', () => {
   });
 
   test('forged Send click with empty recipientIds → distinct copy + deleteFlow (not the "all left" copy)', async () => {
-    // cr round 10: a legitimate Send click only lands when the card has
-    // at least one recipient (Send is disabled in the empty state).
-    // A click with payload.recipientIds === [] therefore implies a
-    // fabricated interaction. The all-unresolved branch's "they left
-    // the server" copy is wrong here — nobody left, nobody was ever
-    // selected. Distinct copy + deleteFlow.
+    // A legitimate Send click only lands when the card has at least
+    // one recipient (Send is disabled in the empty state). A click
+    // with payload.recipientIds === [] therefore implies a fabricated
+    // interaction. The all-unresolved branch's "they left the server"
+    // copy is wrong here — nobody left, nobody was ever selected.
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     await handleSendConfirmClick(int, {
       flow_id: 'fid',
@@ -1362,12 +1370,12 @@ describe('handleSendConfirmClick', () => {
   });
 
   test('bot kicked between confirm and Send → distinct ephemeral, flow row deleted', async () => {
-    // cr round 9: when the bot is removed from the guild between
-    // confirm and Send, `interaction.guild` is null. Without an
-    // explicit guard, resolveRecipientUsers returns every recipientId
-    // in unresolvedIds and the user sees "recipients left the server"
-    // — misleading. Pin the dedicated copy + deleteFlow so the flow
-    // row doesn't linger.
+    // When the bot is removed from the guild between confirm and
+    // Send, `interaction.guild` is null. Without an explicit guard,
+    // resolveRecipientUsers returns every recipientId in unresolvedIds
+    // and the user sees "recipients left the server" — misleading.
+    // Pin the dedicated copy + deleteFlow so the flow row doesn't
+    // linger.
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     int.guild = null;
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
@@ -1434,7 +1442,7 @@ describe('handleSendCancelClick', () => {
   });
 
   test('deleteFlow throw → ephemeral retry, cooldown preserved (Send may still be in flight)', async () => {
-    // Round-8 (cr) added a targeted catch around the Cancel deleteFlow
+    // Targeted catch around the Cancel deleteFlow
     // for symmetry with handleSendConfirmClick. A DDB blip during a
     // Cancel click now surfaces an actionable ephemeral instead of
     // the dispatcher's generic safety net. Cooldown stays set on the
@@ -1499,33 +1507,49 @@ describe('handleSendUserSelect', () => {
     const SKEW = 5;
     expect(callArgs.set_expires_at).toBeGreaterThanOrEqual(beforeSecs + SEND_FLOW_TTL_SECONDS - SKEW);
     expect(callArgs.set_expires_at).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS + SKEW);
-    expect(int.update).toHaveBeenCalled();
-    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    expect(int.editReply).toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/Sending file/);
   });
 
-  test('empty pick → deferUpdate, no transition', async () => {
+  test('empty pick → deferUpdate, no transition, no editReply', async () => {
     const int = makeSelectInteraction({ users: [] });
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.editReply).not.toHaveBeenCalled();
+  });
+
+  test('deferUpdate fires before transitionFlow await — protects Discord 3s ack budget on slow DDB', async () => {
+    // Without this guard the transitionFlow DDB OCC call can blow
+    // Discord's hard ack deadline on tail-latency, surfacing as an
+    // "interaction failed" toast. Mirror handleSendConfirmClick /
+    // handleSendCancelClick: ack first, then do the work.
+    let deferAckedBeforeTransition = false;
+    const int = makeSelectInteraction();
+    mockTransitionFlow.mockImplementationOnce(async () => {
+      deferAckedBeforeTransition = int.deferUpdate.mock.calls.length > 0;
+      return { result: 'ok', version: 2 };
+    });
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(deferAckedBeforeTransition).toBe(true);
   });
 
   test('all bots picked → re-prompt warning prepended to full confirm card (resource header preserved)', async () => {
-    // cr round 10: an invalid pick used to replace card content with
-    // just the warning string — the user lost the "Sending file:
-    // report.pdf / Expires: 24h" header they chose at /qurl file time.
-    // The fix re-renders the full confirm card with the warning
-    // banner prepended via warningsBlock; needsPicker:true keeps the
-    // pick prompt and the picker stays attached.
+    // An invalid pick re-renders the full confirm card with the
+    // warning banner prepended via warningsBlock; needsPicker:true
+    // keeps the pick prompt and the picker stays attached. Replacing
+    // the content with just the warning string would strip the
+    // "Sending file: report.pdf / Expires: 24h" header the user
+    // chose at /qurl file time.
     const int = makeSelectInteraction({
       users: [makeUser(u1, { bot: true })],
     });
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
-    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/bots/);
-    // Resource header survives — this is the regression cr round 10 caught.
+    // Resource header survives — pin the preserved-context contract.
     expect(updated.content).toMatch(/Sending file/);
     expect(updated.content).toMatch(/Expires/);
   });
@@ -1542,10 +1566,9 @@ describe('handleSendUserSelect', () => {
     const int = makeSelectInteraction({ users });
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
-    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/Pick at most/);
-    // Same regression defense as the all-bots branch — resource header
-    // must survive the warning re-render.
+    // Same preserved-context contract as the all-bots branch.
     expect(updated.content).toMatch(/Sending file/);
   });
 
@@ -1569,7 +1592,7 @@ describe('handleSendUserSelect', () => {
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ recipientIds: [u1, u2, u3] }),
     }));
-    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/bot/);
     expect(updated.content).toMatch(/Sending file/);
   });
@@ -1578,7 +1601,7 @@ describe('handleSendUserSelect', () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
     const int = makeSelectInteraction();
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/),
     }));
   });
@@ -1587,7 +1610,7 @@ describe('handleSendUserSelect', () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
     const int = makeSelectInteraction();
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/),
     }));
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -761,6 +761,43 @@ describe('handleQurlFile — slash entry', () => {
     expect(reply.content).toMatch(/Unrecognized expiry/);
   });
 
+  test('all-bots cap-skew: cache-miss bots eat cap, real users get squeezed out', async () => {
+    // recipient-parser.js:214 strips bots ONLY when the cache reports
+    // them. Cache-MISS bots reach members.fetch, get resolved, then
+    // partitionRecipients drops them — but they've already eaten cap
+    // slots in the parser's `ids` array.
+    //
+    // Scenario: 26 mentions = 25 cache-miss bots + 1 real user. Parser
+    // caps at 25 (QURL_SEND_MAX_RECIPIENTS) → keeps the FIRST 25 IDs.
+    // 25 bots get fetched, partition drops them all, user1 was past
+    // the cap and never made it.
+    //
+    // This is the documented v1 cap-skew limitation
+    // (commands.js:partitionRecipients comment). Pin the failure mode
+    // so a future refactor that flips resolve-then-cap ordering can't
+    // silently "fix" it without consciously updating the comment.
+    const mkId = (n) => '1000000000000' + String(n).padStart(6, '0');
+    const realUser = mkId(25);  // beyond the cap
+    const bots = Array.from({ length: 25 }, (_, i) => mkId(i));
+    const mentions = [...bots, realUser].map((id) => `<@${id}>`).join(' ');
+    const fetchByID = {};
+    for (const id of bots) fetchByID[id] = makeUser(id, { bot: true });
+    fetchByID[realUser] = makeUser(realUser);  // resolves cleanly, but past cap
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: mentions },
+      guildMembers: {},  // ALL cache-miss
+      guildFetchByID: fetchByID,
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/No valid recipients/);
+    // 25 cache-miss bots passed the parser (consumed the cap), got
+    // resolved via fetch, then partition dropped them — droppedBots
+    // breakdown should surface.
+    expect(reply.content).toMatch(/bot/);
+  });
+
   test('inner catch on supersedeOrCreate throw clears cooldown + surfaces specific error', async () => {
     // The supersedeOrCreate-specific inner catch is the dominant
     // failure-path test for cooldown release — verifies the canonical
@@ -964,6 +1001,33 @@ describe('handleSendConfirmClick', () => {
       content: expect.stringMatching(/not configured|setup/i),
     }));
   });
+
+  test('partial-resolve at Send click — Send proceeds with remaining users, dropped IDs logged at debug', async () => {
+    // Mid-flight guild churn: row.payload.recipientIds = [u1, gone],
+    // at click time gone left the guild. resolveRecipientUsers returns
+    // {users:[u1's user], unresolvedIds:[gone]}. partitionRecipients
+    // keeps u1. Send should fire executeSendPipeline with the
+    // remaining valid user (NOT abort), with the silent-drop logged
+    // at debug level for forensic trail.
+    const gone = '100000000000000099';
+    const payloadWithGhost = { ...validPayload, recipientIds: [u1, gone] };
+    const int = makeInteraction({
+      guildMembers: { [u1]: {} },
+      guildFetchByID: { [gone]: 'unknown' },
+    });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: payloadWithGhost, version: 1 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Preparing send/),
+    }));
+    // The silent-drop forensic log fires at debug level (not warn)
+    // because mid-flight guild churn is expected/normal behavior.
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/dropping unresolved/),
+      expect.objectContaining({ count: 1 }),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -1078,6 +1142,31 @@ describe('handleSendUserSelect', () => {
     expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/bots/),
     }));
+  });
+
+  test('partial-bot pick → transitionFlow with non-bot users + warning surfaces on card', async () => {
+    // Live picker UX: user selects 3 real users + 1 bot. Partition
+    // drops the bot, valid=[u1,u2,u3], droppedBots=1. transitionFlow
+    // commits the new ids, the re-rendered card shows the warning
+    // line so the user knows the bot didn't make the cut.
+    const u2 = '100000000000000002';
+    const u3 = '100000000000000003';
+    const bot1 = '100000000000000099';
+    const int = makeSelectInteraction({
+      users: [
+        makeUser(u1),
+        makeUser(u2),
+        makeUser(u3),
+        makeUser(bot1, { bot: true }),
+      ],
+    });
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({ recipientIds: [u1, u2, u3] }),
+    }));
+    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/bot/);
+    expect(updated.content).toMatch(/Sending file/);
   });
 
   test('transitionFlow conflict → superseded message', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -501,9 +501,14 @@ describe('parseLocationInput', () => {
     // host pin; this test pins the current contract.
     const spoofed = 'https://google.com.evil.com/maps/place/Eiffel-Tower';
     const r = parseLocationInput(spoofed);
-    // The synth-search URL's HOST is google.com (the search domain),
-    // not the spoofed host. The spoofed input lands URL-encoded INSIDE
-    // the search query, not as the rendered link's host.
+    // INTENDED UX: the recipient embed renders `locationName` as a
+    // LABEL on a Maps link whose TARGET is google.com. The spoofed
+    // string is visible (so the recipient sees what was searched),
+    // but the click goes to google.com/maps/search/?<encoded-spoof>.
+    // sanitizeContentLabel further strips bidi/control + markdown-
+    // escapes the label before it lands in the embed, so the visible
+    // label text can't render as a clickable masked link or flip
+    // direction via U+202E.
     const parsed = new URL(r.locationUrl);
     expect(parsed.hostname).toBe('www.google.com');
     expect(parsed.pathname.startsWith('/maps/search/')).toBe(true);

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -893,6 +893,18 @@ describe('renderConfirmCardContent', () => {
     expect(out).not.toMatch(/\balice\b/);
   });
 
+  test('preview falls back to username when interaction is omitted (no guild member lookup)', () => {
+    // resolveRecipientAlias handles `interaction == null` via optional
+    // chaining (commands.js:~310) and falls through to r.username, so
+    // tests / callers without an interaction object still produce a
+    // usable preview rather than throwing.
+    const u = makeUser('100000000000000001', { username: 'alice' });
+    const out = renderConfirmCardContent({ ...baseProps, validRecipients: [u] });
+    // No `interaction` passed → no guild member cache to consult →
+    // falls back to the user's username.
+    expect(out).toMatch(/alice/);
+  });
+
   test('personal-message blockquote collapses embedded newlines + unicode line/paragraph separators to spaces', () => {
     // Discord blockquotes are per-LINE — only the line starting with
     // `> ` gets the left-bar. A multi-line message would render with

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1,0 +1,1020 @@
+/**
+ * Tests for /qurl file + /qurl map slash commands (PR 7b.2).
+ *
+ * Covers the new handlers from src/commands.js — handleQurlFile,
+ * handleQurlMap, the shared confirm-card pipeline, the flow-dispatch
+ * handlers (UserSelect / Send / Cancel) — plus the pure helpers
+ * (resolveRecipientUsers, partitionRecipients, selfDestructOptionToSeconds,
+ * renderRecipientWarnings, renderConfirmCardContent).
+ *
+ * Mocks mirror tests/qurl-send-back-half.test.js so both files share
+ * a coherent module surface. The new commands are accessed via the
+ * `_test` export. Real flow-state is stubbed — handlers are tested
+ * against the harness contract, not against DDB itself (flow-state.js
+ * has its own spec).
+ */
+
+jest.mock('../src/config', () => ({
+  QURL_API_KEY: 'test-api-key',
+  QURL_ENDPOINT: 'https://api.test.local',
+  CONNECTOR_URL: 'https://connector.test.local',
+  GOOGLE_MAPS_API_KEY: 'test-google-key',
+  QURL_SEND_COOLDOWN_MS: 30000,
+  QURL_SEND_MAX_RECIPIENTS: 25,
+  DATABASE_PATH: ':memory:',
+  PENDING_LINK_EXPIRY_MINUTES: 30,
+  ADMIN_USER_IDS: ['admin-1'],
+  BASE_URL: 'http://localhost:3000',
+  GUILD_ID: 'guild-1',
+  SHARD_ID: '0:1',
+  isMultiTenant: false,
+  ENABLE_OPENNHP_FEATURES: true,
+  isOpenNHPActive: true,
+  STAR_MILESTONES: [10, 25, 50, 100],
+  CONTRIBUTOR_ROLE_NAME: 'Contributor',
+  ACTIVE_CONTRIBUTOR_ROLE_NAME: 'Active Contributor',
+  CORE_CONTRIBUTOR_ROLE_NAME: 'Core Contributor',
+  CHAMPION_ROLE_NAME: 'Champion',
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+// The discord.js mocks here just need to keep the SlashCommandBuilder
+// chain from throwing when commands.js loads. Tests exercise the
+// handler functions directly, not the registration path.
+jest.mock('discord.js', () => {
+  const makeChainable = (extra = {}) => ({
+    setCustomId: jest.fn().mockReturnThis(),
+    setLabel: jest.fn().mockReturnThis(),
+    setEmoji: jest.fn().mockReturnThis(),
+    setStyle: jest.fn().mockReturnThis(),
+    setURL: jest.fn().mockReturnThis(),
+    setTitle: jest.fn().mockReturnThis(),
+    setPlaceholder: jest.fn().mockReturnThis(),
+    addOptions: jest.fn().mockReturnThis(),
+    addChoices: jest.fn().mockReturnThis(),
+    setMinValues: jest.fn().mockReturnThis(),
+    setMaxValues: jest.fn().mockReturnThis(),
+    addComponents: jest.fn().mockReturnThis(),
+    setDisabled: jest.fn().mockReturnThis(),
+    setMaxLength: jest.fn().mockReturnThis(),
+    setRequired: jest.fn().mockReturnThis(),
+    setValue: jest.fn().mockReturnThis(),
+    setName: jest.fn().mockReturnThis(),
+    setDescription: jest.fn().mockReturnThis(),
+    ...extra,
+  });
+  return {
+    SlashCommandBuilder: jest.fn().mockImplementation(() => {
+      const subBuilder = () => makeChainable({
+        addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
+        addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
+        addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
+        addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
+      });
+      const builder = {
+        setName: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        addSubcommand: jest.fn(function (fn) { if (typeof fn === 'function') fn(subBuilder()); return builder; }),
+        addStringOption: jest.fn().mockReturnThis(),
+        addAttachmentOption: jest.fn().mockReturnThis(),
+        addUserOption: jest.fn().mockReturnThis(),
+        addIntegerOption: jest.fn().mockReturnThis(),
+        setDefaultMemberPermissions: jest.fn().mockReturnThis(),
+        toJSON: jest.fn().mockReturnValue({}),
+      };
+      return builder;
+    }),
+    EmbedBuilder: jest.fn().mockImplementation(() => makeChainable({
+      setColor: jest.fn().mockReturnThis(),
+      setDescription: jest.fn().mockReturnThis(),
+      addFields: jest.fn().mockReturnThis(),
+      setFooter: jest.fn().mockReturnThis(),
+      setTimestamp: jest.fn().mockReturnThis(),
+    })),
+    ActionRowBuilder: jest.fn().mockImplementation(() => {
+      const row = { components: [], addComponents: jest.fn(function (...args) { row.components.push(...args.flat()); return row; }) };
+      return row;
+    }),
+    ButtonBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    ButtonStyle: { Primary: 1, Secondary: 2, Success: 3, Danger: 4, Link: 5 },
+    ChannelType: { GuildText: 0, DM: 1, GuildVoice: 2, GuildStageVoice: 13 },
+    ComponentType: { Button: 2, StringSelect: 3, UserSelect: 5 },
+    StringSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    UserSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    ModalBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    TextInputBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    TextInputStyle: { Short: 1, Paragraph: 2 },
+    AttachmentBuilder: jest.fn().mockImplementation((buf, opts) => ({ buf, name: opts?.name })),
+    PermissionFlagsBits: { ManageRoles: 1n, Administrator: 8n, ManageGuild: 32n },
+  };
+});
+
+const mockDb = {
+  recordQURLSendBatch: jest.fn(),
+  updateSendDMStatus: jest.fn(),
+  getRecentSends: jest.fn(() => []),
+  getSendResourceIds: jest.fn(() => []),
+  getSendItems: jest.fn(() => []),
+  markSendRevoked: jest.fn(),
+  getSendConfig: jest.fn(),
+  saveSendConfig: jest.fn(),
+  getGuildApiKey: jest.fn(),
+  getGuildConfig: jest.fn(),
+};
+jest.mock('../src/database', () => mockDb);
+
+jest.mock('../src/discord', () => ({
+  sendDM: jest.fn().mockResolvedValue(true),
+  getChannelMembers: jest.fn(),
+}));
+
+jest.mock('../src/utils/admin', () => ({
+  requireAdmin: jest.fn(async () => true),
+  isAdmin: jest.fn(() => true),
+}));
+
+jest.mock('../src/connector', () => ({
+  downloadAndUpload: jest.fn(),
+  reUploadBuffer: jest.fn(),
+  mintLinks: jest.fn(),
+  uploadJsonToConnector: jest.fn(),
+  isAllowedSourceUrl: (url) => typeof url === 'string' && url.startsWith('https://cdn.discordapp.com'),
+}));
+
+jest.mock('../src/qurl', () => ({
+  createOneTimeLink: jest.fn(),
+  deleteLink: jest.fn(),
+  getResourceStatus: jest.fn(),
+}));
+
+jest.mock('../src/places', () => ({ searchPlaces: jest.fn().mockResolvedValue([]) }));
+
+// Flow-state stubs. Each test overrides per-call to assert on the
+// supersedeOrCreate/transitionFlow/deleteFlow contracts.
+const mockCreateFlow = jest.fn();
+const mockLoadFlow = jest.fn();
+const mockTransitionFlow = jest.fn();
+const mockDeleteFlow = jest.fn();
+const mockSupersedeOrCreate = jest.fn();
+jest.mock('../src/flow-state', () => ({
+  createFlow: (...a) => mockCreateFlow(...a),
+  loadFlow: (...a) => mockLoadFlow(...a),
+  transitionFlow: (...a) => mockTransitionFlow(...a),
+  deleteFlow: (...a) => mockDeleteFlow(...a),
+  supersedeOrCreate: (...a) => mockSupersedeOrCreate(...a),
+}));
+
+// flow-dispatch is a real module — we want registerFlow's
+// idempotent-failure guard to fire on test re-loads.
+const commands = require('../src/commands');
+const { _test } = commands;
+const logger = require('../src/logger');
+const {
+  handleQurlFile,
+  handleQurlMap,
+  resolveRecipientUsers,
+  partitionRecipients,
+  selfDestructOptionToSeconds,
+  renderRecipientWarnings,
+  renderConfirmCardContent,
+  SEND_STAGE_AWAITING_CONFIRM,
+  SEND_USER_SELECT_CUSTOM_ID,
+  SEND_CONFIRM_SEND_CUSTOM_ID,
+  SEND_CONFIRM_CANCEL_CUSTOM_ID,
+  SEND_FLOW_TTL_SECONDS,
+  SELF_DESTRUCT_NO_TIMER_CHOICE,
+  isOnCooldown,
+  clearCooldown,
+  sendCooldowns,
+  executeSendPipeline,
+} = _test;
+
+// Flow-dispatch handlers live at module top-level (consumed by
+// registerFlow at boot). _test only exports things that aren't already
+// at the top level.
+const {
+  handleSendUserSelect,
+  handleSendConfirmClick,
+  handleSendCancelClick,
+} = commands;
+
+// ──────────────────────────────────────────────────────────────
+// Test helpers
+// ──────────────────────────────────────────────────────────────
+
+const SENDER_ID = '900000000000000001';
+
+function makeUser(id, { bot = false, username = `user${id.slice(-3)}` } = {}) {
+  return { id, bot, username };
+}
+
+function makeInteraction({
+  guildId = 'guild-1',
+  channelId = 'ch-1',
+  userId = SENDER_ID,
+  options = {},
+  guildMembers = {},
+  guildFetchByID = null,
+} = {}) {
+  // memberCache: id → { user: {...} } when present
+  const memberCache = new Map();
+  for (const [id, attrs] of Object.entries(guildMembers)) {
+    memberCache.set(id, { user: makeUser(id, attrs) });
+  }
+  const guild = guildId ? {
+    members: {
+      cache: memberCache,
+      fetch: jest.fn(async (id) => {
+        if (guildFetchByID && Object.prototype.hasOwnProperty.call(guildFetchByID, id)) {
+          const r = guildFetchByID[id];
+          if (r === 'unknown') {
+            const err = new Error('Unknown Member'); err.code = 10007; throw err;
+          }
+          if (r === 'ratelimit') {
+            const err = new Error('rate limited'); err.code = 429; throw err;
+          }
+          return { user: r };
+        }
+        const err = new Error('Unknown Member'); err.code = 10007; throw err;
+      }),
+    },
+    roles: { cache: new Map() },
+    channels: { cache: new Map() },
+    id: guildId,
+  } : null;
+
+  const optGetString = jest.fn((name) => {
+    const v = options[name];
+    return v === undefined ? null : v;
+  });
+  const optGetAttachment = jest.fn((name) => options[name] ?? null);
+
+  return {
+    user: { id: userId, username: 'Sender' },
+    guildId,
+    channelId,
+    guild,
+    member: { displayName: 'Sender' },
+    options: {
+      getString: optGetString,
+      getAttachment: optGetAttachment,
+      getSubcommand: () => options._sub || 'file',
+    },
+    reply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    deferReply: jest.fn().mockResolvedValue(undefined),
+    followUp: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+    deferUpdate: jest.fn().mockResolvedValue(undefined),
+    replied: false,
+    deferred: false,
+  };
+}
+
+const VALID_ATTACHMENT = Object.freeze({
+  url: 'https://cdn.discordapp.com/attachments/1/2/x.png',
+  name: 'x.png',
+  contentType: 'image/png',
+  size: 1024,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sendCooldowns.clear();
+  mockSupersedeOrCreate.mockResolvedValue({ created: true, version: 1 });
+  mockDeleteFlow.mockResolvedValue({ deleted: true });
+  mockTransitionFlow.mockResolvedValue({ result: 'ok', version: 2 });
+  // mockResolvedValueOnce queues survive `clearAllMocks` — a queued
+  // value left unconsumed by a prior test (e.g. an early-return path)
+  // would leak into the next test's first call. Drain the queue with
+  // mockReset for the mocks where per-test `mockResolvedValueOnce` is
+  // the dominant pattern.
+  mockDb.getGuildApiKey.mockReset();
+});
+
+// ──────────────────────────────────────────────────────────────
+// Pure helpers
+// ──────────────────────────────────────────────────────────────
+
+describe('selfDestructOptionToSeconds', () => {
+  test.each([
+    ['none', null],
+    [SELF_DESTRUCT_NO_TIMER_CHOICE, null],
+    [null, null],
+    [undefined, null],
+    ['', null],
+    ['60', 60],
+    ['3600', 3600],
+    ['0', null],
+    ['-5', null],
+    ['NaN', null],
+    ['bogus', null],
+    ['1.5', 1],
+  ])('value=%j → seconds=%j', (input, expected) => {
+    expect(selfDestructOptionToSeconds(input)).toBe(expected);
+  });
+});
+
+describe('partitionRecipients', () => {
+  test('drops bots and sender', () => {
+    const users = [
+      makeUser('100000000000000001'),
+      makeUser('100000000000000002', { bot: true }),
+      makeUser(SENDER_ID),
+      makeUser('100000000000000003'),
+    ];
+    const r = partitionRecipients(users, SENDER_ID);
+    expect(r.valid.map((u) => u.id)).toEqual(['100000000000000001', '100000000000000003']);
+    expect(r.droppedBots).toBe(1);
+    expect(r.droppedSelf).toBe(1);
+  });
+
+  test('all bots returns valid=[]', () => {
+    const users = [makeUser('100000000000000001', { bot: true }), makeUser('100000000000000002', { bot: true })];
+    const r = partitionRecipients(users, SENDER_ID);
+    expect(r.valid).toEqual([]);
+    expect(r.droppedBots).toBe(2);
+    expect(r.droppedSelf).toBe(0);
+  });
+
+  test('only sender returns valid=[]', () => {
+    const r = partitionRecipients([makeUser(SENDER_ID)], SENDER_ID);
+    expect(r.valid).toEqual([]);
+    expect(r.droppedSelf).toBe(1);
+  });
+
+  test('empty input', () => {
+    expect(partitionRecipients([], SENDER_ID)).toEqual({ valid: [], droppedBots: 0, droppedSelf: 0 });
+  });
+});
+
+describe('resolveRecipientUsers', () => {
+  test('hits guild cache and skips fetch', async () => {
+    const int = makeInteraction({
+      guildMembers: { '100000000000000001': {}, '100000000000000002': {} },
+    });
+    const r = await resolveRecipientUsers(int, ['100000000000000001', '100000000000000002']);
+    expect(r.users.map((u) => u.id)).toEqual(['100000000000000001', '100000000000000002']);
+    expect(r.unresolvedIds).toEqual([]);
+    expect(int.guild.members.fetch).not.toHaveBeenCalled();
+  });
+
+  test('falls through to fetch on cache miss', async () => {
+    const int = makeInteraction({
+      guildMembers: {},
+      guildFetchByID: { '100000000000000001': makeUser('100000000000000001') },
+    });
+    const r = await resolveRecipientUsers(int, ['100000000000000001']);
+    expect(r.users.map((u) => u.id)).toEqual(['100000000000000001']);
+    expect(r.unresolvedIds).toEqual([]);
+    expect(int.guild.members.fetch).toHaveBeenCalledWith('100000000000000001');
+  });
+
+  test('10007 unknown member → unresolved', async () => {
+    const int = makeInteraction({
+      guildMembers: {},
+      guildFetchByID: { '100000000000000001': 'unknown' },
+    });
+    const r = await resolveRecipientUsers(int, ['100000000000000001']);
+    expect(r.users).toEqual([]);
+    expect(r.unresolvedIds).toEqual(['100000000000000001']);
+  });
+
+  test('non-10007 error → unresolved + warn logged', async () => {
+    const int = makeInteraction({
+      guildMembers: {},
+      guildFetchByID: { '100000000000000001': 'ratelimit' },
+    });
+    const r = await resolveRecipientUsers(int, ['100000000000000001']);
+    expect(r.unresolvedIds).toEqual(['100000000000000001']);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'resolveRecipientUsers: members.fetch failed',
+      expect.any(Object),
+    );
+  });
+
+  test('no guild → everything unresolved', async () => {
+    const int = makeInteraction({ guildId: null });
+    const r = await resolveRecipientUsers(int, ['100000000000000001', '100000000000000002']);
+    expect(r.users).toEqual([]);
+    expect(r.unresolvedIds).toEqual(['100000000000000001', '100000000000000002']);
+  });
+
+  test('mixed cache + fetch + 10007', async () => {
+    const int = makeInteraction({
+      guildMembers: { '100000000000000001': {} },
+      guildFetchByID: {
+        '100000000000000002': makeUser('100000000000000002'),
+        '100000000000000003': 'unknown',
+      },
+    });
+    const r = await resolveRecipientUsers(int, [
+      '100000000000000001', '100000000000000002', '100000000000000003',
+    ]);
+    expect(r.users.map((u) => u.id).sort()).toEqual(['100000000000000001', '100000000000000002']);
+    expect(r.unresolvedIds).toEqual(['100000000000000003']);
+  });
+});
+
+describe('renderRecipientWarnings', () => {
+  test('returns empty when nothing to surface', () => {
+    expect(renderRecipientWarnings({
+      invalidTokens: [], cappedCount: 0, unresolvedIds: [],
+      droppedBots: 0, droppedSelf: 0,
+    })).toBe('');
+  });
+
+  test('cappedCount line', () => {
+    const out = renderRecipientWarnings({
+      invalidTokens: [], cappedCount: 3, unresolvedIds: [],
+      droppedBots: 0, droppedSelf: 0,
+    });
+    expect(out).toMatch(/Capped at 25/);
+    expect(out).toMatch(/3 recipient/);
+  });
+
+  test('invalidTokens code-fenced + cap at 10', () => {
+    const tokens = Array.from({ length: 15 }, (_, i) => `bogus${i}`);
+    const out = renderRecipientWarnings({
+      invalidTokens: tokens, cappedCount: 0, unresolvedIds: [],
+      droppedBots: 0, droppedSelf: 0,
+    });
+    expect(out).toMatch(/```/);
+    expect(out).toMatch(/bogus0/);
+    expect(out).toMatch(/bogus9/);
+    expect(out).not.toMatch(/bogus10/);
+    expect(out).toMatch(/\+5 more/);
+  });
+
+  test('combines all signals', () => {
+    const out = renderRecipientWarnings({
+      invalidTokens: ['<#999>'], cappedCount: 2,
+      unresolvedIds: ['100000000000000001'],
+      droppedBots: 1, droppedSelf: 1,
+    });
+    expect(out).toMatch(/Capped/);
+    expect(out).toMatch(/Could not parse/);
+    expect(out).toMatch(/no longer in this server/);
+    expect(out).toMatch(/bot/);
+    expect(out).toMatch(/yourself/);
+  });
+});
+
+describe('renderConfirmCardContent', () => {
+  const baseProps = {
+    resourceType: 'file',
+    resourceLabel: 'report.pdf',
+    validRecipients: [makeUser('100000000000000001', { username: 'alice' })],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+    warningsBlock: '',
+    needsPicker: false,
+  };
+
+  test('file path shows file glyph + label', () => {
+    const out = renderConfirmCardContent(baseProps);
+    expect(out).toMatch(/Sending file/);
+    expect(out).toMatch(/report\.pdf/);
+    expect(out).toMatch(/Expires/);
+    expect(out).toMatch(/24 hours/);
+  });
+
+  test('map path shows map glyph + label', () => {
+    const out = renderConfirmCardContent({
+      ...baseProps,
+      resourceType: 'maps',
+      resourceLabel: 'Eiffel Tower',
+    });
+    expect(out).toMatch(/Sending location/);
+    expect(out).toMatch(/Eiffel Tower/);
+  });
+
+  test('shows recipient preview (first 5) + remainder count', () => {
+    const users = Array.from({ length: 7 }, (_, i) => makeUser(`10000000000000000${i + 1}`, { username: `u${i}` }));
+    const out = renderConfirmCardContent({ ...baseProps, validRecipients: users });
+    expect(out).toMatch(/7 users/);
+    expect(out).toMatch(/u0/);
+    expect(out).toMatch(/u4/);
+    expect(out).toMatch(/\+2 more/);
+  });
+
+  test('needsPicker hides recipient summary and prompts to pick', () => {
+    const out = renderConfirmCardContent({ ...baseProps, needsPicker: true, validRecipients: [] });
+    expect(out).toMatch(/Pick recipients/);
+    expect(out).not.toMatch(/^To:/m);
+  });
+
+  test('self-destruct line shown when set', () => {
+    const out = renderConfirmCardContent({ ...baseProps, selfDestructSeconds: 300 });
+    expect(out).toMatch(/Self-destruct/);
+  });
+
+  test('personal-message preview cap at 80 chars', () => {
+    const long = 'x'.repeat(120);
+    const out = renderConfirmCardContent({ ...baseProps, personalMessage: long });
+    // 80 chars of x + ellipsis
+    expect(out).toMatch(/x{80}…/);
+  });
+
+  test('warningsBlock prepended', () => {
+    const out = renderConfirmCardContent({ ...baseProps, warningsBlock: '⚠ warned\n\n' });
+    expect(out.startsWith('⚠ warned')).toBe(true);
+  });
+
+  test('escapes markdown in recipient username', () => {
+    const out = renderConfirmCardContent({
+      ...baseProps,
+      validRecipients: [makeUser('100000000000000001', { username: '**bob**' })],
+    });
+    expect(out).not.toMatch(/\*\*bob\*\*/);
+    expect(out).toMatch(/\\\*\\\*bob\\\*\\\*/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleQurlFile — front half
+// ──────────────────────────────────────────────────────────────
+
+describe('handleQurlFile — slash entry', () => {
+  test('rejects in DM context', async () => {
+    const int = makeInteraction({
+      guildId: null,
+      options: { attachment: VALID_ATTACHMENT },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/in a server/),
+      ephemeral: true,
+    }));
+  });
+
+  test('rejects when attachment.url is not Discord CDN (SSRF gate)', async () => {
+    const int = makeInteraction({
+      options: { attachment: { ...VALID_ATTACHMENT, url: 'https://evil.com/x.png' } },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/source not allowed/),
+      ephemeral: true,
+    }));
+  });
+
+  test('rejects disallowed file type', async () => {
+    const int = makeInteraction({
+      options: { attachment: { ...VALID_ATTACHMENT, contentType: 'application/x-evil-macroenabled' } },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/File type not allowed/),
+    }));
+  });
+
+  test('rejects file over size cap', async () => {
+    const int = makeInteraction({
+      options: { attachment: { ...VALID_ATTACHMENT, size: 999_999_999 } },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/too large/),
+    }));
+  });
+
+  test('happy path with recipients string — supersedeOrCreate called + confirm card rendered', async () => {
+    const u1 = '100000000000000001';
+    const u2 = '100000000000000002';
+    const int = makeInteraction({
+      options: {
+        attachment: VALID_ATTACHMENT,
+        recipients: `<@${u1}> <@${u2}>`,
+      },
+      guildMembers: { [u1]: {}, [u2]: {} },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(int.deferReply).toHaveBeenCalled();
+    expect(mockSupersedeOrCreate).toHaveBeenCalledWith(expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      ttl_seconds: SEND_FLOW_TTL_SECONDS,
+    }));
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.resourceType).toBe('file');
+    expect(payload.recipientIds.sort()).toEqual([u1, u2]);
+    expect(payload.expiresIn).toBe('24h');
+    expect(payload.selfDestructSeconds).toBeNull();
+    expect(payload.personalMessage).toBeNull();
+    expect(int.editReply).toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Sending file/);
+    expect(reply.content).toMatch(/x\.png/);
+    expect(reply.components.length).toBeGreaterThan(0);
+  });
+
+  test('happy path without recipients → confirm card with picker', async () => {
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Pick recipients/);
+  });
+
+  test('all recipients are bots → ephemeral error, no flow row', async () => {
+    // recipient-parser silently strips bots at parse time (src/recipient-parser.js:214),
+    // so `partitionRecipients` never sees them. The handler's "breakdownEmpty"
+    // branch surfaces the actionable hint instead.
+    const u1 = '100000000000000001';
+    const u2 = '100000000000000002';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@${u1}> <@${u2}>` },
+      guildMembers: { [u1]: { bot: true }, [u2]: { bot: true } },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/No valid recipients/);
+    expect(reply.content).toMatch(/bots and your own user are skipped/);
+  });
+
+  test('only sender mentioned → ephemeral error', async () => {
+    // Same parser-side filter applies to the sender (src/recipient-parser.js:205).
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@${SENDER_ID}>` },
+      guildMembers: { [SENDER_ID]: {} },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/No valid recipients/);
+    expect(reply.content).toMatch(/bots and your own user are skipped/);
+  });
+
+  test('unknown-member ID surfaced as warning but valid users still proceed', async () => {
+    const known = '100000000000000001';
+    const gone = '100000000000000099';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@${known}> <@${gone}>` },
+      guildMembers: { [known]: {} },
+      guildFetchByID: { [gone]: 'unknown' },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.recipientIds).toEqual([known]);
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/no longer in this server/);
+  });
+
+  test('cooldown active rejects', async () => {
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@100000000000000001>` },
+      guildMembers: { '100000000000000001': {} },
+    });
+    // Force cooldown
+    sendCooldowns.set(SENDER_ID, Date.now());
+    expect(isOnCooldown(SENDER_ID)).toBe(true);
+    await handleQurlFile(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/wait before sending/),
+    }));
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+  });
+
+  test('supersedeOrCreate sibling collision → surfaces sibling message', async () => {
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: { stage: 'awaiting_revoke_select' },
+    });
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int, 'apikey');
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/revoke.*menu open/);
+  });
+
+  test('forwards expires-in + self-destruct + personal-message into payload', async () => {
+    const int = makeInteraction({
+      options: {
+        attachment: VALID_ATTACHMENT,
+        recipients: '<@100000000000000001>',
+        'expires-in': '7d',
+        'self-destruct': '300',
+        'personal-message': 'see you Tuesday',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.expiresIn).toBe('7d');
+    expect(payload.selfDestructSeconds).toBe(300);
+    expect(payload.personalMessage).toBe('see you Tuesday');
+  });
+
+  test('rejects off-set expires-in (defense vs forged interaction)', async () => {
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>', 'expires-in': '99y' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Unrecognized expiry/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleQurlMap — front half
+// ──────────────────────────────────────────────────────────────
+
+describe('handleQurlMap — slash entry', () => {
+  test('Google Maps URL → URL preserved + name extracted from /place/', async () => {
+    const int = makeInteraction({
+      options: {
+        location: 'https://www.google.com/maps/place/Eiffel+Tower/@48.8,2.3',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int, 'apikey');
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.resourceType).toBe('maps');
+    expect(payload.locationUrl).toMatch(/google\.com\/maps\/place\/Eiffel/);
+    expect(payload.locationName).toMatch(/Eiffel Tower/);
+  });
+
+  test('arbitrary text → synthesized search URL', async () => {
+    const int = makeInteraction({
+      options: {
+        location: 'Central Park, NYC',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int, 'apikey');
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.locationUrl).toBe('https://www.google.com/maps/search/Central%20Park%2C%20NYC');
+    expect(payload.locationName).toMatch(/Central Park/);
+  });
+
+  test('location-name override wins over URL-derived name', async () => {
+    const int = makeInteraction({
+      options: {
+        location: 'https://www.google.com/maps/place/Eiffel+Tower',
+        'location-name': 'Custom Label',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int, 'apikey');
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.locationName).toBe('Custom Label');
+  });
+
+  test('empty location string → ephemeral error', async () => {
+    const int = makeInteraction({
+      options: { location: '   ', recipients: '<@100000000000000001>' },
+    });
+    await handleQurlMap(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/empty/),
+    }));
+  });
+
+  test('rejects in DM context', async () => {
+    const int = makeInteraction({
+      guildId: null,
+      options: { location: 'Eiffel', recipients: '<@100000000000000001>' },
+    });
+    await handleQurlMap(int, 'apikey');
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/in a server/),
+    }));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendConfirmClick — Send button
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendConfirmClick', () => {
+  const u1 = '100000000000000001';
+  const validPayload = {
+    resourceType: 'file',
+    attachment: VALID_ATTACHMENT,
+    locationUrl: null,
+    locationName: null,
+    resourceLabel: 'x.png',
+    recipientIds: [u1],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+    sendNonce: 'nonce-1',
+  };
+
+  test('happy path → deleteFlow + executeSendPipeline invoked', async () => {
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    // The pipeline itself isn't reachable without heavy connector mocking,
+    // so we just assert deleteFlow fired AND update() landed on 'Preparing'.
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM, reason: 'terminal',
+    }));
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Preparing send/),
+    }));
+  });
+
+  test('deleteFlow dedup loser → "already processed" reply, no pipeline call', async () => {
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/already processed/),
+      ephemeral: true,
+    }));
+    expect(int.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Preparing/),
+    }));
+  });
+
+  test('all recipients have left guild → terminal, deleteFlow called, no pipeline', async () => {
+    const int = makeInteraction({
+      guildMembers: {},
+      guildFetchByID: { [u1]: 'unknown' },
+    });
+    // No apiKey mock needed — the all-unresolved branch short-circuits
+    // before the Promise.all that resolves the guild API key.
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/no longer available/),
+    }));
+  });
+
+  test('no apiKey resolved → tells user setup is needed', async () => {
+    mockDb.getGuildApiKey.mockResolvedValueOnce(null);
+    // Override config to also have no fallback.
+    const config = require('../src/config');
+    const originalKey = config.QURL_API_KEY;
+    config.QURL_API_KEY = null;
+    try {
+      const int = makeInteraction({ guildMembers: { [u1]: {} } });
+      await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+      expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringMatching(/not configured|setup/i),
+      }));
+    } finally {
+      config.QURL_API_KEY = originalKey;
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendCancelClick
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendCancelClick', () => {
+  test('happy path → deleteFlow + cooldown cleared + update', async () => {
+    const int = makeInteraction();
+    sendCooldowns.set(SENDER_ID, Date.now());
+    await handleSendCancelClick(int, { flow_id: 'fid' });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM, reason: 'terminal',
+    }));
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/cancelled/),
+    }));
+  });
+
+  test('deleteFlow dedup loser → ephemeral "already processed"', async () => {
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const int = makeInteraction();
+    await handleSendCancelClick(int, { flow_id: 'fid' });
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/already processed/),
+      ephemeral: true,
+    }));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendUserSelect
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendUserSelect', () => {
+  const u1 = '100000000000000001';
+
+  function makeSelectInteraction({ users = [makeUser(u1)], ...rest } = {}) {
+    const int = makeInteraction(rest);
+    int.users = new Map(users.map((u) => [u.id, u]));
+    return int;
+  }
+
+  const initialPayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+  };
+
+  test('valid pick → transitionFlow with new recipientIds + update', async () => {
+    const int = makeSelectInteraction();
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: expect.objectContaining({ recipientIds: [u1] }),
+    }));
+    expect(int.update).toHaveBeenCalled();
+    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('empty pick → deferUpdate, no transition', async () => {
+    const int = makeSelectInteraction({ users: [] });
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+  });
+
+  test('all bots picked → re-prompt warning + no transition', async () => {
+    const int = makeSelectInteraction({
+      users: [makeUser(u1, { bot: true })],
+    });
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/bots/),
+    }));
+  });
+
+  test('transitionFlow conflict → superseded message', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    const int = makeSelectInteraction();
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/),
+    }));
+  });
+
+  test('transitionFlow not_found → expired message', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    const int = makeSelectInteraction();
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/expired/),
+    }));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// Constants + registration assertions
+// ──────────────────────────────────────────────────────────────
+
+describe('constants + exports', () => {
+  test('SEND_FLOW_TTL_SECONDS = 180', () => {
+    expect(SEND_FLOW_TTL_SECONDS).toBe(180);
+  });
+
+  test('all customIds are stable string prefixes', () => {
+    expect(SEND_USER_SELECT_CUSTOM_ID).toBe('qurl_send_user_select');
+    expect(SEND_CONFIRM_SEND_CUSTOM_ID).toBe('qurl_send_confirm_send');
+    expect(SEND_CONFIRM_CANCEL_CUSTOM_ID).toBe('qurl_send_confirm_cancel');
+  });
+
+  test('all customIds unique', () => {
+    const ids = new Set([SEND_USER_SELECT_CUSTOM_ID, SEND_CONFIRM_SEND_CUSTOM_ID, SEND_CONFIRM_CANCEL_CUSTOM_ID]);
+    expect(ids.size).toBe(3);
+  });
+
+  test('SEND_STAGE_AWAITING_CONFIRM = "awaiting_send_confirm"', () => {
+    expect(SEND_STAGE_AWAITING_CONFIRM).toBe('awaiting_send_confirm');
+  });
+
+  test('handlers are functions', () => {
+    expect(typeof handleQurlFile).toBe('function');
+    expect(typeof handleQurlMap).toBe('function');
+    expect(typeof handleSendUserSelect).toBe('function');
+    expect(typeof handleSendConfirmClick).toBe('function');
+    expect(typeof handleSendCancelClick).toBe('function');
+  });
+
+  test('executeSendPipeline still exported (back-half hook)', () => {
+    expect(typeof executeSendPipeline).toBe('function');
+  });
+});

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -453,6 +453,25 @@ describe('renderRecipientWarnings', () => {
     expect(out).toMatch(/\+5 more/);
   });
 
+  test('invalidTokens with embedded backticks are stripped so the code-fence stays intact', () => {
+    // recipient-parser.js explicitly does NOT escape invalidTokens —
+    // the caller must defend. A token containing ``` would otherwise
+    // close the fence early and let a masked link or @-mention reach
+    // the Discord renderer.
+    const tokens = ['```\n[evil](https://phish.example)\n```', '`code`', 'plain'];
+    const out = renderRecipientWarnings({
+      invalidTokens: tokens, cappedCount: 0, unresolvedIds: [],
+      droppedBots: 0, droppedSelf: 0,
+    });
+    // Backticks must not appear in the rendered tokens themselves —
+    // they'd terminate the surrounding fence.
+    const fenceContent = out.split('```')[1] || '';
+    expect(fenceContent).not.toMatch(/`/);
+    // The non-backtick content survives.
+    expect(out).toContain('plain');
+    expect(out).toContain('[evil](https://phish.example)');
+  });
+
   test('combines all signals', () => {
     const out = renderRecipientWarnings({
       invalidTokens: ['<#999>'], cappedCount: 2,
@@ -522,6 +541,17 @@ describe('renderConfirmCardContent', () => {
     const out = renderConfirmCardContent({ ...baseProps, personalMessage: long });
     // 80 chars of x + ellipsis
     expect(out).toMatch(/x{80}…/);
+  });
+
+  test('personal-message renders pre-sanitized input verbatim (no double-escape)', () => {
+    // sanitizeMessage already escapes markdown at the slash-option
+    // boundary — a `**bold**` input becomes `\*\*bold\*\*` in the
+    // payload. The card must NOT escape again or the user sees
+    // `\\\*\\\*bold\\\*\\\*`.
+    const presanitized = '\\*\\*emphasis\\*\\*';
+    const out = renderConfirmCardContent({ ...baseProps, personalMessage: presanitized });
+    expect(out).toContain(`"${presanitized}"`);
+    expect(out).not.toMatch(/\\\\\*/);
   });
 
   test('warningsBlock prepended', () => {
@@ -836,17 +866,32 @@ describe('handleSendConfirmClick', () => {
     }));
   });
 
-  test('deleteFlow dedup loser → "already processed" reply, no pipeline call', async () => {
+  test('deleteFlow dedup loser → version-fenced "Recipients changed" reply, no pipeline call', async () => {
+    // `deleted: false` now collapses BOTH duplicate dispatch (Discord
+    // retry / SQS at-least-once redelivery) AND mid-flight picker
+    // mutation (UserSelect transitioned the row between dispatcher's
+    // loadFlow and our deleteFlow). Same user recovery either way.
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/already processed/),
+      content: expect.stringMatching(/Recipients changed|re-click Send/i),
       ephemeral: true,
     }));
     expect(int.update).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing/),
+    }));
+  });
+
+  test('deleteFlow is version-gated to fence the picker-then-Send race', async () => {
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 7 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+      expectedVersion: 7,
     }));
   });
 
@@ -934,12 +979,26 @@ describe('handleSendUserSelect', () => {
   };
 
   test('valid pick → transitionFlow with new recipientIds + update', async () => {
+    const beforeSecs = Math.floor(Date.now() / 1000);
     const int = makeSelectInteraction();
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       stage_to: SEND_STAGE_AWAITING_CONFIRM,
       payload: expect.objectContaining({ recipientIds: [u1] }),
+      terminal: false,
+      // TTL refresh is the whole point of staying at the same stage —
+      // picker churn must not let the row TTL out from under the user
+      // mid-flow.
+      set_expires_at: expect.any(Number),
     }));
+    const callArgs = mockTransitionFlow.mock.calls[0][2];
+    // ±5s clock-skew tolerance keeps the assertion from flaking on
+    // slow CI runners while still catching gross drift (e.g., a
+    // refactor that forgot to add SEND_FLOW_TTL_SECONDS to nowSecs,
+    // or a `set_expires_at: 0` regression).
+    const SKEW = 5;
+    expect(callArgs.set_expires_at).toBeGreaterThanOrEqual(beforeSecs + SEND_FLOW_TTL_SECONDS - SKEW);
+    expect(callArgs.set_expires_at).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS + SKEW);
     expect(int.update).toHaveBeenCalled();
     const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/Sending file/);

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1817,6 +1817,29 @@ describe('handleSendUserSelect', () => {
       content: expect.stringMatching(/expired/),
     }));
   });
+
+  test('transitionFlow throw → targeted ephemeral retry, NOT generic "superseded" copy', async () => {
+    // Without the targeted catch, a DDB blip during transitionFlow
+    // bubbles to the dispatcher's outer catch which surfaces a
+    // generic "superseded" message — wrong, since nothing was actually
+    // superseded. Symmetric with handleSendConfirmClick /
+    // handleSendCancelClick's DDB-call guards.
+    mockTransitionFlow.mockRejectedValueOnce(new Error('ddb gone'));
+    const int = makeSelectInteraction();
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not save your pick/i),
+      ephemeral: true,
+    }));
+    // Generic "superseded" copy must NOT fire here.
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/i),
+    }));
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/transitionFlow threw/),
+      expect.objectContaining({ flow_id: 'fid' }),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -363,6 +363,19 @@ describe('partitionRecipients', () => {
   test('empty input', () => {
     expect(partitionRecipients([], SENDER_ID)).toEqual({ valid: [], droppedBots: 0, droppedSelf: 0 });
   });
+
+  test('contract: does NOT re-dedup — dedup is upstream (parseRecipientMentions Set + Discord picker gateway-event)', () => {
+    // cr round 10 audit: confirm that duplicates passed in are preserved
+    // verbatim. parseRecipientMentions already dedupes via Set
+    // (recipient-parser.js:197-198) and Discord's UserSelectMenu
+    // gateway-event surfaces each picked user at most once. If a future
+    // refactor breaks the parser's dedup, the divergence between
+    // input.length and partition.valid.length must fail loudly here —
+    // silently re-deduping in partitionRecipients would mask the bug.
+    const dup = makeUser('100000000000000001');
+    const r = partitionRecipients([dup, dup, makeUser('100000000000000002')], SENDER_ID);
+    expect(r.valid.length).toBe(3);
+  });
 });
 
 describe('resolveRecipientUsers', () => {
@@ -604,6 +617,29 @@ describe('renderConfirmCardContent', () => {
     // followed by the ellipsis. Backed-off cut: index 79.
     expect(out).toContain(`> ${safePrefix}…`);
     expect(out).not.toMatch(/\\…/);
+  });
+
+  test('personal-message preview back-off handles odd-count multi-backslash boundary', () => {
+    // cr round 10: the previous heuristic only checked the last two
+    // chars (`\` at cut-1 + non-`\` at cut-2). With THREE consecutive
+    // `\` at cut-3..cut-1, the last one starts a fresh escape sequence
+    // but cut-2 also `\` would fool the old check into NOT backing off.
+    // The fix counts trailing `\` and backs off when the count is odd.
+    //
+    // Build: 77 chars + '\\\\\\*' (3 backslashes then `*`) + tail. The
+    // first `\\` is a literal-pair, the third `\` starts the `\*`
+    // escape. Cut lands at position 80 (= '*'); we want a back-off to
+    // 79 so the trailing escape-starter `\` is dropped.
+    const prefix = 'a'.repeat(77);  // 77 chars
+    const message = prefix + '\\\\\\*' + 'rest'.repeat(20);  // 77+4+80 = 161 chars
+    const out = renderConfirmCardContent({ ...baseProps, personalMessage: message });
+    // Backed-off cut: index 79. Preview ends with the literal-pair `\\`
+    // (positions 77-78) and the ellipsis. The escape-starter `\` at
+    // position 79 must be dropped.
+    expect(out).toContain(`> ${prefix}\\\\…`);
+    // Defense: the rendered preview must NOT end with three backslashes
+    // before the ellipsis — that would mean the escape-starter survived.
+    expect(out).not.toMatch(/\\\\\\…/);
   });
 
   test('personal-message renders pre-sanitized input verbatim (no double-escape)', () => {
@@ -1300,6 +1336,31 @@ describe('handleSendConfirmClick', () => {
     );
   });
 
+  test('forged Send click with empty recipientIds → distinct copy + deleteFlow (not the "all left" copy)', async () => {
+    // cr round 10: a legitimate Send click only lands when the card has
+    // at least one recipient (Send is disabled in the empty state).
+    // A click with payload.recipientIds === [] therefore implies a
+    // fabricated interaction. The all-unresolved branch's "they left
+    // the server" copy is wrong here — nobody left, nobody was ever
+    // selected. Distinct copy + deleteFlow.
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    await handleSendConfirmClick(int, {
+      flow_id: 'fid',
+      row: { payload: { ...validPayload, recipientIds: [] }, version: 1 },
+    });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/No recipients were selected/i),
+      components: [],
+    }));
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/no longer reachable/i),
+    }));
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }));
+  });
+
   test('bot kicked between confirm and Send → distinct ephemeral, flow row deleted', async () => {
     // cr round 9: when the bot is removed from the guild between
     // confirm and Send, `interaction.guild` is null. Without an
@@ -1450,15 +1511,23 @@ describe('handleSendUserSelect', () => {
     expect(mockTransitionFlow).not.toHaveBeenCalled();
   });
 
-  test('all bots picked → re-prompt warning + no transition', async () => {
+  test('all bots picked → re-prompt warning prepended to full confirm card (resource header preserved)', async () => {
+    // cr round 10: an invalid pick used to replace card content with
+    // just the warning string — the user lost the "Sending file:
+    // report.pdf / Expires: 24h" header they chose at /qurl file time.
+    // The fix re-renders the full confirm card with the warning
+    // banner prepended via warningsBlock; needsPicker:true keeps the
+    // pick prompt and the picker stays attached.
     const int = makeSelectInteraction({
       users: [makeUser(u1, { bot: true })],
     });
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/bots/),
-    }));
+    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/bots/);
+    // Resource header survives — this is the regression cr round 10 caught.
+    expect(updated.content).toMatch(/Sending file/);
+    expect(updated.content).toMatch(/Expires/);
   });
 
   test('defense-in-depth: cap-exceeded pick rejected even though picker setMaxValues makes it unreachable today', async () => {
@@ -1473,9 +1542,11 @@ describe('handleSendUserSelect', () => {
     const int = makeSelectInteraction({ users });
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/Pick at most/),
-    }));
+    const updated = int.update.mock.calls[int.update.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Pick at most/);
+    // Same regression defense as the all-bots branch — resource header
+    // must survive the warning re-render.
+    expect(updated.content).toMatch(/Sending file/);
   });
 
   test('partial-bot pick → transitionFlow with non-bot users + warning surfaces on card', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -470,6 +470,30 @@ describe('parseLocationInput', () => {
   test('malformed %-encoding in the input does not throw', () => {
     expect(() => parseLocationInput('https://www.google.com/maps/place/%ZZ-broken')).not.toThrow();
   });
+
+  test('spoofed host (google.com.evil.com) fails the regex AND falls through to synth-search', () => {
+    // Defense-in-depth contract: MAPS_URL_PATTERNS pins the literal
+    // `google.com/` token (slash forces an end-of-host boundary), so a
+    // spoofed host like `google.com.evil.com/maps/place/x` cannot match
+    // any pattern. parseLocationInput therefore takes the synth-search
+    // fall-through with the entire raw input as the search query —
+    // isGoogleMapsURL never gets a chance to look at the spoofed host.
+    // The conditional `if (detectedUrl && isGoogleMapsURL(detectedUrl))`
+    // remains as defense-in-depth in case a future pattern relaxes the
+    // host pin; this test pins the current contract.
+    const spoofed = 'https://google.com.evil.com/maps/place/Eiffel-Tower';
+    const r = parseLocationInput(spoofed);
+    // The synth-search URL's HOST is google.com (the search domain),
+    // not the spoofed host. The spoofed input lands URL-encoded INSIDE
+    // the search query, not as the rendered link's host.
+    const parsed = new URL(r.locationUrl);
+    expect(parsed.hostname).toBe('www.google.com');
+    expect(parsed.pathname.startsWith('/maps/search/')).toBe(true);
+    // The raw spoofed input is the search query — recipient embeds
+    // render that as text on a google.com link, not as a clickable
+    // link to the spoofed host.
+    expect(r.locationName).toBe(spoofed);
+  });
 });
 
 describe('safeDecodeURIComponent', () => {
@@ -984,6 +1008,25 @@ describe('handleQurlFile — slash entry', () => {
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
     expect(reply.content).toMatch(/bots and your own user are skipped/);
+  });
+
+  test('all mentioned recipients hit transient lookup failure → retry copy, not "no valid recipients"', async () => {
+    // transient-only path: the user's mentions were VALID but every
+    // members.fetch hit a 429 or gateway blip. Generic "no valid
+    // recipients" misleads — they didn't make any mistake. Encourage
+    // retry instead.
+    const flaky1 = '100000000000000099';
+    const flaky2 = '100000000000000098';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@${flaky1}> <@${flaky2}>` },
+      guildMembers: {},
+      guildFetchByID: { [flaky1]: 'ratelimit', [flaky2]: 'ratelimit' },
+    });
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Could not look up recipients right now.*Try again/i);
+    expect(reply.content).not.toMatch(/No valid recipients to send to/);
   });
 
   test('unknown-member ID surfaced as warning but valid users still proceed', async () => {
@@ -1736,6 +1779,23 @@ describe('handleSendUserSelect', () => {
     });
     await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(deferAckedBeforeTransition).toBe(true);
+  });
+
+  test('all-invalid pick combining bots AND self → message lists BOTH reasons (not just bot-only)', async () => {
+    // Previous wording collapsed to bot-only via a ternary. A pick of
+    // [bot, sender] is BOTH "cannot send to bots" AND "cannot send to
+    // yourself"; the user deserves to see both reasons so they know
+    // why removing only the bot wouldn't be enough.
+    const bot1 = '100000000000000099';
+    const int = makeSelectInteraction({
+      users: [makeUser(bot1, { bot: true }), makeUser(SENDER_ID)],
+    });
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/bots/);
+    expect(updated.content).toMatch(/yourself/i);
+    expect(updated.content).toMatch(/Sending file/);
   });
 
   test('all bots picked → re-prompt warning prepended to full confirm card (resource header preserved)', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -429,6 +429,22 @@ describe('softenCooldown', () => {
     softenCooldown('u1', 0);
     expect(isOnCooldown('u1')).toBe(false);
   });
+
+  test('soften reorders the Map: softened entry moves to the end of iteration order', () => {
+    // LRU iteration contract: setCooldown's bulk eviction (commands.js:~248)
+    // drops the oldest N keys in iteration order. softenCooldown deletes-
+    // then-sets so a soften refreshes the user's iteration position to
+    // the end, keeping them resident through bulk evictions. Without
+    // this, a Cancel-then-Cancel sequence would still drop the active
+    // user during the next eviction wave.
+    sendCooldowns.set('uA', Date.now());
+    sendCooldowns.set('uB', Date.now());
+    sendCooldowns.set('uC', Date.now());
+    // Initial iteration order: A, B, C.
+    softenCooldown('uA', 5000);
+    // After softening A, iteration order should be: B, C, A.
+    expect(Array.from(sendCooldowns.keys())).toEqual(['uB', 'uC', 'uA']);
+  });
 });
 
 describe('parseLocationInput', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -447,12 +447,24 @@ describe('parseLocationInput', () => {
     expect(r.locationName).toBe('Eiffel Tower, Paris');
   });
 
-  test('URL that matches a pattern but fails isGoogleMapsURL falls through to synth-search', () => {
-    // A URL hosted at a non-Google domain that happens to match the
-    // shape — must be handled by isGoogleMapsURL re-validation, not the
-    // pattern match alone.
+  test('plain non-URL text falls through to synth-search', () => {
     const r = parseLocationInput('not a url just plain text input');
     expect(r.locationUrl).toContain('google.com/maps/search');
+  });
+
+  test('https URL that does NOT match MAPS_URL_PATTERNS is treated as plain text and synth-searched', () => {
+    // The MAPS_URL_PATTERNS regexes are quite specific (host + path
+    // shape). A non-Google https URL fails them all, so parseLocationInput
+    // falls through to the plain-text branch and synth-searches with
+    // the raw input as the search query. isGoogleMapsURL re-validation
+    // applies inside parseLocationInput when an extracted URL pattern
+    // matches — the fall-through covers the "doesn't even match the
+    // regex" case directly.
+    const r = parseLocationInput('https://evil.example.com/maps/place/x');
+    expect(r.locationUrl).toContain('google.com/maps/search');
+    // The original URL is encoded into the search query, not used as
+    // the locationUrl.
+    expect(r.locationUrl).not.toContain('evil.example.com/maps/place');
   });
 
   test('malformed %-encoding in the input does not throw', () => {
@@ -1340,7 +1352,7 @@ describe('handleSendConfirmClick', () => {
     }));
   });
 
-  test('no apiKey resolved → tells user setup is needed', async () => {
+  test('no apiKey resolved → tells user setup is needed, cooldown cleared (admin action recovers)', async () => {
     mockDb.getGuildApiKey.mockResolvedValueOnce(null);
     // jest.replaceProperty restores automatically on test teardown
     // and is parallel-test-safe — beats hand-rolled
@@ -1350,10 +1362,14 @@ describe('handleSendConfirmClick', () => {
     const config = require('../src/config');
     jest.replaceProperty(config, 'QURL_API_KEY', null);
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    sendCooldowns.set(SENDER_ID, Date.now());
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/not configured|setup/i),
     }));
+    // Admin action required to recover → don't strand the user for
+    // 30s after `/qurl setup` completes.
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
   test('partial-resolve at Send click — Send proceeds with remaining users, drop surfaced via followUp + info log', async () => {
@@ -1417,12 +1433,14 @@ describe('handleSendConfirmClick', () => {
     );
   });
 
-  test('getGuildApiKey throw at click time → ephemeral retry, NO deleteFlow (row stays alive)', async () => {
+  test('getGuildApiKey throw at click time → ephemeral retry, NO deleteFlow (row stays alive), cooldown cleared', async () => {
     // getGuildApiKey runs BEFORE deleteFlow so a DDB blip doesn't
     // burn the flow row. User can re-click Send within the 3-min TTL
-    // once the blip clears.
+    // once the blip clears. clearCooldown unlocks retry so the user
+    // isn't stranded for the full 30s window on a transient blip.
     mockDb.getGuildApiKey.mockRejectedValueOnce(new Error('ddb gone'));
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    sendCooldowns.set(SENDER_ID, Date.now());
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not look up the qURL API key/),
@@ -1433,6 +1451,8 @@ describe('handleSendConfirmClick', () => {
       expect.stringMatching(/getGuildApiKey threw/),
       expect.objectContaining({ flow_id: 'fid' }),
     );
+    // Zero side effects → cooldown cleared for immediate retry.
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
   test('resolveRecipientUsers throw at click time → ephemeral retry message, NO deleteFlow', async () => {
@@ -1456,6 +1476,7 @@ describe('handleSendConfirmClick', () => {
     Object.defineProperty(int.guild, 'members', {
       get() { throw new Error('cache exploded'); },
     });
+    sendCooldowns.set(SENDER_ID, Date.now());
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: { ...validPayload, recipientIds: [u1] }, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not look up recipients/),
@@ -1466,6 +1487,8 @@ describe('handleSendConfirmClick', () => {
       expect.stringMatching(/resolveRecipientUsers threw/),
       expect.objectContaining({ flow_id: 'fid' }),
     );
+    // Zero side effects → cooldown cleared for immediate retry.
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
   test('forged Send click with empty recipientIds → distinct copy + deleteFlow (not the "all left" copy)', async () => {
@@ -1492,15 +1515,17 @@ describe('handleSendConfirmClick', () => {
     }));
   });
 
-  test('bot kicked between confirm and Send → distinct ephemeral, flow row deleted', async () => {
+  test('bot kicked between confirm and Send → distinct ephemeral, flow row deleted, cooldown cleared', async () => {
     // When the bot is removed from the guild between confirm and
     // Send, `interaction.guild` is null. Without an explicit guard,
     // resolveRecipientUsers returns every recipientId in unresolvedIds
     // and the user sees "recipients left the server" — misleading.
     // Pin the dedicated copy + deleteFlow so the flow row doesn't
-    // linger.
+    // linger. Cooldown clears so the user can re-run immediately
+    // after the admin re-invites the bot.
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     int.guild = null;
+    sendCooldowns.set(SENDER_ID, Date.now());
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/bot is no longer in this server/i),
@@ -1510,6 +1535,7 @@ describe('handleSendConfirmClick', () => {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
     }));
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
     // The misleading "left the server" copy must NOT fire here.
     expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/no longer reachable/i),

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -314,6 +314,8 @@ describe('selfDestructOptionToSeconds', () => {
     [undefined, null],
     ['', null],
     // Preset values pass through:
+    ['0.5', 0.5],  // "1/2 second" preset — Math.floor would have downgraded this to "no timer"
+    ['1', 1],
     ['5', 5],
     ['30', 30],
     ['300', 300],
@@ -328,7 +330,8 @@ describe('selfDestructOptionToSeconds', () => {
     ['-5', null],
     ['NaN', null],
     ['bogus', null],
-    ['1.5', 1],  // Math.floor(1.5)=1 IS a preset
+    ['1.5', null],   // 1.5 is not in the preset set — no downgrade-to-floor
+    ['0.25', null],  // off-preset fractional
   ])('value=%j → seconds=%j', (input, expected) => {
     expect(selfDestructOptionToSeconds(input)).toBe(expected);
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -549,6 +549,16 @@ describe('renderConfirmCardContent', () => {
     expect(out).toMatch(/Eiffel Tower/);
   });
 
+  test('unknown resourceType throws — forces an explicit branch for future types', () => {
+    // Round-7 (cr) added an explicit else-throw so a future resource
+    // type (audio, contact card, etc.) can't silently render as a
+    // location. Pins the contract.
+    expect(() => renderConfirmCardContent({
+      ...baseProps,
+      resourceType: 'audio',
+    })).toThrow(/unknown resourceType.*audio/);
+  });
+
   test('shows recipient preview (first 5) + remainder count', () => {
     const users = Array.from({ length: 7 }, (_, i) => makeUser(`10000000000000000${i + 1}`, { username: `u${i}` }));
     const out = renderConfirmCardContent({ ...baseProps, validRecipients: users });
@@ -1018,18 +1028,24 @@ describe('handleSendConfirmClick', () => {
     sendNonce: 'nonce-1',
   };
 
-  test('happy path → deleteFlow + executeSendPipeline invoked', async () => {
+  test('happy path → deferUpdate + deleteFlow + editReply "Preparing"', async () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    // The pipeline itself isn't reachable without heavy connector mocking,
-    // so we just assert deleteFlow fired AND update() landed on 'Preparing'.
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    // Defer-ack within the 3s window before any awaits — round-7 (cr)
+    // added this so resolveRecipientUsers + getGuildApiKey + deleteFlow
+    // can't blow Discord's hard ack deadline on a cold cache.
+    expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM, reason: 'terminal',
     }));
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
     }));
+    // After deferUpdate, the handler must NOT call .update directly
+    // (would double-ack). Verify by confirming the legacy update
+    // mock got no main-message updates.
+    expect(int.update).not.toHaveBeenCalled();
   });
 
   test('deleteFlow dedup loser → version-fenced "Recipients changed" reply, no pipeline call', async () => {
@@ -1041,11 +1057,11 @@ describe('handleSendConfirmClick', () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Recipients changed|re-click Send/i),
       ephemeral: true,
     }));
-    expect(int.update).not.toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing/),
     }));
   });
@@ -1070,7 +1086,7 @@ describe('handleSendConfirmClick', () => {
     // before the Promise.all that resolves the guild API key.
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/no longer reachable/),
     }));
   });
@@ -1086,7 +1102,7 @@ describe('handleSendConfirmClick', () => {
     jest.replaceProperty(config, 'QURL_API_KEY', null);
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/not configured|setup/i),
     }));
   });
@@ -1108,7 +1124,7 @@ describe('handleSendConfirmClick', () => {
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: payloadWithGhost, version: 1 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
     }));
     // followUp announces the drop to the sender so they know the
@@ -1140,7 +1156,7 @@ describe('handleSendConfirmClick', () => {
     });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: payloadWithFlaky, version: 1 } });
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
     }));
     // followUp distinguishes transient from "left" — retry copy.
@@ -1161,7 +1177,7 @@ describe('handleSendConfirmClick', () => {
     mockDb.getGuildApiKey.mockRejectedValueOnce(new Error('ddb gone'));
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not look up the qURL API key/),
       ephemeral: true,
     }));
@@ -1194,7 +1210,7 @@ describe('handleSendConfirmClick', () => {
       get() { throw new Error('cache exploded'); },
     });
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: { ...validPayload, recipientIds: [u1] }, version: 1 } });
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not look up recipients/),
       ephemeral: true,
     }));
@@ -1221,7 +1237,7 @@ describe('handleSendCancelClick', () => {
       expectedVersion: 3,
     }));
     expect(isOnCooldown(SENDER_ID)).toBe(false);
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/cancelled/),
     }));
   });
@@ -1236,7 +1252,7 @@ describe('handleSendCancelClick', () => {
     sendCooldowns.set(SENDER_ID, cooldownAt);
     const int = makeInteraction();
     await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/already processed|card moved/),
       ephemeral: true,
     }));

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -985,6 +985,50 @@ describe('handleQurlMap — slash entry', () => {
     }));
   });
 
+  test('locationName strips bidi/zero-width control chars (RLO spoof defense)', async () => {
+    // Round-8 (cr): /qurl map's slash option is a new attack surface
+    // that bypasses the modal's natural friction. A crafted U+202E
+    // (RLO) in `location-name` would otherwise flip text direction
+    // in the rendered confirm card. sanitizeContentLabel strips it
+    // via NFKC + bidi/ZWS regex before markdown-escape.
+    const int = makeInteraction({
+      options: {
+        location: 'https://www.google.com/maps/place/Cafe',
+        // U+202E + visible text — bidi-reversed in any naive renderer.
+        'location-name': '‮Backwards Cafe',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.locationName).toBe('Backwards Cafe');
+    expect(payload.locationName).not.toContain('‮');
+  });
+
+  test('locationName 256-cap is codepoint-aware (no surrogate split)', async () => {
+    // Build a 257-char string whose char at index 254 is the first
+    // half of a surrogate pair. Naive .slice(0, 256) would land on
+    // the high surrogate alone and produce invalid UTF-16. The new
+    // sanitizeContentLabel uses Array.from + slice by codepoint.
+    // 4-byte emoji (e.g. 😀 = U+1F600) is a surrogate pair in UTF-16.
+    const name = 'a'.repeat(254) + '😀' + 'extra';  // 254 + 2 surrogates + 5 = 261 code units
+    const int = makeInteraction({
+      options: {
+        location: 'https://www.google.com/maps/place/Cafe',
+        'location-name': name,
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    // Result must NOT contain a lone surrogate. Validity check:
+    // Buffer encoding round-trips clean only when surrogates pair.
+    const lone = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(payload.locationName).not.toMatch(lone);
+  });
+
   test('forged interaction missing required `location` → actionable ephemeral, no flow row', async () => {
     // Discord enforces required options server-side; only a forged
     // interaction can hit the `getString('location', true)` throw.
@@ -1268,6 +1312,28 @@ describe('handleSendCancelClick', () => {
       expectedVersion: 11,
     }));
   });
+
+  test('deleteFlow throw → ephemeral retry, cooldown preserved (Send may still be in flight)', async () => {
+    // Round-8 (cr) added a targeted catch around the Cancel deleteFlow
+    // for symmetry with handleSendConfirmClick. A DDB blip during a
+    // Cancel click now surfaces an actionable ephemeral instead of
+    // the dispatcher's generic safety net. Cooldown stays set on the
+    // throw path — Send may still be in flight, the user's cooldown
+    // should honor the original Send invocation.
+    mockDeleteFlow.mockRejectedValueOnce(new Error('ddb gone'));
+    sendCooldowns.set(SENDER_ID, Date.now());
+    const int = makeInteraction();
+    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not cancel right now/),
+      ephemeral: true,
+    }));
+    expect(isOnCooldown(SENDER_ID)).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/deleteFlow threw/),
+      expect.objectContaining({ flow_id: 'fid' }),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -1336,6 +1402,23 @@ describe('handleSendUserSelect', () => {
     }));
   });
 
+  test('defense-in-depth: cap-exceeded pick rejected even though picker setMaxValues makes it unreachable today', async () => {
+    // The picker's setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,
+    // QURL_SEND_MAX_RECIPIENTS=25) = 10, so production users physically
+    // can't pick more than 25. But a future bump to either constant
+    // (or a forged interaction) could trip this branch — pin the
+    // guard so a refactor that drops it produces a visible failure.
+    // QURL_SEND_MAX_RECIPIENTS = 25 in the mocked config; build a
+    // pick of 26 to exceed it.
+    const users = Array.from({ length: 26 }, (_, i) => makeUser(`1000000000000000${String(i).padStart(2, '0')}`));
+    const int = makeSelectInteraction({ users });
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Pick at most/),
+    }));
+  });
+
   test('partial-bot pick → transitionFlow with non-bot users + warning surfaces on card', async () => {
     // Live picker UX: user selects 3 real users + 1 bot. Partition
     // drops the bot, valid=[u1,u2,u3], droppedBots=1. transitionFlow
@@ -1385,11 +1468,19 @@ describe('handleSendUserSelect', () => {
 // ──────────────────────────────────────────────────────────────
 
 describe('constants + exports', () => {
-  test('SEND_FLOW_TTL_SECONDS = 180', () => {
-    expect(SEND_FLOW_TTL_SECONDS).toBe(180);
-  });
-
-  test('all customIds are stable string prefixes', () => {
+  // customId pins catch wire-protocol drift. They look tautological
+  // (the constants are imported AND asserted against literals here)
+  // but the value is the string Discord routes button clicks to —
+  // a rename in production would invalidate every confirm card that
+  // shipped before the redeploy. The literal pin makes that
+  // breaking-change visible at test time. We do NOT pin
+  // SEND_FLOW_TTL_SECONDS / SEND_STAGE_AWAITING_CONFIRM as literals
+  // because those values are internal (not exposed to Discord) and
+  // the behavioral assertions in the handler describe blocks
+  // (`expect(mockSupersedeOrCreate).toHaveBeenCalledWith({stage:
+  // SEND_STAGE_AWAITING_CONFIRM, ...})`) already pin them by
+  // contract.
+  test('customIds match the wire-protocol values Discord routes against', () => {
     expect(SEND_USER_SELECT_CUSTOM_ID).toBe('qurl_send_user_select');
     expect(SEND_CONFIRM_SEND_CUSTOM_ID).toBe('qurl_send_confirm_send');
     expect(SEND_CONFIRM_CANCEL_CUSTOM_ID).toBe('qurl_send_confirm_cancel');
@@ -1398,18 +1489,6 @@ describe('constants + exports', () => {
   test('all customIds unique', () => {
     const ids = new Set([SEND_USER_SELECT_CUSTOM_ID, SEND_CONFIRM_SEND_CUSTOM_ID, SEND_CONFIRM_CANCEL_CUSTOM_ID]);
     expect(ids.size).toBe(3);
-  });
-
-  test('SEND_STAGE_AWAITING_CONFIRM = "awaiting_send_confirm"', () => {
-    expect(SEND_STAGE_AWAITING_CONFIRM).toBe('awaiting_send_confirm');
-  });
-
-  test('handlers are functions', () => {
-    expect(typeof handleQurlFile).toBe('function');
-    expect(typeof handleQurlMap).toBe('function');
-    expect(typeof handleSendUserSelect).toBe('function');
-    expect(typeof handleSendConfirmClick).toBe('function');
-    expect(typeof handleSendCancelClick).toBe('function');
   });
 
   test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -175,6 +175,9 @@ const {
   selfDestructOptionToSeconds,
   renderRecipientWarnings,
   renderConfirmCardContent,
+  parseLocationInput,
+  safeDecodeURIComponent,
+  softenCooldown,
   SEND_STAGE_AWAITING_CONFIRM,
   SEND_USER_SELECT_CUSTOM_ID,
   SEND_CONFIRM_SEND_CUSTOM_ID,
@@ -182,6 +185,7 @@ const {
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
   isOnCooldown,
+  setCooldown,
   clearCooldown,
   sendCooldowns,
   executeSendPipeline,
@@ -380,6 +384,122 @@ describe('partitionRecipients', () => {
     const dup = makeUser('100000000000000001');
     const r = partitionRecipients([dup, dup, makeUser('100000000000000002')], SENDER_ID);
     expect(r.valid.length).toBe(3);
+  });
+});
+
+describe('softenCooldown', () => {
+  // Cancel-path helper: leave `residualMs` of cooldown remaining,
+  // monotonically SHRINK (never extend). Tests use the real
+  // QURL_SEND_COOLDOWN_MS via config (mocked in the test setup).
+  const config = require('../src/config');
+  const COOLDOWN_MS = config.QURL_SEND_COOLDOWN_MS;
+
+  beforeEach(() => sendCooldowns.clear());
+
+  test('no-op when no cooldown is set', () => {
+    softenCooldown('u1', 5000);
+    expect(sendCooldowns.has('u1')).toBe(false);
+  });
+
+  test('softens a fresh cooldown so ~5s remain', () => {
+    const now = Date.now();
+    sendCooldowns.set('u1', now);
+    softenCooldown('u1', 5000);
+    expect(sendCooldowns.has('u1')).toBe(true);
+    // Resulting `last` should be approximately now - (COOLDOWN - 5000)
+    // so remaining time is 5000ms.
+    const last = sendCooldowns.get('u1');
+    expect(last).toBeLessThanOrEqual(now - (COOLDOWN_MS - 5000) + 5);
+    expect(last).toBeGreaterThanOrEqual(now - (COOLDOWN_MS - 5000) - 5);
+  });
+
+  test('does NOT extend an already-short remaining cooldown', () => {
+    // existing `last` is older than the soften target → remaining is
+    // already less than 5s. Soften must NOT bump it back up.
+    const ancient = Date.now() - (COOLDOWN_MS - 1000);  // 1s remaining
+    sendCooldowns.set('u1', ancient);
+    softenCooldown('u1', 5000);
+    expect(sendCooldowns.get('u1')).toBe(ancient);
+  });
+
+  test('residualMs=0 effectively clears (last pushed far enough back that remaining=0)', () => {
+    sendCooldowns.set('u1', Date.now());
+    softenCooldown('u1', 0);
+    expect(isOnCooldown('u1')).toBe(false);
+  });
+});
+
+describe('parseLocationInput', () => {
+  test('Google Maps short URL passes through verbatim', () => {
+    const r = parseLocationInput('https://goo.gl/maps/abc123');
+    expect(r.locationUrl).toBe('https://goo.gl/maps/abc123');
+  });
+
+  test('Google Maps place URL passes through with derived name', () => {
+    const r = parseLocationInput('https://www.google.com/maps/place/Eiffel+Tower/@48.85,2.29,17z');
+    expect(r.locationUrl).toContain('google.com/maps/place');
+    expect(r.locationName).toBeTruthy();
+  });
+
+  test('plain place name synthesizes a search URL', () => {
+    const r = parseLocationInput('Eiffel Tower, Paris');
+    expect(r.locationUrl).toContain('google.com/maps/search');
+    expect(r.locationName).toBe('Eiffel Tower, Paris');
+  });
+
+  test('URL that matches a pattern but fails isGoogleMapsURL falls through to synth-search', () => {
+    // A URL hosted at a non-Google domain that happens to match the
+    // shape — must be handled by isGoogleMapsURL re-validation, not the
+    // pattern match alone.
+    const r = parseLocationInput('not a url just plain text input');
+    expect(r.locationUrl).toContain('google.com/maps/search');
+  });
+
+  test('malformed %-encoding in the input does not throw', () => {
+    expect(() => parseLocationInput('https://www.google.com/maps/place/%ZZ-broken')).not.toThrow();
+  });
+});
+
+describe('safeDecodeURIComponent', () => {
+  test('decodes normal percent-encoding', () => {
+    expect(safeDecodeURIComponent('Hello%20World')).toBe('Hello World');
+  });
+
+  test('returns raw input on malformed encoding (does not throw)', () => {
+    expect(safeDecodeURIComponent('%ZZ')).toBe('%ZZ');
+    expect(safeDecodeURIComponent('%')).toBe('%');
+    expect(safeDecodeURIComponent('valid%20but%incomplete')).toBe('valid%20but%incomplete');
+  });
+
+  test('handles control chars passing through', () => {
+    expect(safeDecodeURIComponent('plain')).toBe('plain');
+  });
+});
+
+describe('cross-command cooldown contract', () => {
+  // /qurl send, /qurl file, /qurl map share the sendCooldowns Map.
+  // setCooldown from any one MUST block the others — without this
+  // contract, a user could bypass the per-user throttle by alternating
+  // entry points.
+  beforeEach(() => sendCooldowns.clear());
+
+  test('setCooldown via one user blocks isOnCooldown for the same user across all entry points', () => {
+    setCooldown('uA');
+    // The shared Map key is the user ID — no per-command bucket. All
+    // three slash handlers consult the same isOnCooldown helper.
+    expect(isOnCooldown('uA')).toBe(true);
+  });
+
+  test('clearCooldown unlocks all entry points for that user', () => {
+    setCooldown('uA');
+    clearCooldown('uA');
+    expect(isOnCooldown('uA')).toBe(false);
+  });
+
+  test('cooldown is per-user, not global', () => {
+    setCooldown('uA');
+    expect(isOnCooldown('uA')).toBe(true);
+    expect(isOnCooldown('uB')).toBe(false);
   });
 });
 
@@ -1402,36 +1522,51 @@ describe('handleSendConfirmClick', () => {
 // ──────────────────────────────────────────────────────────────
 
 describe('handleSendCancelClick', () => {
-  test('happy path → version-gated deleteFlow + cooldown cleared + update', async () => {
+  test('happy path → version-gated deleteFlow + cooldown softened to ~5s residual + update', async () => {
+    // softenCooldown leaves 5s of throttle so a user can't spam
+    // /qurl file → Cancel → /qurl file → Cancel and rack up
+    // supersedeOrCreate DDB writes with zero cost. A legitimate
+    // "I changed my mind" still has the cooldown softened from full
+    // QURL_SEND_COOLDOWN_MS down to 5s.
     const int = makeInteraction();
-    sendCooldowns.set(SENDER_ID, Date.now());
+    const cooldownStart = Date.now();
+    sendCooldowns.set(SENDER_ID, cooldownStart);
     await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
       expectedVersion: 3,
     }));
-    expect(isOnCooldown(SENDER_ID)).toBe(false);
+    // Cooldown ENTRY still exists (not deleted) — softening pushes
+    // `last` to a value that leaves ~5s remaining. isOnCooldown is
+    // therefore still true (within the 5s residual window).
+    expect(sendCooldowns.has(SENDER_ID)).toBe(true);
+    expect(isOnCooldown(SENDER_ID)).toBe(true);
+    // The new `last` should be older than the original cooldownStart
+    // (softening pushed it back so remaining time is now ~5s).
+    expect(sendCooldowns.get(SENDER_ID)).toBeLessThan(cooldownStart);
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/cancelled/),
     }));
   });
 
-  test('deleteFlow dedup loser → ephemeral message + cooldown PRESERVED', async () => {
-    // Critical: when Send won the race, we must NOT clear cooldown
-    // mid-send-fanout. Otherwise the user can re-fire /qurl file
-    // immediately and bypass the per-user cooldown window while the
-    // first send is still DMing recipients.
+  test('deleteFlow dedup loser → ephemeral message + cooldown PRESERVED (no soften)', async () => {
+    // Critical: when Send won the race, we must NOT touch the cooldown
+    // — Send is fanning out DMs and a soften would let the user
+    // re-fire /qurl file within 5s of clicking Cancel, before the
+    // first send finishes. The Cancel-loser branch leaves the
+    // original cooldown timestamp intact (no softening).
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     const cooldownAt = Date.now();
     sendCooldowns.set(SENDER_ID, cooldownAt);
     const int = makeInteraction();
     await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/already processed|card moved/),
+      content: expect.stringMatching(/card moved/i),
       ephemeral: true,
     }));
-    // Cooldown is still in place — Cancel-loser must not unlock it.
+    // Cooldown is exactly as the test set it — Cancel-loser must not
+    // soften OR clear it.
     expect(isOnCooldown(SENDER_ID)).toBe(true);
     expect(sendCooldowns.get(SENDER_ID)).toBe(cooldownAt);
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1360,12 +1360,11 @@ describe('handleQurlMap — slash entry', () => {
     expect(payload.locationName).not.toMatch(lone);
   });
 
-  test('forged interaction missing required `location` → actionable ephemeral, no flow row', async () => {
-    // Discord enforces required options server-side; only a forged
-    // interaction can hit the `getString('location', true)` throw.
-    // Targeted catch so the user sees an
-    // actionable message instead of the dispatcher's generic safety
-    // net.
+  test('forged interaction missing required `location` → actionable ephemeral, no flow row, cooldown cleared', async () => {
+    // Discord enforces required options server-side; the realistic
+    // cause of a hit is a client/schema desync during a redeploy,
+    // not abuse. Cooldown clears so the user can retry once the
+    // deploy stabilizes.
     const int = makeInteraction({ options: {} });
     int.options.getString = jest.fn((name, required) => {
       if (name === 'location' && required) {
@@ -1381,6 +1380,7 @@ describe('handleQurlMap — slash entry', () => {
       ephemeral: true,
     }));
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 });
 
@@ -1635,6 +1635,31 @@ describe('handleSendConfirmClick', () => {
     );
     // Zero side effects → cooldown cleared for immediate retry.
     expect(isOnCooldown(SENDER_ID)).toBe(false);
+  });
+
+  test('forged Send click with sender-only recipientIds → "Invalid recipient list" copy, NOT "all left"', async () => {
+    // Forged payload edge: recipientIds=[SENDER_ID] passes the empty-
+    // array guard, resolves fine (sender is in guild cache), then
+    // partitionRecipients drops the sender (droppedSelf=1) and
+    // valid.length === 0. Pre-fix this hit the all-unresolved branch
+    // and surfaced "Recipients are no longer reachable (all left the
+    // server)" — misleading. Distinguish by droppedSelf/droppedBots > 0.
+    const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
+    await handleSendConfirmClick(int, {
+      flow_id: 'fid',
+      row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 1 },
+    });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Invalid recipient list/i),
+      components: [],
+    }));
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/all left the server/i),
+    }));
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }));
   });
 
   test('forged Send click with empty recipientIds → distinct copy + deleteFlow (not the "all left" copy)', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -714,6 +714,30 @@ describe('renderRecipientWarnings', () => {
     expect(renderRecipientWarnings({})).toBe('');
     expect(renderRecipientWarnings()).toBe('');
   });
+
+  test('caps each shown invalidToken at 80 codepoints with an ellipsis indicator', () => {
+    // recipient-parser.js caps each token at 256 chars, so worst-case
+    // 10 tokens × 256 = 2.5KB of code-fenced text before any other
+    // warning lines render. The 80-codepoint per-token cap keeps the
+    // warnings block legible and shrinks the worst case meaningfully.
+    const longToken = 'a'.repeat(200);
+    const out = renderRecipientWarnings({ invalidTokens: [longToken] });
+    // The fence-content slice (between the two ```s) carries the
+    // truncated token — confirm it ends with the ellipsis indicator
+    // and that no 81+-char run of `a` survives.
+    const fence = out.split('```')[1] || '';
+    expect(fence).toMatch(/a{80}…/);
+    expect(fence).not.toMatch(/a{81}/);
+  });
+
+  test('does NOT add ellipsis when the token already fits under the cap', () => {
+    // Short tokens render untruncated — pin that the 80-codepoint
+    // cap is not eagerly appending the indicator to every token.
+    const out = renderRecipientWarnings({ invalidTokens: ['shorttoken'] });
+    expect(out).toContain('shorttoken');
+    const fence = out.split('```')[1] || '';
+    expect(fence).not.toContain('…');
+  });
 });
 
 describe('renderConfirmCardContent', () => {
@@ -918,6 +942,36 @@ describe('renderConfirmCardContent', () => {
       personalMessage: 'first line\nsecond\r\nthird fourth fifth',
     });
     expect(out).toContain('> first line second third fourth fifth\n');
+  });
+
+  test('caps total rendered content below Discord\'s 2000-char limit + adds truncation indicator', () => {
+    // Worst-case render: a maximal warningsBlock + a long resourceLabel
+    // + a long personalMessage pre-sanitized preview can plausibly
+    // cross 2000 chars in adversarial inputs. Without a cap, Discord
+    // rejects editReply with a 400 and the throw orphans the flow
+    // row (now cleaned up by the safety-net catch, but the user still
+    // sees a generic error rather than the confirm card).
+    //
+    // Pin: a 3000-char warningsBlock forces the cap to fire, and the
+    // total output stays under 2000 chars with a visible truncation
+    // marker.
+    const bigWarnings = 'WARN ' + 'x'.repeat(3000) + '\n\n';
+    const out = renderConfirmCardContent({
+      ...baseProps,
+      warningsBlock: bigWarnings,
+    });
+    expect(out.length).toBeLessThanOrEqual(2000);
+    expect(out).toMatch(/…\(truncated\)$/);
+  });
+
+  test('does NOT truncate when content fits under the cap (referential-equality fast path)', () => {
+    // The cap path runs `safeCodepointSlice` which returns the input
+    // unchanged when below the cap. Reference equality (`===`) gates
+    // the truncation indicator — pin that the typical case has
+    // neither marker nor extra suffix.
+    const out = renderConfirmCardContent({ ...baseProps });
+    expect(out).not.toMatch(/…\(truncated\)/);
+    expect(out.length).toBeLessThan(2000);
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -879,7 +879,7 @@ describe('handleQurlFile — slash entry', () => {
     }));
   });
 
-  test('rejects when attachment.url is not Discord CDN (SSRF gate)', async () => {
+  test('rejects when attachment.url is not Discord CDN (SSRF gate) — cooldown PRESERVED (probing defense)', async () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, url: 'https://evil.com/x.png' } },
     });
@@ -888,9 +888,12 @@ describe('handleQurlFile — slash entry', () => {
       content: expect.stringMatching(/source not allowed/),
       ephemeral: true,
     }));
+    // SSRF gate is the one rejection that KEEPS the cooldown — probing
+    // the allow-list is an abuse signal, not an honest user error.
+    expect(isOnCooldown(SENDER_ID)).toBe(true);
   });
 
-  test('rejects disallowed file type', async () => {
+  test('rejects disallowed file type — cooldown CLEARED (honest user error, not abuse)', async () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, contentType: 'application/x-evil-macroenabled' } },
     });
@@ -898,9 +901,12 @@ describe('handleQurlFile — slash entry', () => {
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/File type not allowed/),
     }));
+    // Honest user error → unlock retry immediately. Don't strand the
+    // user for 30s on a wrong-file-extension mistake.
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
-  test('rejects file over size cap', async () => {
+  test('rejects file over size cap — cooldown CLEARED (honest user error)', async () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, size: 999_999_999 } },
     });
@@ -908,6 +914,7 @@ describe('handleQurlFile — slash entry', () => {
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/too large/),
     }));
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
   test('happy path with recipients string — supersedeOrCreate called + confirm card rendered', async () => {
@@ -1407,7 +1414,7 @@ describe('handleSendConfirmClick', () => {
     );
   });
 
-  test('partial transient lookup at Send click — Send proceeds with remaining, transient drop surfaced with retry copy', async () => {
+  test('partial transient lookup at Send click — Send proceeds with remaining, transient drop surfaced with retry copy (/qurl file)', async () => {
     // transientFailureIds must be surfaced with retry-encouraging
     // copy (NOT "left the server" wording) — the buckets are split
     // + threaded so a 429/gateway blip doesn't read as "they're gone".
@@ -1422,7 +1429,8 @@ describe('handleSendConfirmClick', () => {
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
     }));
-    // followUp distinguishes transient from "left" — retry copy.
+    // followUp distinguishes transient from "left" — retry copy. The
+    // rerun command name is derived from payload.resourceType.
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/1 couldn't be looked up.*rerun \/qurl file/),
       ephemeral: true,
@@ -1431,6 +1439,37 @@ describe('handleSendConfirmClick', () => {
       expect.stringMatching(/partial drop at click time/),
       expect.objectContaining({ left: 0, transient: 1 }),
     );
+  });
+
+  test('partial transient lookup at Send click — /qurl map payload produces /qurl map rerun hint', async () => {
+    // The same handler serves /qurl file and /qurl map. A user who
+    // invoked /qurl map should NOT be told to "rerun /qurl file" in
+    // the transient-lookup followUp. resourceType=MAPS in the payload
+    // drives the hint.
+    const flaky = '100000000000000099';
+    const mapPayload = {
+      ...validPayload,
+      resourceType: 'maps',
+      attachment: null,
+      locationUrl: 'https://google.com/maps/place/x',
+      locationName: 'x',
+      resourceLabel: 'x',
+      recipientIds: [u1, flaky],
+    };
+    const int = makeInteraction({
+      guildMembers: { [u1]: {} },
+      guildFetchByID: { [flaky]: 'ratelimit' },
+    });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: mapPayload, version: 1 } });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/rerun \/qurl map/),
+      ephemeral: true,
+    }));
+    // Must NOT say /qurl file when the user invoked /qurl map.
+    expect(int.followUp).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/rerun \/qurl file/),
+    }));
   });
 
   test('getGuildApiKey throw at click time → ephemeral retry, NO deleteFlow (row stays alive), cooldown cleared', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -49,34 +49,23 @@ jest.mock('../src/logger', () => ({
 // chain from throwing when commands.js loads. Tests exercise the
 // handler functions directly, not the registration path.
 jest.mock('discord.js', () => {
-  const makeChainable = (extra = {}) => ({
-    setCustomId: jest.fn().mockReturnThis(),
-    setLabel: jest.fn().mockReturnThis(),
-    setEmoji: jest.fn().mockReturnThis(),
-    setStyle: jest.fn().mockReturnThis(),
-    setURL: jest.fn().mockReturnThis(),
-    setTitle: jest.fn().mockReturnThis(),
-    setPlaceholder: jest.fn().mockReturnThis(),
-    addOptions: jest.fn().mockReturnThis(),
-    addChoices: jest.fn().mockReturnThis(),
-    setMinValues: jest.fn().mockReturnThis(),
-    setMaxValues: jest.fn().mockReturnThis(),
-    addComponents: jest.fn().mockReturnThis(),
-    setDisabled: jest.fn().mockReturnThis(),
-    setMaxLength: jest.fn().mockReturnThis(),
-    setRequired: jest.fn().mockReturnThis(),
-    setValue: jest.fn().mockReturnThis(),
-    setName: jest.fn().mockReturnThis(),
-    setDescription: jest.fn().mockReturnThis(),
-    ...extra,
-  });
+  // Shared chainables from tests/helpers/discord-mock.js:
+  //   makeOptionBuilder — option callbacks (addStringOption, etc.)
+  //   makeComponentChainable — component builders (Button, Select,
+  //     Modal, etc.) with a superset surface.
+  // Both inlined inside the jest.mock factory body so the require
+  // dodges jest.mock's hoisting. Centralized so a new chained method
+  // at the discord.js layer touches one site for the whole test suite.
+  const { makeOptionBuilder, makeComponentChainable } = require('./helpers/discord-mock');
   return {
     SlashCommandBuilder: jest.fn().mockImplementation(() => {
-      const subBuilder = () => makeChainable({
-        addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
-        addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
-        addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
-        addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeChainable()); return this; }),
+      const subBuilder = () => ({
+        setName: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        addStringOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+        addAttachmentOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+        addUserOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
+        addIntegerOption: jest.fn(function (fn) { if (typeof fn === 'function') fn(makeOptionBuilder()); return this; }),
       });
       const builder = {
         setName: jest.fn().mockReturnThis(),
@@ -91,7 +80,7 @@ jest.mock('discord.js', () => {
       };
       return builder;
     }),
-    EmbedBuilder: jest.fn().mockImplementation(() => makeChainable({
+    EmbedBuilder: jest.fn().mockImplementation(() => makeComponentChainable({
       setColor: jest.fn().mockReturnThis(),
       setDescription: jest.fn().mockReturnThis(),
       addFields: jest.fn().mockReturnThis(),
@@ -102,14 +91,14 @@ jest.mock('discord.js', () => {
       const row = { components: [], addComponents: jest.fn(function (...args) { row.components.push(...args.flat()); return row; }) };
       return row;
     }),
-    ButtonBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    ButtonBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
     ButtonStyle: { Primary: 1, Secondary: 2, Success: 3, Danger: 4, Link: 5 },
     ChannelType: { GuildText: 0, DM: 1, GuildVoice: 2, GuildStageVoice: 13 },
     ComponentType: { Button: 2, StringSelect: 3, UserSelect: 5 },
-    StringSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
-    UserSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
-    ModalBuilder: jest.fn().mockImplementation(() => makeChainable()),
-    TextInputBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    StringSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
+    UserSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
+    ModalBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
+    TextInputBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
     TextInputStyle: { Short: 1, Paragraph: 2 },
     AttachmentBuilder: jest.fn().mockImplementation((buf, opts) => ({ buf, name: opts?.name })),
     PermissionFlagsBits: { ManageRoles: 1n, Administrator: 8n, ManageGuild: 32n },
@@ -554,6 +543,21 @@ describe('renderConfirmCardContent', () => {
     expect(out).not.toMatch(/\\\\\*/);
   });
 
+  test('personal-message with mixed markdown + escape sequences renders without re-escaping the escapes', () => {
+    // Composite edge case: a real-world sanitizeMessage output for a
+    // user input like `**bold** \\n [link](https://evil)`. The literal
+    // backslashes that sanitizeMessage emits for markdown escapes
+    // must NOT themselves become `\\\\` in the card.
+    const presanitized = '\\*\\*bold\\*\\* \\\\n \\[link\\]\\(https://evil\\)';
+    const out = renderConfirmCardContent({ ...baseProps, personalMessage: presanitized });
+    // The substring renders exactly as supplied — no markdown-escape
+    // pass turns `\\` into `\\\\`.
+    expect(out).toContain(`"${presanitized}"`);
+    // Defense: no `\\\\` (four backslashes) appears — that'd be the
+    // unambiguous double-escape regression signature.
+    expect(out).not.toMatch(/\\\\\\\\/);
+  });
+
   test('warningsBlock prepended', () => {
     const out = renderConfirmCardContent({ ...baseProps, warningsBlock: '⚠ warned\n\n' });
     expect(out.startsWith('⚠ warned')).toBe(true);
@@ -982,7 +986,7 @@ describe('handleSendConfirmClick', () => {
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
     expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/no longer available/),
+      content: expect.stringMatching(/no longer reachable/),
     }));
   });
 
@@ -1002,13 +1006,14 @@ describe('handleSendConfirmClick', () => {
     }));
   });
 
-  test('partial-resolve at Send click — Send proceeds with remaining users, dropped IDs logged at debug', async () => {
+  test('partial-resolve at Send click — Send proceeds with remaining users, drop surfaced via followUp + info log', async () => {
     // Mid-flight guild churn: row.payload.recipientIds = [u1, gone],
     // at click time gone left the guild. resolveRecipientUsers returns
     // {users:[u1's user], unresolvedIds:[gone]}. partitionRecipients
-    // keeps u1. Send should fire executeSendPipeline with the
-    // remaining valid user (NOT abort), with the silent-drop logged
-    // at debug level for forensic trail.
+    // keeps u1. Send fires executeSendPipeline with the remaining
+    // user, the silent-drop is announced to the sender via ephemeral
+    // followUp, and the forensic log lands at info (not debug) so
+    // oncall sees the signal without lowering log verbosity.
     const gone = '100000000000000099';
     const payloadWithGhost = { ...validPayload, recipientIds: [u1, gone] };
     const int = makeInteraction({
@@ -1021,9 +1026,16 @@ describe('handleSendConfirmClick', () => {
     expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
     }));
-    // The silent-drop forensic log fires at debug level (not warn)
-    // because mid-flight guild churn is expected/normal behavior.
-    expect(logger.debug).toHaveBeenCalledWith(
+    // followUp announces the drop to the sender so they know the
+    // delivered count doesn't match the card.
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/1 recipient had left the server/),
+      ephemeral: true,
+    }));
+    // Forensic log at INFO (escalated from debug per cr round 3) —
+    // oncall can grep for mid-flight guild churn without dialing
+    // verbosity up.
+    expect(logger.info).toHaveBeenCalledWith(
       expect.stringMatching(/dropping unresolved/),
       expect.objectContaining({ count: 1 }),
     );

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -275,17 +275,25 @@ const VALID_ATTACHMENT = Object.freeze({
 });
 
 beforeEach(() => {
+  // `clearAllMocks` resets call history but preserves implementations
+  // — critical because the discord.js mock factory at the top of the
+  // file uses jest.fn().mockReturnThis() chains on builder methods
+  // (setCustomId, setLabel, etc.). `resetAllMocks` would wipe those
+  // implementations and crash the next call into a non-function.
   jest.clearAllMocks();
   sendCooldowns.clear();
+  // Targeted mockReset for mocks where the `mockResolvedValueOnce`
+  // queue can leak across tests (an early-return path that doesn't
+  // consume the queued value pollutes the next test's first call).
+  // Re-seeded with `mockResolvedValue` defaults below; tests
+  // override per-call with `mockResolvedValueOnce` as needed.
+  mockSupersedeOrCreate.mockReset();
+  mockDeleteFlow.mockReset();
+  mockTransitionFlow.mockReset();
+  mockDb.getGuildApiKey.mockReset();
   mockSupersedeOrCreate.mockResolvedValue({ created: true, version: 1 });
   mockDeleteFlow.mockResolvedValue({ deleted: true });
   mockTransitionFlow.mockResolvedValue({ result: 'ok', version: 2 });
-  // mockResolvedValueOnce queues survive `clearAllMocks` — a queued
-  // value left unconsumed by a prior test (e.g. an early-return path)
-  // would leak into the next test's first call. Drain the queue with
-  // mockReset for the mocks where per-test `mockResolvedValueOnce` is
-  // the dominant pattern.
-  mockDb.getGuildApiKey.mockReset();
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -376,15 +384,19 @@ describe('resolveRecipientUsers', () => {
     expect(r.unresolvedIds).toEqual(['100000000000000001']);
   });
 
-  test('non-10007 error → unresolved + warn logged', async () => {
+  test('non-10007 error → transientFailureIds (NOT unresolvedIds) + warn logged', async () => {
+    // Rate-limit / gateway-blip 429s and 500-class errors must land
+    // in transientFailureIds so the caller surfaces "try again"
+    // copy instead of "they left the server."
     const int = makeInteraction({
       guildMembers: {},
       guildFetchByID: { '100000000000000001': 'ratelimit' },
     });
     const r = await resolveRecipientUsers(int, ['100000000000000001']);
-    expect(r.unresolvedIds).toEqual(['100000000000000001']);
+    expect(r.transientFailureIds).toEqual(['100000000000000001']);
+    expect(r.unresolvedIds).toEqual([]);
     expect(logger.warn).toHaveBeenCalledWith(
-      'resolveRecipientUsers: members.fetch failed',
+      'resolveRecipientUsers: members.fetch failed (transient)',
       expect.any(Object),
     );
   });
@@ -472,6 +484,25 @@ describe('renderRecipientWarnings', () => {
     expect(out).toMatch(/no longer in this server/);
     expect(out).toMatch(/bot/);
     expect(out).toMatch(/yourself/);
+  });
+
+  test('transientFailureIds rendered with neutral copy (not "left the server")', () => {
+    // Rate-limit / gateway-blip 429s land in transientFailureIds, NOT
+    // unresolvedIds — so the message must encourage retry, not imply
+    // the recipient is gone. cr round 4 caught this misdirection.
+    const out = renderRecipientWarnings({
+      transientFailureIds: ['100000000000000001', '100000000000000002'],
+    });
+    expect(out).toMatch(/2 user.*couldn't be looked up.*try again/);
+    expect(out).not.toMatch(/no longer in this server/);
+  });
+
+  test('renderRecipientWarnings tolerates missing fields via defaults', () => {
+    // The destructure now defaults each field — a future caller that
+    // forgets to pass `transientFailureIds` (or any other bucket)
+    // should get an empty warning, not a `.length`-of-undefined crash.
+    expect(renderRecipientWarnings({})).toBe('');
+    expect(renderRecipientWarnings()).toBe('');
   });
 });
 
@@ -1230,6 +1261,25 @@ describe('constants + exports', () => {
     expect(typeof handleSendUserSelect).toBe('function');
     expect(typeof handleSendConfirmClick).toBe('function');
     expect(typeof handleSendCancelClick).toBe('function');
+  });
+
+  test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {
+    // siblingMessage is registered only on SEND_USER_SELECT_CUSTOM_ID
+    // (commands.js's registerFlow blocks), but flow-dispatch stores
+    // siblingMessages keyed by EXPECTED_STAGE — so a /qurl revoke
+    // supersede that peeks at a row at SEND_STAGE_AWAITING_CONFIRM
+    // gets the same actionable message regardless of which customId
+    // was registered. Pin the lookup so a future refactor that
+    // accidentally keys siblingMessage by customId breaks here.
+    const { siblingMessageForStage } = require('../src/flow-dispatch');
+    const msg = siblingMessageForStage(SEND_STAGE_AWAITING_CONFIRM);
+    expect(msg).toMatch(/qurl file.*qurl map.*confirm card/i);
+    // Defense-in-depth: confirm-card customIds for SEND + CANCEL,
+    // although registered without their own siblingMessage, still
+    // reach the same registered message through the stage lookup.
+    // (Tested indirectly: any customId at this stage maps to the
+    // same single registered message.)
+    expect(msg).toBeTruthy();
   });
 
   test('executeSendPipeline still exported (back-half hook)', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1240,6 +1240,74 @@ describe('handleQurlFile — slash entry', () => {
       expect.objectContaining({ user_id: SENDER_ID }),
     );
   });
+
+  test('safety-net catch deletes orphan flow row when post-supersede throw fires', async () => {
+    // When supersedeOrCreate succeeds and then a downstream call
+    // (renderConfirmCardContent, renderConfirmCardRows, the final
+    // editReply, etc.) throws, the DDB row we just claimed would
+    // sit orphaned until TTL eviction — blocking the user's next
+    // /qurl file or /qurl map under the sibling-flow guard.
+    //
+    // Reproduce: let supersedeOrCreate resolve `created: true`, then
+    // force editReply to throw on its first call (the
+    // renderConfirmCardContent + components delivery). The catch's
+    // version-checked deleteFlow should fire with the correct
+    // stage so a racing confirm-click can't be silently revoked.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    int.editReply.mockRejectedValueOnce(new Error('Discord 500'));
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    expect(mockDeleteFlow).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        stage: 'awaiting_send_confirm',
+        reason: 'terminal',
+      }),
+    );
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+    // Pin `flow_id` in the error-log payload so a refactor that drops
+    // it (and breaks correlating logs ↔ DDB rows during a post-mortem)
+    // surfaces as a test failure rather than silently regressing.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/unexpected throw/),
+      expect.objectContaining({ flow_id: expect.any(String) }),
+    );
+  });
+
+  test('safety-net catch does NOT call deleteFlow when throw fires before supersedeOrCreate', async () => {
+    // If the throw lands before we ever called supersedeOrCreate
+    // there is no DDB row to clean up — calling deleteFlow would be
+    // a wasted round-trip (and noise in DDB metrics). The
+    // `orphanFlowCreated` flag must gate the cleanup precisely.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    int.deferReply.mockRejectedValueOnce(new Error('token expired'));
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+  });
+
+  test('safety-net catch does NOT call deleteFlow when supersedeOrCreate returned created:false (sibling flow)', async () => {
+    // A sibling-flow supersede returns `created: false` — the row
+    // belongs to a different in-flight flow, not us. Deleting it
+    // would silently revoke another user's open confirm card.
+    mockSupersedeOrCreate.mockResolvedValueOnce({
+      created: false,
+      surviving: { stage: 'awaiting_confirm', flow_id: 'other_flow' },
+    });
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -760,6 +760,46 @@ describe('handleQurlFile — slash entry', () => {
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Unrecognized expiry/);
   });
+
+  test('inner catch on supersedeOrCreate throw clears cooldown + surfaces specific error', async () => {
+    // The supersedeOrCreate-specific inner catch is the dominant
+    // failure-path test for cooldown release — verifies the canonical
+    // "DDB outage" branch lifts the cooldown so the user can retry.
+    mockSupersedeOrCreate.mockRejectedValueOnce(new Error('ddb gone'));
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int, 'apikey');
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Could not start a send/);
+  });
+
+  test('safety-net top-level catch clears cooldown on an unanticipated synchronous throw', async () => {
+    // The safety-net's job: catch throws that don't have a targeted
+    // inner catch — synchronous bugs in helpers, malformed cache
+    // entries, future regex changes that fail. Forcing
+    // `deferReply` to throw is the cleanest reproduction: it's the
+    // first await inside the try block, NOT wrapped by any inner
+    // catch, and forcing it to reject simulates a Discord token
+    // exhausted or gateway blip on the entry-time ACK.
+    //
+    // Without the safety-net, setCooldown ran but no clearCooldown
+    // would fire — user is locked out for the full cooldown window
+    // despite never seeing a response.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    int.deferReply.mockRejectedValueOnce(new Error('token expired'));
+    await handleQurlFile(int, 'apikey');
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/unexpected throw/),
+      expect.objectContaining({ user_id: SENDER_ID }),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -911,19 +951,18 @@ describe('handleSendConfirmClick', () => {
 
   test('no apiKey resolved → tells user setup is needed', async () => {
     mockDb.getGuildApiKey.mockResolvedValueOnce(null);
-    // Override config to also have no fallback.
+    // jest.replaceProperty restores automatically on test teardown
+    // and is parallel-test-safe — beats hand-rolled
+    // mutate-restore-in-finally which would silently corrupt the
+    // mocked config if a future refactor parallelizes test cases
+    // within this file.
     const config = require('../src/config');
-    const originalKey = config.QURL_API_KEY;
-    config.QURL_API_KEY = null;
-    try {
-      const int = makeInteraction({ guildMembers: { [u1]: {} } });
-      await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
-      expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
-        content: expect.stringMatching(/not configured|setup/i),
-      }));
-    } finally {
-      config.QURL_API_KEY = originalKey;
-    }
+    jest.replaceProperty(config, 'QURL_API_KEY', null);
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/not configured|setup/i),
+    }));
   });
 });
 
@@ -932,12 +971,14 @@ describe('handleSendConfirmClick', () => {
 // ──────────────────────────────────────────────────────────────
 
 describe('handleSendCancelClick', () => {
-  test('happy path → deleteFlow + cooldown cleared + update', async () => {
+  test('happy path → version-gated deleteFlow + cooldown cleared + update', async () => {
     const int = makeInteraction();
     sendCooldowns.set(SENDER_ID, Date.now());
-    await handleSendCancelClick(int, { flow_id: 'fid' });
+    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
-      stage: SEND_STAGE_AWAITING_CONFIRM, reason: 'terminal',
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+      expectedVersion: 3,
     }));
     expect(isOnCooldown(SENDER_ID)).toBe(false);
     expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -945,13 +986,30 @@ describe('handleSendCancelClick', () => {
     }));
   });
 
-  test('deleteFlow dedup loser → ephemeral "already processed"', async () => {
+  test('deleteFlow dedup loser → ephemeral message + cooldown PRESERVED', async () => {
+    // Critical: when Send won the race, we must NOT clear cooldown
+    // mid-send-fanout. Otherwise the user can re-fire /qurl file
+    // immediately and bypass the per-user cooldown window while the
+    // first send is still DMing recipients.
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const cooldownAt = Date.now();
+    sendCooldowns.set(SENDER_ID, cooldownAt);
     const int = makeInteraction();
-    await handleSendCancelClick(int, { flow_id: 'fid' });
+    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/already processed/),
+      content: expect.stringMatching(/already processed|card moved/),
       ephemeral: true,
+    }));
+    // Cooldown is still in place — Cancel-loser must not unlock it.
+    expect(isOnCooldown(SENDER_ID)).toBe(true);
+    expect(sendCooldowns.get(SENDER_ID)).toBe(cooldownAt);
+  });
+
+  test('Cancel deleteFlow is version-fenced against picker race', async () => {
+    const int = makeInteraction();
+    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 11 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      expectedVersion: 11,
     }));
   });
 });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1680,9 +1680,59 @@ describe('handleSendConfirmClick', () => {
     expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/no longer reachable/i),
     }));
+    // Version-gated delete: pin expectedVersion so a concurrent
+    // UserSelect transition doesn't silently wipe the more-current row.
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
+      expectedVersion: 1,
+    }));
+  });
+
+  test('empty recipientIds + concurrent picker race (deleteFlow returns deleted:false) → "card moved" followUp, no editReply wipe', async () => {
+    // Stale-view scenario: dispatcher's loadFlow saw row v1 with
+    // recipientIds=[], but a UserSelect transition advanced the row
+    // to v2 between then and this Send click. The version-gated
+    // deleteFlow returns deleted:false, surfacing the "card moved"
+    // recovery instead of silently wiping v2.
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    await handleSendConfirmClick(int, {
+      flow_id: 'fid',
+      row: { payload: { ...validPayload, recipientIds: [] }, version: 1 },
+    });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/card moved/i),
+      ephemeral: true,
+    }));
+    // The fixed "No recipients were selected" editReply must NOT
+    // fire on the dedup-loser path.
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/No recipients were selected/i),
+    }));
+  });
+
+  test('all-invalid recipients + concurrent picker race (deleteFlow returns deleted:false) → "card moved" followUp', async () => {
+    // Same shape as the empty-recipients race, but the dispatcher
+    // loaded a row whose recipientIds resolved to all-bots or all-
+    // sender. Version-gated delete catches the concurrent picker
+    // advance and surfaces the recovery.
+    mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
+    const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
+    await handleSendConfirmClick(int, {
+      flow_id: 'fid',
+      row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 5 },
+    });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/card moved/i),
+      ephemeral: true,
+    }));
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Invalid recipient list/i),
+    }));
+    // expectedVersion threaded through.
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      expectedVersion: 5,
     }));
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -614,7 +614,7 @@ describe('handleQurlFile — slash entry', () => {
       guildId: null,
       options: { attachment: VALID_ATTACHMENT },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/in a server/),
       ephemeral: true,
@@ -625,7 +625,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, url: 'https://evil.com/x.png' } },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/source not allowed/),
       ephemeral: true,
@@ -636,7 +636,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, contentType: 'application/x-evil-macroenabled' } },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/File type not allowed/),
     }));
@@ -646,7 +646,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, size: 999_999_999 } },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/too large/),
     }));
@@ -662,7 +662,7 @@ describe('handleQurlFile — slash entry', () => {
       },
       guildMembers: { [u1]: {}, [u2]: {} },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(int.deferReply).toHaveBeenCalled();
     expect(mockSupersedeOrCreate).toHaveBeenCalledWith(expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
@@ -685,7 +685,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Pick recipients/);
@@ -701,7 +701,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: `<@${u1}> <@${u2}>` },
       guildMembers: { [u1]: { bot: true }, [u2]: { bot: true } },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
@@ -714,7 +714,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: `<@${SENDER_ID}>` },
       guildMembers: { [SENDER_ID]: {} },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
@@ -729,7 +729,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { [known]: {} },
       guildFetchByID: { [gone]: 'unknown' },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.recipientIds).toEqual([known]);
@@ -745,7 +745,7 @@ describe('handleQurlFile — slash entry', () => {
     // Force cooldown
     sendCooldowns.set(SENDER_ID, Date.now());
     expect(isOnCooldown(SENDER_ID)).toBe(true);
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/wait before sending/),
     }));
@@ -761,7 +761,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/revoke.*menu open/);
   });
@@ -777,7 +777,7 @@ describe('handleQurlFile — slash entry', () => {
       },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.expiresIn).toBe('7d');
@@ -790,7 +790,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>', 'expires-in': '99y' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Unrecognized expiry/);
@@ -823,7 +823,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: {},  // ALL cache-miss
       guildFetchByID: fetchByID,
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
@@ -842,7 +842,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(isOnCooldown(SENDER_ID)).toBe(false);
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Could not start a send/);
@@ -865,7 +865,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     int.deferReply.mockRejectedValueOnce(new Error('token expired'));
-    await handleQurlFile(int, 'apikey');
+    await handleQurlFile(int);
     expect(isOnCooldown(SENDER_ID)).toBe(false);
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringMatching(/unexpected throw/),
@@ -887,7 +887,7 @@ describe('handleQurlMap — slash entry', () => {
       },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlMap(int, 'apikey');
+    await handleQurlMap(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.resourceType).toBe('maps');
@@ -903,7 +903,7 @@ describe('handleQurlMap — slash entry', () => {
       },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlMap(int, 'apikey');
+    await handleQurlMap(int);
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.locationUrl).toBe('https://www.google.com/maps/search/Central%20Park%2C%20NYC');
     expect(payload.locationName).toMatch(/Central Park/);
@@ -918,7 +918,7 @@ describe('handleQurlMap — slash entry', () => {
       },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlMap(int, 'apikey');
+    await handleQurlMap(int);
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.locationName).toBe('Custom Label');
   });
@@ -927,7 +927,7 @@ describe('handleQurlMap — slash entry', () => {
     const int = makeInteraction({
       options: { location: '   ', recipients: '<@100000000000000001>' },
     });
-    await handleQurlMap(int, 'apikey');
+    await handleQurlMap(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/empty/),
     }));
@@ -938,7 +938,7 @@ describe('handleQurlMap — slash entry', () => {
       guildId: null,
       options: { location: 'Eiffel', recipients: '<@100000000000000001>' },
     });
-    await handleQurlMap(int, 'apikey');
+    await handleQurlMap(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/in a server/),
     }));
@@ -1065,10 +1065,71 @@ describe('handleSendConfirmClick', () => {
     }));
     // Forensic log at INFO (escalated from debug per cr round 3) —
     // oncall can grep for mid-flight guild churn without dialing
-    // verbosity up.
+    // verbosity up. Round 5 split the bucket so the log fields
+    // distinguish left-the-server (10007) from transient.
     expect(logger.info).toHaveBeenCalledWith(
-      expect.stringMatching(/dropping unresolved/),
-      expect.objectContaining({ count: 1 }),
+      expect.stringMatching(/partial drop at click time/),
+      expect.objectContaining({ left: 1, transient: 0 }),
+    );
+  });
+
+  test('partial transient lookup at Send click — Send proceeds with remaining, transient drop surfaced with retry copy', async () => {
+    // cr round 5: transientFailureIds were previously dropped silently
+    // at click time. They must be surfaced with retry-encouraging
+    // copy (NOT "left the server" wording) — the buckets are now
+    // split + threaded.
+    const flaky = '100000000000000099';
+    const payloadWithFlaky = { ...validPayload, recipientIds: [u1, flaky] };
+    const int = makeInteraction({
+      guildMembers: { [u1]: {} },
+      guildFetchByID: { [flaky]: 'ratelimit' },
+    });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: payloadWithFlaky, version: 1 } });
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Preparing send/),
+    }));
+    // followUp distinguishes transient from "left" — retry copy.
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/1 couldn't be looked up.*rerun \/qurl file/),
+      ephemeral: true,
+    }));
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringMatching(/partial drop at click time/),
+      expect.objectContaining({ left: 0, transient: 1 }),
+    );
+  });
+
+  test('resolveRecipientUsers throw at click time → ephemeral retry message, NO deleteFlow', async () => {
+    // cr round 5: handleSendConfirmClick previously had no try/catch
+    // around the click-time resolution. A throw would propagate to the
+    // dispatcher's outer catch and leave the user staring at the
+    // unchanged card. Targeted catch now surfaces a recoverable
+    // ephemeral reply and DOES NOT commit the dedup deleteFlow so the
+    // card stays alive for the 3-min TTL.
+    const int = makeInteraction({
+      guildMembers: {},
+      // Force a throw out of `members.fetch` (not a return-value error,
+      // a real `throw new Error(...)`).
+    });
+    int.guild.members.fetch = jest.fn().mockRejectedValue(new Error('catastrophic'));
+    // Need to bypass batchSettled's swallow path: rejection inside the
+    // callback is caught by Promise.allSettled, then resolveRecipientUsers's
+    // own try/catch handles it. A real throw from BEFORE the try (e.g.
+    // guild === null) is what we want here. Simulate by deleting guild.
+    // Actually simpler — make the entire interaction.guild throw on read.
+    Object.defineProperty(int, 'guild', {
+      get() { throw new Error('cache exploded'); },
+    });
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: { ...validPayload, recipientIds: [u1] }, version: 1 } });
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not look up recipients/),
+      ephemeral: true,
+    }));
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/resolveRecipientUsers threw/),
+      expect.objectContaining({ flow_id: 'fid' }),
     );
   });
 });

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -288,6 +288,31 @@ describe('Helper functions', () => {
       expect(sanitizeMessage('@Everyone')).toContain('@\u200b');
       expect(sanitizeMessage('@HERE')).toContain('@\u200b');
     });
+
+    it('strips bidi / zero-width / control codepoints (RLO spoofing defense)', () => {
+      // U+202E (RLO) flips text direction in Discord renders \u2014 a
+      // crafted personal-message could visually spoof phishing in the
+      // recipient's DM body AND the sender's confirm-card preview.
+      const rlo = String.fromCharCode(0x202E);
+      const zwsp = String.fromCharCode(0x200B);
+      const result = sanitizeMessage(`Hello${rlo}gnitsihP${zwsp}world`);
+      expect(result).not.toMatch(/[\u202e\u200b]/);
+      expect(result).toContain('Hello');
+      expect(result).toContain('gnitsihP');
+      expect(result).toContain('world');
+    });
+
+    it('strips zero-width chars that would otherwise obfuscate @-mentions', () => {
+      // ZWSP between `@` and `everyone` previously slipped past the
+      // @-mention regex because the literal sequence didn't match.
+      // sanitizeMessage now strips bidi/zero-width FIRST, so the
+      // @-mention defense catches the obfuscated form too.
+      const obfuscated = '@every\u200bone heads up';
+      const result = sanitizeMessage(obfuscated);
+      // ZWSP stripped, @everyone caught + neutered with \u200b INSERTED
+      // by the @-mention defense (different position).
+      expect(result).toMatch(/@\u200beveryone/i);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/apps/discord/tests/qurl-send.test.js
+++ b/apps/discord/tests/qurl-send.test.js
@@ -202,6 +202,21 @@ describe('Helper functions', () => {
       expect(isGoogleMapsURL('https://goo.gl.evil.com/maps/abc')).toBe(false);
     });
 
+    it('host-anchor contract: hostname must END at google.{tld} — no suffix attack', () => {
+      // Defense-in-depth pin: even if a future MAPS_URL_PATTERNS
+      // relaxation lets `google.com.evil.com` through the regex,
+      // isGoogleMapsURL is the second line of defense and MUST reject
+      // any host that has additional segments after the google.{tld}
+      // suffix. The host-anchor regex /^(www\.)?google\.[a-z]{2,3}...$/
+      // is what makes this work.
+      expect(isGoogleMapsURL('https://google.com.evil.com/maps/place/x')).toBe(false);
+      expect(isGoogleMapsURL('https://www.google.com.evil.com/maps')).toBe(false);
+      expect(isGoogleMapsURL('https://google.co.uk.evil.com/maps')).toBe(false);
+      // Pre-suffix attacks (e.g. evil-google.com) also rejected.
+      expect(isGoogleMapsURL('https://evil-google.com/maps')).toBe(false);
+      expect(isGoogleMapsURL('https://notgoogle.com/maps')).toBe(false);
+    });
+
     it('handles edge cases', () => {
       expect(isGoogleMapsURL('')).toBe(false);
       expect(isGoogleMapsURL('not a url')).toBe(false);

--- a/apps/discord/tests/sanitize.test.js
+++ b/apps/discord/tests/sanitize.test.js
@@ -4,7 +4,7 @@
  * masked-link phishing in embeds, so adversarial coverage matters.
  */
 
-const { sanitizeFilename, escapeDiscordMarkdown } = require('../src/utils/sanitize');
+const { sanitizeFilename, escapeDiscordMarkdown, sanitizeContentLabel } = require('../src/utils/sanitize');
 
 describe('sanitizeFilename', () => {
   it('strips path traversal', () => {
@@ -81,5 +81,45 @@ describe('escapeDiscordMarkdown', () => {
   it('coerces non-strings', () => {
     expect(escapeDiscordMarkdown(42)).toBe('42');
     expect(escapeDiscordMarkdown(true)).toBe('true');
+  });
+});
+
+describe('sanitizeContentLabel', () => {
+  it('strips bidi/zero-width chars before markdown-escape', () => {
+    const rlo = String.fromCharCode(0x202E);
+    const zwsp = String.fromCharCode(0x200B);
+    expect(sanitizeContentLabel(`${rlo}Backwards${zwsp}Cafe`)).toBe('BackwardsCafe');
+  });
+
+  it('escapes markdown after the strip pass', () => {
+    expect(sanitizeContentLabel('**bold** [link](url)'))
+      .toBe('\\*\\*bold\\*\\* \\[link\\]\\(url\\)');
+  });
+
+  it('caps at the supplied codepoint count, surrogate-pair safe', () => {
+    // 254 ASCII + emoji surrogate pair = 256 codepoints (NFKC keeps
+    // the emoji as a pair), so the cap is not hit.
+    const exact = 'a'.repeat(254) + '\u{1F600}';
+    expect(sanitizeContentLabel(exact, 256)).toBe(exact);
+    // 255 ASCII + emoji (256 codepoints) — at the boundary. Naive
+    // .slice(0, 256) on UTF-16 code units would land mid-surrogate.
+    const boundary = 'a'.repeat(255) + '\u{1F600}';
+    const out = sanitizeContentLabel(boundary, 256);
+    const lone = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(out).not.toMatch(lone);
+  });
+
+  it('returns empty for null/undefined/empty (NOT the display-name Someone fallback)', () => {
+    expect(sanitizeContentLabel(null)).toBe('');
+    expect(sanitizeContentLabel(undefined)).toBe('');
+    expect(sanitizeContentLabel('')).toBe('');
+  });
+
+  it('returns empty for input that becomes empty after strip', () => {
+    // All zero-width — display-name helper falls back to 'Someone'
+    // here, but content-label callers want '' (the
+    // locationName/resourceLabel empty branch then renders nothing
+    // or a default).
+    expect(sanitizeContentLabel('​‌‍')).toBe('');
   });
 });

--- a/apps/discord/tests/sanitize.test.js
+++ b/apps/discord/tests/sanitize.test.js
@@ -4,7 +4,7 @@
  * masked-link phishing in embeds, so adversarial coverage matters.
  */
 
-const { sanitizeFilename, escapeDiscordMarkdown, sanitizeContentLabel } = require('../src/utils/sanitize');
+const { sanitizeFilename, escapeDiscordMarkdown, sanitizeContentLabel, stripBidiAndControls } = require('../src/utils/sanitize');
 
 describe('sanitizeFilename', () => {
   it('strips path traversal', () => {
@@ -121,5 +121,40 @@ describe('sanitizeContentLabel', () => {
     // locationName/resourceLabel empty branch then renders nothing
     // or a default).
     expect(sanitizeContentLabel('​‌‍')).toBe('');
+  });
+});
+
+describe('stripBidiAndControls', () => {
+  it('strips RLO / ZWSP / control codepoints without escaping markdown', () => {
+    const rlo = String.fromCharCode(0x202E);
+    const zwsp = String.fromCharCode(0x200B);
+    const out = stripBidiAndControls(`Hello${rlo}World${zwsp}!`);
+    expect(out).toBe('HelloWorld!');
+  });
+
+  it('does NOT escape markdown chars (sanitizeContentLabel does, this helper does not)', () => {
+    // The personal-message path needs to layer bidi-strip BEFORE its
+    // own markdown escape; this helper must not pre-escape.
+    expect(stripBidiAndControls('**bold**')).toBe('**bold**');
+    expect(stripBidiAndControls('[link](url)')).toBe('[link](url)');
+  });
+
+  it('NFKC-normalizes before strip', () => {
+    // U+FEFF (BOM) and a few other strip codepoints are only matched
+    // against canonical forms after NFKC normalization.
+    const bom = String.fromCharCode(0xFEFF);
+    expect(stripBidiAndControls(`x${bom}y`)).toBe('xy');
+  });
+
+  it('returns empty for null/undefined input (no Someone fallback)', () => {
+    expect(stripBidiAndControls(null)).toBe('');
+    expect(stripBidiAndControls(undefined)).toBe('');
+  });
+
+  it('has no length cap (unlike stripControlAndBidi)', () => {
+    // sanitizeMessage owns its own 500-char cap downstream; this
+    // helper must not pre-truncate.
+    const big = 'a'.repeat(2000);
+    expect(stripBidiAndControls(big)).toBe(big);
   });
 });

--- a/e2e/tests/discord-commands.smoke.test.ts
+++ b/e2e/tests/discord-commands.smoke.test.ts
@@ -131,7 +131,7 @@ describe('Discord command registration (smoke)', () => {
       // Prepend scope to the expectation so a mismatch surfaces which
       // scope regressed in the Jest failure header.
       expect({ scope: qurl._scope, subcommands })
-        .toEqual({ scope: qurl._scope, subcommands: ['help', 'revoke', 'send', 'setup', 'status'] });
+        .toEqual({ scope: qurl._scope, subcommands: ['file', 'help', 'map', 'revoke', 'send', 'setup', 'status'] });
     }
   });
 


### PR DESCRIPTION
## Why

`/qurl send`'s button-driven wizard works but forces every user through a multi-step flow even when they could type the send in one shot. PR 7b.2 ships two slash-command-driven entry points so power users can stay on the keyboard, and lays the foundation for `/qurl send`'s retirement in PR 7b.3 (the legacy form's in-memory `await*` primitives don't survive deploys mid-flow — the new commands' flow_state-backed confirm card does).

This is the second of three PRs converting `/qurl send` to a flow_state-backed shape:
- **7b.1 (#299, merged):** Recipient-mention parser.
- **7b.2 (this PR):** `/qurl file` + `/qurl map` subcommands + confirm card + flow_state wiring.
- **7b.3 (next):** Hard-remove `/qurl send`'s front-half (no grace period).

## Conflict with #294

PR #294 (different author) adds `/qurl send_file` + `/qurl send_location` as **stubbed** shortcuts that delegate to `/qurl send`'s Step 3 form. The "next commit on that branch" plans to extract the legacy form into a shared helper.

This PR takes the architecturally opposite direction agreed in the PR 7-9 rollout plan: **retire** the form (PR 7b.3) rather than refactor it. Building flow_state-backed handlers now — instead of reusing the in-memory form — is what makes the per-shard rollout in PRs 10-15 actually safe under deploy churn (the legacy form drops every in-flight send when an ECS task cycles).

After this PR lands, #294 can be closed (its work is superseded by /qurl file + /qurl map).

## What ships

### New subcommands
- **`/qurl file`** — required `attachment:`, optional `recipients:` (text mention list), `expires-in:`, `self-destruct:`, `personal-message:`.
- **`/qurl map`** — required `location:` (Google Maps URL or place text), optional `recipients:`, `location-name:` (override), plus the same shared options.

### Dual-input recipients
- **With `recipients:` text** → `parseRecipientMentions` (PR 7b.1) → guild `members.fetch` in parallel via `batchSettled` → bot/self filter → confirm card.
- **Without `recipients:` text** → confirm card renders a `UserSelectMenu`; picker interactions transition the same flow row's payload (stage unchanged, version + TTL refreshed via `transitionFlow`) until Send.

### Confirm card (flow_state-backed)
- `supersedeOrCreate({ stage: 'awaiting_send_confirm', ttl_seconds: 180 })` at command invocation.
- Send button → `deleteFlow` (dedup primitive, same ordering as `handleRevokeSelect`) → `executeSendPipeline`.
- Cancel button → `deleteFlow` + clear cooldown.
- 3-minute TTL matches the existing Step-3 form budget.

### Other changes
- Extracted shared `parseLocationInput()` so `/qurl send`'s modal-driven location capture and `/qurl map`'s slash option share one maps URL pattern set + name extractor.
- All three commands share `sendCooldowns` so users can't bypass the cooldown by switching entry points mid-window.
- Updated `/qurl help` to advertise `file` + `map`.

## Testing

- 69 new tests in `tests/qurl-file-map.test.js` covering: pure helpers (`selfDestructOptionToSeconds`, `partitionRecipients`, `resolveRecipientUsers` including cache hit / fetch / 10007 / non-10007), warning rendering, confirm-card content, all three flow handlers (Send / Cancel / UserSelect), happy paths for `/qurl file` + `/qurl map`, all bots / only sender / unknown member / cooldown / SSRF gate / disallowed type / size cap / sibling collision / off-set expiry, register-flow custom IDs and stage constant.
- Full suite: **1368 passed, 47 suites passed** (1254 prior + 69 new + 45 re-enabled in `coverage-boost.test.js` after mock factory consolidation).
- e2e smoke test's pinned subcommand set updated `5 → 7`.

## Test plan
- [x] `npm test` green (1368/1368)
- [x] `npx eslint` clean on all touched files
- [x] `/simplify` review applied: extracted shared `parseLocationInput()`, parallelized `members.fetch` via `batchSettled`, trimmed narration comments
- [ ] Manual smoke on sandbox: `/qurl file recipients:@alice attachment:report.pdf` → expect confirm card
- [ ] Manual smoke: `/qurl map location:"Eiffel Tower"` (no recipients) → expect picker fallback
- [ ] Manual smoke: confirm Send delivers DM links via existing `executeSendPipeline` back-half

🤖 Generated with [Claude Code](https://claude.com/claude-code)