### PR TITLE
feat(discord): resolve /qurl map locations server-side (place_id pin)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -39,7 +39,8 @@ const {
   findPlaceFromText,
   getPlaceDetails,
   buildPlaceUrl,
-  PLACE_ID_SENTINEL_PREFIX,
+  encodePlaceIdSentinel,
+  decodePlaceIdSentinel,
 } = require('./places');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
@@ -493,27 +494,17 @@ function safeDecodeURIComponent(s) {
   try { return decodeURIComponent(s); } catch { return s; }
 }
 
-// Parse a free-form `location:` input into a discriminated shape:
-//   - URL input → { locationUrl, locationName } (synchronous, no API)
-//   - place_id sentinel from the autocomplete dropdown → { placeId }
-//   - free text (sender skipped autocomplete) → { text }
+// Parse a free-form `location:` input into one of three shapes:
+//   - URL input → { locationUrl, locationName }
+//   - place_id sentinel from autocomplete → { placeId }
+//   - free text → { text }
 //
-// Sentinel and text branches return placeholders for locationUrl /
-// locationName so callers can destructure uniformly; the real values
-// come from resolveLocation, which is async and hits Places.
-//
-// Why a sentinel: a synthesized /maps/search/<text> URL is per-viewer
-// geo-biased (Google resolves the query against the recipient's IP),
-// so two recipients of the same qURL can end up at different places.
-// Routing the input through Places + a place_id-pinned URL eliminates
-// the bias — every recipient gets the same canonical destination.
+// Callers pass the result to resolveLocation, which hits Places for the
+// sentinel + text branches. The URL branch synchronously short-circuits.
 function parseLocationInput(rawInput) {
-  if (typeof rawInput === 'string' && rawInput.startsWith(PLACE_ID_SENTINEL_PREFIX)) {
-    return {
-      locationUrl: null,
-      locationName: null,
-      placeId: rawInput.slice(PLACE_ID_SENTINEL_PREFIX.length),
-    };
+  const decodedPlaceId = decodePlaceIdSentinel(rawInput);
+  if (decodedPlaceId) {
+    return { locationUrl: null, locationName: null, placeId: decodedPlaceId };
   }
   let detectedUrl = null;
   for (const pattern of MAPS_URL_PATTERNS) {
@@ -542,54 +533,30 @@ function parseLocationInput(rawInput) {
   };
 }
 
-// Tight timeout on the on-submit Places call. Discord's interaction
-// ACK window is 3 s; we need budget for resolveLocation AND the
-// downstream handleQurlSlashSend defer + render. 1500 ms is well
-// above Google Places p99 for both endpoints — if we hit this
-// timeout, Places is genuinely broken and we'd rather return the
-// error reply within Discord's window than wait longer. Autocomplete
-// keeps the longer default since each keystroke fires its own
-// interaction with its own 3 s budget.
-const RESOLVE_LOCATION_TIMEOUT_MS = 1500;
+// Failure modes of resolveLocation. handleQurlMap maps each to a
+// distinct user-facing reply.
+const RESOLVE_REASON = Object.freeze({
+  NO_API_KEY: 'no_api_key',
+  NOT_FOUND: 'not_found',
+  ERROR: 'error',
+});
 
 // Discriminated result of resolveLocation. Callers check `.ok`:
 //   { ok: true,  locationUrl, locationName }            (success)
-//   { ok: false, reason: 'no_api_key' | 'not_found' | 'error' }
-//
-// Errors are surfaced as honest user messages rather than throwing —
-// handleQurlMap converts each `reason` to its own reply, and the
-// shape lets a test pin the contract without driving the full
-// interaction stack.
+//   { ok: false, reason: RESOLVE_REASON.<...> }         (failure)
 async function resolveLocation(parsed) {
-  // URL branch: parseLocationInput already extracted a Google Maps
-  // URL from the sender input; pass it through without an API call.
-  // Maps shortlinks (goo.gl/...) and /place/<name> URLs are already
-  // stable identifiers — they redirect/resolve to the same destination
-  // for every viewer.
   if (parsed.locationUrl) {
-    return {
-      ok: true,
-      locationUrl: parsed.locationUrl,
-      locationName: parsed.locationName,
-    };
+    return { ok: true, locationUrl: parsed.locationUrl, locationName: parsed.locationName };
   }
   if (!config.GOOGLE_MAPS_API_KEY) {
-    return { ok: false, reason: 'no_api_key' };
+    return { ok: false, reason: RESOLVE_REASON.NO_API_KEY };
   }
   try {
-    let place;
-    if (parsed.placeId) {
-      place = await getPlaceDetails(parsed.placeId, { timeoutMs: RESOLVE_LOCATION_TIMEOUT_MS });
-    } else if (parsed.text) {
-      place = await findPlaceFromText(parsed.text, { timeoutMs: RESOLVE_LOCATION_TIMEOUT_MS });
-    } else {
-      // Defensive: parseLocationInput always populates one of url/
-      // placeId/text. An empty parsed object would mean the input was
-      // whitespace, which handleQurlMap rejects before we get here.
-      return { ok: false, reason: 'not_found' };
-    }
+    const place = parsed.placeId
+      ? await getPlaceDetails(parsed.placeId)
+      : await findPlaceFromText(parsed.text);
     if (!place || !place.placeId) {
-      return { ok: false, reason: 'not_found' };
+      return { ok: false, reason: RESOLVE_REASON.NOT_FOUND };
     }
     return {
       ok: true,
@@ -601,7 +568,7 @@ async function resolveLocation(parsed) {
       kind: parsed.placeId ? 'placeId' : 'text',
       error: err && err.message,
     });
-    return { ok: false, reason: 'error' };
+    return { ok: false, reason: RESOLVE_REASON.ERROR };
   }
 }
 
@@ -3629,25 +3596,18 @@ async function handleQurlMap(interaction) {
     });
   }
 
-  // Resolve the parsed input to a canonical place_id-pinned URL. URL
-  // inputs pass through synchronously (no API call); sentinel + free-
-  // text inputs hit Places at send time so every recipient opens the
-  // same destination regardless of their viewer geo. Without this,
-  // /maps/search/<text> URLs are resolved per-viewer by Google and
-  // recipients in different cities can land at completely different
-  // places — the bug this whole change is fixing.
+  // URL inputs pass through synchronously; sentinel + free-text inputs
+  // hit Places at send time so every recipient opens the same place_id
+  // regardless of viewer geo.
   const resolved = await resolveLocation(parsedLocation);
   if (!resolved.ok) {
     clearCooldown(interaction.user.id);
     let content;
     switch (resolved.reason) {
-      case 'no_api_key':
-        // Hard fail per ops decision — operator must configure the
-        // key, OR the sender can paste a Google Maps URL (URL branch
-        // bypasses Places entirely).
+      case RESOLVE_REASON.NO_API_KEY:
         content = '❌ Location search is unavailable on this server. Re-run with a full Google Maps URL.';
         break;
-      case 'not_found':
+      case RESOLVE_REASON.NOT_FOUND:
         content = `❌ Couldn't find a place matching "${sanitizeContentLabel(locationValue.slice(0, 80))}". Try a more specific name or paste a Google Maps URL.`;
         break;
       default:
@@ -5376,14 +5336,8 @@ const commands = [
             opt.setName('location')
               .setDescription('Google Maps URL, or a place / address to search')
               .setRequired(true)
-              // Autocomplete suggests place_id-pinned matches from
-              // Google Places — picking one round-trips a sentinel
-              // value that resolves to a canonical URL at send time,
-              // so every recipient sees the same destination regardless
-              // of their viewer location. Free-text submissions are
-              // also resolved server-side (see resolveLocation), so
-              // the bug-fix is independent of whether the sender uses
-              // the dropdown.
+              // Picking a suggestion sends a `qurl_place:<id>` sentinel;
+              // free text is resolved server-side via resolveLocation.
               .setAutocomplete(true)
               // 500 chars covers full Google Maps URLs (which can be
               // 200-400 chars after place params + coordinates) plus
@@ -5860,27 +5814,23 @@ function isAckTimeoutError(err) {
   return typeof err.message === 'string' && ACK_TIMEOUT_MSG_RE.test(err.message);
 }
 
-// Minimum partial-input length before we hit Places. Below this,
-// suggestions are noise (single-letter prefixes match thousands of
-// places) and the per-keystroke cost isn't justified.
+// Below this length, autocomplete suggestions are noise (single-letter
+// prefixes match thousands of places) and the per-keystroke Places
+// cost isn't justified.
 const AUTOCOMPLETE_MIN_QUERY_LENGTH = 2;
 
-// Discord caps each autocomplete `name` (the user-visible label) and
-// `value` (returned to the handler on submit) at 100 chars each. The
-// value we send is `qurl_place:<placeId>` — typical place_ids are
-// ~28 chars, so the sentinel+id stays well within budget.
+// Discord caps each choice's `name` (label) and `value` (handler input)
+// at 100 chars. Labels (name + address) often need truncation; values
+// (`qurl_place:<placeId>`) almost never do, but we drop pathological
+// ones so one bad result doesn't fail the whole response.
 const AUTOCOMPLETE_CHOICE_NAME_MAX = 100;
+const AUTOCOMPLETE_CHOICE_VALUE_MAX = 100;
 const AUTOCOMPLETE_MAX_CHOICES = 25;
 
-// Autocomplete dispatcher. Only `/qurl map` + the `location:` option
-// have suggestions today; every other focused field gets an empty
-// response so the dropdown doesn't display stale data.
-//
-// Per Discord's contract, we MUST respond within 3 s — any Places API
-// hiccup falls back to an empty result rather than a thrown handler
-// (which would surface as a "this command is unresponsive" toast).
+// Per Discord's contract, MUST respond within 3 s — Places errors fall
+// back to an empty result rather than a thrown handler (which would
+// surface as a "this command is unresponsive" toast).
 async function handleAutocomplete(interaction) {
-  let respondTo = interaction;
   try {
     if (interaction.commandName !== 'qurl') {
       return interaction.respond([]);
@@ -5894,33 +5844,37 @@ async function handleAutocomplete(interaction) {
     if (rawQuery.length < AUTOCOMPLETE_MIN_QUERY_LENGTH) {
       return interaction.respond([]);
     }
-    // If the sender has already pasted a Google Maps URL, suggestions
-    // would just clutter the dropdown — the URL is already a stable
-    // identifier and parseLocationInput passes it through verbatim.
+    // A pasted URL is already a stable identifier — parseLocationInput
+    // passes it through verbatim and suggestions would just clutter.
     if (/^https?:\/\//i.test(rawQuery)) {
       return interaction.respond([]);
     }
 
     const results = await searchPlaces(rawQuery);
-    const choices = results.slice(0, AUTOCOMPLETE_MAX_CHOICES).map((p) => {
-      // Combine name + address for the visible label, codepoint-aware
-      // truncated to the 100-char cap. Address adds the disambiguation
-      // that motivated this whole change ("White House — 1600 Penn Ave"
-      // vs. "Whitehouse Pub — Manchester, UK").
+    const choices = [];
+    for (const p of results) {
+      if (choices.length >= AUTOCOMPLETE_MAX_CHOICES) break;
+      const value = encodePlaceIdSentinel(p.placeId);
+      if (value.length > AUTOCOMPLETE_CHOICE_VALUE_MAX) continue;
       const label = p.address ? `${p.name} — ${p.address}` : p.name;
-      const name = Array.from(label).slice(0, AUTOCOMPLETE_CHOICE_NAME_MAX).join('');
-      return { name, value: `${PLACE_ID_SENTINEL_PREFIX}${p.placeId}` };
-    });
+      // Fast path the common ASCII case — codepoint-aware truncation
+      // matters only when label.length > NAME_MAX, since UTF-16 vs
+      // codepoint counts diverge only past the boundary.
+      const name = label.length <= AUTOCOMPLETE_CHOICE_NAME_MAX
+        ? label
+        : Array.from(label).slice(0, AUTOCOMPLETE_CHOICE_NAME_MAX).join('');
+      choices.push({ name, value });
+    }
     return interaction.respond(choices);
   } catch (err) {
-    logger.warn('autocomplete handler failed', {
+    // Debug, not warn: Places outages would otherwise spam logs at
+    // keystroke rate. The empty-response fallback IS the contract here;
+    // resolveLocation's send-time call carries the load-bearing warn.
+    logger.debug('autocomplete handler failed', {
       command: interaction.commandName,
       error: err && err.message,
     });
-    // Best-effort empty response so the client doesn't show a stuck
-    // spinner. Swallow a second failure (token already expired) —
-    // there's no recovery path from here.
-    try { await respondTo.respond([]); } catch { /* ignore */ }
+    try { await interaction.respond([]); } catch { /* ignore */ }
     return undefined;
   }
 }
@@ -6203,6 +6157,7 @@ module.exports = {
       renderConfirmCardContent,
       parseLocationInput,
       resolveLocation,
+      RESOLVE_REASON,
       handleAutocomplete,
       safeDecodeURIComponent,
       softenCooldown,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3639,7 +3639,9 @@ async function handleQurlMap(interaction) {
   }
   let { locationUrl, locationName } = resolved;
 
-  // Explicit location-name override wins over the URL-derived name.
+  // Explicit location-name override wins over the resolved name
+  // (whether that came from a URL, a place_id lookup, or a free-text
+  // resolve).
   if (locationNameRaw && locationNameRaw.trim().length > 0) {
     locationName = locationNameRaw.trim();
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5860,13 +5860,28 @@ const AUTOCOMPLETE_CHOICE_NAME_MAX = 100;
 const AUTOCOMPLETE_CHOICE_VALUE_MAX = 100;
 const AUTOCOMPLETE_MAX_CHOICES = 25;
 
-// Per Discord's contract, MUST respond within 3 s — Places errors fall
-// back to an empty result rather than a thrown handler (which would
-// surface as a "this command is unresponsive" toast).
+// Match the production-side decodePlaceIdSentinel shape gate. Filter
+// here too so a malformed Google response — `place_id` with a char
+// outside `[A-Za-z0-9_-]` or shorter than 16 chars — gets skipped at
+// the dropdown rather than rendered as a choice that's about to fail
+// the submit-time decode.
+const AUTOCOMPLETE_PLACE_ID_SHAPE_RE = /^[A-Za-z0-9_-]{16,}$/;
+
+// Per Discord's contract, MUST respond within 3 s. Two-layer error
+// handling: the inner try catches Places I/O failures (ticks the
+// sampled SRE counter; that's its intent — "Places is degraded"); the
+// outer try catches anything else (early-return respond([]) throws on
+// expired token, etc.) without ticking the counter, since those aren't
+// Places-degradation signals.
 async function handleAutocomplete(interaction) {
   try {
+    // `return await` (not bare `return`) so a rejected `respond([])`
+    // promise is caught by the outer try/catch instead of leaking out
+    // of the async function unhandled. Each early-return is the
+    // contract handler — surface the rejection through the outer
+    // recovery path instead of propagating up to the dispatch caller.
     if (interaction.commandName !== 'qurl') {
-      return interaction.respond([]);
+      return await interaction.respond([]);
     }
     // Reject DM autocomplete — handleQurlMap rejects DMs at submit time
     // (see commands.js:~3502) but Discord could still deliver an
@@ -5875,27 +5890,51 @@ async function handleAutocomplete(interaction) {
     // operator's global GOOGLE_MAPS_API_KEY quota for a send that's
     // about to be rejected.
     if (!interaction.guildId) {
-      return interaction.respond([]);
+      return await interaction.respond([]);
     }
     const subcommand = interaction.options.getSubcommand(false);
     const focused = interaction.options.getFocused(true);
     if (subcommand !== 'map' || focused?.name !== 'location') {
-      return interaction.respond([]);
+      return await interaction.respond([]);
     }
     const rawQuery = (focused.value || '').trim();
     if (rawQuery.length < AUTOCOMPLETE_MIN_QUERY_LENGTH) {
-      return interaction.respond([]);
+      return await interaction.respond([]);
     }
     // A pasted URL is already a stable identifier — parseLocationInput
     // passes it through verbatim and suggestions would just clutter.
     if (/^https?:\/\//i.test(rawQuery)) {
-      return interaction.respond([]);
+      return await interaction.respond([]);
     }
 
-    const results = await searchPlaces(rawQuery);
+    let results;
+    try {
+      results = await searchPlaces(rawQuery);
+    } catch (err) {
+      // Per-call log at debug so keystroke-rate failures don't spam.
+      logger.debug('autocomplete handler failed', {
+        command: interaction.commandName,
+        error: err && err.message,
+      });
+      // Sampled SRE signal: emit one warn per BURST failures so a
+      // Places outage is visible (vs. silent autocomplete-only degrade).
+      if (++autocompleteFailureBurst >= AUTOCOMPLETE_FAILURE_LOG_BURST) {
+        logger.warn('autocomplete handler failure burst', {
+          count: autocompleteFailureBurst,
+          error: err && err.message,
+        });
+        autocompleteFailureBurst = 0;
+      }
+      return await interaction.respond([]);
+    }
+
     const choices = [];
     for (const p of results) {
       if (choices.length >= AUTOCOMPLETE_MAX_CHOICES) break;
+      // Skip dud entries early instead of relying on submit-time decode
+      // to reject them — saves the user a "place no longer available"
+      // error on a malformed Google response.
+      if (!AUTOCOMPLETE_PLACE_ID_SHAPE_RE.test(p.placeId)) continue;
       const value = encodePlaceIdSentinel(p.placeId);
       if (value.length > AUTOCOMPLETE_CHOICE_VALUE_MAX) continue;
       const label = p.address ? `${p.name} — ${p.address}` : p.name;
@@ -5917,22 +5956,15 @@ async function handleAutocomplete(interaction) {
       const name = end === label.length ? label : label.slice(0, end);
       choices.push({ name, value });
     }
-    return interaction.respond(choices);
+    return await interaction.respond(choices);
   } catch (err) {
-    // Per-call log at debug so keystroke-rate failures don't spam.
-    logger.debug('autocomplete handler failed', {
+    // Non-Places-I/O failure (respond() on expired token, getSubcommand
+    // throw on malformed interaction, etc.). Doesn't advance the burst
+    // counter — those aren't Places-degradation signals.
+    logger.debug('autocomplete handler unhandled', {
       command: interaction.commandName,
       error: err && err.message,
     });
-    // Sampled SRE signal: emit one warn per BURST failures so a
-    // Places outage is visible (vs. silent autocomplete-only degrade).
-    if (++autocompleteFailureBurst >= AUTOCOMPLETE_FAILURE_LOG_BURST) {
-      logger.warn('autocomplete handler failure burst', {
-        count: autocompleteFailureBurst,
-        error: err && err.message,
-      });
-      autocompleteFailureBurst = 0;
-    }
     try { await interaction.respond([]); } catch { /* ignore */ }
     return undefined;
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5929,6 +5929,11 @@ async function handleAutocomplete(interaction) {
       // to reject them — saves the user a "place no longer available"
       // error on a malformed Google response.
       if (!PLACE_ID_SHAPE_RE.test(p.placeId)) continue;
+      // Places marks `main_text` and `description` as optional; if both
+      // are missing, searchPlaces returns `name: undefined` and the
+      // label would render as the literal string "undefined". Discord
+      // also rejects empty/whitespace names, so just skip.
+      if (!p.name) continue;
       const value = encodePlaceIdSentinel(p.placeId);
       if (value.length > AUTOCOMPLETE_CHOICE_VALUE_MAX) continue;
       const label = p.address ? `${p.name} — ${p.address}` : p.name;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5868,6 +5868,15 @@ async function handleAutocomplete(interaction) {
     if (interaction.commandName !== 'qurl') {
       return interaction.respond([]);
     }
+    // Reject DM autocomplete — handleQurlMap rejects DMs at submit time
+    // (see commands.js:~3502) but Discord could still deliver an
+    // autocomplete interaction without a guildId. Without this guard a
+    // user who somehow triggered autocomplete in DM would burn the
+    // operator's global GOOGLE_MAPS_API_KEY quota for a send that's
+    // about to be rejected.
+    if (!interaction.guildId) {
+      return interaction.respond([]);
+    }
     const subcommand = interaction.options.getSubcommand(false);
     const focused = interaction.options.getFocused(true);
     if (subcommand !== 'map' || focused?.name !== 'location') {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -503,7 +503,7 @@ function safeDecodeURIComponent(s) {
 // sentinel + text branches. The URL branch synchronously short-circuits.
 function parseLocationInput(rawInput) {
   const decodedPlaceId = decodePlaceIdSentinel(rawInput);
-  if (decodedPlaceId) {
+  if (decodedPlaceId !== null) {
     return { locationUrl: null, locationName: null, placeId: decodedPlaceId };
   }
   let detectedUrl = null;
@@ -3114,10 +3114,9 @@ async function handleQurlSlashSend(interaction, params) {
   let flow_id;
   let orphanFlowCreated = false;
   try {
-    // /qurl map may defer earlier (before its server-side Places resolve)
-    // to harden against the 3 s ACK window when Places is slow. Skip the
-    // second defer in that case — discord.js throws "Already replied or
-    // deferred" otherwise.
+    // /qurl map defers before resolveLocation; skip the redundant
+    // defer here so discord.js doesn't throw "Already replied or
+    // deferred".
     if (!interaction.deferred) {
       await interaction.deferReply({ ephemeral: true });
     }
@@ -3602,12 +3601,20 @@ async function handleQurlMap(interaction) {
     });
   }
 
-  // Defer BEFORE the awaited Places call so a slow lookup can't blow
-  // Discord's 3 s ACK window. handleQurlSlashSend below detects
-  // `interaction.deferred` and skips its own deferReply. The
-  // resolveLocation error replies fall through to editReply since the
-  // interaction is now deferred.
-  await interaction.deferReply({ ephemeral: true });
+  // Defer before Places resolve to stay inside Discord's 3 s ACK window.
+  // handleQurlSlashSend below checks `interaction.deferred` and skips
+  // its own defer.
+  try {
+    await interaction.deferReply({ ephemeral: true });
+  } catch (err) {
+    // Token already expired or Discord transiently degraded — clear
+    // cooldown so the user can retry without waiting it out.
+    logger.warn('handleQurlMap: deferReply failed', {
+      user_id: interaction.user.id, error: err && err.message,
+    });
+    clearCooldown(interaction.user.id);
+    return undefined;
+  }
   const resolved = await resolveLocation(parsedLocation);
   if (!resolved.ok) {
     clearCooldown(interaction.user.id);
@@ -3617,7 +3624,13 @@ async function handleQurlMap(interaction) {
         content = '❌ Location search is unavailable on this server. Re-run with a full Google Maps URL.';
         break;
       case RESOLVE_REASON.NOT_FOUND:
-        content = `❌ Couldn't find a place matching "${sanitizeContentLabel(locationValue.slice(0, 80))}". Try a more specific name or paste a Google Maps URL.`;
+        // A stale-sentinel miss (sender picked a suggestion that's since
+        // been deleted upstream) gets a place-specific message. For
+        // free-text misses, echo the (sanitized) input so the sender
+        // can see what they typed.
+        content = parsedLocation.placeId
+          ? '❌ That place is no longer available. Pick another suggestion or paste a Google Maps URL.'
+          : `❌ Couldn't find a place matching "${sanitizeContentLabel(locationValue.slice(0, 80))}". Try a more specific name or paste a Google Maps URL.`;
         break;
       default:
         content = '❌ Location lookup failed. Please try again, or paste a Google Maps URL.';
@@ -5869,7 +5882,10 @@ async function handleAutocomplete(interaction) {
       // Discord validates name length in UTF-16 code units, not code
       // points, so we cap by `.length`. Back off by 1 if the cap would
       // land on a lone high surrogate so we don't ship a half-emoji
-      // (which Discord renders as tofu).
+      // (which Discord renders as tofu). Deliberately NOT
+      // `safeCodepointSlice` — that helper counts codepoints, which
+      // can ship a string whose `.length` > 100 for emoji-heavy labels
+      // (each surrogate pair is 2 UTF-16 units but 1 codepoint).
       let name = label;
       if (label.length > AUTOCOMPLETE_CHOICE_NAME_MAX) {
         let end = AUTOCOMPLETE_CHOICE_NAME_MAX;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5857,12 +5857,17 @@ async function handleAutocomplete(interaction) {
       const value = encodePlaceIdSentinel(p.placeId);
       if (value.length > AUTOCOMPLETE_CHOICE_VALUE_MAX) continue;
       const label = p.address ? `${p.name} — ${p.address}` : p.name;
-      // Fast path the common ASCII case — codepoint-aware truncation
-      // matters only when label.length > NAME_MAX, since UTF-16 vs
-      // codepoint counts diverge only past the boundary.
-      const name = label.length <= AUTOCOMPLETE_CHOICE_NAME_MAX
-        ? label
-        : Array.from(label).slice(0, AUTOCOMPLETE_CHOICE_NAME_MAX).join('');
+      // Discord validates name length in UTF-16 code units, not code
+      // points, so we cap by `.length`. Back off by 1 if the cap would
+      // land on a lone high surrogate so we don't ship a half-emoji
+      // (which Discord renders as tofu).
+      let name = label;
+      if (label.length > AUTOCOMPLETE_CHOICE_NAME_MAX) {
+        let end = AUTOCOMPLETE_CHOICE_NAME_MAX;
+        const lastUnit = label.charCodeAt(end - 1);
+        if (lastUnit >= 0xD800 && lastUnit <= 0xDBFF) end -= 1;
+        name = label.slice(0, end);
+      }
       choices.push({ name, value });
     }
     return interaction.respond(choices);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3114,7 +3114,13 @@ async function handleQurlSlashSend(interaction, params) {
   let flow_id;
   let orphanFlowCreated = false;
   try {
-    await interaction.deferReply({ ephemeral: true });
+    // /qurl map may defer earlier (before its server-side Places resolve)
+    // to harden against the 3 s ACK window when Places is slow. Skip the
+    // second defer in that case — discord.js throws "Already replied or
+    // deferred" otherwise.
+    if (!interaction.deferred) {
+      await interaction.deferReply({ ephemeral: true });
+    }
 
     const recipientsRaw = interaction.options.getString('recipients');
     const expiresIn = interaction.options.getString('expires-in') || '24h';
@@ -3596,9 +3602,12 @@ async function handleQurlMap(interaction) {
     });
   }
 
-  // URL inputs pass through synchronously; sentinel + free-text inputs
-  // hit Places at send time so every recipient opens the same place_id
-  // regardless of viewer geo.
+  // Defer BEFORE the awaited Places call so a slow lookup can't blow
+  // Discord's 3 s ACK window. handleQurlSlashSend below detects
+  // `interaction.deferred` and skips its own deferReply. The
+  // resolveLocation error replies fall through to editReply since the
+  // interaction is now deferred.
+  await interaction.deferReply({ ephemeral: true });
   const resolved = await resolveLocation(parsedLocation);
   if (!resolved.ok) {
     clearCooldown(interaction.user.id);
@@ -3613,7 +3622,7 @@ async function handleQurlMap(interaction) {
       default:
         content = '❌ Location lookup failed. Please try again, or paste a Google Maps URL.';
     }
-    return interaction.reply({ content, ephemeral: true });
+    return interaction.editReply({ content });
   }
   let { locationUrl, locationName } = resolved;
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -34,6 +34,13 @@ const { deleteLink, getResourceStatus } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 const { deleteFlow, transitionFlow, supersedeOrCreate } = require('./flow-state');
 const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } = require('./flow-dispatch');
+const {
+  searchPlaces,
+  findPlaceFromText,
+  getPlaceDetails,
+  buildPlaceUrl,
+  PLACE_ID_SENTINEL_PREFIX,
+} = require('./places');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
@@ -486,16 +493,28 @@ function safeDecodeURIComponent(s) {
   try { return decodeURIComponent(s); } catch { return s; }
 }
 
-// Parse a free-form `location:` input into `{ locationUrl, locationName }`.
-// Detection order:
-//   1. Google Maps URL embedded anywhere in the input → preserve URL,
-//      extract name from `?q=` or `/place/<name>`.
-//   2. Anything else → synthesize a `/maps/search/<input>` URL with the
-//      whole input as the name.
+// Parse a free-form `location:` input into a discriminated shape:
+//   - URL input → { locationUrl, locationName } (synchronous, no API)
+//   - place_id sentinel from the autocomplete dropdown → { placeId }
+//   - free text (sender skipped autocomplete) → { text }
 //
-// Returns BOTH fields; caller is responsible for escaping the name
-// (markdown injection defense) and applying any cap.
+// Sentinel and text branches return placeholders for locationUrl /
+// locationName so callers can destructure uniformly; the real values
+// come from resolveLocation, which is async and hits Places.
+//
+// Why a sentinel: a synthesized /maps/search/<text> URL is per-viewer
+// geo-biased (Google resolves the query against the recipient's IP),
+// so two recipients of the same qURL can end up at different places.
+// Routing the input through Places + a place_id-pinned URL eliminates
+// the bias — every recipient gets the same canonical destination.
 function parseLocationInput(rawInput) {
+  if (typeof rawInput === 'string' && rawInput.startsWith(PLACE_ID_SENTINEL_PREFIX)) {
+    return {
+      locationUrl: null,
+      locationName: null,
+      placeId: rawInput.slice(PLACE_ID_SENTINEL_PREFIX.length),
+    };
+  }
   let detectedUrl = null;
   for (const pattern of MAPS_URL_PATTERNS) {
     const match = rawInput.match(pattern);
@@ -503,16 +522,87 @@ function parseLocationInput(rawInput) {
   }
   if (detectedUrl && isGoogleMapsURL(detectedUrl)) {
     const queryMatch = detectedUrl.match(/[?&]q=([^&]+)/);
+    // `?api=1&query=…` is the canonical "Maps URL" form (the one
+    // resolveLocation constructs). Match it too so a sender who
+    // re-shares a previously-constructed qURL map URL still gets a
+    // name extracted instead of falling back to "location" in the
+    // recipient embed.
+    const apiQueryMatch = detectedUrl.match(/[?&]query=([^&]+)/);
     const placeMatch = detectedUrl.match(/\/place\/([^/@]+)/);
     let name = null;
     if (queryMatch) name = safeDecodeURIComponent(queryMatch[1].replace(/\+/g, ' '));
+    else if (apiQueryMatch) name = safeDecodeURIComponent(apiQueryMatch[1].replace(/\+/g, ' '));
     else if (placeMatch) name = safeDecodeURIComponent(placeMatch[1].replace(/\+/g, ' '));
     return { locationUrl: detectedUrl, locationName: name };
   }
   return {
-    locationUrl: `https://www.google.com/maps/search/${encodeURIComponent(rawInput)}`,
-    locationName: rawInput,
+    locationUrl: null,
+    locationName: null,
+    text: rawInput,
   };
+}
+
+// Tight timeout on the on-submit Places call. Discord's interaction
+// ACK window is 3 s; we need budget for resolveLocation AND the
+// downstream handleQurlSlashSend defer + render. 1500 ms is well
+// above Google Places p99 for both endpoints — if we hit this
+// timeout, Places is genuinely broken and we'd rather return the
+// error reply within Discord's window than wait longer. Autocomplete
+// keeps the longer default since each keystroke fires its own
+// interaction with its own 3 s budget.
+const RESOLVE_LOCATION_TIMEOUT_MS = 1500;
+
+// Discriminated result of resolveLocation. Callers check `.ok`:
+//   { ok: true,  locationUrl, locationName }            (success)
+//   { ok: false, reason: 'no_api_key' | 'not_found' | 'error' }
+//
+// Errors are surfaced as honest user messages rather than throwing —
+// handleQurlMap converts each `reason` to its own reply, and the
+// shape lets a test pin the contract without driving the full
+// interaction stack.
+async function resolveLocation(parsed) {
+  // URL branch: parseLocationInput already extracted a Google Maps
+  // URL from the sender input; pass it through without an API call.
+  // Maps shortlinks (goo.gl/...) and /place/<name> URLs are already
+  // stable identifiers — they redirect/resolve to the same destination
+  // for every viewer.
+  if (parsed.locationUrl) {
+    return {
+      ok: true,
+      locationUrl: parsed.locationUrl,
+      locationName: parsed.locationName,
+    };
+  }
+  if (!config.GOOGLE_MAPS_API_KEY) {
+    return { ok: false, reason: 'no_api_key' };
+  }
+  try {
+    let place;
+    if (parsed.placeId) {
+      place = await getPlaceDetails(parsed.placeId, { timeoutMs: RESOLVE_LOCATION_TIMEOUT_MS });
+    } else if (parsed.text) {
+      place = await findPlaceFromText(parsed.text, { timeoutMs: RESOLVE_LOCATION_TIMEOUT_MS });
+    } else {
+      // Defensive: parseLocationInput always populates one of url/
+      // placeId/text. An empty parsed object would mean the input was
+      // whitespace, which handleQurlMap rejects before we get here.
+      return { ok: false, reason: 'not_found' };
+    }
+    if (!place || !place.placeId) {
+      return { ok: false, reason: 'not_found' };
+    }
+    return {
+      ok: true,
+      locationUrl: buildPlaceUrl(place.name, place.placeId),
+      locationName: place.name || place.address || null,
+    };
+  } catch (err) {
+    logger.warn('resolveLocation: Places API call failed', {
+      kind: parsed.placeId ? 'placeId' : 'text',
+      error: err && err.message,
+    });
+    return { ok: false, reason: 'error' };
+  }
 }
 
 function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
@@ -3525,10 +3615,9 @@ async function handleQurlMap(interaction) {
   // or a pathological input could throw synchronously before reaching
   // handleQurlSlashSend's safety net, leaving cooldown set with no
   // visible response.
-  let locationUrl;
-  let locationName;
+  let parsedLocation;
   try {
-    ({ locationUrl, locationName } = parseLocationInput(locationValue));
+    parsedLocation = parseLocationInput(locationValue);
   } catch (err) {
     logger.error('handleQurlMap: parseLocationInput threw', {
       user_id: interaction.user.id, error: err && err.message,
@@ -3539,6 +3628,35 @@ async function handleQurlMap(interaction) {
       ephemeral: true,
     });
   }
+
+  // Resolve the parsed input to a canonical place_id-pinned URL. URL
+  // inputs pass through synchronously (no API call); sentinel + free-
+  // text inputs hit Places at send time so every recipient opens the
+  // same destination regardless of their viewer geo. Without this,
+  // /maps/search/<text> URLs are resolved per-viewer by Google and
+  // recipients in different cities can land at completely different
+  // places — the bug this whole change is fixing.
+  const resolved = await resolveLocation(parsedLocation);
+  if (!resolved.ok) {
+    clearCooldown(interaction.user.id);
+    let content;
+    switch (resolved.reason) {
+      case 'no_api_key':
+        // Hard fail per ops decision — operator must configure the
+        // key, OR the sender can paste a Google Maps URL (URL branch
+        // bypasses Places entirely).
+        content = '❌ Location search is unavailable on this server. Re-run with a full Google Maps URL.';
+        break;
+      case 'not_found':
+        content = `❌ Couldn't find a place matching "${sanitizeContentLabel(locationValue.slice(0, 80))}". Try a more specific name or paste a Google Maps URL.`;
+        break;
+      default:
+        content = '❌ Location lookup failed. Please try again, or paste a Google Maps URL.';
+    }
+    return interaction.reply({ content, ephemeral: true });
+  }
+  let { locationUrl, locationName } = resolved;
+
   // Explicit location-name override wins over the URL-derived name.
   if (locationNameRaw && locationNameRaw.trim().length > 0) {
     locationName = locationNameRaw.trim();
@@ -5258,6 +5376,15 @@ const commands = [
             opt.setName('location')
               .setDescription('Google Maps URL, or a place / address to search')
               .setRequired(true)
+              // Autocomplete suggests place_id-pinned matches from
+              // Google Places — picking one round-trips a sentinel
+              // value that resolves to a canonical URL at send time,
+              // so every recipient sees the same destination regardless
+              // of their viewer location. Free-text submissions are
+              // also resolved server-side (see resolveLocation), so
+              // the bug-fix is independent of whether the sender uses
+              // the dropdown.
+              .setAutocomplete(true)
               // 500 chars covers full Google Maps URLs (which can be
               // 200-400 chars after place params + coordinates) plus
               // headroom; not tied to the recipients-parser cap because
@@ -5733,13 +5860,78 @@ function isAckTimeoutError(err) {
   return typeof err.message === 'string' && ACK_TIMEOUT_MSG_RE.test(err.message);
 }
 
+// Minimum partial-input length before we hit Places. Below this,
+// suggestions are noise (single-letter prefixes match thousands of
+// places) and the per-keystroke cost isn't justified.
+const AUTOCOMPLETE_MIN_QUERY_LENGTH = 2;
+
+// Discord caps each autocomplete `name` (the user-visible label) and
+// `value` (returned to the handler on submit) at 100 chars each. The
+// value we send is `qurl_place:<placeId>` — typical place_ids are
+// ~28 chars, so the sentinel+id stays well within budget.
+const AUTOCOMPLETE_CHOICE_NAME_MAX = 100;
+const AUTOCOMPLETE_MAX_CHOICES = 25;
+
+// Autocomplete dispatcher. Only `/qurl map` + the `location:` option
+// have suggestions today; every other focused field gets an empty
+// response so the dropdown doesn't display stale data.
+//
+// Per Discord's contract, we MUST respond within 3 s — any Places API
+// hiccup falls back to an empty result rather than a thrown handler
+// (which would surface as a "this command is unresponsive" toast).
+async function handleAutocomplete(interaction) {
+  let respondTo = interaction;
+  try {
+    if (interaction.commandName !== 'qurl') {
+      return interaction.respond([]);
+    }
+    const subcommand = interaction.options.getSubcommand(false);
+    const focused = interaction.options.getFocused(true);
+    if (subcommand !== 'map' || focused?.name !== 'location') {
+      return interaction.respond([]);
+    }
+    const rawQuery = (focused.value || '').trim();
+    if (rawQuery.length < AUTOCOMPLETE_MIN_QUERY_LENGTH) {
+      return interaction.respond([]);
+    }
+    // If the sender has already pasted a Google Maps URL, suggestions
+    // would just clutter the dropdown — the URL is already a stable
+    // identifier and parseLocationInput passes it through verbatim.
+    if (/^https?:\/\//i.test(rawQuery)) {
+      return interaction.respond([]);
+    }
+
+    const results = await searchPlaces(rawQuery);
+    const choices = results.slice(0, AUTOCOMPLETE_MAX_CHOICES).map((p) => {
+      // Combine name + address for the visible label, codepoint-aware
+      // truncated to the 100-char cap. Address adds the disambiguation
+      // that motivated this whole change ("White House — 1600 Penn Ave"
+      // vs. "Whitehouse Pub — Manchester, UK").
+      const label = p.address ? `${p.name} — ${p.address}` : p.name;
+      const name = Array.from(label).slice(0, AUTOCOMPLETE_CHOICE_NAME_MAX).join('');
+      return { name, value: `${PLACE_ID_SENTINEL_PREFIX}${p.placeId}` };
+    });
+    return interaction.respond(choices);
+  } catch (err) {
+    logger.warn('autocomplete handler failed', {
+      command: interaction.commandName,
+      error: err && err.message,
+    });
+    // Best-effort empty response so the client doesn't show a stuck
+    // spinner. Swallow a second failure (token already expired) —
+    // there's no recovery path from here.
+    try { await respondTo.respond([]); } catch { /* ignore */ }
+    return undefined;
+  }
+}
+
 // Handle command interactions
 async function handleCommand(interaction) {
-  // /qurl now has zero options after the button-driven redesign; no other
-  // command in this file uses autocomplete. Discord can still deliver
-  // autocomplete events (legacy clients, stale registrations) — short-
-  // circuit them so they don't fall through to the chat-input path.
-  if (interaction.isAutocomplete()) return;
+  // Autocomplete fires per-keystroke and must respond within 3s. Route
+  // it off the chat-input path so the autocomplete handler doesn't drag
+  // in the metrics + mode-flip-defense overhead that handleQurlSlashSend
+  // and friends need.
+  if (interaction.isAutocomplete()) return handleAutocomplete(interaction);
 
   if (!interaction.isChatInputCommand()) return;
 
@@ -6010,6 +6202,8 @@ module.exports = {
       renderRecipientWarnings,
       renderConfirmCardContent,
       parseLocationInput,
+      resolveLocation,
+      handleAutocomplete,
       safeDecodeURIComponent,
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5900,19 +5900,21 @@ async function handleAutocomplete(interaction) {
       if (value.length > AUTOCOMPLETE_CHOICE_VALUE_MAX) continue;
       const label = p.address ? `${p.name} — ${p.address}` : p.name;
       // Discord validates name length in UTF-16 code units, not code
-      // points, so we cap by `.length`. Back off by 1 if the cap would
-      // land on a lone high surrogate so we don't ship a half-emoji
-      // (which Discord renders as tofu). Deliberately NOT
+      // points, so we cap by `.length`. Back off by 1 if the boundary
+      // would leave a lone high surrogate so we don't ship a
+      // half-emoji (which Discord renders as tofu). Deliberately NOT
       // `safeCodepointSlice` — that helper counts codepoints, which
-      // can ship a string whose `.length` > 100 for emoji-heavy labels
-      // (each surrogate pair is 2 UTF-16 units but 1 codepoint).
-      let name = label;
-      if (label.length > AUTOCOMPLETE_CHOICE_NAME_MAX) {
-        let end = AUTOCOMPLETE_CHOICE_NAME_MAX;
+      // can ship a string whose `.length` > 100 for emoji-heavy
+      // labels (each surrogate pair is 2 UTF-16 units but 1 codepoint).
+      // Always-check (not just on truncation): a label that's exactly
+      // 100 UTF-16 units AND ends with a lone high surrogate would
+      // otherwise slip through the fast path.
+      let end = Math.min(label.length, AUTOCOMPLETE_CHOICE_NAME_MAX);
+      if (end > 0) {
         const lastUnit = label.charCodeAt(end - 1);
         if (lastUnit >= 0xD800 && lastUnit <= 0xDBFF) end -= 1;
-        name = label.slice(0, end);
       }
+      const name = end === label.length ? label : label.slice(0, end);
       choices.push({ name, value });
     }
     return interaction.respond(choices);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -41,6 +41,7 @@ const {
   buildPlaceUrl,
   encodePlaceIdSentinel,
   decodePlaceIdSentinel,
+  PLACE_ID_SHAPE_RE,
 } = require('./places');
 
 // Max tokens the QURL API allows per resource. When exceeded, a new
@@ -5860,13 +5861,6 @@ const AUTOCOMPLETE_CHOICE_NAME_MAX = 100;
 const AUTOCOMPLETE_CHOICE_VALUE_MAX = 100;
 const AUTOCOMPLETE_MAX_CHOICES = 25;
 
-// Match the production-side decodePlaceIdSentinel shape gate. Filter
-// here too so a malformed Google response — `place_id` with a char
-// outside `[A-Za-z0-9_-]` or shorter than 16 chars — gets skipped at
-// the dropdown rather than rendered as a choice that's about to fail
-// the submit-time decode.
-const AUTOCOMPLETE_PLACE_ID_SHAPE_RE = /^[A-Za-z0-9_-]{16,}$/;
-
 // Per Discord's contract, MUST respond within 3 s. Two-layer error
 // handling: the inner try catches Places I/O failures (ticks the
 // sampled SRE counter; that's its intent — "Places is degraded"); the
@@ -5934,7 +5928,7 @@ async function handleAutocomplete(interaction) {
       // Skip dud entries early instead of relying on submit-time decode
       // to reject them — saves the user a "place no longer available"
       // error on a malformed Google response.
-      if (!AUTOCOMPLETE_PLACE_ID_SHAPE_RE.test(p.placeId)) continue;
+      if (!PLACE_ID_SHAPE_RE.test(p.placeId)) continue;
       const value = encodePlaceIdSentinel(p.placeId);
       if (value.length > AUTOCOMPLETE_CHOICE_VALUE_MAX) continue;
       const label = p.address ? `${p.name} — ${p.address}` : p.name;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5843,6 +5843,15 @@ function isAckTimeoutError(err) {
 // cost isn't justified.
 const AUTOCOMPLETE_MIN_QUERY_LENGTH = 2;
 
+// Sampled-warn cadence for autocomplete failures. The catch logs at
+// `debug` per-call to avoid keystroke-rate log spam during a Places
+// outage; this counter emits one `warn` per AUTOCOMPLETE_FAILURE_LOG_BURST
+// failures so SRE has a coarse signal that autocomplete is degraded
+// (vs. no traffic) without flooding logs. resolveLocation's send-time
+// `warn` carries the load-bearing signal — this is secondary visibility.
+const AUTOCOMPLETE_FAILURE_LOG_BURST = 50;
+let autocompleteFailureBurst = 0;
+
 // Discord caps each choice's `name` (label) and `value` (handler input)
 // at 100 chars. Labels (name + address) often need truncation; values
 // (`qurl_place:<placeId>`) almost never do, but we drop pathological
@@ -5899,13 +5908,20 @@ async function handleAutocomplete(interaction) {
     }
     return interaction.respond(choices);
   } catch (err) {
-    // Debug, not warn: Places outages would otherwise spam logs at
-    // keystroke rate. The empty-response fallback IS the contract here;
-    // resolveLocation's send-time call carries the load-bearing warn.
+    // Per-call log at debug so keystroke-rate failures don't spam.
     logger.debug('autocomplete handler failed', {
       command: interaction.commandName,
       error: err && err.message,
     });
+    // Sampled SRE signal: emit one warn per BURST failures so a
+    // Places outage is visible (vs. silent autocomplete-only degrade).
+    if (++autocompleteFailureBurst >= AUTOCOMPLETE_FAILURE_LOG_BURST) {
+      logger.warn('autocomplete handler failure burst', {
+        count: autocompleteFailureBurst,
+        error: err && err.message,
+      });
+      autocompleteFailureBurst = 0;
+    }
     try { await interaction.respond([]); } catch { /* ignore */ }
     return undefined;
   }
@@ -6191,6 +6207,11 @@ module.exports = {
       resolveLocation,
       RESOLVE_REASON,
       handleAutocomplete,
+      // Test-only reset: the autocomplete-failure burst counter is
+      // module-level state that accumulates across tests within a
+      // file unless explicitly cleared.
+      _resetAutocompleteFailureBurst: () => { autocompleteFailureBurst = 0; },
+      AUTOCOMPLETE_FAILURE_LOG_BURST,
       safeDecodeURIComponent,
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5928,7 +5928,16 @@ async function handleAutocomplete(interaction) {
       // Skip dud entries early instead of relying on submit-time decode
       // to reject them — saves the user a "place no longer available"
       // error on a malformed Google response.
-      if (!PLACE_ID_SHAPE_RE.test(p.placeId)) continue;
+      if (!PLACE_ID_SHAPE_RE.test(p.placeId)) {
+        // Debug, not warn: would fire per-keystroke during a Google
+        // place_id format drift, drowning logs. Operator can grep for
+        // this when investigating "why is my dropdown empty?" — that's
+        // the upstream-shape-drift signal.
+        logger.debug('autocomplete: dropped prediction (place_id failed shape check)', {
+          place_id: p.placeId,
+        });
+        continue;
+      }
       // Places marks `main_text` and `description` as optional; if both
       // are missing, searchPlaces returns `name: undefined` and the
       // label would render as the literal string "undefined". Discord

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -17,7 +17,13 @@ function encodePlaceIdSentinel(placeId) {
 
 function decodePlaceIdSentinel(value) {
   if (typeof value !== 'string' || !value.startsWith(PLACE_ID_SENTINEL_PREFIX)) return null;
-  return value.slice(PLACE_ID_SENTINEL_PREFIX.length);
+  const placeId = value.slice(PLACE_ID_SENTINEL_PREFIX.length);
+  // Reject an empty payload: `qurl_place:` with no id behind it would
+  // round-trip as a falsy string, and `parseLocationInput`'s
+  // `if (decodedPlaceId)` check would silently fall through to the
+  // URL/text branches — a sentinel that decoded to "nothing" should
+  // surface as "no match" instead.
+  return placeId.length > 0 ? placeId : null;
 }
 
 // Single timeout for every Places call. Both autocomplete (per
@@ -56,14 +62,27 @@ async function placesFetch(url, params) {
 }
 
 // Bounded TTL cache for autocomplete results. Discord fires
-// `searchPlaces` per keystroke, so a user typing "white house" issues
-// ~9 paid Places Autocomplete calls. A 60 s TTL collapses that to one
-// call per distinct prefix plus a few cache hits as they type. Cap
-// keeps memory bounded across many concurrent senders — when full,
-// drop the oldest entry (FIFO; Map preserves insertion order).
+// `searchPlaces` per keystroke; a 60 s TTL collapses a typing session
+// to one Places call per distinct prefix. Cap keeps memory bounded —
+// when full, drop the oldest entry (FIFO; Map preserves insertion
+// order).
 const AUTOCOMPLETE_CACHE_TTL_MS = 60_000;
 const AUTOCOMPLETE_CACHE_MAX = 500;
 const autocompleteCache = new Map();
+
+// In-flight request dedup. Fast typists can fire multiple keystrokes
+// for the same prefix before the first Places response settles; this
+// returns the same in-flight promise for duplicate concurrent calls
+// (single-flight) rather than paying twice.
+const autocompleteInflight = new Map();
+
+// Cache + single-flight key. Normalize to lowercase + collapsed
+// whitespace so "Whitehouse", "whitehouse", and " White House "
+// share the same entry — Places Autocomplete is case-insensitive,
+// so the cache should be too.
+function cacheKey(query) {
+  return query.toLowerCase().replace(/\s+/g, ' ').trim();
+}
 
 function cacheGet(key) {
   const entry = autocompleteCache.get(key);
@@ -89,22 +108,29 @@ async function searchPlaces(query) {
     return [];
   }
   const safeQuery = sanitizeQueryParam(query);
-  const cached = cacheGet(safeQuery);
+  const key = cacheKey(safeQuery);
+  const cached = cacheGet(key);
   if (cached) return cached;
-  const data = await placesFetch(PLACES_AUTOCOMPLETE_URL, {
-    input: safeQuery,
-    types: 'establishment|geocode',
-  });
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    throw new Error(`Places API status: ${data.status}`);
-  }
-  const results = (data.predictions || []).map(p => ({
-    placeId: p.place_id,
-    name: p.structured_formatting?.main_text || p.description,
-    address: p.structured_formatting?.secondary_text || '',
-  }));
-  cacheSet(safeQuery, results);
-  return results;
+  const inflight = autocompleteInflight.get(key);
+  if (inflight) return inflight;
+  const promise = (async () => {
+    const data = await placesFetch(PLACES_AUTOCOMPLETE_URL, {
+      input: safeQuery,
+      types: 'establishment|geocode',
+    });
+    if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+      throw new Error(`Places API status: ${data.status}`);
+    }
+    const results = (data.predictions || []).map(p => ({
+      placeId: p.place_id,
+      name: p.structured_formatting?.main_text || p.description,
+      address: p.structured_formatting?.secondary_text || '',
+    }));
+    cacheSet(key, results);
+    return results;
+  })().finally(() => autocompleteInflight.delete(key));
+  autocompleteInflight.set(key, promise);
+  return promise;
 }
 
 // Returns null when Find Place returns zero candidates; the caller
@@ -171,9 +197,12 @@ module.exports = {
   PLACE_ID_SENTINEL_PREFIX,
   encodePlaceIdSentinel,
   decodePlaceIdSentinel,
-  // Test-only: clear the cache between tests so a leftover entry from
-  // one test can't satisfy a fetch expectation in the next.
+  // Test-only: clear the cache + in-flight map between tests so leftover
+  // state from one test can't satisfy a fetch expectation in the next.
   ...(process.env.NODE_ENV !== 'production' && {
-    _resetAutocompleteCache: () => autocompleteCache.clear(),
+    _resetAutocompleteCache: () => {
+      autocompleteCache.clear();
+      autocompleteInflight.clear();
+    },
   }),
 };

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -2,49 +2,66 @@ const config = require('./config');
 const logger = require('./logger');
 
 const PLACES_AUTOCOMPLETE_URL = 'https://maps.googleapis.com/maps/api/place/autocomplete/json';
+const PLACES_FINDPLACE_URL = 'https://maps.googleapis.com/maps/api/place/findplacefromtext/json';
+const PLACES_DETAILS_URL = 'https://maps.googleapis.com/maps/api/place/details/json';
 
-async function searchPlaces(query) {
-  if (!config.GOOGLE_MAPS_API_KEY) {
-    logger.warn('GOOGLE_MAPS_API_KEY not set, skipping places autocomplete');
-    return [];
-  }
+// Wire literal used to round-trip a chosen place_id through the Discord
+// slash-option `location:` value. The autocomplete handler encodes
+// selected places as `<prefix><place_id>`; parseLocationInput recognizes
+// this prefix on submit and routes to a Places Details lookup so all
+// recipients see the same canonical place. Without this round-trip the
+// /maps/search/<text> URL we synthesize is per-viewer geo-biased (the
+// bug #322-followup is fixing). Keep this string stable across deploys —
+// any in-flight confirm-card flow_state row carrying a placeId-sentinel
+// in actualUrl is keyed against this literal.
+const PLACE_ID_SENTINEL_PREFIX = 'qurl_place:';
 
-  // Cap user-supplied input before it reaches Google's URL. Google's own
-  // limit is generous but a defensive 500-char guard bounds our request
-  // size and log line length regardless. Also strip ASCII control chars
-  // so header-injection-style payloads can't smuggle newlines or NULs
-  // into the outgoing request URL.
+// Strip ASCII control chars from user-supplied input before it goes
+// into the request URL. Google's own limit is generous but a 500-char
+// cap bounds request size + log line length, and the control-char
+// strip prevents header-injection-style payloads from smuggling
+// newlines or NULs into the outgoing request URL.
+function sanitizeQueryParam(value) {
   // eslint-disable-next-line no-control-regex
-  const safeQuery = String(query || '').replace(/[\x00-\x1f\x7f]/g, '').slice(0, 500);
-  const params = new URLSearchParams({
-    input: safeQuery,
-    key: config.GOOGLE_MAPS_API_KEY,
-    types: 'establishment|geocode',
-  });
+  return String(value || '').replace(/[\x00-\x1f\x7f]/g, '').slice(0, 500);
+}
 
-  // SECURITY: The request URL contains GOOGLE_MAPS_API_KEY as a query param
-  // (Google Places doesn't support header auth). DO NOT log the URL, the
-  // params, or the Request object anywhere — the logger's substring redact
-  // list only catches top-level meta keys, not values embedded inside
-  // strings. Any future error handler that touches `response.url` or the
-  // full request needs to strip the `key` param first.
-  const response = await fetch(`${PLACES_AUTOCOMPLETE_URL}?${params}`, { signal: AbortSignal.timeout(5000) });
+// SECURITY: every Places request URL embeds GOOGLE_MAPS_API_KEY as a
+// query param (Google Places doesn't support header auth). DO NOT log
+// the URL, the params, or the Request object anywhere — the logger's
+// substring redact list only catches top-level meta keys, not values
+// embedded inside strings. Any future error handler that touches
+// `response.url` or the full request needs to strip the `key` param
+// first.
+async function placesFetch(url, params, timeoutMs = 5000) {
+  const qs = new URLSearchParams({ ...params, key: config.GOOGLE_MAPS_API_KEY });
+  const response = await fetch(`${url}?${qs}`, { signal: AbortSignal.timeout(timeoutMs) });
   if (!response.ok) {
     throw new Error(`Places API error: ${response.status}`);
   }
-
-  // The Places API occasionally returns an HTML error page during outages;
-  // `.json()` on that throws a SyntaxError with no context.
+  // The Places API occasionally returns an HTML error page during
+  // outages; .json() on that throws a SyntaxError with no context.
   let data;
   try {
     data = await response.json();
   } catch (err) {
     throw new Error(`Places API returned non-JSON response (${response.status}): ${err.message}`);
   }
+  return data;
+}
+
+async function searchPlaces(query) {
+  if (!config.GOOGLE_MAPS_API_KEY) {
+    logger.warn('GOOGLE_MAPS_API_KEY not set, skipping places autocomplete');
+    return [];
+  }
+  const data = await placesFetch(PLACES_AUTOCOMPLETE_URL, {
+    input: sanitizeQueryParam(query),
+    types: 'establishment|geocode',
+  });
   if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
     throw new Error(`Places API status: ${data.status}`);
   }
-
   return (data.predictions || []).map(p => ({
     placeId: p.place_id,
     name: p.structured_formatting?.main_text || p.description,
@@ -52,4 +69,81 @@ async function searchPlaces(query) {
   }));
 }
 
-module.exports = { searchPlaces };
+// Resolve free text to a single canonical place. Used by the /qurl map
+// server-side fallback when a sender ignores the autocomplete dropdown
+// and submits raw text — we resolve to a place_id-pinned URL at send
+// time so every recipient sees the same destination (vs. Google's
+// per-viewer search-bias on /maps/search/<text>).
+//
+// Returns `null` when Find Place returns zero candidates; the caller
+// surfaces this as an honest "no match" error to the sender.
+async function findPlaceFromText(query, { timeoutMs } = {}) {
+  if (!config.GOOGLE_MAPS_API_KEY) {
+    throw new Error('GOOGLE_MAPS_API_KEY not set');
+  }
+  const data = await placesFetch(PLACES_FINDPLACE_URL, {
+    input: sanitizeQueryParam(query),
+    inputtype: 'textquery',
+    fields: 'place_id,name,formatted_address',
+  }, timeoutMs);
+  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+    throw new Error(`Places API status: ${data.status}`);
+  }
+  const candidate = (data.candidates || [])[0];
+  if (!candidate) return null;
+  return {
+    placeId: candidate.place_id,
+    name: candidate.name || candidate.formatted_address || '',
+    address: candidate.formatted_address || '',
+  };
+}
+
+// Resolve a known place_id to its canonical name + address. Used when
+// the sender picks a suggestion from the autocomplete dropdown — the
+// dropdown value carries the place_id sentinel only (no name, kept
+// short to fit Discord's 100-char choice-value cap), so this call
+// hydrates the human-readable label for the recipient embed.
+async function getPlaceDetails(placeId, { timeoutMs } = {}) {
+  if (!config.GOOGLE_MAPS_API_KEY) {
+    throw new Error('GOOGLE_MAPS_API_KEY not set');
+  }
+  const data = await placesFetch(PLACES_DETAILS_URL, {
+    place_id: sanitizeQueryParam(placeId),
+    fields: 'place_id,name,formatted_address',
+  }, timeoutMs);
+  if (data.status !== 'OK') {
+    if (data.status === 'NOT_FOUND' || data.status === 'INVALID_REQUEST') return null;
+    throw new Error(`Places API status: ${data.status}`);
+  }
+  const r = data.result;
+  if (!r) return null;
+  return {
+    placeId: r.place_id || placeId,
+    name: r.name || r.formatted_address || '',
+    address: r.formatted_address || '',
+  };
+}
+
+// Build the canonical "show this exact place" Maps URL using Google's
+// documented `?api=1` form with `query_place_id` pinning the result to
+// a specific place. This bypasses the per-viewer geo bias that affects
+// /maps/search/<text> URLs — the place_id parameter is the contract
+// that makes every recipient open the same destination.
+//
+// Per Google's URL spec the `query` param is required even when
+// `query_place_id` is set; we pass the canonical place name there.
+function buildPlaceUrl(placeName, placeId) {
+  const url = new URL('https://www.google.com/maps/search/');
+  url.searchParams.set('api', '1');
+  url.searchParams.set('query', placeName || placeId);
+  url.searchParams.set('query_place_id', placeId);
+  return url.toString();
+}
+
+module.exports = {
+  searchPlaces,
+  findPlaceFromText,
+  getPlaceDetails,
+  buildPlaceUrl,
+  PLACE_ID_SENTINEL_PREFIX,
+};

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -24,6 +24,10 @@ function encodePlaceIdSentinel(placeId) {
 // who types `qurl_place:foo` as free text falls through to the text
 // branch (and gets a "couldn't find X" message echoing their input)
 // rather than the misleading "place no longer available" branch.
+// TODO(upstream-place-id-shape): the 16-char floor is our invariant
+// — if Google ever ships a shorter place_id, autocomplete entries
+// for it would be silently dropped and stale picks would refuse to
+// decode. Same drift-marker convention as TODO(upstream-rebrand).
 const PLACE_ID_SHAPE_RE = /^[A-Za-z0-9_-]{16,}$/;
 
 function decodePlaceIdSentinel(value) {

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -91,7 +91,10 @@ function cacheGet(key) {
     autocompleteCache.delete(key);
     return null;
   }
-  return entry.results;
+  // Defensive copy on read so a caller's mutation can't poison the
+  // next hit. Paired with the copy-on-write in cacheSet — together
+  // they isolate the cached array from both writer and reader.
+  return entry.results.slice();
 }
 
 function cacheSet(key, results) {
@@ -99,7 +102,10 @@ function cacheSet(key, results) {
     const oldest = autocompleteCache.keys().next().value;
     if (oldest !== undefined) autocompleteCache.delete(oldest);
   }
-  autocompleteCache.set(key, { results, expiresAt: Date.now() + AUTOCOMPLETE_CACHE_TTL_MS });
+  // Copy on write: searchPlaces returns the same `results` reference
+  // it hands us. Without this copy, a downstream mutation of the
+  // returned array would also mutate the stored entry.
+  autocompleteCache.set(key, { results: results.slice(), expiresAt: Date.now() + AUTOCOMPLETE_CACHE_TTL_MS });
 }
 
 async function searchPlaces(query) {
@@ -126,6 +132,8 @@ async function searchPlaces(query) {
       name: p.structured_formatting?.main_text || p.description,
       address: p.structured_formatting?.secondary_text || '',
     }));
+    // Cache ZERO_RESULTS too — a typo prefix like "asfasdf" otherwise
+    // hits Places on every keystroke. The 60 s TTL bounds staleness.
     cacheSet(key, results);
     return results;
   })().finally(() => autocompleteInflight.delete(key));
@@ -148,7 +156,7 @@ async function findPlaceFromText(query) {
     throw new Error(`Places API status: ${data.status}`);
   }
   const candidate = (data.candidates || [])[0];
-  if (!candidate) return null;
+  if (!candidate || !candidate.place_id) return null;
   return {
     placeId: candidate.place_id,
     name: candidate.name || candidate.formatted_address || '',
@@ -170,8 +178,14 @@ async function getPlaceDetails(placeId) {
   }
   const r = data.result;
   if (!r) return null;
+  // Fall back to the caller's placeId if the response omits it. Reject
+  // entirely if both are empty so buildPlaceUrl downstream can't ship
+  // a URL with `query_place_id=` (which Google renders as a broken
+  // search).
+  const resolvedId = r.place_id || placeId;
+  if (!resolvedId) return null;
   return {
-    placeId: r.place_id || placeId,
+    placeId: resolvedId,
     name: r.name || r.formatted_address || '',
     address: r.formatted_address || '',
   };

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -108,7 +108,10 @@ function cacheGet(key) {
 }
 
 function cacheSet(key, results) {
-  if (autocompleteCache.size >= AUTOCOMPLETE_CACHE_MAX) {
+  // Only evict when actually growing the map. Setting an existing key
+  // updates in place, so evicting first would needlessly drop an
+  // unrelated entry — only matters at saturation but cheap to guard.
+  if (autocompleteCache.size >= AUTOCOMPLETE_CACHE_MAX && !autocompleteCache.has(key)) {
     const oldest = autocompleteCache.keys().next().value;
     if (oldest !== undefined) autocompleteCache.delete(oldest);
   }
@@ -148,7 +151,11 @@ async function searchPlaces(query) {
     // Cache ZERO_RESULTS too — a typo prefix like "asfasdf" otherwise
     // hits Places on every keystroke. The 60 s TTL bounds staleness.
     cacheSet(key, results);
-    return results;
+    // Defensive copy so concurrent single-flight callers each get their
+    // own array (cacheGet already returns a copy on cache-hit; without
+    // this, the in-flight path's callers would share a mutable
+    // reference and one caller's sort/splice would poison the others).
+    return results.slice();
   })().finally(() => autocompleteInflight.delete(key));
   autocompleteInflight.set(key, promise);
   return promise;
@@ -222,6 +229,7 @@ module.exports = {
   getPlaceDetails,
   buildPlaceUrl,
   PLACE_ID_SENTINEL_PREFIX,
+  PLACE_ID_SHAPE_RE,
   encodePlaceIdSentinel,
   decodePlaceIdSentinel,
   // Test-only reset hook. Exported unconditionally — a NODE_ENV gate

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -91,6 +91,13 @@ const autocompleteInflight = new Map();
 // whitespace so "Whitehouse", "whitehouse", and " White House "
 // share the same entry — Places Autocomplete is case-insensitive,
 // so the cache should be too.
+//
+// NOTE: the key has no per-sender / per-geo dimension, so a cache hit
+// returns whoever-primed-the-cache's geo-biased predictions. End
+// behavior is still correct (the picked place_id is canonical), but
+// the dropdown UX may briefly surprise a second sender in a different
+// region. Acceptable for autocomplete (the picked destination is
+// always pinned); revisit if telemetry shows user confusion.
 function cacheKey(query) {
   return query.toLowerCase().replace(/\s+/g, ' ').trim();
 }

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -18,13 +18,19 @@ function encodePlaceIdSentinel(placeId) {
   return `${PLACE_ID_SENTINEL_PREFIX}${placeId}`;
 }
 
+// Documented place_id char class: ASCII alphanumeric + `_-`. Length is
+// not officially capped, but real place_ids are ~27 chars and have
+// never been observed <16. Require >=16 + the char class so a user
+// who types `qurl_place:foo` as free text falls through to the text
+// branch (and gets a "couldn't find X" message echoing their input)
+// rather than the misleading "place no longer available" branch.
+const PLACE_ID_SHAPE_RE = /^[A-Za-z0-9_-]{16,}$/;
+
 function decodePlaceIdSentinel(value) {
   if (typeof value !== 'string' || !value.startsWith(PLACE_ID_SENTINEL_PREFIX)) return null;
   const placeId = value.slice(PLACE_ID_SENTINEL_PREFIX.length);
-  // Reject `qurl_place:` with no id behind it: an empty-payload
-  // sentinel isn't a real selection and shouldn't be treated as one.
-  // Callers should null-check the return.
-  return placeId.length > 0 ? placeId : null;
+  if (!PLACE_ID_SHAPE_RE.test(placeId)) return null;
+  return placeId;
 }
 
 // Single timeout for every Places call. Both autocomplete (per

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -6,9 +6,12 @@ const PLACES_FINDPLACE_URL = 'https://maps.googleapis.com/maps/api/place/findpla
 const PLACES_DETAILS_URL = 'https://maps.googleapis.com/maps/api/place/details/json';
 
 // Wire literal that round-trips a chosen place_id through the Discord
-// slash-option `location:` value. Stable across deploys — any in-flight
-// confirm-card flow_state row carrying a placeId-sentinel in actualUrl
-// is keyed against this literal.
+// slash-option `location:` value (autocomplete encodes → submit decodes).
+// The vulnerable window is autocomplete-pick → slash-submit (seconds);
+// DDB flow_state rows always carry the resolved place_id-pinned URL,
+// not the sentinel. A rename still wants a coordinated deploy so an
+// already-rendered dropdown choice doesn't 404 the resolver, but it's
+// not a multi-minute drain.
 const PLACE_ID_SENTINEL_PREFIX = 'qurl_place:';
 
 function encodePlaceIdSentinel(placeId) {
@@ -111,7 +114,10 @@ function cacheSet(key, results) {
 
 async function searchPlaces(query) {
   if (!config.GOOGLE_MAPS_API_KEY) {
-    logger.warn('GOOGLE_MAPS_API_KEY not set, skipping places autocomplete');
+    // Debug, not warn: fires per keystroke on a misconfigured deploy.
+    // The send-time path surfaces RESOLVE_REASON.NO_API_KEY as a single
+    // visible ephemeral, which is the load-bearing operator signal.
+    logger.debug('GOOGLE_MAPS_API_KEY not set, skipping places autocomplete');
     return [];
   }
   const safeQuery = sanitizeQueryParam(query);

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -5,22 +5,27 @@ const PLACES_AUTOCOMPLETE_URL = 'https://maps.googleapis.com/maps/api/place/auto
 const PLACES_FINDPLACE_URL = 'https://maps.googleapis.com/maps/api/place/findplacefromtext/json';
 const PLACES_DETAILS_URL = 'https://maps.googleapis.com/maps/api/place/details/json';
 
-// Wire literal used to round-trip a chosen place_id through the Discord
-// slash-option `location:` value. The autocomplete handler encodes
-// selected places as `<prefix><place_id>`; parseLocationInput recognizes
-// this prefix on submit and routes to a Places Details lookup so all
-// recipients see the same canonical place. Without this round-trip the
-// /maps/search/<text> URL we synthesize is per-viewer geo-biased (the
-// bug #322-followup is fixing). Keep this string stable across deploys —
-// any in-flight confirm-card flow_state row carrying a placeId-sentinel
-// in actualUrl is keyed against this literal.
+// Wire literal that round-trips a chosen place_id through the Discord
+// slash-option `location:` value. Stable across deploys — any in-flight
+// confirm-card flow_state row carrying a placeId-sentinel in actualUrl
+// is keyed against this literal.
 const PLACE_ID_SENTINEL_PREFIX = 'qurl_place:';
 
-// Strip ASCII control chars from user-supplied input before it goes
-// into the request URL. Google's own limit is generous but a 500-char
-// cap bounds request size + log line length, and the control-char
-// strip prevents header-injection-style payloads from smuggling
-// newlines or NULs into the outgoing request URL.
+function encodePlaceIdSentinel(placeId) {
+  return `${PLACE_ID_SENTINEL_PREFIX}${placeId}`;
+}
+
+function decodePlaceIdSentinel(value) {
+  if (typeof value !== 'string' || !value.startsWith(PLACE_ID_SENTINEL_PREFIX)) return null;
+  return value.slice(PLACE_ID_SENTINEL_PREFIX.length);
+}
+
+// Single timeout for every Places call. Both autocomplete (per
+// keystroke) and resolveLocation (slash submit) share Discord's 3 s
+// ACK window; 1500 ms is well above Places p99 for all three endpoints
+// while leaving budget for the rest of each handler.
+const PLACES_REQUEST_TIMEOUT_MS = 1500;
+
 function sanitizeQueryParam(value) {
   // eslint-disable-next-line no-control-regex
   return String(value || '').replace(/[\x00-\x1f\x7f]/g, '').slice(0, 500);
@@ -33,14 +38,14 @@ function sanitizeQueryParam(value) {
 // embedded inside strings. Any future error handler that touches
 // `response.url` or the full request needs to strip the `key` param
 // first.
-async function placesFetch(url, params, timeoutMs = 5000) {
+async function placesFetch(url, params) {
   const qs = new URLSearchParams({ ...params, key: config.GOOGLE_MAPS_API_KEY });
-  const response = await fetch(`${url}?${qs}`, { signal: AbortSignal.timeout(timeoutMs) });
+  const response = await fetch(`${url}?${qs}`, { signal: AbortSignal.timeout(PLACES_REQUEST_TIMEOUT_MS) });
   if (!response.ok) {
     throw new Error(`Places API error: ${response.status}`);
   }
-  // The Places API occasionally returns an HTML error page during
-  // outages; .json() on that throws a SyntaxError with no context.
+  // Places occasionally returns an HTML error page during outages;
+  // .json() on that throws a SyntaxError with no context.
   let data;
   try {
     data = await response.json();
@@ -50,34 +55,61 @@ async function placesFetch(url, params, timeoutMs = 5000) {
   return data;
 }
 
+// Bounded TTL cache for autocomplete results. Discord fires
+// `searchPlaces` per keystroke, so a user typing "white house" issues
+// ~9 paid Places Autocomplete calls. A 60 s TTL collapses that to one
+// call per distinct prefix plus a few cache hits as they type. Cap
+// keeps memory bounded across many concurrent senders — when full,
+// drop the oldest entry (FIFO; Map preserves insertion order).
+const AUTOCOMPLETE_CACHE_TTL_MS = 60_000;
+const AUTOCOMPLETE_CACHE_MAX = 500;
+const autocompleteCache = new Map();
+
+function cacheGet(key) {
+  const entry = autocompleteCache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt < Date.now()) {
+    autocompleteCache.delete(key);
+    return null;
+  }
+  return entry.results;
+}
+
+function cacheSet(key, results) {
+  if (autocompleteCache.size >= AUTOCOMPLETE_CACHE_MAX) {
+    const oldest = autocompleteCache.keys().next().value;
+    if (oldest !== undefined) autocompleteCache.delete(oldest);
+  }
+  autocompleteCache.set(key, { results, expiresAt: Date.now() + AUTOCOMPLETE_CACHE_TTL_MS });
+}
+
 async function searchPlaces(query) {
   if (!config.GOOGLE_MAPS_API_KEY) {
     logger.warn('GOOGLE_MAPS_API_KEY not set, skipping places autocomplete');
     return [];
   }
+  const safeQuery = sanitizeQueryParam(query);
+  const cached = cacheGet(safeQuery);
+  if (cached) return cached;
   const data = await placesFetch(PLACES_AUTOCOMPLETE_URL, {
-    input: sanitizeQueryParam(query),
+    input: safeQuery,
     types: 'establishment|geocode',
   });
   if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
     throw new Error(`Places API status: ${data.status}`);
   }
-  return (data.predictions || []).map(p => ({
+  const results = (data.predictions || []).map(p => ({
     placeId: p.place_id,
     name: p.structured_formatting?.main_text || p.description,
     address: p.structured_formatting?.secondary_text || '',
   }));
+  cacheSet(safeQuery, results);
+  return results;
 }
 
-// Resolve free text to a single canonical place. Used by the /qurl map
-// server-side fallback when a sender ignores the autocomplete dropdown
-// and submits raw text — we resolve to a place_id-pinned URL at send
-// time so every recipient sees the same destination (vs. Google's
-// per-viewer search-bias on /maps/search/<text>).
-//
-// Returns `null` when Find Place returns zero candidates; the caller
-// surfaces this as an honest "no match" error to the sender.
-async function findPlaceFromText(query, { timeoutMs } = {}) {
+// Returns null when Find Place returns zero candidates; the caller
+// surfaces this as a "no match" error to the sender.
+async function findPlaceFromText(query) {
   if (!config.GOOGLE_MAPS_API_KEY) {
     throw new Error('GOOGLE_MAPS_API_KEY not set');
   }
@@ -85,7 +117,7 @@ async function findPlaceFromText(query, { timeoutMs } = {}) {
     input: sanitizeQueryParam(query),
     inputtype: 'textquery',
     fields: 'place_id,name,formatted_address',
-  }, timeoutMs);
+  });
   if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
     throw new Error(`Places API status: ${data.status}`);
   }
@@ -98,19 +130,14 @@ async function findPlaceFromText(query, { timeoutMs } = {}) {
   };
 }
 
-// Resolve a known place_id to its canonical name + address. Used when
-// the sender picks a suggestion from the autocomplete dropdown — the
-// dropdown value carries the place_id sentinel only (no name, kept
-// short to fit Discord's 100-char choice-value cap), so this call
-// hydrates the human-readable label for the recipient embed.
-async function getPlaceDetails(placeId, { timeoutMs } = {}) {
+async function getPlaceDetails(placeId) {
   if (!config.GOOGLE_MAPS_API_KEY) {
     throw new Error('GOOGLE_MAPS_API_KEY not set');
   }
   const data = await placesFetch(PLACES_DETAILS_URL, {
     place_id: sanitizeQueryParam(placeId),
     fields: 'place_id,name,formatted_address',
-  }, timeoutMs);
+  });
   if (data.status !== 'OK') {
     if (data.status === 'NOT_FOUND' || data.status === 'INVALID_REQUEST') return null;
     throw new Error(`Places API status: ${data.status}`);
@@ -124,14 +151,10 @@ async function getPlaceDetails(placeId, { timeoutMs } = {}) {
   };
 }
 
-// Build the canonical "show this exact place" Maps URL using Google's
-// documented `?api=1` form with `query_place_id` pinning the result to
-// a specific place. This bypasses the per-viewer geo bias that affects
-// /maps/search/<text> URLs — the place_id parameter is the contract
-// that makes every recipient open the same destination.
-//
 // Per Google's URL spec the `query` param is required even when
 // `query_place_id` is set; we pass the canonical place name there.
+// query_place_id pins the result so every recipient opens the same
+// destination regardless of viewer geo.
 function buildPlaceUrl(placeName, placeId) {
   const url = new URL('https://www.google.com/maps/search/');
   url.searchParams.set('api', '1');
@@ -146,4 +169,11 @@ module.exports = {
   getPlaceDetails,
   buildPlaceUrl,
   PLACE_ID_SENTINEL_PREFIX,
+  encodePlaceIdSentinel,
+  decodePlaceIdSentinel,
+  // Test-only: clear the cache between tests so a leftover entry from
+  // one test can't satisfy a fetch expectation in the next.
+  ...(process.env.NODE_ENV !== 'production' && {
+    _resetAutocompleteCache: () => autocompleteCache.clear(),
+  }),
 };

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -18,11 +18,9 @@ function encodePlaceIdSentinel(placeId) {
 function decodePlaceIdSentinel(value) {
   if (typeof value !== 'string' || !value.startsWith(PLACE_ID_SENTINEL_PREFIX)) return null;
   const placeId = value.slice(PLACE_ID_SENTINEL_PREFIX.length);
-  // Reject an empty payload: `qurl_place:` with no id behind it would
-  // round-trip as a falsy string, and `parseLocationInput`'s
-  // `if (decodedPlaceId)` check would silently fall through to the
-  // URL/text branches — a sentinel that decoded to "nothing" should
-  // surface as "no match" instead.
+  // Reject `qurl_place:` with no id behind it: an empty-payload
+  // sentinel isn't a real selection and shouldn't be treated as one.
+  // Callers should null-check the return.
   return placeId.length > 0 ? placeId : null;
 }
 

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -89,6 +89,9 @@ function cacheGet(key) {
     autocompleteCache.delete(key);
     return null;
   }
+  // Note: TTL is from initial insert — a hot entry still expires at
+  // exactly 60 s. Intentional for autocomplete (refresh-after-60s lets
+  // upstream-changed places propagate), not a window-extending LRU.
   // Defensive copy on read so a caller's mutation can't poison the
   // next hit. Paired with the copy-on-write in cacheSet — together
   // they isolate the cached array from both writer and reader.
@@ -209,12 +212,13 @@ module.exports = {
   PLACE_ID_SENTINEL_PREFIX,
   encodePlaceIdSentinel,
   decodePlaceIdSentinel,
-  // Test-only: clear the cache + in-flight map between tests so leftover
-  // state from one test can't satisfy a fetch expectation in the next.
-  ...(process.env.NODE_ENV !== 'production' && {
-    _resetAutocompleteCache: () => {
-      autocompleteCache.clear();
-      autocompleteInflight.clear();
-    },
-  }),
+  // Test-only reset hook. Exported unconditionally — a NODE_ENV gate
+  // would silently ship to any container without NODE_ENV=production
+  // set (common default-empty case). Calling it in production is a
+  // harmless no-op (cache rebuilds in ≤60s); the underscore-prefixed
+  // name signals it's not part of the public API.
+  _resetAutocompleteCache: () => {
+    autocompleteCache.clear();
+    autocompleteInflight.clear();
+  },
 };

--- a/apps/discord/src/places.js
+++ b/apps/discord/src/places.js
@@ -193,11 +193,27 @@ async function getPlaceDetails(placeId) {
     throw new Error('GOOGLE_MAPS_API_KEY not set');
   }
   const data = await placesFetch(PLACES_DETAILS_URL, {
+    // sanitizeQueryParam is a no-op when called from resolveLocation
+    // (the placeId already passed PLACE_ID_SHAPE_RE at decode time),
+    // but kept as defense-in-depth for any future caller that
+    // bypasses decode.
     place_id: sanitizeQueryParam(placeId),
     fields: 'place_id,name,formatted_address',
   });
   if (data.status !== 'OK') {
-    if (data.status === 'NOT_FOUND' || data.status === 'INVALID_REQUEST') return null;
+    if (data.status === 'NOT_FOUND') return null;
+    if (data.status === 'INVALID_REQUEST') {
+      // For a shape-validated sentinel place_id, INVALID_REQUEST
+      // signals key/scope misconfig or upstream-shape drift — NOT
+      // "deleted upstream." Surface so a misconfigured deploy doesn't
+      // hide behind the recipient-facing "place no longer available"
+      // message. (The caller still maps this to NOT_FOUND so the
+      // sender sees a graceful failure.)
+      logger.warn('getPlaceDetails: INVALID_REQUEST for shape-validated place_id (check API key scopes)', {
+        place_id: placeId,
+      });
+      return null;
+    }
     throw new Error(`Places API status: ${data.status}`);
   }
   const r = data.result;

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -228,6 +228,12 @@ jest.mock('../src/places', () => ({
   getPlaceDetails: jest.fn().mockResolvedValue(null),
   buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
+  decodePlaceIdSentinel: (value) => (
+    typeof value === 'string' && value.startsWith('qurl_place:')
+      ? value.slice('qurl_place:'.length)
+      : null
+  ),
 }));
 
 // flow-state is the DDB-backed harness consumed by /qurl revoke

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -224,6 +224,10 @@ jest.mock('../src/qurl', () => ({
 
 jest.mock('../src/places', () => ({
   searchPlaces: jest.fn().mockResolvedValue([]),
+  findPlaceFromText: jest.fn().mockResolvedValue(null),
+  getPlaceDetails: jest.fn().mockResolvedValue(null),
+  buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
+  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
 }));
 
 // flow-state is the DDB-backed harness consumed by /qurl revoke
@@ -2198,26 +2202,29 @@ describe('handleSetupModal (dispatcher path)', () => {
 });
 
 describe('handleCommand — autocomplete', () => {
-  it('returns early for unhandled autocomplete focus (e.g. location)', async () => {
+  it('responds empty for short focused-location values (below min-length)', async () => {
+    // /qurl map's location: option is now autocomplete-enabled.
+    // handleCommand routes the interaction to handleAutocomplete,
+    // which gates on a minimum partial-input length (2 chars). 'Eif'
+    // exceeds the gate, so Places gets called — but since the test
+    // mocks searchPlaces to return [], the dropdown stays empty.
+    // The contract here is that respond() IS called (with []), where
+    // previously it was a silent drop.
     const interaction = makeInteraction({
       commandName: 'qurl',
       isAutocomplete: jest.fn(() => true),
       isChatInputCommand: jest.fn(() => false),
       options: {
         ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'map'),
         getFocused: jest.fn(() => ({ name: 'location', value: 'Eif' })),
       },
     });
 
     await handleCommand(interaction);
 
-    expect(interaction.respond).not.toHaveBeenCalled();
+    expect(interaction.respond).toHaveBeenCalledWith([]);
   });
-
-  // The `target` slash option was removed in the button-driven redesign;
-  // /qurl no longer surfaces any autocomplete. The remaining test above
-  // pins the contract that any autocomplete interaction (legacy client,
-  // stale registration) is short-circuited without dispatch.
 });
 
 // `revokeAllLinks` coverage lives in send-pipeline-back-half.test.js
@@ -2227,20 +2234,24 @@ describe('handleCommand — autocomplete', () => {
 // connector and qurl tests that require resetModules are in send-pipeline-helpers.test.js
 
 describe('autocomplete handling', () => {
-  it('returns early for all autocomplete interactions', async () => {
+  it('routes autocomplete to handleAutocomplete (responds with empty for non-/qurl/map/location focuses)', async () => {
+    // Contract change: handleCommand now dispatches autocomplete to
+    // handleAutocomplete instead of dropping it. For a /qurl autocomplete
+    // whose subcommand isn't 'map', the handler responds with [] (clears
+    // the dropdown) rather than silently dropping the interaction.
     const interaction = makeInteraction({
       commandName: 'qurl',
       isAutocomplete: jest.fn(() => true),
       isChatInputCommand: jest.fn(() => false),
       options: {
         ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'help'),
         getFocused: jest.fn(() => ({ name: 'location', value: 'test query' })),
       },
       user: { id: 'autocomplete-user', username: 'TestUser' },
     });
     await handleCommand(interaction);
 
-    // Autocomplete handler was removed; handleCommand returns early
-    expect(interaction.respond).not.toHaveBeenCalled();
+    expect(interaction.respond).toHaveBeenCalledWith([]);
   });
 });

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -222,20 +222,9 @@ jest.mock('../src/qurl', () => ({
   getResourceStatus: mockGetResourceStatus,
 }));
 
-jest.mock('../src/places', () => ({
-  searchPlaces: jest.fn().mockResolvedValue([]),
-  findPlaceFromText: jest.fn().mockResolvedValue(null),
-  getPlaceDetails: jest.fn().mockResolvedValue(null),
-  buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
-  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
-  PLACE_ID_SHAPE_RE: /^[A-Za-z0-9_-]{16,}$/,
-  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
-  decodePlaceIdSentinel: (value) => {
-    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
-    const placeId = value.slice('qurl_place:'.length);
-    return /^[A-Za-z0-9_-]{16,}$/.test(placeId) ? placeId : null;
-  },
-}));
+// Shared places-mock — see tests/helpers/places-mock.js.
+const { mockPlacesModule } = require('./helpers/places-mock');
+jest.mock('../src/places', () => mockPlacesModule);
 
 // flow-state is the DDB-backed harness consumed by /qurl revoke
 // post-conversion (PR 5). Mock it here rather than hit DDB.

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -228,6 +228,7 @@ jest.mock('../src/places', () => ({
   getPlaceDetails: jest.fn().mockResolvedValue(null),
   buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  PLACE_ID_SHAPE_RE: /^[A-Za-z0-9_-]{16,}$/,
   encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
   decodePlaceIdSentinel: (value) => {
     if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -229,11 +229,11 @@ jest.mock('../src/places', () => ({
   buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
   encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
-  decodePlaceIdSentinel: (value) => (
-    typeof value === 'string' && value.startsWith('qurl_place:')
-      ? value.slice('qurl_place:'.length)
-      : null
-  ),
+  decodePlaceIdSentinel: (value) => {
+    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
+    const placeId = value.slice('qurl_place:'.length);
+    return /^[A-Za-z0-9_-]{16,}$/.test(placeId) ? placeId : null;
+  },
 }));
 
 // flow-state is the DDB-backed harness consumed by /qurl revoke

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -329,16 +329,26 @@ describe('/bulklink — error paths', () => {
 });
 
 describe('handleCommand — autocomplete edge cases', () => {
-  it('returns early for all autocomplete interactions without responding', async () => {
+  it('routes autocomplete to the /qurl map location handler (which gates on /qurl + map + location)', async () => {
+    // Contract changed in the qurl-map-autocomplete rollout: handleCommand
+    // now routes autocomplete interactions to handleAutocomplete instead
+    // of dropping them. The handler responds with [] for non-location
+    // focused options — see handleAutocomplete in src/commands.js. This
+    // smoke pins the routing: with a non-map subcommand the response is
+    // still []  (so the picker UI doesn't render stale data), but the
+    // respond() call DOES fire.
     const interaction = makeInteraction({
       commandName: 'qurl',
       isAutocomplete: jest.fn(() => true),
       isChatInputCommand: jest.fn(() => false),
-      options: { ...makeInteraction().options, getFocused: jest.fn(() => ({ name: 'location', value: 'query' })) },
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'file'),
+        getFocused: jest.fn(() => ({ name: 'location', value: 'query' })),
+      },
     });
     await handleCommand(interaction);
-    // Autocomplete handler was removed; returns early
-    expect(interaction.respond).not.toHaveBeenCalled();
+    expect(interaction.respond).toHaveBeenCalledWith([]);
   });
 });
 

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -223,11 +223,11 @@ jest.mock('../src/places', () => ({
   buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
   encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
-  decodePlaceIdSentinel: (value) => (
-    typeof value === 'string' && value.startsWith('qurl_place:')
-      ? value.slice('qurl_place:'.length)
-      : null
-  ),
+  decodePlaceIdSentinel: (value) => {
+    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
+    const placeId = value.slice('qurl_place:'.length);
+    return /^[A-Za-z0-9_-]{16,}$/.test(placeId) ? placeId : null;
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -216,20 +216,9 @@ jest.mock('../src/qurl', () => ({
   getResourceStatus: mockGetResourceStatus,
 }));
 
-jest.mock('../src/places', () => ({
-  searchPlaces: jest.fn().mockResolvedValue([]),
-  findPlaceFromText: jest.fn().mockResolvedValue(null),
-  getPlaceDetails: jest.fn().mockResolvedValue(null),
-  buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
-  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
-  PLACE_ID_SHAPE_RE: /^[A-Za-z0-9_-]{16,}$/,
-  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
-  decodePlaceIdSentinel: (value) => {
-    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
-    const placeId = value.slice('qurl_place:'.length);
-    return /^[A-Za-z0-9_-]{16,}$/.test(placeId) ? placeId : null;
-  },
-}));
+// Shared places-mock — see tests/helpers/places-mock.js.
+const { mockPlacesModule } = require('./helpers/places-mock');
+jest.mock('../src/places', () => mockPlacesModule);
 
 // ---------------------------------------------------------------------------
 // Require modules under test

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -222,6 +222,7 @@ jest.mock('../src/places', () => ({
   getPlaceDetails: jest.fn().mockResolvedValue(null),
   buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  PLACE_ID_SHAPE_RE: /^[A-Za-z0-9_-]{16,}$/,
   encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
   decodePlaceIdSentinel: (value) => {
     if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -218,6 +218,16 @@ jest.mock('../src/qurl', () => ({
 
 jest.mock('../src/places', () => ({
   searchPlaces: jest.fn().mockResolvedValue([]),
+  findPlaceFromText: jest.fn().mockResolvedValue(null),
+  getPlaceDetails: jest.fn().mockResolvedValue(null),
+  buildPlaceUrl: (name, placeId) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name || placeId)}&query_place_id=${encodeURIComponent(placeId)}`,
+  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
+  decodePlaceIdSentinel: (value) => (
+    typeof value === 'string' && value.startsWith('qurl_place:')
+      ? value.slice('qurl_place:'.length)
+      : null
+  ),
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/discord/tests/helpers/places-mock.js
+++ b/apps/discord/tests/helpers/places-mock.js
@@ -1,0 +1,69 @@
+/**
+ * Shared jest.mock factory for `../src/places`.
+ *
+ * The real places module's behavior (cache, single-flight, Places I/O)
+ * is exercised directly in `tests/places.test.js`. Every other test
+ * file mocks it, but the mock contract has crept up over time —
+ * encode/decode, shape regex, buildPlaceUrl — and the duplicate
+ * implementations across `commands-comprehensive.test.js`,
+ * `coverage-boost.test.js`, and `qurl-file-map.test.js` were a real
+ * drift risk (one file's regex tightens, the other two silently
+ * accept the looser shape).
+ *
+ * Centralizing here. Tests that need to assert against the mock's
+ * call history use the `mockSearchPlaces` / etc. spies from the
+ * caller-side wiring; the production-equivalent helpers
+ * (encode/decode/buildPlaceUrl/shape regex) live here as a single
+ * source of truth.
+ *
+ * Usage:
+ *   const {
+ *     mockPlacesModule,
+ *     mockSearchPlaces,
+ *     mockFindPlaceFromText,
+ *     mockGetPlaceDetails,
+ *   } = require('./helpers/places-mock');
+ *   jest.mock('../src/places', () => mockPlacesModule);
+ *
+ * The `mock`-prefixed export name matters: jest's babel transform
+ * hoists jest.mock() to the top of the file, and only `mock*`-named
+ * closure variables are exempt from its top-level-reference check.
+ */
+
+// Mirror production: PLACE_ID_SHAPE_RE in src/places.js. A drift here
+// means tests would smuggle a bad place_id past the mock decode while
+// production rejects it — change in lockstep with the prod regex.
+const PLACE_ID_SHAPE_RE = /^[A-Za-z0-9_-]{16,}$/;
+
+const mockSearchPlaces = jest.fn().mockResolvedValue([]);
+const mockFindPlaceFromText = jest.fn().mockResolvedValue(null);
+const mockGetPlaceDetails = jest.fn().mockResolvedValue(null);
+
+const mockPlacesModule = {
+  searchPlaces: (...a) => mockSearchPlaces(...a),
+  findPlaceFromText: (...a) => mockFindPlaceFromText(...a),
+  getPlaceDetails: (...a) => mockGetPlaceDetails(...a),
+  buildPlaceUrl: (name, placeId) => {
+    const url = new URL('https://www.google.com/maps/search/');
+    url.searchParams.set('api', '1');
+    url.searchParams.set('query', name || placeId);
+    url.searchParams.set('query_place_id', placeId);
+    return url.toString();
+  },
+  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  PLACE_ID_SHAPE_RE,
+  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
+  decodePlaceIdSentinel: (value) => {
+    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
+    const placeId = value.slice('qurl_place:'.length);
+    return PLACE_ID_SHAPE_RE.test(placeId) ? placeId : null;
+  },
+};
+
+module.exports = {
+  mockPlacesModule,
+  mockSearchPlaces,
+  mockFindPlaceFromText,
+  mockGetPlaceDetails,
+  PLACE_ID_SHAPE_RE,
+};

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -327,7 +327,6 @@ describe('searchPlaces', () => {
     // We fetch (CAP) distinct queries to fill the cache, then one more
     // distinct query to trigger eviction of the oldest, then re-query
     // the oldest and verify it re-fetches.
-    const places = require('../src/places');
     places._resetAutocompleteCache();
     // Mock 502 distinct fetches with unique payloads so each goes
     // through the API. CAP=500 + 1 overflow + 1 re-query = 502.

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -268,6 +268,42 @@ describe('searchPlaces', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test('FIFO eviction at AUTOCOMPLETE_CACHE_MAX — oldest entry drops when cap is hit', async () => {
+    // Don't pin the constant value here (avoid coupling to the
+    // implementation detail), but pin the BEHAVIOR: when the cache is
+    // saturated, the next miss-and-fetch evicts the oldest entry.
+    // Test it by saturating, then re-querying the oldest key — that
+    // re-query should miss and fetch again (proving it was evicted).
+    //
+    // We fetch (CAP) distinct queries to fill the cache, then one more
+    // distinct query to trigger eviction of the oldest, then re-query
+    // the oldest and verify it re-fetches.
+    const places = require('../src/places');
+    places._resetAutocompleteCache();
+    // Mock 502 distinct fetches with unique payloads so each goes
+    // through the API. CAP=500 + 1 overflow + 1 re-query = 502.
+    const CAP = 500;
+    for (let i = 0; i <= CAP + 1; i++) {
+      fetchMock.mockResolvedValueOnce(jsonResponse({
+        status: 'OK',
+        predictions: [{ place_id: `ChIJ${i}`, description: `Place ${i}` }],
+      }));
+    }
+    // Fill the cache.
+    for (let i = 0; i < CAP; i++) {
+      await searchPlaces(`q${i}`);
+    }
+    // One more query — triggers FIFO eviction of "q0" (oldest insert).
+    await searchPlaces('overflow');
+    expect(fetchMock).toHaveBeenCalledTimes(CAP + 1);
+    // Re-query the oldest — if it was evicted, this hits the API again.
+    await searchPlaces('q0');
+    expect(fetchMock).toHaveBeenCalledTimes(CAP + 2);
+    // Re-query a still-resident middle entry — should be cached, no fetch.
+    await searchPlaces(`q${Math.floor(CAP / 2)}`);
+    expect(fetchMock).toHaveBeenCalledTimes(CAP + 2);
+  });
+
   test('cached results are defensive-copied (caller mutation does not poison the cache)', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({
       status: 'OK',

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -92,6 +92,14 @@ describe('encodePlaceIdSentinel / decodePlaceIdSentinel', () => {
     expect(decodePlaceIdSentinel(undefined)).toBeNull();
     expect(decodePlaceIdSentinel(42)).toBeNull();
   });
+
+  test('decode rejects an empty payload ("qurl_place:" with no id)', () => {
+    // Defensive: an empty-payload sentinel decodes to '' (falsy), which
+    // would let parseLocationInput's `if (decodedPlaceId)` silently fall
+    // through to the URL/text branches. Reject explicitly so the
+    // failure surfaces as "no match" instead.
+    expect(decodePlaceIdSentinel('qurl_place:')).toBeNull();
+  });
 });
 
 describe('buildPlaceUrl', () => {
@@ -201,6 +209,44 @@ describe('searchPlaces', () => {
     const a = await searchPlaces('white');
     const b = await searchPlaces('white');
     expect(a).toEqual(b);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache key is case-insensitive + whitespace-normalized', async () => {
+    // Case-only variants of the same query (and surrounding/extra
+    // whitespace) hit the same cache entry because Places Autocomplete
+    // itself is case-insensitive — without the normalization the
+    // autocomplete cache misses for what's effectively one user query.
+    // (Note: "White House" with a space and "Whitehouse" compound are
+    // genuinely different queries to Places and stay distinct.)
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      predictions: [{ place_id: 'ChIJ1', description: 'White House' }],
+    }));
+    await searchPlaces('White House');
+    await searchPlaces('white house');
+    await searchPlaces('  WHITE HOUSE  ');
+    await searchPlaces('white  house'); // extra interior whitespace collapses
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('in-flight requests for the same key are deduped (single-flight)', async () => {
+    // Fast typists can fire multiple keystrokes for the same prefix
+    // before the first response settles — without dedup we'd pay
+    // Places per concurrent call. The second concurrent call must
+    // return the same promise as the first.
+    let resolveBody;
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => {
+      resolveBody = () => resolve(jsonResponse({
+        status: 'OK',
+        predictions: [{ place_id: 'ChIJ1', description: 'White House' }],
+      }));
+    }));
+    const a = searchPlaces('white');
+    const b = searchPlaces('white');
+    resolveBody();
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(ra).toEqual(rb);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -65,18 +65,21 @@ function jsonResponse(body, { status = 200, ok = true } = {}) {
 
 describe('PLACE_ID_SENTINEL_PREFIX', () => {
   test('is the wire literal "qurl_place:" (DO NOT change without a coordinated deploy)', () => {
-    // Pinned because in-flight confirm-card flow_state rows carry this
-    // prefix in actualUrl. A rename would orphan every open send while
-    // the prior deploy's rows drain.
+    // The vulnerable window is autocomplete-pick → slash-submit
+    // (seconds): a previously-rendered dropdown choice would resolve
+    // to NOT_FOUND if the new deploy renamed the literal. DDB rows
+    // always carry the resolved place_id-pinned URL, not the sentinel,
+    // so they're unaffected.
     expect(PLACE_ID_SENTINEL_PREFIX).toBe('qurl_place:');
   });
 });
 
 describe('encodePlaceIdSentinel / decodePlaceIdSentinel', () => {
   test('encode then decode round-trips the placeId', () => {
-    const encoded = encodePlaceIdSentinel('ChIJabc');
-    expect(encoded).toBe('qurl_place:ChIJabc');
-    expect(decodePlaceIdSentinel(encoded)).toBe('ChIJabc');
+    const realisticId = 'ChIJ37FjGE63t4kRD2_jXSF1F9o';
+    const encoded = encodePlaceIdSentinel(realisticId);
+    expect(encoded).toBe(`qurl_place:${realisticId}`);
+    expect(decodePlaceIdSentinel(encoded)).toBe(realisticId);
   });
 
   test('decode returns null for non-sentinel strings', () => {
@@ -99,6 +102,23 @@ describe('encodePlaceIdSentinel / decodePlaceIdSentinel', () => {
     // through to the URL/text branches. Reject explicitly so the
     // failure surfaces as "no match" instead.
     expect(decodePlaceIdSentinel('qurl_place:')).toBeNull();
+  });
+
+  test('decode rejects a payload that does not match the place_id shape', () => {
+    // Defends against a user typing `qurl_place:something` as free
+    // text — the sentinel branch would otherwise misroute them to
+    // the "place no longer available" message (which presumes they
+    // picked from the dropdown). Place IDs are documented as ASCII
+    // alphanumeric + `_-`, typically 27+ chars; the >=16 floor
+    // excludes typos while still accepting real Google IDs.
+    expect(decodePlaceIdSentinel('qurl_place:foo')).toBeNull();
+    expect(decodePlaceIdSentinel('qurl_place:has space123456')).toBeNull(); // space not allowed
+    expect(decodePlaceIdSentinel('qurl_place:has!bang12345678')).toBeNull(); // `!` not allowed
+    expect(decodePlaceIdSentinel('qurl_place:abcdefghijklmno')).toBeNull(); // 15 chars, one short
+    // 16 chars + char class — passes.
+    expect(decodePlaceIdSentinel('qurl_place:abcdefghijklmnop')).toBe('abcdefghijklmnop');
+    // Realistic place_id — passes.
+    expect(decodePlaceIdSentinel('qurl_place:ChIJ37FjGE63t4kRD2_jXSF1F9o')).toBe('ChIJ37FjGE63t4kRD2_jXSF1F9o');
   });
 });
 

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -288,6 +288,35 @@ describe('searchPlaces', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test('cache hit after TTL expiry re-fetches the API (60 s freshness window)', async () => {
+    // The cache TTL is from initial insert (intentional refresh-after-
+    // 60s for upstream-changed places). Pin the contract: a cache hit
+    // BEFORE expiry skips the API; the same key AFTER expiry refetches.
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        status: 'OK',
+        predictions: [{ place_id: 'ChIJ1', description: 'Place v1' }],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        status: 'OK',
+        predictions: [{ place_id: 'ChIJ1', description: 'Place v2 (refreshed)' }],
+      }));
+    const first = await searchPlaces('eiffel');
+    expect(first[0].name).toBe('Place v1');
+    // Still within TTL — second call is a cache hit, no fetch.
+    jest.advanceTimersByTime(59_000);
+    const second = await searchPlaces('eiffel');
+    expect(second[0].name).toBe('Place v1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Past TTL — entry expired, refetch fires.
+    jest.advanceTimersByTime(2_000);
+    const third = await searchPlaces('eiffel');
+    expect(third[0].name).toBe('Place v2 (refreshed)');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
   test('FIFO eviction at AUTOCOMPLETE_CACHE_MAX — oldest entry drops when cap is hit', async () => {
     // Don't pin the constant value here (avoid coupling to the
     // implementation detail), but pin the BEHAVIOR: when the cache is

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -250,6 +250,39 @@ describe('searchPlaces', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  test('in-flight map cleans up after a rejected request (next call hits the API)', async () => {
+    // Without `.finally(autocompleteInflight.delete)`, a rejected
+    // in-flight promise would stick around as a permanently-rejecting
+    // entry — subsequent calls for the same key would re-await the
+    // same rejection and never retry. Pin the cleanup contract.
+    fetchMock.mockRejectedValueOnce(new Error('transient network failure'));
+    await expect(searchPlaces('eiffel')).rejects.toThrow(/transient/);
+    // Second call must hit fetch again (in-flight slot was freed) and
+    // can succeed independently.
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      predictions: [{ place_id: 'ChIJ1', description: 'Eiffel Tower' }],
+    }));
+    const r = await searchPlaces('eiffel');
+    expect(r).toEqual([{ placeId: 'ChIJ1', name: 'Eiffel Tower', address: '' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('cached results are defensive-copied (caller mutation does not poison the cache)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      predictions: [{ place_id: 'ChIJ1', description: 'White House' }],
+    }));
+    const first = await searchPlaces('white');
+    // A future caller could sort/splice the returned array (e.g.
+    // ranking suggestions). Mutating must NOT bleed into the next hit.
+    first.push({ placeId: 'POISON', name: 'X', address: '' });
+    first.length = 0;
+    const second = await searchPlaces('white');
+    expect(second).toEqual([{ placeId: 'ChIJ1', name: 'White House', address: '' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test('strips ASCII control chars + caps at 500 chars before reaching the request URL', async () => {
     // Header-injection defense: a NUL or newline in the query MUST NOT
     // ride into the outgoing URL. (Modern fetch wouldn't allow it
@@ -297,6 +330,18 @@ describe('findPlaceFromText', () => {
 
   test('returns null when status is OK but candidates is empty', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OK', candidates: [] }));
+    const r = await findPlaceFromText('zzzz');
+    expect(r).toBeNull();
+  });
+
+  test('returns null when the top candidate has no place_id (malformed response)', async () => {
+    // Defensive: a candidate without a place_id can't be pinned to a
+    // URL downstream — buildPlaceUrl would emit `query_place_id=`
+    // which Google renders as a broken search. Surface as not_found.
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      candidates: [{ name: 'Place without an id', formatted_address: '...' }],
+    }));
     const r = await findPlaceFromText('zzzz');
     expect(r).toBeNull();
   });
@@ -372,5 +417,17 @@ describe('getPlaceDetails', () => {
     }));
     const r = await getPlaceDetails('ChIJabc');
     expect(r.placeId).toBe('ChIJabc');
+  });
+
+  test('returns null when both the response and caller place_id are empty', async () => {
+    // Edge case: no place_id available anywhere. buildPlaceUrl
+    // downstream would emit `query_place_id=` which Google renders
+    // as a broken search — surface as not_found instead.
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      result: { name: 'X', formatted_address: 'Y' },
+    }));
+    const r = await getPlaceDetails('');
+    expect(r).toBeNull();
   });
 });

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -480,10 +480,32 @@ describe('getPlaceDetails', () => {
     expect(r).toBeNull();
   });
 
-  test('returns null on INVALID_REQUEST (malformed place_id)', async () => {
+  test('returns null on INVALID_REQUEST AND warns (likely API-key/scope misconfig, not deleted-upstream)', async () => {
+    // Sentinel place_ids are shape-validated at decode time; if Places
+    // returns INVALID_REQUEST anyway, that signals misconfig or
+    // upstream-shape drift. Warn so a broken deploy doesn't hide
+    // behind the recipient-facing "place no longer available" message.
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
     fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'INVALID_REQUEST' }));
-    const r = await getPlaceDetails('not-a-real-id');
+    const r = await getPlaceDetails('ChIJxxxxxxxxxxxxxxxx');
     expect(r).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('INVALID_REQUEST'),
+      expect.objectContaining({ place_id: 'ChIJxxxxxxxxxxxxxxxx' }),
+    );
+  });
+
+  test('returns null on NOT_FOUND WITHOUT warning (place legitimately deleted upstream)', async () => {
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'NOT_FOUND' }));
+    const r = await getPlaceDetails('ChIJxxxxxxxxxxxxxxxx');
+    expect(r).toBeNull();
+    // NOT_FOUND is the normal "place deleted" path — no operator
+    // signal needed; the recipient-facing "no longer available"
+    // message is the right surface.
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   test('throws on a non-OK Places status that is not a recognized null-case (OVER_QUERY_LIMIT)', async () => {

--- a/apps/discord/tests/places.test.js
+++ b/apps/discord/tests/places.test.js
@@ -1,0 +1,330 @@
+/**
+ * Direct unit tests for src/places.js.
+ *
+ * Every other test file in the suite mocks ../src/places — so the real
+ * functions in this module have NO coverage from those callers. This
+ * file pins the contract directly:
+ *
+ *   - searchPlaces:           autocomplete dropdown source
+ *   - findPlaceFromText:      free-text → top-match resolver (used by
+ *                             resolveLocation when the sender ignores
+ *                             the autocomplete dropdown)
+ *   - getPlaceDetails:        place_id → canonical name/address (used
+ *                             when the sender PICKS from the dropdown)
+ *   - buildPlaceUrl:          construct the canonical place_id-pinned
+ *                             Maps URL recipients open
+ *   - PLACE_ID_SENTINEL_PREFIX: wire literal stability
+ *
+ * Network is mocked at the global.fetch boundary — these are unit
+ * tests, not contract tests against the live Google Places API.
+ */
+
+jest.mock('../src/config', () => ({
+  GOOGLE_MAPS_API_KEY: 'test-google-key',
+}));
+jest.mock('../src/logger', () => ({
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), audit: jest.fn(),
+}));
+
+const config = require('../src/config');
+const places = require('../src/places');
+const {
+  searchPlaces,
+  findPlaceFromText,
+  getPlaceDetails,
+  buildPlaceUrl,
+  PLACE_ID_SENTINEL_PREFIX,
+  encodePlaceIdSentinel,
+  decodePlaceIdSentinel,
+} = places;
+
+const originalFetch = global.fetch;
+let fetchMock;
+
+beforeEach(() => {
+  fetchMock = jest.fn();
+  global.fetch = fetchMock;
+  // Re-seed the API key default (the no-key test deletes it).
+  config.GOOGLE_MAPS_API_KEY = 'test-google-key';
+  // Clear the autocomplete cache so a hit from a prior test can't
+  // satisfy a fetchMock expectation in this one.
+  places._resetAutocompleteCache();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+function jsonResponse(body, { status = 200, ok = true } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+describe('PLACE_ID_SENTINEL_PREFIX', () => {
+  test('is the wire literal "qurl_place:" (DO NOT change without a coordinated deploy)', () => {
+    // Pinned because in-flight confirm-card flow_state rows carry this
+    // prefix in actualUrl. A rename would orphan every open send while
+    // the prior deploy's rows drain.
+    expect(PLACE_ID_SENTINEL_PREFIX).toBe('qurl_place:');
+  });
+});
+
+describe('encodePlaceIdSentinel / decodePlaceIdSentinel', () => {
+  test('encode then decode round-trips the placeId', () => {
+    const encoded = encodePlaceIdSentinel('ChIJabc');
+    expect(encoded).toBe('qurl_place:ChIJabc');
+    expect(decodePlaceIdSentinel(encoded)).toBe('ChIJabc');
+  });
+
+  test('decode returns null for non-sentinel strings', () => {
+    expect(decodePlaceIdSentinel('Eiffel Tower')).toBeNull();
+    expect(decodePlaceIdSentinel('https://goo.gl/maps/xyz')).toBeNull();
+    expect(decodePlaceIdSentinel('')).toBeNull();
+  });
+
+  test('decode is type-safe (returns null for non-strings)', () => {
+    // parseLocationInput may pass in unexpected values during forged
+    // interactions; the null guard keeps the function total.
+    expect(decodePlaceIdSentinel(null)).toBeNull();
+    expect(decodePlaceIdSentinel(undefined)).toBeNull();
+    expect(decodePlaceIdSentinel(42)).toBeNull();
+  });
+});
+
+describe('buildPlaceUrl', () => {
+  test('emits the documented ?api=1&query=…&query_place_id=… form', () => {
+    const url = buildPlaceUrl('The White House', 'ChIJ37FjGE63t4kRD2_jXSF1F9o');
+    const parsed = new URL(url);
+    expect(parsed.host).toBe('www.google.com');
+    expect(parsed.pathname).toBe('/maps/search/');
+    expect(parsed.searchParams.get('api')).toBe('1');
+    expect(parsed.searchParams.get('query')).toBe('The White House');
+    expect(parsed.searchParams.get('query_place_id')).toBe('ChIJ37FjGE63t4kRD2_jXSF1F9o');
+  });
+
+  test('URL-encodes special characters in the place name (no smuggled params)', () => {
+    // Defense-in-depth: even if a place name from Places contains `&`
+    // or `=`, the URL constructor's searchParams.set handles encoding
+    // so the embedded value can't break out of the query param.
+    const url = buildPlaceUrl('Tom & Jerry\'s = Café', 'ChIJabc');
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('query')).toBe('Tom & Jerry\'s = Café');
+    expect(parsed.searchParams.get('query_place_id')).toBe('ChIJabc');
+  });
+
+  test('falls back to placeId as query when name is empty (still a valid URL)', () => {
+    // Per Google's URL spec, `query` is required even when query_place_id
+    // is set. An empty/null name shouldn't produce ?query=&query_place_id=…
+    // — Maps treats that inconsistently. Using the place_id keeps the URL
+    // well-formed.
+    const url = buildPlaceUrl('', 'ChIJabc');
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('query')).toBe('ChIJabc');
+    expect(parsed.searchParams.get('query_place_id')).toBe('ChIJabc');
+  });
+});
+
+describe('searchPlaces', () => {
+  test('returns [] (no fetch) when GOOGLE_MAPS_API_KEY is unset', async () => {
+    delete config.GOOGLE_MAPS_API_KEY;
+    const r = await searchPlaces('eiffel');
+    expect(r).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('maps predictions to {placeId, name, address} from structured_formatting', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      predictions: [
+        {
+          place_id: 'ChIJ1',
+          description: 'Eiffel Tower, Paris, France',
+          structured_formatting: { main_text: 'Eiffel Tower', secondary_text: 'Paris, France' },
+        },
+        // Fallback path: when structured_formatting is missing, use `description`
+        { place_id: 'ChIJ2', description: 'Tower Bridge, London' },
+      ],
+    }));
+    const r = await searchPlaces('tower');
+    expect(r).toEqual([
+      { placeId: 'ChIJ1', name: 'Eiffel Tower', address: 'Paris, France' },
+      { placeId: 'ChIJ2', name: 'Tower Bridge, London', address: '' },
+    ]);
+  });
+
+  test('treats ZERO_RESULTS as an empty list (no throw)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'ZERO_RESULTS' }));
+    const r = await searchPlaces('asdfasdf');
+    expect(r).toEqual([]);
+  });
+
+  test('throws on a non-OK Places status (OVER_QUERY_LIMIT)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OVER_QUERY_LIMIT' }));
+    await expect(searchPlaces('eiffel')).rejects.toThrow(/OVER_QUERY_LIMIT/);
+  });
+
+  test('throws with status code on a non-2xx HTTP response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(null, { ok: false, status: 503 }));
+    await expect(searchPlaces('eiffel')).rejects.toThrow(/503/);
+  });
+
+  test('throws a typed error when the response is not JSON', async () => {
+    // Places occasionally serves an HTML error page during outages;
+    // raw `.json()` throws SyntaxError with no context.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => { throw new Error('Unexpected token < in JSON at position 0'); },
+    });
+    await expect(searchPlaces('eiffel')).rejects.toThrow(/non-JSON/);
+  });
+
+  test('sends GOOGLE_MAPS_API_KEY as a query param (Places has no header auth)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OK', predictions: [] }));
+    await searchPlaces('eiffel');
+    const calledUrl = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain('key=test-google-key');
+    expect(calledUrl).toContain('input=eiffel');
+  });
+
+  test('caches results per normalized query — repeat lookups skip the API', async () => {
+    // Autocomplete fires per keystroke; a TTL cache collapses the
+    // repeat lookups a single typing session produces ("white", "white
+    // ", "white h", …) so we don't pay per-keystroke against Places.
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      predictions: [{ place_id: 'ChIJ1', description: 'White House' }],
+    }));
+    const a = await searchPlaces('white');
+    const b = await searchPlaces('white');
+    expect(a).toEqual(b);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('strips ASCII control chars + caps at 500 chars before reaching the request URL', async () => {
+    // Header-injection defense: a NUL or newline in the query MUST NOT
+    // ride into the outgoing URL. (Modern fetch wouldn't allow it
+    // anyway, but the sanitize keeps the contract tight.)
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OK', predictions: [] }));
+    await searchPlaces('hello\x00\nworld' + 'x'.repeat(1000));
+    const calledUrl = fetchMock.mock.calls[0][0];
+    expect(calledUrl).not.toMatch(/%00/);
+    expect(calledUrl).not.toMatch(/%0A/);
+    // 500-char cap + 'helloworld' (10 chars after control strip) means
+    // the input= param value is at most 500 chars.
+    const input = new URL(calledUrl).searchParams.get('input');
+    expect(input.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe('findPlaceFromText', () => {
+  test('throws when GOOGLE_MAPS_API_KEY is unset (resolveLocation caller maps this to no_api_key)', async () => {
+    delete config.GOOGLE_MAPS_API_KEY;
+    await expect(findPlaceFromText('eiffel')).rejects.toThrow(/GOOGLE_MAPS_API_KEY/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('returns the top candidate when Places matches', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      candidates: [
+        { place_id: 'ChIJ1', name: 'The White House', formatted_address: '1600 Pennsylvania Ave NW' },
+        { place_id: 'ChIJ2', name: 'White House Pub' },
+      ],
+    }));
+    const r = await findPlaceFromText('the whitehouse');
+    expect(r).toEqual({
+      placeId: 'ChIJ1',
+      name: 'The White House',
+      address: '1600 Pennsylvania Ave NW',
+    });
+  });
+
+  test('returns null on ZERO_RESULTS (caller maps this to not_found)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'ZERO_RESULTS', candidates: [] }));
+    const r = await findPlaceFromText('zzzz');
+    expect(r).toBeNull();
+  });
+
+  test('returns null when status is OK but candidates is empty', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OK', candidates: [] }));
+    const r = await findPlaceFromText('zzzz');
+    expect(r).toBeNull();
+  });
+
+  test('falls back to formatted_address when name is missing', async () => {
+    // Geocoded results (addresses) typically have formatted_address but
+    // no `name`. Use the address as the display name in that case.
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      candidates: [{ place_id: 'ChIJ1', formatted_address: '742 Evergreen Terrace, Springfield' }],
+    }));
+    const r = await findPlaceFromText('742 evergreen');
+    expect(r.name).toBe('742 Evergreen Terrace, Springfield');
+    expect(r.address).toBe('742 Evergreen Terrace, Springfield');
+  });
+
+  test('throws on a non-OK Places status (REQUEST_DENIED)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'REQUEST_DENIED' }));
+    await expect(findPlaceFromText('x')).rejects.toThrow(/REQUEST_DENIED/);
+  });
+
+  test('passes an AbortSignal to fetch (so a hung Places call can be cut)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OK', candidates: [{ place_id: 'ChIJ1', name: 'X' }] }));
+    const r = await findPlaceFromText('x');
+    expect(r.placeId).toBe('ChIJ1');
+    expect(fetchMock.mock.calls[0][1]).toEqual(expect.objectContaining({ signal: expect.any(Object) }));
+  });
+});
+
+describe('getPlaceDetails', () => {
+  test('throws when GOOGLE_MAPS_API_KEY is unset', async () => {
+    delete config.GOOGLE_MAPS_API_KEY;
+    await expect(getPlaceDetails('ChIJabc')).rejects.toThrow(/GOOGLE_MAPS_API_KEY/);
+  });
+
+  test('returns the hydrated place on OK', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      result: { place_id: 'ChIJabc', name: 'The White House', formatted_address: '1600 Pennsylvania Ave NW' },
+    }));
+    const r = await getPlaceDetails('ChIJabc');
+    expect(r).toEqual({
+      placeId: 'ChIJabc',
+      name: 'The White House',
+      address: '1600 Pennsylvania Ave NW',
+    });
+  });
+
+  test('returns null on NOT_FOUND (place_id deleted upstream)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'NOT_FOUND' }));
+    const r = await getPlaceDetails('ChIJ-deleted');
+    expect(r).toBeNull();
+  });
+
+  test('returns null on INVALID_REQUEST (malformed place_id)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'INVALID_REQUEST' }));
+    const r = await getPlaceDetails('not-a-real-id');
+    expect(r).toBeNull();
+  });
+
+  test('throws on a non-OK Places status that is not a recognized null-case (OVER_QUERY_LIMIT)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'OVER_QUERY_LIMIT' }));
+    await expect(getPlaceDetails('ChIJabc')).rejects.toThrow(/OVER_QUERY_LIMIT/);
+  });
+
+  test('falls back to the caller-supplied placeId when the response omits place_id', async () => {
+    // Defensive: Places normally echoes the place_id but if it ever
+    // returns just `name`/`formatted_address` we still need a placeId
+    // to construct buildPlaceUrl downstream.
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: 'OK',
+      result: { name: 'X', formatted_address: 'Y' },
+    }));
+    const r = await getPlaceDetails('ChIJabc');
+    expect(r.placeId).toBe('ChIJabc');
+  });
+});

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1936,6 +1936,28 @@ describe('handleQurlMap — slash entry', () => {
     expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
+  test('stale-sentinel NOT_FOUND → place-specific message (does NOT echo the wire sentinel)', async () => {
+    // Reviewer-flagged contract: when a sender picks a suggestion from
+    // autocomplete and the place is deleted upstream between pick and
+    // submit, the error message must not read `Couldn't find a place
+    // matching "qurl_place:ChIJabc..."` — that's user-hostile and leaks
+    // the wire format. Branch on parsedLocation.placeId to a place-
+    // specific message instead.
+    mockGetPlaceDetails.mockResolvedValueOnce(null);
+    const int = makeInteraction({
+      options: {
+        location: 'qurl_place:ChIJ-deleted-place',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    const editReplyCall = int.editReply.mock.calls[0][0];
+    expect(editReplyCall.content).toMatch(/no longer available/);
+    expect(editReplyCall.content).not.toContain('qurl_place:');
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+  });
+
   test('Places call throws → actionable ephemeral, cooldown cleared, no flow row', async () => {
     mockFindPlaceFromText.mockRejectedValueOnce(new Error('upstream timeout'));
     const int = makeInteraction({

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -142,7 +142,26 @@ jest.mock('../src/qurl', () => ({
   getResourceStatus: jest.fn(),
 }));
 
-jest.mock('../src/places', () => ({ searchPlaces: jest.fn().mockResolvedValue([]) }));
+// places.js is mocked because the resolveLocation server-side path hits
+// Google Places at send time. Defaults: searchPlaces (autocomplete) and
+// findPlaceFromText (free-text fallback) return empty by default — each
+// describe block overrides per-test to assert the contract.
+const mockSearchPlaces = jest.fn().mockResolvedValue([]);
+const mockFindPlaceFromText = jest.fn().mockResolvedValue(null);
+const mockGetPlaceDetails = jest.fn().mockResolvedValue(null);
+jest.mock('../src/places', () => ({
+  searchPlaces: (...a) => mockSearchPlaces(...a),
+  findPlaceFromText: (...a) => mockFindPlaceFromText(...a),
+  getPlaceDetails: (...a) => mockGetPlaceDetails(...a),
+  buildPlaceUrl: (name, placeId) => {
+    const url = new URL('https://www.google.com/maps/search/');
+    url.searchParams.set('api', '1');
+    url.searchParams.set('query', name || placeId);
+    url.searchParams.set('query_place_id', placeId);
+    return url.toString();
+  },
+  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+}));
 
 // Flow-state stubs. Each test overrides per-call to assert on the
 // supersedeOrCreate/transitionFlow/deleteFlow contracts.
@@ -175,6 +194,8 @@ const {
   renderRecipientWarnings,
   renderConfirmCardContent,
   parseLocationInput,
+  resolveLocation,
+  handleAutocomplete,
   safeDecodeURIComponent,
   softenCooldown,
   SEND_STAGE_AWAITING_CONFIRM,
@@ -306,6 +327,9 @@ beforeEach(() => {
   mockDeleteFlow.mockReset();
   mockTransitionFlow.mockReset();
   mockDb.getGuildApiKey.mockReset();
+  mockSearchPlaces.mockReset().mockResolvedValue([]);
+  mockFindPlaceFromText.mockReset().mockResolvedValue(null);
+  mockGetPlaceDetails.mockReset().mockResolvedValue(null);
   mockSupersedeOrCreate.mockResolvedValue({ created: true, version: 1 });
   mockDeleteFlow.mockResolvedValue({ deleted: true });
   mockTransitionFlow.mockResolvedValue({ result: 'ok', version: 2 });
@@ -472,6 +496,8 @@ describe('parseLocationInput', () => {
   test('Google Maps short URL passes through verbatim', () => {
     const r = parseLocationInput('https://goo.gl/maps/abc123');
     expect(r.locationUrl).toBe('https://goo.gl/maps/abc123');
+    expect(r.placeId).toBeUndefined();
+    expect(r.text).toBeUndefined();
   });
 
   test('Google Maps place URL passes through with derived name', () => {
@@ -480,63 +506,302 @@ describe('parseLocationInput', () => {
     expect(r.locationName).toBeTruthy();
   });
 
-  test('plain place name synthesizes a search URL', () => {
+  test('api=1&query= form extracts the name (round-trip for re-shared qURL map URLs)', () => {
+    // The URL form resolveLocation constructs: `/maps/search/?api=1&
+    // query=<name>&query_place_id=<id>`. If a sender re-shares one of
+    // these URLs through /qurl map, parseLocationInput needs to pull
+    // the name out so the recipient embed has a label — without this
+    // branch, only `?q=<name>` and `/place/<name>` were extracted.
+    const url = 'https://www.google.com/maps/search/?api=1&query=Eiffel+Tower&query_place_id=ChIJxxx';
+    const r = parseLocationInput(url);
+    expect(r.locationUrl).toBe(url);
+    expect(r.locationName).toBe('Eiffel Tower');
+  });
+
+  test('place_id sentinel parses into a placeId branch (no URL synthesized)', () => {
+    // Wire contract: the autocomplete handler encodes selected places
+    // as `qurl_place:<placeId>` so the slash submit can route through
+    // a Places Details lookup instead of synthesizing a per-viewer
+    // /maps/search/<text> URL. The sentinel prefix MUST match
+    // PLACE_ID_SENTINEL_PREFIX in places.js — a drift here breaks
+    // every in-flight autocomplete pick.
+    const r = parseLocationInput('qurl_place:ChIJ37FjGE63t4kRD2_jXSF1F9o');
+    expect(r.placeId).toBe('ChIJ37FjGE63t4kRD2_jXSF1F9o');
+    expect(r.locationUrl).toBeNull();
+    expect(r.locationName).toBeNull();
+  });
+
+  test('plain place name returns text branch for server-side resolution', () => {
+    // The free-text branch no longer synthesizes a /maps/search/<text>
+    // URL — that URL was the source of the per-recipient geo-bias bug.
+    // parseLocationInput now defers resolution to resolveLocation,
+    // which hits Places Find Place at send time and pins to a place_id.
     const r = parseLocationInput('Eiffel Tower, Paris');
-    expect(r.locationUrl).toContain('google.com/maps/search');
-    expect(r.locationName).toBe('Eiffel Tower, Paris');
+    expect(r.locationUrl).toBeNull();
+    expect(r.locationName).toBeNull();
+    expect(r.text).toBe('Eiffel Tower, Paris');
   });
 
-  test('plain non-URL text falls through to synth-search', () => {
+  test('plain non-URL text returns text branch', () => {
     const r = parseLocationInput('not a url just plain text input');
-    expect(r.locationUrl).toContain('google.com/maps/search');
+    expect(r.text).toBe('not a url just plain text input');
+    expect(r.locationUrl).toBeNull();
   });
 
-  test('https URL that does NOT match MAPS_URL_PATTERNS is treated as plain text and synth-searched', () => {
-    // The MAPS_URL_PATTERNS regexes are quite specific (host + path
-    // shape). A non-Google https URL fails them all, so parseLocationInput
-    // falls through to the plain-text branch and synth-searches with
-    // the raw input as the search query. isGoogleMapsURL re-validation
-    // applies inside parseLocationInput when an extracted URL pattern
-    // matches — the fall-through covers the "doesn't even match the
-    // regex" case directly.
+  test('https URL that does NOT match MAPS_URL_PATTERNS falls through to text branch', () => {
+    // A non-Google https URL fails every MAPS_URL_PATTERNS regex, so
+    // parseLocationInput hands it to resolveLocation as free text.
+    // resolveLocation will then ask Places to find a real place — the
+    // spoofed host never lands in locationUrl. (Previously the spoofed
+    // URL was URL-encoded into a synth /maps/search/<text> URL; the
+    // recipient-visible behavior is equivalent — google.com host —
+    // but now goes through a place_id resolution rather than a
+    // per-viewer-biased search query.)
     const r = parseLocationInput('https://evil.example.com/maps/place/x');
-    expect(r.locationUrl).toContain('google.com/maps/search');
-    // The original URL is encoded into the search query, not used as
-    // the locationUrl.
-    expect(r.locationUrl).not.toContain('evil.example.com/maps/place');
+    expect(r.locationUrl).toBeNull();
+    expect(r.text).toBe('https://evil.example.com/maps/place/x');
   });
 
   test('malformed %-encoding in the input does not throw', () => {
     expect(() => parseLocationInput('https://www.google.com/maps/place/%ZZ-broken')).not.toThrow();
   });
 
-  test('spoofed host (google.com.evil.com) fails the regex AND falls through to synth-search', () => {
+  test('spoofed host (google.com.evil.com) fails the regex AND falls through to text branch', () => {
     // Defense-in-depth contract: MAPS_URL_PATTERNS pins the literal
     // `google.com/` token (slash forces an end-of-host boundary), so a
     // spoofed host like `google.com.evil.com/maps/place/x` cannot match
-    // any pattern. parseLocationInput therefore takes the synth-search
-    // fall-through with the entire raw input as the search query —
-    // isGoogleMapsURL never gets a chance to look at the spoofed host.
-    // The conditional `if (detectedUrl && isGoogleMapsURL(detectedUrl))`
-    // remains as defense-in-depth in case a future pattern relaxes the
-    // host pin; this test pins the current contract.
+    // any pattern. parseLocationInput therefore routes the whole input
+    // to the text branch — isGoogleMapsURL never gets a chance to look
+    // at the spoofed host. The conditional `if (detectedUrl &&
+    // isGoogleMapsURL(detectedUrl))` remains as defense-in-depth in
+    // case a future pattern relaxes the host pin; this test pins the
+    // current contract.
+    //
+    // Downstream: resolveLocation feeds the spoofed text to Places
+    // Find Place. Whatever Places returns becomes the locationUrl —
+    // a google.com host, place_id-pinned — so the spoofed host never
+    // becomes the link target regardless of what Places interprets.
     const spoofed = 'https://google.com.evil.com/maps/place/Eiffel-Tower';
     const r = parseLocationInput(spoofed);
-    // INTENDED UX: the recipient embed renders `locationName` as a
-    // LABEL on a Maps link whose TARGET is google.com. The spoofed
-    // string is visible (so the recipient sees what was searched),
-    // but the click goes to google.com/maps/search/?<encoded-spoof>.
-    // sanitizeContentLabel further strips bidi/control + markdown-
-    // escapes the label before it lands in the embed, so the visible
-    // label text can't render as a clickable masked link or flip
-    // direction via U+202E.
-    const parsed = new URL(r.locationUrl);
-    expect(parsed.hostname).toBe('www.google.com');
-    expect(parsed.pathname.startsWith('/maps/search/')).toBe(true);
-    // The raw spoofed input is the search query — recipient embeds
-    // render that as text on a google.com link, not as a clickable
-    // link to the spoofed host.
-    expect(r.locationName).toBe(spoofed);
+    expect(r.locationUrl).toBeNull();
+    expect(r.text).toBe(spoofed);
+  });
+});
+
+describe('resolveLocation', () => {
+  // resolveLocation is the server-side hop that turns a parsed
+  // location input into a place_id-pinned URL. URL inputs short-
+  // circuit (no API call). Sentinel + free-text inputs hit Places
+  // — these tests pin the three reason codes and the success shapes.
+  beforeEach(() => {
+    mockSearchPlaces.mockReset().mockResolvedValue([]);
+    mockFindPlaceFromText.mockReset().mockResolvedValue(null);
+    mockGetPlaceDetails.mockReset().mockResolvedValue(null);
+  });
+
+  test('URL branch passes through without an API call', async () => {
+    const r = await resolveLocation({
+      locationUrl: 'https://goo.gl/maps/abc123',
+      locationName: 'My Place',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.locationUrl).toBe('https://goo.gl/maps/abc123');
+    expect(r.locationName).toBe('My Place');
+    expect(mockFindPlaceFromText).not.toHaveBeenCalled();
+    expect(mockGetPlaceDetails).not.toHaveBeenCalled();
+  });
+
+  test('placeId branch calls getPlaceDetails and builds a place_id-pinned URL', async () => {
+    mockGetPlaceDetails.mockResolvedValueOnce({
+      placeId: 'ChIJ37FjGE63t4kRD2_jXSF1F9o',
+      name: 'The White House',
+      address: '1600 Pennsylvania Ave NW, Washington, DC',
+    });
+    const r = await resolveLocation({ placeId: 'ChIJ37FjGE63t4kRD2_jXSF1F9o' });
+    expect(r.ok).toBe(true);
+    expect(r.locationName).toBe('The White House');
+    // The canonical URL must carry both the human-readable query and
+    // the place_id pin. The place_id is what eliminates per-viewer
+    // geo-bias — without it, the URL would degrade to /maps/search/<text>
+    // behavior which is the bug we're fixing.
+    expect(r.locationUrl).toContain('query_place_id=ChIJ37FjGE63t4kRD2_jXSF1F9o');
+    expect(mockGetPlaceDetails).toHaveBeenCalledWith(
+      'ChIJ37FjGE63t4kRD2_jXSF1F9o',
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+  });
+
+  test('text branch calls findPlaceFromText and pins to the top result', async () => {
+    mockFindPlaceFromText.mockResolvedValueOnce({
+      placeId: 'ChIJxxx',
+      name: 'The White House',
+      address: '1600 Pennsylvania Ave NW',
+    });
+    const r = await resolveLocation({ text: 'the whitehouse' });
+    expect(r.ok).toBe(true);
+    expect(r.locationUrl).toContain('query_place_id=ChIJxxx');
+    expect(r.locationName).toBe('The White House');
+  });
+
+  test('text branch returns not_found when Places has no candidates', async () => {
+    mockFindPlaceFromText.mockResolvedValueOnce(null);
+    const r = await resolveLocation({ text: 'asdfasdfasdf' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_found');
+  });
+
+  test('placeId branch returns not_found when Place Details returns null', async () => {
+    mockGetPlaceDetails.mockResolvedValueOnce(null);
+    const r = await resolveLocation({ placeId: 'ChIJ-deleted-place' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_found');
+  });
+
+  test('text branch returns error when the Places call throws', async () => {
+    mockFindPlaceFromText.mockRejectedValueOnce(new Error('upstream timeout'));
+    const r = await resolveLocation({ text: 'somewhere' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('error');
+  });
+
+  test('hard-fails with no_api_key when GOOGLE_MAPS_API_KEY is unset', async () => {
+    // Mutate the already-mocked config in place rather than
+    // jest.resetModules — resetting the module registry would force
+    // commands.js to re-execute, which re-runs registerFlow on a
+    // fresh dispatcher and breaks every downstream "duplicate-register
+    // throws" test in the suite.
+    const configMock = require('../src/config');
+    const orig = configMock.GOOGLE_MAPS_API_KEY;
+    delete configMock.GOOGLE_MAPS_API_KEY;
+    try {
+      const r = await resolveLocation({ text: 'eiffel tower' });
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe('no_api_key');
+    } finally {
+      configMock.GOOGLE_MAPS_API_KEY = orig;
+    }
+  });
+});
+
+describe('handleAutocomplete', () => {
+  // The autocomplete dispatcher must (a) gate on commandName + subcommand
+  // + focused-option-name, (b) honor the min-length cap, (c) skip Places
+  // for URL inputs (where suggestions would just clutter), and (d) build
+  // sentinel `qurl_place:<placeId>` values that the slash submit can
+  // round-trip through resolveLocation. Together these contracts ensure
+  // the autocomplete UX layer feeds the same per-place URL pinning that
+  // the server-side fallback uses.
+  beforeEach(() => {
+    mockSearchPlaces.mockReset().mockResolvedValue([]);
+  });
+
+  function makeAutocompleteInteraction({ subcommand = 'map', focused = { name: 'location', value: 'whitehouse' } } = {}) {
+    const respond = jest.fn().mockResolvedValue(undefined);
+    return {
+      commandName: 'qurl',
+      respond,
+      options: {
+        getSubcommand: () => subcommand,
+        getFocused: () => focused,
+      },
+    };
+  }
+
+  test('responds empty for non-qurl commands', async () => {
+    const int = makeAutocompleteInteraction();
+    int.commandName = 'link';
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  test('responds empty for /qurl file (only /qurl map has suggestions)', async () => {
+    const int = makeAutocompleteInteraction({ subcommand: 'file' });
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  test('responds empty for /qurl map with a non-location focused option', async () => {
+    const int = makeAutocompleteInteraction({ focused: { name: 'personal-message', value: 'hi' } });
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  test('skips Places call for partial queries below the min-length cap', async () => {
+    // Cuts per-keystroke Places cost. The user typically pauses for the
+    // dropdown to populate; without this gate single-letter prefixes
+    // would fire a Places call on every keystroke.
+    const int = makeAutocompleteInteraction({ focused: { name: 'location', value: 'a' } });
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  test('skips Places call when input already looks like a URL', async () => {
+    // URLs are already stable identifiers — autocomplete suggestions
+    // would just clutter the dropdown. The slash submit's URL branch
+    // passes them through verbatim.
+    const int = makeAutocompleteInteraction({ focused: { name: 'location', value: 'https://goo.gl/maps/abc' } });
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  test('returns sentinel-encoded choices with name + address labels', async () => {
+    mockSearchPlaces.mockResolvedValueOnce([
+      { placeId: 'ChIJ1', name: 'The White House', address: '1600 Pennsylvania Ave NW, Washington, DC' },
+      { placeId: 'ChIJ2', name: 'Whitehouse Pub', address: 'Manchester, UK' },
+    ]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    expect(mockSearchPlaces).toHaveBeenCalledWith('whitehouse');
+    expect(int.respond).toHaveBeenCalledTimes(1);
+    const choices = int.respond.mock.calls[0][0];
+    expect(choices).toHaveLength(2);
+    expect(choices[0]).toEqual({
+      name: 'The White House — 1600 Pennsylvania Ave NW, Washington, DC',
+      value: 'qurl_place:ChIJ1',
+    });
+    expect(choices[1].value).toBe('qurl_place:ChIJ2');
+    // Disambiguation is the whole point: the user-visible label has
+    // to differentiate "White House DC" from "Whitehouse Pub UK",
+    // otherwise the autocomplete picker is no better than free text.
+    expect(choices[0].name).not.toBe(choices[1].name);
+  });
+
+  test('truncates a label exceeding the 100-char Discord cap', async () => {
+    const longAddress = '1234 Very Long Street Name, Somewhere Far Away, In A Large City With A Long Name, Region, Country 99999';
+    mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJlong', name: 'Place', address: longAddress }]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    const choice = int.respond.mock.calls[0][0][0];
+    expect(choice.name.length).toBeLessThanOrEqual(100);
+    // The sentinel value is short enough to never need truncation
+    // (qurl_place: + 27-char place_id ≈ 38). Pin this — if a future
+    // change starts packing more into the value we want a test to fail.
+    expect(choice.value.length).toBeLessThanOrEqual(100);
+  });
+
+  test('caps results at 25 (Discord choice limit)', async () => {
+    mockSearchPlaces.mockResolvedValueOnce(
+      Array.from({ length: 40 }, (_, i) => ({ placeId: `ChIJ${i}`, name: `Place ${i}`, address: 'addr' })),
+    );
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    expect(int.respond.mock.calls[0][0]).toHaveLength(25);
+  });
+
+  test('responds empty (does not throw) when Places API throws', async () => {
+    // Autocomplete must not surface "this command failed" toasts on a
+    // transient Places hiccup. Empty response keeps the dropdown UX
+    // graceful — the user can still type free text and the server-side
+    // fallback in resolveLocation will retry at send time.
+    mockSearchPlaces.mockRejectedValueOnce(new Error('Places API status: OVER_QUERY_LIMIT'));
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
   });
 });
 
@@ -1536,7 +1801,16 @@ describe('handleQurlMap — slash entry', () => {
     expect(payload.locationName).toMatch(/Eiffel Tower/);
   });
 
-  test('arbitrary text → synthesized search URL', async () => {
+  test('arbitrary text → resolved through Places to a place_id-pinned URL', async () => {
+    // Free-text inputs route through findPlaceFromText so every
+    // recipient opens the same destination — Google's per-viewer
+    // geo-bias on /maps/search/<text> is the bug this whole change
+    // is fixing.
+    mockFindPlaceFromText.mockResolvedValueOnce({
+      placeId: 'ChIJ4zGFAZpYwokRGUGph3Mf37k',
+      name: 'Central Park',
+      address: 'New York, NY',
+    });
     const int = makeInteraction({
       options: {
         location: 'Central Park, NYC',
@@ -1545,9 +1819,74 @@ describe('handleQurlMap — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     await handleQurlMap(int);
+    expect(mockFindPlaceFromText).toHaveBeenCalledWith(
+      'Central Park, NYC',
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
-    expect(payload.locationUrl).toBe('https://www.google.com/maps/search/Central%20Park%2C%20NYC');
+    expect(payload.locationUrl).toContain('query_place_id=ChIJ4zGFAZpYwokRGUGph3Mf37k');
     expect(payload.locationName).toMatch(/Central Park/);
+  });
+
+  test('place_id sentinel from autocomplete → resolved through Place Details', async () => {
+    // When the sender picks a suggestion from the autocomplete
+    // dropdown, the `location:` value arrives as the sentinel form
+    // `qurl_place:<placeId>`. handleQurlMap routes that through
+    // Place Details (cheap, one API call) to hydrate the canonical
+    // name + address, then pins the URL to the chosen place_id.
+    mockGetPlaceDetails.mockResolvedValueOnce({
+      placeId: 'ChIJabc',
+      name: 'The White House',
+      address: '1600 Pennsylvania Ave NW',
+    });
+    const int = makeInteraction({
+      options: {
+        location: 'qurl_place:ChIJabc',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    expect(mockGetPlaceDetails).toHaveBeenCalledWith('ChIJabc', expect.any(Object));
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.locationUrl).toContain('query_place_id=ChIJabc');
+    expect(payload.locationName).toBe('The White House');
+  });
+
+  test('Places returns no match → actionable ephemeral, cooldown cleared, no flow row', async () => {
+    mockFindPlaceFromText.mockResolvedValueOnce(null);
+    const int = makeInteraction({
+      options: {
+        location: 'zzzz-no-such-place',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Couldn't find/),
+    }));
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    // Honest user error (no matching place) — don't strand them
+    // for 30s. Same shape as the empty-location + DM branches.
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+  });
+
+  test('Places call throws → actionable ephemeral, cooldown cleared, no flow row', async () => {
+    mockFindPlaceFromText.mockRejectedValueOnce(new Error('upstream timeout'));
+    const int = makeInteraction({
+      options: {
+        location: 'somewhere',
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/lookup failed/),
+    }));
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
   test('location-name override wins over URL-derived name', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -889,6 +889,46 @@ describe('handleAutocomplete', () => {
     expect(choices.map(c => c.value)).toEqual([`qurl_place:${good1}`, `qurl_place:${good2}`]);
   });
 
+  test('drops a choice whose name is missing (Places returned no main_text + no description)', async () => {
+    // Places marks both main_text and description as optional. If both
+    // are missing, searchPlaces yields { name: undefined }, and a
+    // naive label would render as the literal string "undefined".
+    // Discord also rejects empty/whitespace names, so the choice must
+    // be skipped — pin both the skip behavior and that valid entries
+    // around it still render.
+    const valid = fakePlaceId('valid_for_label');
+    mockSearchPlaces.mockResolvedValueOnce([
+      { placeId: valid, name: 'Valid', address: 'addr' },
+      { placeId: fakePlaceId('no_name_entry'), name: undefined, address: 'addr2' },
+      { placeId: fakePlaceId('empty_name_xx'), name: '', address: 'addr3' },
+    ]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    const choices = int.respond.mock.calls[0][0];
+    expect(choices).toHaveLength(1);
+    expect(choices[0].value).toBe(`qurl_place:${valid}`);
+  });
+
+  test('outer-catch handles a rejection from an early-return respond() (return await contract)', async () => {
+    // The early-return guards use `return await interaction.respond([])`
+    // (not bare `return`) so a rejected promise is routed through the
+    // outer try/catch instead of leaking out of the async function. A
+    // bare `return` would propagate the rejection to the dispatch
+    // caller (which would surface as "this command is unresponsive"
+    // to the user). Pin: the rejection IS caught + recovery fires.
+    const int = makeAutocompleteInteraction({ guildId: null });
+    let respondCallCount = 0;
+    int.respond = jest.fn(async () => {
+      respondCallCount += 1;
+      if (respondCallCount === 1) throw new Error('Unknown interaction');
+      // The outer-catch's best-effort fallback respond([]) — let this
+      // one resolve so we don't double-throw.
+    });
+    await handleAutocomplete(int);
+    // Outer catch fired its fallback respond([]) on the rejection.
+    expect(respondCallCount).toBe(2);
+  });
+
   test('drops a choice whose place_id fails the documented shape check', async () => {
     // Mirror of the decodePlaceIdSentinel shape gate at encode time.
     // If Google ever ships a malformed place_id (chars outside
@@ -2053,6 +2093,31 @@ describe('handleQurlMap — slash entry', () => {
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.locationUrl).toContain('query_place_id=ChIJ4zGFAZpYwokRGUGph3Mf37k');
     expect(payload.locationName).toMatch(/Central Park/);
+  });
+
+  test('free-text input is trimmed + 500-char-capped before reaching Places', async () => {
+    // handleQurlMap does `trim().slice(0, 500)` on the slash option;
+    // pin the boundary so a forged interaction can't smuggle a
+    // longer-than-the-server-side-cap query through. Whitespace at the
+    // boundary is trimmed FIRST (so the content slice gets the full
+    // 500 chars, not whitespace + 450 content chars).
+    mockFindPlaceFromText.mockResolvedValueOnce({
+      placeId: 'ChIJ4zGFAZpYwokRGUGph3Mf37k', name: 'X', address: 'Y',
+    });
+    const padding = '  '.repeat(40); // 80 chars of leading whitespace, trimmed first
+    const content = 'a'.repeat(600); // 600 chars of content, slice() caps at 500
+    const int = makeInteraction({
+      options: {
+        location: padding + content + padding,
+        recipients: '<@100000000000000001>',
+      },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    const calledWith = mockFindPlaceFromText.mock.calls[0][0];
+    expect(calledWith.length).toBe(500);
+    expect(calledWith.startsWith('a')).toBe(true);
+    expect(calledWith.endsWith('a')).toBe(true);
   });
 
   test('place_id sentinel from autocomplete → resolved through Place Details', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -203,6 +203,8 @@ const {
   resolveLocation,
   RESOLVE_REASON,
   handleAutocomplete,
+  _resetAutocompleteFailureBurst,
+  AUTOCOMPLETE_FAILURE_LOG_BURST,
   safeDecodeURIComponent,
   softenCooldown,
   SEND_STAGE_AWAITING_CONFIRM,
@@ -703,6 +705,10 @@ describe('handleAutocomplete', () => {
   // the server-side fallback uses.
   beforeEach(() => {
     mockSearchPlaces.mockReset().mockResolvedValue([]);
+    // The autocomplete-failure burst counter is module-level state;
+    // reset between tests so a leftover count can't trip the sampled
+    // warn on a later test's first failure.
+    _resetAutocompleteFailureBurst();
   });
 
   function makeAutocompleteInteraction({ subcommand = 'map', focused = { name: 'location', value: 'whitehouse' } } = {}) {
@@ -849,6 +855,56 @@ describe('handleAutocomplete', () => {
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
     expect(int.respond).toHaveBeenCalledWith([]);
+  });
+
+  test('failure burst counter emits one warn per BURST failures (SRE outage signal)', async () => {
+    // Per-call log is `debug` to avoid keystroke-rate spam. The sampled
+    // `warn` is the visible signal for SRE that autocomplete is degraded
+    // (vs. just no traffic). Pins the contract: one warn fires when the
+    // burst counter crosses AUTOCOMPLETE_FAILURE_LOG_BURST, and resets.
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
+    for (let i = 0; i < AUTOCOMPLETE_FAILURE_LOG_BURST - 1; i++) {
+      mockSearchPlaces.mockRejectedValueOnce(new Error('Places API status: UNKNOWN_ERROR'));
+      await handleAutocomplete(makeAutocompleteInteraction());
+    }
+    // Just below the burst threshold — no warn yet.
+    const burstWarns = () => logger.warn.mock.calls.filter(
+      (call) => call[0] === 'autocomplete handler failure burst',
+    ).length;
+    expect(burstWarns()).toBe(0);
+
+    // The BURST-th failure trips the sampled warn.
+    mockSearchPlaces.mockRejectedValueOnce(new Error('Places API status: UNKNOWN_ERROR'));
+    await handleAutocomplete(makeAutocompleteInteraction());
+    expect(burstWarns()).toBe(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'autocomplete handler failure burst',
+      expect.objectContaining({ count: AUTOCOMPLETE_FAILURE_LOG_BURST }),
+    );
+
+    // Counter reset — next burst starts fresh.
+    for (let i = 0; i < AUTOCOMPLETE_FAILURE_LOG_BURST - 1; i++) {
+      mockSearchPlaces.mockRejectedValueOnce(new Error('Places API status: UNKNOWN_ERROR'));
+      await handleAutocomplete(makeAutocompleteInteraction());
+    }
+    expect(burstWarns()).toBe(1);
+  });
+
+  test('failure burst counter does not increment on the success path', async () => {
+    // A successful autocomplete must NOT advance the burst counter,
+    // otherwise the sampled warn would fire eventually during normal
+    // operation and look like an outage in logs.
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
+    mockSearchPlaces.mockResolvedValue([{ placeId: 'ChIJ1', name: 'X', address: 'Y' }]);
+    for (let i = 0; i < AUTOCOMPLETE_FAILURE_LOG_BURST + 5; i++) {
+      await handleAutocomplete(makeAutocompleteInteraction());
+    }
+    const burstWarns = logger.warn.mock.calls.filter(
+      (call) => call[0] === 'autocomplete handler failure burst',
+    ).length;
+    expect(burstWarns).toBe(0);
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -730,6 +730,15 @@ describe('handleAutocomplete', () => {
     };
   }
 
+  // Generate a place_id-shaped string for tests. The autocomplete
+  // handler filters out entries that don't match the documented
+  // place_id char class + length floor, so any fake fixture must
+  // mimic the shape (>=16 chars of [A-Za-z0-9_-]).
+  function fakePlaceId(seed) {
+    const s = String(seed);
+    return s.length >= 16 ? s : `ChIJ${'a'.repeat(16 - s.length)}${s}`;
+  }
+
   test('responds empty for non-qurl commands', async () => {
     const int = makeAutocompleteInteraction();
     int.commandName = 'link';
@@ -786,8 +795,8 @@ describe('handleAutocomplete', () => {
 
   test('returns sentinel-encoded choices with name + address labels', async () => {
     mockSearchPlaces.mockResolvedValueOnce([
-      { placeId: 'ChIJ1', name: 'The White House', address: '1600 Pennsylvania Ave NW, Washington, DC' },
-      { placeId: 'ChIJ2', name: 'Whitehouse Pub', address: 'Manchester, UK' },
+      { placeId: fakePlaceId('whitehouse_dc_id'), name: 'The White House', address: '1600 Pennsylvania Ave NW, Washington, DC' },
+      { placeId: fakePlaceId('whitehouse_uk_id'), name: 'Whitehouse Pub', address: 'Manchester, UK' },
     ]);
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
@@ -797,9 +806,9 @@ describe('handleAutocomplete', () => {
     expect(choices).toHaveLength(2);
     expect(choices[0]).toEqual({
       name: 'The White House — 1600 Pennsylvania Ave NW, Washington, DC',
-      value: 'qurl_place:ChIJ1',
+      value: `qurl_place:${fakePlaceId('whitehouse_dc_id')}`,
     });
-    expect(choices[1].value).toBe('qurl_place:ChIJ2');
+    expect(choices[1].value).toBe(`qurl_place:${fakePlaceId('whitehouse_uk_id')}`);
     // Disambiguation is the whole point: the user-visible label has
     // to differentiate "White House DC" from "Whitehouse Pub UK",
     // otherwise the autocomplete picker is no better than free text.
@@ -808,7 +817,7 @@ describe('handleAutocomplete', () => {
 
   test('truncates a label exceeding the 100-char Discord cap (UTF-16 units)', async () => {
     const longAddress = '1234 Very Long Street Name, Somewhere Far Away, In A Large City With A Long Name, Region, Country 99999';
-    mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJlong', name: 'Place', address: longAddress }]);
+    mockSearchPlaces.mockResolvedValueOnce([{ placeId: fakePlaceId('longlabel'), name: 'Place', address: longAddress }]);
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
     const choice = int.respond.mock.calls[0][0][0];
@@ -830,7 +839,7 @@ describe('handleAutocomplete', () => {
     // pins the always-check contract).
     const malformed = 'a'.repeat(99) + '\uD83D'; // lone high surrogate at index 99 → length 100
     expect(malformed.length).toBe(100);
-    mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJ1', name: malformed, address: '' }]);
+    mockSearchPlaces.mockResolvedValueOnce([{ placeId: fakePlaceId('boundary1'), name: malformed, address: '' }]);
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
     const choice = int.respond.mock.calls[0][0][0];
@@ -849,7 +858,7 @@ describe('handleAutocomplete', () => {
     // AND has no orphan surrogate.
     const emoji = '🏛️'; // 🏛 + variation selector — 3 UTF-16 units
     const name = (emoji + 'X').repeat(40); // 160 UTF-16 units of mixed surrogate + ASCII
-    mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJemoji', name, address: '' }]);
+    mockSearchPlaces.mockResolvedValueOnce([{ placeId: fakePlaceId('emojiplace'), name, address: '' }]);
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
     const choice = int.respond.mock.calls[0][0][0];
@@ -865,21 +874,45 @@ describe('handleAutocomplete', () => {
     // > 100 chars, which would fail Discord's API for the whole
     // response. Drop just that choice so the rest of the dropdown
     // still works.
+    const good1 = fakePlaceId('good1_id');
+    const good2 = fakePlaceId('good2_id');
     mockSearchPlaces.mockResolvedValueOnce([
-      { placeId: 'short', name: 'Good', address: 'addr' },
+      { placeId: good1, name: 'Good', address: 'addr' },
       { placeId: 'x'.repeat(95), name: 'Bad (too long)', address: 'addr' },
-      { placeId: 'also-short', name: 'Also Good', address: 'addr' },
+      { placeId: good2, name: 'Also Good', address: 'addr' },
     ]);
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
     const choices = int.respond.mock.calls[0][0];
     expect(choices).toHaveLength(2);
-    expect(choices.map(c => c.value)).toEqual(['qurl_place:short', 'qurl_place:also-short']);
+    expect(choices.map(c => c.value)).toEqual([`qurl_place:${good1}`, `qurl_place:${good2}`]);
+  });
+
+  test('drops a choice whose place_id fails the documented shape check', async () => {
+    // Mirror of the decodePlaceIdSentinel shape gate at encode time.
+    // If Google ever ships a malformed place_id (chars outside
+    // [A-Za-z0-9_-] or shorter than 16 chars), skip that entry rather
+    // than render a dud choice that submit-time decode would reject.
+    const valid = fakePlaceId('valid_id_one');
+    mockSearchPlaces.mockResolvedValueOnce([
+      { placeId: valid, name: 'Valid', address: 'addr' },
+      { placeId: 'tooshort', name: 'Bad short', address: 'addr' },
+      { placeId: 'has spaces in it just bad', name: 'Bad chars', address: 'addr' },
+    ]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    const choices = int.respond.mock.calls[0][0];
+    expect(choices).toHaveLength(1);
+    expect(choices[0].value).toBe(`qurl_place:${valid}`);
   });
 
   test('caps results at 25 (Discord choice limit)', async () => {
     mockSearchPlaces.mockResolvedValueOnce(
-      Array.from({ length: 40 }, (_, i) => ({ placeId: `ChIJ${i}`, name: `Place ${i}`, address: 'addr' })),
+      Array.from({ length: 40 }, (_, i) => ({
+        placeId: fakePlaceId(`place_id_${i}_padding_xyz`),
+        name: `Place ${i}`,
+        address: 'addr',
+      })),
     );
     const int = makeAutocompleteInteraction();
     await handleAutocomplete(int);
@@ -929,6 +962,25 @@ describe('handleAutocomplete', () => {
       await handleAutocomplete(makeAutocompleteInteraction());
     }
     expect(burstWarns()).toBe(1);
+  });
+
+  test('failure burst counter does not increment when the early-return respond() throws', async () => {
+    // Narrow-catch contract: the burst counter is a "Places is
+    // degraded" signal, not a generic handler-failure counter. If an
+    // early-return `interaction.respond([])` throws (e.g. expired
+    // interaction token), that's a Discord-side issue, not a Places
+    // problem — the counter must NOT advance.
+    const logger = require('../src/logger');
+    logger.warn.mockClear();
+    for (let i = 0; i < AUTOCOMPLETE_FAILURE_LOG_BURST + 5; i++) {
+      const int = makeAutocompleteInteraction({ guildId: null }); // hits DM gate early-return
+      int.respond = jest.fn(async () => { throw new Error('Unknown interaction'); });
+      await handleAutocomplete(int);
+    }
+    const burstWarns = logger.warn.mock.calls.filter(
+      (call) => call[0] === 'autocomplete handler failure burst',
+    ).length;
+    expect(burstWarns).toBe(0);
   });
 
   test('failure burst counter does not increment on the success path', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -774,7 +774,7 @@ describe('handleAutocomplete', () => {
     expect(choices[0].name).not.toBe(choices[1].name);
   });
 
-  test('truncates a label exceeding the 100-char Discord cap', async () => {
+  test('truncates a label exceeding the 100-char Discord cap (UTF-16 units)', async () => {
     const longAddress = '1234 Very Long Street Name, Somewhere Far Away, In A Large City With A Long Name, Region, Country 99999';
     mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJlong', name: 'Place', address: longAddress }]);
     const int = makeAutocompleteInteraction();
@@ -785,6 +785,25 @@ describe('handleAutocomplete', () => {
     // (qurl_place: + 27-char place_id ≈ 38). Pin this — if a future
     // change starts packing more into the value we want a test to fail.
     expect(choice.value.length).toBeLessThanOrEqual(100);
+  });
+
+  test('truncation does not split a surrogate pair (emoji-heavy label stays valid UTF-16)', async () => {
+    // Discord measures name length in UTF-16 code units; a naïve
+    // codepoint slice could ship a string whose .length > 100 if the
+    // first 100 codepoints contain many surrogate pairs, OR could
+    // leave a lone high surrogate at the boundary. The UTF-16 slice
+    // + surrogate-backoff must produce a string that's <= 100 units
+    // AND has no orphan surrogate.
+    const emoji = '🏛️'; // 🏛 + variation selector — 3 UTF-16 units
+    const name = (emoji + 'X').repeat(40); // 160 UTF-16 units of mixed surrogate + ASCII
+    mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJemoji', name, address: '' }]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    const choice = int.respond.mock.calls[0][0][0];
+    expect(choice.name.length).toBeLessThanOrEqual(100);
+    // No lone high surrogate at the boundary.
+    const loneHigh = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+    expect(choice.name).not.toMatch(loneHigh);
   });
 
   test('drops a choice whose value would exceed the 100-char Discord cap', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -711,10 +711,15 @@ describe('handleAutocomplete', () => {
     _resetAutocompleteFailureBurst();
   });
 
-  function makeAutocompleteInteraction({ subcommand = 'map', focused = { name: 'location', value: 'whitehouse' } } = {}) {
+  function makeAutocompleteInteraction({
+    subcommand = 'map',
+    focused = { name: 'location', value: 'whitehouse' },
+    guildId = 'guild-1',
+  } = {}) {
     const respond = jest.fn().mockResolvedValue(undefined);
     return {
       commandName: 'qurl',
+      guildId,
       respond,
       options: {
         getSubcommand: () => subcommand,
@@ -726,6 +731,18 @@ describe('handleAutocomplete', () => {
   test('responds empty for non-qurl commands', async () => {
     const int = makeAutocompleteInteraction();
     int.commandName = 'link';
+    await handleAutocomplete(int);
+    expect(int.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  test('responds empty for DM autocomplete (no guildId)', async () => {
+    // handleQurlMap rejects DMs at submit time, but Discord could
+    // still deliver an autocomplete interaction without a guildId.
+    // Without this gate a DM-typed query would burn the operator's
+    // global GOOGLE_MAPS_API_KEY quota for a send that's about to
+    // be rejected anyway.
+    const int = makeAutocompleteInteraction({ guildId: null });
     await handleAutocomplete(int);
     expect(int.respond).toHaveBeenCalledWith([]);
     expect(mockSearchPlaces).not.toHaveBeenCalled();
@@ -1902,6 +1919,24 @@ describe('handleQurlMap — slash entry', () => {
     expect(payload.resourceType).toBe('maps');
     expect(payload.locationUrl).toMatch(/google\.com\/maps\/place\/Eiffel/);
     expect(payload.locationName).toMatch(/Eiffel Tower/);
+  });
+
+  test('deferReply throws (expired token) → cooldown cleared, no flow row, no editReply', async () => {
+    // Regression: if Discord's interaction token expires between
+    // setCooldown and deferReply (or Discord transiently degrades),
+    // we must not strand the user in a 30s cooldown window with no
+    // visible response. The catch clears cooldown and returns
+    // without attempting an editReply that would also fail.
+    const int = makeInteraction({
+      options: { location: 'somewhere', recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    // Override the mock to throw on defer.
+    int.deferReply = jest.fn(async () => { const e = new Error('Unknown interaction'); e.code = 10062; throw e; });
+    await handleQurlMap(int);
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
+    expect(int.editReply).not.toHaveBeenCalled();
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
   });
 
   test('defers ONCE — handleQurlSlashSend skips its own defer when already deferred', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -161,6 +161,7 @@ jest.mock('../src/places', () => ({
     return url.toString();
   },
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  PLACE_ID_SHAPE_RE: /^[A-Za-z0-9_-]{16,}$/,
   encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
   // Mirror the production shape check so a test that smuggles a
   // too-short fake place_id doesn't pass here while failing in prod.

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -162,11 +162,13 @@ jest.mock('../src/places', () => ({
   },
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
   encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
-  decodePlaceIdSentinel: (value) => (
-    typeof value === 'string' && value.startsWith('qurl_place:')
-      ? value.slice('qurl_place:'.length)
-      : null
-  ),
+  // Mirror the production shape check so a test that smuggles a
+  // too-short fake place_id doesn't pass here while failing in prod.
+  decodePlaceIdSentinel: (value) => {
+    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
+    const placeId = value.slice('qurl_place:'.length);
+    return /^[A-Za-z0-9_-]{16,}$/.test(placeId) ? placeId : null;
+  },
 }));
 
 // Flow-state stubs. Each test overrides per-call to assert on the
@@ -2007,21 +2009,21 @@ describe('handleQurlMap — slash entry', () => {
     // Place Details (cheap, one API call) to hydrate the canonical
     // name + address, then pins the URL to the chosen place_id.
     mockGetPlaceDetails.mockResolvedValueOnce({
-      placeId: 'ChIJabc',
+      placeId: 'ChIJ37FjGE63t4kRD2_jXSF1F9o',
       name: 'The White House',
       address: '1600 Pennsylvania Ave NW',
     });
     const int = makeInteraction({
       options: {
-        location: 'qurl_place:ChIJabc',
+        location: 'qurl_place:ChIJ37FjGE63t4kRD2_jXSF1F9o',
         recipients: '<@100000000000000001>',
       },
       guildMembers: { '100000000000000001': {} },
     });
     await handleQurlMap(int);
-    expect(mockGetPlaceDetails).toHaveBeenCalledWith('ChIJabc');
+    expect(mockGetPlaceDetails).toHaveBeenCalledWith('ChIJ37FjGE63t4kRD2_jXSF1F9o');
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
-    expect(payload.locationUrl).toContain('query_place_id=ChIJabc');
+    expect(payload.locationUrl).toContain('query_place_id=ChIJ37FjGE63t4kRD2_jXSF1F9o');
     expect(payload.locationName).toBe('The White House');
   });
 
@@ -2052,7 +2054,7 @@ describe('handleQurlMap — slash entry', () => {
     // Reviewer-flagged contract: when a sender picks a suggestion from
     // autocomplete and the place is deleted upstream between pick and
     // submit, the error message must not read `Couldn't find a place
-    // matching "qurl_place:ChIJabc..."` — that's user-hostile and leaks
+    // matching "qurl_place:ChIJ37FjGE63t4kRD2_jXSF1F9o..."` — that's user-hostile and leaks
     // the wire format. Branch on parsedLocation.placeId to a place-
     // specific message instead.
     mockGetPlaceDetails.mockResolvedValueOnce(null);

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -201,6 +201,7 @@ const {
   renderConfirmCardContent,
   parseLocationInput,
   resolveLocation,
+  RESOLVE_REASON,
   handleAutocomplete,
   safeDecodeURIComponent,
   softenCooldown,
@@ -656,21 +657,21 @@ describe('resolveLocation', () => {
     mockFindPlaceFromText.mockResolvedValueOnce(null);
     const r = await resolveLocation({ text: 'asdfasdfasdf' });
     expect(r.ok).toBe(false);
-    expect(r.reason).toBe('not_found');
+    expect(r.reason).toBe(RESOLVE_REASON.NOT_FOUND);
   });
 
   test('placeId branch returns not_found when Place Details returns null', async () => {
     mockGetPlaceDetails.mockResolvedValueOnce(null);
     const r = await resolveLocation({ placeId: 'ChIJ-deleted-place' });
     expect(r.ok).toBe(false);
-    expect(r.reason).toBe('not_found');
+    expect(r.reason).toBe(RESOLVE_REASON.NOT_FOUND);
   });
 
   test('text branch returns error when the Places call throws', async () => {
     mockFindPlaceFromText.mockRejectedValueOnce(new Error('upstream timeout'));
     const r = await resolveLocation({ text: 'somewhere' });
     expect(r.ok).toBe(false);
-    expect(r.reason).toBe('error');
+    expect(r.reason).toBe(RESOLVE_REASON.ERROR);
   });
 
   test('hard-fails with no_api_key when GOOGLE_MAPS_API_KEY is unset', async () => {
@@ -685,7 +686,7 @@ describe('resolveLocation', () => {
     try {
       const r = await resolveLocation({ text: 'eiffel tower' });
       expect(r.ok).toBe(false);
-      expect(r.reason).toBe('no_api_key');
+      expect(r.reason).toBe(RESOLVE_REASON.NO_API_KEY);
     } finally {
       configMock.GOOGLE_MAPS_API_KEY = orig;
     }

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -287,7 +287,7 @@ function makeInteraction({
   });
   const optGetAttachment = jest.fn((name) => options[name] ?? null);
 
-  return {
+  const interaction = {
     user: { id: userId, username: 'Sender' },
     guildId,
     channelId,
@@ -300,13 +300,19 @@ function makeInteraction({
     },
     reply: jest.fn().mockResolvedValue(undefined),
     editReply: jest.fn().mockResolvedValue(undefined),
-    deferReply: jest.fn().mockResolvedValue(undefined),
     followUp: jest.fn().mockResolvedValue(undefined),
     update: jest.fn().mockResolvedValue(undefined),
     deferUpdate: jest.fn().mockResolvedValue(undefined),
     replied: false,
     deferred: false,
   };
+  // deferReply MUST flip `deferred` so the no-double-defer contract in
+  // handleQurlSlashSend (`if (!interaction.deferred)`) is actually
+  // exercised — otherwise handleQurlMap → handleQurlSlashSend would
+  // double-defer and the test would silently pass on a path that throws
+  // in production with "Already replied or deferred".
+  interaction.deferReply = jest.fn(async () => { interaction.deferred = true; });
+  return interaction;
 }
 
 const VALID_ATTACHMENT = Object.freeze({
@@ -1841,6 +1847,22 @@ describe('handleQurlMap — slash entry', () => {
     expect(payload.locationName).toMatch(/Eiffel Tower/);
   });
 
+  test('defers ONCE — handleQurlSlashSend skips its own defer when already deferred', async () => {
+    // Regression: handleQurlMap defers BEFORE resolveLocation so a slow
+    // Places call can't blow Discord's 3s ACK window. handleQurlSlashSend
+    // then guards its own deferReply on `!interaction.deferred`. Without
+    // that guard, the second deferReply would throw "Already replied or
+    // deferred" in production (in tests the mock just resolves twice
+    // silently — see makeInteraction's deferReply override).
+    mockFindPlaceFromText.mockResolvedValueOnce({ placeId: 'ChIJ1', name: 'Place', address: '' });
+    const int = makeInteraction({
+      options: { location: 'somewhere', recipients: '<@100000000000000001>' },
+      guildMembers: { '100000000000000001': {} },
+    });
+    await handleQurlMap(int);
+    expect(int.deferReply).toHaveBeenCalledTimes(1);
+  });
+
   test('arbitrary text → resolved through Places to a place_id-pinned URL', async () => {
     // Free-text inputs route through findPlaceFromText so every
     // recipient opens the same destination — Google's per-viewer
@@ -1900,7 +1922,11 @@ describe('handleQurlMap — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     await handleQurlMap(int);
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    // Defers BEFORE the Places call so a slow lookup can't blow
+    // Discord's 3s ACK window — resolveLocation errors land as
+    // editReply, not reply.
+    expect(int.deferReply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/Couldn't find/),
     }));
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
@@ -1919,7 +1945,7 @@ describe('handleQurlMap — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     await handleQurlMap(int);
-    expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
+    expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/lookup failed/),
     }));
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -817,6 +817,27 @@ describe('handleAutocomplete', () => {
     expect(choice.value.length).toBeLessThanOrEqual(100);
   });
 
+  test('boundary — exactly 100 UTF-16 units ending in a lone high surrogate gets backed off', async () => {
+    // Defense-in-depth: a label that's exactly at the cap AND ends
+    // mid-surrogate-pair would otherwise slip past a truncation-only
+    // gate. The check runs on every choice, not just truncated ones.
+    // 98 ASCII + 1 high surrogate + 1 low surrogate = 100 UTF-16
+    // units; the final pair is the boundary. We then trim the source
+    // to 98 + 1 high surrogate = 99 units, ending in a lone high
+    // surrogate (this is contrived — Places wouldn't return this — but
+    // pins the always-check contract).
+    const malformed = 'a'.repeat(99) + '\uD83D'; // lone high surrogate at index 99 → length 100
+    expect(malformed.length).toBe(100);
+    mockSearchPlaces.mockResolvedValueOnce([{ placeId: 'ChIJ1', name: malformed, address: '' }]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    const choice = int.respond.mock.calls[0][0][0];
+    // Backed off by 1 — no lone high surrogate at the boundary.
+    expect(choice.name.length).toBe(99);
+    const loneHigh = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+    expect(choice.name).not.toMatch(loneHigh);
+  });
+
   test('truncation does not split a surrogate pair (emoji-heavy label stays valid UTF-16)', async () => {
     // Discord measures name length in UTF-16 code units; a naïve
     // codepoint slice could ship a string whose .length > 100 if the

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -161,6 +161,12 @@ jest.mock('../src/places', () => ({
     return url.toString();
   },
   PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
+  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
+  decodePlaceIdSentinel: (value) => (
+    typeof value === 'string' && value.startsWith('qurl_place:')
+      ? value.slice('qurl_place:'.length)
+      : null
+  ),
 }));
 
 // Flow-state stubs. Each test overrides per-call to assert on the
@@ -625,10 +631,7 @@ describe('resolveLocation', () => {
     // geo-bias — without it, the URL would degrade to /maps/search/<text>
     // behavior which is the bug we're fixing.
     expect(r.locationUrl).toContain('query_place_id=ChIJ37FjGE63t4kRD2_jXSF1F9o');
-    expect(mockGetPlaceDetails).toHaveBeenCalledWith(
-      'ChIJ37FjGE63t4kRD2_jXSF1F9o',
-      expect.objectContaining({ timeoutMs: expect.any(Number) }),
-    );
+    expect(mockGetPlaceDetails).toHaveBeenCalledWith('ChIJ37FjGE63t4kRD2_jXSF1F9o');
   });
 
   test('text branch calls findPlaceFromText and pins to the top result', async () => {
@@ -782,6 +785,24 @@ describe('handleAutocomplete', () => {
     // (qurl_place: + 27-char place_id ≈ 38). Pin this — if a future
     // change starts packing more into the value we want a test to fail.
     expect(choice.value.length).toBeLessThanOrEqual(100);
+  });
+
+  test('drops a choice whose value would exceed the 100-char Discord cap', async () => {
+    // Defensive: Google docs leave place_id length open-ended. If a
+    // future result ships an >89-char place_id, we'd produce a value
+    // > 100 chars, which would fail Discord's API for the whole
+    // response. Drop just that choice so the rest of the dropdown
+    // still works.
+    mockSearchPlaces.mockResolvedValueOnce([
+      { placeId: 'short', name: 'Good', address: 'addr' },
+      { placeId: 'x'.repeat(95), name: 'Bad (too long)', address: 'addr' },
+      { placeId: 'also-short', name: 'Also Good', address: 'addr' },
+    ]);
+    const int = makeAutocompleteInteraction();
+    await handleAutocomplete(int);
+    const choices = int.respond.mock.calls[0][0];
+    expect(choices).toHaveLength(2);
+    expect(choices.map(c => c.value)).toEqual(['qurl_place:short', 'qurl_place:also-short']);
   });
 
   test('caps results at 25 (Discord choice limit)', async () => {
@@ -1819,10 +1840,7 @@ describe('handleQurlMap — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     await handleQurlMap(int);
-    expect(mockFindPlaceFromText).toHaveBeenCalledWith(
-      'Central Park, NYC',
-      expect.objectContaining({ timeoutMs: expect.any(Number) }),
-    );
+    expect(mockFindPlaceFromText).toHaveBeenCalledWith('Central Park, NYC');
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.locationUrl).toContain('query_place_id=ChIJ4zGFAZpYwokRGUGph3Mf37k');
     expect(payload.locationName).toMatch(/Central Park/);
@@ -1847,7 +1865,7 @@ describe('handleQurlMap — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     await handleQurlMap(int);
-    expect(mockGetPlaceDetails).toHaveBeenCalledWith('ChIJabc', expect.any(Object));
+    expect(mockGetPlaceDetails).toHaveBeenCalledWith('ChIJabc');
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.locationUrl).toContain('query_place_id=ChIJabc');
     expect(payload.locationName).toBe('The White House');

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -142,35 +142,15 @@ jest.mock('../src/qurl', () => ({
   getResourceStatus: jest.fn(),
 }));
 
-// places.js is mocked because the resolveLocation server-side path hits
-// Google Places at send time. Defaults: searchPlaces (autocomplete) and
-// findPlaceFromText (free-text fallback) return empty by default — each
-// describe block overrides per-test to assert the contract.
-const mockSearchPlaces = jest.fn().mockResolvedValue([]);
-const mockFindPlaceFromText = jest.fn().mockResolvedValue(null);
-const mockGetPlaceDetails = jest.fn().mockResolvedValue(null);
-jest.mock('../src/places', () => ({
-  searchPlaces: (...a) => mockSearchPlaces(...a),
-  findPlaceFromText: (...a) => mockFindPlaceFromText(...a),
-  getPlaceDetails: (...a) => mockGetPlaceDetails(...a),
-  buildPlaceUrl: (name, placeId) => {
-    const url = new URL('https://www.google.com/maps/search/');
-    url.searchParams.set('api', '1');
-    url.searchParams.set('query', name || placeId);
-    url.searchParams.set('query_place_id', placeId);
-    return url.toString();
-  },
-  PLACE_ID_SENTINEL_PREFIX: 'qurl_place:',
-  PLACE_ID_SHAPE_RE: /^[A-Za-z0-9_-]{16,}$/,
-  encodePlaceIdSentinel: (placeId) => `qurl_place:${placeId}`,
-  // Mirror the production shape check so a test that smuggles a
-  // too-short fake place_id doesn't pass here while failing in prod.
-  decodePlaceIdSentinel: (value) => {
-    if (typeof value !== 'string' || !value.startsWith('qurl_place:')) return null;
-    const placeId = value.slice('qurl_place:'.length);
-    return /^[A-Za-z0-9_-]{16,}$/.test(placeId) ? placeId : null;
-  },
-}));
+// Shared places-mock — see tests/helpers/places-mock.js for the
+// single source of truth for the encode/decode/shape contract.
+const {
+  mockPlacesModule,
+  mockSearchPlaces,
+  mockFindPlaceFromText,
+  mockGetPlaceDetails,
+} = require('./helpers/places-mock');
+jest.mock('../src/places', () => mockPlacesModule);
 
 // Flow-state stubs. Each test overrides per-call to assert on the
 // supersedeOrCreate/transitionFlow/deleteFlow contracts.


### PR DESCRIPTION
## Summary

Free-text \`/qurl map\` sends synthesized a \`/maps/search/<text>\` URL which Google resolves with viewer-side geo-bias — two recipients of the same qURL could land at different places (\"the whitehouse\" → 1600 Penn for someone in DC, a local pub for someone in Manchester).

Resolves the input to a canonical \`place_id\` at send time so every recipient opens the same destination.

## Behavior

- **Autocomplete on \`location:\`** — surfaces Places suggestions with name + address labels. Selected suggestion encodes as a \`qurl_place:<placeId>\` sentinel.
- **Free-text fallback** — if the sender ignores the dropdown and submits raw text, the handler still resolves via Find Place at submit time. Bug fix is independent of whether the sender used the dropdown.
- **URL inputs** — pass through synchronously (no API call).
- **Hard fail without \`GOOGLE_MAPS_API_KEY\`** — for non-URL input. URL inputs still work, so operators can document \"paste a Maps URL\" as the workaround.
- **1500 ms Places timeout** on the on-submit path so it fits inside Discord's 3 s ACK window even when Places hangs.

## Code changes

- \`apps/discord/src/places.js\` — added \`findPlaceFromText\`, \`getPlaceDetails\`, \`buildPlaceUrl\`, \`PLACE_ID_SENTINEL_PREFIX\`; consolidated fetch logic with optional timeout.
- \`apps/discord/src/commands.js\`:
  - \`setAutocomplete(true)\` on the \`location:\` option.
  - New \`handleAutocomplete\` dispatched from \`handleCommand\` (replacing the silent-drop short-circuit). Gates on \`/qurl map\` + focused-location, min query length 2, skips Places for URL inputs, caps at 25 choices.
  - \`parseLocationInput\` returns one of \`{locationUrl, locationName}\` (URL) | \`{placeId}\` (sentinel) | \`{text}\` (free text). Also extracts names from the canonical \`?api=1&query=…\` URL form so re-shared qURL map URLs render with a name.
  - New async \`resolveLocation\` — URL → pass-through, sentinel → Place Details, free text → Find Place. Returns \`{ok: true, locationUrl, locationName}\` or \`{ok: false, reason: 'no_api_key' | 'not_found' | 'error'}\`.
  - \`handleQurlMap\` awaits \`resolveLocation\` and maps each failure to an actionable ephemeral.

## Tests

\`apps/discord/npm test\` — 1461 pass. New coverage:

- \`parseLocationInput\`: sentinel branch, free-text → text branch, \`query=\` name extraction, spoofed-host falls through to text branch.
- \`resolveLocation\`: URL pass-through (no API call), placeId branch, text branch, not_found, no_api_key (mutates already-mocked config in place to avoid \`jest.resetModules\` cross-test pollution), error.
- \`handleAutocomplete\`: gates on command/subcommand/option name, min-length, URL-skip, sentinel encoding, name+address label, 100-char truncation, 25-choice cap, graceful empty on API throw.
- \`handleQurlMap\`: text + sentinel + not_found + error paths; cooldown cleared on each failure.
- Updated three legacy \"autocomplete dropped\" tests in \`coverage-boost\` / \`commands-comprehensive\` to the new \"routes + responds with []\" contract.

## Wire-protocol changes

- \`qurl_place:\` sentinel literal added to \`location:\` option values. Stable across deploys (commented as such in \`places.js\`).
- No customId or DDB schema changes.

## Test plan

- [x] \`npm test\` (apps/discord) — 1461 pass
- [x] \`npm run lint\` — clean
- [ ] CI green
- [ ] Claude review clean
- [ ] Live smoke: two test accounts in different regions open the same qURL map link and land at the same place
- [ ] Smoke: autocomplete dropdown populates when typing in \`/qurl map location:\`

## Limitations / deferred

None deliberately deferred in this PR. The \`query=\` name extraction in \`parseLocationInput\` is added in the same PR to keep round-trip of re-shared URLs clean (was flagged as a potential gap; closed inline rather than deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)