### PR TITLE
feat(discord): cap in-flight handler dispatches in event consumer (#388)

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -103,7 +103,8 @@ ENABLE_OPENNHP_FEATURES=false
 # re-checking — prevents memory pressure from a sustained burst
 # outpacing downstream DDB/REST drain. Default 100; override only
 # if prod soak surfaces a different sustainable ceiling. Must be
-# a positive integer.
+# a positive integer (scientific notation like 1e3 is also accepted,
+# since Number('1e3')=1000 is a positive integer).
 #
 # Soft cap, not a hard semaphore: pollOnce gates BEFORE the next
 # receive, but a batch already-received can push the in-flight

--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -99,11 +99,20 @@ ENABLE_OPENNHP_FEATURES=false
 
 # Maximum number of in-flight detached handlers the SQS consumer
 # tolerates before pausing receives (backpressure). When the count
-# reaches the cap, pollOnce returns early and waits ~100ms before
+# reaches the cap, pollOnce returns early and waits 100ms before
 # re-checking — prevents memory pressure from a sustained burst
 # outpacing downstream DDB/REST drain. Default 100; override only
 # if prod soak surfaces a different sustainable ceiling. Must be
 # a positive integer.
+#
+# Soft cap, not a hard semaphore: pollOnce gates BEFORE the next
+# receive, but a batch already-received can push the in-flight
+# count to `cap + 9` (RECEIVE_MAX_MESSAGES - 1) before the next
+# gate. Values below 10 have a degenerate overshoot ratio (cap=1
+# can transiently reach 10 in-flight handlers, 10x the configured
+# value); pick at least 10 for the overshoot ceiling to match
+# operator intuition. Size memory headroom assuming `cap + 10`
+# simultaneous handler promises regardless.
 # QURL_BOT_MAX_INFLIGHT_HANDLERS=100
 
 # GitHub OAuth App — REQUIRED only when ENABLE_OPENNHP_FEATURES=true.

--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -97,6 +97,15 @@ ENABLE_OPENNHP_FEATURES=false
 # ENABLE_EVENT_SHIPPER=false
 # QURL_BOT_EVENTS_QUEUE_URL=https://sqs.us-east-2.amazonaws.com/000000000000/qurl-bot-events-sandbox
 
+# Maximum number of in-flight detached handlers the SQS consumer
+# tolerates before pausing receives (backpressure). When the count
+# reaches the cap, pollOnce returns early and waits ~100ms before
+# re-checking — prevents memory pressure from a sustained burst
+# outpacing downstream DDB/REST drain. Default 100; override only
+# if prod soak surfaces a different sustainable ceiling. Must be
+# a positive integer.
+# QURL_BOT_MAX_INFLIGHT_HANDLERS=100
+
 # GitHub OAuth App — REQUIRED only when ENABLE_OPENNHP_FEATURES=true.
 # Single-guild-plain and multi-tenant deployments don't mount /auth or
 # /webhook routes and don't need these values — the boot check

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -85,19 +85,24 @@
 // TODO(infra-publisher-set)` from any infra-side change surfaces
 // this requirement.
 //
-// No backpressure between the consumer and detached handlers: the
-// poll loop keeps pulling 10-message batches as long as the queue
-// has work, but `handleCommand` / `handleFlowInteraction` run
-// detached after the synchronous emit. Under a bursty arrival
-// pattern with slow downstream DDB/REST work, in-flight handler
-// promises accumulate without an upper bound — risking memory
-// pressure if a sustained backlog grows faster than handlers
-// drain. Today's volume bounds (invite-only beta, ~thousands of
-// guilds) make this comfortably theoretical; tracked as an
-// operational concern to revisit before flag-flip in PR 10. If
-// in-flight handler count needs to be capped, a semaphore around
-// `pollOnce` (max N concurrent dispatches before the next receive)
-// is the natural shape. See #388 for the follow-up.
+// Backpressure: the poll loop tracks in-flight detached handlers
+// and pauses receives when `inFlightCount >= MAX_INFLIGHT_HANDLERS`
+// (env-overridable; see QURL_BOT_MAX_INFLIGHT_HANDLERS). Without
+// this, under a bursty arrival pattern with slow downstream
+// DDB/REST work, handler promises would accumulate without bound,
+// risking memory pressure if the backlog grows faster than handlers
+// drain. The cap is the safety net before the worker tier flag-flip
+// in PR 10.
+//
+// How tracking works without coupling to handler internals: the
+// consumer sets `isWorkerDispatch = true` synchronously around the
+// `client.actions.InteractionCreate.handle(data)` call. The listener
+// in src/index.js calls `eventConsumer.trackDispatch(result)` on
+// every dispatch; trackDispatch checks the flag and only registers
+// the promise's settle handler when the dispatch is consumer-driven
+// (worker tier), NOT when it's gateway-WS-driven. The increment
+// runs inside the synchronous emit window; the decrement fires
+// whenever the dispatch promise settles, however much later.
 
 const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require('@aws-sdk/client-sqs');
 const config = require('./config');
@@ -220,17 +225,18 @@ function recordSeen(eventId) {
 // What stop() does NOT await: the async handlers registered on
 // `interactionCreate` (handleCommand / handleFlowInteraction) run
 // detached after the synchronous `client.actions.InteractionCreate.handle`
-// emit. Their promises aren't captured anywhere we can await. A
-// handler still mid-DDB-write when SIGTERM lands could race
-// gracefulShutdown's eventual `db.close()` — same race the
-// pre-existing in-process gateway path has, since the gateway also
-// emits + runs detached. Not worse here than today.
+// emit. The backpressure tracker (trackDispatch / inFlightCount)
+// CAPTURES those promises for bounding-the-cap purposes but stop()
+// doesn't await them — graceful-shutdown's 10s budget would be
+// blown by a long-running DM-fan-out handler. A handler still
+// mid-DDB-write when SIGTERM lands could race gracefulShutdown's
+// eventual `db.close()` — same race the pre-existing in-process
+// gateway path has, since the gateway also emits + runs detached.
 //
 // If a tighter "drain handlers before db close" guarantee is ever
-// needed, options are: (a) capture handler promises via a WeakMap
-// registry the listener populates and the consumer reads; (b) call
-// the dispatcher functions directly instead of going through the
-// emit path. Both are PR-10-or-later refactors.
+// needed, the trackDispatch registry already has the promises;
+// stop() could `await Promise.allSettled([...inFlightPromises])`
+// with its own deadline cap (e.g. 3s). Deferred until needed.
 //
 // receiveAbortController is set per-poll-iteration and used by stop()
 // to cancel an in-flight long-poll ReceiveMessage. Without this, a
@@ -244,6 +250,50 @@ let stopping = false;
 let loopPromise = null;
 let receiveAbortController = null;
 let sqsClient = null;
+
+// Backpressure cap (see module header). pollOnce early-returns
+// when inFlightCount >= MAX_INFLIGHT_HANDLERS and waits
+// INFLIGHT_BACKOFF_MS for the count to drain before re-polling.
+// Default of 100 sized for the realistic invite-only-beta worst
+// case (10-message batches × ~5-10 batches before slowest
+// handler completes). Operator can override via env when prod
+// volume + slowness data is in hand.
+const DEFAULT_MAX_INFLIGHT_HANDLERS = 100;
+const MAX_INFLIGHT_HANDLERS = (() => {
+  const raw = process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
+  if (!raw) return DEFAULT_MAX_INFLIGHT_HANDLERS;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    // logger isn't loaded this early in module init; console.warn
+    // for visibility at boot, then fall back to the default.
+    console.warn(
+      `[event-consumer] QURL_BOT_MAX_INFLIGHT_HANDLERS=${JSON.stringify(raw)} rejected ` +
+      `(must be a positive integer); using default ${DEFAULT_MAX_INFLIGHT_HANDLERS}.`,
+    );
+    return DEFAULT_MAX_INFLIGHT_HANDLERS;
+  }
+  return parsed;
+})();
+
+// Brief pause when at-cap. Short enough that handlers draining
+// quickly resume normal polling; long enough that we don't burn
+// CPU re-checking the cap on every microtask. abortableSleep
+// honors `stopping` so a SIGTERM during a backpressure pause still
+// exits inside the graceful-shutdown budget.
+const INFLIGHT_BACKOFF_MS = 100;
+
+// In-flight handler count (incremented in trackDispatch when a
+// consumer-driven dispatch's promise is registered; decremented
+// when that promise settles). isWorkerDispatch is the per-emit
+// gate that distinguishes consumer-driven dispatches (which we
+// want to count) from gateway-WS-driven dispatches in combined
+// mode (which we don't — the gateway tier doesn't backpressure
+// against itself). The flag is set true synchronously around
+// `client.actions.InteractionCreate.handle(data)` in processMessage
+// and cleared in the finally; the listener's emit fires inside that
+// window because EventEmitter.emit is synchronous.
+let inFlightCount = 0;
+let isWorkerDispatch = false;
 
 // Hook for unit tests: lets the test inject a mock SQSClient
 // (aws-sdk-client-mock'd in tests/event-consumer.test.js) without
@@ -409,6 +459,13 @@ async function processMessage(client, message) {
   // The shared listener registered in src/index.js (gated on
   // isGateway || isWorker) handles routing.
   let dispatchOk = true;
+  // Flag for trackDispatch (called by the listener in src/index.js).
+  // EventEmitter.emit is synchronous, so the listener fires while
+  // this flag is still true; trackDispatch reads the flag and only
+  // registers consumer-driven dispatches in the backpressure cap.
+  // Cleared in the finally so a gateway-WS-driven dispatch landing
+  // after this returns is correctly untracked.
+  isWorkerDispatch = true;
   try {
     client.actions.InteractionCreate.handle(data);
   } catch (err) {
@@ -422,6 +479,8 @@ async function processMessage(client, message) {
       eventId,
       messageId: message.MessageId,
     });
+  } finally {
+    isWorkerDispatch = false;
   }
 
   if (isDup) {
@@ -447,7 +506,50 @@ async function processMessage(client, message) {
   await deleteMessage(message.ReceiptHandle);
 }
 
+// Called by the `interactionCreate` listener in src/index.js for
+// every dispatch. Reads the isWorkerDispatch flag set synchronously
+// around the consumer's `handle()` call to distinguish consumer-
+// driven dispatches (which count against the backpressure cap)
+// from gateway-WS-driven dispatches (which don't — gateway tier
+// doesn't backpressure against itself). Increment runs inside the
+// synchronous emit window; decrement registers on the dispatch
+// promise's `.finally()` so both success and rejection bring the
+// counter back down. A non-promise return (older handlers, or
+// nothing returned for unrouted interaction types) is a no-op.
+function trackDispatch(maybePromise) {
+  if (!isWorkerDispatch) return;
+  if (!maybePromise || typeof maybePromise.then !== 'function') return;
+  inFlightCount += 1;
+  // .finally on the original promise so we don't swallow rejections
+  // — the original chain still rejects, just with the decrement as a
+  // side effect. Wrap the decrement in a try/catch so a malformed
+  // promise can't leave the counter stuck at a high value.
+  maybePromise.finally(() => {
+    inFlightCount -= 1;
+  }).catch(() => {
+    // The decrement already happened in the finally callback; this
+    // catch is only here to absorb the rejection that flows through
+    // the chain so it doesn't surface as an unhandledRejection
+    // attributed to the consumer. The original .then() chain
+    // registered by the listener's caller still sees the rejection.
+  });
+}
+
 async function pollOnce(client) {
+  // Backpressure check: if too many handlers are in-flight, pause
+  // receives until they drain. Returns from this iteration without
+  // pulling messages; pollLoop will call us again, and the
+  // `while (!stopping)` check naturally exits if stop() lands during
+  // the pause. abortableSleep also honors stopping so the pause
+  // doesn't blow the graceful-shutdown budget.
+  if (inFlightCount >= MAX_INFLIGHT_HANDLERS) {
+    logger.debug('Event consumer: in-flight cap reached, pausing receive', {
+      inFlight: inFlightCount,
+      cap: MAX_INFLIGHT_HANDLERS,
+    });
+    await abortableSleep(INFLIGHT_BACKOFF_MS);
+    return;
+  }
   const queueUrl = config.QURL_BOT_EVENTS_QUEUE_URL;
   const cmd = new ReceiveMessageCommand({
     QueueUrl: queueUrl,
@@ -738,11 +840,14 @@ function _resetStateForTest() {
   sqsClient = null;
   seenEventIds.clear();
   lastMissingEventIdWarnMs = 0;
+  inFlightCount = 0;
+  isWorkerDispatch = false;
 }
 
 module.exports = {
   start,
   stop,
+  trackDispatch,
   _test: {
     _setSqsClientForTest,
     _resetStateForTest,
@@ -760,6 +865,16 @@ module.exports = {
     isAbortError,
     abortableSleep,
     SEEN_EVENT_ID_CAP,
+    MAX_INFLIGHT_HANDLERS,
+    INFLIGHT_BACKOFF_MS,
     getReceiveAbortController: () => receiveAbortController,
+    getInFlightCount: () => inFlightCount,
+    isWorkerDispatching: () => isWorkerDispatch,
+    // Test-only setter. trackDispatch reads the module-level
+    // `isWorkerDispatch` directly (not via `isWorkerDispatching()`),
+    // so a jest.spyOn on the introspection helper can't influence it.
+    // Tests that want to simulate the synchronous flag wrap done by
+    // processMessage call this helper instead.
+    _setWorkerDispatchingForTest: (v) => { isWorkerDispatch = !!v; },
   },
 };

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -296,6 +296,19 @@ const MAX_INFLIGHT_HANDLERS = (() => {
     );
     return DEFAULT_MAX_INFLIGHT_HANDLERS;
   }
+  // Defense-in-depth: values below RECEIVE_MAX_MESSAGES produce
+  // degenerate overshoot ratios (cap=1 can transiently reach 10
+  // in-flight, 10x the configured value). Accept the value — an
+  // operator who wants cap=1 to rate-limit hard may have a reason —
+  // but warn so the booted ceiling matches their mental model.
+  if (parsed < RECEIVE_MAX_MESSAGES) {
+    console.warn(
+      `[event-consumer] QURL_BOT_MAX_INFLIGHT_HANDLERS=${parsed} is below ` +
+      `RECEIVE_MAX_MESSAGES (${RECEIVE_MAX_MESSAGES}); effective in-flight ceiling ` +
+      `is ${parsed + RECEIVE_MAX_MESSAGES - 1} due to batch overshoot. ` +
+      `Pick ${RECEIVE_MAX_MESSAGES}+ for the overshoot ratio to match the cap value.`,
+    );
+  }
   return parsed;
 })();
 
@@ -515,6 +528,12 @@ async function processMessage(client, message) {
   // gateway-WS-driven dispatches against the worker cap in combined
   // mode. If you need async work, do it BEFORE this block or AFTER
   // the finally clears the flag.
+  //
+  // The FLAG-WRAP-START / FLAG-WRAP-END sentinels below bracket the
+  // block; the static invariant test in tests/event-consumer.test.js
+  // slices between them and asserts no `await` appears. Do NOT rename
+  // or relocate the sentinels without updating the test.
+  // FLAG-WRAP-START
   isWorkerDispatch = true;
   try {
     client.actions.InteractionCreate.handle(data);
@@ -532,6 +551,7 @@ async function processMessage(client, message) {
   } finally {
     isWorkerDispatch = false;
   }
+  // FLAG-WRAP-END
 
   if (isDup) {
     // Debug log only — at-least-once delivery means a "dup" might
@@ -591,8 +611,18 @@ function trackDispatch(maybePromise) {
     // in src/index.js is now absorbed here. Log it explicitly so a
     // failing handler still produces an error signal — otherwise the
     // backpressure tracker would silently mask handler bugs.
+    //
+    // `kind: 'unhandledRejection'` tags the log so a single CloudWatch
+    // query (filtering on the structured field) can find both this
+    // consumer-driven path AND the gateway-WS-driven path that still
+    // routes through `process.on('unhandledRejection', ...)`. The
+    // gateway handler in src/index.js will be updated in PR 10 to
+    // emit the same field so dashboards see a unified signal. The
+    // `err?.message || String(err)` fallback mirrors the gateway
+    // handler's shape for non-Error rejections.
     logger.error('Event consumer: dispatch handler rejected', {
-      error: err?.message,
+      kind: 'unhandledRejection',
+      error: err?.message || String(err),
       stack: err?.stack,
     });
   });
@@ -612,6 +642,10 @@ async function pollOnce(client) {
   // at info. This matches the `lastMissingEventIdWarnMs` pattern
   // already in this file — transition-loud, steady-state-quiet.
   const capPayload = { inFlight: inFlightCount, cap: MAX_INFLIGHT_HANDLERS };
+  // `>=` (not `>`): the cap is the first paused value, so cap=100
+  // means we pause AT 100 in-flight, not at 101. Steady-state ceiling
+  // is therefore (cap - 1) + RECEIVE_MAX_MESSAGES overshoot. Off-by-
+  // one is intentional and matches the .env.example math.
   if (inFlightCount >= MAX_INFLIGHT_HANDLERS) {
     if (!atCapPauseLogged) {
       logger.warn(AT_CAP_PAUSE_WARN_MSG, capPayload);
@@ -894,6 +928,12 @@ async function stop() {
     // start() (no-op today via the running guard) wouldn't abort a
     // stale controller.
     receiveAbortController = null;
+    // Reset the at-cap log gate so a `start → at-cap → stop → start`
+    // round-trip doesn't inherit a stale `true` and miss the next
+    // streak's transition warn. Production never restarts after stop,
+    // but integration tests that exercise the lifecycle would
+    // otherwise see a phantom suppressed warn.
+    atCapPauseLogged = false;
     // Intentionally do NOT null `sqsClient`. Production never calls
     // start() after stop() — gracefulShutdown runs once at SIGTERM,
     // then process.exit. Reusing the client across a hypothetical

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -641,6 +641,13 @@ async function pollOnce(client) {
   // transition back to below-cap (handled after this branch) logs
   // at info. This matches the `lastMissingEventIdWarnMs` pattern
   // already in this file — transition-loud, steady-state-quiet.
+  // Snapshot capPayload at pollOnce entry. Shared across at-cap
+  // warn/debug AND the release-info branch — so the release log's
+  // `inFlight` field is the value that *triggered* the release
+  // (necessarily below cap), not "drained to N" at the moment of
+  // logging. That's the right framing for pairing pause-start
+  // (entry-snapshot at cap) with pause-end (entry-snapshot below
+  // cap) in CloudWatch.
   const capPayload = { inFlight: inFlightCount, cap: MAX_INFLIGHT_HANDLERS };
   // `>=` (not `>`): the cap is the first paused value, so cap=100
   // means we pause AT 100 in-flight, not at 101. Steady-state ceiling

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -268,8 +268,13 @@ const DEFAULT_MAX_INFLIGHT_HANDLERS = 100;
 const MAX_INFLIGHT_HANDLERS = (() => {
   const raw = process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
   if (!raw) return DEFAULT_MAX_INFLIGHT_HANDLERS;
-  const parsed = parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  // Use Number() + Number.isInteger() rather than parseInt — parseInt
+  // is lenient ('100abc' → 100), and the .env.example promises "must
+  // be a positive integer." Trailing garbage in the env value is more
+  // likely a templating typo than intent; rejecting it surfaces the
+  // bug at boot instead of silently truncating.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
     // logger isn't loaded this early in module init; console.warn
     // for visibility at boot, then fall back to the default.
     console.warn(
@@ -300,6 +305,22 @@ const INFLIGHT_BACKOFF_MS = 100;
 // window because EventEmitter.emit is synchronous.
 let inFlightCount = 0;
 let isWorkerDispatch = false;
+
+// State-machine rate-limit on the at-cap log. Sustained at-cap
+// (slow downstream + bursty arrivals) wakes pollOnce every
+// INFLIGHT_BACKOFF_MS, so without throttling a single backlog
+// produces ~10 lines/sec/worker. Pattern matches
+// `lastMissingEventIdWarnMs`: the *transition* into at-cap is the
+// loud signal (warn), steady-state at-cap is debug, and the
+// transition back to below-cap is info. atCapPauseLogged is the
+// "we've already logged the warn for this streak" gate; cleared
+// when pollOnce next observes a below-cap state. Log messages
+// pulled into constants so monitoring alerts that grep for them
+// stay in sync with the call site even if the wording drifts.
+let atCapPauseLogged = false;
+const AT_CAP_PAUSE_WARN_MSG = 'Event consumer: in-flight cap reached, pausing receive until handlers drain';
+const AT_CAP_PAUSE_DEBUG_MSG = 'Event consumer: still at in-flight cap, continuing pause';
+const AT_CAP_RELEASED_INFO_MSG = 'Event consumer: in-flight cap released, resuming receive';
 
 // Hook for unit tests: lets the test inject a mock SQSClient
 // (aws-sdk-client-mock'd in tests/event-consumer.test.js) without
@@ -471,6 +492,16 @@ async function processMessage(client, message) {
   // registers consumer-driven dispatches in the backpressure cap.
   // Cleared in the finally so a gateway-WS-driven dispatch landing
   // after this returns is correctly untracked.
+  //
+  // CRITICAL INVARIANT — DO NOT add `await` inside this try/finally.
+  // The flag-wrap is correct only because there is no yield between
+  // `isWorkerDispatch = true` and `isWorkerDispatch = false`. A
+  // pre-emit `await logger.x()` or an `await` on handle() would let
+  // a concurrent processMessage (under Promise.allSettled in
+  // pollOnce) observe a leaked true flag, silently miscounting
+  // gateway-WS-driven dispatches against the worker cap in combined
+  // mode. If you need async work, do it BEFORE this block or AFTER
+  // the finally clears the flag.
   isWorkerDispatch = true;
   try {
     client.actions.InteractionCreate.handle(data);
@@ -549,13 +580,38 @@ async function pollOnce(client) {
   // `while (!stopping)` check naturally exits if stop() lands during
   // the pause. abortableSleep also honors stopping so the pause
   // doesn't blow the graceful-shutdown budget.
+  //
+  // Log throttling: only the transition into at-cap is loud (warn);
+  // subsequent at-cap polls in the same streak are debug. The
+  // transition back to below-cap (handled after this branch) logs
+  // at info. This matches the `lastMissingEventIdWarnMs` pattern
+  // already in this file — transition-loud, steady-state-quiet.
   if (inFlightCount >= MAX_INFLIGHT_HANDLERS) {
-    logger.debug('Event consumer: in-flight cap reached, pausing receive', {
+    if (!atCapPauseLogged) {
+      logger.warn(AT_CAP_PAUSE_WARN_MSG, {
+        inFlight: inFlightCount,
+        cap: MAX_INFLIGHT_HANDLERS,
+      });
+      atCapPauseLogged = true;
+    } else {
+      logger.debug(AT_CAP_PAUSE_DEBUG_MSG, {
+        inFlight: inFlightCount,
+        cap: MAX_INFLIGHT_HANDLERS,
+      });
+    }
+    await abortableSleep(INFLIGHT_BACKOFF_MS);
+    return;
+  }
+  // Below-cap path: if we just transitioned out of at-cap, log the
+  // release so operators can match "pause started" with "pause ended"
+  // pairs in CloudWatch. Reset the gate so the next at-cap entry
+  // re-fires the warn (each streak gets exactly one warn).
+  if (atCapPauseLogged) {
+    logger.info(AT_CAP_RELEASED_INFO_MSG, {
       inFlight: inFlightCount,
       cap: MAX_INFLIGHT_HANDLERS,
     });
-    await abortableSleep(INFLIGHT_BACKOFF_MS);
-    return;
+    atCapPauseLogged = false;
   }
   const queueUrl = config.QURL_BOT_EVENTS_QUEUE_URL;
   const cmd = new ReceiveMessageCommand({
@@ -849,6 +905,7 @@ function _resetStateForTest() {
   lastMissingEventIdWarnMs = 0;
   inFlightCount = 0;
   isWorkerDispatch = false;
+  atCapPauseLogged = false;
 }
 
 module.exports = {
@@ -874,9 +931,13 @@ module.exports = {
     SEEN_EVENT_ID_CAP,
     MAX_INFLIGHT_HANDLERS,
     INFLIGHT_BACKOFF_MS,
+    AT_CAP_PAUSE_WARN_MSG,
+    AT_CAP_PAUSE_DEBUG_MSG,
+    AT_CAP_RELEASED_INFO_MSG,
     getReceiveAbortController: () => receiveAbortController,
     getInFlightCount: () => inFlightCount,
     isWorkerDispatching: () => isWorkerDispatch,
+    isAtCapPauseLogged: () => atCapPauseLogged,
     // Test-only setter. trackDispatch reads the module-level
     // `isWorkerDispatch` directly (not via `isWorkerDispatching()`),
     // so a jest.spyOn on the introspection helper can't influence it.

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -244,9 +244,10 @@ function recordSeen(eventId) {
 // gateway path has, since the gateway also emits + runs detached.
 //
 // If a tighter "drain handlers before db close" guarantee is ever
-// needed, the trackDispatch registry already has the promises;
-// stop() could `await Promise.allSettled([...inFlightPromises])`
-// with its own deadline cap (e.g. 3s). Deferred until needed.
+// needed, trackDispatch would have to additionally capture each
+// promise in a Set (it currently only retains the count) so stop()
+// could `await Promise.allSettled([...inFlightPromises])` with its
+// own deadline cap (e.g. 3s). Deferred until needed.
 //
 // receiveAbortController is set per-poll-iteration and used by stop()
 // to cancel an in-flight long-poll ReceiveMessage. Without this, a
@@ -574,11 +575,13 @@ function trackDispatch(maybePromise) {
   // the counter has dropped.
   //
   // Math.max guards against negative drift if a stale promise
-  // resolves after `_resetStateForTest` cleared the count. Tests
-  // that never await their resolvable promises before resetting
-  // would otherwise leak a decrement into the next test's
-  // starting state. Production can't reach this — every increment
-  // is paired with exactly one decrement on the same promise.
+  // resolves after `_resetStateForTest` cleared the count, or
+  // (under `jest --watch` / hot-reload) a stale promise resolves
+  // into the freshly-required module's clean counter. Tests that
+  // don't await their resolvable promises before resetting would
+  // otherwise leak a decrement into the next test's starting
+  // state. Production can't reach this — every increment is paired
+  // with exactly one decrement on the same promise.
   maybePromise.finally(() => {
     inFlightCount = Math.max(0, inFlightCount - 1);
   }).catch((err) => {

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -94,6 +94,16 @@
 // drain. The cap is the safety net before the worker tier flag-flip
 // in PR 10.
 //
+// This is a soft cap, not a hard semaphore. pollOnce checks
+// `inFlightCount >= cap` BEFORE issuing a ReceiveMessage, but a
+// receive that passes the check can return up to RECEIVE_MAX_MESSAGES
+// (10) messages, and each subsequent processMessage increments via
+// trackDispatch. So in a sustained burst, inFlightCount can transiently
+// reach `cap + RECEIVE_MAX_MESSAGES - 1` (≈9% overshoot at the default
+// cap of 100) before the next pollOnce gates. The cap is a backpressure
+// signal — "stop pulling new work" — not a precise upper bound; size
+// memory headroom assuming `cap + 10` simultaneous handler promises.
+//
 // How tracking works without coupling to handler internals: the
 // consumer sets `isWorkerDispatch = true` synchronously around the
 // `client.actions.InteractionCreate.handle(data)` call. The listener
@@ -275,8 +285,10 @@ const MAX_INFLIGHT_HANDLERS = (() => {
   // bug at boot instead of silently truncating.
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed <= 0) {
-    // logger isn't loaded this early in module init; console.warn
-    // for visibility at boot, then fall back to the default.
+    // Intentional console.warn (not logger.warn) for boot-time
+    // visibility before any logger transports attach to a structured
+    // sink. A misconfigured env-var should be obvious on container
+    // stdout regardless of LOG_LEVEL or transport state.
     console.warn(
       `[event-consumer] QURL_BOT_MAX_INFLIGHT_HANDLERS=${JSON.stringify(raw)} rejected ` +
       `(must be a positive integer); using default ${DEFAULT_MAX_INFLIGHT_HANDLERS}.`,
@@ -557,8 +569,18 @@ function trackDispatch(maybePromise) {
   if (!isWorkerDispatch) return;
   if (!maybePromise || typeof maybePromise.then !== 'function') return;
   inFlightCount += 1;
+  // `.finally` runs before `.catch` on rejection, so the decrement
+  // always lands first — the .catch below sees the rejection AFTER
+  // the counter has dropped.
+  //
+  // Math.max guards against negative drift if a stale promise
+  // resolves after `_resetStateForTest` cleared the count. Tests
+  // that never await their resolvable promises before resetting
+  // would otherwise leak a decrement into the next test's
+  // starting state. Production can't reach this — every increment
+  // is paired with exactly one decrement on the same promise.
   maybePromise.finally(() => {
-    inFlightCount -= 1;
+    inFlightCount = Math.max(0, inFlightCount - 1);
   }).catch((err) => {
     // Attaching `.finally()` above counts as a handler for Node's
     // unhandled-rejection bookkeeping, so a rejection that pre-PR
@@ -586,18 +608,13 @@ async function pollOnce(client) {
   // transition back to below-cap (handled after this branch) logs
   // at info. This matches the `lastMissingEventIdWarnMs` pattern
   // already in this file — transition-loud, steady-state-quiet.
+  const capPayload = { inFlight: inFlightCount, cap: MAX_INFLIGHT_HANDLERS };
   if (inFlightCount >= MAX_INFLIGHT_HANDLERS) {
     if (!atCapPauseLogged) {
-      logger.warn(AT_CAP_PAUSE_WARN_MSG, {
-        inFlight: inFlightCount,
-        cap: MAX_INFLIGHT_HANDLERS,
-      });
+      logger.warn(AT_CAP_PAUSE_WARN_MSG, capPayload);
       atCapPauseLogged = true;
     } else {
-      logger.debug(AT_CAP_PAUSE_DEBUG_MSG, {
-        inFlight: inFlightCount,
-        cap: MAX_INFLIGHT_HANDLERS,
-      });
+      logger.debug(AT_CAP_PAUSE_DEBUG_MSG, capPayload);
     }
     await abortableSleep(INFLIGHT_BACKOFF_MS);
     return;
@@ -607,10 +624,7 @@ async function pollOnce(client) {
   // pairs in CloudWatch. Reset the gate so the next at-cap entry
   // re-fires the warn (each streak gets exactly one warn).
   if (atCapPauseLogged) {
-    logger.info(AT_CAP_RELEASED_INFO_MSG, {
-      inFlight: inFlightCount,
-      cap: MAX_INFLIGHT_HANDLERS,
-    });
+    logger.info(AT_CAP_RELEASED_INFO_MSG, capPayload);
     atCapPauseLogged = false;
   }
   const queueUrl = config.QURL_BOT_EVENTS_QUEUE_URL;

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -660,6 +660,13 @@ async function pollOnce(client) {
     } else {
       logger.debug(AT_CAP_PAUSE_DEBUG_MSG, capPayload);
     }
+    // Clear the previous iteration's controller before sleeping —
+    // there's no in-flight ReceiveMessage during a backpressure
+    // pause, so the invariant "non-null iff a receive is in flight"
+    // holds. A stop() landing during the sleep would otherwise call
+    // .abort() on a settled controller (safe no-op today, but the
+    // null-during-sleep shape is the cleaner contract).
+    receiveAbortController = null;
     await abortableSleep(INFLIGHT_BACKOFF_MS);
     return;
   }

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -258,6 +258,12 @@ let sqsClient = null;
 // case (10-message batches × ~5-10 batches before slowest
 // handler completes). Operator can override via env when prod
 // volume + slowness data is in hand.
+//
+// Captured at module load, not re-read per-poll: operators retuning
+// QURL_BOT_MAX_INFLIGHT_HANDLERS via SSM/task-def must redeploy for
+// the new value to take effect. Per-poll re-read would let a typo
+// in the env-update path silently change behavior without an audit
+// trail in the deploy log.
 const DEFAULT_MAX_INFLIGHT_HANDLERS = 100;
 const MAX_INFLIGHT_HANDLERS = (() => {
   const raw = process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
@@ -520,18 +526,19 @@ function trackDispatch(maybePromise) {
   if (!isWorkerDispatch) return;
   if (!maybePromise || typeof maybePromise.then !== 'function') return;
   inFlightCount += 1;
-  // .finally on the original promise so we don't swallow rejections
-  // — the original chain still rejects, just with the decrement as a
-  // side effect. Wrap the decrement in a try/catch so a malformed
-  // promise can't leave the counter stuck at a high value.
   maybePromise.finally(() => {
     inFlightCount -= 1;
-  }).catch(() => {
-    // The decrement already happened in the finally callback; this
-    // catch is only here to absorb the rejection that flows through
-    // the chain so it doesn't surface as an unhandledRejection
-    // attributed to the consumer. The original .then() chain
-    // registered by the listener's caller still sees the rejection.
+  }).catch((err) => {
+    // Attaching `.finally()` above counts as a handler for Node's
+    // unhandled-rejection bookkeeping, so a rejection that pre-PR
+    // would have surfaced at `process.on('unhandledRejection', ...)`
+    // in src/index.js is now absorbed here. Log it explicitly so a
+    // failing handler still produces an error signal — otherwise the
+    // backpressure tracker would silently mask handler bugs.
+    logger.error('Event consumer: dispatch handler rejected', {
+      error: err?.message,
+      stack: err?.stack,
+    });
   });
 }
 

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -102,7 +102,9 @@
 // reach `cap + RECEIVE_MAX_MESSAGES - 1` (≈9% overshoot at the default
 // cap of 100) before the next pollOnce gates. The cap is a backpressure
 // signal — "stop pulling new work" — not a precise upper bound; size
-// memory headroom assuming `cap + 10` simultaneous handler promises.
+// memory headroom assuming `cap + RECEIVE_MAX_MESSAGES` simultaneous
+// handler promises. (Strict ceiling is cap + RECEIVE_MAX_MESSAGES - 1;
+// the .env.example rounds up by 1 for headroom math.)
 //
 // How tracking works without coupling to handler internals: the
 // consumer sets `isWorkerDispatch = true` synchronously around the

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -312,20 +312,28 @@ if (isGateway || isWorker) {
   // mix two state machines (slash dispatch vs. flow-resume) under
   // one error-handling envelope; cleaner to wire them separately.
   client.on('interactionCreate', (interaction) => {
+    let result;
     if (interaction.isChatInputCommand() || interaction.isAutocomplete()) {
-      return handleCommand(interaction);
+      result = handleCommand(interaction);
+    } else if (interaction.isMessageComponent() || interaction.isModalSubmit()) {
+      result = handleFlowInteraction(interaction);
+    } else {
+      // Future Discord interaction types we don't ship today fall
+      // through here. Log at debug so an operator triaging "why isn't
+      // my new component routing" sees the unrouted type rather than
+      // the silent-drop black box the pre-conversion code provided.
+      logger.debug('interactionCreate: unrouted interaction type', {
+        type: interaction.type,
+      });
+      return undefined;
     }
-    if (interaction.isMessageComponent() || interaction.isModalSubmit()) {
-      return handleFlowInteraction(interaction);
-    }
-    // Future Discord interaction types we don't ship today fall
-    // through here. Log at debug so an operator triaging "why isn't
-    // my new component routing" sees the unrouted type rather than
-    // the silent-drop black box the pre-conversion code provided.
-    logger.debug('interactionCreate: unrouted interaction type', {
-      type: interaction.type,
-    });
-    return undefined;
+    // Register the dispatch promise with the consumer's backpressure
+    // tracker. No-op for gateway-WS-driven dispatches (the consumer's
+    // isWorkerDispatch flag is only true during its synchronous emit
+    // call); during a consumer-driven emit, the increment runs here
+    // and the decrement fires when the handler settles.
+    eventConsumer.trackDispatch(result);
+    return result;
   });
 }
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -335,8 +335,13 @@ if (isGateway || isWorker) {
     // isWorkerDispatch flag is only true during its synchronous emit
     // call); during a consumer-driven emit, the increment runs here
     // and the decrement fires when the handler settles.
+    //
+    // No trailing `return result;` — EventEmitter listeners discard
+    // their return value, and a pre-conversion vestigial return would
+    // imply otherwise to a future reader. The unrouted branch's
+    // `return undefined` IS load-bearing (it short-circuits before
+    // trackDispatch), so the asymmetry is intentional.
     eventConsumer.trackDispatch(result);
-    return result;
   });
 }
 
@@ -373,14 +378,15 @@ if (isGateway) {
 // entire process on any stray rejection (transient Discord timeouts, network
 // blips) which made the bot fragile. Truly fatal errors surface via
 // uncaughtException below.
-// TODO(PR-10): emit `kind: 'unhandledRejection'` here too so a single
-// CloudWatch query filtering on the structured field finds both this
-// gateway-WS-driven path AND the worker-tier path that absorbs
-// rejections in event-consumer.js's trackDispatch .catch (which
-// already emits the kind field). Until both paths agree on the tag,
-// alarms either grep the message text or miss one of the tiers.
+// `kind: 'unhandledRejection'` matches the tag emitted by
+// trackDispatch's .catch in event-consumer.js. A single CloudWatch
+// query filtering on the structured field finds both this gateway-WS-
+// driven path AND the worker-tier path that absorbs rejections in the
+// SQS consumer. Without the parity, dashboards either grep the
+// message text or miss one of the tiers.
 process.on('unhandledRejection', (error, _promise) => {
   logger.error('Unhandled promise rejection (logged, not fatal)', {
+    kind: 'unhandledRejection',
     error: error?.message || error,
     stack: error?.stack,
   });

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -373,6 +373,12 @@ if (isGateway) {
 // entire process on any stray rejection (transient Discord timeouts, network
 // blips) which made the bot fragile. Truly fatal errors surface via
 // uncaughtException below.
+// TODO(PR-10): emit `kind: 'unhandledRejection'` here too so a single
+// CloudWatch query filtering on the structured field finds both this
+// gateway-WS-driven path AND the worker-tier path that absorbs
+// rejections in event-consumer.js's trackDispatch .catch (which
+// already emits the kind field). Until both paths agree on the tag,
+// alarms either grep the message text or miss one of the tiers.
 process.on('unhandledRejection', (error, _promise) => {
   logger.error('Unhandled promise rejection (logged, not fatal)', {
     error: error?.message || error,

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -322,6 +322,9 @@ if (isGateway || isWorker) {
       // through here. Log at debug so an operator triaging "why isn't
       // my new component routing" sees the unrouted type rather than
       // the silent-drop black box the pre-conversion code provided.
+      // No trackDispatch call: there's no handler promise to register,
+      // and the consumer's at-cap accounting should not count the
+      // unrouted no-op against its in-flight budget.
       logger.debug('interactionCreate: unrouted interaction type', {
         type: interaction.type,
       });

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -914,6 +914,32 @@ describe('event-consumer: start/stop lifecycle', () => {
 });
 
 describe('event-consumer: backpressure (in-flight handler cap)', () => {
+  // Test helpers. Pulled up here so the tests below stay focused on
+  // intent rather than re-stating boilerplate.
+
+  // Flush queued microtasks. `.finally → .catch` in trackDispatch
+  // is two microtask hops; default n=3 leaves a one-tick margin so a
+  // future chain extension doesn't require revisiting every test.
+  async function flushMicrotasks(n = 3) {
+    for (let i = 0; i < n; i += 1) {
+      // eslint-disable-next-line no-await-in-loop -- sequential by design
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+
+  // Run `fn` with isWorkerDispatch flipped true (matches the
+  // synchronous flag-wrap processMessage performs around handle()),
+  // then restore. Six tests repeat this pattern; helper keeps the
+  // setup intent visible and the flag flip impossible to miss.
+  function withWorkerDispatch(fn) {
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      return fn();
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+  }
+
   test('trackDispatch is a no-op when isWorkerDispatch is false (gateway mode)', () => {
     // Pins the contract that the gateway-WS-driven path doesn't
     // count against the worker's cap. The flag stays false unless
@@ -988,18 +1014,13 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     const handlerPromise = new Promise((r) => { resolveHandler = r; });
 
     // Mirror processMessage's flag wrap.
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
-      eventConsumer.trackDispatch(handlerPromise);
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
+    withWorkerDispatch(() => eventConsumer.trackDispatch(handlerPromise));
 
     expect(eventConsumer._test.getInFlightCount()).toBe(1);
     resolveHandler('done');
     // Wait for the finally callback to run (microtask boundary).
     await handlerPromise;
-    await new Promise((r) => setImmediate(r));
+    await flushMicrotasks();
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
   });
 
@@ -1013,17 +1034,11 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // unhandledRejection in the test runtime.
     handlerPromise.catch(() => { /* absorbed */ });
 
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
-      eventConsumer.trackDispatch(handlerPromise);
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
+    withWorkerDispatch(() => eventConsumer.trackDispatch(handlerPromise));
 
     expect(eventConsumer._test.getInFlightCount()).toBe(1);
     rejectHandler(new Error('handler failed'));
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await flushMicrotasks();
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
   });
 
@@ -1040,16 +1055,10 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // separate chain; trackDispatch's logging path is independent.
     handlerPromise.catch(() => { /* absorbed */ });
 
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
-      eventConsumer.trackDispatch(handlerPromise);
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
+    withWorkerDispatch(() => eventConsumer.trackDispatch(handlerPromise));
 
     // Allow the .finally + .catch microtasks to flush.
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await flushMicrotasks();
 
     expect(logger.error).toHaveBeenCalledWith(
       'Event consumer: dispatch handler rejected',
@@ -1068,16 +1077,13 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // pending promises so the count stays elevated for the duration
     // of the test.
     const pendingHandlers = [];
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
+    withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         const p = new Promise(() => {}); // never resolves
         eventConsumer.trackDispatch(p);
         pendingHandlers.push(p);
       }
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
+    });
     expect(eventConsumer._test.getInFlightCount()).toBe(cap);
 
     sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [{ Body: '{}', ReceiptHandle: 'x' }] });
@@ -1105,14 +1111,11 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // the streak. Without this, a slow downstream wedge would spam
     // logger.warn ~10x/s per worker.
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
+    withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         eventConsumer.trackDispatch(new Promise(() => {})); // never resolves
       }
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
+    });
 
     sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
     const client = makeStubClient();
@@ -1143,17 +1146,14 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // real .finally decrement path — no test-only setter shortcut.
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
     const resolvers = [];
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
+    withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         let resolve;
         const p = new Promise((r) => { resolve = r; });
         resolvers.push(resolve);
         eventConsumer.trackDispatch(p);
       }
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
+    });
 
     sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
     const client = makeStubClient();
@@ -1165,8 +1165,7 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // Drain all handlers: resolve every tracked promise, then let
     // the .finally microtask chain flush so inFlightCount drops to 0.
     resolvers.forEach((r) => r('done'));
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await flushMicrotasks();
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
 
     // Below-cap poll: release-info fires, gate clears.
@@ -1195,6 +1194,39 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // Pins the default — operators reading the .env.example see
     // this number and may rely on it for their soak headroom math.
     expect(eventConsumer._test.MAX_INFLIGHT_HANDLERS).toBe(100);
+  });
+
+  test('processMessage flag-wrap has no `await` between isWorkerDispatch toggles (static invariant)', () => {
+    // Load-bearing invariant: the synchronous flag-wrap around
+    // `client.actions.InteractionCreate.handle(data)` in
+    // processMessage is correct ONLY because there's no `await`
+    // between `isWorkerDispatch = true` and the matching
+    // `isWorkerDispatch = false` in the finally. An `await` inside
+    // the try/finally would let a concurrent processMessage (running
+    // under Promise.allSettled in pollOnce) observe a leaked-true
+    // flag and silently miscount a gateway-WS-driven dispatch as
+    // worker-driven in combined mode.
+    //
+    // Test by reading the source: scan the slice of event-consumer.js
+    // between the `isWorkerDispatch = true` assignment and the
+    // `isWorkerDispatch = false` in the matching finally and assert
+    // no `await` token appears. Approximate (no JS parse), but pins
+    // the constraint better than a comment alone — a future editor
+    // who adds `await logger.x()` inside the block trips this test.
+    const src = require('fs').readFileSync(
+      require('path').resolve(__dirname, '../src/event-consumer.js'),
+      'utf8',
+    );
+    const startIdx = src.indexOf('isWorkerDispatch = true');
+    const endIdx = src.indexOf('isWorkerDispatch = false', startIdx);
+    expect(startIdx).toBeGreaterThan(0);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    const block = src.slice(startIdx, endIdx);
+    // Strip line comments so a documenting reference to `await` in a
+    // comment doesn't false-positive. Block-comments inside the
+    // wrap aren't expected; we keep the regex simple.
+    const stripped = block.replace(/\/\/[^\n]*/g, '');
+    expect(stripped).not.toMatch(/\bawait\b/);
   });
 
   describe('MAX_INFLIGHT_HANDLERS env validation (module-load IIFE)', () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1007,6 +1007,11 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     })));
 
     expect(eventConsumer._test.isWorkerDispatching()).toBe(false);
+    // Counter should not have been incremented either — handle()
+    // threw before the listener could fire its return value into
+    // trackDispatch. Pinning this ensures a future refactor that
+    // moves the increment outside the listener can't leak a slot.
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
   });
 
   test('trackDispatch increments then decrements on promise resolve', async () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1046,6 +1046,25 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
   });
 
+  test('trackDispatch with an already-settled promise still drains the counter', async () => {
+    // A handler that completes synchronously (or returns a resolved
+    // promise from an early short-circuit) lands here. The `.finally`
+    // callback still runs on the microtask boundary, so the
+    // increment-then-decrement holds — but it's worth pinning the
+    // contract so a future refactor that tries to skip registration
+    // for already-settled promises (as a "perf optimization") is
+    // caught.
+    withWorkerDispatch(() => {
+      eventConsumer.trackDispatch(Promise.resolve('already-done'));
+    });
+
+    // Increment was synchronous (inside withWorkerDispatch).
+    expect(eventConsumer._test.getInFlightCount()).toBe(1);
+    // Decrement is deferred to the .finally microtask.
+    await flushMicrotasks();
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
   test('trackDispatch logs handler rejections (preserves error visibility)', async () => {
     // Regression for cr feedback on PR #389: attaching `.finally()`
     // in trackDispatch counts as a handler for Node's unhandled-

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1062,7 +1062,10 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Event consumer: dispatch handler rejected',
-      expect.objectContaining({ error: 'handler boom' }),
+      expect.objectContaining({
+        kind: 'unhandledRejection',
+        error: 'handler boom',
+      }),
     );
   });
 
@@ -1208,19 +1211,29 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // worker-driven in combined mode.
     //
     // Test by reading the source: scan the slice of event-consumer.js
-    // between the `isWorkerDispatch = true` assignment and the
-    // `isWorkerDispatch = false` in the matching finally and assert
-    // no `await` token appears. Approximate (no JS parse), but pins
-    // the constraint better than a comment alone — a future editor
-    // who adds `await logger.x()` inside the block trips this test.
+    // between `// FLAG-WRAP-START` and `// FLAG-WRAP-END` sentinels
+    // bracketing the wrap, and assert no `await` token appears.
+    // Approximate (no JS parse), but pins the constraint better than
+    // a comment alone — a future editor who adds `await logger.x()`
+    // inside the block trips this test. Sentinel-based bracketing
+    // survives file reordering or future additional flag assignments
+    // elsewhere in the module.
     const src = require('fs').readFileSync(
       require('path').resolve(__dirname, '../src/event-consumer.js'),
       'utf8',
     );
-    const startIdx = src.indexOf('isWorkerDispatch = true');
-    const endIdx = src.indexOf('isWorkerDispatch = false', startIdx);
+    const startMarker = '// FLAG-WRAP-START';
+    const endMarker = '// FLAG-WRAP-END';
+    const startIdx = src.indexOf(startMarker);
+    const endIdx = src.indexOf(endMarker, startIdx);
     expect(startIdx).toBeGreaterThan(0);
     expect(endIdx).toBeGreaterThan(startIdx);
+    // Also pin uniqueness — if the sentinels appear more than once,
+    // a future refactor may have copied the block and the slice no
+    // longer represents a single contiguous wrap.
+    expect(src.indexOf(startMarker, startIdx + startMarker.length)).toBe(-1);
+    expect(src.indexOf(endMarker, endIdx + endMarker.length)).toBe(-1);
+
     const block = src.slice(startIdx, endIdx);
     // Strip line comments so a documenting reference to `await` in a
     // comment doesn't false-positive. Block-comments inside the
@@ -1280,12 +1293,31 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     test.each([
       ['50', 50],
       ['200', 200],
-      ['1', 1],
-    ])('accepts %p as %i', (envValue, expected) => {
+      ['10', 10], // exactly RECEIVE_MAX_MESSAGES — no soft-floor warning
+    ])('accepts %p as %i without warning', (envValue, expected) => {
       withIsolatedEnv(envValue, (fresh, warns) => {
         expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(expected);
-        // No warning for valid values.
+        // No rejection AND no soft-floor warning for cap >= 10.
         expect(warns.some((w) => w.includes('rejected'))).toBe(false);
+        expect(warns.some((w) => w.includes('below'))).toBe(false);
+      });
+    });
+
+    test.each([
+      ['1', 1],
+      ['5', 5],
+      ['9', 9],
+    ])('accepts %p as %i but warns about degenerate overshoot ratio', (envValue, expected) => {
+      // Defense-in-depth: cap < RECEIVE_MAX_MESSAGES is accepted (the
+      // operator may want it for rate-limit testing) but warned about
+      // because the effective ceiling overshoots the configured value
+      // by a wide margin (cap=1 → 10 in-flight ceiling = 10x overshoot).
+      withIsolatedEnv(envValue, (fresh, warns) => {
+        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(expected);
+        expect(warns.some((w) => w.includes('rejected'))).toBe(false);
+        expect(
+          warns.some((w) => w.includes('below') && w.includes('RECEIVE_MAX_MESSAGES'))
+        ).toBe(true);
       });
     });
 

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1087,10 +1087,95 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
 
     // The receive was NOT called (cap blocked it).
     expect(sqsMock.commandCalls(ReceiveMessageCommand)).toHaveLength(0);
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('in-flight cap reached'),
+    // First at-cap poll in the streak warns (transition signal),
+    // not debug — see the state-machine throttle in pollOnce.
+    // Assert against the module-level constant so a wording drift
+    // in event-consumer.js fails the test instead of silently
+    // breaking CloudWatch alarms that grep the literal string.
+    expect(logger.warn).toHaveBeenCalledWith(
+      eventConsumer._test.AT_CAP_PAUSE_WARN_MSG,
       expect.objectContaining({ inFlight: cap, cap }),
     );
+    expect(eventConsumer._test.isAtCapPauseLogged()).toBe(true);
+  });
+
+  test('pollOnce only warns once per at-cap streak (debug for subsequent polls)', async () => {
+    // Pins the throttle: a sustained at-cap condition produces one
+    // warn at the entry transition and debug lines for the rest of
+    // the streak. Without this, a slow downstream wedge would spam
+    // logger.warn ~10x/s per worker.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      for (let i = 0; i < cap; i += 1) {
+        eventConsumer.trackDispatch(new Promise(() => {})); // never resolves
+      }
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    const client = makeStubClient();
+
+    // First poll: warn fires.
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.debug).not.toHaveBeenCalledWith(
+      eventConsumer._test.AT_CAP_PAUSE_DEBUG_MSG,
+      expect.anything(),
+    );
+
+    // Subsequent polls in the same streak: debug only, no extra warn.
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(logger.warn).toHaveBeenCalledTimes(1); // still 1
+    expect(logger.debug).toHaveBeenCalledWith(
+      eventConsumer._test.AT_CAP_PAUSE_DEBUG_MSG,
+      expect.objectContaining({ inFlight: cap, cap }),
+    );
+  });
+
+  test('pollOnce logs cap-released info on transition back to below-cap', async () => {
+    // Pins the recovery path: after an at-cap streak, dropping
+    // below cap fires the release-info log so operators can pair
+    // pause-start with pause-end events in CloudWatch. Uses
+    // resolvable promises so the drain runs through trackDispatch's
+    // real .finally decrement path — no test-only setter shortcut.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    const resolvers = [];
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      for (let i = 0; i < cap; i += 1) {
+        let resolve;
+        const p = new Promise((r) => { resolve = r; });
+        resolvers.push(resolve);
+        eventConsumer.trackDispatch(p);
+      }
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    const client = makeStubClient();
+
+    // Enter at-cap state (warn fires, gate is set).
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(eventConsumer._test.isAtCapPauseLogged()).toBe(true);
+
+    // Drain all handlers: resolve every tracked promise, then let
+    // the .finally microtask chain flush so inFlightCount drops to 0.
+    resolvers.forEach((r) => r('done'));
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+
+    // Below-cap poll: release-info fires, gate clears.
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(logger.info).toHaveBeenCalledWith(
+      eventConsumer._test.AT_CAP_RELEASED_INFO_MSG,
+      expect.objectContaining({ cap }),
+    );
+    expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
   });
 
   test('pollOnce proceeds with receive when below cap', async () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1235,10 +1235,15 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(src.indexOf(endMarker, endIdx + endMarker.length)).toBe(-1);
 
     const block = src.slice(startIdx, endIdx);
-    // Strip line comments so a documenting reference to `await` in a
-    // comment doesn't false-positive. Block-comments inside the
-    // wrap aren't expected; we keep the regex simple.
-    const stripped = block.replace(/\/\/[^\n]*/g, '');
+    // Strip BOTH line comments and block comments so a documenting
+    // reference to `await` in either form doesn't false-positive.
+    // Template literals containing the word `await` aren't expected
+    // in the wrap (we'd notice during code review of a tight 25-line
+    // block), so we don't try to strip those — defense-in-depth has
+    // diminishing returns past comments.
+    const stripped = block
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block comments first (multi-line)
+      .replace(/\/\/[^\n]*/g, ''); // then line comments
     expect(stripped).not.toMatch(/\bawait\b/);
   });
 

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1027,6 +1027,36 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
   });
 
+  test('trackDispatch logs handler rejections (preserves error visibility)', async () => {
+    // Regression for cr feedback on PR #389: attaching `.finally()`
+    // in trackDispatch counts as a handler for Node's unhandled-
+    // rejection bookkeeping, so a rejection that pre-PR would have
+    // surfaced at `process.on('unhandledRejection', ...)` in
+    // src/index.js gets absorbed in the trailing `.catch`. Pin the
+    // contract that the catch logs at error so handler bugs still
+    // produce a CloudWatch signal.
+    const handlerPromise = Promise.reject(new Error('handler boom'));
+    // Pre-attach to absorb the rejection in the test runtime as a
+    // separate chain; trackDispatch's logging path is independent.
+    handlerPromise.catch(() => { /* absorbed */ });
+
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      eventConsumer.trackDispatch(handlerPromise);
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+
+    // Allow the .finally + .catch microtasks to flush.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event consumer: dispatch handler rejected',
+      expect.objectContaining({ error: 'handler boom' }),
+    );
+  });
+
   test('pollOnce early-returns + backs off when in-flight at cap', async () => {
     // When inFlightCount >= MAX_INFLIGHT_HANDLERS, pollOnce must
     // skip the receive call and sleep INFLIGHT_BACKOFF_MS to let

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1196,6 +1196,74 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     // this number and may rely on it for their soak headroom math.
     expect(eventConsumer._test.MAX_INFLIGHT_HANDLERS).toBe(100);
   });
+
+  describe('MAX_INFLIGHT_HANDLERS env validation (module-load IIFE)', () => {
+    // The IIFE that parses QURL_BOT_MAX_INFLIGHT_HANDLERS runs at
+    // module-load. To exercise it under varying env values we
+    // re-require the module inside jest.isolateModules with the env
+    // var stubbed, capture console.warn output, and assert the
+    // resolved value + warning content. Pins the validation branch
+    // that production depends on for fail-loud-on-typo behavior.
+    function withIsolatedEnv(envValue, run) {
+      jest.isolateModules(() => {
+        const prev = process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
+        const origConsoleWarn = console.warn;
+        const warns = [];
+        console.warn = (...args) => warns.push(args.join(' '));
+        try {
+          if (envValue === undefined) {
+            delete process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
+          } else {
+            process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS = envValue;
+          }
+          const fresh = require('../src/event-consumer');
+          run(fresh, warns);
+        } finally {
+          console.warn = origConsoleWarn;
+          if (prev === undefined) {
+            delete process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
+          } else {
+            process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS = prev;
+          }
+        }
+      });
+    }
+
+    test.each([
+      ['100abc', 'trailing garbage'],
+      ['-5', 'negative integer'],
+      ['0', 'zero'],
+      ['1.5', 'non-integer'],
+      ['Infinity', 'infinity literal'],
+      ['NaN', 'NaN literal'],
+      ['abc', 'non-numeric'],
+      [' ', 'whitespace'],
+    ])('rejects %p (%s) and falls back to default', (envValue) => {
+      withIsolatedEnv(envValue, (fresh, warns) => {
+        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(100);
+        expect(warns.some((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS') && w.includes('rejected'))).toBe(true);
+      });
+    });
+
+    test.each([
+      ['50', 50],
+      ['200', 200],
+      ['1', 1],
+    ])('accepts %p as %i', (envValue, expected) => {
+      withIsolatedEnv(envValue, (fresh, warns) => {
+        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(expected);
+        // No warning for valid values.
+        expect(warns.some((w) => w.includes('rejected'))).toBe(false);
+      });
+    });
+
+    test('unset env var resolves to default without warning', () => {
+      withIsolatedEnv(undefined, (fresh, warns) => {
+        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(100);
+        expect(warns).toHaveLength(0);
+      });
+    });
+  });
 });
 
 describe('event-consumer: discord.js@14.25.1 internal-API smoke', () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -913,6 +913,176 @@ describe('event-consumer: start/stop lifecycle', () => {
   // ≥ 1), which covers the underlying concern.
 });
 
+describe('event-consumer: backpressure (in-flight handler cap)', () => {
+  test('trackDispatch is a no-op when isWorkerDispatch is false (gateway mode)', () => {
+    // Pins the contract that the gateway-WS-driven path doesn't
+    // count against the worker's cap. The flag stays false unless
+    // the consumer's processMessage explicitly sets it; a stray
+    // call from the listener in gateway-only mode increments
+    // nothing.
+    expect(eventConsumer._test.isWorkerDispatching()).toBe(false);
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+    eventConsumer.trackDispatch(Promise.resolve('ignored'));
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
+  test('trackDispatch handles non-promise inputs without throwing', () => {
+    // The listener returns undefined for unrouted interaction types.
+    // trackDispatch must accept that without throwing or counting.
+    eventConsumer.trackDispatch(undefined);
+    eventConsumer.trackDispatch(null);
+    eventConsumer.trackDispatch('not a promise');
+    eventConsumer.trackDispatch({ then: 'not-a-fn' });
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
+  test('processMessage sets isWorkerDispatch true around handle() and clears in finally', async () => {
+    // The flag must be true exactly during the synchronous
+    // client.actions.InteractionCreate.handle(data) call so the
+    // listener's emit fires inside the window. Verified by spying
+    // on handle and asserting the flag's value inside the spy.
+    sqsMock.on(DeleteMessageCommand).resolves({});
+    const client = makeStubClient();
+    let observedDuringHandle = false;
+    client.actions.InteractionCreate.handle.mockImplementation(() => {
+      observedDuringHandle = eventConsumer._test.isWorkerDispatching();
+    });
+
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, makeMessage({
+      eventType: 'INTERACTION_CREATE',
+      data: { id: 'i1' },
+      event_id: '0:1',
+    })));
+
+    expect(observedDuringHandle).toBe(true);
+    // After processMessage returns, the flag is back to false.
+    expect(eventConsumer._test.isWorkerDispatching()).toBe(false);
+  });
+
+  test('processMessage clears isWorkerDispatch even when handle() throws', async () => {
+    // Pin the finally — without it, a reconstruction throw would
+    // leave the flag stuck at true, and a subsequent gateway-WS
+    // dispatch in combined mode would be incorrectly counted
+    // against the worker cap.
+    sqsMock.on(DeleteMessageCommand).resolves({});
+    const client = makeStubClient();
+    client.actions.InteractionCreate.handle.mockImplementation(() => {
+      throw new Error('reconstruction failed');
+    });
+
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, makeMessage({
+      eventType: 'INTERACTION_CREATE',
+      data: { type: 99 },
+      event_id: '0:err',
+    })));
+
+    expect(eventConsumer._test.isWorkerDispatching()).toBe(false);
+  });
+
+  test('trackDispatch increments then decrements on promise resolve', async () => {
+    // Simulate a consumer-driven dispatch by manually flipping the
+    // flag (mirrors what processMessage does synchronously around
+    // handle()). Register a pending promise; assert the counter
+    // ticks up. Resolve it; assert the counter ticks back down.
+    let resolveHandler;
+    const handlerPromise = new Promise((r) => { resolveHandler = r; });
+
+    // Mirror processMessage's flag wrap.
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      eventConsumer.trackDispatch(handlerPromise);
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+
+    expect(eventConsumer._test.getInFlightCount()).toBe(1);
+    resolveHandler('done');
+    // Wait for the finally callback to run (microtask boundary).
+    await handlerPromise;
+    await new Promise((r) => setImmediate(r));
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
+  test('trackDispatch decrements on promise rejection', async () => {
+    // Same as above but reject the promise; the finally should
+    // still decrement the counter so a failing handler doesn't
+    // leak a slot in the cap.
+    let rejectHandler;
+    const handlerPromise = new Promise((_resolve, reject) => { rejectHandler = reject; });
+    // Pre-attach a catch so the rejection doesn't surface as an
+    // unhandledRejection in the test runtime.
+    handlerPromise.catch(() => { /* absorbed */ });
+
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      eventConsumer.trackDispatch(handlerPromise);
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+
+    expect(eventConsumer._test.getInFlightCount()).toBe(1);
+    rejectHandler(new Error('handler failed'));
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
+  test('pollOnce early-returns + backs off when in-flight at cap', async () => {
+    // When inFlightCount >= MAX_INFLIGHT_HANDLERS, pollOnce must
+    // skip the receive call and sleep INFLIGHT_BACKOFF_MS to let
+    // handlers drain. Pins that the cap is enforced + the receive
+    // path is bypassed.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+
+    // Manually crank inFlightCount up to cap via the tracker. Use
+    // pending promises so the count stays elevated for the duration
+    // of the test.
+    const pendingHandlers = [];
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      for (let i = 0; i < cap; i += 1) {
+        const p = new Promise(() => {}); // never resolves
+        eventConsumer.trackDispatch(p);
+        pendingHandlers.push(p);
+      }
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+    expect(eventConsumer._test.getInFlightCount()).toBe(cap);
+
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [{ Body: '{}', ReceiptHandle: 'x' }] });
+    const client = makeStubClient();
+
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+
+    // The receive was NOT called (cap blocked it).
+    expect(sqsMock.commandCalls(ReceiveMessageCommand)).toHaveLength(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('in-flight cap reached'),
+      expect.objectContaining({ inFlight: cap, cap }),
+    );
+  });
+
+  test('pollOnce proceeds with receive when below cap', async () => {
+    // Sanity-check the other side of the gate — when inFlightCount
+    // is below the cap, pollOnce calls ReceiveMessage normally.
+    expect(eventConsumer._test.getInFlightCount()).toBeLessThan(eventConsumer._test.MAX_INFLIGHT_HANDLERS);
+
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    const client = makeStubClient();
+
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+
+    expect(sqsMock.commandCalls(ReceiveMessageCommand)).toHaveLength(1);
+  });
+
+  test('MAX_INFLIGHT_HANDLERS defaults to 100', () => {
+    // Pins the default — operators reading the .env.example see
+    // this number and may rely on it for their soak headroom math.
+    expect(eventConsumer._test.MAX_INFLIGHT_HANDLERS).toBe(100);
+  });
+});
+
 describe('event-consumer: discord.js@14.25.1 internal-API smoke', () => {
   test('package.json pins discord.js to a single exact version', () => {
     const pkg = require('../package.json');

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -917,9 +917,13 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
   // Test helpers. Pulled up here so the tests below stay focused on
   // intent rather than re-stating boilerplate.
 
-  // Flush queued microtasks. `.finally → .catch` in trackDispatch
-  // is two microtask hops; default n=3 leaves a one-tick margin so a
-  // future chain extension doesn't require revisiting every test.
+  // Flush queued microtasks. The trackDispatch chain is exactly
+  // two hops today: `.finally` (decrement) then `.catch` (error log
+  // or pass-through). Default n=3 = 2 hops + 1 margin, so a future
+  // chain extension (e.g., another `.then` between finally and catch)
+  // doesn't require revisiting every test. The +1 margin is the
+  // load-bearing slack — drop it only if you re-derive the chain
+  // depth and confirm no implicit hop sneaks in.
   async function flushMicrotasks(n = 3) {
     for (let i = 0; i < n; i += 1) {
       // eslint-disable-next-line no-await-in-loop -- sequential by design


### PR DESCRIPTION
## Why

The SQS event consumer (PR #379) dispatches Discord interactions detached after the synchronous `client.actions.InteractionCreate.handle(data)` emit — `handleCommand` / `handleFlowInteraction` run as fire-and-forget promises with no captured reference. Under a sustained burst where downstream DDB/REST work runs slower than message arrival, in-flight handler promises accumulate without bound, risking worker-tier memory pressure before PR 10 ships and the flag flips.

This was filed during PR #379 as a tracked concern (#388). Today's volume bounds (invite-only beta, ~thousands of guilds) make it theoretical, but the cap is the right safety net before we route prod traffic through SQS.

## What

- New module-level state in `src/event-consumer.js`: `MAX_INFLIGHT_HANDLERS` (env-overridable, default 100), `INFLIGHT_BACKOFF_MS` (100), `inFlightCount`, `isWorkerDispatch`.
- New public function `eventConsumer.trackDispatch(maybePromise)` — called by the `interactionCreate` listener in `src/index.js` for every dispatch. Reads `isWorkerDispatch` and only registers consumer-driven dispatches in the cap.
- `processMessage` now sets `isWorkerDispatch = true` synchronously around the `handle()` call and clears it in `finally`. EventEmitter.emit is synchronous, so the listener fires while the flag is still true.
- `pollOnce` checks `inFlightCount >= MAX_INFLIGHT_HANDLERS` at the top and early-returns + `abortableSleep(INFLIGHT_BACKOFF_MS)` if at cap. The sleep honors `stopping`, so SIGTERM during a backpressure pause exits inside the graceful-shutdown budget.
- `src/index.js` listener captures the handler return value and passes it to `trackDispatch`.
- `.env.example` documents the new `QURL_BOT_MAX_INFLIGHT_HANDLERS` knob.
- 9 new tests in `event-consumer.test.js` covering no-op gateway path, non-promise inputs, the flag wrap (including finally-on-throw), increment+decrement on resolve and reject, at-cap early-return, below-cap pass-through, and the default value.

## Why this design

Tracking handler completion without coupling to handler internals is the central problem here. Two options were considered:

1. **Capture the promise in the listener directly.** Requires the listener to know it's the "consumer-driven" path vs the "gateway-WS-driven" path — and in combined mode (gateway + worker in one process), both paths share the same listener.
2. **Flag-based, set synchronously around the emit.** Exploits EventEmitter.emit's synchronous nature so the listener can read a module-level flag set by the caller. Zero coupling to handler internals; gateway-WS-driven dispatches see `isWorkerDispatch === false` and are no-ops.

Option 2 is what's implemented. The synchronous window is tight: there's no `await` between `isWorkerDispatch = true` and `isWorkerDispatch = false`, so concurrent `processMessage` calls in `Promise.allSettled` can't interleave their flag wraps.

## Test plan

- [x] `npm test` — 1856 passing (+40 over the pre-#388 baseline of 1816)
- [x] `npm run lint` — clean (`--max-warnings 0`)
- [x] All 49 `event-consumer.test.js` tests pass, including the 9 new backpressure tests
- [ ] CI green
- [ ] cr review clean

## Rollback

This is a no-op for the legacy in-process gateway path (`ENABLE_EVENT_SHIPPER` unset or `"false"`) — `isWorkerDispatch` stays false, `trackDispatch` is a no-op, `pollOnce` doesn't run. Reverting the PR is safe.

Closes #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)