### PR TITLE
refactor(discord): rename qurl_send_* customIds + handleSend* handlers (#316)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2529,11 +2529,11 @@ const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
 // REVOKE_SELECT_CUSTOM_ID / SETUP_BUTTON_CUSTOM_ID use.
 //
 // WIRE-PROTOCOL: the `qurl_confirm_*` literals below are encoded into
-// every in-flight `flow_state` row for an open confirm card (cleared
-// by SEND_FLOW_TTL_SECONDS = 180s drain). Renaming them is a coordinated
-// flip — see SEND_STAGE_AWAITING_CONFIRM above for the matching stage-
-// value drain. #316 was the post-7b.3 cleanup that dropped the legacy
-// `qurl_send_*` prefix; subsequent renames here need the same drain.
+// every in-flight `flow_state` row for an open confirm card. Renaming
+// them is a coordinated flip — wait for a SEND_FLOW_TTL_SECONDS (180s)
+// drain on the prior deploy so in-flight rows expire before the new
+// dispatcher routes against the new literal. See
+// SEND_STAGE_AWAITING_CONFIRM above for the matching stage-value drain.
 //
 // The post-send Add Recipients / Revoke / Show All buttons live on
 // different customId prefixes (`qurl_add_*`, `qurl_revoke_*`,
@@ -3512,11 +3512,10 @@ async function handleQurlMap(interaction) {
 }
 
 // --- Confirm-card handlers for `/qurl file` + `/qurl map` ---
-// Wire literals (`qurl_confirm_*`) and handler names were renamed away
-// from the legacy `qurl_send_*` / `handleSend*` prefix in #316, after
-// the 7b.3 drain. Any future rename here needs the same
-// SEND_FLOW_TTL_SECONDS (180s) drain on the prior deploy so in-flight
-// `flow_state` rows don't orphan across the boundary.
+// Any future rename of the `qurl_confirm_*` wire literals (or these
+// handler names, since they're paired with them via registerFlow)
+// needs a SEND_FLOW_TTL_SECONDS (180s) drain on the prior deploy so
+// in-flight `flow_state` rows don't orphan across the boundary.
 //
 // Stage stays at SEND_STAGE_AWAITING_CONFIRM — `transitionFlow` with
 // `stage_to` === current stage advances the version (OCC guard) and

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2528,26 +2528,23 @@ const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
 // as a routing key, not an identity signal). Matches the convention
 // REVOKE_SELECT_CUSTOM_ID / SETUP_BUTTON_CUSTOM_ID use.
 //
-// WIRE-PROTOCOL FROZEN until #316. The `qurl_send_*` string literals
-// below are encoded into (a) every in-flight `flow_state` row in DDB
-// for confirm-card sessions (cleared by SEND_FLOW_TTL_SECONDS = 180s
-// drain), AND (b) every active button row on the message that hosted
-// the original confirm card (cleared once monitorLinkStatus stops
-// polling, which can take several minutes on large fan-outs). #316's
-// rename PR must wait for BOTH drains before flipping the literals.
-// See also: SEND_STAGE_AWAITING_CONFIRM above (same wire-protocol
-// constraint for the flow_state.stage column).
-const SEND_USER_SELECT_CUSTOM_ID = 'qurl_send_user_select';
-const SEND_CONFIRM_SEND_CUSTOM_ID = 'qurl_send_confirm_send';
-const SEND_CONFIRM_CANCEL_CUSTOM_ID = 'qurl_send_confirm_cancel';
+// WIRE-PROTOCOL: the `qurl_confirm_*` literals below are encoded into
+// every in-flight `flow_state` row for an open confirm card (cleared
+// by SEND_FLOW_TTL_SECONDS = 180s drain). Renaming them is a coordinated
+// flip — see SEND_STAGE_AWAITING_CONFIRM above for the matching stage-
+// value drain. #316 was the post-7b.3 cleanup that dropped the legacy
+// `qurl_send_*` prefix; subsequent renames here need the same drain.
+const CONFIRM_USER_SELECT_CUSTOM_ID = 'qurl_confirm_user_select';
+const CONFIRM_SEND_CUSTOM_ID = 'qurl_confirm_send';
+const CONFIRM_CANCEL_CUSTOM_ID = 'qurl_confirm_cancel';
 // Confirm-card menus / button — slash options on /qurl file + /qurl map
 // remain as initial defaults (one-shot for power users), but a user who
 // didn't fill them in can still adjust expiry, self-destruct, and note
 // inline on the card.
-const SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID = 'qurl_send_confirm_expiry';
-const SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID = 'qurl_send_confirm_self_destruct';
-const SEND_CONFIRM_NOTE_BUTTON_CUSTOM_ID = 'qurl_send_confirm_note_btn';
-const SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_send_confirm_note_modal';
+const CONFIRM_EXPIRY_SELECT_CUSTOM_ID = 'qurl_confirm_expiry';
+const CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID = 'qurl_confirm_self_destruct';
+const CONFIRM_NOTE_BUTTON_CUSTOM_ID = 'qurl_confirm_note_btn';
+const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // Local to the note modal — kept off the prefix-only customId
 // allowlist because flow-dispatch never routes modal-input fields,
 // only the parent modal customId.
@@ -2903,7 +2900,7 @@ function renderConfirmCardRows({
   const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
   rows.push(new ActionRowBuilder().addComponents(
     new UserSelectMenuBuilder()
-      .setCustomId(SEND_USER_SELECT_CUSTOM_ID)
+      .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
       .setPlaceholder(`Pick recipients (1–${maxValues})`)
       .setMinValues(1)
       .setMaxValues(maxValues)
@@ -2930,7 +2927,7 @@ function renderConfirmCardRows({
   }
   rows.push(new ActionRowBuilder().addComponents(
     new StringSelectMenuBuilder()
-      .setCustomId(SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID)
+      .setCustomId(CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID)
       .setMinValues(1)
       .setMaxValues(1)
       .addOptions(
@@ -2961,7 +2958,7 @@ function renderConfirmCardRows({
   }
   rows.push(new ActionRowBuilder().addComponents(
     new StringSelectMenuBuilder()
-      .setCustomId(SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID)
+      .setCustomId(CONFIRM_EXPIRY_SELECT_CUSTOM_ID)
       .setMinValues(1)
       .setMaxValues(1)
       .addOptions(
@@ -2977,16 +2974,16 @@ function renderConfirmCardRows({
   // can tell at a glance whether a note is attached.
   rows.push(new ActionRowBuilder().addComponents(
     new ButtonBuilder()
-      .setCustomId(SEND_CONFIRM_NOTE_BUTTON_CUSTOM_ID)
+      .setCustomId(CONFIRM_NOTE_BUTTON_CUSTOM_ID)
       .setLabel(personalMessage ? '✏\u{FE0F} Edit note' : '✏\u{FE0F} Add a note (optional)')
       .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
-      .setCustomId(SEND_CONFIRM_SEND_CUSTOM_ID)
+      .setCustomId(CONFIRM_SEND_CUSTOM_ID)
       .setLabel('\u{1F4E4} Send')
       .setStyle(ButtonStyle.Success)
       .setDisabled(sendDisabled),
     new ButtonBuilder()
-      .setCustomId(SEND_CONFIRM_CANCEL_CUSTOM_ID)
+      .setCustomId(CONFIRM_CANCEL_CUSTOM_ID)
       .setLabel('Cancel')
       .setStyle(ButtonStyle.Secondary),
   ));
@@ -3001,7 +2998,7 @@ function renderConfirmCardRows({
 //   locationName: string | null                          (map path)
 //   resourceLabel: string                                (rendered on card)
 // apiKey is INTENTIONALLY not threaded through the front-half.
-// handleSendConfirmClick re-fetches the guild API key at Send time
+// handleConfirmSendClick re-fetches the guild API key at Send time
 // — the key may rotate during the confirm card's 3-min TTL, and the
 // dispatcher's gate at the slash-command entry point only proves the
 // key was present at that single moment. Re-fetching at click time
@@ -3181,7 +3178,7 @@ async function handleQurlSlashSend(interaction, params) {
       // (no NFKC, no bidi/control strip, no @-mention defuse, no
       // markdown escape). Never read it from any rendering path or
       // downstream pipeline — only `personalMessage` (the sanitized
-      // derivative) is safe for those. `handleSendConfirmClick`
+      // derivative) is safe for those. `handleConfirmSendClick`
       // explicitly picks `personalMessage` (not `...payload`) when
       // calling `executeSendPipeline`, which keeps this safe today;
       // a contract test pins that invariant.
@@ -3509,24 +3506,21 @@ async function handleQurlMap(interaction) {
 }
 
 // --- Confirm-card handlers for `/qurl file` + `/qurl map` ---
-// These `handleSend*` names refer to the Send BUTTON on the confirm card
-// (not the deleted `/qurl send` slash command). The associated customId
-// wire literals (`qurl_send_user_select`, `qurl_send_confirm_*`) are
-// preserved post-7b.3 because in-flight `flow_state` rows encode them —
-// renaming would orphan any open confirm card across the deploy
-// boundary. Rename of both the identifiers AND the customIds is tracked
-// in #316, scheduled for a deploy ≥ SEND_FLOW_TTL_SECONDS (180s) after
-// 7b.3 lands so the DDB rows have drained.
+// Wire literals (`qurl_confirm_*`) and handler names were dropped from
+// the legacy `qurl_send_*` / `handleSend*` prefix in #316, post-7b.3
+// drain. Any future rename here needs the same SEND_FLOW_TTL_SECONDS
+// (180s) drain on the prior deploy so in-flight `flow_state` rows
+// don't orphan across the boundary.
 //
 // Stage stays at SEND_STAGE_AWAITING_CONFIRM — `transitionFlow` with
 // `stage_to` === current stage advances the version (OCC guard) and
 // refreshes the TTL, so repeated picker churn doesn't expire the row
 // while the user is still deciding.
-async function handleSendUserSelect(interaction, { flow_id, row }) {
+async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // `deferUpdate` first so the downstream `transitionFlow` (DDB OCC
   // update) can take more than Discord's 3-second hard ack deadline
   // without surfacing as an "interaction failed" toast. Mirrors
-  // handleSendConfirmClick / handleSendCancelClick. All `update`
+  // handleConfirmSendClick / handleConfirmCancelClick. All `update`
   // calls below become `editReply` (the interaction is now deferred).
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
 
@@ -3538,7 +3532,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // Delete the corrupt row + surface actionable "re-run" copy.
   const payloadResource = (row.payload || {}).resourceType;
   if (payloadResource !== RESOURCE_TYPES.FILE && payloadResource !== RESOURCE_TYPES.MAPS) {
-    logger.error('handleSendUserSelect: corrupt flow payload (unknown resourceType)', {
+    logger.error('handleConfirmUserSelect: corrupt flow payload (unknown resourceType)', {
       flow_id, resource_type: payloadResource,
     });
     await deleteFlow(flow_id, {
@@ -3574,7 +3568,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
   // No `resolveRecipientUsers` re-fetch here — Discord's
   // UserSelectMenu only surfaces users visible to the bot in this
   // guild, so picked User IDs are guild-bounded at the gateway-event
-  // level. handleSendConfirmClick re-fetches at click time
+  // level. handleConfirmSendClick re-fetches at click time
   // (partial-drop test pins this) as the actual guild-membership
   // defense; adding it here would burn 10 members.fetch calls per
   // picker tick without catching anything the Send-time check misses.
@@ -3611,7 +3605,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     // the same flow_state version. Log for forensics so a sudden spike
     // in invalid-pick churn surfaces in metrics without lowering log
     // verbosity.
-    logger.debug('handleSendUserSelect: all-invalid pick', {
+    logger.debug('handleConfirmUserSelect: all-invalid pick', {
       flow_id, dropped_bots: droppedBots, dropped_self: droppedSelf,
     });
     const reasons = [];
@@ -3652,7 +3646,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
     warningsBlock: newWarningsBlock,
   };
   // Targeted catch around transitionFlow mirrors the same shape
-  // handleSendConfirmClick / handleSendCancelClick use around their
+  // handleConfirmSendClick / handleConfirmCancelClick use around their
   // DDB calls. A throw here would otherwise bubble to the dispatcher's
   // outer catch which surfaces a generic "superseded" message —
   // wrong, since nothing was actually superseded on a DDB blip.
@@ -3665,7 +3659,7 @@ async function handleSendUserSelect(interaction, { flow_id, row }) {
       set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
     });
   } catch (err) {
-    logger.error('handleSendUserSelect: transitionFlow threw', {
+    logger.error('handleConfirmUserSelect: transitionFlow threw', {
       flow_id, error: err && err.message,
     });
     return interaction.followUp({
@@ -3791,7 +3785,7 @@ async function rerenderConfirmCard(interaction, newPayload) {
 // validation against EXPIRY_LABELS mirrors handleQurlSlashSend's slash-
 // option gate — Discord enforces the choice set server-side, but a
 // forged interaction could land an off-set value here.
-async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
+async function handleConfirmExpirySelect(interaction, { flow_id, row }) {
   // `?.[0]` is paranoia, not load-bearing — Discord guarantees
   // `values` is an array for StringSelectMenu interactions. The
   // guard catches a forged interaction missing the field entirely;
@@ -3801,7 +3795,7 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
   // (the cheaper, single-call ack) instead of `followUp` after a
   // wasted deferUpdate. Symmetric with the self-destruct handler.
   if (!picked || !Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, picked)) {
-    logger.warn('handleSendConfirmExpirySelect: forged off-set expiry value', {
+    logger.warn('handleConfirmExpirySelect: forged off-set expiry value', {
       flow_id, value: truncForLog(picked),
     });
     return interaction.reply({
@@ -3829,7 +3823,7 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
       set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
     });
   } catch (err) {
-    logger.error('handleSendConfirmExpirySelect: transitionFlow threw', {
+    logger.error('handleConfirmExpirySelect: transitionFlow threw', {
       flow_id, error: err && err.message,
     });
     return interaction.followUp({
@@ -3858,7 +3852,7 @@ async function handleSendConfirmExpirySelect(interaction, { flow_id, row }) {
 // from the slash option's `'none'` value handled by
 // selfDestructOptionToSeconds. The helper falls back to null for any
 // unexpected value (forged interaction), which is the safe default.
-async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }) {
+async function handleConfirmSelfDestructSelect(interaction, { flow_id, row }) {
   // `?.[0]` paranoia (see expiry handler) — legitimate
   // StringSelectMenu interactions always carry the values array.
   const pickedValue = interaction.values?.[0];
@@ -3868,7 +3862,7 @@ async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }
   // to null would clear a user's previously-set timer on every probe
   // — symmetric with the expiry handler's reject-and-warn behavior.
   if (!isLegitimateSelfDestructSelectValue(pickedValue)) {
-    logger.warn('handleSendConfirmSelfDestructSelect: forged off-set self-destruct value', {
+    logger.warn('handleConfirmSelfDestructSelect: forged off-set self-destruct value', {
       flow_id, value: truncForLog(pickedValue),
     });
     return interaction.reply({
@@ -3894,7 +3888,7 @@ async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }
       set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
     });
   } catch (err) {
-    logger.error('handleSendConfirmSelfDestructSelect: transitionFlow threw', {
+    logger.error('handleConfirmSelfDestructSelect: transitionFlow threw', {
       flow_id, error: err && err.message,
     });
     return interaction.followUp({
@@ -3919,15 +3913,15 @@ async function handleSendConfirmSelfDestructSelect(interaction, { flow_id, row }
 
 // Note button → opens a modal with the current personalMessage pre-
 // filled. Does NOT call transitionFlow — the flow row is untouched
-// until the modal SUBMITS (handleSendConfirmNoteModal below). This
+// until the modal SUBMITS (handleConfirmNoteModal below). This
 // asymmetry matters: clicking the button to peek at the current note
 // (or even to discard it via cancel) must not bump the flow version
 // and risk fencing out a concurrent picker/expiry/self-destruct
 // mutation.
-async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
+async function handleConfirmNoteButton(interaction, { flow_id, row }) {
   const payload = row.payload || {};
   const modal = new ModalBuilder()
-    .setCustomId(SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID)
+    .setCustomId(CONFIRM_NOTE_MODAL_CUSTOM_ID)
     .setTitle('Personal message');
   modal.addComponents(new ActionRowBuilder().addComponents(
     new TextInputBuilder()
@@ -3946,7 +3940,7 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
       .setValue(payload.personalMessageRaw || '')
   ));
   return interaction.showModal(modal).catch((err) => {
-    logger.warn('handleSendConfirmNoteButton: showModal failed', {
+    logger.warn('handleConfirmNoteButton: showModal failed', {
       flow_id, error: err && err.message,
     });
     // showModal failure leaves the button-click interaction
@@ -3969,7 +3963,7 @@ async function handleSendConfirmNoteButton(interaction, { flow_id, row }) {
 // interaction context. Post-defer error paths use followUp
 // (ephemeral) — reply / update would 409 against the acked
 // interaction.
-async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
+async function handleConfirmNoteModal(interaction, { flow_id, row }) {
   // Defer the modal-submit ack BEFORE the DDB write — without this,
   // a slow conditional write (throttled partition) can push past
   // Discord's 3-second hard deadline, after which `update()` /
@@ -3985,7 +3979,7 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
   try {
     raw = (interaction.fields.getTextInputValue(SEND_NOTE_MODAL_FIELD_ID) || '').trim();
   } catch (err) {
-    logger.warn('handleSendConfirmNoteModal: getTextInputValue threw', {
+    logger.warn('handleConfirmNoteModal: getTextInputValue threw', {
       flow_id, error: err && err.message,
     });
     return interaction.followUp({
@@ -4024,7 +4018,7 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
       set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
     });
   } catch (err) {
-    logger.error('handleSendConfirmNoteModal: transitionFlow threw', {
+    logger.error('handleConfirmNoteModal: transitionFlow threw', {
       flow_id, error: err && err.message,
     });
     // Post-deferUpdate the only safe surface for an error toast is
@@ -4053,7 +4047,7 @@ async function handleSendConfirmNoteModal(interaction, { flow_id, row }) {
 // Send button → fire executeSendPipeline. deleteFlow first as the
 // dedup primitive (duplicate dispatch under future SQS at-least-once
 // must not double-send). Mirrors handleRevokeSelect's ordering.
-async function handleSendConfirmClick(interaction, { flow_id, row }) {
+async function handleConfirmSendClick(interaction, { flow_id, row }) {
   // `deferUpdate` at the very top so the chain
   // `resolveRecipientUsers → getGuildApiKey → deleteFlow → editReply`
   // can take more than Discord's 3-second hard ack deadline without
@@ -4087,7 +4081,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
-    }).catch((err) => logger.warn('handleSendConfirmClick: deleteFlow on bot-kicked failed', {
+    }).catch((err) => logger.warn('handleConfirmSendClick: deleteFlow on bot-kicked failed', {
       flow_id, error: err && err.message,
     }));
     // Zero side effects (no DMs sent, no API calls) — unlock retry
@@ -4119,7 +4113,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       reason: 'terminal',
       expectedVersion: row.version,
     }).catch((err) => {
-      logger.warn('handleSendConfirmClick: deleteFlow on empty-recipients failed', {
+      logger.warn('handleConfirmSendClick: deleteFlow on empty-recipients failed', {
         flow_id, error: err && err.message,
       });
       return { deleted: false };
@@ -4151,7 +4145,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
     db.getGuildApiKey(interaction.guildId),
   ]);
   if (resolveResult.status === 'rejected') {
-    logger.error('handleSendConfirmClick: resolveRecipientUsers threw', {
+    logger.error('handleConfirmSendClick: resolveRecipientUsers threw', {
       flow_id, error: resolveResult.reason && resolveResult.reason.message,
     });
     // Zero side effects — unlock retry so the user can re-click Send
@@ -4166,7 +4160,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   const partialLeftCount = unresolvedIds.length;
   const partialTransientCount = transientFailureIds.length;
   if (partialLeftCount > 0 || partialTransientCount > 0) {
-    logger.info('handleSendConfirmClick: partial drop at click time', {
+    logger.info('handleConfirmSendClick: partial drop at click time', {
       flow_id, left: partialLeftCount, transient: partialTransientCount,
     });
   }
@@ -4192,7 +4186,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
       reason: 'terminal',
       expectedVersion: row.version,
     }).catch((err) => {
-      logger.warn('handleSendConfirmClick: deleteFlow on empty failed', {
+      logger.warn('handleConfirmSendClick: deleteFlow on empty failed', {
         flow_id, error: err && err.message,
       });
       return { deleted: false };
@@ -4236,7 +4230,7 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
   // row before discovering there's no key to send with would strand
   // the user on a dead card.
   if (apiKeyResult.status === 'rejected') {
-    logger.error('handleSendConfirmClick: getGuildApiKey threw', {
+    logger.error('handleConfirmSendClick: getGuildApiKey threw', {
       flow_id, error: apiKeyResult.reason && apiKeyResult.reason.message,
     });
     // Flow row stays alive; unlock retry so the user isn't stranded
@@ -4347,13 +4341,13 @@ async function handleSendConfirmClick(interaction, { flow_id, row }) {
 // supersedeOrCreate DDB writes + Discord interactions with zero
 // throttle. The cooldown-loser branch leaves cooldown untouched
 // (Send is mid-fanout; bypassing is the abuse vector).
-async function handleSendCancelClick(interaction, { flow_id, row }) {
+async function handleConfirmCancelClick(interaction, { flow_id, row }) {
   // Defer-ack within the 3s window. The single deleteFlow call below
   // is fast in the happy path, but a DDB blip or slow region could
-  // still blow the budget. Same pattern handleSendConfirmClick uses
+  // still blow the budget. Same pattern handleConfirmSendClick uses
   // (deferUpdate at top, editReply / followUp downstream).
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
-  // Targeted catch around deleteFlow mirrors handleSendConfirmClick's
+  // Targeted catch around deleteFlow mirrors handleConfirmSendClick's
   // guards on resolveRecipientUsers + getGuildApiKey. Without it, a
   // DDB throw propagates to the dispatcher's outer catch which
   // surfaces a generic "superseded" message — wrong for Cancel
@@ -4367,7 +4361,7 @@ async function handleSendCancelClick(interaction, { flow_id, row }) {
       expectedVersion: row.version,
     }));
   } catch (err) {
-    logger.error('handleSendCancelClick: deleteFlow threw', {
+    logger.error('handleConfirmCancelClick: deleteFlow threw', {
       flow_id, error: err && err.message,
     });
     return interaction.followUp({
@@ -5467,7 +5461,7 @@ const commands = [
       //
       // For /qurl file + /qurl map this read is a fail-fast presence
       // check — the resolved value is intentionally NOT threaded
-      // through to the back-half. handleSendConfirmClick re-fetches at
+      // through to the back-half. handleConfirmSendClick re-fetches at
       // Send-click time so a key rotation during the 3-minute confirm-
       // card window is honored. Threading resolvedApiKey through here
       // would break that rotation-safety property: a future optimization
@@ -5489,7 +5483,7 @@ const commands = [
       }
 
       // /qurl file and /qurl map deliberately don't accept the
-      // dispatcher-resolved apiKey — handleSendConfirmClick re-fetches
+      // dispatcher-resolved apiKey — handleConfirmSendClick re-fetches
       // at Send time so a mid-flow rotation still uses the live key.
       // The dispatcher's API_KEY_GATED_SUBCOMMANDS gate above is the
       // fail-fast presence check.
@@ -5824,9 +5818,9 @@ registerFlow(SETUP_MODAL_CUSTOM_ID, {
 // message, all routed by stage. siblingMessage is registered on the
 // FIRST customId only; flow-dispatch rejects mismatched re-registrations
 // of the same stage so we don't repeat it.
-registerFlow(SEND_USER_SELECT_CUSTOM_ID, {
+registerFlow(CONFIRM_USER_SELECT_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendUserSelect,
+  handler: handleConfirmUserSelect,
   siblingMessage: 'You have a `/qurl file` or `/qurl map` confirm card open in this channel — finish or cancel it first.',
 });
 // siblingMessage intentionally omitted on the SEND + CANCEL custom-
@@ -5835,13 +5829,13 @@ registerFlow(SEND_USER_SELECT_CUSTOM_ID, {
 // USER_SELECT above is reachable from any of the three customIds
 // at SEND_STAGE_AWAITING_CONFIRM. The "siblingMessage keyed by stage"
 // test in qurl-file-map.test.js pins this contract.
-registerFlow(SEND_CONFIRM_SEND_CUSTOM_ID, {
+registerFlow(CONFIRM_SEND_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendConfirmClick,
+  handler: handleConfirmSendClick,
 });
-registerFlow(SEND_CONFIRM_CANCEL_CUSTOM_ID, {
+registerFlow(CONFIRM_CANCEL_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendCancelClick,
+  handler: handleConfirmCancelClick,
 });
 // Confirm-card menus + note button/modal. All share the same
 // expectedStage as the original three customIds above; siblingMessage
@@ -5849,21 +5843,21 @@ registerFlow(SEND_CONFIRM_CANCEL_CUSTOM_ID, {
 // re-registration here. Each handler reads `row.payload` from the
 // dispatcher's loadFlow and uses `expectedVersion: row.version` on
 // transitionFlow for the picker-vs-menu race.
-registerFlow(SEND_CONFIRM_EXPIRY_SELECT_CUSTOM_ID, {
+registerFlow(CONFIRM_EXPIRY_SELECT_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendConfirmExpirySelect,
+  handler: handleConfirmExpirySelect,
 });
-registerFlow(SEND_CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID, {
+registerFlow(CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendConfirmSelfDestructSelect,
+  handler: handleConfirmSelfDestructSelect,
 });
-registerFlow(SEND_CONFIRM_NOTE_BUTTON_CUSTOM_ID, {
+registerFlow(CONFIRM_NOTE_BUTTON_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendConfirmNoteButton,
+  handler: handleConfirmNoteButton,
 });
-registerFlow(SEND_CONFIRM_NOTE_MODAL_CUSTOM_ID, {
+registerFlow(CONFIRM_NOTE_MODAL_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
-  handler: handleSendConfirmNoteModal,
+  handler: handleConfirmNoteModal,
 });
 
 module.exports = {
@@ -5875,13 +5869,13 @@ module.exports = {
   handleRevokeSelect,
   handleSetupButton,
   handleSetupModal,
-  handleSendUserSelect,
-  handleSendConfirmClick,
-  handleSendCancelClick,
-  handleSendConfirmExpirySelect,
-  handleSendConfirmSelfDestructSelect,
-  handleSendConfirmNoteButton,
-  handleSendConfirmNoteModal,
+  handleConfirmUserSelect,
+  handleConfirmSendClick,
+  handleConfirmCancelClick,
+  handleConfirmExpirySelect,
+  handleConfirmSelfDestructSelect,
+  handleConfirmNoteButton,
+  handleConfirmNoteModal,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with
@@ -5954,9 +5948,9 @@ module.exports = {
       safeDecodeURIComponent,
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
-      SEND_USER_SELECT_CUSTOM_ID,
-      SEND_CONFIRM_SEND_CUSTOM_ID,
-      SEND_CONFIRM_CANCEL_CUSTOM_ID,
+      CONFIRM_USER_SELECT_CUSTOM_ID,
+      CONFIRM_SEND_CUSTOM_ID,
+      CONFIRM_CANCEL_CUSTOM_ID,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,
     },

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3506,11 +3506,11 @@ async function handleQurlMap(interaction) {
 }
 
 // --- Confirm-card handlers for `/qurl file` + `/qurl map` ---
-// Wire literals (`qurl_confirm_*`) and handler names were dropped from
-// the legacy `qurl_send_*` / `handleSend*` prefix in #316, post-7b.3
-// drain. Any future rename here needs the same SEND_FLOW_TTL_SECONDS
-// (180s) drain on the prior deploy so in-flight `flow_state` rows
-// don't orphan across the boundary.
+// Wire literals (`qurl_confirm_*`) and handler names were renamed away
+// from the legacy `qurl_send_*` / `handleSend*` prefix in #316, after
+// the 7b.3 drain. Any future rename here needs the same
+// SEND_FLOW_TTL_SECONDS (180s) drain on the prior deploy so in-flight
+// `flow_state` rows don't orphan across the boundary.
 //
 // Stage stays at SEND_STAGE_AWAITING_CONFIRM — `transitionFlow` with
 // `stage_to` === current stage advances the version (OCC guard) and

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2534,6 +2534,12 @@ const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
 // flip — see SEND_STAGE_AWAITING_CONFIRM above for the matching stage-
 // value drain. #316 was the post-7b.3 cleanup that dropped the legacy
 // `qurl_send_*` prefix; subsequent renames here need the same drain.
+//
+// The post-send Add Recipients / Revoke / Show All buttons live on
+// different customId prefixes (`qurl_add_*`, `qurl_revoke_*`,
+// `qurl_expand_*`) — they are NOT affected by renaming the confirm-
+// card literals here, so the 180s flow_state TTL is the only drain
+// that needs to clear.
 const CONFIRM_USER_SELECT_CUSTOM_ID = 'qurl_confirm_user_select';
 const CONFIRM_SEND_CUSTOM_ID = 'qurl_confirm_send';
 const CONFIRM_CANCEL_CUSTOM_ID = 'qurl_confirm_cancel';
@@ -5948,9 +5954,17 @@ module.exports = {
       safeDecodeURIComponent,
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
+      // All seven confirm-card customId literals exported so the
+      // contract test in qurl-file-map.test.js can pin every wire
+      // value — a typo in any of these silently breaks routing for
+      // in-flight confirm cards, so they need to be test-asserted.
       CONFIRM_USER_SELECT_CUSTOM_ID,
       CONFIRM_SEND_CUSTOM_ID,
       CONFIRM_CANCEL_CUSTOM_ID,
+      CONFIRM_EXPIRY_SELECT_CUSTOM_ID,
+      CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID,
+      CONFIRM_NOTE_BUTTON_CUSTOM_ID,
+      CONFIRM_NOTE_MODAL_CUSTOM_ID,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,
     },

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -181,6 +181,10 @@ const {
   CONFIRM_USER_SELECT_CUSTOM_ID,
   CONFIRM_SEND_CUSTOM_ID,
   CONFIRM_CANCEL_CUSTOM_ID,
+  CONFIRM_EXPIRY_SELECT_CUSTOM_ID,
+  CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID,
+  CONFIRM_NOTE_BUTTON_CUSTOM_ID,
+  CONFIRM_NOTE_MODAL_CUSTOM_ID,
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
   isOnCooldown,
@@ -3083,14 +3087,30 @@ describe('constants + exports', () => {
   // SEND_STAGE_AWAITING_CONFIRM, ...})`) already pin them by
   // contract.
   test('customIds match the wire-protocol values Discord routes against', () => {
+    // Pin EVERY confirm-card customId constant. A typo in any one of
+    // these silently breaks routing for in-flight cards across a
+    // deploy, so the contract test asserts against the literal wire
+    // value rather than just the JS constant binding.
     expect(CONFIRM_USER_SELECT_CUSTOM_ID).toBe('qurl_confirm_user_select');
     expect(CONFIRM_SEND_CUSTOM_ID).toBe('qurl_confirm_send');
     expect(CONFIRM_CANCEL_CUSTOM_ID).toBe('qurl_confirm_cancel');
+    expect(CONFIRM_EXPIRY_SELECT_CUSTOM_ID).toBe('qurl_confirm_expiry');
+    expect(CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID).toBe('qurl_confirm_self_destruct');
+    expect(CONFIRM_NOTE_BUTTON_CUSTOM_ID).toBe('qurl_confirm_note_btn');
+    expect(CONFIRM_NOTE_MODAL_CUSTOM_ID).toBe('qurl_confirm_note_modal');
   });
 
   test('all customIds unique', () => {
-    const ids = new Set([CONFIRM_USER_SELECT_CUSTOM_ID, CONFIRM_SEND_CUSTOM_ID, CONFIRM_CANCEL_CUSTOM_ID]);
-    expect(ids.size).toBe(3);
+    const ids = new Set([
+      CONFIRM_USER_SELECT_CUSTOM_ID,
+      CONFIRM_SEND_CUSTOM_ID,
+      CONFIRM_CANCEL_CUSTOM_ID,
+      CONFIRM_EXPIRY_SELECT_CUSTOM_ID,
+      CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID,
+      CONFIRM_NOTE_BUTTON_CUSTOM_ID,
+      CONFIRM_NOTE_MODAL_CUSTOM_ID,
+    ]);
+    expect(ids.size).toBe(7);
   });
 
   test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -178,9 +178,9 @@ const {
   safeDecodeURIComponent,
   softenCooldown,
   SEND_STAGE_AWAITING_CONFIRM,
-  SEND_USER_SELECT_CUSTOM_ID,
-  SEND_CONFIRM_SEND_CUSTOM_ID,
-  SEND_CONFIRM_CANCEL_CUSTOM_ID,
+  CONFIRM_USER_SELECT_CUSTOM_ID,
+  CONFIRM_SEND_CUSTOM_ID,
+  CONFIRM_CANCEL_CUSTOM_ID,
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
   isOnCooldown,
@@ -196,13 +196,13 @@ const {
 // registerFlow at boot). _test only exports things that aren't already
 // at the top level.
 const {
-  handleSendUserSelect,
-  handleSendConfirmClick,
-  handleSendCancelClick,
-  handleSendConfirmExpirySelect,
-  handleSendConfirmSelfDestructSelect,
-  handleSendConfirmNoteButton,
-  handleSendConfirmNoteModal,
+  handleConfirmUserSelect,
+  handleConfirmSendClick,
+  handleConfirmCancelClick,
+  handleConfirmExpirySelect,
+  handleConfirmSelfDestructSelect,
+  handleConfirmNoteButton,
+  handleConfirmNoteModal,
 } = commands;
 
 // ──────────────────────────────────────────────────────────────
@@ -1543,10 +1543,10 @@ describe('handleQurlMap — slash entry', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendConfirmClick — Send button
+// handleConfirmSendClick — Send button
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendConfirmClick', () => {
+describe('handleConfirmSendClick', () => {
   const u1 = '100000000000000001';
   const validPayload = {
     resourceType: 'file',
@@ -1564,7 +1564,7 @@ describe('handleSendConfirmClick', () => {
   test('happy path → deferUpdate + deleteFlow + editReply "Preparing"', async () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     // Defer-ack within the 3s window before any awaits — without this,
     // resolveRecipientUsers + getGuildApiKey + deleteFlow can blow
     // Discord's hard ack deadline on a cold cache.
@@ -1589,7 +1589,7 @@ describe('handleSendConfirmClick', () => {
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Recipients changed|re-click Send/i),
       ephemeral: true,
@@ -1602,7 +1602,7 @@ describe('handleSendConfirmClick', () => {
   test('deleteFlow is version-gated to fence the picker-then-Send race', async () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 7 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 7 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
@@ -1617,7 +1617,7 @@ describe('handleSendConfirmClick', () => {
     });
     // No apiKey mock needed — the all-unresolved branch short-circuits
     // before the Promise.all that resolves the guild API key.
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/no longer reachable/),
@@ -1635,7 +1635,7 @@ describe('handleSendConfirmClick', () => {
     jest.replaceProperty(config, 'QURL_API_KEY', null);
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     sendCooldowns.set(SENDER_ID, Date.now());
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/not configured|setup/i),
     }));
@@ -1659,7 +1659,7 @@ describe('handleSendConfirmClick', () => {
       guildFetchByID: { [gone]: 'unknown' },
     });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: payloadWithGhost, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: payloadWithGhost, version: 1 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({ reason: 'terminal' }));
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
@@ -1690,7 +1690,7 @@ describe('handleSendConfirmClick', () => {
       guildFetchByID: { [flaky]: 'ratelimit' },
     });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: payloadWithFlaky, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: payloadWithFlaky, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Preparing send/),
     }));
@@ -1726,7 +1726,7 @@ describe('handleSendConfirmClick', () => {
       guildFetchByID: { [flaky]: 'ratelimit' },
     });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: mapPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: mapPayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/rerun \/qurl map/),
       ephemeral: true,
@@ -1745,7 +1745,7 @@ describe('handleSendConfirmClick', () => {
     mockDb.getGuildApiKey.mockRejectedValueOnce(new Error('ddb gone'));
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     sendCooldowns.set(SENDER_ID, Date.now());
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not look up the qURL API key/),
       ephemeral: true,
@@ -1775,13 +1775,13 @@ describe('handleSendConfirmClick', () => {
     // callback is caught by Promise.allSettled, then resolveRecipientUsers's
     // own try/catch handles it. Simulate a synchronous blow-up inside
     // resolveRecipientUsers by making `interaction.guild.members`
-    // throw on read — that lands *after* handleSendConfirmClick's
+    // throw on read — that lands *after* handleConfirmSendClick's
     // bot-kicked guard (which only checks `interaction.guild`).
     Object.defineProperty(int.guild, 'members', {
       get() { throw new Error('cache exploded'); },
     });
     sendCooldowns.set(SENDER_ID, Date.now());
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: { ...validPayload, recipientIds: [u1] }, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: { ...validPayload, recipientIds: [u1] }, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not look up recipients/),
       ephemeral: true,
@@ -1803,7 +1803,7 @@ describe('handleSendConfirmClick', () => {
     // and surfaced "Recipients are no longer reachable (all left the
     // server)" — misleading. Distinguish by droppedSelf/droppedBots > 0.
     const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
-    await handleSendConfirmClick(int, {
+    await handleConfirmSendClick(int, {
       flow_id: 'fid',
       row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 1 },
     });
@@ -1827,7 +1827,7 @@ describe('handleSendConfirmClick', () => {
     // interaction. The all-unresolved branch's "they left the server"
     // copy is wrong here — nobody left, nobody was ever selected.
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
-    await handleSendConfirmClick(int, {
+    await handleConfirmSendClick(int, {
       flow_id: 'fid',
       row: { payload: { ...validPayload, recipientIds: [] }, version: 1 },
     });
@@ -1855,7 +1855,7 @@ describe('handleSendConfirmClick', () => {
     // recovery instead of silently wiping v2.
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
-    await handleSendConfirmClick(int, {
+    await handleConfirmSendClick(int, {
       flow_id: 'fid',
       row: { payload: { ...validPayload, recipientIds: [] }, version: 1 },
     });
@@ -1877,7 +1877,7 @@ describe('handleSendConfirmClick', () => {
     // advance and surfaces the recovery.
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
-    await handleSendConfirmClick(int, {
+    await handleConfirmSendClick(int, {
       flow_id: 'fid',
       row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 5 },
     });
@@ -1905,7 +1905,7 @@ describe('handleSendConfirmClick', () => {
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     int.guild = null;
     sendCooldowns.set(SENDER_ID, Date.now());
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: validPayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/bot is no longer in this server/i),
       components: [],
@@ -1923,10 +1923,10 @@ describe('handleSendConfirmClick', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendCancelClick
+// handleConfirmCancelClick
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendCancelClick', () => {
+describe('handleConfirmCancelClick', () => {
   test('happy path → version-gated deleteFlow + cooldown softened to ~5s residual + update', async () => {
     // softenCooldown leaves 5s of throttle so a user can't spam
     // /qurl file → Cancel → /qurl file → Cancel and rack up
@@ -1936,7 +1936,7 @@ describe('handleSendCancelClick', () => {
     const int = makeInteraction();
     const cooldownStart = Date.now();
     sendCooldowns.set(SENDER_ID, cooldownStart);
-    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
+    await handleConfirmCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
@@ -1965,7 +1965,7 @@ describe('handleSendCancelClick', () => {
     const cooldownAt = Date.now();
     sendCooldowns.set(SENDER_ID, cooldownAt);
     const int = makeInteraction();
-    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
+    await handleConfirmCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/card moved/i),
       ephemeral: true,
@@ -1978,7 +1978,7 @@ describe('handleSendCancelClick', () => {
 
   test('Cancel deleteFlow is version-fenced against picker race', async () => {
     const int = makeInteraction();
-    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 11 } });
+    await handleConfirmCancelClick(int, { flow_id: 'fid', row: { version: 11 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       expectedVersion: 11,
     }));
@@ -1986,7 +1986,7 @@ describe('handleSendCancelClick', () => {
 
   test('deleteFlow throw → ephemeral retry, cooldown preserved (Send may still be in flight)', async () => {
     // Targeted catch around the Cancel deleteFlow
-    // for symmetry with handleSendConfirmClick. A DDB blip during a
+    // for symmetry with handleConfirmSendClick. A DDB blip during a
     // Cancel click now surfaces an actionable ephemeral instead of
     // the dispatcher's generic safety net. Cooldown stays set on the
     // throw path — Send may still be in flight, the user's cooldown
@@ -1994,7 +1994,7 @@ describe('handleSendCancelClick', () => {
     mockDeleteFlow.mockRejectedValueOnce(new Error('ddb gone'));
     sendCooldowns.set(SENDER_ID, Date.now());
     const int = makeInteraction();
-    await handleSendCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
+    await handleConfirmCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not cancel right now/),
       ephemeral: true,
@@ -2008,10 +2008,10 @@ describe('handleSendCancelClick', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendUserSelect
+// handleConfirmUserSelect
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendUserSelect', () => {
+describe('handleConfirmUserSelect', () => {
   const u1 = '100000000000000001';
 
   function makeSelectInteraction({ users = [makeUser(u1)], ...rest } = {}) {
@@ -2032,7 +2032,7 @@ describe('handleSendUserSelect', () => {
   test('valid pick → transitionFlow with new recipientIds + update', async () => {
     const beforeSecs = Math.floor(Date.now() / 1000);
     const int = makeSelectInteraction();
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       stage_to: SEND_STAGE_AWAITING_CONFIRM,
       payload: expect.objectContaining({ recipientIds: [u1] }),
@@ -2057,7 +2057,7 @@ describe('handleSendUserSelect', () => {
 
   test('empty pick → deferUpdate, no transition, no editReply', async () => {
     const int = makeSelectInteraction({ users: [] });
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(int.editReply).not.toHaveBeenCalled();
@@ -2066,15 +2066,15 @@ describe('handleSendUserSelect', () => {
   test('deferUpdate fires before transitionFlow await — protects Discord 3s ack budget on slow DDB', async () => {
     // Without this guard the transitionFlow DDB OCC call can blow
     // Discord's hard ack deadline on tail-latency, surfacing as an
-    // "interaction failed" toast. Mirror handleSendConfirmClick /
-    // handleSendCancelClick: ack first, then do the work.
+    // "interaction failed" toast. Mirror handleConfirmSendClick /
+    // handleConfirmCancelClick: ack first, then do the work.
     let deferAckedBeforeTransition = false;
     const int = makeSelectInteraction();
     mockTransitionFlow.mockImplementationOnce(async () => {
       deferAckedBeforeTransition = int.deferUpdate.mock.calls.length > 0;
       return { result: 'ok', version: 2 };
     });
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(deferAckedBeforeTransition).toBe(true);
   });
 
@@ -2087,7 +2087,7 @@ describe('handleSendUserSelect', () => {
     const int = makeSelectInteraction({
       users: [makeUser(bot1, { bot: true }), makeUser(SENDER_ID)],
     });
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/bots/);
@@ -2105,7 +2105,7 @@ describe('handleSendUserSelect', () => {
     const int = makeSelectInteraction({
       users: [makeUser(u1, { bot: true })],
     });
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/bots/);
@@ -2124,7 +2124,7 @@ describe('handleSendUserSelect', () => {
     // pick of 26 to exceed it.
     const users = Array.from({ length: 26 }, (_, i) => makeUser(`1000000000000000${String(i).padStart(2, '0')}`));
     const int = makeSelectInteraction({ users });
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/Pick at most/);
@@ -2148,7 +2148,7 @@ describe('handleSendUserSelect', () => {
         makeUser(bot1, { bot: true }),
       ],
     });
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ recipientIds: [u1, u2, u3] }),
     }));
@@ -2160,7 +2160,7 @@ describe('handleSendUserSelect', () => {
   test('transitionFlow conflict → superseded message', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
     const int = makeSelectInteraction();
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/),
     }));
@@ -2169,7 +2169,7 @@ describe('handleSendUserSelect', () => {
   test('transitionFlow not_found → expired message', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
     const int = makeSelectInteraction();
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/),
     }));
@@ -2179,11 +2179,11 @@ describe('handleSendUserSelect', () => {
     // Without the targeted catch, a DDB blip during transitionFlow
     // bubbles to the dispatcher's outer catch which surfaces a
     // generic "superseded" message — wrong, since nothing was actually
-    // superseded. Symmetric with handleSendConfirmClick /
-    // handleSendCancelClick's DDB-call guards.
+    // superseded. Symmetric with handleConfirmSendClick /
+    // handleConfirmCancelClick's DDB-call guards.
     mockTransitionFlow.mockRejectedValueOnce(new Error('ddb gone'));
     const int = makeSelectInteraction();
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not save your pick/i),
       ephemeral: true,
@@ -2211,7 +2211,7 @@ describe('handleSendUserSelect', () => {
       personalMessageRaw: '**hi**',
     };
     const int = makeSelectInteraction();
-    await handleSendUserSelect(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({
         personalMessage: '\\*\\*hi\\*\\*',
@@ -2222,10 +2222,10 @@ describe('handleSendUserSelect', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendConfirmExpirySelect — inline expiry edit on confirm card
+// handleConfirmExpirySelect — inline expiry edit on confirm card
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendConfirmExpirySelect', () => {
+describe('handleConfirmExpirySelect', () => {
   const u1 = '100000000000000001';
   const basePayload = {
     resourceType: 'file',
@@ -2244,7 +2244,7 @@ describe('handleSendConfirmExpirySelect', () => {
 
   test('happy path persists new expiresIn + re-renders', async () => {
     const int = makeSelectInteraction({ value: '7d' });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       stage_to: SEND_STAGE_AWAITING_CONFIRM,
@@ -2267,7 +2267,7 @@ describe('handleSendConfirmExpirySelect', () => {
     // version bump. Visible feedback (rerender) still fires so the
     // user knows their click registered.
     const int = makeSelectInteraction({ value: '24h' });  // same as basePayload.expiresIn
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(int.editReply).toHaveBeenCalled();
@@ -2279,7 +2279,7 @@ describe('handleSendConfirmExpirySelect', () => {
     // deferUpdate so the forgery branch uses the cheaper single-call
     // `reply` ack instead of `followUp` after a wasted defer.
     const int = makeSelectInteraction({ value: '999d' });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(int.deferUpdate).not.toHaveBeenCalled();
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
@@ -2291,7 +2291,7 @@ describe('handleSendConfirmExpirySelect', () => {
   test('conflict result → superseded copy', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
     const int = makeSelectInteraction({ value: '7d' });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/i),
       components: [],
@@ -2301,7 +2301,7 @@ describe('handleSendConfirmExpirySelect', () => {
   test('not_found result → expired copy', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
     const int = makeSelectInteraction({ value: '7d' });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/i),
       components: [],
@@ -2311,7 +2311,7 @@ describe('handleSendConfirmExpirySelect', () => {
   test('transitionFlow throw → ephemeral retry followUp, no superseded copy', async () => {
     mockTransitionFlow.mockRejectedValueOnce(new Error('DDB blip'));
     const int = makeSelectInteraction({ value: '7d' });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not save/i),
       ephemeral: true,
@@ -2341,7 +2341,7 @@ describe('handleSendConfirmExpirySelect', () => {
       // today; this assertion locks the contract.
       personalMessageRaw: 'hi',
     };
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({
         expiresIn: '7d',
@@ -2361,10 +2361,10 @@ describe('handleSendConfirmExpirySelect', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendConfirmSelfDestructSelect — inline self-destruct edit
+// handleConfirmSelfDestructSelect — inline self-destruct edit
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendConfirmSelfDestructSelect', () => {
+describe('handleConfirmSelfDestructSelect', () => {
   const u1 = '100000000000000001';
   const basePayload = {
     resourceType: 'file',
@@ -2386,7 +2386,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     // selfDestructSelectValueToSeconds rejects (returns null) anything off-preset
     // so the test value must match an existing preset for this assertion.
     const int = makeSelectInteraction({ value: '30' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       stage_to: SEND_STAGE_AWAITING_CONFIRM,
@@ -2406,7 +2406,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     // sentinel maps to null; basePayload.selfDestructSeconds is null
     // so this is a no-op.
     const int = makeSelectInteraction({ value: 'no-timer' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(int.editReply).toHaveBeenCalled();
@@ -2421,7 +2421,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     // no-op path).
     const payloadWithTimer = { ...basePayload, selfDestructSeconds: 30 };
     const int = makeSelectInteraction({ value: 'no-timer' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: payloadWithTimer, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: payloadWithTimer, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ selfDestructSeconds: null }),
     }));
@@ -2438,7 +2438,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     const logger = require('../src/logger');
     logger.warn.mockClear();
     const int = makeSelectInteraction({ value: '999999' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(int.deferUpdate).not.toHaveBeenCalled();
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
@@ -2458,7 +2458,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     const logger = require('../src/logger');
     logger.warn.mockClear();
     const int = makeSelectInteraction({ value: 'no-timer' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
@@ -2468,7 +2468,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     // BEFORE deferUpdate, so we need a legitimate preset to reach
     // the transitionFlow → result-handling branches.
     const int = makeSelectInteraction({ value: '30' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/i),
     }));
@@ -2480,7 +2480,7 @@ describe('handleSendConfirmSelfDestructSelect', () => {
     // BEFORE deferUpdate, so we need a legitimate preset to reach
     // the transitionFlow → result-handling branches.
     const int = makeSelectInteraction({ value: '30' });
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/i),
     }));
@@ -2488,10 +2488,10 @@ describe('handleSendConfirmSelfDestructSelect', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendConfirmNoteButton — opens modal, no flow mutation
+// handleConfirmNoteButton — opens modal, no flow mutation
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendConfirmNoteButton', () => {
+describe('handleConfirmNoteButton', () => {
   const basePayload = {
     resourceType: 'file',
     resourceLabel: 'x.png',
@@ -2509,7 +2509,7 @@ describe('handleSendConfirmNoteButton', () => {
 
   test('opens modal — does NOT mutate flow state (no transitionFlow / deleteFlow)', async () => {
     const int = makeButtonInteraction();
-    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.showModal).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(mockDeleteFlow).not.toHaveBeenCalled();
@@ -2535,7 +2535,7 @@ describe('handleSendConfirmNoteButton', () => {
       personalMessage: '\\*\\*bold\\*\\*',  // sanitized form (would render literally)
       personalMessageRaw: '**bold**',         // what the user actually typed
     };
-    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 1 } });
     expect(int.showModal).toHaveBeenCalled();
     // setValue receives the RAW form so the user sees `**bold**` in
     // the input, not the escaped `\*\*bold\*\*`.
@@ -2547,7 +2547,7 @@ describe('handleSendConfirmNoteButton', () => {
     const { TextInputBuilder } = require('discord.js');
     TextInputBuilder.mockClear();
     const int = makeButtonInteraction();
-    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     const builder = TextInputBuilder.mock.results[0].value;
     expect(builder.setValue).toHaveBeenCalledWith('');
   });
@@ -2562,7 +2562,7 @@ describe('handleSendConfirmNoteButton', () => {
     TextInputBuilder.mockClear();
     const int = makeButtonInteraction();
     const legacyPayload = { ...basePayload, personalMessage: '\\*\\*bold\\*\\*' };
-    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: legacyPayload, version: 1 } });
+    await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload: legacyPayload, version: 1 } });
     const builder = TextInputBuilder.mock.results[0].value;
     expect(builder.setValue).toHaveBeenCalledWith('');
   });
@@ -2574,7 +2574,7 @@ describe('handleSendConfirmNoteButton', () => {
     // bumping the version or fencing out other interactions.
     const int = makeButtonInteraction();
     const payload = { ...basePayload, recipientIds: ['100000000000000001', '100000000000000002'] };
-    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 5 } });
+    await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload, version: 5 } });
     expect(int.showModal).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
   });
@@ -2587,7 +2587,7 @@ describe('handleSendConfirmNoteButton', () => {
     // gap symmetrically with the menu handlers' error paths.
     const int = makeButtonInteraction();
     int.showModal.mockRejectedValueOnce(new Error('Discord 500'));
-    await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not open the note editor/i),
       ephemeral: true,
@@ -2611,7 +2611,7 @@ describe('handleSendConfirmNoteButton', () => {
     const listener = (reason) => { unhandled = reason; };
     process.on('unhandledRejection', listener);
     try {
-      await handleSendConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+      await handleConfirmNoteButton(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
       // Microtask flush — any unhandled rejection from the catch
       // chain would have been queued by now.
       await new Promise((resolve) => setImmediate(resolve));
@@ -2625,10 +2625,10 @@ describe('handleSendConfirmNoteButton', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleSendConfirmNoteModal — modal submit persists sanitized note
+// handleConfirmNoteModal — modal submit persists sanitized note
 // ──────────────────────────────────────────────────────────────
 
-describe('handleSendConfirmNoteModal', () => {
+describe('handleConfirmNoteModal', () => {
   const basePayload = {
     resourceType: 'file',
     resourceLabel: 'x.png',
@@ -2646,7 +2646,7 @@ describe('handleSendConfirmNoteModal', () => {
 
   test('happy path: defers, trims/sanitizes, persists, editReply re-renders', async () => {
     const int = makeModalInteraction({ inputValue: '  **bold** message  ' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     // deferUpdate guards the 3s ack deadline — without it, a slow
     // DDB conditional write could push past Discord's hard limit and
     // both update() and reply() would fail.
@@ -2686,7 +2686,7 @@ describe('handleSendConfirmNoteModal', () => {
       personalMessage: '\\*\\*bold\\*\\*',
       personalMessageRaw: '**bold**',
     };
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: existingPayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: existingPayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     // No-op skip — no DDB write, no version bump, no sibling fence.
     expect(mockTransitionFlow).not.toHaveBeenCalled();
@@ -2702,7 +2702,7 @@ describe('handleSendConfirmNoteModal', () => {
 
   test('empty input on a payload with an existing note → personalMessage: null (clear)', async () => {
     const int = makeModalInteraction({ inputValue: '' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ personalMessage: null, personalMessageRaw: null }),
     }));
@@ -2710,7 +2710,7 @@ describe('handleSendConfirmNoteModal', () => {
 
   test('whitespace-only input on a payload with an existing note → personalMessage: null', async () => {
     const int = makeModalInteraction({ inputValue: '   \n  \t' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({ personalMessage: null, personalMessageRaw: null }),
     }));
@@ -2728,7 +2728,7 @@ describe('handleSendConfirmNoteModal', () => {
     // to null in lockstep.
     const zwsp = String.fromCharCode(0x200B);
     const int = makeModalInteraction({ inputValue: zwsp.repeat(3) });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: payloadWithNote, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
       payload: expect.objectContaining({
         personalMessage: null,
@@ -2742,7 +2742,7 @@ describe('handleSendConfirmNoteModal', () => {
     // is null; submitting empty produces null → no actual change →
     // skip the write + version bump.
     const int = makeModalInteraction({ inputValue: '' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     expect(int.editReply).toHaveBeenCalled();
@@ -2751,7 +2751,7 @@ describe('handleSendConfirmNoteModal', () => {
   test('conflict → superseded copy via editReply (post-deferUpdate)', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
     const int = makeModalInteraction({ inputValue: 'hi' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/superseded/i),
       components: [],
@@ -2761,7 +2761,7 @@ describe('handleSendConfirmNoteModal', () => {
   test('not_found → expired copy via editReply', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
     const int = makeModalInteraction({ inputValue: 'hi' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/expired/i),
     }));
@@ -2778,7 +2778,7 @@ describe('handleSendConfirmNoteModal', () => {
     int.fields.getTextInputValue = jest.fn(() => {
       throw new Error('Unknown custom_id');
     });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not read your note input/i),
@@ -2791,7 +2791,7 @@ describe('handleSendConfirmNoteModal', () => {
   test('transitionFlow throw → ephemeral followUp (NOT update/reply post-defer)', async () => {
     mockTransitionFlow.mockRejectedValueOnce(new Error('DDB blip'));
     const int = makeModalInteraction({ inputValue: 'hi' });
-    await handleSendConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    await handleConfirmNoteModal(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Could not save your note/i),
       ephemeral: true,
@@ -2821,7 +2821,7 @@ describe('handleSendConfirmNoteModal', () => {
       selfDestructSeconds: 30,  // sibling-changed
       version: 2,                // version bumped by the sibling
     };
-    await handleSendConfirmNoteModal(int, {
+    await handleConfirmNoteModal(int, {
       flow_id: 'fid',
       row: { payload: rowAfterSiblingMenu, version: 2 },
     });
@@ -2870,7 +2870,7 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
     // No guildMembers — cache miss. The fallback chain should hit
     // payload.recipientAliases.
     const int = makeSelectInteraction({ value: '7d', guildMembers: {} });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
     expect(int.editReply).toHaveBeenCalled();
     const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
     // Alias renders (markdown chars not present in this alias, so the
@@ -2896,7 +2896,7 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
       warningsBlock: '⚠️ Skipped bots: 1\n\n',
     };
     const int = makeSelectInteraction({ value: '7d', guildMembers: { [u1]: {} } });
-    await handleSendConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
     const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
     expect(lastEdit.content).toMatch(/Skipped bots/);
   });
@@ -2928,7 +2928,7 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
     // corrupted expiresIn unchanged through to the renderer.
     const int = makeInteraction({ guildMembers: { '100000000000000001': {} } });
     int.values = ['30'];  // legit self-destruct preset
-    await handleSendConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    await handleConfirmSelfDestructSelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
     // The rerender pass calls StringSelectMenuBuilder twice (self-
     // destruct row + expiry row). Inspect the addOptions calls and
     // verify the EXPIRY select has exactly one default-true option,
@@ -2936,7 +2936,7 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
     const expirySelectCalls = StringSelectMenuBuilder.mock.results
       .filter((r) => {
         const calls = r.value.setCustomId.mock.calls;
-        return calls.length && calls[0][0] === 'qurl_send_confirm_expiry';
+        return calls.length && calls[0][0] === 'qurl_confirm_expiry';
       });
     expect(expirySelectCalls.length).toBeGreaterThan(0);
     const expiryAddOptionsArgs = expirySelectCalls[expirySelectCalls.length - 1]
@@ -2975,10 +2975,10 @@ describe('renderConfirmCardRows', () => {
     const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
     expect(lastCall.components).toHaveLength(4);
     // 3 ButtonBuilders: Note, Send, Cancel. The Send button is the
-    // one with custom id 'qurl_send_confirm_send'. Find it and assert
+    // one with custom id 'qurl_confirm_send'. Find it and assert
     // setDisabled(true) was called.
     const sendBuilder = ButtonBuilder.mock.results.find(
-      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_send_confirm_send'
+      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_send'
     );
     expect(sendBuilder).toBeDefined();
     expect(sendBuilder.value.setDisabled).toHaveBeenCalledWith(true);
@@ -2994,7 +2994,7 @@ describe('renderConfirmCardRows', () => {
     // Round-13 cr removed the conditional entirely: renderer now
     // always produces 4 rows. The user sees the same layout from
     // frame 0 through every menu interaction. Matches
-    // handleSendUserSelect's post-pick contract — re-picks stay
+    // handleConfirmUserSelect's post-pick contract — re-picks stay
     // possible after a successful pick.
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
@@ -3025,9 +3025,9 @@ describe('renderConfirmCardRows', () => {
       (r) => r.value.setCustomId.mock.calls[0][0]
     );
     expect(customIds).toEqual([
-      'qurl_send_confirm_note_btn',
-      'qurl_send_confirm_send',
-      'qurl_send_confirm_cancel',
+      'qurl_confirm_note_btn',
+      'qurl_confirm_send',
+      'qurl_confirm_cancel',
     ]);
   });
 
@@ -3083,18 +3083,18 @@ describe('constants + exports', () => {
   // SEND_STAGE_AWAITING_CONFIRM, ...})`) already pin them by
   // contract.
   test('customIds match the wire-protocol values Discord routes against', () => {
-    expect(SEND_USER_SELECT_CUSTOM_ID).toBe('qurl_send_user_select');
-    expect(SEND_CONFIRM_SEND_CUSTOM_ID).toBe('qurl_send_confirm_send');
-    expect(SEND_CONFIRM_CANCEL_CUSTOM_ID).toBe('qurl_send_confirm_cancel');
+    expect(CONFIRM_USER_SELECT_CUSTOM_ID).toBe('qurl_confirm_user_select');
+    expect(CONFIRM_SEND_CUSTOM_ID).toBe('qurl_confirm_send');
+    expect(CONFIRM_CANCEL_CUSTOM_ID).toBe('qurl_confirm_cancel');
   });
 
   test('all customIds unique', () => {
-    const ids = new Set([SEND_USER_SELECT_CUSTOM_ID, SEND_CONFIRM_SEND_CUSTOM_ID, SEND_CONFIRM_CANCEL_CUSTOM_ID]);
+    const ids = new Set([CONFIRM_USER_SELECT_CUSTOM_ID, CONFIRM_SEND_CUSTOM_ID, CONFIRM_CANCEL_CUSTOM_ID]);
     expect(ids.size).toBe(3);
   });
 
   test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {
-    // siblingMessage is registered only on SEND_USER_SELECT_CUSTOM_ID
+    // siblingMessage is registered only on CONFIRM_USER_SELECT_CUSTOM_ID
     // (commands.js's registerFlow blocks), but flow-dispatch stores
     // siblingMessages keyed by EXPECTED_STAGE — so a /qurl revoke
     // supersede that peeks at a row at SEND_STAGE_AWAITING_CONFIRM
@@ -3122,10 +3122,10 @@ describe('constants + exports', () => {
     // registerFlow on each customId must throw "already registered".
     const { registerFlow } = require('../src/flow-dispatch');
     const newCustomIds = [
-      'qurl_send_confirm_expiry',
-      'qurl_send_confirm_self_destruct',
-      'qurl_send_confirm_note_btn',
-      'qurl_send_confirm_note_modal',
+      'qurl_confirm_expiry',
+      'qurl_confirm_self_destruct',
+      'qurl_confirm_note_btn',
+      'qurl_confirm_note_modal',
     ];
     for (const id of newCustomIds) {
       expect(() => registerFlow(id, {
@@ -3195,10 +3195,10 @@ describe('constants + exports', () => {
     expect(fnBody).not.toContain('personalMessageRaw');
   });
 
-  test('CONTRACT (runtime): handleSendConfirmClick never reads payload.personalMessageRaw on the Send path', async () => {
+  test('CONTRACT (runtime): handleConfirmSendClick never reads payload.personalMessageRaw on the Send path', async () => {
     // Runtime complement to the static brace-walker above. Wraps
     // row.payload in a Proxy that throws on any get('personalMessageRaw')
-    // access, then drives handleSendConfirmClick through to the
+    // access, then drives handleConfirmSendClick through to the
     // executeSendPipeline call. If the handler (or anything downstream
     // it triggers through this payload reference) reads the field, the
     // Proxy throws and the test fails — survives future syntax changes
@@ -3224,14 +3224,14 @@ describe('constants + exports', () => {
       get(target, prop) {
         if (prop === 'personalMessageRaw') {
           leaked = true;
-          throw new Error('CONTRACT VIOLATION: handleSendConfirmClick read payload.personalMessageRaw');
+          throw new Error('CONTRACT VIOLATION: handleConfirmSendClick read payload.personalMessageRaw');
         }
         return target[prop];
       },
     });
     const int = makeInteraction({ guildMembers: { [u1]: {} } });
     mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
-    await handleSendConfirmClick(int, { flow_id: 'fid', row: { payload: trappedPayload, version: 1 } });
+    await handleConfirmSendClick(int, { flow_id: 'fid', row: { payload: trappedPayload, version: 1 } });
     expect(leaked).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Post-7b.3 cleanup. PR #313 hard-removed `/qurl send` but left the confirm-card customId wire literals and handler functions named after the deleted command. The 180s `SEND_FLOW_TTL_SECONDS` drain has long passed since #313 deployed (~30 minutes ago at branch time), so we can flip the prefix now.

### customId wire literals

| Before | After |
| --- | --- |
| `qurl_send_user_select` | `qurl_confirm_user_select` |
| `qurl_send_confirm_send` | `qurl_confirm_send` |
| `qurl_send_confirm_cancel` | `qurl_confirm_cancel` |
| `qurl_send_confirm_expiry` | `qurl_confirm_expiry` |
| `qurl_send_confirm_self_destruct` | `qurl_confirm_self_destruct` |
| `qurl_send_confirm_note_btn` | `qurl_confirm_note_btn` |
| `qurl_send_confirm_note_modal` | `qurl_confirm_note_modal` |

JS constant names follow: `SEND_*_CUSTOM_ID` → `CONFIRM_*_CUSTOM_ID`.

### Handler renames

| Before | After |
| --- | --- |
| `handleSendUserSelect` | `handleConfirmUserSelect` |
| `handleSendConfirmClick` | `handleConfirmSendClick` |
| `handleSendCancelClick` | `handleConfirmCancelClick` |
| `handleSendConfirmExpirySelect` | `handleConfirmExpirySelect` |
| `handleSendConfirmSelfDestructSelect` | `handleConfirmSelfDestructSelect` |
| `handleSendConfirmNoteButton` | `handleConfirmNoteButton` |
| `handleSendConfirmNoteModal` | `handleConfirmNoteModal` |

### Intentionally NOT renamed

- `SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm'` — `flow_state.stage` value is encoded in DDB rows. Needs its own coordinated drain (separate follow-up).
- `qurl_send_configs` / `qurl_sends` DDB table + column names — per CLAUDE.md, these stay literal across the rebrand.
- `SEND_FLOW_TTL_SECONDS`, `SEND_NOTE_MODAL_FIELD_ID` — internal-only JS names; out of scope.

## Deploy safety

This is a wire-protocol break for in-flight cards across the deploy boundary. Affected paths:

- **Confirm-card buttons (Send / Cancel) + selects (Expiry / Self-Destruct) + Note button.** Card has a 180s `flow_state` TTL; any click after the new image lands on a card minted by the old image fails dispatch (silent drop at `flow-dispatch.js`).
- **Note modal submit.** A user who opened the "Add note" modal on the OLD code right before deploy will submit with the old `qurl_send_confirm_note_modal` customId. Modals are client-side until submit — bounded by however long users keep them open. Same single-broken-interaction failure mode as the other paths, called out explicitly because it's the one path not bounded by the 180s TTL alone.

Drain check before merge: most recent #313 prod deploy at 17:44:45Z (verified via `gh run list --workflow qurl-bot-discord-deploy.yml --repo layervai/qurl-integrations-infra`), well past the 180s TTL at branch time.

Failure mode on the rename deploy: one broken interaction per affected user. No data loss, no orphaned DDB state (`flow_state` row TTLs out cleanly; user reruns `/qurl file` or `/qurl map`). Bot is private beta with no paying customers — acceptable.

## Test plan

- [x] `pnpm test` — 1413 tests pass
- [x] `pnpm lint` — clean (`eslint --max-warnings 0`)
- [x] `grep -rn 'qurl_send_' apps/discord/src apps/discord/tests` returns only DDB literals (`qurl_send_configs`, `qurl_sends`)
- [x] Contract test pins all 7 confirm-card wire literals + asserts uniqueness
- [ ] CI green
- [ ] Claude review clean

Closes #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)