### PR TITLE
feat(discord): gate <@&roleId> mentions on MENTION_EVERYONE / role.mentionable (#326)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2913,6 +2913,16 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
         massMentionDenied = true;
         continue;
       }
+      // Skip undefined-role entries (theoretical — Discord's picker
+      // surfaces roles via `interaction.roles.entries()`, which should
+      // always carry the Role object alongside the ID; but a partial
+      // fetch shape could deliver a bare ID). Symmetric with the
+      // text-path parser's `if (!role) { pushInvalidIfNew(...) }`
+      // branch — without this short-circuit, the `role?.mentionable
+      // !== true` gate below would route a cache-miss role through
+      // the deny path and surface "Non-mentionable role" copy for
+      // what's actually a missing object.
+      if (!isEveryoneRole && !role) continue;
       // Per-role MENTION_EVERYONE gate (issue #326), parallel to the
       // text-path gate in recipient-parser.js. Discord's picker filters
       // non-mentionable roles client-side for users without the perm —
@@ -2921,7 +2931,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
       // branch above already handled (isEveryoneRole), so this gate
       // only fires for non-@everyone roles. `role.mentionable === true`
       // is the per-role bypass (set explicitly by a role owner).
-      if (!isEveryoneRole && role?.mentionable !== true && !canMentionEveryone) {
+      if (!isEveryoneRole && role.mentionable !== true && !canMentionEveryone) {
         if (!roleMentionsDeniedIds.has(roleId)) {
           roleMentionsDeniedIds.add(roleId);
           roleMentionsDenied.push(roleId);
@@ -4247,8 +4257,13 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       // `role.mentionable: true` bypass inline so a user who hits
       // this banner knows the workaround without having to find the
       // per-role copy (which only the partial-valid surface renders).
+      // Phrase the bypass as "have the role marked" rather than
+      // "mark the role" — by definition the user hitting this banner
+      // lacks MENTION_EVERYONE and likely lacks Manage Roles too, so
+      // imperative phrasing reads as misleading agency. The workaround
+      // ("ask an admin") is real but indirect; reflect that in the copy.
       const noun = roleMentionsDenied.length === 1 ? 'role' : 'roles';
-      reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission (or mark the role as mentionable)`);
+      reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission (or have the role marked as mentionable)`);
     }
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3071,6 +3071,13 @@ function renderRecipientWarnings({
   roleMentionsDeniedNames = [],
 } = {}) {
   const lines = [];
+  // Shared sanitizer for user-/admin-controlled strings rendered inline
+  // in a bullet: strip backticks (prevent code-fence breakout) then
+  // codepoint-slice with ellipsis. Used by both the invalidTokens and
+  // roleMentionsDeniedNames bullets — single-sourced so the two paths
+  // can't drift.
+  const sanitizeForBullet = (s) =>
+    sliceWithEllipsis(s.replace(/`/g, ''), WARNING_NAME_CODEPOINT_CAP, '…');
   if (cappedCount > 0) {
     lines.push(`• Capped at ${config.QURL_SEND_MAX_RECIPIENTS} — ${cappedCount} recipient(s) past the cap were dropped.`);
   }
@@ -3091,9 +3098,7 @@ function renderRecipientWarnings({
     // rendering the attacker's entire payload. List cap
     // (WARNING_LIST_DISPLAY_MAX, 10) bounds the bullet count; both
     // constants are shared with the role-mentions-denied path below.
-    const shown = invalidTokens.slice(0, WARNING_LIST_DISPLAY_MAX).map(
-      (t) => sliceWithEllipsis(t.replace(/`/g, ''), WARNING_NAME_CODEPOINT_CAP, '…'),
-    );
+    const shown = invalidTokens.slice(0, WARNING_LIST_DISPLAY_MAX).map(sanitizeForBullet);
     const more = invalidTokens.length > WARNING_LIST_DISPLAY_MAX
       ? ` (+${invalidTokens.length - WARNING_LIST_DISPLAY_MAX} more)`
       : '';
@@ -3154,8 +3159,7 @@ function renderRecipientWarnings({
     //     set, so treat the input as untrusted for rendering.
     const shown = roleMentionsDeniedNames.slice(0, WARNING_LIST_DISPLAY_MAX);
     for (const name of shown) {
-      const safe = sliceWithEllipsis(name.replace(/`/g, ''), WARNING_NAME_CODEPOINT_CAP, '…');
-      lines.push(`• \`@${safe}\` requires the **Mention Everyone** permission or \`role.mentionable: true\` — skipped.`);
+      lines.push(`• \`@${sanitizeForBullet(name)}\` requires the **Mention Everyone** permission or \`role.mentionable: true\` — skipped.`);
     }
     if (roleMentionsDeniedNames.length > WARNING_LIST_DISPLAY_MAX) {
       lines.push(`• (+${roleMentionsDeniedNames.length - WARNING_LIST_DISPLAY_MAX} more role mention(s) skipped.)`);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -430,6 +430,13 @@ function resolveRecipientAlias(r, interaction) {
 // sourced so a future change to the fallback string or cache shape
 // only touches one place (vs. the text-path and picker-path call
 // sites drifting).
+//
+// Uses `||` (not `??`) intentionally so empty-string names also fall
+// through to `unknown-role`. Discord enforces 1–100 char role names
+// server-side, so empty names shouldn't surface in legitimate flows,
+// but a forged interaction or future API shape could carry one. The
+// alternative under `??` would render `@` (the empty backtick block
+// is visually broken). Rendering `unknown-role` is strictly safer.
 function resolveRoleNames(guild, ids) {
   if (!ids || ids.length === 0) return [];
   return ids.map((id) => guild?.roles?.cache?.get(id)?.name || 'unknown-role');
@@ -3040,6 +3047,18 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  *   roleMentionsDeniedNames?: string[],
  * }} [opts]
  */
+// Shared render-bound caps for warnings-block bullets that surface
+// user-controlled (or attacker-influenced) strings. The 80-codepoint
+// cap is shared between invalidTokens and role-name bullets — the
+// two values coincidentally matched when added in #326's review,
+// hoisted here to make the shared intent explicit (one place to
+// bump if Discord's embed budget changes). The display-cap (10
+// entries) bounds the bullet count for both surfaces; the tail count
+// discloses the rest so a forged-interaction enumeration attempt
+// gets surfaced without dwarfing the ephemeral.
+const WARNING_LIST_DISPLAY_MAX = 10;
+const WARNING_NAME_CODEPOINT_CAP = 80;
+
 function renderRecipientWarnings({
   invalidTokens = [],
   cappedCount = 0,
@@ -3064,17 +3083,20 @@ function renderRecipientWarnings({
     // also cap the listed count at 10 so a pathological list can't
     // blow the Discord content budget.
     //
-    // Per-token codepoint cap (80) keeps the worst case bounded:
-    // recipient-parser.js caps each token at 256 chars, so 10 × 256
-    // = 2.5KB of code-fenced text would dwarf the rest of the card
-    // and risk crowding out the action prompt. 80 codepoints is
-    // enough to spot the typo / paste error without rendering the
-    // attacker's entire payload.
-    const TOKEN_DISPLAY_MAX = 80;
-    const shown = invalidTokens.slice(0, 10).map(
-      (t) => sliceWithEllipsis(t.replace(/`/g, ''), TOKEN_DISPLAY_MAX, '…'),
+    // Per-token codepoint cap (WARNING_NAME_CODEPOINT_CAP, 80) keeps
+    // the worst case bounded: recipient-parser.js caps each token at
+    // 256 chars, so 10 × 256 = 2.5KB of code-fenced text would dwarf
+    // the rest of the card and risk crowding out the action prompt.
+    // 80 codepoints is enough to spot the typo / paste error without
+    // rendering the attacker's entire payload. List cap
+    // (WARNING_LIST_DISPLAY_MAX, 10) bounds the bullet count; both
+    // constants are shared with the role-mentions-denied path below.
+    const shown = invalidTokens.slice(0, WARNING_LIST_DISPLAY_MAX).map(
+      (t) => sliceWithEllipsis(t.replace(/`/g, ''), WARNING_NAME_CODEPOINT_CAP, '…'),
     );
-    const more = invalidTokens.length > 10 ? ` (+${invalidTokens.length - 10} more)` : '';
+    const more = invalidTokens.length > WARNING_LIST_DISPLAY_MAX
+      ? ` (+${invalidTokens.length - WARNING_LIST_DISPLAY_MAX} more)`
+      : '';
     lines.push('• Could not parse:\n```\n' + shown.join('\n') + '\n```' + more);
   }
   if (unresolvedIds.length > 0) {
@@ -3115,30 +3137,28 @@ function renderRecipientWarnings({
   if (roleMentionsDeniedNames.length > 0) {
     // One bullet per denied role so the user can tell which mention
     // tripped the gate (the @everyone bullet above doesn't enumerate
-    // because it's always a single semantic action). Cap the list at
-    // 10 to bound the embed footprint under a forged-interaction
-    // attempt to enumerate every guild role; tail-count discloses
-    // the rest.
+    // because it's always a single semantic action).
+    // WARNING_LIST_DISPLAY_MAX (10) bounds the embed footprint under
+    // a forged-interaction attempt to enumerate every guild role;
+    // tail-count discloses the rest.
     //
     // Sanitization mirrors the invalidTokens path above:
     //   - inline code fence (single backtick) so a role name
     //     containing Discord markdown renders literally;
     //   - backticks inside the name stripped to prevent fence
     //     breakout;
-    //   - codepoint-aware slice via sliceWithEllipsis (80 codepoints)
-    //     so a 100-codepoint role name can't dwarf the rest of the
-    //     card. Role names are admin-controlled but Discord doesn't
-    //     restrict the character set, so treat the input as untrusted
-    //     for rendering purposes.
-    const ROLE_DISPLAY_MAX = 10;
-    const ROLE_NAME_CODEPOINT_CAP = 80;
-    const shown = roleMentionsDeniedNames.slice(0, ROLE_DISPLAY_MAX);
+    //   - codepoint-aware slice via sliceWithEllipsis
+    //     (WARNING_NAME_CODEPOINT_CAP, 80) so a 100-codepoint role
+    //     name can't dwarf the rest of the card. Role names are
+    //     admin-controlled but Discord doesn't restrict the character
+    //     set, so treat the input as untrusted for rendering.
+    const shown = roleMentionsDeniedNames.slice(0, WARNING_LIST_DISPLAY_MAX);
     for (const name of shown) {
-      const safe = sliceWithEllipsis(name.replace(/`/g, ''), ROLE_NAME_CODEPOINT_CAP, '…');
+      const safe = sliceWithEllipsis(name.replace(/`/g, ''), WARNING_NAME_CODEPOINT_CAP, '…');
       lines.push(`• \`@${safe}\` requires the **Mention Everyone** permission or \`role.mentionable: true\` — skipped.`);
     }
-    if (roleMentionsDeniedNames.length > ROLE_DISPLAY_MAX) {
-      lines.push(`• (+${roleMentionsDeniedNames.length - ROLE_DISPLAY_MAX} more role mention(s) skipped.)`);
+    if (roleMentionsDeniedNames.length > WARNING_LIST_DISPLAY_MAX) {
+      lines.push(`• (+${roleMentionsDeniedNames.length - WARNING_LIST_DISPLAY_MAX} more role mention(s) skipped.)`);
     }
   }
   if (lines.length === 0) return '';
@@ -4208,8 +4228,16 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     // for the same set of signals but with longer bulleted copy
     // (warnings block vs. rejection banner — different UI contexts).
     // When adding a new reason, update BOTH surfaces.
+    // Reason ordering mirrors renderRecipientWarnings's bullet
+    // ordering (droppedBots → droppedFromRoles → everyoneCacheCold →
+    // massMentionDenied → roleMentionsDenied) so the two surfaces
+    // present multi-signal picks in the same sequence. Most picks
+    // hit at most one signal so ordering is rarely user-visible,
+    // but pin the parity here against future drift.
     const reasons = [];
     if (droppedBots > 0) reasons.push(RECIPIENT_REASON_BOTS_DROPPED);
+    if (droppedFromRoles > 0) reasons.push('Picked role(s) have no non-bot members');
+    if (everyoneCacheCold) reasons.push('Member cache not yet ready — try again in a few seconds');
     if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');
     if (roleMentionsDenied.length > 0) {
       // Condensed copy (count, not per-role) for the rejection banner —
@@ -4222,8 +4250,6 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       const noun = roleMentionsDenied.length === 1 ? 'role' : 'roles';
       reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission (or mark the role as mentionable)`);
     }
-    if (droppedFromRoles > 0) reasons.push('Picked role(s) have no non-bot members');
-    if (everyoneCacheCold) reasons.push('Member cache not yet ready — try again in a few seconds');
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -424,20 +424,11 @@ function resolveRecipientAlias(r, interaction) {
 }
 
 // Resolve role IDs to display names for the `roleMentionsDeniedNames`
-// warning surface (#326). Single-sourced so the text-path and picker-
-// path call sites can't drift.
-//
-// Empty-array short-circuit is a defensive contract guard — the two
-// real call sites both pass arrays from the parser/picker result
-// shape, so reaching it on the hot path is unreachable. Keep it as
-// a documented contract for future callers.
-//
-// Per-id fallback uses `||` (not `??`) so empty-string names —
+// warning surface (#326). `||` (not `??`) so empty-string names —
 // forged interaction / future API shape — also fall through to
-// `unknown-role` rather than rendering `@` with a broken inline code
-// fence.
+// `unknown-role` rather than rendering `@` with broken backticks.
 function resolveRoleNames(guild, ids) {
-  if (!ids || ids.length === 0) return [];
+  if (!ids?.length) return [];
   return ids.map((id) => guild?.roles?.cache?.get(id)?.name || 'unknown-role');
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -423,6 +423,18 @@ function resolveRecipientAlias(r, interaction) {
   return sanitizeDisplayNamePlain(raw);
 }
 
+// Resolve a list of role IDs to display names for the
+// `roleMentionsDeniedNames` warning surface (#326). Falls back to
+// `'unknown-role'` when the role isn't in `guild.roles.cache` — race
+// case where the role was deleted between parse and render. Single-
+// sourced so a future change to the fallback string or cache shape
+// only touches one place (vs. the text-path and picker-path call
+// sites drifting).
+function resolveRoleNames(guild, ids) {
+  if (!ids || ids.length === 0) return [];
+  return ids.map((id) => guild?.roles?.cache?.get(id)?.name || 'unknown-role');
+}
+
 // --- Shared DM delivery payload builder ---
 // Builds the {embeds, components} payload for a per-recipient DM. The
 // embed copy is intentionally evocative ("opened a door", "Door closes")
@@ -2811,8 +2823,12 @@ function partitionRecipients(users, senderId) {
 // Merge a MentionableSelectMenu pick (users + roles) into a deduped
 // User[] for partitionRecipients. The `@everyone` role
 // (role.id === guild.id) is gated on `canMentionEveryone` — same
-// gate as the text-path #323. Non-@everyone role gating is tracked
-// in #326.
+// gate as the text-path #323. Non-mentionable role gating (#326)
+// requires the same MENTION_EVERYONE permission (or `role.mentionable
+// === true` as a per-role bypass) — Discord's picker filters this
+// client-side, but a forged interaction would otherwise bypass it.
+// Denied non-@everyone roles surface via `roleMentionsDenied:
+// string[]` so the caller can render per-role copy with the name.
 //
 // Picked users seed `userMap` BEFORE role expansion so they get cap
 // priority over role-expanded members (mirrors the text-path #323
@@ -2849,6 +2865,15 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
   // silent deferUpdate-only no-op the user-visible path would
   // otherwise hit.
   let everyoneCacheCold = false;
+  // Per-role denied list (issue #326): a picked role that's not
+  // `mentionable: true` AND the sender lacks MENTION_EVERYONE lands
+  // here as `roleId`. Dedup via parallel Set so a future picker that
+  // surfaces the same role twice doesn't double-render. Tracked as
+  // IDs; the caller resolves names via `guild.roles.cache.get(id)
+  // ?.name` so renderRecipientWarnings stays pure (no guild
+  // dependency).
+  const roleMentionsDenied = [];
+  const roleMentionsDeniedIds = new Set();
   // Distinct bot IDs filtered across all picked roles — caller renders
   // .size as "N bot(s) filtered." Tracking as a Set (not a counter)
   // so overlap (bot in two roles, or directly-picked bot also in a
@@ -2879,6 +2904,21 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
         // is a user-visible signal worth showing regardless of whether
         // expansion would have added anyone.
         massMentionDenied = true;
+        continue;
+      }
+      // Per-role MENTION_EVERYONE gate (issue #326), parallel to the
+      // text-path gate in recipient-parser.js. Discord's picker filters
+      // non-mentionable roles client-side for users without the perm —
+      // this gate is defense-in-depth against a forged interaction or
+      // a future client-side filter regression. The @everyone-role
+      // branch above already handled (isEveryoneRole), so this gate
+      // only fires for non-@everyone roles. `role.mentionable === true`
+      // is the per-role bypass (set explicitly by a role owner).
+      if (!isEveryoneRole && role?.mentionable !== true && !canMentionEveryone) {
+        if (!roleMentionsDeniedIds.has(roleId)) {
+          roleMentionsDeniedIds.add(roleId);
+          roleMentionsDenied.push(roleId);
+        }
         continue;
       }
       // `guild` is provably truthy in the @everyone branch (gated by
@@ -2961,6 +3001,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
     massMentionDenied,
     droppedFromRoles: droppedFromRolesSet.size,
     everyoneCacheCold,
+    roleMentionsDenied,
   };
 }
 
@@ -2975,10 +3016,17 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  * builds its own joined-sentence reasons list with shorter copy
  * (rejection banner vs. warnings block — different UI contexts).
  * Both surface the SAME set of signals (droppedBots,
- * droppedFromRoles, massMentionDenied, everyoneCacheCold). When
- * adding or renaming a signal, update BOTH surfaces in lockstep —
- * the helpers don't share a copy table, so a future contributor
- * could easily land one half and not the other.
+ * droppedFromRoles, massMentionDenied, everyoneCacheCold,
+ * roleMentionsDeniedNames). When adding or renaming a signal, update
+ * BOTH surfaces in lockstep — the helpers don't share a copy table,
+ * so a future contributor could easily land one half and not the
+ * other.
+ *
+ * `roleMentionsDeniedNames` is a pre-resolved list of role NAMES
+ * (caller maps role IDs through `guild.roles.cache.get(id)?.name`,
+ * falling back to a placeholder for cache-miss / deleted roles).
+ * Keeping the helper pure of guild lookups mirrors how
+ * `invalidTokens` arrives pre-formatted from the parser.
  *
  * @param {{
  *   invalidTokens?: string[],
@@ -2989,6 +3037,7 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  *   droppedFromRoles?: number,
  *   massMentionDenied?: boolean,
  *   everyoneCacheCold?: boolean,
+ *   roleMentionsDeniedNames?: string[],
  * }} [opts]
  */
 function renderRecipientWarnings({
@@ -3000,6 +3049,7 @@ function renderRecipientWarnings({
   droppedFromRoles = 0,
   massMentionDenied = false,
   everyoneCacheCold = false,
+  roleMentionsDeniedNames = [],
 } = {}) {
   const lines = [];
   if (cappedCount > 0) {
@@ -3061,6 +3111,35 @@ function renderRecipientWarnings({
     // this in DM context (where @everyone has no meaning) so the
     // copy here doesn't need a context qualifier.
     lines.push('• `@everyone` requires the **Mention Everyone** permission — skipped.');
+  }
+  if (roleMentionsDeniedNames.length > 0) {
+    // One bullet per denied role so the user can tell which mention
+    // tripped the gate (the @everyone bullet above doesn't enumerate
+    // because it's always a single semantic action). Cap the list at
+    // 10 to bound the embed footprint under a forged-interaction
+    // attempt to enumerate every guild role; tail-count discloses
+    // the rest.
+    //
+    // Sanitization mirrors the invalidTokens path above:
+    //   - inline code fence (single backtick) so a role name
+    //     containing Discord markdown renders literally;
+    //   - backticks inside the name stripped to prevent fence
+    //     breakout;
+    //   - codepoint-aware slice via sliceWithEllipsis (80 codepoints)
+    //     so a 100-codepoint role name can't dwarf the rest of the
+    //     card. Role names are admin-controlled but Discord doesn't
+    //     restrict the character set, so treat the input as untrusted
+    //     for rendering purposes.
+    const ROLE_DISPLAY_MAX = 10;
+    const ROLE_NAME_CODEPOINT_CAP = 80;
+    const shown = roleMentionsDeniedNames.slice(0, ROLE_DISPLAY_MAX);
+    for (const name of shown) {
+      const safe = sliceWithEllipsis(name.replace(/`/g, ''), ROLE_NAME_CODEPOINT_CAP, '…');
+      lines.push(`• \`@${safe}\` requires the **Mention Everyone** permission or \`role.mentionable: true\` — skipped.`);
+    }
+    if (roleMentionsDeniedNames.length > ROLE_DISPLAY_MAX) {
+      lines.push(`• (+${roleMentionsDeniedNames.length - ROLE_DISPLAY_MAX} more role mention(s) skipped.)`);
+    }
   }
   if (lines.length === 0) return '';
   return '⚠\u{FE0F} **Some recipients were dropped:**\n' + lines.join('\n') + '\n\n';
@@ -3515,8 +3594,19 @@ async function handleQurlSlashSend(interaction, params) {
     // @everyone has no meaning in a DM (Discord doesn't expand it
     // there) and "requires the Mention Everyone permission" reads
     // strangely when there's no permission to grant. The other
-    // warnings (bot/capped/unresolved) still apply and surface.
+    // warnings (bot/capped/unresolved) still apply and surface. Same
+    // suppression applies to `roleMentionsDenied` — role mentions
+    // can't resolve in DM either (the parser's guild.roles.cache is
+    // empty), so this is defense-in-depth: in DM the array is
+    // empty already, but keep the gate consistent with @everyone.
     const isDmContext = !interaction.guild;
+    // Resolve denied role IDs to names for the warnings block.
+    // `resolveRoleNames` falls back to `'unknown-role'` for cache
+    // misses (e.g., role deleted between parse and render) so the
+    // bullet still renders rather than collapsing to `@undefined`.
+    const roleMentionsDeniedNames = !isDmContext
+      ? resolveRoleNames(interaction.guild, parsed.roleMentionsDenied)
+      : [];
     const warningsBlock = renderRecipientWarnings({
       invalidTokens: parsed.invalidTokens,
       cappedCount: parsed.cappedCount,
@@ -3524,6 +3614,7 @@ async function handleQurlSlashSend(interaction, params) {
       transientFailureIds: resolved.transientFailureIds,
       droppedBots,
       massMentionDenied: parsed.massMentionDenied && !isDmContext,
+      roleMentionsDeniedNames,
     });
     if (!recipientsOmitted && valid.length === 0) {
       clearCooldown(interaction.user.id);
@@ -3535,7 +3626,8 @@ async function handleQurlSlashSend(interaction, params) {
         && resolved.unresolvedIds.length === 0
         && droppedBots === 0
         && parsed.invalidTokens.length === 0
-        && parsed.cappedCount === 0;
+        && parsed.cappedCount === 0
+        && roleMentionsDeniedNames.length === 0;
       if (transientOnly) {
         return interaction.editReply({
           content: warningsBlock + '❌ **Could not look up recipients right now.** Try again in a moment.',
@@ -3551,7 +3643,8 @@ async function handleQurlSlashSend(interaction, params) {
         && resolved.unresolvedIds.length === 0
         && resolved.transientFailureIds.length === 0
         && parsed.invalidTokens.length === 0
-        && parsed.cappedCount === 0;
+        && parsed.cappedCount === 0
+        && roleMentionsDeniedNames.length === 0;
       const detail = breakdownEmpty
         ? '\n\nMake sure you @-mention real users (bots are skipped automatically).'
         : '';
@@ -4013,16 +4106,22 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     massMentionDenied,
     droppedFromRoles,
     everyoneCacheCold,
+    roleMentionsDenied,
   } = resolveMentionableSelection({
     interaction,
     canMentionEveryone,
     flow_id,
   });
+  // Resolve denied role IDs to names (with fallback for cache miss /
+  // deleted role) for the warnings block. Kept caller-side so the
+  // renderer stays pure of guild lookups, mirroring the text path.
+  const roleMentionsDeniedNames = resolveRoleNames(interaction.guild, roleMentionsDenied);
   if (
     selected.length === 0
     && !massMentionDenied
     && droppedFromRoles === 0
     && !everyoneCacheCold
+    && roleMentionsDenied.length === 0
   ) {
     // Truly empty pick (no users, no roles, no @everyone, no
     // bot-only roles, cache not cold) → already acked via deferUpdate
@@ -4090,6 +4189,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       mass_mention_denied: massMentionDenied,
       dropped_from_roles: droppedFromRoles,
       everyone_cache_cold: everyoneCacheCold,
+      role_mentions_denied: roleMentionsDenied.length,
     });
     // Reachable cases:
     //   - bot-only individual pick (droppedBots > 0)
@@ -4113,6 +4213,14 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     const reasons = [];
     if (droppedBots > 0) reasons.push(RECIPIENT_REASON_BOTS_DROPPED);
     if (massMentionDenied) reasons.push('`@everyone` requires the **Mention Everyone** permission');
+    if (roleMentionsDenied.length > 0) {
+      // Condensed copy (count, not per-role) for the rejection banner —
+      // the warnings block (renderRecipientWarnings) does per-role
+      // bullets. Different UI contexts, COPY PARITY noted in
+      // renderRecipientWarnings's docstring.
+      const noun = roleMentionsDenied.length === 1 ? 'role' : 'roles';
+      reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission`);
+    }
     if (droppedFromRoles > 0) reasons.push('Picked role(s) have no non-bot members');
     if (everyoneCacheCold) reasons.push('Member cache not yet ready — try again in a few seconds');
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
@@ -4139,6 +4247,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     droppedFromRoles,
     massMentionDenied,
     everyoneCacheCold,
+    roleMentionsDeniedNames,
   });
   const newRecipientAliases = Object.fromEntries(
     valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -423,20 +423,11 @@ function resolveRecipientAlias(r, interaction) {
   return sanitizeDisplayNamePlain(raw);
 }
 
-// Resolve a list of role IDs to display names for the
-// `roleMentionsDeniedNames` warning surface (#326). Falls back to
-// `'unknown-role'` when the role isn't in `guild.roles.cache` — race
-// case where the role was deleted between parse and render. Single-
-// sourced so a future change to the fallback string or cache shape
-// only touches one place (vs. the text-path and picker-path call
-// sites drifting).
-//
-// Uses `||` (not `??`) intentionally so empty-string names also fall
-// through to `unknown-role`. Discord enforces 1–100 char role names
-// server-side, so empty names shouldn't surface in legitimate flows,
-// but a forged interaction or future API shape could carry one. The
-// alternative under `??` would render `@` (the empty backtick block
-// is visually broken). Rendering `unknown-role` is strictly safer.
+// Resolve role IDs to display names for the `roleMentionsDeniedNames`
+// warning surface (#326). Single-sourced so the text-path and picker-
+// path call sites can't drift. `||` (not `??`) so an empty-string
+// name — forged interaction / future API shape — also falls through
+// to `unknown-role` rather than rendering `@`.
 function resolveRoleNames(guild, ids) {
   if (!ids || ids.length === 0) return [];
   return ids.map((id) => guild?.roles?.cache?.get(id)?.name || 'unknown-role');
@@ -505,6 +496,17 @@ const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ n
 // UserSelectMenu AND the post-send "Add Recipients" flow both use this
 // — keep them in lockstep so a future bump doesn't drift.
 const USER_SELECT_PER_PICK_CAP = 10;
+
+// Shared render caps for warnings-block bullets that surface user-
+// or admin-controlled strings (invalidTokens, roleMentionsDeniedNames).
+// 10-bullet cap bounds the embed footprint under a forged-interaction
+// enumeration attempt; 80-codepoint per-string cap keeps a single
+// pathological role name / mention token from dwarfing the rest of
+// the card. Hoisted here (not inline in renderRecipientWarnings) so
+// the shared intent is explicit — one place to bump if Discord's
+// embed budget changes.
+const WARNING_LIST_DISPLAY_MAX = 10;
+const WARNING_NAME_CODEPOINT_CAP = 80;
 
 // Shared Google Maps URL patterns. `/qurl map`'s slash-option
 // `location:` consumes these — extracted to a single source so a
@@ -3057,18 +3059,6 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  *   roleMentionsDeniedNames?: string[],
  * }} [opts]
  */
-// Shared render-bound caps for warnings-block bullets that surface
-// user-controlled (or attacker-influenced) strings. The 80-codepoint
-// cap is shared between invalidTokens and role-name bullets — the
-// two values coincidentally matched when added in #326's review,
-// hoisted here to make the shared intent explicit (one place to
-// bump if Discord's embed budget changes). The display-cap (10
-// entries) bounds the bullet count for both surfaces; the tail count
-// discloses the rest so a forged-interaction enumeration attempt
-// gets surfaced without dwarfing the ephemeral.
-const WARNING_LIST_DISPLAY_MAX = 10;
-const WARNING_NAME_CODEPOINT_CAP = 80;
-
 function renderRecipientWarnings({
   invalidTokens = [],
   cappedCount = 0,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6867,6 +6867,7 @@ module.exports = {
       resolveRecipientUsers,
       partitionRecipients,
       resolveMentionableSelection,
+      resolveRoleNames,
       selfDestructOptionToSeconds,
       renderRecipientWarnings,
       renderConfirmCardContent,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -425,9 +425,17 @@ function resolveRecipientAlias(r, interaction) {
 
 // Resolve role IDs to display names for the `roleMentionsDeniedNames`
 // warning surface (#326). Single-sourced so the text-path and picker-
-// path call sites can't drift. `||` (not `??`) so an empty-string
-// name — forged interaction / future API shape — also falls through
-// to `unknown-role` rather than rendering `@`.
+// path call sites can't drift.
+//
+// Empty-array short-circuit is a defensive contract guard — the two
+// real call sites both pass arrays from the parser/picker result
+// shape, so reaching it on the hot path is unreachable. Keep it as
+// a documented contract for future callers.
+//
+// Per-id fallback uses `||` (not `??`) so empty-string names —
+// forged interaction / future API shape — also fall through to
+// `unknown-role` rather than rendering `@` with a broken inline code
+// fence.
 function resolveRoleNames(guild, ids) {
   if (!ids || ids.length === 0) return [];
   return ids.map((id) => guild?.roles?.cache?.get(id)?.name || 'unknown-role');
@@ -2918,12 +2926,17 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
       // Skip undefined-role entries (theoretical — Discord's picker
       // surfaces roles via `interaction.roles.entries()`, which should
       // always carry the Role object alongside the ID; but a partial
-      // fetch shape could deliver a bare ID). Symmetric with the
-      // text-path parser's `if (!role) { pushInvalidIfNew(...) }`
+      // fetch shape could deliver a bare ID). Gate placement parallels
+      // the text-path parser's `if (!role) { pushInvalidIfNew(...) }`
       // branch — without this short-circuit, the `role?.mentionable
       // !== true` gate below would route a cache-miss role through
       // the deny path and surface "Non-mentionable role" copy for
-      // what's actually a missing object.
+      // what's actually a missing object. RESIDUE DIVERGES BY DESIGN:
+      // the parser surfaces invalid-role IDs in `invalidTokens` so
+      // the user sees a "couldn't parse" bullet, but the picker has
+      // no parse-error context to surface (the picker submitted IDs
+      // are by definition Discord-rendered choices), so silent
+      // `continue` is the right residue here.
       if (!isEveryoneRole && !role) continue;
       // Per-role MENTION_EVERYONE gate (issue #326), parallel to the
       // text-path gate in recipient-parser.js. Discord's picker filters
@@ -3045,7 +3058,11 @@ function resolveMentionableSelection({ interaction, canMentionEveryone, flow_id 
  * (caller maps role IDs through `guild.roles.cache.get(id)?.name`,
  * falling back to a placeholder for cache-miss / deleted roles).
  * Keeping the helper pure of guild lookups mirrors how
- * `invalidTokens` arrives pre-formatted from the parser.
+ * `invalidTokens` arrives pre-formatted from the parser. Names are
+ * truncated AT RENDER time here: each name is capped at
+ * WARNING_NAME_CODEPOINT_CAP (80) codepoints with backticks stripped,
+ * and the listed count is capped at WARNING_LIST_DISPLAY_MAX (10)
+ * with a tail-count line — callers don't need to pre-sanitize.
  *
  * @param {{
  *   invalidTokens?: string[],
@@ -4256,8 +4273,13 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       // lacks MENTION_EVERYONE and likely lacks Manage Roles too, so
       // imperative phrasing reads as misleading agency. The workaround
       // ("ask an admin") is real but indirect; reflect that in the copy.
-      const noun = roleMentionsDenied.length === 1 ? 'role' : 'roles';
-      reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission (or have the role marked as mentionable)`);
+      // Singular/plural noun AND verb stay in lockstep so the single-
+      // role case ("Non-mentionable role requires …") doesn't render
+      // as a noun/verb mismatch — most one-role picks hit this banner.
+      const isSingular = roleMentionsDenied.length === 1;
+      const noun = isSingular ? 'role' : 'roles';
+      const verb = isSingular ? 'requires' : 'require';
+      reasons.push(`Non-mentionable ${noun} ${verb} the **Mention Everyone** permission (or have the role marked as mentionable)`);
     }
     const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in pick';
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3594,19 +3594,17 @@ async function handleQurlSlashSend(interaction, params) {
     // @everyone has no meaning in a DM (Discord doesn't expand it
     // there) and "requires the Mention Everyone permission" reads
     // strangely when there's no permission to grant. The other
-    // warnings (bot/capped/unresolved) still apply and surface. Same
-    // suppression applies to `roleMentionsDenied` — role mentions
-    // can't resolve in DM either (the parser's guild.roles.cache is
-    // empty), so this is defense-in-depth: in DM the array is
-    // empty already, but keep the gate consistent with @everyone.
+    // warnings (bot/capped/unresolved) still apply and surface.
+    //
+    // `roleMentionsDenied` does NOT need an isDmContext guard: the
+    // parser's role loop won't fire without a `guild`, so
+    // `parsed.roleMentionsDenied` is always `[]` in DM —
+    // `resolveRoleNames` returns `[]` for empty input. Symmetric
+    // with the picker-path call site, which calls `resolveRoleNames`
+    // unconditionally (the picker path can't reach DM context at
+    // all because `canMentionEveryone` requires `interaction.guild`).
     const isDmContext = !interaction.guild;
-    // Resolve denied role IDs to names for the warnings block.
-    // `resolveRoleNames` falls back to `'unknown-role'` for cache
-    // misses (e.g., role deleted between parse and render) so the
-    // bullet still renders rather than collapsing to `@undefined`.
-    const roleMentionsDeniedNames = !isDmContext
-      ? resolveRoleNames(interaction.guild, parsed.roleMentionsDenied)
-      : [];
+    const roleMentionsDeniedNames = resolveRoleNames(interaction.guild, parsed.roleMentionsDenied);
     const warningsBlock = renderRecipientWarnings({
       invalidTokens: parsed.invalidTokens,
       cappedCount: parsed.cappedCount,
@@ -4217,9 +4215,12 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       // Condensed copy (count, not per-role) for the rejection banner —
       // the warnings block (renderRecipientWarnings) does per-role
       // bullets. Different UI contexts, COPY PARITY noted in
-      // renderRecipientWarnings's docstring.
+      // renderRecipientWarnings's docstring. Surfaces the
+      // `role.mentionable: true` bypass inline so a user who hits
+      // this banner knows the workaround without having to find the
+      // per-role copy (which only the partial-valid surface renders).
       const noun = roleMentionsDenied.length === 1 ? 'role' : 'roles';
-      reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission`);
+      reasons.push(`Non-mentionable ${noun} require the **Mention Everyone** permission (or mark the role as mentionable)`);
     }
     if (droppedFromRoles > 0) reasons.push('Picked role(s) have no non-bot members');
     if (everyoneCacheCold) reasons.push('Member cache not yet ready — try again in a few seconds');

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -243,7 +243,11 @@ function isBotMember(member) {
 //     `guild.roles.cache`.
 // The `<@&{guildId}>` wire form (Discord's @everyone-role mention) is
 // routed through the `@everyone` channel above (massMentionDenied /
-// guild.members.cache expansion) rather than `role.members`.
+// guild.members.cache expansion) rather than `role.members`. The
+// wire-form check (`guild && roleId === guild.id`) fires BEFORE the
+// `roles.cache.get(roleId)` lookup, so a cold cache that doesn't yet
+// hold the @everyone role still routes correctly (pinned by the
+// `<@&{guildId}> wire form routes to massMentionDenied` test).
 //
 // `interaction` is the slash-command interaction; we need it for:
 //   - interaction.guild               → role-mention expansion via

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -217,8 +217,8 @@ function isBotMember(member) {
 
 // Resolve a list of mention tokens (raw "<@..>" / "<@&..>" / `@everyone`)
 // to a flat user-ID list with the cap + bot filter applied. Returns
-// `{ ids, invalidTokens, cappedCount, massMentionDenied }`; never
-// throws on parse errors — invalid tokens always land in
+// `{ ids, invalidTokens, cappedCount, massMentionDenied, roleMentionsDenied }`;
+// never throws on parse errors — invalid tokens always land in
 // `invalidTokens` for caller-side surfacing. Sender is NOT filtered —
 // self-send is supported; the confirm-card renderer surfaces a neutral
 // notice when sender appears in `ids`.
@@ -232,6 +232,18 @@ function isBotMember(member) {
 //               can surface "you don't have permission to @everyone".
 // Either way the token is stripped from `invalidTokens` to avoid
 // double-surfacing.
+//
+// `<@&roleId>` mentions follow the same privilege model Discord enforces
+// for in-chat role mentions:
+//   - `role.mentionable === true` → expanded unconditionally.
+//   - `role.mentionable === false` → requires `allowMassMention === true`;
+//     denied roles land in `roleMentionsDenied: [roleId, ...]` (array
+//     because a single send can attempt multiple denied roles) so the
+//     caller can emit per-role copy with the role name resolved via
+//     `guild.roles.cache`.
+// The `<@&{guildId}>` wire form (Discord's @everyone-role mention) is
+// routed through the `@everyone` channel above (massMentionDenied /
+// guild.members.cache expansion) rather than `role.members`.
 //
 // `interaction` is the slash-command interaction; we need it for:
 //   - interaction.guild               → role-mention expansion via
@@ -247,7 +259,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // an empty result rather than throwing. Caller branches on
   // `ids.length === 0` to decide whether to render the recipient picker.
   if (raw == null || typeof raw !== 'string') {
-    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, roleMentionsDenied: [] };
   }
   // Mirror the `raw` guard for `interaction` so a null/undefined
   // caller-bug surfaces as an empty result instead of a TypeError
@@ -255,7 +267,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // a clearer crash site for "no caller context"; the parser
   // doesn't gain anything by failing here.
   if (interaction == null) {
-    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, roleMentionsDenied: [] };
   }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
@@ -285,7 +297,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     }
   }
   if (input.length === 0) {
-    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, roleMentionsDenied: [] };
   }
 
   // `seen` is the canonical post-filter unique-candidate set (every
@@ -380,11 +392,55 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     seenIds.add(id);
     invalidTokens.push(rawToken);
   }
+  // Roles that the sender attempted to mention but lacks the permission
+  // for (`role.mentionable !== true` AND `!allowMassMention`). Tracked
+  // as IDs; the caller resolves to names via `guild.roles.cache.get(id)
+  // ?.name` so renderRecipientWarnings can emit "@<roleName> requires
+  // the Mention Everyone permission or role.mentionable: true." Deduped
+  // via a parallel Set so `<@&999> <@&999>` yields one entry — same
+  // pattern as invalidRoleIds above.
+  const roleMentionsDenied = [];
+  const roleMentionsDeniedIds = new Set();
   for (const m of input.matchAll(ROLE_MENTION_RE)) {
     const roleId = m[1];
+    // `<@&{guildId}>` is Discord's wire form for the @everyone role —
+    // the @everyone role's ID always equals `guild.id`. Semantically
+    // this is the same action as the `@everyone` text token, so route
+    // through the existing massMentionDenied / everyonePresent channel:
+    //   - Allowed → set everyonePresent=true and skip the role-loop
+    //     branch; the dedicated @everyone expansion below walks
+    //     guild.members.cache (discord.js's @everyone role.members
+    //     doesn't reliably surface all members — see commands.js:2821).
+    //   - Denied  → mark massMentionDenied so the caller emits the
+    //     "@everyone requires Mention Everyone" copy (not the
+    //     "role mention requires …" copy, which would confuse the user).
+    if (guild && roleId === guild.id) {
+      if (allowMassMention) {
+        everyonePresent = true;
+      } else {
+        massMentionDenied = true;
+      }
+      continue;
+    }
     const role = guild?.roles?.cache?.get(roleId);
     if (!role) {
       pushInvalidIfNew(invalidRoleIds, roleId, m[0]);
+      continue;
+    }
+    // Permission gate (issue #326): non-mentionable roles require
+    // MENTION_EVERYONE — same rule Discord enforces for in-chat role
+    // mentions. Without this gate, a non-admin sender could
+    // `/qurl file recipients:<@&adminRoleId>` to fan a send to admin-
+    // role members, bypassing the same protection the @everyone path
+    // got in #323. `role.mentionable === true` is the per-role bypass
+    // (set explicitly by a role owner). Lands in `roleMentionsDenied`
+    // (NOT invalidTokens) so the caller can emit permission-specific
+    // copy with the role NAME rather than the generic "couldn't parse."
+    if (role.mentionable !== true && !allowMassMention) {
+      if (!roleMentionsDeniedIds.has(roleId)) {
+        roleMentionsDeniedIds.add(roleId);
+        roleMentionsDenied.push(roleId);
+      }
       continue;
     }
     // role.members is a Collection<Snowflake, GuildMember>. Empty for
@@ -662,7 +718,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     });
   }
 
-  return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied };
+  return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied, roleMentionsDenied };
 }
 
 // `isVoiceChannelType` is the same voice/stage-voice predicate the

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -972,6 +972,25 @@ describe('resolveMentionableSelection', () => {
       expect(r.roleMentionsDenied).toEqual(['role-denied-bot']);
     });
 
+    test('undefined role object (partial-fetch edge) → skipped, NOT routed through deny path', () => {
+      // Theoretical edge: `interaction.roles.entries()` carries `[id,
+      // roleObject]` pairs in production, but a partial-fetch shape
+      // could deliver `[id, undefined]`. Without the
+      // `if (!isEveryoneRole && !role) continue;` short-circuit, the
+      // per-role gate (`role?.mentionable !== true`) would route the
+      // cache-miss through the deny path and surface
+      // "Non-mentionable role" copy for what's actually a missing
+      // object. Symmetric with the text-path parser's
+      // `if (!role) { pushInvalidIfNew(...) }` invalid-role branch.
+      const int = makeMentionableInteraction({
+        pickedRoles: [['orphan-id', undefined]],
+      });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.users).toEqual([]);
+      expect(r.roleMentionsDenied).toEqual([]);
+      expect(r.massMentionDenied).toBe(false);
+    });
+
     test('@everyone-role (role.id === guild.id) NOT routed to roleMentionsDenied — uses massMentionDenied', () => {
       // The @everyone branch above (isEveryoneRole) catches role.id ===
       // guild.id BEFORE the per-role gate fires, so massMentionDenied
@@ -3448,7 +3467,11 @@ describe('handleConfirmUserSelect', () => {
     // Per-role-bypass mention surfaces inline on the banner so the
     // user doesn't have to find the per-role bullet copy (which only
     // the partial-valid surface renders) to learn the workaround.
-    expect(updated.content).toMatch(/mark the role as mentionable/i);
+    // Phrasing reflects indirect agency — the user lacks MENTION_EVERYONE
+    // (by definition reaching this banner) and likely lacks Manage Roles,
+    // so "have the role marked" is more accurate than the imperative
+    // "mark the role" would be.
+    expect(updated.content).toMatch(/have the role marked as mentionable/i);
     // Resource header survives — preserved-context contract.
     expect(updated.content).toMatch(/Sending file/);
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -197,6 +197,7 @@ const {
   executeSendPipeline,
   getActiveFileSends,
   setActiveFileSends,
+  resolveRoleNames,
 } = _test;
 
 // Flow-dispatch handlers live at module top-level (consumed by
@@ -984,6 +985,70 @@ describe('resolveMentionableSelection', () => {
       expect(r.massMentionDenied).toBe(true);
       expect(r.roleMentionsDenied).toEqual([]);
     });
+  });
+});
+
+describe('resolveRoleNames (#326 helper)', () => {
+  // Closed-contract pin for the cache-lookup-with-fallback helper
+  // used by both the text-path (`handleQurlSlashSend`) and picker-
+  // path (`handleConfirmUserSelect`) `roleMentionsDeniedNames`
+  // resolution. Centralizing tests here means a future refactor of
+  // the helper signature surfaces in one place rather than via
+  // brittle handler-level integration tests.
+
+  function makeGuild(rolesById = {}) {
+    const cache = new Map(Object.entries(rolesById));
+    return { roles: { cache } };
+  }
+
+  test('returns [] for null / undefined / empty ids (defensive contract)', () => {
+    const guild = makeGuild({});
+    expect(resolveRoleNames(guild, null)).toEqual([]);
+    expect(resolveRoleNames(guild, undefined)).toEqual([]);
+    expect(resolveRoleNames(guild, [])).toEqual([]);
+  });
+
+  test('returns [] when guild is null (defensive — DM context shouldn\'t reach here, but parity with optional chains)', () => {
+    expect(resolveRoleNames(null, ['7000'])).toEqual(['unknown-role']);
+    expect(resolveRoleNames(undefined, ['7000'])).toEqual(['unknown-role']);
+  });
+
+  test('resolves cached role IDs to their names', () => {
+    const guild = makeGuild({
+      '7000': { id: '7000', name: 'admin' },
+      '7001': { id: '7001', name: 'mods' },
+    });
+    expect(resolveRoleNames(guild, ['7000', '7001'])).toEqual(['admin', 'mods']);
+  });
+
+  test('cache miss → `unknown-role` fallback (deleted-mid-flow race)', () => {
+    const guild = makeGuild({});  // role 7000 not in cache
+    expect(resolveRoleNames(guild, ['7000'])).toEqual(['unknown-role']);
+  });
+
+  test('empty-string role name → `unknown-role` fallback (pins `||` vs `??` rationale)', () => {
+    // Discord enforces 1–100 char role names server-side, so empty
+    // names shouldn't surface in legitimate flows — but a forged
+    // interaction or future API edge could carry one. The `||` (not
+    // `??`) in `resolveRoleNames` ensures an empty name falls through
+    // to `unknown-role` rather than rendering `@` (the empty backtick
+    // block would be visually broken). Pin the rationale.
+    const guild = makeGuild({
+      '7000': { id: '7000', name: '' },
+    });
+    expect(resolveRoleNames(guild, ['7000'])).toEqual(['unknown-role']);
+  });
+
+  test('mixed cache-hit / cache-miss / empty-name in one batch → fallback applies per-entry', () => {
+    const guild = makeGuild({
+      '7000': { id: '7000', name: 'admin' },
+      '7002': { id: '7002', name: '' },
+    });
+    expect(resolveRoleNames(guild, ['7000', '7001', '7002'])).toEqual([
+      'admin',
+      'unknown-role',  // cache miss
+      'unknown-role',  // empty name
+    ]);
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -3462,7 +3462,10 @@ describe('handleConfirmUserSelect', () => {
     await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
-    expect(updated.content).toMatch(/Non-mentionable role/i);
+    // Singular noun + singular verb stay in lockstep — most one-role
+    // picks hit this banner, so "role requires" (not "role require")
+    // is the user-visible default.
+    expect(updated.content).toMatch(/Non-mentionable role requires/i);
     expect(updated.content).toMatch(/Mention Everyone/);
     // Per-role-bypass mention surfaces inline on the banner so the
     // user doesn't have to find the per-role bullet copy (which only
@@ -3474,6 +3477,33 @@ describe('handleConfirmUserSelect', () => {
     expect(updated.content).toMatch(/have the role marked as mentionable/i);
     // Resource header survives — preserved-context contract.
     expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('mentionable picker: multiple non-mentionable roles → banner uses plural noun + verb ("roles require")', async () => {
+    // Sibling to the singular-form pin above. Two denied roles in
+    // one pick — the banner reason builder must flip both noun
+    // ("role" → "roles") AND verb ("requires" → "require") in
+    // lockstep. A regression that bumped only one would render
+    // either "roles requires" or "role require." Pin both.
+    const u1 = makeUser('100000000000000001');
+    const u2 = makeUser('100000000000000002');
+    const roleA = ['role-a', {
+      id: 'role-a', name: 'admin-a', mentionable: false,
+      members: new Map([[u1.id, { user: u1 }]]),
+    }];
+    const roleB = ['role-b', {
+      id: 'role-b', name: 'admin-b', mentionable: false,
+      members: new Map([[u2.id, { user: u2 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [roleA, roleB],
+      canMentionEveryone: false,
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Non-mentionable roles require/i);
   });
 
   test('mentionable picker: non-mentionable role + valid user pick → partial-valid, warnings block lists role NAME', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -1008,7 +1008,14 @@ describe('resolveRoleNames (#326 helper)', () => {
     expect(resolveRoleNames(guild, [])).toEqual([]);
   });
 
-  test('returns [] when guild is null (defensive — DM context shouldn\'t reach here, but parity with optional chains)', () => {
+  test('guild=null/undefined with non-empty ids → unknown-role fallback per entry (DM context shouldn\'t reach here, but optional chains carry through)', () => {
+    // Defensive: the text-path call site is reachable from DM context
+    // (where `interaction.guild` is null) even though the parser's
+    // role loop won't actually populate `parsed.roleMentionsDenied`
+    // without a guild. If a future caller path bypasses that
+    // invariant, the optional chain `guild?.roles?.cache?.get(id)`
+    // returns undefined and the `||` falls through to `unknown-role`
+    // — symmetric with the cache-miss behavior, not a hard crash.
     expect(resolveRoleNames(null, ['7000'])).toEqual(['unknown-role']);
     expect(resolveRoleNames(undefined, ['7000'])).toEqual(['unknown-role']);
   });
@@ -3357,6 +3364,40 @@ describe('handleConfirmUserSelect', () => {
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/Cannot send to bots/);
     expect(updated.content).toMatch(/no non-bot members/i);
+  });
+
+  test('mentionable picker: multi-signal pick (bot user + denied non-mentionable role) → banner reasons follow renderRecipientWarnings ordering', async () => {
+    // Pin the reason-ordering parity between the all-invalid
+    // rejection banner and the warnings-block bullets. Both surfaces
+    // sequence multi-signal picks as droppedBots → droppedFromRoles →
+    // everyoneCacheCold → massMentionDenied → roleMentionsDenied, so
+    // a future refactor that reshuffles one side without the other
+    // silently breaks the COPY PARITY contract in
+    // renderRecipientWarnings's docstring. Two signals (droppedBots
+    // + roleMentionsDenied) are the minimum to expose ordering.
+    const directBot = makeUser('100000000000000099', { bot: true });
+    const u1 = makeUser('100000000000000001');
+    const deniedRole = ['role-admin', {
+      id: 'role-admin',
+      name: 'admin',
+      mentionable: false,
+      members: new Map([[u1.id, { user: u1 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [directBot],
+      roles: [deniedRole],
+      canMentionEveryone: false,
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    // Index-of comparison pins ordering without depending on the
+    // exact joiner between reasons (currently ". ").
+    const botIdx = updated.content.indexOf('Cannot send to bots');
+    const roleIdx = updated.content.indexOf('Non-mentionable role');
+    expect(botIdx).toBeGreaterThanOrEqual(0);
+    expect(roleIdx).toBeGreaterThanOrEqual(0);
+    expect(botIdx).toBeLessThan(roleIdx);
   });
 
   test('re-pick preserves personalMessageRaw + personalMessage through the spread', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -3339,6 +3339,10 @@ describe('handleConfirmUserSelect', () => {
     const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(updated.content).toMatch(/Non-mentionable role/i);
     expect(updated.content).toMatch(/Mention Everyone/);
+    // Per-role-bypass mention surfaces inline on the banner so the
+    // user doesn't have to find the per-role bullet copy (which only
+    // the partial-valid surface renders) to learn the workaround.
+    expect(updated.content).toMatch(/mark the role as mentionable/i);
     // Resource header survives — preserved-context contract.
     expect(updated.content).toMatch(/Sending file/);
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -421,11 +421,16 @@ describe('resolveMentionableSelection', () => {
   // QURL_SEND_MAX_RECIPIENTS, gates the @everyone role on canMentionEveryone.
   const GUILD_ID = 'guild-1';
 
-  function makeRole({ id, members = [] }) {
+  // `mentionable` defaults to `true` so the existing test corpus
+  // continues to expand picked roles after the #326 gate landed.
+  // Per-test overrides (`mentionable: false`) exercise the deny path.
+  // `name` is consumed by the caller's `guild.roles.cache.get(id)
+  // ?.name` lookup (renderRecipientWarnings bullet text).
+  function makeRole({ id, members = [], mentionable = true, name }) {
     // role.members is a Discord.js Collection but only `.entries()`
     // (iterable of [id, member]) is read; a Map is shape-compatible.
     const memberMap = new Map(members.map((m) => [m.user.id, m]));
-    return [id, { id, members: memberMap }];
+    return [id, { id, name: name ?? `role-${id}`, members: memberMap, mentionable }];
   }
 
   function makeMentionableInteraction({
@@ -434,9 +439,18 @@ describe('resolveMentionableSelection', () => {
     guildMemberCache = new Map(),
     inDM = false,
   } = {}) {
+    // Mirror picked roles into guild.roles.cache so the caller-side
+    // name lookup (`guild.roles.cache.get(id)?.name`) used by
+    // renderRecipientWarnings to render denied-role bullets has
+    // something to find. Stays a no-op when no roles are picked.
+    const roleCache = new Map();
+    for (const [id, role] of pickedRoles) {
+      roleCache.set(id, role);
+    }
     const guild = inDM ? null : {
       id: GUILD_ID,
       members: { cache: guildMemberCache },
+      roles: { cache: roleCache },
     };
     return {
       guild,
@@ -846,6 +860,7 @@ describe('resolveMentionableSelection', () => {
     // Build members map directly (makeRole helper requires m.user.id).
     const role = ['role-eng', {
       id: 'role-eng',
+      mentionable: true,
       members: new Map([
         ['100000000000000091', { user: undefined }],
         [u1.id, { user: u1 }],
@@ -860,7 +875,7 @@ describe('resolveMentionableSelection', () => {
     expect(r.droppedFromRoles).toBe(0);
   });
 
-  test('returns the documented shape: { users, massMentionDenied, droppedFromRoles, everyoneCacheCold }', () => {
+  test('returns the documented shape: { users, massMentionDenied, droppedFromRoles, everyoneCacheCold, roleMentionsDenied }', () => {
     // Pinning test: a new return field added without updating this
     // assertion will fail loudly here. If you're hitting this after
     // adding a field, update the sorted-keys list AND verify every
@@ -868,7 +883,107 @@ describe('resolveMentionableSelection', () => {
     // (handleConfirmUserSelect at minimum).
     const int = makeMentionableInteraction({});
     const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
-    expect(Object.keys(r).sort()).toEqual(['droppedFromRoles', 'everyoneCacheCold', 'massMentionDenied', 'users']);
+    expect(Object.keys(r).sort()).toEqual(['droppedFromRoles', 'everyoneCacheCold', 'massMentionDenied', 'roleMentionsDenied', 'users']);
+  });
+
+  describe('role-mention permission gate (#326)', () => {
+    // Picker-path parity with the parser-path #326 gate. Discord's
+    // picker filters non-mentionable roles client-side, but a forged
+    // interaction would otherwise bypass the gate — defense-in-depth.
+
+    test('mentionable: false WITHOUT canMentionEveryone → roleMentionsDenied entry, members NOT expanded', () => {
+      const u1 = makeUser('100000000000000001');
+      const u2 = makeUser('100000000000000002');
+      const role = makeRole({
+        id: 'role-admin',
+        members: [{ user: u1 }, { user: u2 }],
+        mentionable: false,
+      });
+      const int = makeMentionableInteraction({ pickedRoles: [role] });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.users).toEqual([]);
+      expect(r.roleMentionsDenied).toEqual(['role-admin']);
+    });
+
+    test('mentionable: false WITH canMentionEveryone → expands normally, no deny', () => {
+      const u1 = makeUser('100000000000000001');
+      const role = makeRole({
+        id: 'role-admin',
+        members: [{ user: u1 }],
+        mentionable: false,
+      });
+      const int = makeMentionableInteraction({ pickedRoles: [role] });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: true });
+      expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+      expect(r.roleMentionsDenied).toEqual([]);
+    });
+
+    test('mentionable: true WITHOUT canMentionEveryone → expands normally (per-role bypass)', () => {
+      const u1 = makeUser('100000000000000001');
+      const role = makeRole({
+        id: 'role-public',
+        members: [{ user: u1 }],
+        mentionable: true,
+      });
+      const int = makeMentionableInteraction({ pickedRoles: [role] });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+      expect(r.roleMentionsDenied).toEqual([]);
+    });
+
+    test('multiple denied roles surface independently (array, not boolean)', () => {
+      const u1 = makeUser('100000000000000001');
+      const u2 = makeUser('100000000000000002');
+      const roleA = makeRole({ id: 'role-a', members: [{ user: u1 }], mentionable: false });
+      const roleB = makeRole({ id: 'role-b', members: [{ user: u2 }], mentionable: false });
+      const int = makeMentionableInteraction({ pickedRoles: [roleA, roleB] });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.roleMentionsDenied.sort()).toEqual(['role-a', 'role-b']);
+      expect(r.users).toEqual([]);
+    });
+
+    test('mix of denied + allowed roles → only denied lands in roleMentionsDenied', () => {
+      const u1 = makeUser('100000000000000001');
+      const u2 = makeUser('100000000000000002');
+      const allowed = makeRole({ id: 'role-allowed', members: [{ user: u1 }], mentionable: true });
+      const denied = makeRole({ id: 'role-denied', members: [{ user: u2 }], mentionable: false });
+      const int = makeMentionableInteraction({ pickedRoles: [allowed, denied] });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.users.map((u) => u.id)).toEqual([u1.id]);
+      expect(r.roleMentionsDenied).toEqual(['role-denied']);
+    });
+
+    test('denied role does NOT increment droppedFromRoles (gate fires before bot filter)', () => {
+      // droppedFromRoles is "bots filtered from picked roles"; a denied
+      // role short-circuits before the bot filter loop runs, so it
+      // contributes 0 to that counter. Pin so a regression that moved
+      // the gate AFTER the bot filter (and double-counted bot members)
+      // surfaces here.
+      const bot = makeUser('100000000000000091', { bot: true });
+      const role = makeRole({
+        id: 'role-denied-bot',
+        members: [{ user: bot }],
+        mentionable: false,
+      });
+      const int = makeMentionableInteraction({ pickedRoles: [role] });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.droppedFromRoles).toBe(0);
+      expect(r.roleMentionsDenied).toEqual(['role-denied-bot']);
+    });
+
+    test('@everyone-role (role.id === guild.id) NOT routed to roleMentionsDenied — uses massMentionDenied', () => {
+      // The @everyone branch above (isEveryoneRole) catches role.id ===
+      // guild.id BEFORE the per-role gate fires, so massMentionDenied
+      // (not roleMentionsDenied) carries the @everyone-specific signal.
+      // A regression that ran the per-role gate FIRST would split the
+      // copy across two surfaces and confuse the user.
+      const int = makeMentionableInteraction({
+        pickedRoles: [[GUILD_ID, { id: GUILD_ID, members: new Map(), mentionable: false }]],
+      });
+      const r = resolveMentionableSelection({ interaction: int, canMentionEveryone: false });
+      expect(r.massMentionDenied).toBe(true);
+      expect(r.roleMentionsDenied).toEqual([]);
+    });
   });
 });
 
@@ -1711,6 +1826,102 @@ describe('handleQurlFile — slash entry', () => {
     // Alice still made it into the recipient list.
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.recipientIds).toEqual([aliceId]);
+  });
+
+  // ── Issue #326 text-path handler tests ──
+  test('text path: <@&roleId> for non-mentionable role WITHOUT MENTION_EVERYONE → warning with role name, no expansion', async () => {
+    // Parser surfaces parsed.roleMentionsDenied with the role ID; the
+    // handler resolves the name via guild.roles.cache.get(id)?.name
+    // and renderRecipientWarnings emits "@<name> requires …" copy.
+    // Pin the end-to-end wiring.
+    const aliceId = '400000000000000010';
+    const bobId = '400000000000000011';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@${aliceId}> <@&7000>` },
+      guildMembers: { [aliceId]: {}, [bobId]: {} },
+    });
+    // Inject role-7000 as non-mentionable with Bob as a member. Without
+    // the gate, Bob would land in recipientIds via role expansion.
+    int.guild.roles.cache.set('7000', {
+      id: '7000',
+      name: 'admin-team',
+      mentionable: false,
+      members: new Map([[bobId, { user: { id: bobId, bot: false } }]]),
+    });
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    // Alice (directly mentioned) IS in recipients; Bob (role member) is NOT.
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.recipientIds).toEqual([aliceId]);
+    const lastEdit = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastEdit.content).toMatch(/@admin-team/);
+    expect(lastEdit.content).toMatch(/Mention Everyone/);
+    expect(lastEdit.content).toMatch(/role\.mentionable: true/);
+  });
+
+  test('text path: every recipient denied-role-only → "no valid recipients" but NOT misleading bot-only log nor transient-retry copy', async () => {
+    // Pin both predicate updates at commands.js (breakdownEmpty,
+    // transientOnly): a recipients string consisting only of denied
+    // <@&roleId> mentions must NOT log the "bot-only-or-self mention
+    // list" signal AND must NOT show "Could not look up recipients
+    // right now. Try again in a moment." copy — both would mislead
+    // the user. Without the `roleMentionsDeniedNames.length === 0`
+    // term in both predicates, a future refactor that drops it
+    // silently regresses to the bot-only log + retry copy.
+    const aliceId = '400000000000000030';
+    const logger = require('../src/logger');
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@&7002>' },
+      guildMembers: { [aliceId]: {} },
+    });
+    int.guild.roles.cache.set('7002', {
+      id: '7002',
+      name: 'private-team',
+      mentionable: false,
+      members: new Map([[aliceId, { user: { id: aliceId, bot: false } }]]),
+    });
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    // Permission-specific copy present.
+    expect(reply.content).toMatch(/@private-team/);
+    expect(reply.content).toMatch(/No valid recipients/);
+    // Transient-retry copy must NOT fire.
+    expect(reply.content).not.toMatch(/Could not look up recipients right now/);
+    // bot-only-or-self log must NOT fire (would mislead operators
+    // analyzing the cap-skew metric).
+    const infoLogCalls = logger.info.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.includes('bot-only-or-self mention list'),
+    );
+    expect(infoLogCalls).toEqual([]);
+  });
+
+  test('text path: <@&roleId> for non-mentionable role WITH MENTION_EVERYONE → expands normally, no warning', async () => {
+    // OR-gate: MENTION_EVERYONE bypasses role.mentionable. Pin the
+    // bypass at the handler boundary (parser-level coverage is in
+    // recipient-parser.test.js).
+    const aliceId = '400000000000000020';
+    const bobId = '400000000000000021';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@&7001>` },
+      guildMembers: { [aliceId]: {}, [bobId]: {} },
+    });
+    int.guild.roles.cache.set('7001', {
+      id: '7001',
+      name: 'admin-team',
+      mentionable: false,
+      members: new Map([
+        [aliceId, { user: { id: aliceId, bot: false } }],
+        [bobId, { user: { id: bobId, bot: false } }],
+      ]),
+    });
+    int.memberPermissions = { has: jest.fn(() => true) };
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+    expect(payload.recipientIds.sort()).toEqual([aliceId, bobId].sort());
+    const lastEdit = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastEdit.content).not.toMatch(/role\.mentionable/);
   });
 
   test('guild context + MENTION_EVERYONE permission → @everyone expands, no warning', async () => {
@@ -2812,6 +3023,7 @@ describe('handleConfirmUserSelect', () => {
     const u3 = '100000000000000003';
     const role = ['role-eng', {
       id: 'role-eng',
+      mentionable: true,
       members: new Map([
         [u2, { user: makeUser(u2) }],
         [u3, { user: makeUser(u3) }],
@@ -2895,6 +3107,7 @@ describe('handleConfirmUserSelect', () => {
     const bot2 = makeUser('100000000000000092', { bot: true });
     const botRole = ['role-bots', {
       id: 'role-bots',
+      mentionable: true,
       members: new Map([[bot1.id, { user: bot1 }], [bot2.id, { user: bot2 }]]),
     }];
     const int = makeSelectInteraction({
@@ -2918,6 +3131,7 @@ describe('handleConfirmUserSelect', () => {
     const senderUser = makeUser(SENDER_ID);
     const senderRole = ['role-sender', {
       id: 'role-sender',
+      mentionable: true,
       members: new Map([[SENDER_ID, { user: senderUser }]]),
     }];
     const int = makeSelectInteraction({
@@ -3043,6 +3257,7 @@ describe('handleConfirmUserSelect', () => {
     const bot1 = makeUser('100000000000000091', { bot: true });
     const mixedRole = ['role-mixed', {
       id: 'role-mixed',
+      mentionable: true,
       members: new Map([[u1.id, { user: u1 }], [bot1.id, { user: bot1 }]]),
     }];
     const int = makeSelectInteraction({
@@ -3065,6 +3280,7 @@ describe('handleConfirmUserSelect', () => {
     const roleBot = makeUser('100000000000000091', { bot: true });
     const botRole = ['role-bots', {
       id: 'role-bots',
+      mentionable: true,
       members: new Map([[roleBot.id, { user: roleBot }]]),
     }];
     const int = makeSelectInteraction({
@@ -3098,6 +3314,115 @@ describe('handleConfirmUserSelect', () => {
         personalMessageRaw: '**hi**',
       }),
     }));
+  });
+
+  // ── Issue #326 picker-path gate (handleConfirmUserSelect wiring) ──
+  test('mentionable picker: non-mentionable role WITHOUT MENTION_EVERYONE → all-invalid banner with role-specific reason', async () => {
+    // Picker-path parallel to the parser-path #326 gate. The role's
+    // members do NOT expand; the all-invalid branch surfaces a
+    // "Non-mentionable role" reason on the rejection banner (NOT
+    // "@everyone" copy — distinct gate, distinct reason).
+    const u1 = makeUser('100000000000000001');
+    const adminRole = ['role-admin', {
+      id: 'role-admin',
+      name: 'admin',
+      mentionable: false,
+      members: new Map([[u1.id, { user: u1 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [adminRole],
+      canMentionEveryone: false,
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/Non-mentionable role/i);
+    expect(updated.content).toMatch(/Mention Everyone/);
+    // Resource header survives — preserved-context contract.
+    expect(updated.content).toMatch(/Sending file/);
+  });
+
+  test('mentionable picker: non-mentionable role + valid user pick → partial-valid, warnings block lists role NAME', async () => {
+    // Mixed pick: a directly-picked user lands in recipients (flow
+    // advances), but the denied role surfaces in the warnings block
+    // with its NAME (per-role copy from renderRecipientWarnings). Pin
+    // the name resolution so a regression that dropped guild.roles.cache
+    // -> name fallback would surface here.
+    const u1 = makeUser('100000000000000001');
+    const u2 = makeUser('100000000000000002');
+    const adminRole = ['role-admin', {
+      id: 'role-admin',
+      name: 'admin-team',
+      mentionable: false,
+      members: new Map([[u2.id, { user: u2 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [u1],
+      roles: [adminRole],
+      canMentionEveryone: false,
+    });
+    // Mirror the picked role into guild.roles.cache so the caller's
+    // name lookup (`guild.roles.cache.get(id)?.name`) finds it.
+    int.guild.roles.cache.set('role-admin', { id: 'role-admin', name: 'admin-team', mentionable: false });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    // u2 (role member) NOT expanded; u1 (directly picked) IS.
+    expect(mockTransitionFlow.mock.calls[0][2].payload.recipientIds).toEqual([u1.id]);
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(updated.content).toMatch(/@admin-team/);
+    expect(updated.content).toMatch(/Mention Everyone/);
+    expect(updated.content).toMatch(/role\.mentionable: true/);
+  });
+
+  test('mentionable picker: denied role with deleted-from-cache name → fallback "unknown-role" renders', async () => {
+    // Race condition: role denied at resolveMentionableSelection time
+    // but removed from guild.roles.cache before renderRecipientWarnings
+    // (e.g., admin deleted the role mid-flow). `guild.roles.cache.get
+    // (id)?.name` returns undefined; caller falls back to
+    // "unknown-role" so the bullet renders rather than collapsing
+    // to `@undefined`.
+    const u1 = makeUser('100000000000000001');
+    const denied = ['role-ghost', {
+      id: 'role-ghost',
+      name: 'ghost',
+      mentionable: false,
+      members: new Map(),
+    }];
+    const int = makeSelectInteraction({
+      users: [u1],
+      roles: [denied],
+      canMentionEveryone: false,
+    });
+    // Picker registers the role, but guild.roles.cache stays empty
+    // (the role was deleted from the guild between pick and render).
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const updated = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    // Fallback name appears in the bullet so the user still sees the
+    // permission copy rather than a broken `@undefined` line.
+    expect(updated.content).toMatch(/@unknown-role/);
+  });
+
+  test('mentionable picker: non-mentionable role + canMentionEveryone → expands normally (no deny)', async () => {
+    // The gate is OR-ed: MENTION_EVERYONE permission bypasses the
+    // role.mentionable check. Pin the bypass — without it, even an
+    // admin couldn't pick a non-mentionable role through the picker.
+    const u1 = makeUser('100000000000000001');
+    const role = ['role-admin', {
+      id: 'role-admin',
+      name: 'admin',
+      mentionable: false,
+      members: new Map([[u1.id, { user: u1 }]]),
+    }];
+    const int = makeSelectInteraction({
+      users: [],
+      roles: [role],
+      canMentionEveryone: true,
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    expect(mockTransitionFlow.mock.calls[0][2].payload.recipientIds).toEqual([u1.id]);
   });
 });
 

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -1090,6 +1090,42 @@ describe('parseRecipientMentions — result-shape contract', () => {
       'roleMentionsDenied',
     ]);
   });
+
+  test('invariant: ids and roleMentionsDenied are always disjoint (gate fires before consider())', () => {
+    // Cross-cutting invariant pin: members of a denied role never
+    // contribute to `ids` because the `role.mentionable !== true &&
+    // !allowMassMention` gate short-circuits BEFORE the `consider()`
+    // calls on role members. A regression that hoisted role-member
+    // iteration above the gate (or swapped the order of the per-
+    // role gate and the `for (const [memberId, ...])` loop) would
+    // surface here.
+    //
+    // Mixed scenario: one allowed role + one denied role sharing a
+    // common-id member. The shared member appears in `ids` via the
+    // allowed role; the denied role still surfaces in
+    // `roleMentionsDenied`. Crucially, the denied role's
+    // exclusive member (101) must NOT appear in `ids`.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {}, '103': {} },
+      roles: {
+        '7000': { members: ['102', '103'], mentionable: true },   // allowed
+        '7001': { members: ['101', '103'], mentionable: false },  // denied; 103 also in allowed role
+      },
+    });
+    const res = parseRecipientMentions('<@&7000> <@&7001>', int, { allowMassMention: false });
+    expect(res.roleMentionsDenied).toEqual(['7001']);
+    // 101 (denied-role-exclusive) must NOT leak into ids.
+    expect(res.ids).not.toContain('101');
+    // Disjointness: no member-ID from the denied-role leaks into ids
+    // (even if the denied-role's IDs were Set member ids, they're
+    // distinct identifier semantics — denied list holds role ids,
+    // ids holds user ids — but we pin the structural invariant: no
+    // overlap between denied-role-EXCLUSIVE members and ids).
+    const deniedExclusive = ['101'];  // 103 is in both roles
+    for (const id of deniedExclusive) {
+      expect(res.ids).not.toContain(id);
+    }
+  });
 });
 
 describe('parseRecipientMentions — invalid tokens', () => {

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -492,6 +492,39 @@ describe('parseRecipientMentions — role-mention permission gate (#326)', () =>
     expect(res.invalidTokens).toEqual([]);
   });
 
+  test('`@everyone` text token + <@&{guildId}> wire form together → idempotent (single semantic action, no double-count)', () => {
+    // Both forms map to the same @everyone semantic. Pin that they
+    // converge on a single state — `everyonePresent: true` (allowed
+    // path) and `massMentionDenied: true` (denied path) — without
+    // double-counting or splitting copy across surfaces. A regression
+    // that routed one form through a different channel would surface
+    // here. Allowed-path: @everyone expansion fires ONCE (members
+    // appear once in ids); denied-path: massMentionDenied is just a
+    // boolean so set-once is the natural shape, but the per-occurrence
+    // member expansion still must not happen.
+    const allowedInt = makeInteraction({
+      guildId: '999',
+      users: { '101': {}, '102': {} },
+    });
+    const allowedRes = parseRecipientMentions('@everyone <@&999>', allowedInt, { allowMassMention: true });
+    expect(allowedRes.ids.sort()).toEqual(['101', '102']);
+    expect(allowedRes.massMentionDenied).toBe(false);
+    expect(allowedRes.roleMentionsDenied).toEqual([]);
+
+    const deniedInt = makeInteraction({
+      guildId: '999',
+      users: { '101': {}, '102': {} },
+    });
+    const deniedRes = parseRecipientMentions('@everyone <@&999>', deniedInt, { allowMassMention: false });
+    expect(deniedRes.ids).toEqual([]);
+    expect(deniedRes.massMentionDenied).toBe(true);
+    expect(deniedRes.roleMentionsDenied).toEqual([]);
+    // Neither form should land in invalidTokens — the dedicated
+    // @everyone channel handles both, and neither leaks to the
+    // "couldn't parse" residue path.
+    expect(deniedRes.invalidTokens).toEqual([]);
+  });
+
   test('<@&{guildId}> with allowMassMention → triggers @everyone expansion via guild.members.cache', () => {
     // Parity with the picker path: when allowed, the @everyone-role
     // wire form expands through guild.members.cache (NOT role.members)

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -34,12 +34,25 @@ const {
 const logger = require('../src/logger');
 
 // Build a synthetic interaction with the cache shape the parser reads.
-// Pass `users` as { id → { bot } } and `roles` as
-// { id → [member_id, member_id, ...] }. Sender defaults to '900000000000000001'.
+// Pass `users` as { id → { bot } }. Sender defaults to '900000000000000001'.
+//
+// `roles` accepts two shapes per entry:
+//   array form  → `{ '7000': ['101', '102'] }` (members; defaults to
+//                 `mentionable: true` so the #326 gate doesn't reject
+//                 the existing test corpus — prod-side roles MUST set
+//                 `mentionable: true` to bypass the gate without
+//                 MENTION_EVERYONE).
+//   object form → `{ '7000': { members: [...], mentionable: false } }`
+//                 (opt in to non-mentionable for #326-gate tests).
+//
+// `guildId` is the guild's snowflake (defaults to undefined to match
+// existing tests' shape). Set to make `<@&{guildId}>` route through
+// the @everyone-role wire-form guard.
+//
 // IDs are all-numeric to match real Discord snowflakes — the parser's
 // regex is `/<@!?(\d+)>/` so letter-prefixed test fixtures would silently
 // drop every mention, masking real coverage.
-function makeInteraction({ senderId = '900000000000000001', users = {}, roles = {}, channels = {} } = {}) {
+function makeInteraction({ senderId = '900000000000000001', users = {}, roles = {}, channels = {}, guildId } = {}) {
   const memberCache = new Map();
   for (const [id, attrs] of Object.entries(users)) {
     memberCache.set(id, { user: { id, bot: !!attrs.bot } });
@@ -49,14 +62,17 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
   // honor. Add the member to the cache when it's listed under a role
   // so the bot filter has something to look up.
   const roleCache = new Map();
-  for (const [roleId, memberIds] of Object.entries(roles)) {
+  for (const [roleId, spec] of Object.entries(roles)) {
+    const isObjectSpec = spec && typeof spec === 'object' && !Array.isArray(spec);
+    const memberIds = isObjectSpec ? (spec.members || []) : spec;
+    const mentionable = isObjectSpec ? spec.mentionable !== false : true;
     const roleMembers = new Map();
     for (const mid of memberIds) {
       const existing = memberCache.get(mid) ?? { user: { id: mid, bot: false } };
       memberCache.set(mid, existing);
       roleMembers.set(mid, existing);
     }
-    roleCache.set(roleId, { members: roleMembers });
+    roleCache.set(roleId, { id: roleId, name: `role-${roleId}`, members: roleMembers, mentionable });
   }
   // Channel shape: { id → { type, members: [id, ...], viewable? } }
   //   type     numeric ChannelType (2 = GuildVoice, 13 = GuildStageVoice;
@@ -96,6 +112,7 @@ function makeInteraction({ senderId = '900000000000000001', users = {}, roles = 
     user: { id: senderId },
     member: { id: senderId },
     guild: {
+      id: guildId,
       members: { cache: memberCache },
       roles: { cache: roleCache },
       channels: { cache: channelCache },
@@ -370,6 +387,139 @@ describe('parseRecipientMentions — role mentions', () => {
     const res = parseRecipientMentions('<@&7000> <@&7000> <@&7000>', int);
     expect(res.ids.sort()).toEqual(['101', '102']);
     expect(res.invalidTokens).toEqual([]);
+  });
+});
+
+describe('parseRecipientMentions — role-mention permission gate (#326)', () => {
+  // Issue #326 parity: <@&roleId> for a non-mentionable role requires
+  // MENTION_EVERYONE (allowMassMention). Mirrors Discord's in-chat
+  // gate; closes the privilege-escalation surface where a non-admin
+  // could `/qurl file recipients:<@&adminRoleId>` to fan-out to an
+  // admin-only role.
+
+  test('mentionable: false WITHOUT allowMassMention → roleMentionsDenied entry, NOT expanded', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+      roles: { '7000': { members: ['101', '102'], mentionable: false } },
+    });
+    const res = parseRecipientMentions('<@&7000>', int, { allowMassMention: false });
+    expect(res.ids).toEqual([]);
+    expect(res.roleMentionsDenied).toEqual(['7000']);
+    // NOT in invalidTokens — distinct surface lets the caller emit
+    // permission-specific copy instead of "couldn't parse."
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('mentionable: false WITH allowMassMention → expands normally, no deny', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+      roles: { '7000': { members: ['101', '102'], mentionable: false } },
+    });
+    const res = parseRecipientMentions('<@&7000>', int, { allowMassMention: true });
+    expect(res.ids.sort()).toEqual(['101', '102']);
+    expect(res.roleMentionsDenied).toEqual([]);
+  });
+
+  test('mentionable: true WITHOUT allowMassMention → expands normally (per-role bypass)', () => {
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+      roles: { '7000': { members: ['101', '102'], mentionable: true } },
+    });
+    const res = parseRecipientMentions('<@&7000>', int, { allowMassMention: false });
+    expect(res.ids.sort()).toEqual(['101', '102']);
+    expect(res.roleMentionsDenied).toEqual([]);
+  });
+
+  test('multiple denied roles surface independently (array, not boolean)', () => {
+    // Per issue spec: a single send can attempt MULTIPLE denied roles —
+    // surface each ID so the caller renders per-role copy with the name.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {}, '201': {}, '202': {} },
+      roles: {
+        '7000': { members: ['101', '102'], mentionable: false },
+        '7001': { members: ['201', '202'], mentionable: false },
+      },
+    });
+    const res = parseRecipientMentions('<@&7000> <@&7001>', int, { allowMassMention: false });
+    expect(res.roleMentionsDenied.sort()).toEqual(['7000', '7001']);
+    expect(res.ids).toEqual([]);
+  });
+
+  test('repeated denied role mention dedupes (one entry, not three)', () => {
+    // Same dedupe pattern as invalidRoleIds (`<@&999> <@&999>` →
+    // one invalidTokens entry). A naive matchAll loop would push the
+    // raw ID per occurrence; the parallel Set guards against that.
+    const int = makeInteraction({
+      users: { '101': {} },
+      roles: { '7000': { members: ['101'], mentionable: false } },
+    });
+    const res = parseRecipientMentions('<@&7000> <@&7000> <@&7000>', int, { allowMassMention: false });
+    expect(res.roleMentionsDenied).toEqual(['7000']);
+  });
+
+  test('mix of denied + allowed roles in one input → only denied lands in roleMentionsDenied', () => {
+    // Cohabitation: a mentionable role still expands while the
+    // non-mentionable peer surfaces as denied. Without per-role
+    // gating, a single denied role would either zero out the whole
+    // send or silently expand alongside the allowed role.
+    const int = makeInteraction({
+      users: { '101': {}, '201': {} },
+      roles: {
+        '7000': { members: ['101'], mentionable: true },     // allowed
+        '7001': { members: ['201'], mentionable: false },    // denied
+      },
+    });
+    const res = parseRecipientMentions('<@&7000> <@&7001>', int, { allowMassMention: false });
+    expect(res.ids).toEqual(['101']);
+    expect(res.roleMentionsDenied).toEqual(['7001']);
+  });
+
+  test('<@&{guildId}> wire form routes to massMentionDenied (NOT roleMentionsDenied)', () => {
+    // The @everyone role's ID equals guild.id. The wire form should
+    // land in massMentionDenied so the caller emits "@everyone
+    // requires Mention Everyone" copy, NOT the per-role copy. This
+    // matches the picker path's `isEveryoneRole` short-circuit.
+    const int = makeInteraction({
+      guildId: '999',
+      users: { '101': {} },
+      roles: { '7000': { members: ['101'], mentionable: true } },
+    });
+    const res = parseRecipientMentions('<@&999>', int, { allowMassMention: false });
+    expect(res.massMentionDenied).toBe(true);
+    expect(res.roleMentionsDenied).toEqual([]);
+    // NOT in invalidTokens either — explicit-route to the @everyone
+    // channel means no "couldn't parse" leak.
+    expect(res.invalidTokens).toEqual([]);
+  });
+
+  test('<@&{guildId}> with allowMassMention → triggers @everyone expansion via guild.members.cache', () => {
+    // Parity with the picker path: when allowed, the @everyone-role
+    // wire form expands through guild.members.cache (NOT role.members)
+    // because discord.js's @everyone role.members is unreliable. Pin
+    // the routing: `everyonePresent` flag fires, dedicated expansion
+    // pass walks the member cache.
+    const int = makeInteraction({
+      guildId: '999',
+      users: { '101': {}, '102': {}, '801': { bot: true } },
+    });
+    const res = parseRecipientMentions('<@&999>', int, { allowMassMention: true });
+    expect(res.massMentionDenied).toBe(false);
+    expect(res.roleMentionsDenied).toEqual([]);
+    expect(res.ids.sort()).toEqual(['101', '102']);
+  });
+
+  test('denied-role does NOT contaminate cappedCount (skipped before consider())', () => {
+    // The gate fires BEFORE the role-loop's `consider()` calls, so
+    // a denied role's members never enter `seen`. A regression that
+    // hoisted the dedupe-add above the gate would inflate cappedCount
+    // by the denied role's size — caller would surface a misleading
+    // "you typed 50, we kept 25" warning.
+    const int = makeInteraction({
+      users: { '101': {}, '102': {} },
+      roles: { '7000': { members: ['101', '102'], mentionable: false } },
+    });
+    const res = parseRecipientMentions('<@&7000>', int, { allowMassMention: false });
+    expect(res.cappedCount).toBe(0);
   });
 });
 
@@ -890,11 +1040,11 @@ describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
 });
 
 describe('parseRecipientMentions — result-shape contract', () => {
-  test('result shape pins exactly four keys (ids, invalidTokens, cappedCount, massMentionDenied)', () => {
+  test('result shape pins exactly five keys (ids, invalidTokens, cappedCount, massMentionDenied, roleMentionsDenied)', () => {
     // Empire of `.toMatchObject` in other tests admits new fields by
     // design (the result shape is allowed to grow), but the closed
     // set of CURRENT keys is load-bearing — callers destructure these
-    // names. Pin the closed set so a future PR that adds a 5th field
+    // names. Pin the closed set so a future PR that adds a 6th field
     // surfaces here intentionally rather than slipping past
     // partial-match assertions.
     const int = makeInteraction({ users: { '111': {} } });
@@ -904,6 +1054,7 @@ describe('parseRecipientMentions — result-shape contract', () => {
       'ids',
       'invalidTokens',
       'massMentionDenied',
+      'roleMentionsDenied',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #326. Privilege-escalation parity fix: PR #323 gated `@everyone` text mentions on MENTION_EVERYONE, but `<@&roleId>` role expansion still expanded non-mentionable roles unconditionally. A non-admin could `/qurl file recipients:<@&adminRoleId>` to fan a send to admin-role members (bounded by the 25-recipient cap, but still a privilege-escalation surface).

This change adds the same gate Discord enforces for in-chat role mentions: `role.mentionable === true` OR sender has MENTION_EVERYONE.

## Motivation

Before this change, the bot bypassed both gates that protect non-mentionable roles in normal Discord chat. The `@everyone` gate (#323) closed the easy surface; this PR closes the parallel surface where a non-admin lists `<@&adminRoleId>` directly in the `recipients:` slash option.

## Changes

**Parser path (`recipient-parser.js`)**
- New `roleMentionsDenied: string[]` return field (array because one send can attempt multiple denied roles).
- Role-mention loop gates on `role.mentionable !== true && !allowMassMention` BEFORE the bot-filter / role.members iteration — denied roles never contribute to `seen` (cappedCount stays accurate).
- `<@&{guildId}>` (Discord's @everyone-role wire form) is now routed through the existing `@everyone` channel (massMentionDenied/everyonePresent), matching the picker path's `isEveryoneRole` short-circuit. Avoids splitting @everyone copy across two warning surfaces.

**Picker path (`commands.js resolveMentionableSelection`)**
- Same gate added for non-@everyone roles. Issue spec scopes #326 to text path only ("Discord's picker filters this client-side"), but that filter is client-side only — a forged interaction or a future client-filter regression would bypass it. The existing TODO at `commands.js:2814` already tracked picker as #326, so this PR closes both surfaces in lockstep.
- New `roleMentionsDenied: string[]` in the return shape.

**UI surfaces (`renderRecipientWarnings` + all-invalid reasons builder)**
- New `roleMentionsDeniedNames` param (helper stays pure — caller does the guild→name resolution via new `resolveRoleNames(guild, ids)` with `'unknown-role'` fallback for deleted-mid-flow races).
- Bullet copy per denied role: `` `@<roleName>` requires the **Mention Everyone** permission or `role.mentionable: true` — skipped. ``
- Role-name sanitization matches the `invalidTokens` path: `sliceWithEllipsis` + backtick strip via a shared `sanitizeForBullet` local (admin-controlled string treated as untrusted for rendering).
- All-invalid rejection banner uses condensed copy (count, not per-role) to keep the banner scannable; per-role bullets live in the warnings block. Singular/plural noun + verb stay in lockstep (`role requires` vs `roles require`).
- `breakdownEmpty` and `transientOnly` predicates updated to include `roleMentionsDeniedNames.length === 0` so denied-role-only sends don't log a misleading "bot-only-or-self mention list" signal or render transient-retry copy.
- **Banner reason ordering reshuffle:** the all-invalid banner's `reasons` array was previously `bots → massMentionDenied → droppedFromRoles → everyoneCacheCold`. Reordered to `bots → droppedFromRoles → everyoneCacheCold → massMentionDenied → roleMentionsDenied` to match `renderRecipientWarnings`'s bullet ordering — pinned by a multi-signal banner test. **User-visible change** for the rare multi-signal pick (bots + @everyone-denied surfaces `bots` first now, not `@everyone-denied`); intentional, documented in the docstring's COPY PARITY note.

## Tests

+23 new tests across the two test files (1553 passing total). Covers:

- All three acceptance-criteria scenarios (denied without perm, allowed with perm, mentionable: true bypass) on BOTH paths.
- `<@&{guildId}>` wire form routes to `massMentionDenied`, not `roleMentionsDenied`.
- `@everyone` text + `<@&{guildId}>` wire form together → idempotent (single semantic action).
- Multi-role denied dedup (array, not boolean).
- Mix of denied + allowed roles in one input.
- Cache-miss + empty-name role-name fallback (`unknown-role` placeholder).
- Result-shape pinning (5 keys parser, 5 keys picker) — closed-set pin so future fields surface intentionally.
- `breakdownEmpty`/`transientOnly` predicate regressions: denied-role-only send must NOT log bot-only signal or render transient-retry copy.
- Singular vs plural noun-verb agreement in banner copy.
- Banner reason ordering parity with warnings-block bullet ordering.
- `ids` and `roleMentionsDenied` disjointness invariant (gate-fires-before-consider).
- Undefined-role short-circuit on picker path (partial-fetch defense).
- `resolveRoleNames` closed contract (6 cases: null/empty ids, null guild, hit, miss, empty-name, mixed batch).

Test fixtures (`makeInteraction` in parser tests, `makeRole`/`makeMentionableInteraction` in picker tests) default `mentionable: true` so the existing 1500+ test corpus continues to pass. Follow-up #348 tracks tightening this default.

## Simplify pass

Applied across multiple rounds:
- Extracted `resolveRoleNames(guild, ids)` to share the cache-lookup-with-fallback between text-path and picker-path call sites.
- Routed role-name rendering through `sliceWithEllipsis` + backtick strip via a shared `sanitizeForBullet` local in `renderRecipientWarnings` (matches `invalidTokens` sanitization).
- Hoisted `WARNING_LIST_DISPLAY_MAX` (10) + `WARNING_NAME_CODEPOINT_CAP` (80) to module-scope constants — shared between `invalidTokens` and `roleMentionsDeniedNames` bullet paths.

Skipped: generalizing `pushInvalidIfNew` to share dedup with `roleMentionsDenied`. The two paths share the dedup shape but not the value semantic — `invalidTokens` pushes raw token text (`m[0]`), `roleMentionsDenied` pushes role ID. Merging would force the role path to fake a "token" value.

## Follow-ups

- #344: text-path send doesn't emit `role_mentions_denied` counter the way picker-path does — pre-existing pattern asymmetry from #323, out of scope here.
- #348: test fixture defaults `mentionable: true` silently bypass the gate in future tests — hygiene improvement.

## Test plan

- [x] All 1553 unit + handler tests pass locally (`npx jest`)
- [x] eslint clean
- [x] CI green on the PR
- [x] cr feedback addressed across 8 rounds (incl. nits)