### PR TITLE
refactor(discord): tighten delivery embed + harden expiresAt validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Open-source integrations for [qURL™](https://layerv.ai) — Quantum URLs that make protected resources invisible by default.
 
-> **Quantum URL (qURL)** · The internet has a hidden layer. This is how you enter.
-
 qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock opens temporary firewall access for the caller's IP — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
 
 This monorepo contains Go-based platform integrations (Slack, Teams, Discord), a CLI tool, and shared libraries for creating and managing qURLs.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -595,19 +595,20 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     // caller bypasses that contract — belt-and-braces vs rendering
     // a visible-but-empty `> *""*` row between sender and expiry.
     //
-    // Order is intentional: substring → replace → trim. The 280 cap
-    // applies to RAW input (bounds the work done by replace/trim
+    // Order is intentional: cap → replace → trim. The 280-codepoint
+    // cap applies to RAW input (bounds the work done by replace/trim
     // against a 10KB single-line pathological input) rather than to
-    // the rendered output. A future "fix" to `replace().trim().
-    // substring(0, 280)` would be a subtly different contract — the
-    // visible output would be capped at 280 chars but unbounded work
-    // would happen before the cap.
+    // the rendered output. A future "fix" to `replace().trim()` then
+    // cap would be a subtly different contract — the visible output
+    // would be capped at 280 but unbounded work would happen before.
     //
-    // NOTE: `substring(0, 280)` is UTF-16-unit-aware, not grapheme-
-    // aware — a surrogate pair (4-byte emoji) straddling unit 280 can
-    // be split, leaving a lone high surrogate. Tracked as #345; not
-    // a security issue, just a visual gotcha.
-    const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
+    // `Array.from(s).slice(0, 280).join('')` is codepoint-aware: a
+    // 4-byte emoji (surrogate pair) is one element in the resulting
+    // array, so the cap can't split it into a lone high surrogate.
+    // 280 codepoints = at most 560 UTF-16 units = still well under
+    // Discord's 4096-char description cap. Mirrors the cap pattern
+    // sanitizeDisplayName uses for senderAlias.
+    const capped = Array.from(personalMessage).slice(0, 280).join('').replace(/[\r\n]+/g, ' ').trim();
     if (capped) descLines.push(`> *"${capped}"*`);
   }
   descLines.push(`🕐 Closes <t:${expiresAt}:R>`);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -425,17 +425,18 @@ function resolveRecipientAlias(r, interaction) {
 
 // --- Shared DM delivery payload builder ---
 // Builds the {embeds, components} payload for a per-recipient DM. The
-// embed copy is intentionally evocative ("opened a door", "Door closes")
+// embed copy is intentionally evocative ("opened a door", "Closes")
 // rather than literal ("shared a file with you") — the brand goal is to
 // convey the qURL hidden-layer model, not just announce a file transfer.
-// The qURL link is rendered as a `🔗 Step Through` Link button rather
+// The qURL link is rendered as a `🚪 Step Through` Link button rather
 // than a bare URL field; recipients click the button to open the link
 // in their default browser.
 //
 // `senderAlias` is the sender's friendly display name (Discord nickname
 // > globalName > username) sourced from resolveSenderAlias.
 // `personalMessage` is optional caller-provided context; if present, it
-// renders as an italicized blockquote above the body paragraph.
+// renders as an italicized blockquote between the sender line and the
+// expiry line.
 //
 // Returns the full Discord message options object (`embeds` + `components`)
 // rather than just the embed, since the button is not part of the embed

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -454,9 +454,6 @@ function resolveRecipientAlias(r, interaction) {
 //     │  🕐 Door closes in 1 day                                    │  (Discord <t:N:R> — auto-updates client-side
 //     │                                                             │   to "in 16 hours" / "in 1 hour" / "1 hour ago")
 //     │                                                             │
-//     │  Quantum URL (qURL) · The internet has a hidden layer.     │  (final embed field;
-//     │  This is how you enter.                                     │   `qURL` → https://layerv.ai)
-//     │                                                             │
 //     │  ┌──────────────────────────┐                               │
 //     │  │   🔗 Step Through        │  (Link button — opens qURL)
 //     │  └──────────────────────────┘                               │
@@ -590,14 +587,6 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
         }
         return `\ud83d\udd50 Door closes <t:${expiresAt}:R>`;
       })(),
-    },
-    {
-      // Brand line lives in a regular embed field (NOT setFooter) because
-      // Discord embed footers are plain-text only and we need the markdown
-      // hyperlink on `qURL` to point at https://layerv.ai. The brand line
-      // anchors the recipient back to the qURL product page.
-      name: '\u200B',
-      value: 'Quantum URL ([qURL](https://layerv.ai)) · The internet has a hidden layer. This is how you enter.',
     },
   );
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1915,6 +1915,18 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // shape). resolveSenderAlias is a pure function of
   // originalInteraction so hoisting is safe and avoids re-resolving
   // the nickname/globalName/username chain per dispatch.
+  //
+  // AUDIT TRADE-OFF: hoisting `expiresAt` outside the per-recipient
+  // try/finally means an `expiryToMs` throw on malformed
+  // `sendConfig.expires_in` bubbles out of handleAddRecipients
+  // entirely — ZERO `DISPATCH_FAILED` audits are emitted for the
+  // batch. The prior code computed expiresAt per-recipient inside the
+  // try, so the same throw would have produced N audits. The hoist is
+  // the correct shape (sendConfig.expires_in is validated upstream
+  // and the per-recipient audits would have been N-failed-for-one-
+  // root-cause noise), but the contract is intentional: an upstream
+  // expires_in regression is invisible at the dispatch-metric layer
+  // and surfaces only via the function-level throw.
   const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
   const senderAlias = resolveSenderAlias(originalInteraction);
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -584,8 +584,15 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // the embed visually compact.
   const descLines = [`**${safeSender}** opened a door for you.`];
   if (personalMessage) {
+    // Skip the styled-blockquote line if the input collapses to an
+    // empty string after newline-flatten + trim (e.g. "  \n \n  ").
+    // The call sites already pass `sanitizeMessage(...) || null` so
+    // an empty input arrives as null and short-circuits the outer
+    // `if (personalMessage)`. This guard only matters if a future
+    // caller bypasses that contract — belt-and-braces vs rendering
+    // a visible-but-empty `> *""*` row between sender and expiry.
     const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
-    descLines.push(`> *"${capped}"*`);
+    if (capped) descLines.push(`> *"${capped}"*`);
   }
   descLines.push(`🕐 Closes <t:${expiresAt}:R>`);
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -550,12 +550,15 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // run before `sanitizeDisplayName` because that helper is total
   // (NFKC + bidi/zero-width strip + markdown escape + 64-char cap +
   // 'Someone' fallback — never throws on any input shape).
-  if (!Number.isInteger(expiresAt)) {
+  if (!Number.isInteger(expiresAt) || expiresAt <= 0) {
     // String() over template interpolation so {} renders as "[object
     // Object]" instead of being coerced via valueOf; typeof gives the
     // operator the shape at a glance for non-primitive contract
-    // violations (object, function, symbol).
-    throw new Error(`buildDeliveryPayload: expiresAt must be an integer Unix-seconds number (got ${String(expiresAt)}, typeof=${typeof expiresAt})`);
+    // violations (object, function, symbol). The `> 0` clause closes
+    // the negative-timestamp gap: `<t:-1:R>` renders as "55 years ago"
+    // in Discord rather than failing visibly, so reject before the
+    // interpolation can produce a misleading recipient surface.
+    throw new Error(`buildDeliveryPayload: expiresAt must be a positive integer Unix-seconds number (got ${String(expiresAt)}, typeof=${typeof expiresAt})`);
   }
 
   // sanitizeDisplayName centralizes spoof defense so a future caller

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1906,6 +1906,18 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   let delivered = 0;
   let failed = 0;
 
+  // Hoist payload-shared inputs outside batchSettled so the entire
+  // batch shares one expiry timestamp and one resolved sender alias.
+  // Mirrors executeSendPipeline's structure — both pipelines now
+  // compute expiresAt once per call rather than once per recipient,
+  // eliminating Date.now() drift between recipients in the same
+  // batch (negligible at the 30m–7d horizon, but it's the unifying
+  // shape). resolveSenderAlias is a pure function of
+  // originalInteraction so hoisting is safe and avoids re-resolving
+  // the nickname/globalName/username chain per dispatch.
+  const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
+  const senderAlias = resolveSenderAlias(originalInteraction);
+
   const dmResults = await batchSettled(newRecipients, async (recipient) => {
     const links = recipientLinks[recipient.id];
     // Defensive guard: recipientLinks is populated above for every newRecipient,
@@ -1932,18 +1944,8 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // counts as dispatch_failed instead of disappearing from CloudWatch.
     let sent = false;
     try {
-      // Same Unix-seconds expiry computation as executeSendPipeline —
-      // see comment there. Computed once per handleAddRecipients call
-      // (outside the .map below), so a single batch's recipients all
-      // share the same expiry. Cheap to recompute on each call; the
-      // alternative would be threading a single timestamp through
-      // sendConfig at save time.
-      const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
       const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
-        // Same alias resolution as executeSendPipeline — see comment
-        // there for the nickname > globalName > username fallback
-        // rationale.
-        senderAlias: resolveSenderAlias(originalInteraction),
+        senderAlias,
         qurlLink: link.qurlLink,
         expiresAt,
         personalMessage: sendConfig.personal_message,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1922,9 +1922,11 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     let sent = false;
     try {
       // Same Unix-seconds expiry computation as executeSendPipeline —
-      // see comment there. Computed once per recipient (cheap; the
+      // see comment there. Computed once per handleAddRecipients call
+      // (outside the .map below), so a single batch's recipients all
+      // share the same expiry. Cheap to recompute on each call; the
       // alternative would be threading a single timestamp through
-      // sendConfig).
+      // sendConfig at save time.
       const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
       const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
         // Same alias resolution as executeSendPipeline — see comment

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -443,17 +443,20 @@ function resolveRecipientAlias(r, interaction) {
 // — it lives in a top-level component row alongside it. Callers pass the
 // returned payload directly to `sendDM`.
 //
-// Example of what the recipient sees:
+// Example of what the recipient sees AFTER Discord renders the embed
+// (blank rows between sections represent Discord's natural line-spacing
+// padding around the description block + below the button row, not
+// literal newlines — the actual `descLines.join('\n')` produces single-
+// newline separators, which Discord then displays with the spacing
+// shown below):
 //
 //     ┌─────────────────────────────────────────────────────────────┐
 //     │  qURL · APP · Today at 2:47 PM                              │  (Discord-rendered header)
 //     │                                                             │
-//     │  Vik opened a door for you.                                 │  (description)
-//     │                                                             │
-//     │  > "Quarterly numbers — for your eyes only."                │  (optional personal message — italic blockquote)
-//     │                                                             │
-//     │  🕐 Closes in 1 day                                         │  (Discord <t:N:R> — auto-updates client-side
-//     │                                                             │   to "in 16 hours" / "in 1 hour" / "1 hour ago")
+//     │  Vik opened a door for you.                                 │  (description, line 1)
+//     │  > "Quarterly numbers — for your eyes only."                │  (description, line 2 — optional italic blockquote)
+//     │  🕐 Closes in 1 day                                         │  (description, line 3 — Discord <t:N:R>, auto-updates
+//     │                                                             │   client-side to "in 16 hours" / "in 1 hour" / "1 hour ago")
 //     │                                                             │
 //     │  ┌──────────────────────────┐                               │
 //     │  │   🚪 Step Through        │  (Link button — opens qURL)

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -540,14 +540,18 @@ function parseLocationInput(rawInput) {
 
 function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
   // Fail-loud on a missing/invalid expiresAt rather than rendering
-  // literal "<t:undefined:R>" or "<t:NaN:R>" to a recipient. Matches
-  // the contract-violation throw in handleAddRecipients. Validate
+  // literal "<t:undefined:R>" or "<t:1735689600.5:R>" to a recipient.
+  // Matches the contract-violation throw in handleAddRecipients.
+  // Discord's `<t:N:R>` markdown wants integer Unix seconds; the lone
+  // call site already wraps in `Math.floor`, so `Number.isInteger`
+  // tightens the contract from "any finite number" to "exactly what
+  // the markdown accepts" without changing legitimate inputs. Validate
   // FIRST so the description below can interpolate directly. Safe to
   // run before `sanitizeDisplayName` because that helper is total
   // (NFKC + bidi/zero-width strip + markdown escape + 64-char cap +
   // 'Someone' fallback — never throws on any input shape).
-  if (!Number.isFinite(expiresAt)) {
-    throw new Error(`buildDeliveryPayload: expiresAt must be a finite Unix-seconds number (got ${expiresAt})`);
+  if (!Number.isInteger(expiresAt)) {
+    throw new Error(`buildDeliveryPayload: expiresAt must be an integer Unix-seconds number (got ${expiresAt})`);
   }
 
   // sanitizeDisplayName centralizes spoof defense so a future caller

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -542,25 +542,14 @@ function parseLocationInput(rawInput) {
 }
 
 function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
-  // Fail-loud on a missing/invalid expiresAt rather than rendering
-  // literal "<t:undefined:R>" or "<t:1735689600.5:R>" to a recipient.
-  // Matches the contract-violation throw in handleAddRecipients.
-  // Discord's `<t:N:R>` markdown wants integer Unix seconds; the lone
-  // call site already wraps in `Math.floor`, so `Number.isInteger`
-  // tightens the contract from "any finite number" to "exactly what
-  // the markdown accepts" without changing legitimate inputs. Validate
-  // FIRST so the description below can interpolate directly. Safe to
-  // run before `sanitizeDisplayName` because that helper is total
-  // (NFKC + bidi/zero-width strip + markdown escape + 64-char cap +
-  // 'Someone' fallback — never throws on any input shape).
+  // Discord's `<t:N:R>` markdown wants a positive integer Unix-seconds
+  // value; anything else renders a misleading recipient surface (e.g.
+  // `<t:0:R>` → "56 years ago", `<t:undefined:R>` → literal text,
+  // `<t:1735689600.5:R>` → parse failure). Match the contract exactly
+  // and fail loud — call sites all compute via `Math.floor(...)` so no
+  // legitimate input is rejected. `typeof` in the throw closes the
+  // null-vs-undefined-vs-object triage gap for operators.
   if (!Number.isInteger(expiresAt) || expiresAt <= 0) {
-    // String() over template interpolation so {} renders as "[object
-    // Object]" instead of being coerced via valueOf; typeof gives the
-    // operator the shape at a glance for non-primitive contract
-    // violations (object, function, symbol). The `> 0` clause closes
-    // the negative-timestamp gap: `<t:-1:R>` renders as "55 years ago"
-    // in Discord rather than failing visibly, so reject before the
-    // interpolation can produce a misleading recipient surface.
     throw new Error(`buildDeliveryPayload: expiresAt must be a positive integer Unix-seconds number (got ${String(expiresAt)}, typeof=${typeof expiresAt})`);
   }
 
@@ -606,6 +595,14 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     // `if (personalMessage)`. This guard only matters if a future
     // caller bypasses that contract — belt-and-braces vs rendering
     // a visible-but-empty `> *""*` row between sender and expiry.
+    //
+    // Order is intentional: substring → replace → trim. The 280 cap
+    // applies to RAW input (bounds the work done by replace/trim
+    // against a 10KB single-line pathological input) rather than to
+    // the rendered output. A future "fix" to `replace().trim().
+    // substring(0, 280)` would be a subtly different contract — the
+    // visible output would be capped at 280 chars but unbounded work
+    // would happen before the cap.
     const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
     if (capped) descLines.push(`> *"${capped}"*`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1285,12 +1285,13 @@ async function executeSendPipeline(interaction, {
   // Computed BEFORE recordQURLSendBatch so a malformed `expiresIn`
   // throwing in `expiryToMs` aborts the dispatch BEFORE any DDB rows
   // are written — otherwise the DB writes would happen, then the throw
-  // would bubble out with no DMs sent, leaving orphan QURL records with
-  // no recipient. The buildDeliveryPayload `Number.isInteger` guard at
-  // the per-recipient render step also runs against this value; if a
-  // future expiryToMs returns a non-integer (e.g. fractional ms / 1000),
-  // it throws here, before the DB write, not at dispatch time. Closes
-  // #352.
+  // would bubble out with no DMs sent, leaving orphan QURL records
+  // with no recipient. The throw fires HERE (at the hoisted compute
+  // site below, function-scoped) rather than at the per-recipient
+  // render step inside batchSettled — that distinction matters for
+  // the failure-mode bookkeeping: a thrown expiryToMs surfaces as a
+  // single uncaught error at the function level, not as N
+  // `DISPATCH_FAILED` audit emissions. Closes #352.
   const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
 
   // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
@@ -1335,6 +1336,14 @@ async function executeSendPipeline(interaction, {
   const failedUsers = [];
   const recipientMap = new Map(recipients.map(r => [r.id, r]));
 
+  // Mirror handleAddRecipients: hoist resolveSenderAlias out of the
+  // per-recipient batchSettled callback. The function is a pure
+  // resolution of nickname > globalName > username from `interaction`,
+  // so the per-link call inside the callback was N redundant
+  // resolutions of the same string. Both pipelines now share the same
+  // hoist pattern for both expiresAt AND senderAlias.
+  const senderAlias = resolveSenderAlias(interaction);
+
   const dmResults = await batchSettled(qurlLinks, async (link) => {
     const recipient = recipientMap.get(link.recipientId);
     // Audit in `finally` so the metric fires for every recipient regardless
@@ -1350,10 +1359,7 @@ async function executeSendPipeline(interaction, {
     let sent = false;
     try {
       const dmPayload = buildDeliveryPayload({
-        // member.displayName resolves to nickname || globalName || username,
-        // so it works whether the sender has a per-guild nickname, only a
-        // global display name, or just the legacy @-handle.
-        senderAlias: resolveSenderAlias(interaction),
+        senderAlias,
         qurlLink: link.qurlLink,
         expiresAt,
         personalMessage,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -546,21 +546,24 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // legitimate input is rejected. `typeof` in the throw closes the
   // null-vs-undefined-vs-object triage gap for operators.
   if (!Number.isInteger(expiresAt) || expiresAt <= 0) {
-    throw new Error(`buildDeliveryPayload: expiresAt must be a positive integer Unix-seconds number (got ${String(expiresAt)}, typeof=${typeof expiresAt})`);
+    const got = String(expiresAt);
+    const gotType = typeof expiresAt;
+    throw new Error(
+      `buildDeliveryPayload: expiresAt must be a positive integer `
+      + `Unix-seconds number (got ${got}, typeof=${gotType})`
+    );
   }
 
   // sanitizeDisplayName centralizes spoof defense so a future caller
   // adding another sender-name surface picks up the same protections.
   const safeSender = sanitizeDisplayName(senderAlias);
 
-  // Single description block: sender → optional personal message →
-  // expiry. Folding all three into one setDescription (rather than
-  // splitting personal message into addFields) keeps the rendered
-  // order matching the design — Discord renders fields BELOW the
-  // description, so an addFields personal-message would land after
-  // the expiry line, not between sender and expiry. It also keeps
-  // the embed compact: addFields adds vertical padding that pushes
-  // the Step Through button further from the sender line.
+  // Discord renders fields BELOW the description, so all three lines
+  // (sender / optional personal message / expiry) must live in one
+  // setDescription block — an addFields personal-message would land
+  // after the expiry line, not between sender and expiry. Folding
+  // also strips addFields' vertical padding, keeping the Step Through
+  // button close to the sender line.
   //
   // `<t:N:R>` is Discord's client-side relative-time markdown: the
   // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
@@ -599,6 +602,11 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     // substring(0, 280)` would be a subtly different contract — the
     // visible output would be capped at 280 chars but unbounded work
     // would happen before the cap.
+    //
+    // NOTE: `substring(0, 280)` is UTF-16-unit-aware, not grapheme-
+    // aware — a surrogate pair (4-byte emoji) straddling unit 280 can
+    // be split, leaving a lone high surrogate. Tracked as #345; not
+    // a security issue, just a visual gotcha.
     const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
     if (capped) descLines.push(`> *"${capped}"*`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -551,7 +551,11 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // (NFKC + bidi/zero-width strip + markdown escape + 64-char cap +
   // 'Someone' fallback — never throws on any input shape).
   if (!Number.isInteger(expiresAt)) {
-    throw new Error(`buildDeliveryPayload: expiresAt must be an integer Unix-seconds number (got ${expiresAt})`);
+    // String() over template interpolation so {} renders as "[object
+    // Object]" instead of being coerced via valueOf; typeof gives the
+    // operator the shape at a glance for non-primitive contract
+    // violations (object, function, symbol).
+    throw new Error(`buildDeliveryPayload: expiresAt must be an integer Unix-seconds number (got ${String(expiresAt)}, typeof=${typeof expiresAt})`);
   }
 
   // sanitizeDisplayName centralizes spoof defense so a future caller

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -443,12 +443,8 @@ function resolveRecipientAlias(r, interaction) {
 // — it lives in a top-level component row alongside it. Callers pass the
 // returned payload directly to `sendDM`.
 //
-// Example of what the recipient sees AFTER Discord renders the embed
-// (blank rows between sections represent Discord's natural line-spacing
-// padding around the description block + below the button row, not
-// literal newlines — the actual `descLines.join('\n')` produces single-
-// newline separators, which Discord then displays with the spacing
-// shown below):
+// Rendered output (blank rows = Discord's natural section spacing,
+// NOT literal `\n` separators — descLines.join('\n') is single-newline):
 //
 //     ┌─────────────────────────────────────────────────────────────┐
 //     │  qURL · APP · Today at 2:47 PM                              │  (Discord-rendered header)

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1271,6 +1271,28 @@ async function executeSendPipeline(interaction, {
     return interaction.editReply({ content: 'Failed to create any links. Please try again.' });
   }
 
+  // Compute the absolute expiry instant once for this dispatch (Unix
+  // seconds — Discord's <t:N:R> format requires seconds, not millis).
+  // Using send-time + duration rather than reading from the API mint
+  // response since `mintLinks` doesn't currently surface `expires_at`.
+  // Drift between this clock and the API's enforcement clock is bounded
+  // by the time between this line and the mint call (sub-second on the
+  // send-pipeline path; can be a few seconds on handleAddRecipients
+  // which re-downloads + re-uploads + re-mints first). Negligible at
+  // the 30m–7d horizon — recipients see "in 24 hours" instead of
+  // "in 23h 59m 56s" on the worst-case path.
+  //
+  // Computed BEFORE recordQURLSendBatch so a malformed `expiresIn`
+  // throwing in `expiryToMs` aborts the dispatch BEFORE any DDB rows
+  // are written — otherwise the DB writes would happen, then the throw
+  // would bubble out with no DMs sent, leaving orphan QURL records with
+  // no recipient. The buildDeliveryPayload `Number.isInteger` guard at
+  // the per-recipient render step also runs against this value; if a
+  // future expiryToMs returns a non-integer (e.g. fractional ms / 1000),
+  // it throws here, before the DB write, not at dispatch time. Closes
+  // #352.
+  const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
+
   // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
   // still exist on the QURL side but there's no local record to revoke them
   // later — abort the send and surface the error instead of continuing to DMs.
@@ -1312,18 +1334,6 @@ async function executeSendPipeline(interaction, {
   let failed = 0;
   const failedUsers = [];
   const recipientMap = new Map(recipients.map(r => [r.id, r]));
-
-  // Compute the absolute expiry instant once for this dispatch (Unix
-  // seconds — Discord's <t:N:R> format requires seconds, not millis).
-  // Using send-time + duration rather than reading from the API mint
-  // response since `mintLinks` doesn't currently surface `expires_at`.
-  // Drift between this clock and the API's enforcement clock is bounded
-  // by the time between this line and the mint call (sub-second on the
-  // send-pipeline path; can be a few seconds on handleAddRecipients
-  // which re-downloads + re-uploads + re-mints first). Negligible at
-  // the 30m–7d horizon — recipients see "in 24 hours" instead of
-  // "in 23h 59m 56s" on the worst-case path.
-  const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
 
   const dmResults = await batchSettled(qurlLinks, async (link) => {
     const recipient = recipientMap.get(link.recipientId);
@@ -1875,6 +1885,29 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Failed to create any links.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
+  // Hoist payload-shared inputs to the top of the dispatch block so
+  // the entire batch shares one expiry timestamp and one resolved
+  // sender alias. Mirrors executeSendPipeline's structure — both
+  // pipelines now compute expiresAt once per call, eliminating
+  // Date.now() drift between recipients in the same batch.
+  // resolveSenderAlias is a pure function of originalInteraction so
+  // hoisting also avoids re-resolving the
+  // nickname/globalName/username chain per dispatch.
+  //
+  // Computed BEFORE recordQURLSendBatch so a malformed
+  // `sendConfig.expires_in` throwing in `expiryToMs` aborts the
+  // dispatch BEFORE any DDB rows are written — otherwise the DB
+  // writes would happen, then the throw would bubble out with no DMs
+  // sent, leaving orphan QURL records with no recipient. The
+  // `handleAddRecipients` path is especially exposed here because
+  // sendConfig.expires_in is read from DDB (rather than validated
+  // upstream like executeSendPipeline's slash-command param), so a
+  // stale/regressed row predating the current validation would slip
+  // through. Throwing pre-write makes the failure mode visible at
+  // the function level rather than as orphan rows. Closes #352.
+  const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
+  const senderAlias = resolveSenderAlias(originalInteraction);
+
   // Persist to DB before DMs
   const batchSends = [];
   for (const [rid, links] of Object.entries(recipientLinks)) {
@@ -1906,30 +1939,6 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // Send DMs — one message per recipient with all their links
   let delivered = 0;
   let failed = 0;
-
-  // Hoist payload-shared inputs outside batchSettled so the entire
-  // batch shares one expiry timestamp and one resolved sender alias.
-  // Mirrors executeSendPipeline's structure — both pipelines now
-  // compute expiresAt once per call rather than once per recipient,
-  // eliminating Date.now() drift between recipients in the same
-  // batch (negligible at the 30m–7d horizon, but it's the unifying
-  // shape). resolveSenderAlias is a pure function of
-  // originalInteraction so hoisting is safe and avoids re-resolving
-  // the nickname/globalName/username chain per dispatch.
-  //
-  // AUDIT TRADE-OFF: hoisting `expiresAt` outside the per-recipient
-  // try/finally means an `expiryToMs` throw on malformed
-  // `sendConfig.expires_in` bubbles out of handleAddRecipients
-  // entirely — ZERO `DISPATCH_FAILED` audits are emitted for the
-  // batch. The prior code computed expiresAt per-recipient inside the
-  // try, so the same throw would have produced N audits. The hoist is
-  // the correct shape (sendConfig.expires_in is validated upstream
-  // and the per-recipient audits would have been N-failed-for-one-
-  // root-cause noise), but the contract is intentional: an upstream
-  // expires_in regression is invisible at the dispatch-metric layer
-  // and surfaces only via the function-level throw.
-  const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
-  const senderAlias = resolveSenderAlias(originalInteraction);
 
   const dmResults = await batchSettled(newRecipients, async (recipient) => {
     const links = recipientLinks[recipient.id];

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -451,11 +451,11 @@ function resolveRecipientAlias(r, interaction) {
 //     │                                                             │
 //     │  > "Quarterly numbers — for your eyes only."                │  (optional personal message — italic blockquote)
 //     │                                                             │
-//     │  🕐 Door closes in 1 day                                    │  (Discord <t:N:R> — auto-updates client-side
+//     │  🕐 Closes in 1 day                                         │  (Discord <t:N:R> — auto-updates client-side
 //     │                                                             │   to "in 16 hours" / "in 1 hour" / "1 hour ago")
 //     │                                                             │
 //     │  ┌──────────────────────────┐                               │
-//     │  │   🔗 Step Through        │  (Link button — opens qURL)
+//     │  │   🚪 Step Through        │  (Link button — opens qURL)
 //     │  └──────────────────────────┘                               │
 //     └─────────────────────────────────────────────────────────────┘
 //
@@ -541,49 +541,57 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // Fail-loud on a missing/invalid expiresAt rather than rendering
   // literal "<t:undefined:R>" or "<t:NaN:R>" to a recipient. Matches
   // the contract-violation throw in handleAddRecipients. Validate
-  // FIRST so the description below can interpolate directly.
+  // FIRST so the description below can interpolate directly. Safe to
+  // run before `sanitizeDisplayName` because that helper is total
+  // (NFKC + bidi/zero-width strip + markdown escape + 64-char cap +
+  // 'Someone' fallback — never throws on any input shape).
   if (!Number.isFinite(expiresAt)) {
     throw new Error(`buildDeliveryPayload: expiresAt must be a finite Unix-seconds number (got ${expiresAt})`);
   }
 
-  // sanitizeDisplayName: NFKC + bidi/zero-width strip + markdown escape
-  // + 64-char cap + 'Someone' fallback. Centralized so a future caller
-  // adding another sender-name surface picks up the same spoof defense.
+  // sanitizeDisplayName centralizes spoof defense so a future caller
+  // adding another sender-name surface picks up the same protections.
   const safeSender = sanitizeDisplayName(senderAlias);
 
-  // Tight two-line description folds sender + expiry into one block —
-  // previously a separate addFields() row, which Discord padded with
-  // extra vertical whitespace pushing the button further away.
+  // Single description block: sender → optional personal message →
+  // expiry. Folding all three into one setDescription (rather than
+  // splitting personal message into addFields) keeps the rendered
+  // order matching the design — Discord renders fields BELOW the
+  // description, so an addFields personal-message would land after
+  // the expiry line, not between sender and expiry. It also keeps
+  // the embed compact: addFields adds vertical padding that pushes
+  // the Step Through button further from the sender line.
+  //
   // `<t:N:R>` is Discord's client-side relative-time markdown: the
   // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
   // and "1 hour ago" once expired. No bot-side editing needed.
+  //
+  // CONTRACT: `personalMessage` arrives pre-sanitized. `/qurl file`
+  // and `/qurl map` pipe raw input through `sanitizeMessage`
+  // (markdown escape + @-mention strip) before constructing this
+  // payload, and the addRecipients path reads from
+  // `sendConfig.personal_message` which was sanitized at write time.
+  // Raw interpolation below is safe ONLY because of that upstream
+  // pass. A future caller that bypasses sanitizeMessage (or a DB row
+  // read that skips re-sanitize) would silently regress to markdown
+  // injection — keep the contract.
+  //
+  // Discord blockquote (`> `) only quotes one line and italic (`*…*`)
+  // does not span newlines, so a multi-line message would render with
+  // only the first line styled. Flatten newlines to a space so the
+  // recipient sees one tidy quote — matches the design mockup which
+  // shows the message as a single-line styled box. 280-char cap keeps
+  // the embed visually compact.
+  const descLines = [`**${safeSender}** opened a door for you.`];
+  if (personalMessage) {
+    const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
+    descLines.push(`> *"${capped}"*`);
+  }
+  descLines.push(`🕐 Closes <t:${expiresAt}:R>`);
+
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
-    .setDescription(
-      `**${safeSender}** opened a door for you.\n`
-      + `🕐 Closes <t:${expiresAt}:R>`
-    );
-
-  if (personalMessage) {
-    // CONTRACT: `personalMessage` arrives pre-sanitized. `/qurl file` and
-    // `/qurl map` pipe raw input through `sanitizeMessage` (markdown
-    // escape + @-mention strip) before constructing this payload, and the
-    // addRecipients path reads from `sendConfig.personal_message` which
-    // was sanitized at write time. Raw interpolation into the template
-    // below is safe ONLY because of that upstream pass. A future caller
-    // that bypasses sanitizeMessage (or a DB row read that skips re-
-    // sanitize) would silently regress to markdown injection — keep the
-    // contract.
-    //
-    // Discord blockquote (`> `) only quotes one line and italic (`*…*`)
-    // does not span newlines, so a multi-line message would render with
-    // only the first line styled. Flatten newlines to a space so the
-    // recipient sees one tidy quote — matches the design mockup which
-    // shows the message as a single-line styled box. 280-char cap keeps
-    // the embed visually compact now that the fixed body copy is gone.
-    const capped = personalMessage.substring(0, 280).replace(/[\r\n]+/g, ' ').trim();
-    embed.addFields({ name: '\u200B', value: `> *"${capped}"*` });
-  }
+    .setDescription(descLines.join('\n'));
 
   // Link button: opens qurlLink in the recipient's browser on a
   // single click. No interaction handler needed — Discord handles
@@ -1298,7 +1306,9 @@ async function executeSendPipeline(interaction, {
     // Audit in `finally` so the metric fires for every recipient regardless
     // of where the dispatch fails — sendDM resolving to false, sendDM
     // throwing (against contract — see apps/discord/src/discord.js), OR
-    // buildDeliveryPayload throwing (e.g. on a pathological personalMessage).
+    // buildDeliveryPayload throwing (e.g. on a non-finite expiresAt — see
+    // its `Number.isFinite` guard; would throw on every iteration of the
+    // batch, since expiresAt is computed once above).
     // Audit fires BEFORE the DB write so a DDB-layer throw can't suppress
     // it either — that's the failure mode the audit metric exists to
     // measure. Coverage spans the entire dispatch attempt, not just the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -583,8 +583,10 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // does not span newlines, so a multi-line message would render with
   // only the first line styled. Flatten newlines to a space so the
   // recipient sees one tidy quote — matches the design mockup which
-  // shows the message as a single-line styled box. 280-char cap keeps
-  // the embed visually compact.
+  // shows the message as a single-line styled box. 280-codepoint cap
+  // keeps the embed visually compact. Headroom: 280 codepoints ≤ 1120
+  // UTF-8 bytes + ~10 chars of `> *"…"*` wrapper + 64-char sender +
+  // ~30-char expiry line ≪ Discord's 4096-char description cap.
   const descLines = [`**${safeSender}** opened a door for you.`];
   if (personalMessage) {
     // Skip the styled-blockquote line if the input collapses to an
@@ -1275,12 +1277,14 @@ async function executeSendPipeline(interaction, {
   // seconds — Discord's <t:N:R> format requires seconds, not millis).
   // Using send-time + duration rather than reading from the API mint
   // response since `mintLinks` doesn't currently surface `expires_at`.
-  // Drift between this clock and the API's enforcement clock is bounded
-  // by the time between this line and the mint call (sub-second on the
-  // send-pipeline path; can be a few seconds on handleAddRecipients
-  // which re-downloads + re-uploads + re-mints first). Negligible at
-  // the 30m–7d horizon — recipients see "in 24 hours" instead of
-  // "in 23h 59m 56s" on the worst-case path.
+  // Drift between this clock and the API's enforcement clock is the
+  // wall-clock gap between THIS compute site and the earlier mint call
+  // (mintLinksInBatches has already returned by the time we land here
+  // on the send-pipeline path; on handleAddRecipients the gap also
+  // covers re-download + re-upload + re-mint). So recipients see
+  // "in 24 hours" measured against send-time, not mint-time. Negligible
+  // at the 30m–7d horizon — even a worst-case 10s gap rounds the same
+  // way in the relative-time display.
   //
   // Computed BEFORE recordQURLSendBatch so a malformed `expiresIn`
   // throwing in `expiryToMs` aborts the dispatch BEFORE any DDB rows

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -538,14 +538,31 @@ function parseLocationInput(rawInput) {
 }
 
 function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
+  // Fail-loud on a missing/invalid expiresAt rather than rendering
+  // literal "<t:undefined:R>" or "<t:NaN:R>" to a recipient. Matches
+  // the contract-violation throw in handleAddRecipients. Validate
+  // FIRST so the description below can interpolate directly.
+  if (!Number.isFinite(expiresAt)) {
+    throw new Error(`buildDeliveryPayload: expiresAt must be a finite Unix-seconds number (got ${expiresAt})`);
+  }
+
   // sanitizeDisplayName: NFKC + bidi/zero-width strip + markdown escape
   // + 64-char cap + 'Someone' fallback. Centralized so a future caller
   // adding another sender-name surface picks up the same spoof defense.
   const safeSender = sanitizeDisplayName(senderAlias);
 
+  // Tight two-line description folds sender + expiry into one block —
+  // previously a separate addFields() row, which Discord padded with
+  // extra vertical whitespace pushing the button further away.
+  // `<t:N:R>` is Discord's client-side relative-time markdown: the
+  // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
+  // and "1 hour ago" once expired. No bot-side editing needed.
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
-    .setDescription(`**${safeSender}** opened a door for you.`);
+    .setDescription(
+      `**${safeSender}** opened a door for you.\n`
+      + `🕐 Closes <t:${expiresAt}:R>`
+    );
 
   if (personalMessage) {
     // CONTRACT: `personalMessage` arrives pre-sanitized. `/qurl file` and
@@ -568,42 +585,19 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     embed.addFields({ name: '\u200B', value: `> *"${capped}"*` });
   }
 
-  embed.addFields(
-    {
-      // Discord's native relative-time markdown: <t:UNIX:R> renders
-      // CLIENT-SIDE based on the viewer's current time, so the recipient
-      // sees "in 1 day" at send time, "in 16 hours" 8 hours later, and
-      // "1 hour ago" once the link has expired. No bot-side editing
-      // needed — Discord handles the live update.
-      //
-      // Fail-loud on a missing/invalid expiresAt rather than rendering
-      // literal "<t:undefined:R>" or "<t:NaN:R>" to a recipient. Matches
-      // the contract-violation throw in handleAddRecipients (same fail-
-      // loud-over-silent-degradation principle).
-      name: '\u200B',
-      value: (() => {
-        if (!Number.isFinite(expiresAt)) {
-          throw new Error(`buildDeliveryPayload: expiresAt must be a finite Unix-seconds number (got ${expiresAt})`);
-        }
-        return `\ud83d\udd50 Door closes <t:${expiresAt}:R>`;
-      })(),
-    },
-  );
-
   // Link button: opens qurlLink in the recipient's browser on a
   // single click. No interaction handler needed — Discord handles
-  // the redirect.
+  // the redirect. ButtonStyle.Link is the only style that carries a
+  // URL (Primary/Success/Danger/Secondary fire interaction handlers,
+  // no redirect).
   //
-  // Style is `ButtonStyle.Link` because Discord requires URL buttons
-  // to be Link-style (Primary/Success/Danger/Secondary cannot carry
-  // a URL — they only fire interaction handlers). Link buttons render
-  // gray, which can read as "text" rather than a clickable affordance.
-  // The leading 🔗 emoji adds visual weight so the recipient sees a
-  // clear button shape; arrow `→` dropped from the label since the
-  // emoji conveys the same "go elsewhere" intent.
+  // 🚪 emoji ties the "opened a door for you" copy to the action —
+  // sender line, embed accent, and button emoji all reinforce one
+  // metaphor instead of three. Door is a stronger visual mark on a
+  // grey-Link button than the generic 🔗 chain it replaces.
   const stepThrough = new ButtonBuilder()
     .setStyle(ButtonStyle.Link)
-    .setEmoji('🔗')
+    .setEmoji('🚪')
     .setLabel('Step Through')
     .setURL(qurlLink);
   const components = [new ActionRowBuilder().addComponents(stepThrough)];

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1318,9 +1318,9 @@ async function executeSendPipeline(interaction, {
     // Audit in `finally` so the metric fires for every recipient regardless
     // of where the dispatch fails — sendDM resolving to false, sendDM
     // throwing (against contract — see apps/discord/src/discord.js), OR
-    // buildDeliveryPayload throwing (e.g. on a non-finite expiresAt — see
-    // its `Number.isFinite` guard; would throw on every iteration of the
-    // batch, since expiresAt is computed once above).
+    // buildDeliveryPayload throwing (e.g. on a non-integer expiresAt —
+    // see its `Number.isInteger` guard; would throw on every iteration
+    // of the batch, since expiresAt is computed once above).
     // Audit fires BEFORE the DB write so a DDB-layer throw can't suppress
     // it either — that's the failure mode the audit metric exists to
     // measure. Coverage spans the entire dispatch attempt, not just the

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -452,9 +452,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
       pushInvalidIfNew(invalidChannelIds, channelId, m[0]);
       continue;
     }
-    const isVoice = channel.type === VOICE_CHANNEL_TYPE
-      || channel.type === STAGE_VOICE_CHANNEL_TYPE;
-    if (!isVoice) {
+    if (!isVoiceChannelType(channel.type)) {
       // Non-voice channel mention — reject. We intentionally do NOT
       // restore the legacy "Everyone in this text channel" behavior
       // (PR #174 fixed the @everyone-on-default-server expansion bug

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -257,23 +257,35 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(desc).toContain(`🕐 Closes <t:${Number.MAX_SAFE_INTEGER}:R>`);
   });
 
-  it('throws if expiresAt is missing, non-finite, a float, or non-positive (fail-loud)', () => {
-    // Note on the "beyond MAX_SAFE_INTEGER" boundary: doubles can
-    // exactly represent every integer up to 2^53, so 2^53 itself is
-    // still `Number.isInteger == true`. Above 2^53, additions of 1
-    // round to the nearest representable double (which is also an
-    // integer at that magnitude), so `Number.isInteger` keeps
-    // returning true. There is no clean "finite integer that
-    // Number.isInteger rejects" boundary — the rejection set is
-    // exactly: non-finite + non-integer-floats + non-positive.
-    for (const bad of [
-      undefined, null, NaN, Infinity, -Infinity, 'soon', {},
-      1735689600.5, 0.1,            // floats
-      0, -1, -1735689600,           // non-positive (negative timestamp would render as "55 years ago" in Discord)
-    ]) {
-      expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: bad }))
-        .toThrow(/expiresAt must be a positive integer Unix-seconds number/);
-    }
+  // Note on the "beyond MAX_SAFE_INTEGER" boundary: doubles can
+  // exactly represent every integer up to 2^53, so 2^53 itself is
+  // still `Number.isInteger == true`. Above 2^53, additions of 1
+  // round to the nearest representable double (which is also an
+  // integer at that magnitude), so `Number.isInteger` keeps returning
+  // true. There is no clean "finite integer that Number.isInteger
+  // rejects" boundary — the rejection set is exactly: non-finite +
+  // non-integer-floats + non-positive.
+  //
+  // it.each() over for-loop: each input gets its own test name so a
+  // regression on one shape doesn't collapse into a single anonymous
+  // failure. Failure output reads e.g. "(1735689600.5) throws fail-loud"
+  // instead of having to dig into the loop body.
+  it.each([
+    [undefined],
+    [null],
+    [NaN],
+    [Infinity],
+    [-Infinity],
+    ['soon'],
+    [{}],
+    [1735689600.5],                  // float
+    [0.1],                           // float
+    [0],                             // non-positive
+    [-1],                            // non-positive (would render as "55 years ago")
+    [-1735689600],                   // non-positive (negative timestamp)
+  ])('throws fail-loud for invalid expiresAt: %p', (bad) => {
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: bad }))
+      .toThrow(/expiresAt must be a positive integer Unix-seconds number/);
   });
 
   // Locks the operator-facing diagnostic shape: the throw message must

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -272,11 +272,53 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
 
   it('flattens newlines in personal message so the styled blockquote stays single-line', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', personalMessage: 'line one\nline two\r\nline three' });
-    const fields = capturedEmbeds[0].addFields.mock.calls.flatMap(c => c);
-    const msgField = fields.find(f => typeof f.value === 'string' && f.value.includes('line one'));
-    expect(msgField).toBeDefined();
-    expect(msgField.value).toBe('> *"line one line two line three"*');
-    expect(msgField.value).not.toMatch(/\n/);
+    const desc = capturedEmbeds[0]._description;
+    // Personal-message line sits inside the description block (folded
+    // alongside sender + expiry so all three render in design order —
+    // sender → message → expiry).
+    expect(desc).toContain('> *"line one line two line three"*');
+    // Newlines inside the message itself are flattened to spaces; the
+    // only newlines in the description are the block separators between
+    // sender / message / expiry lines.
+    const messageLine = desc.split('\n').find(l => l.includes('line one'));
+    expect(messageLine).toBeDefined();
+    expect(messageLine).not.toMatch(/\r/);
+  });
+
+  // Ordering depends on which Embed slot each piece lands in: Discord
+  // renders the description block above any fields, so a personal
+  // message split into addFields would land AFTER the expiry line, not
+  // between sender and expiry. Folding all three into one
+  // setDescription is what guarantees the design ordering. Pin the
+  // relative order so a future refactor that splits any of the three
+  // back into addFields would be caught.
+  it('renders sender → personal message → expiry in that order when all three are present', () => {
+    buildDeliveryPayload({
+      ...baseArgs,
+      senderAlias: 'Vik',
+      personalMessage: 'Quarterly numbers — for your eyes only.',
+      expiresAt: 1735689600,
+    });
+    const desc = capturedEmbeds[0]._description;
+    const senderIdx = desc.indexOf('**Vik**');
+    const messageIdx = desc.indexOf('Quarterly numbers');
+    const expiryIdx = desc.indexOf('Closes <t:');
+    expect(senderIdx).toBeGreaterThanOrEqual(0);
+    expect(messageIdx).toBeGreaterThan(senderIdx);
+    expect(expiryIdx).toBeGreaterThan(messageIdx);
+    // And no addFields call — folded entirely into description.
+    expect(capturedEmbeds[0].addFields).not.toHaveBeenCalled();
+  });
+
+  // When personalMessage is absent, the description still renders
+  // sender → expiry in order (no orphaned blank line between them).
+  it('renders sender → expiry with no gap when personalMessage is omitted', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
+    const desc = capturedEmbeds[0]._description;
+    const lines = desc.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('**Vik** opened a door for you.');
+    expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
   });
 });
 

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -320,6 +320,28 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(lines[0]).toContain('**Vik** opened a door for you.');
     expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
   });
+
+  // Belt-and-braces: a personalMessage that collapses to "" after
+  // newline-flatten + trim must not render a visible-but-empty
+  // `> *""*` blockquote between sender and expiry. The call sites
+  // pass `sanitizeMessage(...) || null` so an empty input short-
+  // circuits at the outer `if (personalMessage)` today, but a
+  // future caller that bypasses that contract would otherwise hit
+  // the empty-quote regression.
+  it('omits the blockquote line when personalMessage collapses to empty after trim', () => {
+    buildDeliveryPayload({
+      ...baseArgs,
+      senderAlias: 'Vik',
+      personalMessage: '  \n \n  ',
+      expiresAt: 1735689600,
+    });
+    const desc = capturedEmbeds[0]._description;
+    expect(desc).not.toContain('> *""*');
+    const lines = desc.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('**Vik** opened a door for you.');
+    expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
+  });
 });
 
 describe('resolveSenderAlias — fallback chain', () => {

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -247,6 +247,22 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // `Number.isInteger` guard tightens the contract from any-finite-number
   // to exactly-what-the-markdown-accepts. Matches the contract guard in
   // handleAddRecipients.
+  // Positive test for the upper-bound reasoning documented in the
+  // throw test below: there is no clean "finite integer that
+  // Number.isInteger rejects" boundary because doubles can exactly
+  // represent every integer up to 2^53. Pin that `Number.MAX_SAFE_INTEGER`
+  // itself is accepted (and renders into the description as the literal
+  // integer), so a future reader who tries `MAX_SAFE_INTEGER + 1` and
+  // sees it still pass doesn't have to re-derive the reasoning. Discord's
+  // <t:N:R> parser will overflow well before 2^53 (its accepted range is
+  // ±10000 years from epoch), but that's Discord's responsibility — the
+  // validator's contract is "positive integer", not "renderable timestamp".
+  it('accepts Number.MAX_SAFE_INTEGER as a positive integer (no synthetic upper bound)', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: Number.MAX_SAFE_INTEGER });
+    const desc = capturedEmbeds[0]._description;
+    expect(desc).toContain(`🕐 Closes <t:${Number.MAX_SAFE_INTEGER}:R>`);
+  });
+
   it('throws if expiresAt is missing, non-finite, a float, or non-positive (fail-loud)', () => {
     // Note on the "beyond MAX_SAFE_INTEGER" boundary: doubles can
     // exactly represent every integer up to 2^53, so 2^53 itself is

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -247,10 +247,22 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // `Number.isInteger` guard tightens the contract from any-finite-number
   // to exactly-what-the-markdown-accepts. Matches the contract guard in
   // handleAddRecipients.
-  it('throws if expiresAt is missing, non-finite, or a float (fail-loud)', () => {
-    for (const bad of [undefined, null, NaN, Infinity, 'soon', {}, 1735689600.5, 0.1]) {
+  it('throws if expiresAt is missing, non-finite, a float, or non-positive (fail-loud)', () => {
+    // Note on the "beyond MAX_SAFE_INTEGER" boundary: doubles can
+    // exactly represent every integer up to 2^53, so 2^53 itself is
+    // still `Number.isInteger == true`. Above 2^53, additions of 1
+    // round to the nearest representable double (which is also an
+    // integer at that magnitude), so `Number.isInteger` keeps
+    // returning true. There is no clean "finite integer that
+    // Number.isInteger rejects" boundary — the rejection set is
+    // exactly: non-finite + non-integer-floats + non-positive.
+    for (const bad of [
+      undefined, null, NaN, Infinity, -Infinity, 'soon', {},
+      1735689600.5, 0.1,            // floats
+      0, -1, -1735689600,           // non-positive (negative timestamp would render as "55 years ago" in Discord)
+    ]) {
       expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: bad }))
-        .toThrow(/expiresAt must be an integer Unix-seconds number/);
+        .toThrow(/expiresAt must be a positive integer Unix-seconds number/);
     }
   });
 
@@ -267,6 +279,8 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
       .toThrow(/got soon, typeof=string/);
     expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600.5 }))
       .toThrow(/got 1735689600\.5, typeof=number/);
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: -1 }))
+      .toThrow(/got -1, typeof=number/);
   });
 
 
@@ -338,6 +352,11 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain('**Vik** opened a door for you.');
     expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
+    // Mirror the all-three-pieces ordering test: also assert addFields
+    // is never called on the no-personalMessage path. Belt-and-braces
+    // against a future regression that adds a field only when one of
+    // the slots is empty (e.g. a "no message attached" placeholder).
+    expect(capturedEmbeds[0].addFields).not.toHaveBeenCalled();
   });
 
   // Belt-and-braces: a personalMessage that collapses to "" after

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -327,6 +327,28 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(stepThrough.setURL).toHaveBeenCalledWith('https://qurl.link/#at_unique_token');
   });
 
+  // Contract pin: buildDeliveryPayload does NOT escape markdown in
+  // personalMessage. By contract (documented at commands.js:631-639),
+  // the call sites pipe raw input through sanitizeMessage before
+  // passing it here. This test pins that the function renders the
+  // string as-is — so a future refactor that adds an internal escape
+  // pass (changing the contract) will surface the change loudly via
+  // this test, not silently double-escape sanitized input.
+  //
+  // The senderAlias path is the opposite: sanitizeDisplayName is called
+  // inside buildDeliveryPayload and DOES escape, pinned by the
+  // 'escapes markdown chars in alias' test above.
+  it('renders personalMessage as-is (no internal markdown escape — by contract)', () => {
+    const raw = '[click](https://evil.com) **bold**';
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', personalMessage: raw });
+    const desc = capturedEmbeds[0]._description;
+    // Brackets, parens, and asterisks are NOT backslash-escaped —
+    // verifies buildDeliveryPayload passes them through verbatim.
+    expect(desc).toContain(`> *"${raw}"*`);
+    expect(desc).not.toContain('\\[click');
+    expect(desc).not.toContain('\\*\\*bold');
+  });
+
   it('flattens newlines in personal message so the styled blockquote stays single-line', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', personalMessage: 'line one\nline two\r\nline three' });
     const desc = capturedEmbeds[0]._description;
@@ -357,12 +379,15 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
       expiresAt: 1735689600,
     });
     const desc = capturedEmbeds[0]._description;
-    const senderIdx = desc.indexOf('**Vik**');
-    const messageIdx = desc.indexOf('Quarterly numbers');
-    const expiryIdx = desc.indexOf('Closes <t:');
-    expect(senderIdx).toBeGreaterThanOrEqual(0);
-    expect(messageIdx).toBeGreaterThan(senderIdx);
-    expect(expiryIdx).toBeGreaterThan(messageIdx);
+    // split-then-index-by-line over indexOf-substring-position: an
+    // `indexOf` check would false-pass if a future personalMessage
+    // happened to contain the literal substring `"Closes <t:"`,
+    // ordering both indices the same way. Pin position by line.
+    const lines = desc.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain('**Vik** opened a door for you.');
+    expect(lines[1]).toContain('Quarterly numbers');
+    expect(lines[2]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
     // And no addFields call — folded entirely into description.
     expect(capturedEmbeds[0].addFields).not.toHaveBeenCalled();
   });

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -240,13 +240,17 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   });
 
   // Defensive guard: a future caller that drops `expiresAt` (or passes
-  // null/undefined/NaN) would otherwise render literal "<t:undefined:R>"
-  // or "<t:NaN:R>" to recipients. The fail-loud throw matches the
-  // contract guard in handleAddRecipients.
-  it('throws if expiresAt is missing or non-finite (fail-loud)', () => {
-    for (const bad of [undefined, null, NaN, Infinity, 'soon', {}]) {
+  // null/undefined/NaN/a float) would otherwise render a malformed
+  // "<t:undefined:R>" / "<t:NaN:R>" / "<t:1735689600.5:R>" to recipients.
+  // Discord's <t:N:R> markdown accepts only integer Unix seconds, which
+  // is what the lone call site produces via `Math.floor`; the
+  // `Number.isInteger` guard tightens the contract from any-finite-number
+  // to exactly-what-the-markdown-accepts. Matches the contract guard in
+  // handleAddRecipients.
+  it('throws if expiresAt is missing, non-finite, or a float (fail-loud)', () => {
+    for (const bad of [undefined, null, NaN, Infinity, 'soon', {}, 1735689600.5, 0.1]) {
       expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: bad }))
-        .toThrow(/expiresAt must be a finite Unix-seconds number/);
+        .toThrow(/expiresAt must be an integer Unix-seconds number/);
     }
   });
 
@@ -277,12 +281,12 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     // alongside sender + expiry so all three render in design order —
     // sender → message → expiry).
     expect(desc).toContain('> *"line one line two line three"*');
-    // Newlines inside the message itself are flattened to spaces; the
-    // only newlines in the description are the block separators between
-    // sender / message / expiry lines.
+    // Both \n and \r inside the message itself are flattened to spaces;
+    // any newline remaining on the message line would mean the
+    // [\r\n]+ → ' ' collapse regressed.
     const messageLine = desc.split('\n').find(l => l.includes('line one'));
     expect(messageLine).toBeDefined();
-    expect(messageLine).not.toMatch(/\r/);
+    expect(messageLine).not.toMatch(/[\n\r]/);
   });
 
   // Ordering depends on which Embed slot each piece lands in: Discord

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -343,6 +343,28 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(desc).not.toContain('\\*\\*bold');
   });
 
+  // Regression net for the codepoint-aware cap (closes #345): a 281-
+  // codepoint string ending in a 4-byte emoji at the boundary must
+  // NOT split the emoji into a lone high surrogate. Array.from + slice
+  // is the codepoint-aware pattern (one array element per codepoint,
+  // including surrogate pairs), mirroring sanitizeDisplayName's cap.
+  //
+  // 🎉 (U+1F389) is a high+low surrogate pair: 2 UTF-16 units, 1
+  // codepoint. The string below has 279 ASCII chars + 🎉 = 280
+  // codepoints exactly, then an extra ASCII tail at codepoint 281
+  // that must NOT make it through the cap.
+  it('does not split surrogate pairs at the 280-codepoint personalMessage boundary (#345)', () => {
+    const message = 'A'.repeat(279) + '🎉' + 'X';  // 281 codepoints; codepoint 280 = 🎉
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', personalMessage: message });
+    const desc = capturedEmbeds[0]._description;
+    // The full 🎉 survives at the boundary (intact codepoint, not split).
+    expect(desc).toContain('🎉');
+    // No lone high surrogate (\uD83C is the high half of 🎉).
+    expect(desc).not.toMatch(/\uD83C(?![\uDC00-\uDFFF])/);
+    // The trailing 'X' beyond codepoint 280 is dropped.
+    expect(desc).not.toMatch(/🎉X/);
+  });
+
   // `> ` line-prefix is the most natural blockquote-injection attempt
   // at this surface — a personalMessage that looks like it embeds its
   // own blockquote should still be wrapped in the outer `> *"..."*`,

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -357,6 +357,11 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
     const desc = capturedEmbeds[0]._description;
     const lines = desc.split('\n');
+    // EXACTLY 2 lines — guards against an orphan blank line creeping
+    // in between sender and expiry when personalMessage is absent.
+    // Do NOT loosen to `toBeGreaterThanOrEqual(2)`: a 3-line desc
+    // would mean someone re-introduced `descLines.push('')` for
+    // padding, which renders as a visible empty row in Discord.
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain('**Vik** opened a door for you.');
     expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
@@ -384,6 +389,9 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     const desc = capturedEmbeds[0]._description;
     expect(desc).not.toContain('> *""*');
     const lines = desc.split('\n');
+    // EXACTLY 2 lines — same orphan-blank-line guard as the no-
+    // personalMessage path above; an empty blockquote line creeping
+    // back in would push this to 3 and render visibly in Discord.
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain('**Vik** opened a door for you.');
     expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -281,6 +281,14 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
       .toThrow(/got 1735689600\.5, typeof=number/);
     expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: -1 }))
       .toThrow(/got -1, typeof=number/);
+    // null vs undefined surfaces matter for triage: `typeof null` is
+    // `'object'` (a longstanding JS oddity), so `got null, typeof=object`
+    // is what the operator should see — different shape from
+    // `got undefined, typeof=undefined`. Pin both.
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: null }))
+      .toThrow(/got null, typeof=object/);
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: undefined }))
+      .toThrow(/got undefined, typeof=undefined/);
   });
 
 

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -227,14 +227,16 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // A future refactor that goes back to baking a static label into the
   // embed ("Door closes in **24 hours**" forever) would silently
   // regress this UX — the assertion below catches it.
-  it('renders Discord native relative-time <t:N:R> for the Door-closes line', () => {
+  it('renders Discord native relative-time <t:N:R> in the description (Closes line)', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
-    const fields = capturedEmbeds[0].addFields.mock.calls.flatMap(call => call);
-    const doorField = fields.find(f => typeof f.value === 'string' && f.value.includes('Door closes'));
-    expect(doorField).toBeDefined();
-    expect(doorField.value).toBe('\ud83d\udd50 Door closes <t:1735689600:R>');
+    // Closes line is folded into the embed description alongside the
+    // sender line (tightened layout \u2014 was a separate addFields() row,
+    // which Discord padded with extra vertical whitespace and pushed
+    // the button further away).
+    const desc = capturedEmbeds[0]._description;
+    expect(desc).toMatch(/\ud83d\udd50 Closes <t:1735689600:R>/);
     // Locks against accidental reversion to a static label
-    expect(doorField.value).not.toMatch(/Door closes in \*\*\d/);
+    expect(desc).not.toMatch(/Closes in \*\*\d/);
   });
 
   // Defensive guard: a future caller that drops `expiresAt` (or passes
@@ -253,15 +255,16 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // `.setURL(qurlLink)` (or downgrades to a non-Link style) would leave
   // recipients with a button that doesn't navigate anywhere. This test
   // asserts the button is built as Link-style with the supplied qURL,
-  // and that the 🔗 emoji prefix survives — Link buttons render gray
-  // and the emoji is what carries the "this is a button" affordance.
+  // and that the 🚪 emoji survives — Link buttons render gray, and the
+  // door emoji ties the "opened a door for you" copy to the action so
+  // the button reads as intentional rather than generic-CTA-grey.
   it('builds the Step Through button as a Link-style button with the qURL as its URL', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', qurlLink: 'https://qurl.link/#at_unique_token' });
     // Last button constructed in the buildDeliveryPayload call is the Step Through.
     const stepThrough = capturedButtons[capturedButtons.length - 1];
     expect(stepThrough).toBeDefined();
     expect(stepThrough._label).toBe('Step Through');
-    expect(stepThrough._emoji).toBe('🔗');
+    expect(stepThrough._emoji).toBe('🚪');
     expect(stepThrough._style).toBe(5); // ButtonStyle.Link
     expect(stepThrough._url).toBe('https://qurl.link/#at_unique_token');
     expect(stepThrough.setURL).toHaveBeenCalledWith('https://qurl.link/#at_unique_token');

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -234,7 +234,7 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     // which Discord padded with extra vertical whitespace and pushed
     // the button further away).
     const desc = capturedEmbeds[0]._description;
-    expect(desc).toMatch(/\ud83d\udd50 Closes <t:1735689600:R>/);
+    expect(desc).toMatch(/🕐 Closes <t:1735689600:R>/);
     // Locks against accidental reversion to a static label
     expect(desc).not.toMatch(/Closes in \*\*\d/);
   });
@@ -247,16 +247,10 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // `Number.isInteger` guard tightens the contract from any-finite-number
   // to exactly-what-the-markdown-accepts. Matches the contract guard in
   // handleAddRecipients.
-  // Positive test for the upper-bound reasoning documented in the
-  // throw test below: there is no clean "finite integer that
-  // Number.isInteger rejects" boundary because doubles can exactly
-  // represent every integer up to 2^53. Pin that `Number.MAX_SAFE_INTEGER`
-  // itself is accepted (and renders into the description as the literal
-  // integer), so a future reader who tries `MAX_SAFE_INTEGER + 1` and
-  // sees it still pass doesn't have to re-derive the reasoning. Discord's
-  // <t:N:R> parser will overflow well before 2^53 (its accepted range is
-  // ±10000 years from epoch), but that's Discord's responsibility — the
-  // validator's contract is "positive integer", not "renderable timestamp".
+  // Positive counterpart to the "no clean upper bound" reasoning in
+  // the adjacent throw test — MAX_SAFE_INTEGER itself is a valid
+  // integer that Number.isInteger accepts, so the validator passes it
+  // through unchanged.
   it('accepts Number.MAX_SAFE_INTEGER as a positive integer (no synthetic upper bound)', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: Number.MAX_SAFE_INTEGER });
     const desc = capturedEmbeds[0]._description;
@@ -347,6 +341,21 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     expect(desc).toContain(`> *"${raw}"*`);
     expect(desc).not.toContain('\\[click');
     expect(desc).not.toContain('\\*\\*bold');
+  });
+
+  // `> ` line-prefix is the most natural blockquote-injection attempt
+  // at this surface — a personalMessage that looks like it embeds its
+  // own blockquote should still be wrapped in the outer `> *"..."*`,
+  // not "fixed up" by the function. Pinned alongside [](), ** to
+  // round out the attack-shape coverage of the no-internal-escape
+  // contract. The `\n` inside the input is flattened to a space by
+  // the newline-flatten pass, so the second `>` lands inline rather
+  // than starting a new blockquote — that's the expected behavior.
+  it('renders personalMessage with `> ` prefixes verbatim (no auto-fix of nested blockquote)', () => {
+    const raw = '> faux quote\n> still faux';
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', personalMessage: raw });
+    const desc = capturedEmbeds[0]._description;
+    expect(desc).toContain('> *"> faux quote > still faux"*');
   });
 
   it('flattens newlines in personal message so the styled blockquote stays single-line', () => {

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -254,6 +254,21 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     }
   });
 
+  // Locks the operator-facing diagnostic shape: the throw message must
+  // include both the stringified value AND its typeof so an oncall
+  // doesn't have to guess whether the bad input was an object, a
+  // function, or a stringified number. `${{}}` would otherwise coerce
+  // to `[object Object]` via valueOf (acceptable), but the typeof tag
+  // is what makes the distinction loud.
+  it('error message exposes both String(value) and typeof for diagnosis', () => {
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: {} }))
+      .toThrow(/got \[object Object\], typeof=object/);
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 'soon' }))
+      .toThrow(/got soon, typeof=string/);
+    expect(() => buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600.5 }))
+      .toThrow(/got 1735689600\.5, typeof=number/);
+  });
+
 
   // Locks the Step Through button shape: a future refactor that drops
   // `.setURL(qurlLink)` (or downgrades to a non-Link style) would leave

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -190,6 +190,21 @@ jest.mock('../src/flow-state', () => ({
   deleteFlow: jest.fn(),
 }));
 
+// Partial-mock time.js so individual tests can force `expiryToMs` to
+// throw without affecting the rest of the suite. Real implementation
+// falls back to DEFAULT_EXPIRY_MS for malformed input (never throws),
+// so the audit-blackhole / orphan-DDB-row failure mode this test pins
+// against is unreachable today — the mock is the only way to exercise
+// the validate-before-DB-write invariant.
+jest.mock('../src/utils/time', () => {
+  const actual = jest.requireActual('../src/utils/time');
+  return {
+    ...actual,
+    expiryToMs: jest.fn(actual.expiryToMs),
+  };
+});
+const mockTime = require('../src/utils/time');
+
 // ---------------------------------------------------------------------------
 // Require modules under test
 // ---------------------------------------------------------------------------
@@ -1251,6 +1266,40 @@ describe('handleAddRecipients — file path failure modes', () => {
     );
 
     expect(result.msg).toMatch(/pool exhausted/i);
+  });
+});
+
+describe('handleAddRecipients — validate expires_in BEFORE recordQURLSendBatch (#352)', () => {
+  // Pins the invariant that a thrown `expiryToMs` aborts the dispatch
+  // BEFORE any DDB rows are written. Today's `expiryToMs` falls back
+  // to DEFAULT_EXPIRY_MS for malformed input and never throws, so this
+  // path is unreachable in practice — but a future regression in
+  // time.js (or a future caller that swaps the helper for one that
+  // does throw) would otherwise leave orphan DDB rows + audit-blackhole
+  // for the batch. The mock forces the throw to exercise the ordering.
+  afterEach(() => { mockTime.expiryToMs.mockImplementation(jest.requireActual('../src/utils/time').expiryToMs); });
+
+  it('does not write to DB if expiryToMs throws (no orphan rows, no audit-blackhole)', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: 'bogus',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
+    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockTime.expiryToMs.mockImplementationOnce(() => { throw new Error('synthetic expiryToMs failure'); });
+
+    await expect(handleAddRecipients(
+      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    )).rejects.toThrow(/synthetic expiryToMs failure/);
+
+    // The structural invariant: recordQURLSendBatch must NOT have been
+    // reached, so no orphan DDB rows for the QURL links minted above.
+    expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
+    // sendDM also unreached — defense-in-depth that nothing actually
+    // dispatched downstream of the bad expiry.
+    expect(mockSendDM).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Polish commits that missed the squash-merge of #330. Net effect: the recipient-facing DM embed drops from ~5 visual rows to 2-3, the Step Through button reads as intentional design instead of generic-CTA-grey, and the `expiresAt` validation contract tightens from any-finite-number to integer-Unix-seconds (what Discord's `<t:N:R>` markdown actually accepts).

## Changes

### 1. Drop the "hidden layer" tagline (`3d889a3`)

Removes `Quantum URL (qURL) · The internet has a hidden layer. This is how you enter.` from:
- The `/qurl file` / `/qurl map` delivery embed (was the last embed field above the Step Through button)
- The README pull-quote subtitle
- The ASCII-art layout doc-comment in `commands.js`

The remaining `https://layerv.ai` references in `/qurl help` / `/qurl setup` / OAuth-error copy still anchor recipients back to the product page when they need it.

### 2. Tighten delivery embed + door-emoji button (`bf5995c`)

**Before** (4 visual rows):
```
**ReelLifeJustin** opened a door for you.

🕐 Door closes in a day

[🔗 Step Through]
```

**After** (3 rows):
```
**ReelLifeJustin** opened a door for you.
🕐 Closes <t:N:R>
[🚪 Step Through]
```

**What moved:**

- **Expiry folded into description.** Was a separate `addFields()` row; Discord renders each field with extra top/bottom padding which pushed the button further from the action. Folding into `setDescription()` strips the padding and unifies the read-flow.
- **🚪 emoji on the button.** Discord won't allow Primary/Success coloring on URL buttons (Link-style only). The way to make the grey button pop without a `custom_id`-redirect round-trip is to give it a thematic anchor. The door emoji ties three surfaces — sender line ("opened a door"), embed framing, button emoji — into one reinforced metaphor instead of three unrelated visuals.

### 3. Render sender → personal message → expiry in design order (`ca8364f`)

The initial tightening folded sender + expiry into `setDescription` but left `personalMessage` in `addFields()`, which Discord renders *below* the description block. So the rendered order was sender → expiry → message → button, not the design's sender → message → expiry → button. Fold all three into one description block so the ordering is guaranteed by where each piece lands, not by call order.

### 4. Defense-in-depth: skip empty styled blockquote (`2f0942b`)

A `personalMessage` that collapses to `""` after newline-flatten + trim (e.g. `"  
 
  "`) would render a visible-but-empty `> *""*` row. Call sites pass `sanitizeMessage(...) || null` so this branch is unreachable today, but the guard prevents regression if a future caller bypasses that contract.

### 5. Sync `buildDeliveryPayload` header prose with new layout (`1bbfdd9`)

Prose comments above the function still referenced `"Door closes"`, `🔗 Step Through`, and `"body paragraph"` — the ASCII art directly below had been updated to match the new shape, so the prose contradicted the diagram.

### 6. Harden `expiresAt` validator: `Number.isFinite` → `Number.isInteger && > 0` (`af7716d`, `f15718b`)

**Contract change** (intentional tightening, not a refactor): the validator now rejects three new input classes in addition to non-finite numbers: (a) **non-integer floats** like `1735689600.5` — Discords `<t:N:R>` markdown wants integer Unix seconds; (b) **zero** — would render `<t:0:R>` as “56 years ago”; (c) **negative numbers** — would render `<t:-1:R>` similarly. The lone call site (`commands.js:1314`, `:1928`) computes `Math.floor((Date.now() + expiryToMs(...))/1000)` so no production input hits any of the new rejections (always a positive integer in the current decade). Matches the contract to what the markdown actually accepts AND to what produces a coherent recipient-facing surface. Throw test expanded to include `1735689600.5`, `0.1`, `0`, `-1`, `-1735689600`, `-Infinity`.

### 7. Sync audit-message comment (`3ee9ef3`)

The audit-in-finally comment in `executeSendPipeline` still mentioned `Number.isFinite`; updated to `Number.isInteger` and `non-integer expiresAt` so `git grep Number.isFinite` doesn't surface a misleading hit.

## Tests

463 tests pass across `build-delivery-embed.test.js`, `qurl-file-map.test.js`, `recipient-parser.test.js`, `commands-comprehensive.test.js`. Test additions:

- **Ordering pin**: `senderIdx < messageIdx < expiryIdx` when all three are present, AND `addFields` is never called. Pair guarantees a future refactor splitting any line back into a field will fail loudly (since fields render below the description).
- **Empty-trim guard**: passes `"  
 
  "` and asserts the description is the same 2-line shape as the no-personalMessage case (no orphan `> *""*` row).
- **No-gap pin**: sender → expiry with no orphaned blank line when personalMessage is omitted.
- **Closes-line assertion** moved from `embed.addFields` mock calls to `embed._description` (Closes line is now folded into description).
- **Button-emoji assertion** 🔗 → 🚪.
- **Float rejection** added to the contract-violation test (`1735689600.5`, `0.1` now throw).
- **Flatten-newlines** tightened from `not.toMatch(//)` to `not.toMatch(/[
]/)` to express intent directly.

Lint clean (`eslint --max-warnings 0`).

## Test plan

- [ ] CI green
- [ ] Claude review clean
- [ ] Live smoke: send `/qurl file` to a recipient → DM embed renders with 2-3 visual rows + door-emoji button → click opens the file.
- [ ] Live smoke: send `/qurl map` with a personal message → personal message blockquote sits between sender line and expiry line; button still pops.
- [ ] Live smoke: send `/qurl file` with no personal message → embed renders sender → expiry directly, no orphan blank row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 8. DRY: inline isVoiceChannelType() in channel-expansion loop (`312a1d2`)

`recipient-parser.js:455` was inlining `channel.type === VOICE_CHANNEL_TYPE || channel.type === STAGE_VOICE_CHANNEL_TYPE` instead of calling the `isVoiceChannelType()` predicate defined in the same file. Surfaced by `/simplify` during convergence checks; replaced with the predicate call.

### 9. Fold in #345 — codepoint-aware personalMessage cap (`3437d67`)

The 280-char personalMessage cap was UTF-16-unit-aware (`substring(0, 280)`), which could split a surrogate pair at the boundary, leaving a lone high surrogate that some Discord mobile clients drop the field for. Switched to `Array.from(s).slice(0, 280).join('')` for codepoint awareness — mirrors the cap pattern `sanitizeDisplayName` already uses for `senderAlias`. Regression test pins surrogate-pair safety at the boundary.

### 10. Fold in #352 — validate expires_in before recordQURLSendBatch (`f95153d`)

Moved `expiresAt = Math.floor((Date.now() + expiryToMs(...)) / 1000)` to BEFORE `db.recordQURLSendBatch` in both `executeSendPipeline` and `handleAddRecipients`. Closes the audit-blackhole + orphan-DDB-row failure mode: if `expiryToMs` ever throws (unreachable today; defends against future regressions in time.js), the dispatch aborts before any DDB rows are written. Regression test mocks `expiryToMs` to throw and asserts `recordQURLSendBatch` was NOT called.