### PR TITLE
feat(discord): show self-destruct time in post-send confirm header

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -22,6 +22,7 @@ const {
   expiryToISO,
   expiryToMs,
   formatSelfDestructLabel,
+  formatSelfDestructSegment,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
@@ -1344,7 +1345,7 @@ async function executeSendPipeline(interaction, {
   // file; message-content rendering escapes per name.
   const failedNamesPlain = failedUsers.map(u => resolveRecipientAlias(u, interaction));
   const buildConfirmMsg = (showAll) => renderSendConfirm({
-    delivered, expiresIn,
+    delivered, expiresIn, selfDestructSeconds,
     failedNamesPlain, successNames, showAll,
   });
 
@@ -1582,7 +1583,7 @@ async function executeSendPipeline(interaction, {
               // Tell the monitor to track the new links (including new resource IDs for location sends)
               monitor.addRecipients(addResult.delivered, addResult.newResourceIds);
               const totalSent = delivered + addRecipientsCount;
-              confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | One-time links`;
+              confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | ${formatSelfDestructSegment(selfDestructSeconds)}`;
               if (failed > 0) confirmMsg += `\n${failed} could not be reached`;
               monitor.updateBaseMsg(confirmMsg);
               await interaction.editReply({ content: monitor.getFullMsg(), components: [buttonRow] });
@@ -4438,10 +4439,10 @@ function renderRevokeMsg(sendId, names, total, showAll, success = names.length) 
 // `recipients.txt` attachment; "(see attached)" is appended only to
 // lines that were actually truncated.
 function renderSendConfirm({
-  delivered, expiresIn,
+  delivered, expiresIn, selfDestructSeconds,
   failedNamesPlain = [], successNames = [], showAll = false,
 }) {
-  const header = `Sent to ${delivered} user${delivered !== 1 ? 's' : ''} | Expires: ${expiresIn} | One-time links`;
+  const header = `Sent to ${delivered} user${delivered !== 1 ? 's' : ''} | Expires: ${expiresIn} | ${formatSelfDestructSegment(selfDestructSeconds)}`;
   const escapedFailed = failedNamesPlain.map(escapeDiscordMarkdown);
   const escapedSuccess = successNames.map(escapeDiscordMarkdown);
 

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -110,10 +110,24 @@ function formatSelfDestructLabel(seconds) {
   return `${seconds}s`;
 }
 
+// formatSelfDestructSegment — renders the self-destruct status as a
+// stand-alone segment for the post-send confirm header
+// (`Sent to N | Expires: 24h | Self-destruct: ...`). A null/undefined/
+// non-finite/non-positive value renders as "off" — the "no timer
+// selected" sentinel — so the segment is always present and aligned
+// with the rest of the header.
+function formatSelfDestructSegment(seconds) {
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return `Self-destruct: ${formatSelfDestructLabel(seconds)}`;
+  }
+  return 'Self-destruct: off';
+}
+
 module.exports = {
   expiryToISO,
   expiryToMs,
   formatSelfDestructLabel,
+  formatSelfDestructSegment,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -801,6 +801,27 @@ describe('renderSendConfirm — post-send confirmation overflow', () => {
     expect(r.needsExpand).toBe(true);
   });
 
+  // Pin the third header segment: self-destruct status. The 7b.3 follow-up
+  // replaced the legacy "One-time links" trailer with the timer the user
+  // picked (or "off" when no timer is set), so the sender sees the actual
+  // viewer behavior right next to the link expiry.
+  it('header includes "Self-destruct: <label>" when a timer is set', () => {
+    const r = renderSendConfirm({
+      ...baseArgs, delivered: 1, successNames: ['alice'], selfDestructSeconds: 300,
+    });
+    expect(r.content).toContain('| Self-destruct: 5 minutes');
+    expect(r.content).not.toContain('One-time');
+  });
+
+  it('header renders "Self-destruct: off" when no timer is set', () => {
+    // selfDestructSeconds omitted (undefined) — same as a send with no
+    // timer picked. The segment is still present for header alignment.
+    const r = renderSendConfirm({
+      ...baseArgs, delivered: 1, successNames: ['alice'],
+    });
+    expect(r.content).toContain('| Self-destruct: off');
+  });
+
   it('small list, showAll=true: full names inline, no truncation marker', () => {
     const successNames = Array.from({ length: REVOKE_TRUNC_LIMIT + 2 }, (_, i) => `u${i}`);
     const r = renderSendConfirm({ ...baseArgs, delivered: successNames.length, successNames, showAll: true });

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -16,6 +16,7 @@ const {
   expiryToISO,
   expiryToMs,
   formatSelfDestructLabel,
+  formatSelfDestructSegment,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
@@ -151,6 +152,33 @@ describe('utils/time', () => {
       expect(formatSelfDestructLabel(-Infinity)).toBe('(invalid)');
     });
 
+  });
+
+  describe('formatSelfDestructSegment', () => {
+    it('renders each preset as "Self-destruct: <label>"', () => {
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(formatSelfDestructSegment(preset.seconds))
+          .toBe(`Self-destruct: ${preset.label}`);
+      }
+    });
+
+    it('renders "Self-destruct: off" when no timer is set', () => {
+      // The post-send confirm header always shows a self-destruct
+      // segment for visual alignment — null/undefined map to the same
+      // "off" sentinel as the form-side "No timer" dropdown option.
+      expect(formatSelfDestructSegment(null)).toBe('Self-destruct: off');
+      expect(formatSelfDestructSegment(undefined)).toBe('Self-destruct: off');
+    });
+
+    it('renders "Self-destruct: off" for non-finite / non-positive values', () => {
+      // Same defense as formatSelfDestructLabel — a corrupted DB row
+      // surfacing NaN/Infinity, or a 0 / negative value, falls through
+      // to the "off" sentinel rather than leaking "(invalid)" or "0s".
+      expect(formatSelfDestructSegment(NaN)).toBe('Self-destruct: off');
+      expect(formatSelfDestructSegment(Infinity)).toBe('Self-destruct: off');
+      expect(formatSelfDestructSegment(0)).toBe('Self-destruct: off');
+      expect(formatSelfDestructSegment(-5)).toBe('Self-destruct: off');
+    });
   });
 
   describe('expiryToISO', () => {


### PR DESCRIPTION
## Summary

The post-send confirm header was:

```
Sent to 2 users | Expires: 24h | One-time links
```

The trailing `One-time links` segment was static info; it didn't reflect the per-send self-destruct timer the user picked on the confirm card. Replace it with the actual setting so the sender can verify the viewer behavior at a glance:

```
Sent to 2 users | Expires: 24h | Self-destruct: 5 minutes
Sent to 2 users | Expires: 24h | Self-destruct: off
```

`off` is shown when no timer was picked (null/undefined) or when the persisted value is non-finite / non-positive — same defense-in-depth approach as the existing `formatSelfDestructLabel` (which falls back to `(invalid)` for non-finite; here we fold those into `off` because the header is a status, not a raw value display).

## Changes

- `src/utils/time.js` — add `formatSelfDestructSegment(seconds)` helper next to `formatSelfDestructLabel`. Wraps the label with `Self-destruct: ` and folds null/non-finite/non-positive to `off`. Both call sites in `commands.js` go through it.
- `src/commands.js` — `renderSendConfirm` now takes `selfDestructSeconds`; the header uses `formatSelfDestructSegment(selfDestructSeconds)` for the third segment. The Add Recipients editReply rebuild uses the same helper (`selfDestructSeconds` is already a top-level `executeSendPipeline` arg, so no signature changes needed there).
- Tests: helper unit tests in `tests/time.test.js`; header assertions in `tests/send-pipeline-back-half.test.js` for both timer-set and no-timer paths.

## Test plan

- [x] `pnpm test` — 1413 tests pass
- [x] `pnpm lint` — clean (`eslint --max-warnings 0`)
- [ ] CI green
- [ ] Claude review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)