### PR TITLE
feat(discord): allow self-send on /qurl file + /qurl map

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2698,6 +2698,12 @@ async function resolveRecipientUsers(interaction, ids) {
 // drops them all — small absolute cost but burns per-guild rate-limit
 // budget that legitimate ops elsewhere could use. The durable fix is
 // the v2 resolve-then-cap refactor tracked in #304.
+//
+// Self-mention cap behavior: since self-send is supported, `<@me>` now
+// CONSUMES a cap slot like any other mention. So `<@me> <@u1>..<@u25>`
+// yields self + 24 others (was: 25 others, pre self-send). This is
+// symmetric with the bot cap-skew above and aligns with the supported-
+// recipient model — sender is just another recipient.
 function partitionRecipients(users, senderId) {
   // Dedup contract is OWNED upstream: parseRecipientMentions dedupes
   // via a Set (recipient-parser.js:197-198) and the UserSelectMenu
@@ -3627,10 +3633,14 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     });
     // Only the bot-only case is reachable here today — self-send is
     // supported, so a pick of just the sender does NOT empty `valid`.
-    // Kept as a list-builder for future filters.
+    // Kept as a list-builder for future filters; the
+    // `|| 'No usable recipients in pick'` fallback prevents a
+    // degraded `⚠ . Re-pick...` message if a future filter is
+    // removed and `valid.length === 0` is hit with droppedBots === 0.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
-    return rejectPick(`⚠\u{FE0F} ${reasons.join('. ')}. Re-pick recipients below.\n\n`);
+    const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
+    return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }
   // Defense-in-depth — unreachable in production today: the picker's
   // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -958,9 +958,10 @@ async function executeSendPipeline(interaction, {
   locationName,
   // MUTATES: the Add Recipients post-send branch dedupe-pushes into
   // this array (see docstring's "transferred ownership" note). The
-  // initial `recipients` is already deduped + bot/sender-filtered by
+  // initial `recipients` is already deduped + bot-filtered by
   // partitionRecipients (see contract pin at commands.js:~3552):
   // upstream owns dedup, this function does NOT re-dedup the initial set.
+  // Sender CAN appear in `recipients` — self-send is supported.
   recipients,
   expiresIn,
   selfDestructSeconds,
@@ -2679,10 +2680,11 @@ async function resolveRecipientUsers(interaction, ids) {
   return { users, unresolvedIds, transientFailureIds };
 }
 
-// Filter resolved Users: drop bots, drop the sender. Returns
-// `{ valid, droppedBots, droppedSelf }` so the caller can surface
-// "X bots / your-own-id were dropped" as a distinct error from
-// "no recipients at all".
+// Filter resolved Users: drop bots, detect whether the sender is
+// included. Returns `{ valid, droppedBots, selfIncluded }` so the
+// caller can surface "X bots were dropped" as a warning and "send
+// includes yourself" as a neutral notice. Sender is NOT filtered —
+// self-send is supported.
 //
 // Known v1 cap-skew: parseRecipientMentions caps to QURL_SEND_MAX_RECIPIENTS
 // BEFORE knowing which IDs are bots. A mention list of
@@ -2705,13 +2707,13 @@ function partitionRecipients(users, senderId) {
   // loudly via the recipient-count divergence test instead.
   const valid = [];
   let droppedBots = 0;
-  let droppedSelf = 0;
+  let selfIncluded = false;
   for (const u of users) {
     if (u.bot) { droppedBots++; continue; }
-    if (u.id === senderId) { droppedSelf++; continue; }
+    if (u.id === senderId) selfIncluded = true;
     valid.push(u);
   }
-  return { valid, droppedBots, droppedSelf };
+  return { valid, droppedBots, selfIncluded };
 }
 
 /**
@@ -2726,7 +2728,6 @@ function partitionRecipients(users, senderId) {
  *   unresolvedIds?: string[],
  *   transientFailureIds?: string[],
  *   droppedBots?: number,
- *   droppedSelf?: number,
  * }} [opts]
  */
 function renderRecipientWarnings({
@@ -2735,7 +2736,6 @@ function renderRecipientWarnings({
   unresolvedIds = [],
   transientFailureIds = [],
   droppedBots = 0,
-  droppedSelf = 0,
 } = {}) {
   const lines = [];
   if (cappedCount > 0) {
@@ -2775,9 +2775,6 @@ function renderRecipientWarnings({
   if (droppedBots > 0) {
     lines.push(`• ${droppedBots} bot(s) cannot receive qURL links — skipped.`);
   }
-  if (droppedSelf > 0) {
-    lines.push('• You cannot send a qURL to yourself — skipped.');
-  }
   if (lines.length === 0) return '';
   return '⚠\u{FE0F} **Some recipients were dropped:**\n' + lines.join('\n') + '\n\n';
 }
@@ -2789,7 +2786,7 @@ function renderRecipientWarnings({
 function renderConfirmCardContent({
   resourceType, resourceLabel, validRecipients,
   expiresIn, selfDestructSeconds, personalMessage,
-  warningsBlock, needsPicker, interaction,
+  warningsBlock, needsPicker, interaction, selfIncluded = false,
 }) {
   let content = warningsBlock || '';
   // Explicit branch per RESOURCE_TYPES value — a future resource
@@ -2803,6 +2800,13 @@ function renderConfirmCardContent({
     content += `🗺\u{FE0F} **Sending location:** ${resourceLabel}\n`;
   } else {
     throw new TypeError(`renderConfirmCardContent: unknown resourceType ${JSON.stringify(resourceType)}`);
+  }
+  // Neutral notice (NOT a warning) when the sender is in the recipient
+  // list. Self-send is supported as a first-class flow; surface it on
+  // the confirm card so the user can verify they meant to include
+  // themselves before clicking Send.
+  if (selfIncluded) {
+    content += 'ℹ\u{FE0F} **Send includes you.**\n';
   }
   if (needsPicker) {
     content += '\n**Pick recipients below** (1–'
@@ -3088,7 +3092,7 @@ async function handleQurlSlashSend(interaction, params) {
       }
     }
 
-    const { valid, droppedBots, droppedSelf } = partitionRecipients(resolved.users, interaction.user.id);
+    const { valid, droppedBots, selfIncluded } = partitionRecipients(resolved.users, interaction.user.id);
 
     // `needsPicker` is true when the user supplied no `recipients:`
     // value at all. When they DID supply one but it post-filtered to
@@ -3102,7 +3106,6 @@ async function handleQurlSlashSend(interaction, params) {
       unresolvedIds: resolved.unresolvedIds,
       transientFailureIds: resolved.transientFailureIds,
       droppedBots,
-      droppedSelf,
     });
     if (!recipientsOmitted && valid.length === 0) {
       clearCooldown(interaction.user.id);
@@ -3113,7 +3116,6 @@ async function handleQurlSlashSend(interaction, params) {
       const transientOnly = resolved.transientFailureIds.length > 0
         && resolved.unresolvedIds.length === 0
         && droppedBots === 0
-        && droppedSelf === 0
         && parsed.invalidTokens.length === 0
         && parsed.cappedCount === 0;
       if (transientOnly) {
@@ -3121,19 +3123,19 @@ async function handleQurlSlashSend(interaction, params) {
           content: warningsBlock + '❌ **Could not look up recipients right now.** Try again in a moment.',
         });
       }
-      // Parser silently strips bots + the sender from `<@id>` mentions
-      // when the cache reports them (recipient-parser.js:205, 214) —
-      // those IDs never reach `partitionRecipients`. If post-parse `ids`
-      // is empty AND the user supplied non-empty `recipients`, surface
-      // a "nothing usable" message even when partition's breakdown is
-      // zero. This is what bot-only / self-only mention lists hit.
-      const breakdownEmpty = droppedBots === 0 && droppedSelf === 0
+      // Parser silently strips bots from `<@id>` mentions when the
+      // cache reports them (recipient-parser.js:~219) — those IDs
+      // never reach `partitionRecipients`. If post-parse `ids` is
+      // empty AND the user supplied non-empty `recipients`, surface
+      // a "nothing usable" message even when partition's breakdown
+      // is zero. This is what bot-only mention lists hit.
+      const breakdownEmpty = droppedBots === 0
         && resolved.unresolvedIds.length === 0
         && resolved.transientFailureIds.length === 0
         && parsed.invalidTokens.length === 0
         && parsed.cappedCount === 0;
       const detail = breakdownEmpty
-        ? '\n\nMake sure you @-mention real users (bots and your own user are skipped automatically).'
+        ? '\n\nMake sure you @-mention real users (bots are skipped automatically).'
         : '';
       // Metric signal for the v1 cap-skew tracked in #304: a
       // mention-list that resolved to NOTHING (parser-stripped bots
@@ -3190,11 +3192,16 @@ async function handleQurlSlashSend(interaction, params) {
       // a contract test pins that invariant.
       personalMessageRaw: personalMessageRawTrimmed,
       // One-time information surface — slash-entry warnings about
-      // bot/self/unresolved mentions persist into the payload so
-      // menu interactions (which don't recompute) still render them.
+      // bot/unresolved mentions persist into the payload so menu
+      // interactions (which don't recompute) still render them.
       // Picker re-pick OVERWRITES with a fresh warningsBlock from the
       // new partition.
       warningsBlock,
+      // Neutral notice signal — surfaced on the confirm card as
+      // "Send includes you." when the sender is in the recipient
+      // list. Persisted (rather than re-derived) so menu re-renders
+      // don't need to know how to compute it.
+      selfIncluded,
       sendNonce,
     };
     let supersede;
@@ -3236,6 +3243,7 @@ async function handleQurlSlashSend(interaction, params) {
       warningsBlock,
       needsPicker,
       interaction,
+      selfIncluded,
     });
     const rows = renderConfirmCardRows({
       sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
@@ -3565,9 +3573,9 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // enforces "only the user who triggered an ephemeral interaction
   // can click its components" at the gateway level, so the clicker
   // === the sender. This invariant is LOAD-BEARING: partitioning
-  // by clicker also drops the SENDER from the pick (droppedSelf),
-  // and a future refactor that flips the confirm card to
-  // non-ephemeral would need to thread the original sender ID
+  // by clicker is how we detect `selfIncluded` (sender appears in
+  // the pick), and a future refactor that flips the confirm card
+  // to non-ephemeral would need to thread the original sender ID
   // through the flow payload + read it here instead.
   //
   // No `resolveRecipientUsers` re-fetch here — Discord's
@@ -3578,7 +3586,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // defense; adding it here would burn 10 members.fetch calls per
   // picker tick without catching anything the Send-time check misses.
   const payload = row.payload || {};
-  const { valid, droppedBots, droppedSelf } = partitionRecipients(selected, interaction.user.id);
+  const { valid, droppedBots, selfIncluded } = partitionRecipients(selected, interaction.user.id);
   // Both invalid-pick branches re-render the full confirm card with a
   // warning banner prepended. Replacing card content with just the
   // warning string strips the resource header ("Sending file:
@@ -3611,11 +3619,13 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     // in invalid-pick churn surfaces in metrics without lowering log
     // verbosity.
     logger.debug('handleConfirmUserSelect: all-invalid pick', {
-      flow_id, dropped_bots: droppedBots, dropped_self: droppedSelf,
+      flow_id, dropped_bots: droppedBots,
     });
+    // Only the bot-only case is reachable here today — self-send is
+    // supported, so a pick of just the sender does NOT empty `valid`.
+    // Kept as a list-builder for future filters.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
-    if (droppedSelf > 0) reasons.push('Cannot send to yourself');
     return rejectPick(`⚠\u{FE0F} ${reasons.join('. ')}. Re-pick recipients below.\n\n`);
   }
   // Defense-in-depth — unreachable in production today: the picker's
@@ -3628,27 +3638,29 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   }
 
   // Recompute warnings + aliases for the new pick. droppedBots and
-  // droppedSelf can flip here (UserSelectMenu doesn't pre-exclude
-  // the invoker or bots), so warnings change with the recipient set.
+  // selfIncluded can flip here (UserSelectMenu doesn't pre-exclude
+  // the invoker or bots), so warnings + the self-notice change with
+  // the recipient set.
   const newWarningsBlock = renderRecipientWarnings({
     droppedBots,
-    droppedSelf,
   });
   const newRecipientAliases = Object.fromEntries(
     valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
   );
   // Asymmetry vs. the menu/modal handlers' no-op short-circuits:
   // the picker DOES NOT skip transitionFlow on a same-recipient-set
-  // re-pick. Re-running here recomputes warningsBlock (droppedBots /
-  // droppedSelf can flip if the picker selection now includes the
-  // sender or a bot) and refreshes recipientAliases (display names
-  // may have changed since the prior pick). Both are user-visible
-  // and worth the version bump.
+  // re-pick. Re-running here recomputes warningsBlock (droppedBots
+  // can flip if the picker selection now includes a bot) plus
+  // selfIncluded (flips if sender enters or leaves the pick), and
+  // refreshes recipientAliases (display names may have changed
+  // since the prior pick). All three are user-visible and worth
+  // the version bump.
   const newPayload = {
     ...payload,
     recipientIds: valid.map((u) => u.id),
     recipientAliases: newRecipientAliases,
     warningsBlock: newWarningsBlock,
+    selfIncluded,
   };
   // Targeted catch around transitionFlow mirrors the same shape
   // handleConfirmSendClick / handleConfirmCancelClick use around their
@@ -3700,6 +3712,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     warningsBlock: newWarningsBlock,
     needsPicker: false,
     interaction,
+    selfIncluded,
   });
   return interaction.editReply({
     content,
@@ -3774,6 +3787,7 @@ async function rerenderConfirmCard(interaction, newPayload) {
     warningsBlock: newPayload.warningsBlock || '',
     needsPicker,
     interaction,
+    selfIncluded: newPayload.selfIncluded === true,
   });
   return interaction.editReply({
     content,
@@ -4169,17 +4183,18 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
       flow_id, left: partialLeftCount, transient: partialTransientCount,
     });
   }
-  const { valid, droppedBots, droppedSelf } = partitionRecipients(users, interaction.user.id);
+  const { valid, droppedBots } = partitionRecipients(users, interaction.user.id);
   if (valid.length === 0) {
     // Distinguish the failure mode by what was dropped. The general
     // case is "everyone left the guild between confirm and Send"
     // (10007 / transient) — but a forged Send click with payload
-    // recipientIds containing only the sender or only bots would
-    // resolve fine and then partition would drop everything, hitting
-    // this branch with the WRONG copy ("they left the server"
-    // misdirects when nobody left — the recipient list was invalid).
-    // Terminal for THIS attempt either way: delete the flow so a
-    // rerun claims a fresh slot.
+    // recipientIds containing only bots would resolve fine and then
+    // partition would drop everything, hitting this branch with the
+    // WRONG copy ("they left the server" misdirects when nobody left
+    // — the recipient list was invalid). Self-send is supported so
+    // a self-only recipientIds is a legitimate Send and never reaches
+    // this branch. Terminal for THIS attempt either way: delete the
+    // flow so a rerun claims a fresh slot.
     //
     // Version-gate the delete (same shape as the happy-path Send and
     // the empty-recipientIds branch): a concurrent UserSelect could
@@ -4202,9 +4217,8 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
         ephemeral: true,
       }).catch(logIgnoredDiscordErr);
     }
-    const wasInvalidList = droppedBots > 0 || droppedSelf > 0;
     return interaction.editReply({
-      content: wasInvalidList
+      content: droppedBots > 0
         ? '❌ Invalid recipient list — re-run the command with at least one real user.'
         : '❌ Recipients are no longer reachable (all left the server). Re-run the command.',
       components: [],

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3199,8 +3199,12 @@ async function handleQurlSlashSend(interaction, params) {
       warningsBlock,
       // Neutral notice signal — surfaced on the confirm card as
       // "Send includes you." when the sender is in the recipient
-      // list. Persisted (rather than re-derived) so menu re-renders
-      // don't need to know how to compute it.
+      // list. Persisted (rather than derived from
+      // `recipientIds.includes(senderId)` at re-render) for the
+      // same reason `warningsBlock` is persisted: keeps the menu
+      // re-render path stateless about who computed what. Derivation
+      // would also work — both shapes are defensible, but mirroring
+      // warningsBlock keeps the payload contract uniform.
       selfIncluded,
       sendNonce,
     };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -55,8 +55,10 @@
 //   }
 //
 // `ids` is deduped, capped at `config.QURL_SEND_MAX_RECIPIENTS` (the
-// same per-send cap the in-channel form enforces), and excludes the
-// invoking user + bots (matches the form's self-send + bot rejection).
+// same per-send cap the in-channel form enforces), and excludes bots
+// (matches the form's bot rejection). The invoking user IS allowed as
+// a recipient — self-send is a supported use case (test the link
+// before forwarding, cross-device handoff, etc.).
 //
 // Role expansion uses interaction.guild.members.cache via discord.js's
 // `Role.members` getter, which filters the guild's member cache for
@@ -133,13 +135,14 @@ const MAX_INVALID_TOKEN_LENGTH = 256;
 const MASSIVE_OVERSHOOT_MULTIPLIER = 2;
 
 // Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / etc.) to
-// a flat user-ID list with the cap + self/bot filters applied. Returns
+// a flat user-ID list with the cap + bot filter applied. Returns
 // `{ ids, invalidTokens, cappedCount }`; never throws on parse errors —
 // invalid tokens always land in `invalidTokens` for caller-side
-// surfacing.
+// surfacing. Sender is NOT filtered — self-send is supported; the
+// confirm-card renderer surfaces a neutral notice when sender appears
+// in `ids`.
 //
 // `interaction` is the slash-command interaction; we need it for:
-//   - interaction.user.id  → exclude the sender from recipients
 //   - interaction.guild    → role-mention expansion via members.cache
 //   - interaction.guild.members.cache.get(id).user.bot → bot filter
 function parseRecipientMentions(raw, interaction) {
@@ -197,7 +200,6 @@ function parseRecipientMentions(raw, interaction) {
   const seen = new Set();
   const ids = new Set();
   const invalidTokens = [];
-  const senderId = interaction.user?.id;
   const guild = interaction.guild;
   // `cap > 0` is guaranteed by the `intEnv(..., { minPositive: true })`
   // validator on QURL_SEND_MAX_RECIPIENTS in config.js — if the env
@@ -216,7 +218,6 @@ function parseRecipientMentions(raw, interaction) {
 
   for (const m of input.matchAll(USER_MENTION_RE)) {
     const id = m[1];
-    if (id === senderId) continue;
     // Bot filter — best-effort via cache. A cache miss (cold cache,
     // partial cache without GUILD_MEMBERS intent, or DM-context with
     // `guild === undefined`) leaves the bot in the result; downstream
@@ -269,25 +270,24 @@ function parseRecipientMentions(raw, interaction) {
       pushRoleErrorIfNew(roleId, m[0]);
       continue;
     }
-    // `usable` counts members that passed the sender/bot filter,
-    // INCLUDING ones already in `seen` (i.e. a role whose every
-    // member was already direct-mentioned still contributes — dedupe
-    // counts). Drives ONLY the "no usable members" → invalidTokens
-    // branch below: empty role / sender-only role / bots-only role.
-    // Critically, `usable++` runs BEFORE the seen-check inside
-    // `consider`, so the "fully-duplicate role isn't useless" test
-    // catches a future refactor reversing that order.
+    // `usable` counts members that passed the bot filter, INCLUDING
+    // ones already in `seen` (i.e. a role whose every member was
+    // already direct-mentioned still contributes — dedupe counts).
+    // Drives ONLY the "no usable members" → invalidTokens branch
+    // below: empty role / bots-only role. Critically, `usable++` runs
+    // BEFORE the seen-check inside `consider`, so the "fully-duplicate
+    // role isn't useless" test catches a future refactor reversing
+    // that order.
     let usable = 0;
     for (const [memberId, roleMember] of members) {
-      if (memberId === senderId) continue;
       if (roleMember?.user?.bot) continue;
       usable++;
       consider(memberId);
     }
     if (usable === 0) {
-      // Role had members but they were all filtered (sender + bots).
+      // Role had members but they were all filtered out as bots.
       // Surface as "no usable members" rather than silently no-op so
-      // the caller can tell the user "the role only contains you / bots."
+      // the caller can tell the user "the role only contains bots."
       pushRoleErrorIfNew(roleId, m[0]);
     }
   }

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -155,7 +155,7 @@ function parseRecipientMentions(raw, interaction) {
   }
   // Mirror the `raw` guard for `interaction` so a null/undefined
   // caller-bug surfaces as an empty result instead of a TypeError
-  // at the `interaction.user?.id` deref below. The back-half has
+  // at the `interaction.guild` deref below. The back-half has
   // a clearer crash site for "no caller context"; the parser
   // doesn't gain anything by failing here.
   if (interaction == null) {
@@ -234,9 +234,14 @@ function parseRecipientMentions(raw, interaction) {
   // / all-members-filtered all land the raw role token in
   // `invalidTokens` so the caller can surface "couldn't resolve
   // @role" rather than silently produce a smaller recipient list.
+  // Self-send via role: if the sender is a member of the mentioned
+  // role, they contribute to the recipient list along with the
+  // role's other (non-bot) members. The confirm card's "Send includes
+  // you." notice surfaces this so users aren't surprised when an
+  // `@team` mention includes themselves.
   // NOTE: these three states are CONFLATED in the current shape —
   // 7b.2 may want to distinguish "role doesn't exist" / "role has
-  // no members" / "all members are you+bots" via separate fields
+  // no members" / "all members are bots" via separate fields
   // (e.g. `emptyRoles`, or check `role.memberCount > 0 && members.size
   // === 0` for the partial-cache case). For now, conflation is
   // acceptable because the user-visible copy ("couldn't expand @role")

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -351,7 +351,7 @@ describe('selfDestructOptionToSeconds', () => {
 });
 
 describe('partitionRecipients', () => {
-  test('drops bots and sender', () => {
+  test('drops bots, keeps sender, flags selfIncluded=true', () => {
     const users = [
       makeUser('100000000000000001'),
       makeUser('100000000000000002', { bot: true }),
@@ -359,9 +359,10 @@ describe('partitionRecipients', () => {
       makeUser('100000000000000003'),
     ];
     const r = partitionRecipients(users, SENDER_ID);
-    expect(r.valid.map((u) => u.id)).toEqual(['100000000000000001', '100000000000000003']);
+    expect(r.valid.map((u) => u.id))
+      .toEqual(['100000000000000001', SENDER_ID, '100000000000000003']);
     expect(r.droppedBots).toBe(1);
-    expect(r.droppedSelf).toBe(1);
+    expect(r.selfIncluded).toBe(true);
   });
 
   test('all bots returns valid=[]', () => {
@@ -369,17 +370,30 @@ describe('partitionRecipients', () => {
     const r = partitionRecipients(users, SENDER_ID);
     expect(r.valid).toEqual([]);
     expect(r.droppedBots).toBe(2);
-    expect(r.droppedSelf).toBe(0);
+    expect(r.selfIncluded).toBe(false);
   });
 
-  test('only sender returns valid=[]', () => {
+  test('only sender is a legitimate single-recipient self-send', () => {
+    // Self-send: sender alone is a valid recipient list.
+    // valid=[sender], selfIncluded=true, no drops.
     const r = partitionRecipients([makeUser(SENDER_ID)], SENDER_ID);
-    expect(r.valid).toEqual([]);
-    expect(r.droppedSelf).toBe(1);
+    expect(r.valid.map((u) => u.id)).toEqual([SENDER_ID]);
+    expect(r.droppedBots).toBe(0);
+    expect(r.selfIncluded).toBe(true);
   });
 
   test('empty input', () => {
-    expect(partitionRecipients([], SENDER_ID)).toEqual({ valid: [], droppedBots: 0, droppedSelf: 0 });
+    expect(partitionRecipients([], SENDER_ID))
+      .toEqual({ valid: [], droppedBots: 0, selfIncluded: false });
+  });
+
+  test('sender NOT in input → selfIncluded=false', () => {
+    const r = partitionRecipients(
+      [makeUser('100000000000000001'), makeUser('100000000000000002')],
+      SENDER_ID,
+    );
+    expect(r.selfIncluded).toBe(false);
+    expect(r.valid.length).toBe(2);
   });
 
   test('contract: does NOT re-dedup — dedup is upstream (parseRecipientMentions Set + Discord picker gateway-event)', () => {
@@ -644,14 +658,14 @@ describe('renderRecipientWarnings', () => {
   test('returns empty when nothing to surface', () => {
     expect(renderRecipientWarnings({
       invalidTokens: [], cappedCount: 0, unresolvedIds: [],
-      droppedBots: 0, droppedSelf: 0,
+      droppedBots: 0,
     })).toBe('');
   });
 
   test('cappedCount line', () => {
     const out = renderRecipientWarnings({
       invalidTokens: [], cappedCount: 3, unresolvedIds: [],
-      droppedBots: 0, droppedSelf: 0,
+      droppedBots: 0,
     });
     expect(out).toMatch(/Capped at 25/);
     expect(out).toMatch(/3 recipient/);
@@ -661,7 +675,7 @@ describe('renderRecipientWarnings', () => {
     const tokens = Array.from({ length: 15 }, (_, i) => `bogus${i}`);
     const out = renderRecipientWarnings({
       invalidTokens: tokens, cappedCount: 0, unresolvedIds: [],
-      droppedBots: 0, droppedSelf: 0,
+      droppedBots: 0,
     });
     expect(out).toMatch(/```/);
     expect(out).toMatch(/bogus0/);
@@ -678,7 +692,7 @@ describe('renderRecipientWarnings', () => {
     const tokens = ['```\n[evil](https://phish.example)\n```', '`code`', 'plain'];
     const out = renderRecipientWarnings({
       invalidTokens: tokens, cappedCount: 0, unresolvedIds: [],
-      droppedBots: 0, droppedSelf: 0,
+      droppedBots: 0,
     });
     // Backticks must not appear in the rendered tokens themselves —
     // they'd terminate the surrounding fence.
@@ -693,13 +707,17 @@ describe('renderRecipientWarnings', () => {
     const out = renderRecipientWarnings({
       invalidTokens: ['<#999>'], cappedCount: 2,
       unresolvedIds: ['100000000000000001'],
-      droppedBots: 1, droppedSelf: 1,
+      droppedBots: 1,
     });
     expect(out).toMatch(/Capped/);
     expect(out).toMatch(/Could not parse/);
     expect(out).toMatch(/no longer in this server/);
     expect(out).toMatch(/bot/);
-    expect(out).toMatch(/yourself/);
+    // "yourself" was the dropped-self warning before #316-followup —
+    // self-send is now supported, so the warning is gone; the confirm
+    // card renderer surfaces a neutral "Send includes you." notice
+    // (asserted in the renderConfirmCardContent suite below).
+    expect(out).not.toMatch(/yourself/);
   });
 
   test('transientFailureIds rendered with neutral copy (not "left the server")', () => {
@@ -803,6 +821,22 @@ describe('renderConfirmCardContent', () => {
   test('self-destruct line shown when set', () => {
     const out = renderConfirmCardContent({ ...baseProps, selfDestructSeconds: 300 });
     expect(out).toMatch(/Self-destruct/);
+  });
+
+  test('selfIncluded=true surfaces "Send includes you." neutral notice', () => {
+    // Self-send is supported — the renderer surfaces a NEUTRAL notice
+    // (not a warning) so the user sees confirmation that the sender
+    // made it into the recipient list.
+    const out = renderConfirmCardContent({ ...baseProps, selfIncluded: true });
+    expect(out).toMatch(/Send includes you/);
+    // Not in the warning block (the leading ⚠ "Some recipients were
+    // dropped" header).
+    expect(out).not.toMatch(/Some recipients were dropped/);
+  });
+
+  test('selfIncluded omitted (default false) → no notice', () => {
+    const out = renderConfirmCardContent(baseProps);
+    expect(out).not.toMatch(/Send includes/);
   });
 
   test('personal-message preview cap at 80 chars, rendered as blockquote', () => {
@@ -1148,20 +1182,26 @@ describe('handleQurlFile — slash entry', () => {
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
-    expect(reply.content).toMatch(/bots and your own user are skipped/);
+    expect(reply.content).toMatch(/bots are skipped/);
   });
 
-  test('only sender mentioned → ephemeral error', async () => {
-    // Same parser-side filter applies to the sender (src/recipient-parser.js:205).
+  test('only sender mentioned → confirm card with self-included notice', async () => {
+    // Self-send: a single `@me` mention is a legitimate recipient list.
+    // No "no valid recipients" error; flow advances to confirm card and
+    // the renderer surfaces the "Send includes you." neutral notice.
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT, recipients: `<@${SENDER_ID}>` },
       guildMembers: { [SENDER_ID]: {} },
     });
     await handleQurlFile(int);
-    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
-    expect(reply.content).toMatch(/No valid recipients/);
-    expect(reply.content).toMatch(/bots and your own user are skipped/);
+    expect(reply.content).toMatch(/Send includes you/);
+    expect(reply.content).not.toMatch(/No valid recipients/);
+    // Payload persists selfIncluded so menu re-renders keep the notice.
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.selfIncluded).toBe(true);
+    expect(payload.recipientIds).toEqual([SENDER_ID]);
   });
 
   test('all mentioned recipients hit transient lookup failure → retry copy, not "no valid recipients"', async () => {
@@ -1799,28 +1839,23 @@ describe('handleConfirmSendClick', () => {
     expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
-  test('forged Send click with sender-only recipientIds → "Invalid recipient list" copy, NOT "all left"', async () => {
-    // Forged payload edge: recipientIds=[SENDER_ID] passes the empty-
-    // array guard, resolves fine (sender is in guild cache), then
-    // partitionRecipients drops the sender (droppedSelf=1) and
-    // valid.length === 0. Pre-fix this hit the all-unresolved branch
-    // and surfaced "Recipients are no longer reachable (all left the
-    // server)" — misleading. Distinguish by droppedSelf/droppedBots > 0.
+  test('Send click with sender-only recipientIds → legitimate self-send, proceeds to dispatch', async () => {
+    // Self-send is a supported recipient list. recipientIds=[SENDER_ID]
+    // partitions to valid=[sender] (selfIncluded=true), so the empty-
+    // valid branch is bypassed and the click proceeds to the send
+    // pipeline. We assert that the "Invalid recipient list" / "all left"
+    // copies are NOT surfaced; the actual dispatch happens in the
+    // executeSendPipeline suite and isn't re-tested here.
     const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
     await handleConfirmSendClick(int, {
       flow_id: 'fid',
       row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 1 },
     });
-    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Invalid recipient list/i),
-      components: [],
     }));
     expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/all left the server/i),
-    }));
-    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
-      stage: SEND_STAGE_AWAITING_CONFIRM,
-      reason: 'terminal',
     }));
   });
 
@@ -1876,14 +1911,16 @@ describe('handleConfirmSendClick', () => {
 
   test('all-invalid recipients + concurrent picker race (deleteFlow returns deleted:false) → "card moved" followUp', async () => {
     // Same shape as the empty-recipients race, but the dispatcher
-    // loaded a row whose recipientIds resolved to all-bots or all-
-    // sender. Version-gated delete catches the concurrent picker
-    // advance and surfaces the recovery.
+    // loaded a row whose recipientIds resolved to all-bots. Version-
+    // gated delete catches the concurrent picker advance and surfaces
+    // the recovery. Self-only is no longer all-invalid — self-send is
+    // supported — so the bot-only path is the only remaining trigger.
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
-    const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
+    const botId = '100000000000000999';
+    const int = makeInteraction({ guildMembers: { [botId]: { bot: true } } });
     await handleConfirmSendClick(int, {
       flow_id: 'fid',
-      row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 5 },
+      row: { payload: { ...validPayload, recipientIds: [botId] }, version: 5 },
     });
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/card moved/i),
@@ -2082,20 +2119,23 @@ describe('handleConfirmUserSelect', () => {
     expect(deferAckedBeforeTransition).toBe(true);
   });
 
-  test('all-invalid pick combining bots AND self → message lists BOTH reasons (not just bot-only)', async () => {
-    // Previous wording collapsed to bot-only via a ternary. A pick of
-    // [bot, sender] is BOTH "cannot send to bots" AND "cannot send to
-    // yourself"; the user deserves to see both reasons so they know
-    // why removing only the bot wouldn't be enough.
+  test('pick combining a bot AND sender → sender survives, bot is dropped, flow advances', async () => {
+    // Self-send: a pick of [bot, sender] partitions to valid=[sender]
+    // (selfIncluded=true). Bot is the only drop. valid.length > 0 so
+    // the flow advances to the confirm card with the self-included
+    // notice; the bot-drop warning still appears.
     const bot1 = '100000000000000099';
     const int = makeSelectInteraction({
       users: [makeUser(bot1, { bot: true }), makeUser(SENDER_ID)],
     });
     await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
-    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.recipientIds).toEqual([SENDER_ID]);
+    expect(payload.selfIncluded).toBe(true);
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
-    expect(updated.content).toMatch(/bots/);
-    expect(updated.content).toMatch(/yourself/i);
+    expect(updated.content).toMatch(/bot/);
+    expect(updated.content).toMatch(/Send includes you/);
     expect(updated.content).toMatch(/Sending file/);
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1843,14 +1843,25 @@ describe('handleConfirmSendClick', () => {
     // Self-send is a supported recipient list. recipientIds=[SENDER_ID]
     // partitions to valid=[sender] (selfIncluded=true), so the empty-
     // valid branch is bypassed and the click proceeds to the send
-    // pipeline. We assert that the "Invalid recipient list" / "all left"
-    // copies are NOT surfaced; the actual dispatch happens in the
-    // executeSendPipeline suite and isn't re-tested here.
+    // pipeline. Positive-path assertions pin the dispatch entry (the
+    // "Preparing send" editReply + the terminal deleteFlow that fires
+    // on the happy path) so a future regression that silently no-ops
+    // for self-only sends shows up here, not just as the absence of
+    // the legacy error copies.
     const int = makeInteraction({ guildMembers: { [SENDER_ID]: {} } });
+    mockDb.getGuildApiKey.mockResolvedValueOnce('apikey-1');
     await handleConfirmSendClick(int, {
       flow_id: 'fid',
       row: { payload: { ...validPayload, recipientIds: [SENDER_ID] }, version: 1 },
     });
+    // Positive: dispatch was entered.
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Preparing send/),
+    }));
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      reason: 'terminal',
+    }));
+    // Negative: legacy error copies must NOT surface.
     expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Invalid recipient list/i),
     }));
@@ -2303,6 +2314,25 @@ describe('handleConfirmExpirySelect', () => {
     // the wire-protocol assertion above.
     const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
     expect(lastEdit.content).toMatch(/7 days/);
+  });
+
+  test('selfIncluded notice survives an expiry change re-render', async () => {
+    // Non-recipient menu transitions (expiry, self-destruct, note
+    // modal) must keep the "Send includes you." notice when the
+    // payload was minted with selfIncluded=true. `rerenderConfirmCard`
+    // reads `newPayload.selfIncluded === true`, so an expiry change
+    // that drops the field by accident would surface here as the
+    // notice disappearing on a non-recipient menu click.
+    const int = makeSelectInteraction({ value: '7d' });
+    const payloadWithSelf = { ...basePayload, selfIncluded: true };
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: payloadWithSelf, version: 1 } });
+    // Persisted in the new payload (transitionFlow spreads ...payload).
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({ selfIncluded: true, expiresIn: '7d' }),
+    }));
+    // Re-rendered content still shows the notice.
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    expect(lastEdit.content).toMatch(/Send includes you/);
   });
 
   test('no-op re-pick (same value as payload) → skip transitionFlow + version bump, still re-render', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -713,10 +713,10 @@ describe('renderRecipientWarnings', () => {
     expect(out).toMatch(/Could not parse/);
     expect(out).toMatch(/no longer in this server/);
     expect(out).toMatch(/bot/);
-    // "yourself" was the dropped-self warning before #316-followup —
-    // self-send is now supported, so the warning is gone; the confirm
-    // card renderer surfaces a neutral "Send includes you." notice
-    // (asserted in the renderConfirmCardContent suite below).
+    // Self-send is supported, so renderRecipientWarnings emits NO
+    // sender-related text. The confirm-card renderer surfaces a
+    // neutral "Send includes you." notice instead (asserted in the
+    // renderConfirmCardContent suite below).
     expect(out).not.toMatch(/yourself/);
   });
 

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -117,13 +117,25 @@ describe('parseRecipientMentions — basic shape', () => {
 });
 
 describe('parseRecipientMentions — filtering', () => {
-  test('excludes the sender (no self-sends)', () => {
+  test('keeps the sender (self-send is supported)', () => {
+    // Self-send: the sender deliberately included themselves via
+    // `@me`. Parser does NOT filter — the confirm card surfaces a
+    // neutral "Send includes you." notice instead.
     const int = makeInteraction({
       senderId: '900000000000000001',
       users: { '900000000000000001': {}, '222222222222222222': {} },
     });
-    expect(parseRecipientMentions('<@900000000000000001> <@222222222222222222>', int))
-      .toEqual({ ids: ['222222222222222222'], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions('<@900000000000000001> <@222222222222222222>', int).ids.sort())
+      .toEqual(['222222222222222222', '900000000000000001']);
+  });
+
+  test('sender alone is a legitimate single-recipient self-send', () => {
+    const int = makeInteraction({
+      senderId: '900000000000000001',
+      users: { '900000000000000001': {} },
+    });
+    expect(parseRecipientMentions('<@900000000000000001>', int))
+      .toEqual({ ids: ['900000000000000001'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('excludes bots flagged in the member cache', () => {
@@ -137,24 +149,11 @@ describe('parseRecipientMentions — filtering', () => {
   test('completely empty interaction ({}) does not throw, returns empty result', () => {
     // The `interaction == null` early-return handles null/undefined,
     // but a truthy empty object still has to walk the optional chains
-    // (`interaction.user?.id`, `interaction.guild?.roles?.cache`)
-    // without crashing. Pin that an `interaction = {}` is tolerated
-    // — a future refactor that switched `.guild?.x` to `.guild.x?` on
-    // the assumption "we've already null-checked" would surface here.
+    // (`interaction.guild?.roles?.cache`) without crashing. Pin that
+    // `interaction = {}` is tolerated — a future refactor that
+    // switched `.guild?.x` to `.guild.x?` on the assumption "we've
+    // already null-checked" would surface here.
     expect(parseRecipientMentions('<@111>', {}))
-      .toEqual({ ids: ['111'], invalidTokens: [], cappedCount: 0 });
-  });
-
-  test('missing interaction.user falls through (sender-exclusion no-ops, no throw)', () => {
-    // Defensive precondition: `interaction.user?.id` is the sender
-    // exclusion anchor. If a caller passes `interaction = { guild }`
-    // (no user — bot misuse, not user input), the optional chain
-    // makes `senderId === undefined` so sender exclusion silently
-    // no-ops. Pin that the parser doesn't throw — the caller bug
-    // surfaces downstream via the back-half's interaction.user.id
-    // read, which is a clearer crash site than a parse-time TypeError.
-    const interaction = { guild: { members: { cache: new Map([['111', { user: { id: '111', bot: false } }]]) }, roles: { cache: new Map() } } };
-    expect(parseRecipientMentions('<@111>', interaction))
       .toEqual({ ids: ['111'], invalidTokens: [], cappedCount: 0 });
   });
 
@@ -188,14 +187,16 @@ describe('parseRecipientMentions — role mentions', () => {
       .toEqual(['101', '102', '103']);
   });
 
-  test('role expansion excludes sender and bots', () => {
+  test('role expansion includes sender but excludes bots', () => {
+    // Self-send: sender expanded out of a role mention stays in the
+    // recipient set. Bots in the role are still filtered.
     const int = makeInteraction({
       senderId: '900',
       users: { '900': {}, '801': { bot: true }, '101': {} },
       roles: { '7000': ['900', '801', '101'] },
     });
-    expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['101'], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions('<@&7000>', int).ids.sort())
+      .toEqual(['101', '900']);
   });
 
   test('role unknown to the guild lands in invalidTokens', () => {
@@ -204,15 +205,25 @@ describe('parseRecipientMentions — role mentions', () => {
       .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
-  test('role with no usable members (all sender/bots) lands in invalidTokens', () => {
+  test('role with no usable members (all bots) lands in invalidTokens', () => {
     const int = makeInteraction({
       senderId: '900',
-      users: { '900': {}, '801': { bot: true } },
-      roles: { '7000': ['900', '801'] },
+      users: { '801': { bot: true } },
+      roles: { '7000': ['801'] },
     });
     const res = parseRecipientMentions('<@&7000>', int);
     expect(res.ids).toEqual([]);
     expect(res.invalidTokens).toEqual(['<@&7000>']);
+  });
+
+  test('role with only the sender expands to the sender (self-only role is valid)', () => {
+    const int = makeInteraction({
+      senderId: '900',
+      users: { '900': {} },
+      roles: { '7000': ['900'] },
+    });
+    expect(parseRecipientMentions('<@&7000>', int))
+      .toEqual({ ids: ['900'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('DM context (guild=undefined) treats role mentions as invalid', () => {


### PR DESCRIPTION
## Summary

Self-send is now supported on `/qurl file` and `/qurl map`. The sender can include themselves as a recipient — useful for:

- Test the link before forwarding it
- Cross-device handoff (send from desktop, receive on phone)
- Self-archival with the self-destruct timer / expiry controls

### UX

**Before:** mentioning `@me` (or picking yourself in the UserSelectMenu) produced a warning — *"You cannot send a qURL to yourself — skipped."* — and the sender was filtered out of the recipient list.

**After:** the sender enters the recipient list normally. The confirm card surfaces a NEUTRAL notice instead:

```
📁 Sending file: report.pdf
ℹ️ Send includes you.
**To:** 3 users (alice, bob, you)
**Expires:** 24h
```

Implicit opt-in: there's no new slash option or subcommand. Self-send is triggered the same way any other recipient is — typing `@me` in the `recipients:` text or picking yourself in the UserSelectMenu. Both are deliberate actions, so there's no accidental-self-send footgun.

### Code changes

- **`recipient-parser.js`**: drop the `id === senderId` filter in both the user-mention loop and the role-expansion loop. The bot filter stays. Drop the unused `senderId` capture. Updated docstring/comments.
- **`commands.js partitionRecipients`**: return `{ valid, droppedBots, selfIncluded }`. Sender stays in `valid[]`; `selfIncluded` is a boolean flag set when the sender appears in `users[]`.
- **`commands.js renderRecipientWarnings`**: drop the `droppedSelf` parameter + the corresponding warning line.
- **`commands.js renderConfirmCardContent`**: accept a `selfIncluded` prop, render `ℹ Send includes you.` above the recipient preview.
- **`commands.js` initial payload + UserSelect transitionFlow payload**: persist `selfIncluded` in `flow_state.payload` so menu re-renders (expiry / self-destruct / note modal) keep the notice.
- **`commands.js` empty-valid branches**: simplified — self-only is now legitimate, so the bot-only path is the only remaining empty trigger.
- **Tests**: full suite update across `recipient-parser.test.js` and `qurl-file-map.test.js`. +2 new tests pinning the `selfIncluded` notice rendering. 1417 tests pass.

### Intentionally NOT changed

- The bot filter — bots still can't receive qURL links.
- SEND_FLOW_TTL_SECONDS, customId wire literals, DDB schema — untouched.
- The DM dispatch path — already DMs whoever's in the recipient list, no change needed.

## Test plan

- [x] `pnpm test` — 1417 tests pass
- [x] `pnpm lint` — clean (`eslint --max-warnings 0`)
- [x] `grep -rn 'droppedSelf' apps/discord` returns zero results
- [ ] CI green
- [ ] Claude review clean
- [ ] Live smoke: `/qurl file` with `recipients:@me` shows the notice + delivers a DM to the sender

🤖 Generated with [Claude Code](https://claude.com/claude-code)