### PR TITLE
feat(discord): surface sender + server provenance on delivery DM

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -790,12 +790,16 @@ function packBulkDeliveryComponents(qurlLinks) {
 // trimming a trailing lone high surrogate if the cap lands mid-pair
 // so the result is never an invalid UTF-16 sequence. Discord renders
 // a lone surrogate as tofu; the trim ensures a clean cut.
-function capUtf16Codepoints(s, maxUtf16Units) {
+function capUtf16Units(s, maxUtf16Units) {
   if (s.length <= maxUtf16Units) return s;
   let truncated = s.slice(0, maxUtf16Units);
   const lastCharCode = truncated.charCodeAt(truncated.length - 1);
   // High-surrogate range (U+D800..U+DBFF): if the cap split a pair,
-  // drop the orphan so the result decodes cleanly.
+  // drop the orphan so the result decodes cleanly. The low-surrogate
+  // case (U+DC00..U+DFFF at the boundary) is unreachable by
+  // construction — `slice(0, n)` would have excluded a low surrogate
+  // at position n, so the high half is the only orphan possible at
+  // position n-1. The asymmetric check is correct, not a bug.
   if (lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) {
     truncated = truncated.slice(0, -1);
   }
@@ -845,7 +849,7 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
   // units codepoint-aware so the API never rejects the embed.
   const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
   const safeGuildName = sanitizeDisplayNamePlain(guildName, { fallback: '' });
-  const authorName = capUtf16Codepoints(
+  const authorName = capUtf16Units(
     safeGuildName ? `${safeSenderPlain} · ${safeGuildName}` : safeSenderPlain,
     256,
   );

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -171,7 +171,7 @@ function isGoogleMapsURL(url) {
 
 
 
-const { DISPLAY_NAME_FALLBACK, sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls, stripControlAndBidi } = require('./utils/sanitize');
+const { DISPLAY_NAME_FALLBACK, sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls } = require('./utils/sanitize');
 
 // Best-effort host extraction for log lines. URL parsing throws on
 // pathological input (no scheme, embedded null, etc.) — swallow and
@@ -746,6 +746,13 @@ function buildStepThroughButton(qurlLink) {
 // What is qURL?] shape executeSendPipeline emits, so a /qurl send
 // followed by /qurl add-recipients renders identically on the
 // recipient side.
+//
+// PRECONDITION: qurlLinks.length >= 1. An empty list would produce
+// a single row containing only the trust button — Discord rejects
+// a component-only payload with no embeds. The caller in
+// handleAddRecipients guards via the `if (!links || links.length
+// === 0)` early return at the batchSettled callback; new callers
+// must guarantee the same.
 function packBulkDeliveryComponents(qurlLinks) {
   const allButtons = [
     ...qurlLinks.map(buildStepThroughButton),
@@ -780,19 +787,18 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
     );
   }
 
-  // Sender lives in the description's markdown context indirectly via
-  // the author row (plaintext slot, no markdown rendering), so the
-  // PLAIN sanitization variant is the right tool — backslash-escapes
-  // would render literally in the author surface, but the bidi/zero-
-  // width spoof defense still applies.
-  const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
-  // guildName uses the lower-level stripControlAndBidi with an empty
-  // fallback: an all-strip hostile guildName (RLO/ZWSP/BOM only) must
-  // collapse to "" so the author row falls back to sender-only, not
+  // Author row is plaintext (no markdown rendering), so the PLAIN
+  // sanitization variant is the right tool for both sender and
+  // guildName halves — backslash-escapes would render literally
+  // here, but the bidi/zero-width spoof defense still applies.
+  // guildName opts into an empty fallback ({ fallback: '' }) so an
+  // all-strip hostile name (RLO/ZWSP/BOM only) collapses to "" and
+  // the author row falls back to sender-only — rather than rendering
   // the nonsense `Vik · Someone` that the DISPLAY_NAME_FALLBACK
-  // default would produce — degrading the trust signal on the exact
+  // default would produce, degrading the trust signal on the exact
   // hostile input the strip exists to defend.
-  const safeGuildName = stripControlAndBidi(guildName, 64, '');
+  const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
+  const safeGuildName = sanitizeDisplayNamePlain(guildName, { fallback: '' });
   const authorName = safeGuildName
     ? `${safeSenderPlain} · ${safeGuildName}`
     : safeSenderPlain;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -171,7 +171,7 @@ function isGoogleMapsURL(url) {
 
 
 
-const { DISPLAY_NAME_FALLBACK, sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls } = require('./utils/sanitize');
+const { DISPLAY_NAME_FALLBACK, sanitizeFilename, escapeDiscordMarkdown, sanitizeDisplayName, sanitizeDisplayNamePlain, sanitizeContentLabel, stripBidiAndControls, stripControlAndBidi } = require('./utils/sanitize');
 
 // Best-effort host extraction for log lines. URL parsing throws on
 // pathological input (no scheme, embedded null, etc.) — swallow and
@@ -477,6 +477,18 @@ function resolveSenderAlias(interaction) {
     ?? DISPLAY_NAME_FALLBACK;
 }
 
+// Author-row provenance fields for the per-recipient DM. `?.` chain
+// defends the edge case where guild is null (commands are guild-only
+// so this shouldn't happen in production). `iconURL()` returns
+// `string | null`; coalesce to `undefined` because some discord.js
+// versions stringify null into the iconURL slot.
+function resolveGuildProvenance(interaction) {
+  return {
+    guildName: interaction?.guild?.name,
+    guildIconUrl: interaction?.guild?.iconURL?.() ?? undefined,
+  };
+}
+
 // Resolve a recipient's per-guild display alias: guild nickname >
 // globalName > username. Falls back through whatever we have on the
 // recipient object so the helper works for User-from-UserSelect,
@@ -699,11 +711,7 @@ async function resolveLocation(parsed) {
 // delivery DM. Mirrors a browser address bar's "click the lock to
 // verify" affordance: a first-time recipient can hit qURL's public
 // landing page to confirm the brand exists before clicking Step
-// Through. Factored out (rather than inlined in buildDeliveryPayload)
-// so the bulk-path call site in handleAddRecipients can append a
-// single trust row at the bottom of N step-throughs without having
-// to strip-and-rebuild — each bulk recipient sees one verify button,
-// not one per qURL link.
+// Through.
 function buildTrustButton() {
   return new ButtonBuilder()
     .setStyle(ButtonStyle.Link)
@@ -712,7 +720,28 @@ function buildTrustButton() {
     .setURL(TRUST.LANDING_URL);
 }
 
-function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, expiresAt, personalMessage }) {
+// The Step Through Link button is the primary action on every DM.
+// Extracted as a factory so the bulk-path call site can compose
+// per-link buttons without round-tripping through buildDeliveryPayload
+// (which always pairs it with a trust button — wasteful when the
+// bulk path packs a single trust button at the bottom for the whole
+// message). 🚪 emoji ties the "opened a door for you" copy to the
+// action — author row, embed accent, and button emoji all reinforce
+// one metaphor.
+function buildStepThroughButton(qurlLink) {
+  return new ButtonBuilder()
+    .setStyle(ButtonStyle.Link)
+    .setEmoji('🚪')
+    .setLabel('Step Through')
+    .setURL(qurlLink);
+}
+
+// Composes the embed only (no button row). Split out so the bulk-path
+// dispatch in handleAddRecipients can build N embeds + N step-through
+// buttons + 1 trust button without round-tripping through
+// buildDeliveryPayload (which always allocates a trust button per
+// call). The single-path call sites use buildDeliveryPayload below.
+function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, personalMessage }) {
   // Discord's `<t:N:R>` markdown wants a positive integer Unix-seconds
   // value; anything else renders a misleading recipient surface (e.g.
   // `<t:0:R>` → "56 years ago", `<t:undefined:R>` → literal text,
@@ -724,35 +753,24 @@ function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, 
     const got = String(expiresAt);
     const gotType = typeof expiresAt;
     throw new Error(
-      `buildDeliveryPayload: expiresAt must be a positive integer `
+      `buildDeliveryEmbed: expiresAt must be a positive integer `
       + `Unix-seconds number (got ${got}, typeof=${gotType})`
     );
   }
 
-  // sanitizeDisplayName centralizes spoof defense so a future caller
-  // adding another sender-name surface picks up the same protections.
-  // Description path (markdown context) uses the escaping variant;
-  // author-row path (plaintext, no markdown rendering) uses the plain
-  // variant — backslash-escapes would render literally in the author
-  // surface but the bidi/zero-width spoof defense still applies.
+  // Sender lives in the description's markdown context indirectly via
+  // the author row (plaintext slot, no markdown rendering), so the
+  // PLAIN sanitization variant is the right tool — backslash-escapes
+  // would render literally in the author surface, but the bidi/zero-
+  // width spoof defense still applies.
   const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
-  // guildName lives in setAuthor's plaintext `name` slot, same as
-  // safeSenderPlain. Two cases must fall through to "sender only"
-  // (no ` · ` separator):
-  //   1. Missing/empty/null guild — interaction.guild is null (commands
-  //      are guild-only so this shouldn't happen in production).
-  //   2. A truthy guildName composed entirely of strip-eligible chars
-  //      (RLO, ZWSP, BOM, soft-hyphen, etc.) — the exact hostile input
-  //      the bidi-strip exists to defend against. sanitizeDisplayName*
-  //      would substitute the "Someone" fallback here, producing the
-  //      nonsense `Vik · Someone` author row. Use stripBidiAndControls
-  //      directly (no fallback), then re-check truthiness, then apply
-  //      the 64-codepoint cap codepoint-aware. Mirrors the cap pattern
-  //      sanitizeDisplayNamePlain uses for senderAlias.
-  const strippedGuild = guildName ? stripBidiAndControls(guildName) : '';
-  const safeGuildName = strippedGuild
-    ? Array.from(strippedGuild).slice(0, 64).join('')
-    : '';
+  // guildName uses the lower-level stripControlAndBidi with an empty
+  // fallback: an all-strip hostile guildName (RLO/ZWSP/BOM only) must
+  // collapse to "" so the author row falls back to sender-only, not
+  // the nonsense `Vik · Someone` that the DISPLAY_NAME_FALLBACK
+  // default would produce — degrading the trust signal on the exact
+  // hostile input the strip exists to defend.
+  const safeGuildName = stripControlAndBidi(guildName, 64, '');
   const authorName = safeGuildName
     ? `${safeSenderPlain} · ${safeGuildName}`
     : safeSenderPlain;
@@ -760,14 +778,8 @@ function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, 
   // Discord renders fields BELOW the description, so all lines (optional
   // personal message + expiry) must live in one setDescription block —
   // an addFields personal-message would land after the expiry line, not
-  // between sender and expiry. Folding also strips addFields' vertical
-  // padding, keeping the Step Through button close to the description.
-  //
-  // The sender + server provenance line was moved to setAuthor (top of
-  // embed, with the guild icon) so the description reads as a clean
-  // action statement: the recipient's eye lands on author → action →
-  // optional context → expiry → button. Same trust signal, less
-  // crowding inside the description.
+  // between description and expiry. Folding also strips addFields'
+  // vertical padding, keeping the Step Through button close.
   //
   // `<t:N:R>` is Discord's client-side relative-time markdown: the
   // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
@@ -819,17 +831,15 @@ function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, 
   }
   descLines.push(`🕐 Closes <t:${expiresAt}:R>`);
 
-  // setAuthor is the embed's "address bar" — anchored top, visually
+  // Author row is the embed's "address bar" — anchored top, visually
   // distinct from the description, the closest analog Discord offers
-  // to a browser's origin display. Sender + guild name together
-  // surface provenance at the spot the recipient's eye naturally
-  // lands first. Icon is only attached when the guild has one — bare
-  // `undefined` (NOT null) is what discord.js wants for "no icon";
-  // some versions stringify null into the URL slot.
+  // to a browser's origin display. Icon is only attached when the
+  // guild has one — bare `undefined` (NOT null) is what discord.js
+  // wants for "no icon"; some versions stringify null into the URL slot.
   const authorOpts = { name: authorName };
   if (guildIconUrl) authorOpts.iconURL = guildIconUrl;
 
-  const embed = new EmbedBuilder()
+  return new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
     .setAuthor(authorOpts)
     .setDescription(descLines.join('\n'))
@@ -838,31 +848,15 @@ function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, 
     // string (not interpolated from qurlLink) keeps the recipient
     // surface stable even if a future minted link uses a subdomain.
     .setFooter({ text: `opens ${TRUST.DESTINATION_DOMAIN}` });
+}
 
-  // Link button: opens qurlLink in the recipient's browser on a
-  // single click. No interaction handler needed — Discord handles
-  // the redirect. ButtonStyle.Link is the only style that carries a
-  // URL (Primary/Success/Danger/Secondary fire interaction handlers,
-  // no redirect).
-  //
-  // 🚪 emoji ties the "opened a door for you" copy to the action —
-  // author line, embed accent, and button emoji all reinforce one
-  // metaphor instead of three. Door is a stronger visual mark on a
-  // grey-Link button than the generic 🔗 chain it replaces.
-  const stepThrough = new ButtonBuilder()
-    .setStyle(ButtonStyle.Link)
-    .setEmoji('🚪')
-    .setLabel('Step Through')
-    .setURL(qurlLink);
-  // Trust button rides in the same ActionRow as Step Through — keeps
-  // the verify path co-located with the primary action (matches the
-  // brand-address-bar metaphor) rather than tucking it into a
-  // separate row below. Bulk-path callers (handleAddRecipients) skip
-  // this row and append their own trust row after packing N step-
-  // throughs 5/row, so a recipient with multiple links sees one
-  // verify button at the bottom rather than N redundant ones.
-  const components = [new ActionRowBuilder().addComponents(stepThrough, buildTrustButton())];
-
+// Convenience wrapper composing the embed + one ActionRow holding
+// [Step Through, What is qURL?]. Used by the single-path call site
+// (executeSendPipeline); the bulk path composes from the primitives
+// directly so it can pack N step-throughs with one shared trust button.
+function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, expiresAt, personalMessage }) {
+  const embed = buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, personalMessage });
+  const components = [new ActionRowBuilder().addComponents(buildStepThroughButton(qurlLink), buildTrustButton())];
   return { embeds: [embed], components };
 }
 
@@ -1658,14 +1652,7 @@ async function executeSendPipeline(interaction, {
   // resolutions of the same string. Both pipelines now share the same
   // hoist pattern for both expiresAt AND senderAlias.
   const senderAlias = resolveSenderAlias(interaction);
-  // Pulled out of the batchSettled callback for the same reason as
-  // senderAlias: a pure read of interaction.guild that the dispatch
-  // loop would otherwise repeat per recipient. `?.` chain defends
-  // the edge case where guild is null (commands are guild-only so
-  // shouldn't happen in production) — buildDeliveryPayload's author
-  // row falls through to "sender only" when guildName is empty.
-  const guildName = interaction.guild?.name;
-  const guildIconUrl = interaction.guild?.iconURL?.() ?? undefined;
+  const { guildName, guildIconUrl } = resolveGuildProvenance(interaction);
 
   const dmResults = await batchSettled(qurlLinks, async (link) => {
     const recipient = recipientMap.get(link.recipientId);
@@ -2265,13 +2252,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // the function level rather than as orphan rows. Closes #352.
   const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
   const senderAlias = resolveSenderAlias(originalInteraction);
-  // Same hoist pattern as executeSendPipeline: read interaction.guild
-  // once and reuse across the dispatch loop. `?.` chain defends the
-  // edge case where guild is null (commands are guild-only so this
-  // shouldn't happen in production); buildDeliveryPayload falls
-  // through to "sender only" in the author row when guildName is empty.
-  const guildName = originalInteraction.guild?.name;
-  const guildIconUrl = originalInteraction.guild?.iconURL?.() ?? undefined;
+  const { guildName, guildIconUrl } = resolveGuildProvenance(originalInteraction);
 
   // Persist to DB before DMs
   const batchSends = [];
@@ -2331,35 +2312,25 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // counts as dispatch_failed instead of disappearing from CloudWatch.
     let result = { ok: false };
     try {
-      const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
+      // Bulk path composes from the primitives: one embed +
+      // one Step Through button per link, plus a single trust button
+      // at the message bottom. Result for links.length === 1 matches
+      // the executeSendPipeline single-row [Step Through, What is qURL?]
+      // layout. links.slice(0, 10) caps at Discord's 10-embed-per-message
+      // limit; the button-row chunking splits all buttons into
+      // ActionRows of 5 (Discord's per-row cap).
+      const cappedLinks = links.slice(0, 10);
+      const allEmbeds = cappedLinks.map(() => buildDeliveryEmbed({
         senderAlias,
         guildName,
         guildIconUrl,
-        qurlLink: link.qurlLink,
         expiresAt,
         personalMessage: sendConfig.personal_message,
       }));
-      // Contract with buildDeliveryPayload: each payload's `components`
-      // array contains exactly one ActionRow whose first child is the
-      // per-link Step Through button (second child is the shared trust
-      // button, which we replace with a single bottom-of-message button
-      // here so multi-link recipients don't see N redundant verify
-      // buttons). We pull each payload's first button and re-pack with
-      // the trust button appended, into 5-per-row ActionRows since
-      // Discord caps at 5 buttons per ActionRow. For links.length === 1
-      // this produces the same single-row [Step Through, What is qURL?]
-      // shape as the executeSendPipeline path.
-      const allEmbeds = payloads.flatMap(p => p.embeds);
-      const stepThroughs = payloads.map(p => {
-        // Hard fail rather than silently drop buttons if the contract
-        // ever changes — easier to catch than a button quietly missing
-        // from a recipient's DM.
-        if (!p.components || !p.components[0] || !Array.isArray(p.components[0].components) || !p.components[0].components[0]) {
-          throw new Error('buildDeliveryPayload contract violated: expected components[0].components[0] to be the Step Through button');
-        }
-        return p.components[0].components[0];
-      });
-      const allButtons = [...stepThroughs, buildTrustButton()];
+      const allButtons = [
+        ...cappedLinks.map(link => buildStepThroughButton(link.qurlLink)),
+        buildTrustButton(),
+      ];
       const allComponents = [];
       for (let i = 0; i < allButtons.length; i += 5) {
         allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
@@ -7950,9 +7921,13 @@ module.exports = {
       sendCooldowns,
       handleAddRecipients,
       buildDeliveryPayload,
+      buildDeliveryEmbed,
+      buildStepThroughButton,
+      buildTrustButton,
       buildRevokedDMPayload,
       persistDispatchResult,
       resolveSenderAlias,
+      resolveGuildProvenance,
       safeUrlHost,
       // Back-half functions exposed for direct unit testing. Without these
       // hooks, coverage of the polling/revoke/add-recipients code paths

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -716,7 +716,11 @@ async function resolveLocation(parsed) {
 function buildTrustButton() {
   return new ButtonBuilder()
     .setStyle(ButtonStyle.Link)
-    .setEmoji('🛡')
+    // U+1F6E1 + U+FE0F. The FE0F variation selector forces emoji-
+    // presentation rendering — without it some clients (older Linux,
+    // some web fallbacks) render the bare shield codepoint as a
+    // text-style glyph rather than the colored emoji.
+    .setEmoji('🛡️')
     .setLabel('What is qURL?')
     .setURL(TRUST.LANDING_URL);
 }
@@ -751,9 +755,13 @@ function buildStepThroughButton(qurlLink) {
 // a single row containing only the trust button — Discord rejects
 // a component-only payload with no embeds. The caller in
 // handleAddRecipients guards via the `if (!links || links.length
-// === 0)` early return at the batchSettled callback; new callers
-// must guarantee the same.
+// === 0)` early return at the batchSettled callback; the throw
+// below pins the same contract for any future caller that misses
+// the docstring.
 function packBulkDeliveryComponents(qurlLinks) {
+  if (!Array.isArray(qurlLinks) || qurlLinks.length === 0) {
+    throw new Error('packBulkDeliveryComponents: qurlLinks must be a non-empty array');
+  }
   const allButtons = [
     ...qurlLinks.map(buildStepThroughButton),
     buildTrustButton(),

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -477,15 +477,16 @@ function resolveSenderAlias(interaction) {
     ?? DISPLAY_NAME_FALLBACK;
 }
 
-// Author-row provenance fields for the per-recipient DM. `?.` chain
-// defends the edge case where guild is null (commands are guild-only
-// so this shouldn't happen in production). `iconURL()` returns
-// `string | null`; coalesce to `undefined` because some discord.js
-// versions stringify null into the iconURL slot.
+// Author-row provenance fields for the per-recipient DM. The
+// `interaction?.guild?` chain defends the edge case where guild is
+// null (commands are guild-only so this shouldn't happen in
+// production). `iconURL()` returns `string | null`; coalesce to
+// `undefined` because some discord.js versions stringify null into
+// the iconURL slot.
 function resolveGuildProvenance(interaction) {
   return {
     guildName: interaction?.guild?.name,
-    guildIconUrl: interaction?.guild?.iconURL?.() ?? undefined,
+    guildIconUrl: interaction?.guild?.iconURL() ?? undefined,
   };
 }
 
@@ -734,6 +735,27 @@ function buildStepThroughButton(qurlLink) {
     .setEmoji('🚪')
     .setLabel('Step Through')
     .setURL(qurlLink);
+}
+
+// Pack a list of qURL links into the bulk-path component rows:
+// one Step Through button per link plus one trust button at the
+// end, chunked 5-per-ActionRow (Discord's per-row cap). The
+// dispatch caller upstream caps links at 10 (Discord's 10-embed-
+// per-message limit), so the worst case is 11 buttons → 3 rows.
+// Behavior at N=1 produces the same single-row [Step Through,
+// What is qURL?] shape executeSendPipeline emits, so a /qurl send
+// followed by /qurl add-recipients renders identically on the
+// recipient side.
+function packBulkDeliveryComponents(qurlLinks) {
+  const allButtons = [
+    ...qurlLinks.map(buildStepThroughButton),
+    buildTrustButton(),
+  ];
+  const rows = [];
+  for (let i = 0; i < allButtons.length; i += 5) {
+    rows.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
+  }
+  return rows;
 }
 
 // Composes the embed only (no button row). Split out so the bulk-path
@@ -2312,13 +2334,10 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     // counts as dispatch_failed instead of disappearing from CloudWatch.
     let result = { ok: false };
     try {
-      // Bulk path composes from the primitives: one embed +
-      // one Step Through button per link, plus a single trust button
-      // at the message bottom. Result for links.length === 1 matches
-      // the executeSendPipeline single-row [Step Through, What is qURL?]
-      // layout. links.slice(0, 10) caps at Discord's 10-embed-per-message
-      // limit; the button-row chunking splits all buttons into
-      // ActionRows of 5 (Discord's per-row cap).
+      // links.slice(0, 10) caps at Discord's 10-embed-per-message
+      // limit; the embed body is identical per-link (sender + guild
+      // + expiry don't vary), so the map only diverges on
+      // qurlLink-bound buttons via packBulkDeliveryComponents.
       const cappedLinks = links.slice(0, 10);
       const allEmbeds = cappedLinks.map(() => buildDeliveryEmbed({
         senderAlias,
@@ -2327,14 +2346,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         expiresAt,
         personalMessage: sendConfig.personal_message,
       }));
-      const allButtons = [
-        ...cappedLinks.map(link => buildStepThroughButton(link.qurlLink)),
-        buildTrustButton(),
-      ];
-      const allComponents = [];
-      for (let i = 0; i < allButtons.length; i += 5) {
-        allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));
-      }
+      const allComponents = packBulkDeliveryComponents(cappedLinks.map(link => link.qurlLink));
 
       result = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });
     } finally {
@@ -7924,6 +7936,7 @@ module.exports = {
       buildDeliveryEmbed,
       buildStepThroughButton,
       buildTrustButton,
+      packBulkDeliveryComponents,
       buildRevokedDMPayload,
       persistDispatchResult,
       resolveSenderAlias,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -737,11 +737,22 @@ function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, 
   // surface but the bidi/zero-width spoof defense still applies.
   const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
   // guildName lives in setAuthor's plaintext `name` slot, same as
-  // safeSenderPlain. Missing/empty guild (commands are guild-only so
-  // this should never happen in production; defended for the edge
-  // case where interaction.guild is null) → omit the server suffix
-  // rather than render a stray ` · ` separator.
-  const safeGuildName = guildName ? sanitizeDisplayNamePlain(guildName) : '';
+  // safeSenderPlain. Two cases must fall through to "sender only"
+  // (no ` · ` separator):
+  //   1. Missing/empty/null guild — interaction.guild is null (commands
+  //      are guild-only so this shouldn't happen in production).
+  //   2. A truthy guildName composed entirely of strip-eligible chars
+  //      (RLO, ZWSP, BOM, soft-hyphen, etc.) — the exact hostile input
+  //      the bidi-strip exists to defend against. sanitizeDisplayName*
+  //      would substitute the "Someone" fallback here, producing the
+  //      nonsense `Vik · Someone` author row. Use stripBidiAndControls
+  //      directly (no fallback), then re-check truthiness, then apply
+  //      the 64-codepoint cap codepoint-aware. Mirrors the cap pattern
+  //      sanitizeDisplayNamePlain uses for senderAlias.
+  const strippedGuild = guildName ? stripBidiAndControls(guildName) : '';
+  const safeGuildName = strippedGuild
+    ? Array.from(strippedGuild).slice(0, 64).join('')
+    : '';
   const authorName = safeGuildName
     ? `${safeSenderPlain} · ${safeGuildName}`
     : safeSenderPlain;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -18,7 +18,7 @@ const crypto = require('crypto');
 const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
-const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, AUDIT_EVENTS } = require('./constants');
+const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, AUDIT_EVENTS, TRUST } = require('./constants');
 const {
   expiryToISO,
   expiryToMs,
@@ -695,7 +695,24 @@ async function resolveLocation(parsed) {
   }
 }
 
-function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessage }) {
+// Trust-signal Link button surfaced beside Step Through on every
+// delivery DM. Mirrors a browser address bar's "click the lock to
+// verify" affordance: a first-time recipient can hit qURL's public
+// landing page to confirm the brand exists before clicking Step
+// Through. Factored out (rather than inlined in buildDeliveryPayload)
+// so the bulk-path call site in handleAddRecipients can append a
+// single trust row at the bottom of N step-throughs without having
+// to strip-and-rebuild — each bulk recipient sees one verify button,
+// not one per qURL link.
+function buildTrustButton() {
+  return new ButtonBuilder()
+    .setStyle(ButtonStyle.Link)
+    .setEmoji('🛡')
+    .setLabel('What is qURL?')
+    .setURL(TRUST.LANDING_URL);
+}
+
+function buildDeliveryPayload({ senderAlias, guildName, guildIconUrl, qurlLink, expiresAt, personalMessage }) {
   // Discord's `<t:N:R>` markdown wants a positive integer Unix-seconds
   // value; anything else renders a misleading recipient surface (e.g.
   // `<t:0:R>` → "56 years ago", `<t:undefined:R>` → literal text,
@@ -714,14 +731,32 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
 
   // sanitizeDisplayName centralizes spoof defense so a future caller
   // adding another sender-name surface picks up the same protections.
-  const safeSender = sanitizeDisplayName(senderAlias);
+  // Description path (markdown context) uses the escaping variant;
+  // author-row path (plaintext, no markdown rendering) uses the plain
+  // variant — backslash-escapes would render literally in the author
+  // surface but the bidi/zero-width spoof defense still applies.
+  const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
+  // guildName lives in setAuthor's plaintext `name` slot, same as
+  // safeSenderPlain. Missing/empty guild (commands are guild-only so
+  // this should never happen in production; defended for the edge
+  // case where interaction.guild is null) → omit the server suffix
+  // rather than render a stray ` · ` separator.
+  const safeGuildName = guildName ? sanitizeDisplayNamePlain(guildName) : '';
+  const authorName = safeGuildName
+    ? `${safeSenderPlain} · ${safeGuildName}`
+    : safeSenderPlain;
 
-  // Discord renders fields BELOW the description, so all three lines
-  // (sender / optional personal message / expiry) must live in one
-  // setDescription block — an addFields personal-message would land
-  // after the expiry line, not between sender and expiry. Folding
-  // also strips addFields' vertical padding, keeping the Step Through
-  // button close to the sender line.
+  // Discord renders fields BELOW the description, so all lines (optional
+  // personal message + expiry) must live in one setDescription block —
+  // an addFields personal-message would land after the expiry line, not
+  // between sender and expiry. Folding also strips addFields' vertical
+  // padding, keeping the Step Through button close to the description.
+  //
+  // The sender + server provenance line was moved to setAuthor (top of
+  // embed, with the guild icon) so the description reads as a clean
+  // action statement: the recipient's eye lands on author → action →
+  // optional context → expiry → button. Same trust signal, less
+  // crowding inside the description.
   //
   // `<t:N:R>` is Discord's client-side relative-time markdown: the
   // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
@@ -743,9 +778,9 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // recipient sees one tidy quote — matches the design mockup which
   // shows the message as a single-line styled box. 280-codepoint cap
   // keeps the embed visually compact. Headroom: 280 codepoints ≤ 1120
-  // UTF-8 bytes + ~10 chars of `> *"…"*` wrapper + 64-char sender +
-  // ~30-char expiry line ≪ Discord's 4096-char description cap.
-  const descLines = [`**${safeSender}** opened a door for you.`];
+  // UTF-8 bytes + ~10 chars of `> *"…"*` wrapper + ~30-char expiry
+  // line ≪ Discord's 4096-char description cap.
+  const descLines = ['opened a door for you.'];
   if (personalMessage) {
     // Skip the styled-blockquote line if the input collapses to an
     // empty string after newline-flatten + trim (e.g. "  \n \n  ").
@@ -773,9 +808,25 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   }
   descLines.push(`🕐 Closes <t:${expiresAt}:R>`);
 
+  // setAuthor is the embed's "address bar" — anchored top, visually
+  // distinct from the description, the closest analog Discord offers
+  // to a browser's origin display. Sender + guild name together
+  // surface provenance at the spot the recipient's eye naturally
+  // lands first. Icon is only attached when the guild has one — bare
+  // `undefined` (NOT null) is what discord.js wants for "no icon";
+  // some versions stringify null into the URL slot.
+  const authorOpts = { name: authorName };
+  if (guildIconUrl) authorOpts.iconURL = guildIconUrl;
+
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
-    .setDescription(descLines.join('\n'));
+    .setAuthor(authorOpts)
+    .setDescription(descLines.join('\n'))
+    // Footer reinforces the destination domain — same trust idea as a
+    // browser showing where a link points before you click. Literal
+    // string (not interpolated from qurlLink) keeps the recipient
+    // surface stable even if a future minted link uses a subdomain.
+    .setFooter({ text: `opens ${TRUST.DESTINATION_DOMAIN}` });
 
   // Link button: opens qurlLink in the recipient's browser on a
   // single click. No interaction handler needed — Discord handles
@@ -784,7 +835,7 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
   // no redirect).
   //
   // 🚪 emoji ties the "opened a door for you" copy to the action —
-  // sender line, embed accent, and button emoji all reinforce one
+  // author line, embed accent, and button emoji all reinforce one
   // metaphor instead of three. Door is a stronger visual mark on a
   // grey-Link button than the generic 🔗 chain it replaces.
   const stepThrough = new ButtonBuilder()
@@ -792,7 +843,14 @@ function buildDeliveryPayload({ senderAlias, qurlLink, expiresAt, personalMessag
     .setEmoji('🚪')
     .setLabel('Step Through')
     .setURL(qurlLink);
-  const components = [new ActionRowBuilder().addComponents(stepThrough)];
+  // Trust button rides in the same ActionRow as Step Through — keeps
+  // the verify path co-located with the primary action (matches the
+  // brand-address-bar metaphor) rather than tucking it into a
+  // separate row below. Bulk-path callers (handleAddRecipients) skip
+  // this row and append their own trust row after packing N step-
+  // throughs 5/row, so a recipient with multiple links sees one
+  // verify button at the bottom rather than N redundant ones.
+  const components = [new ActionRowBuilder().addComponents(stepThrough, buildTrustButton())];
 
   return { embeds: [embed], components };
 }
@@ -1589,6 +1647,14 @@ async function executeSendPipeline(interaction, {
   // resolutions of the same string. Both pipelines now share the same
   // hoist pattern for both expiresAt AND senderAlias.
   const senderAlias = resolveSenderAlias(interaction);
+  // Pulled out of the batchSettled callback for the same reason as
+  // senderAlias: a pure read of interaction.guild that the dispatch
+  // loop would otherwise repeat per recipient. `?.` chain defends
+  // the edge case where guild is null (commands are guild-only so
+  // shouldn't happen in production) — buildDeliveryPayload's author
+  // row falls through to "sender only" when guildName is empty.
+  const guildName = interaction.guild?.name;
+  const guildIconUrl = interaction.guild?.iconURL?.() ?? undefined;
 
   const dmResults = await batchSettled(qurlLinks, async (link) => {
     const recipient = recipientMap.get(link.recipientId);
@@ -1606,6 +1672,8 @@ async function executeSendPipeline(interaction, {
     try {
       const dmPayload = buildDeliveryPayload({
         senderAlias,
+        guildName,
+        guildIconUrl,
         qurlLink: link.qurlLink,
         expiresAt,
         personalMessage,
@@ -2186,6 +2254,13 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // the function level rather than as orphan rows. Closes #352.
   const expiresAt = Math.floor((Date.now() + expiryToMs(sendConfig.expires_in)) / 1000);
   const senderAlias = resolveSenderAlias(originalInteraction);
+  // Same hoist pattern as executeSendPipeline: read interaction.guild
+  // once and reuse across the dispatch loop. `?.` chain defends the
+  // edge case where guild is null (commands are guild-only so this
+  // shouldn't happen in production); buildDeliveryPayload falls
+  // through to "sender only" in the author row when guildName is empty.
+  const guildName = originalInteraction.guild?.name;
+  const guildIconUrl = originalInteraction.guild?.iconURL?.() ?? undefined;
 
   // Persist to DB before DMs
   const batchSends = [];
@@ -2247,25 +2322,33 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     try {
       const payloads = links.slice(0, 10).map(link => buildDeliveryPayload({
         senderAlias,
+        guildName,
+        guildIconUrl,
         qurlLink: link.qurlLink,
         expiresAt,
         personalMessage: sendConfig.personal_message,
       }));
       // Contract with buildDeliveryPayload: each payload's `components`
-      // array contains exactly one ActionRow whose `components` are the
-      // per-link buttons. We pull each payload's first row's children
-      // (one Step Through button per link) and re-pack into 5-per-row
-      // ActionRows since Discord caps at 5 buttons per ActionRow.
+      // array contains exactly one ActionRow whose first child is the
+      // per-link Step Through button (second child is the shared trust
+      // button, which we replace with a single bottom-of-message button
+      // here so multi-link recipients don't see N redundant verify
+      // buttons). We pull each payload's first button and re-pack with
+      // the trust button appended, into 5-per-row ActionRows since
+      // Discord caps at 5 buttons per ActionRow. For links.length === 1
+      // this produces the same single-row [Step Through, What is qURL?]
+      // shape as the executeSendPipeline path.
       const allEmbeds = payloads.flatMap(p => p.embeds);
-      const allButtons = payloads.flatMap(p => {
+      const stepThroughs = payloads.map(p => {
         // Hard fail rather than silently drop buttons if the contract
         // ever changes — easier to catch than a button quietly missing
         // from a recipient's DM.
-        if (!p.components || !p.components[0] || !Array.isArray(p.components[0].components)) {
-          throw new Error('buildDeliveryPayload contract violated: expected components[0].components to be an array');
+        if (!p.components || !p.components[0] || !Array.isArray(p.components[0].components) || !p.components[0].components[0]) {
+          throw new Error('buildDeliveryPayload contract violated: expected components[0].components[0] to be the Step Through button');
         }
-        return p.components[0].components;
+        return p.components[0].components[0];
       });
+      const allButtons = [...stepThroughs, buildTrustButton()];
       const allComponents = [];
       for (let i = 0; i < allButtons.length; i += 5) {
         allComponents.push(new ActionRowBuilder().addComponents(allButtons.slice(i, i + 5)));

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -785,6 +785,23 @@ function packBulkDeliveryComponents(qurlLinks) {
   return rows;
 }
 
+// Cap a string at `maxUtf16Units` UTF-16 code units (matching how
+// Discord's API measures `embed.author.name` and similar limits),
+// trimming a trailing lone high surrogate if the cap lands mid-pair
+// so the result is never an invalid UTF-16 sequence. Discord renders
+// a lone surrogate as tofu; the trim ensures a clean cut.
+function capUtf16Codepoints(s, maxUtf16Units) {
+  if (s.length <= maxUtf16Units) return s;
+  let truncated = s.slice(0, maxUtf16Units);
+  const lastCharCode = truncated.charCodeAt(truncated.length - 1);
+  // High-surrogate range (U+D800..U+DBFF): if the cap split a pair,
+  // drop the orphan so the result decodes cleanly.
+  if (lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated;
+}
+
 // Composes the embed only (no button row). Split out so the bulk-path
 // dispatch in handleAddRecipients can build N embeds + N step-through
 // buttons + 1 trust button without round-tripping through
@@ -819,16 +836,19 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
   // hostile input the strip exists to defend.
   //
   // Combined-length budget: 64 (sender cap) + 3 (` · `) + 64 (guild
-  // cap) = 131 codepoints — well under Discord's 256-char
-  // author.name limit. A future bump of the per-half cap past
-  // ~126 codepoints would push the combined value over that limit
-  // and the API would reject the embed; revisit the math here if
-  // the per-half cap changes.
+  // cap) = 131 codepoints. Discord's author.name limit is 256, but
+  // measured in UTF-16 code units (not codepoints), so a worst-case
+  // mix of 64 surrogate-pair emoji on each half is 64×2 + 3 + 64×2
+  // = 259 UTF-16 units — over the cap. Vanishingly rare in practice
+  // (would need both halves attacker-controlled and all-emoji), but
+  // the slice-and-trim below caps the final string at 256 UTF-16
+  // units codepoint-aware so the API never rejects the embed.
   const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
   const safeGuildName = sanitizeDisplayNamePlain(guildName, { fallback: '' });
-  const authorName = safeGuildName
-    ? `${safeSenderPlain} · ${safeGuildName}`
-    : safeSenderPlain;
+  const authorName = capUtf16Codepoints(
+    safeGuildName ? `${safeSenderPlain} · ${safeGuildName}` : safeSenderPlain,
+    256,
+  );
 
   // Discord renders fields BELOW the description, so all lines (optional
   // personal message + expiry) must live in one setDescription block —
@@ -2374,6 +2394,13 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       // entry via .toJSON() — a pure read of internal state — so
       // reference sharing is safe. Saves N-1 EmbedBuilder allocations
       // + N-1 sanitize-chain runs on the senderAlias/guildName halves.
+      // packBulkDeliveryComponents enforces 1 <= len <= 10 with
+      // fail-loud throws; the upstream guard at line 2372 above
+      // (`if (!links || links.length === 0)`) is what keeps us out
+      // of the lower-bound throw. If a future refactor splits this
+      // dispatch loop or drops that guard, the throw will surface
+      // here at the helper boundary — see packBulkDeliveryComponents
+      // docstring for the contract.
       const cappedLinks = links.slice(0, 10);
       const sharedEmbed = buildDeliveryEmbed({
         senderAlias,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -483,10 +483,16 @@ function resolveSenderAlias(interaction) {
 // production). `iconURL()` returns `string | null`; coalesce to
 // `undefined` because some discord.js versions stringify null into
 // the iconURL slot.
+//
+// `size: 64` matches Discord's embed-author iconURL rendering
+// (~24×24px on most clients, 2× retina ≈ 48px). The default size
+// is the guild-icon-store resolution (up to 4096px), which would
+// ship a much larger asset than gets rendered. Per-DM bandwidth
+// savings × the dispatch loop = a real win at scale.
 function resolveGuildProvenance(interaction) {
   return {
     guildName: interaction?.guild?.name,
-    guildIconUrl: interaction?.guild?.iconURL() ?? undefined,
+    guildIconUrl: interaction?.guild?.iconURL({ size: 64 }) ?? undefined,
   };
 }
 
@@ -751,16 +757,22 @@ function buildStepThroughButton(qurlLink) {
 // followed by /qurl add-recipients renders identically on the
 // recipient side.
 //
-// PRECONDITION: qurlLinks.length >= 1. An empty list would produce
-// a single row containing only the trust button — Discord rejects
-// a component-only payload with no embeds. The caller in
-// handleAddRecipients guards via the `if (!links || links.length
-// === 0)` early return at the batchSettled callback; the throw
-// below pins the same contract for any future caller that misses
-// the docstring.
+// PRECONDITION: 1 <= qurlLinks.length <= 10.
+//   - Empty: a single row containing only the trust button would
+//     ship without any embeds, which Discord rejects.
+//   - >10: N + 1 buttons across 5-per-row chunks exceeds Discord's
+//     5-ActionRow message cap (e.g. N=11 → 3 rows, N=24 → 5 rows,
+//     N=25 → 6 rows = API rejection). The upstream caller in
+//     handleAddRecipients already caps via `links.slice(0, 10)` to
+//     match Discord's 10-embed-per-message limit; the throw below
+//     pins both ends of the contract for any future caller that
+//     misses the docstring.
 function packBulkDeliveryComponents(qurlLinks) {
   if (!Array.isArray(qurlLinks) || qurlLinks.length === 0) {
     throw new Error('packBulkDeliveryComponents: qurlLinks must be a non-empty array');
+  }
+  if (qurlLinks.length > 10) {
+    throw new Error(`packBulkDeliveryComponents: qurlLinks length ${qurlLinks.length} exceeds the 10-link cap`);
   }
   const allButtons = [
     ...qurlLinks.map(buildStepThroughButton),
@@ -805,6 +817,13 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
   // the nonsense `Vik · Someone` that the DISPLAY_NAME_FALLBACK
   // default would produce, degrading the trust signal on the exact
   // hostile input the strip exists to defend.
+  //
+  // Combined-length budget: 64 (sender cap) + 3 (` · `) + 64 (guild
+  // cap) = 131 codepoints — well under Discord's 256-char
+  // author.name limit. A future bump of the per-half cap past
+  // ~126 codepoints would push the combined value over that limit
+  // and the API would reject the embed; revisit the math here if
+  // the per-half cap changes.
   const safeSenderPlain = sanitizeDisplayNamePlain(senderAlias);
   const safeGuildName = sanitizeDisplayNamePlain(guildName, { fallback: '' });
   const authorName = safeGuildName

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2349,17 +2349,21 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     let result = { ok: false };
     try {
       // links.slice(0, 10) caps at Discord's 10-embed-per-message
-      // limit; the embed body is identical per-link (sender + guild
-      // + expiry don't vary), so the map only diverges on
-      // qurlLink-bound buttons via packBulkDeliveryComponents.
+      // limit. The embed body is identical per-link (sender + guild +
+      // expiry don't vary), so build the EmbedBuilder once and repeat
+      // the reference N times. discord.js serializes each embeds[]
+      // entry via .toJSON() — a pure read of internal state — so
+      // reference sharing is safe. Saves N-1 EmbedBuilder allocations
+      // + N-1 sanitize-chain runs on the senderAlias/guildName halves.
       const cappedLinks = links.slice(0, 10);
-      const allEmbeds = cappedLinks.map(() => buildDeliveryEmbed({
+      const sharedEmbed = buildDeliveryEmbed({
         senderAlias,
         guildName,
         guildIconUrl,
         expiresAt,
         personalMessage: sendConfig.personal_message,
-      }));
+      });
+      const allEmbeds = Array(cappedLinks.length).fill(sharedEmbed);
       const allComponents = packBulkDeliveryComponents(cappedLinks.map(link => link.qurlLink));
 
       result = await sendDM(recipient.id, { embeds: allEmbeds, components: allComponents });

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -19,6 +19,17 @@ const RESOURCE_TYPES = {
   MAPS: 'maps',
 };
 
+// Trust signals surfaced on the per-recipient DM embed (sender provenance
+// + "is this real?" verify path). The destination domain in the footer
+// mirrors the host of the minted qURL — keep in lockstep with whatever
+// host qurl-service returns from POST /v1/qurls. The landing URL is the
+// public brand page first-time recipients can hit to verify qURL is a
+// real service before clicking Step Through.
+const TRUST = {
+  LANDING_URL: 'https://layerv.ai/qurl/',
+  DESTINATION_DOMAIN: 'qurl.link',
+};
+
 // DM delivery status values
 const DM_STATUS = {
   SENT: 'sent',
@@ -398,4 +409,5 @@ module.exports = {
   GITHUB_ACTIONS,
   GOOD_FIRST_ISSUE_PATTERNS,
   AUDIT_EVENTS,
+  TRUST,
 };

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -26,6 +26,13 @@ const RESOURCE_TYPES = {
 // public brand page first-time recipients can hit to verify qURL is a
 // real service before clicking Step Through.
 //
+// LANDING_URL is intentionally brand-canonical — it stays pinned to
+// the layerv.ai/qurl page even when a tenant brands their minted-link
+// host via `branded_domain`. The verify path is "is qURL itself
+// real?", not "is this tenant real?"; routing through the canonical
+// brand page is the correct trust signal regardless of which host
+// served the link.
+//
 // TODO(branded-domain): DESTINATION_DOMAIN is a brand-default literal.
 // qurl-service already supports a `branded_domain` concept (tenant-
 // custom hosts on minted links — see qurl-service api.gen.go). Discord

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -33,12 +33,13 @@ const RESOURCE_TYPES = {
 // brand page is the correct trust signal regardless of which host
 // served the link.
 //
-// TODO(branded-domain): DESTINATION_DOMAIN is a brand-default literal.
-// qurl-service already supports a `branded_domain` concept (tenant-
-// custom hosts on minted links — see qurl-service api.gen.go). Discord
-// doesn't consume that field today, but the moment it does, the footer
-// "opens qurl.link" becomes factually wrong while Step Through opens
-// e.g. `door.acme.com`. When qurl-integrations starts honoring
+// TODO(branded-domain) — tracked: layervai/qurl-integrations#383
+// DESTINATION_DOMAIN is a brand-default literal. qurl-service already
+// supports a `branded_domain` concept (tenant-custom hosts on minted
+// links — see qurl-service api.gen.go). Discord doesn't consume that
+// field today, but the moment it does, the footer "opens qurl.link"
+// becomes factually wrong while Step Through opens e.g.
+// `door.acme.com`. When qurl-integrations starts honoring
 // branded_domain in the minted-link response, derive the footer text
 // from link.qurlLink's host rather than this literal.
 const TRUST = {

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -25,6 +25,15 @@ const RESOURCE_TYPES = {
 // host qurl-service returns from POST /v1/qurls. The landing URL is the
 // public brand page first-time recipients can hit to verify qURL is a
 // real service before clicking Step Through.
+//
+// TODO(branded-domain): DESTINATION_DOMAIN is a brand-default literal.
+// qurl-service already supports a `branded_domain` concept (tenant-
+// custom hosts on minted links — see qurl-service api.gen.go). Discord
+// doesn't consume that field today, but the moment it does, the footer
+// "opens qurl.link" becomes factually wrong while Step Through opens
+// e.g. `door.acme.com`. When qurl-integrations starts honoring
+// branded_domain in the minted-link response, derive the footer text
+// from link.qurlLink's host rather than this literal.
 const TRUST = {
   LANDING_URL: 'https://layerv.ai/qurl/',
   DESTINATION_DOMAIN: 'qurl.link',

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -48,16 +48,19 @@ const DISPLAY_NAME_FALLBACK = 'Someone';
 // `maxCodepoints` defaults to 64 (display-name budget). Larger
 // surfaces (locationName, attachment.name → 256) pass their own
 // cap; the strip + NFKC + codepoint-slice contract is identical.
-// Empty / undefined input returns the display-name fallback for the
-// display-name caller; surface-specific callers should branch on
-// the empty case themselves rather than render the fallback.
-function stripControlAndBidi(s, maxCodepoints = 64) {
-  const cleaned = String(s ?? DISPLAY_NAME_FALLBACK).normalize('NFKC').replace(STRIP_RE, '');
+// `fallback` is the string substituted when input is null/undefined
+// AND when the strip + cap chain collapses to empty. Defaults to
+// the display-name fallback for the historical caller; non-display
+// surfaces (e.g. the per-DM guildName provenance row) pass `''`
+// to opt out — surfacing "Someone" on an all-strip hostile guild
+// name would degrade the trust signal the strip exists to defend.
+function stripControlAndBidi(s, maxCodepoints = 64, fallback = DISPLAY_NAME_FALLBACK) {
+  const cleaned = String(s ?? fallback).normalize('NFKC').replace(STRIP_RE, '');
   // Codepoint-aware slice. `String.prototype.slice` operates on UTF-16
   // code units, so a cap on a name like `'A'.repeat(63) + emoji`
   // would split a surrogate pair and Discord would render the lone high
   // surrogate as tofu. `Array.from(str)` iterates by codepoint.
-  return Array.from(cleaned).slice(0, maxCodepoints).join('') || DISPLAY_NAME_FALLBACK;
+  return Array.from(cleaned).slice(0, maxCodepoints).join('') || fallback;
 }
 
 /**
@@ -140,4 +143,5 @@ module.exports = {
   sanitizeDisplayNamePlain,
   sanitizeContentLabel,
   stripBidiAndControls,
+  stripControlAndBidi,
 };

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -111,11 +111,20 @@ function sanitizeDisplayName(s) {
 /**
  * Like sanitizeDisplayName but skips markdown escaping. Use for
  * plain-text contexts where backslash-escapes would render literally
- * (e.g. inside a `.txt` file attachment). NFKC + bidi/zero-width/
- * control strip + 64-codepoint cap still apply.
+ * (e.g. inside a `.txt` file attachment, or a Discord embed's
+ * setAuthor `name` slot). NFKC + bidi/zero-width/control strip +
+ * 64-codepoint cap still apply.
+ *
+ * `fallback` is what's substituted on null/undefined input or when
+ * the strip + cap chain collapses to empty (all-strip hostile
+ * input). Defaults to 'Someone' for the historical caller; surfaces
+ * that would degrade if the fallback string leaked into the rendered
+ * output (e.g. the per-DM author-row guildName, which would render
+ * the nonsense `Vik · Someone` on all-strip hostile input) pass
+ * `{ fallback: '' }` to opt out and handle the empty case themselves.
  */
-function sanitizeDisplayNamePlain(s) {
-  return stripControlAndBidi(s);
+function sanitizeDisplayNamePlain(s, { fallback = DISPLAY_NAME_FALLBACK } = {}) {
+  return stripControlAndBidi(s, 64, fallback);
 }
 
 /**

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -152,5 +152,4 @@ module.exports = {
   sanitizeDisplayNamePlain,
   sanitizeContentLabel,
   stripBidiAndControls,
-  stripControlAndBidi,
 };

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -19,11 +19,13 @@ jest.mock('discord.js', () => {
   const makeEmbed = () => {
     const embed = {
       _description: null,
+      _author: null,
+      _footer: null,
       setColor: jest.fn().mockReturnThis(),
-      setAuthor: jest.fn().mockReturnThis(),
+      setAuthor: jest.fn(function (a) { embed._author = a; return embed; }),
       setDescription: jest.fn(function (d) { embed._description = d; return embed; }),
       addFields: jest.fn().mockReturnThis(),
-      setFooter: jest.fn().mockReturnThis(),
+      setFooter: jest.fn(function (f) { embed._footer = f; return embed; }),
       setTimestamp: jest.fn().mockReturnThis(),
     };
     capturedEmbeds.push(embed);
@@ -143,71 +145,95 @@ const baseArgs = {
   // shows the recipient a live "in 24 hours" / "in 16 hours" / etc.
   expiresAt: 1735689600,  // arbitrary fixed timestamp; tests assert it survives into the embed
   personalMessage: null,
+  // Author-row provenance defaults. The senderAlias-sanitization tests
+  // below leave these as the default and focus assertions on the author
+  // row's `name`; dedicated tests further down exercise guildName /
+  // guildIconUrl edge cases (missing icon, hostile guildName, null
+  // guild). Keep the default benign so a sender-side regression isn't
+  // masked by a server-name surface.
+  guildName: 'Acme Discord',
+  guildIconUrl: 'https://cdn.discordapp.com/icons/g/icon.png',
 };
 
 beforeEach(() => { capturedEmbeds.length = 0; capturedButtons.length = 0; });
 
-describe('buildDeliveryPayload — senderAlias sanitization', () => {
-  it('renders a normal alias unchanged in the description', () => {
+describe('buildDeliveryPayload — senderAlias sanitization (author row)', () => {
+  // Sender provenance now lives in setAuthor's plaintext `name` slot
+  // (the embed's "address bar"), so these assertions target the author
+  // row, not the description. Description-injection is unreachable here
+  // by construction — the author row doesn't render markdown — but the
+  // bidi/zero-width spoof defense still applies (an RLO-prefixed name
+  // would flip the visible direction of the author line just as it
+  // would have inside the old `**Vik**` description slot).
+  it('renders a normal alias unchanged in the author row name', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik' });
-    expect(capturedEmbeds[0]._description).toContain('**Vik** opened a door for you.');
+    expect(capturedEmbeds[0]._author.name).toContain('Vik');
+    expect(capturedEmbeds[0]._description).toContain('opened a door for you.');
+    expect(capturedEmbeds[0]._description).not.toContain('**Vik**');
   });
 
   it('strips U+202E (RLO) from the alias to prevent direction-flip spoof', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: '\u202EAdmin' });
-    const desc = capturedEmbeds[0]._description;
-    expect(desc.includes('\u202E')).toBe(false);
-    expect(desc).toContain('**Admin** opened a door for you.');
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName.includes('\u202E')).toBe(false);
+    expect(authorName).toContain('Admin');
   });
 
   it('strips zero-width spaces and bidi isolates from the alias', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: '\u200BVik\u2066\u2069' });
-    const desc = capturedEmbeds[0]._description;
-    expect(/[\u200B\u2066\u2069]/.test(desc)).toBe(false);
-    expect(desc).toContain('**Vik** opened a door for you.');
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(/[\u200B\u2066\u2069]/.test(authorName)).toBe(false);
+    expect(authorName).toContain('Vik');
   });
 
   it('strips U+061C (Arabic Letter Mark) — completes bidi-control parity with RLM/LRM', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: '\u061CVik' });
-    const desc = capturedEmbeds[0]._description;
-    expect(desc).not.toMatch(/\u061C/);
-    expect(desc).toContain('**Vik** opened a door for you.');
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName).not.toMatch(/\u061C/);
+    expect(authorName).toContain('Vik');
   });
 
   it('strips line/paragraph separators and BOM (would otherwise break embed layout)', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: '\uFEFFVik\u2028\u2029' });
-    const desc = capturedEmbeds[0]._description;
-    expect(/[\uFEFF\u2028\u2029]/.test(desc)).toBe(false);
-    expect(desc).toContain('**Vik** opened a door for you.');
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(/[\uFEFF\u2028\u2029]/.test(authorName)).toBe(false);
+    expect(authorName).toContain('Vik');
   });
 
   it('falls back to "Someone" when alias is entirely strip-eligible chars', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: '\u200B\u202E\u2066\u00AD' });
-    expect(capturedEmbeds[0]._description).toContain('**Someone** opened a door for you.');
+    expect(capturedEmbeds[0]._author.name).toContain('Someone');
   });
 
   it('falls back to "Someone" when alias is null/undefined/empty', () => {
     for (const alias of [null, undefined, '']) {
       capturedEmbeds.length = 0;
       buildDeliveryPayload({ ...baseArgs, senderAlias: alias });
-      expect(capturedEmbeds[0]._description).toContain('**Someone** opened a door for you.');
+      expect(capturedEmbeds[0]._author.name).toContain('Someone');
     }
   });
 
-  it('escapes markdown chars in alias (e.g. masked-link injection)', () => {
+  // Author row is plaintext (Discord doesn't render markdown in setAuthor's
+  // name slot), so a `[click](https://evil.com)` alias renders as literal
+  // characters rather than a clickable masked link. The plain sanitization
+  // path is therefore the correct one — backslash-escapes would appear
+  // visibly. Pin both halves: characters appear verbatim in the author
+  // name (no escape pass), AND no clickable link sneaks into the
+  // description (sender no longer renders there).
+  it('renders markdown-injection alias as literal text (no escape, no clickable link)', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: '[click](https://evil.com)' });
-    const desc = capturedEmbeds[0]._description;
-    // Brackets and parens must be backslash-escaped so Discord renders them
-    // literally instead of as a clickable masked link.
-    expect(desc).toContain('\\[click\\]\\(https://evil.com\\)');
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName).toContain('[click](https://evil.com)');
+    expect(authorName).not.toContain('\\[');
+    expect(capturedEmbeds[0]._description).not.toContain('[click]');
   });
 
   it('caps long aliases at 64 chars (defensive upper bound vs Discord 32-char display-name cap)', () => {
     const long = 'A'.repeat(200);
     buildDeliveryPayload({ ...baseArgs, senderAlias: long });
-    const desc = capturedEmbeds[0]._description;
-    expect(desc).toContain('**' + 'A'.repeat(64) + '** opened a door for you.');
-    expect(desc).not.toContain('**' + 'A'.repeat(65));
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName).toContain('A'.repeat(64));
+    expect(authorName).not.toContain('A'.repeat(65));
   });
 
   // The 64-char cap is codepoint-aware (Array.from + slice + join) — a
@@ -217,10 +243,10 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   it('does not split surrogate pairs at the 64-char boundary', () => {
     const alias = 'A'.repeat(63) + '🎉';
     buildDeliveryPayload({ ...baseArgs, senderAlias: alias });
-    const desc = capturedEmbeds[0]._description;
-    expect(desc).toContain('**' + 'A'.repeat(63) + '🎉** opened a door for you.');
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName).toContain('A'.repeat(63) + '🎉');
     // No lone high surrogate (\uD83C is the high half of 🎉)
-    expect(desc).not.toMatch(/\uD83C(?![\uDC00-\uDFFF])/);
+    expect(authorName).not.toMatch(/\uD83C(?![\uDC00-\uDFFF])/);
   });
 
   // Regression net for the live-countdown design: the Door-closes line
@@ -325,10 +351,12 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // the button reads as intentional rather than generic-CTA-grey.
   it('builds the Step Through button as a Link-style button with the qURL as its URL', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', qurlLink: 'https://qurl.link/#at_unique_token' });
-    // Last button constructed in the buildDeliveryPayload call is the Step Through.
-    const stepThrough = capturedButtons[capturedButtons.length - 1];
+    // capturedButtons holds [stepThrough, trustButton] — the trust button
+    // joined the row alongside Step Through (the "verify this is real"
+    // affordance, brand-address-bar metaphor). Find by label rather than
+    // by index so a future reorder doesn't false-pass this test.
+    const stepThrough = capturedButtons.find(b => b._label === 'Step Through');
     expect(stepThrough).toBeDefined();
-    expect(stepThrough._label).toBe('Step Through');
     expect(stepThrough._emoji).toBe('🚪');
     expect(stepThrough._style).toBe(5); // ButtonStyle.Link
     expect(stepThrough._url).toBe('https://qurl.link/#at_unique_token');
@@ -416,7 +444,7 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   // setDescription is what guarantees the design ordering. Pin the
   // relative order so a future refactor that splits any of the three
   // back into addFields would be caught.
-  it('renders sender → personal message → expiry in that order when all three are present', () => {
+  it('renders action → personal message → expiry in that order when all three are present', () => {
     buildDeliveryPayload({
       ...baseArgs,
       senderAlias: 'Vik',
@@ -428,9 +456,13 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     // `indexOf` check would false-pass if a future personalMessage
     // happened to contain the literal substring `"Closes <t:"`,
     // ordering both indices the same way. Pin position by line.
+    //
+    // Sender no longer appears in the description — it's in the
+    // author row (asserted separately). Line 0 is now the action
+    // statement: "opened a door for you."
     const lines = desc.split('\n');
     expect(lines).toHaveLength(3);
-    expect(lines[0]).toContain('**Vik** opened a door for you.');
+    expect(lines[0]).toBe('opened a door for you.');
     expect(lines[1]).toContain('Quarterly numbers');
     expect(lines[2]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
     // And no addFields call — folded entirely into description.
@@ -438,18 +470,18 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
   });
 
   // When personalMessage is absent, the description still renders
-  // sender → expiry in order (no orphaned blank line between them).
-  it('renders sender → expiry with no gap when personalMessage is omitted', () => {
+  // action → expiry in order (no orphaned blank line between them).
+  it('renders action → expiry with no gap when personalMessage is omitted', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: 1735689600 });
     const desc = capturedEmbeds[0]._description;
     const lines = desc.split('\n');
     // EXACTLY 2 lines — guards against an orphan blank line creeping
-    // in between sender and expiry when personalMessage is absent.
+    // in between action and expiry when personalMessage is absent.
     // Do NOT loosen to `toBeGreaterThanOrEqual(2)`: a 3-line desc
     // would mean someone re-introduced `descLines.push('')` for
     // padding, which renders as a visible empty row in Discord.
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toContain('**Vik** opened a door for you.');
+    expect(lines[0]).toBe('opened a door for you.');
     expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
     // Mirror the all-three-pieces ordering test: also assert addFields
     // is never called on the no-personalMessage path. Belt-and-braces
@@ -460,7 +492,7 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
 
   // Belt-and-braces: a personalMessage that collapses to "" after
   // newline-flatten + trim must not render a visible-but-empty
-  // `> *""*` blockquote between sender and expiry. The call sites
+  // `> *""*` blockquote between action and expiry. The call sites
   // pass `sanitizeMessage(...) || null` so an empty input short-
   // circuits at the outer `if (personalMessage)` today, but a
   // future caller that bypasses that contract would otherwise hit
@@ -479,8 +511,102 @@ describe('buildDeliveryPayload — senderAlias sanitization', () => {
     // personalMessage path above; an empty blockquote line creeping
     // back in would push this to 3 and render visibly in Discord.
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toContain('**Vik** opened a door for you.');
+    expect(lines[0]).toBe('opened a door for you.');
     expect(lines[1]).toMatch(/^🕐 Closes <t:1735689600:R>$/);
+  });
+});
+
+describe('buildDeliveryPayload — author row provenance', () => {
+  // The author row is the embed's "address bar" — anchored top, visually
+  // distinct from the description, the closest analog Discord offers
+  // to a browser's origin display. These tests pin the composition rule
+  // (`${sender} · ${guildName}`) and the iconURL contract (only set when
+  // the guild has one — bare `undefined`, not `null`, on omission).
+  it('composes author name as "sender · guildName" when both are present', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildName: 'Acme Discord' });
+    expect(capturedEmbeds[0]._author.name).toBe('Vik · Acme Discord');
+  });
+
+  it('falls back to sender-only when guildName is missing/empty', () => {
+    for (const guildName of [null, undefined, '']) {
+      capturedEmbeds.length = 0;
+      buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildName });
+      // No trailing ` · ` separator when no guild is known. Defended for
+      // the edge case where interaction.guild is null (commands are
+      // guild-only so this shouldn't fire in production).
+      expect(capturedEmbeds[0]._author.name).toBe('Vik');
+    }
+  });
+
+  it('applies plain (non-markdown-escaping) sanitization to guildName', () => {
+    // Same bidi/zero-width spoof defense the senderAlias path gets — an
+    // attacker controlling guild name could RLO-flip the author row.
+    // Author surface is plaintext, so the markdown-escape pass doesn't
+    // apply; sanitizeDisplayNamePlain is the right tool here.
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildName: '‮Acme​' });
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName).not.toMatch(/[\u202E\u200B]/);
+    expect(authorName).toContain('Acme');
+    expect(authorName).toBe('Vik · Acme');
+  });
+
+  it('attaches guild iconURL when provided', () => {
+    const iconUrl = 'https://cdn.discordapp.com/icons/g/icon.png';
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildIconUrl: iconUrl });
+    expect(capturedEmbeds[0]._author.iconURL).toBe(iconUrl);
+  });
+
+  it('omits iconURL key entirely when guild has no icon', () => {
+    // discord.js wants bare `undefined` (NOT explicit `null`) for "no
+    // icon" — some versions stringify null into the URL slot. Pin that
+    // the key is absent rather than present-and-null.
+    for (const noIcon of [null, undefined, '']) {
+      capturedEmbeds.length = 0;
+      buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildIconUrl: noIcon });
+      expect(capturedEmbeds[0]._author).not.toHaveProperty('iconURL');
+    }
+  });
+});
+
+describe('buildDeliveryPayload — footer + trust button', () => {
+  // Footer reinforces the destination domain the way a browser shows
+  // where a link points before you click. Literal string (not derived
+  // from qurlLink) so a future minted-link subdomain doesn't drift the
+  // recipient-visible domain.
+  it('sets a footer naming the destination domain', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik' });
+    expect(capturedEmbeds[0]._footer).toEqual({ text: 'opens qurl.link' });
+  });
+
+  // The trust button is the "click the lock to verify" affordance —
+  // a first-time recipient can hit qURL's public landing to confirm
+  // the brand exists before clicking Step Through. Locks the URL +
+  // Link style so a future refactor that swaps to a Primary-style
+  // (custom_id-only) button — which would silently break the click-
+  // to-landing flow — surfaces here.
+  it('builds a Link-style "What is qURL?" trust button pointing at the brand landing', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik' });
+    const trust = capturedButtons.find(b => b._label === 'What is qURL?');
+    expect(trust).toBeDefined();
+    expect(trust._emoji).toBe('🛡');
+    expect(trust._style).toBe(5); // ButtonStyle.Link
+    expect(trust._url).toBe('https://layerv.ai/qurl/');
+  });
+
+  // Both buttons live in a single ActionRow next to each other — the
+  // verify path is co-located with the primary action (matches the
+  // brand-address-bar metaphor) rather than tucked into a separate
+  // row below.
+  it('ships Step Through and What is qURL? in the same ActionRow', () => {
+    const { components } = buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik' });
+    expect(components).toHaveLength(1);
+    expect(components[0].addComponents).toHaveBeenCalledTimes(1);
+    // addComponents called with both buttons; pull them out and pin
+    // the order (step-through first, trust second).
+    const args = components[0].addComponents.mock.calls[0];
+    expect(args).toHaveLength(2);
+    expect(args[0]._label).toBe('Step Through');
+    expect(args[1]._label).toBe('What is qURL?');
   });
 });
 

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -554,6 +554,19 @@ describe('buildDeliveryPayload — author row provenance', () => {
     expect(capturedEmbeds[0]._author.name).not.toContain('Someone');
   });
 
+  // The sender + guild halves sanitize through independent
+  // sanitizeDisplayNamePlain calls (default vs. empty-fallback
+  // option). Hostile input on one half must NOT influence the
+  // sanitization result of the other — pin that the cross-half
+  // independence holds at the contract level.
+  it('sanitizes sender and guildName independently (hostile half does not influence the other)', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: '‮Vik', guildName: 'Acme Discord' });
+    expect(capturedEmbeds[0]._author.name).toBe('Vik · Acme Discord');
+    capturedEmbeds.length = 0;
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildName: '‮Acme' });
+    expect(capturedEmbeds[0]._author.name).toBe('Vik · Acme');
+  });
+
   // Mirrors the senderAlias 64-codepoint cap. The same defensive upper
   // bound applies to the guild name — Discord caps guild names at 100
   // chars natively, but a forged interaction / future API shape change

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -630,7 +630,11 @@ describe('buildDeliveryPayload — footer + trust button', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik' });
     const trust = capturedButtons.find(b => b._label === 'What is qURL?');
     expect(trust).toBeDefined();
-    expect(trust._emoji).toBe('🛡');
+    // U+1F6E1 + U+FE0F variation selector — forces emoji-style
+    // rendering on clients that would otherwise show the bare
+    // shield codepoint as a text glyph. A regression dropping the
+    // selector would silently degrade cross-platform appearance.
+    expect(trust._emoji).toBe('🛡️');
     expect(trust._style).toBe(5); // ButtonStyle.Link
     expect(trust._url).toBe('https://layerv.ai/qurl/');
   });
@@ -675,6 +679,31 @@ describe('packBulkDeliveryComponents — 5-per-row chunking', () => {
     const row2 = rowButtons(rows[1]);
     expect(row2).toHaveLength(1);
     expect(row2[0]._label).toBe('What is qURL?');
+  });
+
+  // N=9 is the only configuration where the trust button shares an
+  // ActionRow with multiple unique-URL step-throughs (5 step-throughs
+  // in row 1, 4 step-throughs + 1 trust in row 2). N=4 covers the
+  // shared-row case with a smaller fill; N=9 stresses the boundary.
+  it('N=9: trust button shares the second row with 4 step-throughs', () => {
+    const links = Array.from({ length: 9 }, (_, i) => `https://q.test/u${i}`);
+    const rows = packBulkDeliveryComponents(links);
+    expect(rows).toHaveLength(2);
+    expect(rowButtons(rows[0])).toHaveLength(5);
+    const row2 = rowButtons(rows[1]);
+    expect(row2).toHaveLength(5);
+    expect(row2.slice(0, 4).every(b => b._label === 'Step Through')).toBe(true);
+    expect(row2[4]._label).toBe('What is qURL?');
+  });
+
+  it('throws on empty links — Discord rejects components-only payloads', () => {
+    // Pinned because the precondition is a documented contract, not
+    // just upstream convention. A future caller that bypasses the
+    // `links.length === 0` early return in handleAddRecipients must
+    // fail loud rather than silently produce a malformed payload.
+    expect(() => packBulkDeliveryComponents([])).toThrow(/non-empty array/);
+    expect(() => packBulkDeliveryComponents(null)).toThrow(/non-empty array/);
+    expect(() => packBulkDeliveryComponents(undefined)).toThrow(/non-empty array/);
   });
 
   it('N=10 (Discord embed cap): three rows of [s1..s5], [s6..s10], [trust]', () => {

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -567,6 +567,18 @@ describe('buildDeliveryPayload — author row provenance', () => {
     expect(capturedEmbeds[0]._author.name).toBe('Vik · Acme');
   });
 
+  // Both halves all-strip simultaneously: sender falls back to the
+  // default "Someone" (DISPLAY_NAME_FALLBACK), guildName falls back
+  // to "" (the empty fallback the author row passes), so the
+  // composed result is bare "Someone" — no trailing separator,
+  // no "Someone · Someone". Pins that the two fallbacks compose
+  // correctly against a future regression that swaps either
+  // fallback ordering or strips the empty-string short-circuit.
+  it('both-halves-hostile: composes to bare "Someone" (no Someone · Someone, no trailing separator)', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: '‮​', guildName: '‮​' });
+    expect(capturedEmbeds[0]._author.name).toBe('Someone');
+  });
+
   // Mirrors the senderAlias 64-codepoint cap. The same defensive upper
   // bound applies to the guild name — Discord caps guild names at 100
   // chars natively, but a forged interaction / future API shape change
@@ -704,6 +716,18 @@ describe('packBulkDeliveryComponents — 5-per-row chunking', () => {
     expect(() => packBulkDeliveryComponents([])).toThrow(/non-empty array/);
     expect(() => packBulkDeliveryComponents(null)).toThrow(/non-empty array/);
     expect(() => packBulkDeliveryComponents(undefined)).toThrow(/non-empty array/);
+  });
+
+  it('throws when qurlLinks length exceeds the 10-link cap', () => {
+    // Symmetric with the empty-array throw: N+1 buttons across
+    // 5-per-row chunks for N>10 would exceed Discord's 5-ActionRow
+    // message cap (N=24 → 5 rows is the upper boundary; N=25 → 6
+    // rows = API rejection). The upstream caller in
+    // handleAddRecipients already does `links.slice(0, 10)`, but
+    // the throw pins the contract for any future caller that
+    // misses the docstring.
+    const eleven = Array.from({ length: 11 }, (_, i) => `https://q.test/u${i}`);
+    expect(() => packBulkDeliveryComponents(eleven)).toThrow(/exceeds the 10-link cap/);
   });
 
   it('N=10 (Discord embed cap): three rows of [s1..s5], [s6..s10], [trust]', () => {

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -136,7 +136,15 @@ jest.mock('../src/qurl', () => ({
 jest.mock('../src/connector', () => ({ uploadJsonToConnector: jest.fn() }));
 
 const { _test } = require('../src/commands');
-const { buildDeliveryPayload, buildRevokedDMPayload, resolveSenderAlias } = _test;
+const {
+  buildDeliveryPayload,
+  buildDeliveryEmbed,
+  buildStepThroughButton,
+  buildTrustButton,
+  packBulkDeliveryComponents,
+  buildRevokedDMPayload,
+  resolveSenderAlias,
+} = _test;
 
 const baseArgs = {
   qurlLink: 'https://qurl.link/#at_test',
@@ -628,6 +636,81 @@ describe('buildDeliveryPayload — footer + trust button', () => {
     expect(args).toHaveLength(2);
     expect(args[0]._label).toBe('Step Through');
     expect(args[1]._label).toBe('What is qURL?');
+  });
+});
+
+describe('packBulkDeliveryComponents — 5-per-row chunking', () => {
+  // mock.calls[0][0] is the array of buttons addComponents received
+  // for the row's one call. Production passes a single array argument
+  // (`addComponents(slice)`), so the row owns one mock.call whose
+  // first arg is the slice itself.
+  const rowButtons = (row) => row.addComponents.mock.calls[0][0];
+
+  it('N=4: packs [s1, s2, s3, s4, trust] into a single ActionRow', () => {
+    const rows = packBulkDeliveryComponents(['u1', 'u2', 'u3', 'u4'].map(t => `https://q.test/${t}`));
+    expect(rows).toHaveLength(1);
+    expect(rowButtons(rows[0]).map(b => b._label))
+      .toEqual(['Step Through', 'Step Through', 'Step Through', 'Step Through', 'What is qURL?']);
+  });
+
+  it('N=5: splits into [s1..s5] + [trust] across two rows', () => {
+    const rows = packBulkDeliveryComponents(['u1', 'u2', 'u3', 'u4', 'u5'].map(t => `https://q.test/${t}`));
+    expect(rows).toHaveLength(2);
+    const row1 = rowButtons(rows[0]);
+    expect(row1).toHaveLength(5);
+    expect(row1.every(b => b._label === 'Step Through')).toBe(true);
+    const row2 = rowButtons(rows[1]);
+    expect(row2).toHaveLength(1);
+    expect(row2[0]._label).toBe('What is qURL?');
+  });
+
+  it('N=10 (Discord embed cap): three rows of [s1..s5], [s6..s10], [trust]', () => {
+    const links = Array.from({ length: 10 }, (_, i) => `https://q.test/u${i}`);
+    const rows = packBulkDeliveryComponents(links);
+    // Discord caps a single message at 5 ActionRows; 3 rows leaves
+    // headroom. A regression flipping the step from 5 to 4 would
+    // produce 4 rows here, still under cap but the assertion would
+    // catch it.
+    expect(rows).toHaveLength(3);
+    expect(rowButtons(rows[0])).toHaveLength(5);
+    expect(rowButtons(rows[1])).toHaveLength(5);
+    const lastRow = rowButtons(rows[2]);
+    expect(lastRow).toHaveLength(1);
+    expect(lastRow[0]._label).toBe('What is qURL?');
+    // Pin the link i → button i mapping so a future shuffle would
+    // surface as wrong-URL deliveries.
+    const stepUrls = [
+      ...rowButtons(rows[0]).map(b => b._url),
+      ...rowButtons(rows[1]).map(b => b._url),
+    ];
+    expect(stepUrls).toEqual(links);
+  });
+
+  it('buildStepThroughButton ships as a Link-style button with the supplied qURL as its URL', () => {
+    buildStepThroughButton('https://qurl.link/#at_step');
+    const stepThrough = capturedButtons[capturedButtons.length - 1];
+    expect(stepThrough._label).toBe('Step Through');
+    expect(stepThrough._emoji).toBe('🚪');
+    expect(stepThrough._style).toBe(5); // ButtonStyle.Link
+    expect(stepThrough._url).toBe('https://qurl.link/#at_step');
+  });
+});
+
+describe('buildDeliveryEmbed — embed-only primitive used by bulk path', () => {
+  // The split exists so the bulk path can compose N embeds without
+  // paying for N discarded button rows. A regression that re-added
+  // button-row construction inside buildDeliveryEmbed would
+  // resurrect the per-link allocation waste this split eliminates.
+  it('returns the embed alone (no button row construction)', () => {
+    const embed = buildDeliveryEmbed({
+      senderAlias: 'Vik',
+      guildName: 'Acme Discord',
+      guildIconUrl: undefined,
+      expiresAt: 1735689600,
+      personalMessage: null,
+    });
+    expect(embed).toBe(capturedEmbeds[0]);
+    expect(capturedButtons).toHaveLength(0);
   });
 });
 

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -158,13 +158,10 @@ const baseArgs = {
 beforeEach(() => { capturedEmbeds.length = 0; capturedButtons.length = 0; });
 
 describe('buildDeliveryPayload — senderAlias sanitization (author row)', () => {
-  // Sender provenance now lives in setAuthor's plaintext `name` slot
-  // (the embed's "address bar"), so these assertions target the author
-  // row, not the description. Description-injection is unreachable here
-  // by construction — the author row doesn't render markdown — but the
-  // bidi/zero-width spoof defense still applies (an RLO-prefixed name
-  // would flip the visible direction of the author line just as it
-  // would have inside the old `**Vik**` description slot).
+  // Author row is plaintext (no markdown rendering), so description
+  // markdown-injection vectors are unreachable here — but the bidi /
+  // zero-width spoof defense still applies (an RLO-prefixed name
+  // flips visible direction whether the slot is markdown or plain).
   it('renders a normal alias unchanged in the author row name', () => {
     buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik' });
     expect(capturedEmbeds[0]._author.name).toContain('Vik');
@@ -456,10 +453,6 @@ describe('buildDeliveryPayload — senderAlias sanitization (author row)', () =>
     // `indexOf` check would false-pass if a future personalMessage
     // happened to contain the literal substring `"Closes <t:"`,
     // ordering both indices the same way. Pin position by line.
-    //
-    // Sender no longer appears in the description — it's in the
-    // author row (asserted separately). Line 0 is now the action
-    // statement: "opened a door for you."
     const lines = desc.split('\n');
     expect(lines).toHaveLength(3);
     expect(lines[0]).toBe('opened a door for you.');

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -538,6 +538,34 @@ describe('buildDeliveryPayload — author row provenance', () => {
     }
   });
 
+  // The exact hostile input the bidi-strip exists to defend against:
+  // a truthy guild name composed ENTIRELY of strip-eligible chars
+  // (RLO, ZWSP, soft-hyphen, etc.). sanitizeDisplayName* helpers
+  // substitute the "Someone" display-name fallback on all-strip
+  // input, which would produce the nonsense author row `Vik · Someone`
+  // — degrading the trust signal on the exact input the strip exists
+  // to neutralize. The implementation routes guildName through
+  // stripBidiAndControls (no fallback) so all-strip collapses to ''
+  // and the author row falls back to sender-only.
+  it('falls back to sender-only when guildName is entirely strip-eligible chars (no "Someone" leak)', () => {
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildName: '‮​­' });
+    expect(capturedEmbeds[0]._author.name).toBe('Vik');
+    expect(capturedEmbeds[0]._author.name).not.toContain('Someone');
+  });
+
+  // Mirrors the senderAlias 64-codepoint cap. The same defensive upper
+  // bound applies to the guild name — Discord caps guild names at 100
+  // chars natively, but a forged interaction / future API shape change
+  // could exceed that. 64 codepoints keeps the combined `sender · guild`
+  // author line well under Discord's 256-char author.name limit even
+  // when both halves max out.
+  it('caps long guildName at 64 codepoints', () => {
+    const long = 'G'.repeat(200);
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', guildName: long });
+    const authorName = capturedEmbeds[0]._author.name;
+    expect(authorName).toBe('Vik · ' + 'G'.repeat(64));
+  });
+
   it('applies plain (non-markdown-escaping) sanitization to guildName', () => {
     // Same bidi/zero-width spoof defense the senderAlias path gets — an
     // attacker controlling guild name could RLO-flip the author row.

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -579,6 +579,22 @@ describe('buildDeliveryPayload — author row provenance', () => {
     expect(capturedEmbeds[0]._author.name).toBe('Someone');
   });
 
+  // Worst-case UTF-16 budget: 64 codepoints per half, each a
+  // surrogate-pair emoji, would be 64×2 + 3 + 64×2 = 259 UTF-16
+  // units — over Discord's 256 cap. The capUtf16Codepoints guard
+  // truncates the assembled author.name codepoint-aware so the API
+  // never rejects the embed on this pathological combination.
+  it('caps combined author.name at 256 UTF-16 units (worst-case surrogate-pair emoji on both halves)', () => {
+    const allEmoji = '🎉'.repeat(64);  // 64 codepoints, 128 UTF-16 units
+    buildDeliveryPayload({ ...baseArgs, senderAlias: allEmoji, guildName: allEmoji });
+    const authorName = capturedEmbeds[0]._author.name;
+    // UTF-16 length must fit Discord's author.name cap.
+    expect(authorName.length).toBeLessThanOrEqual(256);
+    // Truncation is codepoint-aware: no lone high surrogate at the
+    // boundary (would render as tofu).
+    expect(authorName).not.toMatch(/\uD83C(?![\uDC00-\uDFFF])/);
+  });
+
   // Mirrors the senderAlias 64-codepoint cap. The same defensive upper
   // bound applies to the guild name — Discord caps guild names at 100
   // chars natively, but a forged interaction / future API shape change

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1764,6 +1764,46 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(emitted).not.toContain('mint_failed');
   });
 
+  // Bulk-path button-packing contract: handleAddRecipients now
+  // discards the trust button inside each per-link payload and
+  // appends ONE trust button at the bottom of the dispatched
+  // message (so multi-link recipients don't see N redundant
+  // "What is qURL?" verify buttons). For the N=1 case asserted
+  // here, the result must match the executeSendPipeline single-
+  // path layout: one ActionRow holding [Step Through, What is qURL?].
+  // A future refactor that re-introduces per-link trust buttons,
+  // or that breaks the contract that components[0].components[0]
+  // is the Step Through button, would surface here.
+  it('packs the trust button once at the bottom (not per-link) for the bulk path', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: null, actual_url: 'https://maps.example.com/x',
+      location_name: 'Eiffel Tower', expires_in: '30m',
+    });
+    mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-pack' });
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/pack', resource_id: 'res-loc-pack' },
+    ]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+    mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
+
+    await handleAddRecipients(
+      'send-pack', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(mockSendDM).toHaveBeenCalledTimes(1);
+    const [, payload] = mockSendDM.mock.calls[0];
+    // One ActionRow holding both buttons — matches the
+    // executeSendPipeline layout for the typical 1-link send.
+    expect(payload.components).toHaveLength(1);
+    const buttons = payload.components[0].components;
+    expect(buttons).toHaveLength(2);
+    // No assertion on label/url shape here; build-delivery-embed.test.js
+    // owns those contracts. This test only pins the packing structure
+    // — that the bulk path produces a [Step Through, What is qURL?]
+    // row, not a separate trust row, in the 1-link case.
+  });
+
   // Locks the single-emission contract: a sendConfig with both file
   // AND location must NOT fire upload_success twice (would double-count
   // UploadCount in CloudWatch). The kind field must be 'mixed'.

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1848,6 +1848,26 @@ describe('handleAddRecipients — happy path (location)', () => {
     if (typeof payload.embeds[0].toJSON === 'function') {
       expect(payload.embeds[0].toJSON()).toEqual(payload.embeds[1].toJSON());
     }
+    // Link-ordering contract: the two minted qURLs (file then location,
+    // per the mintLinks mock sequencing above) must map positionally
+    // onto the Step Through buttons in the assembled payload. A future
+    // refactor that shuffles recipientLinks[recipient.id] between
+    // population and the packBulkDeliveryComponents call would
+    // silently mis-route recipients to the wrong qURL otherwise.
+    // discord.js mock here is the lightweight chainable variant —
+    // setURL.mock.calls captures the URL each button was built with;
+    // pull the URL via the first call's first arg.
+    const urls = payload.components
+      .flatMap(row => row.components)
+      .map(b => b.setURL.mock.calls[0]?.[0])
+      .filter(Boolean);
+    // The two step-throughs (file then location) precede the trust
+    // button; the trust button's URL is the hardcoded brand landing.
+    expect(urls).toEqual([
+      'https://q.test/share-file',
+      'https://q.test/share-loc',
+      'https://layerv.ai/qurl/',
+    ]);
   });
 
   // Locks the single-emission contract: a sendConfig with both file

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1804,6 +1804,43 @@ describe('handleAddRecipients — happy path (location)', () => {
     // row, not a separate trust row, in the 1-link case.
   });
 
+  // The bulk-path shared-embed optimization: at N>1, the EmbedBuilder
+  // is built once and the same reference repeated via Array(N).fill.
+  // discord.js' .toJSON() is a pure read of internal state, so the
+  // optimization is safe — but a future discord.js bump that
+  // introduces a mutating serialize hook (or a buildDeliveryEmbed
+  // change that turns the embed mutation-aware) would break the
+  // pattern silently. This test pins the reference-equality contract.
+  it('shares one EmbedBuilder reference across N>1 embeds in the payload', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-file-shared', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+      actual_url: 'https://maps.example.com/x',
+      location_name: 'Eiffel Tower',
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({
+      resource_id: 'res-file-shared-new', fileBuffer: Buffer.from('x'),
+    });
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/share-file', resource_id: 'res-file-shared-new' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/share-loc', resource_id: 'res-loc-shared-new' }]);
+    mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-shared-new' });
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+
+    await handleAddRecipients(
+      'send-share', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(mockSendDM).toHaveBeenCalledTimes(1);
+    const [, payload] = mockSendDM.mock.calls[0];
+    // file + location → 2 links to the one recipient.
+    expect(payload.embeds).toHaveLength(2);
+    // The optimization: same EmbedBuilder reference, not two copies.
+    expect(payload.embeds[0]).toBe(payload.embeds[1]);
+  });
+
   // Locks the single-emission contract: a sendConfig with both file
   // AND location must NOT fire upload_success twice (would double-count
   // UploadCount in CloudWatch). The kind field must be 'mixed'.

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1839,6 +1839,15 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(payload.embeds).toHaveLength(2);
     // The optimization: same EmbedBuilder reference, not two copies.
     expect(payload.embeds[0]).toBe(payload.embeds[1]);
+    // Belt-and-braces: even if a future discord.js bump introduced a
+    // position-aware toJSON (some library serialize hooks consult
+    // internal counters), the serialized output must remain identical
+    // across the embeds[] entries — otherwise the recipient would see
+    // diverged author/footer/description across embeds that share the
+    // builder reference.
+    if (typeof payload.embeds[0].toJSON === 'function') {
+      expect(payload.embeds[0].toJSON()).toEqual(payload.embeds[1].toJSON());
+    }
   });
 
   // Locks the single-emission contract: a sendConfig with both file


### PR DESCRIPTION
## Summary

Recipient-trust pass on the per-recipient delivery DM, modeled on a browser's address bar. Three signals now travel with every qURL link:

- **Author row** — `<sender> · <guildName>` with the guild icon, anchored top of the embed (the closest analog Discord offers to the browser's origin display). Sender removed from the description's leading line so the action statement reads as a clean "opened a door for you." sentence beneath the author. Guild icon requested at `{ size: 64 }` to match the ~24×24px rendering slot (saves bandwidth on every dispatch vs. the default full-resolution asset).
- **Footer** — `opens qurl.link` reinforces the destination domain. Literal string (see `TRUST.DESTINATION_DOMAIN`) with a `TODO(branded-domain)` marker — tracked at #383 — for the future migration to deriving the host from the minted link's URL once `qurl-service`'s `branded_domain` feature lands.
- **🛡️ What is qURL? button** — Link button alongside Step Through, pointing at `https://layerv.ai/qurl/` so a first-time recipient can verify the brand before clicking through. Intentionally brand-canonical (pinned to layerv.ai regardless of any future `branded_domain` host on the minted link) — the verify path answers "is qURL itself real?", not "is this tenant real?". Factored as a separate `buildTrustButton()` so the bulk-path call site (`handleAddRecipients`) appends a single trust row at the bottom of N step-throughs instead of N redundant verify buttons.

### Sanitization

`sanitizeDisplayNamePlain` was overloaded with an optional `{ fallback }` parameter so the author row's two halves go through one entry point:

- **Sender** uses the default fallback (`DISPLAY_NAME_FALLBACK = "Someone"`): bidi/zero-width strip + 64-codepoint cap + markdown-escape skip (the slot is plaintext).
- **GuildName** passes `{ fallback: '' }`: same strip + cap, but an all-strip hostile guildName collapses to `''` so the author row falls back to sender-only — rather than rendering the nonsense `Vik · Someone` that the default fallback would produce on the exact hostile input the strip exists to defend.

Caught in pre-merge DE review. Pinned by regression tests for cross-half independence (`'‮Vik' × 'Acme Discord'` and vice versa) and the both-halves-hostile composition to bare `"Someone"`.

The assembled `author.name` is additionally capped at 256 UTF-16 code units (Discord's API limit, codepoint-aware to avoid splitting surrogate pairs) — defends the pathological case where both 64-codepoint halves are surrogate-pair emoji (64×2 + 3 + 64×2 = 259 UTF-16 units).

Icon URL passed as `undefined` (NOT null) when the guild has no icon, since some discord.js versions stringify null into the URL slot.

### Bulk-path packing

Extracted `packBulkDeliveryComponents(qurlLinks)` (exported via `_test`) — one Step Through button per link plus one trust button at the end, chunked 5-per-ActionRow. Fail-loud preconditions on both ends: empty array AND >10 links (the latter would exceed Discord's 5-ActionRow cap once N+1 buttons chunk past 25). Unit tests at N=1, N=4, N=5, N=9, N=10, N=0 (throw), N>10 (throw) pin the chunking arithmetic.

`buildDeliveryPayload` was split into composable primitives: `buildDeliveryEmbed` + `buildStepThroughButton` + `buildTrustButton`, with `buildDeliveryPayload` remaining as the thin single-path wrapper. The bulk path composes from primitives directly. For N>1 the EmbedBuilder is built once and the reference repeated via `Array(N).fill(sharedEmbed)` — discord.js serializes via `.toJSON()` (pure read) so sharing is safe; pinned by both a reference-equality and `toJSON()` deep-equality test.

`buildRevokedDMPayload` is intentionally untouched — the revoke-edit DM is a natural follow-up.

### Deferred follow-ups

- #378 — Rename the verbal-mirror sanitize helpers (`stripBidiAndControls` vs `stripControlAndBidi`). Pure rename, out of scope here.
- #380 — Differentiate per-link buttons + embeds in the bulk-path DM (multi-link sends). `links.length` is 1 in production today; the bulk path is functionally correct but visually redundant at N>1.
- #383 — Derive `TRUST.DESTINATION_DOMAIN` (footer host) from the minted-link URL once qurl-service's `branded_domain` field is plumbed through the bot.

## Test plan

- [x] CI: 1757 jest tests pass on the branch (7 new packing tests including N=9, N=0 throw, N>10 throw + 9 author-row provenance tests including UTF-16 worst-case + cross-half-independence + both-halves-hostile + shared-embed toJSON-equality, 14 existing tests updated for the new layout).
- [x] CI: `eslint` clean.
- [ ] Manual: send a qURL via `/qurl file` in a sandbox guild and verify on the recipient side:
  - Author row shows `<sender> · <Guild Name>` with the server icon
  - Description reads "opened a door for you." (no leading sender prefix)
  - Footer reads "opens qurl.link"
  - Two buttons render in one row: `🚪 Step Through` and `🛡️ What is qURL?`
  - **Shield renders as color emoji (not text-style glyph) on Discord desktop, iOS, Android, and web** — confirms the FE0F variation selector survives discord.js' API encoding to the wire format.
  - Clicking "What is qURL?" lands on `https://layerv.ai/qurl/`
- [ ] Manual: invoke `/qurl add recipients` on an existing send and verify a recipient with multiple links sees ONE "What is qURL?" button at the bottom (not one per link).
- [ ] Manual: in a guild with no custom icon, confirm the author row renders without a broken icon placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)