### PR TITLE
feat(discord): toggle /qurl map slash command via MAP_COMMAND_ENABLED (default off)

### DIFF
--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -89,6 +89,15 @@ function missingEventShipperKeys(cfg) {
 // parameter ships with that literal sentinel value — the
 // remediation ("seed a real key") is identical to the
 // missing-key case.
+//
+// TODO(infra-sentinel-sync): the literal "PLACEHOLDER" is also
+// the seed value for `aws_ssm_parameter.bot` in
+// qurl-integrations-infra/qurl-bot-discord/terraform/main.tf
+// (search that repo for `value = "PLACEHOLDER"`). If infra ever
+// renames the sentinel (e.g., "REPLACE_ME"), update here in
+// lockstep — otherwise the boot check silently regresses to
+// "non-empty value passes" and the original incident class
+// returns. `git grep TODO(infra-sentinel-sync)` finds the marker.
 const GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL = 'PLACEHOLDER';
 function missingMapCommandKeys(cfg) {
   if (!cfg.MAP_COMMAND_ENABLED) return [];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -84,6 +84,21 @@ function missingEventShipperKeys(cfg) {
   return cfg.QURL_BOT_EVENTS_QUEUE_URL ? [] : ['QURL_BOT_EVENTS_QUEUE_URL'];
 }
 
+// Mirrors missingEventShipperKeys: parsed cfg in, missing-keys
+// array out. PLACEHOLDER is treated as missing because the SSM
+// parameter ships with that literal sentinel value — the
+// remediation ("seed a real key") is identical to the
+// missing-key case.
+const GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL = 'PLACEHOLDER';
+function missingMapCommandKeys(cfg) {
+  if (!cfg.MAP_COMMAND_ENABLED) return [];
+  const key = cfg.GOOGLE_MAPS_API_KEY;
+  if (!key || key === GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL) {
+    return ['GOOGLE_MAPS_API_KEY'];
+  }
+  return [];
+}
+
 // Process-role parsing for the gateway/HTTP split. Lifted out of
 // index.js so the invalid-value path is testable without spawning a
 // child process — same shape as missingBootKeys above. See
@@ -126,6 +141,8 @@ module.exports = {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  missingMapCommandKeys,
+  GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 };

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -84,11 +84,9 @@ function missingEventShipperKeys(cfg) {
   return cfg.QURL_BOT_EVENTS_QUEUE_URL ? [] : ['QURL_BOT_EVENTS_QUEUE_URL'];
 }
 
-// Mirrors missingEventShipperKeys: parsed cfg in, missing-keys
-// array out. PLACEHOLDER is treated as missing because the SSM
-// parameter ships with that literal sentinel value — the
-// remediation ("seed a real key") is identical to the
-// missing-key case.
+// PLACEHOLDER is treated as missing because the SSM parameter
+// ships with that literal sentinel value; remediation ("seed a
+// real key") is identical to the empty-key case.
 //
 // TODO(infra-sentinel-sync): the literal "PLACEHOLDER" is also
 // the seed value for `aws_ssm_parameter.bot` in

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2731,9 +2731,15 @@ const SETUP_API_KEY_MAX_LENGTH = 64;
 // User-visible success message on successful setup. Exported via
 // _test so test assertions read the production string instead of
 // hardcoding a copy that drifts.
+// Built at module load with the same MAP_COMMAND_ENABLED snapshot
+// the SlashCommandBuilder IIFE uses, so the help/setup copy and the
+// actual slash registration can't disagree about whether /qurl map
+// is reachable.
 const SETUP_SUCCESS_MSG =
   '✅ **qURL is now configured for this server!**\n\n'
-  + 'Your team can use `/qurl file` and `/qurl map` to share files and locations securely.\n'
+  + (config.MAP_COMMAND_ENABLED
+    ? 'Your team can use `/qurl file` and `/qurl map` to share files and locations securely.\n'
+    : 'Your team can use `/qurl file` to share files securely.\n')
   + 'All qURL usage will be billed to your API key.';
 
 // Button-stage handler. Routed by flow-dispatch when the admin
@@ -3173,7 +3179,31 @@ const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
 // Subcommands that require the guild API key resolution + cooldown gate.
 // Single-source allowlist: adding a new send-style subcommand only
 // requires touching this set, not the dispatcher fall-through.
-const API_KEY_GATED_SUBCOMMANDS = new Set(['file', 'map', 'revoke']);
+//
+// `'map'` joins the set only when MAP_COMMAND_ENABLED is on. The
+// conditional inclusion is load-bearing — NOT cosmetic. The gate runs
+// BEFORE the dispatch in execute() below, so if `'map'` stayed in the
+// set with the flag off, a stale-client /qurl map in a guild that
+// hasn't run /qurl setup would hit "qURL is not configured for this
+// server" instead of the QURL_MAP_DISABLED_REPLY the dispatch routes
+// to. Removing it lets the gate skip and the dispatcher's `sub === 'map'`
+// branch surface the right message.
+//
+// IMPORTANT BEFORE FLIPPING MAP_COMMAND_ENABLED=true: seed
+// `/qurl-bot-discord/GOOGLE_MAPS_API_KEY` in SSM. The parameter
+// shipped as the literal string "PLACEHOLDER"; without a real key,
+// Places returns REQUEST_DENIED and every /qurl map invocation fails
+// with the generic "Location lookup failed" reply.
+const API_KEY_GATED_SUBCOMMANDS = new Set(
+  config.MAP_COMMAND_ENABLED ? ['file', 'map', 'revoke'] : ['file', 'revoke'],
+);
+
+// User-facing reply for stale /qurl map submissions when the toggle
+// is off. Discord clients can carry a cached command definition for
+// a few minutes after the registration drops `map`, so a defensive
+// dispatch path lands them here instead of routing into the
+// (now-unreachable) handleQurlMap → Places pipeline.
+const QURL_MAP_DISABLED_REPLY = '❌ `/qurl map` is currently disabled. Use `/qurl file` to share resources securely.';
 
 // Slash-option choice arrays. The same wording flows into both the
 // slash-command autocomplete and the confirm-card dropdowns so users
@@ -7523,105 +7553,115 @@ const commands = [
     // `e2e/tests/discord-commands.smoke.test.ts` too — the smoke test
     // pins the subcommand NAME set (not option types, requiredness, or
     // descriptions) to catch registration regressions at deploy time.
-    data: new SlashCommandBuilder()
-      .setName('qurl')
-      .setDescription('Share resources securely via qURL')
-      .addSubcommand(sub =>
-        sub.setName('file')
-          .setDescription('Share a file via one-time qURL links')
-          .addAttachmentOption(opt =>
-            opt.setName('attachment')
-              .setDescription('The file to share')
-              .setRequired(true)
-          )
-          .addStringOption(opt =>
-            opt.setName('recipients')
-              .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
-              .setRequired(false)
-              .setMaxLength(RECIPIENTS_SLASH_MAX_LENGTH)
-          )
-          .addStringOption(opt =>
-            opt.setName('expires-in')
-              .setDescription('How long the qURL links stay valid (default: 24 hours)')
-              .setRequired(false)
-              .addChoices(...EXPIRY_CHOICES)
-          )
-          .addStringOption(opt =>
-            opt.setName('self-destruct')
-              .setDescription('Optional countdown after first open (default: no timer)')
-              .setRequired(false)
-              .addChoices(...SELF_DESTRUCT_CHOICES)
-          )
-          .addStringOption(opt =>
-            opt.setName('personal-message')
-              .setDescription('Optional note included in each recipient\'s DM')
-              .setRequired(false)
-              .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
-          )
-      )
-      .addSubcommand(sub =>
-        sub.setName('map')
-          .setDescription('Share a Google Maps location via one-time qURL links')
-          .addStringOption(opt =>
-            opt.setName('location')
-              .setDescription('Google Maps URL, or a place / address to search')
-              .setRequired(true)
-              // Picking a suggestion sends a `qurl_place:<id>` sentinel;
-              // free text is resolved server-side via resolveLocation.
-              .setAutocomplete(true)
-              // 500 chars covers full Google Maps URLs (which can be
-              // 200-400 chars after place params + coordinates) plus
-              // headroom; not tied to the recipients-parser cap because
-              // location is a single URL/address, not a token list.
-              .setMaxLength(500)
-          )
-          .addStringOption(opt =>
-            opt.setName('recipients')
-              .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
-              .setRequired(false)
-              .setMaxLength(RECIPIENTS_SLASH_MAX_LENGTH)
-          )
-          .addStringOption(opt =>
-            opt.setName('location-name')
-              .setDescription('Override the label shown to recipients (defaults to URL/address)')
-              .setRequired(false)
-              .setMaxLength(256)
-          )
-          .addStringOption(opt =>
-            opt.setName('expires-in')
-              .setDescription('How long the qURL links stay valid (default: 24 hours)')
-              .setRequired(false)
-              .addChoices(...EXPIRY_CHOICES)
-          )
-          .addStringOption(opt =>
-            opt.setName('self-destruct')
-              .setDescription('Optional countdown after first open (default: no timer)')
-              .setRequired(false)
-              .addChoices(...SELF_DESTRUCT_CHOICES)
-          )
-          .addStringOption(opt =>
-            opt.setName('personal-message')
-              .setDescription('Optional note included in each recipient\'s DM')
-              .setRequired(false)
-              .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
-          )
-      )
-      .addSubcommand(sub =>
-        sub.setName('revoke')
-          .setDescription('Revoke links from a previous send')
-      )
-      .addSubcommand(sub =>
-        sub.setName('help')
-          .setDescription('Show qURL bot help')
-      )
-      .addSubcommand(sub =>
-        sub.setName('setup')
-          .setDescription('Configure your qURL API key for this server (admin only)')
-      )
-      .addSubcommand(sub =>
-        sub.setName('status')
-          .setDescription('Check if qURL is configured (admin only)')
-      ),
+    // IIFE so the `/qurl map` subcommand can be conditionally added
+    // based on config.MAP_COMMAND_ENABLED — a plain fluent chain
+    // can't host an `if`. The order of `addSubcommand` calls below
+    // matches the chain we'd write inline, with `map` inserted
+    // between `file` and `revoke` when the flag is on.
+    data: (() => {
+      const builder = new SlashCommandBuilder()
+        .setName('qurl')
+        .setDescription('Share resources securely via qURL')
+        .addSubcommand(sub =>
+          sub.setName('file')
+            .setDescription('Share a file via one-time qURL links')
+            .addAttachmentOption(opt =>
+              opt.setName('attachment')
+                .setDescription('The file to share')
+                .setRequired(true)
+            )
+            .addStringOption(opt =>
+              opt.setName('recipients')
+                .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
+                .setRequired(false)
+                .setMaxLength(RECIPIENTS_SLASH_MAX_LENGTH)
+            )
+            .addStringOption(opt =>
+              opt.setName('expires-in')
+                .setDescription('How long the qURL links stay valid (default: 24 hours)')
+                .setRequired(false)
+                .addChoices(...EXPIRY_CHOICES)
+            )
+            .addStringOption(opt =>
+              opt.setName('self-destruct')
+                .setDescription('Optional countdown after first open (default: no timer)')
+                .setRequired(false)
+                .addChoices(...SELF_DESTRUCT_CHOICES)
+            )
+            .addStringOption(opt =>
+              opt.setName('personal-message')
+                .setDescription('Optional note included in each recipient\'s DM')
+                .setRequired(false)
+                .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
+            )
+        );
+      if (config.MAP_COMMAND_ENABLED) {
+        builder.addSubcommand(sub =>
+          sub.setName('map')
+            .setDescription('Share a Google Maps location via one-time qURL links')
+            .addStringOption(opt =>
+              opt.setName('location')
+                .setDescription('Google Maps URL, or a place / address to search')
+                .setRequired(true)
+                // Picking a suggestion sends a `qurl_place:<id>` sentinel;
+                // free text is resolved server-side via resolveLocation.
+                .setAutocomplete(true)
+                // 500 chars covers full Google Maps URLs (which can be
+                // 200-400 chars after place params + coordinates) plus
+                // headroom; not tied to the recipients-parser cap because
+                // location is a single URL/address, not a token list.
+                .setMaxLength(500)
+            )
+            .addStringOption(opt =>
+              opt.setName('recipients')
+                .setDescription('Users to send to — paste @mentions. Leave blank to pick from a menu.')
+                .setRequired(false)
+                .setMaxLength(RECIPIENTS_SLASH_MAX_LENGTH)
+            )
+            .addStringOption(opt =>
+              opt.setName('location-name')
+                .setDescription('Override the label shown to recipients (defaults to URL/address)')
+                .setRequired(false)
+                .setMaxLength(256)
+            )
+            .addStringOption(opt =>
+              opt.setName('expires-in')
+                .setDescription('How long the qURL links stay valid (default: 24 hours)')
+                .setRequired(false)
+                .addChoices(...EXPIRY_CHOICES)
+            )
+            .addStringOption(opt =>
+              opt.setName('self-destruct')
+                .setDescription('Optional countdown after first open (default: no timer)')
+                .setRequired(false)
+                .addChoices(...SELF_DESTRUCT_CHOICES)
+            )
+            .addStringOption(opt =>
+              opt.setName('personal-message')
+                .setDescription('Optional note included in each recipient\'s DM')
+                .setRequired(false)
+                .setMaxLength(PERSONAL_MESSAGE_INPUT_MAX)
+            )
+        );
+      }
+      return builder
+        .addSubcommand(sub =>
+          sub.setName('revoke')
+            .setDescription('Revoke links from a previous send')
+        )
+        .addSubcommand(sub =>
+          sub.setName('help')
+            .setDescription('Show qURL bot help')
+        )
+        .addSubcommand(sub =>
+          sub.setName('setup')
+            .setDescription('Configure your qURL API key for this server (admin only)')
+        )
+        .addSubcommand(sub =>
+          sub.setName('status')
+            .setDescription('Check if qURL is configured (admin only)')
+        );
+    })(),
     async execute(interaction) {
       const sub = interaction.options.getSubcommand();
 
@@ -7864,7 +7904,16 @@ const commands = [
       // The dispatcher's API_KEY_GATED_SUBCOMMANDS gate above is the
       // fail-fast presence check.
       if (sub === 'file') return handleQurlFile(interaction);
-      if (sub === 'map') return handleQurlMap(interaction);
+      if (sub === 'map') {
+        // When MAP_COMMAND_ENABLED is off, map isn't registered with
+        // Discord, but a stale client can still route a cached
+        // submission to us — reply with the disabled message instead
+        // of running the handler.
+        if (!config.MAP_COMMAND_ENABLED) {
+          return interaction.reply({ content: QURL_MAP_DISABLED_REPLY, ephemeral: true });
+        }
+        return handleQurlMap(interaction);
+      }
       if (sub === 'revoke') return handleRevoke(interaction, resolvedApiKey);
       if (sub === 'help') {
         // Section order: user-facing flow first (Getting started → How it
@@ -7885,11 +7934,26 @@ const commands = [
           : '**Setting up (for Admins):**\n'
             + '  `/qurl setup` — configure your API key (admin only)\n'
             + '  `/qurl status` — check if qURL is configured (admin only)\n\n';
+        // /qurl map mentions are flagged on config.MAP_COMMAND_ENABLED
+        // so the help copy matches what's actually registered. Flipping
+        // the env var rewrites every surface from one source.
+        const mapEnabled = config.MAP_COMMAND_ENABLED;
+        const mapBullet = mapEnabled
+          ? '  `/qurl map` — share a Google Maps location via one-time qURL links\n'
+          : '';
+        const howItWorksRunLine = mapEnabled
+          ? '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n'
+          : '\t1. Run `/qurl file` and attach the file you want to share\n';
+        const termsResource = mapEnabled ? 'the file or location' : 'the file';
+        // Used in two places (Terms paragraph + Large servers note) —
+        // the bullet rendering is identical in both, so a single token
+        // keeps them in lockstep.
+        const fileOrMapCommand = mapEnabled ? '`/qurl file` or `/qurl map`' : '`/qurl file`';
         return interaction.reply({
           content: '**qURL Bot — Help**\n\n' +
             '**Getting started — Share resources securely via one-time links:**\n' +
             '  `/qurl file` — share a file with users via one-time qURL links\n' +
-            '  `/qurl map` — share a Google Maps location via one-time qURL links\n' +
+            mapBullet +
             '  `/qurl revoke` — revoke links from a previous send\n' +
             '  `/qurl help` — show this message\n\n' +
             '**How it works:**\n' +
@@ -7899,16 +7963,16 @@ const commands = [
             // misalign "1." with "2.", "3.", "4."). The tab indent now
             // matches the two-space indent below, but bypasses the list
             // auto-formatter.
-            '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n' +
+            howItWorksRunLine +
             '  2. Optionally `recipients:@a @b @role` (up to 25 users via @mentions or role expansion) — '
               + 'leave blank to pick from a menu (up to 10 at a time)\n' +
             '  3. Confirm the card, then click **Send**\n' +
             '  4. Recipients get a one-time link by DM that self-destructs on first access (or when the expiry elapses)\n\n' +
             oauthSetupSection +
-            '**Terms:** a *protected resource* is the file or location you\'re sharing. ' +
+            `**Terms:** a *protected resource* is ${termsResource} you're sharing. ` +
             'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
-            'You create a qurl for a protected resource each time you run `/qurl file` or `/qurl map`.\n\n' +
-            '**Large servers (~1000+ members):** `/qurl file` or `/qurl map` with role @mentions ' +
+            `You create a qurl for a protected resource each time you run ${fileOrMapCommand}.\n\n` +
+            `**Large servers (~1000+ members):** ${fileOrMapCommand} with role @mentions ` +
             'may skip members the bot has not yet cached locally (the bot fetches members lazily, ' +
             'and very large servers may not be fully populated). ' +
             'If you need to reach a specific person for sure, use an explicit user @mention instead of a role.\n\n' +
@@ -8094,6 +8158,15 @@ async function handleAutocomplete(interaction) {
     const subcommand = interaction.options.getSubcommand(false);
     const focused = interaction.options.getFocused(true);
     if (subcommand !== 'map' || focused?.name !== 'location') {
+      return await interaction.respond([]);
+    }
+    // Feature-flag gate. When MAP_COMMAND_ENABLED is off the map
+    // subcommand isn't registered, so Discord shouldn't deliver an
+    // autocomplete for it — but a stale client racing the registration
+    // roll could. Short-circuit before searchPlaces so we don't burn
+    // operator GOOGLE_MAPS_API_KEY quota on a submit that will be
+    // rejected by the dispatcher anyway.
+    if (!config.MAP_COMMAND_ENABLED) {
       return await interaction.respond([]);
     }
     const rawQuery = (focused.value || '').trim();
@@ -8511,6 +8584,9 @@ module.exports = {
       parseLocationInput,
       resolveLocation,
       RESOLVE_REASON,
+      // Disabled-state reply for stale /qurl map submissions. Exported
+      // so flag-off tests pin against the production string.
+      QURL_MAP_DISABLED_REPLY,
       handleAutocomplete,
       // Test-only reset: the autocomplete-failure burst counter is
       // module-level state that accumulates across tests within a

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -7899,10 +7899,11 @@ const commands = [
       if (sub === 'file') return handleQurlFile(interaction);
       if (sub === 'map') {
         if (!config.MAP_COMMAND_ENABLED) {
-          // Debug (not warn) because Discord caches command defs for
-          // ~1h after a registration change — this is expected
-          // post-deploy traffic, not an error. Grep this line to see
-          // when stale-client traffic has decayed.
+          // Debug (not warn) — expected post-deploy traffic from
+          // clients with cached command defs, not an error. Cache
+          // TTL depends on registration mode: up to 1h on global
+          // (multi-tenant) registration, near-instant on guild-
+          // scoped (single-GUILD_ID). Grep this line to see decay.
           logger.debug('qurl_map_disabled_reply: stale-client /qurl map submission caught by toggle gate', {
             user_id: interaction.user?.id,
             guild_id: interaction.guildId,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -7937,7 +7937,10 @@ const commands = [
         // single token keeps them in lockstep. `sectionVerb` makes
         // the "Getting started" header track what's actually
         // registered ("Share files" reads more accurately than
-        // "Share resources" when /qurl map is off).
+        // "Share resources" when /qurl map is off). `runLine` uses
+        // the same parenthetical-instruction phrasing in both
+        // branches so flipping the toggle doesn't reshape the
+        // step-1 sentence style.
         const mapCopy = config.MAP_COMMAND_ENABLED
           ? {
             sectionVerb: 'Share resources',
@@ -7949,7 +7952,7 @@ const commands = [
           : {
             sectionVerb: 'Share files',
             bullet: '',
-            runLine: '\t1. Run `/qurl file` and attach the file you want to share\n',
+            runLine: '\t1. Run `/qurl file` (attach a file)\n',
             resource: 'the file',
             cmd: '`/qurl file`',
           };

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -7632,11 +7632,6 @@ const commands = [
             )
         );
       }
-      // Imperative addSubcommand calls to match the style used for
-      // `file` and the conditional `map` block above — uniform shape
-      // makes the order-matters property of slash registration
-      // visually obvious. `addSubcommand` returns `this`, but we
-      // rely on the side effect.
       builder.addSubcommand(sub =>
         sub.setName('revoke')
           .setDescription('Revoke links from a previous send')
@@ -7932,16 +7927,8 @@ const commands = [
           : '**Setting up (for Admins):**\n'
             + '  `/qurl setup` — configure your API key (admin only)\n'
             + '  `/qurl status` — check if qURL is configured (admin only)\n\n';
-        // Flag-on and flag-off help-copy variants kept side-by-side
-        // so a future edit to one branch is obviously checked against
-        // the other. `cmd` is referenced twice (Terms + Large servers);
-        // single token keeps them in lockstep. `sectionVerb` makes
-        // the "Getting started" header track what's actually
-        // registered ("Share files" reads more accurately than
-        // "Share resources" when /qurl map is off). `runLine` uses
-        // the same parenthetical-instruction phrasing in both
-        // branches so flipping the toggle doesn't reshape the
-        // step-1 sentence style.
+        // `cmd` is used in two spots (Terms + Large servers); a
+        // single token keeps them in lockstep across copy edits.
         const mapCopy = config.MAP_COMMAND_ENABLED
           ? {
             sectionVerb: 'Share resources',

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -7632,23 +7632,28 @@ const commands = [
             )
         );
       }
-      return builder
-        .addSubcommand(sub =>
-          sub.setName('revoke')
-            .setDescription('Revoke links from a previous send')
-        )
-        .addSubcommand(sub =>
-          sub.setName('help')
-            .setDescription('Show qURL bot help')
-        )
-        .addSubcommand(sub =>
-          sub.setName('setup')
-            .setDescription('Configure your qURL API key for this server (admin only)')
-        )
-        .addSubcommand(sub =>
-          sub.setName('status')
-            .setDescription('Check if qURL is configured (admin only)')
-        );
+      // Imperative addSubcommand calls to match the style used for
+      // `file` and the conditional `map` block above — uniform shape
+      // makes the order-matters property of slash registration
+      // visually obvious. `addSubcommand` returns `this`, but we
+      // rely on the side effect.
+      builder.addSubcommand(sub =>
+        sub.setName('revoke')
+          .setDescription('Revoke links from a previous send')
+      );
+      builder.addSubcommand(sub =>
+        sub.setName('help')
+          .setDescription('Show qURL bot help')
+      );
+      builder.addSubcommand(sub =>
+        sub.setName('setup')
+          .setDescription('Configure your qURL API key for this server (admin only)')
+      );
+      builder.addSubcommand(sub =>
+        sub.setName('status')
+          .setDescription('Check if qURL is configured (admin only)')
+      );
+      return builder;
     })(),
     async execute(interaction) {
       const sub = interaction.options.getSubcommand();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2731,10 +2731,6 @@ const SETUP_API_KEY_MAX_LENGTH = 64;
 // User-visible success message on successful setup. Exported via
 // _test so test assertions read the production string instead of
 // hardcoding a copy that drifts.
-// Built at module load with the same MAP_COMMAND_ENABLED snapshot
-// the SlashCommandBuilder IIFE uses, so the help/setup copy and the
-// actual slash registration can't disagree about whether /qurl map
-// is reachable.
 const SETUP_SUCCESS_MSG =
   '✅ **qURL is now configured for this server!**\n\n'
   + (config.MAP_COMMAND_ENABLED
@@ -3181,28 +3177,18 @@ const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
 // requires touching this set, not the dispatcher fall-through.
 //
 // `'map'` joins the set only when MAP_COMMAND_ENABLED is on. The
-// conditional inclusion is load-bearing — NOT cosmetic. The gate runs
-// BEFORE the dispatch in execute() below, so if `'map'` stayed in the
-// set with the flag off, a stale-client /qurl map in a guild that
-// hasn't run /qurl setup would hit "qURL is not configured for this
-// server" instead of the QURL_MAP_DISABLED_REPLY the dispatch routes
-// to. Removing it lets the gate skip and the dispatcher's `sub === 'map'`
-// branch surface the right message.
-//
-// IMPORTANT BEFORE FLIPPING MAP_COMMAND_ENABLED=true: seed
-// `/qurl-bot-discord/GOOGLE_MAPS_API_KEY` in SSM. The parameter
-// shipped as the literal string "PLACEHOLDER"; without a real key,
-// Places returns REQUEST_DENIED and every /qurl map invocation fails
-// with the generic "Location lookup failed" reply.
+// conditional removal is load-bearing — the gate runs BEFORE the
+// dispatch in execute() below, so if `'map'` stayed in the set with
+// the flag off, a stale-client /qurl map in an unconfigured guild
+// would hit "qURL is not configured for this server" instead of
+// QURL_MAP_DISABLED_REPLY.
 const API_KEY_GATED_SUBCOMMANDS = new Set(
   config.MAP_COMMAND_ENABLED ? ['file', 'map', 'revoke'] : ['file', 'revoke'],
 );
 
 // User-facing reply for stale /qurl map submissions when the toggle
-// is off. Discord clients can carry a cached command definition for
-// a few minutes after the registration drops `map`, so a defensive
-// dispatch path lands them here instead of routing into the
-// (now-unreachable) handleQurlMap → Places pipeline.
+// is off. Reached when a Discord client routes a cached `map`
+// submission after the registration has dropped it.
 const QURL_MAP_DISABLED_REPLY = '❌ `/qurl map` is currently disabled. Use `/qurl file` to share resources securely.';
 
 // Slash-option choice arrays. The same wording flows into both the
@@ -7905,11 +7891,15 @@ const commands = [
       // fail-fast presence check.
       if (sub === 'file') return handleQurlFile(interaction);
       if (sub === 'map') {
-        // When MAP_COMMAND_ENABLED is off, map isn't registered with
-        // Discord, but a stale client can still route a cached
-        // submission to us — reply with the disabled message instead
-        // of running the handler.
         if (!config.MAP_COMMAND_ENABLED) {
+          // Debug (not warn) because Discord caches command defs for
+          // ~1h after a registration change — this is expected
+          // post-deploy traffic, not an error. Grep this line to see
+          // when stale-client traffic has decayed.
+          logger.debug('qurl_map_disabled_reply: stale-client /qurl map submission caught by toggle gate', {
+            user_id: interaction.user?.id,
+            guild_id: interaction.guildId,
+          });
           return interaction.reply({ content: QURL_MAP_DISABLED_REPLY, ephemeral: true });
         }
         return handleQurlMap(interaction);
@@ -7934,26 +7924,28 @@ const commands = [
           : '**Setting up (for Admins):**\n'
             + '  `/qurl setup` — configure your API key (admin only)\n'
             + '  `/qurl status` — check if qURL is configured (admin only)\n\n';
-        // /qurl map mentions are flagged on config.MAP_COMMAND_ENABLED
-        // so the help copy matches what's actually registered. Flipping
-        // the env var rewrites every surface from one source.
-        const mapEnabled = config.MAP_COMMAND_ENABLED;
-        const mapBullet = mapEnabled
-          ? '  `/qurl map` — share a Google Maps location via one-time qURL links\n'
-          : '';
-        const howItWorksRunLine = mapEnabled
-          ? '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n'
-          : '\t1. Run `/qurl file` and attach the file you want to share\n';
-        const termsResource = mapEnabled ? 'the file or location' : 'the file';
-        // Used in two places (Terms paragraph + Large servers note) —
-        // the bullet rendering is identical in both, so a single token
-        // keeps them in lockstep.
-        const fileOrMapCommand = mapEnabled ? '`/qurl file` or `/qurl map`' : '`/qurl file`';
+        // Flag-on and flag-off help-copy variants kept side-by-side
+        // so a future edit to one branch is obviously checked against
+        // the other. `cmd` is referenced twice (Terms + Large servers);
+        // single token keeps them in lockstep.
+        const mapCopy = config.MAP_COMMAND_ENABLED
+          ? {
+            bullet: '  `/qurl map` — share a Google Maps location via one-time qURL links\n',
+            runLine: '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n',
+            resource: 'the file or location',
+            cmd: '`/qurl file` or `/qurl map`',
+          }
+          : {
+            bullet: '',
+            runLine: '\t1. Run `/qurl file` and attach the file you want to share\n',
+            resource: 'the file',
+            cmd: '`/qurl file`',
+          };
         return interaction.reply({
           content: '**qURL Bot — Help**\n\n' +
             '**Getting started — Share resources securely via one-time links:**\n' +
             '  `/qurl file` — share a file with users via one-time qURL links\n' +
-            mapBullet +
+            mapCopy.bullet +
             '  `/qurl revoke` — revoke links from a previous send\n' +
             '  `/qurl help` — show this message\n\n' +
             '**How it works:**\n' +
@@ -7963,16 +7955,16 @@ const commands = [
             // misalign "1." with "2.", "3.", "4."). The tab indent now
             // matches the two-space indent below, but bypasses the list
             // auto-formatter.
-            howItWorksRunLine +
+            mapCopy.runLine +
             '  2. Optionally `recipients:@a @b @role` (up to 25 users via @mentions or role expansion) — '
               + 'leave blank to pick from a menu (up to 10 at a time)\n' +
             '  3. Confirm the card, then click **Send**\n' +
             '  4. Recipients get a one-time link by DM that self-destructs on first access (or when the expiry elapses)\n\n' +
             oauthSetupSection +
-            `**Terms:** a *protected resource* is ${termsResource} you're sharing. ` +
+            `**Terms:** a *protected resource* is ${mapCopy.resource} you're sharing. ` +
             'A *qurl* (or *access link*) is the single-use URL that delivers it. ' +
-            `You create a qurl for a protected resource each time you run ${fileOrMapCommand}.\n\n` +
-            `**Large servers (~1000+ members):** ${fileOrMapCommand} with role @mentions ` +
+            `You create a qurl for a protected resource each time you run ${mapCopy.cmd}.\n\n` +
+            `**Large servers (~1000+ members):** ${mapCopy.cmd} with role @mentions ` +
             'may skip members the bot has not yet cached locally (the bot fetches members lazily, ' +
             'and very large servers may not be fully populated). ' +
             'If you need to reach a specific person for sure, use an explicit user @mention instead of a role.\n\n' +

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3188,8 +3188,10 @@ const API_KEY_GATED_SUBCOMMANDS = new Set(
 
 // User-facing reply for stale /qurl map submissions when the toggle
 // is off. Reached when a Discord client routes a cached `map`
-// submission after the registration has dropped it.
-const QURL_MAP_DISABLED_REPLY = '❌ `/qurl map` is currently disabled. Use `/qurl file` to share resources securely.';
+// submission after the registration has dropped it. Copy mirrors
+// the flag-off branch of SETUP_SUCCESS_MSG so both surfaces describe
+// the same remaining capability.
+const QURL_MAP_DISABLED_REPLY = '❌ `/qurl map` is currently disabled. Use `/qurl file` to share files securely.';
 
 // Slash-option choice arrays. The same wording flows into both the
 // slash-command autocomplete and the confirm-card dropdowns so users
@@ -7927,15 +7929,20 @@ const commands = [
         // Flag-on and flag-off help-copy variants kept side-by-side
         // so a future edit to one branch is obviously checked against
         // the other. `cmd` is referenced twice (Terms + Large servers);
-        // single token keeps them in lockstep.
+        // single token keeps them in lockstep. `sectionVerb` makes
+        // the "Getting started" header track what's actually
+        // registered ("Share files" reads more accurately than
+        // "Share resources" when /qurl map is off).
         const mapCopy = config.MAP_COMMAND_ENABLED
           ? {
+            sectionVerb: 'Share resources',
             bullet: '  `/qurl map` — share a Google Maps location via one-time qURL links\n',
             runLine: '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n',
             resource: 'the file or location',
             cmd: '`/qurl file` or `/qurl map`',
           }
           : {
+            sectionVerb: 'Share files',
             bullet: '',
             runLine: '\t1. Run `/qurl file` and attach the file you want to share\n',
             resource: 'the file',
@@ -7943,7 +7950,7 @@ const commands = [
           };
         return interaction.reply({
           content: '**qURL Bot — Help**\n\n' +
-            '**Getting started — Share resources securely via one-time links:**\n' +
+            `**Getting started — ${mapCopy.sectionVerb} securely via one-time links:**\n` +
             '  `/qurl file` — share a file with users via one-time qURL links\n' +
             mapCopy.bullet +
             '  `/qurl revoke` — revoke links from a previous send\n' +

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -283,6 +283,12 @@ module.exports = {
   // can't silently re-enable a command that requires a working
   // GOOGLE_MAPS_API_KEY in SSM. See the slash-command builder IIFE
   // in commands.js for the full set of MAP_COMMAND_ENABLED gates.
+  //
+  // Snapshot semantics: this value is read ONCE at module load and
+  // baked into the slash registration (commands.js IIFE) +
+  // SETUP_SUCCESS_MSG. Flipping MAP_COMMAND_ENABLED at runtime is
+  // a no-op until the task restarts; the deploy model handles this
+  // (ECS rolls fresh tasks on every task-def revision).
   MAP_COMMAND_ENABLED: process.env.MAP_COMMAND_ENABLED === 'true',
 
   // qURL send limits (/qurl file + /qurl map) — both must be > 0. A

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -274,6 +274,17 @@ module.exports = {
   // Google Maps (location autocomplete)
   GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,
 
+  // /qurl map feature toggle. Default OFF — the bot ships without
+  // /qurl map registered as a slash subcommand. Operator opts in per
+  // deploy by setting MAP_COMMAND_ENABLED=true on the task definition
+  // (terraform var `map_command_enabled` plumbs this through). Must
+  // be the literal string "true"; any other value (unset, empty,
+  // "TRUE", "1", "yes") keeps the feature off, so an env-var typo
+  // can't silently re-enable a command that requires a working
+  // GOOGLE_MAPS_API_KEY in SSM. See the slash-command builder IIFE
+  // in commands.js for the full set of MAP_COMMAND_ENABLED gates.
+  MAP_COMMAND_ENABLED: process.env.MAP_COMMAND_ENABLED === 'true',
+
   // qURL send limits (/qurl file + /qurl map) — both must be > 0. A
   // cooldown of 0 would silently disable the rate limit; a recipients
   // cap of 0 would reject every send.

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -8,7 +8,7 @@ const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
 const db = require('./store');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
-const { missingBootKeys, missingProdKeys, missingKekRequiredKeys, missingEventShipperKeys, resolveProcessRole } = require('./boot-requirements');
+const { missingBootKeys, missingProdKeys, missingKekRequiredKeys, missingEventShipperKeys, missingMapCommandKeys, resolveProcessRole } = require('./boot-requirements');
 const { initHttpOnly } = require('./http-only-init');
 const eventConsumer = require('./event-consumer');
 
@@ -260,6 +260,19 @@ if (process.env.NODE_ENV === 'production') {
 const eventShipperMissing = missingEventShipperKeys(config);
 if (eventShipperMissing.length > 0) {
   logger.error(`ENABLE_EVENT_SHIPPER=true but missing required env vars: ${eventShipperMissing.join(', ')}`);
+  process.exit(1);
+}
+
+// Symmetric with the eventShipper check above — fail fast on
+// inconsistent flag-vs-secret state. The error message is the
+// operator-facing source of truth for the remediation steps.
+const mapCommandMissing = missingMapCommandKeys(config);
+if (mapCommandMissing.length > 0) {
+  logger.error(
+    `MAP_COMMAND_ENABLED=true but ${mapCommandMissing.join(', ')} is missing or still the literal "PLACEHOLDER" sentinel. ` +
+    'Seed a real Google Maps Platform API key (Places API enabled, no HTTP-referrer restriction) into the ' +
+    '/qurl-bot-discord/GOOGLE_MAPS_API_KEY SSM parameter before re-flipping the toggle.'
+  );
   process.exit(1);
 }
 

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -17,6 +17,8 @@ const {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  missingMapCommandKeys,
+  GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 } = require('../src/boot-requirements');
@@ -162,6 +164,56 @@ describe('missingEventShipperKeys', () => {
       missingEventShipperKeys({
         ENABLE_EVENT_SHIPPER: true,
         QURL_BOT_EVENTS_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events',
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('missingMapCommandKeys', () => {
+  it('returns empty when the flag is off — Maps key state is irrelevant', () => {
+    expect(missingMapCommandKeys({})).toEqual([]);
+    expect(missingMapCommandKeys({ MAP_COMMAND_ENABLED: false })).toEqual([]);
+    // Even with a missing or PLACEHOLDER key — the toggle is the gate.
+    // No /qurl map registration means no Places call possible.
+    expect(
+      missingMapCommandKeys({ MAP_COMMAND_ENABLED: false, GOOGLE_MAPS_API_KEY: '' }),
+    ).toEqual([]);
+    expect(
+      missingMapCommandKeys({
+        MAP_COMMAND_ENABLED: false,
+        GOOGLE_MAPS_API_KEY: GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
+      }),
+    ).toEqual([]);
+  });
+
+  it('flags GOOGLE_MAPS_API_KEY when toggle is on but the key is missing', () => {
+    expect(
+      missingMapCommandKeys({ MAP_COMMAND_ENABLED: true }),
+    ).toEqual(['GOOGLE_MAPS_API_KEY']);
+    expect(
+      missingMapCommandKeys({ MAP_COMMAND_ENABLED: true, GOOGLE_MAPS_API_KEY: '' }),
+    ).toEqual(['GOOGLE_MAPS_API_KEY']);
+  });
+
+  it('flags GOOGLE_MAPS_API_KEY when toggle is on but the key is still the PLACEHOLDER sentinel', () => {
+    // The exact regression that triggered the toggle PR: the SSM
+    // parameter shipped as the literal "PLACEHOLDER" value in both
+    // sandbox + prod accounts. Without this branch, an operator
+    // flipping the toggle without seeding the SSM secret would boot
+    // successfully and fail at the first /qurl map invocation.
+    expect(
+      missingMapCommandKeys({
+        MAP_COMMAND_ENABLED: true,
+        GOOGLE_MAPS_API_KEY: GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
+      }),
+    ).toEqual(['GOOGLE_MAPS_API_KEY']);
+  });
+
+  it('returns empty when toggle is on AND the key is a real value', () => {
+    expect(
+      missingMapCommandKeys({
+        MAP_COMMAND_ENABLED: true,
+        GOOGLE_MAPS_API_KEY: 'AIzaSyA-real-looking-key-1234567890',
       }),
     ).toEqual([]);
   });

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -2201,14 +2201,12 @@ describe('handleSetupModal (dispatcher path)', () => {
 });
 
 describe('handleCommand — autocomplete', () => {
-  it('responds empty for short focused-location values (below min-length)', async () => {
-    // /qurl map's location: option is now autocomplete-enabled.
-    // handleCommand routes the interaction to handleAutocomplete,
-    // which gates on a minimum partial-input length (2 chars). 'Eif'
-    // exceeds the gate, so Places gets called — but since the test
-    // mocks searchPlaces to return [], the dropdown stays empty.
-    // The contract here is that respond() IS called (with []), where
-    // previously it was a silent drop.
+  it('responds empty for /qurl map location autocomplete (flag-off short-circuit)', async () => {
+    // This file's config mock leaves MAP_COMMAND_ENABLED unset — the
+    // bot's production default. handleAutocomplete's flag-off guard
+    // short-circuits to respond([]) before searchPlaces. The contract
+    // here is that respond() IS called (with []), where pre-flag this
+    // path would have invoked Places.
     const interaction = makeInteraction({
       commandName: 'qurl',
       isAutocomplete: jest.fn(() => true),
@@ -2223,6 +2221,86 @@ describe('handleCommand — autocomplete', () => {
     await handleCommand(interaction);
 
     expect(interaction.respond).toHaveBeenCalledWith([]);
+  });
+});
+
+// Flag-off coverage. The config mock at the top of this file does NOT
+// set MAP_COMMAND_ENABLED, so the bot's strict `=== 'true'` parser
+// resolves it to false — matching the production default. Every test
+// in this block verifies a surface that should be inert when the flag
+// is off. The flag-on path is covered by qurl-file-map.test.js (whose
+// config mock sets MAP_COMMAND_ENABLED: true).
+describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
+  const { mockSearchPlaces } = require('./helpers/places-mock');
+
+  it('SETUP_SUCCESS_MSG omits /qurl map', () => {
+    // Built at module load with the flag snapshot. Pin against the
+    // production string via _test so a future copy edit can't drift
+    // this assertion from reality.
+    expect(_test.SETUP_SUCCESS_MSG).not.toContain('/qurl map');
+    expect(_test.SETUP_SUCCESS_MSG).toContain('/qurl file');
+  });
+
+  it('/qurl help reply omits /qurl map references', async () => {
+    const interaction = makeInteraction({
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'help'),
+      },
+    });
+    await handleCommand(interaction);
+    const replyArg = interaction.reply.mock.calls.find(([arg]) => typeof arg?.content === 'string')?.[0];
+    expect(replyArg).toBeDefined();
+    expect(replyArg.content).not.toContain('/qurl map');
+    // Sanity: the help reply is still rendered (we want absence of
+    // map, not absence of help). Catches a regression where the
+    // entire help branch goes silent.
+    expect(replyArg.content).toContain('/qurl file');
+    expect(replyArg.content).toContain('qURL Bot — Help');
+  });
+
+  it('dispatcher replies with QURL_MAP_DISABLED_REPLY for /qurl map (stale-client safety net)', async () => {
+    // Discord won't normally route a `map` submission when the
+    // subcommand isn't registered, but a stale client carrying the
+    // pre-flip command definition can still submit one. The
+    // dispatcher's defensive branch turns that into a clean ephemeral
+    // instead of falling through to handleQurlMap → Places.
+    const interaction = makeInteraction({
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'map'),
+      },
+    });
+    await handleCommand(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: _test.QURL_MAP_DISABLED_REPLY,
+      ephemeral: true,
+    });
+    // handleQurlMap defers + then hits Places; if the dispatcher ever
+    // routed through it by mistake, deferReply would fire. Negative
+    // assertion guards against that regression.
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+  });
+
+  it('autocomplete for /qurl map location does NOT call searchPlaces (Places quota safety)', async () => {
+    // The earlier "responds empty for /qurl map location" test pins
+    // the user-visible contract (respond([])). This one pins the
+    // operator-cost contract: we don't burn the GOOGLE_MAPS_API_KEY
+    // quota on a submit that the dispatcher will reject anyway.
+    mockSearchPlaces.mockClear();
+    const interaction = makeInteraction({
+      commandName: 'qurl',
+      isAutocomplete: jest.fn(() => true),
+      isChatInputCommand: jest.fn(() => false),
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'map'),
+        getFocused: jest.fn(() => ({ name: 'location', value: 'Eiffel Tower' })),
+      },
+    });
+    await handleCommand(interaction);
+    expect(interaction.respond).toHaveBeenCalledWith([]);
+    expect(mockSearchPlaces).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -14,6 +14,13 @@ jest.mock('../src/config', () => ({
   QURL_ENDPOINT: 'https://api.test.local',
   CONNECTOR_URL: 'https://connector.test.local',
   GOOGLE_MAPS_API_KEY: 'test-google-key',
+  // /qurl map feature toggle — explicitly false here so the flag-off
+  // describe block below tests the documented production default. A
+  // missing key would *also* read as falsy (the bot's `=== 'true'`
+  // parser), but a future refactor that flipped the default-on
+  // semantics would silently keep these tests green; the explicit
+  // value pins the contract.
+  MAP_COMMAND_ENABLED: false,
   QURL_SEND_COOLDOWN_MS: 30000,
   QURL_SEND_MAX_RECIPIENTS: 50,
   DATABASE_PATH: ':memory:',
@@ -2301,6 +2308,49 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
     await handleCommand(interaction);
     expect(interaction.respond).toHaveBeenCalledWith([]);
     expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  it('stale /qurl map in an unconfigured guild hits disabled reply BEFORE the API-key gate (routing order)', async () => {
+    // The most subtle invariant of this PR: API_KEY_GATED_SUBCOMMANDS
+    // intentionally OMITS 'map' when the flag is off. If 'map' had
+    // stayed in the set, the dispatcher's gate (commands.js:7882)
+    // would fire "qURL is not configured for this server" BEFORE the
+    // dispatch could route to QURL_MAP_DISABLED_REPLY — a stale
+    // client in a never-configured guild would see the wrong copy.
+    //
+    // Setup: empty per-guild key (mockDb default) AND empty global
+    // fallback (mutated config). The gate would otherwise fire if
+    // 'map' were still in API_KEY_GATED_SUBCOMMANDS; the disabled
+    // reply firing instead is the load-bearing assertion.
+    const configMock = require('../src/config');
+    const origQurlApiKey = configMock.QURL_API_KEY;
+    configMock.QURL_API_KEY = '';
+    mockDb.getGuildApiKey.mockResolvedValueOnce(null);
+    try {
+      const interaction = makeInteraction({
+        options: {
+          ...makeInteraction().options,
+          getSubcommand: jest.fn(() => 'map'),
+        },
+      });
+      await handleCommand(interaction);
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: _test.QURL_MAP_DISABLED_REPLY,
+        ephemeral: true,
+      });
+      // Negative assertion: NONE of the reply calls should be the
+      // "qURL is not configured" gate copy. If a future refactor
+      // accidentally re-adds 'map' to API_KEY_GATED_SUBCOMMANDS, the
+      // dispatcher would reply with the not-configured message
+      // first (and either skip the disabled reply entirely or call
+      // reply twice — both regressions covered by this check).
+      const allReplies = interaction.reply.mock.calls.map(([arg]) => arg?.content || '');
+      for (const content of allReplies) {
+        expect(content).not.toContain('qURL is not configured');
+      }
+    } finally {
+      configMock.QURL_API_KEY = origQurlApiKey;
+    }
   });
 });
 

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -2264,6 +2264,12 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
     // entire help branch goes silent.
     expect(replyArg.content).toContain('/qurl file');
     expect(replyArg.content).toContain('qURL Bot — Help');
+    // Pin the flag-off `sectionVerb` swap — a regression that drops
+    // the conditional verb would render "Share resources" against a
+    // map-disabled deploy. Catches the swap in isolation from the
+    // overall mapCopy structure.
+    expect(replyArg.content).toContain('Share files securely');
+    expect(replyArg.content).not.toContain('Share resources securely');
   });
 
   it('dispatcher replies with QURL_MAP_DISABLED_REPLY for /qurl map (stale-client safety net)', async () => {

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -2313,10 +2313,11 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
   it('stale /qurl map in an unconfigured guild hits disabled reply BEFORE the API-key gate (routing order)', async () => {
     // The most subtle invariant of this PR: API_KEY_GATED_SUBCOMMANDS
     // intentionally OMITS 'map' when the flag is off. If 'map' had
-    // stayed in the set, the dispatcher's gate (commands.js:7882)
-    // would fire "qURL is not configured for this server" BEFORE the
-    // dispatch could route to QURL_MAP_DISABLED_REPLY — a stale
-    // client in a never-configured guild would see the wrong copy.
+    // stayed in the set, the dispatcher's API_KEY_GATED_SUBCOMMANDS
+    // gate would fire "qURL is not configured for this server"
+    // BEFORE the dispatch could route to QURL_MAP_DISABLED_REPLY —
+    // a stale client in a never-configured guild would see the
+    // wrong copy.
     //
     // Setup: empty per-guild key (mockDb default) AND empty global
     // fallback (mutated config). The gate would otherwise fire if

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -2207,29 +2207,14 @@ describe('handleSetupModal (dispatcher path)', () => {
   });
 });
 
-describe('handleCommand — autocomplete', () => {
-  it('responds empty for /qurl map location autocomplete (flag-off short-circuit)', async () => {
-    // This file's config mock leaves MAP_COMMAND_ENABLED unset — the
-    // bot's production default. handleAutocomplete's flag-off guard
-    // short-circuits to respond([]) before searchPlaces. The contract
-    // here is that respond() IS called (with []), where pre-flag this
-    // path would have invoked Places.
-    const interaction = makeInteraction({
-      commandName: 'qurl',
-      isAutocomplete: jest.fn(() => true),
-      isChatInputCommand: jest.fn(() => false),
-      options: {
-        ...makeInteraction().options,
-        getSubcommand: jest.fn(() => 'map'),
-        getFocused: jest.fn(() => ({ name: 'location', value: 'Eif' })),
-      },
-    });
-
-    await handleCommand(interaction);
-
-    expect(interaction.respond).toHaveBeenCalledWith([]);
-  });
-});
+// The pre-flag "responds empty for short focused-location values
+// (below min-length)" test once lived here; under MAP_COMMAND_ENABLED=false
+// its respond([]) assertion was strictly weaker than the flag-off block
+// below (which also asserts mockSearchPlaces was never called). Min-length
+// gate coverage moved entirely to qurl-file-map.test.js's "skips Places
+// call for partial queries below the min-length cap" test, which runs
+// under MAP_COMMAND_ENABLED=true and exercises the path the gate
+// actually guards.
 
 // Flag-off coverage. The config mock at the top of this file does NOT
 // set MAP_COMMAND_ENABLED, so the bot's strict `=== 'true'` parser

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -2334,20 +2334,14 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
         },
       });
       await handleCommand(interaction);
-      expect(interaction.reply).toHaveBeenCalledWith({
-        content: _test.QURL_MAP_DISABLED_REPLY,
-        ephemeral: true,
-      });
-      // Negative assertion: NONE of the reply calls should be the
-      // "qURL is not configured" gate copy. If a future refactor
-      // accidentally re-adds 'map' to API_KEY_GATED_SUBCOMMANDS, the
-      // dispatcher would reply with the not-configured message
-      // first (and either skip the disabled reply entirely or call
-      // reply twice — both regressions covered by this check).
+      // Strict shape: exactly one reply call, exactly the disabled
+      // copy. A future refactor that re-adds 'map' to
+      // API_KEY_GATED_SUBCOMMANDS would either: (a) reply with
+      // "qURL is not configured" instead, OR (b) reply twice (gate
+      // copy first, then disabled copy on fall-through). Both
+      // regressions are caught by the length + value assertion.
       const allReplies = interaction.reply.mock.calls.map(([arg]) => arg?.content || '');
-      for (const content of allReplies) {
-        expect(content).not.toContain('qURL is not configured');
-      }
+      expect(allReplies).toEqual([_test.QURL_MAP_DISABLED_REPLY]);
     } finally {
       configMock.QURL_API_KEY = origQurlApiKey;
     }

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -2207,15 +2207,6 @@ describe('handleSetupModal (dispatcher path)', () => {
   });
 });
 
-// The pre-flag "responds empty for short focused-location values
-// (below min-length)" test once lived here; under MAP_COMMAND_ENABLED=false
-// its respond([]) assertion was strictly weaker than the flag-off block
-// below (which also asserts mockSearchPlaces was never called). Min-length
-// gate coverage moved entirely to qurl-file-map.test.js's "skips Places
-// call for partial queries below the min-length cap" test, which runs
-// under MAP_COMMAND_ENABLED=true and exercises the path the gate
-// actually guards.
-
 // Flag-off coverage. The config mock at the top of this file does NOT
 // set MAP_COMMAND_ENABLED, so the bot's strict `=== 'true'` parser
 // resolves it to false — matching the production default. Every test

--- a/apps/discord/tests/qurl-file-map.test.js
+++ b/apps/discord/tests/qurl-file-map.test.js
@@ -19,6 +19,10 @@ jest.mock('../src/config', () => ({
   QURL_ENDPOINT: 'https://api.test.local',
   CONNECTOR_URL: 'https://connector.test.local',
   GOOGLE_MAPS_API_KEY: 'test-google-key',
+  // /qurl map feature toggle — these tests cover the enabled-feature
+  // path (handleAutocomplete → searchPlaces, handleQurlMap dispatch,
+  // confirm-card MAPS flow). Production default is off.
+  MAP_COMMAND_ENABLED: true,
   QURL_SEND_COOLDOWN_MS: 30000,
   QURL_SEND_MAX_RECIPIENTS: 25,
   DATABASE_PATH: ':memory:',

--- a/e2e/tests/discord-commands.smoke.test.ts
+++ b/e2e/tests/discord-commands.smoke.test.ts
@@ -130,8 +130,22 @@ describe('Discord command registration (smoke)', () => {
         .sort();
       // Prepend scope to the expectation so a mismatch surfaces which
       // scope regressed in the Jest failure header.
+      //
+      // `'map'` is conditional on the deploy-time MAP_COMMAND_ENABLED
+      // toggle (see apps/discord/src/config.js + the commands.js IIFE).
+      // The smoke runner has to read the same flag the bot reads, or
+      // a flag-on deploy would fail the smoke (no map in expected
+      // set) while a flag-off deploy with a stale workflow env would
+      // pass-with-map and silently miss a regression. Plumb
+      // MAP_COMMAND_ENABLED into the smoke step's `env:` block in
+      // .github/workflows/e2e-smoke.yml in lockstep with the bot
+      // task-definition env.
+      const mapEnabled = process.env.MAP_COMMAND_ENABLED === 'true';
+      const expectedSubcommands = mapEnabled
+        ? ['file', 'help', 'map', 'revoke', 'setup', 'status']
+        : ['file', 'help', 'revoke', 'setup', 'status'];
       expect({ scope: qurl._scope, subcommands })
-        .toEqual({ scope: qurl._scope, subcommands: ['file', 'help', 'map', 'revoke', 'setup', 'status'] });
+        .toEqual({ scope: qurl._scope, subcommands: expectedSubcommands });
     }
   });
 

--- a/e2e/tests/discord-commands.smoke.test.ts
+++ b/e2e/tests/discord-commands.smoke.test.ts
@@ -133,14 +133,29 @@ describe('Discord command registration (smoke)', () => {
       //
       // `'map'` is conditional on the deploy-time MAP_COMMAND_ENABLED
       // toggle (see apps/discord/src/config.js + the commands.js IIFE).
-      // The smoke runner has to read the same flag the bot reads, or
-      // a flag-on deploy would fail the smoke (no map in expected
-      // set) while a flag-off deploy with a stale workflow env would
-      // pass-with-map and silently miss a regression. Plumb
-      // MAP_COMMAND_ENABLED into the smoke step's `env:` block in
-      // .github/workflows/e2e-smoke.yml in lockstep with the bot
-      // task-definition env.
-      const mapEnabled = process.env.MAP_COMMAND_ENABLED === 'true';
+      // The smoke runner has to read the same flag the bot reads.
+      // Strict shape check: require the env var to be exactly "true"
+      // or "false" — if a workflow regression drops the "Resolve
+      // MAP_COMMAND_ENABLED" step (see e2e-smoke.yml in
+      // qurl-integrations-infra), the env would be unset and the
+      // smoke would silently default to a flag-off expectation,
+      // masking a flag-on deploy as a regression. Failing the test
+      // up front with a named workflow step is louder than chasing a
+      // mystery subcommand-set diff. Resolved value also logged so
+      // CI output shows what the smoke actually asserted.
+      const rawMapFlag = process.env.MAP_COMMAND_ENABLED;
+      if (rawMapFlag !== 'true' && rawMapFlag !== 'false') {
+        throw new Error(
+          `MAP_COMMAND_ENABLED must be set to "true" or "false" before this smoke runs (got: ${JSON.stringify(rawMapFlag)}). `
+          + 'Set it locally via `MAP_COMMAND_ENABLED=false npm test`, or check that '
+          + 'the "Resolve MAP_COMMAND_ENABLED from <env>.tfvars" step in '
+          + 'qurl-integrations-infra/.github/workflows/e2e-smoke.yml ran '
+          + 'before the smoke step.',
+        );
+      }
+      const mapEnabled = rawMapFlag === 'true';
+      // eslint-disable-next-line no-console
+      console.log(`smoke: MAP_COMMAND_ENABLED resolved to "${rawMapFlag}" (mapEnabled=${mapEnabled})`);
       const expectedSubcommands = mapEnabled
         ? ['file', 'help', 'map', 'revoke', 'setup', 'status']
         : ['file', 'help', 'revoke', 'setup', 'status'];

--- a/e2e/tests/discord-commands.smoke.test.ts
+++ b/e2e/tests/discord-commands.smoke.test.ts
@@ -147,10 +147,8 @@ describe('Discord command registration (smoke)', () => {
       if (rawMapFlag !== 'true' && rawMapFlag !== 'false') {
         throw new Error(
           `MAP_COMMAND_ENABLED must be set to "true" or "false" before this smoke runs (got: ${JSON.stringify(rawMapFlag)}). `
-          + 'Set it locally via `MAP_COMMAND_ENABLED=false npm test`, or check that '
-          + 'the "Resolve MAP_COMMAND_ENABLED from <env>.tfvars" step in '
-          + 'qurl-integrations-infra/.github/workflows/e2e-smoke.yml ran '
-          + 'before the smoke step.',
+          + 'In CI it is set by the e2e-smoke workflow from the deploy env\'s tfvars; '
+          + 'locally, run with e.g. `MAP_COMMAND_ENABLED=false npm test`.',
         );
       }
       const mapEnabled = rawMapFlag === 'true';


### PR DESCRIPTION
## Summary

- New env-driven feature toggle `MAP_COMMAND_ENABLED` (strict `=== 'true'`, default off) that gates `/qurl map` end-to-end: slash registration, dispatcher, autocomplete, help text, and `SETUP_SUCCESS_MSG`.
- Stale-client safety net replies with `QURL_MAP_DISABLED_REPLY` when the flag is off so a cached client submission doesn't fall into `handleQurlMap` → Places.
- Autocomplete short-circuits before `searchPlaces` when the flag is off, protecting the operator's `GOOGLE_MAPS_API_KEY` quota from stale-client races.
- 4 new flag-off assertions in `commands-comprehensive.test.js` lock in the production-default behavior (the existing `qurl-file-map.test.js` covers the flag-on path via its test-only mock).
- `e2e/tests/discord-commands.smoke.test.ts` reads `process.env.MAP_COMMAND_ENABLED` so the expected subcommand set tracks the deployed toggle.

## Why

The sandbox `/qurl-bot-discord/GOOGLE_MAPS_API_KEY` SSM parameter shipped as the literal `"PLACEHOLDER"` value and was never seeded. Every `/qurl map` invocation hit Google Places, got `REQUEST_DENIED`, and surfaced a generic "Location lookup failed" reply. Same situation in prod (`886375649402` / `us-east-2`) — that parameter is also still `"PLACEHOLDER"`. Disabling the command end-to-end is safer than letting a misconfigured deploy keep regressing on senders.

## Companion PR

The terraform var + task-def wiring + e2e-smoke workflow resolve step lives in `layervai/qurl-integrations-infra` (companion PR). The bot reads the env at module load, so flipping `map_command_enabled` in the env's tfvars + applying terraform pushes a new task-def revision and ECS rolls fresh tasks that see the new value.

## Re-enable order (when you want /qurl map back)

1. Seed `/qurl-bot-discord/GOOGLE_MAPS_API_KEY` in SSM in both the sandbox (`730883236711`) and prod (`886375649402`) accounts with a real Google Maps Platform API key (Places API enabled, no HTTP-referrer restriction).
2. Flip `map_command_enabled = "true"` in the env's tfvars in the infra repo + apply.
3. The e2e-smoke workflow auto-resolves the flag from tfvars (no parallel workflow PR required after the companion infra PR lands).

## Test plan

- [x] `npx jest` — 1811/1811 unit tests pass (4 new flag-off assertions added); 1 pre-existing unrelated suite failure (`event-consumer.test.js`, missing `@aws-sdk/client-sqs` dep).
- [x] `npx eslint src/ tests/` — clean.
- [ ] Sandbox deploy → confirm `/qurl map` no longer appears in the slash-command autocomplete for users.
- [ ] Sandbox deploy → run e2e smoke; assert subcommand set is `['file', 'help', 'revoke', 'setup', 'status']` (no `map`).
- [ ] `/qurl help` ephemeral renders without `/qurl map` mentions.
- [ ] `/qurl setup` (admin) success message renders without `/qurl map` mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)