### PR TITLE
feat(discord): allow @everyone in /qurl file + /qurl map (gated on MENTION_EVERYONE)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3098,6 +3098,11 @@ async function handleQurlSlashSend(interaction, params) {
     // surfaces `massMentionDenied: true` when the sender tried but
     // lacks permission — the caller renders a permission-specific
     // warning instead of the generic "couldn't parse" copy.
+    //
+    // `interaction.memberPermissions` is the resolved channel-effective
+    // permission set (guild perms + channel overwrites). A future
+    // refactor switching to `interaction.member.permissions` would
+    // silently lose the channel-overwrite respect — keep this property.
     const canMentionEveryone = interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
     const parsed = parseRecipientMentions(recipientsRaw, interaction, {
       allowMassMention: canMentionEveryone,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2786,9 +2786,9 @@ function renderRecipientWarnings({
   if (massMentionDenied) {
     // Specific copy beats the generic "couldn't parse" path so the
     // user knows it's a PERMISSION issue, not a typo. Mirrors
-    // Discord's own MENTION_EVERYONE gate. Copy is context-agnostic
-    // (no "in this channel") so it reads sensibly even in DM context
-    // where channel-overrides don't apply.
+    // Discord's own MENTION_EVERYONE gate. The caller suppresses
+    // this in DM context (where @everyone has no meaning) so the
+    // copy here doesn't need a context qualifier.
     lines.push('• `@everyone` requires the **Mention Everyone** permission — skipped.');
   }
   if (lines.length === 0) return '';
@@ -3126,13 +3126,19 @@ async function handleQurlSlashSend(interaction, params) {
     // (vs. silently dropping into the picker, which would mask the
     // underlying mention-list problem).
     const recipientsOmitted = recipientsRaw == null || recipientsRaw.trim().length === 0;
+    // Suppress the @everyone permission warning in DM context —
+    // @everyone has no meaning in a DM (Discord doesn't expand it
+    // there) and "requires the Mention Everyone permission" reads
+    // strangely when there's no permission to grant. The other
+    // warnings (bot/capped/unresolved) still apply and surface.
+    const isDmContext = !interaction.guild;
     const warningsBlock = renderRecipientWarnings({
       invalidTokens: parsed.invalidTokens,
       cappedCount: parsed.cappedCount,
       unresolvedIds: resolved.unresolvedIds,
       transientFailureIds: resolved.transientFailureIds,
       droppedBots,
-      massMentionDenied: parsed.massMentionDenied,
+      massMentionDenied: parsed.massMentionDenied && !isDmContext,
     });
     if (!recipientsOmitted && valid.length === 0) {
       clearCooldown(interaction.user.id);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2734,6 +2734,7 @@ function partitionRecipients(users, senderId) {
  *   unresolvedIds?: string[],
  *   transientFailureIds?: string[],
  *   droppedBots?: number,
+ *   massMentionDenied?: boolean,
  * }} [opts]
  */
 function renderRecipientWarnings({
@@ -2742,6 +2743,7 @@ function renderRecipientWarnings({
   unresolvedIds = [],
   transientFailureIds = [],
   droppedBots = 0,
+  massMentionDenied = false,
 } = {}) {
   const lines = [];
   if (cappedCount > 0) {
@@ -2780,6 +2782,12 @@ function renderRecipientWarnings({
   }
   if (droppedBots > 0) {
     lines.push(`• ${droppedBots} bot(s) cannot receive qURL links — skipped.`);
+  }
+  if (massMentionDenied) {
+    // Specific copy beats the generic "couldn't parse" path so the
+    // user knows it's a PERMISSION issue, not a typo. Mirrors
+    // Discord's own MENTION_EVERYONE gate.
+    lines.push('• `@everyone` requires the **Mention Everyone** permission in this channel — skipped.');
   }
   if (lines.length === 0) return '';
   return '⚠\u{FE0F} **Some recipients were dropped:**\n' + lines.join('\n') + '\n\n';
@@ -3081,7 +3089,17 @@ async function handleQurlSlashSend(interaction, params) {
     // (personalMessage is empty/falsy) but pre-fill with invisible chars.
     const personalMessageRawTrimmed = personalMessage ? initialRawTrimmed : null;
 
-    const parsed = parseRecipientMentions(recipientsRaw, interaction);
+    // `@everyone` is gated on the sender's MENTION_EVERYONE permission
+    // in this channel (Discord's own gate for mass-mention). Without
+    // this, any guild member could blast a /qurl send to every member
+    // in the cache, bounded only by the 25-recipient cap. The parser
+    // surfaces `massMentionDenied: true` when the sender tried but
+    // lacks permission — the caller renders a permission-specific
+    // warning instead of the generic "couldn't parse" copy.
+    const canMentionEveryone = interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
+    const parsed = parseRecipientMentions(recipientsRaw, interaction, {
+      allowMassMention: canMentionEveryone,
+    });
 
     let resolved = { users: [], unresolvedIds: [], transientFailureIds: [] };
     if (parsed.ids.length > 0) {
@@ -3112,6 +3130,7 @@ async function handleQurlSlashSend(interaction, params) {
       unresolvedIds: resolved.unresolvedIds,
       transientFailureIds: resolved.transientFailureIds,
       droppedBots,
+      massMentionDenied: parsed.massMentionDenied,
     });
     if (!recipientsOmitted && valid.length === 0) {
       clearCooldown(interaction.user.id);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2786,8 +2786,10 @@ function renderRecipientWarnings({
   if (massMentionDenied) {
     // Specific copy beats the generic "couldn't parse" path so the
     // user knows it's a PERMISSION issue, not a typo. Mirrors
-    // Discord's own MENTION_EVERYONE gate.
-    lines.push('• `@everyone` requires the **Mention Everyone** permission in this channel — skipped.');
+    // Discord's own MENTION_EVERYONE gate. Copy is context-agnostic
+    // (no "in this channel") so it reads sensibly even in DM context
+    // where channel-overrides don't apply.
+    lines.push('• `@everyone` requires the **Mention Everyone** permission — skipped.');
   }
   if (lines.length === 0) return '';
   return '⚠\u{FE0F} **Some recipients were dropped:**\n' + lines.join('\n') + '\n\n';

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -88,6 +88,18 @@ const logger = require('./logger');
 // regex instance.)
 const USER_MENTION_RE = /<@!?(\d+)>/g;
 const ROLE_MENTION_RE = /<@&(\d+)>/g;
+// Matches `@everyone` as a standalone token (word boundaries on both
+// sides). Intentionally narrower than the U+200B defuse regex below —
+// here we're matching for INCLUSION, so we want only real Discord
+// mass-mention tokens, not substrings like `@everyonefoo` that would
+// false-positive. Case-sensitive because Discord's mass-mention parser
+// is itself lowercase-only (`@Everyone` is inert), so widening here
+// would expand for shapes Discord wouldn't have pinged.
+// `@here` is NOT matched — would need GUILD_PRESENCES intent (we
+// only run GuildMembers) to filter online members, and treating it
+// as `@everyone` would be deceptive. Falls through to the invalidTokens
+// defuse path as before; revisit if the bot ever adds the intent.
+const EVERYONE_TOKEN_RE = /(?<![A-Za-z0-9_])@everyone(?![A-Za-z0-9_])/g;
 
 // Hard cap on input length so an adversarial regex-blowup attack
 // (10MB of `<@1>` repetitions) doesn't tie up the worker. Discord's
@@ -134,24 +146,35 @@ const MAX_INVALID_TOKEN_LENGTH = 256;
 // which oncall benefits from seeing as a pattern.
 const MASSIVE_OVERSHOOT_MULTIPLIER = 2;
 
-// Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / etc.) to
-// a flat user-ID list with the cap + bot filter applied. Returns
-// `{ ids, invalidTokens, cappedCount }`; never throws on parse errors —
-// invalid tokens always land in `invalidTokens` for caller-side
-// surfacing. Sender is NOT filtered — self-send is supported; the
-// confirm-card renderer surfaces a neutral notice when sender appears
-// in `ids`.
+// Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / `@everyone`)
+// to a flat user-ID list with the cap + bot filter applied. Returns
+// `{ ids, invalidTokens, cappedCount, massMentionDenied }`; never
+// throws on parse errors — invalid tokens always land in
+// `invalidTokens` for caller-side surfacing. Sender is NOT filtered —
+// self-send is supported; the confirm-card renderer surfaces a neutral
+// notice when sender appears in `ids`.
+//
+// `@everyone` is a privileged mention shape. The caller decides whether
+// to honor it via `opts.allowMassMention` (typically gated behind
+// Discord's MENTION_EVERYONE permission, checked on the slash-command
+// interaction). When the token appears in input:
+//   - allowed → expanded to all non-bot guild members in the cache.
+//   - denied  → `massMentionDenied: true` in the result so the caller
+//               can surface "you don't have permission to @everyone".
+// Either way the token is stripped from `invalidTokens` to avoid
+// double-surfacing.
 //
 // `interaction` is the slash-command interaction; we need it for:
 //   - interaction.guild    → role-mention expansion via members.cache
 //   - interaction.guild.members.cache.get(id).user.bot → bot filter
-function parseRecipientMentions(raw, interaction) {
+function parseRecipientMentions(raw, interaction, opts = {}) {
+  const allowMassMention = opts.allowMassMention === true;
   // Defensive normalization: getString can return null when the option
   // is omitted, and the empty-string path is the same shape — return
   // an empty result rather than throwing. Caller branches on
   // `ids.length === 0` to decide whether to render the recipient picker.
   if (raw == null || typeof raw !== 'string') {
-    return { ids: [], invalidTokens: [], cappedCount: 0 };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false };
   }
   // Mirror the `raw` guard for `interaction` so a null/undefined
   // caller-bug surfaces as an empty result instead of a TypeError
@@ -159,7 +182,7 @@ function parseRecipientMentions(raw, interaction) {
   // a clearer crash site for "no caller context"; the parser
   // doesn't gain anything by failing here.
   if (interaction == null) {
-    return { ids: [], invalidTokens: [], cappedCount: 0 };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false };
   }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
@@ -189,7 +212,7 @@ function parseRecipientMentions(raw, interaction) {
     }
   }
   if (input.length === 0) {
-    return { ids: [], invalidTokens: [], cappedCount: 0 };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false };
   }
 
   // `seen` is the canonical post-filter unique-candidate set (every
@@ -214,6 +237,41 @@ function parseRecipientMentions(raw, interaction) {
     if (seen.has(id)) return;
     seen.add(id);
     if (ids.size < cap) ids.add(id);
+  }
+
+  // @everyone handling. Detection BEFORE the user/role mention passes
+  // so the expansion contributes to `seen`/`ids` alongside any direct
+  // `<@id>` or `<@&id>` mentions (which still dedupe via `consider`).
+  // Detect-via-replace (compare strings) instead of `.test()` so the
+  // shared module-scope `/g` regex's `lastIndex` doesn't carry state
+  // across calls. `String.prototype.replace` always resets internally.
+  let massMentionDenied = false;
+  const everyoneStripped = input.replace(EVERYONE_TOKEN_RE, ' ');
+  if (everyoneStripped !== input) {
+    // @everyone was present. Strip it from `input` (allowed OR
+    // denied) so the residue pass doesn't double-surface it in
+    // `invalidTokens` via the U+200B defuse path.
+    input = everyoneStripped;
+    if (allowMassMention) {
+      const members = guild?.members?.cache;
+      if (members && typeof members.entries === 'function') {
+        // PARTIAL-CACHE BLIND SPOT: same caveat as role expansion
+        // above — in large guilds without a recent GUILD_MEMBERS
+        // chunk, the cache reflects only the currently-loaded subset,
+        // not the guild's true member count. Acceptable v1; the cap
+        // (QURL_SEND_MAX_RECIPIENTS) bounds the worst case anyway.
+        for (const [memberId, member] of members) {
+          if (member?.user?.bot) continue;
+          consider(memberId);
+        }
+      }
+    } else {
+      // Denied path — surface so the caller can warn ("you don't
+      // have MENTION_EVERYONE permission"). Distinct signal from
+      // invalidTokens so the caller can emit the permission copy
+      // rather than the generic "couldn't parse" copy.
+      massMentionDenied = true;
+    }
   }
 
   for (const m of input.matchAll(USER_MENTION_RE)) {
@@ -363,7 +421,7 @@ function parseRecipientMentions(raw, interaction) {
     });
   }
 
-  return { ids: finalIds, invalidTokens, cappedCount };
+  return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied };
 }
 
 module.exports = {

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -36,6 +36,14 @@
 //     that Discord would ping (`<@id>`, `<@&id>`) can't reach this
 //     slot because they parse as valid mentions in the passes above.
 //
+//     Note: standalone `@everyone` tokens are intercepted upstream by
+//     the gated detect-and-strip pass (`allowMassMention` opt — see
+//     parseRecipientMentions docstring below). The defuse here is the
+//     fallback for `@here`, `@Everyone` (inert case), and embedded
+//     forms like `here@everyone` that escape the gated path's word-
+//     boundary. Both layers preserve the "caller-can-interpolate-safely"
+//     contract above.
+//
 // SECURITY: `invalidTokens` ARE NOT escaped against Discord markdown — a pasted
 // `[link](https://evil)`, `||spoiler||`, or backtick-fenced content
 // will render with full markdown semantics if a caller interpolates
@@ -428,11 +436,15 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // fan-out-ping the channel. Insert a zero-width-space after `@`
     // — the rendered glyph is identical, but Discord's tokenizer
     // sees a different word and won't trigger the mass mention.
-    // Use a regex (not exact-match) because `@everyone!`,
-    // `@everyone:`, `@everyone.fix` etc. are single tokens after
-    // the strip pass (residue split class doesn't include
-    // punctuation) and would otherwise slip through. Replace all
-    // occurrences so a token like `here@everyone` is fully fenced.
+    // Standalone `@everyone` is intercepted by the gated detect-and-
+    // strip pass above, so the cases this defuse still catches are
+    // `@here`, `@Everyone` (case-mismatched / inert), and embedded
+    // forms like `here@everyone` that escape the gated path's word-
+    // boundary. Use a regex (not exact-match) because shapes like
+    // `@here:`, `here@everyone` survive the strip pass as single
+    // tokens (residue split class doesn't include punctuation) and
+    // would otherwise slip through. Replace all occurrences so a
+    // token like `here@everyone` is fully fenced.
     //
     // INTENTIONALLY case-sensitive (no `/i` flag) \u2014 Discord's mass-
     // mention parser is itself lowercase-only, so `@Everyone` is

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -180,8 +180,12 @@ function isBotMember(member) {
 // double-surfacing.
 //
 // `interaction` is the slash-command interaction; we need it for:
-//   - interaction.guild    → role-mention expansion via members.cache
-//   - interaction.guild.members.cache.get(id).user.bot → bot filter
+//   - interaction.guild               → role-mention expansion via
+//                                       roles.cache + `@everyone`
+//                                       expansion via members.cache
+//   - interaction.guild.members.cache → bot filter (per-id `.user.bot`
+//                                       lookup) + `@everyone` member
+//                                       enumeration
 function parseRecipientMentions(raw, interaction, opts = {}) {
   const allowMassMention = opts.allowMassMention === true;
   // Defensive normalization: getString can return null when the option
@@ -254,58 +258,25 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     if (ids.size < cap) ids.add(id);
   }
 
-  // @everyone handling. Detection BEFORE the user/role mention passes
-  // so the expansion contributes to `seen`/`ids` alongside any direct
-  // `<@id>` or `<@&id>` mentions (which still dedupe via `consider`).
-  // Detect-via-replace (compare strings) instead of `.test()` so the
-  // shared module-scope `/g` regex's `lastIndex` doesn't carry state
-  // across calls. `String.prototype.replace` always resets internally.
+  // Detect-and-strip `@everyone` BEFORE the mention passes so the
+  // token doesn't leak into the residue (which would U+200B-defuse
+  // it into `invalidTokens` regardless of allow/deny). The actual
+  // expansion runs LAST (after user + role mentions), so explicit
+  // mentions get cap priority. Detect-via-replace (compare strings)
+  // instead of `.test()` so the shared module-scope `/g` regex's
+  // `lastIndex` doesn't carry state across calls.
   let massMentionDenied = false;
+  let everyonePresent = false;
   const everyoneStripped = input.replace(EVERYONE_TOKEN_RE, ' ');
   if (everyoneStripped !== input) {
-    // @everyone was present. Strip it from `input` (allowed OR
-    // denied) so the residue pass doesn't double-surface it in
-    // `invalidTokens` via the U+200B defuse path.
     input = everyoneStripped;
-    if (allowMassMention) {
-      const members = guild?.members?.cache;
-      if (members) {
-        // PARTIAL-CACHE BLIND SPOT: same caveat as role expansion
-        // above — in large guilds without a recent GUILD_MEMBERS
-        // chunk, the cache reflects only the currently-loaded subset,
-        // not the guild's true member count. Acceptable v1; in
-        // realistic guilds (where bots are <1% of members) the cap
-        // (QURL_SEND_MAX_RECIPIENTS) bounds the iteration via the
-        // `break` below. The pathological all-bots case still walks
-        // the entire cache — bounded only by cache size, not the cap.
-        //
-        // ORDERING is cache-insertion-order (discord.js Collection
-        // is a Map): when the cap short-circuits the loop, the first
-        // ~25 members BY CACHE INSERTION ORDER win the slots — not
-        // alphabetical, role-ordered, or recently-active. Users may
-        // see a different subset across invocations as the cache
-        // churns. v2 picker (#324 — MentionableSelectMenu) shifts the
-        // selection burden onto the user and removes this ambiguity.
-        for (const [memberId, member] of members) {
-          // Short-circuit once we've filled the cap — the cache
-          // can be tens of thousands of entries in a large guild,
-          // and the per-iteration bot check is wasted work after
-          // `ids` is full. `seen` still gets populated for cappedCount
-          // accuracy on the path through `consider`; we trade that
-          // small UX nicety (knowing exactly how many were over the
-          // cap) for not scanning a 10k-member cache. Acceptable for
-          // an @everyone send — the user is already getting "expanded
-          // to N members" and the cap message.
-          if (ids.size >= cap) break;
-          if (isBotMember(member)) continue;
-          consider(memberId);
-        }
-      }
-    } else {
+    everyonePresent = true;
+    if (!allowMassMention) {
       // Denied path — surface so the caller can warn ("you don't
       // have MENTION_EVERYONE permission"). Distinct signal from
       // invalidTokens so the caller can emit the permission copy
-      // rather than the generic "couldn't parse" copy.
+      // rather than the generic "couldn't parse" copy. The allowed-
+      // path expansion happens below, after explicit mentions.
       massMentionDenied = true;
     }
   }
@@ -388,6 +359,43 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       // Surface as "no usable members" rather than silently no-op so
       // the caller can tell the user "the role only contains bots."
       pushRoleErrorIfNew(roleId, m[0]);
+    }
+  }
+
+  // @everyone expansion runs LAST so explicit mentions get cap
+  // priority. If the user typed `@everyone <@uncachedUser>`, the
+  // direct mention claims a cap slot first, and @everyone fills the
+  // remainder. Reversing this order silently drops explicit mentions
+  // when the cache is partial — caught by cr round 3.
+  if (everyonePresent && allowMassMention) {
+    const everyoneMembers = guild?.members?.cache;
+    if (everyoneMembers) {
+      // PARTIAL-CACHE BLIND SPOT: same caveat as role expansion
+      // above — in large guilds without a recent GUILD_MEMBERS
+      // chunk, the cache reflects only the currently-loaded subset,
+      // not the guild's true member count. Acceptable v1; in
+      // realistic guilds (where bots are <1% of members) the cap
+      // (QURL_SEND_MAX_RECIPIENTS) bounds the iteration via the
+      // `break` below. The pathological all-bots case still walks
+      // the entire cache — bounded only by cache size, not the cap.
+      //
+      // ORDERING is cache-insertion-order (discord.js Collection
+      // is a Map): when the cap short-circuits the loop, members
+      // win the remaining slots BY CACHE INSERTION ORDER — not
+      // alphabetical, role-ordered, or recently-active. Users may
+      // see a different subset across invocations as the cache
+      // churns. v2 picker (#324 — MentionableSelectMenu) shifts the
+      // selection burden onto the user and removes this ambiguity.
+      for (const [memberId, member] of everyoneMembers) {
+        // Short-circuit once we've filled the cap. We accept the
+        // tradeoff of inaccurate cappedCount (no past-cap members
+        // get added to `seen`) over scanning a 10k-member cache.
+        // The cap message still surfaces from any explicit mentions
+        // that overflowed.
+        if (ids.size >= cap) break;
+        if (isBotMember(member)) continue;
+        consider(memberId);
+      }
     }
   }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -386,6 +386,15 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       // see a different subset across invocations as the cache
       // churns. v2 picker (#324 — MentionableSelectMenu) shifts the
       // selection burden onto the user and removes this ambiguity.
+      //
+      // ITERATION ASSUMES NO CONCURRENT MUTATION: discord.js itself
+      // doesn't guarantee iteration safety for Collections under
+      // gateway-driven mutation (member join/leave events). This
+      // parser runs synchronously inside the slash-command handler
+      // — no awaits between the start of this loop and its `break`
+      // — so the cache snapshot is effectively frozen for the loop
+      // body. A future refactor that introduced an `await` here
+      // would break that assumption.
       for (const [memberId, member] of everyoneMembers) {
         // Short-circuit once we've filled the cap. We accept the
         // tradeoff of inaccurate cappedCount (no past-cap members

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -269,12 +269,15 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     input = everyoneStripped;
     if (allowMassMention) {
       const members = guild?.members?.cache;
-      if (members && typeof members.entries === 'function') {
+      if (members) {
         // PARTIAL-CACHE BLIND SPOT: same caveat as role expansion
         // above — in large guilds without a recent GUILD_MEMBERS
         // chunk, the cache reflects only the currently-loaded subset,
-        // not the guild's true member count. Acceptable v1; the cap
-        // (QURL_SEND_MAX_RECIPIENTS) bounds the worst case anyway.
+        // not the guild's true member count. Acceptable v1; in
+        // realistic guilds (where bots are <1% of members) the cap
+        // (QURL_SEND_MAX_RECIPIENTS) bounds the iteration via the
+        // `break` below. The pathological all-bots case still walks
+        // the entire cache — bounded only by cache size, not the cap.
         //
         // ORDERING is cache-insertion-order (discord.js Collection
         // is a Map): when the cap short-circuits the loop, the first

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -48,10 +48,14 @@
 //
 // Output shape:
 //   {
-//     ids:           [<user_id>, ...],        // deduped, cap-applied
-//     invalidTokens: [<raw_token>, ...],      // pre-escaped (see above)
-//     cappedCount:   <number>,                // 0 if not capped; else
+//     ids:                [<user_id>, ...],   // deduped, cap-applied
+//     invalidTokens:      [<raw_token>, ...], // pre-escaped (see above)
+//     cappedCount:        <number>,           // 0 if not capped; else
 //                                             // `total_pre_cap - cap`
+//     massMentionDenied:  <boolean>,          // true when @everyone
+//                                             // appeared but the caller
+//                                             // denied via the
+//                                             // `allowMassMention` opt
 //   }
 //
 // `ids` is deduped, capped at `config.QURL_SEND_MAX_RECIPIENTS` (the
@@ -88,18 +92,21 @@ const logger = require('./logger');
 // regex instance.)
 const USER_MENTION_RE = /<@!?(\d+)>/g;
 const ROLE_MENTION_RE = /<@&(\d+)>/g;
-// Matches `@everyone` as a standalone token (word boundaries on both
-// sides). Intentionally narrower than the U+200B defuse regex below —
-// here we're matching for INCLUSION, so we want only real Discord
-// mass-mention tokens, not substrings like `@everyonefoo` that would
-// false-positive. Case-sensitive because Discord's mass-mention parser
-// is itself lowercase-only (`@Everyone` is inert), so widening here
-// would expand for shapes Discord wouldn't have pinged.
+// Matches `@everyone` as a standalone token (Unicode word boundaries
+// on both sides). Intentionally narrower than the U+200B defuse regex
+// below — here we're matching for INCLUSION, so we want only real
+// Discord mass-mention tokens, not substrings like `@everyonefoo`
+// that would false-positive. Case-sensitive because Discord's mass-
+// mention parser is itself lowercase-only (`@Everyone` is inert).
+// `\p{L}\p{N}_` (Unicode letters/numbers + underscore) instead of
+// ASCII-only `[A-Za-z0-9_]` so `@everyoneé` / `@everyonefoö` don't
+// false-match the way an ASCII boundary would. Discord's tokenizer
+// is itself Unicode-aware here; the `/u` flag aligns with that.
 // `@here` is NOT matched — would need GUILD_PRESENCES intent (we
 // only run GuildMembers) to filter online members, and treating it
 // as `@everyone` would be deceptive. Falls through to the invalidTokens
 // defuse path as before; revisit if the bot ever adds the intent.
-const EVERYONE_TOKEN_RE = /(?<![A-Za-z0-9_])@everyone(?![A-Za-z0-9_])/g;
+const EVERYONE_TOKEN_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])/gu;
 
 // Hard cap on input length so an adversarial regex-blowup attack
 // (10MB of `<@1>` repetitions) doesn't tie up the worker. Discord's
@@ -268,6 +275,14 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
         // chunk, the cache reflects only the currently-loaded subset,
         // not the guild's true member count. Acceptable v1; the cap
         // (QURL_SEND_MAX_RECIPIENTS) bounds the worst case anyway.
+        //
+        // ORDERING is cache-insertion-order (discord.js Collection
+        // is a Map): when the cap short-circuits the loop, the first
+        // ~25 members BY CACHE INSERTION ORDER win the slots — not
+        // alphabetical, role-ordered, or recently-active. Users may
+        // see a different subset across invocations as the cache
+        // churns. v2 picker (#324 — MentionableSelectMenu) shifts the
+        // selection burden onto the user and removes this ambiguity.
         for (const [memberId, member] of members) {
           // Short-circuit once we've filled the cap — the cache
           // can be tens of thousands of entries in a large guild,

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -146,6 +146,14 @@ const MAX_INVALID_TOKEN_LENGTH = 256;
 // which oncall benefits from seeing as a pattern.
 const MASSIVE_OVERSHOOT_MULTIPLIER = 2;
 
+// Single-source the GuildMember-shape bot check used by every
+// expansion path (direct user mention, role expansion, @everyone
+// expansion). A future discord.js rename of `.user.bot` only needs
+// to touch one line.
+function isBotMember(member) {
+  return member?.user?.bot === true;
+}
+
 // Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / `@everyone`)
 // to a flat user-ID list with the cap + bot filter applied. Returns
 // `{ ids, invalidTokens, cappedCount, massMentionDenied }`; never
@@ -261,7 +269,17 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
         // not the guild's true member count. Acceptable v1; the cap
         // (QURL_SEND_MAX_RECIPIENTS) bounds the worst case anyway.
         for (const [memberId, member] of members) {
-          if (member?.user?.bot) continue;
+          // Short-circuit once we've filled the cap — the cache
+          // can be tens of thousands of entries in a large guild,
+          // and the per-iteration bot check is wasted work after
+          // `ids` is full. `seen` still gets populated for cappedCount
+          // accuracy on the path through `consider`; we trade that
+          // small UX nicety (knowing exactly how many were over the
+          // cap) for not scanning a 10k-member cache. Acceptable for
+          // an @everyone send — the user is already getting "expanded
+          // to N members" and the cap message.
+          if (ids.size >= cap) break;
+          if (isBotMember(member)) continue;
           consider(memberId);
         }
       }
@@ -284,7 +302,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // is acceptable. 7b.2 wiring should NOT assume the parser
     // filtered bots.
     const member = guild?.members?.cache?.get(id);
-    if (member?.user?.bot) continue;
+    if (isBotMember(member)) continue;
     consider(id);
   }
 
@@ -343,7 +361,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // that order.
     let usable = 0;
     for (const [memberId, roleMember] of members) {
-      if (roleMember?.user?.bot) continue;
+      if (isBotMember(roleMember)) continue;
       usable++;
       consider(memberId);
     }

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1204,6 +1204,29 @@ describe('handleQurlFile — slash entry', () => {
     expect(payload.recipientIds).toEqual([SENDER_ID]);
   });
 
+  test('DM context (no guild) suppresses the @everyone permission warning', async () => {
+    // @everyone has no meaning in a DM (Discord doesn't expand it),
+    // so the permission-warning copy ("requires the Mention Everyone
+    // permission") reads strangely if it fires there. The handler
+    // suppresses massMentionDenied surfacing when interaction.guild
+    // is null/undefined. Pin that this suppression is in place so a
+    // future caller refactor that drops the `!isDmContext` check
+    // surfaces here, not as confusing UX.
+    const int = makeInteraction({
+      guildId: null, // → guild = null in makeInteraction
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${SENDER_ID}>` },
+    });
+    await handleQurlFile(int);
+    // Whatever editReply lands, the @everyone permission warning
+    // must not appear. (The flow itself may hard-fail downstream
+    // because resolveRecipientUsers needs guild context — that's a
+    // separate concern; this test only pins the warning suppression.)
+    const calls = int.editReply.mock.calls;
+    for (const [arg] of calls) {
+      expect(arg.content || '').not.toMatch(/Mention Everyone permission/);
+    }
+  });
+
   test('all mentioned recipients hit transient lookup failure → retry copy, not "no valid recipients"', async () => {
     // transient-only path: the user's mentions were VALID but every
     // members.fetch hit a 429 or gateway blip. Generic "no valid

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1227,6 +1227,54 @@ describe('handleQurlFile — slash entry', () => {
     }
   });
 
+  test('guild context + no MENTION_EVERYONE → @everyone warning renders + Alice still parses', async () => {
+    // Positive-case companion to the DM-suppression test above. In
+    // guild context, when the sender lacks MENTION_EVERYONE and types
+    // `@everyone <@alice>`, the parser surfaces massMentionDenied and
+    // the handler renders the permission-specific warning. Alice
+    // expands normally. Pin the visible UX so a future refactor that
+    // accidentally collapses the warning surfaces here.
+    const aliceId = '400000000000000001';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${aliceId}>` },
+      guildMembers: { [aliceId]: {} },
+    });
+    // Default memberPermissions is undefined (no Mention Everyone) —
+    // matches the existing "no permission" assumption across this
+    // test suite.
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const lastEdit = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastEdit.content).toMatch(/Mention Everyone\b/);
+    // Alice still made it into the recipient list.
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.recipientIds).toEqual([aliceId]);
+  });
+
+  test('guild context + MENTION_EVERYONE permission → @everyone expands, no warning', async () => {
+    // Channel-overwrite pinning: the handler reads
+    // `interaction.memberPermissions.has(MentionEveryone)` (channel-
+    // effective perms). A future refactor that switched to
+    // `interaction.member.permissions.has(...)` (guild-wide only)
+    // would silently lose channel-overwrite respect. Pin the
+    // property contract by mocking `memberPermissions.has`.
+    const aliceId = '400000000000000002';
+    const bobId = '400000000000000003';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${aliceId}>` },
+      guildMembers: { [aliceId]: {}, [bobId]: {} },
+    });
+    int.memberPermissions = { has: jest.fn(() => true) };
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const lastEdit = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    // Permission warning must NOT fire.
+    expect(lastEdit.content).not.toMatch(/Mention Everyone permission/);
+    // Both Alice + Bob expanded from @everyone are in the payload.
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.recipientIds.sort()).toEqual([aliceId, bobId].sort());
+  });
+
   test('all mentioned recipients hit transient lookup failure → retry copy, not "no valid recipients"', async () => {
     // transient-only path: the user's mentions were VALID but every
     // members.fetch hit a 429 or gateway blip. Generic "no valid

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -430,6 +430,65 @@ describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
     // get added to `seen` beyond the cap, so cappedCount stays at 0.
     expect(res.cappedCount).toBe(0);
   });
+
+  test('mixed `@everyone @here` in one input: @everyone gated separately, @here defuses', () => {
+    // Both shapes hit different paths simultaneously. With
+    // allowMassMention=false: @everyone surfaces massMentionDenied,
+    // @here surfaces in invalidTokens via the legacy defuse. Pin
+    // the two paths don't interfere.
+    const int = makeInteraction({ users: { '111': {} } });
+    const res = parseRecipientMentions('@everyone @here <@111>', int);
+    expect(res.ids).toEqual(['111']);
+    expect(res.massMentionDenied).toBe(true);
+    expect(res.invalidTokens).toEqual(['@​here']);
+  });
+
+  test('repeated `@everyone @everyone` triggers expansion once (single-shot dedupe via `seen`)', () => {
+    // Even though the parser sees `@everyone` twice, the expansion is
+    // a single pass — consider() dedupes via `seen`. Pin that a
+    // repeated mass-mention doesn't produce duplicate ids.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+    });
+    const res = parseRecipientMentions('@everyone @everyone', int, { allowMassMention: true });
+    expect(res.ids.sort()).toEqual(['101', '102']);
+    expect(res.invalidTokens).toEqual([]);
+    expect(res.massMentionDenied).toBe(false);
+  });
+
+  test('Unicode word boundary: `@everyoneé` (Unicode letter trailing) does NOT match', () => {
+    // EVERYONE_TOKEN_RE uses `\p{L}\p{N}_` (Unicode-aware) instead of
+    // ASCII-only `[A-Za-z0-9_]` so non-ASCII letters following
+    // `@everyone` don't break the word boundary. Pin that
+    // `@everyoneé` falls through to the residue path (NOT mass-mention
+    // expansion). ASCII-only boundary would have over-matched here.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+    });
+    const res = parseRecipientMentions('@everyoneé', int, { allowMassMention: true });
+    expect(res.ids).toEqual([]);
+    expect(res.massMentionDenied).toBe(false);
+    expect(res.invalidTokens).toEqual(['@​everyoneé']);
+  });
+});
+
+describe('parseRecipientMentions — result-shape contract', () => {
+  test('result shape pins exactly four keys (ids, invalidTokens, cappedCount, massMentionDenied)', () => {
+    // Empire of `.toMatchObject` in other tests admits new fields by
+    // design (the result shape is allowed to grow), but the closed
+    // set of CURRENT keys is load-bearing — callers destructure these
+    // names. Pin the closed set so a future PR that adds a 5th field
+    // surfaces here intentionally rather than slipping past
+    // partial-match assertions.
+    const int = makeInteraction({ users: { '111': {} } });
+    const res = parseRecipientMentions('<@111>', int);
+    expect(Object.keys(res).sort()).toEqual([
+      'cappedCount',
+      'ids',
+      'invalidTokens',
+      'massMentionDenied',
+    ]);
+  });
 });
 
 describe('parseRecipientMentions — invalid tokens', () => {
@@ -527,6 +586,18 @@ describe('parseRecipientMentions — invalid tokens', () => {
     expect(res.ids).toEqual(['111']);
     expect(res.massMentionDenied).toBe(true);
     expect(res.invalidTokens).toEqual(['!']);
+  });
+
+  test('@everyone.fix (denied) leaves `.fix` in invalidTokens (parallel to `!` case)', () => {
+    // `.fix` survives the strip-pass split class `[\s,;|/]+` — same
+    // shape as `@everyone!`. Pin the residue so a future split-class
+    // refactor that consumed `.` would surface here, not silently
+    // change UX.
+    const int = makeInteraction({ users: { '111': {} } });
+    const res = parseRecipientMentions('@everyone.fix <@111>', int);
+    expect(res.ids).toEqual(['111']);
+    expect(res.massMentionDenied).toBe(true);
+    expect(res.invalidTokens).toEqual(['.fix']);
   });
 
   test('here@everyone (embedded) stays on the defuse path (not a standalone @everyone)', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -410,6 +410,53 @@ describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
     expect(res.massMentionDenied).toBe(false);
   });
 
+  test('explicit `<@id>` mentions take priority over @everyone expansion when cap is hit', () => {
+    // Critical ordering invariant: the user explicitly named someone
+    // via `<@uncached>`, then also typed `@everyone`. With cache > cap,
+    // an order that ran @everyone FIRST would fill the cap with
+    // arbitrary cached members and silently drop the explicit
+    // `<@uncached>` (since `consider()` adds to `seen` but not `ids`
+    // once `ids.size === cap`). Pin that the explicit mention always
+    // claims a cap slot — @everyone fills the remainder.
+    // Synthetic guild: 30 cached non-bot members at IDs `200000..200029`,
+    // PLUS the explicit mentioned ID `300000000000000001` which is NOT in
+    // the cache. (The bot filter only consults cache for direct mentions,
+    // and a cache miss leaves the ID in per the existing contract.)
+    const cachedUsers = {};
+    for (let i = 0; i < 30; i++) {
+      cachedUsers[`2000000000000${String(i).padStart(5, '0')}`] = {};
+    }
+    const explicitId = '300000000000000001';
+    const int = makeInteraction({ users: cachedUsers });
+    const res = parseRecipientMentions(
+      `<@${explicitId}> @everyone`,
+      int,
+      { allowMassMention: true },
+    );
+    expect(res.ids.length).toBe(25);
+    // The explicit mention must be in the result.
+    expect(res.ids).toContain(explicitId);
+    expect(res.massMentionDenied).toBe(false);
+  });
+
+  test('@everyone + <@&role> combined: dedupe across sources, cap applies', () => {
+    // Both expansion sources fire. A user in the role AND in
+    // `@everyone`'s cache should appear exactly once (consider+seen
+    // dedupe). Cap still bounds the total at 25.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {}, '103': {} },
+      roles: { '7000': ['101', '102'] },
+    });
+    const res = parseRecipientMentions(
+      '<@&7000> @everyone',
+      int,
+      { allowMassMention: true },
+    );
+    expect(res.ids.sort()).toEqual(['101', '102', '103']);
+    expect(res.invalidTokens).toEqual([]);
+    expect(res.massMentionDenied).toBe(false);
+  });
+
   test('allowed: cap short-circuits the cache scan (large guild cap behavior)', () => {
     // The @everyone expansion iterates guild.members.cache — a large
     // guild could have 10k+ entries. Once `ids.size === cap`, the

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -62,23 +62,23 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
 describe('parseRecipientMentions — basic shape', () => {
   test('returns empty result for null/undefined/empty input', () => {
     const int = makeInteraction();
-    expect(parseRecipientMentions(null, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
-    expect(parseRecipientMentions(undefined, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
-    expect(parseRecipientMentions('', int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
-    expect(parseRecipientMentions('   \t\n', int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions(null, int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions(undefined, int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions('', int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions('   \t\n', int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
   });
 
   test('returns empty result when raw is a non-string (defense vs caller bugs)', () => {
     const int = makeInteraction();
-    expect(parseRecipientMentions(42, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
-    expect(parseRecipientMentions({}, int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
-    expect(parseRecipientMentions([], int)).toEqual({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions(42, int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions({}, int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
+    expect(parseRecipientMentions([], int)).toMatchObject({ ids: [], invalidTokens: [], cappedCount: 0 });
   });
 
   test('extracts a single user mention', () => {
     const int = makeInteraction({ users: { '111111111111111111': {} } });
     expect(parseRecipientMentions('<@111111111111111111>', int))
-      .toEqual({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('accepts both <@id> and <@!id> forms (legacy nickname mention)', () => {
@@ -86,13 +86,13 @@ describe('parseRecipientMentions — basic shape', () => {
       users: { '111111111111111111': {}, '222222222222222222': {} },
     });
     expect(parseRecipientMentions('<@111111111111111111> <@!222222222222222222>', int))
-      .toEqual({ ids: ['111111111111111111', '222222222222222222'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['111111111111111111', '222222222222222222'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('dedupes repeated mentions', () => {
     const int = makeInteraction({ users: { '111111111111111111': {} } });
     expect(parseRecipientMentions('<@111111111111111111> <@111111111111111111> <@!111111111111111111>', int))
-      .toEqual({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['111111111111111111'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('cappedCount is 0 when input has no mentions (no false-positive cap signal)', () => {
@@ -135,7 +135,7 @@ describe('parseRecipientMentions — filtering', () => {
       users: { '900000000000000001': {} },
     });
     expect(parseRecipientMentions('<@900000000000000001>', int))
-      .toEqual({ ids: ['900000000000000001'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['900000000000000001'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('excludes bots flagged in the member cache', () => {
@@ -143,7 +143,7 @@ describe('parseRecipientMentions — filtering', () => {
       users: { '111': { bot: true }, '222': {} },
     });
     expect(parseRecipientMentions('<@111> <@222>', int))
-      .toEqual({ ids: ['222'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['222'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('completely empty interaction ({}) does not throw, returns empty result', () => {
@@ -154,7 +154,7 @@ describe('parseRecipientMentions — filtering', () => {
     // switched `.guild?.x` to `.guild.x?` on the assumption "we've
     // already null-checked" would surface here.
     expect(parseRecipientMentions('<@111>', {}))
-      .toEqual({ ids: ['111'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('best-effort bot filter: cache miss leaves the ID in (back-half re-checks)', () => {
@@ -164,7 +164,7 @@ describe('parseRecipientMentions — filtering', () => {
     // check (existing form's "Cannot send to a bot" path) catch it.
     const int = makeInteraction({});  // empty cache
     expect(parseRecipientMentions('<@555>', int))
-      .toEqual({ ids: ['555'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['555'], invalidTokens: [], cappedCount: 0 });
   });
 });
 
@@ -175,7 +175,7 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['101', '102', '103'] },
     });
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['101', '102', '103'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['101', '102', '103'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('merges role expansion with direct user mentions, deduped', () => {
@@ -202,7 +202,7 @@ describe('parseRecipientMentions — role mentions', () => {
   test('role unknown to the guild lands in invalidTokens', () => {
     const int = makeInteraction({});
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
+      .toMatchObject({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
   test('role with no usable members (all bots) lands in invalidTokens', () => {
@@ -223,13 +223,13 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['900'] },
     });
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: ['900'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['900'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('DM context (guild=undefined) treats role mentions as invalid', () => {
     const int = { user: { id: '900' }, guild: undefined };
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
+      .toMatchObject({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
   test('DM context (guild=null) also treats role mentions as invalid', () => {
@@ -240,7 +240,7 @@ describe('parseRecipientMentions — role mentions', () => {
     // on this test, not in prod.
     const int = { user: { id: '900' }, guild: null };
     expect(parseRecipientMentions('<@&7000>', int))
-      .toEqual({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
+      .toMatchObject({ ids: [], invalidTokens: ['<@&7000>'], cappedCount: 0 });
   });
 
   test('repeated residue tokens dedupe in invalidTokens (symmetric with role-error dedup)', () => {
@@ -250,9 +250,9 @@ describe('parseRecipientMentions — role mentions', () => {
     // isn't user-hostile.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <#456> <#456>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
     expect(parseRecipientMentions('<@111> alice alice bob alice', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['alice', 'bob'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['alice', 'bob'], cappedCount: 0 });
   });
 
   test('repeated invalid role mention dedupes in invalidTokens', () => {
@@ -262,7 +262,7 @@ describe('parseRecipientMentions — role mentions', () => {
     // token each time. Symmetric with the residue dedupe above.
     const int = makeInteraction({});  // no role 999
     expect(parseRecipientMentions('<@&999> <@&999> <@&999>', int))
-      .toEqual({ ids: [], invalidTokens: ['<@&999>'], cappedCount: 0 });
+      .toMatchObject({ ids: [], invalidTokens: ['<@&999>'], cappedCount: 0 });
   });
 
   test('direct mentions always win the cap over role-expansion members', () => {
@@ -310,7 +310,7 @@ describe('parseRecipientMentions — role mentions', () => {
       roles: { '7000': ['101'] },
     });
     expect(parseRecipientMentions('<@101> <@&7000>', int))
-      .toEqual({ ids: ['101'], invalidTokens: [], cappedCount: 0 });
+      .toMatchObject({ ids: ['101'], invalidTokens: [], cappedCount: 0 });
   });
 
   test('role mention repeated in input expands once (no double-counting)', () => {
@@ -329,11 +329,91 @@ describe('parseRecipientMentions — role mentions', () => {
   });
 });
 
+describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
+  test('allowed: expands to all non-bot guild members', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {}, '801': { bot: true }, '103': {} },
+    });
+    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
+    expect(res.ids.sort()).toEqual(['101', '102', '103']);
+    expect(res.invalidTokens).toEqual([]);
+    expect(res.massMentionDenied).toBe(false);
+  });
+
+  test('allowed: merges with direct mentions, deduped', () => {
+    // Same user reached via both `@everyone` and a direct `<@id>` is
+    // contributed once (the parser uses a single `consider()` that
+    // dedupes via `seen`). The role-expansion test pins the same
+    // contract for roles; this pins it for the mass-mention path.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+    });
+    const res = parseRecipientMentions('<@101> @everyone', int, { allowMassMention: true });
+    expect(res.ids.sort()).toEqual(['101', '102']);
+  });
+
+  test('allowed: caps at QURL_SEND_MAX_RECIPIENTS, surfaces cappedCount', () => {
+    // Synthetic guild larger than the cap. Pin that the cap applies
+    // post-expansion so a future "expand-without-cap" regression
+    // surfaces here.
+    const users = {};
+    for (let i = 0; i < 40; i++) users[`u${String(i).padStart(18, '0')}`] = {};
+    const int = makeInteraction({ users });
+    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
+    expect(res.ids.length).toBe(25);
+    expect(res.cappedCount).toBe(15);
+  });
+
+  test('denied (default): surfaces massMentionDenied=true, no expansion, no invalidTokens entry', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+    });
+    const res = parseRecipientMentions('@everyone', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual([]);
+    expect(res.massMentionDenied).toBe(true);
+  });
+
+  test('denied: explicit allowMassMention=false is equivalent to default', () => {
+    const int = makeInteraction({ users: { '101': {} } });
+    expect(parseRecipientMentions('@everyone <@101>', int, { allowMassMention: false }))
+      .toMatchObject({ ids: ['101'], invalidTokens: [], massMentionDenied: true });
+  });
+
+  test('no @everyone in input → massMentionDenied=false regardless of permission', () => {
+    const int = makeInteraction({ users: { '101': {} } });
+    // Allowed but not used.
+    expect(parseRecipientMentions('<@101>', int, { allowMassMention: true })
+      .massMentionDenied).toBe(false);
+    // Denied but not attempted.
+    expect(parseRecipientMentions('<@101>', int, { allowMassMention: false })
+      .massMentionDenied).toBe(false);
+  });
+
+  test('allowed: bot filter applies during expansion', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '801': { bot: true }, '802': { bot: true } },
+    });
+    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
+    expect(res.ids).toEqual(['101']);
+  });
+
+  test('allowed with no guild member cache returns empty (DM-context guard)', () => {
+    // DM-context guild=null/undefined: expansion is impossible, but
+    // the parser should NOT throw. Returns empty ids, massMentionDenied
+    // stays false (the user HAD permission, the cache just had nothing).
+    const int = { user: { id: '900' }, guild: undefined };
+    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
+    expect(res.ids).toEqual([]);
+    expect(res.massMentionDenied).toBe(false);
+  });
+});
+
 describe('parseRecipientMentions — invalid tokens', () => {
   test('channel mentions land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <#456>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['<#456>'], cappedCount: 0 });
   });
 
   test('custom emoji (static and animated) land in invalidTokens', () => {
@@ -342,15 +422,15 @@ describe('parseRecipientMentions — invalid tokens', () => {
     // (`<@!?(\d+)>`) or ROLE_MENTION_RE (`<@&(\d+)>`) shapes.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111> <:smile:789>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<:smile:789>'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['<:smile:789>'], cappedCount: 0 });
     expect(parseRecipientMentions('<@111> <a:dance:790>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<a:dance:790>'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['<a:dance:790>'], cappedCount: 0 });
   });
 
   test('bare plaintext usernames land in invalidTokens', () => {
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('alice <@111> bob', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['alice', 'bob'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['alice', 'bob'], cappedCount: 0 });
   });
 
   test('mention with missing closer (truncated input) is treated as invalid', () => {
@@ -362,20 +442,27 @@ describe('parseRecipientMentions — invalid tokens', () => {
     expect(res.invalidTokens.length).toBeGreaterThan(0);
   });
 
-  test('@everyone / @here are pre-escaped with zero-width-space in invalidTokens', () => {
-    // Discord's @everyone / @here are NOT `<@id>` mentions — they're
-    // bare tokens that the API expands at message-send time. A caller
-    // naively interpolating `invalidTokens` into a user-visible
-    // message (`` `Couldn't parse: ${invalidTokens.join(', ')}` ``)
-    // would fan-out-ping the channel. To make the boundary safe by
-    // default, the parser inserts a zero-width space (U+200B) after
-    // the `@` — visually identical, but Discord's tokenizer no longer
-    // recognizes the mass-mention shape.
+  test('@everyone (denied) surfaces massMentionDenied + does NOT defuse into invalidTokens', () => {
+    // With `allowMassMention` defaulting to false, `@everyone` is
+    // recognized but the caller-side gate denies expansion. The
+    // parser surfaces `massMentionDenied: true` so the caller can
+    // emit a permission-specific warning, and strips the token from
+    // input so the residue pass doesn't double-surface it as a
+    // defused invalidToken. Distinct UX from "couldn't parse."
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('@everyone <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@\u200beveryone'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: [], cappedCount: 0, massMentionDenied: true });
+  });
+
+  test('@here still defuses with zero-width-space (no presence intent, not implemented)', () => {
+    // `@here` would need GUILD_PRESENCES intent to filter online
+    // members — the bot only runs GuildMembers, so @here is left
+    // on the legacy defuse path (rewritten with U+200B in
+    // invalidTokens). Pin the invariant so a future PR that
+    // implements @here flips this test deliberately, not silently.
+    const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('@here <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@\u200bhere'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['@\u200bhere'], cappedCount: 0, massMentionDenied: false });
   });
 
   test('@Everyone / @Here (capitalized) are NOT escaped — Discord parser is lowercase-only', () => {
@@ -387,27 +474,41 @@ describe('parseRecipientMentions — invalid tokens', () => {
     // silently widen the regex without flipping this test.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('@Everyone <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@Everyone'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['@Everyone'], cappedCount: 0 });
     expect(parseRecipientMentions('@Here <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@Here'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['@Here'], cappedCount: 0 });
   });
 
-  test('@everyone with trailing punctuation is also escaped (single-token residue)', () => {
-    // The strip-pass split class `[\s,;|/]+` does NOT include `.`,
-    // `:`, `!`, `?`, `-`, so `@everyone!` and `@everyone.fix` survive
-    // as single tokens. Exact-match escape would slip these past the
-    // guard. Pin that the regex-based escape catches them.
+  test('@here with trailing punctuation still defuses into invalidTokens', () => {
+    // @here remains on the legacy defuse path until presence intent
+    // lands — pin that trailing punctuation cases still get U+200B
+    // protection regardless of @everyone's separate gated path.
     const int = makeInteraction({ users: { '111': {} } });
-    expect(parseRecipientMentions('@everyone! <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@\u200beveryone!'], cappedCount: 0 });
-    expect(parseRecipientMentions('@everyone.fix <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@\u200beveryone.fix'], cappedCount: 0 });
     expect(parseRecipientMentions('@here: <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['@\u200bhere:'], cappedCount: 0 });
-    // Embedded mid-token (paste artifact). Regex replaces ALL
-    // occurrences so no `@everyone` / `@here` substring escapes.
+      .toMatchObject({ ids: ['111'], invalidTokens: ['@\u200bhere:'], cappedCount: 0 });
+  });
+
+  test('@everyone with trailing punctuation (denied) still surfaces massMentionDenied', () => {
+    // `@everyone!`, `@everyone.fix`, etc. — the parser's
+    // EVERYONE_TOKEN_RE matches `@everyone` with a non-word lookahead,
+    // so trailing punctuation isn't consumed but the gate still fires.
+    // Any leftover residue (`!`, `.fix`) is a tradeoff worth making —
+    // surfacing the @everyone permission notice is the load-bearing
+    // signal; the leftover punctuation gets a generic "couldn't
+    // parse" treatment if present.
+    const int = makeInteraction({ users: { '111': {} } });
+    const res = parseRecipientMentions('@everyone! <@111>', int);
+    expect(res.ids).toEqual(['111']);
+    expect(res.massMentionDenied).toBe(true);
+  });
+
+  test('here@everyone (embedded) stays on the defuse path (not a standalone @everyone)', () => {
+    // Word-boundary semantics: `here@everyone` has `e` before the `@`,
+    // so EVERYONE_TOKEN_RE's lookbehind rejects it. Falls into the
+    // residue pass and gets U+200B-defused like before.
+    const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('here@everyone <@111>', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['here@\u200beveryone'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['here@\u200beveryone'], cappedCount: 0, massMentionDenied: false });
   });
 
   test('newline characters separate tokens (split regex includes \\n)', () => {
@@ -418,7 +519,7 @@ describe('parseRecipientMentions — invalid tokens', () => {
     // bare-name token.
     const int = makeInteraction({ users: { '111': {} } });
     expect(parseRecipientMentions('<@111>\n<#456>\n\nstray', int))
-      .toEqual({ ids: ['111'], invalidTokens: ['<#456>', 'stray'], cappedCount: 0 });
+      .toMatchObject({ ids: ['111'], invalidTokens: ['<#456>', 'stray'], cappedCount: 0 });
   });
 });
 

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -352,18 +352,6 @@ describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
     expect(res.ids.sort()).toEqual(['101', '102']);
   });
 
-  test('allowed: caps at QURL_SEND_MAX_RECIPIENTS, surfaces cappedCount', () => {
-    // Synthetic guild larger than the cap. Pin that the cap applies
-    // post-expansion so a future "expand-without-cap" regression
-    // surfaces here.
-    const users = {};
-    for (let i = 0; i < 40; i++) users[`u${String(i).padStart(18, '0')}`] = {};
-    const int = makeInteraction({ users });
-    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
-    expect(res.ids.length).toBe(25);
-    expect(res.cappedCount).toBe(15);
-  });
-
   test('denied (default): surfaces massMentionDenied=true, no expansion, no invalidTokens entry', () => {
     const int = makeInteraction({
       users: { '101': {}, '102': {} },
@@ -406,6 +394,41 @@ describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
     const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
     expect(res.ids).toEqual([]);
     expect(res.massMentionDenied).toBe(false);
+  });
+
+  test('allowed but every cached member is a bot → empty expansion, massMentionDenied still false', () => {
+    // Distinguish "expanded to nothing" (cache has only bots) from
+    // "denied" (no MENTION_EVERYONE perm). The caller renders these
+    // differently: "no valid recipients" generic copy vs. the
+    // permission-specific @everyone copy. Pin that the allowed-but-
+    // empty path stays on the generic side.
+    const int = makeInteraction({
+      users: { '801': { bot: true }, '802': { bot: true } },
+    });
+    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
+    expect(res.ids).toEqual([]);
+    expect(res.massMentionDenied).toBe(false);
+  });
+
+  test('allowed: cap short-circuits the cache scan (large guild cap behavior)', () => {
+    // The @everyone expansion iterates guild.members.cache — a large
+    // guild could have 10k+ entries. Once `ids.size === cap`, the
+    // loop breaks rather than scanning the remainder. We can't easily
+    // assert "break ran" directly without instrumentation, but we
+    // can assert the cap-bounded result: 25 (the cap) ids out of 40
+    // synthetic non-bot members, with NO cappedCount surfaced for the
+    // skipped members (the early break is the tradeoff — we don't
+    // count past-cap members in @everyone expansion, unlike the
+    // text-mention path).
+    const users = {};
+    for (let i = 0; i < 40; i++) users[`u${String(i).padStart(18, '0')}`] = {};
+    const int = makeInteraction({ users });
+    const res = parseRecipientMentions('@everyone', int, { allowMassMention: true });
+    expect(res.ids.length).toBe(25);
+    // cappedCount reflects only the members the loop actually saw
+    // past `ids.size === cap`. Since we break immediately, no members
+    // get added to `seen` beyond the cap, so cappedCount stays at 0.
+    expect(res.cappedCount).toBe(0);
   });
 });
 
@@ -488,18 +511,22 @@ describe('parseRecipientMentions — invalid tokens', () => {
       .toMatchObject({ ids: ['111'], invalidTokens: ['@\u200bhere:'], cappedCount: 0 });
   });
 
-  test('@everyone with trailing punctuation (denied) still surfaces massMentionDenied', () => {
+  test('@everyone with trailing punctuation (denied) still surfaces massMentionDenied + leftover lands in invalidTokens', () => {
     // `@everyone!`, `@everyone.fix`, etc. — the parser's
     // EVERYONE_TOKEN_RE matches `@everyone` with a non-word lookahead,
     // so trailing punctuation isn't consumed but the gate still fires.
     // Any leftover residue (`!`, `.fix`) is a tradeoff worth making —
     // surfacing the @everyone permission notice is the load-bearing
     // signal; the leftover punctuation gets a generic "couldn't
-    // parse" treatment if present.
+    // parse" treatment. Pin the residue shape so a future regression
+    // that double-surfaces (`@everyone!` AS A WHOLE in invalidTokens
+    // alongside the massMentionDenied flag) or silently swallows the
+    // `!` is caught here.
     const int = makeInteraction({ users: { '111': {} } });
     const res = parseRecipientMentions('@everyone! <@111>', int);
     expect(res.ids).toEqual(['111']);
     expect(res.massMentionDenied).toBe(true);
+    expect(res.invalidTokens).toEqual(['!']);
   });
 
   test('here@everyone (embedded) stays on the defuse path (not a standalone @everyone)', () => {


### PR DESCRIPTION
## Summary

Allow `@everyone` in the `recipients:` text on `/qurl file` and `/qurl map`. Gated behind Discord's MENTION_EVERYONE permission so any guild member can't blast a /qurl send to all 25 cached members.

This is **Part 1 of 2** of the feature requested ("send to @everyone or to a role"). Part 2 — a `MentionableSelectMenu` picker for selecting roles from a dropdown — is tracked in #324. Role mentions via text (`@TeamName` → `<@&roleId>`) already work today; that path is unchanged.

### UX

- **User types `@everyone alice` and has Mention Everyone permission** → all non-bot guild members expand into the recipient list; the standard cap (25) + bot filter apply.
- **User types `@everyone alice` and does NOT have permission** → confirm card shows a permission-specific warning:
  > ⚠ Some recipients were dropped:
  > • `@everyone` requires the **Mention Everyone** permission — skipped.

  …and Alice expands as usual.
- **DM context**: the `@everyone` permission warning is suppressed (Discord doesn't expand `@everyone` in DMs, so the copy would be misleading). Other warnings still surface.
- **`@here` is intentionally NOT implemented.** It would need GUILD_PRESENCES intent to filter online members; the bot only runs GuildMembers. Stays on the legacy U+200B defuse path (test pinned).

### Code changes

- `recipient-parser.js`:
  - New `EVERYONE_TOKEN_RE` — Unicode-aware word boundary (`\p{L}\p{N}_` with `/u`) so `@everyoneé` doesn't false-match. Case-sensitive (Discord's parser is lowercase-only).
  - New opt `allowMassMention: boolean` on `parseRecipientMentions`.
  - Allowed → expand to all non-bot guild members (loop breaks once cap is hit; cache iteration is bounded). Denied → `massMentionDenied: true` in result. Either way, strip from input before residue pass.
  - New `isBotMember(member)` helper consolidates the `.user.bot === true` check across all three expansion paths.
- `commands.js`:
  - Read `interaction.memberPermissions.has(PermissionFlagsBits.MentionEveryone)`; pass through as `allowMassMention`.
  - `renderRecipientWarnings`: new `massMentionDenied` parameter emits the permission-specific line.
  - DM-context suppression: caller drops the `massMentionDenied` signal when `!interaction.guild`.
- Tests: new `@everyone (allowMassMention)` describe block in `recipient-parser.test.js` covering allowed/denied/cap/dedup/bot-filter/DM-context/Unicode-boundary/repeated-everyone/mixed-with-@here. New result-shape contract test pinning the closed 4-key set. New DM-context warning suppression test at the handler level. 1436 tests pass.

### Wire-protocol changes

None. customIds + DDB schema untouched.

### Deferred via follow-up issues

- **#324** — Part 2: MentionableSelectMenu picker for role-via-dropdown (with the same MENTION_EVERYONE gate for the @everyone role).
- **#325** — `logger.audit` events for @everyone allowed/denied attempts. Both cr reviewers independently flagged this; deserves its own PR with new AUDIT_EVENTS constants.

## Test plan

- [x] `pnpm test` — 1436 tests pass
- [x] `pnpm lint` — clean (`eslint --max-warnings 0`)
- [ ] CI green
- [ ] Claude review clean
- [ ] Live smoke: `/qurl file recipients:@everyone` as admin → all members expand; same as non-admin → permission warning + Alice still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)