### PR TITLE
feat(discord): add @everyone button on /qurl file + /qurl map confirm card

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3859,12 +3859,24 @@ function renderConfirmCardRows({
       displayCount = memberCount;
     }
     const labelCount = displayCount == null ? '?' : String(displayCount);
+    // Disable on both `0` (empty guild — degenerate) AND `null`
+    // (memberCount unavailable + cache cold). The `(?)` label
+    // accompanies the disabled state so the user sees the button can't
+    // act right now rather than getting a silent-no-op click on a
+    // count-less label.
+    //
+    // BOTTOM ROW COMPONENT BUDGET: Discord caps an ActionRow at 5
+    // components. The current worst-case render is
+    // [🔊 Voice] + [📢 @everyone] + Note + Send + Cancel = 5, exactly
+    // at the limit. Adding another button below would silently throw
+    // at discord.js builder time. Re-evaluate the layout (e.g., a
+    // second row for affordances vs. fixed buttons) before adding.
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID)
         .setLabel(`\u{1F4E2} @everyone (${labelCount})`)
         .setStyle(ButtonStyle.Secondary)
-        .setDisabled(displayCount === 0),
+        .setDisabled(displayCount == null || displayCount === 0),
     );
   }
   bottomRow.addComponents(
@@ -5433,12 +5445,34 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   // the bots-only case would surface as "cache not ready" (misleading)
   // instead of "all recipients are bots" (accurate); droppedBots count
   // is also load-bearing for the warning copy.
+  //
+  // NO early break on `selectedUsers.length > cap` (rejected). Such a
+  // break is unsound under bot-clustered iteration order: a 20001-human
+  // guild with bots iterated around the cap boundary would early-exit
+  // before the (cap+1)th HUMAN, producing `valid.length === cap` and
+  // silently bypassing the cap-reject below — the send would proceed
+  // at exactly the cap with the over-cap members invisibly dropped.
+  // Full-cache iteration costs O(cache_size) (~10ms even at 100k),
+  // which is acceptable post-deferUpdate; correctness wins.
+  //
+  // partial-cache rows (member without `.user` — degraded shape from
+  // a partially-loaded `GUILD_MEMBERS_CHUNK`) are silently filtered
+  // and counted for forensics, matching `handleConfirmVoiceEveryone`'s
+  // `partialCacheDrops` telemetry so a future "@everyone under-
+  // resolved on guild X" report has a debug hook.
   const selectedUsers = [];
+  let partialCacheDrops = 0;
   const cache = interaction.guild.members?.cache;
   if (cache && typeof cache.entries === 'function') {
     for (const [, member] of cache) {
       if (member?.user) selectedUsers.push(member.user);
+      else partialCacheDrops++;
     }
+  }
+  if (partialCacheDrops > 0) {
+    logger.debug('handleConfirmEveryone: partial-cache rows dropped from @everyone resolution', {
+      flow_id, dropped: partialCacheDrops, cache_size: cache?.size,
+    });
   }
   if (selectedUsers.length === 0) {
     return rejectEveryone('⚠\u{FE0F} `@everyone` expanded to 0 recipients — member cache not ready. Try again in a moment.\n\n');

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2871,6 +2871,15 @@ const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
 // restored). Lives on its own customId so flow-dispatch routes
 // directly instead of branching inside the voice-everyone handler.
 const CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID = 'qurl_confirm_pick_manual';
+// Whole-guild `@everyone` button on the confirm card. Workaround for
+// Discord's MentionableSelectMenu omitting the `@everyone` role from
+// its dropdown (platform UI filter), which would otherwise leave
+// MENTION_EVERYONE-bearing users with no in-picker affordance for
+// the "fan out to the whole server" intent. Click-time semantics
+// match a synthetic `@everyone` text-mention pick. Picker-mode only —
+// voice-mode already targets the voice population and rendering the
+// button there would mislead users about what "everyone" means.
+const CONFIRM_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_everyone';
 
 // Two recipient-source modes carried on `payload.recipientMode`:
 //   - 'picker' (default): MentionableSelect row is the source of
@@ -3815,6 +3824,47 @@ function renderConfirmCardRows({
         .setLabel(`\u{1F50A} Everyone in ${labelTarget} (${labelCount})`)
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(connectedCount == null || connectedCount === 0),
+    );
+  }
+  // @everyone button — workaround for Discord's MentionableSelectMenu
+  // filtering @everyone out of its dropdown. Gated on the sender's
+  // MENTION_EVERYONE permission (channel-effective, same as the text-
+  // path #323 gate) AND on picker-mode + guild context. In voice-mode
+  // the card already targets the voice population, so showing the
+  // button there would confuse "everyone" semantics. DM context has
+  // no @everyone meaning.
+  //
+  // Count is render-time non-bot when the cache is fully populated
+  // (`cache.size >= memberCount`); falls back to `guild.memberCount`
+  // (total, includes bots — over-count, but the only reliable number
+  // when the cache is cold). Same filter-drift trade-off the voice-
+  // everyone button accepts — `partitionRecipients` is still the
+  // click-time authority.
+  if (
+    mode === RECIPIENT_MODE_PICKER
+    && interaction && interaction.guild
+    && interaction.memberPermissions?.has?.(PermissionFlagsBits.MentionEveryone) === true
+  ) {
+    const guild = interaction.guild;
+    const cache = guild.members?.cache;
+    const memberCount = guild.memberCount;
+    let displayCount = null;
+    if (cache && typeof cache.size === 'number' && memberCount != null && cache.size >= memberCount) {
+      let n = 0;
+      for (const [, m] of cache) {
+        if (!isBotMember(m)) n++;
+      }
+      displayCount = n;
+    } else if (typeof memberCount === 'number') {
+      displayCount = memberCount;
+    }
+    const labelCount = displayCount == null ? '?' : String(displayCount);
+    bottomRow.addComponents(
+      new ButtonBuilder()
+        .setCustomId(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID)
+        .setLabel(`\u{1F4E2} @everyone (${labelCount})`)
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(displayCount === 0),
     );
   }
   bottomRow.addComponents(
@@ -5302,6 +5352,158 @@ async function handleConfirmPickManual(interaction, { flow_id, row }) {
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
+  return rerenderConfirmCard(interaction, newPayload);
+}
+
+// @everyone button — workaround for Discord's MentionableSelectMenu
+// filtering out the @everyone role from its dropdown. Click-time
+// semantics mirror handleConfirmUserSelect's @everyone-role branch:
+// pre-warm cache → expand to all non-bot guild members → partition →
+// transition flow. Permission re-check is defense-in-depth against a
+// forged button click (renderConfirmCardRows already gates button
+// visibility on MENTION_EVERYONE + picker-mode; this defends against
+// a crafted HTTP interaction bypassing the render).
+async function handleConfirmEveryone(interaction, { flow_id, row }) {
+  await interaction.deferUpdate().catch(logIgnoredDiscordErr);
+
+  const payload = row.payload || {};
+  const payloadResource = payload.resourceType;
+  if (payloadResource !== RESOURCE_TYPES.FILE && payloadResource !== RESOURCE_TYPES.MAPS) {
+    logger.error('handleConfirmEveryone: corrupt flow payload (unknown resourceType)', {
+      flow_id, resource_type: payloadResource,
+    });
+    await deleteFlow(flow_id, {
+      stage: SEND_STAGE_AWAITING_CONFIRM,
+      reason: 'terminal',
+    }).catch(logIgnoredDiscordErr);
+    return interaction.editReply({
+      content: '❌ Card data is corrupted — please re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
+  // Symmetric with handleConfirmVoiceEveryone's rejectVoice — same
+  // surface shape (warning banner + re-render with needsPicker). The
+  // persisted recipientIds stay unchanged on rejection (no transition-
+  // Flow fires); the picker re-pick is the natural recovery.
+  const rejectEveryone = (warning) => interaction.editReply({
+    content: renderConfirmCardContent({
+      resourceType: payload.resourceType,
+      resourceLabel: payload.resourceLabel,
+      validRecipients: [],
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+      warningsBlock: warning,
+      needsPicker: true,
+      interaction,
+      recipientMode: RECIPIENT_MODE_PICKER,
+      voiceChannelId: payload.voiceChannelId,
+    }),
+    components: renderConfirmCardRows({
+      sendDisabled: true,
+      expiresIn: payload.expiresIn,
+      selfDestructSeconds: payload.selfDestructSeconds,
+      personalMessage: payload.personalMessage,
+      voiceChannelId: payload.voiceChannelId,
+      interaction,
+      recipientIds: payload.recipientIds || [],
+      recipientMode: RECIPIENT_MODE_PICKER,
+    }),
+  }).catch(logIgnoredDiscordErr);
+
+  // Defense-in-depth permission re-check. The render-time gate already
+  // hides the button without MENTION_EVERYONE, but a forged HTTP
+  // interaction could carry the custom_id without the underlying perm.
+  // Channel-effective perms (interaction.memberPermissions) — same as
+  // the text-path gate at handleQurlSlashSend.
+  const canMentionEveryone = !!interaction.guild
+    && interaction.memberPermissions?.has?.(PermissionFlagsBits.MentionEveryone) === true;
+  if (!canMentionEveryone) {
+    logger.warn('handleConfirmEveryone: click without MENTION_EVERYONE — likely forged', {
+      flow_id, interaction_id: interaction.id,
+    });
+    return rejectEveryone('⚠\u{FE0F} `@everyone` requires the **Mention Everyone** permission.\n\n');
+  }
+
+  await prewarmGuildMembersCache(interaction.guild, { caller: 'handleConfirmEveryone', flow_id });
+
+  // Include bots in selectedUsers and let partitionRecipients filter
+  // them — same pattern as handleConfirmVoiceEveryone. Without this,
+  // the bots-only case would surface as "cache not ready" (misleading)
+  // instead of "all recipients are bots" (accurate); droppedBots count
+  // is also load-bearing for the warning copy.
+  const selectedUsers = [];
+  const cache = interaction.guild.members?.cache;
+  if (cache && typeof cache.entries === 'function') {
+    for (const [, member] of cache) {
+      if (member?.user) selectedUsers.push(member.user);
+    }
+  }
+  if (selectedUsers.length === 0) {
+    return rejectEveryone('⚠\u{FE0F} `@everyone` expanded to 0 recipients — member cache not ready. Try again in a moment.\n\n');
+  }
+  const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);
+  if (valid.length === 0) {
+    const reasons = [];
+    if (droppedBots > 0) reasons.push(RECIPIENT_REASON_BOTS_DROPPED);
+    const reasonText = reasons.length > 0 ? reasons.join('. ') : 'No usable recipients';
+    return rejectEveryone(`⚠\u{FE0F} ${reasonText}. Pick recipients below.\n\n`);
+  }
+  // Cap rejection mirrors handleConfirmVoiceEveryone: hard-reject past
+  // QURL_SEND_MAX_RECIPIENTS rather than silently truncate — the click
+  // is unambiguous all-or-nothing intent.
+  if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
+    return rejectEveryone(`⚠\u{FE0F} Guild has ${valid.length} non-bot members (max ${config.QURL_SEND_MAX_RECIPIENTS}). Use the picker or @mentions to choose a subset.\n\n`);
+  }
+
+  const newWarningsBlock = renderRecipientWarnings({ droppedBots });
+  const newRecipientAliases = Object.fromEntries(
+    valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
+  );
+  // recipientMode stays PICKER — the @everyone button doesn't switch
+  // modes (unlike voice-everyone which moves to RECIPIENT_MODE_VOICE).
+  // Semantically the user is multi-picking from the picker dropdown
+  // via a shortcut; the picker row remains visible for further
+  // adjustment.
+  const newPayload = {
+    ...payload,
+    recipientIds: valid.map((u) => u.id),
+    recipientAliases: newRecipientAliases,
+    warningsBlock: newWarningsBlock,
+    selfIncluded,
+    recipientMode: RECIPIENT_MODE_PICKER,
+  };
+  let result;
+  try {
+    result = await transitionFlow(flow_id, row.version, {
+      stage_to: SEND_STAGE_AWAITING_CONFIRM,
+      payload: newPayload,
+      terminal: false,
+      set_expires_at: Math.floor(Date.now() / 1000) + SEND_FLOW_TTL_SECONDS,
+    });
+  } catch (err) {
+    logger.error('handleConfirmEveryone: transitionFlow threw', {
+      flow_id, error: err && err.message,
+    });
+    return interaction.followUp({
+      content: '❌ Could not save your selection right now. Try again in a moment.',
+      ephemeral: true,
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'conflict') {
+    return interaction.editReply({
+      content: 'Send was superseded — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+  if (result.result === 'not_found') {
+    return interaction.editReply({
+      content: 'This send expired — re-run the command.',
+      components: [],
+    }).catch(logIgnoredDiscordErr);
+  }
+
   return rerenderConfirmCard(interaction, newPayload);
 }
 
@@ -7631,6 +7833,13 @@ registerFlow(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmPickManual,
 });
+// @everyone button — only rendered when sender has MENTION_EVERYONE
+// and recipientMode is PICKER. Same stage + siblingMessage-keyed-by-
+// stage contract as the other CONFIRM_* registrations.
+registerFlow(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID, {
+  expectedStage: SEND_STAGE_AWAITING_CONFIRM,
+  handler: handleConfirmEveryone,
+});
 
 module.exports = {
   commands,
@@ -7650,6 +7859,7 @@ module.exports = {
   handleConfirmNoteModal,
   handleConfirmVoiceEveryone,
   handleConfirmPickManual,
+  handleConfirmEveryone,
   verifyStateBinding,
   // _test is only exported in non-production so live state (sendCooldowns)
   // and internal handlers can't leak into prod consumers. Tests run with

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5496,6 +5496,9 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   if (!canMentionEveryone) {
     logger.warn('handleConfirmEveryone: click without MENTION_EVERYONE — likely forged', {
       flow_id, interaction_id: interaction.id,
+      // `guild_id` for cross-line correlation with the success info
+      // log; `null` in DM context which is itself the forge signal.
+      guild_id: interaction.guildId ?? null,
     });
     return rejectEveryone('⚠\u{FE0F} `@everyone` requires the **Mention Everyone** permission.\n\n');
   }
@@ -5580,6 +5583,18 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
     // Falsy `.bot` → kept; the invariant holds across context-menu /
     // future interaction types too.
     selectedUsers.push(interaction.user);
+  }
+  // Sender-only degenerate: guild has the sender (+ optionally bots)
+  // but no other non-bot members. @everyone's click intent is "fan out
+  // to OTHERS"; falling through to partition would land `valid=[sender]`
+  // and silently send to just the sender — defensible self-send
+  // semantics, but misleading for a click labeled 📢 @everyone. Reject
+  // with explicit copy so the user can decide (self-send via the
+  // picker is still possible). Reached only when sender's row IS in
+  // cache and no other non-bots are present — the bots-only-no-sender
+  // case lands in `valid.length === 0` below with droppedBots > 0.
+  if (senderInCache && !hasOtherNonBotInCache) {
+    return rejectEveryone('⚠\u{FE0F} `@everyone` matched only you — no other non-bot members to send to.\n\n');
   }
   // DIVERGENCE FROM handleConfirmVoiceEveryone: that handler excludes
   // the sender (voice-mode semantic is "everyone else in this voice

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3837,8 +3837,12 @@ function renderConfirmCardRows({
   // Count is render-time non-bot when the cache is fully populated
   // (`cache.size >= memberCount`); falls back to `guild.memberCount`
   // (total, includes bots — over-count, but the only reliable number
-  // when the cache is cold). Same filter-drift trade-off the voice-
-  // everyone button accepts — `partitionRecipients` is still the
+  // when the cache is cold). FILTER DRIFT (distinct from voice-
+  // everyone's): voice-everyone's render-time count can drift from
+  // click-time via members joining/leaving the voice channel between
+  // render and click; @everyone's drift is cold-cache-overcounts-by-
+  // bots, resolved when the click-time pre-warm fills the cache. In
+  // both cases the label is a hint and `partitionRecipients` is the
   // click-time authority.
   if (
     mode === RECIPIENT_MODE_PICKER
@@ -3858,12 +3862,20 @@ function renderConfirmCardRows({
     } else if (typeof memberCount === 'number') {
       displayCount = memberCount;
     }
+    // Disable on three conditions:
+    //  - `null` (memberCount unavailable + cache cold) → `(?)` label
+    //    so the user sees the button can't act vs. silent no-op
+    //  - `0` (degenerate empty guild — theoretically unreachable since
+    //    a 0-member guild can't host a slash command)
+    //  - `> QURL_SEND_MAX_RECIPIENTS` (cap-exceeded) → surface the
+    //    constraint at render time with an explicit suffix in the
+    //    label so the user sees why before clicking, rather than
+    //    getting the click-time hard-reject warning. Cap-reject in
+    //    handleConfirmEveryone is still the authoritative gate
+    //    (defense against memberCount-vs-actual-cache drift).
+    const overCap = displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
     const labelCount = displayCount == null ? '?' : String(displayCount);
-    // Disable on both `0` (empty guild — degenerate) AND `null`
-    // (memberCount unavailable + cache cold). The `(?)` label
-    // accompanies the disabled state so the user sees the button can't
-    // act right now rather than getting a silent-no-op click on a
-    // count-less label.
+    const labelSuffix = overCap ? ` — exceeds ${config.QURL_SEND_MAX_RECIPIENTS} cap` : '';
     //
     // BOTTOM ROW COMPONENT BUDGET: Discord caps an ActionRow at 5
     // components. The current worst-case render is
@@ -3874,9 +3886,9 @@ function renderConfirmCardRows({
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID)
-        .setLabel(`\u{1F4E2} @everyone (${labelCount})`)
+        .setLabel(`\u{1F4E2} @everyone (${labelCount})${labelSuffix}`)
         .setStyle(ButtonStyle.Secondary)
-        .setDisabled(displayCount == null || displayCount === 0),
+        .setDisabled(displayCount == null || displayCount === 0 || overCap),
     );
   }
   bottomRow.addComponents(
@@ -5463,7 +5475,10 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   const selectedUsers = [];
   let partialCacheDrops = 0;
   const cache = interaction.guild.members?.cache;
-  if (cache && typeof cache.entries === 'function') {
+  // Guard matches the operation: `for ... of` reads `[Symbol.iterator]`,
+  // which both `Map` and discord.js `Collection` provide. Truthy-check
+  // alone would NPE on a degraded `{}` cache shape from a partial init.
+  if (cache && typeof cache[Symbol.iterator] === 'function') {
     for (const [, member] of cache) {
       if (member?.user) selectedUsers.push(member.user);
       else partialCacheDrops++;
@@ -5475,6 +5490,12 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
     });
   }
   if (selectedUsers.length === 0) {
+    // "member cache not ready" is the common case (cold cache + non-
+    // zero guild). The degenerate genuinely-empty guild
+    // (`memberCount === 0`) can't reach this branch in production —
+    // handleQurlSlashSend's guild-gate rejects DM at entry and a
+    // guild with zero members can't host a slash command anyway. The
+    // shared copy is acceptable.
     return rejectEveryone('⚠\u{FE0F} `@everyone` expanded to 0 recipients — member cache not ready. Try again in a moment.\n\n');
   }
   const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3627,10 +3627,26 @@ function formatPersonalMessagePreview(message) {
 // re-render on every picker change / expiry select / note add+edit; in
 // a single flow the cache typically doesn't change between re-renders,
 // so iterating it on every render is wasted work. The WeakMap is keyed
-// by `guild` and entries auto-evict when the Guild is GC'd. A future
-// member-join/leave that changes `cache.size` or `memberCount` busts
-// the memo automatically — the key tuple (`cache.size:memberCount`) is
-// the freshness fingerprint.
+// by `guild` and entries auto-evict when the Guild is GC'd.
+//
+// FRESHNESS FINGERPRINT: `cache.size:memberCount` busts the memo when
+// either changes (the common case for member join/leave). KNOWN GAP:
+// a swap event — one human leaves and one bot joins near-simultaneously
+// — keeps both values stable but flips the non-bot count by 1. The
+// memo would return the stale count until the next non-swap churn.
+// Acceptable because (a) the label is documented as a hint, not
+// authoritative, and (b) the click-time `partitionRecipients` is the
+// source of truth. Folding a churn signal into the fingerprint would
+// be cheap if this ever needs tightening.
+//
+// Returns `{ count, accurate }`:
+//   - `accurate: true` when the warm-cache branch fired (cache fully
+//     populated AND bots filtered) — safe to gate render-time disables
+//     on the count
+//   - `accurate: false` for the cold-cache fallback (`memberCount`
+//     includes bots — over-counts by bot population, so a guild near
+//     the cap could false-positive on over-cap disable)
+//   - `count: null` when neither branch can produce a number
 const everyoneCountMemo = new WeakMap();
 function computeEveryoneDisplayCount(guild) {
   const cache = guild?.members?.cache;
@@ -3638,16 +3654,16 @@ function computeEveryoneDisplayCount(guild) {
   if (cache && typeof cache.size === 'number' && memberCount != null && cache.size >= memberCount) {
     const fingerprint = `${cache.size}:${memberCount}`;
     const cached = everyoneCountMemo.get(guild);
-    if (cached && cached.fingerprint === fingerprint) return cached.count;
+    if (cached && cached.fingerprint === fingerprint) return { count: cached.count, accurate: true };
     let n = 0;
     for (const [, m] of cache) {
       if (!isBotMember(m)) n++;
     }
     everyoneCountMemo.set(guild, { fingerprint, count: n });
-    return n;
+    return { count: n, accurate: true };
   }
-  if (typeof memberCount === 'number') return memberCount;
-  return null;
+  if (typeof memberCount === 'number') return { count: memberCount, accurate: false };
+  return { count: null, accurate: false };
 }
 
 function renderConfirmCardRows({
@@ -3879,20 +3895,24 @@ function renderConfirmCardRows({
     && interaction.memberPermissions?.has?.(PermissionFlagsBits.MentionEveryone) === true
   ) {
     const guild = interaction.guild;
-    const displayCount = computeEveryoneDisplayCount(guild);
-    // Disable on two conditions:
+    const { count: displayCount, accurate: countIsAccurate } = computeEveryoneDisplayCount(guild);
+    // Disable on three conditions:
     //  - `null` (memberCount unavailable + cache cold) → `(?)` label
     //    so the user sees the button can't act vs. silent no-op
-    //  - `> QURL_SEND_MAX_RECIPIENTS` (cap-exceeded) → surface the
-    //    constraint at render time with an explicit suffix in the
-    //    label so the user sees why before clicking, rather than
-    //    getting the click-time hard-reject warning. Cap-reject in
-    //    handleConfirmEveryone is still the authoritative gate
-    //    (defense against memberCount-vs-actual-cache drift).
-    // (`=== 0` is structurally unreachable — a guild with zero members
-    // can't host the slash command in the first place — so it's not
-    // worth a defensive branch.)
-    const overCap = displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
+    //  - `0` reachable in degraded cache states (all-bots guild with
+    //    sender's row temporarily missing). The bots-only click-time
+    //    reject still surfaces the right copy, but disabling at render
+    //    avoids the dead-click round trip
+    //  - `> QURL_SEND_MAX_RECIPIENTS` ONLY when `countIsAccurate` —
+    //    the cold-cache fallback returns `memberCount` (over-counts
+    //    by bot population), so disabling on it would false-positive
+    //    on a near-cap guild whose actual non-bot count is under cap
+    //    (e.g., 20100 members with 200 bots → 19900 non-bots, well
+    //    under default 20000 cap, but raw memberCount = 20100). Cold-
+    //    cache over-cap defers to click-time hard-reject in
+    //    handleConfirmEveryone (authoritative — partition runs against
+    //    the prewarmed cache).
+    const overCap = countIsAccurate && displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
     const labelCount = displayCount == null ? '?' : String(displayCount);
     const labelSuffix = overCap ? ` — exceeds ${config.QURL_SEND_MAX_RECIPIENTS} cap` : '';
     //
@@ -3907,7 +3927,7 @@ function renderConfirmCardRows({
         .setCustomId(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID)
         .setLabel(`\u{1F4E2} @everyone (${labelCount})${labelSuffix}`)
         .setStyle(ButtonStyle.Secondary)
-        .setDisabled(displayCount == null || overCap),
+        .setDisabled(displayCount == null || displayCount === 0 || overCap),
     );
   }
   bottomRow.addComponents(
@@ -5517,6 +5537,14 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
     // shared copy is acceptable.
     return rejectEveryone('⚠\u{FE0F} `@everyone` expanded to 0 recipients — member cache not ready. Try again in a moment.\n\n');
   }
+  // DIVERGENCE FROM handleConfirmVoiceEveryone: that handler excludes
+  // the sender (voice-mode semantic is "everyone else in this voice
+  // channel"). The @everyone button intentionally INCLUDES the sender
+  // — it's the dropdown's "select all" shortcut, not a separate "all
+  // others" affordance. A future contributor aligning the two handlers
+  // would silently flip the self-inclusion behavior; the `selfIncluded`
+  // flag flows through to the card's "Send includes you." notice so
+  // the user sees they're in the recipient list.
   const { valid, droppedBots, selfIncluded } = partitionRecipients(selectedUsers, interaction.user.id);
   if (valid.length === 0) {
     const reasons = [];
@@ -7954,6 +7982,13 @@ module.exports = {
       // composition directly (e.g., the DM-context @everyone-gate
       // assertion) without driving through handleQurlFile's entry path.
       renderConfirmCardRows,
+      // Memo for the @everyone non-bot count is module-scoped. Tests
+      // that reuse a guild reference across cases could otherwise get
+      // surprising memo hits; exposing the WeakMap lets a beforeEach
+      // hook clear specific entries. Production callers never need
+      // this — the memo busts on cache.size/memberCount changes.
+      _everyoneCountMemo: everyoneCountMemo,
+      computeEveryoneDisplayCount,
       handleAddRecipients,
       buildDeliveryPayload,
       resolveSenderAlias,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3622,6 +3622,34 @@ function formatPersonalMessagePreview(message) {
 // `recipientMode` defaults to RECIPIENT_MODE_PICKER for stale rows that
 // existed before this field was introduced; the legacy shape is exactly
 // the picker-mode branch below.
+
+// Memoized non-bot count for the @everyone button label. Confirm cards
+// re-render on every picker change / expiry select / note add+edit; in
+// a single flow the cache typically doesn't change between re-renders,
+// so iterating it on every render is wasted work. The WeakMap is keyed
+// by `guild` and entries auto-evict when the Guild is GC'd. A future
+// member-join/leave that changes `cache.size` or `memberCount` busts
+// the memo automatically — the key tuple (`cache.size:memberCount`) is
+// the freshness fingerprint.
+const everyoneCountMemo = new WeakMap();
+function computeEveryoneDisplayCount(guild) {
+  const cache = guild?.members?.cache;
+  const memberCount = guild?.memberCount;
+  if (cache && typeof cache.size === 'number' && memberCount != null && cache.size >= memberCount) {
+    const fingerprint = `${cache.size}:${memberCount}`;
+    const cached = everyoneCountMemo.get(guild);
+    if (cached && cached.fingerprint === fingerprint) return cached.count;
+    let n = 0;
+    for (const [, m] of cache) {
+      if (!isBotMember(m)) n++;
+    }
+    everyoneCountMemo.set(guild, { fingerprint, count: n });
+    return n;
+  }
+  if (typeof memberCount === 'number') return memberCount;
+  return null;
+}
+
 function renderConfirmCardRows({
   sendDisabled, expiresIn, selfDestructSeconds, personalMessage,
   voiceChannelId, interaction, recipientIds, recipientMode,
@@ -3841,38 +3869,29 @@ function renderConfirmCardRows({
   // everyone's): voice-everyone's render-time count can drift from
   // click-time via members joining/leaving the voice channel between
   // render and click; @everyone's drift is cold-cache-overcounts-by-
-  // bots, resolved when the click-time pre-warm fills the cache. In
-  // both cases the label is a hint and `partitionRecipients` is the
-  // click-time authority.
+  // bots OR stale-row-inflation (departed members lingering in cache
+  // briefly between gateway events), resolved when the click-time
+  // pre-warm fills the cache. In all cases the label is a hint and
+  // `partitionRecipients` is the click-time authority.
   if (
     mode === RECIPIENT_MODE_PICKER
     && interaction && interaction.guild
     && interaction.memberPermissions?.has?.(PermissionFlagsBits.MentionEveryone) === true
   ) {
     const guild = interaction.guild;
-    const cache = guild.members?.cache;
-    const memberCount = guild.memberCount;
-    let displayCount = null;
-    if (cache && typeof cache.size === 'number' && memberCount != null && cache.size >= memberCount) {
-      let n = 0;
-      for (const [, m] of cache) {
-        if (!isBotMember(m)) n++;
-      }
-      displayCount = n;
-    } else if (typeof memberCount === 'number') {
-      displayCount = memberCount;
-    }
-    // Disable on three conditions:
+    const displayCount = computeEveryoneDisplayCount(guild);
+    // Disable on two conditions:
     //  - `null` (memberCount unavailable + cache cold) → `(?)` label
     //    so the user sees the button can't act vs. silent no-op
-    //  - `0` (degenerate empty guild — theoretically unreachable since
-    //    a 0-member guild can't host a slash command)
     //  - `> QURL_SEND_MAX_RECIPIENTS` (cap-exceeded) → surface the
     //    constraint at render time with an explicit suffix in the
     //    label so the user sees why before clicking, rather than
     //    getting the click-time hard-reject warning. Cap-reject in
     //    handleConfirmEveryone is still the authoritative gate
     //    (defense against memberCount-vs-actual-cache drift).
+    // (`=== 0` is structurally unreachable — a guild with zero members
+    // can't host the slash command in the first place — so it's not
+    // worth a defensive branch.)
     const overCap = displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
     const labelCount = displayCount == null ? '?' : String(displayCount);
     const labelSuffix = overCap ? ` — exceeds ${config.QURL_SEND_MAX_RECIPIENTS} cap` : '';
@@ -3888,7 +3907,7 @@ function renderConfirmCardRows({
         .setCustomId(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID)
         .setLabel(`\u{1F4E2} @everyone (${labelCount})${labelSuffix}`)
         .setStyle(ButtonStyle.Secondary)
-        .setDisabled(displayCount == null || displayCount === 0 || overCap),
+        .setDisabled(displayCount == null || overCap),
     );
   }
   bottomRow.addComponents(
@@ -7931,6 +7950,10 @@ module.exports = {
       batchSettled,
       expiryToISO,
       sendCooldowns,
+      // Renderer exposed so tests can pin the bottom-row button
+      // composition directly (e.g., the DM-context @everyone-gate
+      // assertion) without driving through handleQurlFile's entry path.
+      renderConfirmCardRows,
       handleAddRecipients,
       buildDeliveryPayload,
       resolveSenderAlias,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3657,7 +3657,14 @@ function computeEveryoneDisplayCount(guild) {
     if (cached && cached.fingerprint === fingerprint) return { count: cached.count, accurate: true };
     let n = 0;
     for (const [, m] of cache) {
-      if (!isBotMember(m)) n++;
+      // `m?.user &&` aligns the render-time label with the click-time
+      // filter in handleConfirmEveryone — that path tallies rows
+      // without `.user` as `partialCacheDrops` and excludes them from
+      // recipients. Without the guard, a degraded GUILD_MEMBERS_CHUNK
+      // row counts as a non-bot here (isBotMember reads `.user?.bot`,
+      // returning false on missing `.user`) but never reaches the
+      // recipient set, leaving the label over-stated.
+      if (m?.user && !isBotMember(m)) n++;
     }
     everyoneCountMemo.set(guild, { fingerprint, count: n });
     return { count: n, accurate: true };
@@ -5513,14 +5520,19 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   // resolved on guild X" report has a debug hook.
   const selectedUsers = [];
   let partialCacheDrops = 0;
+  let senderInCache = false;
   const cache = interaction.guild.members?.cache;
   // Guard matches the operation: `for ... of` reads `[Symbol.iterator]`,
   // which both `Map` and discord.js `Collection` provide. Truthy-check
   // alone would NPE on a degraded `{}` cache shape from a partial init.
   if (cache && typeof cache[Symbol.iterator] === 'function') {
     for (const [, member] of cache) {
-      if (member?.user) selectedUsers.push(member.user);
-      else partialCacheDrops++;
+      if (member?.user) {
+        selectedUsers.push(member.user);
+        if (member.user.id === interaction.user.id) senderInCache = true;
+      } else {
+        partialCacheDrops++;
+      }
     }
   }
   if (partialCacheDrops > 0) {
@@ -5535,7 +5547,30 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
     // handleQurlSlashSend's guild-gate rejects DM at entry and a
     // guild with zero members can't host a slash command anyway. The
     // shared copy is acceptable.
+    // Important: gate the defensive sender push below on cache having
+    // members. A truly empty cache should surface "cache not ready"
+    // rather than silently expanding to just the sender — the latter
+    // would mislead the user into thinking @everyone succeeded.
     return rejectEveryone('⚠\u{FE0F} `@everyone` expanded to 0 recipients — member cache not ready. Try again in a moment.\n\n');
+  }
+  // Defensive sender push: cache has OTHER non-bot members but the
+  // sender's row is somehow missing (rare race during shard resume /
+  // partial chunk delivery post-prewarm). Without this, clicking
+  // 📢 `@everyone` could land `selfIncluded: false` and the user
+  // wouldn't be in the recipient set they explicitly triggered.
+  //
+  // Gated on `hasOtherNonBotInCache` so a bots-only cache still
+  // surfaces the bots-only reject below — silently expanding to
+  // "send to just me" from a bots-only guild misrepresents the
+  // @everyone click. `partitionRecipients` does NOT re-dedup
+  // (contract at commands.js:~3077), so the `senderInCache` check is
+  // load-bearing — pushing unconditionally would land the sender
+  // twice in `valid`.
+  if (!senderInCache) {
+    const hasOtherNonBotInCache = selectedUsers.some(
+      (u) => u && !u.bot && u.id !== interaction.user.id,
+    );
+    if (hasOtherNonBotInCache) selectedUsers.push(interaction.user);
   }
   // DIVERGENCE FROM handleConfirmVoiceEveryone: that handler excludes
   // the sender (voice-mode semantic is "everyone else in this voice
@@ -5605,6 +5640,18 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
       components: [],
     }).catch(logIgnoredDiscordErr);
   }
+
+  // Success-path telemetry: a successful @everyone expansion is a
+  // load-bearing audit signal (an admin fanned a send to N members
+  // of the guild). Error paths already log; without this, ops can
+  // only see "did someone fan out to 18k users?" via a DDB scan of
+  // qurl_send_configs. Info level matches the cadence of other
+  // confirm-card success signals.
+  logger.info('handleConfirmEveryone: @everyone expansion succeeded', {
+    flow_id, guild_id: interaction.guildId, user_id: interaction.user.id,
+    valid_count: valid.length, dropped_bots: droppedBots,
+    partial_cache_drops: partialCacheDrops, self_included: selfIncluded,
+  });
 
   return rerenderConfirmCard(interaction, newPayload);
 }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5525,6 +5525,7 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   const selectedUsers = [];
   let partialCacheDrops = 0;
   let senderInCache = false;
+  let hasOtherNonBotInCache = false;
   const cache = interaction.guild.members?.cache;
   // Guard matches the operation: `for ... of` reads `[Symbol.iterator]`,
   // which both `Map` and discord.js `Collection` provide. Truthy-check
@@ -5534,6 +5535,7 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
       if (member?.user) {
         selectedUsers.push(member.user);
         if (member.user.id === interaction.user.id) senderInCache = true;
+        else if (!member.user.bot) hasOtherNonBotInCache = true;
       } else {
         partialCacheDrops++;
       }
@@ -5571,16 +5573,13 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   // (contract at commands.js:~3077), so the `senderInCache` check is
   // load-bearing — pushing unconditionally would land the sender
   // twice in `valid`.
-  if (!senderInCache) {
-    const hasOtherNonBotInCache = selectedUsers.some(
-      (u) => u && !u.bot && u.id !== interaction.user.id,
-    );
+  if (!senderInCache && hasOtherNonBotInCache) {
     // `interaction.user.bot` may be undefined depending on interaction
     // shape (slash commands can't come from bots in production, so
     // `partitionRecipients`'s `if (u.bot)` is a no-op here regardless).
     // Falsy `.bot` → kept; the invariant holds across context-menu /
     // future interaction types too.
-    if (hasOtherNonBotInCache) selectedUsers.push(interaction.user);
+    selectedUsers.push(interaction.user);
   }
   // DIVERGENCE FROM handleConfirmVoiceEveryone: that handler excludes
   // the sender (voice-mode semantic is "everyone else in this voice
@@ -5661,6 +5660,10 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
     flow_id, guild_id: interaction.guildId, user_id: interaction.user.id,
     valid_count: valid.length, dropped_bots: droppedBots,
     partial_cache_drops: partialCacheDrops, self_included: selfIncluded,
+    // Cache shape for "@everyone underresolved on guild X" forensics —
+    // makes the success line self-contained (no need to cross-reference
+    // the partial-cache debug log to know the cache state at click time).
+    cache_size: cache?.size, member_count: interaction.guild.memberCount,
   });
 
   return rerenderConfirmCard(interaction, newPayload);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3922,6 +3922,10 @@ function renderConfirmCardRows({
     const overCap = countIsAccurate && displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
     const labelCount = displayCount == null ? '?' : String(displayCount);
     const labelSuffix = overCap ? ` — exceeds ${config.QURL_SEND_MAX_RECIPIENTS} cap` : '';
+    // No `VOICE_LABEL_NAME_UTF16_BUDGET`-equivalent here because no
+    // user-controlled string is interpolated: worst-case label is
+    // `📢 @everyone (NNNNN) — exceeds NNNNN cap` ≈ 41 UTF-16 units,
+    // well under Discord's 80-unit button-label cap.
     //
     // BOTTOM ROW COMPONENT BUDGET: Discord caps an ActionRow at 5
     // components. The current worst-case render is
@@ -5537,7 +5541,8 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   }
   if (partialCacheDrops > 0) {
     logger.debug('handleConfirmEveryone: partial-cache rows dropped from @everyone resolution', {
-      flow_id, dropped: partialCacheDrops, cache_size: cache?.size,
+      flow_id, guild_id: interaction.guildId,
+      dropped: partialCacheDrops, cache_size: cache?.size,
     });
   }
   if (selectedUsers.length === 0) {
@@ -5570,6 +5575,11 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
     const hasOtherNonBotInCache = selectedUsers.some(
       (u) => u && !u.bot && u.id !== interaction.user.id,
     );
+    // `interaction.user.bot` may be undefined depending on interaction
+    // shape (slash commands can't come from bots in production, so
+    // `partitionRecipients`'s `if (u.bot)` is a no-op here regardless).
+    // Falsy `.bot` → kept; the invariant holds across context-menu /
+    // future interaction types too.
     if (hasOtherNonBotInCache) selectedUsers.push(interaction.user);
   }
   // DIVERGENCE FROM handleConfirmVoiceEveryone: that handler excludes

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5298,6 +5298,46 @@ describe('handleConfirmEveryone', () => {
     expect(payload.selfIncluded).toBe(true);
   });
 
+  test('sender missing + warm cache with degraded .user-less row + other non-bots → defensive push fires, partial-cache drops counted', async () => {
+    // Positive coverage for the combination of: warm cache with at
+    // least one valid non-bot AND at least one degraded row (`.user`
+    // missing — partial GUILD_MEMBERS_CHUNK shape) AND sender's own
+    // row absent. The defensive push fires (other non-bots present),
+    // the degraded row is counted as partialCacheDrops, and the
+    // success log captures the right shape.
+    const otherUser = '100000000000000088';
+    const int = makeEveryoneInteraction({
+      // Sender absent; one other non-bot present.
+      guildMembers: { [otherUser]: {} },
+      memberCount: 3,  // sender + otherUser + the degraded row below
+    });
+    // Inject a degraded row (no .user) into the warm cache.
+    int.guild.members.cache.set('degraded-1', { /* no .user */ });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    // Sender (defensive push) + otherUser (cache) — degraded row
+    // filtered.
+    expect(payload.recipientIds.sort()).toEqual([SENDER_ID, otherUser].sort());
+    expect(payload.selfIncluded).toBe(true);
+    const logger = require('../src/logger');
+    // partialCacheDrops debug log fires with `dropped: 1`.
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('partial-cache rows dropped'),
+      expect.objectContaining({ dropped: 1 }),
+    );
+    // Success log carries the cache shape.
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('@everyone expansion succeeded'),
+      expect.objectContaining({
+        valid_count: 2,
+        partial_cache_drops: 1,
+        cache_size: 2,  // otherUser + degraded-1 = 2 entries
+        member_count: 3,
+      }),
+    );
+  });
+
   test('sender row missing + bots-only cache → still rejects (defensive push gated)', async () => {
     // Counter-test: the defensive push should NOT fire on a bots-only
     // cache. Silently expanding @everyone to "send to just me" would

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5277,6 +5277,64 @@ describe('handleConfirmEveryone', () => {
     );
   });
 
+  test('sender row missing from cache + other non-bots present → defensively pushed into recipients', async () => {
+    // Rare race: prewarm completes but the sender's own member entry
+    // happened to be missing from the cache (fresh shard resume).
+    // Without the defensive push, clicking 📢 @everyone would silently
+    // drop the sender (`selfIncluded: false`) — they'd be missing from
+    // the recipient set they explicitly triggered.
+    const otherUser = '100000000000000077';
+    const int = makeEveryoneInteraction({
+      // Sender deliberately ABSENT from cache; one other non-bot present.
+      guildMembers: { [otherUser]: {} },
+      memberCount: 2,  // sender + otherUser
+    });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    // Sender + otherUser should both land in recipients (sender via
+    // defensive push, otherUser via cache).
+    expect(payload.recipientIds.sort()).toEqual([SENDER_ID, otherUser].sort());
+    expect(payload.selfIncluded).toBe(true);
+  });
+
+  test('sender row missing + bots-only cache → still rejects (defensive push gated)', async () => {
+    // Counter-test: the defensive push should NOT fire on a bots-only
+    // cache. Silently expanding @everyone to "send to just me" would
+    // misrepresent the user's all-or-nothing intent. The gate on
+    // `hasOtherNonBotInCache` preserves the bots-only reject path.
+    const bot2 = '100000000000000098';
+    const int = makeEveryoneInteraction({
+      // Sender ABSENT; only bots in cache.
+      guildMembers: { [bot1]: { bot: true }, [bot2]: { bot: true } },
+      memberCount: 3,  // sender + 2 bots
+    });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/No usable recipients|bot/i);
+  });
+
+  test('success-path emits info-level audit log with counts', async () => {
+    // Successful @everyone expansion is a load-bearing audit signal —
+    // "did someone fan out to N users?" should be findable in logs
+    // without a DDB scan. Pin the structured-log shape so a future
+    // refactor doesn't silently drop the breadcrumb.
+    const int = makeEveryoneInteraction();
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    const logger = require('../src/logger');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('@everyone expansion succeeded'),
+      expect.objectContaining({
+        flow_id: 'fid',
+        valid_count: expect.any(Number),
+        dropped_bots: expect.any(Number),
+        partial_cache_drops: expect.any(Number),
+        self_included: true,
+      }),
+    );
+  });
+
   test('partial-cache rows (member without .user) → counted in debug log + filtered from selection', async () => {
     // Mirror handleConfirmVoiceEveryone's partialCacheDrops telemetry.
     // Degraded GuildMembersChunk shapes occasionally land entries with

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5241,6 +5241,60 @@ describe('handleConfirmEveryone', () => {
     await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(deferAckedBeforeTransition).toBe(true);
   });
+
+  test('transitionFlow returns conflict → "Send was superseded" copy, no followup', async () => {
+    const int = makeEveryoneInteraction();
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/superseded/i);
+    expect(reply.components).toEqual([]);
+    expect(int.followUp).not.toHaveBeenCalled();
+  });
+
+  test('transitionFlow returns not_found → "send expired" copy, no followup', async () => {
+    const int = makeEveryoneInteraction();
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/expired/i);
+    expect(reply.components).toEqual([]);
+    expect(int.followUp).not.toHaveBeenCalled();
+  });
+
+  test('transitionFlow throws → ephemeral followUp with retry copy', async () => {
+    const int = makeEveryoneInteraction();
+    mockTransitionFlow.mockRejectedValueOnce(new Error('ddb blip'));
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringMatching(/Could not save.*Try again/i),
+      ephemeral: true,
+    }));
+    const logger = require('../src/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('handleConfirmEveryone: transitionFlow threw'),
+      expect.any(Object),
+    );
+  });
+
+  test('partial-cache rows (member without .user) → counted in debug log + filtered from selection', async () => {
+    // Mirror handleConfirmVoiceEveryone's partialCacheDrops telemetry.
+    // Degraded GuildMembersChunk shapes occasionally land entries with
+    // no .user — they're filtered silently, but the count is logged so
+    // a future "@everyone underresolved" report has a forensic hook.
+    const int = makeEveryoneInteraction();
+    // Inject one degraded row alongside the valid ones.
+    int.guild.members.cache.set('degraded-1', { /* no .user */ });
+    int.guild.memberCount = 5;
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    const logger = require('../src/logger');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('partial-cache rows dropped'),
+      expect.objectContaining({ dropped: 1 }),
+    );
+    // Send still proceeds with the valid subset.
+    expect(mockTransitionFlow).toHaveBeenCalled();
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -6530,6 +6584,87 @@ describe('renderConfirmCardRows', () => {
       expect(everyoneBtn).toBeDefined();
       // 3 cached, 1 is a bot → label shows (2).
       expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(2)'));
+    });
+
+    test('disabled when memberCount unavailable AND cache cold (displayCount null)', async () => {
+      // Edge case: cold cache + missing memberCount → can't compute a
+      // count → button shows `(?)` label and stays disabled so the
+      // user sees the button can't act rather than getting a silent
+      // no-op click against a count-less label.
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+        guildMembers: { '100000000000000001': {} },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      // Leave memberCount unset → undefined.
+      delete int.guild.memberCount;
+      await handleQurlFile(int);
+      const everyoneBtn = ButtonBuilder.mock.results.find(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
+      );
+      expect(everyoneBtn).toBeDefined();
+      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(?)'));
+      expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
+    });
+
+    test('does NOT render in DM context (interaction.guild === null)', async () => {
+      // @everyone has no semantics in DM; the gate `interaction.guild`
+      // must skip rendering even with MENTION_EVERYONE set (defense-in-
+      // depth — handleQurlSlashSend rejects DM at entry, but the
+      // renderer is reused on re-renders that could in principle see
+      // a degraded shape).
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      // handleQurlFile rejects DM at entry, so test the renderer via
+      // a fresh slash-entry that DOES have a guild but then exercise
+      // the render-only branch by mocking interaction.guild = null on
+      // a later render path. Cleaner: invoke directly via handleQurlFile
+      // on a guild-less interaction and assert no button construction
+      // happens at all (because the handler returns before render).
+      const int = makeInteraction({
+        guildId: null,  // → guild = null in makeInteraction
+        options: { attachment: VALID_ATTACHMENT },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      await handleQurlFile(int);
+      const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
+      expect(customIds).not.toContain('qurl_confirm_everyone');
+    });
+
+    test('does NOT render in voice-mode (recipientMode === RECIPIENT_MODE_VOICE)', async () => {
+      // Voice-mode already targets the voice-channel population. The
+      // @everyone button there would confuse "everyone" semantics —
+      // does it mean voice or guild? Gate stays at picker-mode only.
+      // Render-only test: drive via rerenderConfirmCard with
+      // recipientMode: 'voice' and verify the button is absent.
+      const { ButtonBuilder } = require('discord.js');
+      const { handleConfirmExpirySelect } = require('../src/commands');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({
+        guildMembers: { '100000000000000001': {} },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 5;
+      // Drive a re-render via expiry select with recipientMode=voice.
+      int.values = ['7d'];
+      const voicePayload = {
+        resourceType: 'file',
+        resourceLabel: 'x.png',
+        recipientIds: ['100000000000000001'],
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        recipientMode: 'voice',
+        voiceChannelId: 'voice-ch-1',
+      };
+      mockTransitionFlow.mockResolvedValueOnce({ result: 'ok', version: 2 });
+      await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: voicePayload, version: 1 } });
+      const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
+      expect(customIds).not.toContain('qurl_confirm_everyone');
+      // sanity check: voice-mode renders the "Pick people instead" button.
+      expect(customIds).toContain('qurl_confirm_pick_manual');
     });
   });
 });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5181,13 +5181,74 @@ describe('handleConfirmEveryone', () => {
     );
   });
 
-  test('cache stays empty after prewarm → reject with "try again" copy', async () => {
-    const int = makeEveryoneInteraction({ guildMembers: {}, memberCount: 0 });
+  test('cache stays empty after prewarm despite populated guild → reject with "try again" copy', async () => {
+    // The production-relevant scenario: prewarm completed but landed
+    // zero members in cache (gateway blip, partial chunk delivery,
+    // discord.js cache eviction race). memberCount > 0 distinguishes
+    // this from the degenerate empty-guild case (which can't reach
+    // the click handler at all — slash commands need a guild context).
+    const int = makeEveryoneInteraction({ guildMembers: {}, memberCount: 5 });
     int.guild.members.fetch = jest.fn().mockResolvedValue(new Map());
     await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
     expect(mockTransitionFlow).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/member cache not ready/i);
+  });
+
+  test('sender-only-in-cache (no other non-bots) → reject with "matched only you" copy', async () => {
+    // Click-intent for 📢 @everyone is "fan out to others." If the
+    // guild has just the sender + bots, falling through to partition
+    // would silently send to just the sender — defensible self-send
+    // semantics, but misleading for an @everyone click. Reject
+    // explicitly; self-send via the picker is still possible.
+    const int = makeEveryoneInteraction({
+      // Sender in cache, only bots otherwise (no other humans).
+      guildMembers: { [SENDER_ID]: {}, [bot1]: { bot: true } },
+      memberCount: 2,
+    });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/matched only you/i);
+  });
+
+  test('valid.length === cap (exactly at boundary) → proceeds (cap-reject is strictly >)', async () => {
+    // Boundary test: the cap-reject is `valid.length > cap`, so exactly
+    // at cap should proceed. Voice-everyone shares the same
+    // partitionRecipients cap surface; cheap insurance against an
+    // off-by-one drift on either handler.
+    const config = require('../src/config');
+    const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
+    try {
+      Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: 3, configurable: true, writable: true });
+      const int = makeEveryoneInteraction({
+        guildMembers: {  // 3 non-bots exactly = cap
+          [SENDER_ID]: {},
+          '100000000000000010': {},
+          '100000000000000011': {},
+        },
+        memberCount: 3,
+      });
+      await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+      expect(mockTransitionFlow).toHaveBeenCalled();
+      const payload = mockTransitionFlow.mock.calls[0][2].payload;
+      expect(payload.recipientIds.length).toBe(3);
+    } finally {
+      Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: originalCap, configurable: true, writable: true });
+    }
+  });
+
+  test('forged-interaction warn log includes guild_id for forensics correlation', async () => {
+    // The success info log carries guild_id; the forged warn log
+    // should too, so ops can correlate "is one user forging across
+    // guilds?" without joining lines.
+    const int = makeEveryoneInteraction({ canMentionEveryone: false });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    const logger = require('../src/logger');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('without MENTION_EVERYONE'),
+      expect.objectContaining({ flow_id: 'fid', guild_id: expect.any(String) }),
+    );
   });
 
   test('only bots in cache → reject with bots-dropped copy', async () => {
@@ -6995,6 +7056,91 @@ describe('renderConfirmCardRows', () => {
       // Sanity check: voice-mode renders the "Pick people instead" button.
       expect(customIds).toContain('qurl_confirm_pick_manual');
     });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// computeEveryoneDisplayCount — direct unit tests for the helper that
+// drives the @everyone button's label count. Exported via `_test` so
+// the WeakMap+fingerprint contract can be pinned in isolation rather
+// than only through `renderConfirmCardRows`.
+// ──────────────────────────────────────────────────────────────
+
+describe('computeEveryoneDisplayCount', () => {
+  const { computeEveryoneDisplayCount, _everyoneCountMemo } = commands._test;
+
+  test('warm cache (cache.size === memberCount) → accurate non-bot count', () => {
+    const guild = {
+      id: 'g-warm',
+      memberCount: 3,
+      members: {
+        cache: new Map([
+          ['u1', { user: { id: 'u1', bot: false } }],
+          ['u2', { user: { id: 'u2', bot: false } }],
+          ['b1', { user: { id: 'b1', bot: true } }],
+        ]),
+      },
+    };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: 2, accurate: true });
+  });
+
+  test('cold cache (cache.size < memberCount) → memberCount fallback, NOT accurate', () => {
+    // Fallback to raw memberCount over-counts by bot population; the
+    // `accurate: false` flag tells callers (render-time over-cap
+    // disable) not to trust the number for safety decisions.
+    const guild = {
+      id: 'g-cold',
+      memberCount: 50,
+      members: { cache: new Map([['u1', { user: { id: 'u1', bot: false } }]]) },
+    };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: 50, accurate: false });
+  });
+
+  test('memberCount undefined + warm-shape cache → cold fallback returns {count: null, accurate: false}', () => {
+    // The `cache.size >= memberCount` test reads as `cache.size >=
+    // undefined`, which evaluates to false → cold branch. memberCount
+    // missing also fails the cold-branch's `typeof === 'number'`
+    // check → final return is `{count: null, accurate: false}`. Pin
+    // this since the comparison's evaluation is non-obvious.
+    const guild = {
+      id: 'g-no-mc',
+      members: { cache: new Map([['u1', { user: { id: 'u1', bot: false } }]]) },
+      // memberCount intentionally absent
+    };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: null, accurate: false });
+  });
+
+  test('cache missing → memberCount fallback when present', () => {
+    const guild = { id: 'g-no-cache', memberCount: 7, members: undefined };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: 7, accurate: false });
+  });
+
+  test('cache and memberCount both missing → null', () => {
+    const guild = { id: 'g-bare', members: undefined };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: null, accurate: false });
+  });
+
+  test('partial-cache row (no .user) does not inflate count', () => {
+    // The `m?.user && !isBotMember(m)` guard aligns the render-time
+    // count with the click-time partition filter — a degraded row
+    // counts as 0 here AND lands in `partialCacheDrops` there.
+    const guild = {
+      id: 'g-partial',
+      memberCount: 2,
+      members: {
+        cache: new Map([
+          ['u1', { user: { id: 'u1', bot: false } }],
+          ['degraded', { /* no .user */ }],
+        ]),
+      },
+    };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: 1, accurate: true });
   });
 });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5315,6 +5315,21 @@ describe('handleConfirmEveryone', () => {
     expect(reply.content).toMatch(/No usable recipients|bot/i);
   });
 
+  test('forged interaction with no guild → reject without crash + permission warning', async () => {
+    // Forged HTTP interaction crafted with the @everyone custom_id but
+    // no guild (DM context). canMentionEveryone derives `false` via
+    // `!!interaction.guild`, so the perm re-check fires and surfaces
+    // the rejection. The reject path re-renders via
+    // renderConfirmCardRows; the @everyone block there dereferences
+    // `interaction.memberPermissions?.has?.(...)` and must not crash
+    // on the null-guild interaction.
+    const int = makeEveryoneInteraction({ guildId: null });  // → guild = null
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Mention Everyone/);
+  });
+
   test('success-path emits info-level audit log with counts', async () => {
     // Successful @everyone expansion is a load-bearing audit signal —
     // "did someone fan out to N users?" should be findable in logs
@@ -6667,7 +6682,7 @@ describe('renderConfirmCardRows', () => {
       expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
     });
 
-    test('does NOT render in DM context — direct renderer assertion', async () => {
+    test('does NOT render in DM context — direct renderer assertion', () => {
       // Pin the renderer's `interaction.guild` gate directly (not via
       // handleQurlFile's entry-point DM-rejection). Without a direct
       // assertion, a future refactor that loosens the renderer gate
@@ -6700,7 +6715,7 @@ describe('renderConfirmCardRows', () => {
       expect(customIds).not.toContain('qurl_confirm_everyone');
     });
 
-    test('non-bot count is memoized across re-renders with stable cache', async () => {
+    test('non-bot count is memoized across re-renders with stable cache', () => {
       // Confirm cards re-render on every picker change / expiry select /
       // note edit. For a large guild the per-render O(N) bot filter
       // would compound; the memo keyed on `cache.size:memberCount` lets
@@ -6761,7 +6776,7 @@ describe('renderConfirmCardRows', () => {
       expect(iterations).toBe(1);
     });
 
-    test('memo busts on cache.size change', async () => {
+    test('memo busts on cache.size change', () => {
       // Member join/leave changes `cache.size` (or `memberCount`),
       // which fingerprints the memo entry and forces re-computation.
       const commands = require('../src/commands');
@@ -6907,37 +6922,37 @@ describe('renderConfirmCardRows', () => {
       expect(customIds.length).toBe(5);
     });
 
-    test('does NOT render in voice-mode (recipientMode === RECIPIENT_MODE_VOICE)', async () => {
+    test('does NOT render in voice-mode (recipientMode === RECIPIENT_MODE_VOICE)', () => {
       // Voice-mode already targets the voice-channel population. The
       // @everyone button there would confuse "everyone" semantics —
       // does it mean voice or guild? Gate stays at picker-mode only.
-      // Render-only test: drive via rerenderConfirmCard with
-      // recipientMode: 'voice' and verify the button is absent.
+      // Direct renderer assertion (matches the DM-context test above)
+      // — couples this contract to the renderer's gate, not to expiry-
+      // select's internals.
       const { ButtonBuilder } = require('discord.js');
-      const { handleConfirmExpirySelect } = require('../src/commands');
+      const { renderConfirmCardRows } = commands._test;
       ButtonBuilder.mockClear();
-      const int = makeInteraction({
-        guildMembers: { '100000000000000001': {} },
-      });
-      int.memberPermissions = { has: jest.fn(() => true) };
-      int.guild.memberCount = 5;
-      // Drive a re-render via expiry select with recipientMode=voice.
-      int.values = ['7d'];
-      const voicePayload = {
-        resourceType: 'file',
-        resourceLabel: 'x.png',
-        recipientIds: ['100000000000000001'],
+      const memberCache = new Map([['100000000000000001', { user: makeUser('100000000000000001') }]]);
+      const interaction = {
+        guild: {
+          id: 'g-voice', members: { cache: memberCache }, memberCount: 5,
+          channels: { cache: new Map() },
+        },
+        memberPermissions: { has: jest.fn(() => true) },
+      };
+      renderConfirmCardRows({
+        sendDisabled: false,
         expiresIn: '24h',
         selfDestructSeconds: null,
         personalMessage: null,
-        recipientMode: 'voice',
         voiceChannelId: 'voice-ch-1',
-      };
-      mockTransitionFlow.mockResolvedValueOnce({ result: 'ok', version: 2 });
-      await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload: voicePayload, version: 1 } });
+        interaction,
+        recipientIds: ['100000000000000001'],
+        recipientMode: 'voice',
+      });
       const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
       expect(customIds).not.toContain('qurl_confirm_everyone');
-      // sanity check: voice-mode renders the "Pick people instead" button.
+      // Sanity check: voice-mode renders the "Pick people instead" button.
       expect(customIds).toContain('qurl_confirm_pick_manual');
     });
   });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5111,6 +5111,139 @@ describe('handleConfirmPickManual', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
+// handleConfirmEveryone — @everyone button click handler
+// ──────────────────────────────────────────────────────────────
+// Workaround for Discord's MentionableSelectMenu filtering @everyone
+// out of its dropdown. Click-time semantics mirror the picker's
+// @everyone-role branch: pre-warm cache → expand to non-bot members →
+// partition → transition flow.
+
+describe('handleConfirmEveryone', () => {
+  const u1 = '100000000000000001';
+  const u2 = '100000000000000002';
+  const bot1 = '100000000000000099';
+
+  function makeEveryoneInteraction({
+    canMentionEveryone = true,
+    guildMembers = {
+      [u1]: {},
+      [u2]: {},
+      [bot1]: { bot: true },
+      [SENDER_ID]: {},
+    },
+    memberCount = 4,
+    ...rest
+  } = {}) {
+    const int = makeInteraction({ guildMembers, ...rest });
+    int.memberPermissions = { has: jest.fn(() => canMentionEveryone) };
+    if (int.guild) int.guild.memberCount = memberCount;
+    return int;
+  }
+
+  const initialPayload = {
+    resourceType: 'file',
+    resourceLabel: 'x.png',
+    recipientIds: [],
+    expiresIn: '24h',
+    selfDestructSeconds: null,
+    personalMessage: null,
+    recipientMode: 'picker',
+  };
+
+  const { handleConfirmEveryone } = require('../src/commands');
+
+  test('happy path → expands to all non-bot members, transitions flow', async () => {
+    const int = makeEveryoneInteraction();
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(int.deferUpdate).toHaveBeenCalled();
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    expect(payload.recipientIds.sort()).toEqual([u1, u2, SENDER_ID].sort());
+    expect(payload.selfIncluded).toBe(true);
+    // Mode stays in PICKER — @everyone is multi-pick shortcut, not a
+    // mode switch (unlike voice-everyone which moves to VOICE mode).
+    expect(payload.recipientMode).toBe('picker');
+  });
+
+  test('without MENTION_EVERYONE → reject with permission warning, no transition', async () => {
+    // Defense-in-depth re-check against forged interactions. Render-
+    // time gate already hides the button; this branch defends against
+    // an HTTP interaction crafted with the custom_id directly.
+    const int = makeEveryoneInteraction({ canMentionEveryone: false });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/Mention Everyone/);
+    const logger = require('../src/logger');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('without MENTION_EVERYONE'),
+      expect.any(Object),
+    );
+  });
+
+  test('cache stays empty after prewarm → reject with "try again" copy', async () => {
+    const int = makeEveryoneInteraction({ guildMembers: {}, memberCount: 0 });
+    int.guild.members.fetch = jest.fn().mockResolvedValue(new Map());
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/member cache not ready/i);
+  });
+
+  test('only bots in cache → reject with bots-dropped copy', async () => {
+    const int = makeEveryoneInteraction({
+      guildMembers: { [bot1]: { bot: true } },
+      memberCount: 1,
+    });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/No usable recipients|bot/i);
+  });
+
+  test('cache size > QURL_SEND_MAX_RECIPIENTS → hard reject (no truncation)', async () => {
+    const config = require('../src/config');
+    const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
+    try {
+      Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: 2, configurable: true, writable: true });
+      const int = makeEveryoneInteraction();  // 3 non-bots > cap 2
+      await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+      expect(mockTransitionFlow).not.toHaveBeenCalled();
+      const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+      expect(reply.content).toMatch(/max 2/);
+      expect(reply.content).toMatch(/picker|@mentions/i);
+    } finally {
+      Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: originalCap, configurable: true, writable: true });
+    }
+  });
+
+  test('corrupt resourceType → deleteFlow + actionable error, no transition', async () => {
+    const int = makeEveryoneInteraction();
+    await handleConfirmEveryone(int, {
+      flow_id: 'fid',
+      row: { payload: { ...initialPayload, resourceType: 'mystery' }, version: 1 },
+    });
+    expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
+      stage: SEND_STAGE_AWAITING_CONFIRM, reason: 'terminal',
+    }));
+    expect(mockTransitionFlow).not.toHaveBeenCalled();
+    const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
+    expect(reply.content).toMatch(/corrupted/i);
+  });
+
+  test('deferUpdate fires before transitionFlow — Discord 3s ack guard', async () => {
+    let deferAckedBeforeTransition = false;
+    const int = makeEveryoneInteraction();
+    mockTransitionFlow.mockImplementationOnce(async () => {
+      deferAckedBeforeTransition = int.deferUpdate.mock.calls.length > 0;
+      return { result: 'ok', version: 2 };
+    });
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
+    expect(deferAckedBeforeTransition).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
 // handleConfirmExpirySelect — inline expiry edit on confirm card
 // ──────────────────────────────────────────────────────────────
 
@@ -6317,6 +6450,86 @@ describe('renderConfirmCardRows', () => {
       const lastCall = int.editReply.mock.calls.slice(-1)[0][0];
       expect(lastCall.content).toContain(`<#${VOICE_CH}>`);
       expect(lastCall.content).toMatch(/you not included/);
+    });
+  });
+
+  // ── @everyone button rendering ──
+  // Workaround for Discord's MentionableSelectMenu filtering @everyone
+  // out of its UI. Render-time gating on MENTION_EVERYONE + picker
+  // mode + guild context. Click-time resolution handled separately
+  // by handleConfirmEveryone tests.
+  describe('@everyone button', () => {
+    test('renders when sender has MENTION_EVERYONE in guild (picker mode)', async () => {
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+        guildMembers: { '100000000000000001': {} },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 5;
+      await handleQurlFile(int);
+      const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
+      expect(customIds).toContain('qurl_confirm_everyone');
+    });
+
+    test('does NOT render without MENTION_EVERYONE', async () => {
+      // Default permission shape falls through the gate. Symmetric with
+      // Discord's MentionableSelectMenu, which also hides @everyone for
+      // non-permitted users.
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+        guildMembers: { '100000000000000001': {} },
+      });
+      await handleQurlFile(int);
+      const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
+      expect(customIds).not.toContain('qurl_confirm_everyone');
+    });
+
+    test('label shows live count from guild.memberCount when cache cold', async () => {
+      // Cold cache (cache.size < memberCount) → label falls back to
+      // memberCount. Overcounts by bot population, but it's the only
+      // reliable number before the click-time pre-warm fires.
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+        guildMembers: { '100000000000000001': {} },  // cache.size === 1
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 42;  // memberCount > cache.size → cold
+      await handleQurlFile(int);
+      const everyoneBtn = ButtonBuilder.mock.results.find(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
+      );
+      expect(everyoneBtn).toBeDefined();
+      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(42)'));
+    });
+
+    test('label shows non-bot count when cache fully populated', async () => {
+      // Warm cache (cache.size >= memberCount) → filter bots and use
+      // the accurate non-bot count.
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+        guildMembers: {
+          '100000000000000001': {},
+          '100000000000000002': {},
+          '100000000000000099': { bot: true },
+        },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 3;  // matches cache.size → warm
+      await handleQurlFile(int);
+      const everyoneBtn = ButtonBuilder.mock.results.find(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
+      );
+      expect(everyoneBtn).toBeDefined();
+      // 3 cached, 1 is a bot → label shows (2).
+      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(2)'));
     });
   });
 });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -6633,6 +6633,71 @@ describe('renderConfirmCardRows', () => {
       expect(customIds).not.toContain('qurl_confirm_everyone');
     });
 
+    test('disabled with "exceeds cap" suffix when memberCount > QURL_SEND_MAX_RECIPIENTS', async () => {
+      // Render-time disable for the over-cap case so the user sees the
+      // constraint BEFORE clicking, rather than getting the click-time
+      // hard-reject warning. The click-time cap-reject in
+      // handleConfirmEveryone is still the authoritative gate.
+      const config = require('../src/config');
+      const { ButtonBuilder } = require('discord.js');
+      const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
+      try {
+        Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: 100, configurable: true, writable: true });
+        ButtonBuilder.mockClear();
+        const int = makeInteraction({
+          options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+          guildMembers: { '100000000000000001': {} },
+        });
+        int.memberPermissions = { has: jest.fn(() => true) };
+        int.guild.memberCount = 500;  // way over cap=100
+        await handleQurlFile(int);
+        const everyoneBtn = ButtonBuilder.mock.results.find(
+          (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
+        );
+        expect(everyoneBtn).toBeDefined();
+        expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('exceeds 100 cap'));
+        expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
+      } finally {
+        Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: originalCap, configurable: true, writable: true });
+      }
+    });
+
+    test('both @everyone AND voice-everyone buttons render together when invoked from voice + MENTION_EVERYONE', async () => {
+      // Pin the 5-component-row invariant in the worst-case render:
+      // [🔊 Voice] + [📢 @everyone] + Note + Send + Cancel = exactly 5,
+      // hitting Discord's hard ActionRow limit. A future refactor that
+      // shifts any of those into a second row (or adds a 6th) would
+      // break this assertion.
+      const { ButtonBuilder, ChannelType } = require('discord.js');
+      ButtonBuilder.mockClear();
+      const voiceChannelId = 'voice-room-1';
+      const int = makeInteraction({
+        channelId: voiceChannelId,
+        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+        guildMembers: { '100000000000000001': {} },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 5;
+      // Drop the slash invocation INTO a voice channel by attaching a
+      // voice-channel shape to the interaction. The slash-entry's
+      // voice-detection branch reads `interaction.channel.type`.
+      int.channel = {
+        id: voiceChannelId, name: 'general', type: ChannelType.GuildVoice,
+        members: new Map([['100000000000000001', { user: makeUser('100000000000000001') }]]),
+      };
+      int.guild.channels.cache.set(voiceChannelId, int.channel);
+      await handleQurlFile(int);
+      const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
+      // Both affordances present; full bottom row = Voice + @everyone +
+      // Note + Send + Cancel = 5 components (Discord's hard cap).
+      expect(customIds).toContain('qurl_confirm_voice_everyone');
+      expect(customIds).toContain('qurl_confirm_everyone');
+      expect(customIds).toContain('qurl_confirm_note_btn');
+      expect(customIds).toContain('qurl_confirm_send');
+      expect(customIds).toContain('qurl_confirm_cancel');
+      expect(customIds.length).toBe(5);
+    });
+
     test('does NOT render in voice-mode (recipientMode === RECIPIENT_MODE_VOICE)', async () => {
       // Voice-mode already targets the voice-channel population. The
       // @everyone button there would confuse "everyone" semantics —

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -6646,24 +6646,42 @@ describe('renderConfirmCardRows', () => {
       // Confirm cards re-render on every picker change / expiry select /
       // note edit. For a large guild the per-render O(N) bot filter
       // would compound; the memo keyed on `cache.size:memberCount` lets
-      // a single flow's re-renders share one count computation. Pin by
-      // observing that `isBotMember` is called O(N) on the FIRST render
-      // and zero times on subsequent renders against the same guild.
-      const { ButtonBuilder } = require('discord.js');
+      // a single flow's re-renders share one count computation. Pin
+      // memoization by counting cache iterations directly — without a
+      // memo, every render would iterate; with the memo, only the
+      // first render does. Behavioral label assertion alone passes
+      // under both implementations, so the iteration counter is
+      // load-bearing.
       const commands = require('../src/commands');
-      const { renderConfirmCardRows } = commands._test;
-      ButtonBuilder.mockClear();
-      // Shared guild reference + warm cache so the warm-path branch fires.
-      const memberCache = new Map();
-      memberCache.set('u1', { user: { id: 'u1', bot: false } });
-      memberCache.set('u2', { user: { id: 'u2', bot: false } });
-      memberCache.set('b1', { user: { id: 'b1', bot: true } });
+      const { renderConfirmCardRows, _everyoneCountMemo } = commands._test;
+      const guildId = 'guild-memo-iter';
+      // Wrap the cache Map to count `[Symbol.iterator]` invocations.
+      // discord.js's `Collection` and a plain `Map` both delegate the
+      // `for ... of` to `[Symbol.iterator]`, so this captures every
+      // full-pass enumeration.
+      const memberCache = new Map([
+        ['u1', { user: { id: 'u1', bot: false } }],
+        ['u2', { user: { id: 'u2', bot: false } }],
+        ['b1', { user: { id: 'b1', bot: true } }],
+      ]);
+      let iterations = 0;
+      const iterCountingCache = new Proxy(memberCache, {
+        get(target, prop) {
+          if (prop === Symbol.iterator) {
+            iterations++;
+            return target[Symbol.iterator].bind(target);
+          }
+          return Reflect.get(target, prop);
+        },
+      });
       const guild = {
-        id: 'guild-memo',
-        members: { cache: memberCache },
+        id: guildId,
+        members: { cache: iterCountingCache },
         memberCount: 3,
         channels: { cache: new Map() },
       };
+      // Defensive: clear any stale memo entry from previous tests.
+      _everyoneCountMemo.delete(guild);
       const interaction = {
         guild,
         memberPermissions: { has: jest.fn(() => true) },
@@ -6678,23 +6696,96 @@ describe('renderConfirmCardRows', () => {
         recipientIds: [],
         recipientMode: 'picker',
       };
-      // Render 5x; observe the @everyone button label stays consistent.
       for (let i = 0; i < 5; i++) renderConfirmCardRows(args);
-      const everyoneLabels = ButtonBuilder.mock.results
-        .filter((r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone')
-        .map((r) => r.value.setLabel.mock.calls[0]?.[0]);
-      // 5 renders → 5 button instances, each labeled `(2)` (3 cached,
-      // 1 bot). The memo invariant is correctness-equivalent to the
-      // non-memoized path; the cost saving is internal.
-      expect(everyoneLabels.length).toBe(5);
-      everyoneLabels.forEach((l) => expect(l).toContain('(2)'));
+      // First render walks the cache to compute non-bot count → 1
+      // iteration. Subsequent renders hit the memo → 0 additional
+      // iterations. Total across 5 renders: 1.
+      expect(iterations).toBe(1);
     });
 
-    test('disabled with "exceeds cap" suffix when memberCount > QURL_SEND_MAX_RECIPIENTS', async () => {
-      // Render-time disable for the over-cap case so the user sees the
-      // constraint BEFORE clicking, rather than getting the click-time
-      // hard-reject warning. The click-time cap-reject in
-      // handleConfirmEveryone is still the authoritative gate.
+    test('memo busts on cache.size change', async () => {
+      // Member join/leave changes `cache.size` (or `memberCount`),
+      // which fingerprints the memo entry and forces re-computation.
+      const commands = require('../src/commands');
+      const { renderConfirmCardRows, _everyoneCountMemo } = commands._test;
+      const memberCache = new Map([
+        ['u1', { user: { id: 'u1', bot: false } }],
+        ['u2', { user: { id: 'u2', bot: false } }],
+      ]);
+      const guild = {
+        id: 'guild-memo-bust',
+        members: { cache: memberCache },
+        memberCount: 2,
+        channels: { cache: new Map() },
+      };
+      _everyoneCountMemo.delete(guild);
+      const args = {
+        sendDisabled: false,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        voiceChannelId: null,
+        interaction: { guild, memberPermissions: { has: jest.fn(() => true) } },
+        recipientIds: [],
+        recipientMode: 'picker',
+      };
+      renderConfirmCardRows(args);  // memo populated with count=2
+      // Member joins → cache grows + memberCount grows. Fingerprint
+      // flips, memo busts on next render.
+      memberCache.set('u3', { user: { id: 'u3', bot: false } });
+      guild.memberCount = 3;
+      const { ButtonBuilder } = require('discord.js');
+      ButtonBuilder.mockClear();
+      renderConfirmCardRows(args);
+      const everyoneBtn = ButtonBuilder.mock.results.find(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
+      );
+      expect(everyoneBtn).toBeDefined();
+      // Post-bust label reflects the new count (3 non-bots), not the
+      // memoized 2.
+      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(3)'));
+    });
+
+    test('disabled with "exceeds cap" suffix when warm-cache non-bot count > cap', async () => {
+      // Render-time over-cap disable fires ONLY when the count is
+      // accurate (warm cache + bot-filtered). Cold-cache over-cap
+      // defers to click-time hard-reject — see counter-test below.
+      const config = require('../src/config');
+      const { ButtonBuilder } = require('discord.js');
+      const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
+      try {
+        Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: 2, configurable: true, writable: true });
+        ButtonBuilder.mockClear();
+        const int = makeInteraction({
+          options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
+          guildMembers: {  // 4 cached, all non-bot → count=4 > cap=2
+            '100000000000000001': {},
+            '100000000000000002': {},
+            '100000000000000003': {},
+            '100000000000000004': {},
+          },
+        });
+        int.memberPermissions = { has: jest.fn(() => true) };
+        int.guild.memberCount = 4;  // matches cache.size → warm + accurate
+        await handleQurlFile(int);
+        const everyoneBtn = ButtonBuilder.mock.results.find(
+          (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
+        );
+        expect(everyoneBtn).toBeDefined();
+        expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('exceeds 2 cap'));
+        expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
+      } finally {
+        Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: originalCap, configurable: true, writable: true });
+      }
+    });
+
+    test('cold-cache memberCount > cap does NOT disable (avoid bot-overcount false-positive)', async () => {
+      // Counter-test: a guild with `memberCount = 500` but only 1
+      // cached member is cold; `displayCount = memberCount` is an
+      // over-count by bot population. Disabling on it would false-
+      // positive on a near-cap guild whose actual non-bot count is
+      // under cap. Defer to click-time hard-reject (which runs against
+      // the prewarmed cache).
       const config = require('../src/config');
       const { ButtonBuilder } = require('discord.js');
       const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
@@ -6703,17 +6794,20 @@ describe('renderConfirmCardRows', () => {
         ButtonBuilder.mockClear();
         const int = makeInteraction({
           options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
-          guildMembers: { '100000000000000001': {} },
+          guildMembers: { '100000000000000001': {} },  // cache.size=1
         });
         int.memberPermissions = { has: jest.fn(() => true) };
-        int.guild.memberCount = 500;  // way over cap=100
+        int.guild.memberCount = 500;  // cache.size < memberCount → cold
         await handleQurlFile(int);
         const everyoneBtn = ButtonBuilder.mock.results.find(
           (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
         );
         expect(everyoneBtn).toBeDefined();
-        expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('exceeds 100 cap'));
-        expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
+        // Label shows raw count without "exceeds" suffix; button is
+        // enabled because we don't trust the cold-path number for
+        // disable decisions.
+        expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.not.stringContaining('exceeds'));
+        expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(false);
       } finally {
         Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: originalCap, configurable: true, writable: true });
       }

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -6609,28 +6609,85 @@ describe('renderConfirmCardRows', () => {
       expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
     });
 
-    test('does NOT render in DM context (interaction.guild === null)', async () => {
-      // @everyone has no semantics in DM; the gate `interaction.guild`
-      // must skip rendering even with MENTION_EVERYONE set (defense-in-
-      // depth — handleQurlSlashSend rejects DM at entry, but the
-      // renderer is reused on re-renders that could in principle see
-      // a degraded shape).
+    test('does NOT render in DM context — direct renderer assertion', async () => {
+      // Pin the renderer's `interaction.guild` gate directly (not via
+      // handleQurlFile's entry-point DM-rejection). Without a direct
+      // assertion, a future refactor that loosens the renderer gate
+      // would only fail tests via the entry-point guard, leaving the
+      // renderer-only contract under-pinned.
       const { ButtonBuilder } = require('discord.js');
+      const commands = require('../src/commands');
+      // _test exports are only available in non-production (NODE_ENV !==
+      // 'production'). Jest runs without setting NODE_ENV → test mode.
+      const { renderConfirmCardRows } = commands._test;
       ButtonBuilder.mockClear();
-      // handleQurlFile rejects DM at entry, so test the renderer via
-      // a fresh slash-entry that DOES have a guild but then exercise
-      // the render-only branch by mocking interaction.guild = null on
-      // a later render path. Cleaner: invoke directly via handleQurlFile
-      // on a guild-less interaction and assert no button construction
-      // happens at all (because the handler returns before render).
-      const int = makeInteraction({
-        guildId: null,  // → guild = null in makeInteraction
-        options: { attachment: VALID_ATTACHMENT },
+      // DM-shaped interaction: no `guild`, but MENTION_EVERYONE is
+      // (defensively) granted on memberPermissions to prove the
+      // renderer doesn't lean on perms alone.
+      const dmInteraction = {
+        guild: null,
+        memberPermissions: { has: jest.fn(() => true) },
+      };
+      renderConfirmCardRows({
+        sendDisabled: false,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        voiceChannelId: null,
+        interaction: dmInteraction,
+        recipientIds: [],
+        recipientMode: 'picker',
       });
-      int.memberPermissions = { has: jest.fn(() => true) };
-      await handleQurlFile(int);
       const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
       expect(customIds).not.toContain('qurl_confirm_everyone');
+    });
+
+    test('non-bot count is memoized across re-renders with stable cache', async () => {
+      // Confirm cards re-render on every picker change / expiry select /
+      // note edit. For a large guild the per-render O(N) bot filter
+      // would compound; the memo keyed on `cache.size:memberCount` lets
+      // a single flow's re-renders share one count computation. Pin by
+      // observing that `isBotMember` is called O(N) on the FIRST render
+      // and zero times on subsequent renders against the same guild.
+      const { ButtonBuilder } = require('discord.js');
+      const commands = require('../src/commands');
+      const { renderConfirmCardRows } = commands._test;
+      ButtonBuilder.mockClear();
+      // Shared guild reference + warm cache so the warm-path branch fires.
+      const memberCache = new Map();
+      memberCache.set('u1', { user: { id: 'u1', bot: false } });
+      memberCache.set('u2', { user: { id: 'u2', bot: false } });
+      memberCache.set('b1', { user: { id: 'b1', bot: true } });
+      const guild = {
+        id: 'guild-memo',
+        members: { cache: memberCache },
+        memberCount: 3,
+        channels: { cache: new Map() },
+      };
+      const interaction = {
+        guild,
+        memberPermissions: { has: jest.fn(() => true) },
+      };
+      const args = {
+        sendDisabled: false,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        voiceChannelId: null,
+        interaction,
+        recipientIds: [],
+        recipientMode: 'picker',
+      };
+      // Render 5x; observe the @everyone button label stays consistent.
+      for (let i = 0; i < 5; i++) renderConfirmCardRows(args);
+      const everyoneLabels = ButtonBuilder.mock.results
+        .filter((r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone')
+        .map((r) => r.value.setLabel.mock.calls[0]?.[0]);
+      // 5 renders → 5 button instances, each labeled `(2)` (3 cached,
+      // 1 bot). The memo invariant is correctness-equivalent to the
+      // non-memoized path; the cost saving is internal.
+      expect(everyoneLabels.length).toBe(5);
+      everyoneLabels.forEach((l) => expect(l).toContain('(2)'));
     });
 
     test('disabled with "exceeds cap" suffix when memberCount > QURL_SEND_MAX_RECIPIENTS', async () => {


### PR DESCRIPTION
## Summary

- Discord's \`MentionableSelectMenu\` filters the \`@everyone\` role out of its dropdown server-side (platform UI behavior, can't be unflipped). Users with MENTION_EVERYONE had no in-UI affordance for "fan out to the whole server" — they had to fall back to typing \`@everyone\` in the slash command's recipients option (and even that broke silently until #363, the cache pre-warm fix this PR is stacked on).
- Add a dedicated **📢 @everyone (N)** button to the confirm card's button row, gated on \`interaction.memberPermissions.has(MentionEveryone)\` and guild context. Click-time semantics mirror the existing picker @everyone-role branch:
  - defense-in-depth permission re-check (defends against a forged HTTP interaction carrying the button's custom_id)
  - cache pre-warm (uses the helper from #363)
  - iterate \`guild.members.cache\` → \`partitionRecipients\` (drops bots, flags \`selfIncluded\`)
  - cap-check (mirrors voice-everyone's hard-reject past \`QURL_SEND_MAX_RECIPIENTS\`)
  - transitionFlow + re-render
- Label count is render-time non-bot when the cache is fully populated (\`cache.size >= memberCount\`), falls back to \`guild.memberCount\` when cold. Same filter-drift trade-off the voice-everyone button accepts — \`partitionRecipients\` is the click-time authority.

## Why

User reported the missing affordance — \`@everyone\` typed in the recipients option worked (after #363) but the picker dropdown showed Users + Roles section without \`@everyone\` in the Roles section. After confirming that Discord's MentionableSelectMenu filters \`@everyone\` server-side, the cleanest fix is a dedicated button — symmetric with the existing "Everyone in voice channel" button users already learn from voice-channel sends. Discoverable, one-click, self-describing label.

## Scope

- \`src/commands.js\`:
  - new \`CONFIRM_EVERYONE_BUTTON_CUSTOM_ID\`
  - \`renderConfirmCardRows\` adds the button to \`bottomRow\` (after voice-everyone if present, before Note/Send/Cancel) when MENTION_EVERYONE
  - new \`handleConfirmEveryone\` handler (mirrors \`handleConfirmVoiceEveryone\`)
  - flow-dispatch registration + module export
- \`tests/qurl-file-map.test.js\`: 11 new tests covering render gating, label count freshness across hot/cold cache, the happy path, forged-perm rejection, cold cache, bots-only, cap rejection, corrupt resourceType, deferUpdate ack guard.

## Test plan

- [ ] CI green
- [ ] Local: \`/qurl file\` as MENTION_EVERYONE user → confirm card shows 📢 @everyone (N) button → click → expands to all non-bot members
- [ ] Local: \`/qurl file\` as non-MENTION_EVERYONE user → button does NOT render
- [ ] Local: button label refreshes count on re-render after a picker change
- [ ] Local: in a voice channel, both 🔊 voice-everyone and 📢 @everyone buttons render side-by-side (5 components in the bottom row, at Discord's limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)