### PR TITLE
fix(discord): restore button-driven selection on /qurl file + /qurl map confirm card

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3873,36 +3873,27 @@ function formatPersonalMessagePreview(message) {
   return `> ${safeCodepointSlice(oneLine, 80)}…`;
 }
 
-// Build the ActionRow set for the confirm card. When `attachPicker`,
-// row 0 is a UserSelectMenu (recipients absent OR a prior pick is in
-// the payload and the user might want to re-pick); otherwise no
-// picker row. Self-destruct + Expiry StringSelectMenus follow (each
-// requires its own row — Discord forbids combining selects with
-// buttons in the same ActionRow). The last row packs the optional
-// note button + Send + Cancel.
+// Build the ActionRow set for the confirm card. Always 4 rows:
+// UserSelectMenu (always attached so re-picks stay available and
+// the layout is stable from frame 0), Self-destruct StringSelectMenu,
+// Expiry StringSelectMenu (each select needs its own row — Discord
+// forbids combining selects with buttons in the same ActionRow),
+// and the bottom row packing Note button + Send + Cancel.
 //
 // Row math (Discord 5-row max):
-//   attachPicker=true:  UserSelect + SelfDestruct + Expiry + [Note,Send,Cancel] = 4 rows
-//   attachPicker=false: SelfDestruct + Expiry + [Note,Send,Cancel] = 3 rows
-//
-// Renamed from `needsPicker` so the content/rows divergence at the
-// post-pick call site (content rendered WITHOUT picker, rows rendered
-// WITH picker — to let the user re-pick) is impossible to silently
-// merge in a future refactor.
+//   UserSelect + SelfDestruct + Expiry + [Note, Send, Cancel] = 4 rows
 function renderConfirmCardRows({
-  attachPicker, sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
+  sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
 }) {
   const rows = [];
-  if (attachPicker) {
-    const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
-    rows.push(new ActionRowBuilder().addComponents(
-      new UserSelectMenuBuilder()
-        .setCustomId(SEND_USER_SELECT_CUSTOM_ID)
-        .setPlaceholder(`Pick recipients (1–${maxValues})`)
-        .setMinValues(1)
-        .setMaxValues(maxValues)
-    ));
-  }
+  const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
+  rows.push(new ActionRowBuilder().addComponents(
+    new UserSelectMenuBuilder()
+      .setCustomId(SEND_USER_SELECT_CUSTOM_ID)
+      .setPlaceholder(`Pick recipients (1–${maxValues})`)
+      .setMinValues(1)
+      .setMaxValues(maxValues)
+  ));
   // Self-destruct StringSelectMenu. Mirrors the OLD /qurl send form's
   // shape at commands.js:~2334: "No self-destruct timer" + 7 presets.
   // The `default: true` flag on the matching option keeps the
@@ -3913,6 +3904,16 @@ function renderConfirmCardRows({
   // render the first option's label — wrong UX).
   const hasTimer = Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0;
   const hasMatchingPreset = hasTimer && SELF_DESTRUCT_PRESETS.some((p) => p.seconds === selfDestructSeconds);
+  if (hasTimer && !hasMatchingPreset) {
+    // Symmetric with the expiry off-set warn below: a finite positive
+    // selfDestructSeconds that misses every preset means a corrupted
+    // row. The "No timer" fallback keeps the header sensible but the
+    // content line still renders "self-destructs in N seconds" — log
+    // so the asymmetric state surfaces in forensics.
+    logger.warn('renderConfirmCardRows: off-preset selfDestructSeconds in payload — falling back to No timer default', {
+      selfDestructSeconds: truncForLog(selfDestructSeconds),
+    });
+  }
   rows.push(new ActionRowBuilder().addComponents(
     new StringSelectMenuBuilder()
       .setCustomId(SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID)
@@ -4216,14 +4217,6 @@ async function handleQurlSlashSend(interaction, params) {
       interaction,
     });
     const rows = renderConfirmCardRows({
-      // Always attach the picker so the row layout is stable from
-      // frame 0 — without this, a slash entry that supplied
-      // `recipients:` would render 3 rows initially and then jump to
-      // 4 the first time the user touched any menu (rerenderConfirmCard
-      // hard-codes attachPicker: true). Always-attached also matches
-      // handleSendUserSelect's post-pick contract: the picker stays
-      // available for re-picks, even after a successful pick.
-      attachPicker: true,
       sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
       expiresIn,
       selfDestructSeconds,
@@ -4581,7 +4574,6 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
       interaction,
     }),
     components: renderConfirmCardRows({
-      attachPicker: true,
       sendDisabled: true,
       expiresIn: payload.expiresIn,
       selfDestructSeconds: payload.selfDestructSeconds,
@@ -4661,13 +4653,11 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  // Intentional flag divergence: the CONTENT renders the resolved
-  // recipient summary ("**To:** N user(s)") — needsPicker:false —
-  // while the ROWS keep the UserSelectMenu attached so the user can
-  // re-pick. Send is enabled because we now have a valid recipient
-  // set. The two flags are deliberately fed opposite values; the
-  // rename from `needsPicker` to `attachPicker` on the rows side
-  // makes this asymmetry impossible to silently consolidate.
+  // The CONTENT renders the resolved recipient summary
+  // ("**To:** N user(s)") with needsPicker:false; the ROWS always
+  // keep the UserSelectMenu attached (renderConfirmCardRows always
+  // produces 4 rows) so the user can re-pick. Send is enabled now
+  // that we have a valid recipient set.
   const content = renderConfirmCardContent({
     resourceType: payload.resourceType,
     resourceLabel: payload.resourceLabel,
@@ -4682,7 +4672,6 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   return interaction.editReply({
     content,
     components: renderConfirmCardRows({
-      attachPicker: true,
       sendDisabled: false,
       expiresIn: payload.expiresIn,
       selfDestructSeconds: payload.selfDestructSeconds,
@@ -4695,10 +4684,8 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 // payload (expiry / self-destruct / note). Each menu handler builds
 // `newPayload` and calls this with the post-transition `interaction` +
 // payload. Keeping the re-render shape in one place avoids the three
-// handlers drifting on `attachPicker` / `sendDisabled` / content flags.
+// handlers drifting on `sendDisabled` / content flags.
 //
-// `attachPicker: true` matches `handleSendUserSelect`'s post-pick
-// behavior (the picker stays attached so the user can re-pick).
 // `sendDisabled` is derived from recipientIds — without it, a user
 // who opened /qurl file without `recipients:` could change expiry
 // before picking and see an enabled Send button against an empty
@@ -4747,7 +4734,6 @@ async function rerenderConfirmCard(interaction, newPayload) {
   return interaction.editReply({
     content,
     components: renderConfirmCardRows({
-      attachPicker: true,
       sendDisabled: needsPicker,
       expiresIn: newPayload.expiresIn,
       selfDestructSeconds: newPayload.selfDestructSeconds,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4616,6 +4616,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   const newRecipientAliases = Object.fromEntries(
     valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
   );
+  // Asymmetry vs. the menu/modal handlers' no-op short-circuits:
+  // the picker DOES NOT skip transitionFlow on a same-recipient-set
+  // re-pick. Re-running here recomputes warningsBlock (droppedBots /
+  // droppedSelf can flip if the picker selection now includes the
+  // sender or a bot) and refreshes recipientAliases (display names
+  // may have changed since the prior pick). Both are user-visible
+  // and worth the version bump.
   const newPayload = {
     ...payload,
     recipientIds: valid.map((u) => u.id),
@@ -4763,11 +4770,11 @@ async function rerenderConfirmCard(interaction, newPayload) {
 // option gate — Discord enforces the choice set server-side, but a
 // forged interaction could land an off-set value here.
 async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
-  // `interaction.values && ...` is paranoia, not load-bearing —
-  // Discord guarantees `values` is an array for StringSelectMenu
-  // interactions. The guard catches a forged interaction missing
-  // the field entirely; legitimate UI paths always provide it.
-  const picked = interaction.values && interaction.values[0];
+  // `?.[0]` is paranoia, not load-bearing — Discord guarantees
+  // `values` is an array for StringSelectMenu interactions. The
+  // guard catches a forged interaction missing the field entirely;
+  // legitimate UI paths always provide it.
+  const picked = interaction.values?.[0];
   // Validate before deferring so the forgery branch can use `reply`
   // (the cheaper, single-call ack) instead of `followUp` after a
   // wasted deferUpdate. Symmetric with the self-destruct handler.
@@ -4830,9 +4837,9 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
 // selfDestructOptionToSeconds. The helper falls back to null for any
 // unexpected value (forged interaction), which is the safe default.
 async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }) {
-  // `interaction.values && ...` is paranoia (see expiry handler) —
-  // legitimate StringSelectMenu interactions always carry the array.
-  const pickedValue = interaction.values && interaction.values[0];
+  // `?.[0]` paranoia (see expiry handler) — legitimate
+  // StringSelectMenu interactions always carry the values array.
+  const pickedValue = interaction.values?.[0];
   // Validate against the closed legitimate set BEFORE acknowledging.
   // Discord enforces the choice list server-side; an off-set value
   // here means a forged interaction. Silently mapping forged values
@@ -4932,11 +4939,14 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
 }
 
 // Note modal-submit → sanitize input, update payload.personalMessage.
-// Modal-submit interactions get a fresh 3s ack window; using
-// `editReply` after `update()` mirrors handleSetupModal's shape.
-// `update()` ACKs against the ORIGINAL message (the confirm card)
-// because flow-dispatch wires modal submits to the same message-bound
-// interaction context.
+// Modal-submit interactions get a fresh 3s ack window. We defer
+// FIRST (deferUpdate) for budget headroom under slow DDB writes,
+// then editReply on the deferred interaction. The deferred ack
+// targets the ORIGINAL message (the confirm card) because flow-
+// dispatch wires modal submits to the same message-bound
+// interaction context. Post-defer error paths use followUp
+// (ephemeral) — reply / update would 409 against the acked
+// interaction.
 async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   // Defer the modal-submit ack BEFORE the DDB write — without this,
   // a slow conditional write (throttled partition) can push past

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4713,6 +4713,18 @@ async function rerenderConfirmCard(interaction, newPayload) {
   const memberCache = interaction.guild?.members?.cache;
   const persistedAliases = newPayload.recipientAliases || {};
   const validRecipients = recipientIds.map((id) => {
+    // Asymmetric inputs through the same render path:
+    //   - cache-hit returns a Discord.js User object (UNSANITIZED
+    //     fields — username/displayName fresh from the gateway).
+    //   - cache-miss returns { displayName: persistedAlias },
+    //     where the alias was ALREADY sanitized at pick time by
+    //     resolveRecipientAlias.
+    // Both then re-flow through renderConfirmCardContent's
+    // `resolveRecipientAlias` pass. The cache-hit branch sanitizes
+    // fresh; the cache-miss branch is a no-op IF sanitize stays
+    // idempotent (pinned by tests/sanitize.test.js's idempotence
+    // block). If anyone splits these into divergent post-processing,
+    // the cache-miss branch loses its protection.
     const cached = memberCache?.get?.(id);
     if (cached?.user) return cached.user;
     // Both fallback branches set `displayName` (NOT `username`) so

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4193,7 +4193,14 @@ async function handleQurlSlashSend(interaction, params) {
       interaction,
     });
     const rows = renderConfirmCardRows({
-      attachPicker: needsPicker,
+      // Always attach the picker so the row layout is stable from
+      // frame 0 — without this, a slash entry that supplied
+      // `recipients:` would render 3 rows initially and then jump to
+      // 4 the first time the user touched any menu (rerenderConfirmCard
+      // hard-codes attachPicker: true). Always-attached also matches
+      // handleSendUserSelect's post-pick contract: the picker stays
+      // available for re-picks, even after a successful pick.
+      attachPicker: true,
       sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
       expiresIn,
       selfDestructSeconds,
@@ -4673,9 +4680,9 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 // who opened /qurl file without `recipients:` could change expiry
 // before picking and see an enabled Send button against an empty
 // recipient set.
-// `ack` lets modal-submit handlers pass `interaction.update` —
-// deferred-ACK menu handlers use the editReply default.
-async function rerenderConfirmCard(interaction, newPayload, ack = (msg) => interaction.editReply(msg)) {
+// All four entry paths (picker, expiry, self-destruct, note modal)
+// defer-ack first, then re-render via editReply.
+async function rerenderConfirmCard(interaction, newPayload) {
   const recipientIds = Array.isArray(newPayload.recipientIds) ? newPayload.recipientIds : [];
   // Resolve each id through three layers, in priority order:
   //   1. members.cache — freshest data when populated
@@ -4705,7 +4712,7 @@ async function rerenderConfirmCard(interaction, newPayload, ack = (msg) => inter
     needsPicker,
     interaction,
   });
-  return ack({
+  return interaction.editReply({
     content,
     components: renderConfirmCardRows({
       attachPicker: true,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4031,10 +4031,15 @@ async function handleQurlSlashSend(interaction, params) {
     // Trim once and derive both forms — raw for Edit-note pre-fill,
     // sanitized for render. Without the raw, the modal would pre-fill
     // the escaped form and a no-op resubmit would double-escape.
-    const personalMessageRawTrimmed = personalMessageRaw
+    const initialRawTrimmed = personalMessageRaw
       ? safeCodepointSlice(personalMessageRaw.trim(), PERSONAL_MESSAGE_INPUT_MAX)
       : null;
-    const personalMessage = personalMessageRawTrimmed ? sanitizeMessage(personalMessageRawTrimmed) : null;
+    const personalMessage = initialRawTrimmed ? sanitizeMessage(initialRawTrimmed) : null;
+    // Null out raw if sanitize stripped to empty (e.g. ZWSP-only input
+    // survives `.trim()` but sanitizeMessage's bidi-strip removes it).
+    // Without this, the Edit-note button would label as "Add a note"
+    // (personalMessage is empty/falsy) but pre-fill with invisible chars.
+    const personalMessageRawTrimmed = personalMessage ? initialRawTrimmed : null;
 
     const parsed = parseRecipientMentions(recipientsRaw, interaction);
 
@@ -4706,11 +4711,11 @@ async function rerenderConfirmCard(interaction, newPayload) {
   // no-op because NFKC + bidi/zero-width strip have fixed points
   // after one pass. If sanitize semantics ever stop being idempotent,
   // this becomes a double-sanitize bug.
-  const memberCache = interaction.guild && interaction.guild.members && interaction.guild.members.cache;
+  const memberCache = interaction.guild?.members?.cache;
   const persistedAliases = newPayload.recipientAliases || {};
   const validRecipients = recipientIds.map((id) => {
-    const cached = memberCache && memberCache.get && memberCache.get(id);
-    if (cached && cached.user) return cached.user;
+    const cached = memberCache?.get?.(id);
+    if (cached?.user) return cached.user;
     // Both fallback branches set `displayName` (NOT `username`) so
     // resolveRecipientAlias's precedence (displayName → globalName →
     // username → user-${id}) hits the first branch consistently.
@@ -4923,8 +4928,12 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   }
   // Cap matches the slash-entry path; both forms derive from the same
   // trimmed-and-capped raw so an Edit round-trip is idempotent.
-  const personalMessageRaw = raw ? safeCodepointSlice(raw, PERSONAL_MESSAGE_INPUT_MAX) : null;
-  const personalMessage = personalMessageRaw ? sanitizeMessage(personalMessageRaw) : null;
+  const rawCapped = raw ? safeCodepointSlice(raw, PERSONAL_MESSAGE_INPUT_MAX) : null;
+  const personalMessage = rawCapped ? sanitizeMessage(rawCapped) : null;
+  // Null out raw if sanitize stripped to empty (ZWSP-only / bidi-only
+  // input). Keeps the button label and the modal pre-fill consistent
+  // — see slash-entry site for the rationale.
+  const personalMessageRaw = personalMessage ? rawCapped : null;
   const payload = row.payload || {};
   const newPayload = { ...payload, personalMessage, personalMessageRaw };
   let result;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4909,6 +4909,11 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
       .setRequired(false)
       // Pre-fill from raw to avoid double-escape on resubmit. Empty
       // fallback for legacy flow rows missing the field (3-min TTL).
+      // Note: raw can contain bidi/zero-width chars (sanitize hasn't
+      // run on raw); pre-filling them into the TextInput is by design
+      // for round-trip correctness, and the surface is ephemeral-to-
+      // self (only the invoking user sees the modal). If this ever
+      // gets piped to a non-ephemeral context, sanitize the prefill.
       .setValue(payload.personalMessageRaw || '')
   ));
   return interaction.showModal(modal).catch((err) => {
@@ -4967,6 +4972,16 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   // input). Keeps the button label and the modal pre-fill consistent.
   const personalMessageRaw = personalMessage ? rawCapped : null;
   const payload = row.payload || {};
+  // No-op submit (same content as current state) → skip the DDB
+  // write + version bump (symmetric with expiry / self-destruct
+  // handlers). Compare BOTH forms because a sanitize-semantics
+  // change could leave sanitized identical but raw drifted; matching
+  // both is the correct invariant. Visible feedback (rerender) still
+  // fires so the user knows the submit registered.
+  if (personalMessage === (payload.personalMessage ?? null)
+      && personalMessageRaw === (payload.personalMessageRaw ?? null)) {
+    return rerenderConfirmCard(interaction, payload);
+  }
   const newPayload = { ...payload, personalMessage, personalMessageRaw };
   let result;
   try {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3534,7 +3534,7 @@ const SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_send_confirm_note_modal';
 // Local to the note modal — kept off the prefix-only customId
 // allowlist because flow-dispatch never routes modal-input fields,
 // only the parent modal customId.
-const SEND_NOTE_MODAL_INPUT_ID = 'message_value';
+const SEND_NOTE_MODAL_FIELD_ID = 'message_value';
 
 // 3-minute confirm-card window. Matches /qurl send's Step-3 form
 // timeout at line ~2293 so users have the same time-to-finish budget
@@ -3929,14 +3929,24 @@ function renderConfirmCardRows({
   // Expiry StringSelectMenu. Default-true on the matching option same
   // as self-destruct above. EXPIRY_CHOICES is shared with the slash-
   // option choice list so users see identical labels in autocomplete
-  // and in the form.
+  // and in the form. `hasExpiryMatch` defends against a corrupted DDB
+  // row carrying an off-`EXPIRY_LABELS` value — without it every
+  // option would be un-defaulted and Discord renders the first
+  // option's label, misrepresenting the actual stored value. Falls
+  // back to defaulting the codebase-default '24h' option so the card
+  // still shows SOMETHING meaningful.
+  const hasExpiryMatch = EXPIRY_CHOICES.some((c) => c.value === expiresIn);
   rows.push(new ActionRowBuilder().addComponents(
     new StringSelectMenuBuilder()
       .setCustomId(SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID)
       .setMinValues(1)
       .setMaxValues(1)
       .addOptions(
-        ...EXPIRY_CHOICES.map((c) => ({ label: c.name, value: c.value, default: c.value === expiresIn }))
+        ...EXPIRY_CHOICES.map((c) => ({
+          label: c.name,
+          value: c.value,
+          default: hasExpiryMatch ? c.value === expiresIn : c.value === '24h',
+        }))
       )
   ));
   // Bottom row: Note button + Send + Cancel. Label flips between
@@ -4691,6 +4701,11 @@ async function rerenderConfirmCard(interaction, newPayload) {
   //   3. fabricated `user-${id}` fallback — last resort if both miss
   // resolveRecipientAlias does its own NFKC + bidi/zero-width strip
   // on whichever wins, so the rendered text is always sanitized.
+  // The aliases in persistedAliases were ALREADY produced by
+  // resolveRecipientAlias at pick time — re-running it here is a
+  // no-op because NFKC + bidi/zero-width strip have fixed points
+  // after one pass. If sanitize semantics ever stop being idempotent,
+  // this becomes a double-sanitize bug.
   const memberCache = interaction.guild && interaction.guild.members && interaction.guild.members.cache;
   const persistedAliases = newPayload.recipientAliases || {};
   const validRecipients = recipientIds.map((id) => {
@@ -4855,7 +4870,7 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
     .setTitle('Personal message');
   modal.addComponents(new ActionRowBuilder().addComponents(
     new TextInputBuilder()
-      .setCustomId(SEND_NOTE_MODAL_INPUT_ID)
+      .setCustomId(SEND_NOTE_MODAL_FIELD_ID)
       .setLabel('Optional note (leave blank to clear)')
       .setStyle(TextInputStyle.Paragraph)
       .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
@@ -4892,7 +4907,20 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   // `reply()` both fail and the user gets an "interaction failed"
   // toast. Mirrors the menu handlers' shape.
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
-  const raw = interaction.fields.getTextInputValue(SEND_NOTE_MODAL_INPUT_ID).trim();
+  // Defensive read: `getTextInputValue` throws if the customId
+  // allowlist ever drifts from SEND_NOTE_MODAL_FIELD_ID. The
+  // try/catch + empty-string fallback keeps the handler resilient
+  // — an unrecognized field reads as empty input, which routes to
+  // the clear-note branch instead of leaving the modal-submit
+  // interaction unresolved past deferUpdate.
+  let raw = '';
+  try {
+    raw = (interaction.fields.getTextInputValue(SEND_NOTE_MODAL_FIELD_ID) || '').trim();
+  } catch (err) {
+    logger.warn('handleSendConfirmNoteModal: getTextInputValue threw', {
+      flow_id, error: err && err.message,
+    });
+  }
   // Cap matches the slash-entry path; both forms derive from the same
   // trimmed-and-capped raw so an Edit round-trip is idempotent.
   const personalMessageRaw = raw ? safeCodepointSlice(raw, PERSONAL_MESSAGE_INPUT_MAX) : null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3517,6 +3517,18 @@ const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
 const SEND_USER_SELECT_CUSTOM_ID = 'qurl_send_user_select';
 const SEND_CONFIRM_SEND_CUSTOM_ID = 'qurl_send_confirm_send';
 const SEND_CONFIRM_CANCEL_CUSTOM_ID = 'qurl_send_confirm_cancel';
+// Confirm-card menus / button restored from the OLD `/qurl send` UX —
+// slash options on /qurl file + /qurl map remain as initial defaults
+// (one-shot for power users), but a user who didn't fill them in can
+// still adjust expiry, self-destruct, and note inline on the card.
+const SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID = 'qurl_send_confirm_expiry';
+const SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID = 'qurl_send_confirm_self_destruct';
+const SEND_CONFIRM_NOTE_BUTTON_CUSTOM_ID = 'qurl_send_confirm_note_btn';
+const SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_send_confirm_note_modal';
+// Local to the note modal — kept off the prefix-only customId
+// allowlist because flow-dispatch never routes modal-input fields,
+// only the parent modal customId.
+const SEND_NOTE_MODAL_INPUT_ID = 'message_value';
 
 // 3-minute confirm-card window. Matches /qurl send's Step-3 form
 // timeout at line ~2293 so users have the same time-to-finish budget
@@ -3857,13 +3869,22 @@ function formatPersonalMessagePreview(message) {
 // Build the ActionRow set for the confirm card. When `attachPicker`,
 // row 0 is a UserSelectMenu (recipients absent OR a prior pick is in
 // the payload and the user might want to re-pick); otherwise no
-// picker row. Send/Cancel always in the last row.
+// picker row. Self-destruct + Expiry StringSelectMenus follow (each
+// requires its own row — Discord forbids combining selects with
+// buttons in the same ActionRow). The last row packs the optional
+// note button + Send + Cancel.
+//
+// Row math (Discord 5-row max):
+//   attachPicker=true:  UserSelect + SelfDestruct + Expiry + [Note,Send,Cancel] = 4 rows
+//   attachPicker=false: SelfDestruct + Expiry + [Note,Send,Cancel] = 3 rows
 //
 // Renamed from `needsPicker` so the content/rows divergence at the
 // post-pick call site (content rendered WITHOUT picker, rows rendered
 // WITH picker — to let the user re-pick) is impossible to silently
 // merge in a future refactor.
-function renderConfirmCardRows({ attachPicker, sendDisabled }) {
+function renderConfirmCardRows({
+  attachPicker, sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
+}) {
   const rows = [];
   if (attachPicker) {
     const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
@@ -3875,7 +3896,51 @@ function renderConfirmCardRows({ attachPicker, sendDisabled }) {
         .setMaxValues(maxValues)
     ));
   }
+  // Self-destruct StringSelectMenu. Mirrors the OLD /qurl send form's
+  // shape at commands.js:~2334: "No self-destruct timer" + 7 presets.
+  // The `default: true` flag on the matching option keeps the
+  // collapsed-header text reflective of the current value across
+  // re-renders. `hasTimer` + `hasMatchingPreset` defend against a
+  // corrupted DDB row carrying an off-preset finite value (which would
+  // otherwise leave every option un-defaulted and force Discord to
+  // render the first option's label — wrong UX).
+  const hasTimer = Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0;
+  const hasMatchingPreset = hasTimer && SELF_DESTRUCT_PRESETS.some((p) => p.seconds === selfDestructSeconds);
   rows.push(new ActionRowBuilder().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID)
+      .setMinValues(1)
+      .setMaxValues(1)
+      .addOptions(
+        { label: 'No self-destruct timer', value: SELF_DESTRUCT_NO_TIMER_VALUE, default: !hasMatchingPreset },
+        ...SELF_DESTRUCT_PRESETS.map((p) => ({
+          label: `\u{1F4A5} ${p.label}`,
+          value: String(p.seconds),
+          default: hasMatchingPreset && selfDestructSeconds === p.seconds,
+        }))
+      )
+  ));
+  // Expiry StringSelectMenu. Default-true on the matching option same
+  // as self-destruct above. EXPIRY_CHOICES is shared with the slash-
+  // option choice list so users see identical labels in autocomplete
+  // and in the form.
+  rows.push(new ActionRowBuilder().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID)
+      .setMinValues(1)
+      .setMaxValues(1)
+      .addOptions(
+        ...EXPIRY_CHOICES.map((c) => ({ label: c.name, value: c.value, default: c.value === expiresIn }))
+      )
+  ));
+  // Bottom row: Note button + Send + Cancel. Label flips between
+  // "Add a note" and "Edit note" based on current state so the user
+  // can tell at a glance whether a note is attached.
+  rows.push(new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(SEND_CONFIRM_NOTE_BUTTON_CUSTOM_ID)
+      .setLabel(personalMessage ? '✏\u{FE0F} Edit note' : '✏\u{FE0F} Add a note (optional)')
+      .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
       .setCustomId(SEND_CONFIRM_SEND_CUSTOM_ID)
       .setLabel('\u{1F4E4} Send')
@@ -4092,6 +4157,9 @@ async function handleQurlSlashSend(interaction, params) {
     const rows = renderConfirmCardRows({
       attachPicker: needsPicker,
       sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
+      expiresIn,
+      selfDestructSeconds,
+      personalMessage,
     });
     // `return await` (not bare `return`) is load-bearing: without it
     // a Discord-side rejection on the confirm-card delivery would
@@ -4444,7 +4512,13 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
       needsPicker: true,
       interaction,
     }),
-    components: renderConfirmCardRows({ attachPicker: true, sendDisabled: true }),
+    components: renderConfirmCardRows({
+      attachPicker: true,
+      sendDisabled: true,
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+    }),
   }).catch(logIgnoredDiscordErr);
   if (valid.length === 0) {
     // No transitionFlow on the all-invalid branch — the card stays at
@@ -4538,7 +4612,258 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   });
   return interaction.editReply({
     content,
-    components: renderConfirmCardRows({ attachPicker: true, sendDisabled: false }),
+    components: renderConfirmCardRows({
+      attachPicker: true,
+      sendDisabled: false,
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+    }),
+  }).catch(logIgnoredDiscordErr);
+}
+
+// Shared re-render after a confirm-card menu/button updates the flow
+// payload (expiry / self-destruct / note). Each menu handler builds
+// `newPayload` and calls this with the post-transition `interaction` +
+// payload. Keeping the re-render shape in one place avoids the three
+// handlers drifting on `attachPicker` / `sendDisabled` / content flags.
+//
+// `attachPicker: true` matches `handleSendUserSelect`'s post-pick
+// behavior (the picker stays attached so the user can re-pick).
+// `sendDisabled` is derived from recipientIds — without it, a user
+// who opened /qurl file without `recipients:` could change expiry
+// before picking and see an enabled Send button against an empty
+// recipient set.
+async function rerenderConfirmCard(interaction, newPayload) {
+  const recipientIds = Array.isArray(newPayload.recipientIds) ? newPayload.recipientIds : [];
+  // Re-resolve the User objects from cache for the preview. Cache-only
+  // (no members.fetch) — handleSendConfirmClick re-fetches at Send
+  // time; the preview here just needs the username/nickname for
+  // display. A picked user that left the guild between pick and
+  // menu-click renders as their ID via resolveRecipientAlias's
+  // fallback, which is correct (the actual partial-drop handling
+  // lives at Send-click time).
+  const memberCache = interaction.guild && interaction.guild.members && interaction.guild.members.cache;
+  const validRecipients = recipientIds.map((id) => {
+    const cached = memberCache && memberCache.get && memberCache.get(id);
+    return cached && cached.user ? cached.user : { id, username: id, bot: false };
+  });
+  const needsPicker = recipientIds.length === 0;
+  const content = renderConfirmCardContent({
+    resourceType: newPayload.resourceType,
+    resourceLabel: newPayload.resourceLabel,
+    validRecipients,
+    expiresIn: newPayload.expiresIn,
+    selfDestructSeconds: newPayload.selfDestructSeconds,
+    personalMessage: newPayload.personalMessage,
+    warningsBlock: '',
+    needsPicker,
+    interaction,
+  });
+  return interaction.editReply({
+    content,
+    components: renderConfirmCardRows({
+      attachPicker: true,
+      sendDisabled: needsPicker,
+      expiresIn: newPayload.expiresIn,
+      selfDestructSeconds: newPayload.selfDestructSeconds,
+      personalMessage: newPayload.personalMessage,
+    }),
+  }).catch(logIgnoredDiscordErr);
+}
+
+// Expiry StringSelectMenu → update payload.expiresIn. Defense-in-depth
+// validation against EXPIRY_LABELS mirrors handleQurlSlashSend's slash-
+// option gate — Discord enforces the choice set server-side, but a
+// forged interaction could land an off-set value here.
+async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+  const picked = interaction.values && interaction.values[0];
+  if (!picked || !Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, picked)) {
+    logger.warn('handleSendConfirmExpirySelect: forged off-set expiry value', {
+      flow_id, value: picked,
+    });
+    return interaction.followUp({
+      content: '❌ Unrecognized expiry value. Re-pick from the list.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  const payload = row.payload || {};
+  const newPayload = { ...payload, expiresIn: picked };
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleSendConfirmExpirySelect: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not save your pick right now. Try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'conflict') {
+    return interaction.editReply({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.editReply({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  return rerenderConfirmCard(interaction, newPayload);
+}
+
+// Self-destruct StringSelectMenu → update payload.selfDestructSeconds.
+// Uses the FORM value-space helper (selfDestructSelectValueToSeconds)
+// because the menu options use SELF_DESTRUCT_NO_TIMER_VALUE — distinct
+// from the slash option's `'none'` value handled by
+// selfDestructOptionToSeconds. The helper falls back to null for any
+// unexpected value (forged interaction), which is the safe default.
+async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }) {
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+  const selfDestructSeconds = selfDestructSelectValueToSeconds(
+    interaction.values && interaction.values[0]
+  );
+  const payload = row.payload || {};
+  const newPayload = { ...payload, selfDestructSeconds };
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleSendConfirmSelfDestructSelect: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not save your pick right now. Try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'conflict') {
+    return interaction.editReply({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.editReply({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  return rerenderConfirmCard(interaction, newPayload);
+}
+
+// Note button → opens a modal with the current personalMessage pre-
+// filled. Does NOT call transitionFlow — the flow row is untouched
+// until the modal SUBMITS (handleSendConfirmNoteModal below). This
+// asymmetry matters: clicking the button to peek at the current note
+// (or even to discard it via cancel) must not bump the flow version
+// and risk fencing out a concurrent picker/expiry/self-destruct
+// mutation.
+async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
+  const payload = row.payload || {};
+  const modal = new ModalBuilder()
+    .setCustomId(SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID)
+    .setTitle('Personal message');
+  modal.addComponents(new ActionRowBuilder().addComponents(
+    new TextInputBuilder()
+      .setCustomId(SEND_NOTE_MODAL_INPUT_ID)
+      .setLabel('Optional note (leave blank to clear)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setMaxLength(280)
+      .setRequired(false)
+      .setValue(payload.personalMessage || '')
+  ));
+  return interaction.showModal(modal).catch((err) => {
+    logger.warn('handleSendConfirmNoteButton: showModal failed', {
+      flow_id, error: err && err.message,
+    });
+  });
+}
+
+// Note modal-submit → sanitize input, update payload.personalMessage.
+// Modal-submit interactions get a fresh 3s ack window; using
+// `editReply` after `update()` mirrors handleSetupModal's shape.
+// `update()` ACKs against the ORIGINAL message (the confirm card)
+// because flow-dispatch wires modal submits to the same message-bound
+// interaction context.
+async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
+  const raw = interaction.fields.getTextInputValue(SEND_NOTE_MODAL_INPUT_ID).trim();
+  const personalMessage = raw ? sanitizeMessage(raw) : null;
+  const payload = row.payload || {};
+  const newPayload = { ...payload, personalMessage };
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleSendConfirmNoteModal: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.reply({
+      content: '❌ Could not save your note right now. Try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'conflict') {
+    return interaction.update({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.update({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  // Build the same re-rendered content/rows shape as the menus, but
+  // ACK via `update` (modal-submit) instead of editReply (deferred).
+  const recipientIds = Array.isArray(newPayload.recipientIds) ? newPayload.recipientIds : [];
+  const memberCache = interaction.guild && interaction.guild.members && interaction.guild.members.cache;
+  const validRecipients = recipientIds.map((id) => {
+    const cached = memberCache && memberCache.get && memberCache.get(id);
+    return cached && cached.user ? cached.user : { id, username: id, bot: false };
+  });
+  const needsPicker = recipientIds.length === 0;
+  const content = renderConfirmCardContent({
+    resourceType: newPayload.resourceType,
+    resourceLabel: newPayload.resourceLabel,
+    validRecipients,
+    expiresIn: newPayload.expiresIn,
+    selfDestructSeconds: newPayload.selfDestructSeconds,
+    personalMessage: newPayload.personalMessage,
+    warningsBlock: '',
+    needsPicker,
+    interaction,
+  });
+  return interaction.update({
+    content,
+    components: renderConfirmCardRows({
+      attachPicker: true,
+      sendDisabled: needsPicker,
+      expiresIn: newPayload.expiresIn,
+      selfDestructSeconds: newPayload.selfDestructSeconds,
+      personalMessage: newPayload.personalMessage,
+    }),
   }).catch(logIgnoredDiscordErr);
 }
 
@@ -6355,6 +6680,28 @@ registerFlow(SEND_CONFIRM_CANCEL_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleSendCancelClick,
 });
+// Confirm-card menus + note button/modal. All share the same
+// expectedStage as the original three customIds above; siblingMessage
+// is keyed by stage (registered on USER_SELECT only), so no
+// re-registration here. Each handler reads `row.payload` from the
+// dispatcher's loadFlow and uses `expectedVersion: row.version` on
+// transitionFlow for the picker-vs-menu race.
+registerFlow(SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendConfirmExpirySelect,
+});
+registerFlow(SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendConfirmSelfDestructSelect,
+});
+registerFlow(SEND_CONFIRM_NOTE_BUTTON_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendConfirmNoteButton,
+});
+registerFlow(SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleSendConfirmNoteModal,
+});
 
 module.exports = {
   commands,
@@ -6368,6 +6715,10 @@ module.exports = {
   handleSendUserSelect,
   handleSendConfirmClick,
   handleSendCancelClick,
+  handleSendConfirmExpirySelect,
+  handleSendConfirmSelfDestructSelect,
+  handleSendConfirmNoteButton,
+  handleSendConfirmNoteModal,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -197,6 +197,12 @@ function sliceWithEllipsis(s, maxCodepoints, indicator) {
   return sliced === s ? s : sliced + indicator;
 }
 
+// Discord-enforced input bound on every legitimate personalMessage
+// ingress (slash option setMaxLength + modal TextInput setMaxLength).
+// `personalMessageRaw` storage uses this cap so forged interactions
+// can't grow flow rows past the legitimate ceiling.
+const PERSONAL_MESSAGE_INPUT_MAX = 280;
+
 function sanitizeMessage(msg) {
   // Order matters:
   //  1. NFKC-normalize + strip bidi/zero-width/control codepoints first
@@ -4012,7 +4018,13 @@ async function handleQurlSlashSend(interaction, params) {
       });
     }
     const selfDestructSeconds = selfDestructOptionToSeconds(selfDestructValue);
-    const personalMessage = personalMessageRaw ? sanitizeMessage(personalMessageRaw) : null;
+    // Trim once and derive both forms — raw for Edit-note pre-fill,
+    // sanitized for render. Without the raw, the modal would pre-fill
+    // the escaped form and a no-op resubmit would double-escape.
+    const personalMessageRawTrimmed = personalMessageRaw
+      ? safeCodepointSlice(personalMessageRaw.trim(), PERSONAL_MESSAGE_INPUT_MAX)
+      : null;
+    const personalMessage = personalMessageRawTrimmed ? sanitizeMessage(personalMessageRawTrimmed) : null;
 
     const parsed = parseRecipientMentions(recipientsRaw, interaction);
 
@@ -4112,6 +4124,7 @@ async function handleQurlSlashSend(interaction, params) {
       expiresIn,
       selfDestructSeconds,
       personalMessage,
+      personalMessageRaw: personalMessageRawTrimmed,
       sendNonce,
     };
     let supersede;
@@ -4634,7 +4647,9 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 // who opened /qurl file without `recipients:` could change expiry
 // before picking and see an enabled Send button against an empty
 // recipient set.
-async function rerenderConfirmCard(interaction, newPayload) {
+// `ack` lets modal-submit handlers pass `interaction.update` —
+// deferred-ACK menu handlers use the editReply default.
+async function rerenderConfirmCard(interaction, newPayload, ack = (msg) => interaction.editReply(msg)) {
   const recipientIds = Array.isArray(newPayload.recipientIds) ? newPayload.recipientIds : [];
   // Re-resolve the User objects from cache for the preview. Cache-only
   // (no members.fetch) — handleSendConfirmClick re-fetches at Send
@@ -4660,7 +4675,7 @@ async function rerenderConfirmCard(interaction, newPayload) {
     needsPicker,
     interaction,
   });
-  return interaction.editReply({
+  return ack({
     content,
     components: renderConfirmCardRows({
       attachPicker: true,
@@ -4730,9 +4745,16 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
 // unexpected value (forged interaction), which is the safe default.
 async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }) {
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
-  const selfDestructSeconds = selfDestructSelectValueToSeconds(
-    interaction.values && interaction.values[0]
-  );
+  const pickedValue = interaction.values && interaction.values[0];
+  const selfDestructSeconds = selfDestructSelectValueToSeconds(pickedValue);
+  // Helper silently falls back to null for unknown values to avoid
+  // punishing a legitimate UI bug, but flag forgeries for forensics.
+  if (pickedValue !== undefined && pickedValue !== SELF_DESTRUCT_NO_TIMER_VALUE
+      && !SELF_DESTRUCT_PRESETS.some((p) => String(p.seconds) === pickedValue)) {
+    logger.warn('handleSendConfirmSelfDestructSelect: forged off-set self-destruct value', {
+      flow_id, value: pickedValue,
+    });
+  }
   const payload = row.payload || {};
   const newPayload = { ...payload, selfDestructSeconds };
   let result;
@@ -4784,9 +4806,11 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
       .setCustomId(SEND_NOTE_MODAL_INPUT_ID)
       .setLabel('Optional note (leave blank to clear)')
       .setStyle(TextInputStyle.Paragraph)
-      .setMaxLength(280)
+      .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
       .setRequired(false)
-      .setValue(payload.personalMessage || '')
+      // Pre-fill from raw to avoid double-escape on resubmit. Empty
+      // fallback for legacy flow rows missing the field (3-min TTL).
+      .setValue(payload.personalMessageRaw || '')
   ));
   return interaction.showModal(modal).catch((err) => {
     logger.warn('handleSendConfirmNoteButton: showModal failed', {
@@ -4803,9 +4827,12 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
 // interaction context.
 async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   const raw = interaction.fields.getTextInputValue(SEND_NOTE_MODAL_INPUT_ID).trim();
-  const personalMessage = raw ? sanitizeMessage(raw) : null;
+  // Cap matches the slash-entry path; both forms derive from the same
+  // trimmed-and-capped raw so an Edit round-trip is idempotent.
+  const personalMessageRaw = raw ? safeCodepointSlice(raw, PERSONAL_MESSAGE_INPUT_MAX) : null;
+  const personalMessage = personalMessageRaw ? sanitizeMessage(personalMessageRaw) : null;
   const payload = row.payload || {};
-  const newPayload = { ...payload, personalMessage };
+  const newPayload = { ...payload, personalMessage, personalMessageRaw };
   let result;
   try {
     result = await transitionFlow(flow_id, row.version, {
@@ -4823,48 +4850,23 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
+  // Modal-submit ACK goes through `update()` against the parent
+  // confirm-card message, not editReply. Both branches and the
+  // happy-path rerender share the same ack target via `update`.
+  const ack = (msg) => interaction.update(msg);
   if (result.result === 'conflict') {
-    return interaction.update({
+    return ack({
       content: 'Send was superseded — re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
   if (result.result === 'not_found') {
-    return interaction.update({
+    return ack({
       content: 'This send expired — re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
-  // Build the same re-rendered content/rows shape as the menus, but
-  // ACK via `update` (modal-submit) instead of editReply (deferred).
-  const recipientIds = Array.isArray(newPayload.recipientIds) ? newPayload.recipientIds : [];
-  const memberCache = interaction.guild && interaction.guild.members && interaction.guild.members.cache;
-  const validRecipients = recipientIds.map((id) => {
-    const cached = memberCache && memberCache.get && memberCache.get(id);
-    return cached && cached.user ? cached.user : { id, username: id, bot: false };
-  });
-  const needsPicker = recipientIds.length === 0;
-  const content = renderConfirmCardContent({
-    resourceType: newPayload.resourceType,
-    resourceLabel: newPayload.resourceLabel,
-    validRecipients,
-    expiresIn: newPayload.expiresIn,
-    selfDestructSeconds: newPayload.selfDestructSeconds,
-    personalMessage: newPayload.personalMessage,
-    warningsBlock: '',
-    needsPicker,
-    interaction,
-  });
-  return interaction.update({
-    content,
-    components: renderConfirmCardRows({
-      attachPicker: true,
-      sendDisabled: needsPicker,
-      expiresIn: newPayload.expiresIn,
-      selfDestructSeconds: newPayload.selfDestructSeconds,
-      personalMessage: newPayload.personalMessage,
-    }),
-  }).catch(logIgnoredDiscordErr);
+  return rerenderConfirmCard(interaction, newPayload, ack);
 }
 
 // Send button → fire executeSendPipeline. deleteFlow first as the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4696,9 +4696,13 @@ async function rerenderConfirmCard(interaction, newPayload) {
   const validRecipients = recipientIds.map((id) => {
     const cached = memberCache && memberCache.get && memberCache.get(id);
     if (cached && cached.user) return cached.user;
+    // Both fallback branches set `displayName` (NOT `username`) so
+    // resolveRecipientAlias's precedence (displayName → globalName →
+    // username → user-${id}) hits the first branch consistently.
+    // Asymmetric shape would be a footgun if anyone touches that
+    // precedence later.
     const alias = persistedAliases[id];
-    if (alias) return { id, displayName: alias, bot: false };
-    return { id, username: `user-${id}`, bot: false };
+    return { id, displayName: alias || `user-${id}`, bot: false };
   });
   const needsPicker = recipientIds.length === 0;
   const content = renderConfirmCardContent({

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4043,7 +4043,11 @@ async function handleQurlSlashSend(interaction, params) {
     const initialRawTrimmed = personalMessageRaw
       ? safeCodepointSlice(personalMessageRaw.trim(), PERSONAL_MESSAGE_INPUT_MAX)
       : null;
-    const personalMessage = initialRawTrimmed ? sanitizeMessage(initialRawTrimmed) : null;
+    // `|| null`: sanitizeMessage returns '' (not null) when the input
+    // strips to empty (ZWSP-only / bidi-only). Normalize to null so
+    // downstream falsy checks AND the `personalMessage ? rawCapped : null`
+    // lockstep below behave consistently.
+    const personalMessage = initialRawTrimmed ? (sanitizeMessage(initialRawTrimmed) || null) : null;
     // Null out raw if sanitize stripped to empty (e.g. ZWSP-only input
     // survives `.trim()` but sanitizeMessage's bidi-strip removes it).
     // Without this, the Edit-note button would label as "Add a note"
@@ -4911,26 +4915,17 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   // toast. Mirrors the menu handlers' shape.
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   // Defensive read: `getTextInputValue` throws if the customId
-  // allowlist ever drifts from SEND_NOTE_MODAL_FIELD_ID. The
-  // try/catch + empty-string fallback keeps the handler resilient
-  // — an unrecognized field reads as empty input, which routes to
-  // the clear-note branch instead of leaving the modal-submit
-  // interaction unresolved past deferUpdate.
-  let raw = '';
-  let getValueThrew = false;
+  // allowlist ever drifts from SEND_NOTE_MODAL_FIELD_ID. Don't
+  // silently clear the existing note — surface an ephemeral error
+  // so the user knows their submit failed and their stored note is
+  // unchanged. Early-return preserves the existing payload.
+  let raw;
   try {
     raw = (interaction.fields.getTextInputValue(SEND_NOTE_MODAL_FIELD_ID) || '').trim();
   } catch (err) {
-    getValueThrew = true;
     logger.warn('handleSendConfirmNoteModal: getTextInputValue threw', {
       flow_id, error: err && err.message,
     });
-  }
-  // If the field read threw (customId allowlist drift), don't
-  // silently clear the existing note — surface an ephemeral error
-  // so the user knows their submit failed and their stored note is
-  // unchanged. The early-return preserves the existing payload.
-  if (getValueThrew) {
     return interaction.followUp({
       content: '❌ Could not read your note input — try again. (Your existing note, if any, is unchanged.)',
       ephemeral: true,
@@ -4939,10 +4934,12 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   // Cap matches the slash-entry path; both forms derive from the same
   // trimmed-and-capped raw so an Edit round-trip is idempotent.
   const rawCapped = raw ? safeCodepointSlice(raw, PERSONAL_MESSAGE_INPUT_MAX) : null;
-  const personalMessage = rawCapped ? sanitizeMessage(rawCapped) : null;
+  // `|| null`: sanitizeMessage returns '' (not null) when the input
+  // strips to empty. Normalize so the lockstep below treats both
+  // forms consistently. See slash-entry site for the full rationale.
+  const personalMessage = rawCapped ? (sanitizeMessage(rawCapped) || null) : null;
   // Null out raw if sanitize stripped to empty (ZWSP-only / bidi-only
-  // input). Keeps the button label and the modal pre-fill consistent
-  // — see slash-entry site for the rationale.
+  // input). Keeps the button label and the modal pre-fill consistent.
   const personalMessageRaw = personalMessage ? rawCapped : null;
   const payload = row.payload || {};
   const newPayload = { ...payload, personalMessage, personalMessageRaw };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -24,6 +24,7 @@ const {
   expiryToMs,
   formatSelfDestructLabel,
   selfDestructSelectValueToSeconds,
+  isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
   SELF_DESTRUCT_NO_TIMER_VALUE,
 } = require('./utils/time');
@@ -4814,9 +4815,7 @@ async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }
   // here means a forged interaction. Silently mapping forged values
   // to null would clear a user's previously-set timer on every probe
   // — symmetric with the expiry handler's reject-and-warn behavior.
-  const isLegitimate = pickedValue === SELF_DESTRUCT_NO_TIMER_VALUE
-    || SELF_DESTRUCT_PRESETS.some((p) => String(p.seconds) === pickedValue);
-  if (!isLegitimate) {
+  if (!isLegitimateSelfDestructSelectValue(pickedValue)) {
     logger.warn('handleSendConfirmSelfDestructSelect: forged off-set self-destruct value', {
       flow_id, value: truncForLog(pickedValue),
     });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4864,6 +4864,14 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
     logger.warn('handleSendConfirmNoteButton: showModal failed', {
       flow_id, error: err && err.message,
     });
+    // showModal failure leaves the button-click interaction
+    // unacknowledged. Without a fallback ack the user sees Discord's
+    // generic "interaction failed" toast with no remediation hint —
+    // symmetric with the menu handlers' error-followUp shape.
+    return interaction.reply({
+      content: '❌ Could not open the note editor — try again.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
   });
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4761,6 +4761,10 @@ async function rerenderConfirmCard(interaction, newPayload) {
 // option gate — Discord enforces the choice set server-side, but a
 // forged interaction could land an off-set value here.
 async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
+  // `interaction.values && ...` is paranoia, not load-bearing —
+  // Discord guarantees `values` is an array for StringSelectMenu
+  // interactions. The guard catches a forged interaction missing
+  // the field entirely; legitimate UI paths always provide it.
   const picked = interaction.values && interaction.values[0];
   // Validate before deferring so the forgery branch can use `reply`
   // (the cheaper, single-call ack) instead of `followUp` after a
@@ -4816,6 +4820,8 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
 // selfDestructOptionToSeconds. The helper falls back to null for any
 // unexpected value (forged interaction), which is the safe default.
 async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }) {
+  // `interaction.values && ...` is paranoia (see expiry handler) —
+  // legitimate StringSelectMenu interactions always carry the array.
   const pickedValue = interaction.values && interaction.values[0];
   // Validate against the closed legitimate set BEFORE acknowledging.
   // Discord enforces the choice list server-side; an off-set value

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4134,6 +4134,15 @@ async function handleQurlSlashSend(interaction, params) {
       expiresIn,
       selfDestructSeconds,
       personalMessage,
+      // CONTRACT: `personalMessageRaw` is for modal-prefill ONLY.
+      // It is the trimmed-and-capped user input WITHOUT sanitization
+      // (no NFKC, no bidi/control strip, no @-mention defuse, no
+      // markdown escape). Never read it from any rendering path or
+      // downstream pipeline — only `personalMessage` (the sanitized
+      // derivative) is safe for those. `handleSendConfirmClick`
+      // explicitly picks `personalMessage` (not `...payload`) when
+      // calling `executeSendPipeline`, which keeps this safe today;
+      // a contract test pins that invariant.
       personalMessageRaw: personalMessageRawTrimmed,
       // One-time information surface — slash-entry warnings about
       // bot/self/unresolved mentions persist into the payload so
@@ -4713,17 +4722,20 @@ async function rerenderConfirmCard(interaction, newPayload, ack = (msg) => inter
 // option gate — Discord enforces the choice set server-side, but a
 // forged interaction could land an off-set value here.
 async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
-  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const picked = interaction.values && interaction.values[0];
+  // Validate before deferring so the forgery branch can use `reply`
+  // (the cheaper, single-call ack) instead of `followUp` after a
+  // wasted deferUpdate. Symmetric with the self-destruct handler.
   if (!picked || !Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, picked)) {
     logger.warn('handleSendConfirmExpirySelect: forged off-set expiry value', {
       flow_id, value: picked,
     });
-    return interaction.followUp({
+    return interaction.reply({
       content: '❌ Unrecognized expiry value. Re-pick from the list.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const payload = row.payload || {};
   const newPayload = { ...payload, expiresIn: picked };
   let result;
@@ -4765,17 +4777,25 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
 // selfDestructOptionToSeconds. The helper falls back to null for any
 // unexpected value (forged interaction), which is the safe default.
 async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }) {
-  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const pickedValue = interaction.values && interaction.values[0];
-  const selfDestructSeconds = selfDestructSelectValueToSeconds(pickedValue);
-  // Helper silently falls back to null for unknown values to avoid
-  // punishing a legitimate UI bug, but flag forgeries for forensics.
-  if (pickedValue !== undefined && pickedValue !== SELF_DESTRUCT_NO_TIMER_VALUE
-      && !SELF_DESTRUCT_PRESETS.some((p) => String(p.seconds) === pickedValue)) {
+  // Validate against the closed legitimate set BEFORE acknowledging.
+  // Discord enforces the choice list server-side; an off-set value
+  // here means a forged interaction. Silently mapping forged values
+  // to null would clear a user's previously-set timer on every probe
+  // — symmetric with the expiry handler's reject-and-warn behavior.
+  const isLegitimate = pickedValue === SELF_DESTRUCT_NO_TIMER_VALUE
+    || SELF_DESTRUCT_PRESETS.some((p) => String(p.seconds) === pickedValue);
+  if (!isLegitimate) {
     logger.warn('handleSendConfirmSelfDestructSelect: forged off-set self-destruct value', {
       flow_id, value: pickedValue,
     });
+    return interaction.reply({
+      content: '❌ Unrecognized self-destruct value. Re-pick from the list.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
   }
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+  const selfDestructSeconds = selfDestructSelectValueToSeconds(pickedValue);
   const payload = row.payload || {};
   const newPayload = { ...payload, selfDestructSeconds };
   let result;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4782,6 +4782,14 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
   }
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const payload = row.payload || {};
+  // No-op re-pick (same value as current state) → skip the DDB write
+  // + version bump. A version bump would needlessly fence any
+  // concurrent sibling interaction (picker / self-destruct / note
+  // modal) that's mid-flight. Still re-render the card so the user
+  // gets visible feedback that their click registered.
+  if (picked === payload.expiresIn) {
+    return rerenderConfirmCard(interaction, payload);
+  }
   const newPayload = { ...payload, expiresIn: picked };
   let result;
   try {
@@ -4842,6 +4850,11 @@ async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const selfDestructSeconds = selfDestructSelectValueToSeconds(pickedValue);
   const payload = row.payload || {};
+  // No-op re-pick (same value as current state) → skip the write +
+  // version bump (see expiry handler for the full rationale).
+  if (selfDestructSeconds === payload.selfDestructSeconds) {
+    return rerenderConfirmCard(interaction, payload);
+  }
   const newPayload = { ...payload, selfDestructSeconds };
   let result;
   try {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4735,7 +4735,7 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
   // wasted deferUpdate. Symmetric with the self-destruct handler.
   if (!picked || !Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, picked)) {
     logger.warn('handleSendConfirmExpirySelect: forged off-set expiry value', {
-      flow_id, value: picked,
+      flow_id, value: truncForLog(picked),
     });
     return interaction.reply({
       content: '❌ Unrecognized expiry value. Re-pick from the list.',
@@ -4794,7 +4794,7 @@ async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }
     || SELF_DESTRUCT_PRESETS.some((p) => String(p.seconds) === pickedValue);
   if (!isLegitimate) {
     logger.warn('handleSendConfirmSelfDestructSelect: forged off-set self-destruct value', {
-      flow_id, value: pickedValue,
+      flow_id, value: truncForLog(pickedValue),
     });
     return interaction.reply({
       content: '❌ Unrecognized self-destruct value. Re-pick from the list.',

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3937,6 +3937,13 @@ function renderConfirmCardRows({
   // back to defaulting the codebase-default '24h' option so the card
   // still shows SOMETHING meaningful.
   const hasExpiryMatch = EXPIRY_CHOICES.some((c) => c.value === expiresIn);
+  if (!hasExpiryMatch && expiresIn != null) {
+    // Log so corrupted rows surface in forensics rather than just
+    // getting papered over by the 24h fallback.
+    logger.warn('renderConfirmCardRows: off-EXPIRY_LABELS expiresIn in payload — falling back to 24h default', {
+      expiresIn: truncForLog(expiresIn),
+    });
+  }
   rows.push(new ActionRowBuilder().addComponents(
     new StringSelectMenuBuilder()
       .setCustomId(SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID)
@@ -4918,12 +4925,24 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   // the clear-note branch instead of leaving the modal-submit
   // interaction unresolved past deferUpdate.
   let raw = '';
+  let getValueThrew = false;
   try {
     raw = (interaction.fields.getTextInputValue(SEND_NOTE_MODAL_FIELD_ID) || '').trim();
   } catch (err) {
+    getValueThrew = true;
     logger.warn('handleSendConfirmNoteModal: getTextInputValue threw', {
       flow_id, error: err && err.message,
     });
+  }
+  // If the field read threw (customId allowlist drift), don't
+  // silently clear the existing note — surface an ephemeral error
+  // so the user knows their submit failed and their stored note is
+  // unchanged. The early-return preserves the existing payload.
+  if (getValueThrew) {
+    return interaction.followUp({
+      content: '❌ Could not read your note input — try again. (Your existing note, if any, is unchanged.)',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
   }
   // Cap matches the slash-entry path; both forms derive from the same
   // trimmed-and-capped raw so an Edit round-trip is idempotent.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4114,6 +4114,15 @@ async function handleQurlSlashSend(interaction, params) {
     // revoke's pattern.
     flow_id = flowIdForInteraction(interaction);
     const sendNonce = crypto.randomBytes(8).toString('hex');
+    // Persist resolved aliases keyed by id. `rerenderConfirmCard`
+    // falls back to these when the menu/note interaction fires after
+    // the member-cache entry has been evicted (rare given the 3-min
+    // flow TTL, but the alternative is showing the raw snowflake).
+    // resolveRecipientAlias returns the PLAIN form — markdown escape
+    // happens at render time.
+    const recipientAliases = Object.fromEntries(
+      valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
+    );
     const payload = {
       resourceType: params.resourceType,
       attachment: params.attachment,
@@ -4121,10 +4130,17 @@ async function handleQurlSlashSend(interaction, params) {
       locationName: params.locationName,
       resourceLabel: params.resourceLabel,
       recipientIds,
+      recipientAliases,
       expiresIn,
       selfDestructSeconds,
       personalMessage,
       personalMessageRaw: personalMessageRawTrimmed,
+      // One-time information surface — slash-entry warnings about
+      // bot/self/unresolved mentions persist into the payload so
+      // menu interactions (which don't recompute) still render them.
+      // Picker re-pick OVERWRITES with a fresh warningsBlock from the
+      // new partition.
+      warningsBlock,
       sendNonce,
     };
     let supersede;
@@ -4555,7 +4571,22 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     return rejectPick(`⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.\n\n`);
   }
 
-  const newPayload = { ...payload, recipientIds: valid.map((u) => u.id) };
+  // Recompute warnings + aliases for the new pick. droppedBots and
+  // droppedSelf can flip here (UserSelectMenu doesn't pre-exclude
+  // the invoker or bots), so warnings change with the recipient set.
+  const newWarningsBlock = renderRecipientWarnings({
+    droppedBots,
+    droppedSelf,
+  });
+  const newRecipientAliases = Object.fromEntries(
+    valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
+  );
+  const newPayload = {
+    ...payload,
+    recipientIds: valid.map((u) => u.id),
+    recipientAliases: newRecipientAliases,
+    warningsBlock: newWarningsBlock,
+  };
   // Targeted catch around transitionFlow mirrors the same shape
   // handleSendConfirmClick / handleSendCancelClick use around their
   // DDB calls. A throw here would otherwise bubble to the dispatcher's
@@ -4591,20 +4622,6 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  // Recompute warnings against the new pick. `droppedBots` AND
-  // `droppedSelf` can flip here — Discord's UserSelectMenu doesn't
-  // exclude the invoker, so a user picking themselves bumps
-  // droppedSelf; bots present in the picker bump droppedBots.
-  // `cappedCount` / `invalidTokens` / unresolved / transient buckets
-  // are string-path-only (parser never ran on the picker selection),
-  // so they stay empty here. The earlier zero-valid short-circuit
-  // already handled the empty case; what's left below is the
-  // partial-pick UX where SOME picked users are valid but the
-  // warning still surfaces the dropped ones.
-  const warningsBlock = renderRecipientWarnings({
-    droppedBots,
-    droppedSelf,
-  });
   // Intentional flag divergence: the CONTENT renders the resolved
   // recipient summary ("**To:** N user(s)") — needsPicker:false —
   // while the ROWS keep the UserSelectMenu attached so the user can
@@ -4619,7 +4636,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     expiresIn: payload.expiresIn,
     selfDestructSeconds: payload.selfDestructSeconds,
     personalMessage: payload.personalMessage,
-    warningsBlock,
+    warningsBlock: newWarningsBlock,
     needsPicker: false,
     interaction,
   });
@@ -4651,17 +4668,21 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
 // deferred-ACK menu handlers use the editReply default.
 async function rerenderConfirmCard(interaction, newPayload, ack = (msg) => interaction.editReply(msg)) {
   const recipientIds = Array.isArray(newPayload.recipientIds) ? newPayload.recipientIds : [];
-  // Re-resolve the User objects from cache for the preview. Cache-only
-  // (no members.fetch) — handleSendConfirmClick re-fetches at Send
-  // time; the preview here just needs the username/nickname for
-  // display. A picked user that left the guild between pick and
-  // menu-click renders as their ID via resolveRecipientAlias's
-  // fallback, which is correct (the actual partial-drop handling
-  // lives at Send-click time).
+  // Resolve each id through three layers, in priority order:
+  //   1. members.cache — freshest data when populated
+  //   2. payload.recipientAliases — persisted at pick time, survives
+  //      cache eviction between pick and menu-click
+  //   3. fabricated `user-${id}` fallback — last resort if both miss
+  // resolveRecipientAlias does its own NFKC + bidi/zero-width strip
+  // on whichever wins, so the rendered text is always sanitized.
   const memberCache = interaction.guild && interaction.guild.members && interaction.guild.members.cache;
+  const persistedAliases = newPayload.recipientAliases || {};
   const validRecipients = recipientIds.map((id) => {
     const cached = memberCache && memberCache.get && memberCache.get(id);
-    return cached && cached.user ? cached.user : { id, username: id, bot: false };
+    if (cached && cached.user) return cached.user;
+    const alias = persistedAliases[id];
+    if (alias) return { id, displayName: alias, bot: false };
+    return { id, username: `user-${id}`, bot: false };
   });
   const needsPicker = recipientIds.length === 0;
   const content = renderConfirmCardContent({
@@ -4671,7 +4692,7 @@ async function rerenderConfirmCard(interaction, newPayload, ack = (msg) => inter
     expiresIn: newPayload.expiresIn,
     selfDestructSeconds: newPayload.selfDestructSeconds,
     personalMessage: newPayload.personalMessage,
-    warningsBlock: '',
+    warningsBlock: newPayload.warningsBlock || '',
     needsPicker,
     interaction,
   });
@@ -4826,6 +4847,12 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
 // because flow-dispatch wires modal submits to the same message-bound
 // interaction context.
 async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
+  // Defer the modal-submit ack BEFORE the DDB write — without this,
+  // a slow conditional write (throttled partition) can push past
+  // Discord's 3-second hard deadline, after which `update()` /
+  // `reply()` both fail and the user gets an "interaction failed"
+  // toast. Mirrors the menu handlers' shape.
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
   const raw = interaction.fields.getTextInputValue(SEND_NOTE_MODAL_INPUT_ID).trim();
   // Cap matches the slash-entry path; both forms derive from the same
   // trimmed-and-capped raw so an Edit round-trip is idempotent.
@@ -4845,28 +4872,27 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
     logger.error('handleSendConfirmNoteModal: transitionFlow threw', {
       flow_id, error: err && err.message,
     });
-    return interaction.reply({
+    // Post-deferUpdate the only safe surface for an error toast is
+    // followUp (ephemeral). reply() would 409 — the interaction is
+    // already acked.
+    return interaction.followUp({
       content: '❌ Could not save your note right now. Try again in a moment.',
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
-  // Modal-submit ACK goes through `update()` against the parent
-  // confirm-card message, not editReply. Both branches and the
-  // happy-path rerender share the same ack target via `update`.
-  const ack = (msg) => interaction.update(msg);
   if (result.result === 'conflict') {
-    return ack({
+    return interaction.editReply({
       content: 'Send was superseded — re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
   if (result.result === 'not_found') {
-    return ack({
+    return interaction.editReply({
       content: 'This send expired — re-run the command.',
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
-  return rerenderConfirmCard(interaction, newPayload, ack);
+  return rerenderConfirmCard(interaction, newPayload);
 }
 
 // Send button → fire executeSendPipeline. deleteFlow first as the
@@ -6023,7 +6049,7 @@ const commands = [
             opt.setName('personal-message')
               .setDescription('Optional note included in each recipient\'s DM')
               .setRequired(false)
-              .setMaxLength(280)
+              .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
           )
       )
       .addSubcommand(sub =>
@@ -6067,7 +6093,7 @@ const commands = [
             opt.setName('personal-message')
               .setDescription('Optional note included in each recipient\'s DM')
               .setRequired(false)
-              .setMaxLength(280)
+              .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
           )
       )
       .addSubcommand(sub =>

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -79,6 +79,21 @@ function selfDestructSelectValueToSeconds(value) {
   return null;
 }
 
+// True if `value` matches the closed legitimate option set of the
+// form-side self-destruct StringSelectMenu (the no-timer sentinel OR
+// a stringified preset seconds value). Use this to gate forgery-
+// rejection paths — `selfDestructSelectValueToSeconds` returns null
+// for BOTH legitimate "no timer" AND forged values, so callers that
+// need to distinguish (reject + warn-log vs. apply) want this
+// predicate, not the converter's return value.
+function isLegitimateSelfDestructSelectValue(value) {
+  if (value === SELF_DESTRUCT_NO_TIMER_VALUE) return true;
+  for (const preset of SELF_DESTRUCT_PRESETS) {
+    if (value === String(preset.seconds)) return true;
+  }
+  return false;
+}
+
 // formatSelfDestructLabel — renders a stored seconds value as the matching
 // preset's friendly label (e.g., 0.5 → "1/2 second"). Used by the form to
 // echo what the user picked. Falls back to a compact "Ns" rendering for
@@ -98,6 +113,7 @@ module.exports = {
   expiryToMs,
   formatSelfDestructLabel,
   selfDestructSelectValueToSeconds,
+  isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
   SELF_DESTRUCT_NO_TIMER_VALUE,
 };

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2952,6 +2952,29 @@ describe('constants + exports', () => {
     expect(msg).toBeTruthy();
   });
 
+  test('all four new confirm-card menu customIds are registered (duplicate-register throws)', () => {
+    // Pins the registration of expiry / self-destruct / note button /
+    // note modal customIds. Their siblingMessage is inherited from the
+    // SEND_STAGE_AWAITING_CONFIRM keyed entry above — so a refactor
+    // that fails to register one of these would surface as an
+    // unrouted dispatch, not a wrong siblingMessage. This test exists
+    // to catch the registration-omission shape directly: a duplicate
+    // registerFlow on each customId must throw "already registered".
+    const { registerFlow } = require('../src/flow-dispatch');
+    const newCustomIds = [
+      'qurl_send_confirm_expiry',
+      'qurl_send_confirm_self_destruct',
+      'qurl_send_confirm_note_btn',
+      'qurl_send_confirm_note_modal',
+    ];
+    for (const id of newCustomIds) {
+      expect(() => registerFlow(id, {
+        expectedStage: 'noop_stage_for_collision_check',
+        handler: () => undefined,
+      })).toThrow(/already registered/);
+    }
+  });
+
   test('executeSendPipeline still exported (back-half hook)', () => {
     expect(typeof executeSendPipeline).toBe('function');
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2755,6 +2755,51 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
     const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
     expect(lastEdit.content).toMatch(/Skipped bots/);
   });
+
+  test('off-EXPIRY_LABELS expiresIn in payload → renderer defaults the 24h option (no first-option misrepresentation)', async () => {
+    // Defense-in-depth: a corrupted DDB row carrying expiresIn outside
+    // EXPIRY_LABELS (e.g. left over from a deprecated value, or written
+    // by a misbehaving migration) would leave every option un-defaulted
+    // in the StringSelectMenu — Discord then renders the first option's
+    // label in the collapsed header, MISREPRESENTING the actual stored
+    // value to the user. The renderer falls back to defaulting '24h'
+    // in that case so the card still shows SOMETHING meaningful AND
+    // matches the codebase default.
+    const { StringSelectMenuBuilder } = require('discord.js');
+    StringSelectMenuBuilder.mockClear();
+    const payload = {
+      resourceType: 'file',
+      resourceLabel: 'x.png',
+      recipientIds: ['100000000000000001'],
+      recipientAliases: { '100000000000000001': 'Alice' },
+      expiresIn: '999d',  // corrupted: not in EXPIRY_LABELS
+      selfDestructSeconds: null,
+      personalMessage: null,
+    };
+    // Use the self-destruct handler to trigger a rerender WITHOUT
+    // overwriting the corrupted expiresIn (the expiry handler would
+    // replace it with the user's pick, masking the bug). Self-destruct
+    // touches only selfDestructSeconds, so the rerender carries the
+    // corrupted expiresIn unchanged through to the renderer.
+    const int = makeInteraction({ guildMembers: { '100000000000000001': {} } });
+    int.values = ['30'];  // legit self-destruct preset
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    // The rerender pass calls StringSelectMenuBuilder twice (self-
+    // destruct row + expiry row). Inspect the addOptions calls and
+    // verify the EXPIRY select has exactly one default-true option,
+    // and that option's value is '24h'.
+    const expirySelectCalls = StringSelectMenuBuilder.mock.results
+      .filter((r) => {
+        const calls = r.value.setCustomId.mock.calls;
+        return calls.length && calls[0][0] === 'qurl_send_confirm_expiry';
+      });
+    expect(expirySelectCalls.length).toBeGreaterThan(0);
+    const expiryAddOptionsArgs = expirySelectCalls[expirySelectCalls.length - 1]
+      .value.addOptions.mock.calls[0];
+    const defaultedExpiryOptions = expiryAddOptionsArgs.filter((o) => o.default);
+    expect(defaultedExpiryOptions).toHaveLength(1);
+    expect(defaultedExpiryOptions[0].value).toBe('24h');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -2938,6 +2983,11 @@ describe('constants + exports', () => {
     expect(startIdx).toBeGreaterThanOrEqual(0);
     // Walk forward tracking brace depth; first time depth returns to
     // 0 after entering the body marks the end of the function.
+    // LIMITATION: braces inside string literals / template literals /
+    // regex literals would mis-balance the count. The current
+    // executeSendPipeline body is free of those constructs — if a
+    // future change adds one (e.g. `const re = /\{[^}]*\}/;`), this
+    // walker needs upgrading to a real tokenizer.
     let i = src.indexOf('{', startIdx);
     expect(i).toBeGreaterThanOrEqual(0);
     let depth = 0;

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2628,6 +2628,39 @@ describe('handleSendConfirmNoteModal', () => {
     expect(int.reply).not.toHaveBeenCalled();
     expect(int.update).not.toHaveBeenCalled();
   });
+
+  test('sibling-mutation merge: row carries an expiry change made during typing → persisted alongside the note', async () => {
+    // Lock in the merge semantics for the "user types in modal while
+    // another desktop window changes expiry" race. The dispatcher
+    // loads the freshest row at submit time, so row.payload carries
+    // the sibling's mutation. `{ ...row.payload, personalMessage }`
+    // must preserve that mutation — without it, the modal submit
+    // would silently undo whatever the sibling set.
+    //
+    // Setup: row.payload has expiresIn: '7d' (the sibling's change)
+    // and the original selfDestructSeconds. Modal submit's note must
+    // land alongside both.
+    const int = makeModalInteraction({ inputValue: 'hello' });
+    const rowAfterSiblingMenu = {
+      ...basePayload,
+      expiresIn: '7d',          // sibling-changed
+      selfDestructSeconds: 30,  // sibling-changed
+      version: 2,                // version bumped by the sibling
+    };
+    await handleSendConfirmNoteModal(int, {
+      flow_id: 'fid',
+      row: { payload: rowAfterSiblingMenu, version: 2 },
+    });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 2, expect.objectContaining({
+      payload: expect.objectContaining({
+        personalMessage: expect.stringMatching(/hello/),
+        personalMessageRaw: 'hello',
+        // Sibling's changes must survive the merge.
+        expiresIn: '7d',
+        selfDestructSeconds: 30,
+      }),
+    }));
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2199,6 +2199,28 @@ describe('handleSendUserSelect', () => {
       expect.objectContaining({ flow_id: 'fid' }),
     );
   });
+
+  test('re-pick preserves personalMessageRaw + personalMessage through the spread', async () => {
+    // Picker's newPayload is `{ ...payload, recipientIds, recipientAliases,
+    // warningsBlock }` — the spread carries personalMessage and
+    // personalMessageRaw through. A regression that destructured
+    // `personalMessage` (without `Raw`) into newPayload would silently
+    // drop the Edit-pre-fill on the next click. Symmetric with the
+    // expiry-handler's "preserves all other payload fields" test.
+    const payloadWithNote = {
+      ...initialPayload,
+      personalMessage: '\\*\\*hi\\*\\*',
+      personalMessageRaw: '**hi**',
+    };
+    const int = makeSelectInteraction();
+    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({
+        personalMessage: '\\*\\*hi\\*\\*',
+        personalMessageRaw: '**hi**',
+      }),
+    }));
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2717,10 +2717,18 @@ describe('renderConfirmCardRows', () => {
     expect(lastCall.components).toHaveLength(4);
   });
 
-  test('with attachPicker=false → 3 rows (no picker, 2 selects + button row)', async () => {
-    // Provide a valid recipient via the `recipients:` slash option —
-    // partition resolves it, needsPicker becomes false, rows render
-    // without the UserSelectMenu.
+  test('slash-entry WITH recipients → 4 rows (picker still attached so layout is stable across menu interactions)', async () => {
+    // Round-4 cr surfaced: the picker was conditionally attached on
+    // initial render (3 rows when recipients supplied) but
+    // rerenderConfirmCard hard-codes attachPicker:true (4 rows). The
+    // row count jumped from 3 to 4 the first time the user clicked
+    // any menu, which was a visible mid-flow layout shift.
+    //
+    // Fix: always attach the picker on initial render too. The user
+    // sees the same 4-row layout from frame 0 through every menu
+    // interaction. The picker remaining available also matches
+    // handleSendUserSelect's post-pick contract — re-picks stay
+    // possible after a successful pick.
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
@@ -2728,7 +2736,7 @@ describe('renderConfirmCardRows', () => {
     await handleQurlFile(int);
     const editReplyCalls = int.editReply.mock.calls;
     const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
-    expect(lastCall.components).toHaveLength(3);
+    expect(lastCall.components).toHaveLength(4);
   });
 
   test('button row carries Note + Send + Cancel in that order (3 buttons, identifiable customIds)', async () => {
@@ -2839,5 +2847,41 @@ describe('constants + exports', () => {
 
   test('executeSendPipeline still exported (back-half hook)', () => {
     expect(typeof executeSendPipeline).toBe('function');
+  });
+
+  test('CONTRACT: executeSendPipeline never reads personalMessageRaw', () => {
+    // Static guard against future bit-rot. `personalMessageRaw` is
+    // for modal-prefill only — it's the trimmed user input WITHOUT
+    // NFKC + bidi-strip + markdown-escape passes. A future refactor
+    // that accidentally reads it from any rendering path or the
+    // pipeline would bypass sanitization and could render injected
+    // markdown / masked links into recipient DMs.
+    //
+    // The contract is preserved structurally today: executeSendPipeline
+    // destructures by explicit field name (not `...payload` spread).
+    // This test extracts the function body from source and pins that
+    // the substring `personalMessageRaw` does not appear inside it.
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.resolve(__dirname, '../src/commands.js'), 'utf8');
+    const startMarker = 'async function executeSendPipeline(';
+    const startIdx = src.indexOf(startMarker);
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    // Walk forward tracking brace depth; first time depth returns to
+    // 0 after entering the body marks the end of the function.
+    let i = src.indexOf('{', startIdx);
+    expect(i).toBeGreaterThanOrEqual(0);
+    let depth = 0;
+    let end = -1;
+    for (; i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}') {
+        depth--;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    expect(end).toBeGreaterThan(startIdx);
+    const fnBody = src.slice(startIdx, end + 1);
+    expect(fnBody).not.toContain('personalMessageRaw');
   });
 });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2241,13 +2241,16 @@ describe('handleSendConfirmExpirySelect', () => {
     expect(lastEdit.content).toMatch(/7 days/);
   });
 
-  test('forged off-set expiry value → followUp warn, NO transitionFlow', async () => {
+  test('forged off-set expiry value → reply warn BEFORE defer, NO transitionFlow', async () => {
     // Defense-in-depth: Discord enforces the choice set, but a forged
-    // interaction could land an arbitrary string. Reject before persisting.
+    // interaction could land an arbitrary string. Validate BEFORE
+    // deferUpdate so the forgery branch uses the cheaper single-call
+    // `reply` ack instead of `followUp` after a wasted defer.
     const int = makeSelectInteraction({ value: '999d' });
     await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
-    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.deferUpdate).not.toHaveBeenCalled();
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Unrecognized expiry/i),
       ephemeral: true,
     }));
@@ -2355,22 +2358,23 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     }));
   });
 
-  test('unknown forged value → null (safe fallback) + logs warn for forensic trace', async () => {
-    // selfDestructSelectValueToSeconds returns null for any value not
-    // in the closed preset set. A forged '999999' here lands as
-    // selfDestructSeconds: null — same shape as "no timer." Safe
-    // default; the alternative (rejecting like the expiry handler
-    // does) would deny the user any save until they re-pick from the
-    // legit list, which is needlessly punishing for a defensive case.
-    // BUT — the silent fallback would erase the user's previously-set
-    // timer with zero forensic signal. Logging `warn` keeps the
-    // forgery trace without blocking the UX.
+  test('unknown forged value → reply warn BEFORE defer, NO transitionFlow', async () => {
+    // Symmetric with the expiry handler. The previous round had a
+    // silent-fallback path that mapped forged values to null (no
+    // timer) — that would silently clear a user's previously-set
+    // timer on every forgery probe. Reject + warn + no save matches
+    // the realistic threat model: Discord enforces the option set
+    // server-side, so an off-set value here is forgery, not a
+    // legitimate UI bug.
     const logger = require('../src/logger');
     logger.warn.mockClear();
     const int = makeSelectInteraction({ value: '999999' });
     await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
-    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
-      payload: expect.objectContaining({ selfDestructSeconds: null }),
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.deferUpdate).not.toHaveBeenCalled();
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Unrecognized self-destruct/i),
+      ephemeral: true,
     }));
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringMatching(/forged off-set self-destruct/i),
@@ -2391,7 +2395,10 @@ describe('handleSendConfirmSelfDestructSelect', () => {
 
   test('conflict → superseded copy', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
-    const int = makeSelectInteraction({ value: '60' });
+    // '30' is in SELF_DESTRUCT_PRESETS. Forged values now reject
+    // BEFORE deferUpdate, so we need a legitimate preset to reach
+    // the transitionFlow → result-handling branches.
+    const int = makeSelectInteraction({ value: '30' });
     await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/i),
@@ -2400,7 +2407,10 @@ describe('handleSendConfirmSelfDestructSelect', () => {
 
   test('not_found → expired copy', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
-    const int = makeSelectInteraction({ value: '60' });
+    // '30' is in SELF_DESTRUCT_PRESETS. Forged values now reject
+    // BEFORE deferUpdate, so we need a legitimate preset to reach
+    // the transitionFlow → result-handling branches.
+    const int = makeSelectInteraction({ value: '30' });
     await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/i),

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2289,7 +2289,14 @@ describe('handleSendConfirmExpirySelect', () => {
     }));
   });
 
-  test('preserves all other payload fields across transition', async () => {
+  test('preserves all other payload fields across transition + warns on corrupted selfDestructSeconds', async () => {
+    // `selfDestructSeconds: 60` is OFF-PRESET (presets are
+    // [0.5, 1, 5, 30, 300, 1800, 3600]). The rerender path's
+    // renderConfirmCardRows logs a warn on this case (cr round-13)
+    // — pin that the expiry-handler entry trips the same forensic
+    // surface, not just the rerenderConfirmCard cache-miss tests.
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
     const int = makeSelectInteraction({ value: '7d' });
     const payload = {
       ...basePayload,
@@ -2313,6 +2320,11 @@ describe('handleSendConfirmExpirySelect', () => {
         resourceType: 'file',
       }),
     }));
+    // Corruption warn fired from the rerender pass.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/off-preset selfDestructSeconds/i),
+      expect.objectContaining({ selfDestructSeconds: '60' })
+    );
   });
 });
 
@@ -3140,6 +3152,59 @@ describe('constants + exports', () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: trappedPayload, version: 1 } });
+    expect(leaked).toBe(false);
+  });
+
+  test('CONTRACT (runtime, pipeline-direct): executeSendPipeline never reads personalMessageRaw from its params', async () => {
+    // Complement to the handler-level Proxy test above. cr round-15
+    // flagged that the handler-level test only catches a click-path
+    // refactor that spreads row.payload — it doesn't catch a future
+    // change that adds `personalMessageRaw` to executeSendPipeline's
+    // destructure list. This test wraps the params object that
+    // executeSendPipeline receives in a Proxy that throws on
+    // get('personalMessageRaw'). If the destructure or any internal
+    // access touches the field, the Proxy throws and the test fails.
+    const u1 = '100000000000000001';
+    const validParams = {
+      apiKey: 'apikey-1',
+      resourceType: 'file',
+      attachment: VALID_ATTACHMENT,
+      locationUrl: null,
+      locationName: null,
+      recipients: [{ id: u1, username: 'Alice', bot: false }],
+      target: 'user',
+      isVoiceContext: false,
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: 'safe content',
+      // Intentionally smuggled into params alongside personalMessage —
+      // a future refactor that destructures it would trip the Proxy.
+      personalMessageRaw: '**FORBIDDEN_RAW**',
+      sendNonce: 'nonce-pipeline-contract',
+    };
+    let leaked = false;
+    const trappedParams = new Proxy(validParams, {
+      get(target, prop) {
+        if (prop === 'personalMessageRaw') {
+          leaked = true;
+          throw new Error('CONTRACT VIOLATION: executeSendPipeline read params.personalMessageRaw');
+        }
+        return target[prop];
+      },
+    });
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    // executeSendPipeline does its own resolveRecipientUsers / API
+    // calls; we just need to fire it and verify the Proxy didn't
+    // throw on a destructure. The downstream calls will fail with
+    // mocked-out dependencies, which is fine — the Proxy fires at
+    // destructure-time (function entry), before any IO.
+    try {
+      await executeSendPipeline(int, trappedParams);
+    } catch (err) {
+      // Re-throw only if the Proxy was the one that threw. Other
+      // errors (mocked-axios reject, etc) are expected and irrelevant.
+      if (leaked) throw err;
+    }
     expect(leaked).toBe(false);
   });
 });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2509,6 +2509,24 @@ describe('handleSendConfirmNoteButton', () => {
     expect(int.showModal).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
   });
+
+  test('showModal failure → ephemeral reply fallback (no silent "interaction failed" toast)', async () => {
+    // showModal failure leaves the button-click unacknowledged. The
+    // pre-fix behavior swallowed the error in .catch with only a
+    // warn log, leaving the user with Discord's generic "interaction
+    // failed" toast and no remediation. The fallback ack closes that
+    // gap symmetrically with the menu handlers' error paths.
+    const int = makeButtonInteraction();
+    int.showModal.mockRejectedValueOnce(new Error('Discord 500'));
+    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not open the note editor/i),
+      ephemeral: true,
+    }));
+    // Flow state must remain untouched — showModal failure is a
+    // pure UX surface; we don't bump the version on it.
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2241,6 +2241,18 @@ describe('handleSendConfirmExpirySelect', () => {
     expect(lastEdit.content).toMatch(/7 days/);
   });
 
+  test('no-op re-pick (same value as payload) → skip transitionFlow + version bump, still re-render', async () => {
+    // Pin the no-op optimization: re-picking the current value
+    // doesn't fence concurrent sibling interactions via a needless
+    // version bump. Visible feedback (rerender) still fires so the
+    // user knows their click registered.
+    const int = makeSelectInteraction({ value: '24h' });  // same as basePayload.expiresIn
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.editReply).toHaveBeenCalled();
+  });
+
   test('forged off-set expiry value → reply warn BEFORE defer, NO transitionFlow', async () => {
     // Defense-in-depth: Discord enforces the choice set, but a forged
     // interaction could land an arbitrary string. Validate BEFORE
@@ -2369,13 +2381,27 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     expect(lastEdit.content).toMatch(/30 seconds/);
   });
 
-  test('"no-timer" form-side sentinel → null', async () => {
+  test('no-op re-pick (same selfDestructSeconds as payload) → skip transitionFlow + version bump, still re-render', async () => {
+    // Symmetric with the expiry handler's no-op test. `no-timer`
+    // sentinel maps to null; basePayload.selfDestructSeconds is null
+    // so this is a no-op.
+    const int = makeSelectInteraction({ value: 'no-timer' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.editReply).toHaveBeenCalled();
+  });
+
+  test('"no-timer" form-side sentinel → null (when changing FROM a previous timer)', async () => {
     // Form value-space uses SELF_DESTRUCT_NO_TIMER_VALUE (distinct
     // from the slash-option side's 'none'). The helper maps it to
     // null. Pin so a refactor that conflates the two value-spaces
-    // fails this test.
+    // fails this test. Use a non-null current value so the no-op
+    // short-circuit doesn't skip the write (separate test pins the
+    // no-op path).
+    const payloadWithTimer = { ...basePayload, selfDestructSeconds: 30 };
     const int = makeSelectInteraction({ value: 'no-timer' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: payloadWithTimer, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ selfDestructSeconds: null }),
     }));
@@ -2892,9 +2918,11 @@ describe('renderConfirmCardRows', () => {
   // or by inspecting what renderConfirmCardRows would attach (via the
   // editReply calls). Simpler: drive via the entry path and inspect.
 
-  test('with attachPicker=true → 4 rows (picker + 2 selects + button row)', async () => {
-    // handleQurlSlashSend's needsPicker branch (recipients omitted)
-    // renders with attachPicker:true. Inspect the editReply payload.
+  test('slash-entry WITHOUT recipients → 4 rows (picker + 2 selects + button row)', async () => {
+    // Renderer always produces 4 rows (picker + self-destruct +
+    // expiry + bottom button row). The slash-entry "no recipients"
+    // path is one of two entry shapes; the "with recipients" test
+    // below pins the other half (picker still attached for re-picks).
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT },  // no `recipients` → needsPicker
     });
@@ -2907,13 +2935,13 @@ describe('renderConfirmCardRows', () => {
   test('slash-entry WITH recipients → 4 rows (picker still attached so layout is stable across menu interactions)', async () => {
     // Round-4 cr surfaced: the picker was conditionally attached on
     // initial render (3 rows when recipients supplied) but
-    // rerenderConfirmCard hard-codes attachPicker:true (4 rows). The
-    // row count jumped from 3 to 4 the first time the user clicked
-    // any menu, which was a visible mid-flow layout shift.
+    // rerenderConfirmCard always rendered 4. The row count jumped
+    // from 3 to 4 the first time the user clicked any menu, which
+    // was a visible mid-flow layout shift.
     //
-    // Fix: always attach the picker on initial render too. The user
-    // sees the same 4-row layout from frame 0 through every menu
-    // interaction. The picker remaining available also matches
+    // Round-13 cr removed the conditional entirely: renderer now
+    // always produces 4 rows. The user sees the same layout from
+    // frame 0 through every menu interaction. Matches
     // handleSendUserSelect's post-pick contract — re-picks stay
     // possible after a successful pick.
     const int = makeInteraction({

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2291,7 +2291,17 @@ describe('handleSendConfirmExpirySelect', () => {
 
   test('preserves all other payload fields across transition', async () => {
     const int = makeSelectInteraction({ value: '7d' });
-    const payload = { ...basePayload, selfDestructSeconds: 60, personalMessage: 'hi' };
+    const payload = {
+      ...basePayload,
+      selfDestructSeconds: 60,
+      personalMessage: 'hi',
+      // Explicitly include personalMessageRaw to pin the round-trip
+      // invariant: a regression that destructured `personalMessage`
+      // (without `Raw`) into newPayload would silently drop it and
+      // break the next Edit-note pre-fill. The spread covers it
+      // today; this assertion locks the contract.
+      personalMessageRaw: 'hi',
+    };
     await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({
@@ -2299,6 +2309,7 @@ describe('handleSendConfirmExpirySelect', () => {
         recipientIds: [u1],
         selfDestructSeconds: 60,
         personalMessage: 'hi',
+        personalMessageRaw: 'hi',
         resourceType: 'file',
       }),
     }));
@@ -2912,6 +2923,13 @@ describe('constants + exports', () => {
     // destructures by explicit field name (not `...payload` spread).
     // This test extracts the function body from source and pins that
     // the substring `personalMessageRaw` does not appear inside it.
+    //
+    // **If this test fails:** the substring scan is intentionally
+    // coarse — even a comment like `// don't read personalMessageRaw
+    // here` inside executeSendPipeline trips it. Document the
+    // invariant at the field declaration in handleQurlSlashSend
+    // (search commands.js for "CONTRACT: `personalMessageRaw` is for
+    // modal-prefill ONLY"), not inside executeSendPipeline's body.
     const fs = require('fs');
     const path = require('path');
     const src = fs.readFileSync(path.resolve(__dirname, '../src/commands.js'), 'utf8');

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2538,6 +2538,32 @@ describe('handleSendConfirmNoteButton', () => {
     // pure UX surface; we don't bump the version on it.
     expect(mockTransitionFlow).not.toHaveBeenCalled();
   });
+
+  test('showModal failure → if fallback reply ALSO rejects, no unhandled rejection escapes', async () => {
+    // Dual-500 case: showModal fails (Discord blip) AND the ephemeral
+    // reply fallback fails (interaction already acked by some other
+    // path, or another Discord blip). The .catch(logIgnoredDiscordErr)
+    // on the fallback should absorb the rejection. Without that
+    // safety net, an unhandled rejection escapes and could crash the
+    // event loop or trigger node's `unhandledRejection` listeners.
+    const int = makeButtonInteraction();
+    int.showModal.mockRejectedValueOnce(new Error('Discord 500'));
+    int.reply.mockRejectedValueOnce(new Error('Already acked'));
+    let unhandled = null;
+    const listener = (reason) => { unhandled = reason; };
+    process.on('unhandledRejection', listener);
+    try {
+      await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+      // Microtask flush — any unhandled rejection from the catch
+      // chain would have been queued by now.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).toBeNull();
+    } finally {
+      process.off('unhandledRejection', listener);
+    }
+    expect(int.showModal).toHaveBeenCalled();
+    expect(int.reply).toHaveBeenCalled();
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -2641,6 +2667,27 @@ describe('handleSendConfirmNoteModal', () => {
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/i),
     }));
+  });
+
+  test('getTextInputValue throws → ephemeral followUp ("could not read"), NO transitionFlow, existing note preserved', async () => {
+    // Customs-id allowlist drift: getTextInputValue throws for an
+    // unknown field id. The previous defensive try/catch silently
+    // routed to clear-note, dropping the user's existing note with no
+    // feedback. New behavior: log + surface an ephemeral followUp
+    // making the failure visible; existing note stays put (no
+    // transitionFlow fired).
+    const int = makeModalInteraction({ inputValue: 'hi' });
+    int.fields.getTextInputValue = jest.fn(() => {
+      throw new Error('Unknown custom_id');
+    });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not read your note input/i),
+      ephemeral: true,
+    }));
+    // Existing payload untouched — no clear-note silently applied.
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
   });
 
   test('transitionFlow throw → ephemeral followUp (NOT update/reply post-defer)', async () => {
@@ -3025,5 +3072,45 @@ describe('constants + exports', () => {
     expect(end).toBeGreaterThan(startIdx);
     const fnBody = src.slice(startIdx, end + 1);
     expect(fnBody).not.toContain('personalMessageRaw');
+  });
+
+  test('CONTRACT (runtime): handleSendConfirmClick never reads payload.personalMessageRaw on the Send path', async () => {
+    // Runtime complement to the static brace-walker above. Wraps
+    // row.payload in a Proxy that throws on any get('personalMessageRaw')
+    // access, then drives handleSendConfirmClick through to the
+    // executeSendPipeline call. If the handler (or anything downstream
+    // it triggers through this payload reference) reads the field, the
+    // Proxy throws and the test fails — survives future syntax changes
+    // the brace-walker can't (string/regex literals containing braces).
+    const u1 = '100000000000000001';
+    const basePayload = {
+      resourceType: 'file',
+      attachment: VALID_ATTACHMENT,
+      locationUrl: null,
+      locationName: null,
+      resourceLabel: 'x.png',
+      recipientIds: [u1],
+      recipientAliases: { [u1]: 'Alice' },
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: 'safe content',
+      personalMessageRaw: '**FORBIDDEN_RAW**',
+      warningsBlock: '',
+      sendNonce: 'nonce-contract',
+    };
+    let leaked = false;
+    const trappedPayload = new Proxy(basePayload, {
+      get(target, prop) {
+        if (prop === 'personalMessageRaw') {
+          leaked = true;
+          throw new Error('CONTRACT VIOLATION: handleSendConfirmClick read payload.personalMessageRaw');
+        }
+        return target[prop];
+      },
+    });
+    const int = makeInteraction({ guildMembers: { [u1]: {} } });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
+    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: trappedPayload, version: 1 } });
+    expect(leaked).toBe(false);
   });
 });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -200,6 +200,10 @@ const {
   handleSendUserSelect,
   handleSendConfirmClick,
   handleSendCancelClick,
+  handleSendConfirmExpirySelect,
+  handleSendConfirmSelfDestructSelect,
+  handleSendConfirmNoteButton,
+  handleSendConfirmNoteModal,
 } = commands;
 
 // ──────────────────────────────────────────────────────────────
@@ -2160,6 +2164,440 @@ describe('handleSendUserSelect', () => {
       expect.stringMatching(/transitionFlow threw/),
       expect.objectContaining({ flow_id: 'fid' }),
     );
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendConfirmExpirySelect — inline expiry edit on confirm card
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendConfirmExpirySelect', () => {
+  const u1 = '100000000000000001';
+  const basePayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [u1],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+  };
+
+  function makeSelectInteraction({ value = '7d', ...rest } = {}) {
+    const int = makeInteraction(rest);
+    int.values = [value];
+    return int;
+  }
+
+  test('happy path persists new expiresIn + re-renders', async () => {
+    const int = makeSelectInteraction({ value: '7d' });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: expect.objectContaining({ expiresIn: '7d', recipientIds: [u1] }),
+      terminal: false,
+      set_expires_at: expect.any(Number),
+    }));
+    expect(int.editReply).toHaveBeenCalled();
+    // Pin the user-facing render — verifies the new value reaches the
+    // confirm-card content, not just DDB. A refactor landing the right
+    // value in flow state but rendering the old label would slip past
+    // the wire-protocol assertion above.
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    expect(lastEdit.content).toMatch(/7 days/);
+  });
+
+  test('forged off-set expiry value → followUp warn, NO transitionFlow', async () => {
+    // Defense-in-depth: Discord enforces the choice set, but a forged
+    // interaction could land an arbitrary string. Reject before persisting.
+    const int = makeSelectInteraction({ value: '999d' });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Unrecognized expiry/i),
+      ephemeral: true,
+    }));
+  });
+
+  test('conflict result → superseded copy', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    const int = makeSelectInteraction({ value: '7d' });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/i),
+      components: [],
+    }));
+  });
+
+  test('not_found result → expired copy', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    const int = makeSelectInteraction({ value: '7d' });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/expired/i),
+      components: [],
+    }));
+  });
+
+  test('transitionFlow throw → ephemeral retry followUp, no superseded copy', async () => {
+    mockTransitionFlow.mockRejectedValueOnce(new Error('DDB blip'));
+    const int = makeSelectInteraction({ value: '7d' });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not save/i),
+      ephemeral: true,
+    }));
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/i),
+    }));
+  });
+
+  test('preserves all other payload fields across transition', async () => {
+    const int = makeSelectInteraction({ value: '7d' });
+    const payload = { ...basePayload, selfDestructSeconds: 60, personalMessage: 'hi' };
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({
+        expiresIn: '7d',
+        recipientIds: [u1],
+        selfDestructSeconds: 60,
+        personalMessage: 'hi',
+        resourceType: 'file',
+      }),
+    }));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendConfirmSelfDestructSelect — inline self-destruct edit
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendConfirmSelfDestructSelect', () => {
+  const u1 = '100000000000000001';
+  const basePayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [u1],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+  };
+
+  function makeSelectInteraction({ value = '60', ...rest } = {}) {
+    const int = makeInteraction(rest);
+    int.values = [value];
+    return int;
+  }
+
+  test('happy path persists new selfDestructSeconds + re-renders', async () => {
+    // Use 30 — SELF_DESTRUCT_PRESETS only contains [0.5, 1, 5, 30, 300, 1800, 3600].
+    // selfDestructSelectValueToSeconds rejects (returns null) anything off-preset
+    // so the test value must match an existing preset for this assertion.
+    const int = makeSelectInteraction({ value: '30' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: expect.objectContaining({ selfDestructSeconds: 30 }),
+      terminal: false,
+    }));
+    expect(int.editReply).toHaveBeenCalled();
+    // Pin the user-facing render — wire-protocol assertion above proves
+    // we persisted the new value; this proves the rerendered content
+    // shows it back to the user.
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    expect(lastEdit.content).toMatch(/30 seconds/);
+  });
+
+  test('"no-timer" form-side sentinel → null', async () => {
+    // Form value-space uses SELF_DESTRUCT_NO_TIMER_VALUE (distinct
+    // from the slash-option side's 'none'). The helper maps it to
+    // null. Pin so a refactor that conflates the two value-spaces
+    // fails this test.
+    const int = makeSelectInteraction({ value: 'no-timer' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({ selfDestructSeconds: null }),
+    }));
+  });
+
+  test('unknown forged value → null (safe fallback)', async () => {
+    // selfDestructSelectValueToSeconds returns null for any value not
+    // in the closed preset set. A forged '999999' here lands as
+    // selfDestructSeconds: null — same shape as "no timer." Safe
+    // default; the alternative (rejecting like the expiry handler
+    // does) would deny the user any save until they re-pick from the
+    // legit list, which is needlessly punishing for a defensive case.
+    const int = makeSelectInteraction({ value: '999999' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({ selfDestructSeconds: null }),
+    }));
+  });
+
+  test('conflict → superseded copy', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    const int = makeSelectInteraction({ value: '60' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/i),
+    }));
+  });
+
+  test('not_found → expired copy', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    const int = makeSelectInteraction({ value: '60' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/expired/i),
+    }));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendConfirmNoteButton — opens modal, no flow mutation
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendConfirmNoteButton', () => {
+  const basePayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+  };
+
+  function makeButtonInteraction(rest = {}) {
+    const int = makeInteraction(rest);
+    int.showModal = jest.fn().mockResolvedValue(undefined);
+    return int;
+  }
+
+  test('opens modal — does NOT mutate flow state (no transitionFlow / deleteFlow)', async () => {
+    const int = makeButtonInteraction();
+    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.showModal).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+  });
+
+  test('modal pre-filled with current personalMessage when one exists', async () => {
+    // The discord.js component mocks don't preserve state, so we
+    // inspect builder method invocations to verify the pre-fill.
+    // Each TextInputBuilder instance has its own jest.fn-based
+    // setValue; the most-recent call captures what the modal passes
+    // to the TextInput.
+    const { TextInputBuilder } = require('discord.js');
+    TextInputBuilder.mockClear();
+    const int = makeButtonInteraction();
+    const payload = { ...basePayload, personalMessage: 'existing note' };
+    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    expect(int.showModal).toHaveBeenCalled();
+    // The TextInputBuilder was constructed once; its setValue was
+    // called with the pre-fill string.
+    const builder = TextInputBuilder.mock.results[0].value;
+    expect(builder.setValue).toHaveBeenCalledWith('existing note');
+  });
+
+  test('modal pre-fills empty string when no personalMessage is set', async () => {
+    const { TextInputBuilder } = require('discord.js');
+    TextInputBuilder.mockClear();
+    const int = makeButtonInteraction();
+    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const builder = TextInputBuilder.mock.results[0].value;
+    expect(builder.setValue).toHaveBeenCalledWith('');
+  });
+
+  test('safe when clicked after recipients fully chosen (idempotent — no transitionFlow)', async () => {
+    // The "Note button after picking everything" case from the plan:
+    // safe-by-construction because this handler never touches flow
+    // state — the user can repeatedly open + close the modal without
+    // bumping the version or fencing out other interactions.
+    const int = makeButtonInteraction();
+    const payload = { ...basePayload, recipientIds: ['100000000000000001', '100000000000000002'] };
+    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 5 } });
+    expect(int.showModal).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleSendConfirmNoteModal — modal submit persists sanitized note
+// ──────────────────────────────────────────────────────────────
+
+describe('handleSendConfirmNoteModal', () => {
+  const basePayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: ['100000000000000001'],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+  };
+
+  function makeModalInteraction({ inputValue = 'hello', ...rest } = {}) {
+    const int = makeInteraction(rest);
+    int.update = jest.fn().mockResolvedValue(undefined);
+    int.fields = { getTextInputValue: jest.fn(() => inputValue) };
+    return int;
+  }
+
+  test('happy path: trims input, sanitizes markdown, persists, updates message', async () => {
+    const int = makeModalInteraction({ inputValue: '  **bold** message  ' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({
+        // sanitizeMessage runs markdown-escape — the `**` becomes `\\*\\*`
+        // so the note renders as literal text in the recipient DM.
+        personalMessage: expect.stringMatching(/\\\*\\\*bold\\\*\\\* message/),
+      }),
+    }));
+    expect(int.update).toHaveBeenCalled();
+    // Pin the user-facing render — note shows up in the rerendered
+    // confirm card content, not just DDB.
+    const lastUpdate = int.update.mock.calls.slice(-1)[0][0];
+    expect(lastUpdate.content).toMatch(/\\\*\\\*bold\\\*\\\* message/);
+  });
+
+  test('empty input → personalMessage: null (clear note)', async () => {
+    const int = makeModalInteraction({ inputValue: '' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({ personalMessage: null }),
+    }));
+  });
+
+  test('whitespace-only input → personalMessage: null', async () => {
+    const int = makeModalInteraction({ inputValue: '   \n  \t' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({ personalMessage: null }),
+    }));
+  });
+
+  test('conflict → superseded copy via update (not editReply — modal-submit context)', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    const int = makeModalInteraction({ inputValue: 'hi' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/i),
+      components: [],
+    }));
+  });
+
+  test('not_found → expired copy via update', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    const int = makeModalInteraction({ inputValue: 'hi' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/expired/i),
+    }));
+  });
+
+  test('transitionFlow throw → ephemeral reply (modal-submit has no defer to follow up from)', async () => {
+    mockTransitionFlow.mockRejectedValueOnce(new Error('DDB blip'));
+    const int = makeModalInteraction({ inputValue: 'hi' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not save your note/i),
+      ephemeral: true,
+    }));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// renderConfirmCardRows — row layout + label flips
+// ──────────────────────────────────────────────────────────────
+
+describe('renderConfirmCardRows', () => {
+  // The renderer lives at module scope but isn't exported directly.
+  // We assert via a behavioral round-trip through handleQurlSlashSend
+  // or by inspecting what renderConfirmCardRows would attach (via the
+  // editReply calls). Simpler: drive via the entry path and inspect.
+
+  test('with attachPicker=true → 4 rows (picker + 2 selects + button row)', async () => {
+    // handleQurlSlashSend's needsPicker branch (recipients omitted)
+    // renders with attachPicker:true. Inspect the editReply payload.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT },  // no `recipients` → needsPicker
+    });
+    await handleQurlFile(int);
+    const editReplyCalls = int.editReply.mock.calls;
+    const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
+    expect(lastCall.components).toHaveLength(4);
+  });
+
+  test('with attachPicker=false → 3 rows (no picker, 2 selects + button row)', async () => {
+    // Provide a valid recipient via the `recipients:` slash option —
+    // partition resolves it, needsPicker becomes false, rows render
+    // without the UserSelectMenu.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int);
+    const editReplyCalls = int.editReply.mock.calls;
+    const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
+    expect(lastCall.components).toHaveLength(3);
+  });
+
+  test('button row carries Note + Send + Cancel in that order (3 buttons, identifiable customIds)', async () => {
+    // The discord.js mock's ButtonBuilder doesn't preserve state, but
+    // each instance's `setCustomId` jest.fn captures the call. The
+    // three ButtonBuilder instances created during this render are
+    // the Note, Send, and Cancel buttons — in that left-to-right
+    // construction order, matching the bottom row layout.
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int);
+    // 3 buttons constructed for the bottom row of the confirm card.
+    expect(ButtonBuilder).toHaveBeenCalledTimes(3);
+    const customIds = ButtonBuilder.mock.results.map(
+      (r) => r.value.setCustomId.mock.calls[0][0]
+    );
+    expect(customIds).toEqual([
+      'qurl_send_confirm_note_btn',
+      'qurl_send_confirm_send',
+      'qurl_send_confirm_cancel',
+    ]);
+  });
+
+  test('Note button label is "Add a note (optional)" when no personal-message set', async () => {
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int);
+    const noteBtn = ButtonBuilder.mock.results[0].value;
+    expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Add a note/));
+  });
+
+  test('Note button label is "Edit note" when personal-message IS set', async () => {
+    // Split from the "Add a note" test because both share `sendCooldowns`
+    // module state via `setCooldown`; running both in the same test
+    // would put the second invocation on cooldown and short-circuit
+    // before renderConfirmCardRows. beforeEach calls sendCooldowns.clear()
+    // so each test starts fresh.
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
+    const int = makeInteraction({
+      options: {
+        attachment: VALID_ATTACHMENT,
+        recipients: '<@100000000000000001>',
+        'personal-message': 'hello',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlFile(int);
+    const noteBtn = ButtonBuilder.mock.results[0].value;
+    expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Edit note/));
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2650,6 +2650,27 @@ describe('handleSendConfirmNoteModal', () => {
     }));
   });
 
+  test('ZWSP-only input (survives trim, sanitize strips) → both fields null in lockstep', async () => {
+    // The trim-vs-sanitize gap: zero-width space (U+200B) isn't in
+    // ECMAScript's WhiteSpace set, so .trim() leaves it. But
+    // sanitizeMessage's bidi/zero-width strip removes it, producing
+    // an empty personalMessage. Without the "null out raw if
+    // sanitize stripped to empty" fix, personalMessageRaw would
+    // retain the invisible char — the button would label as "Add a
+    // note" (empty personalMessage is falsy) while the modal pre-
+    // fills invisible chars on the next Edit. Both fields must go
+    // to null in lockstep.
+    const zwsp = String.fromCharCode(0x200B);
+    const int = makeModalInteraction({ inputValue: zwsp.repeat(3) });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({
+        personalMessage: null,
+        personalMessageRaw: null,
+      }),
+    }));
+  });
+
   test('conflict → superseded copy via editReply (post-deferUpdate)', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
     const int = makeModalInteraction({ inputValue: 'hi' });
@@ -3058,6 +3079,14 @@ describe('constants + exports', () => {
     // executeSendPipeline body is free of those constructs — if a
     // future change adds one (e.g. `const re = /\{[^}]*\}/;`), this
     // walker needs upgrading to a real tokenizer.
+    //
+    // ALSO LIMITATION: destructured default params with object
+    // literals (e.g. `personalMessage = { fallback: null }`) trip
+    // the same brace-count failure mode — the first `{` after the
+    // signature would be the default's, not the body's. The runtime
+    // Proxy CONTRACT test below is the load-bearing safety net for
+    // these cases; this static check is belt-and-suspenders against
+    // the common refactor shape.
     let i = src.indexOf('{', startIdx);
     expect(i).toBeGreaterThanOrEqual(0);
     let depth = 0;

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2649,13 +2649,17 @@ describe('handleSendConfirmNoteModal', () => {
     expect(lastEdit.content).toMatch(/\\\*\\\*bold\\\*\\\* message/);
   });
 
-  test('round-trip: re-submit unchanged raw input does NOT double-escape', async () => {
-    // The bug this guards against: pre-fill with sanitized → resubmit
-    // sanitizes again → backslashes escalate. The fix is the raw/
-    // sanitized split; this test pins the round-trip is idempotent.
+  test('round-trip no-op: re-submit unchanged input → skip transitionFlow + version bump, still re-render', async () => {
+    // Two invariants in one test:
+    //  1. Round-trip is idempotent — re-sanitizing the same raw
+    //     produces the same sanitized form (no double-escape).
+    //  2. No-op submit short-circuits the DDB write + version bump
+    //     (symmetric with expiry / self-destruct handlers). The
+    //     idempotence is what MAKES the no-op short-circuit safe:
+    //     sanitize semantics guarantee the derived forms match the
+    //     stored forms, so the equality check fires correctly.
     // Simulates: user typed `**bold**`, clicked Edit (pre-fill shows
-    // raw via the button test), submitted unchanged → raw resubmits,
-    // sanitized re-derives identically.
+    // raw via the button test), submitted unchanged.
     const int = makeModalInteraction({ inputValue: '**bold**' });
     const existingPayload = {
       ...basePayload,
@@ -2663,32 +2667,36 @@ describe('handleSendConfirmNoteModal', () => {
       personalMessageRaw: '**bold**',
     };
     await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: existingPayload, version: 1 } });
-    // Sanitized form remains single-escaped, not double.
-    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
-      payload: expect.objectContaining({
-        personalMessage: '\\*\\*bold\\*\\*',
-        personalMessageRaw: '**bold**',
-      }),
-    }));
+    expect(int.deferUpdate).toHaveBeenCalled();
+    // No-op skip — no DDB write, no version bump, no sibling fence.
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    // Visible feedback fires.
+    expect(int.editReply).toHaveBeenCalled();
   });
 
-  test('empty input → personalMessage: null (clear note)', async () => {
+  // The clear-note tests use a payload with a PREVIOUS note so the
+  // round-17 no-op short-circuit doesn't skip the write (it would
+  // for an already-null personalMessage on an empty submit). Each
+  // test exercises a different "stripped to empty" input shape.
+  const payloadWithNote = { ...basePayload, personalMessage: 'old note', personalMessageRaw: 'old note' };
+
+  test('empty input on a payload with an existing note → personalMessage: null (clear)', async () => {
     const int = makeModalInteraction({ inputValue: '' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
-      payload: expect.objectContaining({ personalMessage: null }),
+      payload: expect.objectContaining({ personalMessage: null, personalMessageRaw: null }),
     }));
   });
 
-  test('whitespace-only input → personalMessage: null', async () => {
+  test('whitespace-only input on a payload with an existing note → personalMessage: null', async () => {
     const int = makeModalInteraction({ inputValue: '   \n  \t' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
-      payload: expect.objectContaining({ personalMessage: null }),
+      payload: expect.objectContaining({ personalMessage: null, personalMessageRaw: null }),
     }));
   });
 
-  test('ZWSP-only input (survives trim, sanitize strips) → both fields null in lockstep', async () => {
+  test('ZWSP-only input on a payload with an existing note → both fields null in lockstep', async () => {
     // The trim-vs-sanitize gap: zero-width space (U+200B) isn't in
     // ECMAScript's WhiteSpace set, so .trim() leaves it. But
     // sanitizeMessage's bidi/zero-width strip removes it, producing
@@ -2700,13 +2708,24 @@ describe('handleSendConfirmNoteModal', () => {
     // to null in lockstep.
     const zwsp = String.fromCharCode(0x200B);
     const int = makeModalInteraction({ inputValue: zwsp.repeat(3) });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({
         personalMessage: null,
         personalMessageRaw: null,
       }),
     }));
+  });
+
+  test('empty submit on a payload with NO existing note → no-op skip (already cleared)', async () => {
+    // Symmetric with the menu no-op tests. basePayload.personalMessage
+    // is null; submitting empty produces null → no actual change →
+    // skip the write + version bump.
+    const int = makeModalInteraction({ inputValue: '' });
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.editReply).toHaveBeenCalled();
   });
 
   test('conflict → superseded copy via editReply (post-deferUpdate)', async () => {
@@ -2918,11 +2937,16 @@ describe('renderConfirmCardRows', () => {
   // or by inspecting what renderConfirmCardRows would attach (via the
   // editReply calls). Simpler: drive via the entry path and inspect.
 
-  test('slash-entry WITHOUT recipients → 4 rows (picker + 2 selects + button row)', async () => {
+  test('slash-entry WITHOUT recipients → 4 rows, Send disabled, expiry/self-destruct/note interactable', async () => {
     // Renderer always produces 4 rows (picker + self-destruct +
-    // expiry + bottom button row). The slash-entry "no recipients"
-    // path is one of two entry shapes; the "with recipients" test
-    // below pins the other half (picker still attached for re-picks).
+    // expiry + bottom button row). On a no-recipients initial render,
+    // Send must be DISABLED (no recipients to send to) while the
+    // expiry/self-destruct/note selects+button stay INTERACTABLE so
+    // the user can pre-configure their send before picking
+    // recipients. Inspect the ButtonBuilder mock for the Send button's
+    // setDisabled call.
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT },  // no `recipients` → needsPicker
     });
@@ -2930,6 +2954,14 @@ describe('renderConfirmCardRows', () => {
     const editReplyCalls = int.editReply.mock.calls;
     const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
     expect(lastCall.components).toHaveLength(4);
+    // 3 ButtonBuilders: Note, Send, Cancel. The Send button is the
+    // one with custom id 'qurl_send_confirm_send'. Find it and assert
+    // setDisabled(true) was called.
+    const sendBuilder = ButtonBuilder.mock.results.find(
+      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_send_confirm_send'
+    );
+    expect(sendBuilder).toBeDefined();
+    expect(sendBuilder.value.setDisabled).toHaveBeenCalledWith(true);
   });
 
   test('slash-entry WITH recipients → 4 rows (picker still attached so layout is stable across menu interactions)', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2321,18 +2321,38 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     }));
   });
 
-  test('unknown forged value → null (safe fallback)', async () => {
+  test('unknown forged value → null (safe fallback) + logs warn for forensic trace', async () => {
     // selfDestructSelectValueToSeconds returns null for any value not
     // in the closed preset set. A forged '999999' here lands as
     // selfDestructSeconds: null — same shape as "no timer." Safe
     // default; the alternative (rejecting like the expiry handler
     // does) would deny the user any save until they re-pick from the
     // legit list, which is needlessly punishing for a defensive case.
+    // BUT — the silent fallback would erase the user's previously-set
+    // timer with zero forensic signal. Logging `warn` keeps the
+    // forgery trace without blocking the UX.
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
     const int = makeSelectInteraction({ value: '999999' });
     await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ selfDestructSeconds: null }),
     }));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/forged off-set self-destruct/i),
+      expect.objectContaining({ flow_id: 'fid', value: '999999' })
+    );
+  });
+
+  test('legitimate "no-timer" value does NOT trigger forgery warn', async () => {
+    // The forgery-warn must not false-positive on the no-timer
+    // sentinel (which also maps to null via the helper but is the
+    // legitimate way to clear a timer).
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
+    const int = makeSelectInteraction({ value: 'no-timer' });
+    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   test('conflict → superseded copy', async () => {
@@ -2382,22 +2402,32 @@ describe('handleSendConfirmNoteButton', () => {
     expect(mockDeleteFlow).not.toHaveBeenCalled();
   });
 
-  test('modal pre-filled with current personalMessage when one exists', async () => {
+  test('modal pre-filled with RAW input (not sanitized) for round-trip safety', async () => {
     // The discord.js component mocks don't preserve state, so we
     // inspect builder method invocations to verify the pre-fill.
     // Each TextInputBuilder instance has its own jest.fn-based
     // setValue; the most-recent call captures what the modal passes
     // to the TextInput.
+    //
+    // CRITICAL: pre-fill uses payload.personalMessageRaw (the raw
+    // user input), NOT payload.personalMessage (the sanitized form).
+    // Without this distinction, pre-filling with `\*\*bold\*\*` and
+    // resubmitting unchanged would re-sanitize → `\\\*\\\*bold\\\*\\\*`
+    // (double-escape), and every Edit cycle would escalate.
     const { TextInputBuilder } = require('discord.js');
     TextInputBuilder.mockClear();
     const int = makeButtonInteraction();
-    const payload = { ...basePayload, personalMessage: 'existing note' };
+    const payload = {
+      ...basePayload,
+      personalMessage: '\\*\\*bold\\*\\*',  // sanitized form (would render literally)
+      personalMessageRaw: '**bold**',         // what the user actually typed
+    };
     await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 1 } });
     expect(int.showModal).toHaveBeenCalled();
-    // The TextInputBuilder was constructed once; its setValue was
-    // called with the pre-fill string.
+    // setValue receives the RAW form so the user sees `**bold**` in
+    // the input, not the escaped `\*\*bold\*\*`.
     const builder = TextInputBuilder.mock.results[0].value;
-    expect(builder.setValue).toHaveBeenCalledWith('existing note');
+    expect(builder.setValue).toHaveBeenCalledWith('**bold**');
   });
 
   test('modal pre-fills empty string when no personalMessage is set', async () => {
@@ -2405,6 +2435,21 @@ describe('handleSendConfirmNoteButton', () => {
     TextInputBuilder.mockClear();
     const int = makeButtonInteraction();
     await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const builder = TextInputBuilder.mock.results[0].value;
+    expect(builder.setValue).toHaveBeenCalledWith('');
+  });
+
+  test('modal pre-fills empty for legacy flow rows missing personalMessageRaw', async () => {
+    // Forward-compat: a flow row created before the personalMessageRaw
+    // field was added has personalMessage but no Raw counterpart.
+    // Falling back to empty string is the safe choice (user sees blank,
+    // can re-type) — pre-filling from the sanitized personalMessage
+    // would re-trigger the double-escape bug this field exists to fix.
+    const { TextInputBuilder } = require('discord.js');
+    TextInputBuilder.mockClear();
+    const int = makeButtonInteraction();
+    const legacyPayload = { ...basePayload, personalMessage: '\\*\\*bold\\*\\*' };
+    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: legacyPayload, version: 1 } });
     const builder = TextInputBuilder.mock.results[0].value;
     expect(builder.setValue).toHaveBeenCalledWith('');
   });
@@ -2451,6 +2496,10 @@ describe('handleSendConfirmNoteModal', () => {
         // sanitizeMessage runs markdown-escape — the `**` becomes `\\*\\*`
         // so the note renders as literal text in the recipient DM.
         personalMessage: expect.stringMatching(/\\\*\\\*bold\\\*\\\* message/),
+        // Raw form retained for the next Edit cycle's pre-fill —
+        // without this, opening Edit would show the escaped form
+        // and a no-op resubmit would re-sanitize to double-escape.
+        personalMessageRaw: '**bold** message',
       }),
     }));
     expect(int.update).toHaveBeenCalled();
@@ -2458,6 +2507,29 @@ describe('handleSendConfirmNoteModal', () => {
     // confirm card content, not just DDB.
     const lastUpdate = int.update.mock.calls.slice(-1)[0][0];
     expect(lastUpdate.content).toMatch(/\\\*\\\*bold\\\*\\\* message/);
+  });
+
+  test('round-trip: re-submit unchanged raw input does NOT double-escape', async () => {
+    // The bug this guards against: pre-fill with sanitized → resubmit
+    // sanitizes again → backslashes escalate. The fix is the raw/
+    // sanitized split; this test pins the round-trip is idempotent.
+    // Simulates: user typed `**bold**`, clicked Edit (pre-fill shows
+    // raw via the button test), submitted unchanged → raw resubmits,
+    // sanitized re-derives identically.
+    const int = makeModalInteraction({ inputValue: '**bold**' });
+    const existingPayload = {
+      ...basePayload,
+      personalMessage: '\\*\\*bold\\*\\*',
+      personalMessageRaw: '**bold**',
+    };
+    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: existingPayload, version: 1 } });
+    // Sanitized form remains single-escaped, not double.
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({
+        personalMessage: '\\*\\*bold\\*\\*',
+        personalMessageRaw: '**bold**',
+      }),
+    }));
   });
 
   test('empty input → personalMessage: null (clear note)', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1081,11 +1081,45 @@ describe('handleQurlFile — slash entry', () => {
     expect(payload.expiresIn).toBe('24h');
     expect(payload.selfDestructSeconds).toBeNull();
     expect(payload.personalMessage).toBeNull();
+    // Resolved aliases persist into payload so menu-handler reruns
+    // (rerenderConfirmCard) can render names even if the member-cache
+    // entry is evicted before the user picks expiry/self-destruct.
+    expect(payload.recipientAliases).toEqual(
+      expect.objectContaining({ [u1]: expect.any(String), [u2]: expect.any(String) })
+    );
+    // warningsBlock present (empty here — no dropped tokens) so menu
+    // interactions can re-render with the same surface as slash entry.
+    expect(payload).toHaveProperty('warningsBlock');
     expect(int.editReply).toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Sending file/);
     expect(reply.content).toMatch(/x\.png/);
     expect(reply.components.length).toBeGreaterThan(0);
+  });
+
+  test('/qurl map slash entry persists recipientAliases (parity with /qurl file)', async () => {
+    // Both entry points share handleQurlSlashSend's payload-construction
+    // path. This sanity test pins that the alias-persistence guarantee
+    // covers /qurl map as well — without it, a regression that only
+    // skipped aliases on one entry point would leave map-flow Edit
+    // notes / menu interactions falling back to the raw snowflake on
+    // cache miss.
+    const u1 = '100000000000000001';
+    const int = makeInteraction({
+      options: {
+        _sub: 'map',
+        location: 'https://maps.app.goo.gl/abcXYZ',
+        recipients: `<@${u1}>`,
+      },
+      guildMembers: { [u1]: {} },
+    });
+    await handleQurlMap(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.resourceType).toBe('maps');
+    expect(payload.recipientAliases).toEqual(
+      expect.objectContaining({ [u1]: expect.any(String) })
+    );
   });
 
   test('happy path without recipients → confirm card with picker', async () => {
@@ -2483,14 +2517,17 @@ describe('handleSendConfirmNoteModal', () => {
 
   function makeModalInteraction({ inputValue = 'hello', ...rest } = {}) {
     const int = makeInteraction(rest);
-    int.update = jest.fn().mockResolvedValue(undefined);
     int.fields = { getTextInputValue: jest.fn(() => inputValue) };
     return int;
   }
 
-  test('happy path: trims input, sanitizes markdown, persists, updates message', async () => {
+  test('happy path: defers, trims/sanitizes, persists, editReply re-renders', async () => {
     const int = makeModalInteraction({ inputValue: '  **bold** message  ' });
     await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    // deferUpdate guards the 3s ack deadline — without it, a slow
+    // DDB conditional write could push past Discord's hard limit and
+    // both update() and reply() would fail.
+    expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({
         // sanitizeMessage runs markdown-escape — the `**` becomes `\\*\\*`
@@ -2502,11 +2539,11 @@ describe('handleSendConfirmNoteModal', () => {
         personalMessageRaw: '**bold** message',
       }),
     }));
-    expect(int.update).toHaveBeenCalled();
+    expect(int.editReply).toHaveBeenCalled();
     // Pin the user-facing render — note shows up in the rerendered
     // confirm card content, not just DDB.
-    const lastUpdate = int.update.mock.calls.slice(-1)[0][0];
-    expect(lastUpdate.content).toMatch(/\\\*\\\*bold\\\*\\\* message/);
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    expect(lastEdit.content).toMatch(/\\\*\\\*bold\\\*\\\* message/);
   });
 
   test('round-trip: re-submit unchanged raw input does NOT double-escape', async () => {
@@ -2548,33 +2585,103 @@ describe('handleSendConfirmNoteModal', () => {
     }));
   });
 
-  test('conflict → superseded copy via update (not editReply — modal-submit context)', async () => {
+  test('conflict → superseded copy via editReply (post-deferUpdate)', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
     const int = makeModalInteraction({ inputValue: 'hi' });
     await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/i),
       components: [],
     }));
   });
 
-  test('not_found → expired copy via update', async () => {
+  test('not_found → expired copy via editReply', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
     const int = makeModalInteraction({ inputValue: 'hi' });
     await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
-    expect(int.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/i),
     }));
   });
 
-  test('transitionFlow throw → ephemeral reply (modal-submit has no defer to follow up from)', async () => {
+  test('transitionFlow throw → ephemeral followUp (NOT update/reply post-defer)', async () => {
     mockTransitionFlow.mockRejectedValueOnce(new Error('DDB blip'));
     const int = makeModalInteraction({ inputValue: 'hi' });
     await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not save your note/i),
       ephemeral: true,
     }));
+    // Negative assertion — once deferUpdate has fired, reply() and
+    // update() would 409 (interaction already acked). The throw path
+    // MUST surface the error via followUp, not either of those.
+    expect(int.reply).not.toHaveBeenCalled();
+    expect(int.update).not.toHaveBeenCalled();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// rerenderConfirmCard cache-miss fallback (verified end-to-end via
+// the expiry handler — rerenderConfirmCard isn't exported)
+// ──────────────────────────────────────────────────────────────
+
+describe('rerenderConfirmCard cache-miss recipient fallback', () => {
+  const u1 = '100000000000000001';
+  const persistedAlias = 'Alice (display)';
+
+  function makeSelectInteraction({ value = '7d', ...rest } = {}) {
+    const int = makeInteraction(rest);
+    int.values = [value];
+    return int;
+  }
+
+  test('renders persisted alias when member-cache is empty', async () => {
+    // The bug this guards: a member-cache miss between pick and menu
+    // change would render the raw 18-digit snowflake. Persisting
+    // resolvedAliases at pick-time + reading them in rerenderConfirmCard
+    // means the user always sees a name (cached when available, the
+    // persisted alias otherwise).
+    const payload = {
+      resourceType: 'file',
+      resourceLabel: 'x.png',
+      recipientIds: [u1],
+      recipientAliases: { [u1]: persistedAlias },
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+    };
+    // No guildMembers — cache miss. The fallback chain should hit
+    // payload.recipientAliases.
+    const int = makeSelectInteraction({ value: '7d', guildMembers: {} });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    expect(int.editReply).toHaveBeenCalled();
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    // Alias renders (markdown chars not present in this alias, so the
+    // escape pass is a no-op). The raw snowflake MUST NOT appear in the
+    // recipient preview line.
+    expect(lastEdit.content).toMatch(/Alice/);
+    expect(lastEdit.content).not.toMatch(new RegExp(u1));
+  });
+
+  test('warningsBlock from payload carries across menu interactions', async () => {
+    // The other half of the cr finding: when slash entry records
+    // "Skipped bots: 1" warnings, changing expiry shouldn't drop
+    // them. Verifies the payload-persisted warningsBlock flows
+    // through rerenderConfirmCard.
+    const payload = {
+      resourceType: 'file',
+      resourceLabel: 'x.png',
+      recipientIds: [u1],
+      recipientAliases: { [u1]: 'Alice' },
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+      warningsBlock: '⚠️ Skipped bots: 1\n\n',
+    };
+    const int = makeSelectInteraction({ value: '7d', guildMembers: { [u1]: {} } });
+    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    expect(lastEdit.content).toMatch(/Skipped bots/);
   });
 });
 

--- a/apps/discord/tests/sanitize.test.js
+++ b/apps/discord/tests/sanitize.test.js
@@ -4,7 +4,7 @@
  * masked-link phishing in embeds, so adversarial coverage matters.
  */
 
-const { sanitizeFilename, escapeDiscordMarkdown, sanitizeContentLabel, stripBidiAndControls } = require('../src/utils/sanitize');
+const { sanitizeFilename, escapeDiscordMarkdown, sanitizeContentLabel, stripBidiAndControls, sanitizeDisplayNamePlain } = require('../src/utils/sanitize');
 
 describe('sanitizeFilename', () => {
   it('strips path traversal', () => {
@@ -156,5 +156,47 @@ describe('stripBidiAndControls', () => {
     // helper must not pre-truncate.
     const big = 'a'.repeat(2000);
     expect(stripBidiAndControls(big)).toBe(big);
+  });
+});
+
+describe('sanitizeDisplayNamePlain — idempotence (load-bearing for rerenderConfirmCard cache-miss path)', () => {
+  // The flow_state payload persists `recipientAliases` produced by
+  // resolveRecipientAlias at pick time. On rerenderConfirmCard's
+  // cache-miss path, the persisted alias is re-passed through
+  // resolveRecipientAlias → sanitizeDisplayNamePlain. The chain is
+  // idempotent today (NFKC + bidi/zero-width strip have fixed points
+  // after one pass + the 64-codepoint cap leaves an already-capped
+  // input unchanged). These tests pin that invariant: a future
+  // sanitize-semantics change that breaks idempotence flips the
+  // cache-miss render into a double-sanitize bug, and these red lights
+  // catch it before that.
+
+  it('idempotent on plain ASCII', () => {
+    const once = sanitizeDisplayNamePlain('Alice');
+    expect(sanitizeDisplayNamePlain(once)).toBe(once);
+  });
+
+  it('idempotent after RLO strip', () => {
+    const rlo = String.fromCharCode(0x202E);
+    const once = sanitizeDisplayNamePlain(`${rlo}Bob`);
+    expect(sanitizeDisplayNamePlain(once)).toBe(once);
+  });
+
+  it('idempotent after NFKC normalization', () => {
+    // U+FF21 (FULLWIDTH LATIN CAPITAL A) normalizes to 'A' under NFKC.
+    const once = sanitizeDisplayNamePlain('Ａlice');
+    expect(sanitizeDisplayNamePlain(once)).toBe(once);
+  });
+
+  it('idempotent on an already-capped 64-codepoint input', () => {
+    const long = 'x'.repeat(64);
+    const once = sanitizeDisplayNamePlain(long);
+    expect(sanitizeDisplayNamePlain(once)).toBe(once);
+    expect(once).toHaveLength(64);
+  });
+
+  it('idempotent on emoji (surrogate-pair safe)', () => {
+    const once = sanitizeDisplayNamePlain('\u{1F600} Alice');
+    expect(sanitizeDisplayNamePlain(once)).toBe(once);
   });
 });

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -17,6 +17,7 @@ const {
   expiryToMs,
   formatSelfDestructLabel,
   selfDestructSelectValueToSeconds,
+  isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
   SELF_DESTRUCT_NO_TIMER_VALUE,
 } = require('../src/utils/time');
@@ -91,6 +92,37 @@ describe('utils/time', () => {
       // shouldn't accidentally become a half-set timer.
       for (const v of ['', '0', '2', '60', '7200', 'abc', '0x1', null, undefined]) {
         expect(selfDestructSelectValueToSeconds(v)).toBeNull();
+      }
+    });
+  });
+
+  describe('isLegitimateSelfDestructSelectValue', () => {
+    // Predicate used by the form-side reject-vs-apply gate. Differs
+    // from `selfDestructSelectValueToSeconds` (which returns null for
+    // BOTH legitimate "no timer" AND forged values) by returning
+    // `true` only for the closed legitimate set.
+    it('true for the no-timer sentinel', () => {
+      expect(isLegitimateSelfDestructSelectValue(SELF_DESTRUCT_NO_TIMER_VALUE)).toBe(true);
+    });
+
+    it('true for every preset seconds value (stringified)', () => {
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(isLegitimateSelfDestructSelectValue(String(preset.seconds))).toBe(true);
+      }
+    });
+
+    it('false for forged / unexpected values', () => {
+      for (const v of ['', '0', '2', '60', '7200', 'abc', '0x1', null, undefined]) {
+        expect(isLegitimateSelfDestructSelectValue(v)).toBe(false);
+      }
+    });
+
+    it('false for numeric preset (must be the stringified form)', () => {
+      // The select carries values as strings ('0.5', '1', ...). Direct
+      // numeric input would forge past `selfDestructSelectValueToSeconds`
+      // if String equality wasn't strict — this test pins the gate.
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(isLegitimateSelfDestructSelectValue(preset.seconds)).toBe(false);
       }
     });
   });


### PR DESCRIPTION
## Summary

PR 7b.2 (#301) shipped \`/qurl file\` and \`/qurl map\` with slash-option-only entry for expiry, self-destruct, and personal message — the confirm card had no inline controls. After picking recipients, users hit a Send/Cancel-only card with no way to change those values short of canceling and re-running the slash command. Reported in-channel by a user testing the live bot.

This PR restores parity with the legacy \`/qurl send\` UX:

- **Expiry StringSelectMenu** (30m / 1h / 6h / 24h / 7d), current value marked \`default: true\`
- **Self-destruct StringSelectMenu** (No timer + presets), distinct value-space from the slash option (\`no-timer\` sentinel vs \`'none'\`)
- **"Add a note" / "Edit note" button** → ModalBuilder with the current raw user input pre-filled (NOT the sanitized form — see "Round-trip correctness" below)

Slash-option defaults still feed the initial card state — this is additive UX, not a behavior change.

## Architecture

Each menu handler reuses the same flow_state transition + OCC fencing pattern as the recipient picker:
- Same \`expectedStage\` (\`SEND_STAGE_AWAITING_CONFIRM\`), \`expectedVersion\` from the row — race-fenced against picker and sibling menus
- All four entry paths (picker, expiry, self-destruct, note modal) defer-ack first then re-render via \`editReply\` through the shared \`rerenderConfirmCard\` helper
- Note button does NOT touch flow state — opens the modal directly, so repeated open/close doesn't bump the version or fence siblings
- Modal submit \`deferUpdate\`s first (3s ack budget against slow DDB writes), then \`editReply\` on success / \`followUp\` on throw
- Picker is **always attached** on every render (slash entry + every menu interaction) so the row layout is stable from frame 0 — matches \`handleSendUserSelect\`'s post-pick contract

## Round-trip correctness

Storage splits the personal message into two fields:
- \`personalMessageRaw\` — trimmed user input, capped via \`safeCodepointSlice\` at \`PERSONAL_MESSAGE_INPUT_MAX = 280\` (the Discord-enforced input bound on both ingress paths). **For modal pre-fill ONLY.** Never read it from any rendering path or downstream pipeline — only \`personalMessage\` (the sanitized form) is safe for those.
- \`personalMessage\` — \`sanitizeMessage(raw)\`, the render-ready sanitized form.

A static contract test pins that \`executeSendPipeline\`'s function body never references \`personalMessageRaw\` — defense against future bit-rot where a refactor might accidentally read raw instead of sanitized.

Both forms derive from the same trimmed-and-capped raw at every ingress (slash entry + modal submit), so an Edit-and-resubmit round-trip is idempotent. Without this split, pre-filling from the sanitized form would re-sanitize on no-op resubmit and double-escape the backslashes on every cycle.

## Cache-miss recipient fallback

\`rerenderConfirmCard\` resolves picked users through three layers in priority order:
1. \`interaction.guild.members.cache\` — freshest data when populated
2. \`payload.recipientAliases\` (new field) — persisted at slash-entry / picker-rePick time; survives cache eviction between pick and menu-click
3. \`user-\${id}\` fabricated fallback — last resort

The recipient warningsBlock is also persisted in payload so menu interactions render with the same warning surface as the initial card.

## Defense-in-depth

Both menu handlers validate the picked value against their closed legitimate set **before** \`deferUpdate\` so the forgery branch uses the cheaper single-call \`reply\` ack:
- **Expiry**: rejects values not in \`EXPIRY_LABELS\`, surfaces \"Unrecognized expiry value\" via ephemeral \`reply\`, logs \`warn\` for forensics, NO transitionFlow.
- **Self-destruct**: rejects values not in \`{no-timer sentinel, ...preset seconds}\`, same shape as expiry — \`reply\` + \`warn\` + no save. Discord enforces the option set server-side, so an off-set value here is forgery; silently mutating state (a previous design) would clear a user's prior timer on every probe.

Modal submit \`sanitizeMessage\`s the input: NFKC + bidi strip + @-mention defuse + markdown escape + 500-codepoint cap.

## Tests

Coverage matrix across 6 describe blocks:

- \`handleSendConfirmExpirySelect\` — happy path, forged value rejection via reply (asserts no deferUpdate), conflict / not_found / throw, payload field preservation
- \`handleSendConfirmSelfDestructSelect\` — happy path, \`no-timer\` sentinel mapping, forged value rejection via reply + warn-log (asserts no deferUpdate, no transitionFlow), conflict / not_found, legitimate-value-no-false-positive
- \`handleSendConfirmNoteButton\` — modal opens without mutating flow state, modal pre-filled from \`personalMessageRaw\` (NOT the sanitized form), legacy-row fallback to empty, idempotent after picker
- \`handleSendConfirmNoteModal\` — deferUpdate gates the ack, happy path with trim + sanitize, round-trip idempotency (no double-escape on no-op resubmit), empty / whitespace → \`null\`, conflict / not_found via \`editReply\`, throw → \`followUp\` with negative-assertion that \`reply\`/\`update\` aren't called post-defer
- \`rerenderConfirmCard\` cache-miss fallback — renders persisted alias when member-cache is empty, warningsBlock carries across menu interactions
- \`renderConfirmCardRows\` — 4 rows always (picker stable), button construction order, Add/Edit label flip

Plus \`/qurl map\` payload-parity test pinning that both entry points share the same payload-construction path (\`recipientAliases\`, \`warningsBlock\` populated identically).

Plus the static CONTRACT test pinning \`executeSendPipeline\` never reads \`personalMessageRaw\`.

Happy-path tests for all three menu handlers pin the user-facing rendering — \`expect(lastEdit.content).toMatch(/7 days/)\` etc. — so a refactor that lands the right value in DDB but renders the old label would fail.

\`/simplify\` ran clean.

## Follow-up

#309 — Modal typed-note-lost-on-conflict UX paper cut (filed as enhancement; future work to surface typed text via ephemeral followUp on supersede).

## Test plan

- [ ] CI green (1485 tests pass locally, lint clean)
- [ ] \`cr\` workflow clean
- [ ] **Manual verification in beta bot guild after merge** — UI not yet exercised in a live Discord client; the test suite verifies wire-protocol + render content but not visual layout / row order / select default-selection rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)