### PR TITLE
feat(discord): stop() drains in-flight handlers with deadline cap (#391)

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -116,6 +116,19 @@ ENABLE_OPENNHP_FEATURES=false
 # simultaneous handler promises regardless.
 # QURL_BOT_MAX_INFLIGHT_HANDLERS=100
 
+# Maximum time (ms) stop() waits for in-flight handler promises to
+# settle during graceful shutdown before proceeding to db.close().
+# Default 3000. Range [100, 8000] — clamped so a typo can't block
+# stop() past gracefulShutdown's 10s budget. Out-of-range values
+# fall back to the default with a console warning.
+#
+# Tune up if prod soak surfaces handlers consistently exceeding 3s
+# (DDB latency spikes, slow REST round-trips) and you'd rather wait
+# than race db.close(). Tune down if shutdown latency matters more
+# than completing in-flight work. Captured at module load; redeploy
+# to retune.
+# QURL_BOT_DRAIN_DEADLINE_MS=3000
+
 # GitHub OAuth App — REQUIRED only when ENABLE_OPENNHP_FEATURES=true.
 # Single-guild-plain and multi-tenant deployments don't mount /auth or
 # /webhook routes and don't need these values — the boot check

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -968,10 +968,12 @@ async function stop() {
     // force-exit fires regardless, so we cap our wait at 3s to
     // leave room for db.close() and any other shutdown work.
     //
-    // Snapshot the set into an array before allSettled: pending
-    // .finally callbacks mutate inFlightPromises during the await,
-    // and Set iteration is fine with concurrent mutation but the
-    // explicit copy makes intent obvious.
+    // Explicit copy `[...inFlightPromises]` rather than passing the
+    // Set directly: Promise.allSettled materializes its input
+    // synchronously at call time, so a Set arg would behave the same.
+    // The spread is for readability — "snapshot of the set as of this
+    // moment, then await every one of those" reads more directly than
+    // letting allSettled iterate the live set.
     if (inFlightPromises.size > 0) {
       const drainCount = inFlightPromises.size;
       const drainStart = Date.now();

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -937,6 +937,15 @@ async function stop() {
   // pass !running, both abort, both await loopPromise. Harmless but
   // racy on the running=false reset; the stopping check makes the
   // single-stopper invariant explicit.
+  //
+  // Caveat for a hypothetical second caller: the early-return DOES
+  // NOT wait for the first caller's drain to complete. A second
+  // stop() that lands during drain returns immediately. In practice
+  // gracefulShutdown only calls stop() once, so this is theoretical
+  // — but if a future refactor opens the door to concurrent stops,
+  // the second caller would need to await the first's loopPromise
+  // (or a shared "drainPromise" handle) to get "drain complete"
+  // semantics, not just "stop is already in progress."
   if (!running || stopping) return;
   stopping = true;
   // Cancel the in-flight long-poll so stop() returns within tens of
@@ -957,15 +966,27 @@ async function stop() {
   }
   logger.info('Event consumer: stopping');
   try {
-    await loopPromise;
-    // After loopPromise resolves, every processMessage's
-    // synchronous-emit window has completed, so trackDispatch has
-    // captured all in-flight handler promises that the worker
-    // dispatched. Wait up to DRAIN_DEADLINE_MS for those detached
-    // handlers (DDB writes, REST calls, DM fan-out) to settle so
-    // the subsequent db.close() in gracefulShutdown doesn't race
-    // them. The deadline is non-negotiable — index.js's 10s
-    // force-exit fires regardless, so we cap our wait at 3s to
+    // Isolate the loopPromise wait from the drain: if pollLoop
+    // rejects (rare — its own catch covers routine errors, so this
+    // is an unforeseen sync throw or similar), we still want to
+    // drain. trackDispatch's set is maintained synchronously around
+    // emits, so its state after a loop crash still accurately
+    // reflects in-flight handler promises — draining is meaningful
+    // even if the loop itself died.
+    try {
+      await loopPromise;
+    } catch (err) {
+      logger.error('Event consumer: error during stop', { error: err.message });
+    }
+
+    // After loopPromise settles (success or failure), every
+    // processMessage's synchronous-emit window has completed, so
+    // trackDispatch has captured all in-flight handler promises
+    // the worker dispatched. Wait up to DRAIN_DEADLINE_MS for those
+    // detached handlers (DDB writes, REST calls, DM fan-out) to
+    // settle so the subsequent db.close() in gracefulShutdown
+    // doesn't race them. The deadline is non-negotiable — index.js's
+    // 10s force-exit fires regardless, so we cap our wait at 3s to
     // leave room for db.close() and any other shutdown work.
     //
     // Spread for readability — passing the Set directly would behave
@@ -973,7 +994,10 @@ async function stop() {
     // reads more directly as "await each of these promises."
     if (inFlightPromises.size > 0) {
       const drainCount = inFlightPromises.size;
-      const drainStart = Date.now();
+      // hrtime.bigint() is monotonic — Date.now() is wall-clock and
+      // can jump under NTP adjustments mid-drain. Cost is the same;
+      // monotonic is the correct shape for elapsed measurement.
+      const drainStartNs = process.hrtime.bigint();
       logger.info('Event consumer: draining in-flight handlers', {
         count: drainCount,
         deadlineMs: DRAIN_DEADLINE_MS,
@@ -989,7 +1013,13 @@ async function stop() {
       } finally {
         clearTimeout(drainTimer);
       }
-      const elapsed = Date.now() - drainStart;
+      const elapsedMs = Number((process.hrtime.bigint() - drainStartNs) / 1_000_000n);
+      // The post-race size check is the discriminator (not the race
+      // winner): when allSettled wins, each promise's trackDispatch-
+      // registered `.finally` runs before allSettled's continuation,
+      // so by the time we read `.size` here the set is already empty
+      // on the happy path. On the deadline path the set still holds
+      // whatever didn't settle.
       if (inFlightPromises.size > 0) {
         // Deadline elapsed before all handlers settled. Log at warn —
         // the same race the pre-#391 path always had (handlers racing
@@ -998,17 +1028,15 @@ async function stop() {
         logger.warn('Event consumer: drain deadline elapsed, proceeding with handlers still in-flight', {
           unsettled: inFlightPromises.size,
           settled: drainCount - inFlightPromises.size,
-          elapsedMs: elapsed,
+          elapsedMs,
         });
       } else {
         logger.info('Event consumer: drain complete', {
           count: drainCount,
-          elapsedMs: elapsed,
+          elapsedMs,
         });
       }
     }
-  } catch (err) {
-    logger.error('Event consumer: error during stop', { error: err.message });
   } finally {
     running = false;
     // Reset stopping alongside running so a caller introspecting
@@ -1110,5 +1138,11 @@ module.exports = {
     // run quickly. `_resetStateForTest` restores the default between
     // tests so changes don't leak.
     _setDrainDeadlineForTest: (ms) => { DRAIN_DEADLINE_MS = ms; },
+    // Test-only setter for `loopPromise`. Lets tests inject a
+    // rejected promise to simulate a pollLoop crash without
+    // actually crashing the loop — the "drain runs even when
+    // loopPromise rejects" test uses this. `_resetStateForTest`
+    // sets loopPromise back to null.
+    _setLoopPromiseForTest: (p) => { loopPromise = p; },
   },
 };

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -86,7 +86,7 @@
 // this requirement.
 //
 // Backpressure: the poll loop tracks in-flight detached handlers
-// and pauses receives when `inFlightCount >= MAX_INFLIGHT_HANDLERS`
+// and pauses receives when `inFlightPromises.size >= MAX_INFLIGHT_HANDLERS`
 // (env-overridable; see QURL_BOT_MAX_INFLIGHT_HANDLERS). Without
 // this, under a bursty arrival pattern with slow downstream
 // DDB/REST work, handler promises would accumulate without bound,
@@ -94,27 +94,27 @@
 // drain. The cap is the safety net before the worker tier flag-flip
 // in PR 10.
 //
-// SCOPE: this is a receive-gate mechanism only. It pauses new work
-// when capacity is exhausted; it does NOT help with graceful
-// shutdown. trackDispatch retains a count, not promise references,
-// so stop() cannot drain in-flight handlers — a SIGTERM during a
-// detached DDB write races gracefulShutdown's db.close() (same race
-// the pre-PR gateway path has, since the gateway also runs handlers
-// detached). For drain-on-shutdown support, see #391: the refactor
-// would also capture promises in a Set so stop() can `await
-// Promise.allSettled([...inFlightPromises])` with a deadline cap.
+// Two purposes: (1) the cap pauses receives when capacity is
+// exhausted; (2) the set of references lets stop() await a
+// deadline-capped drain of in-flight handlers before
+// gracefulShutdown proceeds to db.close(). See the stop() comment
+// block below for the drain contract — a SIGTERM during a detached
+// DDB write still races db.close() if the handler exceeds the
+// DRAIN_DEADLINE_MS (3s) cap, but typical workloads settle well
+// under that and the race window is meaningfully reduced.
 //
 // This is a soft cap, not a hard semaphore. pollOnce checks
-// `inFlightCount >= cap` BEFORE issuing a ReceiveMessage, but a
-// receive that passes the check can return up to RECEIVE_MAX_MESSAGES
-// (10) messages, and each subsequent processMessage increments via
-// trackDispatch. So in a sustained burst, inFlightCount can transiently
-// reach `cap + RECEIVE_MAX_MESSAGES - 1` (≈9% overshoot at the default
-// cap of 100) before the next pollOnce gates. The cap is a backpressure
-// signal — "stop pulling new work" — not a precise upper bound; size
-// memory headroom assuming `cap + RECEIVE_MAX_MESSAGES` simultaneous
-// handler promises. (Strict ceiling is cap + RECEIVE_MAX_MESSAGES - 1;
-// the .env.example rounds up by 1 for headroom math.)
+// `inFlightPromises.size >= cap` BEFORE issuing a ReceiveMessage,
+// but a receive that passes the check can return up to
+// RECEIVE_MAX_MESSAGES (10) messages, and each subsequent
+// processMessage adds via trackDispatch. So in a sustained burst,
+// the set can transiently reach `cap + RECEIVE_MAX_MESSAGES - 1`
+// (≈9% overshoot at the default cap of 100) before the next pollOnce
+// gates. The cap is a backpressure signal — "stop pulling new work"
+// — not a precise upper bound; size memory headroom assuming
+// `cap + RECEIVE_MAX_MESSAGES` simultaneous handler promises.
+// (Strict ceiling is cap + RECEIVE_MAX_MESSAGES - 1; the .env.example
+// rounds up by 1 for headroom math.)
 //
 // How tracking works without coupling to handler internals: the
 // consumer sets `isWorkerDispatch = true` synchronously around the
@@ -244,22 +244,24 @@ function recordSeen(eventId) {
 // serializes "all messages in this batch were dispatched (emit +
 // DeleteMessage attempted)" against loopPromise resolution.
 //
-// What stop() does NOT await: the async handlers registered on
-// `interactionCreate` (handleCommand / handleFlowInteraction) run
-// detached after the synchronous `client.actions.InteractionCreate.handle`
-// emit. The backpressure tracker (trackDispatch / inFlightCount)
-// CAPTURES those promises for bounding-the-cap purposes but stop()
-// doesn't await them — graceful-shutdown's 10s budget would be
-// blown by a long-running DM-fan-out handler. A handler still
-// mid-DDB-write when SIGTERM lands could race gracefulShutdown's
-// eventual `db.close()` — same race the pre-existing in-process
-// gateway path has, since the gateway also emits + runs detached.
+// What stop() awaits: the poll loop (loopPromise) AND a
+// deadline-capped drain of detached handlers tracked by
+// trackDispatch. After loopPromise resolves, every processMessage's
+// emit window has completed and trackDispatch holds references to
+// every handler promise the worker dispatched. stop() then awaits
+// `Promise.allSettled([...inFlightPromises])` racing a
+// DRAIN_DEADLINE_MS (3s) timer — handlers that don't settle by
+// then race db.close() the same way they did pre-#391, but typical
+// workloads (DDB writes, REST round-trips) settle well under 3s,
+// so the drain reduces the race window meaningfully. The
+// gracefulShutdown 10s budget in index.js still bounds the total;
+// 3s for drain leaves room for db.close() and Discord teardown.
 //
-// If a tighter "drain handlers before db close" guarantee is ever
-// needed, trackDispatch would have to additionally capture each
-// promise in a Set (it currently only retains the count) so stop()
-// could `await Promise.allSettled([...inFlightPromises])` with its
-// own deadline cap (e.g. 3s). Deferred until needed.
+// What stop() still does NOT guarantee: handlers exceeding the 3s
+// drain deadline. A slow DM-fan-out batch that runs past the
+// deadline races db.close() the same way the pre-PR gateway path
+// always has (since the gateway also emits + runs detached). The
+// drain is a *probability improvement*, not a correctness change.
 //
 // receiveAbortController is set per-poll-iteration and used by stop()
 // to cancel an in-flight long-poll ReceiveMessage. Without this, a
@@ -331,17 +333,37 @@ const MAX_INFLIGHT_HANDLERS = (() => {
 // exits inside the graceful-shutdown budget.
 const INFLIGHT_BACKOFF_MS = 100;
 
-// In-flight handler count (incremented in trackDispatch when a
-// consumer-driven dispatch's promise is registered; decremented
-// when that promise settles). isWorkerDispatch is the per-emit
-// gate that distinguishes consumer-driven dispatches (which we
-// want to count) from gateway-WS-driven dispatches in combined
-// mode (which we don't — the gateway tier doesn't backpressure
-// against itself). The flag is set true synchronously around
+// Maximum time stop() waits for in-flight handler promises to
+// settle before proceeding past `await loopPromise`. Stays well
+// under gracefulShutdown's 10s budget so db.close() has room to run
+// even when the deadline fires. Handlers that haven't settled by
+// then race db.close() the same way they did pre-#391, but the
+// drain reduces the race window meaningfully for typical workloads.
+//
+// Mutable (not const) so tests can shrink the deadline to keep the
+// suite fast. _resetStateForTest restores the default; production
+// code never mutates this — only `_setDrainDeadlineForTest` does.
+const DEFAULT_DRAIN_DEADLINE_MS = 3000;
+let DRAIN_DEADLINE_MS = DEFAULT_DRAIN_DEADLINE_MS;
+
+// In-flight handler promises (added in trackDispatch when a
+// consumer-driven dispatch is registered; deleted when that
+// promise settles). isWorkerDispatch is the per-emit gate that
+// distinguishes consumer-driven dispatches (which we register)
+// from gateway-WS-driven dispatches in combined mode (which we
+// don't — the gateway tier doesn't backpressure against itself).
+// The flag is set true synchronously around
 // `client.actions.InteractionCreate.handle(data)` in processMessage
 // and cleared in the finally; the listener's emit fires inside that
 // window because EventEmitter.emit is synchronous.
-let inFlightCount = 0;
+//
+// Set rather than a bare counter: `.size` gives O(1) cap checks AND
+// the live set of references lets stop() await drain via
+// `Promise.allSettled([...inFlightPromises])`. Set.delete on a
+// non-member is a no-op, so stale .finally callbacks from
+// `_resetStateForTest` or hot-reload can't drift the size — the
+// underflow guard the previous counter shape needed is gone.
+const inFlightPromises = new Set();
 let isWorkerDispatch = false;
 
 // State-machine rate-limit on the at-cap log. Sustained at-cap
@@ -601,27 +623,17 @@ async function processMessage(client, message) {
 function trackDispatch(maybePromise) {
   if (!isWorkerDispatch) return;
   if (!maybePromise || typeof maybePromise.then !== 'function') return;
-  inFlightCount += 1;
-  // `.finally` runs before `.catch` on rejection, so the decrement
+  inFlightPromises.add(maybePromise);
+  // `.finally` runs before `.catch` on rejection, so the delete
   // always lands first — the .catch below sees the rejection AFTER
-  // the counter has dropped.
+  // the promise has been removed from the set.
   //
-  // Underflow guard: every increment is paired with exactly one
-  // decrement on the same promise, so production cannot reach
-  // inFlightCount <= 0 here. If we do, a test resolved its
-  // resolvable promise after `_resetStateForTest` cleared the count
-  // (or jest --watch hot-reloaded the module between the increment
-  // and decrement). Log loud and skip the decrement: the previous
-  // Math.max(0, ...) clamp silently absorbed this, hiding any future
-  // double-decrement regression behind a test-pollution disguise.
+  // Set.delete on a non-member is a no-op, so stale .finally
+  // callbacks (after _resetStateForTest clears the set, or a
+  // hot-reload swaps modules) silently no-op rather than drifting
+  // the size negative. No underflow guard needed.
   maybePromise.finally(() => {
-    if (inFlightCount <= 0) {
-      logger.error('Event consumer: trackDispatch decrement would underflow inFlightCount (internal invariant violation)', {
-        inFlightCount,
-      });
-      return;
-    }
-    inFlightCount -= 1;
+    inFlightPromises.delete(maybePromise);
   }).catch((err) => {
     // Attaching `.finally()` above counts as a handler for Node's
     // unhandled-rejection bookkeeping, so a rejection that pre-PR
@@ -667,12 +679,12 @@ async function pollOnce(client) {
   // logging. That's the right framing for pairing pause-start
   // (entry-snapshot at cap) with pause-end (entry-snapshot below
   // cap) in CloudWatch.
-  const capPayload = { inFlight: inFlightCount, cap: MAX_INFLIGHT_HANDLERS };
+  const capPayload = { inFlight: inFlightPromises.size, cap: MAX_INFLIGHT_HANDLERS };
   // `>=` (not `>`): the cap is the first paused value, so cap=100
   // means we pause AT 100 in-flight, not at 101. Steady-state ceiling
   // is therefore (cap - 1) + RECEIVE_MAX_MESSAGES overshoot. Off-by-
   // one is intentional and matches the .env.example math.
-  if (inFlightCount >= MAX_INFLIGHT_HANDLERS) {
+  if (inFlightPromises.size >= MAX_INFLIGHT_HANDLERS) {
     if (!atCapPauseLogged) {
       logger.warn(AT_CAP_PAUSE_WARN_MSG, capPayload);
       atCapPauseLogged = true;
@@ -946,6 +958,56 @@ async function stop() {
   logger.info('Event consumer: stopping');
   try {
     await loopPromise;
+    // After loopPromise resolves, every processMessage's
+    // synchronous-emit window has completed, so trackDispatch has
+    // captured all in-flight handler promises that the worker
+    // dispatched. Wait up to DRAIN_DEADLINE_MS for those detached
+    // handlers (DDB writes, REST calls, DM fan-out) to settle so
+    // the subsequent db.close() in gracefulShutdown doesn't race
+    // them. The deadline is non-negotiable — index.js's 10s
+    // force-exit fires regardless, so we cap our wait at 3s to
+    // leave room for db.close() and any other shutdown work.
+    //
+    // Snapshot the set into an array before allSettled: pending
+    // .finally callbacks mutate inFlightPromises during the await,
+    // and Set iteration is fine with concurrent mutation but the
+    // explicit copy makes intent obvious.
+    if (inFlightPromises.size > 0) {
+      const drainCount = inFlightPromises.size;
+      const drainStart = Date.now();
+      logger.info('Event consumer: draining in-flight handlers', {
+        count: drainCount,
+        deadlineMs: DRAIN_DEADLINE_MS,
+      });
+      let drainTimer;
+      try {
+        await Promise.race([
+          Promise.allSettled([...inFlightPromises]),
+          new Promise((resolve) => {
+            drainTimer = setTimeout(resolve, DRAIN_DEADLINE_MS);
+          }),
+        ]);
+      } finally {
+        clearTimeout(drainTimer);
+      }
+      const elapsed = Date.now() - drainStart;
+      if (inFlightPromises.size > 0) {
+        // Deadline elapsed before all handlers settled. Log at warn —
+        // the same race the pre-#391 path always had (handlers racing
+        // db.close), now bounded. Operators paging on a flood of these
+        // would tune DRAIN_DEADLINE_MS or chase the slow downstream.
+        logger.warn('Event consumer: drain deadline elapsed, proceeding with handlers still in-flight', {
+          unsettled: inFlightPromises.size,
+          settled: drainCount - inFlightPromises.size,
+          elapsedMs: elapsed,
+        });
+      } else {
+        logger.info('Event consumer: drain complete', {
+          count: drainCount,
+          elapsedMs: elapsed,
+        });
+      }
+    }
   } catch (err) {
     logger.error('Event consumer: error during stop', { error: err.message });
   } finally {
@@ -993,9 +1055,10 @@ function _resetStateForTest() {
   sqsClient = null;
   seenEventIds.clear();
   lastMissingEventIdWarnMs = 0;
-  inFlightCount = 0;
+  inFlightPromises.clear();
   isWorkerDispatch = false;
   atCapPauseLogged = false;
+  DRAIN_DEADLINE_MS = DEFAULT_DRAIN_DEADLINE_MS;
 }
 
 module.exports = {
@@ -1021,11 +1084,15 @@ module.exports = {
     SEEN_EVENT_ID_CAP,
     MAX_INFLIGHT_HANDLERS,
     INFLIGHT_BACKOFF_MS,
+    DRAIN_DEADLINE_MS,
     AT_CAP_PAUSE_WARN_MSG,
     AT_CAP_PAUSE_DEBUG_MSG,
     AT_CAP_RELEASED_INFO_MSG,
     getReceiveAbortController: () => receiveAbortController,
-    getInFlightCount: () => inFlightCount,
+    // Returns the in-flight count by reading `.size` on the live
+    // Set. Kept under the historical name for test-site stability;
+    // semantically still "how many handlers are tracked right now."
+    getInFlightCount: () => inFlightPromises.size,
     isWorkerDispatching: () => isWorkerDispatch,
     isAtCapPauseLogged: () => atCapPauseLogged,
     // Test-only setter. trackDispatch reads the module-level
@@ -1034,5 +1101,11 @@ module.exports = {
     // Tests that want to simulate the synchronous flag wrap done by
     // processMessage call this helper instead.
     _setWorkerDispatchingForTest: (v) => { isWorkerDispatch = !!v; },
+    // Test-only setter for the drain deadline. Default 3000ms is
+    // too slow for the suite to wait through on every deadline-elapsed
+    // test; tests shrink it to ~50ms so the unhappy-path assertions
+    // run quickly. `_resetStateForTest` restores the default between
+    // tests so changes don't leak.
+    _setDrainDeadlineForTest: (ms) => { DRAIN_DEADLINE_MS = ms; },
   },
 };

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -968,12 +968,9 @@ async function stop() {
     // force-exit fires regardless, so we cap our wait at 3s to
     // leave room for db.close() and any other shutdown work.
     //
-    // Explicit copy `[...inFlightPromises]` rather than passing the
-    // Set directly: Promise.allSettled materializes its input
-    // synchronously at call time, so a Set arg would behave the same.
-    // The spread is for readability — "snapshot of the set as of this
-    // moment, then await every one of those" reads more directly than
-    // letting allSettled iterate the live set.
+    // Spread for readability — passing the Set directly would behave
+    // identically (allSettled materializes synchronously) but `[...]`
+    // reads more directly as "await each of these promises."
     if (inFlightPromises.size > 0) {
       const drainCount = inFlightPromises.size;
       const drainStart = Date.now();

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -1084,7 +1084,11 @@ module.exports = {
     SEEN_EVENT_ID_CAP,
     MAX_INFLIGHT_HANDLERS,
     INFLIGHT_BACKOFF_MS,
-    DRAIN_DEADLINE_MS,
+    // DRAIN_DEADLINE_MS is mutable (so tests can shrink it), so
+    // expose as a getter — a snapshot-at-module-load export would
+    // silently read 3000 even after _setDrainDeadlineForTest(50)
+    // mutated the live value.
+    getDrainDeadlineMs: () => DRAIN_DEADLINE_MS,
     AT_CAP_PAUSE_WARN_MSG,
     AT_CAP_PAUSE_DEBUG_MSG,
     AT_CAP_RELEASED_INFO_MSG,

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -341,10 +341,42 @@ const INFLIGHT_BACKOFF_MS = 100;
 // drain reduces the race window meaningfully for typical workloads.
 //
 // Mutable (not const) so tests can shrink the deadline to keep the
-// suite fast. _resetStateForTest restores the default; production
-// code never mutates this — only `_setDrainDeadlineForTest` does.
+// suite fast. _resetStateForTest restores the env-resolved default;
+// production code never mutates this — only `_setDrainDeadlineForTest`
+// does.
+//
+// Env-overridable via QURL_BOT_DRAIN_DEADLINE_MS. Sanity-clamped to
+// [100, MAX_DRAIN_DEADLINE_MS] so a typo can't accidentally:
+//   - block stop() indefinitely (upper bound stays under
+//     gracefulShutdown's 10s budget)
+//   - drop to a value too tight to give any handler a real chance
+//     (lower bound is 100ms — anything shorter is operationally a
+//     "drain disabled" knob, which the env-unset path already
+//     provides via setting a value that just always fires).
 const DEFAULT_DRAIN_DEADLINE_MS = 3000;
-let DRAIN_DEADLINE_MS = DEFAULT_DRAIN_DEADLINE_MS;
+const MAX_DRAIN_DEADLINE_MS = 8000;
+const MIN_DRAIN_DEADLINE_MS = 100;
+let DRAIN_DEADLINE_MS = (() => {
+  const raw = process.env.QURL_BOT_DRAIN_DEADLINE_MS;
+  if (!raw) return DEFAULT_DRAIN_DEADLINE_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.warn(
+      `[event-consumer] QURL_BOT_DRAIN_DEADLINE_MS=${JSON.stringify(raw)} rejected ` +
+      `(must be a positive integer); using default ${DEFAULT_DRAIN_DEADLINE_MS}.`,
+    );
+    return DEFAULT_DRAIN_DEADLINE_MS;
+  }
+  if (parsed < MIN_DRAIN_DEADLINE_MS || parsed > MAX_DRAIN_DEADLINE_MS) {
+    console.warn(
+      `[event-consumer] QURL_BOT_DRAIN_DEADLINE_MS=${parsed} out of range ` +
+      `[${MIN_DRAIN_DEADLINE_MS}, ${MAX_DRAIN_DEADLINE_MS}]; using default ` +
+      `${DEFAULT_DRAIN_DEADLINE_MS} (upper bound preserves gracefulShutdown headroom).`,
+    );
+    return DEFAULT_DRAIN_DEADLINE_MS;
+  }
+  return parsed;
+})();
 
 // In-flight handler promises (added in trackDispatch when a
 // consumer-driven dispatch is registered; deleted when that
@@ -936,16 +968,9 @@ async function stop() {
   // both routing through gracefulShutdown) would otherwise both
   // pass !running, both abort, both await loopPromise. Harmless but
   // racy on the running=false reset; the stopping check makes the
-  // single-stopper invariant explicit.
-  //
-  // Caveat for a hypothetical second caller: the early-return DOES
-  // NOT wait for the first caller's drain to complete. A second
-  // stop() that lands during drain returns immediately. In practice
-  // gracefulShutdown only calls stop() once, so this is theoretical
-  // — but if a future refactor opens the door to concurrent stops,
-  // the second caller would need to await the first's loopPromise
-  // (or a shared "drainPromise" handle) to get "drain complete"
-  // semantics, not just "stop is already in progress."
+  // single-stopper invariant explicit. A second caller during drain
+  // returns immediately (without awaiting drain completion) —
+  // theoretical today since gracefulShutdown only calls stop() once.
   if (!running || stopping) return;
   stopping = true;
   // Cancel the in-flight long-poll so stop() returns within tens of
@@ -989,9 +1014,7 @@ async function stop() {
     // 10s force-exit fires regardless, so we cap our wait at 3s to
     // leave room for db.close() and any other shutdown work.
     //
-    // Spread for readability — passing the Set directly would behave
-    // identically (allSettled materializes synchronously) but `[...]`
-    // reads more directly as "await each of these promises."
+    // Spread is cosmetic — allSettled also accepts a Set directly.
     if (inFlightPromises.size > 0) {
       const drainCount = inFlightPromises.size;
       // hrtime.bigint() is monotonic — Date.now() is wall-clock and
@@ -1140,8 +1163,13 @@ module.exports = {
     _setDrainDeadlineForTest: (ms) => { DRAIN_DEADLINE_MS = ms; },
     // Test-only setter for `loopPromise`. Lets tests inject a
     // rejected promise to simulate a pollLoop crash without
-    // actually crashing the loop — the "drain runs even when
-    // loopPromise rejects" test uses this. `_resetStateForTest`
+    // actually crashing the loop. CAVEAT: if the test already
+    // called start(), the REAL pollLoop is still running in the
+    // background — overwriting the promise reference here doesn't
+    // halt it. Tests relying on this helper should either rely on
+    // `stopping=true` + `abort()` to retire the real loop within
+    // their assertions, or accept that `_resetStateForTest` in
+    // beforeEach is the cleanup point. `_resetStateForTest` itself
     // sets loopPromise back to null.
     _setLoopPromiseForTest: (p) => { loopPromise = p; },
   },

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -911,6 +911,118 @@ describe('event-consumer: start/stop lifecycle', () => {
   // The "abort silently exits pollLoop" test above already pins
   // that pollLoop's loop body actually runs (asserts receiveCount
   // ≥ 1), which covers the underlying concern.
+
+  // Helpers reused across the drain tests below. Local rather than
+  // module-level because they assume the start/stop lifecycle setup.
+  function withWorkerDispatchHelper(fn) {
+    eventConsumer._test._setWorkerDispatchingForTest(true);
+    try {
+      return fn();
+    } finally {
+      eventConsumer._test._setWorkerDispatchingForTest(false);
+    }
+  }
+
+  test('stop() drains in-flight handlers before resolving (settled within deadline)', async () => {
+    // Pins the drain contract: stop() should await the in-flight
+    // handler promises captured by trackDispatch before returning,
+    // so gracefulShutdown's subsequent db.close() doesn't race a
+    // handler's mid-DDB-write. Resolution is deferred to a setTimeout
+    // so the .finally microtasks haven't fired by the time stop()
+    // reaches its drain branch — the drain enters with promises
+    // still pending, awaits them via allSettled, logs "drain
+    // complete" before stop() resolves.
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    // Tight deadline so the test stays fast even if a CI host is
+    // slow — the resolution timer below fires well inside this
+    // budget, so the deadline-elapsed branch shouldn't trigger.
+    eventConsumer._test._setDrainDeadlineForTest(500);
+    const client = makeStubClient();
+    eventConsumer.start(client);
+
+    // Register two resolvable promises via trackDispatch.
+    const resolvers = [];
+    withWorkerDispatchHelper(() => {
+      for (let i = 0; i < 2; i += 1) {
+        let resolve;
+        const p = new Promise((r) => { resolve = r; });
+        resolvers.push(resolve);
+        eventConsumer.trackDispatch(p);
+      }
+    });
+    expect(eventConsumer._test.getInFlightCount()).toBe(2);
+
+    // Schedule resolution to fire DURING the drain wait. setTimeout
+    // (not a synchronous resolve) so the .finally microtasks haven't
+    // already run by the time stop()'s drain branch executes.
+    setTimeout(() => resolvers.forEach((r) => r('done')), 20);
+    await eventConsumer.stop();
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Event consumer: drain complete',
+      expect.objectContaining({ count: 2 }),
+    );
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+  });
+
+  test('stop() returns within deadline when handlers do not settle', async () => {
+    // Pins the deadline contract: stop() must NOT block indefinitely
+    // on a never-resolving handler. Shrink the deadline so the test
+    // doesn't wait the full 3s default; assert the warn log fires
+    // and stop() resolves within a margin of the deadline.
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    eventConsumer._test._setDrainDeadlineForTest(50);
+
+    const client = makeStubClient();
+    eventConsumer.start(client);
+
+    // Register a never-resolving promise so the drain hits its deadline.
+    withWorkerDispatchHelper(() => {
+      eventConsumer.trackDispatch(new Promise(() => {}));
+    });
+    expect(eventConsumer._test.getInFlightCount()).toBe(1);
+
+    const start = Date.now();
+    await eventConsumer.stop();
+    const elapsed = Date.now() - start;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Event consumer: drain deadline elapsed, proceeding with handlers still in-flight',
+      expect.objectContaining({ unsettled: 1, settled: 0 }),
+    );
+    // Stop() returned even though the handler never settled. Allow
+    // a generous upper bound for CI flakiness; the assertion is
+    // "stop didn't hang past the deadline by an order of magnitude."
+    expect(elapsed).toBeLessThan(50 * 20);
+  });
+
+  test('stop() skips drain branch when no handlers are in-flight (no spurious logs)', async () => {
+    // Pins the no-op path: an idle worker stop()s without firing the
+    // drain logs (drainCount > 0 gate). Common case in production —
+    // most stops will land between bursts when no handlers are pending.
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    const client = makeStubClient();
+    eventConsumer.start(client);
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+
+    await eventConsumer.stop();
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      'Event consumer: draining in-flight handlers',
+      expect.anything(),
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      'Event consumer: drain complete',
+      expect.anything(),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'Event consumer: drain deadline elapsed, proceeding with handlers still in-flight',
+      expect.anything(),
+    );
+  });
 });
 
 describe('event-consumer: backpressure (in-flight handler cap)', () => {
@@ -1097,34 +1209,28 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     );
   });
 
-  test('trackDispatch decrement logs loud and skips when underflow would occur', async () => {
-    // Replaces the previous silent `Math.max(0, ...)` clamp: if a
-    // promise settles after `_resetStateForTest` zeroed the count
-    // (or hot-reload swapped modules), the decrement would underflow.
-    // Production cannot reach this — every increment is paired with
-    // exactly one decrement on the same promise — so this firing
-    // means a test or external caller broke the invariant. Pin that
-    // we log the underflow at error level (so the suite surfaces the
-    // bug) and skip the decrement (so subsequent tests see 0, not -1).
+  test('trackDispatch tolerates _resetStateForTest mid-flight (Set.delete is a no-op on non-member)', async () => {
+    // PR #391 replaced the counter+underflow-guard pattern with a
+    // Set<Promise>. Set.delete on a non-member is a no-op, so a
+    // stale .finally callback firing AFTER _resetStateForTest cleared
+    // the set silently does nothing — no error log, no negative size.
+    // This pins the "set semantics absorb test pollution" property
+    // that justified removing the fail-loud underflow guard.
     let resolveHandler;
     const handlerPromise = new Promise((r) => { resolveHandler = r; });
     withWorkerDispatch(() => eventConsumer.trackDispatch(handlerPromise));
     expect(eventConsumer._test.getInFlightCount()).toBe(1);
 
-    // Simulate the test-pollution scenario: reset state (zeros the
-    // count) BEFORE the registered promise settles, then resolve.
-    // The .finally fires against the zeroed counter and trips the
-    // underflow guard.
     eventConsumer._test._resetStateForTest();
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
     resolveHandler('done');
     await flushMicrotasks();
 
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('trackDispatch decrement would underflow'),
-      expect.objectContaining({ inFlightCount: 0 }),
+    // No "underflow" log fired — the new path can't reach that branch.
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.stringContaining('underflow'),
+      expect.anything(),
     );
-    // Count stayed at 0 — the decrement was skipped, not applied.
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
   });
 

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1541,6 +1541,84 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
       });
     });
   });
+
+  describe('DRAIN_DEADLINE_MS env validation (module-load IIFE)', () => {
+    // Mirrors the MAX_INFLIGHT_HANDLERS validation block. The
+    // drain deadline is range-clamped (not just positive-integer)
+    // because a too-large value would push past gracefulShutdown's
+    // 10s budget and a too-small value would be operationally a
+    // disabled-drain knob.
+    function withIsolatedEnv(envValue, run) {
+      jest.isolateModules(() => {
+        const prev = process.env.QURL_BOT_DRAIN_DEADLINE_MS;
+        const origConsoleWarn = console.warn;
+        const warns = [];
+        console.warn = (...args) => warns.push(args.join(' '));
+        try {
+          if (envValue === undefined) {
+            delete process.env.QURL_BOT_DRAIN_DEADLINE_MS;
+          } else {
+            process.env.QURL_BOT_DRAIN_DEADLINE_MS = envValue;
+          }
+          const fresh = require('../src/event-consumer');
+          run(fresh, warns);
+        } finally {
+          console.warn = origConsoleWarn;
+          if (prev === undefined) {
+            delete process.env.QURL_BOT_DRAIN_DEADLINE_MS;
+          } else {
+            process.env.QURL_BOT_DRAIN_DEADLINE_MS = prev;
+          }
+        }
+      });
+    }
+
+    test.each([
+      ['100abc', 'trailing garbage'],
+      ['-5', 'negative integer'],
+      ['0', 'zero'],
+      ['1.5', 'non-integer'],
+      ['abc', 'non-numeric'],
+    ])('rejects %p (%s) and falls back to default', (envValue) => {
+      withIsolatedEnv(envValue, (fresh, warns) => {
+        expect(fresh._test.getDrainDeadlineMs()).toBe(3000);
+        expect(
+          warns.some((w) => w.includes('QURL_BOT_DRAIN_DEADLINE_MS') && w.includes('rejected'))
+        ).toBe(true);
+      });
+    });
+
+    test.each([
+      ['99', 'just below the floor'],
+      ['8001', 'just above the ceiling'],
+      ['50000', 'order of magnitude over'],
+    ])('clamps out-of-range %p (%s) to default', (envValue) => {
+      withIsolatedEnv(envValue, (fresh, warns) => {
+        expect(fresh._test.getDrainDeadlineMs()).toBe(3000);
+        expect(
+          warns.some((w) => w.includes('out of range'))
+        ).toBe(true);
+      });
+    });
+
+    test.each([
+      ['100', 100], // exact floor
+      ['1500', 1500],
+      ['8000', 8000], // exact ceiling
+    ])('accepts in-range %p as %i', (envValue, expected) => {
+      withIsolatedEnv(envValue, (fresh, warns) => {
+        expect(fresh._test.getDrainDeadlineMs()).toBe(expected);
+        expect(warns).toHaveLength(0);
+      });
+    });
+
+    test('unset env var resolves to default without warning', () => {
+      withIsolatedEnv(undefined, (fresh, warns) => {
+        expect(fresh._test.getDrainDeadlineMs()).toBe(3000);
+        expect(warns).toHaveLength(0);
+      });
+    });
+  });
 });
 
 describe('event-consumer: discord.js@14.25.1 internal-API smoke', () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -998,6 +998,17 @@ describe('event-consumer: start/stop lifecycle', () => {
     expect(elapsed).toBeLessThan(50 * 20);
   });
 
+  test('getDrainDeadlineMs reflects live value after _setDrainDeadlineForTest', () => {
+    // The deadline is mutable so tests can shrink it without
+    // polluting prod with a config knob. The `_test` export is a
+    // getter (not a value-snapshot) so introspection reflects the
+    // live variable — pin that contract so a future refactor back
+    // to a value-export trips this test.
+    expect(eventConsumer._test.getDrainDeadlineMs()).toBe(3000);
+    eventConsumer._test._setDrainDeadlineForTest(50);
+    expect(eventConsumer._test.getDrainDeadlineMs()).toBe(50);
+  });
+
   test('stop() skips drain branch when no handlers are in-flight (no spurious logs)', async () => {
     // Pins the no-op path: an idle worker stop()s without firing the
     // drain logs (drainCount > 0 gate). Common case in production —

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1013,6 +1013,47 @@ describe('event-consumer: start/stop lifecycle', () => {
     expect(eventConsumer._test.getDrainDeadlineMs()).toBe(50);
   });
 
+  test('stop() drains even when loopPromise rejects (loop crash does not skip drain)', async () => {
+    // Pin the round-3 cr fix: a pollLoop crash (rare — its own catch
+    // covers routine errors) used to skip the drain because the
+    // drain block was inside the same try as `await loopPromise`.
+    // Restructured so the loop-crash log and the drain are
+    // independent: the trackDispatch set's state is coherent after
+    // a loop crash (additions are synchronous around emits), so
+    // draining is meaningful regardless of loop outcome.
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    eventConsumer._test._setDrainDeadlineForTest(500);
+    const client = makeStubClient();
+    eventConsumer.start(client);
+
+    // Replace the loopPromise with one that rejects so the inner
+    // try/catch fires (simulating a pollLoop crash). The drain
+    // should still run because it's outside that inner try.
+    eventConsumer._test._setLoopPromiseForTest(Promise.reject(new Error('loop crashed')));
+
+    const resolvers = [];
+    withWorkerDispatch(() => {
+      let resolve;
+      const p = new Promise((r) => { resolve = r; });
+      resolvers.push(resolve);
+      eventConsumer.trackDispatch(p);
+    });
+    expect(eventConsumer._test.getInFlightCount()).toBe(1);
+
+    setTimeout(() => resolvers.forEach((r) => r('done')), 20);
+    await eventConsumer.stop();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event consumer: error during stop',
+      expect.objectContaining({ error: 'loop crashed' }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Event consumer: drain complete',
+      expect.objectContaining({ count: 1 }),
+    );
+  });
+
   test('stop() skips drain branch when no handlers are in-flight (no spurious logs)', async () => {
     // Pins the no-op path: an idle worker stop()s without firing the
     // drain logs (drainCount > 0 gate). Common case in production —

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -99,6 +99,21 @@ function withMockedSqs(fn) {
   return fn();
 }
 
+// Run `fn` with isWorkerDispatch flipped true (matches the
+// synchronous flag-wrap processMessage performs around handle()),
+// then restore. Used by tests that exercise trackDispatch directly
+// rather than going through processMessage. Lives at module scope
+// so both the start/stop lifecycle and backpressure describe blocks
+// share one definition.
+function withWorkerDispatch(fn) {
+  eventConsumer._test._setWorkerDispatchingForTest(true);
+  try {
+    return fn();
+  } finally {
+    eventConsumer._test._setWorkerDispatchingForTest(false);
+  }
+}
+
 describe('event-consumer: recordSeen LRU', () => {
   const { recordSeen, seenEventIds, SEEN_EVENT_ID_CAP } = eventConsumer._test;
 
@@ -912,17 +927,6 @@ describe('event-consumer: start/stop lifecycle', () => {
   // that pollLoop's loop body actually runs (asserts receiveCount
   // ≥ 1), which covers the underlying concern.
 
-  // Helpers reused across the drain tests below. Local rather than
-  // module-level because they assume the start/stop lifecycle setup.
-  function withWorkerDispatchHelper(fn) {
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
-      return fn();
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
-    }
-  }
-
   test('stop() drains in-flight handlers before resolving (settled within deadline)', async () => {
     // Pins the drain contract: stop() should await the in-flight
     // handler promises captured by trackDispatch before returning,
@@ -943,7 +947,7 @@ describe('event-consumer: start/stop lifecycle', () => {
 
     // Register two resolvable promises via trackDispatch.
     const resolvers = [];
-    withWorkerDispatchHelper(() => {
+    withWorkerDispatch(() => {
       for (let i = 0; i < 2; i += 1) {
         let resolve;
         const p = new Promise((r) => { resolve = r; });
@@ -979,7 +983,7 @@ describe('event-consumer: start/stop lifecycle', () => {
     eventConsumer.start(client);
 
     // Register a never-resolving promise so the drain hits its deadline.
-    withWorkerDispatchHelper(() => {
+    withWorkerDispatch(() => {
       eventConsumer.trackDispatch(new Promise(() => {}));
     });
     expect(eventConsumer._test.getInFlightCount()).toBe(1);
@@ -1051,19 +1055,6 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     for (let i = 0; i < n; i += 1) {
       // eslint-disable-next-line no-await-in-loop -- sequential by design
       await new Promise((r) => setImmediate(r));
-    }
-  }
-
-  // Run `fn` with isWorkerDispatch flipped true (matches the
-  // synchronous flag-wrap processMessage performs around handle()),
-  // then restore. Six tests repeat this pattern; helper keeps the
-  // setup intent visible and the flag flip impossible to miss.
-  function withWorkerDispatch(fn) {
-    eventConsumer._test._setWorkerDispatchingForTest(true);
-    try {
-      return fn();
-    } finally {
-      eventConsumer._test._setWorkerDispatchingForTest(false);
     }
   }
 


### PR DESCRIPTION
## Why

PR #389 added a backpressure cap that pauses receives when in-flight handlers exceed a limit. The DE review of that PR noted the cap could not help with graceful shutdown because \`trackDispatch\` only retained a *count*, not the promise references — \`stop()\` had nothing to await. A SIGTERM during a detached DDB write races \`gracefulShutdown\`'s \`db.close()\`, same as the pre-PR gateway path. PR #393 documented this as a known scope limitation pointing at this follow-up (#391).

This PR closes that gap.

## What

**Refactor \`inFlightCount\` → \`inFlightPromises\` (Set<Promise>).**
The cap check (\`pollOnce\`) reads \`.size\` instead of an int. trackDispatch \`Set.add\` on increment, \`Set.delete\` in \`.finally\` on decrement.

Knock-on simplification: the underflow guard from PR #393 is gone. \`Set.delete\` on a non-member is a no-op, so stale \`.finally\` callbacks (after \`_resetStateForTest\` or hot-reload) silently no-op rather than drifting size negative. The "test-scaffolding-in-production" smell the DE review flagged is structurally resolved.

**\`stop()\` new drain block.**
After \`await loopPromise\`, if \`inFlightPromises.size > 0\`:

\`\`\`js
await Promise.race([
  Promise.allSettled([...inFlightPromises]),
  new Promise((resolve) => {
    drainTimer = setTimeout(resolve, DRAIN_DEADLINE_MS);
  }),
]);
\`\`\`

Three terminal outcomes, each logged:
- All handlers settled in time → \`info\` *"drain complete"* with count + elapsedMs
- Deadline elapsed with stragglers → \`warn\` *"drain deadline elapsed, proceeding with handlers still in-flight"* with unsettled + settled + elapsedMs
- Set empty at \`stop()\` entry → no log fires (the idle-worker path; common case in production)

The \`clearTimeout\` runs in a \`finally\` so the timer doesn't keep the event loop alive past the drain.

**Deadline.**
\`DRAIN_DEADLINE_MS = 3000\` — well under \`gracefulShutdown\`'s 10s budget so \`db.close()\` has room even when the deadline fires. Mutable (not const) so tests can shrink it; production never mutates it.

## Test plan

- [x] \`npm test\` — 1881 passing (1877 → 1881, +4 net):
  - \`stop() drains in-flight handlers before resolving (settled within deadline)\` — uses \`setTimeout\` to defer resolution so the .finally microtasks haven't fired by the time the drain branch runs
  - \`stop() returns within deadline when handlers do not settle\` — never-resolving promise, 50ms deadline; assert warn log + bounded elapsed
  - \`stop() skips drain branch when no handlers are in-flight\` — pin the idle-worker path (no log noise on normal stops)
  - \`getDrainDeadlineMs reflects live value after _setDrainDeadlineForTest\` — pin the mutable-with-getter contract on the test affordance
  - The PR #393 underflow test was replaced with a "Set tolerates stale .finally" test since the underflow path is structurally unreachable now
- [x] \`eslint --max-warnings 0\` clean
- [ ] CI green
- [ ] cr review clean

## Rollback

Behavioral change: \`stop()\` now waits up to 3s longer when handlers are in-flight. If that latency causes incidents (e.g., shutdown-storm scenarios where many workers are stopping concurrently and the cumulative 3s waits exceed budget), the rollback path is either:
- Revert this PR (clean — no downstream PRs depend on the Set yet)
- Shrink \`DRAIN_DEADLINE_MS\` via a quick PR (mutable, one-line change)

The Set refactor is also reversible — \`inFlightCount\` was a thin wrapper; \`getInFlightCount()\` test helper still works (reads \`.size\`).

Deployment topology is single-process-per-worker (one task = one Node process = one consumer), so the \`gracefulShutdown\` 10s budget caps total shutdown time per worker independently — concurrent worker stops don't cumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)