### PR TITLE
feat(discord): voice-everyone is default mode when /qurl is invoked from voice (sender excluded)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3957,6 +3957,17 @@ async function handleQurlSlashSend(interaction, params) {
     // degraded states the user can't otherwise diagnose. The picker +
     // bottom voice button remain available throughout so the user can
     // recover when voice state changes (someone joins, bots kicked).
+    //
+    // SNAPSHOT vs. CLICK-TIME asymmetry: this slash-entry path freezes
+    // `recipientIds` at command receipt — someone joining the channel
+    // between `/qurl file` and the Send click is NOT added. The "🔊
+    // Everyone in #voice" button (handleConfirmVoiceEveryone) goes the
+    // other way: re-resolves `channel.members` at click time. The two
+    // shapes are reachable from the same UI but produce different
+    // recipient sets; that's a deliberate UX call (the auto-default
+    // card shows "N users in #voice" and Send must mean that set,
+    // not whoever happens to be in voice at click time). Documented
+    // here so a future contributor doesn't "fix" the asymmetry.
     let recipientMode = RECIPIENT_MODE_PICKER;
     let finalValid = valid;
     let finalSelfIncluded = selfIncluded;
@@ -4974,7 +4985,12 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // Tracked in #339 if a future product decision needs to align
   // these surfaces (e.g., button truncates with confirm-card warning).
   if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
-    return rejectVoice(`⚠\u{FE0F} Voice channel has ${valid.length} connected (max ${config.QURL_SEND_MAX_RECIPIENTS}). Use the picker or @mentions to choose a subset.\n\n`);
+    // "eligible recipients" (NOT "connected") — `valid.length` is the
+    // post-partition count (sender + bots already filtered out).
+    // Discord's voice panel shows raw connections, so phrasing this as
+    // "connected" would diverge from what the user sees there. Stays
+    // in lockstep with the slash-entry over-cap banner.
+    return rejectVoice(`⚠\u{FE0F} Voice channel has ${valid.length} eligible recipients (max ${config.QURL_SEND_MAX_RECIPIENTS}). Use the picker or @mentions to choose a subset.\n\n`);
   }
 
   const newWarningsBlock = renderRecipientWarnings({

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2779,10 +2779,22 @@ const CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID = 'qurl_confirm_pick_manual';
 //     the picker row is hidden. Bottom row swaps in "👥 Pick people
 //     instead" so the user can fall back to manual selection.
 // Stale flow_state rows (created before this field existed) read as
-// undefined — every consumer normalizes via `?? RECIPIENT_MODE_PICKER`
-// so they keep the legacy picker shape until they expire.
+// undefined — `normalizeRecipientMode` below maps undefined / any
+// off-set value to RECIPIENT_MODE_PICKER so they keep the legacy
+// picker shape until they expire.
 const RECIPIENT_MODE_PICKER = 'picker';
 const RECIPIENT_MODE_VOICE = 'voice';
+
+// Single source of truth for "this token is voice; everything else
+// reads as picker." Three render sites (renderConfirmCardContent,
+// renderConfirmCardRows, rerenderConfirmCard) previously open-coded
+// `mode === RECIPIENT_MODE_VOICE ? VOICE : PICKER` — if any of those
+// drifted (e.g. someone tested `mode === 'voice'` against a typo'd
+// constant), the layout would split between branches. The helper
+// pins the stale-row default in one place.
+function normalizeRecipientMode(mode) {
+  return mode === RECIPIENT_MODE_VOICE ? RECIPIENT_MODE_VOICE : RECIPIENT_MODE_PICKER;
+}
 
 // Recipient-rejection reason strings shared by every handler that
 // can drop a selection to empty (picker, voice-everyone). Hoisted
@@ -2964,15 +2976,13 @@ function partitionRecipients(users, senderId, { excludeSender = false } = {}) {
   let selfIncluded = false;
   for (const u of users) {
     if (u.bot) { droppedBots++; continue; }
-    if (u.id === senderId) {
-      // Voice-everyone path drops the sender silently — they pressed
-      // the "Everyone in #voice" affordance, which semantically means
-      // "everyone else." No droppedBots-style accounting because the
-      // user-visible message ("you not included") is rendered from
-      // the recipientMode, not from a partition counter.
-      if (excludeSender) continue;
-      selfIncluded = true;
-    }
+    // Voice-everyone path drops the sender silently — they pressed
+    // the "Everyone in #voice" affordance, which semantically means
+    // "everyone else." No droppedBots-style accounting because the
+    // user-visible message ("you not included") is rendered from
+    // the recipientMode, not from a partition counter.
+    if (u.id === senderId && excludeSender) continue;
+    if (u.id === senderId) selfIncluded = true;
     valid.push(u);
   }
   return { valid, droppedBots, selfIncluded };
@@ -3338,7 +3348,7 @@ function renderConfirmCardContent({
   recipientMode, voiceChannelId,
 }) {
   let content = warningsBlock || '';
-  const mode = recipientMode === RECIPIENT_MODE_VOICE ? RECIPIENT_MODE_VOICE : RECIPIENT_MODE_PICKER;
+  const mode = normalizeRecipientMode(recipientMode);
   // Explicit branch per RESOURCE_TYPES value — a future resource
   // type (audio, contact card, etc.) MUST add its own branch here.
   // Throwing on unknown beats silently rendering the new type as a
@@ -3501,7 +3511,7 @@ function renderConfirmCardRows({
   voiceChannelId, interaction, recipientIds, recipientMode,
 }) {
   const rows = [];
-  const mode = recipientMode === RECIPIENT_MODE_VOICE ? RECIPIENT_MODE_VOICE : RECIPIENT_MODE_PICKER;
+  const mode = normalizeRecipientMode(recipientMode);
   const baseCap = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
   // When text-resolved recipients are already present, widen max_values
   // so we can pre-check them via addDefaultUsers (Discord requires
@@ -3940,14 +3950,13 @@ async function handleQurlSlashSend(interaction, params) {
     // `excludeSender` option; the "Everyone in #voice" affordance
     // semantically means "everyone else," not "and CC myself."
     //
-    // Fall back to picker-mode (no override) when the voice channel:
-    //   - has no connected non-bot members other than the sender
-    //   - exceeds QURL_SEND_MAX_RECIPIENTS (mirrors the button-handler
-    //     hard-reject at handleConfirmVoiceEveryone)
-    //   - is missing channel.members (cache miss / intent issue)
-    // The picker stays rendered AND the bottom "🔊 Everyone in #voice"
-    // button remains available, so the user can recover if the voice
-    // channel state changes (someone joins, bots get kicked).
+    // Banner asymmetry on the picker-mode fallback: sender-only /
+    // bots-only / truly-empty falls back QUIETLY (the user didn't ask
+    // for voice-everyone — surfacing "voice is empty" would be noise),
+    // while over-cap and cache-miss surface a banner because they're
+    // degraded states the user can't otherwise diagnose. The picker +
+    // bottom voice button remain available throughout so the user can
+    // recover when voice state changes (someone joins, bots kicked).
     let recipientMode = RECIPIENT_MODE_PICKER;
     let finalValid = valid;
     let finalSelfIncluded = selfIncluded;
@@ -3961,27 +3970,55 @@ async function handleQurlSlashSend(interaction, params) {
       // -outside-guild path; the cache lookup is the established
       // contract for "voice members at this channel id."
       const voiceChannel = interaction.guild?.channels?.cache?.get?.(voiceChannelId);
-      const voiceMembers = [];
-      if (voiceChannel?.members) {
+      if (!voiceChannel?.members) {
+        // Cache miss: voice channel evicted or `GuildVoiceStates`
+        // intent dropped mid-flight. Surface a banner + log so a
+        // degraded environment doesn't silently lose voice-mode.
+        logger.info('handleQurlSlashSend: voice-mode skipped — channel members cache missing', {
+          user_id: interaction.user.id, voice_channel_id: voiceChannelId,
+        });
+        finalWarningsBlock = warningsBlock
+          + `⚠\u{FE0F} Couldn't read voice channel members — pick recipients below.\n\n`;
+      } else {
+        const voiceMembers = [];
         for (const [, m] of voiceChannel.members) {
           if (m?.user) voiceMembers.push(m.user);
         }
-      }
-      const voicePart = partitionRecipients(
-        voiceMembers, interaction.user.id, { excludeSender: true }
-      );
-      if (voicePart.valid.length > 0
-          && voicePart.valid.length <= config.QURL_SEND_MAX_RECIPIENTS) {
-        recipientMode = RECIPIENT_MODE_VOICE;
-        finalValid = voicePart.valid;
-        finalSelfIncluded = false;
-        // Voice path produces its own warnings — only droppedBots is
-        // relevant when `recipients:` was omitted (no text-parsing
-        // warnings apply). Surface bot drops so the user knows why the
-        // count is lower than the channel's connected total.
-        finalWarningsBlock = renderRecipientWarnings({
-          droppedBots: voicePart.droppedBots,
-        });
+        const voicePart = partitionRecipients(
+          voiceMembers, interaction.user.id, { excludeSender: true }
+        );
+        // Inverted shape: commit voice-mode iff the resolved set fits
+        // the cap; otherwise branch by reason. Avoids an empty
+        // "if (length === 0) {}" no-op for the sender-only / bots-only
+        // / truly-empty case — those simply drop through to the
+        // picker-mode default (set above) with no banner.
+        if (voicePart.valid.length > 0
+            && voicePart.valid.length <= config.QURL_SEND_MAX_RECIPIENTS) {
+          recipientMode = RECIPIENT_MODE_VOICE;
+          finalValid = voicePart.valid;
+          finalSelfIncluded = false;
+          // Voice path produces its own warnings — only droppedBots is
+          // relevant when `recipients:` was omitted (no text-parsing
+          // warnings apply). Surface bot drops so the user knows why the
+          // count is lower than the channel's connected total.
+          finalWarningsBlock = renderRecipientWarnings({
+            droppedBots: voicePart.droppedBots,
+          });
+        } else if (voicePart.valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
+          // Over-cap (mirrors button-handler hard-reject). Under default
+          // config (20k cap vs 99-member voice cap) unreachable, but a
+          // shrunk env override could trip this — silent fallback would
+          // leave the user wondering why voice-mode didn't take.
+          logger.info('handleQurlSlashSend: voice-mode skipped — exceeds QURL_SEND_MAX_RECIPIENTS', {
+            user_id: interaction.user.id,
+            voice_channel_id: voiceChannelId,
+            connected: voicePart.valid.length,
+            cap: config.QURL_SEND_MAX_RECIPIENTS,
+          });
+          finalWarningsBlock = warningsBlock
+            + `⚠\u{FE0F} Voice channel has ${voicePart.valid.length} connected `
+            + `(max ${config.QURL_SEND_MAX_RECIPIENTS}) — pick recipients below.\n\n`;
+        }
       }
     }
     const needsPicker = recipientMode === RECIPIENT_MODE_PICKER && recipientsOmitted;
@@ -5148,9 +5185,7 @@ async function rerenderConfirmCard(interaction, newPayload) {
   // recipientMode drives both row layout AND content prefix. Default
   // 'picker' for stale flow_state rows that pre-date the field (they
   // keep the legacy picker shape until they TTL out).
-  const recipientMode = newPayload.recipientMode === RECIPIENT_MODE_VOICE
-    ? RECIPIENT_MODE_VOICE
-    : RECIPIENT_MODE_PICKER;
+  const recipientMode = normalizeRecipientMode(newPayload.recipientMode);
   // `needsPicker` (the "Pick recipients below" prompt) is only shown
   // in picker-mode with no recipients yet. In voice-mode with an empty
   // recipientIds (e.g., voice channel emptied after switch), the card
@@ -7543,6 +7578,7 @@ module.exports = {
       CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
       RECIPIENT_MODE_PICKER,
       RECIPIENT_MODE_VOICE,
+      normalizeRecipientMode,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,
     },

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3364,10 +3364,16 @@ function renderConfirmCardContent({
   // Neutral notice (NOT a warning) when the sender is in the recipient
   // list. Self-send is supported as a first-class flow; surface it on
   // the confirm card so the user can verify they meant to include
-  // themselves before clicking Send. Unreachable in voice-mode —
-  // partitionRecipients drops the sender pre-validity when the path
-  // calls it with `excludeSender: true`.
-  if (selfIncluded) {
+  // themselves before clicking Send.
+  //
+  // Mode guard: every voice-mode write path explicitly sets
+  // `selfIncluded: false` (slash-entry override + handleConfirmVoiceEveryone
+  // + handleConfirmPickManual), so `selfIncluded === true` is
+  // structurally unreachable in voice-mode. The guard is defense
+  // against a forged or schema-drifted payload that would otherwise
+  // produce contradictory copy: "Send includes you." stacked on top
+  // of "(you not included)" in the voice-mode "To:" line.
+  if (selfIncluded && mode !== RECIPIENT_MODE_VOICE) {
     content += 'ℹ\u{FE0F} **Send includes you.**\n';
   }
   if (needsPicker) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4009,14 +4009,21 @@ async function handleQurlSlashSend(interaction, params) {
           // config (20k cap vs 99-member voice cap) unreachable, but a
           // shrunk env override could trip this — silent fallback would
           // leave the user wondering why voice-mode didn't take.
+          //
+          // Wording note: `voicePart.valid.length` is the POST-filter
+          // count (sender + bots excluded). The Discord client's voice
+          // panel shows raw connections, so phrasing this as "eligible
+          // recipients" avoids a confusing cross-check (e.g., panel
+          // shows 100 / banner says "39 connected"). The log field
+          // stays `eligible` for consistency.
           logger.info('handleQurlSlashSend: voice-mode skipped — exceeds QURL_SEND_MAX_RECIPIENTS', {
             user_id: interaction.user.id,
             voice_channel_id: voiceChannelId,
-            connected: voicePart.valid.length,
+            eligible: voicePart.valid.length,
             cap: config.QURL_SEND_MAX_RECIPIENTS,
           });
           finalWarningsBlock = warningsBlock
-            + `⚠\u{FE0F} Voice channel has ${voicePart.valid.length} connected `
+            + `⚠\u{FE0F} Voice channel has ${voicePart.valid.length} eligible recipients `
             + `(max ${config.QURL_SEND_MAX_RECIPIENTS}) — pick recipients below.\n\n`;
         }
       }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3991,11 +3991,15 @@ async function handleQurlSlashSend(interaction, params) {
         // Cache miss: voice channel evicted or `GuildVoiceStates`
         // intent dropped mid-flight. Surface a banner + log so a
         // degraded environment doesn't silently lose voice-mode.
+        //
+        // Banner replaces (not appends to) `warningsBlock`: the
+        // text-path warnings can't exist on this branch because
+        // `recipientsOmitted` is true (no `recipients:` arg means no
+        // tokens to parse, so `warningsBlock` is always `''` here).
         logger.info('handleQurlSlashSend: voice-mode skipped — channel members cache missing', {
           user_id: interaction.user.id, voice_channel_id: voiceChannelId,
         });
-        finalWarningsBlock = warningsBlock
-          + `⚠\u{FE0F} Couldn't read voice channel members — pick recipients below.\n\n`;
+        finalWarningsBlock = `⚠\u{FE0F} Couldn't read voice channel members — pick recipients below.\n\n`;
       } else {
         const voiceMembers = [];
         for (const [, m] of voiceChannel.members) {
@@ -4005,10 +4009,13 @@ async function handleQurlSlashSend(interaction, params) {
           voiceMembers, interaction.user.id, { excludeSender: true }
         );
         // Inverted shape: commit voice-mode iff the resolved set fits
-        // the cap; otherwise branch by reason. Avoids an empty
-        // "if (length === 0) {}" no-op for the sender-only / bots-only
-        // / truly-empty case — those simply drop through to the
-        // picker-mode default (set above) with no banner.
+        // the cap; otherwise branch by reason. Sender-only / truly-
+        // empty falls through to picker-mode with NO banner (user
+        // didn't ask for voice-everyone; there's nothing actionable to
+        // surface). Bots-only DOES surface a banner — a voice channel
+        // populated entirely by bots is the kind of "wait, didn't it
+        // know I was in voice?" state that benefits from the dropped-
+        // bots accounting being visible.
         if (voicePart.valid.length > 0
             && voicePart.valid.length <= config.QURL_SEND_MAX_RECIPIENTS) {
           recipientMode = RECIPIENT_MODE_VOICE;
@@ -4018,6 +4025,13 @@ async function handleQurlSlashSend(interaction, params) {
           // relevant when `recipients:` was omitted (no text-parsing
           // warnings apply). Surface bot drops so the user knows why the
           // count is lower than the channel's connected total.
+          finalWarningsBlock = renderRecipientWarnings({
+            droppedBots: voicePart.droppedBots,
+          });
+        } else if (voicePart.valid.length === 0 && voicePart.droppedBots > 0) {
+          // Bots-only voice channel. Quiet fallback would leave the
+          // user wondering why the auto-default didn't take; the bot-
+          // drop accounting explains it.
           finalWarningsBlock = renderRecipientWarnings({
             droppedBots: voicePart.droppedBots,
           });
@@ -4039,8 +4053,9 @@ async function handleQurlSlashSend(interaction, params) {
             eligible: voicePart.valid.length,
             cap: config.QURL_SEND_MAX_RECIPIENTS,
           });
-          finalWarningsBlock = warningsBlock
-            + `⚠\u{FE0F} Voice channel has ${voicePart.valid.length} eligible recipients `
+          // Banner replaces `warningsBlock` (always `''` on this
+          // branch — see cache-miss comment above).
+          finalWarningsBlock = `⚠\u{FE0F} Voice channel has ${voicePart.valid.length} eligible recipients `
             + `(max ${config.QURL_SEND_MAX_RECIPIENTS}) — pick recipients below.\n\n`;
         }
       }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2764,6 +2764,25 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // Tracked in #339 if a future product decision (stage channels with
 // thousands of audience) needs to revisit this for stage-only.
 const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
+// "Pick people instead" button — rendered only in voice-mode (i.e.
+// `payload.recipientMode === 'voice'`). Clearing it flips the card
+// back to picker-mode (recipientIds dropped, MentionableSelect row
+// restored). Lives on its own customId so flow-dispatch routes
+// directly instead of branching inside the voice-everyone handler.
+const CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID = 'qurl_confirm_pick_manual';
+
+// Two recipient-source modes carried on `payload.recipientMode`:
+//   - 'picker' (default): MentionableSelect row is the source of
+//     truth; bottom row carries the "🔊 Everyone in #voice" affordance
+//     when the slash command was invoked from voice.
+//   - 'voice': recipientIds were resolved from `channel.members` and
+//     the picker row is hidden. Bottom row swaps in "👥 Pick people
+//     instead" so the user can fall back to manual selection.
+// Stale flow_state rows (created before this field existed) read as
+// undefined — every consumer normalizes via `?? RECIPIENT_MODE_PICKER`
+// so they keep the legacy picker shape until they expire.
+const RECIPIENT_MODE_PICKER = 'picker';
+const RECIPIENT_MODE_VOICE = 'voice';
 
 // Recipient-rejection reason strings shared by every handler that
 // can drop a selection to empty (picker, voice-everyone). Hoisted
@@ -2906,8 +2925,14 @@ async function resolveRecipientUsers(interaction, ids) {
 // Filter resolved Users: drop bots, detect whether the sender is
 // included. Returns `{ valid, droppedBots, selfIncluded }` so the
 // caller can surface "X bots were dropped" as a warning and "send
-// includes yourself" as a neutral notice. Sender is NOT filtered —
-// self-send is supported.
+// includes yourself" as a neutral notice. Sender is NOT filtered by
+// default — self-send is supported via the picker / text paths.
+//
+// `excludeSender: true` is the voice-everyone contract: the "Everyone
+// in #voice" affordance is interpreted as "everyone else in the room",
+// not "and CC myself". Sender is dropped pre-validity so `selfIncluded`
+// is always false on that path (the content renderer's "Send includes
+// you." notice would be misleading after exclusion).
 //
 // Known v1 cap-skew: parseRecipientMentions caps to QURL_SEND_MAX_RECIPIENTS
 // BEFORE knowing which IDs are bots. A mention list of
@@ -2927,7 +2952,7 @@ async function resolveRecipientUsers(interaction, ids) {
 // yields self + 24 others (was: 25 others, pre self-send). This is
 // symmetric with the bot cap-skew above and aligns with the supported-
 // recipient model — sender is just another recipient.
-function partitionRecipients(users, senderId) {
+function partitionRecipients(users, senderId, { excludeSender = false } = {}) {
   // Dedup contract is OWNED upstream: parseRecipientMentions dedupes
   // via a Set (recipient-parser.js:197-198) and the UserSelectMenu
   // gateway-event surfaces each picked user at most once. This loop
@@ -2939,7 +2964,15 @@ function partitionRecipients(users, senderId) {
   let selfIncluded = false;
   for (const u of users) {
     if (u.bot) { droppedBots++; continue; }
-    if (u.id === senderId) selfIncluded = true;
+    if (u.id === senderId) {
+      // Voice-everyone path drops the sender silently — they pressed
+      // the "Everyone in #voice" affordance, which semantically means
+      // "everyone else." No droppedBots-style accounting because the
+      // user-visible message ("you not included") is rendered from
+      // the recipientMode, not from a partition counter.
+      if (excludeSender) continue;
+      selfIncluded = true;
+    }
     valid.push(u);
   }
   return { valid, droppedBots, selfIncluded };
@@ -3302,8 +3335,10 @@ function renderConfirmCardContent({
   resourceType, resourceLabel, validRecipients,
   expiresIn, selfDestructSeconds, personalMessage,
   warningsBlock, needsPicker, interaction, selfIncluded = false,
+  recipientMode, voiceChannelId,
 }) {
   let content = warningsBlock || '';
+  const mode = recipientMode === RECIPIENT_MODE_VOICE ? RECIPIENT_MODE_VOICE : RECIPIENT_MODE_PICKER;
   // Explicit branch per RESOURCE_TYPES value — a future resource
   // type (audio, contact card, etc.) MUST add its own branch here.
   // Throwing on unknown beats silently rendering the new type as a
@@ -3319,7 +3354,9 @@ function renderConfirmCardContent({
   // Neutral notice (NOT a warning) when the sender is in the recipient
   // list. Self-send is supported as a first-class flow; surface it on
   // the confirm card so the user can verify they meant to include
-  // themselves before clicking Send.
+  // themselves before clicking Send. Unreachable in voice-mode —
+  // partitionRecipients drops the sender pre-validity when the path
+  // calls it with `excludeSender: true`.
   if (selfIncluded) {
     content += 'ℹ\u{FE0F} **Send includes you.**\n';
   }
@@ -3327,6 +3364,24 @@ function renderConfirmCardContent({
     content += '\n**Pick recipients below** (1–'
       + String(Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS))
       + ' users), then click **Send**.\n';
+  } else if (mode === RECIPIENT_MODE_VOICE) {
+    // Voice-mode "To:" — names omitted in favor of the channel context.
+    // The #voice mention is the source of truth for who's included;
+    // listing alias names would just duplicate the scrollback the user
+    // already sees in Discord. "(you not included)" makes the sender-
+    // exclusion contract explicit on the card.
+    //
+    // SAFETY: use Discord's native channel-mention syntax `<#id>` (which
+    // Discord renders client-side from the channel id) instead of
+    // interpolating `channel.name` raw. A name like `**spoiler**`,
+    // `_underline_`, `||hidden||`, or one containing the literal
+    // `*(you not included)*` substring would otherwise inject markdown
+    // into the confirm card. Mirrors the same gotcha noted at the
+    // voice-button label site (where button-label rendering doesn't
+    // process markdown, but message content does).
+    const channelRef = voiceChannelId ? `<#${voiceChannelId}>` : 'the voice channel';
+    const userWord = validRecipients.length === 1 ? 'user' : 'users';
+    content += `\n**To:** ${validRecipients.length} ${userWord} in ${channelRef} *(you not included)*\n`;
   } else {
     // First-N preview keeps the card scannable when a paste resolves
     // to many users. resolveRecipientAlias prefers nickname > globalName >
@@ -3409,9 +3464,9 @@ function formatPersonalMessagePreview(message) {
   return `> ${safeCodepointSlice(oneLine, 80)}…`;
 }
 
-// Build the ActionRow set for the confirm card. Always 4 rows so the
-// layout is stable from frame 0 — each select needs its own row
-// (Discord forbids selects + buttons in the same ActionRow).
+// Build the ActionRow set for the confirm card. Layout depends on
+// `recipientMode` — each select needs its own row (Discord forbids
+// selects + buttons in the same ActionRow).
 //
 // MentionableSelect (per #328) surfaces users AND roles in one menu;
 // role picks expand in handleConfirmUserSelect via
@@ -3421,22 +3476,32 @@ function formatPersonalMessagePreview(message) {
 // need the 180s flow_state drain coordination from #316.
 //
 // Row math (Discord 5-row max, 5-buttons-per-row max):
-//   Mentionable + SelfDestruct + Expiry +
-//   [(optional 🔊 Voice), Note, Send, Cancel] = 4 rows, ≤ 4 buttons
+//   PICKER mode: Mentionable + SelfDestruct + Expiry +
+//     [(optional 🔊 Voice), Note, Send, Cancel] = 4 rows, ≤ 4 buttons
+//   VOICE mode:  SelfDestruct + Expiry +
+//     [👥 Pick people instead, Note, Send, Cancel]   = 3 rows, 4 buttons
 //
-// The voice button is rendered only when `voiceChannelId` is non-null
-// (snapshot into payload by `handleQurlSlashSend` when the slash
-// command was invoked from a voice / stage-voice channel). Disabled
-// with a `(0)` count when the channel has no connected non-bot members
-// at render time — honest UX so the user can see WHY the button is
-// inert. The actual member resolution still happens at click time
-// (see `handleConfirmVoiceEveryone`); the count here is a snapshot
-// hint so the label isn't blank.
+// The bottom-row affordance flips with the mode:
+//   - `'picker'` + voiceChannelId set → 🔊 Everyone in #voice button.
+//     Disabled with a `(0)` count when the channel has no connected
+//     non-bot members at render time — honest UX so the user can see
+//     WHY the button is inert.
+//   - `'voice'` → 👥 Pick people instead button. Picker row is removed
+//     entirely; the user has committed to voice-everyone semantics and
+//     this button is their escape hatch back to manual selection.
+// The actual member resolution still happens at click time (see
+// `handleConfirmVoiceEveryone`); the count here is a snapshot hint so
+// the label isn't blank.
+//
+// `recipientMode` defaults to RECIPIENT_MODE_PICKER for stale rows that
+// existed before this field was introduced; the legacy shape is exactly
+// the picker-mode branch below.
 function renderConfirmCardRows({
   sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
-  voiceChannelId, interaction, recipientIds,
+  voiceChannelId, interaction, recipientIds, recipientMode,
 }) {
   const rows = [];
+  const mode = recipientMode === RECIPIENT_MODE_VOICE ? RECIPIENT_MODE_VOICE : RECIPIENT_MODE_PICKER;
   const baseCap = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
   // When text-resolved recipients are already present, widen max_values
   // so we can pre-check them via addDefaultUsers (Discord requires
@@ -3453,19 +3518,21 @@ function renderConfirmCardRows({
   // only "1–10" would mislead users who pick 10 roles expecting 10
   // recipients.
   const recipientCap = config.QURL_SEND_MAX_RECIPIENTS;
-  const picker = new MentionableSelectMenuBuilder()
-    .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
-    .setPlaceholder(`Pick up to ${maxValues} users/roles (recipients capped at ${recipientCap})`)
-    .setMinValues(1)
-    .setMaxValues(maxValues);
-  if (defaults.length > 0) {
-    // Text-path recipientIds are user IDs only — parseRecipientMentions
-    // expands roles to members before partition. addDefaultUsers is the
-    // matching API on MentionableSelectMenuBuilder (addDefaultRoles
-    // would be wrong here — we never persist role IDs).
-    picker.addDefaultUsers(...defaults.slice(0, maxValues));
+  if (mode === RECIPIENT_MODE_PICKER) {
+    const picker = new MentionableSelectMenuBuilder()
+      .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
+      .setPlaceholder(`Pick up to ${maxValues} users/roles (recipients capped at ${recipientCap})`)
+      .setMinValues(1)
+      .setMaxValues(maxValues);
+    if (defaults.length > 0) {
+      // Text-path recipientIds are user IDs only — parseRecipientMentions
+      // expands roles to members before partition. addDefaultUsers is the
+      // matching API on MentionableSelectMenuBuilder (addDefaultRoles
+      // would be wrong here — we never persist role IDs).
+      picker.addDefaultUsers(...defaults.slice(0, maxValues));
+    }
+    rows.push(new ActionRowBuilder().addComponents(picker));
   }
-  rows.push(new ActionRowBuilder().addComponents(picker));
   // Self-destruct StringSelectMenu: "No self-destruct timer" + 7
   // curated presets sourced from SELF_DESTRUCT_PRESETS in utils/time.
   // The `default: true` flag on the matching option keeps the
@@ -3530,11 +3597,25 @@ function renderConfirmCardRows({
         }))
       )
   ));
-  // Bottom row: [optional 🔊 Voice] + Note + Send + Cancel. Note label
-  // flips between "Add a note" and "Edit note" based on current state
-  // so the user can tell at a glance whether a note is attached.
+  // Bottom row: [optional 🔊 Voice | 👥 Pick people instead] + Note +
+  // Send + Cancel. Note label flips between "Add a note" and "Edit
+  // note" based on current state so the user can tell at a glance
+  // whether a note is attached. The leading-button affordance is
+  // mode-dependent: picker-mode shows the voice-everyone entry button
+  // (only when the slash was invoked from voice); voice-mode shows the
+  // "Pick people instead" escape hatch.
   const bottomRow = new ActionRowBuilder();
-  if (voiceChannelId) {
+  if (mode === RECIPIENT_MODE_VOICE && voiceChannelId) {
+    // Voice-mode escape hatch. The handler clears recipientIds and
+    // flips recipientMode back to 'picker'. Style as Secondary so it
+    // doesn't compete visually with Send (Success).
+    bottomRow.addComponents(
+      new ButtonBuilder()
+        .setCustomId(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID)
+        .setLabel('\u{1F465} Pick people instead')
+        .setStyle(ButtonStyle.Secondary),
+    );
+  } else if (mode === RECIPIENT_MODE_PICKER && voiceChannelId) {
     // Live count via interaction.guild for the label. Every production
     // caller (handleQurlSlashSend, handleConfirmUserSelect,
     // handleConfirmVoiceEveryone, rerenderConfirmCard) passes
@@ -3830,24 +3911,6 @@ async function handleQurlSlashSend(interaction, params) {
       });
     }
 
-    const needsPicker = recipientsOmitted;
-    const recipientIds = valid.map((u) => u.id);
-
-    // supersedeOrCreate handles the "another /qurl file/map is open"
-    // case — sibling-flow disambig surfaces a stage-specific message;
-    // same-stage rerun atomically claims the slot. Mirrors /qurl
-    // revoke's pattern.
-    flow_id = flowIdForInteraction(interaction);
-    const sendNonce = crypto.randomBytes(8).toString('hex');
-    // Persist resolved aliases keyed by id. `rerenderConfirmCard`
-    // falls back to these when the menu/note interaction fires after
-    // the member-cache entry has been evicted (rare given the 3-min
-    // flow TTL, but the alternative is showing the raw snowflake).
-    // resolveRecipientAlias returns the PLAIN form — markdown escape
-    // happens at render time.
-    const recipientAliases = Object.fromEntries(
-      valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
-    );
     // Voice-channel context snapshot. The "Everyone in this voice
     // channel" confirm-card button is rendered when this is set.
     // Snapshot at slash-command time (NOT re-derived at button-click)
@@ -3866,6 +3929,79 @@ async function handleQurlSlashSend(interaction, params) {
     const voiceChannelId = isVoiceChannelType(interaction.channel?.type)
       ? interaction.channel.id
       : null;
+
+    // Voice-everyone auto-default. When the slash command was invoked
+    // from a voice channel AND `recipients:` was omitted, resolve to
+    // voice-connected members (excluding sender + bots) and render the
+    // card in voice-mode. This makes "/qurl file" from inside #voice
+    // behave the way users naturally expect — the room is the audience.
+    //
+    // Sender is filtered pre-validity via partitionRecipients's
+    // `excludeSender` option; the "Everyone in #voice" affordance
+    // semantically means "everyone else," not "and CC myself."
+    //
+    // Fall back to picker-mode (no override) when the voice channel:
+    //   - has no connected non-bot members other than the sender
+    //   - exceeds QURL_SEND_MAX_RECIPIENTS (mirrors the button-handler
+    //     hard-reject at handleConfirmVoiceEveryone)
+    //   - is missing channel.members (cache miss / intent issue)
+    // The picker stays rendered AND the bottom "🔊 Everyone in #voice"
+    // button remains available, so the user can recover if the voice
+    // channel state changes (someone joins, bots get kicked).
+    let recipientMode = RECIPIENT_MODE_PICKER;
+    let finalValid = valid;
+    let finalSelfIncluded = selfIncluded;
+    let finalWarningsBlock = warningsBlock;
+    if (recipientsOmitted && voiceChannelId) {
+      // Read voice-connected members through the same channel cache
+      // lookup that handleConfirmVoiceEveryone and the bottom-button
+      // count use (`guild.channels.cache.get(voiceChannelId)`). Reading
+      // via `interaction.channel.members` would land identical state in
+      // production but diverge in tests and on the rare command-from-
+      // -outside-guild path; the cache lookup is the established
+      // contract for "voice members at this channel id."
+      const voiceChannel = interaction.guild?.channels?.cache?.get?.(voiceChannelId);
+      const voiceMembers = [];
+      if (voiceChannel?.members) {
+        for (const [, m] of voiceChannel.members) {
+          if (m?.user) voiceMembers.push(m.user);
+        }
+      }
+      const voicePart = partitionRecipients(
+        voiceMembers, interaction.user.id, { excludeSender: true }
+      );
+      if (voicePart.valid.length > 0
+          && voicePart.valid.length <= config.QURL_SEND_MAX_RECIPIENTS) {
+        recipientMode = RECIPIENT_MODE_VOICE;
+        finalValid = voicePart.valid;
+        finalSelfIncluded = false;
+        // Voice path produces its own warnings — only droppedBots is
+        // relevant when `recipients:` was omitted (no text-parsing
+        // warnings apply). Surface bot drops so the user knows why the
+        // count is lower than the channel's connected total.
+        finalWarningsBlock = renderRecipientWarnings({
+          droppedBots: voicePart.droppedBots,
+        });
+      }
+    }
+    const needsPicker = recipientMode === RECIPIENT_MODE_PICKER && recipientsOmitted;
+    const recipientIds = finalValid.map((u) => u.id);
+
+    // supersedeOrCreate handles the "another /qurl file/map is open"
+    // case — sibling-flow disambig surfaces a stage-specific message;
+    // same-stage rerun atomically claims the slot. Mirrors /qurl
+    // revoke's pattern.
+    flow_id = flowIdForInteraction(interaction);
+    const sendNonce = crypto.randomBytes(8).toString('hex');
+    // Persist resolved aliases keyed by id. `rerenderConfirmCard`
+    // falls back to these when the menu/note interaction fires after
+    // the member-cache entry has been evicted (rare given the 3-min
+    // flow TTL, but the alternative is showing the raw snowflake).
+    // resolveRecipientAlias returns the PLAIN form — markdown escape
+    // happens at render time.
+    const recipientAliases = Object.fromEntries(
+      finalValid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
+    );
     const payload = {
       resourceType: params.resourceType,
       attachment: params.attachment,
@@ -3875,6 +4011,11 @@ async function handleQurlSlashSend(interaction, params) {
       recipientIds,
       recipientAliases,
       voiceChannelId,
+      // Mode token. Drives both the row layout (picker vs. pick-people-
+      // -instead button) and the "To:" copy. Defaults to 'picker' at
+      // every read site so a row that pre-dates this field (in-flight
+      // at deploy time) keeps the legacy shape until it TTLs out.
+      recipientMode,
       expiresIn,
       selfDestructSeconds,
       personalMessage,
@@ -3892,8 +4033,9 @@ async function handleQurlSlashSend(interaction, params) {
       // bot/unresolved mentions persist into the payload so menu
       // interactions (which don't recompute) still render them.
       // Picker re-pick OVERWRITES with a fresh warningsBlock from the
-      // new partition.
-      warningsBlock,
+      // new partition. Voice-mode override replaces text-path warnings
+      // with the voice-partition's droppedBots-only summary.
+      warningsBlock: finalWarningsBlock,
       // Neutral notice signal — surfaced on the confirm card as
       // "Send includes you." when the sender is in the recipient
       // list. Persisted (rather than derived from
@@ -3902,7 +4044,8 @@ async function handleQurlSlashSend(interaction, params) {
       // re-render path stateless about who computed what. Derivation
       // would also work — both shapes are defensible, but mirroring
       // warningsBlock keeps the payload contract uniform.
-      selfIncluded,
+      // Always false in voice-mode (sender is excluded pre-validity).
+      selfIncluded: finalSelfIncluded,
       sendNonce,
     };
     let supersede;
@@ -3937,14 +4080,16 @@ async function handleQurlSlashSend(interaction, params) {
     const content = renderConfirmCardContent({
       resourceType: params.resourceType,
       resourceLabel: params.resourceLabel,
-      validRecipients: valid,
+      validRecipients: finalValid,
       expiresIn,
       selfDestructSeconds,
       personalMessage,
-      warningsBlock,
+      warningsBlock: finalWarningsBlock,
       needsPicker,
       interaction,
-      selfIncluded,
+      selfIncluded: finalSelfIncluded,
+      recipientMode,
+      voiceChannelId,
     });
     const rows = renderConfirmCardRows({
       sendDisabled: needsPicker,  // Send stays disabled until UserSelectMenu fires
@@ -3954,6 +4099,7 @@ async function handleQurlSlashSend(interaction, params) {
       voiceChannelId,
       interaction,
       recipientIds,
+      recipientMode,
     });
     // `return await` (not bare `return`) is load-bearing: without it
     // a Discord-side rejection on the confirm-card delivery would
@@ -4376,6 +4522,8 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       warningsBlock: warning,
       needsPicker: true,
       interaction,
+      recipientMode: RECIPIENT_MODE_PICKER,
+      voiceChannelId: payload.voiceChannelId,
     }),
     components: renderConfirmCardRows({
       sendDisabled: true,
@@ -4388,6 +4536,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       // transitionFlow fires here) so the user can recover their prior
       // valid selection on re-open instead of starting from empty.
       recipientIds: payload.recipientIds || [],
+      recipientMode: RECIPIENT_MODE_PICKER,
     }),
   }).catch(logIgnoredDiscordErr);
   if (valid.length === 0) {
@@ -4497,6 +4646,13 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     recipientAliases: newRecipientAliases,
     warningsBlock: newWarningsBlock,
     selfIncluded,
+    // Picker activity definitionally lands the card in picker-mode.
+    // If the user clicked the picker (which is the only entry to this
+    // handler), they are NOT in voice-everyone mode — even if the
+    // inbound payload still carried `'voice'` from a stale superseded
+    // flow. Explicit override here keeps a `...payload` spread from
+    // leaking voice-mode forward.
+    recipientMode: RECIPIENT_MODE_PICKER,
   };
   // Targeted catch around transitionFlow mirrors the same shape
   // handleConfirmSendClick / handleConfirmCancelClick use around their
@@ -4534,10 +4690,9 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   }
 
   // The CONTENT renders the resolved recipient summary
-  // ("**To:** N user(s)") with needsPicker:false; the ROWS always
-  // keep the UserSelectMenu attached (renderConfirmCardRows always
-  // produces 4 rows) so the user can re-pick. Send is enabled now
-  // that we have a valid recipient set.
+  // ("**To:** N user(s)") with needsPicker:false; the ROWS keep the
+  // picker attached in picker-mode so the user can re-pick. Send is
+  // enabled now that we have a valid recipient set.
   const content = renderConfirmCardContent({
     resourceType: payload.resourceType,
     resourceLabel: payload.resourceLabel,
@@ -4549,6 +4704,8 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     needsPicker: false,
     interaction,
     selfIncluded,
+    recipientMode: RECIPIENT_MODE_PICKER,
+    voiceChannelId: payload.voiceChannelId,
   });
   return interaction.editReply({
     content,
@@ -4560,6 +4717,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
       voiceChannelId: payload.voiceChannelId,
       interaction,
       recipientIds: newPayload.recipientIds,
+      recipientMode: RECIPIENT_MODE_PICKER,
     }),
   }).catch(logIgnoredDiscordErr);
 }
@@ -4654,6 +4812,13 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // so the stale recipientIds can't fan out; the picker re-pick
   // path is the natural way to refresh them. Matches `rejectPick`'s
   // pattern in handleConfirmUserSelect.
+  // Reject paths render in picker-mode regardless of the inbound
+  // `payload.recipientMode` — the warning copy ("Pick recipients
+  // below.") wires the user toward the picker, so the picker row must
+  // be present. The flow_state row's `recipientMode` is NOT updated
+  // here (no transitionFlow fires on reject); a subsequent picker /
+  // expiry / note interaction will re-derive layout from whatever
+  // mode the payload still carries.
   const rejectVoice = (warning) => interaction.editReply({
     content: renderConfirmCardContent({
       resourceType: payload.resourceType,
@@ -4665,6 +4830,8 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       warningsBlock: warning,
       needsPicker: true,
       interaction,
+      recipientMode: RECIPIENT_MODE_PICKER,
+      voiceChannelId,
     }),
     components: renderConfirmCardRows({
       sendDisabled: true,
@@ -4677,6 +4844,7 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       // no transitionFlow fires) so the user can recover their prior
       // valid selection on re-open of the picker.
       recipientIds: payload.recipientIds || [],
+      recipientMode: RECIPIENT_MODE_PICKER,
     }),
   }).catch(logIgnoredDiscordErr);
 
@@ -4721,15 +4889,24 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       channel_size: channel.members.size,
     });
   }
-  const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);
+  // Sender is excluded from the voice-everyone set: clicking "Everyone
+  // in #voice" semantically means "everyone else in the room," not
+  // "and CC myself." This matches the slash-command auto-default at
+  // handleQurlSlashSend's voice-mode override.
+  const { valid, droppedBots } = partitionRecipients(
+    selectedUsers, interaction.user.id, { excludeSender: true }
+  );
   if (valid.length === 0) {
     // Reached when every connected member was filtered out — today
-    // that's the bots-only case (droppedBots > 0). The fallback
+    // that's the bots-only case (droppedBots > 0), the sender-only
+    // case (sender is the only non-bot in voice), or both. The fallback
     // text covers a future filter addition (e.g., role-blocklist)
     // that drops everyone for a different reason.
     const reasons = [];
     if (droppedBots > 0) reasons.push(RECIPIENT_REASON_BOTS_DROPPED);
-    const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients in voice channel';
+    const reasonText = reasons.length > 0
+      ? reasons.join('. ')
+      : "You're the only one in this voice channel";
     return rejectVoice(`⚠\u{FE0F} ${reasonText}. Pick recipients below.\n\n`);
   }
   // The 20k QURL_SEND_MAX_RECIPIENTS default is sized to accommodate
@@ -4767,7 +4944,15 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     recipientIds: valid.map((u) => u.id),
     recipientAliases: newRecipientAliases,
     warningsBlock: newWarningsBlock,
-    selfIncluded,
+    // Sender was excluded in `partitionRecipients` above with
+    // `{ excludeSender: true }`, so `selfIncluded` is structurally
+    // false on this path. Explicit so a future refactor that drops
+    // the option can't silently flip the flag back to true via the
+    // `...payload` spread carrying a stale value forward.
+    selfIncluded: false,
+    // Voice-mode commits the layout: picker row disappears, bottom
+    // row swaps in the "👥 Pick people instead" escape hatch.
+    recipientMode: RECIPIENT_MODE_VOICE,
   };
   let result;
   try {
@@ -4809,7 +4994,9 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     warningsBlock: newWarningsBlock,
     needsPicker: false,
     interaction,
-    selfIncluded,
+    selfIncluded: false,
+    recipientMode: RECIPIENT_MODE_VOICE,
+    voiceChannelId,
   });
   return interaction.editReply({
     content,
@@ -4821,8 +5008,90 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
       voiceChannelId,
       interaction,
       recipientIds: newPayload.recipientIds,
+      recipientMode: RECIPIENT_MODE_VOICE,
     }),
   }).catch(logIgnoredDiscordErr);
+}
+
+// Confirm-card "👥 Pick people instead" button — voice-mode escape
+// hatch. Flips `recipientMode` back to 'picker', clears recipientIds
+// (the voice-resolved set was authored for "everyone," not a starting
+// point for hand-curation; carrying it forward would land the user in
+// picker-mode with the voice population pre-selected, which is a
+// confusing "did my switch take?" state).
+//
+// No resource resolution / member lookups happen here — purely a UI
+// mode toggle. transitionFlow still fires so the persisted payload
+// matches what the card shows; otherwise a subsequent expiry / note
+// re-render would re-derive picker layout from a payload that still
+// said `recipientMode: 'voice'` and snap back.
+async function handleConfirmPickManual(interaction, { flow_id, row }) {
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
+  const payload = row.payload || {};
+  // resourceType guard mirrors the other confirm-card handlers — a
+  // corrupt or stale row would otherwise throw inside
+  // renderConfirmCardContent's resource-type switch.
+  const payloadResource = payload.resourceType;
+  if (payloadResource !== RESOURCE_TYPES.FILE && payloadResource !== RESOURCE_TYPES.MAPS) {
+    logger.error('handleConfirmPickManual: corrupt flow payload (unknown resourceType)', {
+      flow_id, resource_type: payloadResource,
+    });
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch(logIgnoredDiscordErr);
+    return interaction.editReply({
+      content: '❌ Card data is corrupted — please re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  // Drop recipientIds (and the voice-derived aliases) so the picker
+  // re-renders with the "Pick recipients below" prompt + Send disabled
+  // — the user is starting recipient selection over by definition of
+  // having clicked "Pick people instead."
+  const newPayload = {
+    ...payload,
+    recipientIds: [],
+    recipientAliases: {},
+    recipientMode: RECIPIENT_MODE_PICKER,
+    selfIncluded: false,
+    // Voice-mode's warningsBlock (e.g. droppedBots from voice members)
+    // doesn't apply once the user opts into manual selection — the
+    // picker will produce its own warningsBlock on the next pick.
+    warningsBlock: '',
+  };
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleConfirmPickManual: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not switch to manual picker right now. Try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'conflict') {
+    return interaction.editReply({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.editReply({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  return rerenderConfirmCard(interaction, newPayload);
 }
 
 // Shared re-render after a confirm-card menu/button updates the flow
@@ -4876,7 +5145,20 @@ async function rerenderConfirmCard(interaction, newPayload) {
     const alias = persistedAliases[id];
     return { id, displayName: alias || `user-${id}`, bot: false };
   });
-  const needsPicker = recipientIds.length === 0;
+  // recipientMode drives both row layout AND content prefix. Default
+  // 'picker' for stale flow_state rows that pre-date the field (they
+  // keep the legacy picker shape until they TTL out).
+  const recipientMode = newPayload.recipientMode === RECIPIENT_MODE_VOICE
+    ? RECIPIENT_MODE_VOICE
+    : RECIPIENT_MODE_PICKER;
+  // `needsPicker` (the "Pick recipients below" prompt) is only shown
+  // in picker-mode with no recipients yet. In voice-mode with an empty
+  // recipientIds (e.g., voice channel emptied after switch), the card
+  // shows "To: 0 users in #voice (you not included)" — the user can
+  // click "Pick people instead" to recover.
+  const needsPicker = recipientMode === RECIPIENT_MODE_PICKER && recipientIds.length === 0;
+  // Send-disabled is recipient-empty regardless of mode.
+  const sendDisabled = recipientIds.length === 0;
   const content = renderConfirmCardContent({
     resourceType: newPayload.resourceType,
     resourceLabel: newPayload.resourceLabel,
@@ -4888,17 +5170,20 @@ async function rerenderConfirmCard(interaction, newPayload) {
     needsPicker,
     interaction,
     selfIncluded: newPayload.selfIncluded === true,
+    recipientMode,
+    voiceChannelId: newPayload.voiceChannelId,
   });
   return interaction.editReply({
     content,
     components: renderConfirmCardRows({
-      sendDisabled: needsPicker,
+      sendDisabled,
       expiresIn: newPayload.expiresIn,
       selfDestructSeconds: newPayload.selfDestructSeconds,
       personalMessage: newPayload.personalMessage,
       voiceChannelId: newPayload.voiceChannelId,
       interaction,
       recipientIds,
+      recipientMode,
     }),
   }).catch(logIgnoredDiscordErr);
 }
@@ -7131,6 +7416,12 @@ registerFlow(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmVoiceEveryone,
 });
+// "Pick people instead" — voice-mode → picker-mode toggle. Same stage
+// contract as the other CONFIRM_* registrations.
+registerFlow(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleConfirmPickManual,
+});
 
 module.exports = {
   commands,
@@ -7149,6 +7440,7 @@ module.exports = {
   handleConfirmNoteButton,
   handleConfirmNoteModal,
   handleConfirmVoiceEveryone,
+  handleConfirmPickManual,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with
@@ -7248,6 +7540,9 @@ module.exports = {
       CONFIRM_NOTE_BUTTON_CUSTOM_ID,
       CONFIRM_NOTE_MODAL_CUSTOM_ID,
       CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID,
+      CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
+      RECIPIENT_MODE_PICKER,
+      RECIPIENT_MODE_VOICE,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,
     },

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2887,7 +2887,11 @@ describe('handleQurlFile — slash entry', () => {
         expect(payload.recipientMode).toBe('picker');
         expect(payload.recipientIds).toEqual([]);
         // User sees the "why" rather than a silent voice→picker switch.
-        expect(payload.warningsBlock).toMatch(/Voice channel has 2 connected/);
+        // Wording is "eligible recipients" (post-filter count) not raw
+        // "connected" — sender + bots are already filtered out by this
+        // point, so phrasing as "connected" would diverge from what
+        // Discord's voice panel shows.
+        expect(payload.warningsBlock).toMatch(/Voice channel has 2 eligible recipients/);
         expect(payload.warningsBlock).toMatch(/max 1/);
       } finally {
         config.QURL_SEND_MAX_RECIPIENTS = originalCap;

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2873,6 +2873,23 @@ describe('handleQurlFile — slash entry', () => {
       expect(payload.recipientIds).not.toContain(bot);
     });
 
+    test('bots-only voice → picker fallback WITH bot-drop banner (not silent)', async () => {
+      // Distinction from sender-only / truly-empty: those silently
+      // fall back because there's nothing actionable to surface, but
+      // a voice channel populated entirely by bots is the kind of
+      // "wait, didn't it know I was in voice?" state where the
+      // bot-drop accounting clarifies WHY voice-mode didn't take.
+      const int = makeVoiceEntryInteraction({
+        members: [bot],
+        botIds: [bot],
+      });
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('picker');
+      expect(payload.recipientIds).toEqual([]);
+      expect(payload.warningsBlock).toMatch(/bot/i);
+    });
+
     test('sender-only voice → falls back to picker-mode (no auto voice)', async () => {
       // After excludeSender the voice set is empty. Don't surface a
       // warning; the user didn't ask for voice-everyone, so falling
@@ -2940,7 +2957,12 @@ describe('handleQurlFile — slash entry', () => {
       // "everyone in voice." Voice-mode auto-default only fires when
       // recipients is omitted entirely.
       const int = makeVoiceEntryInteraction({ members: [u1, u2] });
-      int.options.getString = (key) => (key === 'recipients' ? `<@${u1}>` : null);
+      // Re-implement the jest.fn() stub rather than replacing the
+      // property — keeps the call-tracking behavior that the rest of
+      // the suite relies on.
+      int.options.getString.mockImplementation((key) =>
+        (key === 'recipients' ? `<@${u1}>` : null)
+      );
       await handleQurlFile(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -201,6 +201,9 @@ const {
   CONFIRM_NOTE_BUTTON_CUSTOM_ID,
   CONFIRM_NOTE_MODAL_CUSTOM_ID,
   CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID,
+  CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
+  RECIPIENT_MODE_PICKER,
+  RECIPIENT_MODE_VOICE,
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
   isOnCooldown,
@@ -225,6 +228,7 @@ const {
   handleConfirmNoteButton,
   handleConfirmNoteModal,
   handleConfirmVoiceEveryone,
+  handleConfirmPickManual,
 } = commands;
 
 // ──────────────────────────────────────────────────────────────
@@ -2758,6 +2762,93 @@ describe('handleQurlFile — slash entry', () => {
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     expect(mockDeleteFlow).not.toHaveBeenCalled();
   });
+
+  describe('voice-channel slash entry (auto voice-everyone default)', () => {
+    // When `/qurl file` is invoked from a voice channel WITHOUT a
+    // `recipients:` value, the front half auto-resolves the voice-
+    // connected members (minus sender + bots) and lands in voice-mode.
+    // These tests pin (a) the recipient set excludes the sender,
+    // (b) the persisted payload carries recipientMode:'voice', and
+    // (c) the fall-back to picker-mode is silent when voice is empty
+    // / sender-only / over-cap.
+
+    const VOICE_CH = 'voice-ch-slash-1';
+    const u1 = '100000000000000011';
+    const u2 = '100000000000000012';
+    const bot = '100000000000000099';
+
+    function makeVoiceEntryInteraction({ members = [], botIds = [] } = {}) {
+      const chanMembers = new Map();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT },
+      });
+      // Stamp the voice channel as the invocation channel + cache row.
+      int.channel = { id: VOICE_CH, type: 2 };
+      for (const mid of members) {
+        const isBot = botIds.includes(mid);
+        const member = { user: { id: mid, bot: isBot } };
+        int.guild.members.cache.set(mid, member);
+        chanMembers.set(mid, member);
+      }
+      int.guild.channels.cache.set(VOICE_CH, {
+        id: VOICE_CH, type: 2, name: 'general', members: chanMembers,
+      });
+      return int;
+    }
+
+    test('happy path: voice members minus sender land in payload, recipientMode:"voice"', async () => {
+      const int = makeVoiceEntryInteraction({ members: [SENDER_ID, u1, u2] });
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('voice');
+      expect(payload.recipientIds.sort()).toEqual([u1, u2].sort());
+      expect(payload.recipientIds).not.toContain(SENDER_ID);
+      expect(payload.selfIncluded).toBe(false);
+    });
+
+    test('bots in voice are filtered before voice-mode is committed', async () => {
+      const int = makeVoiceEntryInteraction({
+        members: [u1, bot, u2],
+        botIds: [bot],
+      });
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('voice');
+      expect(payload.recipientIds.sort()).toEqual([u1, u2].sort());
+      expect(payload.recipientIds).not.toContain(bot);
+    });
+
+    test('sender-only voice → falls back to picker-mode (no auto voice)', async () => {
+      // After excludeSender the voice set is empty. Don't surface a
+      // warning; the user didn't ask for voice-everyone, so falling
+      // back to the picker UX is the quiet path.
+      const int = makeVoiceEntryInteraction({ members: [SENDER_ID] });
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('picker');
+      expect(payload.recipientIds).toEqual([]);
+    });
+
+    test('empty voice channel → falls back to picker-mode', async () => {
+      const int = makeVoiceEntryInteraction({ members: [] });
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('picker');
+      expect(payload.recipientIds).toEqual([]);
+    });
+
+    test('explicit `recipients:` overrides voice-mode default (manual selection wins)', async () => {
+      // A user who typed `recipients:` clearly meant THOSE people, not
+      // "everyone in voice." Voice-mode auto-default only fires when
+      // recipients is omitted entirely.
+      const int = makeVoiceEntryInteraction({ members: [u1, u2] });
+      int.options.getString = (key) => (key === 'recipients' ? `<@${u1}>` : null);
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('picker');
+      expect(payload.recipientIds).toEqual([u1]);
+    });
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -4379,18 +4470,20 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(lastCall.content).not.toMatch(/No one is connected/i);
   });
 
-  test('sender is voice-connected → selfIncluded:true propagates to the new payload', async () => {
-    // Symmetric with handleConfirmUserSelect's "self-send" coverage —
-    // partitionRecipients flips selfIncluded when the invoking user
-    // appears in the resolved set. The confirm-card renderer reads
-    // this flag to surface the "Send includes you." neutral notice.
-    // Without this test, a future refactor that bypassed
-    // partitionRecipients (e.g., reading recipientIds directly from
-    // channel.members.keys()) would silently drop the notice.
+  test('sender is voice-connected → excluded from recipientIds + selfIncluded:false', async () => {
+    // Voice-everyone semantically means "everyone else in the room,"
+    // not "and CC myself." partitionRecipients's `excludeSender: true`
+    // option drops the sender pre-validity, so the new payload
+    // structurally cannot carry selfIncluded:true on this path. Pins
+    // the contract — a future refactor that read recipientIds from
+    // channel.members.keys() directly would silently re-include the
+    // sender.
     const int = makeVoiceInteraction({ members: [SENDER_ID, u1] });
     await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     const payload = mockTransitionFlow.mock.calls[0][2].payload;
-    expect(payload.selfIncluded).toBe(true);
+    expect(payload.recipientIds).toEqual([u1]);
+    expect(payload.recipientIds).not.toContain(SENDER_ID);
+    expect(payload.selfIncluded).toBe(false);
   });
 
   test('sender NOT in voice channel → selfIncluded:false on the new payload', async () => {
@@ -4398,6 +4491,30 @@ describe('handleConfirmVoiceEveryone', () => {
     await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     const payload = mockTransitionFlow.mock.calls[0][2].payload;
     expect(payload.selfIncluded).toBe(false);
+  });
+
+  test('new payload carries recipientMode:"voice" — commits the layout switch', async () => {
+    // Voice-mode hides the picker row and swaps the bottom button to
+    // "👥 Pick people instead." Without persisting the mode, a
+    // subsequent expiry/note interaction's re-render would re-derive
+    // picker-mode layout and snap back, leaving the user in a
+    // confusing "did my click take?" state.
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.recipientMode).toBe('voice');
+  });
+
+  test('sender-only voice channel → reject path with "you\'re the only one" copy', async () => {
+    // After excludeSender, a channel containing only the sender yields
+    // valid:[]. The reject copy surfaces the actual reason rather than
+    // the misleading "No one is connected" branch (which is reserved
+    // for an actually-empty channel).
+    const int = makeVoiceInteraction({ members: [SENDER_ID] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/only one in this voice channel/i);
   });
 
   test('transitionFlow conflict → superseded message (OCC race with sibling interaction)', async () => {
@@ -4501,6 +4618,97 @@ describe('handleConfirmVoiceEveryone', () => {
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(lastCall.content).toMatch(/Card data is corrupted/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// handleConfirmPickManual — "Pick people instead" button on the
+// confirm card. Voice-mode escape hatch: flips recipientMode back to
+// 'picker', clears the voice-resolved recipientIds, and re-renders.
+// ──────────────────────────────────────────────────────────────
+
+describe('handleConfirmPickManual', () => {
+  const u1 = '100000000000000001';
+  const u2 = '100000000000000002';
+  const VOICE_CH = 'voice-ch-pm';
+
+  const voicePayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [u1, u2],
+    recipientAliases: { [u1]: 'alice', [u2]: 'bob' },
+    recipientMode: 'voice',
+    voiceChannelId: VOICE_CH,
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+    warningsBlock: '',
+  };
+
+  test('clears recipientIds + recipientAliases and flips recipientMode → "picker"', async () => {
+    const int = makeInteraction();
+    await handleConfirmPickManual(int, { flow_id: 'fid', row: { payload: voicePayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).toHaveBeenCalledWith('fid', 1, expect.objectContaining({
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: expect.objectContaining({
+        recipientMode: 'picker',
+        recipientIds: [],
+        recipientAliases: {},
+        selfIncluded: false,
+      }),
+      terminal: false,
+    }));
+  });
+
+  test('preserves resourceType / expiresIn / personalMessage from the original payload', async () => {
+    // The toggle is purely UI mode; resource + send-config fields
+    // carry through unchanged so the user keeps their context.
+    const int = makeInteraction();
+    const payloadWithExtras = {
+      ...voicePayload,
+      expiresIn: '7d',
+      selfDestructSeconds: 60,
+      personalMessage: 'hi team',
+    };
+    await handleConfirmPickManual(int, { flow_id: 'fid', row: { payload: payloadWithExtras, version: 1 } });
+    const newPayload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(newPayload.resourceType).toBe('file');
+    expect(newPayload.expiresIn).toBe('7d');
+    expect(newPayload.selfDestructSeconds).toBe(60);
+    expect(newPayload.personalMessage).toBe('hi team');
+    expect(newPayload.voiceChannelId).toBe(VOICE_CH);
+  });
+
+  test('corrupt resourceType → deleteFlow + "Card data is corrupted" copy', async () => {
+    const int = makeInteraction();
+    const corrupt = { ...voicePayload, resourceType: 'audio' };
+    await handleConfirmPickManual(int, { flow_id: 'fid', row: { payload: corrupt, version: 1 } });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }));
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/Card data is corrupted/);
+  });
+
+  test('transitionFlow conflict → superseded message', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    const int = makeInteraction();
+    await handleConfirmPickManual(int, { flow_id: 'fid', row: { payload: voicePayload, version: 1 } });
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/superseded/);
+    expect(lastCall.components).toEqual([]);
+  });
+
+  test('transitionFlow not_found → expired message', async () => {
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    const int = makeInteraction();
+    await handleConfirmPickManual(int, { flow_id: 'fid', row: { payload: voicePayload, version: 1 } });
+    const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(lastCall.content).toMatch(/expired/);
+    expect(lastCall.components).toEqual([]);
   });
 });
 
@@ -5450,7 +5658,14 @@ describe('renderConfirmCardRows', () => {
     // Discord's 80-UTF-16 hard cap.
     const allEmojiName = '🎉'.repeat(46);
     expect(allEmojiName.length).toBe(92); // confirm worst-case UTF-16
-    const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+    // Pass a `recipients:` mention so the slash-entry path stays in
+    // picker-mode — the voice button is rendered (and label-truncated)
+    // only in picker-mode. The voice-mode auto-default would swap in
+    // a "Pick people instead" button instead, hiding what we're testing.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000099>' },
+      guildMembers: { '100000000000000099': {} },
+    });
     int.channel = { id: 'voice-emoji', type: 2 };
     int.guild.channels.cache.set('voice-emoji', {
       id: 'voice-emoji', name: allEmojiName, type: 2,
@@ -5490,7 +5705,12 @@ describe('renderConfirmCardRows', () => {
     // 45, 46 to land near the slice boundary.
     const longName = 'a'.repeat(44) + '🎉🎉🎉' + 'b'.repeat(47);
     const int = makeInteraction({
-      options: { attachment: VALID_ATTACHMENT },
+      // `recipients:` keeps the slash-entry in picker-mode so the
+      // voice-everyone button (the subject under test) renders.
+      // Voice-mode auto-default would otherwise swap it for "Pick
+      // people instead."
+      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000099>' },
+      guildMembers: { '100000000000000099': {} },
       // Inject the channel into the interaction so renderConfirmCardRows'
       // live read finds it.
     });
@@ -5521,6 +5741,101 @@ describe('renderConfirmCardRows', () => {
         i++; // skip the trail surrogate
       }
     }
+  });
+
+  describe('voice-mode layout (recipientMode:"voice")', () => {
+    // Round-trip the render layout via handleQurlFile invoked from a
+    // voice channel WITHOUT `recipients:`. The slash-entry voice-mode
+    // auto-default lands the card in voice-mode, which:
+    //   - HIDES the MentionableSelect picker row
+    //   - SHOWS a "👥 Pick people instead" button
+    //   - DOES NOT show the "🔊 Everyone in #voice" button (that's
+    //     the entry point INTO voice mode; once you're in, it's gone)
+    // Without these pins, a future refactor that re-enables the picker
+    // in voice-mode (or drops the pick-manual button) passes every
+    // other test in this file.
+
+    const VOICE_CH = 'voice-ch-layout';
+    const u1 = '100000000000000031';
+
+    function setupVoice(int) {
+      int.channel = { id: VOICE_CH, type: 2 };
+      const member = { user: { id: u1, bot: false } };
+      int.guild.members.cache.set(u1, member);
+      int.guild.channels.cache.set(VOICE_CH, {
+        id: VOICE_CH, type: 2, name: 'general',
+        members: new Map([[u1, member]]),
+      });
+    }
+
+    test('picker row is NOT rendered (MentionableSelectMenuBuilder never instantiated)', async () => {
+      const { MentionableSelectMenuBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+      setupVoice(int);
+      await handleQurlFile(int);
+      // The literal "one or the other" contract — voice-mode kills the
+      // picker. A test that asserted on `editReply.components.length`
+      // alone would silently drift if rows were added/removed elsewhere.
+      expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
+    });
+
+    test('"Pick people instead" button IS rendered; "Everyone in #voice" button is NOT', async () => {
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+      setupVoice(int);
+      await handleQurlFile(int);
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toContain('qurl_confirm_pick_manual');
+      expect(customIds).not.toContain('qurl_confirm_voice_everyone');
+    });
+
+    test('bottom row has exactly 4 buttons in order: Pick-manual, Note, Send, Cancel', async () => {
+      // Layout pin. Voice-mode bottom row carries the escape hatch +
+      // the standard note/send/cancel trio. The pick-manual button is
+      // leftmost (replacing the voice-everyone affordance in picker
+      // mode); any future refactor that re-orders these should update
+      // this test deliberately.
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+      setupVoice(int);
+      await handleQurlFile(int);
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toEqual([
+        'qurl_confirm_pick_manual',
+        'qurl_confirm_note_btn',
+        'qurl_confirm_send',
+        'qurl_confirm_cancel',
+      ]);
+    });
+
+    test('voice-mode "To:" line uses a native channel mention (not raw channel.name) — markdown-injection safe', async () => {
+      // Regression pin: channel names like `**spoiler**` or `||hide||`
+      // would otherwise inject markdown into the confirm card content.
+      // Rendering via `<#channelId>` lets Discord resolve the mention
+      // client-side without going through name interpolation.
+      const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+      int.channel = { id: VOICE_CH, type: 2 };
+      const member = { user: { id: u1, bot: false } };
+      int.guild.members.cache.set(u1, member);
+      int.guild.channels.cache.set(VOICE_CH, {
+        id: VOICE_CH, type: 2,
+        name: '**inject** _under_ ||hide||',
+        members: new Map([[u1, member]]),
+      });
+      await handleQurlFile(int);
+      const editReplyCalls = int.editReply.mock.calls;
+      const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
+      expect(lastCall.content).toContain(`<#${VOICE_CH}>`);
+      expect(lastCall.content).not.toContain('**inject**');
+      expect(lastCall.content).not.toContain('||hide||');
+    });
   });
 });
 
@@ -5624,6 +5939,7 @@ describe('constants + exports', () => {
     expect(CONFIRM_NOTE_BUTTON_CUSTOM_ID).toBe('qurl_confirm_note_btn');
     expect(CONFIRM_NOTE_MODAL_CUSTOM_ID).toBe('qurl_confirm_note_modal');
     expect(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID).toBe('qurl_confirm_voice_everyone');
+    expect(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID).toBe('qurl_confirm_pick_manual');
   });
 
   test('all customIds unique', () => {
@@ -5636,8 +5952,18 @@ describe('constants + exports', () => {
       CONFIRM_NOTE_BUTTON_CUSTOM_ID,
       CONFIRM_NOTE_MODAL_CUSTOM_ID,
       CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID,
+      CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
     ]);
-    expect(ids.size).toBe(8);
+    expect(ids.size).toBe(9);
+  });
+
+  test('recipientMode tokens are stable wire values (persisted in flow_state rows)', () => {
+    // The mode token gets serialized into DDB along with the rest of
+    // the payload. Renaming the literal would orphan in-flight cards
+    // across a deploy — the dispatcher reads the field at click time
+    // and would silently mis-route. Pin the literals here.
+    expect(RECIPIENT_MODE_PICKER).toBe('picker');
+    expect(RECIPIENT_MODE_VOICE).toBe('voice');
   });
 
   test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {
@@ -5675,6 +6001,21 @@ describe('constants + exports', () => {
       'qurl_confirm_note_modal',
     ];
     for (const id of newCustomIds) {
+      expect(() => registerFlow(id, {
+        expectedStage: 'noop_stage_for_collision_check',
+        handler: () => undefined,
+      })).toThrow(/already registered/);
+    }
+  });
+
+  test('voice-everyone + pick-manual buttons are registered at the confirm-card stage', () => {
+    // Same shape as the "four new confirm-card menu customIds" check.
+    // Catches the registration-omission shape for the voice-mode pair
+    // — a missed registerFlow surfaces as an unrouted dispatch in
+    // production, which is harder to debug than a duplicate-register
+    // throw at startup.
+    const { registerFlow } = require('../src/flow-dispatch');
+    for (const id of ['qurl_confirm_voice_everyone', 'qurl_confirm_pick_manual']) {
       expect(() => registerFlow(id, {
         expectedStage: 'noop_stage_for_collision_check',
         handler: () => undefined,

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2026,6 +2026,27 @@ describe('renderConfirmCardContent', () => {
     expect(out).not.toMatch(/Send includes/);
   });
 
+  test('voice-mode + selfIncluded=true → notice suppressed (forged/drifted payload defense)', () => {
+    // Every production voice-mode write path sets selfIncluded:false,
+    // so this state is structurally unreachable. The renderer guard
+    // exists for a forged or schema-drifted payload that would
+    // otherwise stack a contradictory "Send includes you." notice on
+    // top of the voice-mode "(you not included)" copy on the "To:"
+    // line. Pin the guard so a future refactor can't silently let the
+    // two messages coexist.
+    const u1 = { id: '100000000000000001', username: 'alice' };
+    const out = renderConfirmCardContent({
+      ...baseProps,
+      validRecipients: [u1],
+      selfIncluded: true,
+      recipientMode: 'voice',
+      voiceChannelId: 'voice-ch',
+    });
+    expect(out).not.toMatch(/Send includes you/);
+    // Voice-mode "To:" still renders correctly.
+    expect(out).toMatch(/you not included/);
+  });
+
   test('personal-message preview cap at 80 chars, rendered as blockquote', () => {
     const long = 'x'.repeat(120);
     const out = renderConfirmCardContent({ ...baseProps, personalMessage: long });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -204,6 +204,7 @@ const {
   CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
   RECIPIENT_MODE_PICKER,
   RECIPIENT_MODE_VOICE,
+  normalizeRecipientMode,
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
   isOnCooldown,
@@ -438,6 +439,39 @@ describe('partitionRecipients', () => {
     const dup = makeUser('100000000000000001');
     const r = partitionRecipients([dup, dup, makeUser('100000000000000002')], SENDER_ID);
     expect(r.valid.length).toBe(3);
+  });
+
+  test('excludeSender:true drops the sender pre-validity (selfIncluded stays false)', () => {
+    // Voice-everyone semantics. The sender is dropped silently — no
+    // droppedBots-style accounting, and `selfIncluded` cannot be true
+    // on this path. The user-visible "you not included" copy is
+    // rendered from recipientMode, not from this partition return.
+    const users = [
+      makeUser('100000000000000001'),
+      makeUser(SENDER_ID),
+      makeUser('100000000000000002'),
+    ];
+    const r = partitionRecipients(users, SENDER_ID, { excludeSender: true });
+    expect(r.valid.map((u) => u.id))
+      .toEqual(['100000000000000001', '100000000000000002']);
+    expect(r.droppedBots).toBe(0);
+    expect(r.selfIncluded).toBe(false);
+  });
+
+  test('excludeSender:true + sender-only input → valid=[] (caller handles fallback copy)', () => {
+    const r = partitionRecipients([makeUser(SENDER_ID)], SENDER_ID, { excludeSender: true });
+    expect(r.valid).toEqual([]);
+    expect(r.droppedBots).toBe(0);
+    expect(r.selfIncluded).toBe(false);
+  });
+
+  test('excludeSender default (false) preserves legacy self-send behavior', () => {
+    // Picker / text paths call without the option and rely on the
+    // sender appearing in `valid` with `selfIncluded:true`. Pin that
+    // omitting the option doesn't accidentally activate exclusion.
+    const r = partitionRecipients([makeUser(SENDER_ID)], SENDER_ID);
+    expect(r.valid.map((u) => u.id)).toEqual([SENDER_ID]);
+    expect(r.selfIncluded).toBe(true);
   });
 });
 
@@ -2837,6 +2871,45 @@ describe('handleQurlFile — slash entry', () => {
       expect(payload.recipientIds).toEqual([]);
     });
 
+    test('over-cap voice → falls back to picker-mode WITH banner explaining why', async () => {
+      // Unreachable under default config (20k cap vs Discord's 99-member
+      // voice cap), but a shrunk env override would trip this. Silent
+      // fallback would leave the user wondering why voice-mode didn't
+      // take. Banner + info log document the degraded state. Mirrors
+      // the button-handler's hard-reject copy at handleConfirmVoiceEveryone.
+      const config = require('../src/config');
+      const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
+      config.QURL_SEND_MAX_RECIPIENTS = 1;  // force over-cap with 2 members
+      try {
+        const int = makeVoiceEntryInteraction({ members: [u1, u2] });
+        await handleQurlFile(int);
+        const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+        expect(payload.recipientMode).toBe('picker');
+        expect(payload.recipientIds).toEqual([]);
+        // User sees the "why" rather than a silent voice→picker switch.
+        expect(payload.warningsBlock).toMatch(/Voice channel has 2 connected/);
+        expect(payload.warningsBlock).toMatch(/max 1/);
+      } finally {
+        config.QURL_SEND_MAX_RECIPIENTS = originalCap;
+      }
+    });
+
+    test('voice channel cache miss → picker-mode with "Couldn\'t read voice channel" banner', async () => {
+      // Cache miss simulates the GuildVoiceStates intent dropping or
+      // the channel being evicted between command receipt and our
+      // lookup. Banner surfaces the degraded state instead of silently
+      // landing in picker-mode.
+      const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
+      int.channel = { id: VOICE_CH, type: 2 };
+      // Inject the channel id WITHOUT registering it in the cache —
+      // makes guild.channels.cache.get(id) return undefined, the cache-
+      // miss shape.
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('picker');
+      expect(payload.warningsBlock).toMatch(/Couldn't read voice channel members/);
+    });
+
     test('explicit `recipients:` overrides voice-mode default (manual selection wins)', async () => {
       // A user who typed `recipients:` clearly meant THOSE people, not
       // "everyone in voice." Voice-mode auto-default only fires when
@@ -4710,6 +4783,24 @@ describe('handleConfirmPickManual', () => {
     expect(lastCall.content).toMatch(/expired/);
     expect(lastCall.components).toEqual([]);
   });
+
+  test('transitionFlow synchronous throw → ephemeral retry followUp (DDB blip recovery)', async () => {
+    // Symmetric with the expiry / self-destruct handler throw tests.
+    // A DDB outage during the mode-toggle write would otherwise bubble
+    // through the dispatcher's generic "superseded" copy — wrong, since
+    // nothing was actually superseded. The targeted followUp keeps the
+    // user's interaction acked and surfaces actionable retry copy.
+    mockTransitionFlow.mockRejectedValueOnce(new Error('DDB blip'));
+    const int = makeInteraction();
+    await handleConfirmPickManual(int, { flow_id: 'fid', row: { payload: voicePayload, version: 1 } });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not switch to manual picker/i),
+      ephemeral: true,
+    }));
+    expect(int.editReply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/superseded/i),
+    }));
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -5455,6 +5546,48 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
     expect(defaultedExpiryOptions).toHaveLength(1);
     expect(defaultedExpiryOptions[0].value).toBe('24h');
   });
+
+  test('voice-mode + empty recipientIds → "0 users in #voice" + Send disabled (no auto-revert to picker)', async () => {
+    // Reachable when a voice channel empties out between renders (every
+    // non-sender member leaves voice). Voice-mode is sticky: rather
+    // than silently snapping back to picker-mode mid-flow, the card
+    // shows the honest empty state and the user clicks "Pick people
+    // instead" to recover. Send stays disabled (recipientIds=[]) so a
+    // wayward click can't fan out to zero recipients.
+    const { ButtonBuilder } = require('discord.js');
+    ButtonBuilder.mockClear();
+    const payload = {
+      resourceType: 'file',
+      resourceLabel: 'x.png',
+      recipientIds: [],
+      recipientAliases: {},
+      recipientMode: 'voice',
+      voiceChannelId: 'voice-empty',
+      expiresIn: '24h',
+      selfDestructSeconds: null,
+      personalMessage: null,
+    };
+    const int = makeInteraction();
+    int.values = ['7d'];
+    await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+    const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
+    // Voice-mode rendering still applies — content shows the channel
+    // mention + "(you not included)" notice even with zero recipients.
+    expect(lastEdit.content).toMatch(/0 users in <#voice-empty>/);
+    expect(lastEdit.content).toMatch(/you not included/);
+    // The picker prompt MUST NOT appear (we're in voice-mode).
+    expect(lastEdit.content).not.toMatch(/Pick recipients below/);
+    // Send is disabled (no recipients), pick-manual is rendered as
+    // the recovery path.
+    const sendBtn = ButtonBuilder.mock.results.find(
+      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_send'
+    );
+    expect(sendBtn.value.setDisabled).toHaveBeenCalledWith(true);
+    const customIds = ButtonBuilder.mock.results.map(
+      (r) => r.value.setCustomId.mock.calls[0]?.[0]
+    );
+    expect(customIds).toContain('qurl_confirm_pick_manual');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -5964,6 +6097,21 @@ describe('constants + exports', () => {
     // and would silently mis-route. Pin the literals here.
     expect(RECIPIENT_MODE_PICKER).toBe('picker');
     expect(RECIPIENT_MODE_VOICE).toBe('voice');
+  });
+
+  test('normalizeRecipientMode: only "voice" maps to voice; everything else picker', () => {
+    // Stale flow_state rows (created before this field existed) read
+    // as undefined. Off-set values (forged interaction, schema drift,
+    // typo in a future refactor) also fall back to picker. Pin the
+    // table so a future refactor that flips the default can't slip
+    // through.
+    expect(normalizeRecipientMode('voice')).toBe('voice');
+    expect(normalizeRecipientMode('picker')).toBe('picker');
+    expect(normalizeRecipientMode(undefined)).toBe('picker');
+    expect(normalizeRecipientMode(null)).toBe('picker');
+    expect(normalizeRecipientMode('')).toBe('picker');
+    expect(normalizeRecipientMode('VOICE')).toBe('picker'); // case-sensitive
+    expect(normalizeRecipientMode('unknown')).toBe('picker');
   });
 
   test('siblingMessage is keyed by stage so any of the three confirm-card customIds surfaces the same message', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -4674,7 +4674,11 @@ describe('handleConfirmVoiceEveryone', () => {
       await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
       expect(mockTransitionFlow).not.toHaveBeenCalled();
       const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
-      expect(lastCall.content).toMatch(/Voice channel has 2 connected \(max 1\)/i);
+      // "eligible recipients" wording is shared with the slash-entry
+      // over-cap banner — both counts are post-partition (sender +
+      // bots filtered), so "connected" would diverge from Discord's
+      // voice panel.
+      expect(lastCall.content).toMatch(/Voice channel has 2 eligible recipients \(max 1\)/i);
       expect(lastCall.content).toMatch(/picker or @mentions/i);
     } finally {
       config.QURL_SEND_MAX_RECIPIENTS = origCap;
@@ -5972,6 +5976,48 @@ describe('renderConfirmCardRows', () => {
       expect(lastCall.content).toContain(`<#${VOICE_CH}>`);
       expect(lastCall.content).not.toContain('**inject**');
       expect(lastCall.content).not.toContain('||hide||');
+    });
+
+    test('voice-mode survives an unrelated menu interaction (expiry change) without decaying to picker', async () => {
+      // Belt-and-braces: after the slash-entry voice-mode auto-default
+      // commits, an expiry-change re-renders the card through
+      // rerenderConfirmCard. If the rerender path defaulted to
+      // picker-mode (instead of reading payload.recipientMode), the
+      // card would silently snap layout mid-flow. The dedicated
+      // voice-mode-with-empty-recipients test covers the degenerate
+      // case; this pins the happy path round-trip.
+      const { MentionableSelectMenuBuilder, ButtonBuilder } = require('discord.js');
+      // Construct a post-slash-entry voice-mode payload (what
+      // handleQurlSlashSend would have written to flow_state).
+      const payload = {
+        resourceType: 'file',
+        resourceLabel: 'x.png',
+        recipientIds: [u1],
+        recipientAliases: { [u1]: 'alice' },
+        recipientMode: 'voice',
+        voiceChannelId: VOICE_CH,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        warningsBlock: '',
+      };
+      MentionableSelectMenuBuilder.mockClear();
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({ guildMembers: { [u1]: {} } });
+      int.values = ['7d'];  // change expiry from 24h → 7d
+      await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
+      // Layout pin: picker still hidden, pick-manual still rendered,
+      // voice-everyone still NOT rendered. The "To:" line still uses
+      // the channel mention.
+      expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toContain('qurl_confirm_pick_manual');
+      expect(customIds).not.toContain('qurl_confirm_voice_everyone');
+      const lastCall = int.editReply.mock.calls.slice(-1)[0][0];
+      expect(lastCall.content).toContain(`<#${VOICE_CH}>`);
+      expect(lastCall.content).toMatch(/you not included/);
     });
   });
 });


### PR DESCRIPTION
## Summary

- When `/qurl file` or `/qurl map` is invoked from a voice channel **without** an explicit `recipients:` list, the confirm card auto-resolves to voice-connected members (sender + bots excluded) and lands in **voice-mode**: MentionableSelect picker is hidden, bottom row swaps the `🔊 Everyone in #voice` affordance for `👥 Pick people instead` as the escape hatch back to manual selection.
- The existing `🔊 Everyone in #voice` button (clicked from picker-mode) **now also excludes the sender** from the resolved set — symmetric with the slash-entry contract. "Everyone in voice" means everyone *else* in the room.
- Voice-mode "To:" line renders via Discord's native `<#channelId>` mention rather than interpolating `channel.name` raw — closes a markdown-injection vector (channels named `**bold**` / `||hide||` would otherwise inject formatting into the card).
- Picker activity from `handleConfirmUserSelect` and the `Pick people instead` toggle explicitly reset `recipientMode → 'picker'` so a `...payload` spread can't leak a stale `'voice'` mode forward.

## Mode tokens
- `payload.recipientMode = 'picker' | 'voice'`. New field; stale flow_state rows that pre-date it default to `'picker'` at every read site so legacy cards keep the existing shape until they TTL out (180s `SEND_FLOW_TTL_SECONDS`).

## Test plan
- [x] `npm run lint` clean
- [x] Full `npm test` suite green (1669 tests, 47 suites)
- [x] New coverage: 5 slash-entry voice-default tests, 5 `handleConfirmPickManual` tests, 4 voice-mode layout tests (picker hidden, pick-manual button present, voice-everyone button absent, markdown-injection regression), pins on new customId + mode tokens
- [ ] Manual verification in sandbox: `/qurl file` from a voice channel with N>0 other connected members lands on voice-mode card; `Pick people instead` swaps back to picker; `Everyone in #voice` button from picker-mode excludes sender

🤖 Generated with [Claude Code](https://claude.com/claude-code)