### PR TITLE
chore(discord): trim confirm-card copy

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3559,9 +3559,7 @@ function renderConfirmCardContent({
     content += 'ℹ\u{FE0F} **Send includes you.**\n';
   }
   if (needsPicker) {
-    content += '\n**Pick recipients below** (1–'
-      + String(Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS))
-      + ' users), then click **Send**.\n';
+    content += '\n**Pick recipients below.**\n';
   } else if (mode === RECIPIENT_MODE_VOICE) {
     // Voice-mode "To:" — names omitted in favor of the channel context.
     // The #voice mention is the source of truth for who's included;
@@ -3611,7 +3609,7 @@ function renderConfirmCardContent({
     // of the card.
     content += `**Note:** ${formatPersonalMessagePreview(personalMessage)}\n`;
   }
-  content += '\nClick **Send** to deliver one-time qURL links, or **Cancel** to abort.';
+  content += '\nClick **Send** to deliver one-time qURL, or **Cancel** to abort.';
   // Fail-safe cap below Discord's 2000-char content limit so adversarial
   // inputs can't trip a 400 from editReply and orphan the flow row.
   // Cap (1988) + '…(truncated)' indicator (12 codepoints) = 2000 max
@@ -3710,16 +3708,10 @@ function renderConfirmCardRows({
   const maxValues = defaults.length > 0
     ? Math.min(DISCORD_SELECT_MAX_VALUES_HARD_CAP, config.QURL_SEND_MAX_RECIPIENTS, Math.max(baseCap, defaults.length))
     : baseCap;
-  // Placeholder surfaces both ceilings: pick-slot count (Discord's
-  // setMaxValues) AND the post-expansion recipient cap. With roles in
-  // the picker, a single slot can expand to many members — saying
-  // only "1–10" would mislead users who pick 10 roles expecting 10
-  // recipients.
-  const recipientCap = config.QURL_SEND_MAX_RECIPIENTS;
   if (mode === RECIPIENT_MODE_PICKER) {
     const picker = new MentionableSelectMenuBuilder()
       .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
-      .setPlaceholder(`Pick up to ${maxValues} users/roles (recipients capped at ${recipientCap})`)
+      .setPlaceholder(`Pick up to ${maxValues} users/roles`)
       .setMinValues(1)
       .setMaxValues(maxValues);
     if (defaults.length > 0) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -805,7 +805,7 @@ function buildRevokedDMPayload({ senderAlias }) {
   const safeSender = sanitizeDisplayName(senderAlias);
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
-    .setDescription(`🚪 **${safeSender}** closed the door.\nThis link is no longer active.`);
+    .setDescription(`🚪 **${safeSender}** closed the door.\nThis qURL is no longer active.`);
   return { embeds: [embed], components: [] };
 }
 

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -522,7 +522,7 @@ describe('buildRevokedDMPayload — post-revoke recipient-side render', () => {
     capturedEmbeds.length = 0;
     buildRevokedDMPayload({ senderAlias: 'Vik' });
     expect(capturedEmbeds[0]._description).toContain('**Vik** closed the door.');
-    expect(capturedEmbeds[0]._description).toContain('This link is no longer active.');
+    expect(capturedEmbeds[0]._description).toContain('This qURL is no longer active.');
   });
 
   it('passes components: [] explicitly so the Step Through button is cleared on edit', () => {


### PR DESCRIPTION
## Summary
- Drop \`(1–N users), then click Send\` parenthetical from the **Pick recipients below** prompt — 10 isn't the cap.
- Drop \`(recipients capped at M)\` from the picker placeholder — noise no one needs.
- Shorten \`Click **Send** to deliver one-time qURL links\` → \`Click **Send** to deliver one-time qURL\`.

## Test plan
- [ ] Invoke \`/qurl file\` / \`/qurl map\` with no recipients → confirm card shows just **Pick recipients below.**
- [ ] Open the picker → placeholder reads \`Pick up to N users/roles\` (no parenthetical).
- [ ] Footer line reads \`Click **Send** to deliver one-time qURL, or **Cancel** to abort.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)