### PR TITLE
fix(discord): pre-warm guild.members cache before @everyone / role expansion

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -263,17 +263,35 @@ const MASS_MENTION_HINT_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])|<@&\d
 // has no LRU and eviction relies on `GUILD_MEMBER_REMOVE` gateway
 // events. Acceptable for our scale; revisit if a future regression in
 // gateway event delivery causes drift.
+//
+// In-flight de-duplication via the `prewarmInFlight` map below: two
+// concurrent `/qurl file @everyone` invocations in the same guild from
+// a cold cache share the same underlying `members.fetch()` promise.
+// Without coalescing, abuse via concurrent invocations could burn
+// chunk-request budget linearly. discord.js may also coalesce the
+// `GUILD_REQUEST_MEMBERS` chunks internally, but we don't rely on it
+// — the map is keyed by `guild.id` so cross-guild calls still proceed
+// in parallel.
+const prewarmInFlight = new Map();
 async function prewarmGuildMembersCache(guild, logCtx) {
   if (!guild || !guild.members || typeof guild.members.fetch !== 'function') return;
   const cacheSize = guild.members.cache?.size ?? 0;
   if (cacheSize >= (guild.memberCount ?? Infinity)) return;
-  try {
-    await guild.members.fetch({ time: TIMEOUTS.MEMBER_PREFETCH });
-  } catch (err) {
-    logger.warn('members.fetch pre-warm failed; @everyone/role expansion may underresolve', {
-      ...logCtx, guild_id: guild.id, error: err && err.message,
-    });
-  }
+  const existing = prewarmInFlight.get(guild.id);
+  if (existing) return existing;
+  const inFlight = (async () => {
+    try {
+      await guild.members.fetch({ time: TIMEOUTS.MEMBER_PREFETCH });
+    } catch (err) {
+      logger.warn('members.fetch pre-warm failed; @everyone/role expansion may underresolve', {
+        ...logCtx, guild_id: guild.id, error: err && err.message,
+      });
+    } finally {
+      prewarmInFlight.delete(guild.id);
+    }
+  })();
+  prewarmInFlight.set(guild.id, inFlight);
+  return inFlight;
 }
 
 function sanitizeMessage(msg) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -245,11 +245,14 @@ const PERSONAL_MESSAGE_INPUT_MAX = 280;
 // multi-tenant gateway — eagerly fetching every member of every joined
 // guild on connect would blow the rate-limit budget at install spikes).
 // Shape-only — permission gating happens later inside the parser via
-// `allowMassMention` / `role.mentionable`. Word-boundary class matches
-// recipient-parser.js's `EVERYONE_TOKEN_RE` so `@everyonefoo` doesn't
-// false-trigger the fetch (and a drift between the two would silently
-// cache-warm for inputs the parser then ignores).
+// `allowMassMention` / `role.mentionable`. Word-boundary class is a
+// parallel copy of recipient-parser.js's `EVERYONE_TOKEN_RE` so
+// `@everyonefoo` doesn't false-trigger the fetch (drift between the
+// two would silently cache-warm for inputs the parser then ignores).
+// If `EVERYONE_TOKEN_RE` ever moves to a shared module, derive this
+// from it rather than maintaining the parallel copy.
 const MASS_MENTION_HINT_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])|<@&\d+>/u;
+const ROLE_MENTION_HINT_RE = /<@&\d+>/;
 
 // Helper for the two pre-warm sites. Returns a Promise so the caller
 // can await before reading `guild.members.cache`. Swallows errors —
@@ -274,6 +277,10 @@ const MASS_MENTION_HINT_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])|<@&\d
 // in parallel.
 const prewarmInFlight = new Map();
 async function prewarmGuildMembersCache(guild, logCtx) {
+  // Uniform Promise return shape regardless of which branch the caller
+  // hits — early-exit paths used to resolve `undefined`, which works
+  // for `await prewarmGuildMembersCache(...)` callers but would surprise
+  // a future caller that does `.then(...)`.
   if (!guild || !guild.members || typeof guild.members.fetch !== 'function') return;
   const cacheSize = guild.members.cache?.size ?? 0;
   if (cacheSize >= (guild.memberCount ?? Infinity)) return;
@@ -3826,7 +3833,15 @@ async function handleQurlSlashSend(interaction, params) {
     // refactor switching to `interaction.member.permissions` would
     // silently lose the channel-overwrite respect — keep this property.
     const canMentionEveryone = interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
-    if (MASS_MENTION_HINT_RE.test(recipientsRaw || '')) {
+    // Skip the fetch when only `@everyone` is in the input AND the
+    // sender lacks MENTION_EVERYONE — the parser will deny the
+    // expansion (massMentionDenied), so the chunk request would be
+    // wasted. Role-mention shapes (`<@&id>`) still trigger the fetch
+    // regardless of permission because role expansion gates on
+    // `role.mentionable === true` per-role, not the global perm.
+    const hasMassMention = MASS_MENTION_HINT_RE.test(recipientsRaw || '');
+    const hasRoleMention = ROLE_MENTION_HINT_RE.test(recipientsRaw || '');
+    if (hasMassMention && (canMentionEveryone || hasRoleMention)) {
       await prewarmGuildMembersCache(interaction.guild, { caller: 'handleQurlSlashSend' });
     }
     const parsed = parseRecipientMentions(recipientsRaw, interaction, {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -252,7 +252,7 @@ const PERSONAL_MESSAGE_INPUT_MAX = 280;
 // If `EVERYONE_TOKEN_RE` ever moves to a shared module, derive this
 // from it rather than maintaining the parallel copy.
 const MASS_MENTION_HINT_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])|<@&\d+>/u;
-const ROLE_MENTION_HINT_RE = /<@&\d+>/;
+const ROLE_MENTION_HINT_RE = /<@&\d+>/u;
 
 // Helper for the two pre-warm sites. Returns a Promise so the caller
 // can await before reading `guild.members.cache`. Swallows errors —
@@ -4425,6 +4425,17 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // non-@everyone role is a filtered view of `guild.members.cache`, so
   // both hit the same empty-cache failure mode. Direct user picks skip
   // the fetch — Discord ships the User object in `interaction.users`.
+  //
+  // DIVERGES from the text-path gate at handleQurlSlashSend, which
+  // additionally requires `canMentionEveryone || hasRoleMention` to
+  // skip the wasted fetch on bare `@everyone` typed without perm. The
+  // picker omits the @everyone role from its UI (Discord platform
+  // filter — out of scope here), so the only roles reaching this gate
+  // are user-deliberately-picked custom roles. A wasted fetch on a
+  // non-mentionable custom role pick (which the per-role
+  // `role.mentionable` gate inside `resolveMentionableSelection` will
+  // ultimately deny) is rare enough that the simpler trigger is worth
+  // the marginal optimization loss.
   if (interaction.roles?.size > 0) {
     await prewarmGuildMembersCache(interaction.guild, { caller: 'handleConfirmUserSelect', flow_id });
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -238,6 +238,44 @@ function sliceWithEllipsis(s, maxCodepoints, indicator) {
 // can't grow flow rows past the legitimate ceiling.
 const PERSONAL_MESSAGE_INPUT_MAX = 280;
 
+// Triggers `guild.members.fetch()` pre-warm before parsing recipients —
+// any `@everyone` text token OR any `<@&{snowflake}>` role-mention. Both
+// paths read `guild.members.cache`, which discord.js v14 leaves empty
+// (we deliberately skip `chunkOnStartup`/`ws.large_threshold` on the
+// multi-tenant gateway — eagerly fetching every member of every joined
+// guild on connect would blow the rate-limit budget at install spikes).
+// Shape-only — permission gating happens later inside the parser via
+// `allowMassMention` / `role.mentionable`. Word-boundary class matches
+// recipient-parser.js's `EVERYONE_TOKEN_RE` so `@everyonefoo` doesn't
+// false-trigger the fetch (and a drift between the two would silently
+// cache-warm for inputs the parser then ignores).
+const MASS_MENTION_HINT_RE = /(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])|<@&\d+>/u;
+
+// Helper for the two pre-warm sites. Returns a Promise so the caller
+// can await before reading `guild.members.cache`. Swallows errors —
+// degraded expansion (parser sees a partial cache) is the correct
+// fallback for transient API blips; surfacing the failure to the user
+// would confuse them about a problem they can't act on. Skipped when
+// the cache already reports `memberCount` (defaults to `Infinity` if
+// memberCount is missing so we fail-open and fetch when uncertain) so
+// a hot cache from a prior invocation isn't burned a second time. The
+// populated cache is intentionally retained — discord.js `Collection`
+// has no LRU and eviction relies on `GUILD_MEMBER_REMOVE` gateway
+// events. Acceptable for our scale; revisit if a future regression in
+// gateway event delivery causes drift.
+async function prewarmGuildMembersCache(guild, logCtx) {
+  if (!guild || !guild.members || typeof guild.members.fetch !== 'function') return;
+  const cacheSize = guild.members.cache?.size ?? 0;
+  if (cacheSize >= (guild.memberCount ?? Infinity)) return;
+  try {
+    await guild.members.fetch({ time: TIMEOUTS.MEMBER_PREFETCH });
+  } catch (err) {
+    logger.warn('members.fetch pre-warm failed; @everyone/role expansion may underresolve', {
+      ...logCtx, guild_id: guild.id, error: err && err.message,
+    });
+  }
+}
+
 function sanitizeMessage(msg) {
   // Order matters:
   //  1. NFKC-normalize + strip bidi/zero-width/control codepoints first
@@ -3770,6 +3808,9 @@ async function handleQurlSlashSend(interaction, params) {
     // refactor switching to `interaction.member.permissions` would
     // silently lose the channel-overwrite respect — keep this property.
     const canMentionEveryone = interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
+    if (MASS_MENTION_HINT_RE.test(recipientsRaw || '')) {
+      await prewarmGuildMembersCache(interaction.guild, { caller: 'handleQurlSlashSend' });
+    }
     const parsed = parseRecipientMentions(recipientsRaw, interaction, {
       allowMassMention: canMentionEveryone,
     });
@@ -4347,6 +4388,13 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // the text-path gate in #323.
   const canMentionEveryone = !!interaction.guild
     && interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone) === true;
+  // Trigger on any role pick (not just @everyone): `role.members` for a
+  // non-@everyone role is a filtered view of `guild.members.cache`, so
+  // both hit the same empty-cache failure mode. Direct user picks skip
+  // the fetch — Discord ships the User object in `interaction.users`.
+  if (interaction.roles?.size > 0) {
+    await prewarmGuildMembersCache(interaction.guild, { caller: 'handleConfirmUserSelect', flow_id });
+  }
   const {
     users: selected,
     massMentionDenied,

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -40,8 +40,11 @@ const TIMEOUTS = {
   DEFER_REPLY: 3000,          // 3 seconds
   QURL_REVOKE_WINDOW: 900000, // 15 minutes - button stays active, /qurl revoke works forever
   // Bound for `guild.members.fetch()` pre-warm before @everyone / role
-  // expansion. discord.js returns a partial result on timeout, which is
-  // acceptable — degraded expansion beats a stuck slash command.
+  // expansion. discord.js *rejects* on timeout (not "returns partial"),
+  // but chunks update `guild.members.cache` as they arrive — so the
+  // pre-warm helper's catch lands partial state in the cache before the
+  // rejection fires, and the parser proceeds against whatever arrived.
+  // Degraded expansion beats a stuck slash command.
   MEMBER_PREFETCH: 8000,
 };
 

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -39,6 +39,10 @@ const TIMEOUTS = {
   BUTTON_INTERACTION: 60000,  // 1 minute
   DEFER_REPLY: 3000,          // 3 seconds
   QURL_REVOKE_WINDOW: 900000, // 15 minutes - button stays active, /qurl revoke works forever
+  // Bound for `guild.members.fetch()` pre-warm before @everyone / role
+  // expansion. discord.js returns a partial result on timeout, which is
+  // acceptable — degraded expansion beats a stuck slash command.
+  MEMBER_PREFETCH: 8000,
 };
 
 // Limits

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2771,12 +2771,20 @@ describe('handleQurlFile — slash entry', () => {
 // the trigger conditions so a future refactor that drops the pre-warm
 // regresses here, not in production.
 
-// Identifies the pre-warm call by its options-object shape (`{ time }`)
-// to disambiguate from the per-ID `members.fetch(id)` calls in
-// resolveRecipientUsers. Asserting on the shape rather than the count
-// also surfaces a future refactor that switched to a different
-// discord.js API (e.g. `members.fetch(undefined)`).
-const isPrewarmCall = ([arg]) => arg && typeof arg === 'object' && typeof arg.time === 'number';
+// Identifies the pre-warm call by its options-object shape: a bulk
+// chunk fetch carries `{ time }` ONLY — no `user`/`query`/`limit`/
+// `force`. Disambiguates from the per-ID `members.fetch(id)` calls in
+// resolveRecipientUsers AND from a future bounded per-user fetch like
+// `members.fetch({ user: id, time: 2000 })` that would happen to
+// carry a `time` field. Asserting absence of the per-user keys makes
+// the disambiguation explicit so the helper stays accurate as the
+// discord.js API surface grows.
+const isPrewarmCall = ([arg]) =>
+  arg && typeof arg === 'object'
+  && typeof arg.time === 'number'
+  && arg.user === undefined
+  && arg.query === undefined
+  && arg.limit === undefined;
 
 describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
   test('@everyone in recipients string → members.fetch() pre-warm fires', async () => {
@@ -2830,6 +2838,20 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
+  test('@everyonefoo (no word boundary) → pre-warm does NOT fire', async () => {
+    // MASS_MENTION_HINT_RE uses `(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])`
+    // — same word-boundary class as recipient-parser.js's
+    // EVERYONE_TOKEN_RE. Without the boundary, a typo / paste like
+    // `@everyonefoo` would burn a chunk fetch even though the parser
+    // ignores the token. A future simplification to `/@everyone|<@&\d+>/u`
+    // would silently regress the budget defense — this test pins it.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '@everyonefoo' },
+    });
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
   test('cache already at memberCount → members.fetch() pre-warm short-circuits', async () => {
     // Hot-cache short-circuit defends against re-fetching when a prior
     // invocation in the same process lifetime already populated the
@@ -2845,6 +2867,48 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     int.guild.memberCount = 2; // matches cache.size from guildMembers above
     await handleQurlFile(int);
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
+  test('concurrent invocations in the same guild share one in-flight fetch', async () => {
+    // Two simultaneous /qurl file @everyone calls against a cold cache
+    // should NOT each fire their own chunk request. The prewarm helper's
+    // in-flight Map<guildId, Promise> coalesces them — abuse via
+    // concurrent invocations otherwise burns chunk-request budget
+    // linearly. discord.js may also coalesce GUILD_REQUEST_MEMBERS
+    // internally, but we don't rely on that.
+    const aliceId = '500000000000000010';
+    // Pin the same guild object across both invocations — keyed by
+    // guild.id, the in-flight map only coalesces same-guild calls.
+    const sharedFetch = jest.fn(() => new Promise(() => { /* never resolves */ }));
+    const sharedGuild = {
+      id: 'shared-guild',
+      members: { cache: new Map(), fetch: sharedFetch },
+      roles: { cache: new Map() },
+      channels: { cache: new Map() },
+      memberCount: 10,
+    };
+    function makeShared() {
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${aliceId}>` },
+        guildMembers: { [aliceId]: {} },
+      });
+      int.guild = sharedGuild;
+      int.guildId = sharedGuild.id;
+      int.memberPermissions = { has: jest.fn(() => true) };
+      return int;
+    }
+    const int1 = makeShared();
+    const int2 = makeShared();
+    // Fire both concurrently. handleQurlFile awaits the pre-warm, but
+    // because sharedFetch never resolves we don't actually need to
+    // await the full handlers — just trigger them and assert the
+    // fetch was called at most once across both.
+    handleQurlFile(int1);
+    handleQurlFile(int2);
+    // Microtask flush so both handlers reach the prewarm await.
+    await new Promise((r) => setImmediate(r));
+    const prewarmCalls = sharedFetch.mock.calls.filter(isPrewarmCall);
+    expect(prewarmCalls.length).toBe(1);
   });
 
   test('members.fetch() rejection is swallowed — flow continues in degraded mode', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2877,9 +2877,13 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     // linearly. discord.js may also coalesce GUILD_REQUEST_MEMBERS
     // internally, but we don't rely on that.
     const aliceId = '500000000000000010';
-    // Pin the same guild object across both invocations — keyed by
-    // guild.id, the in-flight map only coalesces same-guild calls.
-    const sharedFetch = jest.fn(() => new Promise(() => { /* never resolves */ }));
+    // A controllable fetch — caller resolves `release` after the
+    // assertion so both handlers complete cleanly. Without the resolve,
+    // the two awaiting `handleQurlFile` calls would leak through to
+    // process exit and Jest's `--detectOpenHandles` would surface them.
+    let release;
+    const fetchGate = new Promise((r) => { release = r; });
+    const sharedFetch = jest.fn(() => fetchGate);
     const sharedGuild = {
       id: 'shared-guild',
       members: { cache: new Map(), fetch: sharedFetch },
@@ -2897,18 +2901,16 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       int.memberPermissions = { has: jest.fn(() => true) };
       return int;
     }
-    const int1 = makeShared();
-    const int2 = makeShared();
-    // Fire both concurrently. handleQurlFile awaits the pre-warm, but
-    // because sharedFetch never resolves we don't actually need to
-    // await the full handlers — just trigger them and assert the
-    // fetch was called at most once across both.
-    handleQurlFile(int1);
-    handleQurlFile(int2);
+    const p1 = handleQurlFile(makeShared());
+    const p2 = handleQurlFile(makeShared());
     // Microtask flush so both handlers reach the prewarm await.
     await new Promise((r) => setImmediate(r));
     const prewarmCalls = sharedFetch.mock.calls.filter(isPrewarmCall);
     expect(prewarmCalls.length).toBe(1);
+    // Release the gate so handlers settle and Jest doesn't carry an
+    // open handle past the test.
+    release(new Map());
+    await Promise.all([p1, p2]);
   });
 
   test('members.fetch() rejection is swallowed — flow continues in degraded mode', async () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2761,6 +2761,120 @@ describe('handleQurlFile — slash entry', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
+// guild.members cache pre-warm for @everyone / role expansion
+// ──────────────────────────────────────────────────────────────
+// discord.js v14 leaves `guild.members.cache` empty by default (no
+// `chunkOnStartup`, no `ws.large_threshold` override) on our multi-
+// tenant gateway, so the parser's `@everyone` branch and `role.members`
+// filtering for `<@&id>` both silently collapse to just the interacting
+// user. Pre-warming via `members.fetch()` is the fix; these tests pin
+// the trigger conditions so a future refactor that drops the pre-warm
+// regresses here, not in production.
+
+// Identifies the pre-warm call by its options-object shape (`{ time }`)
+// to disambiguate from the per-ID `members.fetch(id)` calls in
+// resolveRecipientUsers. Asserting on the shape rather than the count
+// also surfaces a future refactor that switched to a different
+// discord.js API (e.g. `members.fetch(undefined)`).
+const isPrewarmCall = ([arg]) => arg && typeof arg === 'object' && typeof arg.time === 'number';
+
+describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
+  test('@everyone in recipients string → members.fetch() pre-warm fires', async () => {
+    const aliceId = '500000000000000001';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${aliceId}>` },
+      guildMembers: { [aliceId]: {} },
+    });
+    int.memberPermissions = { has: jest.fn(() => true) };
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
+  });
+
+  test('<@&roleId> in recipients string → members.fetch() pre-warm fires', async () => {
+    // role.members for non-@everyone roles is a filtered view of
+    // guild.members.cache, so the trigger has to include arbitrary
+    // role-mention wire shapes, not just literal @everyone.
+    const aliceId = '500000000000000002';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@&7100>` },
+      guildMembers: { [aliceId]: {} },
+    });
+    int.guild.roles.cache.set('7100', {
+      id: '7100', name: 'team', mentionable: true,
+      members: new Map([[aliceId, { user: { id: aliceId, bot: false } }]]),
+    });
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
+  });
+
+  test('plain <@userId> mentions only → members.fetch() pre-warm does NOT fire', async () => {
+    // Defends the common case (a few user mentions) against paying the
+    // pre-warm cost. Gate is the mass-mention shape regex, not the
+    // existence of any mention.
+    const aliceId = '500000000000000003';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `<@${aliceId}>` },
+      guildMembers: { [aliceId]: {} },
+    });
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
+  test('empty recipients string → members.fetch() pre-warm does NOT fire', async () => {
+    // Defense against a `recipientsRaw` of `null` / `''` triggering the
+    // regex via the `|| ''` fallback. Empty input → no mentions → no fetch.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT }, // no recipients
+    });
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
+  test('cache already at memberCount → members.fetch() pre-warm short-circuits', async () => {
+    // Hot-cache short-circuit defends against re-fetching when a prior
+    // invocation in the same process lifetime already populated the
+    // cache. Without this, every @everyone send burns the full chunk
+    // round-trip.
+    const aliceId = '500000000000000005';
+    const bobId = '500000000000000006';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone` },
+      guildMembers: { [aliceId]: {}, [bobId]: {} },
+    });
+    int.memberPermissions = { has: jest.fn(() => true) };
+    int.guild.memberCount = 2; // matches cache.size from guildMembers above
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
+  test('members.fetch() rejection is swallowed — flow continues in degraded mode', async () => {
+    // 429 / gateway blip on the pre-warm must not crash the handler.
+    // The catch logs a warn and the parser proceeds against whatever
+    // the cache currently holds (potentially empty → @everyone silently
+    // expands to 0). Worst case the user re-runs.
+    const aliceId = '500000000000000004';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${aliceId}>` },
+      guildMembers: { [aliceId]: {} },
+    });
+    int.memberPermissions = { has: jest.fn(() => true) };
+    int.guild.members.fetch = jest.fn(async (arg) => {
+      if (isPrewarmCall([arg])) {
+        const err = new Error('rate limited'); err.code = 429; throw err;
+      }
+      return { user: makeUser(arg) };
+    });
+    await handleQurlFile(int);
+    expect(mockSupersedeOrCreate).toHaveBeenCalled();
+    const logger = require('../src/logger');
+    const warnCall = logger.warn.mock.calls.find(
+      ([msg]) => typeof msg === 'string' && msg.includes('members.fetch pre-warm failed'),
+    );
+    expect(warnCall).toBeTruthy();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
 // handleQurlMap — front half
 // ──────────────────────────────────────────────────────────────
 
@@ -4223,6 +4337,49 @@ describe('handleConfirmUserSelect', () => {
     await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).toHaveBeenCalled();
     expect(mockTransitionFlow.mock.calls[0][2].payload.recipientIds).toEqual([u1.id]);
+  });
+
+  // ── guild.members cache pre-warm (picker path) ──
+  // Symmetric with the text-path pre-warm tests above handleQurlMap:
+  // resolveMentionableSelection reads guild.members.cache for both
+  // `@everyone` (direct iteration) and arbitrary roles (`role.members`
+  // is a filtered view of the same cache). Without the pre-warm, any
+  // role pick silently expands to just the interacting user.
+  test('role pick → members.fetch() pre-warm fires', async () => {
+    const role = { id: 'roleA', name: 'team', mentionable: true, members: new Map([[u1, { user: makeUser(u1) }]]) };
+    const int = makeSelectInteraction({ users: [], roles: [['roleA', role]] });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
+  });
+
+  test('users-only pick → members.fetch() pre-warm does NOT fire', async () => {
+    // Pure user picks don't touch guild.members.cache — Discord
+    // ships the User object directly in interaction.users. Skipping
+    // the pre-warm keeps the common-case cost at zero.
+    const int = makeSelectInteraction({ users: [makeUser(u1)], roles: [] });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
+  test('role pick + members.fetch() rejection is swallowed — flow continues', async () => {
+    // Picker analog of the text-path degraded-mode test: a 429 on the
+    // pre-warm must not crash the handler. Expansion falls back to
+    // whatever the cache currently holds.
+    const role = { id: 'roleB', name: 'team', mentionable: true, members: new Map([[u1, { user: makeUser(u1) }]]) };
+    const int = makeSelectInteraction({ users: [], roles: [['roleB', role]] });
+    int.guild.members.fetch = jest.fn(async (arg) => {
+      if (isPrewarmCall([arg])) {
+        const err = new Error('rate limited'); err.code = 429; throw err;
+      }
+      return { user: makeUser(arg) };
+    });
+    await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const logger = require('../src/logger');
+    const warnCall = logger.warn.mock.calls.find(
+      ([msg]) => typeof msg === 'string' && msg.includes('members.fetch pre-warm failed'),
+    );
+    expect(warnCall).toBeTruthy();
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2838,6 +2838,39 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
+  test('@everyone WITHOUT MENTION_EVERYONE → pre-warm does NOT fire (parser will deny anyway)', async () => {
+    // Pin the asymmetric gate in handleQurlSlashSend: `@everyone` alone
+    // typed by a sender without MENTION_EVERYONE → the parser hits
+    // `massMentionDenied` and never expands, so the chunk request
+    // would be wasted. A future refactor that drops the perm-gate
+    // would silently regress the chunk-budget defense.
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: '@everyone' },
+    });
+    // No memberPermissions set → has(MentionEveryone) returns undefined → falsy.
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
+  });
+
+  test('@everyone + <@&roleId> WITHOUT MENTION_EVERYONE → pre-warm STILL fires (role path)', async () => {
+    // Counter-test to the above: when the input ALSO contains a role
+    // mention, the prewarm fires regardless of MENTION_EVERYONE because
+    // role expansion gates on `role.mentionable === true` per-role, not
+    // the global perm. The role-mention path needs the cache.
+    const aliceId = '500000000000000077';
+    const int = makeInteraction({
+      options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@&7200>` },
+      guildMembers: { [aliceId]: {} },
+    });
+    int.guild.roles.cache.set('7200', {
+      id: '7200', name: 'team', mentionable: true,
+      members: new Map([[aliceId, { user: { id: aliceId, bot: false } }]]),
+    });
+    // No memberPermissions set → has(MentionEveryone) returns undefined → falsy.
+    await handleQurlFile(int);
+    expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
+  });
+
   test('@everyonefoo (no word boundary) → pre-warm does NOT fire', async () => {
     // MASS_MENTION_HINT_RE uses `(?<![\p{L}\p{N}_])@everyone(?![\p{L}\p{N}_])`
     // — same word-boundary class as recipient-parser.js's


### PR DESCRIPTION
## Summary

- `@everyone` in `/qurl file` / `/qurl map` recipients was silently expanding to **just the sender**. Same failure mode for any `<@&roleId>` text mention OR any role pick in the confirm-card MentionableSelectMenu.
- Root cause: **discord.js v14 does NOT auto-populate `guild.members.cache` from the GUILD_CREATE payload.** Our multi-tenant gateway deliberately skips `chunkOnStartup` / `ws.large_threshold` (eagerly fetching every member of every guild we're installed in would burn our rate-limit budget on install spikes — those wake every shard at once). The cache effectively only contains whoever the bot has touched, which on a fresh slash command is just the interacting user.
- Fix: call `guild.members.fetch({ time: TIMEOUTS.MEMBER_PREFETCH })` before parsing when:
  - **Text path:** the recipients string contains a mass-mention shape (`@everyone` token OR `<@&id>` wire form).
  - **Picker path:** the user picked at least one role (`interaction.roles?.size > 0`).
- The fetch is gated on `cache.size < memberCount` so a hot cache from a prior invocation in the same process lifetime isn't refetched. Time-capped at 8s so adversarial-size guilds can't hang the slash command. Rejection is swallowed and logged — degraded expansion (parser sees a partial cache) is the correct fallback for transient API blips; surfacing it to the user would confuse them about a problem they can't act on.

## Why

Reported by a beta user: typing `@everyone` in the recipients option resolved to "1 recipient — the sender" with no warnings. Verified the failure mode reproduces deterministically in a small (<10 member) test guild — well below Discord's default `large_threshold=50`, so the standard "GUILD_CREATE includes all members for small guilds" assumption doesn't save us. The cache *receives* the members in the payload; discord.js just doesn't *cache* them by default.

The Discord MentionableSelectMenu's UI-side omission of the `@everyone` role (the user reported "@everyone isn't in the Roles section") is a Discord platform behavior, not a cache problem — it's not addressed here. Considered as a follow-up if we want to add a dedicated `@everyone` chip on the confirm card.

## Scope

- `src/commands.js` — new `prewarmGuildMembersCache` helper + `MASS_MENTION_HINT_RE`; wired into `handleQurlSlashSend` (text path) and `handleConfirmUserSelect` (picker path).
- `src/constants.js` — `TIMEOUTS.MEMBER_PREFETCH = 8000`.
- `tests/qurl-file-map.test.js` — 8 new tests pinning trigger conditions (fires on `@everyone`, fires on `<@&id>`, fires on role pick, does NOT fire on plain user mentions / empty / users-only pick / hot cache, rejection is swallowed).

## Test plan

- [ ] CI green
- [ ] Local: in a test guild, `/qurl file recipients:@everyone` now resolves to the full member set (not just sender)
- [ ] Local: `/qurl file recipients:<@&someRoleId>` resolves to the role's members
- [ ] Local: `/qurl file` confirm-card MentionableSelectMenu → pick a role → resolves to role members
- [ ] Local: `/qurl file recipients:<@user1> <@user2>` (no mass-mention) does NOT fire an extra `members.fetch` (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)