### PR TITLE
feat(slack): add /qurl setalias and /qurl unsetalias verbs (rewrite of #230 for net/http)

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -179,9 +179,12 @@ type Handler struct {
 
 // SetAliasStore wires the per-channel alias persistence surface into
 // the /qurl setalias / /qurl unsetalias verbs. Must be called before
-// srv.Serve — the field is read on the request hot path without
+// `srv.Serve` — the field is read on the request hot path without
 // synchronization, and the only safe write window is before any
-// goroutine can observe it.
+// goroutine can observe it. The panic-on-double-wiring below catches
+// accidental double-`SetAliasStore(realStore)` in init code; it is
+// NOT a synchronization primitive, and calling this from a running
+// handler is undefined regardless of the panic.
 //
 // Calling with nil is a no-op for the field (the verbs will reply
 // with a "not configured" ephemeral) so cmd/main.go can omit the

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -178,16 +178,24 @@ type Handler struct {
 }
 
 // SetAliasStore wires the per-channel alias persistence surface into
-// the /qurl setalias / /qurl unsetalias verbs. Must be called exactly
-// once, before srv.Serve. nil is a no-op (the verbs will reply with
-// a "not configured" ephemeral) so cmd/main.go can omit the call on
-// sandbox deploys that haven't onboarded the slackdata package yet.
-// A second non-nil call panics — the field is read on the request
-// hot path without synchronization, and the only safe write window
-// is before any goroutine can observe it.
+// the /qurl setalias / /qurl unsetalias verbs. Must be called before
+// srv.Serve — the field is read on the request hot path without
+// synchronization, and the only safe write window is before any
+// goroutine can observe it.
+//
+// Calling with nil is a no-op for the field (the verbs will reply
+// with a "not configured" ephemeral) so cmd/main.go can omit the
+// call on sandbox deploys that haven't onboarded the slackdata
+// package yet — and a defensive `SetAliasStore(nil)` followed by a
+// real wiring later is fine. Calling with a non-nil store after the
+// field is already non-nil panics, so the real store can't be
+// silently swapped under a running handler.
 func (h *Handler) SetAliasStore(store AliasStore) {
+	if store == nil {
+		return
+	}
 	if h.aliasStore != nil {
-		panic("SetAliasStore called twice — must be called once before Serve")
+		panic("SetAliasStore called twice with a non-nil store — must be wired once before Serve")
 	}
 	h.aliasStore = store
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -186,10 +186,13 @@ type Handler struct {
 // Calling with nil is a no-op for the field (the verbs will reply
 // with a "not configured" ephemeral) so cmd/main.go can omit the
 // call on sandbox deploys that haven't onboarded the slackdata
-// package yet — and a defensive `SetAliasStore(nil)` followed by a
-// real wiring later is fine. Calling with a non-nil store after the
-// field is already non-nil panics, so the real store can't be
-// silently swapped under a running handler.
+// package yet. Both directions of the nil/non-nil sequence are
+// allowed: a defensive `SetAliasStore(nil)` followed by a real
+// wiring later is fine, and a real wiring followed by a defensive
+// `SetAliasStore(nil)` is also a no-op (the real store stays wired).
+// Calling with a non-nil store after the field is already non-nil
+// panics, so the real store can't be silently swapped under a
+// running handler.
 func (h *Handler) SetAliasStore(store AliasStore) {
 	if store == nil {
 		return

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -138,6 +138,13 @@ type Handler struct {
 	// missing env vars) — /qurl setup returns a "not configured"
 	// ephemeral in that case rather than minting a useless link.
 	oauthSetup *oauth.SetupConfig
+	// aliasStore persists per-channel alias bindings for the
+	// `/qurl setalias` / `/qurl unsetalias` verbs. nil when not
+	// configured (sandbox / pre-#231/#233 deploys) — handlers fail
+	// fast with an operator-visible ephemeral rather than silently
+	// dropping the write. See handler_alias.go for the interface
+	// shape and the schema-gap rationale.
+	aliasStore AliasStore
 	// baseCtx is captured at NewHandler time from cfg.BaseContext (or
 	// context.Background()). Each async goroutine derives a
 	// context.WithTimeout(baseCtx, asyncWorkTimeout) — canceling baseCtx
@@ -168,6 +175,21 @@ type Handler struct {
 	// returned value, which is the SSRF-sanitization pattern CodeQL's
 	// taint analysis recognizes.
 	validateResponseURLFn func(string) (*url.URL, error)
+}
+
+// SetAliasStore wires the per-channel alias persistence surface into
+// the /qurl setalias / /qurl unsetalias verbs. Must be called exactly
+// once, before srv.Serve. nil is a no-op (the verbs will reply with
+// a "not configured" ephemeral) so cmd/main.go can omit the call on
+// sandbox deploys that haven't onboarded the slackdata package yet.
+// A second non-nil call panics — the field is read on the request
+// hot path without synchronization, and the only safe write window
+// is before any goroutine can observe it.
+func (h *Handler) SetAliasStore(store AliasStore) {
+	if h.aliasStore != nil {
+		panic("SetAliasStore called twice — must be called once before Serve")
+	}
+	h.aliasStore = store
 }
 
 // SetOAuthSetup wires the per-workspace OAuth configuration into the
@@ -472,6 +494,13 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 		// falls through to the unknown-subcommand branch and gets a
 		// help nudge.
 		h.handleList(w, values)
+	case text == "setalias" || strings.HasPrefix(text, "setalias "):
+		// Bare `setalias` falls through too — parseAliasArgs renders
+		// the usage hint, so the user gets the right grammar without
+		// a separate "missing args" branch here.
+		h.handleSetAlias(w, values)
+	case text == "unsetalias" || strings.HasPrefix(text, "unsetalias "):
+		h.handleUnsetAlias(w, values)
 	default:
 		// Surfaced to telemetry so a workspace using a stale slash-command
 		// spec is visible in dashboards (rather than only via user reports).
@@ -580,6 +609,8 @@ func helpMessage() string {
 • ` + "`/qurl setup`" + ` — Connect qURL to your Slack workspace (workspace admin only)
 • ` + "`/qurl create <url>`" + ` — Create a qURL for the given URL
 • ` + "`/qurl list`" + ` — Show your 5 most recent qURLs
+• ` + "`/qurl setalias $<alias> <url-or-resource-id>`" + ` — Bind an alias to this channel (admin only)
+• ` + "`/qurl unsetalias $<alias>`" + ` — Clear this channel's alias (admin only)
 • ` + "`/qurl help`" + ` — Show this help message`
 }
 

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -185,6 +185,40 @@ func requireAlias(tok string) (alias, userMsg string) {
 	return alias, ""
 }
 
+// aliasPreamble is the shared prelude for both alias verbs after
+// argument parsing: pull team_id + channel_id off the form, verify
+// the AliasStore is wired, and set up the worker context. Returns
+// (ctx, cancel, teamID, channelID, ok); on !ok the helper has
+// already written the user-facing response and the caller must
+// return without dialing the store. cancel is always callable
+// (no-op when !ok) so caller-side `defer cancel()` is unconditional.
+func (h *Handler) aliasPreamble(w http.ResponseWriter, values url.Values, verb string) (ctx context.Context, cancel context.CancelFunc, teamID, channelID string, ok bool) {
+	cancel = func() {}
+	teamID = strings.TrimSpace(values.Get(fieldTeamID))
+	channelID = strings.TrimSpace(values.Get(fieldChannelID))
+	if teamID == "" || channelID == "" {
+		// Slack always sends these on a slash-command payload; the
+		// guard catches a malformed test fixture or a future
+		// regression in form parsing rather than silently writing a
+		// row with empty keys.
+		slog.Warn("alias verb missing team_id or channel_id", "verb", verb, "team_id_present", teamID != "", "channel_id_present", channelID != "")
+		respondSlack(w, "Could not read your Slack workspace or channel ID from the command payload.")
+		return
+	}
+	if h.aliasStore == nil {
+		// Soft-fail when AliasStore is not configured (sandbox /
+		// pre-#231/#233 deploys). Surfacing a configuration error
+		// rather than silently dropping makes the bot's state
+		// debuggable from the operator side.
+		slog.Warn("alias verb invoked with no AliasStore wired — refusing", "verb", verb)
+		respondSlack(w, "Alias storage is not configured on this Slack bot deployment. Contact the operator.")
+		return
+	}
+	ctx, cancel = context.WithTimeout(h.baseCtx, asyncWorkTimeout)
+	ok = true
+	return
+}
+
 // handleSetAlias routes `/qurl setalias $<alias> <target>`.
 //
 // **Admin restriction:** This handler is admin-gated at the Slack app
@@ -214,29 +248,10 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 		return
 	}
 
-	teamID := strings.TrimSpace(values.Get(fieldTeamID))
-	channelID := strings.TrimSpace(values.Get(fieldChannelID))
-	if teamID == "" || channelID == "" {
-		// Slack always sends these on a slash-command payload; the
-		// guard catches a malformed test fixture or a future
-		// regression in form parsing rather than silently writing a
-		// row with empty keys.
-		slog.Warn("setalias missing team_id or channel_id", "team_id_present", teamID != "", "channel_id_present", channelID != "")
-		respondSlack(w, "Could not read your Slack workspace or channel ID from the command payload.")
+	ctx, cancel, teamID, channelID, ok := h.aliasPreamble(w, values, "setalias")
+	if !ok {
 		return
 	}
-
-	if h.aliasStore == nil {
-		// Soft-fail when AliasStore is not configured (sandbox /
-		// pre-#231/#233 deploys). Surfacing a configuration error
-		// rather than silently dropping makes the bot's state
-		// debuggable from the operator side.
-		slog.Warn("setalias invoked with no AliasStore wired — refusing")
-		respondSlack(w, "Alias storage is not configured on this Slack bot deployment. Contact the operator.")
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(h.baseCtx, asyncWorkTimeout)
 	defer cancel()
 
 	existingAlias, existingRID, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)
@@ -295,21 +310,10 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 		return
 	}
 
-	teamID := strings.TrimSpace(values.Get(fieldTeamID))
-	channelID := strings.TrimSpace(values.Get(fieldChannelID))
-	if teamID == "" || channelID == "" {
-		slog.Warn("unsetalias missing team_id or channel_id", "team_id_present", teamID != "", "channel_id_present", channelID != "")
-		respondSlack(w, "Could not read your Slack workspace or channel ID from the command payload.")
+	ctx, cancel, teamID, channelID, ok := h.aliasPreamble(w, values, "unsetalias")
+	if !ok {
 		return
 	}
-
-	if h.aliasStore == nil {
-		slog.Warn("unsetalias invoked with no AliasStore wired — refusing")
-		respondSlack(w, "Alias storage is not configured on this Slack bot deployment. Contact the operator.")
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(h.baseCtx, asyncWorkTimeout)
 	defer cancel()
 
 	existingAlias, _, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -14,40 +14,47 @@ import (
 
 // AliasStore is the persistence surface the alias verbs depend on.
 //
-// One alias is bound per (slack_team_id, slack_channel_id) row by
-// design — this matches the post-pivot channel_policies table shape
-// owned by qurl-bot-slack-side terraform (modules/qurl-slack-ddb,
-// SLACK_QURL_ROLLOUT.md 2026-05-12 architectural update). A small
-// interface here rather than a direct dep on the slackdata package
-// keeps this PR shippable against main even while #231/#233's
-// slackdata pivot rework is in flight; the eventual store satisfies
-// the same shape.
+// Many aliases may be bound to a single (slack_team_id,
+// slack_channel_id) row concurrently — the channel_policies table
+// carries an app-managed `alias_bindings: Map<alias_name,
+// resource_id>` attribute so a channel can host `$grafana`,
+// `$staging-db`, `$logs` etc. simultaneously, each pointing at a
+// distinct resource. A small interface here rather than a direct dep
+// on the slackdata package keeps this PR shippable against main even
+// while #231/#233's slackdata pivot rework is in flight; the eventual
+// store satisfies the same shape.
 //
-// **Schema gap (out-of-scope here):** the pre-pivot UX promised
-// multiple aliases per channel, but the post-pivot row carries a
-// single alias attribute per (team, channel). The right fix is a
-// schema reshape (per-alias SK, or an `aliases` SS attribute) tracked
-// separately — see qurl-integrations #233's comment thread. The
-// verbs here intentionally enforce one-alias-per-channel and surface
-// the existing-different-alias case with a refusal message asking
-// the operator to `unsetalias` first, so the remediation lands at
-// the schema layer rather than papered over in the handler.
+// Schema decision locked 2026-05-17: app-managed Map attribute on the
+// existing PK/SK; no GSI, no SK reshape, no data migration (the table
+// is empty pending Slack bot sandbox deploy).
 type AliasStore interface {
-	// LookupChannelAlias returns the (alias, resourceID) pair bound to
-	// (teamID, channelID), or ErrAliasNotFound if no alias is set.
-	LookupChannelAlias(ctx context.Context, teamID, channelID string) (alias, resourceID string, err error)
-	// SetChannelAlias upserts the alias→resourceID binding on
-	// (teamID, channelID). Replaces any prior alias on the row.
-	SetChannelAlias(ctx context.Context, teamID, channelID, alias, resourceID string) error
-	// ClearChannelAlias removes the alias binding on (teamID, channelID).
-	// Returns ErrAliasNotFound if there was no alias to clear.
-	ClearChannelAlias(ctx context.Context, teamID, channelID string) error
+	// BindChannelAlias atomically binds aliasName→resourceID on
+	// (teamID, channelID). Implementations issue a DynamoDB UpdateItem
+	// `SET alias_bindings.#a = :rid` with
+	// `ConditionExpression: attribute_not_exists(alias_bindings.#a)` so
+	// a duplicate alias name in the same channel returns
+	// ErrAliasAlreadyBound rather than overwriting a teammate's
+	// binding. Other aliases on the same channel are untouched.
+	BindChannelAlias(ctx context.Context, teamID, channelID, aliasName, resourceID string) error
+	// UnbindChannelAlias removes aliasName from (teamID, channelID).
+	// Implementations issue `REMOVE alias_bindings.#a` with
+	// `ConditionExpression: attribute_exists(alias_bindings.#a)`.
+	// Returns ErrAliasNotFound when aliasName is not bound in the
+	// channel. Other aliases on the same channel are untouched.
+	UnbindChannelAlias(ctx context.Context, teamID, channelID, aliasName string) error
 }
 
-// ErrAliasNotFound is returned by AliasStore implementations when the
-// requested (team, channel) row has no alias bound. Handlers use
-// errors.Is to map to the "no alias set" friendly copy.
-var ErrAliasNotFound = errors.New("no alias bound to this channel")
+// ErrAliasAlreadyBound is returned by AliasStore implementations when
+// BindChannelAlias is called for an aliasName that already has a
+// binding in (teamID, channelID). Handlers use errors.Is to map this
+// to the 409 / "alias already bound" friendly copy.
+var ErrAliasAlreadyBound = errors.New("alias already bound in this channel")
+
+// ErrAliasNotFound is returned by AliasStore implementations when
+// UnbindChannelAlias is called for an aliasName that has no binding
+// in (teamID, channelID). Handlers use errors.Is to map this to the
+// 404 / "alias not bound" friendly copy.
+var ErrAliasNotFound = errors.New("alias not bound in this channel")
 
 // resourceIDPrefix is the wire prefix on every qurl-service resource
 // id. setalias discriminates URL targets from resource-id targets on
@@ -268,35 +275,19 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 	}
 	defer cancel()
 
-	existingAlias, existingRID, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)
-	if err != nil && !errors.Is(err, ErrAliasNotFound) {
-		slog.Error("setalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel IDs are Slack-controlled but log-injection-safe.
-		respondSlack(w, "Failed to look up the current alias for this channel. Please try again.")
+	// Multi-alias write: BindChannelAlias issues an atomic UpdateItem
+	// on alias_bindings.#a with attribute_not_exists. A second alias
+	// name on the same channel succeeds (different map key); a
+	// duplicate alias name surfaces as ErrAliasAlreadyBound and is
+	// rendered as a refusal. The refusal copy names only the alias
+	// (not its bound target) to keep the info-disclosure surface
+	// narrow — claude-bot review #5 on the prior single-alias version.
+	err := h.aliasStore.BindChannelAlias(ctx, teamID, channelID, args.Alias, args.Target)
+	if errors.Is(err, ErrAliasAlreadyBound) {
+		respondSlack(w, fmt.Sprintf("Alias `$%s` is already bound in this channel. Run `/qurl unsetalias $%s` first, or pick a different alias.", args.Alias, args.Alias))
 		return
 	}
-
-	// Same-target no-op: alias is already bound to this exact target
-	// in this exact channel. Surface the no-op explicitly rather than
-	// re-writing the row.
-	if existingAlias == args.Alias && existingRID == args.Target {
-		respondSlack(w, fmt.Sprintf("Alias `$%s` already points to `%s` in this channel. No change.", args.Alias, args.Target))
-		return
-	}
-
-	// Different-existing-alias path: per the schema gap, we can't
-	// hold multiple aliases per channel. Surface this to the admin
-	// rather than silently overwriting — overwriting a teammate's
-	// alias is a footgun. The refusal names the bound alias only
-	// (not its target) — narrows the info-disclosure surface if
-	// the Slack-manifest admin gate slips. The admin can run
-	// `/qurl unsetalias` to inspect the target if they actually
-	// need it.
-	if existingAlias != "" && existingAlias != args.Alias {
-		respondSlack(w, fmt.Sprintf("This channel already has alias `$%s` bound. Run `/qurl unsetalias $%s` first, or pick a different channel.", existingAlias, existingAlias))
-		return
-	}
-
-	if err := h.aliasStore.SetChannelAlias(ctx, teamID, channelID, args.Alias, args.Target); err != nil {
+	if err != nil {
 		slog.Error("setalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel/alias are validated upstream.
 		respondSlack(w, "Failed to update alias. Please try again.")
 		return
@@ -311,13 +302,11 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 // "info-disclosure" concern (a non-admin probing alias existence via
 // the response delta) is closed structurally by the manifest gate.
 //
-// **Alias-mismatch posture:** the user names the alias they want to
-// clear. If the channel actually has a different alias bound, the
-// handler surfaces the mismatch rather than silently clearing the
-// wrong binding. This is the principle-of-least-surprise path — an
-// admin running `/qurl unsetalias $foo` while the channel actually
-// has `$bar` bound should learn about the mismatch, not have `$bar`
-// silently disappear.
+// **Not-bound posture:** UnbindChannelAlias is conditional on
+// attribute_exists(alias_bindings.#a) — clearing an alias that
+// isn't bound surfaces as ErrAliasNotFound and is rendered as
+// "no such alias on this channel." Other aliases on the same channel
+// are untouched.
 func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	rest := strings.TrimSpace(strings.TrimPrefix(text, "unsetalias"))
@@ -334,29 +323,12 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 	}
 	defer cancel()
 
-	existingAlias, _, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)
-	switch {
-	case errors.Is(err, ErrAliasNotFound):
-		respondSlack(w, "No alias is set on this channel. Nothing to clear.")
-		return
-	case err != nil:
-		slog.Error("unsetalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel IDs are Slack-controlled but log-injection-safe.
-		respondSlack(w, "Failed to look up the current alias for this channel. Please try again.")
-		return
-	case existingAlias != args.Alias:
-		respondSlack(w, fmt.Sprintf("This channel has alias `$%s` bound, not `$%s`. Refusing to clear a different alias.", existingAlias, args.Alias))
+	err := h.aliasStore.UnbindChannelAlias(ctx, teamID, channelID, args.Alias)
+	if errors.Is(err, ErrAliasNotFound) {
+		respondSlack(w, fmt.Sprintf("Alias `$%s` is not bound in this channel. Nothing to clear.", args.Alias))
 		return
 	}
-
-	if err := h.aliasStore.ClearChannelAlias(ctx, teamID, channelID); err != nil {
-		if errors.Is(err, ErrAliasNotFound) {
-			// TOCTOU window: another admin cleared the alias between
-			// the lookup and the clear. The user's intent is
-			// satisfied either way; render the success copy so they
-			// don't retry on a transient race.
-			respondSlack(w, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", args.Alias))
-			return
-		}
+	if err != nil {
 		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel/alias are validated upstream.
 		respondSlack(w, "Failed to clear alias. Please try again.")
 		return

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -1,0 +1,343 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// AliasStore is the persistence surface the alias verbs depend on.
+//
+// One alias is bound per (slack_team_id, slack_channel_id) row by
+// design — this matches the post-pivot channel_policies table shape
+// owned by qurl-bot-slack-side terraform (modules/qurl-slack-ddb,
+// SLACK_QURL_ROLLOUT.md 2026-05-12 architectural update). A small
+// interface here rather than a direct dep on the slackdata package
+// keeps this PR shippable against main even while #231/#233's
+// slackdata pivot rework is in flight; the eventual store satisfies
+// the same shape.
+//
+// **Schema gap (out-of-scope here):** the pre-pivot UX promised
+// multiple aliases per channel, but the post-pivot row carries a
+// single alias attribute per (team, channel). The right fix is a
+// schema reshape (per-alias SK, or an `aliases` SS attribute) tracked
+// separately — see qurl-integrations #233's comment thread. The
+// verbs here intentionally enforce one-alias-per-channel and surface
+// the existing-different-alias case via the rebind modal so the
+// remediation lands at the schema layer rather than papered over in
+// the handler.
+type AliasStore interface {
+	// LookupChannelAlias returns the (alias, resourceID) pair bound to
+	// (teamID, channelID), or ErrAliasNotFound if no alias is set.
+	LookupChannelAlias(ctx context.Context, teamID, channelID string) (alias, resourceID string, err error)
+	// SetChannelAlias upserts the alias→resourceID binding on
+	// (teamID, channelID). Replaces any prior alias on the row.
+	SetChannelAlias(ctx context.Context, teamID, channelID, alias, resourceID string) error
+	// ClearChannelAlias removes the alias binding on (teamID, channelID).
+	// Returns ErrAliasNotFound if there was no alias to clear.
+	ClearChannelAlias(ctx context.Context, teamID, channelID string) error
+}
+
+// ErrAliasNotFound is returned by AliasStore implementations when the
+// requested (team, channel) row has no alias bound. Handlers use
+// errors.Is to map to the "no alias set" friendly copy.
+var ErrAliasNotFound = errors.New("no alias bound to this channel")
+
+// resourceIDPrefix is the wire prefix on every qurl-service resource
+// id. setalias discriminates URL targets from resource-id targets on
+// this prefix (raw URLs vs `r_…`).
+const resourceIDPrefix = "r_"
+
+// aliasMaxLen caps alias length at the qurl-service schema's bound
+// (mirrors qurl-service `qurl_resources.alias` GSI key length, nhp
+// #1825). Parsing rejects above-cap aliases so the user sees a
+// friendlier error than the eventual upstream rejection.
+const aliasMaxLen = 64
+
+// aliasCharsetPattern matches the recognized alias charset: lowercase
+// alnum + dash, with the leading and trailing char alnum. Intentionally
+// permissive on internal `--` runs because qurl-service's own
+// authoritative validator accepts them; the parser only enforces the
+// leading/trailing rule, which is what surfaces with a friendlier
+// error than punting downstream.
+var aliasCharsetPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`)
+
+// aliasUsage is the help-text body returned when setalias/unsetalias
+// is invoked with an obvious typo. Centralized so the parser-rejection
+// path and the missing-arg path share the same copy.
+const aliasUsage = "Usage:\n• `/qurl setalias $<alias> <url-or-resource-id>`\n• `/qurl unsetalias $<alias>`\n\nAliases are lowercase alphanumeric + dashes, up to 64 chars."
+
+// URL scheme constants. Lifted so the parser, validator, and any
+// future caller can't drift on the literal string match — and so
+// goconst's "3+ occurrences" rule stays clean as the parser grows.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// Parser-rejection user copy. These strings are returned via
+// [parseAliasArgs] as the second return value (a user-facing message)
+// when the grammar doesn't match — handlers route them straight into
+// the ephemeral response, so the wire copy is reviewable in one
+// place. Tests pin substrings, not whole-message identity, so
+// expanding usage text won't churn the test surface.
+//
+// Plain strings instead of `error` because (a) these are surface
+// copy not propagated errors, (b) sentence punctuation is right for
+// the user but trips ST1005 if we wrap in `error`, and (c) the
+// dispatcher needs the literal string anyway.
+const (
+	msgAliasTargetInvalid = "Target must be a URL (http/https) or a resource id (`r_…`).\n\n" + aliasUsage
+	msgAliasMissing       = "Missing alias.\n\n" + aliasUsage
+	msgAliasNoSigil       = "Alias must start with `$` (e.g. `$staging`).\n\n" + aliasUsage
+	msgAliasEmptyName     = "Missing alias name after `$`.\n\n" + aliasUsage
+)
+
+// aliasArgs is the parsed shape of a `/qurl setalias $a <target>` or
+// `/qurl unsetalias $a` text body. Kept as a separate value type so
+// the parser is unit-testable without spinning a full handler.
+type aliasArgs struct {
+	Alias  string // sigil stripped (no leading `$`)
+	Target string // URL or `r_…` resource id; empty for unsetalias
+}
+
+// parseAliasArgs validates the trailing-arg shape of setalias /
+// unsetalias.
+//
+// For setalias, `rest` must be `$<alias> <target>` (exactly 2 tokens).
+// For unsetalias, `rest` must be `$<alias>` (exactly 1 token). When
+// the grammar doesn't match, returns (nil, userCopy) — the second
+// return is the ephemeral text to surface to the user, NOT a Go error
+// to propagate. (User-facing copy carries sentence punctuation that
+// ST1005 rejects on `error`-typed values.)
+//
+// Target validation is intentionally light: a `r_…` prefix routes
+// through the resource-id branch, otherwise the token must parse as a
+// URL with an http/https scheme. The deeper "is this an active
+// resource?" check is the persistence layer's job.
+func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg string) {
+	tokens := strings.Fields(text)
+	if wantTarget {
+		if len(tokens) != 2 {
+			return nil, aliasUsage
+		}
+	} else {
+		if len(tokens) != 1 {
+			return nil, aliasUsage
+		}
+	}
+
+	alias, msg := requireAlias(tokens[0])
+	if msg != "" {
+		return nil, msg
+	}
+	out := &aliasArgs{Alias: alias}
+	if !wantTarget {
+		return out, ""
+	}
+
+	tgt := tokens[1]
+	if strings.HasPrefix(tgt, resourceIDPrefix) {
+		// `r_…` short-circuit. We don't enforce a deeper character set
+		// here — qurl-service's resource-id validator is the
+		// authoritative gate. Empty body (`r_`) falls through as a
+		// recognizable error at the persistence layer.
+		out.Target = tgt
+		return out, ""
+	}
+	u, err := url.Parse(tgt)
+	if err != nil || (u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS) || u.Host == "" {
+		return nil, msgAliasTargetInvalid
+	}
+	out.Target = tgt
+	return out, ""
+}
+
+// requireAlias checks that `tok` is `$<alias>` and returns the alias
+// without the sigil. Mirrors the grammar in the broader parser
+// (apps/slack/internal/parser.go on #228) so a future consolidation
+// is a textual no-op.
+//
+// Returns (alias, "") on success and ("", userCopy) on rejection.
+// See [parseAliasArgs] for the rationale on plain strings vs error.
+func requireAlias(tok string) (alias, userMsg string) {
+	if tok == "" {
+		return "", msgAliasMissing
+	}
+	if !strings.HasPrefix(tok, "$") {
+		return "", msgAliasNoSigil
+	}
+	alias = strings.TrimPrefix(tok, "$")
+	if alias == "" {
+		return "", msgAliasEmptyName
+	}
+	if len(alias) > aliasMaxLen {
+		return "", fmt.Sprintf("Alias `$%s` is longer than %d characters.", alias, aliasMaxLen)
+	}
+	if !aliasCharsetPattern.MatchString(alias) {
+		return "", fmt.Sprintf("Alias `$%s` must be lowercase alphanumeric + dashes (no leading/trailing dash).", alias)
+	}
+	return alias, ""
+}
+
+// handleSetAlias routes `/qurl setalias $<alias> <target>`.
+//
+// **Admin restriction:** This handler is admin-gated at the Slack app
+// manifest level — the `/qurl setalias` command must be declared
+// admin-only in the install config. The same posture is used for
+// `/qurl setup` (see handleSetup) — gating in the manifest avoids an
+// extra Slack API round-trip per invocation. The CR feedback on the
+// old #230 (claude-bot review id 2026-05-10) flagged "admin gate
+// before alias resolution" as an info-disclosure surface. Moving the
+// gate to the manifest closes that gap structurally: a non-admin's
+// command never reaches this handler.
+//
+// **Synchronous reply contract:** sets reply ephemerally per the
+// admin-verb posture in the rollout doc — user feedback is
+// admin-only, so default-public would be wrong. The qurl-bot-slack
+// stack today returns the user copy directly on the slash-command
+// HTTP body; the async response_url path (postResponse) is used only
+// when the work cannot complete inside Slack's 3-second ack window.
+// Alias upsert is a single DDB UpdateItem — synchronous is fine.
+func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
+	text := strings.TrimSpace(values.Get(fieldText))
+	rest := strings.TrimSpace(strings.TrimPrefix(text, "setalias"))
+
+	args, userMsg := parseAliasArgs(rest, true)
+	if userMsg != "" {
+		respondSlack(w, userMsg)
+		return
+	}
+
+	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	channelID := strings.TrimSpace(values.Get(fieldChannelID))
+	if teamID == "" || channelID == "" {
+		// Slack always sends these on a slash-command payload; the
+		// guard catches a malformed test fixture or a future
+		// regression in form parsing rather than silently writing a
+		// row with empty keys.
+		slog.Warn("setalias missing team_id or channel_id", "team_id_present", teamID != "", "channel_id_present", channelID != "")
+		respondSlack(w, "Could not read your Slack workspace or channel ID from the command payload.")
+		return
+	}
+
+	if h.aliasStore == nil {
+		// Soft-fail when AliasStore is not configured (sandbox /
+		// pre-#231/#233 deploys). Surfacing a configuration error
+		// rather than silently dropping makes the bot's state
+		// debuggable from the operator side.
+		slog.Warn("setalias invoked with no AliasStore wired — refusing")
+		respondSlack(w, "Alias storage is not configured on this Slack bot deployment. Contact the operator.")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(h.baseCtx, asyncWorkTimeout)
+	defer cancel()
+
+	existingAlias, existingRID, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)
+	if err != nil && !errors.Is(err, ErrAliasNotFound) {
+		slog.Error("setalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID)
+		respondSlack(w, "Failed to look up the current alias for this channel. Please try again.")
+		return
+	}
+
+	// Same-target no-op: alias is already bound to this exact target
+	// in this exact channel. Surface the no-op explicitly rather than
+	// re-writing the row.
+	if existingAlias == args.Alias && existingRID == args.Target {
+		respondSlack(w, fmt.Sprintf("Alias `$%s` already points to `%s` in this channel. No change.", args.Alias, args.Target))
+		return
+	}
+
+	// Different-existing-alias path: per the schema gap, we can't
+	// hold multiple aliases per channel. Surface this to the admin
+	// rather than silently overwriting — overwriting a teammate's
+	// alias is a footgun.
+	if existingAlias != "" && existingAlias != args.Alias {
+		respondSlack(w, fmt.Sprintf("This channel already has alias `$%s` bound to `%s`. Run `/qurl unsetalias $%s` first, or pick a different channel.", existingAlias, existingRID, existingAlias))
+		return
+	}
+
+	if err := h.aliasStore.SetChannelAlias(ctx, teamID, channelID, args.Alias, args.Target); err != nil {
+		slog.Error("setalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias)
+		respondSlack(w, "Failed to update alias. Please try again.")
+		return
+	}
+	respondSlack(w, fmt.Sprintf("Alias `$%s` now points to `%s` in this channel.", args.Alias, args.Target))
+}
+
+// handleUnsetAlias routes `/qurl unsetalias $<alias>`.
+//
+// **Admin restriction:** Same Slack-manifest-level gate as
+// handleSetAlias — see that comment. The CR feedback's
+// "info-disclosure" concern (a non-admin probing alias existence via
+// the response delta) is closed structurally by the manifest gate.
+//
+// **Alias-mismatch posture:** the user names the alias they want to
+// clear. If the channel actually has a different alias bound, the
+// handler surfaces the mismatch rather than silently clearing the
+// wrong binding. This is the principle-of-least-surprise path — an
+// admin running `/qurl unsetalias $foo` while the channel actually
+// has `$bar` bound should learn about the mismatch, not have `$bar`
+// silently disappear.
+func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
+	text := strings.TrimSpace(values.Get(fieldText))
+	rest := strings.TrimSpace(strings.TrimPrefix(text, "unsetalias"))
+
+	args, userMsg := parseAliasArgs(rest, false)
+	if userMsg != "" {
+		respondSlack(w, userMsg)
+		return
+	}
+
+	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	channelID := strings.TrimSpace(values.Get(fieldChannelID))
+	if teamID == "" || channelID == "" {
+		slog.Warn("unsetalias missing team_id or channel_id", "team_id_present", teamID != "", "channel_id_present", channelID != "")
+		respondSlack(w, "Could not read your Slack workspace or channel ID from the command payload.")
+		return
+	}
+
+	if h.aliasStore == nil {
+		slog.Warn("unsetalias invoked with no AliasStore wired — refusing")
+		respondSlack(w, "Alias storage is not configured on this Slack bot deployment. Contact the operator.")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(h.baseCtx, asyncWorkTimeout)
+	defer cancel()
+
+	existingAlias, _, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)
+	switch {
+	case errors.Is(err, ErrAliasNotFound):
+		respondSlack(w, "No alias is set on this channel. Nothing to clear.")
+		return
+	case err != nil:
+		slog.Error("unsetalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID)
+		respondSlack(w, "Failed to look up the current alias for this channel. Please try again.")
+		return
+	case existingAlias != args.Alias:
+		respondSlack(w, fmt.Sprintf("This channel has alias `$%s` bound, not `$%s`. Refusing to clear a different alias.", existingAlias, args.Alias))
+		return
+	}
+
+	if err := h.aliasStore.ClearChannelAlias(ctx, teamID, channelID); err != nil {
+		if errors.Is(err, ErrAliasNotFound) {
+			// TOCTOU window: another admin cleared the alias between
+			// the lookup and the clear. The user's intent is
+			// satisfied either way; render the success copy so they
+			// don't retry on a transient race.
+			respondSlack(w, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", args.Alias))
+			return
+		}
+		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias)
+		respondSlack(w, "Failed to clear alias. Please try again.")
+		return
+	}
+	respondSlack(w, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", args.Alias))
+}

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -28,9 +28,9 @@ import (
 // schema reshape (per-alias SK, or an `aliases` SS attribute) tracked
 // separately — see qurl-integrations #233's comment thread. The
 // verbs here intentionally enforce one-alias-per-channel and surface
-// the existing-different-alias case via the rebind modal so the
-// remediation lands at the schema layer rather than papered over in
-// the handler.
+// the existing-different-alias case with a refusal message asking
+// the operator to `unsetalias` first, so the remediation lands at
+// the schema layer rather than papered over in the handler.
 type AliasStore interface {
 	// LookupChannelAlias returns the (alias, resourceID) pair bound to
 	// (teamID, channelID), or ErrAliasNotFound if no alias is set.

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -198,10 +198,10 @@ func requireAlias(tok string) (alias, userMsg string) {
 		return "", msgAliasEmptyName
 	}
 	if len(alias) > aliasMaxLen {
-		return "", fmt.Sprintf("Alias `$%s` is longer than %d characters.", alias, aliasMaxLen)
+		return "", fmt.Sprintf("Alias `$%s` is longer than %d characters.\n\n%s", alias, aliasMaxLen, aliasUsage)
 	}
 	if !aliasCharsetPattern.MatchString(alias) {
-		return "", fmt.Sprintf("Alias `$%s` must be lowercase alphanumeric + dashes (no leading/trailing dash).", alias)
+		return "", fmt.Sprintf("Alias `$%s` must be lowercase alphanumeric + dashes (no leading/trailing dash).\n\n%s", alias, aliasUsage)
 	}
 	return alias, ""
 }
@@ -301,6 +301,11 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, "Failed to update alias. Please try again.")
 		return
 	}
+	// Admin-verb audit trail: log the bound (alias, target) pair on
+	// success so post-incident reconstruction doesn't depend on
+	// re-querying the DDB table at the time of the question. team/channel/alias
+	// are validated upstream; target is the literal we just persisted.
+	slog.Info("alias bound", "team_id", teamID, "channel_id", channelID, "alias", args.Alias, "target", args.Target) //nolint:gosec // G706: slog escapes control bytes in attribute values; values are validated upstream.
 	respondSlack(w, fmt.Sprintf("Alias `$%s` now points to `%s` in this channel.", args.Alias, args.Target))
 }
 
@@ -342,5 +347,8 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, "Failed to clear alias. Please try again.")
 		return
 	}
+	// Admin-verb audit trail: counterpart to the setalias "alias bound"
+	// audit line. team/channel/alias are validated upstream.
+	slog.Info("alias cleared", "team_id", teamID, "channel_id", channelID, "alias", args.Alias) //nolint:gosec // G706: slog escapes control bytes in attribute values; values are validated upstream.
 	respondSlack(w, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", args.Alias))
 }

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // AliasStore is the persistence surface the alias verbs depend on.
@@ -151,14 +152,17 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 	}
 
 	tgt := tokens[1]
-	// Reject backticks before any further parsing: the handler echoes
-	// the target into a Slack inline-code fence (\`<tgt>\`) on the
-	// success-copy path, and a backtick inside `tgt` breaks the
-	// rendered formatting. The admin-gate trust model makes this
-	// rendering hygiene, not security — but a one-character footgun
-	// is worth closing at the parser rather than at the response.
-	if strings.ContainsRune(tgt, '`') {
-		return nil, msgAliasTargetInvalid
+	// Reject backticks and any non-printable rune before any further
+	// parsing. The handler echoes the target into a Slack inline-code
+	// fence (\`<tgt>\`) on the success-copy path, and the audit log
+	// emits it on the happy path — backticks break the fence, control
+	// bytes garble the log line, and both are footguns we close at
+	// the parser rather than at the response. The admin-gate trust
+	// model makes these rendering/logging hygiene, not security.
+	for _, r := range tgt {
+		if r == '`' || !unicode.IsPrint(r) {
+			return nil, msgAliasTargetInvalid
+		}
 	}
 	if strings.HasPrefix(tgt, resourceIDPrefix) {
 		// `r_…` short-circuit. We don't enforce a deeper character set
@@ -213,7 +217,11 @@ func requireAlias(tok string) (alias, userMsg string) {
 // error" rather than "Slack reported timeout while we kept working
 // and the user retried." Re-evaluate (move to runAsync + response_url)
 // only if DDB tail latency starts exceeding this budget in practice.
-const aliasSyncTimeout = 2500 * time.Millisecond
+//
+// `var` (not `const`) so tests can swap in a short budget without
+// dropping a 2.5-second real-time wait into the suite. Production
+// code never mutates this — the test path is the only writer.
+var aliasSyncTimeout = 2500 * time.Millisecond
 
 // aliasPreamble is the shared prelude for both alias verbs after
 // argument parsing: pull team_id + channel_id off the form, verify
@@ -304,9 +312,35 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 	// Admin-verb audit trail: log the bound (alias, target) pair on
 	// success so post-incident reconstruction doesn't depend on
 	// re-querying the DDB table at the time of the question. team/channel/alias
-	// are validated upstream; target is the literal we just persisted.
-	slog.Info("alias bound", "team_id", teamID, "channel_id", channelID, "alias", args.Alias, "target", args.Target) //nolint:gosec // G706: slog escapes control bytes in attribute values; values are validated upstream.
+	// are validated upstream; target is redacted (userinfo + raw query
+	// stripped) so credentials embedded by a setting admin don't
+	// land in operator-visible logs where the readership is wider
+	// than the writer's admin scope.
+	slog.Info("alias bound", "team_id", teamID, "channel_id", channelID, "alias", args.Alias, "target", redactURLForLog(args.Target)) //nolint:gosec // G706: slog escapes control bytes in attribute values; values are validated upstream.
 	respondSlack(w, fmt.Sprintf("Alias `$%s` now points to `%s` in this channel.", args.Alias, args.Target))
+}
+
+// redactURLForLog strips userinfo (e.g. `user:token@`) and any raw
+// query string from a setalias target before it lands in operator
+// logs. The success-copy path still shows the verbatim target to the
+// admin who set it, but the audit-log readership is typically wider
+// than the manifest-gated admin pool and shouldn't see embedded
+// credentials. Non-URL targets (`r_…` resource ids, or anything that
+// fails to re-parse) are returned unchanged — the parser has already
+// fenced backticks and non-printable runes upstream.
+func redactURLForLog(target string) string {
+	if strings.HasPrefix(target, resourceIDPrefix) {
+		return target
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return target
+	}
+	redacted := *u
+	redacted.User = nil
+	redacted.RawQuery = ""
+	redacted.Fragment = ""
+	return redacted.String()
 }
 
 // handleUnsetAlias routes `/qurl unsetalias $<alias>`.

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // AliasStore is the persistence surface the alias verbs depend on.
@@ -145,8 +146,11 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 	if strings.HasPrefix(tgt, resourceIDPrefix) {
 		// `r_…` short-circuit. We don't enforce a deeper character set
 		// here — qurl-service's resource-id validator is the
-		// authoritative gate. Empty body (`r_`) falls through as a
-		// recognizable error at the persistence layer.
+		// authoritative gate — but we DO reject the bare `r_` sigil
+		// before writing it, so a junk DDB row never lands.
+		if len(tgt) == len(resourceIDPrefix) {
+			return nil, msgAliasTargetInvalid
+		}
 		out.Target = tgt
 		return out, ""
 	}
@@ -185,6 +189,15 @@ func requireAlias(tok string) (alias, userMsg string) {
 	return alias, ""
 }
 
+// aliasSyncTimeout caps the sync alias-verb deadline tight enough to
+// fail inside Slack's 3-second slash-command ack window. Two DDB
+// calls (lookup + write) typically resolve in <100ms, so 2.5s leaves
+// headroom while keeping the bot's failure mode "we surfaced an
+// error" rather than "Slack reported timeout while we kept working
+// and the user retried." Re-evaluate (move to runAsync + response_url)
+// only if DDB tail latency starts exceeding this budget in practice.
+const aliasSyncTimeout = 2500 * time.Millisecond
+
 // aliasPreamble is the shared prelude for both alias verbs after
 // argument parsing: pull team_id + channel_id off the form, verify
 // the AliasStore is wired, and set up the worker context. Returns
@@ -214,7 +227,7 @@ func (h *Handler) aliasPreamble(w http.ResponseWriter, values url.Values, verb s
 		respondSlack(w, "Alias storage is not configured on this Slack bot deployment. Contact the operator.")
 		return
 	}
-	ctx, cancel = context.WithTimeout(h.baseCtx, asyncWorkTimeout)
+	ctx, cancel = context.WithTimeout(h.baseCtx, aliasSyncTimeout)
 	ok = true
 	return
 }
@@ -256,7 +269,7 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 
 	existingAlias, existingRID, err := h.aliasStore.LookupChannelAlias(ctx, teamID, channelID)
 	if err != nil && !errors.Is(err, ErrAliasNotFound) {
-		slog.Error("setalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID)
+		slog.Error("setalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel IDs are Slack-controlled but log-injection-safe.
 		respondSlack(w, "Failed to look up the current alias for this channel. Please try again.")
 		return
 	}
@@ -272,14 +285,18 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 	// Different-existing-alias path: per the schema gap, we can't
 	// hold multiple aliases per channel. Surface this to the admin
 	// rather than silently overwriting — overwriting a teammate's
-	// alias is a footgun.
+	// alias is a footgun. The refusal names the bound alias only
+	// (not its target) — narrows the info-disclosure surface if
+	// the Slack-manifest admin gate slips. The admin can run
+	// `/qurl unsetalias` to inspect the target if they actually
+	// need it.
 	if existingAlias != "" && existingAlias != args.Alias {
-		respondSlack(w, fmt.Sprintf("This channel already has alias `$%s` bound to `%s`. Run `/qurl unsetalias $%s` first, or pick a different channel.", existingAlias, existingRID, existingAlias))
+		respondSlack(w, fmt.Sprintf("This channel already has alias `$%s` bound. Run `/qurl unsetalias $%s` first, or pick a different channel.", existingAlias, existingAlias))
 		return
 	}
 
 	if err := h.aliasStore.SetChannelAlias(ctx, teamID, channelID, args.Alias, args.Target); err != nil {
-		slog.Error("setalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias)
+		slog.Error("setalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel/alias are validated upstream.
 		respondSlack(w, "Failed to update alias. Please try again.")
 		return
 	}
@@ -322,7 +339,7 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, "No alias is set on this channel. Nothing to clear.")
 		return
 	case err != nil:
-		slog.Error("unsetalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID)
+		slog.Error("unsetalias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel IDs are Slack-controlled but log-injection-safe.
 		respondSlack(w, "Failed to look up the current alias for this channel. Please try again.")
 		return
 	case existingAlias != args.Alias:
@@ -339,7 +356,7 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 			respondSlack(w, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", args.Alias))
 			return
 		}
-		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias)
+		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias) //nolint:gosec // G706: slog escapes control bytes in attribute values; team/channel/alias are validated upstream.
 		respondSlack(w, "Failed to clear alias. Please try again.")
 		return
 	}

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -151,6 +151,15 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 	}
 
 	tgt := tokens[1]
+	// Reject backticks before any further parsing: the handler echoes
+	// the target into a Slack inline-code fence (\`<tgt>\`) on the
+	// success-copy path, and a backtick inside `tgt` breaks the
+	// rendered formatting. The admin-gate trust model makes this
+	// rendering hygiene, not security — but a one-character footgun
+	// is worth closing at the parser rather than at the response.
+	if strings.ContainsRune(tgt, '`') {
+		return nil, msgAliasTargetInvalid
+	}
 	if strings.HasPrefix(tgt, resourceIDPrefix) {
 		// `r_…` short-circuit. We don't enforce a deeper character set
 		// here — qurl-service's resource-id validator is the

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -63,9 +63,10 @@ const aliasMaxLen = 64
 // aliasCharsetPattern matches the recognized alias charset: lowercase
 // alnum + dash, with the leading and trailing char alnum. Intentionally
 // permissive on internal `--` runs because qurl-service's own
-// authoritative validator accepts them; the parser only enforces the
-// leading/trailing rule, which is what surfaces with a friendlier
-// error than punting downstream.
+// authoritative validator (the sparse GSI key handler from nhp #1825)
+// accepts them; the parser only enforces the leading/trailing rule,
+// which is what surfaces with a friendlier error than punting
+// downstream.
 var aliasCharsetPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`)
 
 // aliasUsage is the help-text body returned when setalias/unsetalias

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -148,7 +148,7 @@ func decodeSlackText(t *testing.T, raw []byte) string {
 		t.Fatalf("unmarshal response body: %v\nraw=%s", err, string(raw))
 	}
 	if resp[respFieldResponseType] != respTypeEphemeral {
-		t.Errorf("response_type = %q, want %q", resp["response_type"], respTypeEphemeral)
+		t.Errorf("response_type = %q, want %q", resp[respFieldResponseType], respTypeEphemeral)
 	}
 	return resp[respFieldText]
 }
@@ -180,14 +180,19 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 		{name: "garbage target rejected", input: "$staging not-a-url", wantErr: true},
 		{name: "alias over cap rejected", input: "$" + strings.Repeat("a", 65) + " https://x.example", wantErr: true},
 		{name: "bare r_ sigil rejected", input: "$staging r_", wantErr: true},
+		// Backtick in target would break the Slack inline-code fence
+		// the success-copy interpolates the target into. Rejected at
+		// parse time so the response renders cleanly.
+		{name: "backtick in r_ target rejected", input: "$staging r_abc`bad", wantErr: true},
+		{name: "backtick in URL target rejected", input: "$staging https://example.com/`x", wantErr: true},
 
 		// Fence: http://localhost is currently ACCEPTED. The parser
 		// stays scheme-permissive because qurl-service is the
-		// authoritative validator on target reachability. If/when
-		// the parser grows a public-host gate (claude-bot review #3
-		// SSRF-adjacent follow-up), flip this row to wantErr and
-		// the test starts enforcing the new contract.
-		{name: "localhost target ACCEPTED (TODO: SSRF gate)", input: "$staging http://localhost:3000", wantAlias: "staging", wantTgt: "http://localhost:3000"},
+		// authoritative validator on target reachability. The
+		// public-host gate follow-up is tracked in #350; when that
+		// lands, flip this row to wantErr and the test starts
+		// enforcing the new contract.
+		{name: "localhost target ACCEPTED (see #350: SSRF gate)", input: "$staging http://localhost:3000", wantAlias: "staging", wantTgt: "http://localhost:3000"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -363,6 +368,36 @@ func TestSetChannelAlias_DuplicateAliasSameChannelReturns409(t *testing.T) {
 	b := store.bindings(testAliasTeamID, testAliasChannelID)
 	if b[testAliasName] != "r_first" {
 		t.Errorf("original binding clobbered: bindings = %v", b)
+	}
+}
+
+// TestSetAlias_MissingTeamOrChannelID pins the defensive guard in
+// aliasPreamble: a Slack form payload that arrives without team_id or
+// channel_id surfaces the "Could not read your Slack workspace or
+// channel ID" copy and never dials the store. Catches a malformed
+// fixture or a future regression in form parsing rather than silently
+// writing a row keyed on empty strings.
+func TestSetAlias_MissingTeamOrChannelID(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	// channel_id empty.
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, "")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "Could not read your Slack workspace or channel ID") {
+		t.Errorf("missing channel_id response = %q, want defensive-guard copy", got)
+	}
+	// team_id empty.
+	body2, sign2 := aliasSlashRequest(t, "setalias $staging https://example.com", "", testAliasChannelID)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, newSignedRequest(t, "/slack/commands", body2, sign2))
+	got2 := decodeSlackText(t, w2.Body.Bytes())
+	if !strings.Contains(got2, "Could not read your Slack workspace or channel ID") {
+		t.Errorf("missing team_id response = %q, want defensive-guard copy", got2)
+	}
+	// Store must not have been dialed in either branch.
+	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
+		t.Errorf("missing-id guard should have short-circuited before store dial, got bindings=%v", b)
 	}
 }
 
@@ -566,4 +601,30 @@ func TestSetAliasStore_DoubleSetPanics(t *testing.T) {
 		}
 	}()
 	h.SetAliasStore(store)
+}
+
+// TestSetAliasStore_NilPassthrough pins the documented contract that
+// a nil argument is a no-op (the verbs reply with the "not configured"
+// copy via the aliasPreamble guard) and that a defensive
+// SetAliasStore(nil) doesn't block a later real wiring. This is the
+// shape cmd/main.go uses on sandbox deploys.
+func TestSetAliasStore_NilPassthrough(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	// nil is a no-op; field stays nil.
+	h.SetAliasStore(nil)
+	if h.aliasStore != nil {
+		t.Fatal("SetAliasStore(nil) should leave aliasStore unset")
+	}
+	// Real wiring afterward still works.
+	store := newFakeAliasStore()
+	h.SetAliasStore(store)
+	if h.aliasStore == nil {
+		t.Fatal("SetAliasStore(store) should wire the field after a prior nil call")
+	}
+	// A second nil call after a real store is still a no-op (doesn't
+	// swap or panic).
+	h.SetAliasStore(nil)
+	if h.aliasStore == nil {
+		t.Fatal("SetAliasStore(nil) after wiring should not clear the field")
+	}
 }

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -24,70 +24,89 @@ const (
 )
 
 // fakeAliasStore is an in-memory AliasStore for handler tests. One
-// record per (team, channel) — the same shape the post-pivot
-// channel_policies table enforces. Methods are safe under t.Parallel
-// since the handler-level tests don't fan out concurrent reads on
-// the same row.
+// row per (team, channel), each row carrying a `bindings` map keyed
+// by alias name — the same shape the channel_policies table's
+// alias_bindings Map attribute enforces. Methods are safe under
+// t.Parallel since the handler-level tests don't fan out concurrent
+// reads on the same row.
 type fakeAliasStore struct {
 	mu sync.Mutex
-	// rows is keyed by team|channel; value is "alias|resourceID".
-	rows map[string]aliasRow
+	// rows is keyed by team|channel; value is alias→resourceID.
+	rows map[string]map[string]string
 
-	// errLookup, errSet, errClear let tests inject deterministic
-	// errors without spinning a real DDB fake.
-	errLookup error
-	errSet    error
-	errClear  error
-}
-
-type aliasRow struct {
-	alias      string
-	resourceID string
+	// errBind, errUnbind let tests inject deterministic errors without
+	// spinning a real DDB fake. Set to a sentinel (ErrAliasAlreadyBound
+	// / ErrAliasNotFound) to exercise the typed-conflict branches.
+	errBind   error
+	errUnbind error
 }
 
 func newFakeAliasStore() *fakeAliasStore {
-	return &fakeAliasStore{rows: map[string]aliasRow{}}
+	return &fakeAliasStore{rows: map[string]map[string]string{}}
 }
 
 func (f *fakeAliasStore) key(teamID, channelID string) string {
 	return teamID + "|" + channelID
 }
 
-func (f *fakeAliasStore) LookupChannelAlias(_ context.Context, teamID, channelID string) (alias, resourceID string, err error) {
+func (f *fakeAliasStore) BindChannelAlias(_ context.Context, teamID, channelID, aliasName, resourceID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.errLookup != nil {
-		return "", "", f.errLookup
-	}
-	r, ok := f.rows[f.key(teamID, channelID)]
-	if !ok {
-		return "", "", ErrAliasNotFound
-	}
-	return r.alias, r.resourceID, nil
-}
-
-func (f *fakeAliasStore) SetChannelAlias(_ context.Context, teamID, channelID, alias, resourceID string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.errSet != nil {
-		return f.errSet
-	}
-	f.rows[f.key(teamID, channelID)] = aliasRow{alias: alias, resourceID: resourceID}
-	return nil
-}
-
-func (f *fakeAliasStore) ClearChannelAlias(_ context.Context, teamID, channelID string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.errClear != nil {
-		return f.errClear
+	if f.errBind != nil {
+		return f.errBind
 	}
 	k := f.key(teamID, channelID)
-	if _, ok := f.rows[k]; !ok {
+	row, ok := f.rows[k]
+	if !ok {
+		row = map[string]string{}
+		f.rows[k] = row
+	}
+	if _, exists := row[aliasName]; exists {
+		return ErrAliasAlreadyBound
+	}
+	row[aliasName] = resourceID
+	return nil
+}
+
+func (f *fakeAliasStore) UnbindChannelAlias(_ context.Context, teamID, channelID, aliasName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errUnbind != nil {
+		return f.errUnbind
+	}
+	k := f.key(teamID, channelID)
+	row, ok := f.rows[k]
+	if !ok {
 		return ErrAliasNotFound
 	}
-	delete(f.rows, k)
+	if _, exists := row[aliasName]; !exists {
+		return ErrAliasNotFound
+	}
+	delete(row, aliasName)
+	if len(row) == 0 {
+		// Mirror the real-store invariant: row is created lazily on
+		// first bind and conceptually disappears when emptied, so
+		// "no aliases" looks the same as "row never existed."
+		delete(f.rows, k)
+	}
 	return nil
+}
+
+// bindings returns a copy of the current alias→resourceID map for
+// (teamID, channelID), or nil if the row has no bindings. Test-only
+// inspection helper.
+func (f *fakeAliasStore) bindings(teamID, channelID string) map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row, ok := f.rows[f.key(teamID, channelID)]
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(row))
+	for k, v := range row {
+		out[k] = v
+	}
+	return out
 }
 
 // newAliasTestHandler builds a Handler wired with a fakeAliasStore.
@@ -243,12 +262,9 @@ func TestSetAlias_HappyURL(t *testing.T) {
 	if !strings.Contains(got, "now points to") || !strings.Contains(got, "$staging") {
 		t.Errorf("response = %q, missing success copy", got)
 	}
-	a, rid, err := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
-	if err != nil {
-		t.Fatalf("post-setalias lookup: %v", err)
-	}
-	if a != testAliasName || rid != testAliasURL {
-		t.Errorf("stored row = (%q, %q), want (staging, https://example.com)", a, rid)
+	b := store.bindings(testAliasTeamID, testAliasChannelID)
+	if b[testAliasName] != testAliasURL {
+		t.Errorf("stored bindings = %v, want {%q: %q}", b, testAliasName, testAliasURL)
 	}
 }
 
@@ -262,9 +278,9 @@ func TestSetAlias_HappyResourceID(t *testing.T) {
 	if w.Code != 200 {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
-	_, rid, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
-	if rid != "r_abc123" {
-		t.Errorf("stored resourceID = %q, want r_abc123", rid)
+	b := store.bindings(testAliasTeamID, testAliasChannelID)
+	if b[testAliasName] != "r_abc123" {
+		t.Errorf("stored bindings = %v, want {%q: r_abc123}", b, testAliasName)
 	}
 }
 
@@ -283,49 +299,70 @@ func TestSetAlias_ParserError(t *testing.T) {
 	if !strings.Contains(got, "must start with `$`") {
 		t.Errorf("response = %q, want sigil error", got)
 	}
-	if _, _, err := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID); !errors.Is(err, ErrAliasNotFound) {
-		t.Errorf("store was touched on parser-rejection path: %v", err)
+	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
+		t.Errorf("store was touched on parser-rejection path: %v", b)
 	}
 }
 
-func TestSetAlias_SameTargetNoOp(t *testing.T) {
+func TestSetChannelAlias_SecondAliasOnSameChannelSucceeds(t *testing.T) {
+	// Schema decision 2026-05-17: a channel can host many aliases
+	// simultaneously. After binding $a, binding $b must succeed; both
+	// bindings must coexist in the resulting row.
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL)
 
-	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+	body1, sign1 := aliasSlashRequest(t, "setalias $a https://a.example", testAliasTeamID, testAliasChannelID)
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, newSignedRequest(t, "/slack/commands", body1, sign1))
+	if got := decodeSlackText(t, w1.Body.Bytes()); !strings.Contains(got, "now points to") {
+		t.Fatalf("first bind response = %q, want success copy", got)
+	}
 
-	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "No change.") {
-		t.Errorf("response = %q, missing no-change copy", got)
+	body2, sign2 := aliasSlashRequest(t, "setalias $b https://b.example", testAliasTeamID, testAliasChannelID)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, newSignedRequest(t, "/slack/commands", body2, sign2))
+	if got := decodeSlackText(t, w2.Body.Bytes()); !strings.Contains(got, "now points to") || !strings.Contains(got, "$b") {
+		t.Errorf("second bind response = %q, want success copy referencing $b", got)
+	}
+
+	b := store.bindings(testAliasTeamID, testAliasChannelID)
+	if b["a"] != "https://a.example" {
+		t.Errorf("$a binding lost: bindings = %v", b)
+	}
+	if b["b"] != "https://b.example" {
+		t.Errorf("$b binding missing: bindings = %v", b)
 	}
 }
 
-func TestSetAlias_DifferentExistingAliasBlocks(t *testing.T) {
-	// Schema-gap fence: the channel already has $other bound. Refuse
-	// to overwrite a teammate's alias without explicit
-	// /qurl unsetalias first. The test row pins the refusal copy so
-	// a future regression that silently overwrites lights this up.
+func TestSetChannelAlias_DuplicateAliasSameChannelReturns409(t *testing.T) {
+	// Binding the same alias name twice in the same channel must
+	// surface as a typed conflict (ErrAliasAlreadyBound). A different
+	// resource id on the second call does NOT silently overwrite.
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing")
 
-	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
-
-	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "$other") || !strings.Contains(got, "unsetalias") {
-		t.Errorf("response = %q, want refusal copy referencing $other and unsetalias", got)
+	body1, sign1 := aliasSlashRequest(t, "setalias $staging r_first", testAliasTeamID, testAliasChannelID)
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, newSignedRequest(t, "/slack/commands", body1, sign1))
+	if got := decodeSlackText(t, w1.Body.Bytes()); !strings.Contains(got, "now points to") {
+		t.Fatalf("first bind response = %q, want success copy", got)
 	}
-	// Refusal copy must NOT leak the bound target (claude-bot review #5
-	// — info-disclosure narrowing). The test row pins this.
-	if strings.Contains(got, "r_existing") {
+
+	body2, sign2 := aliasSlashRequest(t, "setalias $staging r_second", testAliasTeamID, testAliasChannelID)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, newSignedRequest(t, "/slack/commands", body2, sign2))
+	got := decodeSlackText(t, w2.Body.Bytes())
+	if !strings.Contains(got, "already bound") || !strings.Contains(got, "$staging") {
+		t.Errorf("duplicate bind response = %q, want already-bound copy", got)
+	}
+	// Refusal copy must NOT leak the bound target (info-disclosure
+	// narrowing carried over from the single-alias era).
+	if strings.Contains(got, "r_first") {
 		t.Errorf("refusal leaked bound target: %q", got)
 	}
-	a, _, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
-	if a != testOtherAlias {
-		t.Errorf("alias was overwritten: stored = %q, want %q", a, testOtherAlias)
+
+	// Original binding intact.
+	b := store.bindings(testAliasTeamID, testAliasChannelID)
+	if b[testAliasName] != "r_first" {
+		t.Errorf("original binding clobbered: bindings = %v", b)
 	}
 }
 
@@ -344,7 +381,7 @@ func TestSetAlias_NoStoreWired(t *testing.T) {
 
 func TestSetAlias_StoreWriteError(t *testing.T) {
 	h, store := newAliasTestHandler(t)
-	store.errSet = errors.New("ddb conditional failure")
+	store.errBind = errors.New("ddb conditional failure")
 
 	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
@@ -358,7 +395,7 @@ func TestSetAlias_StoreWriteError(t *testing.T) {
 
 func TestUnsetAlias_Happy(t *testing.T) {
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL)
+	_ = store.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL)
 
 	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
@@ -368,12 +405,43 @@ func TestUnsetAlias_Happy(t *testing.T) {
 	if !strings.Contains(got, "no longer bound") {
 		t.Errorf("response = %q, want unset success copy", got)
 	}
-	if _, _, err := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID); !errors.Is(err, ErrAliasNotFound) {
-		t.Errorf("expected row cleared, got err=%v", err)
+	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
+		t.Errorf("expected row cleared, got bindings=%v", b)
 	}
 }
 
-func TestUnsetAlias_NotSet(t *testing.T) {
+func TestClearChannelAlias_OneOfManyLeavesOthers(t *testing.T) {
+	// Multi-alias semantics: clearing $a leaves $b on the same row.
+	h, store := newAliasTestHandler(t)
+	ctx := context.Background()
+	if err := store.BindChannelAlias(ctx, testAliasTeamID, testAliasChannelID, "a", "https://a.example"); err != nil {
+		t.Fatalf("seed $a: %v", err)
+	}
+	if err := store.BindChannelAlias(ctx, testAliasTeamID, testAliasChannelID, "b", "https://b.example"); err != nil {
+		t.Fatalf("seed $b: %v", err)
+	}
+
+	body, sign := aliasSlashRequest(t, "unsetalias $a", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "no longer bound") || !strings.Contains(got, "$a") {
+		t.Errorf("response = %q, want unset success copy referencing $a", got)
+	}
+
+	b := store.bindings(testAliasTeamID, testAliasChannelID)
+	if _, ok := b["a"]; ok {
+		t.Errorf("$a was not cleared: bindings = %v", b)
+	}
+	if b["b"] != "https://b.example" {
+		t.Errorf("$b was disturbed: bindings = %v", b)
+	}
+}
+
+func TestClearChannelAlias_NotPresentReturns404(t *testing.T) {
+	// Clearing an alias that isn't bound surfaces the typed
+	// ErrAliasNotFound branch as "not bound; nothing to clear."
 	h, _ := newAliasTestHandler(t)
 
 	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
@@ -381,48 +449,43 @@ func TestUnsetAlias_NotSet(t *testing.T) {
 	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
 
 	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "No alias is set") {
-		t.Errorf("response = %q, want not-set copy", got)
+	if !strings.Contains(got, "not bound") || !strings.Contains(got, "$staging") {
+		t.Errorf("response = %q, want not-bound copy referencing $staging", got)
 	}
 }
 
-func TestUnsetAlias_MismatchRefuses(t *testing.T) {
-	// The channel has $other bound; user runs unsetalias $foo. The
-	// least-surprise posture is "refuse and surface the mismatch"
-	// rather than silently nuke the wrong alias.
+func TestClearChannelAlias_NotPresentWithOtherAliasBound(t *testing.T) {
+	// Clearing $foo when only $other is bound must return the
+	// typed not-found refusal AND leave $other intact. This is the
+	// multi-alias analog of the old "mismatch refuses" test.
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing")
+	_ = store.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing")
 
 	body, sign := aliasSlashRequest(t, "unsetalias $foo", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
 
 	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "not `$foo`") {
-		t.Errorf("response = %q, want mismatch refusal copy", got)
+	if !strings.Contains(got, "not bound") || !strings.Contains(got, "$foo") {
+		t.Errorf("response = %q, want not-bound refusal referencing $foo", got)
 	}
-	a, _, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
-	if a != testOtherAlias {
-		t.Errorf("alias was cleared on mismatch: stored = %q, want %q", a, testOtherAlias)
+	b := store.bindings(testAliasTeamID, testAliasChannelID)
+	if b[testOtherAlias] != "r_existing" {
+		t.Errorf("$other was disturbed: bindings = %v", b)
 	}
 }
 
-func TestUnsetAlias_TOCTOUClearedRace(t *testing.T) {
-	// Race: lookup returns the expected alias, but ClearChannelAlias
-	// returns ErrAliasNotFound (another admin cleared it between the
-	// two calls). The user's intent is satisfied — render the
-	// success copy rather than confusing them with a 404.
+func TestUnsetAlias_StoreWriteError(t *testing.T) {
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, "r_x")
-	store.errClear = ErrAliasNotFound
+	store.errUnbind = errors.New("ddb transient failure")
 
 	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
 
 	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "no longer bound") {
-		t.Errorf("response = %q, want TOCTOU success copy", got)
+	if !strings.Contains(got, "Failed to clear alias") {
+		t.Errorf("response = %q, want clear-failed copy", got)
 	}
 }
 
@@ -468,7 +531,7 @@ func TestHelpListsNewVerbs(t *testing.T) {
 // = channel only) would break tenancy hard, so pin the fence here.
 func TestSetAlias_CrossTenancyIsolation(t *testing.T) {
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), "T1", "C_shared", testAliasName, testAliasURL)
+	_ = store.BindChannelAlias(context.Background(), "T1", "C_shared", testAliasName, testAliasURL)
 
 	// T2 admin in the same channel ID — should see "no alias" and
 	// be allowed to set their own.
@@ -482,14 +545,14 @@ func TestSetAlias_CrossTenancyIsolation(t *testing.T) {
 	}
 
 	// T1's binding should be intact.
-	t1Alias, t1RID, _ := store.LookupChannelAlias(context.Background(), "T1", "C_shared")
-	if t1Alias != testAliasName || t1RID != testAliasURL {
-		t.Errorf("T1 binding was disturbed: got (%q, %q), want (%q, %q)", t1Alias, t1RID, testAliasName, testAliasURL)
+	t1 := store.bindings("T1", "C_shared")
+	if t1[testAliasName] != testAliasURL {
+		t.Errorf("T1 binding was disturbed: got %v, want {%q: %q}", t1, testAliasName, testAliasURL)
 	}
 	// T2 wrote its own row.
-	t2Alias, _, _ := store.LookupChannelAlias(context.Background(), "T2", "C_shared")
-	if t2Alias != testOtherAlias {
-		t.Errorf("T2 binding missing: got %q, want %q", t2Alias, testOtherAlias)
+	t2 := store.bindings("T2", "C_shared")
+	if t2[testOtherAlias] != "https://t2.example" {
+		t.Errorf("T2 binding missing: got %v", t2)
 	}
 }
 

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -20,6 +20,7 @@ const (
 	testAliasURL       = "https://example.com"
 	testAliasName      = "staging"
 	testSlashCmd       = "/qurl"
+	testOtherAlias     = "other"
 )
 
 // fakeAliasStore is an in-memory AliasStore for handler tests. One
@@ -159,6 +160,15 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 		{name: "non-http target rejected", input: "$staging ftp://example.com", wantErr: true},
 		{name: "garbage target rejected", input: "$staging not-a-url", wantErr: true},
 		{name: "alias over cap rejected", input: "$" + strings.Repeat("a", 65) + " https://x.example", wantErr: true},
+		{name: "bare r_ sigil rejected", input: "$staging r_", wantErr: true},
+
+		// Fence: http://localhost is currently ACCEPTED. The parser
+		// stays scheme-permissive because qurl-service is the
+		// authoritative validator on target reachability. If/when
+		// the parser grows a public-host gate (claude-bot review #3
+		// SSRF-adjacent follow-up), flip this row to wantErr and
+		// the test starts enforcing the new contract.
+		{name: "localhost target ACCEPTED (TODO: SSRF gate)", input: "$staging http://localhost:3000", wantAlias: "staging", wantTgt: "http://localhost:3000"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -298,7 +308,7 @@ func TestSetAlias_DifferentExistingAliasBlocks(t *testing.T) {
 	// /qurl unsetalias first. The test row pins the refusal copy so
 	// a future regression that silently overwrites lights this up.
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, "other", "r_existing")
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing")
 
 	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
@@ -308,9 +318,14 @@ func TestSetAlias_DifferentExistingAliasBlocks(t *testing.T) {
 	if !strings.Contains(got, "$other") || !strings.Contains(got, "unsetalias") {
 		t.Errorf("response = %q, want refusal copy referencing $other and unsetalias", got)
 	}
+	// Refusal copy must NOT leak the bound target (claude-bot review #5
+	// — info-disclosure narrowing). The test row pins this.
+	if strings.Contains(got, "r_existing") {
+		t.Errorf("refusal leaked bound target: %q", got)
+	}
 	a, _, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
-	if a != "other" {
-		t.Errorf("alias was overwritten: stored = %q, want %q", a, "other")
+	if a != testOtherAlias {
+		t.Errorf("alias was overwritten: stored = %q, want %q", a, testOtherAlias)
 	}
 }
 
@@ -376,7 +391,7 @@ func TestUnsetAlias_MismatchRefuses(t *testing.T) {
 	// least-surprise posture is "refuse and surface the mismatch"
 	// rather than silently nuke the wrong alias.
 	h, store := newAliasTestHandler(t)
-	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, "other", "r_existing")
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing")
 
 	body, sign := aliasSlashRequest(t, "unsetalias $foo", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
@@ -387,8 +402,8 @@ func TestUnsetAlias_MismatchRefuses(t *testing.T) {
 		t.Errorf("response = %q, want mismatch refusal copy", got)
 	}
 	a, _, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
-	if a != "other" {
-		t.Errorf("alias was cleared on mismatch: stored = %q, want %q", a, "other")
+	if a != testOtherAlias {
+		t.Errorf("alias was cleared on mismatch: stored = %q, want %q", a, testOtherAlias)
 	}
 }
 
@@ -441,6 +456,40 @@ func TestHelpListsNewVerbs(t *testing.T) {
 	}
 	if !strings.Contains(got, "unsetalias") {
 		t.Errorf("/qurl help = %q, missing unsetalias", got)
+	}
+}
+
+// TestSetAlias_CrossTenancyIsolation fences that an alias bound in
+// (T1, C1) is invisible to (T2, C1) and vice versa. The
+// channel_policies PK is `slack_team_id` so a T2 admin's setalias on
+// the same channel-ID must observe "no alias" — not T1's binding.
+// fakeAliasStore keys on `team|channel` so this is structurally
+// covered, but a regression that switched key construction (e.g. PK
+// = channel only) would break tenancy hard, so pin the fence here.
+func TestSetAlias_CrossTenancyIsolation(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	_ = store.SetChannelAlias(context.Background(), "T1", "C_shared", testAliasName, testAliasURL)
+
+	// T2 admin in the same channel ID — should see "no alias" and
+	// be allowed to set their own.
+	body, sign := aliasSlashRequest(t, "setalias $other https://t2.example", "T2", "C_shared")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "now points to") {
+		t.Errorf("T2 setalias should succeed; response = %q", got)
+	}
+
+	// T1's binding should be intact.
+	t1Alias, t1RID, _ := store.LookupChannelAlias(context.Background(), "T1", "C_shared")
+	if t1Alias != testAliasName || t1RID != testAliasURL {
+		t.Errorf("T1 binding was disturbed: got (%q, %q), want (%q, %q)", t1Alias, t1RID, testAliasName, testAliasURL)
+	}
+	// T2 wrote its own row.
+	t2Alias, _, _ := store.LookupChannelAlias(context.Background(), "T2", "C_shared")
+	if t2Alias != testOtherAlias {
+		t.Errorf("T2 binding missing: got %q, want %q", t2Alias, testOtherAlias)
 	}
 }
 

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -1,0 +1,457 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Shared fixture values for alias-handler tests. Lifted to package
+// level so goconst (3+ occurrences) stays clean and a change to
+// "what's the test workspace?" only happens in one place.
+const (
+	testAliasTeamID    = "T1"
+	testAliasChannelID = "C1"
+	testAliasURL       = "https://example.com"
+	testAliasName      = "staging"
+	testSlashCmd       = "/qurl"
+)
+
+// fakeAliasStore is an in-memory AliasStore for handler tests. One
+// record per (team, channel) — the same shape the post-pivot
+// channel_policies table enforces. Methods are safe under t.Parallel
+// since the handler-level tests don't fan out concurrent reads on
+// the same row.
+type fakeAliasStore struct {
+	mu sync.Mutex
+	// rows is keyed by team|channel; value is "alias|resourceID".
+	rows map[string]aliasRow
+
+	// errLookup, errSet, errClear let tests inject deterministic
+	// errors without spinning a real DDB fake.
+	errLookup error
+	errSet    error
+	errClear  error
+}
+
+type aliasRow struct {
+	alias      string
+	resourceID string
+}
+
+func newFakeAliasStore() *fakeAliasStore {
+	return &fakeAliasStore{rows: map[string]aliasRow{}}
+}
+
+func (f *fakeAliasStore) key(teamID, channelID string) string {
+	return teamID + "|" + channelID
+}
+
+func (f *fakeAliasStore) LookupChannelAlias(_ context.Context, teamID, channelID string) (alias, resourceID string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errLookup != nil {
+		return "", "", f.errLookup
+	}
+	r, ok := f.rows[f.key(teamID, channelID)]
+	if !ok {
+		return "", "", ErrAliasNotFound
+	}
+	return r.alias, r.resourceID, nil
+}
+
+func (f *fakeAliasStore) SetChannelAlias(_ context.Context, teamID, channelID, alias, resourceID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errSet != nil {
+		return f.errSet
+	}
+	f.rows[f.key(teamID, channelID)] = aliasRow{alias: alias, resourceID: resourceID}
+	return nil
+}
+
+func (f *fakeAliasStore) ClearChannelAlias(_ context.Context, teamID, channelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errClear != nil {
+		return f.errClear
+	}
+	k := f.key(teamID, channelID)
+	if _, ok := f.rows[k]; !ok {
+		return ErrAliasNotFound
+	}
+	delete(f.rows, k)
+	return nil
+}
+
+// newAliasTestHandler builds a Handler wired with a fakeAliasStore.
+// Returns both so individual tests can pre-seed rows or inject error
+// states without touching the handler internals.
+func newAliasTestHandler(t *testing.T) (*Handler, *fakeAliasStore) {
+	t.Helper()
+	h := newTestHandler(t, noopQURLServer(t))
+	store := newFakeAliasStore()
+	h.aliasStore = store
+	return h, store
+}
+
+// aliasSlashRequest builds a signed /slack/commands request for the
+// given text, posted by a user in (teamID, channelID). Returns the
+// body twice: once as the request body, once as the sign-body (the
+// pair matches the newSignedRequest contract used elsewhere in
+// handler_test.go).
+func aliasSlashRequest(t *testing.T, text, teamID, channelID string) (body, signBody string) {
+	t.Helper()
+	body = url.Values{
+		fieldCommand:   {testSlashCmd},
+		fieldText:      {text},
+		fieldTeamID:    {teamID},
+		fieldChannelID: {channelID},
+		fieldUserID:    {"U_admin"},
+		fieldTriggerID: {"trig-1"},
+	}.Encode()
+	return body, body
+}
+
+// decodeSlackText extracts the ephemeral text from a slash-command
+// response body. Centralized so the "response_type+text" envelope
+// shape stays asserted in one place.
+func decodeSlackText(t *testing.T, raw []byte) string {
+	t.Helper()
+	var resp map[string]string
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal response body: %v\nraw=%s", err, string(raw))
+	}
+	if resp[respFieldResponseType] != respTypeEphemeral {
+		t.Errorf("response_type = %q, want %q", resp["response_type"], respTypeEphemeral)
+	}
+	return resp[respFieldText]
+}
+
+// --- parser unit tests ---------------------------------------------------
+
+func TestParseAliasArgs_SetAlias(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantAlias string
+		wantTgt   string
+	}{
+		{name: "happy URL", input: "$staging https://example.com", wantAlias: testAliasName, wantTgt: testAliasURL},
+		{name: "happy resource id", input: "$staging r_abc123", wantAlias: testAliasName, wantTgt: "r_abc123"},
+		{name: "single-char alias allowed", input: "$a https://x.example", wantAlias: "a", wantTgt: "https://x.example"},
+		{name: "internal dashes allowed", input: "$demo-grafana https://x.example", wantAlias: "demo-grafana", wantTgt: "https://x.example"},
+
+		{name: "missing target", input: "$staging", wantErr: true},
+		{name: "missing alias", input: testAliasURL, wantErr: true},
+		{name: "no sigil", input: "staging https://example.com", wantErr: true},
+		{name: "empty alias after sigil", input: "$ https://example.com", wantErr: true},
+		{name: "uppercase rejected", input: "$Staging https://example.com", wantErr: true},
+		{name: "trailing dash rejected", input: "$staging- https://example.com", wantErr: true},
+		{name: "leading dash rejected", input: "$-staging https://example.com", wantErr: true},
+		{name: "extra args rejected", input: "$staging https://example.com extra", wantErr: true},
+		{name: "non-http target rejected", input: "$staging ftp://example.com", wantErr: true},
+		{name: "garbage target rejected", input: "$staging not-a-url", wantErr: true},
+		{name: "alias over cap rejected", input: "$" + strings.Repeat("a", 65) + " https://x.example", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, userMsg := parseAliasArgs(tc.input, true)
+			if tc.wantErr {
+				if userMsg == "" {
+					t.Fatalf("expected rejection, got %+v", got)
+				}
+				return
+			}
+			if userMsg != "" {
+				t.Fatalf("unexpected rejection: %s", userMsg)
+			}
+			if got.Alias != tc.wantAlias {
+				t.Errorf("Alias = %q, want %q", got.Alias, tc.wantAlias)
+			}
+			if got.Target != tc.wantTgt {
+				t.Errorf("Target = %q, want %q", got.Target, tc.wantTgt)
+			}
+		})
+	}
+}
+
+func TestParseAliasArgs_UnsetAlias(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantAlias string
+	}{
+		{name: "happy", input: "$staging", wantAlias: testAliasName},
+		{name: "trailing args rejected", input: "$staging extra", wantErr: true},
+		{name: "missing alias", input: "", wantErr: true},
+		{name: "no sigil", input: "staging", wantErr: true},
+		{name: "uppercase rejected", input: "$Staging", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, userMsg := parseAliasArgs(tc.input, false)
+			if tc.wantErr {
+				if userMsg == "" {
+					t.Fatalf("expected rejection, got %+v", got)
+				}
+				return
+			}
+			if userMsg != "" {
+				t.Fatalf("unexpected rejection: %s", userMsg)
+			}
+			if got.Alias != tc.wantAlias {
+				t.Errorf("Alias = %q, want %q", got.Alias, tc.wantAlias)
+			}
+			if got.Target != "" {
+				t.Errorf("Target = %q, want empty (unsetalias has no target)", got.Target)
+			}
+		})
+	}
+}
+
+// --- handler-level tests -------------------------------------------------
+
+func TestSetAlias_HappyURL(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "now points to") || !strings.Contains(got, "$staging") {
+		t.Errorf("response = %q, missing success copy", got)
+	}
+	a, rid, err := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
+	if err != nil {
+		t.Fatalf("post-setalias lookup: %v", err)
+	}
+	if a != testAliasName || rid != testAliasURL {
+		t.Errorf("stored row = (%q, %q), want (staging, https://example.com)", a, rid)
+	}
+}
+
+func TestSetAlias_HappyResourceID(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	body, sign := aliasSlashRequest(t, "setalias $staging r_abc123", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	_, rid, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
+	if rid != "r_abc123" {
+		t.Errorf("stored resourceID = %q, want r_abc123", rid)
+	}
+}
+
+func TestSetAlias_ParserError(t *testing.T) {
+	// Fence: a parser-rejection path must not call into the store.
+	// Counts as a regression test for "admin-gate before resolution"
+	// — the parser sits in front of every store call, so a malformed
+	// command can't probe for resource existence.
+	h, store := newAliasTestHandler(t)
+	body, sign := aliasSlashRequest(t, "setalias staging https://example.com", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "must start with `$`") {
+		t.Errorf("response = %q, want sigil error", got)
+	}
+	if _, _, err := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID); !errors.Is(err, ErrAliasNotFound) {
+		t.Errorf("store was touched on parser-rejection path: %v", err)
+	}
+}
+
+func TestSetAlias_SameTargetNoOp(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL)
+
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "No change.") {
+		t.Errorf("response = %q, missing no-change copy", got)
+	}
+}
+
+func TestSetAlias_DifferentExistingAliasBlocks(t *testing.T) {
+	// Schema-gap fence: the channel already has $other bound. Refuse
+	// to overwrite a teammate's alias without explicit
+	// /qurl unsetalias first. The test row pins the refusal copy so
+	// a future regression that silently overwrites lights this up.
+	h, store := newAliasTestHandler(t)
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, "other", "r_existing")
+
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "$other") || !strings.Contains(got, "unsetalias") {
+		t.Errorf("response = %q, want refusal copy referencing $other and unsetalias", got)
+	}
+	a, _, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
+	if a != "other" {
+		t.Errorf("alias was overwritten: stored = %q, want %q", a, "other")
+	}
+}
+
+func TestSetAlias_NoStoreWired(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "not configured") {
+		t.Errorf("response = %q, want not-configured copy", got)
+	}
+}
+
+func TestSetAlias_StoreWriteError(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	store.errSet = errors.New("ddb conditional failure")
+
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "Failed to update alias") {
+		t.Errorf("response = %q, want update-failed copy", got)
+	}
+}
+
+func TestUnsetAlias_Happy(t *testing.T) {
+	h, store := newAliasTestHandler(t)
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL)
+
+	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "no longer bound") {
+		t.Errorf("response = %q, want unset success copy", got)
+	}
+	if _, _, err := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID); !errors.Is(err, ErrAliasNotFound) {
+		t.Errorf("expected row cleared, got err=%v", err)
+	}
+}
+
+func TestUnsetAlias_NotSet(t *testing.T) {
+	h, _ := newAliasTestHandler(t)
+
+	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "No alias is set") {
+		t.Errorf("response = %q, want not-set copy", got)
+	}
+}
+
+func TestUnsetAlias_MismatchRefuses(t *testing.T) {
+	// The channel has $other bound; user runs unsetalias $foo. The
+	// least-surprise posture is "refuse and surface the mismatch"
+	// rather than silently nuke the wrong alias.
+	h, store := newAliasTestHandler(t)
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, "other", "r_existing")
+
+	body, sign := aliasSlashRequest(t, "unsetalias $foo", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "not `$foo`") {
+		t.Errorf("response = %q, want mismatch refusal copy", got)
+	}
+	a, _, _ := store.LookupChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID)
+	if a != "other" {
+		t.Errorf("alias was cleared on mismatch: stored = %q, want %q", a, "other")
+	}
+}
+
+func TestUnsetAlias_TOCTOUClearedRace(t *testing.T) {
+	// Race: lookup returns the expected alias, but ClearChannelAlias
+	// returns ErrAliasNotFound (another admin cleared it between the
+	// two calls). The user's intent is satisfied — render the
+	// success copy rather than confusing them with a 404.
+	h, store := newAliasTestHandler(t)
+	_ = store.SetChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, "r_x")
+	store.errClear = ErrAliasNotFound
+
+	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "no longer bound") {
+		t.Errorf("response = %q, want TOCTOU success copy", got)
+	}
+}
+
+func TestUnsetAlias_NoStoreWired(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "not configured") {
+		t.Errorf("response = %q, want not-configured copy", got)
+	}
+}
+
+func TestHelpListsNewVerbs(t *testing.T) {
+	// CR feedback fence from old #230: /qurl help must surface
+	// setalias and unsetalias. The old PR had a stale helpMessage()
+	// that listed only create/list/help even after the alias verbs
+	// landed. This test pins the help copy includes both.
+	h := newTestHandler(t, noopQURLServer(t))
+	body, sign := aliasSlashRequest(t, "help", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "setalias") {
+		t.Errorf("/qurl help = %q, missing setalias", got)
+	}
+	if !strings.Contains(got, "unsetalias") {
+		t.Errorf("/qurl help = %q, missing unsetalias", got)
+	}
+}
+
+func TestSetAliasStore_DoubleSetPanics(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	store := newFakeAliasStore()
+	h.SetAliasStore(store)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on second SetAliasStore, got none")
+		}
+	}()
+	h.SetAliasStore(store)
+}

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // Shared fixture values for alias-handler tests. Lifted to package
@@ -39,6 +40,12 @@ type fakeAliasStore struct {
 	// / ErrAliasNotFound) to exercise the typed-conflict branches.
 	errBind   error
 	errUnbind error
+
+	// blockBind, when true, makes BindChannelAlias wait on ctx.Done()
+	// and return ctx.Err(). Used by the aliasSyncTimeout fence test
+	// (a slow DDB write must surface as a write-failed reply, not
+	// block past Slack's ack window).
+	blockBind bool
 }
 
 func newFakeAliasStore() *fakeAliasStore {
@@ -49,7 +56,16 @@ func (f *fakeAliasStore) key(teamID, channelID string) string {
 	return teamID + "|" + channelID
 }
 
-func (f *fakeAliasStore) BindChannelAlias(_ context.Context, teamID, channelID, aliasName, resourceID string) error {
+func (f *fakeAliasStore) BindChannelAlias(ctx context.Context, teamID, channelID, aliasName, resourceID string) error {
+	// Block before taking the row lock so the timeout test doesn't
+	// also have to coordinate with anything else holding f.mu.
+	f.mu.Lock()
+	block := f.blockBind
+	f.mu.Unlock()
+	if block {
+		<-ctx.Done()
+		return ctx.Err()
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.errBind != nil {
@@ -185,6 +201,12 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 		// parse time so the response renders cleanly.
 		{name: "backtick in r_ target rejected", input: "$staging r_abc`bad", wantErr: true},
 		{name: "backtick in URL target rejected", input: "$staging https://example.com/`x", wantErr: true},
+		// Non-printable runes in target garble the audit log line and
+		// the Slack response. Rejected at parse time alongside the
+		// backtick guard so the success-copy + slog.Info surfaces
+		// remain hygienic.
+		{name: "control byte in r_ target rejected", input: "$staging r_abc\x01bad", wantErr: true},
+		{name: "control byte in URL target rejected", input: "$staging https://example.com/\x01x", wantErr: true},
 
 		// Fence: http://localhost is currently ACCEPTED. The parser
 		// stays scheme-permissive because qurl-service is the
@@ -338,7 +360,7 @@ func TestSetChannelAlias_SecondAliasOnSameChannelSucceeds(t *testing.T) {
 	}
 }
 
-func TestSetChannelAlias_DuplicateAliasSameChannelReturns409(t *testing.T) {
+func TestSetChannelAlias_DuplicateAliasIsRefused(t *testing.T) {
 	// Binding the same alias name twice in the same channel must
 	// surface as a typed conflict (ErrAliasAlreadyBound). A different
 	// resource id on the second call does NOT silently overwrite.
@@ -398,6 +420,58 @@ func TestSetAlias_MissingTeamOrChannelID(t *testing.T) {
 	// Store must not have been dialed in either branch.
 	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
 		t.Errorf("missing-id guard should have short-circuited before store dial, got bindings=%v", b)
+	}
+}
+
+// TestRedactURLForLog fences the audit-log redaction contract:
+// userinfo (credentials embedded by a setting admin) and raw query
+// strings (often carry tokens/keys) are stripped before the target
+// lands in operator-visible logs. r_… resource ids and unparseable
+// strings pass through unchanged.
+func TestRedactURLForLog(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain https", input: "https://example.com/path", want: "https://example.com/path"},
+		{name: "userinfo stripped", input: "https://user:token@example.com/path", want: "https://example.com/path"},
+		{name: "raw query stripped", input: "https://example.com/path?key=secret", want: "https://example.com/path"},
+		{name: "fragment stripped", input: "https://example.com/path#section", want: "https://example.com/path"},
+		{name: "userinfo + query stripped", input: "https://u:p@example.com/path?k=v", want: "https://example.com/path"},
+		{name: "resource id passthrough", input: "r_abc123", want: "r_abc123"},
+		{name: "unparseable passthrough", input: "::not-a-url", want: "::not-a-url"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactURLForLog(tc.input)
+			if got != tc.want {
+				t.Errorf("redactURLForLog(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSetAlias_SyncTimeoutExceeded fences the aliasSyncTimeout budget:
+// a BindChannelAlias that doesn't return inside the budget must
+// surface as a write-failed reply (not block past Slack's 3-second
+// ack window). Shortens aliasSyncTimeout for the duration of the
+// test so the suite doesn't pay a 2.5s real-time tax.
+func TestSetAlias_SyncTimeoutExceeded(t *testing.T) {
+	orig := aliasSyncTimeout
+	aliasSyncTimeout = 25 * time.Millisecond
+	t.Cleanup(func() { aliasSyncTimeout = orig })
+
+	h, store := newAliasTestHandler(t)
+	store.blockBind = true
+
+	body, sign := aliasSlashRequest(t, "setalias $staging https://example.com", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "Failed to update alias") {
+		t.Errorf("response = %q, want update-failed copy (ctx deadline exceeded)", got)
 	}
 }
 
@@ -476,7 +550,7 @@ func TestClearChannelAlias_OneOfManyLeavesOthers(t *testing.T) {
 	}
 }
 
-func TestClearChannelAlias_NotPresentReturns404(t *testing.T) {
+func TestClearChannelAlias_NotPresentIsNoop(t *testing.T) {
 	// Clearing an alias that isn't bound surfaces the typed
 	// ErrAliasNotFound branch as "not bound; nothing to clear."
 	h, _ := newAliasTestHandler(t)

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -430,7 +430,9 @@ func TestSetAlias_StoreWriteError(t *testing.T) {
 
 func TestUnsetAlias_Happy(t *testing.T) {
 	h, store := newAliasTestHandler(t)
-	_ = store.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL)
+	if err := store.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testAliasName, testAliasURL); err != nil {
+		t.Fatalf("seed bind: %v", err)
+	}
 
 	body, sign := aliasSlashRequest(t, "unsetalias $staging", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
@@ -494,7 +496,9 @@ func TestClearChannelAlias_NotPresentWithOtherAliasBound(t *testing.T) {
 	// typed not-found refusal AND leave $other intact. This is the
 	// multi-alias analog of the old "mismatch refuses" test.
 	h, store := newAliasTestHandler(t)
-	_ = store.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing")
+	if err := store.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testOtherAlias, "r_existing"); err != nil {
+		t.Fatalf("seed bind: %v", err)
+	}
 
 	body, sign := aliasSlashRequest(t, "unsetalias $foo", testAliasTeamID, testAliasChannelID)
 	w := httptest.NewRecorder()
@@ -566,7 +570,9 @@ func TestHelpListsNewVerbs(t *testing.T) {
 // = channel only) would break tenancy hard, so pin the fence here.
 func TestSetAlias_CrossTenancyIsolation(t *testing.T) {
 	h, store := newAliasTestHandler(t)
-	_ = store.BindChannelAlias(context.Background(), "T1", "C_shared", testAliasName, testAliasURL)
+	if err := store.BindChannelAlias(context.Background(), "T1", "C_shared", testAliasName, testAliasURL); err != nil {
+		t.Fatalf("seed T1 bind: %v", err)
+	}
 
 	// T2 admin in the same channel ID — should see "no alias" and
 	// be allowed to set their own.


### PR DESCRIPTION
## Summary

Hand-crafted rewrite of #230 (Lambda-shape, ~1,346 lines) against the current net/http shape on `main` post-#254. Salvages the CR feedback from #230's five fix-commits by folding the underlying concerns into the rewrite rather than a mechanical patch-port. Closes [Wave 4 setalias/unsetalias](../SLACK_QURL_ROLLOUT.md) on the rollout.

**Scope:** `/qurl setalias $<alias> <url-or-resource-id>` and `/qurl unsetalias $<alias>` admin verbs. Channel-scoped multi-alias persistence via a small `AliasStore` interface (DDB-direct, pivot-aligned — no qurl-service HTTP). Per-PR delta: ~937 lines (`handler_alias.go` + `handler_alias_test.go` + small wire-up in `handler.go`).

## Why this is a fresh PR rather than a rebase

#230 was seeded on a Lambda shape (`events.APIGatewayProxyRequest`/`APIGatewayProxyResponse`) before #254 landed the Lambda → net/http migration. Two new files (`handler_setalias.go` + test, both `import "github.com/aws/aws-lambda-go/events"`) couldn't rebase mechanically. Kevin green-lit the hand-craft.

Additionally, Justin's 2026-05-12 pivot ([qurl-integrations-infra #523 review](https://github.com/layervai/qurl-integrations-infra/pull/523)) closed the qurl-service alias-endpoints surface #230 was coding against (`/internal/v1/admin/*` and the `qurl_resources.alias` GSI on the service side). Aliases now live on the `qurl-bot-slack`-owned `channel_policies` DDB. The rewrite is pivot-native; no admin_client.go / no resource_client.go.

## Schema decision (locked 2026-05-17): multi-alias per channel via `alias_bindings`

The `channel_policies` row carries an app-managed `alias_bindings: Map<alias_name, resource_id>` attribute. A channel hosts an unbounded set of `$alias→resource` bindings concurrently — `$grafana`, `$staging-db`, `$logs` etc. coexist on the same row.

- **BindChannelAlias** (setalias) issues a DynamoDB `UpdateItem` with `SET alias_bindings.#a = :rid` and `ConditionExpression: attribute_not_exists(alias_bindings.#a)` → returns `ErrAliasAlreadyBound` (rendered as a 409-style refusal) if the alias name is already taken in the channel. Other aliases on the same channel are untouched.
- **UnbindChannelAlias** (unsetalias) issues `REMOVE alias_bindings.#a` with `ConditionExpression: attribute_exists(alias_bindings.#a)` → returns `ErrAliasNotFound` (rendered as a 404-style "nothing to clear") if absent. Other aliases on the same channel are untouched.

The atomic conditional writes structurally close the TOCTOU window that the prior single-alias version's lookup-then-write sequence had. No data migration (the table is empty pending Slack bot sandbox deploy).

## CR feedback salvaged from #230

Reviewed [issue comments 2026-05-10](https://github.com/layervai/qurl-integrations/pull/230#issuecomment) (rounds 1 and 2 from claude-bot). Each item below maps to how this rewrite addresses it.

| Old #230 CR item | Fix commit on #230 | How this PR addresses it |
|---|---|---|
| Modal `block_id` mismatch silently dismissed errors | `133cdde` | **Removed**. Sync ephemeral reply only; no modal in scope. |
| `unsetalias` info-disclosure (admin gate ran after lookup) | `5b981f1` | **Closed structurally**. Admin restriction is at the Slack app manifest level (mirrors the existing `/qurl setup` posture). |
| `/qurl help` listed only `create`/`list`/`help` | `b3be6a8` | `helpMessage()` updated to include `setalias` and `unsetalias`. Fenced by `TestHelpListsNewVerbs`. |
| go-toolchain stdlib CVE-bump | `3cdd79f` | Not applicable — `go.mod` directive on main is current. `govulncheck` clean. |
| Naming nits, sentinel cleanup, unused-field drops, dropped `IdempotencyKey()` call, `slog.Warn` on `PostResponseURL` failures, TOCTOU comment | `29f9296` | TOCTOU window closed structurally by the atomic conditional writes (see Schema decision). Idempotency-Key not in scope for this PR — alias upsert is a single conditional DDB write. |

## CR feedback addressed in this PR (post-rewrite)

Three rounds of claude-bot review on this PR landed since the initial hand-craft. Major items:

- **Sync handler vs Slack 3s ack window** — Replaced `asyncWorkTimeout` (25s) with `aliasSyncTimeout` (2.5s).
- **Bare `r_` accepted** — Parser rejects empty resource-id sigil.
- **Mismatch refusal leaked bound target** — Refusal copy now names only the alias.
- **Cross-tenancy isolation fence** — `TestSetAlias_CrossTenancyIsolation`.
- **TOCTOU window on setalias** — Closed structurally by the schema migration to atomic conditional writes.
- **`SetAliasStore` doc/code drift** — Tightened to "nil is a no-op; non-nil after non-nil panics."
- **Backtick injection in success copy** — Parser rejects backticks in `<target>` before they reach the Slack inline-code fence.
- **Defensive `aliasPreamble` missing-id branch** — Now covered by `TestSetAlias_MissingTeamOrChannelID`.

## Deferred follow-ups

- **#350** — Public-host SSRF gate on `/qurl setalias` targets (`http://localhost`, RFC1918, link-local). Currently accepted by the parser since qurl-service is the authoritative validator; tracked separately and fenced by a test row.
- **#351** — Optional in-code admin gate behind a config flag (defense-in-depth on the manifest-level admin gate).

## Cross-PR awareness

- **#228 (parser + idempotency)** — Not depended on. When #228 lands, the inline `parseAliasArgs` here can be replaced with a textual swap to `Parse(text)` + dispatch on `Subcommand`/`AdminAction`.
- **#231 (admin verbs) / #233 (qurl get + aliases)** — Sibling Wave 4 PRs. Both define a richer `slackdata.Store` that satisfies the `AliasStore` interface here as a no-op swap (`BindChannelAlias`/`UnbindChannelAlias` map directly to the new `alias_bindings` Map attribute).

## What changed

- `apps/slack/internal/handler.go` — wire `setalias`/`unsetalias` into the slash-command dispatcher; add `helpMessage()` lines for both verbs; add `Handler.aliasStore` field + `SetAliasStore()` setter (nil-passthrough; panics on non-nil-after-non-nil to prevent a running-handler swap).
- `apps/slack/internal/handler_alias.go` — `AliasStore` interface (`BindChannelAlias` / `UnbindChannelAlias`), sentinel errors (`ErrAliasAlreadyBound`, `ErrAliasNotFound`), parser (`parseAliasArgs`, `requireAlias`), `aliasPreamble`, `handleSetAlias`, `handleUnsetAlias`.
- `apps/slack/internal/handler_alias_test.go` — parser table tests (set + unset arms, including backtick-injection guard), handler-level happy/refusal/multi-alias/cross-tenancy/double-set/nil-passthrough tests, fakeAliasStore with multi-alias rows.

## Tests

`go test ./apps/slack/internal/... -race -count=1` — green.
`golangci-lint run --timeout=5m ./apps/slack/internal/...` — clean on the new files (`nolint:gosec G706` directives mirror handler.go's existing posture for CI's older lint version).
`govulncheck ./...` — clean.
`pre-commit run --files …` — green on all hooks.

## Test plan

- [ ] CI green on `feat/slack-setalias-unsetalias-v2` (lint, race tests, govulncheck)
- [ ] After AliasStore-side wiring lands (via #231 or successor): integration test against staging — `/qurl setalias $foo https://x` + `/qurl setalias $bar r_abc` coexist; `/qurl unsetalias $foo` leaves `$bar` intact
- [ ] After admin-manifest gate is verified in the Slack app config: non-admin invocation should fail at the manifest level (never reach the handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
