### PR TITLE
fix(discord): backpressure DE-review follow-ups (stale comment, fail-loud underflow, scope doc)

### DIFF
--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -94,6 +94,16 @@
 // drain. The cap is the safety net before the worker tier flag-flip
 // in PR 10.
 //
+// SCOPE: this is a receive-gate mechanism only. It pauses new work
+// when capacity is exhausted; it does NOT help with graceful
+// shutdown. trackDispatch retains a count, not promise references,
+// so stop() cannot drain in-flight handlers — a SIGTERM during a
+// detached DDB write races gracefulShutdown's db.close() (same race
+// the pre-PR gateway path has, since the gateway also runs handlers
+// detached). For drain-on-shutdown support, see #391: the refactor
+// would also capture promises in a Set so stop() can `await
+// Promise.allSettled([...inFlightPromises])` with a deadline cap.
+//
 // This is a soft cap, not a hard semaphore. pollOnce checks
 // `inFlightCount >= cap` BEFORE issuing a ReceiveMessage, but a
 // receive that passes the check can return up to RECEIVE_MAX_MESSAGES
@@ -596,16 +606,22 @@ function trackDispatch(maybePromise) {
   // always lands first — the .catch below sees the rejection AFTER
   // the counter has dropped.
   //
-  // Math.max guards against negative drift if a stale promise
-  // resolves after `_resetStateForTest` cleared the count, or
-  // (under `jest --watch` / hot-reload) a stale promise resolves
-  // into the freshly-required module's clean counter. Tests that
-  // don't await their resolvable promises before resetting would
-  // otherwise leak a decrement into the next test's starting
-  // state. Production can't reach this — every increment is paired
-  // with exactly one decrement on the same promise.
+  // Underflow guard: every increment is paired with exactly one
+  // decrement on the same promise, so production cannot reach
+  // inFlightCount <= 0 here. If we do, a test resolved its
+  // resolvable promise after `_resetStateForTest` cleared the count
+  // (or jest --watch hot-reloaded the module between the increment
+  // and decrement). Log loud and skip the decrement: the previous
+  // Math.max(0, ...) clamp silently absorbed this, hiding any future
+  // double-decrement regression behind a test-pollution disguise.
   maybePromise.finally(() => {
-    inFlightCount = Math.max(0, inFlightCount - 1);
+    if (inFlightCount <= 0) {
+      logger.error('Event consumer: trackDispatch decrement would underflow inFlightCount (internal invariant violation)', {
+        inFlightCount,
+      });
+      return;
+    }
+    inFlightCount -= 1;
   }).catch((err) => {
     // Attaching `.finally()` above counts as a handler for Node's
     // unhandled-rejection bookkeeping, so a rejection that pre-PR
@@ -616,10 +632,11 @@ function trackDispatch(maybePromise) {
     //
     // `kind: 'unhandledRejection'` tags the log so a single CloudWatch
     // query (filtering on the structured field) can find both this
-    // consumer-driven path AND the gateway-WS-driven path that still
-    // routes through `process.on('unhandledRejection', ...)`. The
-    // gateway handler in src/index.js will be updated in PR 10 to
-    // emit the same field so dashboards see a unified signal. The
+    // consumer-driven path AND the gateway-WS-driven path through
+    // `process.on('unhandledRejection', ...)` in src/index.js, which
+    // already emits the same field. The two call sites agree on the
+    // tag today; an alarm rule pivoting on `kind=unhandledRejection`
+    // covers both tiers without per-tier rules. The
     // `err?.message || String(err)` fallback mirrors the gateway
     // handler's shape for non-Error rejections.
     logger.error('Event consumer: dispatch handler rejected', {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1097,6 +1097,37 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     );
   });
 
+  test('trackDispatch decrement logs loud and skips when underflow would occur', async () => {
+    // Replaces the previous silent `Math.max(0, ...)` clamp: if a
+    // promise settles after `_resetStateForTest` zeroed the count
+    // (or hot-reload swapped modules), the decrement would underflow.
+    // Production cannot reach this — every increment is paired with
+    // exactly one decrement on the same promise — so this firing
+    // means a test or external caller broke the invariant. Pin that
+    // we log the underflow at error level (so the suite surfaces the
+    // bug) and skip the decrement (so subsequent tests see 0, not -1).
+    let resolveHandler;
+    const handlerPromise = new Promise((r) => { resolveHandler = r; });
+    withWorkerDispatch(() => eventConsumer.trackDispatch(handlerPromise));
+    expect(eventConsumer._test.getInFlightCount()).toBe(1);
+
+    // Simulate the test-pollution scenario: reset state (zeros the
+    // count) BEFORE the registered promise settles, then resolve.
+    // The .finally fires against the zeroed counter and trips the
+    // underflow guard.
+    eventConsumer._test._resetStateForTest();
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+    resolveHandler('done');
+    await flushMicrotasks();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('trackDispatch decrement would underflow'),
+      expect.objectContaining({ inFlightCount: 0 }),
+    );
+    // Count stayed at 0 — the decrement was skipped, not applied.
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
   test('pollOnce early-returns + backs off when in-flight at cap', async () => {
     // When inFlightCount >= MAX_INFLIGHT_HANDLERS, pollOnce must
     // skip the receive call and sleep INFLIGHT_BACKOFF_MS to let


### PR DESCRIPTION
## Why

Post-merge DE review of PR #389 (event-consumer backpressure) surfaced three items the 10-round cr loop missed. None are emergencies; all are worth landing before PR 10 flips \`ENABLE_EVENT_SHIPPER\` for prod traffic.

## What

**1. Fix a stale comment in trackDispatch's \`.catch\`.**
The comment said "the gateway handler in src/index.js will be updated in PR 10 to emit the same field." That update landed IN PR #389 (round 9 — both call sites now emit \`kind: 'unhandledRejection'\`). A future reader hits a contradiction between the comment and reality. Reworded to describe present state.

**2. Replace the \`Math.max(0, inFlightCount - 1)\` clamp with a fail-loud underflow guard.**
The clamp was justified as "defends against test pollution" — but it silently absorbed exactly the class of regression it was meant to surface. A future double-decrement bug would have shown up as "tests pass, counter drifts down," not "tests fail loud."

New shape:
\`\`\`js
maybePromise.finally(() => {
  if (inFlightCount <= 0) {
    logger.error('Event consumer: trackDispatch decrement would underflow inFlightCount (internal invariant violation)', { inFlightCount });
    return;
  }
  inFlightCount -= 1;
});
\`\`\`

Production behavior is identical — the path was already unreachable in production (every increment is paired with one decrement on the same promise). Test behavior is now diagnostic: a CloudWatch-grade error log surfaces the bug instead of silently masking it. New test pins the contract.

**3. Add a SCOPE note to the backpressure section of the module header.**
Reviewer flagged that the existing text implied broader functionality than the mechanism actually has. The cap is a **receive-gate only** — it pauses new work when capacity is exhausted; it does NOT help with graceful shutdown, because trackDispatch retains a count, not promise references. \`stop()\` cannot drain in-flight handlers. #391 is the path forward to add drain support (refactor to Set<Promise> + deadline-capped \`Promise.allSettled\` in stop()). Until that lands, a SIGTERM during a detached DDB write races \`gracefulShutdown\`'s \`db.close()\` — same race the pre-PR gateway path has.

## Test plan

- [x] \`npm test\` — 1877 passing (+1 underflow test over the 1876 baseline)
- [x] \`npm run lint\` — clean (\`--max-warnings 0\`)
- [x] New test \`trackDispatch decrement logs loud and skips when underflow would occur\` exercises the new fail-loud path explicitly
- [ ] CI green
- [ ] cr review clean

## Rollback

Pure documentation + a defensive-guard semantic tightening. Behavior under all observable contracts is identical:
- Production: \`Math.max(0, n-1)\` and \`if (n<=0) skip; else n-1\` produce the same counter value for all reachable inputs (n > 0).
- Tests: existing tests don't trigger the underflow path; new test does.

Reverting the PR is safe; reverting just the underflow change requires also reverting the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)