### PR TITLE
feat(discord): hide picker after @everyone or voice fan-out

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3908,24 +3908,7 @@ function renderConfirmCardRows({
     // Count is render-time, not click-time — members can join/leave
     // voice between renders. Click-time resolution in
     // handleConfirmVoiceEveryone is the authoritative recipient set;
-    // the label is a freshness hint that re-derives on every other
-    // confirm-card interaction (picker / expiry / note edits all flow
-    // through renderConfirmCardRows again).
-    // Filter-drift contract: the render-time count below uses
-    // `isBotMember(m)` to compute (N), while click-time resolution
-    // in handleConfirmVoiceEveryone routes channel.members through
-    // `partitionRecipients` for the authoritative recipient set.
-    // Both apply the same bot filter today, so the count is honest.
-    // If `partitionRecipients` ever picks up additional drops (role-
-    // blocklist, self-filter toggle, etc.), the render-time `(N)`
-    // will silently overstate the click-time set — keep the two
-    // filter sources aligned, or accept a stale label and document
-    // the drift here.
-    // Live connected-non-bot count is still computed so the button
-    // can be disabled when the channel is empty or unreadable — it
-    // just doesn't surface in the label anymore (kept terse per
-    // product UX call). `connectedCount == null` is the single
-    // sentinel for "render the disabled button shell."
+    // the count here only drives the disable state.
     let connectedCount = null;
     if (interaction) {
       const channel = interaction.guild?.channels?.cache?.get?.(voiceChannelId);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2915,7 +2915,7 @@ const CONFIRM_EXPIRY_SELECT_CUSTOM_ID = 'qurl_confirm_expiry';
 const CONFIRM_SELF_DESTRUCT_SELECT_CUSTOM_ID = 'qurl_confirm_self_destruct';
 const CONFIRM_NOTE_BUTTON_CUSTOM_ID = 'qurl_confirm_note_btn';
 const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
-// Confirm-card "Everyone in this voice channel" button. Rendered only
+// Confirm-card "Everyone on voice" button. Rendered only
 // when the slash command was invoked from a voice / stage-voice channel
 // (`payload.voiceChannelId` is set by `handleQurlSlashSend`). Mirrors
 // the role-mention/`<#voice>` parser path: resolve voice-connected
@@ -2946,11 +2946,12 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // Tracked in #339 if a future product decision (stage channels with
 // thousands of audience) needs to revisit this for stage-only.
 const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
-// "Pick people instead" button — rendered only in voice-mode (i.e.
-// `payload.recipientMode === 'voice'`). Clearing it flips the card
-// back to picker-mode (recipientIds dropped, MentionableSelect row
-// restored). Lives on its own customId so flow-dispatch routes
-// directly instead of branching inside the voice-everyone handler.
+// "Pick people instead" button — rendered in voice-mode and
+// everyone-mode (i.e. `payload.recipientMode === 'voice' || 'everyone'`).
+// Clicking it flips the card back to picker-mode (recipientIds
+// dropped, MentionableSelect row restored). Lives on its own customId
+// so flow-dispatch routes directly instead of branching inside the
+// voice/@everyone handlers.
 const CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID = 'qurl_confirm_pick_manual';
 // Whole-guild `@everyone` button on the confirm card. Workaround for
 // Discord's MentionableSelectMenu omitting the `@everyone` role from
@@ -2958,33 +2959,44 @@ const CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID = 'qurl_confirm_pick_manual';
 // MENTION_EVERYONE-bearing users with no in-picker affordance for
 // the "fan out to the whole server" intent. Click-time semantics
 // match a synthetic `@everyone` text-mention pick. Picker-mode only —
-// voice-mode already targets the voice population and rendering the
-// button there would mislead users about what "everyone" means.
+// voice-mode already targets the voice population (different
+// "everyone"), and everyone-mode is the post-click state where this
+// button has already done its job (re-rendering it would invite a
+// re-click that just churns the version with no state change).
 const CONFIRM_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_everyone';
 
-// Two recipient-source modes carried on `payload.recipientMode`:
+// Three recipient-source modes carried on `payload.recipientMode`:
 //   - 'picker' (default): MentionableSelect row is the source of
-//     truth; bottom row carries the "🔊 Everyone in #voice" affordance
-//     when the slash command was invoked from voice.
+//     truth; bottom row carries the "🔊 Everyone on voice" affordance
+//     when the slash command was invoked from voice, plus the
+//     "📢 @everyone" affordance when the sender has MENTION_EVERYONE.
 //   - 'voice': recipientIds were resolved from `channel.members` and
 //     the picker row is hidden. Bottom row swaps in "👥 Pick people
 //     instead" so the user can fall back to manual selection.
+//   - 'everyone': recipientIds were resolved from the guild's full
+//     non-bot member set via the 📢 @everyone shortcut. Like voice,
+//     the picker row is hidden and the bottom row carries the
+//     "👥 Pick people instead" escape hatch — auto-filling the
+//     picker would either silently truncate at Discord's 25-entry
+//     hard cap or read back through `handleConfirmUserSelect` and
+//     replace the @everyone fan-out with a subset.
 // Stale flow_state rows (created before this field existed) read as
 // undefined — `normalizeRecipientMode` below maps undefined / any
 // off-set value to RECIPIENT_MODE_PICKER so they keep the legacy
 // picker shape until they expire.
 const RECIPIENT_MODE_PICKER = 'picker';
 const RECIPIENT_MODE_VOICE = 'voice';
+const RECIPIENT_MODE_EVERYONE = 'everyone';
 
-// Single source of truth for "this token is voice; everything else
-// reads as picker." Three render sites (renderConfirmCardContent,
-// renderConfirmCardRows, rerenderConfirmCard) previously open-coded
-// `mode === RECIPIENT_MODE_VOICE ? VOICE : PICKER` — if any of those
-// drifted (e.g. someone tested `mode === 'voice'` against a typo'd
-// constant), the layout would split between branches. The helper
-// pins the stale-row default in one place.
+// Single source of truth for the closed-set map. Multiple render
+// sites (renderConfirmCardContent, renderConfirmCardRows,
+// rerenderConfirmCard) previously open-coded the ternary; an off-set
+// or typo'd constant would silently fall through to PICKER and break
+// the layout swap. The helper pins the stale-row default in one place.
 function normalizeRecipientMode(mode) {
-  return mode === RECIPIENT_MODE_VOICE ? RECIPIENT_MODE_VOICE : RECIPIENT_MODE_PICKER;
+  if (mode === RECIPIENT_MODE_VOICE) return RECIPIENT_MODE_VOICE;
+  if (mode === RECIPIENT_MODE_EVERYONE) return RECIPIENT_MODE_EVERYONE;
+  return RECIPIENT_MODE_PICKER;
 }
 
 // Recipient-rejection reason strings shared by every handler that
@@ -3168,10 +3180,10 @@ function partitionRecipients(users, senderId, { excludeSender = false } = {}) {
   for (const u of users) {
     if (u.bot) { droppedBots++; continue; }
     // Voice-everyone path drops the sender silently — they pressed
-    // the "Everyone in #voice" affordance, which semantically means
+    // the "Everyone on voice" affordance, which semantically means
     // "everyone else." No droppedBots-style accounting because the
-    // user-visible message ("you not included") is rendered from
-    // the recipientMode, not from a partition counter.
+    // exclusion is inferred from voice-mode semantics rather than
+    // surfaced in user-visible copy.
     if (u.id === senderId && excludeSender) continue;
     if (u.id === senderId) selfIncluded = true;
     valid.push(u);
@@ -3562,8 +3574,8 @@ function renderConfirmCardContent({
   // + handleConfirmPickManual), so `selfIncluded === true` is
   // structurally unreachable in voice-mode. The guard is defense
   // against a forged or schema-drifted payload that would otherwise
-  // produce contradictory copy: "Send includes you." stacked on top
-  // of "(you not included)" in the voice-mode "To:" line.
+  // produce contradictory copy ("Send includes you." stacked on top
+  // of a voice-mode "To:" line whose semantics exclude the sender).
   if (selfIncluded && mode !== RECIPIENT_MODE_VOICE) {
     content += 'ℹ\u{FE0F} **Send includes you.**\n';
   }
@@ -3573,20 +3585,22 @@ function renderConfirmCardContent({
     // Voice-mode "To:" — names omitted in favor of the channel context.
     // The #voice mention is the source of truth for who's included;
     // listing alias names would just duplicate the scrollback the user
-    // already sees in Discord. "(you not included)" makes the sender-
-    // exclusion contract explicit on the card.
+    // already sees in Discord. Sender exclusion is left inferred from
+    // voice-mode semantics (the user clicked "Everyone on voice" knowing
+    // they themselves wouldn't qURL themselves) rather than spelled out
+    // — the explicit "(you not included)" disclosure dropped per UX
+    // call; selfIncluded:false is still load-bearing on the data side.
     //
     // SAFETY: use Discord's native channel-mention syntax `<#id>` (which
     // Discord renders client-side from the channel id) instead of
     // interpolating `channel.name` raw. A name like `**spoiler**`,
-    // `_underline_`, `||hidden||`, or one containing the literal
-    // `*(you not included)*` substring would otherwise inject markdown
+    // `_underline_`, or `||hidden||` would otherwise inject markdown
     // into the confirm card. Mirrors the same gotcha noted at the
     // voice-button label site (where button-label rendering doesn't
     // process markdown, but message content does).
     const channelRef = voiceChannelId ? `<#${voiceChannelId}>` : 'the voice channel';
     const userWord = validRecipients.length === 1 ? 'user' : 'users';
-    content += `\n**To:** ${validRecipients.length} ${userWord} in ${channelRef} *(you not included)*\n`;
+    content += `\n**To:** ${validRecipients.length} ${userWord} in ${channelRef}\n`;
   } else {
     // First-N preview keeps the card scannable when a paste resolves
     // to many users. resolveRecipientAlias prefers nickname > globalName >
@@ -3681,22 +3695,27 @@ function formatPersonalMessagePreview(message) {
 // need the 180s flow_state drain coordination from #316.
 //
 // Row math (Discord 5-row max, 5-buttons-per-row max):
-//   PICKER mode: Mentionable + SelfDestruct + Expiry +
-//     [(optional 🔊 Voice), Note, Send, Cancel] = 4 rows, ≤ 4 buttons
-//   VOICE mode:  SelfDestruct + Expiry +
+//   PICKER mode:   Mentionable + SelfDestruct + Expiry +
+//     [(optional 🔊 Voice), (optional 📢 @everyone), Note, Send, Cancel]
+//     = 4 rows, ≤ 5 buttons
+//   VOICE mode:    SelfDestruct + Expiry +
+//     [👥 Pick people instead, Note, Send, Cancel]   = 3 rows, 4 buttons
+//   EVERYONE mode: SelfDestruct + Expiry +
 //     [👥 Pick people instead, Note, Send, Cancel]   = 3 rows, 4 buttons
 //
 // The bottom-row affordance flips with the mode:
-//   - `'picker'` + voiceChannelId set → 🔊 Everyone in #voice button.
+//   - `'picker'` + voiceChannelId set → 🔊 Everyone on voice button.
 //     Disabled with a `(0)` count when the channel has no connected
 //     non-bot members at render time — honest UX so the user can see
 //     WHY the button is inert.
-//   - `'voice'` → 👥 Pick people instead button. Picker row is removed
-//     entirely; the user has committed to voice-everyone semantics and
-//     this button is their escape hatch back to manual selection.
+//   - `'voice'` or `'everyone'` → 👥 Pick people instead button.
+//     Picker row is removed entirely; the user has committed to a
+//     bulk-select semantics and this button is their escape hatch
+//     back to manual selection. Both modes share a single handler
+//     (handleConfirmPickManual) that resets recipientMode to 'picker'.
 // The actual member resolution still happens at click time (see
-// `handleConfirmVoiceEveryone`); the count here is a snapshot hint so
-// the label isn't blank.
+// `handleConfirmVoiceEveryone` and `handleConfirmEveryone`); the
+// counts here are snapshot hints so the labels aren't blank.
 //
 // `recipientMode` defaults to RECIPIENT_MODE_PICKER for stale rows that
 // existed before this field was introduced; the legacy shape is exactly
@@ -3852,13 +3871,23 @@ function renderConfirmCardRows({
   // note" based on current state so the user can tell at a glance
   // whether a note is attached. The leading-button affordance is
   // mode-dependent: picker-mode shows the voice-everyone entry button
-  // (only when the slash was invoked from voice); voice-mode shows the
-  // "Pick people instead" escape hatch.
+  // (only when the slash was invoked from voice); voice-mode and
+  // everyone-mode show the "Pick people instead" escape hatch.
   const bottomRow = new ActionRowBuilder();
   if (mode === RECIPIENT_MODE_VOICE && voiceChannelId) {
     // Voice-mode escape hatch. The handler clears recipientIds and
     // flips recipientMode back to 'picker'. Style as Secondary so it
     // doesn't compete visually with Send (Success).
+    bottomRow.addComponents(
+      new ButtonBuilder()
+        .setCustomId(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID)
+        .setLabel('\u{1F465} Pick people instead')
+        .setStyle(ButtonStyle.Secondary),
+    );
+  } else if (mode === RECIPIENT_MODE_EVERYONE) {
+    // Everyone-mode escape hatch — same handler as voice-mode. Picker
+    // row is hidden above; this is the only path back to manual
+    // selection without re-running the slash command.
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID)
@@ -3891,8 +3920,12 @@ function renderConfirmCardRows({
     // will silently overstate the click-time set — keep the two
     // filter sources aligned, or accept a stale label and document
     // the drift here.
+    // Live connected-non-bot count is still computed so the button
+    // can be disabled when the channel is empty or unreadable — it
+    // just doesn't surface in the label anymore (kept terse per
+    // product UX call). `connectedCount == null` is the single
+    // sentinel for "render the disabled button shell."
     let connectedCount = null;
-    let channelName = null;
     if (interaction) {
       const channel = interaction.guild?.channels?.cache?.get?.(voiceChannelId);
       if (channel?.members) {
@@ -3901,51 +3934,12 @@ function renderConfirmCardRows({
           if (!isBotMember(m)) n++;
         }
         connectedCount = n;
-        channelName = channel.name || null;
       }
     }
-    const labelCount = connectedCount == null ? '?' : String(connectedCount);
-    // Name the target channel in the label so a user who invoked
-    // from #voice-A and drifted to #voice-B mid-flow can tell the
-    // button still targets the original channel. Discord button-label
-    // hard cap is 80 UTF-16 code units (NOT codepoints — Discord
-    // measures UTF-16 surrogate-pair-aware, so an emoji-heavy 46-
-    // codepoint name occupies up to 92 UTF-16 units). Budget the
-    // name in UTF-16 units (channelName.length, which IS UTF-16 unit
-    // count in JS strings) so the upper bound is hard-guaranteed
-    // regardless of emoji density.
-    //
-    // Fixed prefix + suffix:
-    //   `🔊 ` (3) + `Everyone in #` (13) + ` (NNNNN)` (max 8) = 24
-    //   (🔊 is a surrogate pair = 2 UTF-16 units + a space).
-    // 50 leaves 6 units of headroom for label evolution. The `…`
-    // ellipsis adds 1 UTF-16 unit, so the budget includes its slot:
-    // a max-truncation label measures 24 + 49 + 1 = 74 UTF-16 units.
-    //
-    // SAFETY: channel.name is interpolated raw into the button label
-    // — Discord BUTTON labels do not render markdown / mentions /
-    // emoji shortcodes, so a channel name containing `**bold**` or
-    // `<@123>` is displayed verbatim. A future refactor that moves
-    // this label into an embed description / message content would
-    // need to escape `channel.name` against markdown/mention parsing.
-    const VOICE_LABEL_NAME_UTF16_BUDGET = 50;
-    // Back off if the cut would split a surrogate pair (a high
-    // surrogate at the last position with no paired low surrogate
-    // would render as `�`). Reserve 1 UTF-16 unit for the ellipsis.
-    const safeName = (() => {
-      if (!channelName) return null;
-      if (channelName.length <= VOICE_LABEL_NAME_UTF16_BUDGET) return channelName;
-      let cut = VOICE_LABEL_NAME_UTF16_BUDGET - 1;
-      // High surrogate at cut-1 → cut would split it; back off 1 unit.
-      const code = channelName.charCodeAt(cut - 1);
-      if (code >= 0xD800 && code <= 0xDBFF) cut -= 1;
-      return `${channelName.slice(0, cut)}…`;
-    })();
-    const labelTarget = safeName ? `#${safeName}` : 'this voice channel';
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID)
-        .setLabel(`\u{1F50A} Everyone in ${labelTarget} (${labelCount})`)
+        .setLabel('\u{1F50A} Everyone on voice')
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(connectedCount == null || connectedCount === 0),
     );
@@ -3993,12 +3987,11 @@ function renderConfirmCardRows({
     //    handleConfirmEveryone (authoritative — partition runs against
     //    the prewarmed cache).
     const overCap = countIsAccurate && displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
-    const labelCount = displayCount == null ? '?' : String(displayCount);
-    const labelSuffix = overCap ? ` — exceeds ${config.QURL_SEND_MAX_RECIPIENTS} cap` : '';
-    // No `VOICE_LABEL_NAME_UTF16_BUDGET`-equivalent here because no
-    // user-controlled string is interpolated: worst-case label is
-    // `📢 @everyone (NNNNN) — exceeds NNNNN cap` ≈ 41 UTF-16 units,
-    // well under Discord's 80-unit button-label cap.
+    // Fixed label — no live count, no overcap suffix. The disabled+
+    // greyed-out button is the visual signal for the three degraded
+    // states (count unavailable, empty guild, exceeds cap); the click-
+    // time reject in `handleConfirmEveryone` carries the actionable
+    // reason copy when the disable can't fire (cold-cache overcap).
     //
     // BOTTOM ROW COMPONENT BUDGET: Discord caps an ActionRow at 5
     // components. The current worst-case render is
@@ -4009,7 +4002,7 @@ function renderConfirmCardRows({
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_EVERYONE_BUTTON_CUSTOM_ID)
-        .setLabel(`\u{1F4E2} @everyone (${labelCount})${labelSuffix}`)
+        .setLabel('\u{1F4E2} @everyone')
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(displayCount == null || displayCount === 0 || overCap),
     );
@@ -4236,8 +4229,8 @@ async function handleQurlSlashSend(interaction, params) {
       });
     }
 
-    // Voice-channel context snapshot. The "Everyone in this voice
-    // channel" confirm-card button is rendered when this is set.
+    // Voice-channel context snapshot. The "Everyone on voice"
+    // confirm-card button is rendered when this is set.
     // Snapshot at slash-command time (NOT re-derived at button-click)
     // because:
     //   - interaction.channel at click time tracks the channel the
@@ -4246,7 +4239,7 @@ async function handleQurlSlashSend(interaction, params) {
     //     contract and matches the rest of the flow-state pattern.
     //   - A user who opens /qurl file from a voice channel, then
     //     drags themselves into a different channel mid-confirm,
-    //     should still see "Everyone in this voice channel" target
+    //     should still see "Everyone on voice" target
     //     the channel they invoked from, not the channel they're now
     //     in.
     // The actual member resolution still happens at click time via
@@ -4262,7 +4255,7 @@ async function handleQurlSlashSend(interaction, params) {
     // behave the way users naturally expect — the room is the audience.
     //
     // Sender is filtered pre-validity via partitionRecipients's
-    // `excludeSender` option; the "Everyone in #voice" affordance
+    // `excludeSender` option; the "Everyone on voice" affordance
     // semantically means "everyone else," not "and CC myself."
     //
     // Banner asymmetry on the picker-mode fallback: sender-only /
@@ -4276,7 +4269,7 @@ async function handleQurlSlashSend(interaction, params) {
     // SNAPSHOT vs. CLICK-TIME asymmetry: this slash-entry path freezes
     // `recipientIds` at command receipt — someone joining the channel
     // between `/qurl file` and the Send click is NOT added. The "🔊
-    // Everyone in #voice" button (handleConfirmVoiceEveryone) goes the
+    // Everyone on voice" button (handleConfirmVoiceEveryone) goes the
     // other way: re-resolves `channel.members` at click time. The two
     // shapes are reachable from the same UI but produce different
     // recipient sets; that's a deliberate UX call (the auto-default
@@ -4287,7 +4280,22 @@ async function handleQurlSlashSend(interaction, params) {
     let finalValid = valid;
     let finalSelfIncluded = selfIncluded;
     let finalWarningsBlock = warningsBlock;
-    if (recipientsOmitted && voiceChannelId) {
+    // Text-mention `@everyone` (typed in the `recipients:` slash option,
+    // or its `<@&{guildId}>` wire form) lands the card in EVERYONE
+    // mode — same as clicking the 📢 @everyone confirm-card button.
+    // Auto-filling the picker with up to 25 of the expanded set would
+    // either misrepresent the recipient list (only a subset shows) or
+    // invite a picker re-interaction that silently replaces the
+    // expansion with a truncated subset via handleConfirmUserSelect.
+    // Hiding the picker matches the button-click UX.
+    //
+    // Gated on `valid.length > 0` because the empty-after-partition
+    // case is already handled above with a "❌ No valid recipients"
+    // banner; landing that in EVERYONE-mode would render a card with
+    // no recipients but no picker either.
+    if (parsed.massMentionExpanded && valid.length > 0) {
+      recipientMode = RECIPIENT_MODE_EVERYONE;
+    } else if (recipientsOmitted && voiceChannelId) {
       // Read voice-connected members through the same channel cache
       // lookup that handleConfirmVoiceEveryone and the bottom-button
       // count use (`guild.channels.cache.get(voiceChannelId)`). Reading
@@ -5051,10 +5059,12 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     selfIncluded,
     // Picker activity definitionally lands the card in picker-mode.
     // If the user clicked the picker (which is the only entry to this
-    // handler), they are NOT in voice-everyone mode — even if the
-    // inbound payload still carried `'voice'` from a stale superseded
-    // flow. Explicit override here keeps a `...payload` spread from
-    // leaking voice-mode forward.
+    // handler), they are NOT in voice or everyone mode — even if the
+    // inbound payload still carried `'voice'` / `'everyone'` from a
+    // stale superseded flow (picker is hidden in those modes, but a
+    // forged interaction or stale UI could still emit the event).
+    // Explicit override here keeps a `...payload` spread from leaking
+    // a non-picker mode forward.
     recipientMode: RECIPIENT_MODE_PICKER,
   };
   // Targeted catch around transitionFlow mirrors the same shape
@@ -5125,7 +5135,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   }).catch(logIgnoredDiscordErr);
 }
 
-// Confirm-card "Everyone in this voice channel" button. Mirrors the
+// Confirm-card "Everyone on voice" button. Mirrors the
 // UserSelectMenu handler's shape (deferUpdate → resolve → partition →
 // transitionFlow → re-render) but reads the voice-connected member
 // set AT CLICK TIME from the guild's voice-state cache rather than
@@ -5421,18 +5431,20 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   }).catch(logIgnoredDiscordErr);
 }
 
-// Confirm-card "👥 Pick people instead" button — voice-mode escape
-// hatch. Flips `recipientMode` back to 'picker', clears recipientIds
-// (the voice-resolved set was authored for "everyone," not a starting
-// point for hand-curation; carrying it forward would land the user in
-// picker-mode with the voice population pre-selected, which is a
-// confusing "did my switch take?" state).
+// Confirm-card "👥 Pick people instead" button — escape hatch from
+// both voice-mode and everyone-mode back to picker-mode. Flips
+// `recipientMode` to 'picker', clears recipientIds (the voice- or
+// guild-resolved set was authored for "everyone," not a starting
+// point for hand-curation; carrying it forward would land the user
+// in picker-mode with the population pre-selected, which is a
+// confusing "did my switch take?" state — and a 25-entry truncated
+// view of any larger set).
 //
 // No resource resolution / member lookups happen here — purely a UI
 // mode toggle. transitionFlow still fires so the persisted payload
 // matches what the card shows; otherwise a subsequent expiry / note
 // re-render would re-derive picker layout from a payload that still
-// said `recipientMode: 'voice'` and snap back.
+// carried the prior mode and snap back.
 async function handleConfirmPickManual(interaction, { flow_id, row }) {
   await interaction.deferUpdate().catch(logIgnoredDiscordErr);
 
@@ -5695,18 +5707,20 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
   const newRecipientAliases = Object.fromEntries(
     valid.map((u) => [u.id, resolveRecipientAlias(u, interaction)])
   );
-  // recipientMode stays PICKER — the @everyone button doesn't switch
-  // modes (unlike voice-everyone which moves to RECIPIENT_MODE_VOICE).
-  // Semantically the user is multi-picking from the picker dropdown
-  // via a shortcut; the picker row remains visible for further
-  // adjustment.
+  // Mode switches to EVERYONE — like voice-everyone, the click is
+  // unambiguous "fan out to all" intent. Picker row is hidden in the
+  // re-render so the user can't accidentally read back a 25-entry
+  // truncated picker selection over the @everyone fan-out (Discord's
+  // MentionableSelect default_values is capped at 25, and any picker
+  // interaction routes through handleConfirmUserSelect which replaces
+  // recipientIds with the picker's view of the world).
   const newPayload = {
     ...payload,
     recipientIds: valid.map((u) => u.id),
     recipientAliases: newRecipientAliases,
     warningsBlock: newWarningsBlock,
     selfIncluded,
-    recipientMode: RECIPIENT_MODE_PICKER,
+    recipientMode: RECIPIENT_MODE_EVERYONE,
   };
   let result;
   try {
@@ -5815,8 +5829,8 @@ async function rerenderConfirmCard(interaction, newPayload) {
   // `needsPicker` (the "Pick recipients below" prompt) is only shown
   // in picker-mode with no recipients yet. In voice-mode with an empty
   // recipientIds (e.g., voice channel emptied after switch), the card
-  // shows "To: 0 users in #voice (you not included)" — the user can
-  // click "Pick people instead" to recover.
+  // shows "To: 0 users in #voice" — the user can click "Pick people
+  // instead" to recover.
   const needsPicker = recipientMode === RECIPIENT_MODE_PICKER && recipientIds.length === 0;
   // Send-disabled is recipient-empty regardless of mode.
   const sendDisabled = recipientIds.length === 0;
@@ -8192,8 +8206,8 @@ registerFlow(CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmVoiceEveryone,
 });
-// "Pick people instead" — voice-mode → picker-mode toggle. Same stage
-// contract as the other CONFIRM_* registrations.
+// "Pick people instead" — voice/everyone-mode → picker-mode toggle.
+// Same stage contract as the other CONFIRM_* registrations.
 registerFlow(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmPickManual,
@@ -8340,6 +8354,7 @@ module.exports = {
       CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
       RECIPIENT_MODE_PICKER,
       RECIPIENT_MODE_VOICE,
+      RECIPIENT_MODE_EVERYONE,
       normalizeRecipientMode,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2947,11 +2947,11 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // thousands of audience) needs to revisit this for stage-only.
 const CONFIRM_VOICE_EVERYONE_BUTTON_CUSTOM_ID = 'qurl_confirm_voice_everyone';
 // "Pick people instead" button — rendered in voice-mode and
-// everyone-mode (i.e. `payload.recipientMode === 'voice' || 'everyone'`).
-// Clicking it flips the card back to picker-mode (recipientIds
-// dropped, MentionableSelect row restored). Lives on its own customId
-// so flow-dispatch routes directly instead of branching inside the
-// voice/@everyone handlers.
+// everyone-mode (i.e. `payload.recipientMode` is `'voice'` or
+// `'everyone'`). Clicking it flips the card back to picker-mode
+// (recipientIds dropped, MentionableSelect row restored). Lives on
+// its own customId so flow-dispatch routes directly instead of
+// branching inside the voice/@everyone handlers.
 const CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID = 'qurl_confirm_pick_manual';
 // Whole-guild `@everyone` button on the confirm card. Workaround for
 // Discord's MentionableSelectMenu omitting the `@everyone` role from
@@ -3876,14 +3876,19 @@ function renderConfirmCardRows({
   const bottomRow = new ActionRowBuilder();
   // Voice-mode and everyone-mode share the same escape hatch: picker
   // row is hidden above, so this button is the only path back to
-  // manual selection without re-running the slash command. The
-  // voice-mode branch additionally requires `voiceChannelId` (the
-  // button only renders for the slash-entry voice-auto-default path
-  // that snapshotted a channel id); everyone-mode has no such
-  // dependency. Style as Secondary so it doesn't compete visually
-  // with Send (Success). Handler is shared (handleConfirmPickManual)
-  // and resets recipientMode → 'picker'.
-  if ((mode === RECIPIENT_MODE_VOICE && voiceChannelId) || mode === RECIPIENT_MODE_EVERYONE) {
+  // manual selection without re-running the slash command. Style as
+  // Secondary so it doesn't compete visually with Send (Success).
+  // Handler is shared (handleConfirmPickManual) and resets
+  // recipientMode → 'picker'.
+  //
+  // DEFENSIVE: voice-mode gate does NOT require voiceChannelId.
+  // Every production write path pairs voice-mode with voiceChannelId,
+  // but a forged or schema-drifted payload presenting voice-mode
+  // without it would otherwise fall through to the picker-no-voice
+  // branch below and render the 📢 @everyone entry button against a
+  // hidden picker — no recovery path. Closing the gate here keeps
+  // the escape hatch reachable in that degraded state.
+  if (mode === RECIPIENT_MODE_VOICE || mode === RECIPIENT_MODE_EVERYONE) {
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID)
@@ -4289,6 +4294,16 @@ async function handleQurlSlashSend(interaction, params) {
     // case is already handled above with a "❌ No valid recipients"
     // banner; landing that in EVERYONE-mode would render a card with
     // no recipients but no picker either.
+    //
+    // ORDERING: this branch deliberately precedes the voice-mode
+    // auto-default below. `massMentionExpanded` requires
+    // `recipientsOmitted: false` (the user typed something to be
+    // parsed), and voice-mode auto-default requires
+    // `recipientsOmitted: true`, so the two branches are mutually
+    // exclusive in production. The ordering still encodes "explicit
+    // @everyone wins over voice auto-default" as documentation — a
+    // future refactor that loosens either guard MUST keep this
+    // precedence or the auto-default could shadow an explicit @-text.
     if (parsed.massMentionExpanded && valid.length > 0) {
       recipientMode = RECIPIENT_MODE_EVERYONE;
     } else if (recipientsOmitted && voiceChannelId) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3990,9 +3990,18 @@ function renderConfirmCardRows({
     const overCap = countIsAccurate && displayCount != null && displayCount > config.QURL_SEND_MAX_RECIPIENTS;
     // Fixed label — no live count, no overcap suffix. The disabled+
     // greyed-out button is the visual signal for the three degraded
-    // states (count unavailable, empty guild, exceeds cap); the click-
-    // time reject in `handleConfirmEveryone` carries the actionable
-    // reason copy when the disable can't fire (cold-cache overcap).
+    // states (count unavailable, empty guild, exceeds cap).
+    //
+    // UX TRADE-OFF: the warm-cache over-cap branch DOES disable here
+    // with no in-card "exceeds N cap" hint anymore. Previously the
+    // label spelled out the reason; now the user sees only a greyed-
+    // out button. Deliberate per product call ("terse labels"); the
+    // disable trigger is structurally rare (guild with > 20k non-bot
+    // members), and the cold-cache over-cap branch still surfaces
+    // the actionable copy via `handleConfirmEveryone`'s click-time
+    // reject (this render-time disable can't fire on cold cache, so
+    // the click goes through). If the warm-cache hint ever needs to
+    // come back, the lever is right here.
     //
     // BOTTOM ROW COMPONENT BUDGET: Discord caps an ActionRow at 5
     // components. The current worst-case render is
@@ -4290,10 +4299,24 @@ async function handleQurlSlashSend(interaction, params) {
     // expansion with a truncated subset via handleConfirmUserSelect.
     // Hiding the picker matches the button-click UX.
     //
-    // Gated on `valid.length > 0` because the empty-after-partition
-    // case is already handled above with a "❌ No valid recipients"
-    // banner; landing that in EVERYONE-mode would render a card with
-    // no recipients but no picker either.
+    // MIXED MENTIONS: `recipients: @everyone @alice` lands in
+    // EVERYONE mode too — alice is already in the @everyone set, so
+    // the explicit mention is semantically absorbed (the parser
+    // dedups via `seen`). A user trying to NARROW @everyone by
+    // listing names doesn't get that — they get the full fan-out.
+    // Correct behavior (you can't subtract from "everyone") but
+    // worth knowing if support asks.
+    //
+    // Gated on `valid.length > 0` as defense-in-depth. Structurally
+    // redundant today: the early-return at the top of this function
+    // already rejects `!recipientsOmitted && valid.length === 0`, and
+    // `massMentionExpanded` implies `recipientsOmitted === false`
+    // (no @everyone token without a recipients arg). So the only
+    // arrival shape here has `valid.length > 0`. Keeping the gate
+    // pins the EVERYONE-mode invariant locally — a future refactor
+    // that loosens or moves the upstream early-return can't silently
+    // land us in EVERYONE-mode with an empty recipient set (which
+    // would render a card with no recipients and no picker).
     //
     // ORDERING: this branch deliberately precedes the voice-mode
     // auto-default below. `massMentionExpanded` requires

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3874,20 +3874,16 @@ function renderConfirmCardRows({
   // (only when the slash was invoked from voice); voice-mode and
   // everyone-mode show the "Pick people instead" escape hatch.
   const bottomRow = new ActionRowBuilder();
-  if (mode === RECIPIENT_MODE_VOICE && voiceChannelId) {
-    // Voice-mode escape hatch. The handler clears recipientIds and
-    // flips recipientMode back to 'picker'. Style as Secondary so it
-    // doesn't compete visually with Send (Success).
-    bottomRow.addComponents(
-      new ButtonBuilder()
-        .setCustomId(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID)
-        .setLabel('\u{1F465} Pick people instead')
-        .setStyle(ButtonStyle.Secondary),
-    );
-  } else if (mode === RECIPIENT_MODE_EVERYONE) {
-    // Everyone-mode escape hatch — same handler as voice-mode. Picker
-    // row is hidden above; this is the only path back to manual
-    // selection without re-running the slash command.
+  // Voice-mode and everyone-mode share the same escape hatch: picker
+  // row is hidden above, so this button is the only path back to
+  // manual selection without re-running the slash command. The
+  // voice-mode branch additionally requires `voiceChannelId` (the
+  // button only renders for the slash-entry voice-auto-default path
+  // that snapshotted a channel id); everyone-mode has no such
+  // dependency. Style as Secondary so it doesn't compete visually
+  // with Send (Success). Handler is shared (handleConfirmPickManual)
+  // and resets recipientMode → 'picker'.
+  if ((mode === RECIPIENT_MODE_VOICE && voiceChannelId) || mode === RECIPIENT_MODE_EVERYONE) {
     bottomRow.addComponents(
       new ButtonBuilder()
         .setCustomId(CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID)

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4307,16 +4307,12 @@ async function handleQurlSlashSend(interaction, params) {
     // Correct behavior (you can't subtract from "everyone") but
     // worth knowing if support asks.
     //
-    // Gated on `valid.length > 0` as defense-in-depth. Structurally
-    // redundant today: the early-return at the top of this function
-    // already rejects `!recipientsOmitted && valid.length === 0`, and
-    // `massMentionExpanded` implies `recipientsOmitted === false`
-    // (no @everyone token without a recipients arg). So the only
-    // arrival shape here has `valid.length > 0`. Keeping the gate
-    // pins the EVERYONE-mode invariant locally — a future refactor
-    // that loosens or moves the upstream early-return can't silently
-    // land us in EVERYONE-mode with an empty recipient set (which
-    // would render a card with no recipients and no picker).
+    // Gated on `valid.length > 0` as defense-in-depth — pins the
+    // EVERYONE-mode invariant locally so a future refactor that
+    // loosens the upstream `!recipientsOmitted && valid.length === 0`
+    // early-return can't silently land us in EVERYONE-mode with no
+    // recipients (which would render a card with no recipients AND
+    // no picker).
     //
     // ORDERING: this branch deliberately precedes the voice-mode
     // auto-default below. `massMentionExpanded` requires

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4321,6 +4321,11 @@ async function handleQurlSlashSend(interaction, params) {
     // contributor pursuing strict click/text parity knows the lever.
     if (parsed.massMentionExpanded && valid.length > 0) {
       recipientMode = RECIPIENT_MODE_EVERYONE;
+      // `finalValid`, `finalSelfIncluded`, `finalWarningsBlock` stay as-is —
+      // parser output is authoritative for EVERYONE mode (no voice-resolve
+      // re-partition needed). Pinned here so a future refactor that adds
+      // an EVERYONE-mode re-partition step doesn't forget which branch
+      // owns the reassignment.
     } else if (recipientsOmitted && voiceChannelId) {
       // Read voice-connected members through the same channel cache
       // lookup that handleConfirmVoiceEveryone and the bottom-button

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4323,6 +4323,19 @@ async function handleQurlSlashSend(interaction, params) {
     // @everyone wins over voice auto-default" as documentation — a
     // future refactor that loosens either guard MUST keep this
     // precedence or the auto-default could shadow an explicit @-text.
+    //
+    // SENDER-PUSH DIVERGENCE: handleConfirmEveryone (the button-click
+    // path) defensively pushes `interaction.user` when the sender's
+    // row is missing from `members.cache` (shard-resume / partial-
+    // chunk race after prewarm). The text path here intentionally
+    // does NOT mirror that — `partitionRecipients` runs on the parser
+    // output upstream, which has already been prewarmed at line 4142.
+    // In the narrow race where the sender is missing post-prewarm,
+    // the text path yields `selfIncluded: false` while a click on the
+    // 📢 @everyone button would yield `selfIncluded: true`. Acceptable
+    // because the user explicitly typed `@everyone` (so they're aware
+    // of the recipient list at Send time), but documented so a future
+    // contributor pursuing strict click/text parity knows the lever.
     if (parsed.massMentionExpanded && valid.length > 0) {
       recipientMode = RECIPIENT_MODE_EVERYONE;
     } else if (recipientsOmitted && voiceChannelId) {

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -84,13 +84,23 @@
 //                                               // `allowMassMention` opt
 //     massMentionExpanded:  <boolean>,          // true iff @everyone was
 //                                               // allowed AND the walk
-//                                               // actually added at least
-//                                               // one non-bot entry from
-//                                               // `members.cache`. False
-//                                               // when cache was cold,
-//                                               // all-bot, or cap-saturated
-//                                               // before the walk reached
-//                                               // it. Mutually exclusive
+//                                               // iterated at least one
+//                                               // non-bot member from
+//                                               // `members.cache` (the
+//                                               // member may already be
+//                                               // in `ids` via a prior
+//                                               // named mention — dedup
+//                                               // happens inside
+//                                               // `consider()`; the flag
+//                                               // records that the
+//                                               // expansion ran, not
+//                                               // that it added new
+//                                               // entries). False when
+//                                               // cache was cold,
+//                                               // all-bot, or cap-
+//                                               // saturated before the
+//                                               // walk reached it.
+//                                               // Mutually exclusive
 //                                               // with massMentionDenied.
 //   }
 //
@@ -652,11 +662,19 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
         consider(memberId);
         // Set inside the walk (rather than deriving from
         // `everyonePresent && allowMassMention` at the bottom) so the
-        // flag means "expansion actually ran and added at least one
-        // non-bot entry," not "expansion was permitted." Keeps the
-        // name honest against future short-circuits — cap exhausted
-        // by named mentions before this loop runs, empty cache, all-
-        // bot cache — that would otherwise leave the flag overstating.
+        // flag means "expansion iterated at least one non-bot member,"
+        // not "expansion was permitted." Robust against future short-
+        // circuits — cap exhausted by named mentions before this loop
+        // runs, empty cache, all-bot cache — that would otherwise
+        // leave the flag overstating.
+        //
+        // NOTE: `consider()` is a silent no-op when `seen.has(id)`, so
+        // a mixed-mentions input like `<@alice> @everyone` where alice
+        // is also in the @everyone set still sets the flag — the walk
+        // iterated alice and dedup'd internally. Documented call-site
+        // behavior (`commands.js`'s MIXED MENTIONS comment) intentionally
+        // treats this as EVERYONE-mode, so the dedup-then-set ordering
+        // matches the intended downstream semantic.
         massMentionExpanded = true;
       }
     }
@@ -740,15 +758,16 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   }
 
   // `massMentionExpanded` was set inside the @everyone walk above
-  // (true iff at least one non-bot entry was actually added). Surfacing
-  // it lets callers route the slash-text "@everyone" path into
-  // RECIPIENT_MODE_EVERYONE without duplicating the regex-match-and-
-  // permission-check (or reaching past the parser to detect the
-  // `<@&{guildId}>` wire form). False when the user typed @everyone
-  // but lacked permission (the denied path lands on `massMentionDenied`
-  // instead) or when the cache was cold / cap-saturated by the time the
-  // walk reached it (caller's `valid.length` check still catches that
-  // downstream).
+  // (true iff the walk iterated at least one non-bot member —
+  // `consider()` dedups internally, so a mixed-mentions input still
+  // sets the flag). Surfacing it lets callers route the slash-text
+  // "@everyone" path into RECIPIENT_MODE_EVERYONE without duplicating
+  // the regex-match-and-permission-check (or reaching past the parser
+  // to detect the `<@&{guildId}>` wire form). False when the user typed
+  // @everyone but lacked permission (the denied path lands on
+  // `massMentionDenied` instead) or when the cache was cold /
+  // cap-saturated by the time the walk reached it (caller's
+  // `valid.length` check still catches that downstream).
   return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied, massMentionExpanded, roleMentionsDenied };
 }
 

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -74,14 +74,20 @@
 //
 // Output shape:
 //   {
-//     ids:                [<user_id>, ...],   // deduped, cap-applied
-//     invalidTokens:      [<raw_token>, ...], // pre-escaped (see above)
-//     cappedCount:        <number>,           // 0 if not capped; else
-//                                             // `total_pre_cap - cap`
-//     massMentionDenied:  <boolean>,          // true when @everyone
-//                                             // appeared but the caller
-//                                             // denied via the
-//                                             // `allowMassMention` opt
+//     ids:                  [<user_id>, ...],   // deduped, cap-applied
+//     invalidTokens:        [<raw_token>, ...], // pre-escaped (see above)
+//     cappedCount:          <number>,           // 0 if not capped; else
+//                                               // `total_pre_cap - cap`
+//     massMentionDenied:    <boolean>,          // true when @everyone
+//                                               // appeared but the caller
+//                                               // denied via the
+//                                               // `allowMassMention` opt
+//     massMentionExpanded:  <boolean>,          // true when @everyone
+//                                               // appeared AND was
+//                                               // expanded (allowed +
+//                                               // walked guild members).
+//                                               // Mutually exclusive
+//                                               // with massMentionDenied.
 //   }
 //
 // `ids` is deduped, capped at `config.QURL_SEND_MAX_RECIPIENTS` (the
@@ -263,7 +269,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // an empty result rather than throwing. Caller branches on
   // `ids.length === 0` to decide whether to render the recipient picker.
   if (raw == null || typeof raw !== 'string') {
-    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, roleMentionsDenied: [] };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, massMentionExpanded: false, roleMentionsDenied: [] };
   }
   // Mirror the `raw` guard for `interaction` so a null/undefined
   // caller-bug surfaces as an empty result instead of a TypeError
@@ -271,7 +277,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // a clearer crash site for "no caller context"; the parser
   // doesn't gain anything by failing here.
   if (interaction == null) {
-    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, roleMentionsDenied: [] };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, massMentionExpanded: false, roleMentionsDenied: [] };
   }
   // Length-cap BEFORE regex matching to keep the global-flag iteration
   // bounded under adversarial input. The /g flag scans linearly but
@@ -301,7 +307,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     }
   }
   if (input.length === 0) {
-    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, roleMentionsDenied: [] };
+    return { ids: [], invalidTokens: [], cappedCount: 0, massMentionDenied: false, massMentionExpanded: false, roleMentionsDenied: [] };
   }
 
   // `seen` is the canonical post-filter unique-candidate set (every
@@ -720,7 +726,16 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     });
   }
 
-  return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied, roleMentionsDenied };
+  // `massMentionExpanded` mirrors the parser's internal
+  // `everyonePresent && allowMassMention` predicate — the condition
+  // under which the @everyone expansion ran above. Surfacing it lets
+  // callers route the slash-text "@everyone" path into RECIPIENT_MODE_
+  // EVERYONE without duplicating the regex-match-and-permission-check
+  // (or reaching past the parser to detect the `<@&{guildId}>` wire
+  // form). False when the user typed @everyone but lacked permission
+  // (the denied path lands on `massMentionDenied` instead).
+  const massMentionExpanded = everyonePresent && allowMassMention;
+  return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied, massMentionExpanded, roleMentionsDenied };
 }
 
 // `isVoiceChannelType` is the same voice/stage-voice predicate the

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -82,11 +82,15 @@
 //                                               // appeared but the caller
 //                                               // denied via the
 //                                               // `allowMassMention` opt
-//     massMentionExpanded:  <boolean>,          // true when @everyone
-//                                               // appeared AND was
-//                                               // expanded (allowed +
-//                                               // walked guild members).
-//                                               // Mutually exclusive
+//     massMentionExpanded:  <boolean>,          // true iff @everyone was
+//                                               // allowed AND the walk
+//                                               // actually added at least
+//                                               // one non-bot entry from
+//                                               // `members.cache`. False
+//                                               // when cache was cold,
+//                                               // all-bot, or cap-saturated
+//                                               // before the walk reached
+//                                               // it. Mutually exclusive
 //                                               // with massMentionDenied.
 //   }
 //
@@ -608,6 +612,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
   // `@everyone <@uncachedUser>`, the direct mention claims a cap slot
   // first, and @everyone fills the remainder. Reversing this order
   // silently drops explicit mentions when the cache is partial.
+  let massMentionExpanded = false;
   if (everyonePresent && allowMassMention) {
     const everyoneMembers = guild?.members?.cache;
     if (everyoneMembers) {
@@ -645,6 +650,14 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
         if (ids.size >= cap) break;
         if (isBotMember(member)) continue;
         consider(memberId);
+        // Set inside the walk (rather than deriving from
+        // `everyonePresent && allowMassMention` at the bottom) so the
+        // flag means "expansion actually ran and added at least one
+        // non-bot entry," not "expansion was permitted." Keeps the
+        // name honest against future short-circuits — cap exhausted
+        // by named mentions before this loop runs, empty cache, all-
+        // bot cache — that would otherwise leave the flag overstating.
+        massMentionExpanded = true;
       }
     }
   }
@@ -726,15 +739,16 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     });
   }
 
-  // `massMentionExpanded` mirrors the parser's internal
-  // `everyonePresent && allowMassMention` predicate — the condition
-  // under which the @everyone expansion ran above. Surfacing it lets
-  // callers route the slash-text "@everyone" path into RECIPIENT_MODE_
-  // EVERYONE without duplicating the regex-match-and-permission-check
-  // (or reaching past the parser to detect the `<@&{guildId}>` wire
-  // form). False when the user typed @everyone but lacked permission
-  // (the denied path lands on `massMentionDenied` instead).
-  const massMentionExpanded = everyonePresent && allowMassMention;
+  // `massMentionExpanded` was set inside the @everyone walk above
+  // (true iff at least one non-bot entry was actually added). Surfacing
+  // it lets callers route the slash-text "@everyone" path into
+  // RECIPIENT_MODE_EVERYONE without duplicating the regex-match-and-
+  // permission-check (or reaching past the parser to detect the
+  // `<@&{guildId}>` wire form). False when the user typed @everyone
+  // but lacked permission (the denied path lands on `massMentionDenied`
+  // instead) or when the cache was cold / cap-saturated by the time the
+  // walk reached it (caller's `valid.length` check still catches that
+  // downstream).
   return { ids: finalIds, invalidTokens, cappedCount, massMentionDenied, massMentionExpanded, roleMentionsDenied };
 }
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -7420,18 +7420,21 @@ describe('constants + exports', () => {
     expect(RECIPIENT_MODE_VOICE).toBe('voice');
   });
 
-  test('normalizeRecipientMode: only "voice" maps to voice; everything else picker', () => {
+  test('normalizeRecipientMode: closed set {voice, everyone, picker}; everything else picker', () => {
     // Stale flow_state rows (created before this field existed) read
     // as undefined. Off-set values (forged interaction, schema drift,
     // typo in a future refactor) also fall back to picker. Pin the
-    // table so a future refactor that flips the default can't slip
+    // table so a future refactor that flips the default — or
+    // accidentally collapses 'everyone' back to 'picker' — can't slip
     // through.
     expect(normalizeRecipientMode('voice')).toBe('voice');
+    expect(normalizeRecipientMode('everyone')).toBe('everyone');
     expect(normalizeRecipientMode('picker')).toBe('picker');
     expect(normalizeRecipientMode(undefined)).toBe('picker');
     expect(normalizeRecipientMode(null)).toBe('picker');
     expect(normalizeRecipientMode('')).toBe('picker');
     expect(normalizeRecipientMode('VOICE')).toBe('picker'); // case-sensitive
+    expect(normalizeRecipientMode('EVERYONE')).toBe('picker'); // case-sensitive
     expect(normalizeRecipientMode('unknown')).toBe('picker');
   });
 

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -6861,7 +6861,6 @@ describe('renderConfirmCardRows', () => {
         'qurl_confirm_cancel',
       ]);
     });
-
   });
 
   // ── @everyone button rendering ──

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -5520,6 +5520,34 @@ describe('handleConfirmEveryone', () => {
     // Send still proceeds with the valid subset.
     expect(mockTransitionFlow).toHaveBeenCalled();
   });
+
+  test('mid-deploy forward: legacy picker-mode row with pre-filled recipientIds → click @everyone → lands in EVERYONE mode', async () => {
+    // Forward-direction mid-deploy contract. A pre-PR bot would have
+    // auto-filled the picker after an @everyone click and written
+    // `recipientMode: 'picker'` with populated `recipientIds`. When a
+    // post-PR bot processes that row and the user clicks 📢 @everyone
+    // again, the transition MUST overwrite to `'everyone'` so the
+    // re-render hides the picker (rather than spreading the legacy
+    // 'picker' mode forward). Without this contract, the user would
+    // see the auto-fill leak persist post-deploy.
+    const int = makeEveryoneInteraction();
+    // Legacy row shape: picker-mode + a pre-filled subset (the old
+    // auto-fill behavior would have written a truncated set here).
+    const legacyPayload = {
+      ...initialPayload,
+      recipientMode: 'picker',
+      recipientIds: [u1],  // legacy picker-mode auto-fill subset
+      recipientAliases: { [u1]: 'alice' },
+    };
+    await handleConfirmEveryone(int, { flow_id: 'fid', row: { payload: legacyPayload, version: 1 } });
+    expect(mockTransitionFlow).toHaveBeenCalled();
+    const payload = mockTransitionFlow.mock.calls[0][2].payload;
+    // Mode overwrites — not spread-leaked from the legacy row.
+    expect(payload.recipientMode).toBe('everyone');
+    // Recipient set is fresh from cache iteration, not the legacy
+    // truncated subset.
+    expect(payload.recipientIds.sort()).toEqual([u1, u2, SENDER_ID].sort());
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -444,8 +444,8 @@ describe('partitionRecipients', () => {
   test('excludeSender:true drops the sender pre-validity (selfIncluded stays false)', () => {
     // Voice-everyone semantics. The sender is dropped silently — no
     // droppedBots-style accounting, and `selfIncluded` cannot be true
-    // on this path. The user-visible "you not included" copy is
-    // rendered from recipientMode, not from this partition return.
+    // on this path. The sender exclusion is inferred from voice-mode
+    // UI semantics rather than surfaced in user-visible copy.
     const users = [
       makeUser('100000000000000001'),
       makeUser(SENDER_ID),
@@ -2030,10 +2030,10 @@ describe('renderConfirmCardContent', () => {
     // Every production voice-mode write path sets selfIncluded:false,
     // so this state is structurally unreachable. The renderer guard
     // exists for a forged or schema-drifted payload that would
-    // otherwise stack a contradictory "Send includes you." notice on
-    // top of the voice-mode "(you not included)" copy on the "To:"
-    // line. Pin the guard so a future refactor can't silently let the
-    // two messages coexist.
+    // otherwise stack a "Send includes you." notice on top of a
+    // voice-mode "To:" line whose semantics already exclude the
+    // sender. Pin the guard so a future refactor can't silently let
+    // the contradiction surface.
     const u1 = { id: '100000000000000001', username: 'alice' };
     const out = renderConfirmCardContent({
       ...baseProps,
@@ -2043,8 +2043,8 @@ describe('renderConfirmCardContent', () => {
       voiceChannelId: 'voice-ch',
     });
     expect(out).not.toMatch(/Send includes you/);
-    // Voice-mode "To:" still renders correctly.
-    expect(out).toMatch(/you not included/);
+    // Voice-mode "To:" still renders correctly with the channel mention.
+    expect(out).toMatch(/<#voice-ch>/);
   });
 
   test('personal-message preview cap at 80 chars, rendered as blockquote', () => {
@@ -2967,6 +2967,55 @@ describe('handleQurlFile — slash entry', () => {
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');
       expect(payload.recipientIds).toEqual([u1]);
+    });
+
+    test('text `@everyone` in recipients → EVERYONE mode (picker hidden, no auto-fill)', async () => {
+      // Mirror of the 📢 @everyone button-click path. When the user
+      // types `@everyone` in the recipients field and has
+      // MENTION_EVERYONE, the parser's `massMentionExpanded` flag
+      // lands the card in EVERYONE mode so the picker stays hidden —
+      // auto-filling it would either truncate at Discord's 25-entry
+      // default_values cap or invite a picker re-interaction that
+      // silently replaces the fan-out via handleConfirmUserSelect.
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '@everyone' },
+        guildMembers: {
+          [SENDER_ID]: {},
+          '100000000000000051': {},
+          '100000000000000052': {},
+        },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 3;
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('everyone');
+      // Fan-out includes the sender (selfIncluded=true), matching
+      // the button-click path's semantics.
+      expect(payload.selfIncluded).toBe(true);
+      expect(payload.recipientIds.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('text `@everyone` WITHOUT MENTION_EVERYONE → stays PICKER (parser denied expansion)', async () => {
+      // Counter-test: `massMentionDenied:true` does NOT set the
+      // EVERYONE-mode trigger — `massMentionExpanded` is mutually
+      // exclusive with `massMentionDenied`. The slash-entry hits the
+      // permission-denied warning banner and renders the picker
+      // normally for the user to choose recipients manually.
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '@everyone' },
+        guildMembers: { [SENDER_ID]: {} },
+      });
+      // Default permission shape → no MENTION_EVERYONE.
+      await handleQurlFile(int);
+      const supersedeCalls = mockSupersedeOrCreate.mock.calls;
+      // No confirm card persisted (recipientsOmitted=false + valid=0 →
+      // the "no valid recipients" early-return fires before
+      // supersedeOrCreate). This is the existing behavior; the EVERYONE-
+      // mode trigger isn't reached because the parser denied the
+      // expansion. Pin via the absence of a supersedeOrCreate call so
+      // a future refactor that changes the denied-path UX surfaces here.
+      expect(supersedeCalls.length).toBe(0);
     });
   });
 });
@@ -4694,7 +4743,7 @@ describe('handleConfirmUserSelect', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleConfirmVoiceEveryone — "Everyone in this voice channel"
+// handleConfirmVoiceEveryone — "Everyone on voice"
 // button on the confirm card, rendered only when the slash command
 // was invoked from a voice / stage-voice channel. Resolves voice-
 // connected non-bot members AT CLICK TIME from the voice-state
@@ -5160,9 +5209,11 @@ describe('handleConfirmEveryone', () => {
     const payload = mockTransitionFlow.mock.calls[0][2].payload;
     expect(payload.recipientIds.sort()).toEqual([u1, u2, SENDER_ID].sort());
     expect(payload.selfIncluded).toBe(true);
-    // Mode stays in PICKER — @everyone is multi-pick shortcut, not a
-    // mode switch (unlike voice-everyone which moves to VOICE mode).
-    expect(payload.recipientMode).toBe('picker');
+    // Mode switches to EVERYONE so the re-render hides the picker
+    // row. Auto-filling the picker would either silently truncate at
+    // Discord's 25-entry default_values cap or read back through the
+    // picker handler and replace the @everyone fan-out with a subset.
+    expect(payload.recipientMode).toBe('everyone');
   });
 
   test('without MENTION_EVERYONE → reject with permission warning, no transition', async () => {
@@ -6240,9 +6291,11 @@ describe('rerenderConfirmCard cache-miss recipient fallback', () => {
     await handleConfirmExpirySelect(int, { flow_id: 'fid', row: { payload, version: 1 } });
     const lastEdit = int.editReply.mock.calls.slice(-1)[0][0];
     // Voice-mode rendering still applies — content shows the channel
-    // mention + "(you not included)" notice even with zero recipients.
+    // mention even with zero recipients.
     expect(lastEdit.content).toMatch(/0 users in <#voice-empty>/);
-    expect(lastEdit.content).toMatch(/you not included/);
+    // The "(you not included)" disclosure used to ride along here;
+    // dropped per UX call. Sender exclusion stays inferred.
+    expect(lastEdit.content).not.toMatch(/you not included/);
     // The picker prompt MUST NOT appear (we're in voice-mode).
     expect(lastEdit.content).not.toMatch(/Pick recipients below/);
     // Send is disabled (no recipients), pick-manual is rendered as
@@ -6442,34 +6495,26 @@ describe('renderConfirmCardRows', () => {
     expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids);
   });
 
-  test('voice button label stays under Discord\'s 80 UTF-16 cap with an ALL-EMOJI channel name (worst case)', async () => {
-    // Round-14 cr bug-guard: a 46-codepoint all-emoji channel name
-    // (which Discord allows up to its 100-char limit) occupies 92
-    // UTF-16 units. The prior codepoint-based budget would slice at
-    // 46 codepoints (=92 UTF-16 units) + prefix + suffix → ~116-unit
-    // label, busting Discord's 80-UTF-16 hard cap and getting
-    // rejected at API send. The UTF-16-unit budget caps this.
+  test('voice button label is the fixed "Everyone on voice" form, independent of channel name', async () => {
+    // The label used to interpolate `#{channelName}` (with UTF-16-
+    // aware truncation against Discord's 80-unit button-label cap),
+    // and also carried a live `(N)` count. It's now a fixed string
+    // with no count and no channel name. Pin the new shape so a
+    // future refactor that re-introduces either has to update this
+    // test deliberately (and reconsider the markdown-injection surface
+    // area that came with channel-name interpolation).
     const { ButtonBuilder } = require('discord.js');
     ButtonBuilder.mockClear();
-    // 46 🎉 emoji — each is a surrogate pair (U+1F389, 2 UTF-16 units)
-    // so the channel name occupies 92 UTF-16 units. Discord caps
-    // channel names at 100 chars, so this is realistic. The prior
-    // codepoint-based budget would slice at 46 codepoints (92
-    // UTF-16 units) + prefix + suffix → ~116-unit label, busting
-    // Discord's 80-UTF-16 hard cap.
-    const allEmojiName = '🎉'.repeat(46);
-    expect(allEmojiName.length).toBe(92); // confirm worst-case UTF-16
-    // Pass a `recipients:` mention so the slash-entry path stays in
-    // picker-mode — the voice button is rendered (and label-truncated)
-    // only in picker-mode. The voice-mode auto-default would swap in
-    // a "Pick people instead" button instead, hiding what we're testing.
+    // An adversarial channel name that previously had to be UTF-16-
+    // truncated. Now it should not appear in the label at all.
+    const adversarialName = '🎉'.repeat(46) + '**bold**<@123>';
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000099>' },
       guildMembers: { '100000000000000099': {} },
     });
-    int.channel = { id: 'voice-emoji', type: 2 };
-    int.guild.channels.cache.set('voice-emoji', {
-      id: 'voice-emoji', name: allEmojiName, type: 2,
+    int.channel = { id: 'voice-fixed', type: 2 };
+    int.guild.channels.cache.set('voice-fixed', {
+      id: 'voice-fixed', name: adversarialName, type: 2,
       members: new Map([['111', { user: { id: '111', bot: false } }]]),
     });
     await handleQurlFile(int);
@@ -6478,70 +6523,19 @@ describe('renderConfirmCardRows', () => {
     );
     expect(voiceBtn).toBeDefined();
     const label = voiceBtn.value.setLabel.mock.calls[0][0];
-    // The hard contract: under 80 UTF-16 units regardless of input.
+    // Fixed-shape contract — no count, no channel name.
+    expect(label).toBe('\u{1F50A} Everyone on voice');
+    // Discord 80-UTF-16-unit cap stays trivially satisfied.
     expect(label.length).toBeLessThanOrEqual(80);
-    expect(label).toMatch(/…/);
-    // Surrogate-pair safety still holds for the all-emoji case.
-    for (let i = 0; i < label.length; i++) {
-      const code = label.charCodeAt(i);
-      if (code >= 0xD800 && code <= 0xDBFF) {
-        const next = label.charCodeAt(i + 1);
-        expect(next).toBeGreaterThanOrEqual(0xDC00);
-        expect(next).toBeLessThanOrEqual(0xDFFF);
-        i++;
-      }
-    }
-  });
-
-  test('voice button label stays under Discord\'s 80 UTF-16 cap even with a 100-char emoji-containing channel name', async () => {
-    // Pins the codepoint-aware truncation: a channel name with an
-    // emoji at position 45 must NOT split a UTF-16 surrogate pair
-    // (would render `�` on the button) AND the full label must stay
-    // under Discord's 80 UTF-16 unit hard cap. Without the
-    // safeCodepointSlice / Array.from length check, a long emoji-
-    // containing name would either overflow or render mangled.
-    const { ButtonBuilder } = require('discord.js');
-    ButtonBuilder.mockClear();
-    // 100-char name with emoji (🎉 = surrogate pair) at index 44,
-    // 45, 46 to land near the slice boundary.
-    const longName = 'a'.repeat(44) + '🎉🎉🎉' + 'b'.repeat(47);
-    const int = makeInteraction({
-      // `recipients:` keeps the slash-entry in picker-mode so the
-      // voice-everyone button (the subject under test) renders.
-      // Voice-mode auto-default would otherwise swap it for "Pick
-      // people instead."
-      options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000099>' },
-      guildMembers: { '100000000000000099': {} },
-      // Inject the channel into the interaction so renderConfirmCardRows'
-      // live read finds it.
-    });
-    int.channel = { id: 'voice-long', type: 2 };
-    int.guild.channels.cache.set('voice-long', {
-      id: 'voice-long', name: longName, type: 2,
-      members: new Map([['111', { user: { id: '111', bot: false } }]]),
-    });
-    await handleQurlFile(int);
-    const voiceBtn = ButtonBuilder.mock.results.find(
-      (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_voice_everyone'
-    );
-    expect(voiceBtn).toBeDefined();
-    const labelCall = voiceBtn.value.setLabel.mock.calls[0];
-    const label = labelCall[0];
-    // UTF-16 unit length (string.length) must stay under 80.
-    expect(label.length).toBeLessThanOrEqual(80);
-    // Truncation indicator present when the name was longer than the budget.
-    expect(label).toMatch(/…/);
-    // Surrogate pair safety: no orphan lead-surrogate (0xD800-0xDBFF
-    // without a paired trail surrogate). Quick scan.
-    for (let i = 0; i < label.length; i++) {
-      const code = label.charCodeAt(i);
-      if (code >= 0xD800 && code <= 0xDBFF) {
-        const next = label.charCodeAt(i + 1);
-        expect(next).toBeGreaterThanOrEqual(0xDC00);
-        expect(next).toBeLessThanOrEqual(0xDFFF);
-        i++; // skip the trail surrogate
-      }
-    }
+    // Channel name (including the markdown-injection payload) is not
+    // interpolated.
+    expect(label).not.toContain('🎉');
+    expect(label).not.toContain('**');
+    expect(label).not.toContain('<@');
+    expect(label).not.toContain('#');
+    expect(label).not.toContain('…');
+    // No live count suffix anymore.
+    expect(label).not.toMatch(/\(\d+\)/);
   });
 
   describe('voice-mode layout (recipientMode:"voice")', () => {
@@ -6550,7 +6544,7 @@ describe('renderConfirmCardRows', () => {
     // auto-default lands the card in voice-mode, which:
     //   - HIDES the MentionableSelect picker row
     //   - SHOWS a "👥 Pick people instead" button
-    //   - DOES NOT show the "🔊 Everyone in #voice" button (that's
+    //   - DOES NOT show the "🔊 Everyone on voice" button (that's
     //     the entry point INTO voice mode; once you're in, it's gone)
     // Without these pins, a future refactor that re-enables the picker
     // in voice-mode (or drops the pick-manual button) passes every
@@ -6581,7 +6575,7 @@ describe('renderConfirmCardRows', () => {
       expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
     });
 
-    test('"Pick people instead" button IS rendered; "Everyone in #voice" button is NOT', async () => {
+    test('"Pick people instead" button IS rendered; "Everyone on voice" button is NOT', async () => {
       const { ButtonBuilder } = require('discord.js');
       ButtonBuilder.mockClear();
       const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
@@ -6677,7 +6671,99 @@ describe('renderConfirmCardRows', () => {
       expect(customIds).not.toContain('qurl_confirm_voice_everyone');
       const lastCall = int.editReply.mock.calls.slice(-1)[0][0];
       expect(lastCall.content).toContain(`<#${VOICE_CH}>`);
-      expect(lastCall.content).toMatch(/you not included/);
+      // "(you not included)" disclosure was dropped per UX call;
+      // sender exclusion is inferred from voice-mode semantics.
+      expect(lastCall.content).not.toMatch(/you not included/);
+    });
+  });
+
+  describe('everyone-mode layout (recipientMode:"everyone")', () => {
+    // Mirror of the voice-mode layout block above. After handleConfirmEveryone
+    // commits a fan-out, the card re-renders in everyone-mode, which:
+    //   - HIDES the MentionableSelect picker row (so a stray picker
+    //     interaction can't replace the fan-out with a 25-cap subset)
+    //   - SHOWS a "👥 Pick people instead" button as the escape hatch
+    //   - DOES NOT show the "📢 @everyone" or "🔊 Everyone on voice"
+    //     entry buttons (you're already past them)
+    // Driven through the renderer directly so the layout is asserted
+    // without re-running the full slash → click round trip.
+    const renderEveryoneRows = (overrides = {}) => {
+      const { MentionableSelectMenuBuilder, ButtonBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      ButtonBuilder.mockClear();
+      const memberCache = new Map([
+        ['100000000000000001', { user: { id: '100000000000000001', bot: false } }],
+        ['100000000000000002', { user: { id: '100000000000000002', bot: false } }],
+      ]);
+      const interaction = {
+        guild: {
+          id: 'g-everyone-layout',
+          members: { cache: memberCache },
+          memberCount: 2,
+          channels: { cache: new Map() },
+        },
+        memberPermissions: { has: jest.fn(() => true) },
+      };
+      const { renderConfirmCardRows } = commands._test;
+      renderConfirmCardRows({
+        sendDisabled: false,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        voiceChannelId: null,
+        interaction,
+        recipientIds: ['100000000000000001', '100000000000000002'],
+        recipientMode: 'everyone',
+        ...overrides,
+      });
+      return { MentionableSelectMenuBuilder, ButtonBuilder };
+    };
+
+    test('picker row is NOT rendered', () => {
+      const { MentionableSelectMenuBuilder } = renderEveryoneRows();
+      expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
+    });
+
+    test('"Pick people instead" button IS rendered', () => {
+      const { ButtonBuilder } = renderEveryoneRows();
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toContain('qurl_confirm_pick_manual');
+    });
+
+    test('"@everyone" entry button is NOT rendered (already past the entry point)', () => {
+      const { ButtonBuilder } = renderEveryoneRows();
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).not.toContain('qurl_confirm_everyone');
+    });
+
+    test('"Everyone on voice" entry button is NOT rendered (even with voiceChannelId set)', () => {
+      // The voiceChannelId snapshot survives on the payload across modes;
+      // make sure the mode gate still hides the voice-everyone entry
+      // button so the user doesn't see a stale affordance.
+      const { ButtonBuilder } = renderEveryoneRows({ voiceChannelId: 'voice-ch-1' });
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).not.toContain('qurl_confirm_voice_everyone');
+    });
+
+    test('bottom row has exactly 4 buttons in order: Pick-manual, Note, Send, Cancel', () => {
+      // Matches the voice-mode layout exactly — everyone-mode shares the
+      // same escape-hatch row shape.
+      const { ButtonBuilder } = renderEveryoneRows();
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toEqual([
+        'qurl_confirm_pick_manual',
+        'qurl_confirm_note_btn',
+        'qurl_confirm_send',
+        'qurl_confirm_cancel',
+      ]);
     });
   });
 
@@ -6716,29 +6802,13 @@ describe('renderConfirmCardRows', () => {
       expect(customIds).not.toContain('qurl_confirm_everyone');
     });
 
-    test('label shows live count from guild.memberCount when cache cold', async () => {
-      // Cold cache (cache.size < memberCount) → label falls back to
-      // memberCount. Overcounts by bot population, but it's the only
-      // reliable number before the click-time pre-warm fires.
-      const { ButtonBuilder } = require('discord.js');
-      ButtonBuilder.mockClear();
-      const int = makeInteraction({
-        options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
-        guildMembers: { '100000000000000001': {} },  // cache.size === 1
-      });
-      int.memberPermissions = { has: jest.fn(() => true) };
-      int.guild.memberCount = 42;  // memberCount > cache.size → cold
-      await handleQurlFile(int);
-      const everyoneBtn = ButtonBuilder.mock.results.find(
-        (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
-      );
-      expect(everyoneBtn).toBeDefined();
-      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(42)'));
-    });
-
-    test('label shows non-bot count when cache fully populated', async () => {
-      // Warm cache (cache.size >= memberCount) → filter bots and use
-      // the accurate non-bot count.
+    test('label is the fixed "📢 @everyone" form — no live count, no overcap suffix', async () => {
+      // The label used to carry a `(N)` count and an `— exceeds N cap`
+      // suffix; both were dropped per UX call so the label stays terse
+      // and the disabled+greyed-out button is the only state signal.
+      // `computeEveryoneDisplayCount` still runs for the disable check
+      // (see counts-and-disable tests below); only the label-surface
+      // changed.
       const { ButtonBuilder } = require('discord.js');
       ButtonBuilder.mockClear();
       const int = makeInteraction({
@@ -6750,21 +6820,27 @@ describe('renderConfirmCardRows', () => {
         },
       });
       int.memberPermissions = { has: jest.fn(() => true) };
-      int.guild.memberCount = 3;  // matches cache.size → warm
+      int.guild.memberCount = 3;
       await handleQurlFile(int);
       const everyoneBtn = ButtonBuilder.mock.results.find(
         (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
       );
       expect(everyoneBtn).toBeDefined();
-      // 3 cached, 1 is a bot → label shows (2).
-      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(2)'));
+      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith('\u{1F4E2} @everyone');
+      // Defense-in-depth: pin the missing pieces directly so a future
+      // refactor that re-introduces them surfaces here.
+      const label = everyoneBtn.value.setLabel.mock.calls[0][0];
+      expect(label).not.toMatch(/\(\d+\)/);
+      expect(label).not.toMatch(/exceeds/);
+      expect(label).not.toMatch(/\(\?\)/);
     });
 
     test('disabled when memberCount unavailable AND cache cold (displayCount null)', async () => {
       // Edge case: cold cache + missing memberCount → can't compute a
-      // count → button shows `(?)` label and stays disabled so the
-      // user sees the button can't act rather than getting a silent
-      // no-op click against a count-less label.
+      // count → button stays disabled so the user sees the button can't
+      // act rather than getting a silent no-op click. The label no
+      // longer carries a `(?)` indicator (UX call); the disabled state
+      // is communicated by the greyed-out button alone.
       const { ButtonBuilder } = require('discord.js');
       ButtonBuilder.mockClear();
       const int = makeInteraction({
@@ -6779,7 +6855,6 @@ describe('renderConfirmCardRows', () => {
         (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
       );
       expect(everyoneBtn).toBeDefined();
-      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(?)'));
       expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
     });
 
@@ -6880,15 +6955,30 @@ describe('renderConfirmCardRows', () => {
     test('memo busts on cache.size change', () => {
       // Member join/leave changes `cache.size` (or `memberCount`),
       // which fingerprints the memo entry and forces re-computation.
+      // Verified via direct iteration counter — the label is now
+      // fixed and can't observe the recomputation, but the memo is
+      // still load-bearing for the disable check (over-cap / zero /
+      // null branches), so we pin it via the same Proxy iterator
+      // pattern as the memoization test above.
       const commands = require('../src/commands');
       const { renderConfirmCardRows, _everyoneCountMemo } = commands._test;
       const memberCache = new Map([
         ['u1', { user: { id: 'u1', bot: false } }],
         ['u2', { user: { id: 'u2', bot: false } }],
       ]);
+      let iterations = 0;
+      const iterCountingCache = new Proxy(memberCache, {
+        get(target, prop) {
+          if (prop === Symbol.iterator) {
+            iterations++;
+            return target[Symbol.iterator].bind(target);
+          }
+          return Reflect.get(target, prop);
+        },
+      });
       const guild = {
         id: 'guild-memo-bust',
-        members: { cache: memberCache },
+        members: { cache: iterCountingCache },
         memberCount: 2,
         channels: { cache: new Map() },
       };
@@ -6903,27 +6993,23 @@ describe('renderConfirmCardRows', () => {
         recipientIds: [],
         recipientMode: 'picker',
       };
-      renderConfirmCardRows(args);  // memo populated with count=2
+      renderConfirmCardRows(args);  // memo populated, 1 iteration
+      expect(iterations).toBe(1);
       // Member joins → cache grows + memberCount grows. Fingerprint
-      // flips, memo busts on next render.
+      // flips, memo busts on next render → cache re-walked.
       memberCache.set('u3', { user: { id: 'u3', bot: false } });
       guild.memberCount = 3;
-      const { ButtonBuilder } = require('discord.js');
-      ButtonBuilder.mockClear();
       renderConfirmCardRows(args);
-      const everyoneBtn = ButtonBuilder.mock.results.find(
-        (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
-      );
-      expect(everyoneBtn).toBeDefined();
-      // Post-bust label reflects the new count (3 non-bots), not the
-      // memoized 2.
-      expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('(3)'));
+      expect(iterations).toBe(2);
     });
 
-    test('disabled with "exceeds cap" suffix when warm-cache non-bot count > cap', async () => {
+    test('disabled when warm-cache non-bot count > cap (no overcap suffix in label)', async () => {
       // Render-time over-cap disable fires ONLY when the count is
       // accurate (warm cache + bot-filtered). Cold-cache over-cap
       // defers to click-time hard-reject — see counter-test below.
+      // The label used to carry an "— exceeds N cap" suffix in this
+      // branch; dropped per UX call. The disabled+greyed-out button
+      // is the only state signal now.
       const config = require('../src/config');
       const { ButtonBuilder } = require('discord.js');
       const originalCap = config.QURL_SEND_MAX_RECIPIENTS;
@@ -6946,7 +7032,7 @@ describe('renderConfirmCardRows', () => {
           (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
         );
         expect(everyoneBtn).toBeDefined();
-        expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith(expect.stringContaining('exceeds 2 cap'));
+        expect(everyoneBtn.value.setLabel).toHaveBeenCalledWith('\u{1F4E2} @everyone');
         expect(everyoneBtn.value.setDisabled).toHaveBeenCalledWith(true);
       } finally {
         Object.defineProperty(config, 'QURL_SEND_MAX_RECIPIENTS', { value: originalCap, configurable: true, writable: true });

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -6735,6 +6735,41 @@ describe('renderConfirmCardRows', () => {
       // sender exclusion is inferred from voice-mode semantics.
       expect(lastCall.content).not.toMatch(/you not included/);
     });
+
+    test('forged voice-mode without voiceChannelId still renders the escape hatch (defensive)', () => {
+      // Production never pairs RECIPIENT_MODE_VOICE without voiceChannelId,
+      // but a forged or schema-drifted payload could. Without the
+      // defensive `voiceChannelId`-less branch in renderConfirmCardRows,
+      // such a payload would skip the escape-hatch branch entirely AND
+      // skip the @everyone entry branch (gated on PICKER), leaving the
+      // user with no path back to manual selection. Pin recovery.
+      const { MentionableSelectMenuBuilder, ButtonBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      ButtonBuilder.mockClear();
+      const interaction = {
+        guild: {
+          id: 'g-forged-voice', members: { cache: new Map() }, memberCount: 1,
+          channels: { cache: new Map() },
+        },
+        memberPermissions: { has: jest.fn(() => false) },
+      };
+      const { renderConfirmCardRows } = commands._test;
+      renderConfirmCardRows({
+        sendDisabled: false,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        voiceChannelId: null,  // ← forged/drifted state
+        interaction,
+        recipientIds: ['100000000000000001'],
+        recipientMode: 'voice',
+      });
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toContain('qurl_confirm_pick_manual');
+      expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
+    });
   });
 
   describe('everyone-mode layout (recipientMode:"everyone")', () => {
@@ -6826,40 +6861,6 @@ describe('renderConfirmCardRows', () => {
       ]);
     });
 
-    test('forged voice-mode without voiceChannelId still renders the escape hatch (defensive)', () => {
-      // Production never pairs RECIPIENT_MODE_VOICE without voiceChannelId,
-      // but a forged or schema-drifted payload could. Without the
-      // defensive `voiceChannelId`-less branch in renderConfirmCardRows,
-      // such a payload would skip the escape-hatch branch entirely AND
-      // skip the @everyone entry branch (gated on PICKER), leaving the
-      // user with no path back to manual selection. Pin recovery.
-      const { MentionableSelectMenuBuilder, ButtonBuilder } = require('discord.js');
-      MentionableSelectMenuBuilder.mockClear();
-      ButtonBuilder.mockClear();
-      const interaction = {
-        guild: {
-          id: 'g-forged-voice', members: { cache: new Map() }, memberCount: 1,
-          channels: { cache: new Map() },
-        },
-        memberPermissions: { has: jest.fn(() => false) },
-      };
-      const { renderConfirmCardRows } = commands._test;
-      renderConfirmCardRows({
-        sendDisabled: false,
-        expiresIn: '24h',
-        selfDestructSeconds: null,
-        personalMessage: null,
-        voiceChannelId: null,  // ← forged/drifted state
-        interaction,
-        recipientIds: ['100000000000000001'],
-        recipientMode: 'voice',
-      });
-      const customIds = ButtonBuilder.mock.results.map(
-        (r) => r.value.setCustomId.mock.calls[0]?.[0]
-      );
-      expect(customIds).toContain('qurl_confirm_pick_manual');
-      expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
-    });
   });
 
   // ── @everyone button rendering ──

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -204,6 +204,7 @@ const {
   CONFIRM_PICK_MANUAL_BUTTON_CUSTOM_ID,
   RECIPIENT_MODE_PICKER,
   RECIPIENT_MODE_VOICE,
+  RECIPIENT_MODE_EVERYONE,
   normalizeRecipientMode,
   SEND_FLOW_TTL_SECONDS,
   SELF_DESTRUCT_NO_TIMER_CHOICE,
@@ -7451,6 +7452,7 @@ describe('constants + exports', () => {
     // and would silently mis-route. Pin the literals here.
     expect(RECIPIENT_MODE_PICKER).toBe('picker');
     expect(RECIPIENT_MODE_VOICE).toBe('voice');
+    expect(RECIPIENT_MODE_EVERYONE).toBe('everyone');
   });
 
   test('normalizeRecipientMode: closed set {voice, everyone, picker}; everything else picker', () => {

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -6765,6 +6765,41 @@ describe('renderConfirmCardRows', () => {
         'qurl_confirm_cancel',
       ]);
     });
+
+    test('forged voice-mode without voiceChannelId still renders the escape hatch (defensive)', () => {
+      // Production never pairs RECIPIENT_MODE_VOICE without voiceChannelId,
+      // but a forged or schema-drifted payload could. Without the
+      // defensive `voiceChannelId`-less branch in renderConfirmCardRows,
+      // such a payload would skip the escape-hatch branch entirely AND
+      // skip the @everyone entry branch (gated on PICKER), leaving the
+      // user with no path back to manual selection. Pin recovery.
+      const { MentionableSelectMenuBuilder, ButtonBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      ButtonBuilder.mockClear();
+      const interaction = {
+        guild: {
+          id: 'g-forged-voice', members: { cache: new Map() }, memberCount: 1,
+          channels: { cache: new Map() },
+        },
+        memberPermissions: { has: jest.fn(() => false) },
+      };
+      const { renderConfirmCardRows } = commands._test;
+      renderConfirmCardRows({
+        sendDisabled: false,
+        expiresIn: '24h',
+        selfDestructSeconds: null,
+        personalMessage: null,
+        voiceChannelId: null,  // ← forged/drifted state
+        interaction,
+        recipientIds: ['100000000000000001'],
+        recipientMode: 'voice',
+      });
+      const customIds = ButtonBuilder.mock.results.map(
+        (r) => r.value.setCustomId.mock.calls[0]?.[0]
+      );
+      expect(customIds).toContain('qurl_confirm_pick_manual');
+      expect(MentionableSelectMenuBuilder).not.toHaveBeenCalled();
+    });
   });
 
   // ── @everyone button rendering ──

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -2996,6 +2996,38 @@ describe('handleQurlFile — slash entry', () => {
       expect(payload.recipientIds.length).toBeGreaterThanOrEqual(2);
     });
 
+    test('text `@everyone` with sender MISSING from members.cache post-prewarm → selfIncluded:false (documented divergence from button-click path)', async () => {
+      // Pins the divergence documented at commands.js:~4296 (slash-text
+      // EVERYONE branch). In the narrow shard-resume / partial-chunk
+      // race where prewarm runs but the sender's row never lands in
+      // `members.cache`, the text path expands @everyone over whatever
+      // IS in cache and yields `selfIncluded:false`. The button-click
+      // path (handleConfirmEveryone at commands.js:5694) would
+      // defensively push `interaction.user` for the same cache state
+      // and yield `selfIncluded:true`.
+      //
+      // A future contributor "fixing" the asymmetry by mirroring the
+      // defensive push on the text path would flip this assertion and
+      // be forced to revisit the documented divergence — that's the
+      // point of pinning it.
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: '@everyone' },
+        // SENDER_ID intentionally omitted: simulates the post-prewarm
+        // race where the chunk-fetch landed everyone EXCEPT the sender.
+        guildMembers: {
+          '100000000000000051': {},
+          '100000000000000052': {},
+        },
+      });
+      int.memberPermissions = { has: jest.fn(() => true) };
+      int.guild.memberCount = 3;
+      await handleQurlFile(int);
+      const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(payload.recipientMode).toBe('everyone');
+      expect(payload.selfIncluded).toBe(false);
+      expect(payload.recipientIds).not.toContain(SENDER_ID);
+    });
+
     test('text `@everyone` WITHOUT MENTION_EVERYONE → stays PICKER (parser denied expansion)', async () => {
       // Counter-test: `massMentionDenied:true` does NOT set the
       // EVERYONE-mode trigger — `massMentionExpanded` is mutually

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -1073,11 +1073,11 @@ describe('parseRecipientMentions — @everyone (allowMassMention)', () => {
 });
 
 describe('parseRecipientMentions — result-shape contract', () => {
-  test('result shape pins exactly five keys (ids, invalidTokens, cappedCount, massMentionDenied, roleMentionsDenied)', () => {
+  test('result shape pins exactly six keys (ids, invalidTokens, cappedCount, massMentionDenied, massMentionExpanded, roleMentionsDenied)', () => {
     // Empire of `.toMatchObject` in other tests admits new fields by
     // design (the result shape is allowed to grow), but the closed
     // set of CURRENT keys is load-bearing — callers destructure these
-    // names. Pin the closed set so a future PR that adds a 6th field
+    // names. Pin the closed set so a future PR that adds a 7th field
     // surfaces here intentionally rather than slipping past
     // partial-match assertions.
     const int = makeInteraction({ users: { '111': {} } });
@@ -1087,6 +1087,7 @@ describe('parseRecipientMentions — result-shape contract', () => {
       'ids',
       'invalidTokens',
       'massMentionDenied',
+      'massMentionExpanded',
       'roleMentionsDenied',
     ]);
   });


### PR DESCRIPTION
## Why

The 📢 @everyone confirm-card button on `/qurl file` and `/qurl map` was auto-filling the MentionableSelect picker with up to 25 of N recipients after a fan-out. To a user looking at the card, that read as **"the bot capped my @everyone at 10/25 people"** — and worse, any subsequent picker interaction would route through `handleConfirmUserSelect` and silently replace the full fan-out with whatever subset of names happened to be pre-selected.

The actual recipient set was always bounded by `QURL_SEND_MAX_RECIPIENTS = 20000`; the perceived cap was the picker's own UX leaking into a flow that didn't need it. This PR removes the leak and trims the surrounding copy.

## Summary

- **New `RECIPIENT_MODE_EVERYONE`** alongside `picker` / `voice`. After 📢 @everyone (click OR text-mention), the card hides the MentionableSelect picker entirely and surfaces a `👥 Pick people instead` escape hatch — same shape as voice-mode. Eliminates the auto-fill misread.
- **Text-mention parity:** `parseRecipientMentions` now returns `massMentionExpanded: boolean` (the precise "expansion ran" predicate, distinct from `massMentionDenied`). `handleQurlSlashSend` reads it to land text `/qurl file @everyone` in EVERYONE-mode too — previously this path went through PICKER-mode with the same auto-fill problem.
- **Terser button labels.** 🔊 button is now `🔊 Everyone on voice` (was `🔊 Everyone in #{channelName} (N)` with UTF-16-aware truncation against Discord's 80-unit cap). 📢 button is now `📢 @everyone` (was `📢 @everyone (N) — exceeds N cap`). Live counts and the over-cap suffix are gone; the disabled+greyed-out button is the only state signal. Reduces markdown-injection surface area on channel names too.
- **Drop `(you not included)` disclosure** from the voice-mode "To:" line. Sender exclusion stays inferred from voice-mode semantics. The data-side `selfIncluded:false` invariant is unchanged; the renderer guard against `selfIncluded:true` in voice-mode still suppresses a contradictory "Send includes you." notice on forged/drifted payloads.

## Mode behavior matrix

| Mode | Picker row | Bottom-row entry buttons | Escape hatch |
|---|---|---|---|
| `picker` | ✅ shown | 🔊 Voice (in voice channel), 📢 @everyone (with perm) | — |
| `voice` | ❌ hidden | — | 👥 Pick people instead |
| `everyone` (new) | ❌ hidden | — | 👥 Pick people instead |

## Mid-deploy / stale-row safety

- `normalizeRecipientMode` maps unknown values to `picker`, so old bot reading a new `'everyone'` row gracefully degrades to the legacy auto-fill behavior (no data loss, just a UI regression for a single confirm card mid-deploy).
- `handleConfirmUserSelect` explicitly overrides `recipientMode → 'picker'` on every transition so a forged interaction or stale UI emitting a picker event from EVERYONE mode can't re-leak the prior mode forward.
- All `handleConfirmEveryone` reject paths set `RECIPIENT_MODE_PICKER` — error recovery never strands the user in EVERYONE mode with empty recipients.

## Test plan

- [x] `npm test` — 1778/1778 pass, 47 suites
- [x] `npm run lint` — clean
- [ ] Manual: `/qurl file` + click 📢 @everyone → picker disappears, "Pick people instead" appears, Send fans out to full guild
- [ ] Manual: `/qurl file recipients:@everyone` (with MENTION_EVERYONE) → same end state as button click
- [ ] Manual: `/qurl file` from voice channel → 🔊 Everyone on voice label, "To:" line shows channel mention without "(you not included)"
- [ ] Manual: click "Pick people instead" from each non-picker mode → returns to PICKER with empty recipients

🤖 Generated with [Claude Code](https://claude.com/claude-code)