### PR TITLE
feat(discord): swap UserSelectMenu for MentionableSelectMenu on confirm card (#324)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2813,6 +2813,14 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
       //    against a pathological all-bot role where the size guard
       //    can never fire. Logs at debug so a user-reported "I picked
       //    a role and got fewer than expected" has a forensic hook.
+      //
+      // The counter is incremented BEFORE the dedupe checks below, so
+      // a bot in two picked roles costs 2 iteration slots even though
+      // it lands in droppedFromRolesSet once. That's intentional —
+      // the bound governs CPU cost (entries inspected), not the
+      // user-visible count semantic. Hoisting the dedupe above the
+      // counter would let a contrived "same 100 members across N
+      // roles" pick grind for free.
       for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
         if (inspectedFromRoles >= ITER_BOUND) {
@@ -2862,6 +2870,16 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  * string when nothing is worth surfacing — keeps callers simple
  * (`warningsBlock + content`) without a separate "do I have any
  * warnings" check.
+ *
+ * COPY PARITY: the partial-valid pick path renders bulleted lines
+ * from here; the all-invalid pick path in handleConfirmUserSelect
+ * builds its own joined-sentence reasons list with shorter copy
+ * (rejection banner vs. warnings block — different UI contexts).
+ * Both surface the SAME set of signals (droppedBots,
+ * droppedFromRoles, massMentionDenied, everyoneCacheCold). When
+ * adding or renaming a signal, update BOTH surfaces in lockstep —
+ * the helpers don't share a copy table, so a future contributor
+ * could easily land one half and not the other.
  *
  * @param {{
  *   invalidTokens?: string[],
@@ -3866,6 +3884,11 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     // Multiple reasons can fire together: e.g. directly-picked bot
     // and a bot-only role both surface since they describe
     // independent picker actions.
+    //
+    // COPY PARITY: the partial-valid path uses renderRecipientWarnings
+    // for the same set of signals but with longer bulleted copy
+    // (warnings block vs. rejection banner — different UI contexts).
+    // When adding a new reason, update BOTH surfaces.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
     if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2871,6 +2871,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  *   droppedBots?: number,
  *   droppedFromRoles?: number,
  *   massMentionDenied?: boolean,
+ *   everyoneCacheCold?: boolean,
  * }} [opts]
  */
 function renderRecipientWarnings({
@@ -2881,6 +2882,7 @@ function renderRecipientWarnings({
   droppedBots = 0,
   droppedFromRoles = 0,
   massMentionDenied = false,
+  everyoneCacheCold = false,
 } = {}) {
   const lines = [];
   if (cappedCount > 0) {
@@ -2927,6 +2929,13 @@ function renderRecipientWarnings({
     // user took a different picker action (selecting a role rather
     // than an individual bot).
     lines.push(`• ${droppedFromRoles} bot(s) filtered from picked role(s) — skipped.`);
+  }
+  if (everyoneCacheCold) {
+    // Symmetric with droppedFromRoles: surfaced even on partial-valid
+    // picks (named user + @everyone with cold cache → user lands but
+    // @everyone silently expanded to zero, which the user would
+    // otherwise have no way to know).
+    lines.push('• Member cache not yet ready — `@everyone` expanded to 0 members. Try again in a few seconds.');
   }
   if (massMentionDenied) {
     // Specific copy beats the generic "couldn't parse" path so the
@@ -3073,10 +3082,16 @@ function renderConfirmCardRows({
 }) {
   const rows = [];
   const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
+  // Placeholder surfaces both ceilings: pick-slot count (Discord's
+  // setMaxValues) AND the post-expansion recipient cap. With roles in
+  // the picker, a single slot can expand to many members — saying
+  // only "1–10" would mislead users who pick 10 roles expecting 10
+  // recipients.
+  const recipientCap = config.QURL_SEND_MAX_RECIPIENTS;
   rows.push(new ActionRowBuilder().addComponents(
     new MentionableSelectMenuBuilder()
       .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
-      .setPlaceholder(`Pick users or roles (1–${maxValues})`)
+      .setPlaceholder(`Pick up to ${maxValues} users/roles (recipients capped at ${recipientCap})`)
       .setMinValues(1)
       .setMaxValues(maxValues)
   ));
@@ -3879,6 +3894,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     droppedBots,
     droppedFromRoles,
     massMentionDenied,
+    everyoneCacheCold,
   });
   const newRecipientAliases = Object.fromEntries(
     valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2738,13 +2738,11 @@ function partitionRecipients(users, senderId) {
 // instead of `role.members` — discord.js doesn't reliably surface
 // all members through @everyone's role.members.
 //
-// `droppedFromRoles` counts picker-action bot filtering (bot members
-// the helper skipped during role expansion). It is a count of
-// *iterations*, not unique bot IDs — if the same bot is also picked
-// individually OR appears in two picked roles, it can be counted
-// more than once. The caller treats it as a boolean signal for the
-// "bot(s) filtered from picked role(s)" warning line, so the count
-// is only used as `> 0` / "N" in user-visible copy.
+// `droppedFromRoles` is the count of DISTINCT bot-user IDs filtered
+// during role expansion (Set-backed) — matches what the user sees
+// rendered as "N bot(s) filtered from picked role(s)." A bot that
+// appears in two picked roles, or is directly picked AND also in a
+// picked role, is counted at most once.
 //
 // Map/Collection compatibility: `interaction.users` and
 // `interaction.roles` are discord.js Collections (which extend Map)
@@ -2760,16 +2758,21 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
     }
   }
   let massMentionDenied = false;
-  // Accumulates across all picked roles intentionally — the bound is
-  // an iteration-cost cap, not per-role correctness, so a pathological
-  // first role legitimately pre-truncates expansion of later roles.
-  let droppedFromRoles = 0;
+  // Distinct bot IDs filtered across all picked roles — caller renders
+  // .size as "N bot(s) filtered." Tracking as a Set (not a counter)
+  // so overlap (bot in two roles, or directly-picked bot also in a
+  // role) doesn't inflate the user-visible number.
+  const droppedFromRolesSet = new Set();
+  // Raw inner-loop iterations across all picked roles. Bounds the
+  // iteration COST independent of unique-bot semantics, so a
+  // pathological 10k-entry role can't grind for free.
+  let inspectedFromRoles = 0;
   // 4× cap (=100) balances pathological-role protection against the
   // UX edge where a real role iterates bots first and humans behind:
   // 2× was tight enough that a "bots-up-front" role could leave the
-  // user under-expanded with no visible signal beyond a high
-  // droppedFromRoles count. 4× pushes the rate-of-occurrence well
-  // below any plausible non-pathological role layout.
+  // user under-expanded with no visible signal beyond a high count.
+  // 4× pushes the rate-of-occurrence well below any plausible
+  // non-pathological role layout.
   const ITER_BOUND = 4 * config.QURL_SEND_MAX_RECIPIENTS;
   if (interaction.roles && typeof interaction.roles.entries === 'function') {
     for (const [roleId, role] of interaction.roles.entries()) {
@@ -2781,46 +2784,55 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
         massMentionDenied = true;
         continue;
       }
+      // `guild` is provably truthy in the @everyone branch (gated by
+      // `guild && roleId === guild.id` above).
       const source = isEveryoneRole
-        ? guild?.members?.cache
+        ? guild.members?.cache
         : role?.members;
       if (!source || typeof source.entries !== 'function') continue;
       // Two break conditions, both belt-and-suspenders:
       //  - userMap.size at cap: stops adding new entries once the
       //    downstream partition cap would be hit anyway.
-      //  - droppedFromRoles + size past 4× cap: bounds iteration
+      //  - inspectedFromRoles past 4× cap: bounds iteration cost
       //    against a pathological all-bot role where the size guard
-      //    can never fire (bots only increment droppedFromRoles).
-      //    Logs at debug so a user-reported "I picked a role and got
-      //    fewer than expected" has a forensic hook.
+      //    can never fire. Logs at debug so a user-reported "I picked
+      //    a role and got fewer than expected" has a forensic hook.
       for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
-        if (droppedFromRoles + userMap.size >= ITER_BOUND) {
+        if (inspectedFromRoles >= ITER_BOUND) {
           logger.debug('resolveMentionableSelection: ITER_BOUND hit during role expansion', {
             flow_id: flowIdForLog,
             role_id: roleId,
-            dropped_from_roles: droppedFromRoles,
+            inspected_from_roles: inspectedFromRoles,
             user_map_size: userMap.size,
             iter_bound: ITER_BOUND,
           });
           break;
         }
+        inspectedFromRoles += 1;
+        // Dedupe BEFORE the bot check: a directly-picked bot is
+        // already in userMap (seeded above), and partitionRecipients
+        // will report it via droppedBots. Skipping here means it
+        // doesn't ALSO tick the role-side bot signal — avoids
+        // surfacing two warnings for the same underlying bot.
+        if (userMap.has(memberId)) continue;
+        if (droppedFromRolesSet.has(memberId)) continue;
         if (isBotMember(member)) {
-          droppedFromRoles += 1;
+          droppedFromRolesSet.add(memberId);
           continue;
         }
-        // `has` check preserves field fidelity, not cap-priority
-        // (which is enforced by the user-pick seeding above happening
-        // before role expansion). It keeps the original User object
-        // from interaction.users instead of overwriting with
-        // member.user, which can differ in optional fields like
-        // `globalName` that downstream alias rendering reads.
-        if (userMap.has(memberId)) continue;
+        // member.user is kept here (not the picker's User object)
+        // because picked-user seeding already happened; field fidelity
+        // for picked users is preserved by the userMap.has skip above.
         userMap.set(memberId, member.user);
       }
     }
   }
-  return { users: [...userMap.values()], massMentionDenied, droppedFromRoles };
+  return {
+    users: [...userMap.values()],
+    massMentionDenied,
+    droppedFromRoles: droppedFromRolesSet.size,
+  };
 }
 
 /**

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2746,7 +2746,11 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
     }
   }
   let massMentionDenied = false;
+  // Accumulates across all picked roles intentionally — the bound is
+  // an iteration-cost cap, not per-role correctness, so a pathological
+  // first role legitimately pre-truncates expansion of later roles.
   let droppedFromRoles = 0;
+  const ITER_BOUND = 2 * config.QURL_SEND_MAX_RECIPIENTS;
   if (interaction.roles && typeof interaction.roles.entries === 'function') {
     for (const [roleId, role] of interaction.roles.entries()) {
       const isEveryoneRole = guild && roleId === guild.id;
@@ -2767,7 +2771,6 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
       //  - droppedFromRoles + size past 2× cap: bounds iteration
       //    against a pathological all-bot role where the size guard
       //    can never fire (bots only increment droppedFromRoles).
-      const ITER_BOUND = 2 * config.QURL_SEND_MAX_RECIPIENTS;
       for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
         if (droppedFromRoles + userMap.size >= ITER_BOUND) break;
@@ -2801,6 +2804,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
  *   unresolvedIds?: string[],
  *   transientFailureIds?: string[],
  *   droppedBots?: number,
+ *   droppedFromRoles?: number,
  *   massMentionDenied?: boolean,
  * }} [opts]
  */
@@ -2810,6 +2814,7 @@ function renderRecipientWarnings({
   unresolvedIds = [],
   transientFailureIds = [],
   droppedBots = 0,
+  droppedFromRoles = 0,
   massMentionDenied = false,
 } = {}) {
   const lines = [];
@@ -2849,6 +2854,14 @@ function renderRecipientWarnings({
   }
   if (droppedBots > 0) {
     lines.push(`• ${droppedBots} bot(s) cannot receive qURL links — skipped.`);
+  }
+  if (droppedFromRoles > 0) {
+    // Surfaced symmetrically with droppedBots so the user knows the
+    // role pick was partially filtered (vs. silently shrinking the
+    // recipient count). Distinct copy from droppedBots since the
+    // user took a different picker action (selecting a role rather
+    // than an individual bot).
+    lines.push(`• ${droppedFromRoles} bot(s) filtered from picked role(s) — skipped.`);
   }
   if (massMentionDenied) {
     // Specific copy beats the generic "couldn't parse" path so the
@@ -3783,6 +3796,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // reaches a state where `massMentionDenied` could be true.
   const newWarningsBlock = renderRecipientWarnings({
     droppedBots,
+    droppedFromRoles,
     massMentionDenied,
   });
   const newRecipientAliases = Object.fromEntries(

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2749,7 +2749,7 @@ function partitionRecipients(users, senderId) {
 // in prod and plain Maps in tests. Both implement `.values()`,
 // `.entries()`, and `Symbol.iterator` — the duck-type guards below
 // gate on the methods we actually call.
-function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id }) {
+function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id = null }) {
   const guild = interaction.guild;
   const userMap = new Map();
   if (interaction.users && typeof interaction.users.values === 'function') {
@@ -2802,13 +2802,19 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
       const source = isEveryoneRole
         ? guild.members?.cache
         : role?.members;
+      // Two distinct cold-cache shapes both surface the same UX
+      // signal (everyoneCacheCold):
+      //   - `source` undefined / non-iterable: discord.js hasn't
+      //     created the cache slot yet (e.g., `guild.members = {}`
+      //     immediately post-restart).
+      //   - `source.size === 0`: cache slot exists but no members
+      //     populated yet (e.g., between bot ready and
+      //     chunk-on-startup completion).
       if (!source || typeof source.entries !== 'function') {
         if (isEveryoneRole) everyoneCacheCold = true;
         continue;
       }
       if (isEveryoneRole && source.size === 0) {
-        // Cache exists but is empty — same UX problem as missing
-        // cache. Don't iterate (no-op anyway), surface the signal.
         everyoneCacheCold = true;
         continue;
       }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2749,7 +2749,7 @@ function partitionRecipients(users, senderId) {
 // in prod and plain Maps in tests. Both implement `.values()`,
 // `.entries()`, and `Symbol.iterator` — the duck-type guards below
 // gate on the methods we actually call.
-function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdForLog }) {
+function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id }) {
   const guild = interaction.guild;
   const userMap = new Map();
   if (interaction.users && typeof interaction.users.values === 'function') {
@@ -2758,6 +2758,13 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
     }
   }
   let massMentionDenied = false;
+  // Set when the user picked @everyone WITH MENTION_EVERYONE but the
+  // guild.members cache is missing or empty — e.g. immediately after
+  // a bot restart, before the lazy-load fills it. Lets the caller
+  // surface a "try again in a few seconds" reason instead of the
+  // silent deferUpdate-only no-op the user-visible path would
+  // otherwise hit.
+  let everyoneCacheCold = false;
   // Distinct bot IDs filtered across all picked roles — caller renders
   // .size as "N bot(s) filtered." Tracking as a Set (not a counter)
   // so overlap (bot in two roles, or directly-picked bot also in a
@@ -2789,7 +2796,16 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
       const source = isEveryoneRole
         ? guild.members?.cache
         : role?.members;
-      if (!source || typeof source.entries !== 'function') continue;
+      if (!source || typeof source.entries !== 'function') {
+        if (isEveryoneRole) everyoneCacheCold = true;
+        continue;
+      }
+      if (isEveryoneRole && source.size === 0) {
+        // Cache exists but is empty — same UX problem as missing
+        // cache. Don't iterate (no-op anyway), surface the signal.
+        everyoneCacheCold = true;
+        continue;
+      }
       // Two break conditions, both belt-and-suspenders:
       //  - userMap.size at cap: stops adding new entries once the
       //    downstream partition cap would be hit anyway.
@@ -2801,7 +2817,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
         if (inspectedFromRoles >= ITER_BOUND) {
           logger.debug('resolveMentionableSelection: ITER_BOUND hit during role expansion', {
-            flow_id: flowIdForLog,
+            flow_id,
             role_id: roleId,
             inspected_from_roles: inspectedFromRoles,
             user_map_size: userMap.size,
@@ -2810,6 +2826,11 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
           break;
         }
         inspectedFromRoles += 1;
+        // Defense: partial GuildMember objects from sparse fetches
+        // could carry an undefined `.user`. Downstream partitionRecipients
+        // would deref `.bot` / `.id` on undefined; skip such entries
+        // up front. Symmetric with the picked-users seed guard above.
+        if (!member?.user?.id) continue;
         // Dedupe BEFORE the bot check: a directly-picked bot is
         // already in userMap (seeded above), and partitionRecipients
         // will report it via droppedBots. Skipping here means it
@@ -2832,6 +2853,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdFo
     users: [...userMap.values()],
     massMentionDenied,
     droppedFromRoles: droppedFromRolesSet.size,
+    everyoneCacheCold,
   };
 }
 
@@ -3734,16 +3756,26 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // the text-path gate in #323.
   const canMentionEveryone = !!interaction.guild
     && interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
-  const { users: selected, massMentionDenied, droppedFromRoles } = resolveMentionableSelection({
+  const {
+    users: selected,
+    massMentionDenied,
+    droppedFromRoles,
+    everyoneCacheCold,
+  } = resolveMentionableSelection({
     interaction,
     canMentionEveryone,
-    flowIdForLog: flow_id,
+    flow_id,
   });
-  if (selected.length === 0 && !massMentionDenied && droppedFromRoles === 0) {
+  if (
+    selected.length === 0
+    && !massMentionDenied
+    && droppedFromRoles === 0
+    && !everyoneCacheCold
+  ) {
     // Truly empty pick (no users, no roles, no @everyone, no
-    // bot-only roles) → already acked via deferUpdate above. Other
-    // empty-selected cases fall through to the all-invalid branch
-    // below so the user sees a reason banner.
+    // bot-only roles, cache not cold) → already acked via deferUpdate
+    // above. Other empty-selected cases fall through to the
+    // all-invalid branch below so the user sees a reason banner.
     return undefined;
   }
   // `interaction.user.id` IS the original sender's ID — Discord
@@ -3803,6 +3835,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       dropped_bots: droppedBots,
       mass_mention_denied: massMentionDenied,
       dropped_from_roles: droppedFromRoles,
+      everyone_cache_cold: everyoneCacheCold,
     });
     // Reachable cases:
     //   - bot-only individual pick (droppedBots > 0)
@@ -3810,15 +3843,19 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     //     (massMentionDenied === true)
     //   - picked a role whose only members are bots
     //     (droppedFromRoles > 0, selected.length === 0)
+    //   - picked @everyone WITH perm but guild.members.cache is
+    //     missing / empty (everyoneCacheCold === true) — typically
+    //     right after a bot restart, before chunk-on-startup lands
     // List-builder pattern; the fallback prevents a degraded
     // `⚠ . Re-pick...` message if all conditions are false.
-    // Both bot-related reasons can fire together: a pick combining a
-    // directly-picked bot and a bot-only role surfaces both signals
-    // since they describe independent picker actions.
+    // Multiple reasons can fire together: e.g. directly-picked bot
+    // and a bot-only role both surface since they describe
+    // independent picker actions.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
     if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');
     if (droppedFromRoles > 0) reasons.push('Picked role(s) have no non-bot members');
+    if (everyoneCacheCold) reasons.push('Member cache not yet ready — try again in a few seconds');
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2746,10 +2746,14 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
     }
   }
   let massMentionDenied = false;
+  let droppedFromRoles = 0;
   if (interaction.roles && typeof interaction.roles.entries === 'function') {
-    for (const [roleId, role] of interaction.roles) {
+    for (const [roleId, role] of interaction.roles.entries()) {
       const isEveryoneRole = guild && roleId === guild.id;
       if (isEveryoneRole && !canMentionEveryone) {
+        // Surfaced even if userMap is already at cap — the gate firing
+        // is a user-visible signal worth showing regardless of whether
+        // expansion would have added anyone.
         massMentionDenied = true;
         continue;
       }
@@ -2759,15 +2763,22 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
       if (!source || typeof source.entries !== 'function') continue;
       // Cap short-circuit avoids building a 10k-entry userMap when a
       // large role is picked; downstream partition still enforces.
-      for (const [memberId, member] of source) {
+      for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
-        if (isBotMember(member)) continue;
+        if (isBotMember(member)) {
+          droppedFromRoles += 1;
+          continue;
+        }
+        // `has` check is load-bearing for cap-priority: keeps the
+        // first-seen User (the one from interaction.users) over the
+        // role-member view, which may differ in optional fields like
+        // `globalName` that downstream alias rendering reads.
         if (userMap.has(memberId)) continue;
         userMap.set(memberId, member.user);
       }
     }
   }
-  return { users: [...userMap.values()], massMentionDenied };
+  return { users: [...userMap.values()], massMentionDenied, droppedFromRoles };
 }
 
 /**
@@ -3659,14 +3670,15 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // the text-path gate in #323.
   const canMentionEveryone = !!interaction.guild
     && interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
-  const { users: selected, massMentionDenied } = resolveMentionableSelection({
+  const { users: selected, massMentionDenied, droppedFromRoles } = resolveMentionableSelection({
     interaction,
     canMentionEveryone,
   });
-  if (selected.length === 0 && !massMentionDenied) {
-    // Empty pick (no users, no roles, no @everyone) → already acked
-    // via deferUpdate above. Nothing to edit. The massMentionDenied
-    // branch is handled in the rejection path below.
+  if (selected.length === 0 && !massMentionDenied && droppedFromRoles === 0) {
+    // Truly empty pick (no users, no roles, no @everyone, no
+    // bot-only roles) → already acked via deferUpdate above. Other
+    // empty-selected cases fall through to the all-invalid branch
+    // below so the user sees a reason banner.
     return undefined;
   }
   // `interaction.user.id` IS the original sender's ID — Discord
@@ -3722,18 +3734,23 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     // in invalid-pick churn surfaces in metrics without lowering log
     // verbosity.
     logger.debug('handleConfirmUserSelect: all-invalid pick', {
-      flow_id, dropped_bots: droppedBots, mass_mention_denied: massMentionDenied,
+      flow_id,
+      dropped_bots: droppedBots,
+      mass_mention_denied: massMentionDenied,
+      dropped_from_roles: droppedFromRoles,
     });
     // Reachable cases:
-    //   - bot-only pick (droppedBots > 0)
+    //   - bot-only individual pick (droppedBots > 0)
     //   - picked the @everyone role without MENTION_EVERYONE perm
     //     (massMentionDenied === true)
-    //   - picked a role with zero non-bot members
+    //   - picked a role whose only members are bots
+    //     (droppedFromRoles > 0, selected.length === 0)
     // List-builder pattern; the fallback prevents a degraded
     // `⚠ . Re-pick...` message if all conditions are false.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
     if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');
+    if (droppedFromRoles > 0 && droppedBots === 0) reasons.push('Picked role(s) have no non-bot members');
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2761,17 +2761,25 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
         ? guild?.members?.cache
         : role?.members;
       if (!source || typeof source.entries !== 'function') continue;
-      // Cap short-circuit avoids building a 10k-entry userMap when a
-      // large role is picked; downstream partition still enforces.
+      // Two break conditions, both belt-and-suspenders:
+      //  - userMap.size at cap: stops adding new entries once the
+      //    downstream partition cap would be hit anyway.
+      //  - droppedFromRoles + size past 2× cap: bounds iteration
+      //    against a pathological all-bot role where the size guard
+      //    can never fire (bots only increment droppedFromRoles).
+      const ITER_BOUND = 2 * config.QURL_SEND_MAX_RECIPIENTS;
       for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
+        if (droppedFromRoles + userMap.size >= ITER_BOUND) break;
         if (isBotMember(member)) {
           droppedFromRoles += 1;
           continue;
         }
-        // `has` check is load-bearing for cap-priority: keeps the
-        // first-seen User (the one from interaction.users) over the
-        // role-member view, which may differ in optional fields like
+        // `has` check preserves field fidelity, not cap-priority
+        // (which is enforced by the user-pick seeding above happening
+        // before role expansion). It keeps the original User object
+        // from interaction.users instead of overwriting with
+        // member.user, which can differ in optional fields like
         // `globalName` that downstream alias rendering reads.
         if (userMap.has(memberId)) continue;
         userMap.set(memberId, member.user);
@@ -3747,10 +3755,13 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     //     (droppedFromRoles > 0, selected.length === 0)
     // List-builder pattern; the fallback prevents a degraded
     // `⚠ . Re-pick...` message if all conditions are false.
+    // Both bot-related reasons can fire together: a pick combining a
+    // directly-picked bot and a bot-only role surfaces both signals
+    // since they describe independent picker actions.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
     if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');
-    if (droppedFromRoles > 0 && droppedBots === 0) reasons.push('Picked role(s) have no non-bot members');
+    if (droppedFromRoles > 0) reasons.push('Picked role(s) have no non-bot members');
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2737,7 +2737,21 @@ function partitionRecipients(users, senderId) {
 // For the @everyone role specifically, iterate `guild.members.cache`
 // instead of `role.members` — discord.js doesn't reliably surface
 // all members through @everyone's role.members.
-function resolveMentionableSelection({ interaction, canMentionEveryone }) {
+//
+// `droppedFromRoles` counts picker-action bot filtering (bot members
+// the helper skipped during role expansion). It is a count of
+// *iterations*, not unique bot IDs — if the same bot is also picked
+// individually OR appears in two picked roles, it can be counted
+// more than once. The caller treats it as a boolean signal for the
+// "bot(s) filtered from picked role(s)" warning line, so the count
+// is only used as `> 0` / "N" in user-visible copy.
+//
+// Map/Collection compatibility: `interaction.users` and
+// `interaction.roles` are discord.js Collections (which extend Map)
+// in prod and plain Maps in tests. Both implement `.values()`,
+// `.entries()`, and `Symbol.iterator` — the duck-type guards below
+// gate on the methods we actually call.
+function resolveMentionableSelection({ interaction, canMentionEveryone, flowIdForLog }) {
   const guild = interaction.guild;
   const userMap = new Map();
   if (interaction.users && typeof interaction.users.values === 'function') {
@@ -2750,7 +2764,13 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
   // an iteration-cost cap, not per-role correctness, so a pathological
   // first role legitimately pre-truncates expansion of later roles.
   let droppedFromRoles = 0;
-  const ITER_BOUND = 2 * config.QURL_SEND_MAX_RECIPIENTS;
+  // 4× cap (=100) balances pathological-role protection against the
+  // UX edge where a real role iterates bots first and humans behind:
+  // 2× was tight enough that a "bots-up-front" role could leave the
+  // user under-expanded with no visible signal beyond a high
+  // droppedFromRoles count. 4× pushes the rate-of-occurrence well
+  // below any plausible non-pathological role layout.
+  const ITER_BOUND = 4 * config.QURL_SEND_MAX_RECIPIENTS;
   if (interaction.roles && typeof interaction.roles.entries === 'function') {
     for (const [roleId, role] of interaction.roles.entries()) {
       const isEveryoneRole = guild && roleId === guild.id;
@@ -2768,12 +2788,23 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
       // Two break conditions, both belt-and-suspenders:
       //  - userMap.size at cap: stops adding new entries once the
       //    downstream partition cap would be hit anyway.
-      //  - droppedFromRoles + size past 2× cap: bounds iteration
+      //  - droppedFromRoles + size past 4× cap: bounds iteration
       //    against a pathological all-bot role where the size guard
       //    can never fire (bots only increment droppedFromRoles).
+      //    Logs at debug so a user-reported "I picked a role and got
+      //    fewer than expected" has a forensic hook.
       for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
-        if (droppedFromRoles + userMap.size >= ITER_BOUND) break;
+        if (droppedFromRoles + userMap.size >= ITER_BOUND) {
+          logger.debug('resolveMentionableSelection: ITER_BOUND hit during role expansion', {
+            flow_id: flowIdForLog,
+            role_id: roleId,
+            dropped_from_roles: droppedFromRoles,
+            user_map_size: userMap.size,
+            iter_bound: ITER_BOUND,
+          });
+          break;
+        }
         if (isBotMember(member)) {
           droppedFromRoles += 1;
           continue;
@@ -3694,6 +3725,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   const { users: selected, massMentionDenied, droppedFromRoles } = resolveMentionableSelection({
     interaction,
     canMentionEveryone,
+    flowIdForLog: flow_id,
   });
   if (selected.length === 0 && !massMentionDenied && droppedFromRoles === 0) {
     // Truly empty pick (no users, no roles, no @everyone, no

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2774,6 +2774,12 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
   // iteration COST independent of unique-bot semantics, so a
   // pathological 10k-entry role can't grind for free.
   let inspectedFromRoles = 0;
+  // Gate the ITER_BOUND debug log so it fires AT MOST ONCE per call.
+  // The counter is function-scoped, so without this gate role B's
+  // inner loop would log a redundant line on every iteration past
+  // role A's budget exhaustion. Forensic value is one line per call,
+  // not N.
+  let boundLogged = false;
   // 4× cap (=100) balances pathological-role protection against the
   // UX edge where a real role iterates bots first and humans behind:
   // 2× was tight enough that a "bots-up-front" role could leave the
@@ -2824,13 +2830,16 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
       for (const [memberId, member] of source.entries()) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
         if (inspectedFromRoles >= ITER_BOUND) {
-          logger.debug('resolveMentionableSelection: ITER_BOUND hit during role expansion', {
-            flow_id,
-            role_id: roleId,
-            inspected_from_roles: inspectedFromRoles,
-            user_map_size: userMap.size,
-            iter_bound: ITER_BOUND,
-          });
+          if (!boundLogged) {
+            logger.debug('resolveMentionableSelection: ITER_BOUND hit during role expansion', {
+              flow_id,
+              role_id: roleId,
+              inspected_from_roles: inspectedFromRoles,
+              user_map_size: userMap.size,
+              iter_bound: ITER_BOUND,
+            });
+            boundLogged = true;
+          }
           break;
         }
         inspectedFromRoles += 1;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -8,6 +8,7 @@ const {
   ComponentType,
   StringSelectMenuBuilder,
   UserSelectMenuBuilder,
+  MentionableSelectMenuBuilder,
   ModalBuilder,
   TextInputBuilder,
   TextInputStyle,
@@ -2722,6 +2723,75 @@ function partitionRecipients(users, senderId) {
   return { valid, droppedBots, selfIncluded };
 }
 
+// Resolve a MentionableSelectMenu pick to a flat User[] suitable for
+// partitionRecipients. The picker surfaces both users + roles in one
+// menu — this helper merges them into one deduped User list with the
+// same shape partitionRecipients expects.
+//
+// Reads:
+//   - interaction.users  → Collection<id, User>  (picked individual users)
+//   - interaction.roles  → Collection<id, Role>  (picked roles, expanded
+//                                                  to non-bot members)
+//   - interaction.guild  → for the @everyone role detection (its ID
+//                                                  matches guild.id)
+//
+// The `@everyone` role is gated on the caller-supplied
+// `canMentionEveryone` flag — same gate as the text-path #323. When
+// denied, the helper sets `massMentionDenied: true` and skips that
+// role's expansion. Other roles expand unconditionally; this PR is
+// scope-limited (the broader role-mentionable / MENTION_EVERYONE
+// gate parity for non-@everyone roles is tracked in #326).
+//
+// Bot members are filtered during role expansion (mirrors the parser).
+// Sender is NOT filtered — selfIncluded detection happens downstream
+// in partitionRecipients, consistent with the text-path contract.
+function resolveMentionableSelection({ interaction, canMentionEveryone }) {
+  const guild = interaction.guild;
+  const userMap = new Map();
+  // Picked individual users come as User objects with `.bot` directly
+  // accessible — partitionRecipients reads `.bot` so the shape is fine
+  // to pass through.
+  if (interaction.users && typeof interaction.users.values === 'function') {
+    for (const u of interaction.users.values()) {
+      if (u && u.id) userMap.set(u.id, u);
+    }
+  }
+  let massMentionDenied = false;
+  if (interaction.roles && typeof interaction.roles.entries === 'function') {
+    for (const [roleId, role] of interaction.roles) {
+      const isEveryoneRole = guild && roleId === guild.id;
+      if (isEveryoneRole && !canMentionEveryone) {
+        // Gate parallel to the text path: surface a denial signal so
+        // the caller renders the permission-specific warning; skip
+        // this role's expansion.
+        massMentionDenied = true;
+        continue;
+      }
+      // For the @everyone role specifically, iterate guild.members.cache
+      // — `role.members` for @everyone may not reliably surface all
+      // members in discord.js. For named roles, role.members is the
+      // pre-filtered Collection of role-bearers.
+      const source = isEveryoneRole
+        ? guild?.members?.cache
+        : role?.members;
+      if (!source || typeof source.entries !== 'function') continue;
+      // Same cap short-circuit logic as the text-path @everyone
+      // expansion: the picker can carry a role with thousands of
+      // members; we stop adding once we'd exceed the cap. Cap
+      // enforcement happens via the post-resolve partition; here we
+      // just avoid building a 10k-entry userMap.
+      for (const [memberId, member] of source) {
+        if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
+        if (!member?.user) continue;
+        if (member.user.bot) continue;
+        if (userMap.has(memberId)) continue;
+        userMap.set(memberId, member.user);
+      }
+    }
+  }
+  return { users: [...userMap.values()], massMentionDenied };
+}
+
 /**
  * Render a warnings block for the confirm card. Returns the empty
  * string when nothing is worth surfacing — keeps callers simple
@@ -2911,23 +2981,38 @@ function formatPersonalMessagePreview(message) {
 }
 
 // Build the ActionRow set for the confirm card. Always 4 rows:
-// UserSelectMenu (always attached so re-picks stay available and
-// the layout is stable from frame 0), Self-destruct StringSelectMenu,
-// Expiry StringSelectMenu (each select needs its own row — Discord
-// forbids combining selects with buttons in the same ActionRow),
-// and the bottom row packing Note button + Send + Cancel.
+// MentionableSelectMenu (always attached so re-picks stay available
+// and the layout is stable from frame 0), Self-destruct
+// StringSelectMenu, Expiry StringSelectMenu (each select needs its
+// own row — Discord forbids combining selects with buttons in the
+// same ActionRow), and the bottom row packing Note button + Send +
+// Cancel.
+//
+// MentionableSelect (not UserSelect) so the picker surfaces both
+// individual users AND roles (including the `@everyone` role).
+// Role picks expand to members in handleConfirmUserSelect via
+// resolveMentionableSelection; the `@everyone` role is gated on
+// MENTION_EVERYONE at expansion time, same gate the text-path
+// `@everyone` uses (#323).
+//
+// CONFIRM_USER_SELECT_CUSTOM_ID wire literal stays as-is despite the
+// shape change — the customId is just a routing key; renaming it
+// would need the same 180s flow_state drain coordination #316
+// covered, and the literal isn't semantically wrong (a picked role
+// resolves to users at expansion time). Internal JS constant name
+// also kept to avoid churn.
 //
 // Row math (Discord 5-row max):
-//   UserSelect + SelfDestruct + Expiry + [Note, Send, Cancel] = 4 rows
+//   Mentionable + SelfDestruct + Expiry + [Note, Send, Cancel] = 4 rows
 function renderConfirmCardRows({
   sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
 }) {
   const rows = [];
   const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
   rows.push(new ActionRowBuilder().addComponents(
-    new UserSelectMenuBuilder()
+    new MentionableSelectMenuBuilder()
       .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
-      .setPlaceholder(`Pick recipients (1–${maxValues})`)
+      .setPlaceholder(`Pick users or roles (1–${maxValues})`)
       .setMinValues(1)
       .setMaxValues(maxValues)
   ));
@@ -3600,15 +3685,21 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  // `interaction.users` is a discord.js Collection in production,
-  // duck-typed as a Map in tests — both support `.values()` so the
-  // iteration here is interchangeable. A future test refactor that
-  // switches to Collection-only methods (`.first()`, `.filter()`)
-  // would break the test harness without breaking prod; keep the
-  // Map-compatible API surface.
-  const selected = [...interaction.users.values()];
-  if (selected.length === 0) {
-    // Empty pick → already acked via deferUpdate above. Nothing to edit.
+  // Resolve the MentionableSelectMenu pick: merges picked users +
+  // role-expanded members into one User[] with @everyone-role
+  // gating. Returns `massMentionDenied: true` when the user picked
+  // the `@everyone` role but lacks MENTION_EVERYONE — parallel to
+  // the text-path gate in #323.
+  const canMentionEveryone = !!interaction.guild
+    && interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
+  const { users: selected, massMentionDenied } = resolveMentionableSelection({
+    interaction,
+    canMentionEveryone,
+  });
+  if (selected.length === 0 && !massMentionDenied) {
+    // Empty pick (no users, no roles, no @everyone) → already acked
+    // via deferUpdate above. Nothing to edit. The massMentionDenied
+    // branch is handled in the rejection path below.
     return undefined;
   }
   // `interaction.user.id` IS the original sender's ID — Discord
@@ -3621,12 +3712,15 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // through the flow payload + read it here instead.
   //
   // No `resolveRecipientUsers` re-fetch here — Discord's
-  // UserSelectMenu only surfaces users visible to the bot in this
-  // guild, so picked User IDs are guild-bounded at the gateway-event
-  // level. handleConfirmSendClick re-fetches at click time
-  // (partial-drop test pins this) as the actual guild-membership
-  // defense; adding it here would burn 10 members.fetch calls per
-  // picker tick without catching anything the Send-time check misses.
+  // MentionableSelectMenu only surfaces users + roles visible to
+  // the bot in this guild, so picked IDs are guild-bounded at the
+  // gateway-event level. Role expansion happens inline against
+  // `role.members` / `guild.members.cache` (already populated for
+  // any user the bot can see). handleConfirmSendClick re-fetches at
+  // click time (partial-drop test pins this) as the actual guild-
+  // membership defense; adding it here would burn members.fetch
+  // calls per picker tick without catching anything the Send-time
+  // check misses.
   const payload = row.payload || {};
   const { valid, droppedBots, selfIncluded } = partitionRecipients(selected, interaction.user.id);
   // Both invalid-pick branches re-render the full confirm card with a
@@ -3661,16 +3755,18 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     // in invalid-pick churn surfaces in metrics without lowering log
     // verbosity.
     logger.debug('handleConfirmUserSelect: all-invalid pick', {
-      flow_id, dropped_bots: droppedBots,
+      flow_id, dropped_bots: droppedBots, mass_mention_denied: massMentionDenied,
     });
-    // Only the bot-only case is reachable here today — self-send is
-    // supported, so a pick of just the sender does NOT empty `valid`.
-    // Kept as a list-builder for future filters; the
-    // `|| 'No usable recipients in pick'` fallback prevents a
-    // degraded `⚠ . Re-pick...` message if a future filter is
-    // removed and `valid.length === 0` is hit with droppedBots === 0.
+    // Reachable cases:
+    //   - bot-only pick (droppedBots > 0)
+    //   - picked the @everyone role without MENTION_EVERYONE perm
+    //     (massMentionDenied === true)
+    //   - picked a role with zero non-bot members
+    // List-builder pattern; the fallback prevents a degraded
+    // `⚠ . Re-pick...` message if all conditions are false.
     const reasons = [];
     if (droppedBots > 0) reasons.push('Cannot send to bots');
+    if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }
@@ -3683,12 +3779,16 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     return rejectPick(`⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.\n\n`);
   }
 
-  // Recompute warnings + aliases for the new pick. droppedBots and
-  // selfIncluded can flip here (UserSelectMenu doesn't pre-exclude
-  // the invoker or bots), so warnings + the self-notice change with
-  // the recipient set.
+  // Recompute warnings + aliases for the new pick. droppedBots,
+  // selfIncluded, and massMentionDenied can all flip here (the
+  // picker doesn't pre-exclude the invoker, bots, or the @everyone
+  // role), so warnings + the self-notice change with the recipient
+  // set. DM suppression isn't needed — `canMentionEveryone` already
+  // requires `interaction.guild` (above), so a DM interaction never
+  // reaches a state where `massMentionDenied` could be true.
   const newWarningsBlock = renderRecipientWarnings({
     droppedBots,
+    massMentionDenied,
   });
   const newRecipientAliases = Object.fromEntries(
     valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
@@ -6006,6 +6106,7 @@ module.exports = {
       handleQurlMap,
       resolveRecipientUsers,
       partitionRecipients,
+      resolveMentionableSelection,
       selfDestructOptionToSeconds,
       renderRecipientWarnings,
       renderConfirmCardContent,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2519,6 +2519,7 @@ async function handleSetupModal(interaction, { flow_id }) {
 
 const {
   parseRecipientMentions,
+  isBotMember,
   MAX_SLASH_OPTION_LENGTH: RECIPIENTS_SLASH_MAX_LENGTH,
 } = require('./recipient-parser');
 
@@ -2723,34 +2724,22 @@ function partitionRecipients(users, senderId) {
   return { valid, droppedBots, selfIncluded };
 }
 
-// Resolve a MentionableSelectMenu pick to a flat User[] suitable for
-// partitionRecipients. The picker surfaces both users + roles in one
-// menu — this helper merges them into one deduped User list with the
-// same shape partitionRecipients expects.
+// Merge a MentionableSelectMenu pick (users + roles) into a deduped
+// User[] for partitionRecipients. The `@everyone` role
+// (role.id === guild.id) is gated on `canMentionEveryone` — same
+// gate as the text-path #323. Non-@everyone role gating is tracked
+// in #326.
 //
-// Reads:
-//   - interaction.users  → Collection<id, User>  (picked individual users)
-//   - interaction.roles  → Collection<id, Role>  (picked roles, expanded
-//                                                  to non-bot members)
-//   - interaction.guild  → for the @everyone role detection (its ID
-//                                                  matches guild.id)
+// Picked users seed `userMap` BEFORE role expansion so they get cap
+// priority over role-expanded members (mirrors the text-path #323
+// round-4 fix).
 //
-// The `@everyone` role is gated on the caller-supplied
-// `canMentionEveryone` flag — same gate as the text-path #323. When
-// denied, the helper sets `massMentionDenied: true` and skips that
-// role's expansion. Other roles expand unconditionally; this PR is
-// scope-limited (the broader role-mentionable / MENTION_EVERYONE
-// gate parity for non-@everyone roles is tracked in #326).
-//
-// Bot members are filtered during role expansion (mirrors the parser).
-// Sender is NOT filtered — selfIncluded detection happens downstream
-// in partitionRecipients, consistent with the text-path contract.
+// For the @everyone role specifically, iterate `guild.members.cache`
+// instead of `role.members` — discord.js doesn't reliably surface
+// all members through @everyone's role.members.
 function resolveMentionableSelection({ interaction, canMentionEveryone }) {
   const guild = interaction.guild;
   const userMap = new Map();
-  // Picked individual users come as User objects with `.bot` directly
-  // accessible — partitionRecipients reads `.bot` so the shape is fine
-  // to pass through.
   if (interaction.users && typeof interaction.users.values === 'function') {
     for (const u of interaction.users.values()) {
       if (u && u.id) userMap.set(u.id, u);
@@ -2761,29 +2750,18 @@ function resolveMentionableSelection({ interaction, canMentionEveryone }) {
     for (const [roleId, role] of interaction.roles) {
       const isEveryoneRole = guild && roleId === guild.id;
       if (isEveryoneRole && !canMentionEveryone) {
-        // Gate parallel to the text path: surface a denial signal so
-        // the caller renders the permission-specific warning; skip
-        // this role's expansion.
         massMentionDenied = true;
         continue;
       }
-      // For the @everyone role specifically, iterate guild.members.cache
-      // — `role.members` for @everyone may not reliably surface all
-      // members in discord.js. For named roles, role.members is the
-      // pre-filtered Collection of role-bearers.
       const source = isEveryoneRole
         ? guild?.members?.cache
         : role?.members;
       if (!source || typeof source.entries !== 'function') continue;
-      // Same cap short-circuit logic as the text-path @everyone
-      // expansion: the picker can carry a role with thousands of
-      // members; we stop adding once we'd exceed the cap. Cap
-      // enforcement happens via the post-resolve partition; here we
-      // just avoid building a 10k-entry userMap.
+      // Cap short-circuit avoids building a 10k-entry userMap when a
+      // large role is picked; downstream partition still enforces.
       for (const [memberId, member] of source) {
         if (userMap.size >= config.QURL_SEND_MAX_RECIPIENTS) break;
-        if (!member?.user) continue;
-        if (member.user.bot) continue;
+        if (isBotMember(member)) continue;
         if (userMap.has(memberId)) continue;
         userMap.set(memberId, member.user);
       }
@@ -2980,27 +2958,16 @@ function formatPersonalMessagePreview(message) {
   return `> ${safeCodepointSlice(oneLine, 80)}…`;
 }
 
-// Build the ActionRow set for the confirm card. Always 4 rows:
-// MentionableSelectMenu (always attached so re-picks stay available
-// and the layout is stable from frame 0), Self-destruct
-// StringSelectMenu, Expiry StringSelectMenu (each select needs its
-// own row — Discord forbids combining selects with buttons in the
-// same ActionRow), and the bottom row packing Note button + Send +
-// Cancel.
+// Build the ActionRow set for the confirm card. Always 4 rows so the
+// layout is stable from frame 0 — each select needs its own row
+// (Discord forbids selects + buttons in the same ActionRow).
 //
-// MentionableSelect (not UserSelect) so the picker surfaces both
-// individual users AND roles (including the `@everyone` role).
-// Role picks expand to members in handleConfirmUserSelect via
-// resolveMentionableSelection; the `@everyone` role is gated on
-// MENTION_EVERYONE at expansion time, same gate the text-path
-// `@everyone` uses (#323).
-//
-// CONFIRM_USER_SELECT_CUSTOM_ID wire literal stays as-is despite the
-// shape change — the customId is just a routing key; renaming it
-// would need the same 180s flow_state drain coordination #316
-// covered, and the literal isn't semantically wrong (a picked role
-// resolves to users at expansion time). Internal JS constant name
-// also kept to avoid churn.
+// MentionableSelect surfaces users AND roles in one menu; role picks
+// expand in handleConfirmUserSelect via resolveMentionableSelection
+// with @everyone-role MENTION_EVERYONE gating (same gate as the
+// text-path #323). CONFIRM_USER_SELECT_CUSTOM_ID wire literal kept —
+// renaming would need the 180s flow_state drain coordination from
+// #316.
 //
 // Row math (Discord 5-row max):
 //   Mentionable + SelfDestruct + Expiry + [Note, Send, Cancel] = 4 rows

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -491,6 +491,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
 
 module.exports = {
   parseRecipientMentions,
+  isBotMember,
   MAX_INPUT_LENGTH,
   MAX_INVALID_TOKEN_LENGTH,
   MAX_SLASH_OPTION_LENGTH,

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -64,6 +64,12 @@ jest.mock('discord.js', () => {
       setMaxValues: jest.fn().mockReturnThis(),
       setPlaceholder: jest.fn().mockReturnThis(),
     })),
+    MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
+      setCustomId: jest.fn().mockReturnThis(),
+      setMinValues: jest.fn().mockReturnThis(),
+      setMaxValues: jest.fn().mockReturnThis(),
+      setPlaceholder: jest.fn().mockReturnThis(),
+    })),
     ModalBuilder: jest.fn().mockImplementation(() => ({
       setCustomId: jest.fn().mockReturnThis(),
       setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -128,6 +128,12 @@ jest.mock('discord.js', () => {
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
   })),
+  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
+    setCustomId: jest.fn().mockReturnThis(),
+    setPlaceholder: jest.fn().mockReturnThis(),
+    setMinValues: jest.fn().mockReturnThis(),
+    setMaxValues: jest.fn().mockReturnThis(),
+  })),
   ModalBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -74,7 +74,7 @@ jest.mock('discord.js', () => {
   // method at the discord.js layer (setMaxLength, addChoices, etc.)
   // touches one site for the whole test suite — PR #301 regression
   // surfaced this exact gap when setMaxLength was added.
-  const { makeOptionBuilder } = require('./helpers/discord-mock');
+  const { makeOptionBuilder, makeComponentChainable } = require('./helpers/discord-mock');
   return {
   SlashCommandBuilder: jest.fn().mockImplementation(() => {
     const subBuilder = () => ({
@@ -128,12 +128,7 @@ jest.mock('discord.js', () => {
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
   })),
-  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
-    setCustomId: jest.fn().mockReturnThis(),
-    setPlaceholder: jest.fn().mockReturnThis(),
-    setMinValues: jest.fn().mockReturnThis(),
-    setMaxValues: jest.fn().mockReturnThis(),
-  })),
+  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
   ModalBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -129,6 +129,12 @@ jest.mock('discord.js', () => {
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
   })),
+  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
+    setCustomId: jest.fn().mockReturnThis(),
+    setPlaceholder: jest.fn().mockReturnThis(),
+    setMinValues: jest.fn().mockReturnThis(),
+    setMaxValues: jest.fn().mockReturnThis(),
+  })),
   ModalBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -75,7 +75,7 @@ jest.mock('discord.js', () => {
   // Same instance used by commands-comprehensive.test.js so a new
   // chained method (setMaxLength, addChoices, etc.) at the
   // discord.js layer only touches one site.
-  const { makeOptionBuilder } = require('./helpers/discord-mock');
+  const { makeOptionBuilder, makeComponentChainable } = require('./helpers/discord-mock');
   return {
   SlashCommandBuilder: jest.fn().mockImplementation(() => {
     const subBuilder = () => ({
@@ -129,12 +129,7 @@ jest.mock('discord.js', () => {
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
   })),
-  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
-    setCustomId: jest.fn().mockReturnThis(),
-    setPlaceholder: jest.fn().mockReturnThis(),
-    setMinValues: jest.fn().mockReturnThis(),
-    setMaxValues: jest.fn().mockReturnThis(),
-  })),
+  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
   ModalBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
     setTitle: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -813,6 +813,11 @@ describe('resolveMentionableSelection', () => {
   });
 
   test('returns the documented shape: { users, massMentionDenied, droppedFromRoles, everyoneCacheCold }', () => {
+    // Pinning test: a new return field added without updating this
+    // assertion will fail loudly here. If you're hitting this after
+    // adding a field, update the sorted-keys list AND verify every
+    // caller of resolveMentionableSelection handles the new field
+    // (handleConfirmUserSelect at minimum).
     const int = makeMentionableInteraction({});
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
     expect(Object.keys(r).sort()).toEqual(['droppedFromRoles', 'everyoneCacheCold', 'massMentionDenied', 'users']);

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -452,6 +452,18 @@ describe('resolveMentionableSelection', () => {
     expect(r.massMentionDenied).toBe(false);
   });
 
+  test('filters out malformed user entries lacking .id (defense against partial User payload)', () => {
+    // The seed loop guards with `if (u && u.id) userMap.set(u.id, u);`
+    // — discord.js shouldn't ever surface a partial User, but the
+    // Collection→Map duck-typing in the test harness leaves room for
+    // a future regression to drop the guard. Pin the defense.
+    const u1 = makeUser('100000000000000001');
+    const partial = { id: undefined, username: 'partial' };
+    const int = makeMentionableInteraction({ pickedUsers: [u1, partial] });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+  });
+
   test('named role expands its members onto the user list, filters bots', () => {
     const u1 = makeUser('100000000000000001');
     const bot1 = makeUser('100000000000000099', { bot: true });
@@ -576,13 +588,14 @@ describe('resolveMentionableSelection', () => {
     expect(r.massMentionDenied).toBe(false);
   });
 
-  test('pathological all-bot role iteration bounded by 2x cap (belt-and-suspenders against userMap.size never growing)', () => {
+  test('pathological all-bot role iteration bounded by 4× cap (belt-and-suspenders against userMap.size never growing)', () => {
     // The userMap.size cap-break never fires for an all-bot role
     // because bots only increment droppedFromRoles. Without the
     // iteration-count guard, a pathological 10k-bot role would
-    // iterate all 10k entries. Bound at 2× QURL_SEND_MAX_RECIPIENTS
-    // (50) keeps it cheap even if exposure widens later.
-    const bots = Array.from({ length: 200 }, (_, i) => ({
+    // iterate all 10k entries. Bound at 4× QURL_SEND_MAX_RECIPIENTS
+    // (=100) keeps it cheap while still surfacing humans behind
+    // bot-prefixes in non-pathological roles.
+    const bots = Array.from({ length: 300 }, (_, i) => ({
       user: makeUser(`100000000000000${String(i).padStart(3, '0')}`, { bot: true }),
     }));
     const int = makeMentionableInteraction({
@@ -590,8 +603,8 @@ describe('resolveMentionableSelection', () => {
     });
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
     expect(r.users).toEqual([]);
-    // Iterated at most 2× cap (=50) before bailing.
-    expect(r.droppedFromRoles).toBeLessThanOrEqual(50);
+    // Iterated at most 4× cap (=100) before bailing.
+    expect(r.droppedFromRoles).toBeLessThanOrEqual(100);
     expect(r.droppedFromRoles).toBeGreaterThan(0);
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -571,10 +571,43 @@ describe('resolveMentionableSelection', () => {
     expect(r.massMentionDenied).toBe(false);
   });
 
-  test('returns the documented shape: { users, massMentionDenied }', () => {
+  test('bot-only role pick → droppedFromRoles counts the filtered bots', () => {
+    // Without this signal the call site has no way to differentiate a
+    // truly empty pick (silent return) from a role-of-bots pick (where
+    // the user clicked a role and the bot filtered everything) — the
+    // user would get zero feedback. Pin the count.
+    const bot1 = makeUser('100000000000000091', { bot: true });
+    const bot2 = makeUser('100000000000000092', { bot: true });
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({
+        id: 'role-bots',
+        members: [{ user: bot1 }, { user: bot2 }],
+      })],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users).toEqual([]);
+    expect(r.droppedFromRoles).toBe(2);
+    expect(r.massMentionDenied).toBe(false);
+  });
+
+  test('mixed role: non-bots survive, bots increment droppedFromRoles', () => {
+    const u1 = makeUser('100000000000000001');
+    const bot1 = makeUser('100000000000000091', { bot: true });
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({
+        id: 'role-eng',
+        members: [{ user: u1 }, { user: bot1 }],
+      })],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+    expect(r.droppedFromRoles).toBe(1);
+  });
+
+  test('returns the documented shape: { users, massMentionDenied, droppedFromRoles }', () => {
     const int = makeMentionableInteraction({});
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
-    expect(Object.keys(r).sort()).toEqual(['massMentionDenied', 'users']);
+    expect(Object.keys(r).sort()).toEqual(['droppedFromRoles', 'massMentionDenied', 'users']);
   });
 });
 
@@ -2587,6 +2620,32 @@ describe('handleConfirmUserSelect', () => {
     expect(recipientIds.sort()).toEqual([u2, u3].sort());
     // Bot members filtered out by resolveMentionableSelection.
     expect(recipientIds).not.toContain(bot1);
+  });
+
+  test('mentionable picker: bot-only role pick → all-invalid branch with role-specific reason (no silent swallow)', async () => {
+    // The UX regression cr #328 flagged: a picker-only flow where the
+    // user picks a role of bots would early-return silently (the helper
+    // filtered everything to zero, but `droppedBots` from
+    // partitionRecipients stayed 0 because nothing reached it). Without
+    // surfacing the role-specific reason, the user clicks the role and
+    // sees nothing — reads as "the bot is broken." Helper now tracks
+    // droppedFromRoles and the all-invalid branch surfaces the case.
+    const bot1 = makeUser('100000000000000091', { bot: true });
+    const bot2 = makeUser('100000000000000092', { bot: true });
+    const botRole = ['role-bots', {
+      id: 'role-bots',
+      members: new Map([[bot1.id, { user: bot1 }], [bot2.id, { user: bot2 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [botRole],
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/no non-bot members/i);
+    // Resource header survives — same preserved-context contract.
+    expect(updated.content).toMatch(/Sending file/);
   });
 
   test('re-pick preserves personalMessageRaw + personalMessage through the spread', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2919,6 +2919,32 @@ describe('handleConfirmUserSelect', () => {
     expect(updated.content).toMatch(/Send includes you/);
   });
 
+  test('mentionable picker: sender via @everyone-cache expansion → selfIncluded flips on (parity with named-role path)', async () => {
+    // Pin the @everyone branch as well as named-role: a sender-filter
+    // regression inside resolveMentionableSelection on the
+    // guild.members.cache iteration branch would slip past the
+    // named-role test alone. The @everyone path iterates a different
+    // collection (guild.members.cache vs role.members) so it needs
+    // its own coverage.
+    const senderMember = { user: makeUser(SENDER_ID) };
+    const cache = new Map([[SENDER_ID, senderMember]]);
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [],
+      canMentionEveryone: true,
+      guildMemberCache: cache,
+    });
+    const everyoneId = int.guild.id;
+    int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.recipientIds).toEqual([SENDER_ID]);
+    expect(payload.selfIncluded).toBe(true);
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Send includes you/);
+  });
+
   test('mentionable picker: missing interaction.memberPermissions → canMentionEveryone defaults false, @everyone denied', async () => {
     // Discord normally populates `memberPermissions` on guild
     // interactions, but the `?.has(...) === true` chain handles

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -571,6 +571,25 @@ describe('resolveMentionableSelection', () => {
     expect(r.massMentionDenied).toBe(false);
   });
 
+  test('pathological all-bot role iteration bounded by 2x cap (belt-and-suspenders against userMap.size never growing)', () => {
+    // The userMap.size cap-break never fires for an all-bot role
+    // because bots only increment droppedFromRoles. Without the
+    // iteration-count guard, a pathological 10k-bot role would
+    // iterate all 10k entries. Bound at 2× QURL_SEND_MAX_RECIPIENTS
+    // (50) keeps it cheap even if exposure widens later.
+    const bots = Array.from({ length: 200 }, (_, i) => ({
+      user: makeUser(`100000000000000${String(i).padStart(3, '0')}`, { bot: true }),
+    }));
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: 'role-bots', members: bots })],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users).toEqual([]);
+    // Iterated at most 2× cap (=50) before bailing.
+    expect(r.droppedFromRoles).toBeLessThanOrEqual(50);
+    expect(r.droppedFromRoles).toBeGreaterThan(0);
+  });
+
   test('bot-only role pick → droppedFromRoles counts the filtered bots', () => {
     // Without this signal the call site has no way to differentiate a
     // truly empty pick (silent return) from a role-of-bots pick (where
@@ -2646,6 +2665,27 @@ describe('handleConfirmUserSelect', () => {
     expect(updated.content).toMatch(/no non-bot members/i);
     // Resource header survives — same preserved-context contract.
     expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('mentionable picker: bot user + bot-only-role pick → BOTH reasons surface (independent signals)', async () => {
+    // Pin against the earlier gating that hid the role-bots reason
+    // when an individual bot was also picked. Both reasons describe
+    // independent picker actions and should both surface.
+    const directBot = makeUser('100000000000000099', { bot: true });
+    const roleBot = makeUser('100000000000000091', { bot: true });
+    const botRole = ['role-bots', {
+      id: 'role-bots',
+      members: new Map([[roleBot.id, { user: roleBot }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [directBot],
+      roles: [botRole],
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Cannot send to bots/);
+    expect(updated.content).toMatch(/no non-bot members/i);
   });
 
   test('re-pick preserves personalMessageRaw + personalMessage through the spread', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -634,6 +634,32 @@ describe('resolveMentionableSelection', () => {
     expect(r.droppedFromRoles).toBe(1);
   });
 
+  test('named-role overlap: directly-picked user object identity preserved (cap-priority parity with @everyone)', () => {
+    // Symmetric with the @everyone-via-guild.members.cache cap-priority
+    // test, but for a named role. The directly-picked User object must
+    // survive when the same id also appears in a picked role's
+    // .members — userMap.has(memberId) continue skips the role-side
+    // overwrite, so optional fields like `globalName` on the picker's
+    // User stick around for downstream alias rendering.
+    const u1Picked = makeUser('100000000000000001');
+    // A separate, distinguishable User object with the SAME id — what
+    // role.members would surface (it's a different object reference).
+    const u1FromRole = { ...makeUser('100000000000000001'), tag: 'from-role-view' };
+    const role = makeRole({
+      id: 'role-eng',
+      members: [{ user: u1FromRole }],
+    });
+    const int = makeMentionableInteraction({
+      pickedUsers: [u1Picked],
+      pickedRoles: [role],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.length).toBe(1);
+    // Object identity preserved: it's u1Picked, NOT u1FromRole.
+    expect(r.users[0]).toBe(u1Picked);
+    expect(r.users[0]).not.toBe(u1FromRole);
+  });
+
   test('directly-picked bot + same bot in role → droppedFromRoles 0 (partition reports it via droppedBots)', () => {
     // The role-side dedupe-before-bot-check skip means a bot that's
     // already in userMap (from interaction.users) doesn't ALSO tick

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -611,6 +611,38 @@ describe('resolveMentionableSelection', () => {
     expect(r.droppedFromRoles).toBe(ITER_BOUND);
   });
 
+  test('ITER_BOUND accumulates ACROSS roles (function-scoped, not per-role)', () => {
+    // The inspectedFromRoles counter is function-scoped intentionally
+    // so a pathological role A can pre-truncate role B's expansion.
+    // Without this test, a future refactor moving `let
+    // inspectedFromRoles = 0;` inside the outer for-loop would silently
+    // flip the semantics to per-role bounds — passing the single-role
+    // test above but allowing N × 100-iteration grinds. Pin the
+    // cross-role accumulation behavior here.
+    const config = require('../src/config');
+    const ITER_BOUND = 4 * config.QURL_SEND_MAX_RECIPIENTS;
+    // Role A: 100 bots (will fully exhaust ITER_BOUND).
+    const botsA = Array.from({ length: 100 }, (_, i) => ({
+      user: makeUser(`100000000000000${String(i).padStart(3, '0')}`, { bot: true }),
+    }));
+    // Role B: 10 humans (would normally land in userMap, but role A
+    // exhausted the iteration budget first).
+    const humansB = Array.from({ length: 10 }, (_, i) => ({
+      user: makeUser(`200000000000000${String(i).padStart(3, '0')}`),
+    }));
+    const int = makeMentionableInteraction({
+      pickedRoles: [
+        makeRole({ id: 'role-a-bots', members: botsA }),
+        makeRole({ id: 'role-b-humans', members: humansB }),
+      ],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    // Role B's humans were never reached — ITER_BOUND tripped during
+    // role A's iteration.
+    expect(r.users).toEqual([]);
+    expect(r.droppedFromRoles).toBe(ITER_BOUND);
+  });
+
   test('overlap dedup: same bot in two picked roles counted once in droppedFromRoles', () => {
     // Set-backed droppedFromRoles means the same bot ID across two
     // picked roles contributes 1 to the user-visible count, not 2.
@@ -2866,6 +2898,35 @@ describe('handleConfirmUserSelect', () => {
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/@everyone/);
     expect(updated.content).toMatch(/Mention Everyone/);
+  });
+
+  test('mentionable picker: partial-valid pick with cold-cache @everyone → flow advances AND everyoneCacheCold warning surfaces', async () => {
+    // UX asymmetry parallel to the droppedFromRoles partial-valid
+    // surfacing: a user with MENTION_EVERYONE who picks one named
+    // user + @everyone (cache cold post-restart) gets the named user
+    // through partition (selected.length === 1, valid.length === 1)
+    // BUT @everyone silently expanded to zero. Without surfacing
+    // everyoneCacheCold in renderRecipientWarnings, the user has no
+    // way to know @everyone failed and would assume the bot honored
+    // their pick correctly.
+    const u1 = makeUser('100000000000000001');
+    const int = makeSelectInteraction({
+      users: [u1],
+      roles: [],
+      canMentionEveryone: true,
+    });
+    // Strip the cache — guild remains, cache undefined.
+    int.guild.members = {};
+    const everyoneId = int.guild.id;
+    int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    // Flow advances with the named user.
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    expect(mockTransitionFlow.mock.calls[0][2].payload.recipientIds).toEqual([u1.id]);
+    // But the warning surfaces so the user knows @everyone failed.
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Member cache not yet ready/);
+    expect(updated.content).toMatch(/expanded to 0 members/);
   });
 
   test('mentionable picker: guild without members.cache (cold cache after restart) → surfaces "Member cache not yet ready" reason', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -588,13 +588,15 @@ describe('resolveMentionableSelection', () => {
     expect(r.massMentionDenied).toBe(false);
   });
 
-  test('pathological all-bot role iteration bounded by 4× cap (belt-and-suspenders against userMap.size never growing)', () => {
+  test('pathological all-bot role iteration bounded at exactly 4× cap (=100, pins the multiplier)', () => {
     // The userMap.size cap-break never fires for an all-bot role
-    // because bots only increment droppedFromRoles. Without the
+    // because bots only increment droppedFromRolesSet. Without the
     // iteration-count guard, a pathological 10k-bot role would
     // iterate all 10k entries. Bound at 4× QURL_SEND_MAX_RECIPIENTS
-    // (=100) keeps it cheap while still surfacing humans behind
-    // bot-prefixes in non-pathological roles.
+    // (=100); pin the multiplier exactly so a future halving back
+    // to 2× would fail this test (≤100 would silently still pass).
+    const config = require('../src/config');
+    const ITER_BOUND = 4 * config.QURL_SEND_MAX_RECIPIENTS;
     const bots = Array.from({ length: 300 }, (_, i) => ({
       user: makeUser(`100000000000000${String(i).padStart(3, '0')}`, { bot: true }),
     }));
@@ -603,9 +605,55 @@ describe('resolveMentionableSelection', () => {
     });
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
     expect(r.users).toEqual([]);
-    // Iterated at most 4× cap (=100) before bailing.
-    expect(r.droppedFromRoles).toBeLessThanOrEqual(100);
-    expect(r.droppedFromRoles).toBeGreaterThan(0);
+    // Exactly ITER_BOUND distinct bot IDs landed in the Set before
+    // the iteration counter tripped the break. With unique bot IDs
+    // (the fixture), set.size === inspectedFromRoles.
+    expect(r.droppedFromRoles).toBe(ITER_BOUND);
+  });
+
+  test('overlap dedup: same bot in two picked roles counted once in droppedFromRoles', () => {
+    // Set-backed droppedFromRoles means the same bot ID across two
+    // picked roles contributes 1 to the user-visible count, not 2.
+    // Pin against a future revert to counter semantics that would
+    // surface "2 bot(s)" when only 1 distinct bot existed.
+    const bot1 = makeUser('100000000000000099', { bot: true });
+    const u1 = makeUser('100000000000000001');
+    const roleA = makeRole({
+      id: 'role-a',
+      members: [{ user: bot1 }, { user: u1 }],
+    });
+    const roleB = makeRole({
+      id: 'role-b',
+      members: [{ user: bot1 }],
+    });
+    const int = makeMentionableInteraction({
+      pickedRoles: [roleA, roleB],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+    expect(r.droppedFromRoles).toBe(1);
+  });
+
+  test('directly-picked bot + same bot in role → droppedFromRoles 0 (partition reports it via droppedBots)', () => {
+    // The role-side dedupe-before-bot-check skip means a bot that's
+    // already in userMap (from interaction.users) doesn't ALSO tick
+    // the role counter. Downstream partitionRecipients reports it via
+    // droppedBots; surfacing two warnings for the same bot would be
+    // a UX nit.
+    const bot1 = makeUser('100000000000000099', { bot: true });
+    const role = makeRole({
+      id: 'role-with-bot',
+      members: [{ user: bot1 }],
+    });
+    const int = makeMentionableInteraction({
+      pickedUsers: [bot1],
+      pickedRoles: [role],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    // Bot lands in users array (caller's partitionRecipients drops it).
+    expect(r.users.map((u) => u.id)).toEqual([bot1.id]);
+    // Role-side did NOT also tick the role-bot counter.
+    expect(r.droppedFromRoles).toBe(0);
   });
 
   test('bot-only role pick → droppedFromRoles counts the filtered bots', () => {
@@ -2683,6 +2731,73 @@ describe('handleConfirmUserSelect', () => {
     expect(updated.content).toMatch(/no non-bot members/i);
     // Resource header survives — same preserved-context contract.
     expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('mentionable picker: sender via role pick → flow advances, selfIncluded flips on (#322 parity)', async () => {
+    // Defense against a future refactor that adds a sender-filter
+    // inside resolveMentionableSelection — partitionRecipients OWNS
+    // the selfIncluded detection (commands.js contract). A
+    // sender-only role pick lands the sender in `selected`, partition
+    // sees them, valid.length === 1, selfIncluded === true.
+    const senderUser = makeUser(SENDER_ID);
+    const senderRole = ['role-sender', {
+      id: 'role-sender',
+      members: new Map([[SENDER_ID, { user: senderUser }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [senderRole],
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.recipientIds).toEqual([SENDER_ID]);
+    expect(payload.selfIncluded).toBe(true);
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Send includes you/);
+  });
+
+  test('mentionable picker: missing interaction.memberPermissions → canMentionEveryone defaults false, @everyone denied', async () => {
+    // Discord normally populates `memberPermissions` on guild
+    // interactions, but the `?.has(...) === true` chain handles
+    // undefined defensively. Pin that defense against a future
+    // simplification that drops the optional chain.
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [],
+      canMentionEveryone: false,
+    });
+    int.memberPermissions = undefined;
+    const everyoneId = int.guild.id;
+    int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/@everyone/);
+    expect(updated.content).toMatch(/Mention Everyone/);
+  });
+
+  test('mentionable picker: guild without members.cache (cold cache after restart) → @everyone-allowed no-ops cleanly', async () => {
+    // Right after a bot restart, guild.members.cache may not yet be
+    // populated. The duck-type guard `if (!source || typeof
+    // source.entries !== 'function') continue;` skips the expansion
+    // cleanly rather than throwing. Pin the defense.
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [],
+      canMentionEveryone: true,
+    });
+    // Strip the cache entirely — guild remains, but `.members.cache`
+    // is undefined.
+    int.guild.members = {};
+    const everyoneId = int.guild.id;
+    int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    // No expansion happened → selected is empty, massMentionDenied is
+    // false (perm was granted), droppedFromRoles is 0 → early-return.
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(int.editReply).not.toHaveBeenCalled();
   });
 
   test('mentionable picker: partial-valid role (humans + bots) → flow advances AND droppedFromRoles warning surfaces', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -715,10 +715,75 @@ describe('resolveMentionableSelection', () => {
     expect(r.droppedFromRoles).toBe(1);
   });
 
-  test('returns the documented shape: { users, massMentionDenied, droppedFromRoles }', () => {
+  test('everyoneCacheCold: @everyone WITH perm but missing guild.members.cache → flag set, no expansion', () => {
+    // Surfaces the "cold cache, try again" UX signal so the caller
+    // can render a "Member cache not yet ready" reason instead of a
+    // silent deferUpdate-only no-op.
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: GUILD_ID, members: [] })],
+      // guildMemberCache omitted → guild.members.cache is undefined
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: true });
+    expect(r.users).toEqual([]);
+    expect(r.everyoneCacheCold).toBe(true);
+    expect(r.massMentionDenied).toBe(false);
+  });
+
+  test('everyoneCacheCold: @everyone WITH perm but EMPTY guild.members.cache → flag set (cache defined but no entries)', () => {
+    // The "cache exists but is empty" case looks identical to "cache
+    // missing" from the user's perspective — both yield zero expansion.
+    // The helper treats them the same.
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: GUILD_ID, members: [] })],
+      guildMemberCache: new Map(), // defined but size === 0
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: true });
+    expect(r.users).toEqual([]);
+    expect(r.everyoneCacheCold).toBe(true);
+  });
+
+  test('everyoneCacheCold stays false when @everyone is DENIED (cache state irrelevant)', () => {
+    // When MENTION_EVERYONE is denied, the cache state is irrelevant
+    // because we never look at it. massMentionDenied is the relevant
+    // signal; everyoneCacheCold should NOT also fire and clutter the
+    // warnings.
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: GUILD_ID, members: [] })],
+      // No guildMemberCache (would be cold if perm were granted)
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.massMentionDenied).toBe(true);
+    expect(r.everyoneCacheCold).toBe(false);
+  });
+
+  test('defense: role member with undefined .user is skipped (partial GuildMember from sparse fetch)', () => {
+    // In standard discord.js, `member.user` is always populated. A
+    // partial GuildMember from a sparse `members.fetch({ withPresences:
+    // false, time: 100 })` can carry an undefined `.user`. Without the
+    // defense, downstream partitionRecipients would deref `u.bot` /
+    // `u.id` on undefined and throw. Pin the skip.
+    const u1 = makeUser('100000000000000001');
+    // Build members map directly (makeRole helper requires m.user.id).
+    const role = ['role-eng', {
+      id: 'role-eng',
+      members: new Map([
+        ['100000000000000091', { user: undefined }],
+        [u1.id, { user: u1 }],
+        ['100000000000000092', { /* no .user property at all */ }],
+      ]),
+    }];
+    const int = makeMentionableInteraction({
+      pickedRoles: [role],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+    expect(r.droppedFromRoles).toBe(0);
+  });
+
+  test('returns the documented shape: { users, massMentionDenied, droppedFromRoles, everyoneCacheCold }', () => {
     const int = makeMentionableInteraction({});
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
-    expect(Object.keys(r).sort()).toEqual(['droppedFromRoles', 'massMentionDenied', 'users']);
+    expect(Object.keys(r).sort()).toEqual(['droppedFromRoles', 'everyoneCacheCold', 'massMentionDenied', 'users']);
   });
 });
 
@@ -2803,11 +2868,12 @@ describe('handleConfirmUserSelect', () => {
     expect(updated.content).toMatch(/Mention Everyone/);
   });
 
-  test('mentionable picker: guild without members.cache (cold cache after restart) → @everyone-allowed no-ops cleanly', async () => {
+  test('mentionable picker: guild without members.cache (cold cache after restart) → surfaces "Member cache not yet ready" reason', async () => {
     // Right after a bot restart, guild.members.cache may not yet be
-    // populated. The duck-type guard `if (!source || typeof
-    // source.entries !== 'function') continue;` skips the expansion
-    // cleanly rather than throwing. Pin the defense.
+    // populated. Without a user-visible signal, the user picks
+    // @everyone and sees nothing happen — reads as "the bot is
+    // broken." The helper sets everyoneCacheCold, and the all-invalid
+    // branch surfaces a "try again" reason so the user has recourse.
     const int = makeSelectInteraction({
       users: [],
       roles: [],
@@ -2819,11 +2885,11 @@ describe('handleConfirmUserSelect', () => {
     const everyoneId = int.guild.id;
     int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
     await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
-    // No expansion happened → selected is empty, massMentionDenied is
-    // false (perm was granted), droppedFromRoles is 0 → early-return.
     expect(mockTransitionFlow).not.toHaveBeenCalled();
-    expect(int.deferUpdate).toHaveBeenCalled();
-    expect(int.editReply).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Member cache not yet ready/);
+    // Resource header survives — preserved-context contract.
+    expect(updated.content).toMatch(/Sending file/);
   });
 
   test('mentionable picker: partial-valid role (humans + bots) → flow advances AND droppedFromRoles warning surfaces', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -556,9 +556,14 @@ describe('resolveMentionableSelection', () => {
     const resultIds = r.users.map((u) => u.id);
     expect(resultIds.length).toBe(25);
     // All 5 explicit picks survived — none were evicted by role
-    // expansion filling the cap.
-    for (const explicitId of explicitIds) {
-      expect(resultIds).toContain(explicitId);
+    // expansion filling the cap. Field-fidelity check: also pin
+    // OBJECT IDENTITY so the picked-user reference (which may carry
+    // optional fields like `globalName` not present on the cache's
+    // `member.user`) is the one that survives, not the cache view.
+    // A regression that dropped the `userMap.has(memberId) continue`
+    // would still pass the .toContain() check above.
+    for (let i = 0; i < explicitUsers.length; i++) {
+      expect(r.users.find((u) => u.id === explicitIds[i])).toBe(explicitUsers[i]);
     }
   });
 
@@ -2664,6 +2669,31 @@ describe('handleConfirmUserSelect', () => {
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/no non-bot members/i);
     // Resource header survives — same preserved-context contract.
+    expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('mentionable picker: partial-valid role (humans + bots) → flow advances AND droppedFromRoles warning surfaces', async () => {
+    // Symmetric with the per-user droppedBots warning: a role pick
+    // that mixes humans and bots advances the flow with the humans
+    // BUT also surfaces a warning line so the user knows the role
+    // was partially filtered. Without this, the partial case is
+    // silent — the user sees a smaller recipient count than they
+    // expected with no explanation.
+    const u1 = makeUser('100000000000000001');
+    const bot1 = makeUser('100000000000000091', { bot: true });
+    const mixedRole = ['role-mixed', {
+      id: 'role-mixed',
+      members: new Map([[u1.id, { user: u1 }], [bot1.id, { user: bot1 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [mixedRole],
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    expect(mockTransitionFlow.mock.calls[0][2].payload.recipientIds).toEqual([u1.id]);
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/bot\(s\) filtered from picked role/i);
     expect(updated.content).toMatch(/Sending file/);
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -97,6 +97,7 @@ jest.mock('discord.js', () => {
     ComponentType: { Button: 2, StringSelect: 3, UserSelect: 5 },
     StringSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
     UserSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
+    MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
     ModalBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
     TextInputBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
     TextInputStyle: { Short: 1, Paragraph: 2 },
@@ -174,6 +175,7 @@ const {
   selfDestructOptionToSeconds,
   renderRecipientWarnings,
   renderConfirmCardContent,
+  resolveMentionableSelection,
   parseLocationInput,
   safeDecodeURIComponent,
   softenCooldown,
@@ -407,6 +409,172 @@ describe('partitionRecipients', () => {
     const dup = makeUser('100000000000000001');
     const r = partitionRecipients([dup, dup, makeUser('100000000000000002')], SENDER_ID);
     expect(r.valid.length).toBe(3);
+  });
+});
+
+describe('resolveMentionableSelection', () => {
+  // Picker-path helper (Mentionable select returns BOTH users + roles in
+  // one interaction): expands the role members → flat user list, filters
+  // bots, dedupes against directly picked users, caps at
+  // QURL_SEND_MAX_RECIPIENTS, gates the @everyone role on canMentionEveryone.
+  const GUILD_ID = 'guild-1';
+
+  function makeRole({ id, members = [] }) {
+    // role.members is a Discord.js Collection but only `.entries()`
+    // (iterable of [id, member]) is read; a Map is shape-compatible.
+    const memberMap = new Map(members.map((m) => [m.user.id, m]));
+    return [id, { id, members: memberMap }];
+  }
+
+  function makeMentionableInteraction({
+    pickedUsers = [],
+    pickedRoles = [],
+    guildMemberCache = new Map(),
+    inDM = false,
+  } = {}) {
+    const guild = inDM ? null : {
+      id: GUILD_ID,
+      members: { cache: guildMemberCache },
+    };
+    return {
+      guild,
+      users: new Map(pickedUsers.map((u) => [u.id, u])),
+      roles: new Map(pickedRoles),
+    };
+  }
+
+  test('users only (no roles) → returns those users verbatim, no denial', () => {
+    const u1 = makeUser('100000000000000001');
+    const u2 = makeUser('100000000000000002');
+    const int = makeMentionableInteraction({ pickedUsers: [u1, u2] });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id)).toEqual([u1.id, u2.id]);
+    expect(r.massMentionDenied).toBe(false);
+  });
+
+  test('named role expands its members onto the user list, filters bots', () => {
+    const u1 = makeUser('100000000000000001');
+    const bot1 = makeUser('100000000000000099', { bot: true });
+    const u2 = makeUser('100000000000000002');
+    const int = makeMentionableInteraction({
+      pickedRoles: [
+        makeRole({
+          id: 'role-eng',
+          members: [{ user: u1 }, { user: bot1 }, { user: u2 }],
+        }),
+      ],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id).sort()).toEqual([u1.id, u2.id].sort());
+    expect(r.massMentionDenied).toBe(false);
+  });
+
+  test('user + role overlap dedupes (same id appears once)', () => {
+    const u1 = makeUser('100000000000000001');
+    const int = makeMentionableInteraction({
+      pickedUsers: [u1],
+      pickedRoles: [makeRole({ id: 'role-eng', members: [{ user: u1 }] })],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+  });
+
+  test('@everyone role (role.id === guild.id) WITHOUT MENTION_EVERYONE → denied, no expansion', () => {
+    const u1 = makeUser('100000000000000001');
+    const guildMembers = new Map([[u1.id, { user: u1 }]]);
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: GUILD_ID, members: [] })],
+      guildMemberCache: guildMembers,
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users).toEqual([]);
+    expect(r.massMentionDenied).toBe(true);
+  });
+
+  test('@everyone role WITH MENTION_EVERYONE → expands via guild.members.cache (NOT role.members)', () => {
+    // discord.js may not surface all members through @everyone's
+    // role.members; resolveMentionableSelection has a guard that
+    // routes @everyone-role expansion to guild.members.cache instead.
+    // Pin that branch.
+    const u1 = makeUser('100000000000000001');
+    const u2 = makeUser('100000000000000002');
+    const bot1 = makeUser('100000000000000099', { bot: true });
+    const guildMembers = new Map([
+      [u1.id, { user: u1 }],
+      [u2.id, { user: u2 }],
+      [bot1.id, { user: bot1 }],
+    ]);
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: GUILD_ID, members: [] })],
+      guildMemberCache: guildMembers,
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: true });
+    expect(r.users.map((u) => u.id).sort()).toEqual([u1.id, u2.id].sort());
+    expect(r.massMentionDenied).toBe(false);
+  });
+
+  test('cap short-circuits role expansion at QURL_SEND_MAX_RECIPIENTS (25) — does not over-collect 10k members', () => {
+    // Mirrors the text-path @everyone cap-short-circuit. Defends
+    // against a fleet of 1k+ guilds where role.members iteration would
+    // otherwise build a 10k-entry userMap before the downstream
+    // partition cap kicked in.
+    const members = Array.from({ length: 60 }, (_, i) => ({
+      user: makeUser(`100000000000000${String(i).padStart(3, '0')}`),
+    }));
+    const int = makeMentionableInteraction({
+      pickedRoles: [makeRole({ id: 'role-eng', members })],
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users.length).toBe(25);
+  });
+
+  test('cap priority: explicit user picks survive when role expansion would otherwise evict them', () => {
+    // Picker-path analog of the text-path #323 round-4 fix
+    // (recipient-parser.js: explicit `<@id>` mentions get cap priority
+    // over `@everyone` expansion). resolveMentionableSelection seeds
+    // `userMap` with picked users FIRST, then role expansion runs the
+    // `if (userMap.size >= cap) break;` short-circuit — so the 5
+    // explicit picks must occupy 5 of the 25 slots before any role
+    // member can be added. A future refactor that flips the order, or
+    // adds an inline cap inside the user-pick loop, would silently
+    // break the invariant and let cache-iteration order decide which
+    // picks survive — pin the fix here.
+    const explicitIds = Array.from({ length: 5 }, (_, i) => `300000000000000${String(i).padStart(3, '0')}`);
+    const explicitUsers = explicitIds.map((id) => makeUser(id));
+    const cacheMembers = new Map(
+      Array.from({ length: 30 }, (_, i) => {
+        const id = `100000000000000${String(i).padStart(3, '0')}`;
+        return [id, { user: makeUser(id) }];
+      }),
+    );
+    const int = makeMentionableInteraction({
+      pickedUsers: explicitUsers,
+      pickedRoles: [makeRole({ id: GUILD_ID, members: [] })],
+      guildMemberCache: cacheMembers,
+    });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: true });
+    const resultIds = r.users.map((u) => u.id);
+    expect(resultIds.length).toBe(25);
+    // All 5 explicit picks survived — none were evicted by role
+    // expansion filling the cap.
+    for (const explicitId of explicitIds) {
+      expect(resultIds).toContain(explicitId);
+    }
+  });
+
+  test('DM context (no guild) → empty users, no denial flag (no roles surface at all)', () => {
+    // In a DM, interaction.roles never carries the @everyone role; the
+    // helper should return cleanly with no expansion attempted.
+    const int = makeMentionableInteraction({ inDM: true });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users).toEqual([]);
+    expect(r.massMentionDenied).toBe(false);
+  });
+
+  test('returns the documented shape: { users, massMentionDenied }', () => {
+    const int = makeMentionableInteraction({});
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(Object.keys(r).sort()).toEqual(['massMentionDenied', 'users']);
   });
 });
 
@@ -2137,9 +2305,27 @@ describe('handleConfirmCancelClick', () => {
 describe('handleConfirmUserSelect', () => {
   const u1 = '100000000000000001';
 
-  function makeSelectInteraction({ users = [makeUser(u1)], ...rest } = {}) {
+  function makeSelectInteraction({
+    users = [makeUser(u1)],
+    roles = [],
+    canMentionEveryone = false,
+    guildMemberCache = null,
+    ...rest
+  } = {}) {
     const int = makeInteraction(rest);
     int.users = new Map(users.map((u) => [u.id, u]));
+    // Mentionable picker also surfaces roles on interaction.roles.
+    // Default empty so existing user-only tests stay shape-compatible
+    // with resolveMentionableSelection's iteration guard.
+    int.roles = new Map(roles);
+    int.memberPermissions = {
+      has: jest.fn(() => canMentionEveryone),
+    };
+    if (guildMemberCache && int.guild) {
+      // Replace the default empty member cache so @everyone-role
+      // expansion has members to iterate.
+      int.guild.members.cache = guildMemberCache;
+    }
     return int;
   }
 
@@ -2322,6 +2508,85 @@ describe('handleConfirmUserSelect', () => {
       expect.stringMatching(/transitionFlow threw/),
       expect.objectContaining({ flow_id: 'fid' }),
     );
+  });
+
+  test('mentionable picker: role pick → role members expanded, flow advances with merged recipientIds', async () => {
+    // Mentionable picker can surface BOTH users and roles in one
+    // interaction. The role's non-bot members get merged into the
+    // recipient list, deduped against directly picked users.
+    const u2 = '100000000000000002';
+    const u3 = '100000000000000003';
+    const role = ['role-eng', {
+      id: 'role-eng',
+      members: new Map([
+        [u2, { user: makeUser(u2) }],
+        [u3, { user: makeUser(u3) }],
+      ]),
+    }];
+    const int = makeSelectInteraction({
+      users: [makeUser(u1)],
+      roles: [role],
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      payload: expect.objectContaining({
+        recipientIds: expect.arrayContaining([u1, u2, u3]),
+      }),
+    }));
+    expect(mockTransitionFlow.mock.calls[0][2].payload.recipientIds.length).toBe(3);
+  });
+
+  test('mentionable picker: @everyone role WITHOUT MENTION_EVERYONE → all-invalid branch surfaces gated warning', async () => {
+    // Parallel to the text-path #323 gate: picking the @everyone role
+    // (role.id === guild.id) when the user lacks MENTION_EVERYONE
+    // surfaces `massMentionDenied: true` from resolveMentionableSelection,
+    // hits the all-invalid branch, and renders the permission-specific
+    // reason on the rejection banner. No transitionFlow fires.
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [],
+      canMentionEveryone: false,
+    });
+    // Derive @everyone role id from int.guild.id rather than a literal —
+    // a future change to the makeInteraction default would otherwise
+    // silently break the role-id === guild-id detection.
+    const everyoneId = int.guild.id;
+    int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/@everyone/);
+    expect(updated.content).toMatch(/Mention Everyone/);
+    // Resource header survives — same preserved-context contract.
+    expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('mentionable picker: @everyone role WITH MENTION_EVERYONE → expands via guild.members.cache, flow advances', async () => {
+    // With the perm, @everyone-role expansion routes through
+    // guild.members.cache (not role.members — discord.js doesn't
+    // reliably surface all members through @everyone's role.members).
+    const u2 = '100000000000000002';
+    const u3 = '100000000000000003';
+    const bot1 = '100000000000000099';
+    const cache = new Map([
+      [u2, { user: makeUser(u2) }],
+      [u3, { user: makeUser(u3) }],
+      [bot1, { user: makeUser(bot1, { bot: true }) }],
+    ]);
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [],
+      canMentionEveryone: true,
+      guildMemberCache: cache,
+    });
+    const everyoneId = int.guild.id;
+    int.roles = new Map([[everyoneId, { id: everyoneId, members: new Map() }]]);
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const recipientIds = mockTransitionFlow.mock.calls[0][2].payload.recipientIds;
+    expect(recipientIds.sort()).toEqual([u2, u3].sort());
+    // Bot members filtered out by resolveMentionableSelection.
+    expect(recipientIds).not.toContain(bot1);
   });
 
   test('re-pick preserves personalMessageRaw + personalMessage through the spread', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -643,7 +643,7 @@ describe('resolveMentionableSelection', () => {
     expect(r.droppedFromRoles).toBe(ITER_BOUND);
   });
 
-  test('iteration cost vs count semantic: overlap bots consume iter budget twice but Set counts them once', () => {
+  test('iteration cost vs count semantic: counter-before-dedupe causes overlap to consume an iter slot, blocking a later human', () => {
     // Pin the documented intent at commands.js: counter increments
     // BEFORE the dedupe check, so a bot in two picked roles costs 2
     // iteration slots even though droppedFromRolesSet has 1 entry.
@@ -651,29 +651,41 @@ describe('resolveMentionableSelection', () => {
     // (in pursuit of "symmetry") would let a contrived "same N
     // members across M roles" pick grind for free.
     //
-    // Setup: role A has 1 unique bot (the "overlap" bot) + 49 other
-    // bots (50 total). Role B has the same overlap bot + 49 DIFFERENT
-    // bots. Total unique bots: 1 + 49 + 49 = 99. Total iterations if
-    // unbounded: 50 + 50 = 100 — exactly ITER_BOUND. So role B's last
-    // unique bot is the one that trips the bound.
-    const overlapBot = makeUser('100000000000000099', { bot: true });
-    const roleAOnly = Array.from({ length: 49 }, (_, i) => ({
+    // Earlier formulation of this test (just counted distinct bots
+    // across 2 roles) couldn't distinguish the two orderings since
+    // both produce the same .size. The fixture below DOES
+    // distinguish:
+    //
+    //   Role A: 99 unique bots → counter=99, set.size=99
+    //   Role B: 1 overlap bot, then 1 human
+    //
+    // Counter-before-dedupe (CURRENT):
+    //   - B iter 1 (overlap): counter→100, dedupe-skip via set.
+    //   - B iter 2 (human): bound check trips (100 >= 100), break.
+    //   - users=[], droppedFromRoles=99.
+    //
+    // Hoisted-dedupe (THE REGRESSION):
+    //   - B iter 1: dedupe-skip BEFORE counter, counter stays 99.
+    //   - B iter 2: bound passes (99 < 100), counter→100, human added.
+    //   - users=[human], droppedFromRoles=99.
+    //
+    // Asserting users.length === 0 is what catches the refactor.
+    const roleABots = Array.from({ length: 99 }, (_, i) => ({
       user: makeUser(`200000000000000${String(i).padStart(3, '0')}`, { bot: true }),
     }));
-    const roleBOnly = Array.from({ length: 49 }, (_, i) => ({
-      user: makeUser(`300000000000000${String(i).padStart(3, '0')}`, { bot: true }),
-    }));
-    const roleA = makeRole({ id: 'role-a', members: [{ user: overlapBot }, ...roleAOnly] });
-    const roleB = makeRole({ id: 'role-b', members: [{ user: overlapBot }, ...roleBOnly] });
+    const overlapBot = roleABots[0].user; // same User ref as role A's first bot
+    const human = makeUser('100000000000000001');
+    const roleA = makeRole({ id: 'role-a', members: roleABots });
+    const roleB = makeRole({
+      id: 'role-b',
+      members: [{ user: overlapBot }, { user: human }],
+    });
     const int = makeMentionableInteraction({ pickedRoles: [roleA, roleB] });
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    // Human blocked because the overlap bot consumed iter slot 100
+    // before the human could be inspected — the hoisted-dedupe
+    // regression would land the human instead.
     expect(r.users).toEqual([]);
-    // 99 unique bots in the Set. If a future refactor moved the
-    // dedupe check above the counter, role B's overlap iteration
-    // would short-circuit (skipped at userMap.has via the Set), and
-    // the bound would only trip after 100 *unique* members =
-    // unreachable with this fixture. Asserting 99 (vs. 100) pins the
-    // counter-before-dedupe ordering.
     expect(r.droppedFromRoles).toBe(99);
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -643,6 +643,40 @@ describe('resolveMentionableSelection', () => {
     expect(r.droppedFromRoles).toBe(ITER_BOUND);
   });
 
+  test('iteration cost vs count semantic: overlap bots consume iter budget twice but Set counts them once', () => {
+    // Pin the documented intent at commands.js: counter increments
+    // BEFORE the dedupe check, so a bot in two picked roles costs 2
+    // iteration slots even though droppedFromRolesSet has 1 entry.
+    // A regression that hoisted the dedupe check above the counter
+    // (in pursuit of "symmetry") would let a contrived "same N
+    // members across M roles" pick grind for free.
+    //
+    // Setup: role A has 1 unique bot (the "overlap" bot) + 49 other
+    // bots (50 total). Role B has the same overlap bot + 49 DIFFERENT
+    // bots. Total unique bots: 1 + 49 + 49 = 99. Total iterations if
+    // unbounded: 50 + 50 = 100 — exactly ITER_BOUND. So role B's last
+    // unique bot is the one that trips the bound.
+    const overlapBot = makeUser('100000000000000099', { bot: true });
+    const roleAOnly = Array.from({ length: 49 }, (_, i) => ({
+      user: makeUser(`200000000000000${String(i).padStart(3, '0')}`, { bot: true }),
+    }));
+    const roleBOnly = Array.from({ length: 49 }, (_, i) => ({
+      user: makeUser(`300000000000000${String(i).padStart(3, '0')}`, { bot: true }),
+    }));
+    const roleA = makeRole({ id: 'role-a', members: [{ user: overlapBot }, ...roleAOnly] });
+    const roleB = makeRole({ id: 'role-b', members: [{ user: overlapBot }, ...roleBOnly] });
+    const int = makeMentionableInteraction({ pickedRoles: [roleA, roleB] });
+    const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+    expect(r.users).toEqual([]);
+    // 99 unique bots in the Set. If a future refactor moved the
+    // dedupe check above the counter, role B's overlap iteration
+    // would short-circuit (skipped at userMap.has via the Set), and
+    // the bound would only trip after 100 *unique* members =
+    // unreachable with this fixture. Asserting 99 (vs. 100) pins the
+    // counter-before-dedupe ordering.
+    expect(r.droppedFromRoles).toBe(99);
+  });
+
   test('overlap dedup: same bot in two picked roles counted once in droppedFromRoles', () => {
     // Set-backed droppedFromRoles means the same bot ID across two
     // picked roles contributes 1 to the user-visible count, not 2.

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -118,6 +118,7 @@ jest.mock('discord.js', () => {
     ComponentType: { Button: 2, StringSelect: 3, UserSelect: 5 },
     StringSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
     UserSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
+    MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => makeChainable()),
     ModalBuilder: jest.fn().mockImplementation(() => makeChainable()),
     TextInputBuilder: jest.fn().mockImplementation(() => makeChainable()),
     TextInputStyle: { Short: 1, Paragraph: 2 },

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -94,6 +94,12 @@ jest.mock('discord.js', () => ({
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
   })),
+  MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
+    setCustomId: jest.fn().mockReturnThis(),
+    setPlaceholder: jest.fn().mockReturnThis(),
+    setMinValues: jest.fn().mockReturnThis(),
+    setMaxValues: jest.fn().mockReturnThis(),
+  })),
 }));
 
 // We do NOT want database.js to open a real file or start intervals
@@ -1377,6 +1383,12 @@ describe('handleAddRecipients', () => {
         addOptions: jest.fn().mockReturnThis(),
       })),
       UserSelectMenuBuilder: jest.fn().mockImplementation(() => ({
+        setCustomId: jest.fn().mockReturnThis(),
+        setPlaceholder: jest.fn().mockReturnThis(),
+        setMinValues: jest.fn().mockReturnThis(),
+        setMaxValues: jest.fn().mockReturnThis(),
+      })),
+      MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
         setCustomId: jest.fn().mockReturnThis(),
         setPlaceholder: jest.fn().mockReturnThis(),
         setMinValues: jest.fn().mockReturnThis(),


### PR DESCRIPTION
## Why

Part 2 of the @everyone + role-picker feature. PR #323 added text-path `@everyone` and role mentions. The dropdown picker was still `UserSelectMenu` — only individual users, no roles. This PR closes that gap: users can pick **users, roles, and the `@everyone` role** from one menu, matching the text-path surface.

Closes #324.

## What

- **Builder swap.** `renderConfirmCardRows` now uses `MentionableSelectMenuBuilder` in place of `UserSelectMenuBuilder`. Placeholder updated to `"Pick users or roles (1–N)"`.
- **New helper:** `resolveMentionableSelection({ interaction, canMentionEveryone })` merges `interaction.users` + `interaction.roles` into one deduped `User[]` with the same shape `partitionRecipients` expects. Returns `{ users, massMentionDenied, droppedFromRoles, everyoneCacheCold }`.
  - Named roles expand via `role.members` (the Collection of role-bearers).
  - The `@everyone` role (`role.id === guild.id`) expands via `guild.members.cache` instead — discord.js doesn't reliably surface all members through `@everyone`'s `role.members`.
  - Bot members are filtered during expansion (mirrors the parser).
  - Cap short-circuit at `QURL_SEND_MAX_RECIPIENTS` prevents a 10k-member role from building a 10k-entry `userMap` before the downstream partition cap kicks in.
- **Gate parity.** The `@everyone` role is gated on `MENTION_EVERYONE` — same gate as the text path in #323, read off `interaction.memberPermissions` (channel-effective, respects overwrites). When denied, the helper sets `massMentionDenied: true` and skips that role's expansion.
- **Handler integration.** `handleConfirmUserSelect` reads `canMentionEveryone`, threads `massMentionDenied` through `renderRecipientWarnings` and the all-invalid rejection banner. The all-invalid branch lists every reason that fired (bots, @everyone-denied, empty-role).
- **CustomId literal preserved.** `CONFIRM_USER_SELECT_CUSTOM_ID` (`qurl_confirm_user_select`) stays as-is. The customId is just a routing key, and renaming would need the same 180s flow_state drain coordination #316 covered. Internal JS constant name kept for symmetry.

## Cap-priority invariant (picker-path analog of the #323 round-4 fix)

`resolveMentionableSelection` seeds `userMap` with **picked users first**, then runs role expansion under the `if (userMap.size >= cap) break;` short-circuit. So a 5-user + `@everyone` pick on a 30-member guild keeps all 5 explicit picks plus 20 role-expanded members at the 25-cap — explicit picks never get evicted by cache-iteration order. Pinned by a dedicated test.

## Tests

**8 new `resolveMentionableSelection` unit tests:**
- users only → returns picked users, no denial
- named role expands members, filters bots
- user + role overlap dedupes
- `@everyone` role WITHOUT `MENTION_EVERYONE` → denied, no expansion, `massMentionDenied: true`
- `@everyone` role WITH `MENTION_EVERYONE` → expands via `guild.members.cache`
- cap short-circuits role expansion at 25
- **cap priority**: 5 explicit picks + `@everyone` on 30-member cache → all 5 explicit picks survive at 25-cap
- DM context (no guild) → empty users, no denial
- shape contract: `{ users, massMentionDenied }`

**3 new `handleConfirmUserSelect` tests:**
- role pick → role members expanded, flow advances with merged recipientIds
- `@everyone` role WITHOUT `MENTION_EVERYONE` → all-invalid branch surfaces gated warning, resource header preserved
- `@everyone` role WITH `MENTION_EVERYONE` → expands via cache, bot members filtered, flow advances

**Discord.js mocks** in 6 test files updated to expose `MentionableSelectMenuBuilder`.

Full suite: 1452 tests pass, lint clean.

## Test plan

- [ ] Picker shows roles + users in one menu (manual test in dev guild)
- [ ] Picking a role expands to its non-bot members
- [ ] Picking `@everyone` expands all non-bot members IF the picker has `MENTION_EVERYONE`; otherwise the gated warning surfaces (parallel to text path)
- [ ] Cap applies post-expansion
- [ ] Sender included via role membership triggers `selfIncluded` notice (from #322)
- [ ] All-bots role pick → invalid-pick warning
- [ ] Existing `handleConfirmUserSelect` tests still pass; new tests cover the role-expansion + `@everyone`-via-role paths
- [ ] Confirm card label/placeholder reflects the new picker scope

## Out of scope (deferred)

- `Add Recipients` button flow (`qurl_addusers_${sendId}`) still uses `UserSelectMenu`. The flow is smaller and individual users cover the dominant use case. File a follow-up issue if reviewer wants parity.
- Customid wire-literal rename (`qurl_confirm_user_select` → `qurl_confirm_mentionable_select`). Same 180s flow_state drain coordination as #316; not worth the churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

