### PR TITLE
feat(discord): restore voice-channel-everyone on /qurl file + /qurl map

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3052,10 +3052,27 @@ function renderConfirmCardRows({
       connectedCount = n;
     }
     const labelCount = connectedCount == null ? '?' : String(connectedCount);
+    // Name the target channel in the label so a user who invoked
+    // from #voice-A and drifted to #voice-B mid-flow can tell the
+    // button still targets the original channel. Discord button-label
+    // hard cap is 80 chars; budget enforced by truncating the channel
+    // name (the prefix + suffix is ~32 chars, leaving ~46 for the
+    // name — Discord channel names cap at 100 chars so truncation is
+    // possible). On cache miss (channel was deleted between render
+    // and re-render) the legacy "this voice channel" copy is correct,
+    // since we can't name a channel we can't read.
+    const channelName = channel?.name;
+    const VOICE_LABEL_NAME_BUDGET = 46;
+    const safeName = channelName
+      ? (channelName.length > VOICE_LABEL_NAME_BUDGET
+          ? `${channelName.slice(0, VOICE_LABEL_NAME_BUDGET - 1)}…`
+          : channelName)
+      : null;
+    const labelTarget = safeName ? `#${safeName}` : 'this voice channel';
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID)
-        .setLabel(`\u{1F50A} Everyone in this voice channel (${labelCount})`)
+        .setLabel(`\u{1F50A} Everyone in ${labelTarget} (${labelCount})`)
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(connectedCount === null || connectedCount === 0),
     );
@@ -3898,13 +3915,36 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   if (!voiceChannelId) {
     // Button shouldn't have rendered without this field. A click here
     // is either a forged interaction or a payload that lost the field
-    // (schema drift). Re-render the card without the button rather
-    // than deleting the row — the user can still pick recipients
-    // through the UserSelectMenu.
+    // (schema drift). Re-render the card WITHOUT the voice button
+    // (renderConfirmCardRows conditions on voiceChannelId being set)
+    // so the broken affordance is removed AND the user gets visible
+    // feedback that something changed — silently absorbing the click
+    // post-deferUpdate would leave the user staring at an unchanged
+    // card with no indication their click registered.
     logger.warn('handleConfirmVoiceEveryone: voice button click against payload with no voiceChannelId', {
       flow_id, interaction_id: interaction.id,
     });
-    return undefined;
+    return interaction.editReply({
+      content: renderConfirmCardContent({
+        resourceType: payload.resourceType,
+        resourceLabel: payload.resourceLabel,
+        validRecipients: [],
+        expiresIn: payload.expiresIn,
+        selfDestructSeconds: payload.selfDestructSeconds,
+        personalMessage: payload.personalMessage,
+        warningsBlock: '',
+        needsPicker: true,
+        interaction,
+      }),
+      components: renderConfirmCardRows({
+        sendDisabled: true,
+        expiresIn: payload.expiresIn,
+        selfDestructSeconds: payload.selfDestructSeconds,
+        personalMessage: payload.personalMessage,
+        voiceChannelId: null,
+        interaction,
+      }),
+    }).catch(logIgnoredDiscordErr);
   }
 
   // Re-render with a warning banner. Same shape as the picker's

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3035,6 +3035,13 @@ function renderConfirmCardRows({
     // fall back to `?` so the button still renders without crashing.
     // The button itself is disabled in either degraded case (no count
     // = nothing to send to anyway from this affordance).
+    //
+    // Count is render-time, not click-time — members can join/leave
+    // voice between renders. Click-time resolution in
+    // handleConfirmVoiceEveryone is the authoritative recipient set;
+    // the label is a freshness hint that re-derives on every other
+    // confirm-card interaction (picker / expiry / note edits all flow
+    // through renderConfirmCardRows again).
     const channel = interaction?.guild?.channels?.cache?.get?.(voiceChannelId);
     let connectedCount = null;
     if (channel?.members) {
@@ -3894,7 +3901,9 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     // (schema drift). Re-render the card without the button rather
     // than deleting the row — the user can still pick recipients
     // through the UserSelectMenu.
-    logger.warn('handleConfirmVoiceEveryone: voice button click against payload with no voiceChannelId', { flow_id });
+    logger.warn('handleConfirmVoiceEveryone: voice button click against payload with no voiceChannelId', {
+      flow_id, interaction_id: interaction.id,
+    });
     return undefined;
   }
 
@@ -3902,6 +3911,14 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // rejectPick path so the user sees why the button didn't take.
   // Pass the local `voiceChannelId` (already proven truthy above) for
   // consistency with the other handler reads below.
+  //
+  // The payload keeps `voiceChannelId` set even on the reject path —
+  // intentionally. A transient cache miss (voice intent dropped,
+  // members momentarily evicted) will re-disable the button via the
+  // count=null branch on this re-render, but a subsequent picker /
+  // expiry / note interaction will run renderConfirmCardRows again
+  // with the now-repopulated cache and re-enable the button. Recovery
+  // is automatic; persisting the field is the load-bearing piece.
   const rejectVoice = (warning) => interaction.editReply({
     content: renderConfirmCardContent({
       resourceType: payload.resourceType,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1094,7 +1094,7 @@ async function executeSendPipeline(interaction, {
       threshold: sendThreshold,
       cap: config.QURL_SEND_MAX_RECIPIENTS,
       resource_type: resourceType,
-      sender_id: interaction.user.id,
+      user_id: interaction.user.id,
       guild_id: interaction.guildId,
     });
   }
@@ -3103,7 +3103,7 @@ function renderConfirmCardRows({
     // interaction; renderer-shape unit tests that drive layout-only
     // assertions may omit it. Either degraded case (no interaction,
     // missing channel, no members collection) lands the button in
-    // the disabled-with-count=null branch — `connectedCount === null`
+    // the disabled-with-count=null branch — `connectedCount == null`
     // is the single sentinel for "render the disabled button shell".
     //
     // Count is render-time, not click-time — members can join/leave
@@ -3112,6 +3112,16 @@ function renderConfirmCardRows({
     // the label is a freshness hint that re-derives on every other
     // confirm-card interaction (picker / expiry / note edits all flow
     // through renderConfirmCardRows again).
+    // Filter-drift contract: the render-time count below uses
+    // `isBotMember(m)` to compute (N), while click-time resolution
+    // in handleConfirmVoiceEveryone routes channel.members through
+    // `partitionRecipients` for the authoritative recipient set.
+    // Both apply the same bot filter today, so the count is honest.
+    // If `partitionRecipients` ever picks up additional drops (role-
+    // blocklist, self-filter toggle, etc.), the render-time `(N)`
+    // will silently overstate the click-time set — keep the two
+    // filter sources aligned, or accept a stale label and document
+    // the drift here.
     let connectedCount = null;
     let channelName = null;
     if (interaction) {
@@ -3163,7 +3173,7 @@ function renderConfirmCardRows({
         .setCustomId(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID)
         .setLabel(`\u{1F50A} Everyone in ${labelTarget} (${labelCount})`)
         .setStyle(ButtonStyle.Secondary)
-        .setDisabled(connectedCount === null || connectedCount === 0),
+        .setDisabled(connectedCount == null || connectedCount === 0),
     );
   }
   bottomRow.addComponents(

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2615,13 +2615,28 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // path. Today the live `(N)` count on the button label is the user's
 // best signal that a click against a 500-person stage will fan out
 // to 500 DMs.
+//
+// NOT GATED ON MENTION_EVERYONE (intentional asymmetry with the
+// @everyone slash-text path): the button is rendered only when the
+// slash command was invoked from inside a voice channel, which
+// intrinsically proves the sender's co-presence. A user already in
+// a voice channel can DM each member individually; bundling the
+// operation doesn't escalate privilege. Mirrors the same rationale
+// at the parser `<#voice>` expansion site in recipient-parser.js.
+// Tracked in #339 if a future product decision (stage channels with
+// thousands of audience) needs to revisit this for stage-only.
 const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
 
 // Recipient-rejection reason strings shared by every handler that
 // can drop a selection to empty (picker, voice-everyone). Hoisted
 // from inline literals so a copy-edit (e.g., to "Cannot DM bots")
-// updates every surface at once.
+// updates every surface at once. Voice-specific warning copy is also
+// hoisted here so all the user-visible strings live in one place
+// rather than being scattered through 800+ lines of handler code.
 const RECIPIENT_REASON_BOTS_DROPPED = 'Cannot send to bots';
+const VOICE_REJECT_CHANNEL_UNREADABLE = `⚠\u{FE0F} Couldn't read the voice channel — it may have been deleted. Pick recipients below.\n\n`;
+const VOICE_REJECT_EMPTY_CHANNEL = `⚠\u{FE0F} No one is connected to that voice channel right now. Pick recipients below.\n\n`;
+const VOICE_REJECT_CONTEXT_LOST = `⚠\u{FE0F} Voice channel context was lost — use the picker below to choose recipients.\n\n`;
 // Local to the note modal — kept off the prefix-only customId
 // allowlist because flow-dispatch never routes modal-input fields,
 // only the parent modal customId.
@@ -3123,6 +3138,13 @@ function renderConfirmCardRows({
     // is possible; on cache miss (channel was deleted between render
     // and re-render) the legacy "this voice channel" copy is correct,
     // since we can't name a channel we can't read.
+    //
+    // SAFETY: channel.name is interpolated raw into the button label
+    // — Discord BUTTON labels do not render markdown / mentions /
+    // emoji shortcodes, so a channel name containing `**bold**` or
+    // `<@123>` is displayed verbatim. A future refactor that moves
+    // this label into an embed description / message content would
+    // need to escape `channel.name` against markdown/mention parsing.
     const VOICE_LABEL_NAME_BUDGET = 46;
     // safeCodepointSlice (defined above) is codepoint-aware so a
     // surrogate-pair emoji at index 45 doesn't get sliced mid-
@@ -4011,7 +4033,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     return rerenderConfirmCard(interaction, {
       ...payload,
       voiceChannelId: null,
-      warningsBlock: `⚠\u{FE0F} Voice channel context was lost — use the picker below to choose recipients.\n\n`,
+      warningsBlock: VOICE_REJECT_CONTEXT_LOST,
     });
   }
 
@@ -4064,7 +4086,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // recently dropped, etc.) lands in the warning branch.
   const channel = interaction.guild?.channels?.cache?.get(voiceChannelId);
   if (!channel || !channel.members) {
-    return rejectVoice(`⚠\u{FE0F} Couldn't read the voice channel — it may have been deleted. Pick recipients below.\n\n`);
+    return rejectVoice(VOICE_REJECT_CHANNEL_UNREADABLE);
   }
   // True-empty channel gets honest "no one connected" copy.
   // bots-only flows through partition below and surfaces "Cannot send
@@ -4073,7 +4095,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // and force the bots-only case into a misleading "no usable
   // recipients" fallback).
   if (channel.members.size === 0) {
-    return rejectVoice(`⚠\u{FE0F} No one is connected to that voice channel right now. Pick recipients below.\n\n`);
+    return rejectVoice(VOICE_REJECT_EMPTY_CHANNEL);
   }
   // GuildMember → User shape so partitionRecipients sees the same
   // shape the picker hands it. Skip entries with no .user (defensive
@@ -4114,6 +4136,20 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // depth against a misconfigured smaller env override rather than the
   // common path. The picker's similar guard at handleConfirmUserSelect
   // is identically structured.
+  //
+  // CAP DIVERGENCE (intentional): the parser's `<#voice>` path
+  // truncates at cap (silent partial-resolution with `cappedCount`
+  // surfaced), while this button path hard-rejects past cap. Different
+  // UX shapes for the same conceptual input ("everyone in voice")
+  // is acceptable because:
+  //   - The button is unambiguous "all-or-nothing" intent — a partial
+  //     fan-out misrepresents the click.
+  //   - The parser path mixes channel mentions with other mentions,
+  //     where partial-resolution is the existing pattern.
+  //   - The reject is unreachable under defaults (voice caps < 20k);
+  //     only env-overridden smaller caps trip it.
+  // Tracked in #339 if a future product decision needs to align
+  // these surfaces (e.g., button truncates with confirm-card warning).
   if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
     return rejectVoice(`⚠\u{FE0F} Voice channel has ${valid.length} connected (max ${config.QURL_SEND_MAX_RECIPIENTS}). Use the picker or @mentions to choose a subset.\n\n`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3077,10 +3077,15 @@ function renderConfirmCardRows({
   const bottomRow = new ActionRowBuilder();
   if (voiceChannelId) {
     // Live count via interaction.guild for the label. interaction may
-    // be absent on the (rare) test path that builds rows without it;
-    // fall back to `?` so the button still renders without crashing.
-    // The button itself is disabled in either degraded case (no count
-    // = nothing to send to anyway from this affordance).
+    // be absent on the rare test path that calls renderConfirmCardRows
+    // directly without constructing an interaction stub (e.g., the
+    // qurl-file-map.test.js renderer-shape tests that exercise row
+    // count + layout without exercising guild-cache resolution); fall
+    // back to `?` so the button still renders without crashing. Every
+    // production caller (handleQurlSlashSend, handleConfirmUserSelect,
+    // handleConfirmVoiceEveryone, rerenderConfirmCard) passes
+    // interaction. The button itself is disabled in either degraded
+    // case (no count = nothing to send to anyway from this affordance).
     //
     // Count is render-time, not click-time — members can join/leave
     // voice between renders. Click-time resolution in
@@ -4059,9 +4064,23 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // shape the picker hands it. Skip entries with no .user (defensive
   // against partial-cache rows); partitionRecipients handles the
   // bot filter + droppedBots accounting.
+  //
+  // Partial-cache drops are logged at debug level — silent shrinkage
+  // of the recipient set is hard to diagnose post-hoc without
+  // telemetry. The log fires per shrunk send (not per dropped
+  // member) so volume tracks frequency of the degraded state, not
+  // member count.
   const selectedUsers = [];
+  let partialCacheDrops = 0;
   for (const [, m] of channel.members) {
     if (m?.user) selectedUsers.push(m.user);
+    else partialCacheDrops++;
+  }
+  if (partialCacheDrops > 0) {
+    logger.debug('handleConfirmVoiceEveryone: partial-cache rows dropped from voice resolution', {
+      flow_id, voice_channel_id: voiceChannelId, dropped: partialCacheDrops,
+      channel_size: channel.members.size,
+    });
   }
   const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);
   if (valid.length === 0) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -54,13 +54,13 @@ const TOKENS_PER_RESOURCE = 10;
 // so log volume tracks operational importance.
 const LARGE_SEND_RECIPIENT_FLOOR = 1000;
 function largeSendThreshold() {
-  // `Math.max(1, …)` on the inner half: a pathologically-low cap
-  // override (e.g., 1) would otherwise yield `Math.floor(1/2) = 0`,
-  // making `>= 0` always true and firing the WARN on every send.
-  // Floor at 1 so the threshold is always a positive integer; the
-  // `>= threshold` comparison at the call site still works correctly
-  // for any cap ≥ 1 (the config validator rejects cap ≤ 0).
-  return Math.min(LARGE_SEND_RECIPIENT_FLOOR, Math.max(1, Math.floor(config.QURL_SEND_MAX_RECIPIENTS / 2)));
+  // `half || 1` floors the threshold at 1 so a pathologically-low cap
+  // override (e.g., cap=1 → floor(0.5)=0) doesn't make `>= 0` always
+  // true and fire the WARN on every send. Threshold is always a
+  // positive integer; the config validator rejects cap ≤ 0 so the
+  // 0→1 substitution only fires for cap=1.
+  const half = Math.floor(config.QURL_SEND_MAX_RECIPIENTS / 2);
+  return Math.min(LARGE_SEND_RECIPIENT_FLOOR, half || 1);
 }
 
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
@@ -3082,16 +3082,14 @@ function renderConfirmCardRows({
   // so the user can tell at a glance whether a note is attached.
   const bottomRow = new ActionRowBuilder();
   if (voiceChannelId) {
-    // Live count via interaction.guild for the label. interaction may
-    // be absent on the rare test path that calls renderConfirmCardRows
-    // directly without constructing an interaction stub (e.g., the
-    // qurl-file-map.test.js renderer-shape tests that exercise row
-    // count + layout without exercising guild-cache resolution); fall
-    // back to `?` so the button still renders without crashing. Every
-    // production caller (handleQurlSlashSend, handleConfirmUserSelect,
+    // Live count via interaction.guild for the label. Every production
+    // caller (handleQurlSlashSend, handleConfirmUserSelect,
     // handleConfirmVoiceEveryone, rerenderConfirmCard) passes
-    // interaction. The button itself is disabled in either degraded
-    // case (no count = nothing to send to anyway from this affordance).
+    // interaction; renderer-shape unit tests that drive layout-only
+    // assertions may omit it. Either degraded case (no interaction,
+    // missing channel, no members collection) lands the button in
+    // the disabled-with-count=null branch — `connectedCount === null`
+    // is the single sentinel for "render the disabled button shell".
     //
     // Count is render-time, not click-time — members can join/leave
     // voice between renders. Click-time resolution in
@@ -3099,14 +3097,18 @@ function renderConfirmCardRows({
     // the label is a freshness hint that re-derives on every other
     // confirm-card interaction (picker / expiry / note edits all flow
     // through renderConfirmCardRows again).
-    const channel = interaction?.guild?.channels?.cache?.get?.(voiceChannelId);
     let connectedCount = null;
-    if (channel?.members) {
-      let n = 0;
-      for (const [, m] of channel.members) {
-        if (!isBotMember(m)) n++;
+    let channelName = null;
+    if (interaction) {
+      const channel = interaction.guild?.channels?.cache?.get?.(voiceChannelId);
+      if (channel?.members) {
+        let n = 0;
+        for (const [, m] of channel.members) {
+          if (!isBotMember(m)) n++;
+        }
+        connectedCount = n;
+        channelName = channel.name || null;
       }
-      connectedCount = n;
     }
     const labelCount = connectedCount == null ? '?' : String(connectedCount);
     // Name the target channel in the label so a user who invoked
@@ -3121,7 +3123,6 @@ function renderConfirmCardRows({
     // is possible; on cache miss (channel was deleted between render
     // and re-render) the legacy "this voice channel" copy is correct,
     // since we can't name a channel we can't read.
-    const channelName = channel?.name;
     const VOICE_LABEL_NAME_BUDGET = 46;
     // safeCodepointSlice (defined above) is codepoint-aware so a
     // surrogate-pair emoji at index 45 doesn't get sliced mid-

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2519,6 +2519,7 @@ async function handleSetupModal(interaction, { flow_id }) {
 const {
   parseRecipientMentions,
   isVoiceChannelType,
+  isBotMember,
   MAX_SLASH_OPTION_LENGTH: RECIPIENTS_SLASH_MAX_LENGTH,
 } = require('./recipient-parser');
 
@@ -2563,6 +2564,12 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // (replacing the legacy `/qurl send`'s wizard option deleted in
 // PR #313 alongside `getChannelMembers`).
 const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
+
+// Recipient-rejection reason strings shared by every handler that
+// can drop a selection to empty (picker, voice-everyone). Hoisted
+// from inline literals so a copy-edit (e.g., to "Cannot DM bots")
+// updates every surface at once.
+const RECIPIENT_REASON_BOTS_DROPPED = 'Cannot send to bots';
 // Local to the note modal — kept off the prefix-only customId
 // allowlist because flow-dispatch never routes modal-input fields,
 // only the parent modal customId.
@@ -3033,7 +3040,7 @@ function renderConfirmCardRows({
     if (channel?.members) {
       let n = 0;
       for (const [, m] of channel.members) {
-        if (!m?.user?.bot) n++;
+        if (!isBotMember(m)) n++;
       }
       connectedCount = n;
     }
@@ -3743,7 +3750,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     // degraded `⚠ . Re-pick...` message if a future filter is
     // removed and `valid.length === 0` is hit with droppedBots === 0.
     const reasons = [];
-    if (droppedBots > 0) reasons.push('Cannot send to bots');
+    if (droppedBots > 0) reasons.push(RECIPIENT_REASON_BOTS_DROPPED);
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }
@@ -3863,8 +3870,8 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
 
   const payload = row.payload || {};
-  // resourceType guard mirrors handleConfirmUserSelect:3626 — a
-  // corrupt/stale row would otherwise throw from renderConfirmCardContent.
+  // resourceType guard mirrors handleConfirmUserSelect — a corrupt /
+  // stale row would otherwise throw from renderConfirmCardContent.
   const payloadResource = payload.resourceType;
   if (payloadResource !== RESOURCE_TYPES.FILE && payloadResource !== RESOURCE_TYPES.MAPS) {
     logger.error('handleConfirmVoiceEveryone: corrupt flow payload (unknown resourceType)', {
@@ -3893,6 +3900,8 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
 
   // Re-render with a warning banner. Same shape as the picker's
   // rejectPick path so the user sees why the button didn't take.
+  // Pass the local `voiceChannelId` (already proven truthy above) for
+  // consistency with the other handler reads below.
   const rejectVoice = (warning) => interaction.editReply({
     content: renderConfirmCardContent({
       resourceType: payload.resourceType,
@@ -3910,7 +3919,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       expiresIn: payload.expiresIn,
       selfDestructSeconds: payload.selfDestructSeconds,
       personalMessage: payload.personalMessage,
-      voiceChannelId: payload.voiceChannelId,
+      voiceChannelId,
       interaction,
     }),
   }).catch(logIgnoredDiscordErr);
@@ -3925,24 +3934,31 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   if (!channel || !channel.members) {
     return rejectVoice(`⚠\u{FE0F} Couldn't read the voice channel — it may have been deleted. Pick recipients below.\n\n`);
   }
-  // Filter bots inline (mirrors recipient-parser's voice-expansion
-  // pass) and convert GuildMember → User so partitionRecipients sees
-  // the same shape the picker hands it.
+  // True-empty channel gets honest "no one connected" copy.
+  // bots-only flows through partition below and surfaces "Cannot send
+  // to bots" — that copy depends on partitionRecipients owning the
+  // bot filter end-to-end (a pre-filter here would zero out droppedBots
+  // and force the bots-only case into a misleading "no usable
+  // recipients" fallback).
+  if (channel.members.size === 0) {
+    return rejectVoice(`⚠\u{FE0F} No one is connected to that voice channel right now. Pick recipients below.\n\n`);
+  }
+  // GuildMember → User shape so partitionRecipients sees the same
+  // shape the picker hands it. Skip entries with no .user (defensive
+  // against partial-cache rows); partitionRecipients handles the
+  // bot filter + droppedBots accounting.
   const selectedUsers = [];
   for (const [, m] of channel.members) {
-    if (m?.user?.bot) continue;
     if (m?.user) selectedUsers.push(m.user);
-  }
-  if (selectedUsers.length === 0) {
-    return rejectVoice(`⚠\u{FE0F} No one is connected to that voice channel right now. Pick recipients below.\n\n`);
   }
   const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);
   if (valid.length === 0) {
-    // Defense-in-depth — the pre-filter above already dropped bots,
-    // so reaching here means every connected non-bot got filtered by
-    // a future addition to partitionRecipients. Surface generic copy.
+    // Reached when every connected member was filtered out — today
+    // that's the bots-only case (droppedBots > 0). The fallback
+    // text covers a future filter addition (e.g., role-blocklist)
+    // that drops everyone for a different reason.
     const reasons = [];
-    if (droppedBots > 0) reasons.push('Cannot send to bots');
+    if (droppedBots > 0) reasons.push(RECIPIENT_REASON_BOTS_DROPPED);
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in voice channel';
     return rejectVoice(`⚠\u{FE0F} ${reasonText}. Pick recipients below.\n\n`);
   }
@@ -4018,7 +4034,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       expiresIn: payload.expiresIn,
       selfDestructSeconds: payload.selfDestructSeconds,
       personalMessage: payload.personalMessage,
-      voiceChannelId: payload.voiceChannelId,
+      voiceChannelId,
       interaction,
     }),
   }).catch(logIgnoredDiscordErr);
@@ -6277,10 +6293,10 @@ module.exports = {
       safeDecodeURIComponent,
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
-      // All eight confirm-card customId literals exported so the
-      // contract test in qurl-file-map.test.js can pin every wire
-      // value — a typo in any of these silently breaks routing for
-      // in-flight confirm cards, so they need to be test-asserted.
+      // Every confirm-card customId is exported so the contract test
+      // in qurl-file-map.test.js can pin every wire value — a typo
+      // in any of these silently breaks routing for in-flight confirm
+      // cards, so they need to be test-asserted.
       CONFIRM_USER_SELECT_CUSTOM_ID,
       CONFIRM_SEND_CUSTOM_ID,
       CONFIRM_CANCEL_CUSTOM_ID,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3139,15 +3139,19 @@ function renderConfirmCardRows({
     // Name the target channel in the label so a user who invoked
     // from #voice-A and drifted to #voice-B mid-flow can tell the
     // button still targets the original channel. Discord button-label
-    // hard cap is 80 UTF-16 code units; the fixed prefix + suffix
-    // measures ~26-28 UTF-16 units depending on count width:
+    // hard cap is 80 UTF-16 code units (NOT codepoints — Discord
+    // measures UTF-16 surrogate-pair-aware, so an emoji-heavy 46-
+    // codepoint name occupies up to 92 UTF-16 units). Budget the
+    // name in UTF-16 units (channelName.length, which IS UTF-16 unit
+    // count in JS strings) so the upper bound is hard-guaranteed
+    // regardless of emoji density.
+    //
+    // Fixed prefix + suffix:
     //   `🔊 ` (3) + `Everyone in #` (13) + ` (NNNNN)` (max 8) = 24
-    //   (🔊 is a surrogate pair = 2 UTF-16 units + a VS16/space).
-    // 46 leaves ~10 units of headroom for label evolution / emoji
-    // additions. Discord channel names cap at 100 chars so truncation
-    // is possible; on cache miss (channel was deleted between render
-    // and re-render) the legacy "this voice channel" copy is correct,
-    // since we can't name a channel we can't read.
+    //   (🔊 is a surrogate pair = 2 UTF-16 units + a space).
+    // 50 leaves 6 units of headroom for label evolution. The `…`
+    // ellipsis adds 1 UTF-16 unit, so the budget includes its slot:
+    // a max-truncation label measures 24 + 49 + 1 = 74 UTF-16 units.
     //
     // SAFETY: channel.name is interpolated raw into the button label
     // — Discord BUTTON labels do not render markdown / mentions /
@@ -3155,18 +3159,19 @@ function renderConfirmCardRows({
     // `<@123>` is displayed verbatim. A future refactor that moves
     // this label into an embed description / message content would
     // need to escape `channel.name` against markdown/mention parsing.
-    const VOICE_LABEL_NAME_BUDGET = 46;
-    // safeCodepointSlice (defined above) is codepoint-aware so a
-    // surrogate-pair emoji at index 45 doesn't get sliced mid-
-    // codepoint and render as `�` on the button. Channel names with
-    // emoji (Discord allows them in names) are the realistic case
-    // this guards against. The `…` ellipsis fits inside the budget
-    // since safeCodepointSlice caps at N codepoints, not N + 1.
-    const safeName = channelName
-      ? (Array.from(channelName).length > VOICE_LABEL_NAME_BUDGET
-          ? `${safeCodepointSlice(channelName, VOICE_LABEL_NAME_BUDGET - 1)}…`
-          : channelName)
-      : null;
+    const VOICE_LABEL_NAME_UTF16_BUDGET = 50;
+    // Back off if the cut would split a surrogate pair (a high
+    // surrogate at the last position with no paired low surrogate
+    // would render as `�`). Reserve 1 UTF-16 unit for the ellipsis.
+    const safeName = (() => {
+      if (!channelName) return null;
+      if (channelName.length <= VOICE_LABEL_NAME_UTF16_BUDGET) return channelName;
+      let cut = VOICE_LABEL_NAME_UTF16_BUDGET - 1;
+      // High surrogate at cut-1 → cut would split it; back off 1 unit.
+      const code = channelName.charCodeAt(cut - 1);
+      if (code >= 0xD800 && code <= 0xDBFF) cut -= 1;
+      return `${channelName.slice(0, cut)}…`;
+    })();
     const labelTarget = safeName ? `#${safeName}` : 'this voice channel';
     bottomRow.addComponents(
       new ButtonBuilder()
@@ -4094,7 +4099,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // connected members for voice/stage-voice channels. A cache miss
   // (channel was deleted between render and click, voice intent was
   // recently dropped, etc.) lands in the warning branch.
-  const channel = interaction.guild?.channels?.cache?.get(voiceChannelId);
+  const channel = interaction.guild?.channels?.cache?.get?.(voiceChannelId);
   if (!channel || !channel.members) {
     return rejectVoice(VOICE_REJECT_CHANNEL_UNREADABLE);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2518,6 +2518,7 @@ async function handleSetupModal(interaction, { flow_id }) {
 
 const {
   parseRecipientMentions,
+  isVoiceChannelType,
   MAX_SLASH_OPTION_LENGTH: RECIPIENTS_SLASH_MAX_LENGTH,
 } = require('./recipient-parser');
 
@@ -2552,6 +2553,16 @@ const CONFIRM_EXPIRY_SELECT_CUSTOM_ID = 'qurl_confirm_expiry';
 const CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID = 'qurl_confirm_self_destruct';
 const CONFIRM_NOTE_BUTTON_CUSTOM_ID = 'qurl_confirm_note_btn';
 const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
+// Confirm-card "Everyone in this voice channel" button. Rendered only
+// when the slash command was invoked from a voice / stage-voice channel
+// (`payload.voiceChannelId` is set by `handleQurlSlashSend`). Mirrors
+// the role-mention/`<#voice>` parser path: resolve voice-connected
+// non-bot members via `channel.members` AT CLICK TIME, not render time,
+// so a 30s-old member snapshot doesn't silently send to people who
+// left. PR #174's "voice-connected only" semantics are restored here
+// (replacing the legacy `/qurl send`'s wizard option deleted in
+// PR #313 alongside `getChannelMembers`).
+const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
 // Local to the note modal — kept off the prefix-only customId
 // allowlist because flow-dispatch never routes modal-input fields,
 // only the parent modal customId.
@@ -2915,12 +2926,24 @@ function formatPersonalMessagePreview(message) {
 // the layout is stable from frame 0), Self-destruct StringSelectMenu,
 // Expiry StringSelectMenu (each select needs its own row — Discord
 // forbids combining selects with buttons in the same ActionRow),
-// and the bottom row packing Note button + Send + Cancel.
+// and the bottom row packing the optional voice-everyone button +
+// Note button + Send + Cancel.
 //
-// Row math (Discord 5-row max):
-//   UserSelect + SelfDestruct + Expiry + [Note, Send, Cancel] = 4 rows
+// Row math (Discord 5-row max, 5-buttons-per-row max):
+//   UserSelect + SelfDestruct + Expiry +
+//   [(optional 🔊 Voice), Note, Send, Cancel] = 4 rows, ≤ 4 buttons
+//
+// The voice button is rendered only when `voiceChannelId` is non-null
+// (snapshot into payload by `handleQurlSlashSend` when the slash
+// command was invoked from a voice / stage-voice channel). Disabled
+// with a `(0)` count when the channel has no connected non-bot members
+// at render time — honest UX so the user can see WHY the button is
+// inert. The actual member resolution still happens at click time
+// (see `handleConfirmVoiceEveryone`); the count here is a snapshot
+// hint so the label isn't blank.
 function renderConfirmCardRows({
   sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
+  voiceChannelId, interaction,
 }) {
   const rows = [];
   const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
@@ -2995,10 +3018,35 @@ function renderConfirmCardRows({
         }))
       )
   ));
-  // Bottom row: Note button + Send + Cancel. Label flips between
-  // "Add a note" and "Edit note" based on current state so the user
-  // can tell at a glance whether a note is attached.
-  rows.push(new ActionRowBuilder().addComponents(
+  // Bottom row: [optional 🔊 Voice] + Note + Send + Cancel. Note label
+  // flips between "Add a note" and "Edit note" based on current state
+  // so the user can tell at a glance whether a note is attached.
+  const bottomRow = new ActionRowBuilder();
+  if (voiceChannelId) {
+    // Live count via interaction.guild for the label. interaction may
+    // be absent on the (rare) test path that builds rows without it;
+    // fall back to `?` so the button still renders without crashing.
+    // The button itself is disabled in either degraded case (no count
+    // = nothing to send to anyway from this affordance).
+    const channel = interaction?.guild?.channels?.cache?.get?.(voiceChannelId);
+    let connectedCount = null;
+    if (channel?.members) {
+      let n = 0;
+      for (const [, m] of channel.members) {
+        if (!m?.user?.bot) n++;
+      }
+      connectedCount = n;
+    }
+    const labelCount = connectedCount == null ? '?' : String(connectedCount);
+    bottomRow.addComponents(
+      new ButtonBuilder()
+        .setCustomId(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID)
+        .setLabel(`\u{1F50A} Everyone in this voice channel (${labelCount})`)
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(connectedCount === null || connectedCount === 0),
+    );
+  }
+  bottomRow.addComponents(
     new ButtonBuilder()
       .setCustomId(CONFIRM_NOTE_BUTTON_CUSTOM_ID)
       .setLabel(personalMessage ? '✏\u{FE0F} Edit note' : '✏\u{FE0F} Add a note (optional)')
@@ -3012,7 +3060,8 @@ function renderConfirmCardRows({
       .setCustomId(CONFIRM_CANCEL_CUSTOM_ID)
       .setLabel('Cancel')
       .setStyle(ButtonStyle.Secondary),
-  ));
+  );
+  rows.push(bottomRow);
   return rows;
 }
 
@@ -3094,9 +3143,10 @@ async function handleQurlSlashSend(interaction, params) {
     // `@everyone` is gated on the sender's MENTION_EVERYONE permission
     // in this channel (Discord's own gate for mass-mention). Without
     // this, any guild member could blast a /qurl send to every member
-    // in the cache, bounded only by the 25-recipient cap. The parser
-    // surfaces `massMentionDenied: true` when the sender tried but
-    // lacks permission — the caller renders a permission-specific
+    // in the cache, bounded only by the QURL_SEND_MAX_RECIPIENTS cap
+    // (now 20k — sized for voice/stage-everyone, see config.js). The
+    // parser surfaces `massMentionDenied: true` when the sender tried
+    // but lacks permission — the caller renders a permission-specific
     // warning instead of the generic "couldn't parse" copy.
     //
     // `interaction.memberPermissions` is the resolved channel-effective
@@ -3208,6 +3258,24 @@ async function handleQurlSlashSend(interaction, params) {
     const recipientAliases = Object.fromEntries(
       valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
     );
+    // Voice-channel context snapshot. The "Everyone in this voice
+    // channel" confirm-card button is rendered when this is set.
+    // Snapshot at slash-command time (NOT re-derived at button-click)
+    // because:
+    //   - interaction.channel at click time tracks the channel the
+    //     ephemeral message lives in, which DOES match invocation
+    //     channel in practice — but pinning via payload is the durable
+    //     contract and matches the rest of the flow-state pattern.
+    //   - A user who opens /qurl file from a voice channel, then
+    //     drags themselves into a different channel mid-confirm,
+    //     should still see "Everyone in this voice channel" target
+    //     the channel they invoked from, not the channel they're now
+    //     in.
+    // The actual member resolution still happens at click time via
+    // channel.members — see handleConfirmVoiceEveryone.
+    const voiceChannelId = isVoiceChannelType(interaction.channel?.type)
+      ? interaction.channel.id
+      : null;
     const payload = {
       resourceType: params.resourceType,
       attachment: params.attachment,
@@ -3216,6 +3284,7 @@ async function handleQurlSlashSend(interaction, params) {
       resourceLabel: params.resourceLabel,
       recipientIds,
       recipientAliases,
+      voiceChannelId,
       expiresIn,
       selfDestructSeconds,
       personalMessage,
@@ -3292,6 +3361,8 @@ async function handleQurlSlashSend(interaction, params) {
       expiresIn,
       selfDestructSeconds,
       personalMessage,
+      voiceChannelId,
+      interaction,
     });
     // `return await` (not bare `return`) is load-bearing: without it
     // a Discord-side rejection on the confirm-card delivery would
@@ -3653,6 +3724,8 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       expiresIn: payload.expiresIn,
       selfDestructSeconds: payload.selfDestructSeconds,
       personalMessage: payload.personalMessage,
+      voiceChannelId: payload.voiceChannelId,
+      interaction,
     }),
   }).catch(logIgnoredDiscordErr);
   if (valid.length === 0) {
@@ -3767,6 +3840,186 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       expiresIn: payload.expiresIn,
       selfDestructSeconds: payload.selfDestructSeconds,
       personalMessage: payload.personalMessage,
+      voiceChannelId: payload.voiceChannelId,
+      interaction,
+    }),
+  }).catch(logIgnoredDiscordErr);
+}
+
+// Confirm-card "Everyone in this voice channel" button. Mirrors the
+// UserSelectMenu handler's shape (deferUpdate → resolve → partition →
+// transitionFlow → re-render) but reads the voice-connected member
+// set AT CLICK TIME from the guild's voice-state cache rather than
+// taking the selection from a Discord-emitted picker payload. This
+// click-time read is load-bearing: a 30s-old snapshot would silently
+// send to users who already left voice.
+//
+// The button is only rendered when payload.voiceChannelId is set
+// (snapshot at slash-command time). A click without that field is
+// either a forged interaction or a malformed flow row — treat as a
+// corrupt payload and surface re-run copy, same shape as
+// handleConfirmUserSelect's resourceType guard.
+async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
+  const payload = row.payload || {};
+  // resourceType guard mirrors handleConfirmUserSelect:3626 — a
+  // corrupt/stale row would otherwise throw from renderConfirmCardContent.
+  const payloadResource = payload.resourceType;
+  if (payloadResource !== RESOURCE_TYPES.FILE && payloadResource !== RESOURCE_TYPES.MAPS) {
+    logger.error('handleConfirmVoiceEveryone: corrupt flow payload (unknown resourceType)', {
+      flow_id, resource_type: payloadResource,
+    });
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch(logIgnoredDiscordErr);
+    return interaction.editReply({
+      content: '❌ Card data is corrupted — please re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  const voiceChannelId = payload.voiceChannelId;
+  if (!voiceChannelId) {
+    // Button shouldn't have rendered without this field. A click here
+    // is either a forged interaction or a payload that lost the field
+    // (schema drift). Re-render the card without the button rather
+    // than deleting the row — the user can still pick recipients
+    // through the UserSelectMenu.
+    logger.warn('handleConfirmVoiceEveryone: voice button click against payload with no voiceChannelId', { flow_id });
+    return undefined;
+  }
+
+  // Re-render with a warning banner. Same shape as the picker's
+  // rejectPick path so the user sees why the button didn't take.
+  const rejectVoice = (warning) => interaction.editReply({
+    content: renderConfirmCardContent({
+      resourceType: payload.resourceType,
+      resourceLabel: payload.resourceLabel,
+      validRecipients: [],
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+      warningsBlock: warning,
+      needsPicker: true,
+      interaction,
+    }),
+    components: renderConfirmCardRows({
+      sendDisabled: true,
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+      voiceChannelId: payload.voiceChannelId,
+      interaction,
+    }),
+  }).catch(logIgnoredDiscordErr);
+
+  // Resolve voice-connected members AT CLICK TIME from the voice-state
+  // cache (populated by the GuildVoiceStates intent). channel.members
+  // is a Collection<Snowflake, GuildMember> filtered to currently-
+  // connected members for voice/stage-voice channels. A cache miss
+  // (channel was deleted between render and click, voice intent was
+  // recently dropped, etc.) lands in the warning branch.
+  const channel = interaction.guild?.channels?.cache?.get(voiceChannelId);
+  if (!channel || !channel.members) {
+    return rejectVoice(`⚠\u{FE0F} Couldn't read the voice channel — it may have been deleted. Pick recipients below.\n\n`);
+  }
+  // Filter bots inline (mirrors recipient-parser's voice-expansion
+  // pass) and convert GuildMember → User so partitionRecipients sees
+  // the same shape the picker hands it.
+  const selectedUsers = [];
+  for (const [, m] of channel.members) {
+    if (m?.user?.bot) continue;
+    if (m?.user) selectedUsers.push(m.user);
+  }
+  if (selectedUsers.length === 0) {
+    return rejectVoice(`⚠\u{FE0F} No one is connected to that voice channel right now. Pick recipients below.\n\n`);
+  }
+  const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);
+  if (valid.length === 0) {
+    // Defense-in-depth — the pre-filter above already dropped bots,
+    // so reaching here means every connected non-bot got filtered by
+    // a future addition to partitionRecipients. Surface generic copy.
+    const reasons = [];
+    if (droppedBots > 0) reasons.push('Cannot send to bots');
+    const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in voice channel';
+    return rejectVoice(`⚠\u{FE0F} ${reasonText}. Pick recipients below.\n\n`);
+  }
+  // The 20k QURL_SEND_MAX_RECIPIENTS default is sized to accommodate
+  // voice/stage capacity (Discord's voice channel caps at 99; stage
+  // channels are higher), so a hard cap rejection here is defense-in-
+  // depth against a misconfigured smaller env override rather than the
+  // common path. The picker's similar guard at handleConfirmUserSelect
+  // is identically structured.
+  if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
+    return rejectVoice(`⚠\u{FE0F} Voice channel has ${valid.length} connected (max ${config.QURL_SEND_MAX_RECIPIENTS}). Use the picker or @mentions to choose a subset.\n\n`);
+  }
+
+  const newWarningsBlock = renderRecipientWarnings({
+    droppedBots,
+  });
+  const newRecipientAliases = Object.fromEntries(
+    valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
+  );
+  const newPayload = {
+    ...payload,
+    recipientIds: valid.map((u) => u.id),
+    recipientAliases: newRecipientAliases,
+    warningsBlock: newWarningsBlock,
+    selfIncluded,
+  };
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleConfirmVoiceEveryone: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not save your selection right now. Try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'conflict') {
+    return interaction.editReply({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.editReply({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  const content = renderConfirmCardContent({
+    resourceType: payload.resourceType,
+    resourceLabel: payload.resourceLabel,
+    validRecipients: valid,
+    expiresIn: payload.expiresIn,
+    selfDestructSeconds: payload.selfDestructSeconds,
+    personalMessage: payload.personalMessage,
+    warningsBlock: newWarningsBlock,
+    needsPicker: false,
+    interaction,
+    selfIncluded,
+  });
+  return interaction.editReply({
+    content,
+    components: renderConfirmCardRows({
+      sendDisabled: false,
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+      voiceChannelId: payload.voiceChannelId,
+      interaction,
     }),
   }).catch(logIgnoredDiscordErr);
 }
@@ -3842,6 +4095,8 @@ async function rerenderConfirmCard(interaction, newPayload) {
       expiresIn: newPayload.expiresIn,
       selfDestructSeconds: newPayload.selfDestructSeconds,
       personalMessage: newPayload.personalMessage,
+      voiceChannelId: newPayload.voiceChannelId,
+      interaction,
     }),
   }).catch(logIgnoredDiscordErr);
 }
@@ -5924,6 +6179,14 @@ registerFlow(CONFIRM_NOTE_MODAL_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmNoteModal,
 });
+// Voice-everyone button — only present on the confirm card when the
+// slash command was invoked from a voice / stage-voice channel.
+// Same stage + siblingMessage-keyed-by-stage contract as the other
+// CONFIRM_* registrations above.
+registerFlow(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleConfirmVoiceEveryone,
+});
 
 module.exports = {
   commands,
@@ -5941,6 +6204,7 @@ module.exports = {
   handleConfirmSelfDestructSelect,
   handleConfirmNoteButton,
   handleConfirmNoteModal,
+  handleConfirmVoiceEveryone,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with
@@ -6013,7 +6277,7 @@ module.exports = {
       safeDecodeURIComponent,
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
-      // All seven confirm-card customId literals exported so the
+      // All eight confirm-card customId literals exported so the
       // contract test in qurl-file-map.test.js can pin every wire
       // value — a typo in any of these silently breaks routing for
       // in-flight confirm cards, so they need to be test-asserted.
@@ -6024,6 +6288,7 @@ module.exports = {
       CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID,
       CONFIRM_NOTE_BUTTON_CUSTOM_ID,
       CONFIRM_NOTE_MODAL_CUSTOM_ID,
+      CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,
     },

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -54,7 +54,13 @@ const TOKENS_PER_RESOURCE = 10;
 // so log volume tracks operational importance.
 const LARGE_SEND_RECIPIENT_FLOOR = 1000;
 function largeSendThreshold() {
-  return Math.min(LARGE_SEND_RECIPIENT_FLOOR, Math.floor(config.QURL_SEND_MAX_RECIPIENTS / 2));
+  // `Math.max(1, …)` on the inner half: a pathologically-low cap
+  // override (e.g., 1) would otherwise yield `Math.floor(1/2) = 0`,
+  // making `>= 0` always true and firing the WARN on every send.
+  // Floor at 1 so the threshold is always a positive integer; the
+  // `>= threshold` comparison at the call site still works correctly
+  // for any cap ≥ 1 (the config validator rejects cap ≤ 0).
+  return Math.min(LARGE_SEND_RECIPIENT_FLOOR, Math.max(1, Math.floor(config.QURL_SEND_MAX_RECIPIENTS / 2)));
 }
 
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
@@ -3997,7 +4003,15 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     logger.warn('handleConfirmVoiceEveryone: voice button click against payload with no voiceChannelId', {
       flow_id, interaction_id: interaction.id,
     });
-    return rerenderConfirmCard(interaction, { ...payload, voiceChannelId: null });
+    // Surface a warning banner alongside the re-render so the user
+    // can tell the voice button vanished intentionally (vs. an
+    // unexplained UI flicker). The button removal is automatic via
+    // `voiceChannelId: null` flowing through to renderConfirmCardRows.
+    return rerenderConfirmCard(interaction, {
+      ...payload,
+      voiceChannelId: null,
+      warningsBlock: `⚠\u{FE0F} Voice channel context was lost — use the picker below to choose recipients.\n\n`,
+    });
   }
 
   // Re-render with a warning banner. Same shape as the picker's
@@ -6399,6 +6413,11 @@ module.exports = {
       // alarm — table-driven tests pin every shape so a silent regex
       // breakage can't slip through.
       isAckTimeoutError,
+      // largeSendThreshold formula has non-trivial math + a
+      // degenerate-cap guard; exposed for direct unit testing
+      // rather than asserting via log-spy.
+      largeSendThreshold,
+      LARGE_SEND_RECIPIENT_FLOOR,
       // Setup-flow constants — exposed so tests assert against
       // production values, not stale duplicates that would silently
       // pass when the constants are tuned. The regex export lets

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -39,16 +39,23 @@ const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } 
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
-// Threshold above which a single send earns a `WARN`-level audit log
-// at executeSendPipeline entry. Operator visibility into "this send
-// is going to take a while" without waiting for a Discord rate-limit
-// dashboard to surface it. 1000 chosen as the cliff where DM fan-out
-// at Discord's ~5/sec per-bot limit starts taking minutes (1000 / 5
-// = ~3 min) and qurl-service re-uploads start being non-trivial
-// (1000 / TOKENS_PER_RESOURCE = 100 re-uploads). Sub-threshold sends
-// stay quiet at the default `INFO` level so log volume tracks
-// operational importance.
-const LARGE_SEND_RECIPIENT_THRESHOLD = 1000;
+// Absolute floor above which a single send earns a `WARN`-level
+// audit log at executeSendPipeline entry. 1000 chosen as the cliff
+// where DM fan-out at Discord's ~5/sec per-bot limit starts taking
+// minutes (1000 / 5 = ~3 min) and qurl-service re-uploads get
+// non-trivial (1000 / TOKENS_PER_RESOURCE = 100 re-uploads).
+//
+// The effective threshold (`largeSendThreshold()` below) takes the
+// MIN of this floor and half the configured cap, so operators who
+// env-override `QURL_SEND_MAX_RECIPIENTS` down (e.g., 500) still see
+// the WARN fire on sends that are "operationally large for them"
+// (250 on a 500 cap) rather than only on sends near the absolute
+// floor. Sub-threshold sends stay quiet at the default `INFO` level
+// so log volume tracks operational importance.
+const LARGE_SEND_RECIPIENT_FLOOR = 1000;
+function largeSendThreshold() {
+  return Math.min(LARGE_SEND_RECIPIENT_FLOOR, Math.floor(config.QURL_SEND_MAX_RECIPIENTS / 2));
+}
 
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
@@ -1069,16 +1076,18 @@ async function executeSendPipeline(interaction, {
     failGate(RangeError, `executeSendPipeline: recipients.length (${recipients.length}) exceeds QURL_SEND_MAX_RECIPIENTS (${config.QURL_SEND_MAX_RECIPIENTS})`);
   }
   // Operator-visibility hook for big sends. Fires when a single send
-  // crosses LARGE_SEND_RECIPIENT_THRESHOLD so the operational cost
-  // (qurl-service re-uploads + DM fan-out duration at Discord's
-  // per-bot rate limit) surfaces in logs before it shows up on a
-  // rate-limit dashboard. Sender + guild ids are the natural pivots
-  // for "which guild kicked off this 5k-recipient send."
-  if (recipients.length >= LARGE_SEND_RECIPIENT_THRESHOLD) {
+  // crosses `largeSendThreshold()` so the operational cost (qurl-
+  // service re-uploads + DM fan-out duration at Discord's per-bot
+  // rate limit) surfaces in logs before it shows up on a rate-limit
+  // dashboard. Sender + guild ids + resourceType are the natural
+  // pivots for "which guild kicked off this 5k-recipient file send."
+  const sendThreshold = largeSendThreshold();
+  if (recipients.length >= sendThreshold) {
     logger.warn('Large recipient send initiated', {
       recipient_count: recipients.length,
-      threshold: LARGE_SEND_RECIPIENT_THRESHOLD,
+      threshold: sendThreshold,
       cap: config.QURL_SEND_MAX_RECIPIENTS,
+      resource_type: resourceType,
       sender_id: interaction.user.id,
       guild_id: interaction.guildId,
     });
@@ -3103,9 +3112,15 @@ function renderConfirmCardRows({
     // since we can't name a channel we can't read.
     const channelName = channel?.name;
     const VOICE_LABEL_NAME_BUDGET = 46;
+    // safeCodepointSlice (defined above) is codepoint-aware so a
+    // surrogate-pair emoji at index 45 doesn't get sliced mid-
+    // codepoint and render as `�` on the button. Channel names with
+    // emoji (Discord allows them in names) are the realistic case
+    // this guards against. The `…` ellipsis fits inside the budget
+    // since safeCodepointSlice caps at N codepoints, not N + 1.
     const safeName = channelName
-      ? (channelName.length > VOICE_LABEL_NAME_BUDGET
-          ? `${channelName.slice(0, VOICE_LABEL_NAME_BUDGET - 1)}…`
+      ? (Array.from(channelName).length > VOICE_LABEL_NAME_BUDGET
+          ? `${safeCodepointSlice(channelName, VOICE_LABEL_NAME_BUDGET - 1)}…`
           : channelName)
       : null;
     const labelTarget = safeName ? `#${safeName}` : 'this voice channel';
@@ -3992,6 +4007,13 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // expiry / note interaction will run renderConfirmCardRows again
   // with the now-repopulated cache and re-enable the button. Recovery
   // is automatic; persisting the field is the load-bearing piece.
+  //
+  // No `transitionFlow` call here either — the persisted
+  // `recipientIds` from the original slash command (if any) stays on
+  // the row. Send is disabled in this re-render (sendDisabled:true)
+  // so the stale recipientIds can't fan out; the picker re-pick
+  // path is the natural way to refresh them. Matches `rejectPick`'s
+  // pattern in handleConfirmUserSelect.
   const rejectVoice = (warning) => interaction.editReply({
     content: renderConfirmCardContent({
       resourceType: payload.resourceType,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3055,10 +3055,13 @@ function renderConfirmCardRows({
     // Name the target channel in the label so a user who invoked
     // from #voice-A and drifted to #voice-B mid-flow can tell the
     // button still targets the original channel. Discord button-label
-    // hard cap is 80 chars; budget enforced by truncating the channel
-    // name (the prefix + suffix is ~32 chars, leaving ~46 for the
-    // name — Discord channel names cap at 100 chars so truncation is
-    // possible). On cache miss (channel was deleted between render
+    // hard cap is 80 UTF-16 code units; the fixed prefix + suffix
+    // measures ~26-28 UTF-16 units depending on count width:
+    //   `🔊 ` (3) + `Everyone in #` (13) + ` (NNNNN)` (max 8) = 24
+    //   (🔊 is a surrogate pair = 2 UTF-16 units + a VS16/space).
+    // 46 leaves ~10 units of headroom for label evolution / emoji
+    // additions. Discord channel names cap at 100 chars so truncation
+    // is possible; on cache miss (channel was deleted between render
     // and re-render) the legacy "this voice channel" copy is correct,
     // since we can't name a channel we can't read.
     const channelName = channel?.name;
@@ -3901,6 +3904,11 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     logger.error('handleConfirmVoiceEveryone: corrupt flow payload (unknown resourceType)', {
       flow_id, resource_type: payloadResource,
     });
+    // deleteFlow is best-effort here — `.catch(logIgnoredDiscordErr)`
+    // swallows transient DDB failures so a flow-state-write blip
+    // doesn't block the user-visible error. The row will TTL out
+    // (3-min SEND_FLOW_TTL_SECONDS) even if this delete misses; the
+    // user-facing "Card data is corrupted" message lands either way.
     await deleteFlow(flow_id, {
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -39,6 +39,17 @@ const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } 
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
 
+// Threshold above which a single send earns a `WARN`-level audit log
+// at executeSendPipeline entry. Operator visibility into "this send
+// is going to take a while" without waiting for a Discord rate-limit
+// dashboard to surface it. 1000 chosen as the cliff where DM fan-out
+// at Discord's ~5/sec per-bot limit starts taking minutes (1000 / 5
+// = ~3 min) and qurl-service re-uploads start being non-trivial
+// (1000 / TOKENS_PER_RESOURCE = 100 re-uploads). Sub-threshold sends
+// stay quiet at the default `INFO` level so log volume tracks
+// operational importance.
+const LARGE_SEND_RECIPIENT_THRESHOLD = 1000;
+
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
 // degraded, we log a warning and continue rather than fail the whole flow.
@@ -1056,6 +1067,21 @@ async function executeSendPipeline(interaction, {
   }
   if (recipients.length > config.QURL_SEND_MAX_RECIPIENTS) {
     failGate(RangeError, `executeSendPipeline: recipients.length (${recipients.length}) exceeds QURL_SEND_MAX_RECIPIENTS (${config.QURL_SEND_MAX_RECIPIENTS})`);
+  }
+  // Operator-visibility hook for big sends. Fires when a single send
+  // crosses LARGE_SEND_RECIPIENT_THRESHOLD so the operational cost
+  // (qurl-service re-uploads + DM fan-out duration at Discord's
+  // per-bot rate limit) surfaces in logs before it shows up on a
+  // rate-limit dashboard. Sender + guild ids are the natural pivots
+  // for "which guild kicked off this 5k-recipient send."
+  if (recipients.length >= LARGE_SEND_RECIPIENT_THRESHOLD) {
+    logger.warn('Large recipient send initiated', {
+      recipient_count: recipients.length,
+      threshold: LARGE_SEND_RECIPIENT_THRESHOLD,
+      cap: config.QURL_SEND_MAX_RECIPIENTS,
+      sender_id: interaction.user.id,
+      guild_id: interaction.guildId,
+    });
   }
 
   await interaction.editReply({ content: `Preparing links for ${recipients.length} recipient(s)...`, components: [] }).catch(logIgnoredDiscordErr);
@@ -2563,6 +2589,17 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // left. PR #174's "voice-connected only" semantics are restored here
 // (replacing the legacy `/qurl send`'s wizard option deleted in
 // PR #313 alongside `getChannelMembers`).
+//
+// STAGE-CHANNEL SEMANTICS: discord.js's `channel.members` for stage
+// channels includes BOTH speakers and audience (everyone currently
+// connected to the voice gateway in that stage). This is the
+// "voice-connected" contract carried over from PR #174 and matches
+// the legacy `/qurl send` behavior. A future stage-specific UX
+// might want speakers-only (filter by `member.voice.suppress ===
+// false`) — that's a separate affordance, not a regression in this
+// path. Today the live `(N)` count on the button label is the user's
+// best signal that a click against a 500-person stage will fan out
+// to 500 DMs.
 const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
 
 // Recipient-rejection reason strings shared by every handler that
@@ -3924,35 +3961,23 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     // Button shouldn't have rendered without this field. A click here
     // is either a forged interaction or a payload that lost the field
     // (schema drift). Re-render the card WITHOUT the voice button
-    // (renderConfirmCardRows conditions on voiceChannelId being set)
-    // so the broken affordance is removed AND the user gets visible
-    // feedback that something changed — silently absorbing the click
-    // post-deferUpdate would leave the user staring at an unchanged
-    // card with no indication their click registered.
+    // (rerenderConfirmCard's renderConfirmCardRows conditions on
+    // voiceChannelId being set) so the broken affordance is removed
+    // AND the user gets visible feedback that something changed —
+    // silently absorbing the click post-deferUpdate would leave the
+    // user staring at an unchanged card with no indication their
+    // click registered.
+    //
+    // Reuses `rerenderConfirmCard` (instead of an inline rebuild) so
+    // any previously-picked recipients in the payload still show in
+    // the re-rendered card — the inline-rebuild alternative would
+    // surface validRecipients:[] in the UI while the persisted
+    // payload still carried the old recipientIds, masking real
+    // bugs as a UI/state inconsistency.
     logger.warn('handleConfirmVoiceEveryone: voice button click against payload with no voiceChannelId', {
       flow_id, interaction_id: interaction.id,
     });
-    return interaction.editReply({
-      content: renderConfirmCardContent({
-        resourceType: payload.resourceType,
-        resourceLabel: payload.resourceLabel,
-        validRecipients: [],
-        expiresIn: payload.expiresIn,
-        selfDestructSeconds: payload.selfDestructSeconds,
-        personalMessage: payload.personalMessage,
-        warningsBlock: '',
-        needsPicker: true,
-        interaction,
-      }),
-      components: renderConfirmCardRows({
-        sendDisabled: true,
-        expiresIn: payload.expiresIn,
-        selfDestructSeconds: payload.selfDestructSeconds,
-        personalMessage: payload.personalMessage,
-        voiceChannelId: null,
-        interaction,
-      }),
-    }).catch(logIgnoredDiscordErr);
+    return rerenderConfirmCard(interaction, { ...payload, voiceChannelId: null });
   }
 
   // Re-render with a warning banner. Same shape as the picker's

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -277,7 +277,19 @@ module.exports = {
   // qURL send limits (/qurl file + /qurl map) — both must be > 0. A
   // cooldown of 0 would silently disable the rate limit; a recipients
   // cap of 0 would reject every send.
-  QURL_SEND_MAX_RECIPIENTS: intEnv('QURL_SEND_MAX_RECIPIENTS', 50, { minPositive: true }),
+  //
+  // 20,000 default chosen to accommodate the voice-everyone path against
+  // stage channels (Discord's largest gathering surface). Operational
+  // implications a max-size send carries:
+  //   - up to ceil(20000/TOKENS_PER_RESOURCE) = 2000 re-uploads to
+  //     qurl-service per send (`mintLinksInBatches`).
+  //   - DM delivery is bounded by Discord's per-bot DM rate limit
+  //     (~5/sec); a 20k send takes >1 hour to finish DM fan-out, and
+  //     `monitorLinkStatus`'s interval-based progress tracking must
+  //     survive that duration.
+  // Per-guild operators can dial this down via the env override if
+  // their qurl-service plan or DM-throughput posture demands it.
+  QURL_SEND_MAX_RECIPIENTS: intEnv('QURL_SEND_MAX_RECIPIENTS', 20000, { minPositive: true }),
   QURL_SEND_COOLDOWN_MS: intEnv('QURL_SEND_COOLDOWN_MS', 30000, { minPositive: true }),
 
   SHARD_ID,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -286,7 +286,10 @@ module.exports = {
   //   - DM delivery is bounded by Discord's per-bot DM rate limit
   //     (~5/sec); a 20k send takes >1 hour to finish DM fan-out, and
   //     `monitorLinkStatus`'s interval-based progress tracking must
-  //     survive that duration.
+  //     survive that duration. A regression test pinning that
+  //     lifetime is tracked in issue #331 — open against any change
+  //     that touches `monitorLinkStatus`'s interval/cleanup logic
+  //     until it lands.
   // Per-guild operators can dial this down via the env override if
   // their qurl-service plan or DM-throughput posture demands it.
   QURL_SEND_MAX_RECIPIENTS: intEnv('QURL_SEND_MAX_RECIPIENTS', 20000, { minPositive: true }),

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -279,8 +279,18 @@ module.exports = {
   // cap of 0 would reject every send.
   //
   // 20,000 default chosen to accommodate the voice-everyone path against
-  // stage channels (Discord's largest gathering surface). Operational
-  // implications a max-size send carries:
+  // stage channels (Discord's largest gathering surface). Heads-up for
+  // operators reading the release notes: the same cap bounds EVERY
+  // recipient-resolution path — `<@user>` list expansion, `<@&role>`
+  // expansion, `<#voice>` expansion, the UserSelectMenu picker, AND
+  // `@everyone` (gated on MENTION_EVERYONE). The 50 → 20,000 jump
+  // therefore re-shapes the `@everyone` blast radius by 400× for any
+  // member granted MENTION_EVERYONE in a guild that takes the new
+  // default. Guilds that intentionally constrained the prior 50-recipient
+  // ceiling for non-voice surfaces should set `QURL_SEND_MAX_RECIPIENTS`
+  // to the desired bound in their env; the voice-everyone path will then
+  // partial-resolve up to that bound rather than refusing.
+  // Operational implications a max-size send carries:
   //   - up to ceil(20000/TOKENS_PER_RESOURCE) = 2000 re-uploads to
   //     qurl-service per send (`mintLinksInBatches`).
   //   - DM delivery is bounded by Discord's per-bot DM rate limit

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -42,19 +42,23 @@ assertIntent(intents, GatewayIntentBits.GuildVoiceStates, '/qurl file + /qurl ma
 
 // Negative-intent canaries — pin that the bot has NOT silently
 // re-broadened gateway scope. Every intent listed here is either:
-//   - privileged (would re-introduce dev-portal toggle dependency:
-//     MessageContent, GuildPresences); or
+//   - privileged (would re-introduce dev-portal toggle dependency):
+//     - MessageContent
+//     - GuildPresences
 //   - non-privileged but only useful for code paths we deleted (the
 //     symbol was removed by PR #313 and doesn't exist in the tree —
 //     `git log --diff-filter=D` if you need the historical context):
 //     - DirectMessages → previously consumed by the deleted handleSend
 //       DM file-pivot via `awaitMessages`
-// `GuildVoiceStates` was previously listed here (dropped by PR #313
-// when its only consumer — `getChannelMembers`'s voice-channel branch
-// — was deleted). It was re-added in the voice-everyone restoration:
-// `channel.members` for voice/stage channels reads the voice-state
-// cache, which is only populated when the intent is declared. The
-// positive assertIntent above pins the load-bearing feature.
+//
+// `GuildVoiceStates` was previously listed in this negative-canary
+// block (dropped by PR #313 when its only consumer —
+// `getChannelMembers`'s voice-channel branch — was deleted), and was
+// re-added in the voice-everyone restoration: `channel.members` for
+// voice/stage channels reads the voice-state cache, which is only
+// populated when the intent is declared. The positive assertIntent
+// above pins the load-bearing feature.
+//
 // A future PR that re-adds any of these without a paired assertIntent
 // + use-case write-up will fail at boot rather than silently expanding
 // what crosses the Discord gateway. See PR #313 / issue #317 for

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -14,6 +14,7 @@ const { escapeDiscordMarkdown: md } = require('./utils/sanitize');
 const intents = [
   GatewayIntentBits.Guilds,
   GatewayIntentBits.GuildMembers,
+  GatewayIntentBits.GuildVoiceStates,
 ];
 
 // Per-feature intent canaries. Each line pins one intent to one feature
@@ -37,18 +38,23 @@ function assertIntent(intentsList, bit, requiredFor) {
 }
 assertIntent(intents, GatewayIntentBits.Guilds, 'guild bootstrap (caches guilds the bot is in)');
 assertIntent(intents, GatewayIntentBits.GuildMembers, '/qurl file + /qurl map recipient resolution (members.cache for role-mention expansion + members.fetch for selected-user backfill)');
+assertIntent(intents, GatewayIntentBits.GuildVoiceStates, '/qurl file + /qurl map voice-channel-everyone resolution (channel.members for voice-connected snapshot in the confirm card button + <#voice> mention expansion in the recipients string)');
 
 // Negative-intent canaries — pin that the bot has NOT silently
 // re-broadened gateway scope. Every intent listed here is either:
 //   - privileged (would re-introduce dev-portal toggle dependency:
 //     MessageContent, GuildPresences); or
-//   - non-privileged but only useful for code paths we deleted (both
-//     symbols were removed by PR #313 and don't exist in the tree —
+//   - non-privileged but only useful for code paths we deleted (the
+//     symbol was removed by PR #313 and doesn't exist in the tree —
 //     `git log --diff-filter=D` if you need the historical context):
 //     - DirectMessages → previously consumed by the deleted handleSend
 //       DM file-pivot via `awaitMessages`
-//     - GuildVoiceStates → previously consumed by the deleted
-//       getChannelMembers helper's voice-channel branch
+// `GuildVoiceStates` was previously listed here (dropped by PR #313
+// when its only consumer — `getChannelMembers`'s voice-channel branch
+// — was deleted). It was re-added in the voice-everyone restoration:
+// `channel.members` for voice/stage channels reads the voice-state
+// cache, which is only populated when the intent is declared. The
+// positive assertIntent above pins the load-bearing feature.
 // A future PR that re-adds any of these without a paired assertIntent
 // + use-case write-up will fail at boot rather than silently expanding
 // what crosses the Discord gateway. See PR #313 / issue #317 for
@@ -70,7 +76,6 @@ function assertNoIntent(intentsList, bit, name) {
 assertNoIntent(intents, GatewayIntentBits.MessageContent, 'MessageContent');
 assertNoIntent(intents, GatewayIntentBits.GuildPresences, 'GuildPresences');
 assertNoIntent(intents, GatewayIntentBits.DirectMessages, 'DirectMessages');
-assertNoIntent(intents, GatewayIntentBits.GuildVoiceStates, 'GuildVoiceStates');
 
 const client = new Client({ intents });
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -14,16 +14,23 @@
 //   - Role mentions:    <@&987654>                → expand to current
 //                                                   guild members of that role
 //   - Channel mentions: <#456789>                 → only voice / stage-voice
-//                                                   channels; expand to the
-//                                                   voice-connected non-bot
-//                                                   member set via
-//                                                   `channel.members`. Non-
-//                                                   voice channels land in
+//                                                   channels the sender can
+//                                                   see (ViewChannel-gated);
+//                                                   expand to the voice-
+//                                                   connected non-bot member
+//                                                   set via `channel.members`.
+//                                                   Non-voice channels and
+//                                                   non-visible voice
+//                                                   channels both land in
 //                                                   `invalidTokens` so the
 //                                                   caller can surface
 //                                                   "couldn't expand
-//                                                   #text-channel" rather
-//                                                   than silently dropping.
+//                                                   #channel" rather than
+//                                                   silently dropping
+//                                                   (or, worse, leaking
+//                                                   members of a private
+//                                                   channel whose snowflake
+//                                                   the sender knows).
 // Mention extraction is regex-based — separators don't matter for
 // the mentions themselves (`<@111><@222>` matches both). The
 // separator class only affects the residue/invalid-token strip
@@ -141,6 +148,15 @@ const CHANNEL_MENTION_RE = /<#(\d+)>/g;
 // numeric values" spec pins the contract.
 const VOICE_CHANNEL_TYPE = 2;
 const STAGE_VOICE_CHANNEL_TYPE = 13;
+
+// discord.js PermissionFlagsBits.ViewChannel pinned numerically (bit
+// 10 = 1 << 10) for the same reason as the channel-type constants:
+// no discord.js require in the parser, plus a test spec pins the
+// value against future discord.js renumbers. discord.js represents
+// permissions as BigInt; PermissionsBitField.has accepts either a
+// BigInt or a number, so the numeric literal works for both prod
+// (real PermissionsBitField) and tests (Map-shaped mock).
+const VIEW_CHANNEL_PERMISSION = 1n << 10n;
 
 // Hard cap on input length so an adversarial regex-blowup attack
 // (10MB of `<@1>` repetitions) doesn't tie up the worker. Discord's
@@ -348,21 +364,23 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // getter filters the full guild member cache per call, so N role
   // mentions = N O(guild_size) scans. Bounded by the 4000-char input
   // cap and Discord's slash-option max.
-  // Dedupe role-error pushes by role ID so `<@&999> <@&999>` against
-  // an unknown role yields one invalidTokens entry, not two. The
-  // strip-pass's residue-tokens already dedupe naturally via input
-  // grouping; this set restores the same property for role errors.
+  // Per-kind invalidTokens dedupe sets. Sharing the dedupe helper
+  // across role + channel error paths means `<@&999> <@&999>` and
+  // `<#999> <#999>` each yield one invalidTokens entry, not two —
+  // the strip-pass's residue-tokens already dedupe naturally via
+  // input grouping, and this restores the same property for the
+  // expansion paths.
   const invalidRoleIds = new Set();
-  function pushRoleErrorIfNew(roleId, rawToken) {
-    if (invalidRoleIds.has(roleId)) return;
-    invalidRoleIds.add(roleId);
+  function pushInvalidIfNew(seenIds, id, rawToken) {
+    if (seenIds.has(id)) return;
+    seenIds.add(id);
     invalidTokens.push(rawToken);
   }
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
     const roleId = m[1];
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
-      pushRoleErrorIfNew(roleId, m[0]);
+      pushInvalidIfNew(invalidRoleIds, roleId, m[0]);
       continue;
     }
     // role.members is a Collection<Snowflake, GuildMember>. Empty for
@@ -371,7 +389,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // "couldn't expand @role").
     const members = role.members;
     if (!members || members.size === 0) {
-      pushRoleErrorIfNew(roleId, m[0]);
+      pushInvalidIfNew(invalidRoleIds, roleId, m[0]);
       continue;
     }
     // `usable` counts members that passed the bot filter, INCLUDING
@@ -392,38 +410,22 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       // Role had members but they were all filtered out as bots.
       // Surface as "no usable members" rather than silently no-op so
       // the caller can tell the user "the role only contains bots."
-      pushRoleErrorIfNew(roleId, m[0]);
+      pushInvalidIfNew(invalidRoleIds, roleId, m[0]);
     }
   }
 
   // Channel expansion: voice / stage-voice channels expand to their
-  // currently-connected non-bot member set; every other channel type
-  // (text / forum / category / announcement / thread) lands in
-  // `invalidTokens` so the caller can surface "couldn't expand
-  // #channel" rather than silently send to an empty set. Runs BEFORE
-  // @everyone so explicit channel mentions claim cap slots first.
-  //
-  // `channel.members` for voice channels is discord.js v14's view
-  // over the voice-state cache — populated only when the
-  // `GuildVoiceStates` gateway intent is declared (see
-  // `discord.js` boot canary). Cold-cache / DM-context degrades
-  // safely: `channels.cache.get(id)` returns undefined and the
-  // token lands in `invalidTokens`.
-  //
-  // Dedupe channel-error pushes by channel ID (symmetric with the
-  // role-error dedup path above) so `<#999> <#999>` against an
-  // unknown channel yields ONE entry, not two.
+  // currently-connected non-bot member set. Runs BEFORE @everyone so
+  // explicit channel mentions claim cap slots first. `channel.members`
+  // reads the voice-state cache, which is only populated when the
+  // `GuildVoiceStates` gateway intent is declared (pinned by the boot
+  // canary in discord.js).
   const invalidChannelIds = new Set();
-  function pushChannelErrorIfNew(channelId, rawToken) {
-    if (invalidChannelIds.has(channelId)) return;
-    invalidChannelIds.add(channelId);
-    invalidTokens.push(rawToken);
-  }
   for (const m of input.matchAll(CHANNEL_MENTION_RE)) {
     const channelId = m[1];
     const channel = guild?.channels?.cache?.get(channelId);
     if (!channel) {
-      pushChannelErrorIfNew(channelId, m[0]);
+      pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
     }
     const isVoice = channel.type === VOICE_CHANNEL_TYPE
@@ -435,7 +437,23 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       // by removing it). Voice membership is unambiguously
       // "voice-connected"; text-channel membership is permission-
       // bound and varies across server topologies.
-      pushChannelErrorIfNew(channelId, m[0]);
+      pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
+      continue;
+    }
+    // ViewChannel gate — the bot's channels.cache holds every channel
+    // it has visibility into, so without this check a user who
+    // discovers a private voice channel's snowflake (audit logs,
+    // mod-tool exports, leaked URLs) could DM-blast its connected
+    // members via `/qurl file recipients:<#hidden-voice-id>` even
+    // when they themselves can't see the channel in the client.
+    // Fail-closed: if `permissionsFor` is missing (degraded test
+    // mock, future discord.js shape change) or returns falsy, we
+    // reject the mention. The button-driven voice-everyone path
+    // doesn't need this gate — invoking the slash command from
+    // inside a voice channel intrinsically proves visibility.
+    const viewerPerms = channel.permissionsFor?.(interaction.member ?? interaction.user?.id);
+    if (!viewerPerms || !viewerPerms.has(VIEW_CHANNEL_PERMISSION)) {
+      pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
     }
     // channel.members for voice channels is a Collection<Snowflake,
@@ -446,7 +464,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // role-expansion, and @everyone passes via isBotMember.
     const members = channel.members;
     if (!members || members.size === 0) {
-      pushChannelErrorIfNew(channelId, m[0]);
+      pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
     }
     let usable = 0;
@@ -456,7 +474,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       consider(memberId);
     }
     if (usable === 0) {
-      pushChannelErrorIfNew(channelId, m[0]);
+      pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
     }
   }
 
@@ -464,8 +482,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // channel) get cap priority. If the user typed
   // `@everyone <@uncachedUser>`, the direct mention claims a cap slot
   // first, and @everyone fills the remainder. Reversing this order
-  // silently drops explicit mentions when the cache is partial —
-  // caught by cr round 3 on PR #323.
+  // silently drops explicit mentions when the cache is partial.
   if (everyonePresent && allowMassMention) {
     const everyoneMembers = guild?.members?.cache;
     if (everyoneMembers) {
@@ -560,8 +577,9 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     }
     // Dedupe residue tokens by the post-escape rendered form so
     // `<#456> <#456>` or `alice alice` produces ONE entry, not two.
-    // Symmetric with the role-error dedup path (pushRoleErrorIfNew
-    // above) \u2014 a caller's "couldn't parse: X, X" embed is hostile.
+    // Symmetric with the role/channel-error dedup paths
+    // (pushInvalidIfNew above) \u2014 a caller's "couldn't parse: X, X"
+    // embed is hostile.
     if (residueSeen.has(escaped)) continue;
     residueSeen.add(escaped);
     invalidTokens.push(escaped);
@@ -599,9 +617,11 @@ function isVoiceChannelType(type) {
 module.exports = {
   parseRecipientMentions,
   isVoiceChannelType,
+  isBotMember,
   MAX_INPUT_LENGTH,
   MAX_INVALID_TOKEN_LENGTH,
   MAX_SLASH_OPTION_LENGTH,
   VOICE_CHANNEL_TYPE,
   STAGE_VOICE_CHANNEL_TYPE,
+  VIEW_CHANNEL_PERMISSION,
 };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -144,8 +144,8 @@ const CHANNEL_MENTION_RE = /<#(\d+)>/g;
 // `discord.js` for one constant pair, and so unit tests can build a
 // `channel` mock without instantiating discord.js's ChannelType. A
 // discord.js bump that renumbers these would break voice expansion
-// silently; the `recipient-parser.test.js` "GuildVoice + GuildStageVoice
-// numeric values" spec pins the contract.
+// silently; the `voice-channel type constants` describe block in
+// `recipient-parser.test.js` pins the contract.
 const VOICE_CHANNEL_TYPE = 2;
 const STAGE_VOICE_CHANNEL_TYPE = 13;
 
@@ -451,7 +451,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // reject the mention. The button-driven voice-everyone path
     // doesn't need this gate — invoking the slash command from
     // inside a voice channel intrinsically proves visibility.
-    const viewerPerms = channel.permissionsFor?.(interaction.member ?? interaction.user?.id);
+    const viewerPerms = channel.permissionsFor?.(interaction.member);
     if (!viewerPerms || !viewerPerms.has(VIEW_CHANNEL_PERMISSION)) {
       pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
@@ -467,6 +467,11 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
     }
+    // Walks every member regardless of cap — `consider()` caps `ids`
+    // but `seen` grows unbounded. Symmetric with the @everyone loop
+    // below: in both cases, iteration is bounded by Discord's channel
+    // capacity (99 for voice, ~10k for stage), and the cost is
+    // dominated by `partitionRecipients` + transitionFlow downstream.
     let usable = 0;
     for (const [memberId, channelMember] of members) {
       if (isBotMember(channelMember)) continue;

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -152,10 +152,14 @@ const STAGE_VOICE_CHANNEL_TYPE = 13;
 // discord.js PermissionFlagsBits.ViewChannel pinned numerically (bit
 // 10 = 1 << 10) for the same reason as the channel-type constants:
 // no discord.js require in the parser, plus a test spec pins the
-// value against future discord.js renumbers. discord.js represents
-// permissions as BigInt; PermissionsBitField.has accepts either a
-// BigInt or a number, so the numeric literal works for both prod
-// (real PermissionsBitField) and tests (Map-shaped mock).
+// value against future discord.js renumbers.
+//
+// BigInt (vs the numeric `VOICE_CHANNEL_TYPE = 2` / `STAGE_VOICE_-
+// CHANNEL_TYPE = 13`): discord.js represents PERMISSIONS as BigInt
+// (single bits at positions 0..63), but represents CHANNEL TYPES as
+// small numeric enum values (0..15). PermissionsBitField.has accepts
+// either a BigInt or a Number for forward-compat, but the canonical
+// shape is BigInt — matching that here keeps comparisons type-true.
 const VIEW_CHANNEL_PERMISSION = 1n << 10n;
 
 // Hard cap on input length so an adversarial regex-blowup attack
@@ -400,6 +404,14 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // BEFORE the seen-check inside `consider`, so the "fully-duplicate
     // role isn't useless" test catches a future refactor reversing
     // that order.
+    //
+    // Intentionally NO `ids.size >= cap` early-break here (unlike the
+    // channel-expansion and @everyone loops): role expansion walks
+    // every member so `consider()` can grow `seen` past the cap,
+    // giving downstream `cappedCount` an accurate "you typed 55, we
+    // kept 25" signal. Early-breaking would zero out cappedCount
+    // because seen never grows past cap once break fires. Pinned by
+    // the "cappedCount accounts for role-expansion overflow" test.
     let usable = 0;
     for (const [memberId, roleMember] of members) {
       if (isBotMember(roleMember)) continue;
@@ -481,12 +493,20 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // "cap was already filled by earlier expansions, voice silently
     // no-ops" — the latter must NOT push to invalidTokens, since the
     // channel itself was perfectly valid; the cap just had no room.
-    // Loop ordering mirrors the role-expansion loop above: cap check
-    // FIRST (so a bot-heavy channel doesn't waste cycles after the
-    // cap fills), then bot filter (a bot at index N where ids.size ===
-    // cap-1 correctly skips without claiming the last slot), then
-    // consider. Reversing cap-vs-bot order would let a bot's `continue`
-    // hide the cap fill from the next iteration.
+    //
+    // Loop ordering: cap check FIRST (avoid wasting cycles after the
+    // cap fills on a bot-heavy channel), then bot filter (a bot at
+    // index N where ids.size === cap-1 correctly skips without
+    // claiming the last slot), then consider. Reversing cap-vs-bot
+    // order would let a bot's `continue` hide the cap fill.
+    //
+    // Intentionally DIVERGES from the role-expansion loop above
+    // (which has no early-break): role expansion preserves the
+    // `cappedCount` overshoot signal by walking every member;
+    // voice/stage expansion can have ~10k-member iteration cost,
+    // and the user's mental model for "everyone in this voice
+    // channel" doesn't need a precise overshoot count the way
+    // `<@&role>` does.
     let usable = 0;
     let capHit = false;
     for (const [memberId, channelMember] of members) {

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -481,6 +481,12 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // "cap was already filled by earlier expansions, voice silently
     // no-ops" — the latter must NOT push to invalidTokens, since the
     // channel itself was perfectly valid; the cap just had no room.
+    // Loop ordering mirrors the role-expansion loop above: cap check
+    // FIRST (so a bot-heavy channel doesn't waste cycles after the
+    // cap fills), then bot filter (a bot at index N where ids.size ===
+    // cap-1 correctly skips without claiming the last slot), then
+    // consider. Reversing cap-vs-bot order would let a bot's `continue`
+    // hide the cap fill from the next iteration.
     let usable = 0;
     let capHit = false;
     for (const [memberId, channelMember] of members) {

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -467,18 +467,29 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
     }
-    // Walks every member regardless of cap — `consider()` caps `ids`
-    // but `seen` grows unbounded. Symmetric with the @everyone loop
-    // below: in both cases, iteration is bounded by Discord's channel
-    // capacity (99 for voice, ~10k for stage), and the cost is
-    // dominated by `partitionRecipients` + transitionFlow downstream.
+    // Early-break on cap, mirroring the @everyone loop's
+    // `if (ids.size >= cap) break;` (see the ordering comment block
+    // there for the full rationale on cache-insertion-order semantics
+    // — voice expansion inherits the same caveat: under-cap overflow
+    // wins remaining slots by Discord Collection insertion order, not
+    // alphabetical / role-ordered / recently-active). Without the
+    // break, a stage channel with thousands of members + a small
+    // env-overridden cap would walk the entire member set after the
+    // cap was hit — bounded but wasted work.
+    //
+    // `capHit` separates "no usable members" (empty / bots-only) from
+    // "cap was already filled by earlier expansions, voice silently
+    // no-ops" — the latter must NOT push to invalidTokens, since the
+    // channel itself was perfectly valid; the cap just had no room.
     let usable = 0;
+    let capHit = false;
     for (const [memberId, channelMember] of members) {
+      if (ids.size >= cap) { capHit = true; break; }
       if (isBotMember(channelMember)) continue;
       usable++;
       consider(memberId);
     }
-    if (usable === 0) {
+    if (usable === 0 && !capHit) {
       pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
     }
   }

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -10,9 +10,20 @@
 // hands us the raw "<@123> <@456> <@&789>" text).
 //
 // What we accept:
-//   - User mentions:  <@123456> or <@!123456>   → user ID 123456
-//   - Role mentions:  <@&987654>                → expand to current
-//                                                 guild members of that role
+//   - User mentions:    <@123456> or <@!123456>   → user ID 123456
+//   - Role mentions:    <@&987654>                → expand to current
+//                                                   guild members of that role
+//   - Channel mentions: <#456789>                 → only voice / stage-voice
+//                                                   channels; expand to the
+//                                                   voice-connected non-bot
+//                                                   member set via
+//                                                   `channel.members`. Non-
+//                                                   voice channels land in
+//                                                   `invalidTokens` so the
+//                                                   caller can surface
+//                                                   "couldn't expand
+//                                                   #text-channel" rather
+//                                                   than silently dropping.
 // Mention extraction is regex-based — separators don't matter for
 // the mentions themselves (`<@111><@222>` matches both). The
 // separator class only affects the residue/invalid-token strip
@@ -20,7 +31,7 @@
 // — covers free-form paste from contact lists / CSV-ish formats).
 //
 // What we reject (returned in `invalidTokens`):
-//   - Channel mentions <#...>
+//   - Channel mentions <#...> for non-voice channels (see above).
 //   - Custom emoji <:name:id>
 //   - Bare plaintext (no `<@...>` wrapping) — there's no reliable way
 //     to resolve "alice" to a user ID without an autocomplete round-trip,
@@ -115,6 +126,21 @@ const ROLE_MENTION_RE = /<@&(\d+)>/g;
 // as `@everyone` would be deceptive. Falls through to the invalidTokens
 // defuse path as before; revisit if the bot ever adds the intent.
 const EVERYONE_TOKEN_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])/gu;
+
+// Channel mention shape: `<#123>`. Discord also emits `<#!123>` for
+// some legacy contexts, but the slash-input field never produces the
+// `!` form for channels (only for users), so the regex stays strict.
+const CHANNEL_MENTION_RE = /<#(\d+)>/g;
+
+// discord.js GatewayIntentBits.GuildVoice / GuildStageVoice enum
+// values pinned here (2 / 13) so the parser doesn't have to require
+// `discord.js` for one constant pair, and so unit tests can build a
+// `channel` mock without instantiating discord.js's ChannelType. A
+// discord.js bump that renumbers these would break voice expansion
+// silently; the `recipient-parser.test.js` "GuildVoice + GuildStageVoice
+// numeric values" spec pins the contract.
+const VOICE_CHANNEL_TYPE = 2;
+const STAGE_VOICE_CHANNEL_TYPE = 13;
 
 // Hard cap on input length so an adversarial regex-blowup attack
 // (10MB of `<@1>` repetitions) doesn't tie up the worker. Discord's
@@ -370,11 +396,76 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     }
   }
 
-  // @everyone expansion runs LAST so explicit mentions get cap
-  // priority. If the user typed `@everyone <@uncachedUser>`, the
-  // direct mention claims a cap slot first, and @everyone fills the
-  // remainder. Reversing this order silently drops explicit mentions
-  // when the cache is partial — caught by cr round 3.
+  // Channel expansion: voice / stage-voice channels expand to their
+  // currently-connected non-bot member set; every other channel type
+  // (text / forum / category / announcement / thread) lands in
+  // `invalidTokens` so the caller can surface "couldn't expand
+  // #channel" rather than silently send to an empty set. Runs BEFORE
+  // @everyone so explicit channel mentions claim cap slots first.
+  //
+  // `channel.members` for voice channels is discord.js v14's view
+  // over the voice-state cache — populated only when the
+  // `GuildVoiceStates` gateway intent is declared (see
+  // `discord.js` boot canary). Cold-cache / DM-context degrades
+  // safely: `channels.cache.get(id)` returns undefined and the
+  // token lands in `invalidTokens`.
+  //
+  // Dedupe channel-error pushes by channel ID (symmetric with the
+  // role-error dedup path above) so `<#999> <#999>` against an
+  // unknown channel yields ONE entry, not two.
+  const invalidChannelIds = new Set();
+  function pushChannelErrorIfNew(channelId, rawToken) {
+    if (invalidChannelIds.has(channelId)) return;
+    invalidChannelIds.add(channelId);
+    invalidTokens.push(rawToken);
+  }
+  for (const m of input.matchAll(CHANNEL_MENTION_RE)) {
+    const channelId = m[1];
+    const channel = guild?.channels?.cache?.get(channelId);
+    if (!channel) {
+      pushChannelErrorIfNew(channelId, m[0]);
+      continue;
+    }
+    const isVoice = channel.type === VOICE_CHANNEL_TYPE
+      || channel.type === STAGE_VOICE_CHANNEL_TYPE;
+    if (!isVoice) {
+      // Non-voice channel mention — reject. We intentionally do NOT
+      // restore the legacy "Everyone in this text channel" behavior
+      // (PR #174 fixed the @everyone-on-default-server expansion bug
+      // by removing it). Voice membership is unambiguously
+      // "voice-connected"; text-channel membership is permission-
+      // bound and varies across server topologies.
+      pushChannelErrorIfNew(channelId, m[0]);
+      continue;
+    }
+    // channel.members for voice channels is a Collection<Snowflake,
+    // GuildMember> of voice-connected members. Empty when no one is
+    // connected — treat like an unknown channel so the caller can
+    // surface "no one is in #channel" rather than silently produce a
+    // smaller recipient list. Bot filter mirrors the user-mention,
+    // role-expansion, and @everyone passes via isBotMember.
+    const members = channel.members;
+    if (!members || members.size === 0) {
+      pushChannelErrorIfNew(channelId, m[0]);
+      continue;
+    }
+    let usable = 0;
+    for (const [memberId, channelMember] of members) {
+      if (isBotMember(channelMember)) continue;
+      usable++;
+      consider(memberId);
+    }
+    if (usable === 0) {
+      pushChannelErrorIfNew(channelId, m[0]);
+    }
+  }
+
+  // @everyone expansion runs LAST so explicit mentions (user / role /
+  // channel) get cap priority. If the user typed
+  // `@everyone <@uncachedUser>`, the direct mention claims a cap slot
+  // first, and @everyone fills the remainder. Reversing this order
+  // silently drops explicit mentions when the cache is partial —
+  // caught by cr round 3 on PR #323.
   if (everyonePresent && allowMassMention) {
     const everyoneMembers = guild?.members?.cache;
     if (everyoneMembers) {
@@ -416,18 +507,24 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     }
   }
 
-  // Detect non-mention residue (channel mentions, custom emoji, bare
-  // names) by stripping valid mentions and surfacing what's left.
-  // Intentionally lossy on subtle parsing — the goal is "tell the user
-  // we didn't understand THIS bit", not a perfect tokenizer.
+  // Detect non-mention residue (custom emoji, bare names, unknown
+  // bracketed tokens) by stripping valid mentions and surfacing what's
+  // left. Intentionally lossy on subtle parsing — the goal is "tell the
+  // user we didn't understand THIS bit", not a perfect tokenizer.
   //
   // Separator class includes `;`, `|`, `/` in addition to whitespace
   // and `,` — these are common when pasting from contact lists or
   // CSV-ish formats. Without them the user gets `;` and `|` echoed
   // back as "invalid tokens."
+  //
+  // CHANNEL_MENTION_RE is stripped here even when the channel resolved
+  // to an invalidTokens entry above — the channel-expansion pass
+  // already surfaced it; the residue pass would otherwise double-
+  // report the same `<#id>` as a leftover token.
   const stripped = input
     .replace(USER_MENTION_RE, ' ')
-    .replace(ROLE_MENTION_RE, ' ');
+    .replace(ROLE_MENTION_RE, ' ')
+    .replace(CHANNEL_MENTION_RE, ' ');
   const leftover = stripped.split(/[\s,;|/]+/).filter(Boolean);
   const residueSeen = new Set();
   for (const tok of leftover) {
@@ -489,9 +586,22 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied };
 }
 
+// `isVoiceChannelType` is the same voice/stage-voice predicate the
+// channel-mention expander uses, exported so the confirm-card renderer
+// can detect "this slash command was invoked from a voice channel"
+// without dragging in the discord.js ChannelType enum. Keeping the
+// predicate parser-owned ensures both the `<#voice>` expansion and
+// the confirm-card button branch on the same set of channel types.
+function isVoiceChannelType(type) {
+  return type === VOICE_CHANNEL_TYPE || type === STAGE_VOICE_CHANNEL_TYPE;
+}
+
 module.exports = {
   parseRecipientMentions,
+  isVoiceChannelType,
   MAX_INPUT_LENGTH,
   MAX_INVALID_TOKEN_LENGTH,
   MAX_SLASH_OPTION_LENGTH,
+  VOICE_CHANNEL_TYPE,
+  STAGE_VOICE_CHANNEL_TYPE,
 };

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -458,11 +458,18 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // mod-tool exports, leaked URLs) could DM-blast its connected
     // members via `/qurl file recipients:<#hidden-voice-id>` even
     // when they themselves can't see the channel in the client.
-    // Fail-closed: if `permissionsFor` is missing (degraded test
-    // mock, future discord.js shape change) or returns falsy, we
-    // reject the mention. The button-driven voice-everyone path
-    // doesn't need this gate — invoking the slash command from
-    // inside a voice channel intrinsically proves visibility.
+    // Fail-closed: a missing `interaction.member` (DM context the
+    // outer guild check already eliminated; defense-in-depth here
+    // against a degraded-shape regression), a missing
+    // `permissionsFor` (degraded test mock, future discord.js shape
+    // change), or a falsy permission check all reject the mention.
+    // The button-driven voice-everyone path doesn't need this gate —
+    // invoking the slash command from inside a voice channel
+    // intrinsically proves visibility.
+    if (!interaction.member) {
+      pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
+      continue;
+    }
     const viewerPerms = channel.permissionsFor?.(interaction.member);
     if (!viewerPerms || !viewerPerms.has(VIEW_CHANNEL_PERMISSION)) {
       pushInvalidIfNew(invalidChannelIds, channelId, m[0]);

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -432,6 +432,18 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // reads the voice-state cache, which is only populated when the
   // `GuildVoiceStates` gateway intent is declared (pinned by the boot
   // canary in discord.js).
+  //
+  // NOT GATED ON MENTION_EVERYONE (intentional asymmetry with the
+  // @everyone path below): voice channels are scoped co-presence
+  // surfaces — the ViewChannel gate above already proves the sender
+  // can see the channel, and Discord's voice-channel cap of 99
+  // connected (stage channels are higher but require explicit
+  // role-eligibility to join speakers) bounds the fan-out at the
+  // platform level. A user who can see a voice channel can DM each
+  // member individually; bundling the operation doesn't escalate
+  // their privilege. Tracked in #339 if a future product decision
+  // (stage channels with thousands of audience members) needs to
+  // revisit this.
   const invalidChannelIds = new Set();
   for (const m of input.matchAll(CHANNEL_MENTION_RE)) {
     const channelId = m[1];

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -84,7 +84,7 @@ jest.mock('discord.js', () => {
     ChannelType: { GuildText: 0, GuildVoice: 2 },
     ComponentType: { Button: 2, StringSelect: 3, UserSelect: 5 },
     Client: jest.fn().mockImplementation(() => ({ on: jest.fn(), once: jest.fn(), login: jest.fn() })),
-    GatewayIntentBits: { Guilds: 1, GuildMembers: 2 },
+    GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128 },
     Partials: { Channel: 0, Message: 1 },
     Events: { ClientReady: 'ready', InteractionCreate: 'interactionCreate' },
   };

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -104,7 +104,14 @@ const mockClient = {
 
 jest.mock('discord.js', () => ({
   Client: jest.fn(() => mockClient),
-  GatewayIntentBits: { Guilds: 1, GuildMembers: 2 },
+  // GuildVoiceStates (=128 in production discord.js) is load-bearing
+  // for the /qurl file + /qurl map voice-channel-everyone path —
+  // channel.members for voice channels reads the voice-state cache
+  // which is only populated when the intent is declared. The discord.js
+  // module's assertIntent at boot would throw if this bit is missing
+  // from the mock; the value here matches discord.js's enum so future
+  // production-shape canary tests can rely on it.
+  GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128 },
   EmbedBuilder: jest.fn().mockImplementation(() => ({
     setColor: jest.fn().mockReturnThis(), setTitle: jest.fn().mockReturnThis(),
     setDescription: jest.fn().mockReturnThis(), addFields: jest.fn().mockReturnThis(),
@@ -642,14 +649,27 @@ describe('discord module', () => {
         '/qurl file + /qurl map recipient resolution (members.cache for role-mention expansion + members.fetch for selected-user backfill)'))
         .toThrow(/\/qurl file \+ \/qurl map recipient resolution/);
     });
+
+    // GuildVoiceStates is the second load-bearing intent: its boot
+    // canary at discord.js pins the voice-everyone resolution path.
+    // A future PR that drops the intent without removing the feature
+    // (channel.members for voice channels reads the voice-state cache)
+    // must trip this assertion at module load.
+    it('production assertIntent for GuildVoiceStates surfaces the voice-everyone resolution feature label', () => {
+      expect(() => discord.assertIntent([1 /* Guilds */, 2 /* GuildMembers */], 128 /* GuildVoiceStates */,
+        '/qurl file + /qurl map voice-channel-everyone resolution (channel.members for voice-connected snapshot in the confirm card button + <#voice> mention expansion in the recipients string)'))
+        .toThrow(/voice-channel-everyone resolution/);
+    });
   });
 
   describe('assertNoIntent (negative canary)', () => {
     // Pins the negative-intent guard: if a future PR silently adds back
-    // MessageContent / GuildPresences / DirectMessages / GuildVoiceStates
-    // to the intents array, the assertNoIntent invocations at
-    // discord.js:~45-50 fail loud at boot. This test pins both branches
-    // (re-added intent throws; absent intent doesn't).
+    // MessageContent / GuildPresences / DirectMessages to the intents
+    // array, the assertNoIntent invocations at discord.js fail loud at
+    // boot. This test pins both branches (re-added intent throws;
+    // absent intent doesn't). GuildVoiceStates was previously listed
+    // here but was re-added (with paired assertIntent above) when the
+    // voice-everyone path was restored.
     it('throws when the disallowed intent IS in the intents list', () => {
       const intentsList = [1 /* Guilds */, 2 /* GuildMembers */, 4096 /* DirectMessages */];
       expect(() => discord.assertNoIntent(intentsList, 4096, 'DirectMessages'))

--- a/apps/discord/tests/opennhp-gating.test.js
+++ b/apps/discord/tests/opennhp-gating.test.js
@@ -96,7 +96,7 @@ const mockClient = {
 
 jest.mock('discord.js', () => ({
   Client: jest.fn(() => mockClient),
-  GatewayIntentBits: { Guilds: 1, GuildMembers: 2 },
+  GatewayIntentBits: { Guilds: 1, GuildMembers: 2, GuildVoiceStates: 128 },
   EmbedBuilder: jest.fn().mockImplementation(() => ({
     setColor: jest.fn().mockReturnThis(), setTitle: jest.fn().mockReturnThis(),
     setDescription: jest.fn().mockReturnThis(), addFields: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -185,6 +185,7 @@ const {
   CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID,
   CONFIRM_NOTE_BUTTON_CUSTOM_ID,
   CONFIRM_NOTE_MODAL_CUSTOM_ID,
+  CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID,
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
   isOnCooldown,
@@ -207,6 +208,7 @@ const {
   handleConfirmSelfDestructSelect,
   handleConfirmNoteButton,
   handleConfirmNoteModal,
+  handleConfirmVoiceEveryone,
 } = commands;
 
 // ──────────────────────────────────────────────────────────────
@@ -2348,6 +2350,125 @@ describe('handleConfirmUserSelect', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
+// handleConfirmVoiceEveryone — "Everyone in this voice channel"
+// button on the confirm card, rendered only when the slash command
+// was invoked from a voice / stage-voice channel. Resolves voice-
+// connected non-bot members AT CLICK TIME from the voice-state
+// cache rather than trusting a render-time snapshot.
+// ──────────────────────────────────────────────────────────────
+
+describe('handleConfirmVoiceEveryone', () => {
+  const VOICE_CH = 'voice-ch-1';
+  const u1 = '100000000000000001';
+  const u2 = '100000000000000002';
+  const bot1 = '100000000000000099';
+
+  // Build a guild whose channels.cache contains a voice channel with
+  // the supplied member list. Bots in `members` get bot:true on the
+  // member-cache user so partitionRecipients drops them.
+  function makeVoiceInteraction({ members = [], channelType = 2, botIds = [] } = {}) {
+    const int = makeInteraction();
+    int.guild.channels.cache = new Map();
+    const chanMembers = new Map();
+    for (const mid of members) {
+      const isBot = botIds.includes(mid);
+      const member = { user: { id: mid, bot: isBot } };
+      int.guild.members.cache.set(mid, member);
+      chanMembers.set(mid, member);
+    }
+    int.guild.channels.cache.set(VOICE_CH, {
+      id: VOICE_CH, type: channelType, members: chanMembers,
+    });
+    return int;
+  }
+
+  const basePayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+    voiceChannelId: VOICE_CH,
+  };
+
+  test('happy path: voice-connected non-bot members populate recipientIds and advance the flow', async () => {
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: expect.objectContaining({
+        recipientIds: expect.arrayContaining([u1, u2]),
+        voiceChannelId: VOICE_CH,
+      }),
+      terminal: false,
+    }));
+    const ids = mockTransitionFlow.mock.calls[0][2].payload.recipientIds;
+    expect(ids).toHaveLength(2);
+  });
+
+  test('happy path: bots are filtered out of the connected set', async () => {
+    const int = makeVoiceInteraction({ members: [u1, bot1, u2], botIds: [bot1] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const ids = mockTransitionFlow.mock.calls[0][2].payload.recipientIds;
+    expect(ids.sort()).toEqual([u1, u2].sort());
+    expect(ids).not.toContain(bot1);
+  });
+
+  test('missing voiceChannelId in payload: early-return without throwing or calling transitionFlow', async () => {
+    // The button should not have rendered without voiceChannelId; a
+    // click here means a forged interaction or schema drift. Handler
+    // logs and returns undefined rather than deleting the row.
+    const int = makeVoiceInteraction({ members: [u1] });
+    const payloadWithoutVoice = { ...basePayload, voiceChannelId: null };
+    await expect(
+      handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: payloadWithoutVoice, version: 1 } })
+    ).resolves.toBeUndefined();
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+  });
+
+  test('channel deleted between render and click: rejectVoice path runs (warning re-render, no transition)', async () => {
+    // Cache miss simulates the channel being deleted (or the voice
+    // intent dropping mid-flow). The handler should NOT call
+    // transitionFlow — it re-renders the card with a warning banner.
+    const int = makeInteraction();
+    int.guild.channels.cache = new Map(); // no entry for VOICE_CH
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.editReply).toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/Couldn't read the voice channel/i);
+  });
+
+  test('empty voice channel: rejectVoice path runs (no-one-connected copy, no transition)', async () => {
+    const int = makeVoiceInteraction({ members: [] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/No one is connected/i);
+  });
+
+  test('corrupt payload (unknown resourceType): deleteFlow + actionable re-run copy', async () => {
+    // Mirrors handleConfirmUserSelect's resourceType guard — a
+    // corrupt/stale row would otherwise crash the renderer with a
+    // generic "superseded" toast.
+    const int = makeVoiceInteraction({ members: [u1] });
+    const corruptPayload = { ...basePayload, resourceType: 'bogus' };
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: corruptPayload, version: 1 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }));
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/Card data is corrupted/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
 // handleConfirmExpirySelect — inline expiry edit on confirm card
 // ──────────────────────────────────────────────────────────────
 
@@ -3239,6 +3360,7 @@ describe('constants + exports', () => {
     expect(CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID).toBe('qurl_confirm_self_destruct');
     expect(CONFIRM_NOTE_BUTTON_CUSTOM_ID).toBe('qurl_confirm_note_btn');
     expect(CONFIRM_NOTE_MODAL_CUSTOM_ID).toBe('qurl_confirm_note_modal');
+    expect(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID).toBe('qurl_confirm_voice_everyone');
   });
 
   test('all customIds unique', () => {
@@ -3250,8 +3372,9 @@ describe('constants + exports', () => {
       CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID,
       CONFIRM_NOTE_BUTTON_CUSTOM_ID,
       CONFIRM_NOTE_MODAL_CUSTOM_ID,
+      CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID,
     ]);
-    expect(ids.size).toBe(7);
+    expect(ids.size).toBe(8);
   });
 
   test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2536,6 +2536,32 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(lastCall.components).toEqual([]);
   });
 
+  test('partial-cache row (member missing .user) emits a debug log per send (silent-shrinkage telemetry)', async () => {
+    // Pins the round-9 telemetry contract: silent shrinkage of the
+    // recipient set due to partial-cache rows is hard to diagnose
+    // post-hoc without a log. The debug-level emission is per-send
+    // (not per-member) so volume tracks frequency of the degraded
+    // state, not the count of dropped members. A future refactor
+    // that drops the log fails this spec.
+    const logger = require('../src/logger');
+    logger.debug.mockClear();
+    const int = makeVoiceInteraction({ members: [u1] });
+    // Inject a partial-cache row: member entry exists but has no .user.
+    const channel = int.guild.channels.cache.get(VOICE_CH);
+    channel.members.set('partial-cache-id', {});  // no .user → drop
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/partial-cache/i),
+      expect.objectContaining({
+        flow_id: 'fid',
+        voice_channel_id: VOICE_CH,
+        dropped: 1,
+      })
+    );
+    // Send still proceeds with the .user-populated member.
+    expect(mockTransitionFlow).toHaveBeenCalled();
+  });
+
   test('voice-everyone button succeeds when sender lacks MENTION_EVERYONE (no asymmetric gate)', async () => {
     // Pins the intentional asymmetry documented at the button block:
     // ViewChannel-only gating (not MENTION_EVERYONE) is the right
@@ -3461,6 +3487,50 @@ describe('renderConfirmCardRows', () => {
     await handleQurlFile(int);
     const noteBtn = ButtonBuilder.mock.results[0].value;
     expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Edit note/));
+  });
+
+  test('voice button label stays under Discord\'s 80 UTF-16 cap with an ALL-EMOJI channel name (worst case)', async () => {
+    // Round-14 cr bug-guard: a 46-codepoint all-emoji channel name
+    // (which Discord allows up to its 100-char limit) occupies 92
+    // UTF-16 units. The prior codepoint-based budget would slice at
+    // 46 codepoints (=92 UTF-16 units) + prefix + suffix → ~116-unit
+    // label, busting Discord's 80-UTF-16 hard cap and getting
+    // rejected at API send. The UTF-16-unit budget caps this.
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
+    // 46 🎉 emoji — each is a surrogate pair (U+1F389, 2 UTF-16 units)
+    // so the channel name occupies 92 UTF-16 units. Discord caps
+    // channel names at 100 chars, so this is realistic. The prior
+    // codepoint-based budget would slice at 46 codepoints (92
+    // UTF-16 units) + prefix + suffix → ~116-unit label, busting
+    // Discord's 80-UTF-16 hard cap.
+    const allEmojiName = '🎉'.repeat(46);
+    expect(allEmojiName.length).toBe(92); // confirm worst-case UTF-16
+    const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+    int.channel = { id: 'voice-emoji', type: 2 };
+    int.guild.channels.cache.set('voice-emoji', {
+      id: 'voice-emoji', name: allEmojiName, type: 2,
+      members: new Map([['111', { user: { id: '111', bot: false } }]]),
+    });
+    await handleQurlFile(int);
+    const voiceBtn = ButtonBuilder.mock.results.find(
+      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_voice_everyone'
+    );
+    expect(voiceBtn).toBeDefined();
+    const label = voiceBtn.value.setLabel.mock.calls[0][0];
+    // The hard contract: under 80 UTF-16 units regardless of input.
+    expect(label.length).toBeLessThanOrEqual(80);
+    expect(label).toMatch(/…/);
+    // Surrogate-pair safety still holds for the all-emoji case.
+    for (let i = 0; i < label.length; i++) {
+      const code = label.charCodeAt(i);
+      if (code >= 0xD800 && code <= 0xDBFF) {
+        const next = label.charCodeAt(i + 1);
+        expect(next).toBeGreaterThanOrEqual(0xDC00);
+        expect(next).toBeLessThanOrEqual(0xDFFF);
+        i++;
+      }
+    }
   });
 
   test('voice button label stays under Discord\'s 80 UTF-16 cap even with a 100-char emoji-containing channel name', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2439,6 +2439,33 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(lastCall.components.length).toBeGreaterThan(0);
   });
 
+  test('missing voiceChannelId WITH previously-picked recipients: re-render preserves recipients (no UI/state drift)', async () => {
+    // Bug-guard: the inline-rebuild alternative would render the
+    // card with validRecipients:[] while the persisted payload still
+    // carried the old recipientIds. The handler routes through
+    // rerenderConfirmCard, which reads recipientIds from the payload
+    // and reconstructs validRecipients — so the UI matches state.
+    const int = makeVoiceInteraction({ members: [u1] });
+    // Seed cache so rerenderConfirmCard can resolve the recipient.
+    int.guild.members.cache.set(u1, { user: makeUser(u1) });
+    const payloadWithoutVoice = {
+      ...basePayload,
+      voiceChannelId: null,
+      recipientIds: [u1],
+      recipientAliases: { [u1]: 'alice' },
+    };
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: payloadWithoutVoice, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    // Resource header still rendered — user retains context.
+    expect(lastCall.content).toMatch(/Sending file/);
+    // Previously-picked recipient surfaces in the content summary
+    // ("**To:** 1 user (…)"), not just the persisted-but-invisible
+    // state. The inline-rebuild alternative would have rendered
+    // validRecipients:[] here, masking the persisted state drift.
+    expect(lastCall.content).toMatch(/\*\*To:\*\* 1 user/);
+  });
+
   test('channel deleted between render and click: rejectVoice path runs (warning re-render, no transition)', async () => {
     // Cache miss simulates the channel being deleted (or the voice
     // intent dropping mid-flow). The handler should NOT call

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -3445,6 +3445,52 @@ describe('renderConfirmCardRows', () => {
     const noteBtn = ButtonBuilder.mock.results[0].value;
     expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Edit note/));
   });
+
+  test('voice button label stays under Discord\'s 80 UTF-16 cap even with a 100-char emoji-containing channel name', async () => {
+    // Pins the codepoint-aware truncation: a channel name with an
+    // emoji at position 45 must NOT split a UTF-16 surrogate pair
+    // (would render `�` on the button) AND the full label must stay
+    // under Discord's 80 UTF-16 unit hard cap. Without the
+    // safeCodepointSlice / Array.from length check, a long emoji-
+    // containing name would either overflow or render mangled.
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
+    // 100-char name with emoji (🎉 = surrogate pair) at index 44,
+    // 45, 46 to land near the slice boundary.
+    const longName = 'a'.repeat(44) + '🎉🎉🎉' + 'b'.repeat(47);
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT },
+      // Inject the channel into the interaction so renderConfirmCardRows'
+      // live read finds it.
+    });
+    int.channel = { id: 'voice-long', type: 2 };
+    int.guild.channels.cache.set('voice-long', {
+      id: 'voice-long', name: longName, type: 2,
+      members: new Map([['111', { user: { id: '111', bot: false } }]]),
+    });
+    await handleQurlFile(int);
+    const voiceBtn = ButtonBuilder.mock.results.find(
+      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_voice_everyone'
+    );
+    expect(voiceBtn).toBeDefined();
+    const labelCall = voiceBtn.value.setLabel.mock.calls[0];
+    const label = labelCall[0];
+    // UTF-16 unit length (string.length) must stay under 80.
+    expect(label.length).toBeLessThanOrEqual(80);
+    // Truncation indicator present when the name was longer than the budget.
+    expect(label).toMatch(/…/);
+    // Surrogate pair safety: no orphan lead-surrogate (0xD800-0xDBFF
+    // without a paired trail surrogate). Quick scan.
+    for (let i = 0; i < label.length; i++) {
+      const code = label.charCodeAt(i);
+      if (code >= 0xD800 && code <= 0xDBFF) {
+        const next = label.charCodeAt(i + 1);
+        expect(next).toBeGreaterThanOrEqual(0xDC00);
+        expect(next).toBeLessThanOrEqual(0xDFFF);
+        i++; // skip the trail surrogate
+      }
+    }
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -3611,10 +3611,27 @@ describe('largeSendThreshold', () => {
 
   test('degenerate override (cap=1): floors at 1 (NOT 0 — would fire every send)', () => {
     // Bug-guard: Math.floor(1/2) = 0 would make `>= threshold` true
-    // for every send, including 0-recipient ones. Math.max(1, …)
-    // floors at 1 so the threshold is always a positive integer.
+    // for every send, including 0-recipient ones. The `|| 1`
+    // substitution floors at 1 so the threshold is always a positive
+    // integer.
     const orig = config.QURL_SEND_MAX_RECIPIENTS;
     config.QURL_SEND_MAX_RECIPIENTS = 1;
+    try {
+      expect(largeSendThreshold()).toBe(1);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = orig;
+    }
+  });
+
+  test('boundary (cap=2): floor(2/2)=1 wins WITHOUT the substitution — pins discontinuity', () => {
+    // Round-15 cr: a 2-recipient send on cap=2 warns; a 1-recipient
+    // send on cap=2 does not (threshold=1). The substitution-vs-
+    // half-cap boundary is at cap=2 — pin the intentional shape so
+    // a future refactor (e.g., switching from `half || 1` to
+    // `Math.max(2, half)`) breaks this test instead of silently
+    // moving the boundary.
+    const orig = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 2;
     try {
       expect(largeSendThreshold()).toBe(1);
     } finally {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2451,6 +2451,42 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(lastCall.content).toMatch(/No one is connected/i);
   });
 
+  test('bots-only voice channel: surfaces "Cannot send to bots" (NOT the empty-channel copy)', async () => {
+    // Pre-DE-pass had an inline bot pre-filter here that zeroed out
+    // droppedBots, forcing the bots-only case into the misleading
+    // "No one is connected" branch. Letting partitionRecipients own
+    // the bot accounting end-to-end is what produces the accurate
+    // copy. This test pins that behavioral contract.
+    const int = makeVoiceInteraction({ members: [bot1], botIds: [bot1] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/Cannot send to bots/i);
+    expect(lastCall.content).not.toMatch(/No one is connected/i);
+  });
+
+  test('cap overshoot (env-overridden small cap): hard-rejects with subset-prompt copy', async () => {
+    // With the production 20k default, voice-channel capacity (99
+    // for voice, larger for stage) never trips this branch — it's
+    // defense-in-depth against a misconfigured env override (e.g.,
+    // a guild operator dialing the cap down to constrain blast
+    // radius). The reject copy steers the user toward picker /
+    // @-mentions for a subset selection.
+    const config = require('../src/config');
+    const origCap = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 1;
+    try {
+      const int = makeVoiceInteraction({ members: [u1, u2] });
+      await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+      expect(mockTransitionFlow).not.toHaveBeenCalled();
+      const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+      expect(lastCall.content).toMatch(/Voice channel has 2 connected \(max 1\)/i);
+      expect(lastCall.content).toMatch(/picker or @mentions/i);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = origCap;
+    }
+  });
+
   test('corrupt payload (unknown resourceType): deleteFlow + actionable re-run copy', async () => {
     // Mirrors handleConfirmUserSelect's resourceType guard — a
     // corrupt/stale row would otherwise crash the renderer with a

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2536,6 +2536,23 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(lastCall.components).toEqual([]);
   });
 
+  test('voice-everyone button succeeds when sender lacks MENTION_EVERYONE (no asymmetric gate)', async () => {
+    // Pins the intentional asymmetry documented at the button block:
+    // ViewChannel-only gating (not MENTION_EVERYONE) is the right
+    // posture for a co-presence surface. If a future security pass
+    // adds the MENTION_EVERYONE gate to one path and forgets the
+    // other, this fails loud.
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    // memberPermissions.has(MENTION_EVERYONE) returns false (default
+    // makeInteraction shape — no permissions populated). Voice path
+    // must still succeed.
+    int.memberPermissions = { has: () => false };
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.recipientIds.sort()).toEqual([u1, u2].sort());
+  });
+
   test('transitionFlow not_found → expired message (row TTL elapsed between click and write)', async () => {
     mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
     const int = makeVoiceInteraction({ members: [u1, u2] });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2416,17 +2416,27 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(ids).not.toContain(bot1);
   });
 
-  test('missing voiceChannelId in payload: early-return without throwing or calling transitionFlow', async () => {
+  test('missing voiceChannelId in payload: re-renders card WITHOUT the voice button (visible feedback)', async () => {
     // The button should not have rendered without voiceChannelId; a
     // click here means a forged interaction or schema drift. Handler
-    // logs and returns undefined rather than deleting the row.
+    // must give the user VISIBLE feedback that something changed —
+    // a silent ack after deferUpdate would leave the user staring at
+    // an unchanged card wondering if their click registered. The
+    // re-render strips the broken affordance (renderConfirmCardRows
+    // conditions on voiceChannelId being set); the user can pick
+    // recipients through the still-visible UserSelectMenu.
     const int = makeVoiceInteraction({ members: [u1] });
     const payloadWithoutVoice = { ...basePayload, voiceChannelId: null };
-    await expect(
-      handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: payloadWithoutVoice, version: 1 } })
-    ).resolves.toBeUndefined();
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: payloadWithoutVoice, version: 1 } });
     expect(int.deferUpdate).toHaveBeenCalled();
     expect(mockTransitionFlow).not.toHaveBeenCalled();
+    expect(int.editReply).toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    // Card content re-rendered (not just components: []) so the
+    // user sees the resource header still — they didn't lose context.
+    expect(lastCall.content).toBeTruthy();
+    expect(Array.isArray(lastCall.components)).toBe(true);
+    expect(lastCall.components.length).toBeGreaterThan(0);
   });
 
   test('channel deleted between render and click: rejectVoice path runs (warning re-render, no transition)', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2465,6 +2465,49 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(lastCall.content).not.toMatch(/No one is connected/i);
   });
 
+  test('sender is voice-connected → selfIncluded:true propagates to the new payload', async () => {
+    // Symmetric with handleConfirmUserSelect's "self-send" coverage —
+    // partitionRecipients flips selfIncluded when the invoking user
+    // appears in the resolved set. The confirm-card renderer reads
+    // this flag to surface the "Send includes you." neutral notice.
+    // Without this test, a future refactor that bypassed
+    // partitionRecipients (e.g., reading recipientIds directly from
+    // channel.members.keys()) would silently drop the notice.
+    const int = makeVoiceInteraction({ members: [SENDER_ID, u1] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.selfIncluded).toBe(true);
+  });
+
+  test('sender NOT in voice channel → selfIncluded:false on the new payload', async () => {
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.selfIncluded).toBe(false);
+  });
+
+  test('transitionFlow conflict → superseded message (OCC race with sibling interaction)', async () => {
+    // Mirrors handleConfirmUserSelect's conflict-path test. The
+    // version-checked transitionFlow can lose to a concurrent picker
+    // click / menu change / cancel; the handler must surface
+    // "Send was superseded" rather than the generic editReply.
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/superseded/);
+    expect(lastCall.components).toEqual([]);
+  });
+
+  test('transitionFlow not_found → expired message (row TTL elapsed between click and write)', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/expired/);
+    expect(lastCall.components).toEqual([]);
+  });
+
   test('cap overshoot (env-overridden small cap): hard-rejects with subset-prompt copy', async () => {
     // With the production 20k default, voice-channel capacity (99
     // for voice, larger for stage) never trips this branch — it's

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -3494,6 +3494,59 @@ describe('renderConfirmCardRows', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
+// largeSendThreshold formula — covers the floor / half-cap branches +
+// degenerate cap guard.
+// ──────────────────────────────────────────────────────────────
+
+describe('largeSendThreshold', () => {
+  const { largeSendThreshold, LARGE_SEND_RECIPIENT_FLOOR } = commands._test;
+  const config = require('../src/config');
+
+  test('default cap (20k): floor wins (1000)', () => {
+    const orig = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 20000;
+    try {
+      expect(largeSendThreshold()).toBe(LARGE_SEND_RECIPIENT_FLOOR);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = orig;
+    }
+  });
+
+  test('small override (cap=500): half-cap wins (250)', () => {
+    const orig = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 500;
+    try {
+      expect(largeSendThreshold()).toBe(250);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = orig;
+    }
+  });
+
+  test('degenerate override (cap=1): floors at 1 (NOT 0 — would fire every send)', () => {
+    // Bug-guard: Math.floor(1/2) = 0 would make `>= threshold` true
+    // for every send, including 0-recipient ones. Math.max(1, …)
+    // floors at 1 so the threshold is always a positive integer.
+    const orig = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 1;
+    try {
+      expect(largeSendThreshold()).toBe(1);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = orig;
+    }
+  });
+
+  test('cap exactly at floor (1000): half-cap (500) wins', () => {
+    const orig = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 1000;
+    try {
+      expect(largeSendThreshold()).toBe(500);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = orig;
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
 // Constants + registration assertions
 // ──────────────────────────────────────────────────────────────
 

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -29,6 +29,7 @@ const {
   MAX_INVALID_TOKEN_LENGTH,
   VOICE_CHANNEL_TYPE,
   STAGE_VOICE_CHANNEL_TYPE,
+  VIEW_CHANNEL_PERMISSION,
 } = require('../src/recipient-parser');
 const logger = require('../src/logger');
 
@@ -57,11 +58,15 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
     }
     roleCache.set(roleId, { members: roleMembers });
   }
-  // Channel shape: { id → { type, members: [id, ...] } } where type
-  // is the numeric ChannelType (2 = GuildVoice, 13 = GuildStageVoice;
-  // any other value tests the non-voice rejection path). Voice-
-  // connected members are added to the guild member cache so the
-  // bot filter (and post-filter dedupe semantics) match production.
+  // Channel shape: { id → { type, members: [id, ...], viewable? } }
+  //   type     numeric ChannelType (2 = GuildVoice, 13 = GuildStageVoice;
+  //            any other value tests the non-voice rejection path).
+  //   members  voice-connected member IDs (added to guild member cache so
+  //            the bot filter + post-filter dedupe semantics match
+  //            production).
+  //   viewable defaults to true; set false to test the ViewChannel-gate
+  //            rejection path (private voice channels the bot has cached
+  //            but the sender can't see in their client).
   const channelCache = new Map();
   for (const [channelId, attrs] of Object.entries(channels)) {
     const memberIds = attrs.members || [];
@@ -71,10 +76,25 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
       memberCache.set(mid, existing);
       chMembers.set(mid, existing);
     }
-    channelCache.set(channelId, { id: channelId, type: attrs.type, members: chMembers });
+    const viewable = attrs.viewable !== false;
+    // permissionsFor is the read-of-record for the ViewChannel gate.
+    // Real discord.js returns a Readonly<PermissionsBitField>; the
+    // mock returns the minimum shape the parser exercises (`.has`).
+    // Argument is ignored — viewability is per-channel-fixture, not
+    // per-caller, which is sufficient because the parser only ever
+    // asks about the invoking user.
+    channelCache.set(channelId, {
+      id: channelId,
+      type: attrs.type,
+      members: chMembers,
+      permissionsFor: () => ({
+        has: (bit) => bit !== VIEW_CHANNEL_PERMISSION || viewable,
+      }),
+    });
   }
   return {
     user: { id: senderId },
+    member: { id: senderId },
     guild: {
       members: { cache: memberCache },
       roles: { cache: roleCache },
@@ -378,6 +398,13 @@ describe('voice-channel type constants (discord.js ChannelType pin)', () => {
     expect(isVoiceChannelType(undefined)).toBe(false);
     expect(isVoiceChannelType(null)).toBe(false);
   });
+
+  // ViewChannel permission bit pinned at 1 << 10 (1024). A discord.js
+  // bump that renumbers the bit would silently break the private-
+  // voice-channel-leak defense — this spec keeps the contract honest.
+  test('VIEW_CHANNEL_PERMISSION is 1 << 10', () => {
+    expect(VIEW_CHANNEL_PERMISSION).toBe(1024n);
+  });
 });
 
 describe('parseRecipientMentions — channel mentions (voice / stage-voice)', () => {
@@ -441,6 +468,40 @@ describe('parseRecipientMentions — channel mentions (voice / stage-voice)', ()
         '500': { type: GUILD_VOICE, members: ['801', '802'] },
       },
     });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
+  });
+
+  test('voice channel the sender CANNOT see (ViewChannel denied) lands in invalidTokens — no private-channel-leak', () => {
+    // The bot's channels.cache holds every channel it can see, so
+    // without the ViewChannel gate a user could DM-blast members of
+    // a private voice channel just by knowing its snowflake. Pin
+    // that channels with viewable:false fall through to
+    // invalidTokens despite type=GuildVoice + non-empty members.
+    const int = makeInteraction({
+      channels: {
+        '500': { type: GUILD_VOICE, members: ['111', '222'], viewable: false },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
+  });
+
+  test('missing permissionsFor on the channel cache (degraded shape) fails closed', () => {
+    // Defense-in-depth: real discord.js always supplies permissionsFor
+    // on GuildChannel, but a future shape change or partially-mocked
+    // test fixture would otherwise silently bypass the gate. Pin
+    // the fail-closed behavior so the bypass surfaces as "couldn't
+    // expand" rather than a silent leak.
+    const int = makeInteraction();
+    int.guild.channels.cache = new Map([[
+      '500',
+      // intentionally NO permissionsFor — the parser must treat
+      // this as denied, not as "assume allowed".
+      { id: '500', type: GUILD_VOICE, members: new Map([['111', { user: { id: '111', bot: false } }]]) },
+    ]]);
     const res = parseRecipientMentions('<#500>', int);
     expect(res.ids).toEqual([]);
     expect(res.invalidTokens).toEqual(['<#500>']);

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -22,7 +22,14 @@ jest.mock('../src/config', () => ({
   QURL_SEND_MAX_RECIPIENTS: 25,
 }));
 
-const { parseRecipientMentions, MAX_INPUT_LENGTH, MAX_INVALID_TOKEN_LENGTH } = require('../src/recipient-parser');
+const {
+  parseRecipientMentions,
+  isVoiceChannelType,
+  MAX_INPUT_LENGTH,
+  MAX_INVALID_TOKEN_LENGTH,
+  VOICE_CHANNEL_TYPE,
+  STAGE_VOICE_CHANNEL_TYPE,
+} = require('../src/recipient-parser');
 const logger = require('../src/logger');
 
 // Build a synthetic interaction with the cache shape the parser reads.
@@ -31,7 +38,7 @@ const logger = require('../src/logger');
 // IDs are all-numeric to match real Discord snowflakes — the parser's
 // regex is `/<@!?(\d+)>/` so letter-prefixed test fixtures would silently
 // drop every mention, masking real coverage.
-function makeInteraction({ senderId = '900000000000000001', users = {}, roles = {} } = {}) {
+function makeInteraction({ senderId = '900000000000000001', users = {}, roles = {}, channels = {} } = {}) {
   const memberCache = new Map();
   for (const [id, attrs] of Object.entries(users)) {
     memberCache.set(id, { user: { id, bot: !!attrs.bot } });
@@ -50,11 +57,28 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
     }
     roleCache.set(roleId, { members: roleMembers });
   }
+  // Channel shape: { id → { type, members: [id, ...] } } where type
+  // is the numeric ChannelType (2 = GuildVoice, 13 = GuildStageVoice;
+  // any other value tests the non-voice rejection path). Voice-
+  // connected members are added to the guild member cache so the
+  // bot filter (and post-filter dedupe semantics) match production.
+  const channelCache = new Map();
+  for (const [channelId, attrs] of Object.entries(channels)) {
+    const memberIds = attrs.members || [];
+    const chMembers = new Map();
+    for (const mid of memberIds) {
+      const existing = memberCache.get(mid) ?? { user: { id: mid, bot: false } };
+      memberCache.set(mid, existing);
+      chMembers.set(mid, existing);
+    }
+    channelCache.set(channelId, { id: channelId, type: attrs.type, members: chMembers });
+  }
   return {
     user: { id: senderId },
     guild: {
       members: { cache: memberCache },
       roles: { cache: roleCache },
+      channels: { cache: channelCache },
     },
   };
 }
@@ -326,6 +350,166 @@ describe('parseRecipientMentions — role mentions', () => {
     const res = parseRecipientMentions('<@&7000> <@&7000> <@&7000>', int);
     expect(res.ids.sort()).toEqual(['101', '102']);
     expect(res.invalidTokens).toEqual([]);
+  });
+});
+
+describe('voice-channel type constants (discord.js ChannelType pin)', () => {
+  // Pins the numeric values the parser hard-codes (`channel.type ===
+  // 2 || channel.type === 13`). A discord.js bump that renumbers
+  // GuildVoice / GuildStageVoice would break the voice-everyone path
+  // silently without these assertions — the parser would treat real
+  // voice channels as non-voice and reject the mention.
+  test('VOICE_CHANNEL_TYPE is 2 (GuildVoice)', () => {
+    expect(VOICE_CHANNEL_TYPE).toBe(2);
+  });
+  test('STAGE_VOICE_CHANNEL_TYPE is 13 (GuildStageVoice)', () => {
+    expect(STAGE_VOICE_CHANNEL_TYPE).toBe(13);
+  });
+  test('isVoiceChannelType matches both voice + stage-voice', () => {
+    expect(isVoiceChannelType(2)).toBe(true);
+    expect(isVoiceChannelType(13)).toBe(true);
+  });
+  test('isVoiceChannelType rejects every other channel type (text, category, forum, etc.)', () => {
+    expect(isVoiceChannelType(0)).toBe(false);   // GuildText
+    expect(isVoiceChannelType(4)).toBe(false);   // GuildCategory
+    expect(isVoiceChannelType(5)).toBe(false);   // GuildAnnouncement
+    expect(isVoiceChannelType(10)).toBe(false);  // AnnouncementThread
+    expect(isVoiceChannelType(15)).toBe(false);  // GuildForum
+    expect(isVoiceChannelType(undefined)).toBe(false);
+    expect(isVoiceChannelType(null)).toBe(false);
+  });
+});
+
+describe('parseRecipientMentions — channel mentions (voice / stage-voice)', () => {
+  // ChannelType numeric values mirrored from discord.js:
+  //   GuildVoice = 2
+  //   GuildStageVoice = 13
+  //   GuildText = 0 (rejected — non-voice)
+  const GUILD_VOICE = 2;
+  const GUILD_STAGE_VOICE = 13;
+  const GUILD_TEXT = 0;
+
+  test('voice channel expands to currently-connected non-bot members', () => {
+    const int = makeInteraction({
+      channels: {
+        '500': { type: GUILD_VOICE, members: ['111', '222', '333'] },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids.sort()).toEqual(['111', '222', '333']);
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('stage-voice channel expands the same way as voice', () => {
+    const int = makeInteraction({
+      channels: {
+        '501': { type: GUILD_STAGE_VOICE, members: ['111', '222'] },
+      },
+    });
+    const res = parseRecipientMentions('<#501>', int);
+    expect(res.ids.sort()).toEqual(['111', '222']);
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('voice channel filters bots from the connected set', () => {
+    const int = makeInteraction({
+      users: { '801': { bot: true } },
+      channels: {
+        '500': { type: GUILD_VOICE, members: ['111', '801', '222'] },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids.sort()).toEqual(['111', '222']);
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('empty voice channel lands in invalidTokens (no silent empty expansion)', () => {
+    const int = makeInteraction({
+      channels: {
+        '500': { type: GUILD_VOICE, members: [] },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
+  });
+
+  test('voice channel with only bots lands in invalidTokens', () => {
+    const int = makeInteraction({
+      users: { '801': { bot: true }, '802': { bot: true } },
+      channels: {
+        '500': { type: GUILD_VOICE, members: ['801', '802'] },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
+  });
+
+  test('text channel mention is rejected into invalidTokens (no @everyone-in-text-channel regression)', () => {
+    // Pins PR #174's fix: text-channel "everyone" used to expand to
+    // every ViewChannel-permission holder, which on default Discord
+    // is the entire guild. We REJECT non-voice channel mentions
+    // outright so a user typing `<#text-channel>` doesn't accidentally
+    // blast the whole server.
+    const int = makeInteraction({
+      channels: {
+        '500': { type: GUILD_TEXT, members: ['111', '222'] },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
+  });
+
+  test('unknown channel (cache miss) lands in invalidTokens', () => {
+    const int = makeInteraction({ channels: {} });
+    const res = parseRecipientMentions('<#999>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#999>']);
+  });
+
+  test('dedupes repeated channel mentions into one invalidTokens entry', () => {
+    // Symmetric with the role-error dedup path (`<@&999> <@&999>`
+    // produces one entry, not two). A caller's "couldn't parse: X, X"
+    // embed is hostile.
+    const int = makeInteraction({ channels: {} });
+    const res = parseRecipientMentions('<#999> <#999>', int);
+    expect(res.invalidTokens).toEqual(['<#999>']);
+  });
+
+  test('voice expansion combines with explicit user mentions (dedupe across paths)', () => {
+    const int = makeInteraction({
+      users: { '111': {}, '222': {}, '333': {} },
+      channels: {
+        '500': { type: GUILD_VOICE, members: ['111', '222'] },
+      },
+    });
+    // '111' appears in both the explicit mention AND the voice
+    // channel; should dedupe to one entry. '333' is mention-only.
+    const res = parseRecipientMentions('<@111> <@333> <#500>', int);
+    expect(res.ids.sort()).toEqual(['111', '222', '333']);
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('channel mention does not show up in invalidTokens twice (channel-expansion + residue-strip)', () => {
+    // The residue-strip pass also strips <#id>; without that, a
+    // resolved voice channel would surface as both an expansion AND
+    // a leftover invalid token. Test pins the strip.
+    const int = makeInteraction({
+      channels: {
+        '500': { type: GUILD_VOICE, members: ['111'] },
+      },
+    });
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('DM-context (no guild) lands channel mention in invalidTokens', () => {
+    // Same cold-cache / DM degradation path as user mentions.
+    const res = parseRecipientMentions('<#500>', { user: { id: '900000000000000001' } });
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
   });
 });
 

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -572,6 +572,59 @@ describe('parseRecipientMentions — channel mentions (voice / stage-voice)', ()
     expect(res.ids).toEqual([]);
     expect(res.invalidTokens).toEqual(['<#500>']);
   });
+
+  test('explicit channel mentions claim cap slots BEFORE @everyone (priority ordering)', () => {
+    // The parser's channel-expansion pass runs BEFORE @everyone so
+    // direct mentions (user / role / channel) claim cap slots first
+    // and @everyone fills the remainder. Reversing the order would
+    // silently drop explicit mentions when the cache is partial or
+    // the cap is tight — pin the contract here.
+    //
+    // Setup: cap = 25 (test default), 100 unrelated guild members,
+    // 3-member voice channel. With voice running BEFORE @everyone,
+    // the 3 voice members win cap slots first and @everyone fills
+    // the remaining 22.
+    const users = {};
+    for (let i = 1; i <= 100; i++) {
+      users[`9${String(i).padStart(17, '0')}`] = {};
+    }
+    const voiceMembers = ['111', '222', '333'];
+    for (const id of voiceMembers) users[id] = {};
+    const int = makeInteraction({
+      users,
+      channels: { '500': { type: GUILD_VOICE, members: voiceMembers } },
+    });
+    const res = parseRecipientMentions('@everyone <#500>', int, { allowMassMention: true });
+    // All three voice members must appear (proof: they claimed cap
+    // slots before the larger @everyone pool overflowed the cap).
+    for (const id of voiceMembers) expect(res.ids).toContain(id);
+    expect(res.ids).toHaveLength(25);
+  });
+
+  test('voice channel after cap-filling user mentions: silently no-ops (NOT marked invalid)', () => {
+    // Bug-guard: early break on `ids.size >= cap` must NOT mark the
+    // channel invalid when the cap was already filled by upstream
+    // expansions. The channel was perfectly valid; it just had no
+    // room to contribute. Without `capHit` tracking, the channel
+    // would surface as an invalidTokens entry, misleading the user.
+    const users = { '111': {}, '222': {}, '333': {}, 'aaa': {}, 'bbb': {} };
+    const int = makeInteraction({
+      users,
+      channels: { '500': { type: GUILD_VOICE, members: ['aaa', 'bbb'] } },
+    });
+    // Override cap to a small value so the user mentions alone fill it.
+    const config = require('../src/config');
+    const origCap = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 3;
+    try {
+      const res = parseRecipientMentions('<@111> <@222> <@333> <#500>', int);
+      expect(res.ids.sort()).toEqual(['111', '222', '333']);
+      // Channel was valid; it just contributed nothing because the cap was full.
+      expect(res.invalidTokens).toEqual([]);
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = origCap;
+    }
+  });
 });
 
 describe('parseRecipientMentions — @everyone (allowMassMention)', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -590,6 +590,27 @@ describe('parseRecipientMentions — channel mentions (voice / stage-voice)', ()
     expect(res.invalidTokens.length).toBe(1);
   });
 
+  test('<#voice> succeeds independently when sender lacks MENTION_EVERYONE (massMentionDenied stays orthogonal)', () => {
+    // Cross-feature interaction: a sender who can see the voice
+    // channel but lacks MENTION_EVERYONE should still get the
+    // voice expansion; @everyone should land in massMentionDenied
+    // independently. The two paths must not block each other —
+    // pinning the orthogonality so a future refactor doesn't
+    // entangle them (e.g., short-circuiting all expansions when
+    // any one is denied).
+    const int = makeInteraction({
+      users: { '111': {}, '222': {} },
+      channels: { '500': { type: 2, members: ['111', '222'] } },
+    });
+    const res = parseRecipientMentions('@everyone <#500>', int, { allowMassMention: false });
+    expect(res.ids.sort()).toEqual(['111', '222']);
+    expect(res.massMentionDenied).toBe(true);
+    // @everyone was stripped from invalidTokens (per the
+    // allowMassMention contract) AND the voice channel expanded
+    // cleanly — neither path interferes with the other.
+    expect(res.invalidTokens).toEqual([]);
+  });
+
   test('interaction.member undefined with present guild fails closed (no silent view bypass)', () => {
     // Defense-in-depth: real discord.js always populates member for
     // guild slash commands. A degraded interaction shape (test mock

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -573,6 +573,57 @@ describe('parseRecipientMentions — channel mentions (voice / stage-voice)', ()
     expect(res.invalidTokens).toEqual(['<#500>']);
   });
 
+  test('rejected channel mention is NOT double-reported by the residue-strip pass', () => {
+    // Pins the load-bearing CHANNEL_MENTION_RE strip in the residue
+    // pass. Without it, a rejected channel mention would surface
+    // TWICE in invalidTokens: once from the channel-expansion loop
+    // (cache miss / non-voice / view-denied → pushInvalidIfNew) and
+    // once from the residue-strip pass (split on whitespace would
+    // tokenize the surviving `<#999>` as a leftover invalid token).
+    // The .toEqual length-1 assertion is what guards the strip; if
+    // the strip were ever removed, this fails loudly rather than
+    // surfacing as a "couldn't parse: <#999>, <#999>" user-visible
+    // hostile embed.
+    const int = makeInteraction({ channels: {} });
+    const res = parseRecipientMentions('<#999>', int);
+    expect(res.invalidTokens).toEqual(['<#999>']);
+    expect(res.invalidTokens.length).toBe(1);
+  });
+
+  test('interaction.member undefined with present guild fails closed (no silent view bypass)', () => {
+    // Defense-in-depth: real discord.js always populates member for
+    // guild slash commands. A degraded interaction shape (test mock
+    // bug, future discord.js refactor) where member is undefined
+    // must NOT silently bypass the ViewChannel gate — passing
+    // undefined to channel.permissionsFor returns null in real
+    // discord.js, which fails closed via the `!viewerPerms` branch.
+    // This test pins that contract against a mock that returns null
+    // from permissionsFor when called with undefined.
+    const channelCache = new Map([[
+      '500',
+      {
+        id: '500',
+        type: 2, // GuildVoice
+        members: new Map([['111', { user: { id: '111', bot: false } }]]),
+        // Returns null when called with undefined member, matching
+        // real discord.js behavior.
+        permissionsFor: (memberOrId) => memberOrId == null ? null : ({ has: () => true }),
+      },
+    ]]);
+    const int = {
+      user: { id: '900000000000000001' },
+      // member intentionally absent
+      guild: {
+        members: { cache: new Map([['111', { user: { id: '111', bot: false } }]]) },
+        roles: { cache: new Map() },
+        channels: { cache: channelCache },
+      },
+    };
+    const res = parseRecipientMentions('<#500>', int);
+    expect(res.ids).toEqual([]);
+    expect(res.invalidTokens).toEqual(['<#500>']);
+  });
+
   test('explicit channel mentions claim cap slots BEFORE @everyone (priority ordering)', () => {
     // The parser's channel-expansion pass runs BEFORE @everyone so
     // direct mentions (user / role / channel) claim cap slots first


### PR DESCRIPTION
## Summary

- Restores the voice-channel-everyone targeting capability that PR #313 inadvertently dropped when it hard-removed `/qurl send` (commit message claimed `/qurl file` + `/qurl map` covered every `/qurl send` capability — they didn't cover this one).
- Two surfaces: (1) a 🔊 "Everyone in this voice channel (N)" button on the confirm card when the slash command is invoked from voice / stage-voice; (2) `<#voice-channel>` syntax in the `recipients:` field expands to voice-connected non-bot members.
- Re-adds the `GuildVoiceStates` gateway intent (no REST alternative for "who's in voice channel X") with a positive `assertIntent` canary replacing the previous negative-canary guard.
- Bumps `QURL_SEND_MAX_RECIPIENTS` default 50 → 20,000 (per stage-channel sizing requirement).

## Motivation

Reported regression: "we lost the ability to send to everyone in voice when we implemented `file` and `map` vs the old `send`." This was specifically the legacy `/qurl send` wizard's "Everyone in this voice channel" option from PR #174 (voice-connected-only semantics, fixed the prior @everyone-on-default-server expansion bug). It was deleted alongside `getChannelMembers` in PR #313 and never restored.

## What changed

**`src/discord.js`** — `GuildVoiceStates` re-added to the intents array with a positive `assertIntent` citing voice-everyone resolution as the load-bearing feature. The previous `assertNoIntent` for that bit is removed. Negative-canary doc block updated to acknowledge the reversal. (PR #313's tradeoff acknowledged in the commit body.)

**`src/recipient-parser.js`** — New `CHANNEL_MENTION_RE` + `isVoiceChannelType` predicate (exported). `parseRecipientMentions` now has a channel-expansion pass that runs **before** the `@everyone` expansion (so explicit channel mentions claim cap slots first, matching the user/role priority pattern). Voice/stage-voice channels expand to voice-connected non-bot members; every other channel type lands in `invalidTokens` — text-channel "everyone" expansion stays rejected (PR #174 regression guard). `CHANNEL_MENTION_RE` also stripped in the residue pass so resolved channels don't double-report as leftover tokens.

**`src/commands.js`** —
- `voiceChannelId` snapshot into the flow payload at `handleQurlSlashSend` time (durable across re-renders, not re-derived at click).
- New `CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID` (`qurl_confirm_voice_everyone`).
- `renderConfirmCardRows` conditionally renders the button on the bottom row when `payload.voiceChannelId` is set; label shows live `(N)` count, disabled with `(0)` when no one is connected (honest UX vs. silent reject-on-click). Button only renders when in voice context — text-channel invocations are unchanged.
- New `handleConfirmVoiceEveryone` mirrors `handleConfirmUserSelect`'s shape (`deferUpdate` → resolve → `partitionRecipients` → `transitionFlow` → re-render). **Resolves voice-connected members AT CLICK TIME via `channel.members`**, not render time — a 30s-old snapshot would silently send to users who already left voice. Reject paths cover channel-deleted, empty, bots-only, and corrupt-payload cases.
- Flow handler registered at the same `SEND_STAGE_AWAITING_CONFIRM` stage; sibling-message-by-stage contract preserved.

**`src/config.js`** — `QURL_SEND_MAX_RECIPIENTS` default bumped 50 → 20,000. Op implications documented in-line: a max-size send can trigger ~2,000 re-uploads to qurl-service (`mintLinksInBatches` chunks at `TOKENS_PER_RESOURCE=10`), and DM delivery is bounded by Discord's ~5/sec per-bot rate limit, so a 20k send takes >1 hour to finish fan-out — `monitorLinkStatus`'s interval-based progress tracking must survive that duration. Per-guild operators can dial down via env override.

## Tests

- `tests/recipient-parser.test.js` — new "channel mentions (voice / stage-voice)" describe (10 cases: voice expand, stage-voice expand, bot filter, empty-channel reject, bots-only reject, **text-channel reject (PR #174 regression guard)**, unknown-channel cache miss, dedupe, cross-path dedupe with explicit user mentions, residue double-report guard, DM context). New "voice-channel type constants" describe pins `GuildVoice=2` / `GuildStageVoice=13` so a future discord.js bump breaks loud rather than silently treating real voice channels as non-voice.
- `tests/discord.test.js` — `GuildVoiceStates` added to the `GatewayIntentBits` mock at production value (128); new positive `assertIntent` spec for the voice-everyone feature label.
- `tests/qurl-file-map.test.js` — new `handleConfirmVoiceEveryone` describe (6 cases: happy path populates recipientIds, bot filter, missing-`voiceChannelId` early-return, channel-deleted `rejectVoice`, empty-channel `rejectVoice`, corrupt-payload guard). Custom-id contract test extended to assert `CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID`; uniqueness test bumped 7 → 8.
- `tests/build-delivery-embed.test.js` / `tests/opennhp-gating.test.js` — per-suite `GatewayIntentBits` mocks updated to include the new bit so module load survives the `assertIntent` canary at boot.

330 tests across the directly affected suites pass. Lint clean (`eslint --max-warnings 0`).

## Operational call-outs

- **Gateway event volume.** `GuildVoiceStates` re-add reverses PR #313's tradeoff. Voice state events fire on join/leave/mute/unmute. Bounded by guild voice-channel activity; acceptable trade for the restored capability since no REST alternative exists for voice-channel membership.
- **20k cap.** A truly maxed-out send is heavy: ~2000 qurl-service re-uploads + 60+ minutes of DM fan-out. Per the env-override comment in `config.js`, guilds with smaller plans can dial it back.

## Test plan

- [ ] CI green
- [ ] Claude review clean
- [ ] Live smoke: `/qurl file` invoked from a voice channel → button renders with live count → click → confirm card shows resolved recipients → Send → DMs land for every connected non-bot.
- [ ] Live smoke: `/qurl file recipients:<#voice-channel-id>` → recipients populated from voice members.
- [ ] Live smoke: `/qurl file` from text channel → no voice button rendered (regression guard).
- [ ] Live smoke: empty voice channel → button disabled with `(0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)