### PR TITLE
feat(discord): edit recipient DMs on successful revoke

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6134,11 +6134,9 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   // so they see immediately that the link is dead rather than tapping a
   // Step Through button that now 404s. Per-recipient (one DM per
   // recipient, even if multiple resources fanned out to them) — keep
-  // the first VALID row per recipient_discord_id (passes all the skip
-  // guards below). The de-dup check fires before the validity checks
-  // intentionally: if the first row for a recipient is invalid the
-  // de-dup misses, the validity guards correctly skip it, and the
-  // next valid row for the same recipient is still considered.
+  // the first VALID row per recipient_discord_id. De-dup check fires
+  // first so the first valid row wins; an earlier invalid row (no
+  // refs / wrong status) doesn't poison the de-dup slot.
   //
   // ORDERING: DELETEs ran above; the edit fires AFTER they settle.
   // Reversing the order would create a window where the recipient sees

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6160,9 +6160,18 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   // so they see immediately that the link is dead rather than tapping a
   // Step Through button that now 404s. Per-recipient (one DM per
   // recipient, even if multiple resources fanned out to them) — keep
-  // the first VALID row per recipient_discord_id. The de-dup guard
-  // runs first, but invalid rows `continue` before reaching `.set()`,
-  // so a later valid row for the same recipient still wins the slot.
+  // the first VALID row per recipient_discord_id. Invalid rows fall
+  // through without setting, so editTargets.has() stays false until a
+  // valid row lands, which then wins the slot.
+  //
+  // INVARIANT: "first valid wins" is safe because each recipient has
+  // at most one DM channel (the bot opens one DM thread per user via
+  // sendDM's POST /users/@me/channels). Multi-resource fan-out reuses
+  // the same dm_channel_id / dm_message_id pair across rows for that
+  // recipient, so picking the first one isn't lossy. If a future
+  // change ever sends a recipient two SEPARATE DMs for one send_id,
+  // the second one becomes silently un-editable — flip to a
+  // per-message-id Map at that point.
   //
   // ORDERING: DELETEs ran above; the edit fires AFTER they settle.
   // Reversing the order would create a window where the recipient sees

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -755,17 +755,29 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
     await db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId);
     return;
   }
-  // Defensive: ok:true but missing refs would diverge DISPATCH_SENT
-  // from the DDB record (failed). Emit DISPATCH_SENT_NO_REFS so the
-  // dashboard can reconcile the gap without a mystery, plus a warn
-  // log for grep-ability. Record as failed for DDB safety.
   if (result.ok === true) {
+    // Defensive: the DM was actually delivered (sendDM said ok), but
+    // discord.js silently omitted channelId / messageId. Record SENT
+    // so DDB matches observable reality — `count(dm_status='sent')`
+    // stays a faithful delivery-rate metric. The revoke path's
+    // missing-refs guard (see editTargets builder) naturally skips
+    // the DM edit for these rows. Emit DISPATCH_SENT_NO_REFS so the
+    // gap between DISPATCH_SENT and the editable-on-revoke subset is
+    // queryable from CloudWatch.
+    //
+    // CANONICAL DELIVERY-RATE METRIC: DDB `count(dm_status='sent')`
+    // or CloudWatch `dispatch_sent` (they should agree). The
+    // `dispatch_sent_no_refs` event is a CANARY, not a subtractor —
+    // if it fires, oncall investigates the discord.js response shape;
+    // don't auto-subtract it from DISPATCH_SENT in dashboards.
     logger.audit(AUDIT_EVENTS.DISPATCH_SENT_NO_REFS, { send_id: sendId });
-    logger.warn('sendDM resolved ok but missing channelId/messageId — recording as failed', {
+    logger.warn('sendDM resolved ok but missing channelId/messageId — recording as sent (revoke edit will skip)', {
       sendId, recipientDiscordId,
       hasChannelId: Boolean(result.channelId),
       hasMessageId: Boolean(result.messageId),
     });
+    await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
+    return;
   }
   await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED);
 }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -782,23 +782,12 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
     return;
   }
   if (result.ok === true) {
-    // Defensive: the DM was actually delivered (sendDM said ok), but
-    // discord.js silently omitted channelId / messageId. Record SENT
-    // so DDB matches observable reality — `count(dm_status='sent')`
-    // stays a faithful delivery-rate metric. The revoke path's
-    // missing-refs guard (see editTargets builder) naturally skips
-    // the DM edit for these rows.
-    //
-    // CANONICAL DELIVERY-RATE METRIC: DDB `count(dm_status='sent')`
-    // or CloudWatch `dispatch_sent` (they should agree). The
-    // `dispatch_sent_no_refs` event is a CANARY, not a subtractor —
-    // if it fires, oncall investigates the discord.js response shape;
-    // don't auto-subtract it from DISPATCH_SENT in dashboards.
-    //
-    // Audit + warn fire BEFORE the persist so a DDB failure can't
-    // mask the discord.js shape-drift canary. If the persist also
-    // fails, DISPATCH_PERSIST_FAILED fires alongside (separate
-    // signal, separate dashboard).
+    // sendDM said ok but discord.js omitted channelId / messageId.
+    // Record SENT so DDB delivery rollups stay faithful; the revoke
+    // path's missing-refs guard skips the DM edit naturally.
+    // dispatch_sent_no_refs is a CANARY (not a DISPATCH_SENT
+    // subtractor) — emitted before the persist so a DDB outage
+    // can't mask a discord.js shape-drift.
     logger.audit(AUDIT_EVENTS.DISPATCH_SENT_NO_REFS, { send_id: sendId });
     logger.warn('sendDM resolved ok but missing channelId/messageId — recording as sent (revoke edit will skip)', {
       sendId, recipientDiscordId,
@@ -6207,7 +6196,16 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
         channelId: it.dm_channel_id, messageId: it.dm_message_id,
       });
     }
-    if (editTargets.size > 0) {
+    if (editTargets.size === 0) {
+      // Surface the silent-skip path so a developer running locally
+      // against SQLite (where DM refs are intentionally not persisted
+      // — see #365) can tell the edit is being skipped on purpose
+      // rather than chasing a phantom bug. Debug level so it doesn't
+      // surface in prod logs by default.
+      logger.debug('Revoke succeeded but no editable DM targets', {
+        sendId, revoke_success: success,
+      });
+    } else {
       const editPayload = buildRevokedDMPayload({ senderAlias });
       // Same fan-out width as the DELETE batch above. Discord's per-
       // channel rate-limit buckets are unique per recipient (each DM

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -79,7 +79,7 @@ function largeSendThreshold() {
 // Extracted to deduplicate ~13 identical `.catch(err => logger.warn(...))`
 // one-liners across this file.
 const logIgnoredDiscordErr = (err) => logger.warn('Discord API op failed (ignored)', { error: err.message });
-const { sendDM } = require('./discord');
+const { sendDM, editDM } = require('./discord');
 
 
 // Generate an OAuth state token bound to the initiating Discord user.
@@ -731,6 +731,23 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   const components = [new ActionRowBuilder().addComponents(stepThrough)];
 
   return { embeds: [embed], components };
+}
+
+// Payload for editing a recipient's DM after the sender successfully
+// revokes the qurl. Replaces "Alice opened a door" + Step Through with
+// "Alice closed the door — this link is no longer active." and strips
+// the link button.
+//
+// CONTRACT: `components: []` MUST be passed explicitly. Discord's
+// message edit endpoint does NOT clear fields that aren't supplied —
+// omitting components would leave the original Step Through button
+// live in the recipient's DM, pointing at a now-dead qurl resource.
+function buildRevokedDMPayload({ senderAlias }) {
+  const safeSender = sanitizeDisplayName(senderAlias);
+  const embed = new EmbedBuilder()
+    .setColor(COLORS.QURL_BRAND)
+    .setDescription(`🚪 **${safeSender}** closed the door.\nThis link is no longer active.`);
+  return { embeds: [embed], components: [] };
 }
 
 // --- Link status monitor ---
@@ -1456,7 +1473,7 @@ async function executeSendPipeline(interaction, {
     // it either — that's the failure mode the audit metric exists to
     // measure. Coverage spans the entire dispatch attempt, not just the
     // network leg.
-    let sent = false;
+    let result = { ok: false };
     try {
       const dmPayload = buildDeliveryPayload({
         senderAlias,
@@ -1464,11 +1481,18 @@ async function executeSendPipeline(interaction, {
         expiresAt,
         personalMessage,
       });
-      sent = await sendDM(link.recipientId, dmPayload);
+      result = await sendDM(link.recipientId, dmPayload);
     } finally {
-      logger.audit(sent === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+      logger.audit(result.ok === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     }
+    const sent = result.ok === true;
     await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
+    // Persist DM refs so /qurl revoke can edit the recipient's DM in
+    // place ("Alice closed the door") after a successful revoke. No-op
+    // when the send failed — there's no message to edit.
+    if (sent && result.channelId && result.messageId) {
+      await db.updateSendDMRefs(sendId, link.recipientId, result.channelId, result.messageId);
+    }
     return { recipientId: link.recipientId, username: recipient?.username, sent };
   }, 5);
 
@@ -1653,7 +1677,7 @@ async function executeSendPipeline(interaction, {
         await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
         await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
         try {
-          const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
+          const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey, resolveSenderAlias(interaction));
           // Iterate `recipients` (canonical send-confirmation order)
           // and filter by membership — `successUserIds` walks Set
           // insertion order from resource-grouped iteration, which
@@ -2097,7 +2121,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // packing, network call — so a malformed sendConfig (e.g. pathological
     // personalMessage that throws inside buildDeliveryPayload) still
     // counts as dispatch_failed instead of disappearing from CloudWatch.
-    let sent = false;
+    let result = { ok: false };
     try {
       const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
         senderAlias,
@@ -2125,15 +2149,19 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
       }
 
-      sent = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
+      result = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
     } finally {
-      logger.audit(sent === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
+      logger.audit(result.ok === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     }
+    const sent = result.ok === true;
     // updateSendDMStatus updates every qurl_sends row matching (sendId,
     // recipient.id), so a single call covers all links for this recipient.
     // The previous `for (let i = 0; i < links.length; i++)` loop wrote the
     // same update links.length times.
     await db.updateSendDMStatus(sendId, recipient.id, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
+    if (sent && result.channelId && result.messageId) {
+      await db.updateSendDMRefs(sendId, recipient.id, result.channelId, result.messageId);
+    }
     return { sent, username: recipient.username };
   }, 5);
 
@@ -2382,7 +2410,7 @@ async function handleRevokeSelect(interaction, { flow_id }) {
   }
 
   const sendId = interaction.values[0];
-  const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey);
+  const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey, resolveSenderAlias(interaction));
 
   // Slash-command path lacks the in-scope `recipients` array needed
   // to resolve names → no "Revoked for: …" line here. Operators
@@ -6004,10 +6032,16 @@ function renderSendConfirm({
   return { content: msg, attachmentText: null, needsExpand: successNames.length > REVOKE_TRUNC_LIMIT };
 }
 
-async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
+async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias) {
   // Pull per-recipient items so per-link success can be mapped back to
   // a Discord user id for display. Caller resolves IDs → usernames
   // against its in-scope `recipients` array.
+  //
+  // Items also carry `dm_channel_id` / `dm_message_id` / `dm_status`
+  // (populated by sendDM's ref-capture in executeSendPipeline +
+  // handleAddRecipients) so this function can edit each strict-success
+  // recipient's DM in place after revoke. Rows predating that wire-up
+  // have the refs unset — the edit step skips them.
   const items = await db.getSendItems(sendId, senderDiscordId);
 
   // deleteLink deletes the whole resource; one DELETE per unique
@@ -6077,6 +6111,51 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey) {
     total: auditTotal,
     users: { success, total },
   });
+
+  // Edit each strict-success recipient's DM to "Alice closed the door"
+  // so they see immediately that the link is dead rather than tapping a
+  // Step Through button that now 404s. Per-recipient (one DM per
+  // recipient, even if multiple resources fanned out to them) — collapse
+  // items to the first delivered row per recipient_discord_id.
+  //
+  // Skips:
+  //   - recipients not in successUserIds (failed revoke = link was
+  //     already opened, so the recipient already passed through the
+  //     door — nothing to edit)
+  //   - rows with dm_status !== 'sent' (DM never made it; no message
+  //     exists to edit)
+  //   - rows lacking dm_channel_id / dm_message_id (legacy, pre-
+  //     ref-capture rows)
+  //
+  // Errors are swallowed (logged inside editDM at info/warn) — a 404 /
+  // 403 / unknown-message is operational, not a bug, and must not
+  // skew the revoke success counts the caller reports to the operator.
+  if (success > 0 && senderAlias) {
+    const successSet = new Set(successUserIds);
+    const editTargets = new Map(); // recipient_id → {channelId, messageId}
+    for (const it of items) {
+      if (!successSet.has(it.recipient_discord_id)) continue;
+      if (editTargets.has(it.recipient_discord_id)) continue;
+      if (it.dm_status !== DM_STATUS.SENT) continue;
+      if (!it.dm_channel_id || !it.dm_message_id) continue;
+      editTargets.set(it.recipient_discord_id, {
+        channelId: it.dm_channel_id, messageId: it.dm_message_id,
+      });
+    }
+    if (editTargets.size > 0) {
+      const editPayload = buildRevokedDMPayload({ senderAlias });
+      // Same fan-out width as the DELETE batch above — Discord PATCHes
+      // share the same channel-bucket rate limit so 5-wide is plenty.
+      const entries = [...editTargets.entries()];
+      await batchSettled(entries, async ([, refs]) => {
+        await editDM(refs.channelId, refs.messageId, editPayload);
+      }, 5);
+      logger.info('Edited DMs after revoke', {
+        sendId, edited_targets: editTargets.size, revoke_success: success,
+      });
+    }
+  }
+
   // failureUserIds is computed but not yet rendered — the "Note:
   // already-opened links cannot be revoked" disclaimer covers the
   // common cause. Returned for callers that want to surface partial-
@@ -7576,6 +7655,7 @@ module.exports = {
       sendCooldowns,
       handleAddRecipients,
       buildDeliveryPayload,
+      buildRevokedDMPayload,
       resolveSenderAlias,
       safeUrlHost,
       // Back-half functions exposed for direct unit testing. Without these

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -79,7 +79,8 @@ function largeSendThreshold() {
 // Extracted to deduplicate ~13 identical `.catch(err => logger.warn(...))`
 // one-liners across this file.
 const logIgnoredDiscordErr = (err) => logger.warn('Discord API op failed (ignored)', { error: err.message });
-const { sendDM, editDM } = require('./discord');
+const { sendDM } = require('./discord');
+const { editDM } = require('./discord-rest');
 
 
 // Generate an OAuth state token bound to the initiating Discord user.
@@ -733,21 +734,28 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   return { embeds: [embed], components };
 }
 
-// Payload for editing a recipient's DM after the sender successfully
-// revokes the qurl. Replaces "Alice opened a door" + Step Through with
-// "Alice closed the door — this link is no longer active." and strips
-// the link button.
-//
 // CONTRACT: `components: []` MUST be passed explicitly. Discord's
-// message edit endpoint does NOT clear fields that aren't supplied —
+// PATCH /messages does NOT clear fields that aren't supplied —
 // omitting components would leave the original Step Through button
-// live in the recipient's DM, pointing at a now-dead qurl resource.
+// live in the recipient's DM, pointing at a now-dead qURL resource.
 function buildRevokedDMPayload({ senderAlias }) {
   const safeSender = sanitizeDisplayName(senderAlias);
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
     .setDescription(`🚪 **${safeSender}** closed the door.\nThis link is no longer active.`);
   return { embeds: [embed], components: [] };
+}
+
+// Records the outcome of a sendDM dispatch attempt into qurl_sends.
+// Happy path coalesces dm_status='sent' + DM refs into one DDB Update
+// so the hot dispatch path stays at one write per recipient. Failure
+// path is status-only — there's no message to edit later.
+async function persistDispatchResult(sendId, recipientDiscordId, result) {
+  if (result.ok === true && result.channelId && result.messageId) {
+    await db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId);
+  } else {
+    await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED);
+  }
 }
 
 // --- Link status monitor ---
@@ -1485,15 +1493,8 @@ async function executeSendPipeline(interaction, {
     } finally {
       logger.audit(result.ok === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     }
-    const sent = result.ok === true;
-    await db.updateSendDMStatus(sendId, link.recipientId, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    // Persist DM refs so /qurl revoke can edit the recipient's DM in
-    // place ("Alice closed the door") after a successful revoke. No-op
-    // when the send failed — there's no message to edit.
-    if (sent && result.channelId && result.messageId) {
-      await db.updateSendDMRefs(sendId, link.recipientId, result.channelId, result.messageId);
-    }
-    return { recipientId: link.recipientId, username: recipient?.username, sent };
+    await persistDispatchResult(sendId, link.recipientId, result);
+    return { recipientId: link.recipientId, username: recipient?.username, sent: result.ok === true };
   }, 5);
 
   for (const r of dmResults) {
@@ -2153,16 +2154,10 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     } finally {
       logger.audit(result.ok === true ? AUDIT_EVENTS.DISPATCH_SENT : AUDIT_EVENTS.DISPATCH_FAILED, { send_id: sendId });
     }
-    const sent = result.ok === true;
-    // updateSendDMStatus updates every qurl_sends row matching (sendId,
-    // recipient.id), so a single call covers all links for this recipient.
-    // The previous `for (let i = 0; i < links.length; i++)` loop wrote the
-    // same update links.length times.
-    await db.updateSendDMStatus(sendId, recipient.id, sent ? DM_STATUS.SENT : DM_STATUS.FAILED);
-    if (sent && result.channelId && result.messageId) {
-      await db.updateSendDMRefs(sendId, recipient.id, result.channelId, result.messageId);
-    }
-    return { sent, username: recipient.username };
+    // One persist write per recipient regardless of links.length —
+    // both store methods key on (send_id, recipient_discord_id).
+    await persistDispatchResult(sendId, recipient.id, result);
+    return { sent: result.ok === true, username: recipient.username };
   }, 5);
 
   for (const r of dmResults) {
@@ -6033,15 +6028,10 @@ function renderSendConfirm({
 }
 
 async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias) {
-  // Pull per-recipient items so per-link success can be mapped back to
-  // a Discord user id for display. Caller resolves IDs → usernames
-  // against its in-scope `recipients` array.
-  //
-  // Items also carry `dm_channel_id` / `dm_message_id` / `dm_status`
-  // (populated by sendDM's ref-capture in executeSendPipeline +
-  // handleAddRecipients) so this function can edit each strict-success
-  // recipient's DM in place after revoke. Rows predating that wire-up
-  // have the refs unset — the edit step skips them.
+  // Items carry dm_channel_id / dm_message_id / dm_status so the post-
+  // revoke step can edit each strict-success recipient's DM in place.
+  // Legacy rows predating that wire-up have the refs unset — the edit
+  // step skips them.
   const items = await db.getSendItems(sendId, senderDiscordId);
 
   // deleteLink deletes the whole resource; one DELETE per unique
@@ -6130,7 +6120,7 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias) {
   // Errors are swallowed (logged inside editDM at info/warn) — a 404 /
   // 403 / unknown-message is operational, not a bug, and must not
   // skew the revoke success counts the caller reports to the operator.
-  if (success > 0 && senderAlias) {
+  if (success > 0) {
     const successSet = new Set(successUserIds);
     const editTargets = new Map(); // recipient_id → {channelId, messageId}
     for (const it of items) {
@@ -6147,11 +6137,17 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias) {
       // Same fan-out width as the DELETE batch above — Discord PATCHes
       // share the same channel-bucket rate limit so 5-wide is plenty.
       const entries = [...editTargets.entries()];
-      await batchSettled(entries, async ([, refs]) => {
-        await editDM(refs.channelId, refs.messageId, editPayload);
+      const editResults = await batchSettled(entries, async ([, refs]) => {
+        const res = await editDM(refs.channelId, refs.messageId, editPayload);
+        if (!res.ok) throw new Error('editDM returned not-ok');
+        return res;
       }, 5);
+      const edited = editResults.filter(r => r.status === 'fulfilled').length;
       logger.info('Edited DMs after revoke', {
-        sendId, edited_targets: editTargets.size, revoke_success: success,
+        sendId,
+        attempted: editTargets.size,
+        edited,
+        failed: editTargets.size - edited,
       });
     }
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6164,14 +6164,19 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   // through without setting, so editTargets.has() stays false until a
   // valid row lands, which then wins the slot.
   //
-  // INVARIANT: "first valid wins" is safe because each recipient has
-  // at most one DM channel (the bot opens one DM thread per user via
-  // sendDM's POST /users/@me/channels). Multi-resource fan-out reuses
-  // the same dm_channel_id / dm_message_id pair across rows for that
-  // recipient, so picking the first one isn't lossy. If a future
-  // change ever sends a recipient two SEPARATE DMs for one send_id,
-  // the second one becomes silently un-editable — flip to a
-  // per-message-id Map at that point.
+  // INVARIANT(one-dm-per-recipient): "first valid wins" is safe
+  // because each recipient has at most one DM channel (the bot opens
+  // one DM thread per user via sendDM's POST /users/@me/channels).
+  // Multi-resource fan-out reuses the same dm_channel_id /
+  // dm_message_id pair across rows for that recipient, so picking
+  // the first one isn't lossy.
+  //
+  // INVARIANT-BREAKER: if a future change ever sends a recipient two
+  // SEPARATE DMs for one send_id (e.g., multi-message dispatch when
+  // the embed/component count exceeds Discord's limits), the second
+  // DM becomes silently un-editable. Grep for `INVARIANT-BREAKER`
+  // from that PR to find this site, and flip to a per-message-id
+  // Map keyed by `(recipient_discord_id, dm_message_id)`.
   //
   // ORDERING: DELETEs ran above; the edit fires AFTER they settle.
   // Reversing the order would create a window where the recipient sees

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -755,11 +755,12 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
     await db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId);
     return;
   }
-  // Defensive: ok:true but missing refs would diverge the audit metric
-  // (DISPATCH_SENT) from the DDB record (failed). Surface the gap loudly
-  // and record as failed — keeps DDB honest if discord.js ever changes
-  // the user.send() response shape.
+  // Defensive: ok:true but missing refs would diverge DISPATCH_SENT
+  // from the DDB record (failed). Emit DISPATCH_SENT_NO_REFS so the
+  // dashboard can reconcile the gap without a mystery, plus a warn
+  // log for grep-ability. Record as failed for DDB safety.
   if (result.ok === true) {
+    logger.audit(AUDIT_EVENTS.DISPATCH_SENT_NO_REFS, { send_id: sendId });
     logger.warn('sendDM resolved ok but missing channelId/messageId — recording as failed', {
       sendId, recipientDiscordId,
       hasChannelId: Boolean(result.channelId),
@@ -6120,8 +6121,12 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   // Edit each strict-success recipient's DM to "Alice closed the door"
   // so they see immediately that the link is dead rather than tapping a
   // Step Through button that now 404s. Per-recipient (one DM per
-  // recipient, even if multiple resources fanned out to them) — collapse
-  // items to the first delivered row per recipient_discord_id.
+  // recipient, even if multiple resources fanned out to them) — keep
+  // the first VALID row per recipient_discord_id (passes all the skip
+  // guards below). The de-dup check fires before the validity checks
+  // intentionally: if the first row for a recipient is invalid the
+  // de-dup misses, the validity guards correctly skip it, and the
+  // next valid row for the same recipient is still considered.
   //
   // ORDERING: DELETEs ran above; the edit fires AFTER they settle.
   // Reversing the order would create a window where the recipient sees

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -171,7 +171,7 @@ function isGoogleMapsURL(url) {
 
 
 
-const { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls } = require('./utils/sanitize');
+const { DISPLAY_NAME_FALLBACK, sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls } = require('./utils/sanitize');
 
 // Best-effort host extraction for log lines. URL parsing throws on
 // pathological input (no scheme, embedded null, etc.) — swallow and
@@ -402,16 +402,16 @@ async function batchSettled(items, fn, batchSize = 5) {
 //      discord.js v14.18+).
 //   3. user.username — direct username read; defends against test
 //      mocks or shapes where the v14 displayName getter is absent.
-//   4. 'Someone' — last-resort literal so callers never get null.
+//   4. DISPLAY_NAME_FALLBACK — last-resort so callers never get null.
 // Optional chains throughout so a malformed interaction (no user, no
-// member) returns 'Someone' instead of throwing inside DM-dispatch.
+// member) returns the fallback instead of throwing inside DM-dispatch.
 // Used by the DM-embed renderer so every recipient sees the same
 // sender name across the dispatch.
 function resolveSenderAlias(interaction) {
   return interaction?.member?.displayName
     ?? interaction?.user?.displayName
     ?? interaction?.user?.username
-    ?? 'Someone';
+    ?? DISPLAY_NAME_FALLBACK;
 }
 
 // Resolve a recipient's per-guild display alias: guild nickname >
@@ -755,13 +755,10 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
     await db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId);
     return;
   }
-  // Defensive: sendDM returned ok but discord.js silently omitted
-  // channelId / messageId. Today that doesn't happen — `user.send()`
-  // resolves to a Message with both — but if a future discord.js
-  // changes the response shape, the audit metric would fire
-  // DISPATCH_SENT while DDB records `failed`. Surface the divergence
-  // loudly so it's catchable in logs without dropping into prod
-  // behavior change. Treat as a failed dispatch for safety.
+  // Defensive: ok:true but missing refs would diverge the audit metric
+  // (DISPATCH_SENT) from the DDB record (failed). Surface the gap loudly
+  // and record as failed — keeps DDB honest if discord.js ever changes
+  // the user.send() response shape.
   if (result.ok === true) {
     logger.warn('sendDM resolved ok but missing channelId/messageId — recording as failed', {
       sendId, recipientDiscordId,
@@ -6041,12 +6038,11 @@ function renderSendConfirm({
   return { content: msg, attachmentText: null, needsExpand: successNames.length > REVOKE_TRUNC_LIMIT };
 }
 
-// senderAlias defaults to 'Someone' as a defense-in-depth in case a
-// future caller forgets the 4th arg. Production callers always pass
-// `resolveSenderAlias(interaction)`, which has its own 'Someone'
-// fallback; this default keeps the recipient-side copy graceful if
-// that contract ever drifts.
-async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = 'Someone') {
+// Defaulted senderAlias is defense-in-depth — production callers
+// always pass resolveSenderAlias(interaction), which has its own
+// DISPLAY_NAME_FALLBACK, so a forgotten 4th arg still renders
+// gracefully on the recipient side.
+async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DISPLAY_NAME_FALLBACK) {
   // Items carry dm_channel_id / dm_message_id / dm_status so the post-
   // revoke step can edit each strict-success recipient's DM in place.
   // Legacy rows predating that wire-up have the refs unset — the edit
@@ -6127,10 +6123,18 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = 'So
   // recipient, even if multiple resources fanned out to them) — collapse
   // items to the first delivered row per recipient_discord_id.
   //
+  // ORDERING: DELETEs ran above; the edit fires AFTER they settle.
+  // Reversing the order would create a window where the recipient sees
+  // "closed the door" while the link still resolves until DELETE
+  // completes. With DELETE first, the worst case is a brief window where
+  // the live button now 404s — the same window that existed before this
+  // feature, minus the post-revoke rewrite.
+  //
   // Skips:
-  //   - recipients not in successUserIds (failed revoke = link was
-  //     already opened, so the recipient already passed through the
-  //     door — nothing to edit)
+  //   - recipients not in successUserIds (their revoke failed; either
+  //     the link was already opened, or a mixed-outcome recipient with
+  //     some links failed — either way the door isn't fully closed for
+  //     them, so the "closed the door" copy would be misleading)
   //   - rows with dm_status !== 'sent' (DM never made it; no message
   //     exists to edit)
   //   - rows lacking dm_channel_id / dm_message_id (legacy, pre-
@@ -6175,7 +6179,7 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = 'So
       let failed = 0;
       for (const r of editResults) {
         if (r.status === 'fulfilled') edited++;
-        else if (r.reason && r.reason.expected) expectedFailures++;
+        else if (r.reason?.expected === true) expectedFailures++;
         else failed++;
       }
       logger.info('Edited DMs after revoke', {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -761,22 +761,25 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
     // so DDB matches observable reality — `count(dm_status='sent')`
     // stays a faithful delivery-rate metric. The revoke path's
     // missing-refs guard (see editTargets builder) naturally skips
-    // the DM edit for these rows. Emit DISPATCH_SENT_NO_REFS so the
-    // gap between DISPATCH_SENT and the editable-on-revoke subset is
-    // queryable from CloudWatch.
+    // the DM edit for these rows.
+    //
+    // Order matters: DDB write FIRST, audit + warn SECOND. If the DDB
+    // write throws, the canary hasn't fired yet — neither the audit
+    // event nor the warn line will misleadingly claim SENT was
+    // recorded. Both fire only when SENT was actually persisted.
     //
     // CANONICAL DELIVERY-RATE METRIC: DDB `count(dm_status='sent')`
     // or CloudWatch `dispatch_sent` (they should agree). The
     // `dispatch_sent_no_refs` event is a CANARY, not a subtractor —
     // if it fires, oncall investigates the discord.js response shape;
     // don't auto-subtract it from DISPATCH_SENT in dashboards.
+    await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
     logger.audit(AUDIT_EVENTS.DISPATCH_SENT_NO_REFS, { send_id: sendId });
     logger.warn('sendDM resolved ok but missing channelId/messageId — recording as sent (revoke edit will skip)', {
       sendId, recipientDiscordId,
       hasChannelId: Boolean(result.channelId),
       hasMessageId: Boolean(result.messageId),
     });
-    await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
     return;
   }
   await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED);
@@ -6172,8 +6175,11 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
     }
     if (editTargets.size > 0) {
       const editPayload = buildRevokedDMPayload({ senderAlias });
-      // Same fan-out width as the DELETE batch above — Discord PATCHes
-      // share the same channel-bucket rate limit so 5-wide is plenty.
+      // Same fan-out width as the DELETE batch above. Discord's per-
+      // channel rate-limit buckets are unique per recipient (each DM
+      // channel is its own bucket), so 5 concurrent PATCHes don't share
+      // a bucket; the bound exists to limit global rate-limit pressure
+      // and audit-log burst, not per-channel contention.
       const entries = [...editTargets.entries()];
       // editDM swallows its own exceptions and returns { ok, expected }.
       // Re-throw on `!ok` so batchSettled buckets failures uniformly;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6181,10 +6181,12 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   // feature, minus the post-revoke rewrite.
   //
   // Skips:
-  //   - recipients not in successUserIds (their revoke failed; either
-  //     the link was already opened, or a mixed-outcome recipient with
-  //     some links failed — either way the door isn't fully closed for
-  //     them, so the "closed the door" copy would be misleading)
+  //   - recipients not in successUserIds (their revoke didn't fully
+  //     succeed — the link may have been already opened, a transient
+  //     qURL API error during DELETE, or a mixed-outcome recipient
+  //     with some links failed. Either way the door isn't fully
+  //     closed for them, so the "closed the door" copy would be
+  //     misleading)
   //   - rows with dm_status !== 'sent' (DM never made it; no message
   //     exists to edit)
   //   - rows lacking dm_channel_id / dm_message_id (legacy, pre-

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -750,9 +750,35 @@ function buildRevokedDMPayload({ senderAlias }) {
 // Happy path coalesces dm_status='sent' + DM refs into one DDB Update
 // so the hot dispatch path stays at one write per recipient. Failure
 // path is status-only — there's no message to edit later.
+//
+// NEVER throws on a delivered DM. If the DDB write fails (outage,
+// throttle, validation), DISPATCH_PERSIST_FAILED fires + an error is
+// logged, but the function returns normally so the caller continues
+// to report the recipient as delivered. Throwing here would convert
+// a real DM into a "could not be reached" line on the operator's
+// reply — worse than the bookkeeping miss.
 async function persistDispatchResult(sendId, recipientDiscordId, result) {
+  // Wraps the DDB call so a write failure can't propagate up as a
+  // failed dispatch. `delivered` ⇒ the DM is real and the operator
+  // should still see this recipient as reached.
+  const persist = async (op, delivered) => {
+    try {
+      await op();
+    } catch (err) {
+      if (delivered) {
+        logger.audit(AUDIT_EVENTS.DISPATCH_PERSIST_FAILED, { send_id: sendId });
+      }
+      logger.error('persistDispatchResult: qurl_sends write failed', {
+        sendId, recipientDiscordId, delivered, errorMessage: err.message,
+      });
+    }
+  };
+
   if (result.ok === true && result.channelId && result.messageId) {
-    await db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId);
+    await persist(
+      () => db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId),
+      true,
+    );
     return;
   }
   if (result.ok === true) {
@@ -763,26 +789,34 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
     // missing-refs guard (see editTargets builder) naturally skips
     // the DM edit for these rows.
     //
-    // Order matters: DDB write FIRST, audit + warn SECOND. If the DDB
-    // write throws, the canary hasn't fired yet — neither the audit
-    // event nor the warn line will misleadingly claim SENT was
-    // recorded. Both fire only when SENT was actually persisted.
-    //
     // CANONICAL DELIVERY-RATE METRIC: DDB `count(dm_status='sent')`
     // or CloudWatch `dispatch_sent` (they should agree). The
     // `dispatch_sent_no_refs` event is a CANARY, not a subtractor —
     // if it fires, oncall investigates the discord.js response shape;
     // don't auto-subtract it from DISPATCH_SENT in dashboards.
-    await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
+    //
+    // Audit + warn fire BEFORE the persist so a DDB failure can't
+    // mask the discord.js shape-drift canary. If the persist also
+    // fails, DISPATCH_PERSIST_FAILED fires alongside (separate
+    // signal, separate dashboard).
     logger.audit(AUDIT_EVENTS.DISPATCH_SENT_NO_REFS, { send_id: sendId });
     logger.warn('sendDM resolved ok but missing channelId/messageId — recording as sent (revoke edit will skip)', {
       sendId, recipientDiscordId,
       hasChannelId: Boolean(result.channelId),
       hasMessageId: Boolean(result.messageId),
     });
+    await persist(
+      () => db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT),
+      true,
+    );
     return;
   }
-  await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED);
+  // sendDM failed — the DM is not real. A bookkeeping error here is
+  // strictly a dropped status update; the recipient was never reached.
+  await persist(
+    () => db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED),
+    false,
+  );
 }
 
 // --- Link status monitor ---

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -753,9 +753,23 @@ function buildRevokedDMPayload({ senderAlias }) {
 async function persistDispatchResult(sendId, recipientDiscordId, result) {
   if (result.ok === true && result.channelId && result.messageId) {
     await db.markSendDMDelivered(sendId, recipientDiscordId, result.channelId, result.messageId);
-  } else {
-    await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED);
+    return;
   }
+  // Defensive: sendDM returned ok but discord.js silently omitted
+  // channelId / messageId. Today that doesn't happen — `user.send()`
+  // resolves to a Message with both — but if a future discord.js
+  // changes the response shape, the audit metric would fire
+  // DISPATCH_SENT while DDB records `failed`. Surface the divergence
+  // loudly so it's catchable in logs without dropping into prod
+  // behavior change. Treat as a failed dispatch for safety.
+  if (result.ok === true) {
+    logger.warn('sendDM resolved ok but missing channelId/messageId — recording as failed', {
+      sendId, recipientDiscordId,
+      hasChannelId: Boolean(result.channelId),
+      hasMessageId: Boolean(result.messageId),
+    });
+  }
+  await db.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.FAILED);
 }
 
 // --- Link status monitor ---
@@ -6027,7 +6041,12 @@ function renderSendConfirm({
   return { content: msg, attachmentText: null, needsExpand: successNames.length > REVOKE_TRUNC_LIMIT };
 }
 
-async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias) {
+// senderAlias defaults to 'Someone' as a defense-in-depth in case a
+// future caller forgets the 4th arg. Production callers always pass
+// `resolveSenderAlias(interaction)`, which has its own 'Someone'
+// fallback; this default keeps the recipient-side copy graceful if
+// that contract ever drifts.
+async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = 'Someone') {
   // Items carry dm_channel_id / dm_message_id / dm_status so the post-
   // revoke step can edit each strict-success recipient's DM in place.
   // Legacy rows predating that wire-up have the refs unset — the edit
@@ -6137,17 +6156,38 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias) {
       // Same fan-out width as the DELETE batch above — Discord PATCHes
       // share the same channel-bucket rate limit so 5-wide is plenty.
       const entries = [...editTargets.entries()];
+      // editDM swallows its own exceptions and returns { ok, expected }.
+      // Re-throw on `!ok` so batchSettled buckets failures uniformly;
+      // pass through res.expected so the rolled-up log can distinguish
+      // operational outcomes (recipient deleted DM / blocked bot) from
+      // surprises that warrant oncall attention.
       const editResults = await batchSettled(entries, async ([, refs]) => {
         const res = await editDM(refs.channelId, refs.messageId, editPayload);
-        if (!res.ok) throw new Error('editDM returned not-ok');
+        if (!res.ok) {
+          const e = new Error('editDM returned not-ok');
+          e.expected = res.expected;
+          throw e;
+        }
         return res;
       }, 5);
-      const edited = editResults.filter(r => r.status === 'fulfilled').length;
+      let edited = 0;
+      let expectedFailures = 0;
+      let failed = 0;
+      for (const r of editResults) {
+        if (r.status === 'fulfilled') edited++;
+        else if (r.reason && r.reason.expected) expectedFailures++;
+        else failed++;
+      }
       logger.info('Edited DMs after revoke', {
         sendId,
         attempted: editTargets.size,
         edited,
-        failed: editTargets.size - edited,
+        // Recipient-side operational outcomes (DM deleted, bot blocked,
+        // etc.) — already logged at info inside editDM. Split out here
+        // so the rolled-up failure count in CloudWatch isn't poisoned
+        // by user-side state changes.
+        expectedFailures,
+        failed,
       });
     }
   }
@@ -7652,6 +7692,7 @@ module.exports = {
       handleAddRecipients,
       buildDeliveryPayload,
       buildRevokedDMPayload,
+      persistDispatchResult,
       resolveSenderAlias,
       safeUrlHost,
       // Back-half functions exposed for direct unit testing. Without these

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -757,6 +757,14 @@ function buildRevokedDMPayload({ senderAlias }) {
 // to report the recipient as delivered. Throwing here would convert
 // a real DM into a "could not be reached" line on the operator's
 // reply — worse than the bookkeeping miss.
+//
+// CALLER INVARIANT: every call site MUST await db.recordQURLSendBatch
+// before invoking the dispatch loop that calls this function. The
+// underlying UpdateCommand has no attribute_exists guard (#366), so
+// without that ordering a stale recipient_discord_id would create an
+// orphan row. executeSendPipeline + handleAddRecipients both honor
+// this — recordQURLSendBatch awaits to completion (with an early-
+// return on throw) before the batchSettled dispatch loop starts.
 async function persistDispatchResult(sendId, recipientDiscordId, result) {
   // Wraps the DDB call so a write failure can't propagate up as a
   // failed dispatch. `delivered` ⇒ the DM is real and the operator

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6134,9 +6134,9 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   // so they see immediately that the link is dead rather than tapping a
   // Step Through button that now 404s. Per-recipient (one DM per
   // recipient, even if multiple resources fanned out to them) — keep
-  // the first VALID row per recipient_discord_id. De-dup check fires
-  // first so the first valid row wins; an earlier invalid row (no
-  // refs / wrong status) doesn't poison the de-dup slot.
+  // the first VALID row per recipient_discord_id. The de-dup guard
+  // runs first, but invalid rows `continue` before reaching `.set()`,
+  // so a later valid row for the same recipient still wins the slot.
   //
   // ORDERING: DELETEs ran above; the edit fires AFTER they settle.
   // Reversing the order would create a window where the recipient sees

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -136,6 +136,13 @@ const AUDIT_EVENTS = {
   // a mystery gap. Should always read zero — if it lights up, the
   // discord.js user.send() response shape has changed.
   DISPATCH_SENT_NO_REFS: 'dispatch_sent_no_refs',
+  // DISPATCH_PERSIST_FAILED fires when sendDM succeeded but the
+  // bookkeeping write to qurl_sends threw (DDB outage, throttle,
+  // ValidationException, etc.). The DM is real; the dispatch loop
+  // continues to report the recipient as delivered. This event is
+  // a canary for an oncall-relevant DDB issue separate from the
+  // dispatch-success-rate signal — should always read zero.
+  DISPATCH_PERSIST_FAILED: 'dispatch_persist_failed',
   // REVOKE_SUCCESS fires when at least one per-link delete succeeded;
   // REVOKE_FAILED fires when every per-link delete threw (success === 0
   // && total > 0). When total === 0 (nothing to revoke — already-revoked

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -128,6 +128,14 @@ const AUDIT_EVENTS = {
   UPLOAD_SUCCESS: 'upload_success',
   DISPATCH_SENT: 'dispatch_sent',
   DISPATCH_FAILED: 'dispatch_failed',
+  // DISPATCH_SENT_NO_REFS fires when sendDM resolved ok:true but the
+  // channelId / messageId came back missing — the audit-vs-DDB
+  // divergence persistDispatchResult records as `failed`. Distinct
+  // from DISPATCH_SENT so the dashboard can reconcile CloudWatch
+  // `dispatch_sent` count with DDB `count(dm_status='sent')` without
+  // a mystery gap. Should always read zero — if it lights up, the
+  // discord.js user.send() response shape has changed.
+  DISPATCH_SENT_NO_REFS: 'dispatch_sent_no_refs',
   // REVOKE_SUCCESS fires when at least one per-link delete succeeded;
   // REVOKE_FAILED fires when every per-link delete threw (success === 0
   // && total > 0). When total === 0 (nothing to revoke — already-revoked

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -719,6 +719,14 @@ const dbModule = {
     stmt.run(status, sendId, recipientDiscordId);
   },
 
+  // No-op stub. The DDB backend persists the DM channel + message ids so
+  // /qurl revoke can edit recipients' DMs in place; the SQLite backend
+  // is local-dev only (production sets STORE_TYPE=ddb) and intentionally
+  // does not carry that schema. Local revokes still succeed — they just
+  // skip the "Alice closed the door" edit on the recipient side.
+  // eslint-disable-next-line no-unused-vars
+  updateSendDMRefs(_sendId, _recipientDiscordId, _channelId, _messageId) {},
+
   getRecentSends(senderDiscordId, limit = 10) {
     // LEFT JOIN on qurl_send_configs so we can:
     // 1. Filter out already-revoked sends. With LEFT JOIN, rows that

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -723,10 +723,10 @@ const dbModule = {
   // SQLite is local-dev only — STORE_TYPE=ddb in prod. We still write
   // dm_status='sent' so local delivery-count rollups stay consistent;
   // the DM refs are intentionally not persisted (signature mirrors the
-  // DDB contract; `_channelId` / `_messageId` are swallowed here), so
-  // /qURL revoke skips the recipient-side DM edit when running against
-  // SQLite.
-  // eslint-disable-next-line no-unused-vars
+  // DDB contract; `_channelId` / `_messageId` are swallowed here, the
+  // leading-underscore convention is exempted by the project's eslint
+  // argsIgnorePattern), so /qURL revoke skips the recipient-side DM
+  // edit when running against SQLite.
   markSendDMDelivered(sendId, recipientDiscordId, _channelId, _messageId) {
     this.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
   },

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const config = require('./config');
 const logger = require('./logger');
+const { DM_STATUS } = require('./constants');
 
 // Ensure data directory exists
 const dbDir = path.dirname(config.DATABASE_PATH);
@@ -719,13 +720,14 @@ const dbModule = {
     stmt.run(status, sendId, recipientDiscordId);
   },
 
-  // No-op stub. The DDB backend persists the DM channel + message ids so
-  // /qurl revoke can edit recipients' DMs in place; the SQLite backend
-  // is local-dev only (production sets STORE_TYPE=ddb) and intentionally
-  // does not carry that schema. Local revokes still succeed — they just
-  // skip the "Alice closed the door" edit on the recipient side.
+  // SQLite is local-dev only — STORE_TYPE=ddb in prod. We still write
+  // dm_status='sent' so local delivery-count rollups stay consistent;
+  // the DM refs are intentionally not persisted, so /qURL revoke
+  // skips the recipient-side DM edit when running against SQLite.
   // eslint-disable-next-line no-unused-vars
-  updateSendDMRefs(_sendId, _recipientDiscordId, _channelId, _messageId) {},
+  markSendDMDelivered(sendId, recipientDiscordId, _channelId, _messageId) {
+    this.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
+  },
 
   getRecentSends(senderDiscordId, limit = 10) {
     // LEFT JOIN on qurl_send_configs so we can:

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -722,10 +722,12 @@ const dbModule = {
 
   // SQLite is local-dev only — STORE_TYPE=ddb in prod. We still write
   // dm_status='sent' so local delivery-count rollups stay consistent;
-  // the DM refs (channelId, messageId — passed by the caller but
-  // dropped here) are intentionally not persisted, so /qURL revoke
-  // skips the recipient-side DM edit when running against SQLite.
-  markSendDMDelivered(sendId, recipientDiscordId) {
+  // the DM refs are intentionally not persisted (signature mirrors the
+  // DDB contract; `_channelId` / `_messageId` are swallowed here), so
+  // /qURL revoke skips the recipient-side DM edit when running against
+  // SQLite.
+  // eslint-disable-next-line no-unused-vars
+  markSendDMDelivered(sendId, recipientDiscordId, _channelId, _messageId) {
     this.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
   },
 

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -722,10 +722,10 @@ const dbModule = {
 
   // SQLite is local-dev only — STORE_TYPE=ddb in prod. We still write
   // dm_status='sent' so local delivery-count rollups stay consistent;
-  // the DM refs are intentionally not persisted, so /qURL revoke
+  // the DM refs (channelId, messageId — passed by the caller but
+  // dropped here) are intentionally not persisted, so /qURL revoke
   // skips the recipient-side DM edit when running against SQLite.
-  // eslint-disable-next-line no-unused-vars
-  markSendDMDelivered(sendId, recipientDiscordId, _channelId, _messageId) {
+  markSendDMDelivered(sendId, recipientDiscordId) {
     this.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
   },
 

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -727,8 +727,16 @@ const dbModule = {
   // leading-underscore convention is exempted by the project's eslint
   // argsIgnorePattern), so /qURL revoke skips the recipient-side DM
   // edit when running against SQLite.
+  //
+  // Debug log surfaces the divergence at WRITE time (not just at
+  // revoke time when the missing-refs guard finally fires) so a
+  // local dev sees the silent-skip the moment a DM dispatch lands.
+  // See #365 for the full SQLite getSendItems projection wire-up.
   markSendDMDelivered(sendId, recipientDiscordId, _channelId, _messageId) {
     this.updateSendDMStatus(sendId, recipientDiscordId, DM_STATUS.SENT);
+    logger.debug('SqliteStore.markSendDMDelivered: dm_channel_id / dm_message_id intentionally not persisted (see #365)', {
+      sendId, recipientDiscordId,
+    });
   },
 
   getRecentSends(senderDiscordId, limit = 10) {

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -98,15 +98,20 @@ async function sendDM(userId, message) {
 // proxy returning a synthetic 404, or a Discord-side bug. Logging
 // those at warn keeps the unknowns visible. New expected codes belong
 // here, not in the predicate.
-const DM_EDIT_EXPECTED_API_CODES = new Set([
-  10003, // Unknown Channel — DM channel deleted
-  10008, // Unknown Message — recipient deleted the DM
-  50001, // Missing Access — bot kicked / lost shared guild
+// Codes plus human-readable descriptions. The description lands in the
+// info-level log when it matches, so a future log search for an
+// unexpected spike (e.g., 50007 on PATCH — not observed today) reads
+// the cause directly rather than requiring an external code lookup.
+const DM_EDIT_EXPECTED_API_CODE_DESCRIPTIONS = new Map([
+  [10003, 'Unknown Channel — DM channel deleted'],
+  [10008, 'Unknown Message — recipient deleted the DM'],
+  [50001, 'Missing Access — bot kicked / lost shared guild'],
   // 50007 is observed at POST /messages time (new DM rejected), not
   // typically at PATCH on an existing message in an already-open DM
   // channel. Kept defensively — if it ever fires on PATCH it's still
-  // a recipient-side state change, not an oncall surprise.
-  50007, // Cannot send messages to this user — DMs disabled / blocked
+  // a recipient-side state change, not an oncall surprise. The
+  // description tag in the log makes the spike greppable for #369.
+  [50007, 'Cannot send messages to this user — DMs disabled / blocked'],
 ]);
 
 /**
@@ -133,11 +138,17 @@ async function editDM(channelId, messageId, message) {
     await client.rest.patch(Routes.channelMessage(channelId, messageId), { body: message });
     return { ok: true };
   } catch (error) {
-    const expected = DM_EDIT_EXPECTED_API_CODES.has(error.code);
+    const expectedDescription = DM_EDIT_EXPECTED_API_CODE_DESCRIPTIONS.get(error.code);
+    const expected = expectedDescription !== undefined;
     const level = expected ? 'info' : 'warn';
     logger[level]('Failed to edit DM', {
       channelId, messageId, status: error.status, code: error.code,
       errorMessage: error.message,
+      // Present only on the expected branch — names which entry in
+      // DM_EDIT_EXPECTED_API_CODE_DESCRIPTIONS matched. Keeps a future
+      // spike in any single expected code (e.g., 50007 on PATCH)
+      // greppable from CloudWatch without an external lookup.
+      ...(expected && { expectedReason: expectedDescription }),
     });
     return { ok: false, expected };
   }

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -102,6 +102,10 @@ const DM_EDIT_EXPECTED_API_CODES = new Set([
   10003, // Unknown Channel — DM channel deleted
   10008, // Unknown Message — recipient deleted the DM
   50001, // Missing Access — bot kicked / lost shared guild
+  // 50007 is observed at POST /messages time (new DM rejected), not
+  // typically at PATCH on an existing message in an already-open DM
+  // channel. Kept defensively — if it ever fires on PATCH it's still
+  // a recipient-side state change, not an oncall surprise.
   50007, // Cannot send messages to this user — DMs disabled / blocked
 ]);
 

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -86,17 +86,23 @@ async function sendDM(userId, message) {
   }
 }
 
-// Discord status codes / api codes that are operational outcomes for a
-// DM edit — recipient deleted the message, blocked the bot, closed the
-// channel, the bot was kicked from a shared guild. Surface as
+// Discord API codes that are operational outcomes for a DM edit —
+// recipient deleted the message, blocked the bot, closed the channel,
+// the bot was kicked from a shared guild. Surface as
 // `{ ok: false, expected: true }` at info level so they don't pollute
-// oncall signal. New codes belong here, not in the predicate.
-const DM_EDIT_EXPECTED_HTTP_STATUS = new Set([403, 404]);
+// oncall signal.
+//
+// Gated on the API code (not bare HTTP status) on purpose: a 403 or
+// 404 WITHOUT one of these codes is suspicious — examples include a
+// revoked bot token mid-flight (403 with no JSON body), a routing
+// proxy returning a synthetic 404, or a Discord-side bug. Logging
+// those at warn keeps the unknowns visible. New expected codes belong
+// here, not in the predicate.
 const DM_EDIT_EXPECTED_API_CODES = new Set([
-  10003, // Unknown Channel
-  10008, // Unknown Message
-  50001, // Missing Access
-  50007, // Cannot send messages to this user
+  10003, // Unknown Channel — DM channel deleted
+  10008, // Unknown Message — recipient deleted the DM
+  50001, // Missing Access — bot kicked / lost shared guild
+  50007, // Cannot send messages to this user — DMs disabled / blocked
 ]);
 
 /**
@@ -114,8 +120,7 @@ async function editDM(channelId, messageId, message) {
     await client.rest.patch(Routes.channelMessage(channelId, messageId), { body: message });
     return { ok: true };
   } catch (error) {
-    const expected = DM_EDIT_EXPECTED_HTTP_STATUS.has(error.status)
-      || DM_EDIT_EXPECTED_API_CODES.has(error.code);
+    const expected = DM_EDIT_EXPECTED_API_CODES.has(error.code);
     const level = expected ? 'info' : 'warn';
     logger[level]('Failed to edit DM', {
       channelId, messageId, status: error.status, code: error.code,
@@ -162,18 +167,11 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 // Today the helpers below are unused production code — they're the
 // landing pads for the route migration after this PR ships.
 module.exports = {
-  // Property getter — resolves to client.rest at access time, NOT at
-  // module load. This matters because: (a) partial test mocks of
-  // `../src/discord` don't crash at require-time when commands.js
-  // pulls in editDM, and (b) the same shared instance backs each
-  // call inside this module via `client.rest.X` directly. Note for
-  // consumers: `const { rest } = require('./discord-rest')` evaluates
-  // the getter at destructure time and pins to the current
-  // `client.rest`. Production safe because client.login() and
-  // http-only-init's setToken() both mutate `client.rest` in place
-  // rather than reassigning. If that ever changes, destructure-then-
-  // call becomes stale and consumers should switch to property
-  // access (`discordRest.rest.post(...)`).
+  // Lazy access — `client.rest` resolves at property-access time, not
+  // module load, so partial test mocks of `../src/discord` don't crash
+  // require-time. Internal helpers above read `client.rest.X` directly
+  // for the same reason. No production consumer destructures this; the
+  // export is here for the discord-rest test that pins it.
   get rest() { return client.rest; },
   sendDM,
   editDM,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -177,8 +177,9 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 
 // TODO(pr-4d): migrate routes/oauth.js + routes/webhooks.js to call
 // these helpers instead of the gateway-cache helpers in src/discord.js.
-// Today the helpers below are unused production code — they're the
-// landing pads for the route migration after this PR ships.
+// `editDM` is consumed by commands.js's revoke path; `sendDM` /
+// `addRoleToMember` / `removeRoleFromMember` are landing pads for the
+// route migration.
 // Helpers read `client.rest.X` directly (rather than capturing
 // `client.rest` at module load) so partial test mocks of
 // `../src/discord` don't crash require-time. No production consumer

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -32,15 +32,6 @@ const { Routes } = require('discord-api-types/v10');
 const { client } = require('./discord');
 const logger = require('./logger');
 
-// Shared instance — same object as `require('./discord').client.rest`.
-// Read lazily via a getter (rather than `const rest = client.rest` at
-// module load) so partial test mocks of `../src/discord` don't crash
-// at require-time when commands.js pulls editDM. Production tokens
-// land on `client.rest` from `client.login()` or `http-only-init`'s
-// explicit `setToken`; either way the getter resolves to the same
-// object by the time a helper is invoked.
-const rest = () => client.rest;
-
 /**
  * Send a direct message to a Discord user via REST (no Gateway).
  *
@@ -69,10 +60,10 @@ const rest = () => client.rest;
 
 async function sendDM(userId, message) {
   try {
-    const channel = await rest().post(Routes.userChannels(), {
+    const channel = await client.rest.post(Routes.userChannels(), {
       body: { recipient_id: userId },
     });
-    const sent = await rest().post(Routes.channelMessages(channel.id), {
+    const sent = await client.rest.post(Routes.channelMessages(channel.id), {
       body: message,
     });
     return { ok: true, channelId: channel.id, messageId: sent.id };
@@ -120,7 +111,7 @@ const DM_EDIT_EXPECTED_API_CODES = new Set([
  */
 async function editDM(channelId, messageId, message) {
   try {
-    await rest().patch(Routes.channelMessage(channelId, messageId), { body: message });
+    await client.rest.patch(Routes.channelMessage(channelId, messageId), { body: message });
     return { ok: true };
   } catch (error) {
     const expected = DM_EDIT_EXPECTED_HTTP_STATUS.has(error.status)
@@ -141,7 +132,7 @@ async function editDM(channelId, messageId, message) {
  */
 async function addRoleToMember(guildId, userId, roleId) {
   try {
-    await rest().put(Routes.guildMemberRole(guildId, userId, roleId));
+    await client.rest.put(Routes.guildMemberRole(guildId, userId, roleId));
     return { ok: true };
   } catch (err) {
     logger.error('addRoleToMember via REST failed', {
@@ -156,7 +147,7 @@ async function addRoleToMember(guildId, userId, roleId) {
  */
 async function removeRoleFromMember(guildId, userId, roleId) {
   try {
-    await rest().delete(Routes.guildMemberRole(guildId, userId, roleId));
+    await client.rest.delete(Routes.guildMemberRole(guildId, userId, roleId));
     return { ok: true };
   } catch (err) {
     logger.error('removeRoleFromMember via REST failed', {
@@ -171,10 +162,18 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 // Today the helpers below are unused production code — they're the
 // landing pads for the route migration after this PR ships.
 module.exports = {
-  // Resolves to client.rest at access time (not module-load time) so
-  // partial test mocks of `../src/discord` don't crash early. Public
-  // shape unchanged for existing callers: `const { rest } = require(...)`
-  // still pins a direct reference to the shared REST instance.
+  // Property getter — resolves to client.rest at access time, NOT at
+  // module load. This matters because: (a) partial test mocks of
+  // `../src/discord` don't crash at require-time when commands.js
+  // pulls in editDM, and (b) the same shared instance backs each
+  // call inside this module via `client.rest.X` directly. Note for
+  // consumers: `const { rest } = require('./discord-rest')` evaluates
+  // the getter at destructure time and pins to the current
+  // `client.rest`. Production safe because client.login() and
+  // http-only-init's setToken() both mutate `client.rest` in place
+  // rather than reassigning. If that ever changes, destructure-then-
+  // call becomes stale and consumers should switch to property
+  // access (`discordRest.rest.post(...)`).
   get rest() { return client.rest; },
   sendDM,
   editDM,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -44,10 +44,12 @@ const rest = client.rest;
  *      channel, returns { id }.
  *   2. POST /channels/:id/messages → posts the message body.
  *
- * Returns `{ ok: true, channelId }` on success, `{ ok: false, error }`
- * on failure. Callers log/branch on `.ok` rather than letting
- * exceptions propagate — matches the ergonomics of the legacy
- * gateway-based `sendDM` in `discord.js`.
+ * Returns `{ ok: true, channelId, messageId }` on success,
+ * `{ ok: false, error }` on failure. Callers log/branch on `.ok` rather
+ * than letting exceptions propagate — matches the ergonomics of the
+ * legacy gateway-based `sendDM` in `discord.js`. `messageId` is captured
+ * so the /qurl revoke path can edit the recipient's DM in place after a
+ * successful revoke.
  *
  * @param {string} userId — Discord snowflake.
  * @param {object} message — discord.js-compatible message payload
@@ -65,10 +67,10 @@ async function sendDM(userId, message) {
     const channel = await rest.post(Routes.userChannels(), {
       body: { recipient_id: userId },
     });
-    await rest.post(Routes.channelMessages(channel.id), {
+    const sent = await rest.post(Routes.channelMessages(channel.id), {
       body: message,
     });
-    return { ok: true, channelId: channel.id };
+    return { ok: true, channelId: channel.id, messageId: sent.id };
   } catch (err) {
     // Discord returns HTTP 403 for several recipient-side reasons:
     // DMs disabled, the bot was blocked, server-level DM restrictions,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -154,7 +154,11 @@ async function editDM(channelId, messageId, message) {
       // greppable from CloudWatch without an external lookup.
       ...(expected && { expectedReason: expectedDescription }),
     });
-    return { ok: false, expected };
+    // `code` and `reason` exposed on the return so callers' rolled-up
+    // logs can carry the same diagnostic without re-grepping the per-
+    // edit log line. `code` is undefined for non-Discord-shape errors;
+    // `reason` is undefined unless the code matched the expected set.
+    return { ok: false, expected, code: error.code, reason: expectedDescription };
   }
 }
 

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -179,13 +179,11 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 // these helpers instead of the gateway-cache helpers in src/discord.js.
 // Today the helpers below are unused production code — they're the
 // landing pads for the route migration after this PR ships.
+// Helpers read `client.rest.X` directly (rather than capturing
+// `client.rest` at module load) so partial test mocks of
+// `../src/discord` don't crash require-time. No production consumer
+// needs a direct `rest` reference today.
 module.exports = {
-  // Lazy access — `client.rest` resolves at property-access time, not
-  // module load, so partial test mocks of `../src/discord` don't crash
-  // require-time. Internal helpers above read `client.rest.X` directly
-  // for the same reason. No production consumer destructures this; the
-  // export is here for the discord-rest test that pins it.
-  get rest() { return client.rest; },
   sendDM,
   editDM,
   addRoleToMember,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -158,6 +158,9 @@ async function editDM(channelId, messageId, message) {
     // logs can carry the same diagnostic without re-grepping the per-
     // edit log line. `code` is undefined for non-Discord-shape errors;
     // `reason` is undefined unless the code matched the expected set.
+    // Currently unread by the revoke-loop caller (it consumes only
+    // `expected` via the re-thrown error) — landing pad for the
+    // dashboard work tracked in #368 / #370 / #372.
     return { ok: false, expected, code: error.code, reason: expectedDescription };
   }
 }

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -138,6 +138,10 @@ async function editDM(channelId, messageId, message) {
     await client.rest.patch(Routes.channelMessage(channelId, messageId), { body: message });
     return { ok: true };
   } catch (error) {
+    // Map.get(undefined) returns undefined, which falls through to the
+    // unexpected (warn-level) branch. Intentional: an error with no
+    // API code (e.g., revoked-token 403 with no JSON body, synthetic
+    // proxy 404) is exactly the kind of surprise oncall should see.
     const expectedDescription = DM_EDIT_EXPECTED_API_CODE_DESCRIPTIONS.get(error.code);
     const expected = expectedDescription !== undefined;
     const level = expected ? 'info' : 'warn';

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -114,6 +114,15 @@ const DM_EDIT_EXPECTED_API_CODES = new Set([
  * clear unset fields. Callers MUST pass `components: []` explicitly
  * to strip a previous Link button. See buildRevokedDMPayload in
  * commands.js for the contract-bearing payload.
+ *
+ * No retry on transient 5xx / 429. `client.rest` handles 429 backoff
+ * automatically, but a 502/503 from Discord during a revoke fan-out
+ * would leave the original Step Through button live in that
+ * recipient's DM after the underlying qURL is already DELETEd. The
+ * link button now 404s — i.e. the same UX that existed before this
+ * feature, just on whatever subset of recipients hit the transient.
+ * Accept as a known limitation; the revoke success/total counts are
+ * not affected (those track the DELETE, not the edit).
  */
 async function editDM(channelId, messageId, message) {
   try {

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -33,8 +33,13 @@ const { client } = require('./discord');
 const logger = require('./logger');
 
 // Shared instance — same object as `require('./discord').client.rest`.
-// Re-exported below for tests + potential direct use.
-const rest = client.rest;
+// Read lazily via a getter (rather than `const rest = client.rest` at
+// module load) so partial test mocks of `../src/discord` don't crash
+// at require-time when commands.js pulls editDM. Production tokens
+// land on `client.rest` from `client.login()` or `http-only-init`'s
+// explicit `setToken`; either way the getter resolves to the same
+// object by the time a helper is invoked.
+const rest = () => client.rest;
 
 /**
  * Send a direct message to a Discord user via REST (no Gateway).
@@ -48,7 +53,7 @@ const rest = client.rest;
  * `{ ok: false, error }` on failure. Callers log/branch on `.ok` rather
  * than letting exceptions propagate — matches the ergonomics of the
  * legacy gateway-based `sendDM` in `discord.js`. `messageId` is captured
- * so the /qurl revoke path can edit the recipient's DM in place after a
+ * so the /qURL revoke path can edit the recipient's DM in place after a
  * successful revoke.
  *
  * @param {string} userId — Discord snowflake.
@@ -64,10 +69,10 @@ const rest = client.rest;
 
 async function sendDM(userId, message) {
   try {
-    const channel = await rest.post(Routes.userChannels(), {
+    const channel = await rest().post(Routes.userChannels(), {
       body: { recipient_id: userId },
     });
-    const sent = await rest.post(Routes.channelMessages(channel.id), {
+    const sent = await rest().post(Routes.channelMessages(channel.id), {
       body: message,
     });
     return { ok: true, channelId: channel.id, messageId: sent.id };
@@ -90,6 +95,45 @@ async function sendDM(userId, message) {
   }
 }
 
+// Discord status codes / api codes that are operational outcomes for a
+// DM edit — recipient deleted the message, blocked the bot, closed the
+// channel, the bot was kicked from a shared guild. Surface as
+// `{ ok: false, expected: true }` at info level so they don't pollute
+// oncall signal. New codes belong here, not in the predicate.
+const DM_EDIT_EXPECTED_HTTP_STATUS = new Set([403, 404]);
+const DM_EDIT_EXPECTED_API_CODES = new Set([
+  10003, // Unknown Channel
+  10008, // Unknown Message
+  50001, // Missing Access
+  50007, // Cannot send messages to this user
+]);
+
+/**
+ * Edit a previously-sent DM via REST (no Gateway). Single PATCH —
+ * no `channels.fetch` + `messages.fetch` preamble that would be 2
+ * extra round-trips on a cold cache.
+ *
+ * CONTRACT: Discord's PATCH /channels/:cid/messages/:mid does NOT
+ * clear unset fields. Callers MUST pass `components: []` explicitly
+ * to strip a previous Link button. See buildRevokedDMPayload in
+ * commands.js for the contract-bearing payload.
+ */
+async function editDM(channelId, messageId, message) {
+  try {
+    await rest().patch(Routes.channelMessage(channelId, messageId), { body: message });
+    return { ok: true };
+  } catch (error) {
+    const expected = DM_EDIT_EXPECTED_HTTP_STATUS.has(error.status)
+      || DM_EDIT_EXPECTED_API_CODES.has(error.code);
+    const level = expected ? 'info' : 'warn';
+    logger[level]('Failed to edit DM', {
+      channelId, messageId, status: error.status, code: error.code,
+      errorMessage: error.message,
+    });
+    return { ok: false, expected };
+  }
+}
+
 /**
  * Add a role to a guild member via REST (no Gateway).
  * Idempotent on the Discord side — re-adding an existing role is
@@ -97,7 +141,7 @@ async function sendDM(userId, message) {
  */
 async function addRoleToMember(guildId, userId, roleId) {
   try {
-    await rest.put(Routes.guildMemberRole(guildId, userId, roleId));
+    await rest().put(Routes.guildMemberRole(guildId, userId, roleId));
     return { ok: true };
   } catch (err) {
     logger.error('addRoleToMember via REST failed', {
@@ -112,7 +156,7 @@ async function addRoleToMember(guildId, userId, roleId) {
  */
 async function removeRoleFromMember(guildId, userId, roleId) {
   try {
-    await rest.delete(Routes.guildMemberRole(guildId, userId, roleId));
+    await rest().delete(Routes.guildMemberRole(guildId, userId, roleId));
     return { ok: true };
   } catch (err) {
     logger.error('removeRoleFromMember via REST failed', {
@@ -127,8 +171,13 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 // Today the helpers below are unused production code — they're the
 // landing pads for the route migration after this PR ships.
 module.exports = {
-  rest,
+  // Resolves to client.rest at access time (not module-load time) so
+  // partial test mocks of `../src/discord` don't crash early. Public
+  // shape unchanged for existing callers: `const { rest } = require(...)`
+  // still pins a direct reference to the shared REST instance.
+  get rest() { return client.rest; },
   sendDM,
+  editDM,
   addRoleToMember,
   removeRoleFromMember,
 };

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -879,16 +879,60 @@ async function postWeeklyDigest() {
   }
 }
 
-// Send DM to user
+// Send DM to user.
+//
+// Returns `{ ok: true, channelId, messageId }` on success — channel +
+// message ids are captured so the /qurl revoke path can edit the
+// recipient's DM in place ("Alice closed the door") after a successful
+// revoke instead of leaving a stale Step Through button behind. The
+// returned `Message` from discord.js exposes both via `message.channelId`
+// and `message.id`.
+//
+// On failure returns `{ ok: false }`. Existing fire-and-forget callers
+// (welcome DMs, OAuth callbacks) `await sendDM(...)` and discard the
+// result; only the qURL send path branches on `.ok`.
 async function sendDM(discordId, message) {
   try {
     const user = await client.users.fetch(discordId);
-    await user.send(message);
+    const sent = await user.send(message);
     logger.debug('Sent DM', { discordId });
-    return true;
+    return { ok: true, channelId: sent.channelId, messageId: sent.id };
   } catch (error) {
     logger.warn(`Failed to DM user ${discordId}`, { error: error.message });
-    return false;
+    return { ok: false };
+  }
+}
+
+// Edit a previously-sent DM. Used by /qurl revoke to replace the
+// "Alice opened a door" embed + Step Through button with a "closed the
+// door" embed once revocation succeeds for that recipient. Returns
+// `{ ok: true }` on success.
+//
+// 404 / 403 / 10008 (Unknown Message) / 50001 (Missing Access) are
+// expected operational outcomes — recipient deleted the DM, blocked
+// the bot, or removed the channel — and surface as `{ ok: false,
+// expected: true }` at info level. Other errors log at warn.
+//
+// Discord's PATCH /channels/:cid/messages/:mid does NOT clear unset
+// fields; callers MUST pass `components: []` explicitly to strip the
+// Step Through button, otherwise the live link button persists in the
+// recipient's DM after the qurl resource has been revoked. The
+// `buildRevokedDMPayload` helper in commands.js bakes that in.
+async function editDM(channelId, messageId, message) {
+  try {
+    const channel = await client.channels.fetch(channelId);
+    const msg = await channel.messages.fetch(messageId);
+    await msg.edit(message);
+    return { ok: true };
+  } catch (error) {
+    const expected = error.status === 403 || error.status === 404
+      || error.code === 10008 || error.code === 50001;
+    const level = expected ? 'info' : 'warn';
+    logger[level]('Failed to edit DM', {
+      channelId, messageId, status: error.status, code: error.code,
+      errorMessage: error.message,
+    });
+    return { ok: false, expected };
   }
 }
 
@@ -919,6 +963,7 @@ module.exports = {
   postToGitHubFeed,
   postWeeklyDigest,
   sendDM,
+  editDM,
   refreshCache,
   shutdown,
   // Exported only for unit tests to verify the boot canaries throw

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -879,18 +879,11 @@ async function postWeeklyDigest() {
   }
 }
 
-// Send DM to user.
-//
-// Returns `{ ok: true, channelId, messageId }` on success — channel +
-// message ids are captured so the /qurl revoke path can edit the
-// recipient's DM in place ("Alice closed the door") after a successful
-// revoke instead of leaving a stale Step Through button behind. The
-// returned `Message` from discord.js exposes both via `message.channelId`
-// and `message.id`.
-//
-// On failure returns `{ ok: false }`. Existing fire-and-forget callers
-// (welcome DMs, OAuth callbacks) `await sendDM(...)` and discard the
-// result; only the qURL send path branches on `.ok`.
+// Returns `{ ok, channelId, messageId }`. The refs feed the /qURL
+// revoke path (see buildRevokedDMPayload + editDM in discord-rest.js)
+// so it can edit the recipient's DM in place after a successful
+// revoke. Fire-and-forget callers (welcome DMs, OAuth callbacks)
+// can keep awaiting and discarding the result.
 async function sendDM(discordId, message) {
   try {
     const user = await client.users.fetch(discordId);
@@ -900,39 +893,6 @@ async function sendDM(discordId, message) {
   } catch (error) {
     logger.warn(`Failed to DM user ${discordId}`, { error: error.message });
     return { ok: false };
-  }
-}
-
-// Edit a previously-sent DM. Used by /qurl revoke to replace the
-// "Alice opened a door" embed + Step Through button with a "closed the
-// door" embed once revocation succeeds for that recipient. Returns
-// `{ ok: true }` on success.
-//
-// 404 / 403 / 10008 (Unknown Message) / 50001 (Missing Access) are
-// expected operational outcomes — recipient deleted the DM, blocked
-// the bot, or removed the channel — and surface as `{ ok: false,
-// expected: true }` at info level. Other errors log at warn.
-//
-// Discord's PATCH /channels/:cid/messages/:mid does NOT clear unset
-// fields; callers MUST pass `components: []` explicitly to strip the
-// Step Through button, otherwise the live link button persists in the
-// recipient's DM after the qurl resource has been revoked. The
-// `buildRevokedDMPayload` helper in commands.js bakes that in.
-async function editDM(channelId, messageId, message) {
-  try {
-    const channel = await client.channels.fetch(channelId);
-    const msg = await channel.messages.fetch(messageId);
-    await msg.edit(message);
-    return { ok: true };
-  } catch (error) {
-    const expected = error.status === 403 || error.status === 404
-      || error.code === 10008 || error.code === 50001;
-    const level = expected ? 'info' : 'warn';
-    logger[level]('Failed to edit DM', {
-      channelId, messageId, status: error.status, code: error.code,
-      errorMessage: error.message,
-    });
-    return { ok: false, expected };
   }
 }
 
@@ -963,7 +923,6 @@ module.exports = {
   postToGitHubFeed,
   postWeeklyDigest,
   sendDM,
-  editDM,
   refreshCache,
   shutdown,
   // Exported only for unit tests to verify the boot canaries throw

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -89,7 +89,7 @@ const STORE_METHODS = Object.freeze([
   'recordQURLSend',
   'recordQURLSendBatch',
   'updateSendDMStatus',
-  'updateSendDMRefs',
+  'markSendDMDelivered',
   'getRecentSends',
   'markSendRevoked',
   'saveSendConfig',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -89,6 +89,7 @@ const STORE_METHODS = Object.freeze([
   'recordQURLSend',
   'recordQURLSendBatch',
   'updateSendDMStatus',
+  'updateSendDMRefs',
   'getRecentSends',
   'markSendRevoked',
   'saveSendConfig',

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -64,6 +64,7 @@ const {
 const { encrypt, encryptStrict, decrypt } = require('../utils/crypto');
 const config = require('../config');
 const logger = require('../logger');
+const { DM_STATUS } = require('../constants');
 
 // Badge taxonomy — same values as SqliteStore so callers that
 // compare across envs see identical enum values.
@@ -1026,16 +1027,14 @@ async function updateSendDMStatus(sendId, recipientDiscordId, status) {
   }));
 }
 
-// Persist the DM channel + message ids for a delivered send. Required so
-// /qurl revoke can edit the recipient's DM in place ("Alice closed the
-// door") instead of leaving a stale Step Through button pointing at a
-// dead link.
-async function updateSendDMRefs(sendId, recipientDiscordId, channelId, messageId) {
+// Coalesces dm_status + DM channel/message refs into one Update so the
+// hot dispatch path stays at one DDB write per successful recipient.
+async function markSendDMDelivered(sendId, recipientDiscordId, channelId, messageId) {
   await ddb.send(new UpdateCommand({
     TableName: TABLES.qurl_sends,
     Key: { send_id: sendId, recipient_discord_id: recipientDiscordId },
-    UpdateExpression: 'SET dm_channel_id = :c, dm_message_id = :m',
-    ExpressionAttributeValues: { ':c': channelId, ':m': messageId },
+    UpdateExpression: 'SET dm_status = :s, dm_channel_id = :c, dm_message_id = :m',
+    ExpressionAttributeValues: { ':s': DM_STATUS.SENT, ':c': channelId, ':m': messageId },
   }));
 }
 
@@ -1535,7 +1534,7 @@ module.exports = {
   // Weekly digest
   getWeeklyDigestData,
   // QURL sends
-  recordQURLSend, recordQURLSendBatch, updateSendDMStatus, updateSendDMRefs,
+  recordQURLSend, recordQURLSendBatch, updateSendDMStatus, markSendDMDelivered,
   getRecentSends, markSendRevoked,
   saveSendConfig, getSendConfig, getSendResourceIds, getSendItems,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1317,10 +1317,11 @@ async function getSendItems(sendId, senderDiscordId) {
   return items.map(item => ({
     resource_id: item.resource_id,
     recipient_discord_id: item.recipient_discord_id,
-    // dm_channel_id / dm_message_id are set by updateSendDMRefs after a
-    // successful sendDM; legacy rows predating that wire-up have them
-    // unset, in which case the revoke path skips the DM edit. dm_status
-    // gates the same skip — failed deliveries have nothing to edit.
+    // dm_channel_id / dm_message_id are written by markSendDMDelivered
+    // after a successful sendDM; legacy rows predating that wire-up
+    // have them unset, in which case the revoke path skips the DM
+    // edit. dm_status gates the same skip — failed deliveries have
+    // nothing to edit.
     dm_channel_id: item.dm_channel_id,
     dm_message_id: item.dm_message_id,
     dm_status: item.dm_status,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1307,6 +1307,14 @@ async function getSendResourceIds(sendId, senderDiscordId) {
 // recipients can exceed the 1MB Query page cap. Without queryAll,
 // resource_ids on later pages would silently drop and the revoke
 // path would skip them.
+//
+// RETURN SHAPE: { resource_id, recipient_discord_id, dm_channel_id?,
+// dm_message_id?, dm_status? }. The dm_* fields are written by
+// markSendDMDelivered after a successful sendDM and consumed by the
+// revoke loop's editTargets builder (commands.js) to PATCH the
+// recipient's DM to "closed the door". Legacy rows predating the
+// ref-capture wire-up have those fields unset — the revoke loop's
+// missing-refs guard skips the edit naturally.
 async function getSendItems(sendId, senderDiscordId) {
   const items = await queryAll({
     TableName: TABLES.qurl_sends,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1026,6 +1026,19 @@ async function updateSendDMStatus(sendId, recipientDiscordId, status) {
   }));
 }
 
+// Persist the DM channel + message ids for a delivered send. Required so
+// /qurl revoke can edit the recipient's DM in place ("Alice closed the
+// door") instead of leaving a stale Step Through button pointing at a
+// dead link.
+async function updateSendDMRefs(sendId, recipientDiscordId, channelId, messageId) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_sends,
+    Key: { send_id: sendId, recipient_discord_id: recipientDiscordId },
+    UpdateExpression: 'SET dm_channel_id = :c, dm_message_id = :m',
+    ExpressionAttributeValues: { ':c': channelId, ':m': messageId },
+  }));
+}
+
 async function getRecentSends(senderDiscordId, limit = 10) {
   // SQL did a LEFT JOIN on qurl_send_configs + GROUP BY send_id to
   // produce one row per send with per-send metadata. DDB: query the
@@ -1305,6 +1318,13 @@ async function getSendItems(sendId, senderDiscordId) {
   return items.map(item => ({
     resource_id: item.resource_id,
     recipient_discord_id: item.recipient_discord_id,
+    // dm_channel_id / dm_message_id are set by updateSendDMRefs after a
+    // successful sendDM; legacy rows predating that wire-up have them
+    // unset, in which case the revoke path skips the DM edit. dm_status
+    // gates the same skip — failed deliveries have nothing to edit.
+    dm_channel_id: item.dm_channel_id,
+    dm_message_id: item.dm_message_id,
+    dm_status: item.dm_status,
   }));
 }
 
@@ -1515,7 +1535,8 @@ module.exports = {
   // Weekly digest
   getWeeklyDigestData,
   // QURL sends
-  recordQURLSend, recordQURLSendBatch, updateSendDMStatus, getRecentSends, markSendRevoked,
+  recordQURLSend, recordQURLSendBatch, updateSendDMStatus, updateSendDMRefs,
+  getRecentSends, markSendRevoked,
   saveSendConfig, getSendConfig, getSendResourceIds, getSendItems,
   // Guild configs
   getGuildApiKey, setGuildApiKey, removeGuildApiKey, getGuildConfig, getGuildConfigWithApiKey,

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -40,19 +40,24 @@ const STRIP_RE = new RegExp(
   'g',
 );
 
+// Last-resort display-name fallback. Centralized so the
+// resolveSenderAlias chain, sanitizeDisplayName, and the
+// defensive default in revokeAllLinks all agree on one literal.
+const DISPLAY_NAME_FALLBACK = 'Someone';
+
 // `maxCodepoints` defaults to 64 (display-name budget). Larger
 // surfaces (locationName, attachment.name → 256) pass their own
 // cap; the strip + NFKC + codepoint-slice contract is identical.
-// Empty / undefined input returns the 'Someone' fallback for the
+// Empty / undefined input returns the display-name fallback for the
 // display-name caller; surface-specific callers should branch on
-// the empty case themselves rather than render "Someone".
+// the empty case themselves rather than render the fallback.
 function stripControlAndBidi(s, maxCodepoints = 64) {
-  const cleaned = String(s ?? 'Someone').normalize('NFKC').replace(STRIP_RE, '');
+  const cleaned = String(s ?? DISPLAY_NAME_FALLBACK).normalize('NFKC').replace(STRIP_RE, '');
   // Codepoint-aware slice. `String.prototype.slice` operates on UTF-16
   // code units, so a cap on a name like `'A'.repeat(63) + emoji`
   // would split a surrogate pair and Discord would render the lone high
   // surrogate as tofu. `Array.from(str)` iterates by codepoint.
-  return Array.from(cleaned).slice(0, maxCodepoints).join('') || 'Someone';
+  return Array.from(cleaned).slice(0, maxCodepoints).join('') || DISPLAY_NAME_FALLBACK;
 }
 
 /**
@@ -97,7 +102,7 @@ function sanitizeContentLabel(s, maxCodepoints = 256) {
  * cannot be truncated mid-pair into a single backslash.
  */
 function sanitizeDisplayName(s) {
-  return escapeDiscordMarkdown(stripControlAndBidi(s)) || 'Someone';
+  return escapeDiscordMarkdown(stripControlAndBidi(s)) || DISPLAY_NAME_FALLBACK;
 }
 
 /**
@@ -127,4 +132,12 @@ function stripBidiAndControls(s) {
   return String(s ?? '').normalize('NFKC').replace(STRIP_RE, '');
 }
 
-module.exports = { sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls };
+module.exports = {
+  DISPLAY_NAME_FALLBACK,
+  sanitizeFilename,
+  escapeDiscordMarkdown,
+  sanitizeDisplayName,
+  sanitizeDisplayNamePlain,
+  sanitizeContentLabel,
+  stripBidiAndControls,
+};

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -134,7 +134,7 @@ jest.mock('../src/qurl', () => ({
 jest.mock('../src/connector', () => ({ uploadJsonToConnector: jest.fn() }));
 
 const { _test } = require('../src/commands');
-const { buildDeliveryPayload, resolveSenderAlias } = _test;
+const { buildDeliveryPayload, buildRevokedDMPayload, resolveSenderAlias } = _test;
 
 const baseArgs = {
   qurlLink: 'https://qurl.link/#at_test',
@@ -514,5 +514,29 @@ describe('resolveSenderAlias — fallback chain', () => {
     expect(resolveSenderAlias({ member: null, user: null })).toBe('Someone');
     expect(resolveSenderAlias(null)).toBe('Someone');
     expect(resolveSenderAlias(undefined)).toBe('Someone');
+  });
+});
+
+describe('buildRevokedDMPayload — post-revoke recipient-side render', () => {
+  it('renders the "closed the door" embed with the sender alias bolded', () => {
+    capturedEmbeds.length = 0;
+    buildRevokedDMPayload({ senderAlias: 'Vik' });
+    expect(capturedEmbeds[0]._description).toContain('**Vik** closed the door.');
+    expect(capturedEmbeds[0]._description).toContain('This link is no longer active.');
+  });
+
+  it('passes components: [] explicitly so the Step Through button is cleared on edit', () => {
+    // Discord PATCH /messages does NOT clear unset fields. If this assertion
+    // ever flips to `undefined`, the original Step Through button would
+    // remain live in the recipient's DM after revoke — pointing at a
+    // dead qurl resource.
+    const payload = buildRevokedDMPayload({ senderAlias: 'Vik' });
+    expect(payload.components).toEqual([]);
+  });
+
+  it('strips bidi / zero-width spoof chars from the alias before rendering', () => {
+    capturedEmbeds.length = 0;
+    buildRevokedDMPayload({ senderAlias: '‮Admin' });
+    expect(capturedEmbeds[0]._description).not.toContain('‮');
   });
 });

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -148,6 +148,24 @@ describe('editDM via REST', () => {
     const result = await editDM('c', 'm', { embeds: [], components: [] });
     expect(result).toEqual({ ok: false, expected: false });
   });
+
+  it('marks bare 403 / 404 without a known API code as UNEXPECTED', async () => {
+    // Defense against the cr-flagged scenario: Discord-side bugs,
+    // proxy 404s, and revoked-token 403s shouldn't get the silent
+    // info-level treatment reserved for known operational outcomes.
+    // The API code is the gate; status alone is not.
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('Forbidden'), { status: 403, code: undefined }),
+    );
+    const r403 = await editDM('c', 'm', { embeds: [], components: [] });
+    expect(r403).toEqual({ ok: false, expected: false });
+
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('Not Found'), { status: 404, code: undefined }),
+    );
+    const r404 = await editDM('c', 'm', { embeds: [], components: [] });
+    expect(r404).toEqual({ ok: false, expected: false });
+  });
 });
 
 describe('addRoleToMember via REST', () => {

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -32,6 +32,7 @@ jest.mock('../src/discord', () => {
     post: jest.fn(),
     put: jest.fn(),
     delete: jest.fn(),
+    patch: jest.fn(),
   };
   return {
     client: { rest: mockRestInstance },
@@ -41,12 +42,13 @@ jest.mock('../src/discord', () => {
 
 const restMock = require('../src/discord').__mockRestInstance;
 
-const { rest: exportedRest, sendDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
+const { rest: exportedRest, sendDM, editDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
 
 beforeEach(() => {
   restMock.post.mockReset();
   restMock.put.mockReset();
   restMock.delete.mockReset();
+  restMock.patch.mockReset();
 });
 
 describe('module wiring', () => {
@@ -58,12 +60,12 @@ describe('module wiring', () => {
 });
 
 describe('sendDM via REST', () => {
-  it('creates DM channel then posts message, returns ok:true', async () => {
+  it('creates DM channel then posts message, returns ok:true with channel + message ids', async () => {
     restMock.post
-      .mockResolvedValueOnce({ id: 'channel-1' }) // create channel
-      .mockResolvedValueOnce({}); // post message
+      .mockResolvedValueOnce({ id: 'channel-1' })     // create channel
+      .mockResolvedValueOnce({ id: 'message-1' });    // post message
     const result = await sendDM('user-1', { content: 'hi' });
-    expect(result).toEqual({ ok: true, channelId: 'channel-1' });
+    expect(result).toEqual({ ok: true, channelId: 'channel-1', messageId: 'message-1' });
     expect(restMock.post).toHaveBeenCalledTimes(2);
     // First call: create DM channel — POST /users/@me/channels.
     expect(restMock.post.mock.calls[0][0]).toBe('/users/@me/channels');
@@ -105,6 +107,46 @@ describe('sendDM via REST', () => {
     expect(result.status).toBe(429);
     expect(result.error).toBe('rate limited');
     expect(restMock.post).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('editDM via REST', () => {
+  it('PATCHes the target message in one REST call and returns ok', async () => {
+    restMock.patch.mockResolvedValueOnce(undefined);
+    const payload = { embeds: [{ description: 'closed' }], components: [] };
+    const result = await editDM('channel-1', 'message-1', payload);
+    expect(result).toEqual({ ok: true });
+    expect(restMock.patch).toHaveBeenCalledTimes(1);
+    expect(restMock.patch.mock.calls[0][0]).toBe('/channels/channel-1/messages/message-1');
+    expect(restMock.patch.mock.calls[0][1]).toEqual({ body: payload });
+  });
+
+  it('marks 10008 (Unknown Message — recipient deleted the DM) as expected', async () => {
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('Unknown Message'), { status: 404, code: 10008 }),
+    );
+    const result = await editDM('c', 'm', { embeds: [], components: [] });
+    expect(result).toEqual({ ok: false, expected: true });
+  });
+
+  it.each([
+    ['10003', 10003, 404],  // Unknown Channel
+    ['50001', 50001, 403],  // Missing Access
+    ['50007', 50007, 403],  // Cannot send messages to this user
+  ])('marks %s as expected', async (_name, code, status) => {
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('expected'), { status, code }),
+    );
+    const result = await editDM('c', 'm', { embeds: [], components: [] });
+    expect(result).toEqual({ ok: false, expected: true });
+  });
+
+  it('marks unrecognized errors as unexpected (logged at warn)', async () => {
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('boom'), { status: 500, code: 0 }),
+    );
+    const result = await editDM('c', 'm', { embeds: [], components: [] });
+    expect(result).toEqual({ ok: false, expected: false });
   });
 });
 

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -127,32 +127,42 @@ describe('editDM via REST', () => {
     expect(restMock.patch.mock.calls[0][1]).toEqual({ body: payload });
   });
 
-  it('marks 10008 (Unknown Message — recipient deleted the DM) as expected', async () => {
+  it('marks 10008 (Unknown Message — recipient deleted the DM) as expected and exposes code+reason', async () => {
     restMock.patch.mockRejectedValueOnce(
       Object.assign(new Error('Unknown Message'), { status: 404, code: 10008 }),
     );
     const result = await editDM('c', 'm', { embeds: [], components: [] });
-    expect(result).toEqual({ ok: false, expected: true });
+    expect(result).toEqual({
+      ok: false,
+      expected: true,
+      code: 10008,
+      reason: expect.stringContaining('Unknown Message'),
+    });
   });
 
   it.each([
-    ['10003', 10003, 404],  // Unknown Channel
-    ['50001', 50001, 403],  // Missing Access
-    ['50007', 50007, 403],  // Cannot send messages to this user
-  ])('marks %s as expected', async (_name, code, status) => {
+    ['10003', 10003, 404, 'Unknown Channel'],
+    ['50001', 50001, 403, 'Missing Access'],
+    ['50007', 50007, 403, 'Cannot send messages to this user'],
+  ])('marks %s as expected and surfaces code+reason on the return', async (_name, code, status, descriptionFragment) => {
     restMock.patch.mockRejectedValueOnce(
       Object.assign(new Error('expected'), { status, code }),
     );
     const result = await editDM('c', 'm', { embeds: [], components: [] });
-    expect(result).toEqual({ ok: false, expected: true });
+    expect(result).toEqual({
+      ok: false,
+      expected: true,
+      code,
+      reason: expect.stringContaining(descriptionFragment),
+    });
   });
 
-  it('marks unrecognized errors as unexpected (logged at warn)', async () => {
+  it('marks unrecognized errors as unexpected (logged at warn) — code passes through, reason is undefined', async () => {
     restMock.patch.mockRejectedValueOnce(
       Object.assign(new Error('boom'), { status: 500, code: 0 }),
     );
     const result = await editDM('c', 'm', { embeds: [], components: [] });
-    expect(result).toEqual({ ok: false, expected: false });
+    expect(result).toEqual({ ok: false, expected: false, code: 0, reason: undefined });
   });
 
   it('marks bare 403 / 404 without a known API code as UNEXPECTED', async () => {
@@ -164,13 +174,13 @@ describe('editDM via REST', () => {
       Object.assign(new Error('Forbidden'), { status: 403, code: undefined }),
     );
     const r403 = await editDM('c', 'm', { embeds: [], components: [] });
-    expect(r403).toEqual({ ok: false, expected: false });
+    expect(r403).toEqual({ ok: false, expected: false, code: undefined, reason: undefined });
 
     restMock.patch.mockRejectedValueOnce(
       Object.assign(new Error('Not Found'), { status: 404, code: undefined }),
     );
     const r404 = await editDM('c', 'm', { embeds: [], components: [] });
-    expect(r404).toEqual({ ok: false, expected: false });
+    expect(r404).toEqual({ ok: false, expected: false, code: undefined, reason: undefined });
   });
 
   it('tags the expected log line with expectedReason for greppability', async () => {

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -163,6 +163,39 @@ describe('editDM via REST', () => {
     const r404 = await editDM('c', 'm', { embeds: [], components: [] });
     expect(r404).toEqual({ ok: false, expected: false });
   });
+
+  it('tags the expected log line with expectedReason for greppability', async () => {
+    // Closes the cr-flagged invisibility gap: a future spike in any
+    // single expected code (notably 50007 on PATCH, which isn't
+    // observed today — see #369) should be greppable from CloudWatch
+    // by the human-readable description rather than requiring an
+    // external code lookup.
+    const logger = require('../src/logger');
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('Cannot send messages to this user'), { status: 403, code: 50007 }),
+    );
+    await editDM('c', 'm', { embeds: [], components: [] });
+    expect(logger.info).toHaveBeenCalledWith(
+      'Failed to edit DM',
+      expect.objectContaining({
+        code: 50007,
+        expectedReason: expect.stringContaining('Cannot send messages to this user'),
+      }),
+    );
+    // Unexpected branch must NOT carry the expectedReason field.
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    restMock.patch.mockRejectedValueOnce(
+      Object.assign(new Error('Internal Server Error'), { status: 500, code: 0 }),
+    );
+    await editDM('c', 'm', { embeds: [], components: [] });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to edit DM',
+      expect.not.objectContaining({ expectedReason: expect.anything() }),
+    );
+  });
 });
 
 describe('addRoleToMember via REST', () => {

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -51,10 +51,19 @@ beforeEach(() => {
   restMock.patch.mockReset();
 });
 
-// Each helper-level test implicitly pins the shared-rate-limit-bucket
-// invariant: every helper calls `client.rest.X` (verified via
-// `restMock.post/put/delete/patch.mock.calls`), so they share the
-// same rate-limit bucket as the gateway-cache helpers in discord.js.
+describe('shared rate-limit bucket invariant', () => {
+  it('reads client.rest directly (not a new REST instance) so the bucket state is shared', () => {
+    // Tests below implicitly pin this via `restMock.post/patch/.mock.calls`
+    // assertions — but a future refactor that swaps `client.rest.post(...)`
+    // for `new REST(...).post(...)` would still pass those (the
+    // interception is on `require('../src/discord').client.rest`, not
+    // on the REST constructor). This explicit toBe check fails loudly
+    // on that drift, matching the assertion the removed module-wiring
+    // test previously carried.
+    const { client } = require('../src/discord');
+    expect(client.rest).toBe(restMock);
+  });
+});
 
 describe('sendDM via REST', () => {
   it('creates DM channel then posts message, returns ok:true with channel + message ids', async () => {

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -42,7 +42,7 @@ jest.mock('../src/discord', () => {
 
 const restMock = require('../src/discord').__mockRestInstance;
 
-const { rest: exportedRest, sendDM, editDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
+const { sendDM, editDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
 
 beforeEach(() => {
   restMock.post.mockReset();
@@ -51,13 +51,10 @@ beforeEach(() => {
   restMock.patch.mockReset();
 });
 
-describe('module wiring', () => {
-  it('re-exports the shared client.rest instance (not a new one)', () => {
-    // Sharing the rate-limit bucket state is the whole reason this module
-    // imports client.rest instead of constructing its own REST().
-    expect(exportedRest).toBe(restMock);
-  });
-});
+// Each helper-level test implicitly pins the shared-rate-limit-bucket
+// invariant: every helper calls `client.rest.X` (verified via
+// `restMock.post/put/delete/patch.mock.calls`), so they share the
+// same rate-limit bucket as the gateway-cache helpers in discord.js.
 
 describe('sendDM via REST', () => {
   it('creates DM channel then posts message, returns ok:true with channel + message ids', async () => {

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -51,19 +51,12 @@ beforeEach(() => {
   restMock.patch.mockReset();
 });
 
-describe('shared rate-limit bucket invariant', () => {
-  it('reads client.rest directly (not a new REST instance) so the bucket state is shared', () => {
-    // Tests below implicitly pin this via `restMock.post/patch/.mock.calls`
-    // assertions — but a future refactor that swaps `client.rest.post(...)`
-    // for `new REST(...).post(...)` would still pass those (the
-    // interception is on `require('../src/discord').client.rest`, not
-    // on the REST constructor). This explicit toBe check fails loudly
-    // on that drift, matching the assertion the removed module-wiring
-    // test previously carried.
-    const { client } = require('../src/discord');
-    expect(client.rest).toBe(restMock);
-  });
-});
+// Shared-rate-limit-bucket invariant: every helper reads `client.rest.X`
+// directly (vs. `new REST(...)`) so the bucket state is shared with the
+// gateway-cache helpers in discord.js. The helper-level tests below
+// pin this behaviorally via `restMock.{post,put,delete,patch}.mock.calls`
+// — a future refactor that swapped to `new REST(...)` would not hit the
+// `restMock` interception and the call-count assertions would break.
 
 describe('sendDM via REST', () => {
   it('creates DM channel then posts message, returns ok:true with channel + message ids', async () => {

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -330,30 +330,6 @@ describe('discord module', () => {
     });
   });
 
-  describe('editDM', () => {
-    it('edits the target message and returns ok', async () => {
-      const mockMsg = { edit: jest.fn().mockResolvedValue(undefined) };
-      const mockChannel = {
-        messages: { fetch: jest.fn().mockResolvedValue(mockMsg) },
-      };
-      mockClient.channels = mockClient.channels || {};
-      mockClient.channels.fetch = jest.fn().mockResolvedValue(mockChannel);
-      const payload = { embeds: [{ description: 'closed' }], components: [] };
-      const result = await discord.editDM('c-1', 'm-1', payload);
-      expect(result).toEqual({ ok: true });
-      expect(mockChannel.messages.fetch).toHaveBeenCalledWith('m-1');
-      expect(mockMsg.edit).toHaveBeenCalledWith(payload);
-    });
-
-    it('marks 404 as expected (recipient deleted the message)', async () => {
-      const err = Object.assign(new Error('Unknown Message'), { status: 404, code: 10008 });
-      mockClient.channels = mockClient.channels || {};
-      mockClient.channels.fetch = jest.fn().mockRejectedValue(err);
-      const result = await discord.editDM('c-x', 'm-x', { embeds: [], components: [] });
-      expect(result).toEqual({ ok: false, expected: true });
-    });
-  });
-
   describe('shutdown', () => {
     it('destroys client', () => {
       discord.shutdown();

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -314,17 +314,43 @@ describe('discord module', () => {
   });
 
   describe('sendDM', () => {
-    it('sends DM and returns true', async () => {
-      const mockUser = { send: jest.fn().mockResolvedValue(true) };
+    it('sends DM and returns ok with channel + message ids', async () => {
+      const mockUser = {
+        send: jest.fn().mockResolvedValue({ id: 'm-1', channelId: 'c-1' }),
+      };
       mockClient.users.fetch.mockResolvedValue(mockUser);
       const result = await discord.sendDM('u1', 'Hello');
-      expect(result).toBe(true);
+      expect(result).toEqual({ ok: true, channelId: 'c-1', messageId: 'm-1' });
     });
 
-    it('returns false on error', async () => {
+    it('returns { ok: false } on error', async () => {
       mockClient.users.fetch.mockRejectedValue(new Error('fail'));
       const result = await discord.sendDM('u2', 'Hello');
-      expect(result).toBe(false);
+      expect(result).toEqual({ ok: false });
+    });
+  });
+
+  describe('editDM', () => {
+    it('edits the target message and returns ok', async () => {
+      const mockMsg = { edit: jest.fn().mockResolvedValue(undefined) };
+      const mockChannel = {
+        messages: { fetch: jest.fn().mockResolvedValue(mockMsg) },
+      };
+      mockClient.channels = mockClient.channels || {};
+      mockClient.channels.fetch = jest.fn().mockResolvedValue(mockChannel);
+      const payload = { embeds: [{ description: 'closed' }], components: [] };
+      const result = await discord.editDM('c-1', 'm-1', payload);
+      expect(result).toEqual({ ok: true });
+      expect(mockChannel.messages.fetch).toHaveBeenCalledWith('m-1');
+      expect(mockMsg.edit).toHaveBeenCalledWith(payload);
+    });
+
+    it('marks 404 as expected (recipient deleted the message)', async () => {
+      const err = Object.assign(new Error('Unknown Message'), { status: 404, code: 10008 });
+      mockClient.channels = mockClient.channels || {};
+      mockClient.channels.fetch = jest.fn().mockRejectedValue(err);
+      const result = await discord.editDM('c-x', 'm-x', { embeds: [], components: [] });
+      expect(result).toEqual({ ok: false, expected: true });
     });
   });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -853,6 +853,31 @@ describe('revokeAllLinks', () => {
       expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-ok', 'm-ok']);
     });
 
+    it('does NOT edit the DM of a mixed-outcome recipient (one of their resources failed to revoke)', async () => {
+      // Within one recipient: two resources, one DELETE succeeds + one
+      // DELETE fails. Pins that the mixed-outcome recipient lands in
+      // failureUserIds (not successUserIds) AND that editDM is NOT
+      // called for them — the door isn't fully closed, so the
+      // "closed the door" copy would be misleading. Companion to the
+      // bucket-level `failure-wins` test above.
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-a', recipient_discord_id: 'mixed', dm_status: 'sent', dm_channel_id: 'c-mixed', dm_message_id: 'm-mixed' },
+        { resource_id: 'res-b', recipient_discord_id: 'mixed', dm_status: 'sent', dm_channel_id: 'c-mixed', dm_message_id: 'm-mixed' },
+        { resource_id: 'res-c', recipient_discord_id: 'clean', dm_status: 'sent', dm_channel_id: 'c-clean', dm_message_id: 'm-clean' },
+      ]);
+      mockDeleteLink
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('already opened'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await revokeAllLinks('send-mixed-within', 'sender-1', 'apikey', 'Alice');
+
+      expect(result.successUserIds).toEqual(['clean']);
+      expect(result.failureUserIds).toEqual(['mixed']);
+      expect(mockEditDM).toHaveBeenCalledTimes(1);
+      expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-clean', 'm-clean']);
+    });
+
     it('emits no edit log when every strict-success row is legacy (no editable targets)', async () => {
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-a', recipient_discord_id: 'u-a', dm_status: 'sent' }, // legacy, no refs
@@ -978,6 +1003,7 @@ describe('persistDispatchResult — divergence guard', () => {
     mockDb.markSendDMDelivered.mockClear();
     mockDb.updateSendDMStatus.mockClear();
     logger.warn.mockClear();
+    logger.audit.mockClear();
   });
 
   it('happy path: writes markSendDMDelivered with both refs', async () => {
@@ -985,20 +1011,23 @@ describe('persistDispatchResult — divergence guard', () => {
     expect(mockDb.markSendDMDelivered).toHaveBeenCalledWith('s', 'r', 'c', 'm');
     expect(mockDb.updateSendDMStatus).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.audit).not.toHaveBeenCalledWith('dispatch_sent_no_refs', expect.anything());
   });
 
-  it('plain failure: writes FAILED without warning', async () => {
+  it('plain failure: writes FAILED without warning or divergence audit', async () => {
     await persistDispatchResult('s', 'r', { ok: false });
     expect(mockDb.markSendDMDelivered).not.toHaveBeenCalled();
     expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'failed');
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.audit).not.toHaveBeenCalledWith('dispatch_sent_no_refs', expect.anything());
   });
 
-  it('warns + records FAILED when sendDM resolves ok but refs are missing (future regression catch)', async () => {
+  it('emits DISPATCH_SENT_NO_REFS + warns + records FAILED on ok-but-missing-refs divergence', async () => {
     // discord.js's user.send() resolves to a Message with channelId/id;
-    // if that contract ever drifts we'd silently fire DISPATCH_SENT
-    // while DDB records `failed`. The warn here surfaces the divergence
-    // for log-based alerting without changing recorded state.
+    // if that contract drifts, DISPATCH_SENT would fire while DDB
+    // records `failed`. The dedicated dispatch_sent_no_refs audit event
+    // makes the divergence queryable from CloudWatch so dashboards can
+    // reconcile against DDB without a mystery gap.
     await persistDispatchResult('s', 'r', { ok: true });
     expect(mockDb.markSendDMDelivered).not.toHaveBeenCalled();
     expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'failed');
@@ -1006,6 +1035,7 @@ describe('persistDispatchResult — divergence guard', () => {
       expect.stringContaining('missing channelId/messageId'),
       expect.objectContaining({ sendId: 's', recipientDiscordId: 'r' }),
     );
+    expect(logger.audit).toHaveBeenCalledWith('dispatch_sent_no_refs', { send_id: 's' });
   });
 });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -878,7 +878,7 @@ describe('revokeAllLinks', () => {
       expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-clean', 'm-clean']);
     });
 
-    it('emits no edit log when every strict-success row is legacy (no editable targets)', async () => {
+    it('emits debug silent-skip log + no info edit log when every strict-success row is legacy', async () => {
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-a', recipient_discord_id: 'u-a', dm_status: 'sent' }, // legacy, no refs
         { resource_id: 'res-b', recipient_discord_id: 'u-b', dm_status: 'sent' }, // legacy, no refs
@@ -888,11 +888,17 @@ describe('revokeAllLinks', () => {
       await revokeAllLinks('send-all-legacy', 'sender-1', 'apikey', 'Alice');
 
       expect(mockEditDM).not.toHaveBeenCalled();
-      // Skip the "Edited DMs after revoke" log entirely when there's
-      // nothing to edit — keeps CloudWatch alerts from interpreting
-      // attempted=0 as a noteworthy event.
+      // Skip the "Edited DMs after revoke" info log entirely when
+      // there's nothing to edit — keeps CloudWatch alerts from
+      // interpreting attempted=0 as a noteworthy event.
       const editedLog = logger.info.mock.calls.find(c => c[0] === 'Edited DMs after revoke');
       expect(editedLog).toBeUndefined();
+      // Debug-level silent-skip log surfaces the SQLite local-dev path
+      // (where DM refs aren't persisted) so devs don't chase a phantom
+      // bug. Doesn't fire in prod by default.
+      const skipLog = logger.debug.mock.calls.find(c => c[0] === 'Revoke succeeded but no editable DM targets');
+      expect(skipLog).toBeTruthy();
+      expect(skipLog[1]).toMatchObject({ sendId: 'send-all-legacy', revoke_success: 2 });
     });
 
     it('skips rows with no stored DM refs (legacy sends predating the wire-up)', async () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1022,18 +1022,27 @@ describe('persistDispatchResult — divergence guard', () => {
     expect(logger.audit).not.toHaveBeenCalledWith('dispatch_sent_no_refs', expect.anything());
   });
 
-  it('emits DISPATCH_SENT_NO_REFS + warns + records FAILED on ok-but-missing-refs divergence', async () => {
-    // discord.js's user.send() resolves to a Message with channelId/id;
-    // if that contract drifts, DISPATCH_SENT would fire while DDB
-    // records `failed`. The dedicated dispatch_sent_no_refs audit event
-    // makes the divergence queryable from CloudWatch so dashboards can
-    // reconcile against DDB without a mystery gap.
+  it('records SENT + emits DISPATCH_SENT_NO_REFS + warns on ok-but-missing-refs divergence', async () => {
+    // The DM was actually delivered (sendDM said ok), so DDB records
+    // SENT to keep delivery-rate metrics faithful. The dedicated
+    // dispatch_sent_no_refs audit event is the canary if discord.js's
+    // user.send() response shape ever drifts; the revoke path's
+    // missing-refs guard naturally skips the DM edit for these rows.
     await persistDispatchResult('s', 'r', { ok: true });
     expect(mockDb.markSendDMDelivered).not.toHaveBeenCalled();
-    expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'failed');
+    expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'sent');
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('missing channelId/messageId'),
-      expect.objectContaining({ sendId: 's', recipientDiscordId: 'r' }),
+      // hasChannelId / hasMessageId pinned so a future refactor that
+      // drops the diagnostic fields fails loudly — they're the only
+      // way for an operator to tell which side of the response shape
+      // drifted.
+      expect.objectContaining({
+        sendId: 's',
+        recipientDiscordId: 'r',
+        hasChannelId: false,
+        hasMessageId: false,
+      }),
     );
     expect(logger.audit).toHaveBeenCalledWith('dispatch_sent_no_refs', { send_id: 's' });
   });

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -228,6 +228,7 @@ const {
   mintLinksInBatches,
   activeMonitors,
   executeSendPipeline,
+  persistDispatchResult,
 } = _test;
 
 // ---------------------------------------------------------------------------
@@ -890,21 +891,42 @@ describe('revokeAllLinks', () => {
       expect(result.total).toBe(1);
     });
 
-    it('logs split attempted/edited/failed counts when some edits succeed and others fail', async () => {
+    it('logs split attempted/edited/expectedFailures/failed counts', async () => {
+      // Three recipients — one ok, one operational outcome (recipient
+      // deleted DM), one true failure. The split log lets CloudWatch
+      // alert on `failed` without false-positiving on user-side state
+      // changes (`expectedFailures`).
       mockDb.getSendItems.mockResolvedValueOnce([
-        { resource_id: 'res-1', recipient_discord_id: 'u-ok',   dm_status: 'sent', dm_channel_id: 'c-ok',   dm_message_id: 'm-ok' },
-        { resource_id: 'res-2', recipient_discord_id: 'u-fail', dm_status: 'sent', dm_channel_id: 'c-fail', dm_message_id: 'm-fail' },
+        { resource_id: 'res-1', recipient_discord_id: 'u-ok',  dm_status: 'sent', dm_channel_id: 'c-ok',  dm_message_id: 'm-ok' },
+        { resource_id: 'res-2', recipient_discord_id: 'u-exp', dm_status: 'sent', dm_channel_id: 'c-exp', dm_message_id: 'm-exp' },
+        { resource_id: 'res-3', recipient_discord_id: 'u-bad', dm_status: 'sent', dm_channel_id: 'c-bad', dm_message_id: 'm-bad' },
       ]);
       mockDeleteLink.mockResolvedValue(undefined);
       mockEditDM
         .mockResolvedValueOnce({ ok: true })
-        .mockResolvedValueOnce({ ok: false, expected: true });
+        .mockResolvedValueOnce({ ok: false, expected: true })
+        .mockResolvedValueOnce({ ok: false, expected: false });
 
       await revokeAllLinks('send-split-log', 'sender-1', 'apikey', 'Alice');
 
       const logCall = logger.info.mock.calls.find(c => c[0] === 'Edited DMs after revoke');
       expect(logCall).toBeTruthy();
-      expect(logCall[1]).toMatchObject({ attempted: 2, edited: 1, failed: 1 });
+      expect(logCall[1]).toMatchObject({ attempted: 3, edited: 1, expectedFailures: 1, failed: 1 });
+    });
+
+    it('still edits DMs gracefully when senderAlias is omitted (forgotten-4th-arg defense)', async () => {
+      // Production callers always pass resolveSenderAlias(interaction);
+      // this pins the defaulted-param defense so a forgotten arg renders
+      // the recipient-side copy as "Someone closed the door" instead of
+      // throwing or producing "undefined closed the door".
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-no-alias', 'sender-1', 'apikey'); // no senderAlias
+
+      expect(mockEditDM).toHaveBeenCalledTimes(1);
     });
 
     it('de-dupes per recipient when multiple rows share recipient_discord_id', async () => {
@@ -921,6 +943,42 @@ describe('revokeAllLinks', () => {
 
       expect(mockEditDM).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('persistDispatchResult — divergence guard', () => {
+  beforeEach(() => {
+    mockDb.markSendDMDelivered.mockClear();
+    mockDb.updateSendDMStatus.mockClear();
+    logger.warn.mockClear();
+  });
+
+  it('happy path: writes markSendDMDelivered with both refs', async () => {
+    await persistDispatchResult('s', 'r', { ok: true, channelId: 'c', messageId: 'm' });
+    expect(mockDb.markSendDMDelivered).toHaveBeenCalledWith('s', 'r', 'c', 'm');
+    expect(mockDb.updateSendDMStatus).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('plain failure: writes FAILED without warning', async () => {
+    await persistDispatchResult('s', 'r', { ok: false });
+    expect(mockDb.markSendDMDelivered).not.toHaveBeenCalled();
+    expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'failed');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns + records FAILED when sendDM resolves ok but refs are missing (future regression catch)', async () => {
+    // discord.js's user.send() resolves to a Message with channelId/id;
+    // if that contract ever drifts we'd silently fire DISPATCH_SENT
+    // while DDB records `failed`. The warn here surfaces the divergence
+    // for log-based alerting without changing recorded state.
+    await persistDispatchResult('s', 'r', { ok: true });
+    expect(mockDb.markSendDMDelivered).not.toHaveBeenCalled();
+    expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'failed');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('missing channelId/messageId'),
+      expect.objectContaining({ sendId: 's', recipientDiscordId: 'r' }),
+    );
   });
 });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -896,6 +896,28 @@ describe('revokeAllLinks', () => {
       expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-clean', 'm-clean']);
     });
 
+    it('does NOT call editDM when every DELETE threw (success === 0)', async () => {
+      // Pins the `if (success > 0)` guard at the top of the post-
+      // revoke edit block. When every per-resource DELETE fails (e.g.,
+      // the qURL service is fully down), successUserIds is empty and
+      // no recipient has had their link revoked. Editing their DM to
+      // "closed the door" would be a lie.
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-a', recipient_discord_id: 'u-a', dm_status: 'sent', dm_channel_id: 'c-a', dm_message_id: 'm-a' },
+        { resource_id: 'res-b', recipient_discord_id: 'u-b', dm_status: 'sent', dm_channel_id: 'c-b', dm_message_id: 'm-b' },
+      ]);
+      mockDeleteLink.mockRejectedValue(new Error('qURL service down'));
+
+      const result = await revokeAllLinks('send-all-fail', 'sender-1', 'apikey', 'Alice');
+
+      expect(result.success).toBe(0);
+      expect(mockEditDM).not.toHaveBeenCalled();
+      // Also no debug skip-log: the `if (success > 0)` guard short-
+      // circuits before we even try to build editTargets.
+      const skipLog = logger.debug.mock.calls.find(c => c[0] === 'Revoke succeeded but no editable DM targets');
+      expect(skipLog).toBeUndefined();
+    });
+
     it('emits debug silent-skip log + no info edit log when every strict-success row is legacy', async () => {
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-a', recipient_discord_id: 'u-a', dm_status: 'sent' }, // legacy, no refs

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -919,13 +919,21 @@ describe('revokeAllLinks', () => {
       expect(mockEditDM).not.toHaveBeenCalled();
     });
 
-    it('does not affect revoke success/total even when every DM edit fails', async () => {
+    it.each([
+      ['rejection',     () => mockEditDM.mockRejectedValueOnce(new Error('boom'))],
+      ['ok:false',      () => mockEditDM.mockResolvedValueOnce({ ok: false, expected: false })],
+      ['ok:false+exp',  () => mockEditDM.mockResolvedValueOnce({ ok: false, expected: true })],
+    ])('does not affect revoke success/total when DM edit fails as %s', async (_shape, setupMock) => {
+      // Both shapes of edit failure (thrown + soft ok:false return)
+      // and both severities (expected / unexpected) must keep the
+      // revoke success/total counts honest — those track the DELETE,
+      // not the edit, so a recipient-side state change can't poison
+      // the operator-facing tally.
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
       ]);
       mockDeleteLink.mockResolvedValue(undefined);
-      // Both shapes of edit failure: rejection AND ok:false return.
-      mockEditDM.mockRejectedValueOnce(new Error('boom'));
+      setupMock();
 
       const result = await revokeAllLinks('send-edit-fail', 'sender-1', 'apikey', 'Alice');
 
@@ -1022,30 +1030,26 @@ describe('persistDispatchResult — divergence guard', () => {
     expect(logger.audit).not.toHaveBeenCalledWith('dispatch_sent_no_refs', expect.anything());
   });
 
-  it('records SENT + emits DISPATCH_SENT_NO_REFS + warns on ok-but-missing-refs divergence', async () => {
-    // The DM was actually delivered (sendDM said ok), so DDB records
-    // SENT to keep delivery-rate metrics faithful. The dedicated
-    // dispatch_sent_no_refs audit event is the canary if discord.js's
-    // user.send() response shape ever drifts; the revoke path's
-    // missing-refs guard naturally skips the DM edit for these rows.
-    await persistDispatchResult('s', 'r', { ok: true });
+  it.each([
+    ['only messageId missing', { ok: true, channelId: 'c' },                 false, true ],
+    ['only channelId missing', { ok: true, messageId: 'm' },                 true,  false],
+    ['both missing',           { ok: true },                                  false, false],
+  ])('records SENT + emits DISPATCH_SENT_NO_REFS on divergence (%s)', async (_name, result, hasMessageId, hasChannelId) => {
+    // Asymmetric coverage protects against a future refactor that
+    // flips `&&` to `||` in the persistDispatchResult guard — only
+    // BOTH refs present should land on the happy path.
+    await persistDispatchResult('s', 'r', result);
     expect(mockDb.markSendDMDelivered).not.toHaveBeenCalled();
     expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('s', 'r', 'sent');
+    expect(logger.audit).toHaveBeenCalledWith('dispatch_sent_no_refs', { send_id: 's' });
+    // Diagnostic fields tell the operator which side of the response
+    // shape drifted.
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('missing channelId/messageId'),
-      // hasChannelId / hasMessageId pinned so a future refactor that
-      // drops the diagnostic fields fails loudly — they're the only
-      // way for an operator to tell which side of the response shape
-      // drifted.
-      expect.objectContaining({
-        sendId: 's',
-        recipientDiscordId: 'r',
-        hasChannelId: false,
-        hasMessageId: false,
-      }),
+      expect.objectContaining({ hasChannelId, hasMessageId }),
     );
-    expect(logger.audit).toHaveBeenCalledWith('dispatch_sent_no_refs', { send_id: 's' });
   });
+
 });
 
 describe('renderSendConfirm — post-send confirmation overflow', () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -132,7 +132,7 @@ jest.mock('discord.js', () => {
 const mockDb = {
   recordQURLSendBatch: jest.fn(),
   updateSendDMStatus: jest.fn(),
-  updateSendDMRefs: jest.fn(),
+  markSendDMDelivered: jest.fn(),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   getSendItems: jest.fn(() => []),
@@ -153,6 +153,8 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
+}));
+jest.mock('../src/discord-rest', () => ({
   editDM: mockEditDM,
 }));
 
@@ -874,17 +876,6 @@ describe('revokeAllLinks', () => {
       expect(mockEditDM).not.toHaveBeenCalled();
     });
 
-    it('does not edit any DM when senderAlias is omitted (back-compat — legacy callers)', async () => {
-      mockDb.getSendItems.mockResolvedValueOnce([
-        { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
-      ]);
-      mockDeleteLink.mockResolvedValue(undefined);
-
-      await revokeAllLinks('send-noalias', 'sender-1', 'apikey'); // no senderAlias
-
-      expect(mockEditDM).not.toHaveBeenCalled();
-    });
-
     it('does not affect revoke success/total even when every DM edit fails', async () => {
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
@@ -897,6 +888,23 @@ describe('revokeAllLinks', () => {
 
       expect(result.success).toBe(1);
       expect(result.total).toBe(1);
+    });
+
+    it('logs split attempted/edited/failed counts when some edits succeed and others fail', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-1', recipient_discord_id: 'u-ok',   dm_status: 'sent', dm_channel_id: 'c-ok',   dm_message_id: 'm-ok' },
+        { resource_id: 'res-2', recipient_discord_id: 'u-fail', dm_status: 'sent', dm_channel_id: 'c-fail', dm_message_id: 'm-fail' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+      mockEditDM
+        .mockResolvedValueOnce({ ok: true })
+        .mockResolvedValueOnce({ ok: false, expected: true });
+
+      await revokeAllLinks('send-split-log', 'sender-1', 'apikey', 'Alice');
+
+      const logCall = logger.info.mock.calls.find(c => c[0] === 'Edited DMs after revoke');
+      expect(logCall).toBeTruthy();
+      expect(logCall[1]).toMatchObject({ attempted: 2, edited: 1, failed: 1 });
     });
 
     it('de-dupes per recipient when multiple rows share recipient_discord_id', async () => {
@@ -1516,8 +1524,9 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(result.failed).toBe(0);
     expect(result.msg).toMatch(/Added 2 recipients/);
     expect(result.newResourceIds).toEqual(expect.arrayContaining(['res-loc-new']));
-    // updateSendDMStatus called once per recipient with SENT.
-    expect(mockDb.updateSendDMStatus).toHaveBeenCalledTimes(2);
+    // Happy-path delivery coalesces status='sent' + DM refs into a
+    // single markSendDMDelivered write per recipient.
+    expect(mockDb.markSendDMDelivered).toHaveBeenCalledTimes(2);
     // Audit emission: upload_success + dispatch_sent (×2 recipients).
     // mint_* is intentionally not emitted from the bot — see
     // constants.js AUDIT_EVENTS comment.

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -132,6 +132,7 @@ jest.mock('discord.js', () => {
 const mockDb = {
   recordQURLSendBatch: jest.fn(),
   updateSendDMStatus: jest.fn(),
+  updateSendDMRefs: jest.fn(),
   getRecentSends: jest.fn(() => []),
   getSendResourceIds: jest.fn(() => []),
   getSendItems: jest.fn(() => []),
@@ -141,7 +142,8 @@ const mockDb = {
 };
 jest.mock('../src/database', () => mockDb);
 
-const mockSendDM = jest.fn().mockResolvedValue(true);
+const mockSendDM = jest.fn().mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+const mockEditDM = jest.fn().mockResolvedValue({ ok: true });
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
   notifyPRMerge: jest.fn(),
@@ -151,6 +153,7 @@ jest.mock('../src/discord', () => ({
   postStarMilestone: jest.fn(),
   postToGitHubFeed: jest.fn(),
   sendDM: mockSendDM,
+  editDM: mockEditDM,
 }));
 
 jest.mock('../src/utils/admin', () => ({
@@ -801,6 +804,116 @@ describe('revokeAllLinks', () => {
     expect(result.successUserIds).toEqual(['bob']);
     expect(result.failureUserIds).toEqual(['alice']);
   });
+
+  describe('post-revoke DM edit', () => {
+    beforeEach(() => {
+      mockEditDM.mockClear();
+      mockEditDM.mockResolvedValue({ ok: true });
+    });
+
+    it('edits the DM of every strict-success recipient with stored channel + message ids', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
+        { resource_id: 'res-2', recipient_discord_id: 'u-2', dm_status: 'sent', dm_channel_id: 'c-2', dm_message_id: 'm-2' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-edit', 'sender-1', 'apikey', 'Alice');
+
+      expect(mockEditDM).toHaveBeenCalledTimes(2);
+      const calls = mockEditDM.mock.calls.map(c => [c[0], c[1]]).sort();
+      expect(calls).toEqual([['c-1', 'm-1'], ['c-2', 'm-2']]);
+      // Edit payload MUST include components: [] so the original Step
+      // Through button is cleared — Discord doesn't drop unset fields
+      // on PATCH /messages, so omitting this would leave the live link
+      // button in the recipient's DM after revoke. Embed copy is
+      // exercised by build-delivery-embed.test.js's buildRevokedDMPayload
+      // suite (where the mock captures setDescription).
+      const payload = mockEditDM.mock.calls[0][2];
+      expect(payload.components).toEqual([]);
+      expect(payload.embeds).toHaveLength(1);
+    });
+
+    it('skips recipients whose revoke failed (link was already opened)', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-ok',   recipient_discord_id: 'u-ok',   dm_status: 'sent', dm_channel_id: 'c-ok',   dm_message_id: 'm-ok' },
+        { resource_id: 'res-fail', recipient_discord_id: 'u-fail', dm_status: 'sent', dm_channel_id: 'c-fail', dm_message_id: 'm-fail' },
+      ]);
+      mockDeleteLink
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('already opened'));
+
+      await revokeAllLinks('send-partial', 'sender-1', 'apikey', 'Alice');
+
+      // Only the strict-success recipient gets the DM edit.
+      expect(mockEditDM).toHaveBeenCalledTimes(1);
+      expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-ok', 'm-ok']);
+    });
+
+    it('skips rows with no stored DM refs (legacy sends predating the wire-up)', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-new',    recipient_discord_id: 'u-new',    dm_status: 'sent', dm_channel_id: 'c-new', dm_message_id: 'm-new' },
+        { resource_id: 'res-legacy', recipient_discord_id: 'u-legacy', dm_status: 'sent' }, // no channel / message id
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-legacy', 'sender-1', 'apikey', 'Alice');
+
+      expect(mockEditDM).toHaveBeenCalledTimes(1);
+      expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-new', 'm-new']);
+    });
+
+    it('skips rows where the DM never delivered (dm_status !== sent)', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-failed', recipient_discord_id: 'u-failed', dm_status: 'failed', dm_channel_id: 'c-x', dm_message_id: 'm-x' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-nodm', 'sender-1', 'apikey', 'Alice');
+
+      expect(mockEditDM).not.toHaveBeenCalled();
+    });
+
+    it('does not edit any DM when senderAlias is omitted (back-compat — legacy callers)', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-noalias', 'sender-1', 'apikey'); // no senderAlias
+
+      expect(mockEditDM).not.toHaveBeenCalled();
+    });
+
+    it('does not affect revoke success/total even when every DM edit fails', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+      // Both shapes of edit failure: rejection AND ok:false return.
+      mockEditDM.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await revokeAllLinks('send-edit-fail', 'sender-1', 'apikey', 'Alice');
+
+      expect(result.success).toBe(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('de-dupes per recipient when multiple rows share recipient_discord_id', async () => {
+      // SQLite has no UNIQUE constraint on (send_id, recipient_discord_id);
+      // a hypothetical multi-resource fan-out to one recipient would yield
+      // multiple rows. The DM edit should fire ONCE per recipient.
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
+        { resource_id: 'res-2', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-dup', 'sender-1', 'apikey', 'Alice');
+
+      expect(mockEditDM).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('renderSendConfirm — post-send confirmation overflow', () => {
@@ -1388,7 +1501,7 @@ describe('handleAddRecipients — happy path (location)', () => {
       { qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' },
       { qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' },
     ]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
     mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
 
     const result = await handleAddRecipients(
@@ -1438,7 +1551,7 @@ describe('handleAddRecipients — happy path (location)', () => {
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/loc', resource_id: 'res-loc-new' }]);
     // Location path succeeds.
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     await handleAddRecipients(
       'send-mixed', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
@@ -1461,7 +1574,8 @@ describe('handleAddRecipients — happy path (location)', () => {
       { qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' },
     ]);
     // First DM fails, second succeeds.
-    mockSendDM.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockSendDM.mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true, channelId: 'dm-c-2', messageId: 'dm-m-2' });
     mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
 
     const result = await handleAddRecipients(

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -743,6 +743,24 @@ describe('revokeAllLinks', () => {
     expect(events).not.toContain('revoke_failed');
   });
 
+  it('propagates a getSendItems failure to the caller (no DELETE attempted, no audit emitted)', async () => {
+    // DDB outage during getSendItems means the function can't safely
+    // run revokes (no items to iterate) — propagate the error so the
+    // button-click handler surfaces a generic failure to the operator
+    // rather than reporting 0/0 success. Pinned for symmetry with the
+    // other "DDB throws" cases inside persistDispatchResult.
+    mockDb.getSendItems.mockRejectedValueOnce(new Error('DDB throttled'));
+
+    await expect(
+      revokeAllLinks('send-throw', 'sender-1', 'apikey'),
+    ).rejects.toThrow('DDB throttled');
+
+    expect(mockDeleteLink).not.toHaveBeenCalled();
+    const events = logger.audit.mock.calls.map(c => c[0]);
+    expect(events).not.toContain('revoke_success');
+    expect(events).not.toContain('revoke_failed');
+  });
+
   // mintLinksInBatches packs up to TOKENS_PER_RESOURCE recipients onto
   // a single resource_id. Without grouping, the 2nd…Nth DELETE for a
   // shared resource throws 404 and would mis-classify N-1 recipients

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -853,6 +853,23 @@ describe('revokeAllLinks', () => {
       expect(mockEditDM.mock.calls[0].slice(0, 2)).toEqual(['c-ok', 'm-ok']);
     });
 
+    it('emits no edit log when every strict-success row is legacy (no editable targets)', async () => {
+      mockDb.getSendItems.mockResolvedValueOnce([
+        { resource_id: 'res-a', recipient_discord_id: 'u-a', dm_status: 'sent' }, // legacy, no refs
+        { resource_id: 'res-b', recipient_discord_id: 'u-b', dm_status: 'sent' }, // legacy, no refs
+      ]);
+      mockDeleteLink.mockResolvedValue(undefined);
+
+      await revokeAllLinks('send-all-legacy', 'sender-1', 'apikey', 'Alice');
+
+      expect(mockEditDM).not.toHaveBeenCalled();
+      // Skip the "Edited DMs after revoke" log entirely when there's
+      // nothing to edit — keeps CloudWatch alerts from interpreting
+      // attempted=0 as a noteworthy event.
+      const editedLog = logger.info.mock.calls.find(c => c[0] === 'Edited DMs after revoke');
+      expect(editedLog).toBeUndefined();
+    });
+
     it('skips rows with no stored DM refs (legacy sends predating the wire-up)', async () => {
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-new',    recipient_discord_id: 'u-new',    dm_status: 'sent', dm_channel_id: 'c-new', dm_message_id: 'm-new' },
@@ -914,11 +931,10 @@ describe('revokeAllLinks', () => {
       expect(logCall[1]).toMatchObject({ attempted: 3, edited: 1, expectedFailures: 1, failed: 1 });
     });
 
-    it('still edits DMs gracefully when senderAlias is omitted (forgotten-4th-arg defense)', async () => {
+    it('renders the fallback alias when senderAlias is omitted (forgotten-4th-arg defense)', async () => {
       // Production callers always pass resolveSenderAlias(interaction);
-      // this pins the defaulted-param defense so a forgotten arg renders
-      // the recipient-side copy as "Someone closed the door" instead of
-      // throwing or producing "undefined closed the door".
+      // pin the defaulted-param defense so a forgotten arg renders
+      // "Someone closed the door" instead of "undefined closed the door".
       mockDb.getSendItems.mockResolvedValueOnce([
         { resource_id: 'res-1', recipient_discord_id: 'u-1', dm_status: 'sent', dm_channel_id: 'c-1', dm_message_id: 'm-1' },
       ]);
@@ -927,6 +943,17 @@ describe('revokeAllLinks', () => {
       await revokeAllLinks('send-no-alias', 'sender-1', 'apikey'); // no senderAlias
 
       expect(mockEditDM).toHaveBeenCalledTimes(1);
+      // The Embed mock chains via setDescription returning `this`, so
+      // the rendered description lives on the captured mock — verify
+      // the fallback string actually lands in the embed.
+      const payload = mockEditDM.mock.calls[0][2];
+      expect(payload.embeds).toHaveLength(1);
+      // EmbedBuilder mock in this test only chains; assert via the
+      // setDescription spy on the captured embed instance.
+      const embed = payload.embeds[0];
+      const setDescCall = embed.setDescription.mock?.calls?.[0]?.[0];
+      expect(setDescCall).toBeTruthy();
+      expect(setDescCall).toMatch(/\*\*Someone\*\* closed the door/);
     });
 
     it('de-dupes per recipient when multiple rows share recipient_discord_id', async () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1009,9 +1009,12 @@ describe('revokeAllLinks', () => {
 describe('persistDispatchResult — divergence guard', () => {
   beforeEach(() => {
     mockDb.markSendDMDelivered.mockClear();
+    mockDb.markSendDMDelivered.mockResolvedValue(undefined);
     mockDb.updateSendDMStatus.mockClear();
+    mockDb.updateSendDMStatus.mockResolvedValue(undefined);
     logger.warn.mockClear();
     logger.audit.mockClear();
+    logger.error.mockClear();
   });
 
   it('happy path: writes markSendDMDelivered with both refs', async () => {
@@ -1050,6 +1053,53 @@ describe('persistDispatchResult — divergence guard', () => {
     );
   });
 
+  it('does NOT throw when markSendDMDelivered fails — emits DISPATCH_PERSIST_FAILED + logs error', async () => {
+    // The DM was actually delivered. A bookkeeping failure here must
+    // not propagate up as a thrown rejection — the dispatch lambda
+    // would otherwise classify the recipient as "could not be reached"
+    // even though the DM landed in their inbox. Closes the cr-flagged
+    // gap where a wider markSendDMDelivered Update widens the
+    // ValidationException surface.
+    mockDb.markSendDMDelivered.mockRejectedValueOnce(new Error('throttled'));
+    await expect(
+      persistDispatchResult('s', 'r', { ok: true, channelId: 'c', messageId: 'm' }),
+    ).resolves.toBeUndefined();
+    expect(logger.audit).toHaveBeenCalledWith('dispatch_persist_failed', { send_id: 's' });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('qurl_sends write failed'),
+      expect.objectContaining({ sendId: 's', recipientDiscordId: 'r', delivered: true }),
+    );
+  });
+
+  it('emits DISPATCH_PERSIST_FAILED when divergence-branch updateSendDMStatus fails (canary survives DDB outage)', async () => {
+    // Cycle-7 ordering moved the audit AFTER the DDB write; cycle-8
+    // cr flagged that this masks the discord.js shape-drift canary
+    // during a DDB outage. Audit + warn now fire BEFORE the persist
+    // (canary preserved), and DISPATCH_PERSIST_FAILED fires alongside
+    // when the persist also fails.
+    mockDb.updateSendDMStatus.mockRejectedValueOnce(new Error('throttled'));
+    await expect(
+      persistDispatchResult('s', 'r', { ok: true }),
+    ).resolves.toBeUndefined();
+    expect(logger.audit).toHaveBeenCalledWith('dispatch_sent_no_refs', { send_id: 's' });
+    expect(logger.audit).toHaveBeenCalledWith('dispatch_persist_failed', { send_id: 's' });
+  });
+
+  it('does NOT emit DISPATCH_PERSIST_FAILED when the FAILED-status write fails (no delivered DM)', async () => {
+    // sendDM said failed; no DM exists. A bookkeeping miss here is a
+    // dropped status update, not a real-vs-recorded divergence. Log
+    // an error for grep-ability but skip the canary event so it
+    // stays a high-signal indicator of "delivered but not recorded."
+    mockDb.updateSendDMStatus.mockRejectedValueOnce(new Error('throttled'));
+    await expect(
+      persistDispatchResult('s', 'r', { ok: false }),
+    ).resolves.toBeUndefined();
+    expect(logger.audit).not.toHaveBeenCalledWith('dispatch_persist_failed', expect.anything());
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('qurl_sends write failed'),
+      expect.objectContaining({ sendId: 's', recipientDiscordId: 'r', delivered: false }),
+    );
+  });
 });
 
 describe('renderSendConfirm — post-send confirmation overflow', () => {

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -111,6 +111,7 @@ jest.mock('../src/database', () => {
     recordQURLSend: jest.fn(),
     recordQURLSendBatch: jest.fn(),
     updateSendDMStatus: jest.fn(),
+    updateSendDMRefs: jest.fn(),
     getRecentSends: jest.fn(() => []),
     getSendResourceIds: jest.fn(() => []),
     saveSendConfig: jest.fn(),
@@ -1421,13 +1422,14 @@ describe('handleAddRecipients', () => {
       recordQURLSend: jest.fn(),
       recordQURLSendBatch: jest.fn(),
       updateSendDMStatus: jest.fn(),
+      updateSendDMRefs: jest.fn(),
       getRecentSends: jest.fn(() => []),
       getSendResourceIds: jest.fn(() => []),
     };
     jest.mock('../src/database', () => mockDb);
 
     // Mock discord helper
-    mockSendDM = jest.fn().mockResolvedValue(true);
+    mockSendDM = jest.fn().mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
     jest.mock('../src/discord', () => ({
       assignContributorRole: jest.fn(),
       notifyPRMerge: jest.fn(),
@@ -1437,6 +1439,7 @@ describe('handleAddRecipients', () => {
       postStarMilestone: jest.fn(),
       postToGitHubFeed: jest.fn(),
       sendDM: mockSendDM,
+      editDM: jest.fn().mockResolvedValue({ ok: true }),
     }));
 
     // Mock admin util
@@ -1591,7 +1594,7 @@ describe('handleAddRecipients', () => {
       { qurl_link: 'https://q.test/mint-2' },
     ]);
 
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1642,7 +1645,7 @@ describe('handleAddRecipients', () => {
     });
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'conn-res-44', fileBuffer: new ArrayBuffer(8) });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/mint-3' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-3', bot: false, username: 'Carol' },
@@ -1675,7 +1678,7 @@ describe('handleAddRecipients', () => {
       hash: 'loc-hash',
     });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/otl-1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Charlie' },
@@ -1710,7 +1713,7 @@ describe('handleAddRecipients', () => {
     });
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'res-loc-2', hash: 'loc-hash' });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/otl-2' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-2', bot: false, username: 'Dave' },
@@ -1743,7 +1746,7 @@ describe('handleAddRecipients', () => {
       success: true,
     });
     mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/maps-1' }]);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Dana' },
@@ -1781,8 +1784,8 @@ describe('handleAddRecipients', () => {
 
     // First DM succeeds, second fails
     mockSendDM
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+      .mockResolvedValueOnce({ ok: true, channelId: 'dm-c-1', messageId: 'dm-m-1' })
+      .mockResolvedValueOnce({ ok: false });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1833,7 +1836,7 @@ describe('handleAddRecipients', () => {
       { qurl_link: 'https://q.test/link2' },
     ]);
 
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1904,7 +1907,7 @@ describe('handleAddRecipients', () => {
       .mockResolvedValueOnce(batch1Links)
       .mockResolvedValueOnce(batch2Links);
 
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection(userList);
     const result = await handleAddRecipients('send-batch', users, mockOriginalInteraction, 'test-api-key');
@@ -1938,7 +1941,7 @@ describe('handleAddRecipients', () => {
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res-C', fileBuffer: new ArrayBuffer(8) });
     const links = Array.from({ length: 8 }, (_, i) => ({ qurl_link: `https://q.test/l-${i}` }));
     mockMintLinks.mockResolvedValueOnce(links);
-    mockSendDM.mockResolvedValue(true);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection(userList);
     const result = await handleAddRecipients('send-ok', users, mockOriginalInteraction, 'test-api-key');

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -111,7 +111,7 @@ jest.mock('../src/database', () => {
     recordQURLSend: jest.fn(),
     recordQURLSendBatch: jest.fn(),
     updateSendDMStatus: jest.fn(),
-    updateSendDMRefs: jest.fn(),
+    markSendDMDelivered: jest.fn(),
     getRecentSends: jest.fn(() => []),
     getSendResourceIds: jest.fn(() => []),
     saveSendConfig: jest.fn(),
@@ -1422,7 +1422,7 @@ describe('handleAddRecipients', () => {
       recordQURLSend: jest.fn(),
       recordQURLSendBatch: jest.fn(),
       updateSendDMStatus: jest.fn(),
-      updateSendDMRefs: jest.fn(),
+      markSendDMDelivered: jest.fn(),
       getRecentSends: jest.fn(() => []),
       getSendResourceIds: jest.fn(() => []),
     };
@@ -1439,6 +1439,8 @@ describe('handleAddRecipients', () => {
       postStarMilestone: jest.fn(),
       postToGitHubFeed: jest.fn(),
       sendDM: mockSendDM,
+    }));
+    jest.mock('../src/discord-rest', () => ({
       editDM: jest.fn().mockResolvedValue({ ok: true }),
     }));
 
@@ -1796,7 +1798,9 @@ describe('handleAddRecipients', () => {
 
     expect(result.msg).toMatch(/Added 1 recipient/);
     expect(result.msg).toMatch(/1 could not be reached/);
-    expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('send-partial', 'rcpt-1', 'sent');
+    // Happy path coalesces status='sent' + DM refs into markSendDMDelivered;
+    // failure path keeps the status-only update (no refs to persist).
+    expect(mockDb.markSendDMDelivered).toHaveBeenCalledWith('send-partial', 'rcpt-1', 'dm-c-1', 'dm-m-1');
     expect(mockDb.updateSendDMStatus).toHaveBeenCalledWith('send-partial', 'rcpt-2', 'failed');
   });
 


### PR DESCRIPTION
## Summary

- When a sender revokes a qURL, recipients whose link was successfully revoked (i.e. they hadn't clicked yet) now see their original DM rewritten in place: **🚪 Alice closed the door. This link is no longer active.** — Step Through button stripped.
- Replaces a confusing UX where the recipient was left with a live-looking button that 404s.
- Recipients whose revoke failed (link already opened) and recipients whose DM never delivered are skipped — no spurious edits.

## How

- `sendDM` (gateway + REST) now returns `{ ok, channelId, messageId }`. New `editDM(channelId, messageId, payload)` helper on the REST module (single PATCH via `client.rest.patch(Routes.channelMessage(...))` — no `channels.fetch` / `messages.fetch` preamble on cold cache).
- New `db.markSendDMDelivered(sendId, recipientDiscordId, channelId, messageId)` coalesces `dm_status='sent'` + the DM refs into one DDB Update — hot dispatch path stays at one write per recipient. Wired into `executeSendPipeline` + `handleAddRecipients` via a small `persistDispatchResult` helper.
- `revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias)` edits each strict-success recipient's DM after the per-resource DELETE settles. Errors are bucketed via `batchSettled` and logged as `attempted / edited / expectedFailures / failed`; recipient-side operational outcomes (DM deleted, bot blocked, channel closed) are split out from real surprises so CloudWatch alerts stay honest.
- New `buildRevokedDMPayload({ senderAlias })` passes `components: []` explicitly — Discord's `PATCH /messages` doesn't drop unset fields, so this is load-bearing for clearing the Step Through button.
- Audit metric `DISPATCH_SENT`/`DISPATCH_FAILED` now branches on `result.ok === true` instead of boolean truthiness. New `DISPATCH_SENT_NO_REFS` canary fires (and persists `dm_status='sent'`) if discord.js's `user.send()` ever returns ok without the refs — the revoke loop's missing-refs guard skips the DM edit naturally for those rows.

## Backend scope

Production-only behavior. The DDB store gets the real `markSendDMDelivered` + projects `dm_channel_id`/`dm_message_id`/`dm_status` on `getSendItems`. The SQLite store (local-dev only) gets a stub that still writes `dm_status='sent'` so local delivery-count rollups stay consistent, but does not persist the DM refs — local revokes still succeed, they just skip the recipient-side DM edit.

Legacy rows predating this change (no DM refs stored) silently skip the edit — verified by a dedicated test case.

## Follow-ups

- layervai/qurl-integrations#365 — SQLite `getSendItems` projection wire-up for local-dev DM-edit exercising.
- layervai/qurl-integrations#366 — `attribute_exists(send_id)` ConditionExpression on the qurl_sends UpdateCommand surface.
- layervai/qurl-integrations#367 — `buildRevokedDMPayload` resource-type-aware copy for multi-resource sends.
- layervai/qurl-integrations-infra#917 — CloudWatch alarm on `dispatch_sent_no_refs > 0` (canary for discord.js response-shape drift).

## Test plan

- [x] `npm test` — 1712 pass, 47 suites (14 new tests)
- [x] `npm run lint` — clean
- [ ] Manual: /qurl file → revoke a fresh send → confirm recipient's DM rewrites to "closed the door" and Step Through button is gone
- [ ] Manual: /qurl file → recipient clicks → sender revokes → confirm clicked recipient's DM is unchanged
- [ ] Manual: legacy pre-deploy send → revoke after deploy → confirm revoke still succeeds (DM edit skipped silently)
- [ ] Manual: revoke after recipient blocks the bot → confirm revoke counts unaffected, info-level log only

🤖 Generated with [Claude Code](https://claude.com/claude-code)