### PR TITLE
refactor(discord): harden handleAddRecipients with allowed-set entry gate + isValidExpiry refactor

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -499,6 +499,20 @@ const EXPIRY_LABELS = {
 
 const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ name, value }));
 
+// Pure predicate. The 5 call sites (failGate at executeSendPipeline,
+// entry gate at handleAddRecipients, expiry-select handlers, voice-
+// everyone select-menu fallback) all need different error rendering
+// shapes — `failGate`, return-error-obj, fallback-with-warn — so
+// only the membership check is DRY'd here; the per-site error
+// surface stays inline.
+// `Object.prototype.hasOwnProperty.call` (not `EXPIRY_LABELS[v]`) is
+// load-bearing for prototype-pollution safety AND because a
+// caller-supplied `toString`/`constructor` key could otherwise pass
+// the truthy check.
+function isValidExpiry(v) {
+  return Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, v);
+}
+
 // Per-pick cap on UserSelectMenuBuilder.setMaxValues. Discord's hard
 // limit is 25; capping at 10 bounds the UX. The initial confirm-card
 // UserSelectMenu AND the post-send "Add Recipients" flow both use this
@@ -1128,7 +1142,7 @@ async function executeSendPipeline(interaction, {
   // ship an off-set value (`'25h'`, `'bogus'`) that lands in the
   // DB and trips downstream when `expiryToISO` / `expiryToMs`
   // hit it. Validate at the boundary instead.
-  if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
+  if (!isValidExpiry(expiresIn)) {
     failGate(TypeError, `executeSendPipeline: expiresIn must be one of ${Object.keys(EXPIRY_LABELS).join('|')} (got ${truncForLog(expiresIn)})`);
   }
 
@@ -1772,15 +1786,19 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Send configuration not found.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: [] };
   }
 
-  // #352 entry gate. Symmetric with the executeSendPipeline failGate
-  // (`grep "expiresIn must be one of"`) — closes the unprotected
+  // #352 entry gate. Shares the same `EXPIRY_LABELS` membership
+  // predicate as the executeSendPipeline failGate
+  // (`grep "expiresIn must be one of"`), closing the unprotected
   // path where a stale/regressed sendConfig row could ship an
   // off-set value. Protects BOTH downstream `expiryToMs` AND
   // `expiryToISO` (each used below for mint + DM dispatch) from
-  // their shared silent-24h-default fallback. Returns an error
-  // object rather than throwing to match handleAddRecipients'
-  // contract — the caller renders it on the post-send confirm card.
-  if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, sendConfig.expires_in)) {
+  // their shared silent-24h-default fallback. Failure shape
+  // diverges from failGate intentionally: failGate throws (caller
+  // catches at the slash-command boundary), while this gate returns
+  // an error object — handleAddRecipients's caller renders the
+  // string on the post-send confirm card, where a throw would land
+  // as a generic "Internal error" with no actionable message.
+  if (!isValidExpiry(sendConfig.expires_in)) {
     logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
       msg: 'Cannot add recipients — this send\'s saved expiry is invalid (the original send\'s links still work; create a new send to reach additional recipients).',
@@ -3658,7 +3676,7 @@ async function handleQurlSlashSend(interaction, params) {
     // Defense-in-depth: expiresIn comes from the slash command's choice
     // list which Discord enforces server-side, but a forged interaction
     // could carry an off-set value. EXPIRY_LABELS owns the closed set.
-    if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, expiresIn)) {
+    if (!isValidExpiry(expiresIn)) {
       clearCooldown(interaction.user.id);
       return interaction.editReply({
         content: '❌ Unrecognized expiry value. Re-run and pick from the list.',
@@ -4880,7 +4898,7 @@ async function handleConfirmExpirySelect(interaction, { flow_id, row }) {
   // Validate before deferring so the forgery branch can use `reply`
   // (the cheaper, single-call ack) instead of `followUp` after a
   // wasted deferUpdate. Symmetric with the self-destruct handler.
-  if (!picked || !Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, picked)) {
+  if (!picked || !isValidExpiry(picked)) {
     logger.warn('handleConfirmExpirySelect: forged off-set expiry value', {
       flow_id, value: truncForLog(picked),
     });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1357,9 +1357,11 @@ async function executeSendPipeline(interaction, {
 
   // #352 ordering invariant: expiresAt computed BEFORE any DDB
   // write. Defense-in-depth — the failGate above already rejects
-  // malformed expiresIn before reaching here. Clock drift vs. the
-  // API's enforcement clock is sub-second on this path; negligible
-  // at the 30m–7d horizon.
+  // malformed expiresIn before reaching here. Using send-time +
+  // duration (rather than reading `expires_at` from the API's mint
+  // response) since `mintLinks` doesn't currently surface that
+  // field. Clock drift vs. the API's enforcement clock is sub-second
+  // on this path; negligible at the 30m–7d horizon.
   const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
 
   // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
@@ -3491,7 +3493,7 @@ function renderConfirmCardRows({
   // option's label, misrepresenting the actual stored value. Falls
   // back to defaulting the codebase-default '24h' option so the card
   // still shows SOMETHING meaningful.
-  const hasExpiryMatch = EXPIRY_CHOICES.some((c) => c.value === expiresIn);
+  const hasExpiryMatch = isValidExpiry(expiresIn);
   if (!hasExpiryMatch && expiresIn != null) {
     // Log so corrupted rows surface in forensics rather than just
     // getting papered over by the 24h fallback.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1842,7 +1842,10 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // string on the post-send confirm card, where a throw would land
   // as a generic "Internal error" with no actionable message.
   if (!isValidExpiry(sendConfig.expires_in)) {
-    logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
+    // warn (not error): a stale/corrupted DDB row is user-recoverable
+    // (re-send), not paging-worthy. Matches renderConfirmCardRows's
+    // analogous off-EXPIRY_LABELS log level. Forensics-only signal.
+    logger.warn('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
       msg: 'Cannot add recipients — this send\'s saved expiry is invalid (the original send\'s links still work; create a new send to reach additional recipients).',
       newResourceIds: [], delivered: 0, failed: 0, newRecipients: [],

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -496,17 +496,11 @@ const EXPIRY_LABELS = {
 
 const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ name, value }));
 
-// Pure predicate. The 5 call sites (failGate at executeSendPipeline,
-// entry gate at handleAddRecipients, renderConfirmCardRows default-
-// selection guard, slash-command forged-interaction guard,
-// handleConfirmExpirySelect forged-value guard) all need different
-// error rendering shapes — `failGate` throws, return-error-obj,
-// fallback-with-warn — so only the membership check is DRY'd here;
-// the per-site error surface stays inline.
-// `Object.prototype.hasOwnProperty.call` (not `EXPIRY_LABELS[v]`) is
-// load-bearing for prototype-pollution safety AND because a
-// caller-supplied `toString`/`constructor` key could otherwise pass
-// the truthy check.
+// Pure predicate for the EXPIRY_LABELS closed-set membership check.
+// `Object.prototype.hasOwnProperty.call` (NOT `EXPIRY_LABELS[v]`) is
+// load-bearing: a caller-supplied `'toString'`/`'constructor'` key
+// would otherwise pass a truthy check via prototype access.
+// `git grep isValidExpiry` for call sites.
 function isValidExpiry(v) {
   return Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, v);
 }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1847,7 +1847,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // analogous off-EXPIRY_LABELS log level. Forensics-only signal.
     logger.warn('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
-      msg: 'Cannot add recipients — this send\'s saved expiry is invalid (the original send\'s links still work; create a new send to reach additional recipients).',
+      msg: `Cannot add recipients — this send's saved expiry is invalid (the original send's links still work; create a new send to reach additional recipients).`,
       newResourceIds: [], delivered: 0, failed: 0, newRecipients: [],
     };
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1795,7 +1795,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, sendConfig.expires_in)) {
     logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
-      msg: 'Cannot add recipients — saved expiry is invalid. Please create a new send.',
+      msg: 'Cannot add recipients — this send\'s saved expiry is invalid (the original send\'s links still work; create a new send to reach additional recipients).',
       newResourceIds: [], delivered: 0, failed: 0, newRecipients: [],
     };
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1779,16 +1779,19 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   }
 
   // Validate `sendConfig.expires_in` at the entry, BEFORE any mint or
-  // recordQURLSendBatch work (issue #352). Symmetric with the failGate
-  // at executeSendPipeline:~1131 — closes the unprotected path where a
-  // stale/regressed sendConfig row (or a future direct sendConfig
-  // writer) ships an off-set value that would otherwise default to 24h
-  // silently inside `expiryToMs` / `expiryToISO`. Rejecting here means
-  // no QURL links get minted (sparing the upstream API call) and no
-  // DDB rows get written, so there's nothing to revoke / no orphan to
-  // clean up. Returns a user-visible message rather than throwing
-  // (matches handleAddRecipients's error-return contract; the caller
-  // renders it on the post-send confirm card).
+  // recordQURLSendBatch work (issue #352). Symmetric with the
+  // executeSendPipeline failGate (`grep "expiresIn must be one of"`
+  // — anchored on the throw message rather than a line number so
+  // future drift doesn't rot the breadcrumb) — closes the
+  // unprotected path where a stale/regressed sendConfig row (or a
+  // future direct sendConfig writer) ships an off-set value that
+  // would otherwise default to 24h silently inside `expiryToMs` /
+  // `expiryToISO`. Rejecting here means no QURL links get minted
+  // (sparing the upstream API call) and no DDB rows get written, so
+  // there's nothing to revoke / no orphan to clean up. Returns a
+  // user-visible message rather than throwing (matches
+  // handleAddRecipients's error-return contract; the caller renders
+  // it on the post-send confirm card).
   if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, sendConfig.expires_in)) {
     logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1341,17 +1341,11 @@ async function executeSendPipeline(interaction, {
     return interaction.editReply({ content: 'Failed to create any links. Please try again.' });
   }
 
-  // Compute expiresAt BEFORE recordQURLSendBatch so a future
-  // `expiryToMs`-throws regression can't leave orphan DDB rows (#352).
-  // Today this is defense-in-depth — the failGate above at the
-  // `expiresIn` allowed-set check already rejects malformed values
-  // before any mint or DB work — but pinning the ordering invariant
-  // here keeps the property load-bearing regardless of upstream gate
-  // drift. Drift between this clock and the API's enforcement clock
-  // is bounded by the time between this line and the mint call
-  // (sub-second on the send-pipeline path). Negligible at the
-  // 30m–7d horizon — recipients see "in 24 hours" instead of
-  // "in 23h 59m 56s" on the worst-case path.
+  // #352 ordering invariant: expiresAt computed BEFORE any DDB
+  // write. Defense-in-depth — the failGate above already rejects
+  // malformed expiresIn before reaching here. Clock drift vs. the
+  // API's enforcement clock is sub-second on this path; negligible
+  // at the 30m–7d horizon.
   const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
 
   // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
@@ -1778,20 +1772,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Send configuration not found.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: [] };
   }
 
-  // Validate `sendConfig.expires_in` at the entry, BEFORE any mint or
-  // recordQURLSendBatch work (issue #352). Symmetric with the
-  // executeSendPipeline failGate (`grep "expiresIn must be one of"`
-  // — anchored on the throw message rather than a line number so
-  // future drift doesn't rot the breadcrumb) — closes the
-  // unprotected path where a stale/regressed sendConfig row (or a
-  // future direct sendConfig writer) ships an off-set value that
-  // would otherwise default to 24h silently inside `expiryToMs` /
-  // `expiryToISO`. Rejecting here means no QURL links get minted
-  // (sparing the upstream API call) and no DDB rows get written, so
-  // there's nothing to revoke / no orphan to clean up. Returns a
-  // user-visible message rather than throwing (matches
-  // handleAddRecipients's error-return contract; the caller renders
-  // it on the post-send confirm card).
+  // #352 entry gate. Symmetric with the executeSendPipeline failGate
+  // (`grep "expiresIn must be one of"`) — closes the unprotected
+  // path where a stale/regressed sendConfig row could ship an
+  // off-set value. Protects BOTH downstream `expiryToMs` AND
+  // `expiryToISO` (each used below for mint + DM dispatch) from
+  // their shared silent-24h-default fallback. Returns an error
+  // object rather than throwing to match handleAddRecipients'
+  // contract — the caller renders it on the post-send confirm card.
   if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, sendConfig.expires_in)) {
     logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
@@ -1979,12 +1967,9 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       });
     }
   }
-  // Compute expiresAt BEFORE recordQURLSendBatch (and once per call,
-  // not per recipient) so a future `expiryToMs`-throws regression
-  // can't leave orphan DDB rows (#352). The entry-gate above already
-  // rejects malformed `sendConfig.expires_in`, but pinning the
-  // ordering here keeps the property load-bearing if the entry gate
-  // ever drifts. Same Unix-seconds + drift caveat as executeSendPipeline.
+  // #352 ordering invariant: expiresAt computed BEFORE any DDB write
+  // (and once per call, not per recipient). Defense-in-depth on top
+  // of the entry gate above. Same drift caveat as executeSendPipeline.
   const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
 
   // Same guarantee as executeSendPipeline: if the DB write fails, abort

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -497,11 +497,12 @@ const EXPIRY_LABELS = {
 const EXPIRY_CHOICES = Object.entries(EXPIRY_LABELS).map(([value, name]) => ({ name, value }));
 
 // Pure predicate. The 5 call sites (failGate at executeSendPipeline,
-// entry gate at handleAddRecipients, expiry-select handlers, voice-
-// everyone select-menu fallback) all need different error rendering
-// shapes — `failGate`, return-error-obj, fallback-with-warn — so
-// only the membership check is DRY'd here; the per-site error
-// surface stays inline.
+// entry gate at handleAddRecipients, renderConfirmCardRows default-
+// selection guard, slash-command forged-interaction guard,
+// handleConfirmExpirySelect forged-value guard) all need different
+// error rendering shapes — `failGate` throws, return-error-obj,
+// fallback-with-warn — so only the membership check is DRY'd here;
+// the per-site error surface stays inline.
 // `Object.prototype.hasOwnProperty.call` (not `EXPIRY_LABELS[v]`) is
 // load-bearing for prototype-pollution safety AND because a
 // caller-supplied `toString`/`constructor` key could otherwise pass
@@ -2019,10 +2020,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // Hoist payload-shared inputs to the top of the dispatch block so
   // the entire batch shares one expiry timestamp and one resolved
   // sender alias. Mirrors executeSendPipeline's structure — both
-  // pipelines now compute expiresAt once per call, eliminating
-  // Date.now() drift between recipients in the same batch.
-  // resolveSenderAlias is a pure function of originalInteraction so
-  // hoisting also avoids re-resolving the
+  // pipelines now compute the Unix-seconds expiresAt once per call,
+  // eliminating Date.now() drift between recipients in the same
+  // batch. (The ISO-string `expiresAt` inside the file/location prep
+  // branches calls expiryToISO independently for mintLinks — that's
+  // a separate type for a separate consumer; sub-second drift between
+  // the minted-link expiry and the DM-payload expiry is negligible
+  // at the 30m–7d horizon.) resolveSenderAlias is a pure function of
+  // originalInteraction so hoisting also avoids re-resolving the
   // nickname/globalName/username chain per dispatch.
   //
   // Computed BEFORE recordQURLSendBatch so a malformed
@@ -2050,7 +2055,6 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       });
     }
   }
-
   // Same guarantee as executeSendPipeline: if the DB write fails, abort
   // BEFORE any DMs go out so we don't leave live QURL links with no
   // local record.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1341,6 +1341,19 @@ async function executeSendPipeline(interaction, {
     return interaction.editReply({ content: 'Failed to create any links. Please try again.' });
   }
 
+  // Compute expiresAt BEFORE recordQURLSendBatch so a future
+  // `expiryToMs`-throws regression can't leave orphan DDB rows (#352).
+  // Today this is defense-in-depth — the failGate above at the
+  // `expiresIn` allowed-set check already rejects malformed values
+  // before any mint or DB work — but pinning the ordering invariant
+  // here keeps the property load-bearing regardless of upstream gate
+  // drift. Drift between this clock and the API's enforcement clock
+  // is bounded by the time between this line and the mint call
+  // (sub-second on the send-pipeline path). Negligible at the
+  // 30m–7d horizon — recipients see "in 24 hours" instead of
+  // "in 23h 59m 56s" on the worst-case path.
+  const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
+
   // Persist ALL links to DB BEFORE sending DMs. If the write fails the links
   // still exist on the QURL side but there's no local record to revoke them
   // later — abort the send and surface the error instead of continuing to DMs.
@@ -1377,23 +1390,11 @@ async function executeSendPipeline(interaction, {
     });
   }
 
-  // Send DMs
+  // Send DMs (`expiresAt` computed above the DDB write — see #352).
   let delivered = 0;
   let failed = 0;
   const failedUsers = [];
   const recipientMap = new Map(recipients.map(r => [r.id, r]));
-
-  // Compute the absolute expiry instant once for this dispatch (Unix
-  // seconds — Discord's <t:N:R> format requires seconds, not millis).
-  // Using send-time + duration rather than reading from the API mint
-  // response since `mintLinks` doesn't currently surface `expires_at`.
-  // Drift between this clock and the API's enforcement clock is bounded
-  // by the time between this line and the mint call (sub-second on the
-  // send-pipeline path; can be a few seconds on handleAddRecipients
-  // which re-downloads + re-uploads + re-mints first). Negligible at
-  // the 30m–7d horizon — recipients see "in 24 hours" instead of
-  // "in 23h 59m 56s" on the worst-case path.
-  const expiresAt = Math.floor((Date.now() + expiryToMs(expiresIn)) / 1000);
 
   const dmResults = await batchSettled(qurlLinks, async (link) => {
     const recipient = recipientMap.get(link.recipientId);
@@ -1775,6 +1776,25 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     return { msg: 'Send configuration not found.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: [] };
   }
 
+  // Validate `sendConfig.expires_in` at the entry, BEFORE any mint or
+  // recordQURLSendBatch work (issue #352). Symmetric with the failGate
+  // at executeSendPipeline:~1131 — closes the unprotected path where a
+  // stale/regressed sendConfig row (or a future direct sendConfig
+  // writer) ships an off-set value that would otherwise default to 24h
+  // silently inside `expiryToMs` / `expiryToISO`. Rejecting here means
+  // no QURL links get minted (sparing the upstream API call) and no
+  // DDB rows get written, so there's nothing to revoke / no orphan to
+  // clean up. Returns a user-visible message rather than throwing
+  // (matches handleAddRecipients's error-return contract; the caller
+  // renders it on the post-send confirm card).
+  if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, sendConfig.expires_in)) {
+    logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: sendConfig.expires_in });
+    return {
+      msg: 'Cannot add recipients — saved expiry is invalid. Please create a new send.',
+      newResourceIds: [], delivered: 0, failed: 0, newRecipients: [],
+    };
+  }
+
   // Filter out bots and the sender. Convert the Discord Collection to a
   // plain array so later callers (map/forEach over newRecipients[i]) work.
   const newRecipients = [...usersCollection
@@ -1954,6 +1974,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       });
     }
   }
+  // Compute expiresAt BEFORE recordQURLSendBatch (and once per call,
+  // not per recipient) so a future `expiryToMs`-throws regression
+  // can't leave orphan DDB rows (#352). The entry-gate above already
+  // rejects malformed `sendConfig.expires_in`, but pinning the
+  // ordering here keeps the property load-bearing if the entry gate
+  // ever drifts. Same Unix-seconds + drift caveat as executeSendPipeline.
+  const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
+
   // Same guarantee as executeSendPipeline: if the DB write fails, abort
   // BEFORE any DMs go out so we don't leave live QURL links with no
   // local record.
@@ -2001,11 +2029,9 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // counts as dispatch_failed instead of disappearing from CloudWatch.
     let sent = false;
     try {
-      // Same Unix-seconds expiry computation as executeSendPipeline —
-      // see comment there. Computed once per recipient (cheap; the
-      // alternative would be threading a single timestamp through
-      // sendConfig).
-      const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
+      // `expiresAt` hoisted above the recordQURLSendBatch call (see
+      // the #352 comment there) — closes the per-recipient redundant
+      // computation alongside the orphan-DDB-row ordering fix.
       const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
         // Same alias resolution as executeSendPipeline — see comment
         // there for the nickname > globalName > username fallback

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1390,7 +1390,9 @@ async function executeSendPipeline(interaction, {
     });
   }
 
-  // Send DMs (`expiresAt` computed above the DDB write — see #352).
+  // Send DMs. `expiresAt` is Unix seconds, computed above the DDB
+  // write — see the #352 hoist comment near recordQURLSendBatch for
+  // the clock-drift caveat that was previously documented here.
   let delivered = 0;
   let failed = 0;
   const failedUsers = [];
@@ -1788,7 +1790,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // (matches handleAddRecipients's error-return contract; the caller
   // renders it on the post-send confirm card).
   if (!Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, sendConfig.expires_in)) {
-    logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: sendConfig.expires_in });
+    logger.error('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
       msg: 'Cannot add recipients — saved expiry is invalid. Please create a new send.',
       newResourceIds: [], delivered: 0, failed: 0, newRecipients: [],

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1174,6 +1174,7 @@ describe('handleAddRecipients — pre-flight guards', () => {
     ['undefined', undefined],
     ['null', null],
     ['number (not string)', 24],
+    ['NaN', NaN],
   ])('refuses when sendConfig.expires_in=%s (off allowed set) (#352)', async (_label, expiresIn) => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: 'res-1',
@@ -1612,6 +1613,7 @@ describe('executeSendPipeline — expiresIn allowed-set gate', () => {
     ['empty string', ''],
     ['undefined', undefined],
     ['number (not string)', 24],
+    ['NaN', NaN],
   ])('throws on expiresIn=%s', async (_label, expiresIn) => {
     const interaction = makeInteraction();
     await expect(executeSendPipeline(interaction, makePipelineParams({ expiresIn })))

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1089,7 +1089,7 @@ describe('handleAddRecipients — pre-flight guards', () => {
 
   it('returns "No valid recipients" when only bots/sender are in selection', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1111,7 +1111,7 @@ describe('handleAddRecipients — pre-flight guards', () => {
 
   it('returns "incomplete" when send config has neither file nor location', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: null, actual_url: null, expires_in: '5m',
+      connector_resource_id: null, actual_url: null, expires_in: '30m',
     });
 
     const result = await handleAddRecipients(
@@ -1127,7 +1127,7 @@ describe('handleAddRecipients — pre-flight guards', () => {
   // would break that wiring silently.
   it('returns newRecipients with {id, username} pairs (post-Add revoke wiring)', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: null, actual_url: null, expires_in: '5m',
+      connector_resource_id: null, actual_url: null, expires_in: '30m',
     });
 
     const result = await handleAddRecipients(
@@ -1145,12 +1145,72 @@ describe('handleAddRecipients — pre-flight guards', () => {
       { id: 'u2', username: 'Bob' },
     ]);
   });
+
+  // #352: a stale or directly-written sendConfig row could carry an
+  // off-set `expires_in` value. The pre-flight gate rejects it BEFORE
+  // any mint or recordQURLSendBatch work, so we can't strand QURL
+  // links upstream or write orphan DDB rows. Symmetric with the
+  // failGate inside executeSendPipeline.
+  it('refuses when sendConfig.expires_in is off the allowed set (#352)', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1',
+      expires_in: '25h',  // not in EXPIRY_LABELS — would silently default to 24h under expiryToMs
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+
+    const result = await handleAddRecipients(
+      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(result.msg).toMatch(/saved expiry is invalid/i);
+    expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
+  });
+
+  // #352 belt-and-suspenders: even if a future expires_in slips
+  // through the pre-flight gate, the expiresAt computation is hoisted
+  // ABOVE recordQURLSendBatch, so a throw there can't leave orphan
+  // DDB rows. Mock expiryToMs to throw and verify the ordering
+  // invariant directly.
+  it('hoists expiresAt above recordQURLSendBatch so a throw can\'t leave orphan rows (#352)', async () => {
+    const time = require('../src/utils/time');
+    const original = time.expiryToMs;
+    time.expiryToMs = jest.fn(() => { throw new Error('synthetic expiryToMs throw'); });
+    try {
+      mockDb.getSendConfig.mockResolvedValueOnce({
+        connector_resource_id: 'res-1', expires_in: '30m',  // passes the pre-flight gate
+        attachment_url: 'https://cdn.discordapp.com/x.png',
+        attachment_name: 'x.png', attachment_content_type: 'image/png',
+      });
+
+      let threw = false;
+      try {
+        await handleAddRecipients(
+          'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+          makeInteraction(), 'apikey',
+        );
+      } catch {
+        threw = true;
+      }
+      // Either the function threw or it bailed via the file/location
+      // outer-catch — either way, recordQURLSendBatch MUST NOT have
+      // been called, which is the load-bearing assertion.
+      expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
+      // Sanity: at minimum, NO DDB write occurred even if the function
+      // returned gracefully. The throw/no-throw outcome is incidental
+      // to the ordering invariant.
+      void threw;
+    } finally {
+      time.expiryToMs = original;
+    }
+  });
 });
 
 describe('handleAddRecipients — file path failure modes', () => {
   it('refuses when stored attachment_url is missing', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: null, attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
 
@@ -1164,7 +1224,7 @@ describe('handleAddRecipients — file path failure modes', () => {
 
   it('refuses when stored attachment_url is not a Discord CDN URL (SSRF guard)', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://evil.example.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1183,7 +1243,7 @@ describe('handleAddRecipients — file path failure modes', () => {
 
   it('surfaces "URL has expired" when re-download throws a 403/expired/network error', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1199,7 +1259,7 @@ describe('handleAddRecipients — file path failure modes', () => {
 
   it('surfaces generic "Failed to prepare links" when re-download throws an unknown error', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1215,7 +1275,7 @@ describe('handleAddRecipients — file path failure modes', () => {
 
   it('reports underdelivery when mintLinks returns fewer links than recipients', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1242,7 +1302,7 @@ describe('handleAddRecipients — file path failure modes', () => {
     // to "expired" / "Failed to prepare links" rather than "pool exhausted".
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: null, actual_url: 'https://maps.example.com/x',
-      location_name: 'Eiffel Tower', expires_in: '5m',
+      location_name: 'Eiffel Tower', expires_in: '30m',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
     mockMintLinks.mockRejectedValueOnce(new Error('HTTP 429: rate limit exceeded'));
@@ -1259,7 +1319,7 @@ describe('handleAddRecipients — file path failure modes', () => {
 describe('handleAddRecipients — DB failure mid-flow', () => {
   it('aborts before DMs when recordQURLSendBatch fails (no orphan live links)', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '5m',
+      connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1283,7 +1343,7 @@ describe('handleAddRecipients — happy path (location)', () => {
   it('mints, records, DMs, returns delivered count', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: null, actual_url: 'https://maps.example.com/x',
-      location_name: 'Eiffel Tower', expires_in: '5m', personal_message: 'check this out',
+      location_name: 'Eiffel Tower', expires_in: '30m', personal_message: 'check this out',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
     mockMintLinks.mockResolvedValueOnce([
@@ -1325,7 +1385,7 @@ describe('handleAddRecipients — happy path (location)', () => {
   // UploadCount in CloudWatch). The kind field must be 'mixed'.
   it('emits exactly ONE upload_success with kind=mixed when both file + location prep paths run', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-file-orig', expires_in: '5m',
+      connector_resource_id: 'res-file-orig', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
       // Both paths active.
@@ -1355,7 +1415,7 @@ describe('handleAddRecipients — happy path (location)', () => {
   it('reports failed DMs as failed in the return value', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: null, actual_url: 'https://maps.example.com/x',
-      location_name: 'Eiffel Tower', expires_in: '5m',
+      location_name: 'Eiffel Tower', expires_in: '30m',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
     mockMintLinks.mockResolvedValueOnce([
@@ -1523,6 +1583,32 @@ describe('executeSendPipeline — expiresIn allowed-set gate', () => {
 
   test.each(['30m', '1h', '6h', '24h', '7d'])('accepts the allowed value: %s', async (expiresIn) => {
     await expectGateAccepts(makePipelineParams({ expiresIn }), /expiresIn must be one of/);
+  });
+
+  // #352: expiresAt is computed BEFORE recordQURLSendBatch so a future
+  // `expiryToMs`-throws regression can't leave orphan DDB rows. Today
+  // the entry-level failGate above protects, but the hoist makes the
+  // ordering invariant explicit. Mock expiryToMs to throw and verify
+  // recordQURLSendBatch isn't called even though we got past the
+  // allowed-set gate.
+  test('hoists expiresAt above recordQURLSendBatch so a throw can\'t leave orphan rows (#352)', async () => {
+    const time = require('../src/utils/time');
+    const original = time.expiryToMs;
+    time.expiryToMs = jest.fn(() => { throw new Error('synthetic expiryToMs throw'); });
+    try {
+      mockDb.recordQURLSendBatch.mockClear();
+      const interaction = makeInteraction();
+      let threw = false;
+      try {
+        await executeSendPipeline(interaction, makePipelineParams({ expiresIn: '30m' }));
+      } catch {
+        threw = true;
+      }
+      expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
+      void threw;
+    } finally {
+      time.expiryToMs = original;
+    }
   });
 });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1165,11 +1165,18 @@ describe('handleAddRecipients — pre-flight guards', () => {
   // off-set `expires_in` value. The pre-flight gate rejects it BEFORE
   // any mint or recordQURLSendBatch work, so we can't strand QURL
   // links upstream or write orphan DDB rows. Symmetric with the
-  // failGate inside executeSendPipeline.
-  it('refuses when sendConfig.expires_in is off the allowed set (#352)', async () => {
+  // failGate inside executeSendPipeline — coverage shapes mirror the
+  // executeSendPipeline allowed-set gate test below.
+  test.each([
+    ['off-set numeric-style', '25h'],
+    ['totally bogus', 'never'],
+    ['empty string', ''],
+    ['undefined', undefined],
+    ['number (not string)', 24],
+  ])('refuses when sendConfig.expires_in=%s (off allowed set) (#352)', async (_label, expiresIn) => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: 'res-1',
-      expires_in: '25h',  // not in EXPIRY_LABELS — would silently default to 24h under expiryToMs
+      expires_in: expiresIn,
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
@@ -1188,10 +1195,12 @@ describe('handleAddRecipients — pre-flight guards', () => {
     // facing metric can be wired on the same shape. The motivation
     // for #352 was preserving audit visibility on the orphan-row
     // failure mode; the entry gate's log is the operator-side
-    // counterpart to user-visible `result.msg`.
+    // counterpart to user-visible `result.msg`. `truncForLog` coerces
+    // via String(v), so non-string inputs (e.g. number 24) surface
+    // as their stringified form.
     expect(logger.warn).toHaveBeenCalledWith(
       'addRecipients refused invalid expires_in',
-      expect.objectContaining({ sendId: 'send-1', expiresIn: '25h' }),
+      expect.objectContaining({ sendId: 'send-1', expiresIn: String(expiresIn) }),
     );
   });
 
@@ -1592,6 +1601,11 @@ describe('executeSendPipeline — attachment.url SSRF re-validation gate', () =>
 });
 
 describe('executeSendPipeline — expiresIn allowed-set gate', () => {
+  // Defensive: any test in this block that pollutes expiryToMs (the
+  // #352 hoist test below uses mockImplementationOnce) gets reset.
+  // Mirrors the parallel block at the top of handleAddRecipients tests.
+  afterEach(() => { mockTime.expiryToMs.mockImplementation(jest.requireActual('../src/utils/time').expiryToMs); });
+
   test.each([
     ['off-set numeric-style', '25h'],
     ['totally bogus', 'never'],

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1189,47 +1189,12 @@ describe('handleAddRecipients — pre-flight guards', () => {
     // for #352 was preserving audit visibility on the orphan-row
     // failure mode; the entry gate's log is the operator-side
     // counterpart to user-visible `result.msg`.
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       'addRecipients refused invalid expires_in',
       expect.objectContaining({ sendId: 'send-1', expiresIn: '25h' }),
     );
   });
 
-  // #352 belt-and-suspenders: even if a future expires_in slips
-  // through the pre-flight gate, the expiresAt computation is hoisted
-  // ABOVE recordQURLSendBatch, so a throw there can't leave orphan
-  // DDB rows. Mock `expiryToMs` to throw — file-prep must succeed
-  // so execution reaches the hoist site (otherwise the test passes
-  // vacuously because file-prep's outer try/catch would return
-  // before recordQURLSendBatch regardless).
-  it('hoists expiresAt above recordQURLSendBatch so a throw can\'t leave orphan rows (#352)', async () => {
-    const { expiryToMs } = require('../src/utils/time');
-    expiryToMs.mockImplementationOnce(() => { throw new Error('synthetic expiryToMs throw'); });
-
-    mockDb.getSendConfig.mockResolvedValueOnce({
-      connector_resource_id: 'res-1', expires_in: '30m',  // passes the pre-flight gate
-      attachment_url: 'https://cdn.discordapp.com/x.png',
-      attachment_name: 'x.png', attachment_content_type: 'image/png',
-    });
-    // File-prep succeeds — so execution proceeds PAST the file/location
-    // outer try/catch and reaches the new hoist site immediately
-    // before recordQURLSendBatch.
-    mockDownloadAndUpload.mockResolvedValueOnce({
-      resource_id: 'res-new', fileBuffer: new ArrayBuffer(10),
-    });
-    mockMintLinks.mockResolvedValueOnce([
-      { qurl_link: 'https://q.test/1', resource_id: 'res-new' },
-    ]);
-
-    await expect(handleAddRecipients(
-      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
-      makeInteraction(), 'apikey',
-    )).rejects.toThrow(/synthetic expiryToMs throw/);
-
-    // Load-bearing assertion: even though file-prep succeeded and
-    // links were minted upstream, NO DDB rows were written.
-    expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
-  });
 });
 
 describe('handleAddRecipients — file path failure modes', () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -180,6 +180,24 @@ jest.mock('../src/qurl', () => ({
 
 jest.mock('../src/places', () => ({ searchPlaces: jest.fn().mockResolvedValue([]) }));
 
+// Mock `expiryToMs` as a jest.fn that defaults to the real implementation,
+// so the #352 "hoist throws before recordQURLSendBatch" tests can
+// `mockImplementationOnce(() => { throw ... })` and have the override
+// reach the commands.js call site. CommonJS destructure in commands.js
+// (`const { expiryToMs } = require('./utils/time')`) captures the
+// jest.fn reference at module-load time — without the jest.mock here,
+// post-hoc reassignment of `time.expiryToMs` would NOT replace the
+// local binding inside commands.js, and the throw-tests would pass
+// vacuously (the file-prep code throws first because
+// `mockDownloadAndUpload` returns undefined by default).
+jest.mock('../src/utils/time', () => {
+  const actual = jest.requireActual('../src/utils/time');
+  return {
+    ...actual,
+    expiryToMs: jest.fn(actual.expiryToMs),
+  };
+});
+
 // Stub flow-state so loading commands.js doesn't reach into DDB.
 // These tests target the back-half (monitorLinkStatus, revokeAllLinks,
 // handleAddRecipients) — none of which touch flow_state — but
@@ -1171,39 +1189,37 @@ describe('handleAddRecipients — pre-flight guards', () => {
   // #352 belt-and-suspenders: even if a future expires_in slips
   // through the pre-flight gate, the expiresAt computation is hoisted
   // ABOVE recordQURLSendBatch, so a throw there can't leave orphan
-  // DDB rows. Mock expiryToMs to throw and verify the ordering
-  // invariant directly.
+  // DDB rows. Mock `expiryToMs` to throw — file-prep must succeed
+  // so execution reaches the hoist site (otherwise the test passes
+  // vacuously because file-prep's outer try/catch would return
+  // before recordQURLSendBatch regardless).
   it('hoists expiresAt above recordQURLSendBatch so a throw can\'t leave orphan rows (#352)', async () => {
-    const time = require('../src/utils/time');
-    const original = time.expiryToMs;
-    time.expiryToMs = jest.fn(() => { throw new Error('synthetic expiryToMs throw'); });
-    try {
-      mockDb.getSendConfig.mockResolvedValueOnce({
-        connector_resource_id: 'res-1', expires_in: '30m',  // passes the pre-flight gate
-        attachment_url: 'https://cdn.discordapp.com/x.png',
-        attachment_name: 'x.png', attachment_content_type: 'image/png',
-      });
+    const { expiryToMs } = require('../src/utils/time');
+    expiryToMs.mockImplementationOnce(() => { throw new Error('synthetic expiryToMs throw'); });
 
-      let threw = false;
-      try {
-        await handleAddRecipients(
-          'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
-          makeInteraction(), 'apikey',
-        );
-      } catch {
-        threw = true;
-      }
-      // Either the function threw or it bailed via the file/location
-      // outer-catch — either way, recordQURLSendBatch MUST NOT have
-      // been called, which is the load-bearing assertion.
-      expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
-      // Sanity: at minimum, NO DDB write occurred even if the function
-      // returned gracefully. The throw/no-throw outcome is incidental
-      // to the ordering invariant.
-      void threw;
-    } finally {
-      time.expiryToMs = original;
-    }
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: '30m',  // passes the pre-flight gate
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    // File-prep succeeds — so execution proceeds PAST the file/location
+    // outer try/catch and reaches the new hoist site immediately
+    // before recordQURLSendBatch.
+    mockDownloadAndUpload.mockResolvedValueOnce({
+      resource_id: 'res-new', fileBuffer: new ArrayBuffer(10),
+    });
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1', resource_id: 'res-new' },
+    ]);
+
+    await expect(handleAddRecipients(
+      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    )).rejects.toThrow(/synthetic expiryToMs throw/);
+
+    // Load-bearing assertion: even though file-prep succeeded and
+    // links were minted upstream, NO DDB rows were written.
+    expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
   });
 });
 
@@ -1588,27 +1604,31 @@ describe('executeSendPipeline — expiresIn allowed-set gate', () => {
   // #352: expiresAt is computed BEFORE recordQURLSendBatch so a future
   // `expiryToMs`-throws regression can't leave orphan DDB rows. Today
   // the entry-level failGate above protects, but the hoist makes the
-  // ordering invariant explicit. Mock expiryToMs to throw and verify
-  // recordQURLSendBatch isn't called even though we got past the
-  // allowed-set gate.
+  // ordering invariant explicit. Mock `expiryToMs` to throw — file-
+  // prep must succeed so execution actually reaches the hoist site,
+  // otherwise the test passes vacuously (mintLinks would throw first
+  // with no mock implementation, hitting an upstream code path).
   test('hoists expiresAt above recordQURLSendBatch so a throw can\'t leave orphan rows (#352)', async () => {
-    const time = require('../src/utils/time');
-    const original = time.expiryToMs;
-    time.expiryToMs = jest.fn(() => { throw new Error('synthetic expiryToMs throw'); });
-    try {
-      mockDb.recordQURLSendBatch.mockClear();
-      const interaction = makeInteraction();
-      let threw = false;
-      try {
-        await executeSendPipeline(interaction, makePipelineParams({ expiresIn: '30m' }));
-      } catch {
-        threw = true;
-      }
-      expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
-      void threw;
-    } finally {
-      time.expiryToMs = original;
-    }
+    const { expiryToMs } = require('../src/utils/time');
+    expiryToMs.mockImplementationOnce(() => { throw new Error('synthetic expiryToMs throw'); });
+    mockDb.recordQURLSendBatch.mockClear();
+
+    // File-prep succeeds so execution proceeds past mintLinksInBatches
+    // to the new hoist site right above recordQURLSendBatch.
+    mockDownloadAndUpload.mockResolvedValueOnce({
+      resource_id: 'res-new', fileBuffer: new ArrayBuffer(10),
+    });
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1', resource_id: 'res-new' },
+    ]);
+
+    const interaction = makeInteraction();
+    await expect(executeSendPipeline(interaction, makePipelineParams({ expiresIn: '30m' })))
+      .rejects.toThrow(/synthetic expiryToMs throw/);
+
+    // Load-bearing assertion: even though file-prep succeeded and
+    // links were minted upstream, NO DDB rows were written.
+    expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1172,6 +1172,7 @@ describe('handleAddRecipients — pre-flight guards', () => {
     ['totally bogus', 'never'],
     ['empty string', ''],
     ['undefined', undefined],
+    ['null', null],
     ['number (not string)', 24],
   ])('refuses when sendConfig.expires_in=%s (off allowed set) (#352)', async (_label, expiresIn) => {
     mockDb.getSendConfig.mockResolvedValueOnce({
@@ -1203,7 +1204,6 @@ describe('handleAddRecipients — pre-flight guards', () => {
       expect.objectContaining({ sendId: 'send-1', expiresIn: String(expiresIn) }),
     );
   });
-
 });
 
 describe('handleAddRecipients — file path failure modes', () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1183,7 +1183,19 @@ describe('handleAddRecipients — pre-flight guards', () => {
     );
 
     expect(result.msg).toMatch(/saved expiry is invalid/i);
+    // UX: surface that the ORIGINAL send is intact — only Add
+    // Recipients is blocked. Support-ticket-friendly wording.
+    expect(result.msg).toMatch(/original send's links still work/i);
     expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
+    // Audit signal: pin the structured log so a future operator-
+    // facing metric can be wired on the same shape. The motivation
+    // for #352 was preserving audit visibility on the orphan-row
+    // failure mode; the entry gate's log is the operator-side
+    // counterpart to user-visible `result.msg`.
+    expect(logger.error).toHaveBeenCalledWith(
+      'addRecipients refused invalid expires_in',
+      expect.objectContaining({ sendId: 'send-1', expiresIn: '25h' }),
+    );
   });
 
   // #352 belt-and-suspenders: even if a future expires_in slips


### PR DESCRIPTION
## Summary

#352 was closed by #342 (the expiresAt hoist above `recordQURLSendBatch` in both `executeSendPipeline` and `handleAddRecipients`). This PR layers two further defenses on top of that hoist:

1. **Entry-level allowed-set gate in `handleAddRecipients`** — refuses with a user-facing message BEFORE the hoisted `expiryToMs` call, on top of #342's lower-level hoist defense.
2. **`isValidExpiry(v)` predicate** — consolidates 5 closed-set membership checks scattered across `commands.js` (4 inline `Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, v)` + 1 `EXPIRY_CHOICES.some(c => c.value === v)` at `renderConfirmCardRows` — the latter is a free O(n)→O(1) win since `EXPIRY_CHOICES` is derived from `EXPIRY_LABELS`).

## Why this matters on top of #342

`#342`'s hoist makes the function reject cleanly if `expiryToMs` ever throws — but the throw path requires a future regression in `utils/time.js` (today's `expiryToMs` falls back to `DEFAULT_EXPIRY_MS` and never throws). Until that hypothetical regression lands, the hoist's protection is unreachable in production.

The new entry-level gate is reachable today: a stale or directly-written `qurl_send_configs` row could carry an `expires_in` value outside `EXPIRY_LABELS` (`'25h'`, `'5m'`, malformed strings). Under #342's hoist alone, that row silently defaults to 24h via `expiryToMs`'s lenient fallback — recipients see a 24h timer even though no operator ever configured one. The entry gate refuses such rows with a support-ticket-friendly message:

> Cannot add recipients — this send's saved expiry is invalid (the original send's links still work; create a new send to reach additional recipients).

`executeSendPipeline` already has this protection via the existing `failGate` (~commands.js:1145); this PR brings `handleAddRecipients` to parity.

## `isValidExpiry(v)` refactor

5 closed-set membership sites consolidated: failGate in executeSendPipeline, new entry gate in handleAddRecipients, expiry-select handlers, and `renderConfirmCardRows`'s default-selection guard (was `EXPIRY_CHOICES.some(...)` — semantically equivalent to `hasOwnProperty.call(EXPIRY_LABELS, v)` since `EXPIRY_CHOICES` is derived, and the swap is a free O(n)→O(1) win). Extracted to a 1-line predicate near `EXPIRY_LABELS`. Caller-side error handling stays site-specific (failGate throws / handleAddRecipients returns error obj / expiry-select handler defaults), but the predicate itself is shared.

## Changes

- `src/commands.js`:
  - `isValidExpiry(v)` predicate near `EXPIRY_LABELS` declaration.
  - Entry-level allowed-set gate in `handleAddRecipients` (returns error msg, logs structured `addRecipients refused invalid expires_in` at `warn` level for operator-side audit).
  - 5 call sites consolidated to use `isValidExpiry()`.
- `tests/send-pipeline-back-half.test.js`:
  - +1 entry-gate refusal test, parameterized across 7 off-set shapes (`'25h'`, `'never'`, `''`, `undefined`, `null`, `24`, `NaN`). Mirrors the executeSendPipeline gate test coverage shape.
  - Fixture sweep `expires_in: '5m'` → `'30m'` across 13 sites (`'5m'` wasn't in production `EXPIRY_LABELS`; the corpus was riding on `expiryToMs`'s silent fallback).

## Test plan

- [x] All 1660 unit + handler tests pass locally (`npx jest`)
- [x] eslint clean
- [x] /simplify pass clean
- [ ] CI green on the PR
- [ ] cr feedback addressed (incl. nits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)