### PR TITLE
fix(discord): pre-check text-resolved recipients in confirm-card picker

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -496,6 +496,13 @@ const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ n
 // — keep them in lockstep so a future bump doesn't drift.
 const USER_SELECT_PER_PICK_CAP = 10;
 
+// Discord's hard cap on select-menu max_values. The initial confirm-card
+// renderer widens max_values to fit text-resolved recipientIds (so
+// addDefaultUsers can pre-check them — default_values.length ≤
+// max_values is a Discord-side invariant), and that widen is bounded
+// by this cap so we never construct a menu Discord rejects at validation.
+const DISCORD_SELECT_MAX_VALUES_HARD_CAP = 25;
+
 // Shared Google Maps URL patterns. `/qurl map`'s slash-option
 // `location:` consumes these — extracted to a single source so a
 // future "new URL shape" tweak only happens here.
@@ -3264,23 +3271,38 @@ function formatPersonalMessagePreview(message) {
 // hint so the label isn't blank.
 function renderConfirmCardRows({
   sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
-  voiceChannelId, interaction,
+  voiceChannelId, interaction, recipientIds,
 }) {
   const rows = [];
-  const maxValues = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
+  const baseCap = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
+  // When text-resolved recipients are already present, widen max_values
+  // so we can pre-check them via addDefaultUsers (Discord requires
+  // default_values.length ≤ max_values). Widen clamps at the hard cap;
+  // recipientIds past the hard cap are still in payload.recipientIds and
+  // get the send — only the visual pre-check truncates.
+  const defaults = Array.isArray(recipientIds) ? recipientIds : [];
+  const maxValues = defaults.length > 0
+    ? Math.min(DISCORD_SELECT_MAX_VALUES_HARD_CAP, config.QURL_SEND_MAX_RECIPIENTS, Math.max(baseCap, defaults.length))
+    : baseCap;
   // Placeholder surfaces both ceilings: pick-slot count (Discord's
   // setMaxValues) AND the post-expansion recipient cap. With roles in
   // the picker, a single slot can expand to many members — saying
   // only "1–10" would mislead users who pick 10 roles expecting 10
   // recipients.
   const recipientCap = config.QURL_SEND_MAX_RECIPIENTS;
-  rows.push(new ActionRowBuilder().addComponents(
-    new MentionableSelectMenuBuilder()
-      .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
-      .setPlaceholder(`Pick up to ${maxValues} users/roles (recipients capped at ${recipientCap})`)
-      .setMinValues(1)
-      .setMaxValues(maxValues)
-  ));
+  const picker = new MentionableSelectMenuBuilder()
+    .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
+    .setPlaceholder(`Pick up to ${maxValues} users/roles (recipients capped at ${recipientCap})`)
+    .setMinValues(1)
+    .setMaxValues(maxValues);
+  if (defaults.length > 0) {
+    // Text-path recipientIds are user IDs only — parseRecipientMentions
+    // expands roles to members before partition. addDefaultUsers is the
+    // matching API on MentionableSelectMenuBuilder (addDefaultRoles
+    // would be wrong here — we never persist role IDs).
+    picker.addDefaultUsers(...defaults.slice(0, maxValues));
+  }
+  rows.push(new ActionRowBuilder().addComponents(picker));
   // Self-destruct StringSelectMenu: "No self-destruct timer" + 7
   // curated presets sourced from SELF_DESTRUCT_PRESETS in utils/time.
   // The `default: true` flag on the matching option keeps the
@@ -3756,6 +3778,7 @@ async function handleQurlSlashSend(interaction, params) {
       personalMessage,
       voiceChannelId,
       interaction,
+      recipientIds,
     });
     // `return await` (not bare `return`) is load-bearing: without it
     // a Discord-side rejection on the confirm-card delivery would
@@ -4180,6 +4203,10 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       personalMessage: payload.personalMessage,
       voiceChannelId: payload.voiceChannelId,
       interaction,
+      // Mirror payload.recipientIds (unchanged on the reject branch — no
+      // transitionFlow fires here) so the user can recover their prior
+      // valid selection on re-open instead of starting from empty.
+      recipientIds: payload.recipientIds || [],
     }),
   }).catch(logIgnoredDiscordErr);
   if (valid.length === 0) {
@@ -4322,6 +4349,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       personalMessage: payload.personalMessage,
       voiceChannelId: payload.voiceChannelId,
       interaction,
+      recipientIds: newPayload.recipientIds,
     }),
   }).catch(logIgnoredDiscordErr);
 }
@@ -4435,6 +4463,10 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       personalMessage: payload.personalMessage,
       voiceChannelId,
       interaction,
+      // Mirror payload.recipientIds (unchanged on the reject branch —
+      // no transitionFlow fires) so the user can recover their prior
+      // valid selection on re-open of the picker.
+      recipientIds: payload.recipientIds || [],
     }),
   }).catch(logIgnoredDiscordErr);
 
@@ -4578,6 +4610,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       personalMessage: payload.personalMessage,
       voiceChannelId,
       interaction,
+      recipientIds: newPayload.recipientIds,
     }),
   }).catch(logIgnoredDiscordErr);
 }
@@ -4655,6 +4688,7 @@ async function rerenderConfirmCard(interaction, newPayload) {
       personalMessage: newPayload.personalMessage,
       voiceChannelId: newPayload.voiceChannelId,
       interaction,
+      recipientIds,
     }),
   }).catch(logIgnoredDiscordErr);
 }

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -63,6 +63,8 @@ jest.mock('discord.js', () => {
       setMinValues: jest.fn().mockReturnThis(),
       setMaxValues: jest.fn().mockReturnThis(),
       setPlaceholder: jest.fn().mockReturnThis(),
+      setDefaultValues: jest.fn().mockReturnThis(),
+      addDefaultUsers: jest.fn().mockReturnThis(),
     })),
     MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
       setCustomId: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -127,6 +127,8 @@ jest.mock('discord.js', () => {
     setPlaceholder: jest.fn().mockReturnThis(),
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
+    setDefaultValues: jest.fn().mockReturnThis(),
+    addDefaultUsers: jest.fn().mockReturnThis(),
   })),
   MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
   ModalBuilder: jest.fn().mockImplementation(() => ({

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -128,6 +128,8 @@ jest.mock('discord.js', () => {
     setPlaceholder: jest.fn().mockReturnThis(),
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
+    setDefaultValues: jest.fn().mockReturnThis(),
+    addDefaultUsers: jest.fn().mockReturnThis(),
   })),
   MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => makeComponentChainable()),
   ModalBuilder: jest.fn().mockImplementation(() => ({

--- a/apps/discord/tests/helpers/discord-mock.js
+++ b/apps/discord/tests/helpers/discord-mock.js
@@ -51,6 +51,8 @@ function makeComponentChainable(extra = {}) {
     addOptions: jest.fn().mockReturnThis(),
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
+    setDefaultValues: jest.fn().mockReturnThis(),
+    addDefaultUsers: jest.fn().mockReturnThis(),
     addComponents: jest.fn().mockReturnThis(),
     setDisabled: jest.fn().mockReturnThis(),
     setValue: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -4878,6 +4878,73 @@ describe('renderConfirmCardRows', () => {
     expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Edit note/));
   });
 
+  test('slash-entry WITH recipients → picker pre-checks the text-resolved ids via addDefaultUsers', async () => {
+    // Power-user bug: typing `recipients:@a @b` then opening the picker
+    // showed an empty dropdown — the originally-selected users were not
+    // pre-checked. Fix routes the resolved recipientIds through
+    // renderConfirmCardRows → MentionableSelectMenuBuilder.addDefaultUsers
+    // so Discord pre-checks them on dropdown open. The send still
+    // proceeds with the same set; this is purely a re-open UX fix.
+    // Roles in text get expanded to users by parseRecipientMentions, so
+    // we never pre-check roles here (addDefaultRoles would be wrong).
+    const { MentionableSelectMenuBuilder } = require('discord.js');
+    MentionableSelectMenuBuilder.mockClear();
+    const int = makeInteraction({
+      options: {
+        attachment: VALID_ATTACHMENT,
+        recipients: '<@100000000000000001> <@100000000000000002>',
+      },
+      guildMembers: {
+        '100000000000000001': {},
+        '100000000000000002': {},
+      },
+    });
+    await handleQurlFile(int);
+    expect(MentionableSelectMenuBuilder).toHaveBeenCalledTimes(1);
+    const builder = MentionableSelectMenuBuilder.mock.results[0].value;
+    expect(builder.addDefaultUsers).toHaveBeenCalledWith(
+      '100000000000000001',
+      '100000000000000002',
+    );
+  });
+
+  test('slash-entry WITHOUT recipients → picker does NOT call addDefaultUsers', async () => {
+    // When there are no resolved recipients (needsPicker:true), the
+    // renderer must skip the addDefaultUsers call entirely — Discord
+    // rejects a select menu where default_values is empty-but-present,
+    // and the picker stays empty by design for first-pick UX.
+    const { MentionableSelectMenuBuilder } = require('discord.js');
+    MentionableSelectMenuBuilder.mockClear();
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT },  // no recipients → needsPicker
+    });
+    await handleQurlFile(int);
+    expect(MentionableSelectMenuBuilder).toHaveBeenCalledTimes(1);
+    const builder = MentionableSelectMenuBuilder.mock.results[0].value;
+    expect(builder.addDefaultUsers).not.toHaveBeenCalled();
+  });
+
+  test('slash-entry with >USER_SELECT_PER_PICK_CAP recipients widens max_values to fit all defaults', async () => {
+    // Discord requires default_values.length ≤ max_values. The picker's
+    // default per-pick cap is 10; if the user text-resolved 12 valid
+    // recipients, the initial render must widen max_values to 12 so
+    // addDefaultUsers(12 ids) is accepted (bounded by Discord's 25 hard
+    // cap on select-menu max_values).
+    const { MentionableSelectMenuBuilder } = require('discord.js');
+    MentionableSelectMenuBuilder.mockClear();
+    const ids = Array.from({ length: 12 }, (_, i) => `1000000000000000${String(i + 10)}`);
+    const mentionList = ids.map((id) => `<@${id}>`).join(' ');
+    const guildMembers = Object.fromEntries(ids.map((id) => [id, {}]));
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: mentionList },
+      guildMembers,
+    });
+    await handleQurlFile(int);
+    const builder = MentionableSelectMenuBuilder.mock.results[0].value;
+    expect(builder.setMaxValues).toHaveBeenCalledWith(12);
+    expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids);
+  });
+
   test('voice button label stays under Discord\'s 80 UTF-16 cap with an ALL-EMOJI channel name (worst case)', async () => {
     // Round-14 cr bug-guard: a 46-codepoint all-emoji channel name
     // (which Discord allows up to its 100-char limit) occupies 92

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -67,6 +67,8 @@ jest.mock('discord.js', () => {
       addOptions: jest.fn().mockReturnThis(),
       setMinValues: jest.fn().mockReturnThis(),
       setMaxValues: jest.fn().mockReturnThis(),
+      setDefaultValues: jest.fn().mockReturnThis(),
+      addDefaultUsers: jest.fn().mockReturnThis(),
       addComponents: jest.fn().mockReturnThis(),
       setDisabled: jest.fn().mockReturnThis(),
       setMaxLength: jest.fn().mockReturnThis(),

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -93,6 +93,8 @@ jest.mock('discord.js', () => ({
     setPlaceholder: jest.fn().mockReturnThis(),
     setMinValues: jest.fn().mockReturnThis(),
     setMaxValues: jest.fn().mockReturnThis(),
+    setDefaultValues: jest.fn().mockReturnThis(),
+    addDefaultUsers: jest.fn().mockReturnThis(),
   })),
   MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
     setCustomId: jest.fn().mockReturnThis(),
@@ -1387,6 +1389,8 @@ describe('handleAddRecipients', () => {
         setPlaceholder: jest.fn().mockReturnThis(),
         setMinValues: jest.fn().mockReturnThis(),
         setMaxValues: jest.fn().mockReturnThis(),
+        setDefaultValues: jest.fn().mockReturnThis(),
+        addDefaultUsers: jest.fn().mockReturnThis(),
       })),
       MentionableSelectMenuBuilder: jest.fn().mockImplementation(() => ({
         setCustomId: jest.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary
- Text-typed `recipients:@a @b` resolved into `payload.recipientIds` but the MentionableSelectMenu rendered empty — opening the dropdown showed nothing pre-checked, forcing power users to re-pick.
- Threads `recipientIds` through `renderConfirmCardRows` and calls `addDefaultUsers` so Discord pre-checks the originally-typed users on open.
- Widens `setMaxValues` when defaults exceed the per-pick cap (Discord requires `default_values.length ≤ max_values`), bounded by Discord's 25-item hard cap on select menus. Defaults past 25 truncate visually; the send still uses the full `payload.recipientIds` set.

## Test plan
- [x] Existing `renderConfirmCardRows` describe block still passes (4-row layout, Send-disabled-without-recipients, button row order).
- [x] New regression tests:
  - WITH recipients → picker calls `addDefaultUsers(...recipientIds)`.
  - WITHOUT recipients → picker does NOT call `addDefaultUsers`.
  - With >10 recipients → `setMaxValues` widens to fit (12 in the test).
- [x] Full discord test suite: 1597 passed.
- [x] Lint clean (`npm run lint`).
- [ ] Manual: `/qurl file recipients:@a @b` → open picker → both users appear pre-checked.
- [ ] Manual: `/qurl file` (no recipients) → picker opens empty as before.
- [ ] Manual: `/qurl file recipients:@a @b @SomeRole12Members` → picker shows the role-expanded users pre-checked (up to 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)