### PR TITLE
feat(discord): gateway publisher + worker-tier wiring (PR 10, zero-downtime Pillar 1)

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -99,10 +99,16 @@ ENABLE_OPENNHP_FEATURES=false
 # publishes) + PROCESS_ROLE=http (consumes, can scale horizontally). For
 # local dev / sandbox in one process, leave ENABLE_EVENT_SHIPPER unset.
 #
-# Rollback cliff: rolling back from the split shape requires switching
-# both task definitions to PROCESS_ROLE=combined + ENABLE_EVENT_SHIPPER
-# unset (or `git revert` + emergency redeploy). See
-# apps/discord/docs/zero-downtime-design.md for the full cutover sequence.
+# Rollback cliff: while PR 10's gated phase is in effect, flipping
+# `ENABLE_EVENT_SHIPPER=false` on the split task definitions reverts
+# to the legacy in-process gateway dispatch path — a clean flag-flip
+# rollback. After the follow-up cleanup PR removes the
+# `if (config.ENABLE_EVENT_SHIPPER)` raw-hook gate in src/index.js
+# and makes the producer unconditional, the flag-flip rollback is
+# gone and the only remaining path is `git revert` + emergency
+# redeploy. The cleanup PR will explicitly document the soak window
+# before that point. See apps/discord/docs/zero-downtime-design.md
+# (Rollback section) for the full cutover sequence.
 # ENABLE_EVENT_SHIPPER=false
 # QURL_BOT_EVENTS_QUEUE_URL=https://sqs.us-east-2.amazonaws.com/000000000000/qurl-bot-events-sandbox
 

--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -80,20 +80,29 @@ ENABLE_OPENNHP_FEATURES=false
 # DDB_TABLE_PREFIX=qurl-bot-discord-sandbox
 
 # Event shipper (zero-downtime design, Pillar 1). When ENABLE_EVENT_SHIPPER
-# is set to the literal string "true", the gateway tier forwards every
-# Discord dispatch to SQS instead of running handlers in-process, and the
-# worker tier (PROCESS_ROLE=http or combined) polls SQS and dispatches via
-# the same handler path. When unset or any other value, the bot runs the
-# legacy in-process shape.
+# is set to the literal string "true", the gateway tier (PROCESS_ROLE=gateway)
+# forwards every Discord INTERACTION_CREATE dispatch to SQS via a raw-frame
+# listener, and the worker tier (PROCESS_ROLE=http) polls SQS and dispatches
+# via client.actions.InteractionCreate.handle — same routing as a real
+# gateway-WS-driven interaction. When unset or any other value, the bot
+# runs the legacy in-process shape (gateway WS frame → local listener).
 #
 # QURL_BOT_EVENTS_QUEUE_URL is the SQS Standard queue provisioned by the
 # qurl-integrations-infra `qurl-bot-events` module. Required when
 # ENABLE_EVENT_SHIPPER=true; the boot check refuses to start without it.
 #
-# Rollback cliff: ENABLE_EVENT_SHIPPER is valid only through the gateway
-# strip-down (PR 10). The follow-up that removes the in-process fallback
-# also removes this flag; after that, rollback is `git revert` + emergency
-# redeploy. See apps/discord/docs/zero-downtime-design.md for details.
+# Unsupported combination: PROCESS_ROLE=combined + ENABLE_EVENT_SHIPPER=true
+# is REJECTED at boot. In combined mode both the gateway publish hook
+# AND the worker consumer would arm in one process, dispatching every
+# interaction twice (in-process WS frame + SQS round-trip). The supported
+# flag-on shape is the two-process split: PROCESS_ROLE=gateway (singleton,
+# publishes) + PROCESS_ROLE=http (consumes, can scale horizontally). For
+# local dev / sandbox in one process, leave ENABLE_EVENT_SHIPPER unset.
+#
+# Rollback cliff: rolling back from the split shape requires switching
+# both task definitions to PROCESS_ROLE=combined + ENABLE_EVENT_SHIPPER
+# unset (or `git revert` + emergency redeploy). See
+# apps/discord/docs/zero-downtime-design.md for the full cutover sequence.
 # ENABLE_EVENT_SHIPPER=false
 # QURL_BOT_EVENTS_QUEUE_URL=https://sqs.us-east-2.amazonaws.com/000000000000/qurl-bot-events-sandbox
 
@@ -116,17 +125,25 @@ ENABLE_OPENNHP_FEATURES=false
 # simultaneous handler promises regardless.
 # QURL_BOT_MAX_INFLIGHT_HANDLERS=100
 
-# Maximum time (ms) stop() waits for in-flight handler promises to
-# settle during graceful shutdown before proceeding to db.close().
-# Default 3000. Range [100, 8000] — clamped so a typo can't block
-# stop() past gracefulShutdown's 10s budget. Out-of-range values
-# fall back to the default with a console warning.
+# Maximum time (ms) stop() waits for in-flight work to settle during
+# graceful shutdown before proceeding to db.close(). Default 3000.
+# Range [100, 8000] — clamped so a typo can't block stop() past
+# gracefulShutdown's 10s budget. Out-of-range values fall back to
+# the default with a console warning.
 #
-# Tune up if prod soak surfaces handlers consistently exceeding 3s
-# (DDB latency spikes, slow REST round-trips) and you'd rather wait
-# than race db.close(). Tune down if shutdown latency matters more
-# than completing in-flight work. Captured at module load; redeploy
-# to retune.
+# Applies to both:
+#   - event-consumer: in-flight handler promises (worker tier)
+#   - event-publisher: in-flight SendMessage promises (gateway tier)
+# A single knob both reads because both share the gracefulShutdown
+# budget; splitting would let one side cannibalize the other's
+# headroom. In the split shape (combined + flag-on rejected), only
+# one of them is actually draining per process.
+#
+# Tune up if prod soak surfaces work consistently exceeding 3s (DDB
+# latency spikes, slow REST round-trips, SQS endpoint hangs) and
+# you'd rather wait than race db.close(). Tune down if shutdown
+# latency matters more than completing in-flight work. Captured at
+# module load; redeploy to retune.
 # QURL_BOT_DRAIN_DEADLINE_MS=3000
 
 # GitHub OAuth App — REQUIRED only when ENABLE_OPENNHP_FEATURES=true.

--- a/apps/discord/docs/zero-downtime-design.md
+++ b/apps/discord/docs/zero-downtime-design.md
@@ -659,22 +659,35 @@ Each phase has an independent rollback path:
 | Phase | Rollback |
 |---|---|
 | Flow state | Revert command-file PRs. DDB flow rows expire on their TTL. |
-| Event shipper | App-side feature flag `ENABLE_EVENT_SHIPPER=false` falls back to in-process dispatch on the gateway role. **Valid only through PR 10** — see cliff note below. |
+| Event shipper | App-side feature flag `ENABLE_EVENT_SHIPPER=false` falls back to in-process dispatch on the gateway role. **Valid through the gated phase** — see cliff note below. |
 | Cross-process RESUME | App-side feature flag `ENABLE_GATEWAY_RESUME=false` falls back to in-memory session state (Discord IDENTIFY-only every boot). |
 | Hot-standby | Set `gateway_desired_count = 1` in tfvars. The standby-discovery path sees no peer and the active becomes a single-replica gateway. |
 
-**Rollback cliff: `ENABLE_EVENT_SHIPPER`.** The flag-based rollback works
-only while PR 10 (gateway strip-down) is gated — i.e., the gateway role
-still has in-process command handlers wired to fall back to. The moment
-PR 10 lands without the flag (the dual-path scaffolding is removed),
-flipping `ENABLE_EVENT_SHIPPER=false` has nothing to fall back to and
-the gateway boots into a partially-wired state. After that point,
-rollback is `git revert` on PR 10 + emergency redeploy, not a flag flip.
-The cliff is a deliberate trade-off: keeping the dual-path scaffolding
-forever bloats the gateway image and obscures whose code path is live.
-PR 10's description must explicitly call out the soak window before
-removing the flag (recommendation: 1 week of clean prod traffic on the
-event-shipper path before deleting the in-process fallback).
+**Rollback cliff: `ENABLE_EVENT_SHIPPER`.** PR 10 ships the producer +
+worker-side dispatch path under the `ENABLE_EVENT_SHIPPER` flag,
+keeping the legacy in-process gateway dispatch as fall-back. While
+both code paths coexist, `ENABLE_EVENT_SHIPPER=false` is a valid
+flag-flip rollback. A later cleanup PR will delete the legacy
+in-process gateway listener gate `(isGateway && !config.ENABLE_EVENT_SHIPPER)`
+and make the producer unconditional. After that cleanup lands,
+flipping the flag false has nothing to fall back to and rollback is
+`git revert` + emergency redeploy. The cliff is a deliberate trade-off:
+keeping the dual-path scaffolding forever bloats the gateway image
+and obscures whose code path is live. The cleanup PR's description
+must explicitly call out the soak window before removing the flag
+(recommendation: 1 week of clean prod traffic on the event-shipper
+path before deleting the in-process fallback).
+
+**Unsupported combination:** `PROCESS_ROLE=combined` paired with
+`ENABLE_EVENT_SHIPPER=true` is rejected at boot
+(`unsupportedRoleShipperCombo` in `src/boot-requirements.js`). In
+combined mode the gateway publish hook AND the worker consumer
+would arm in one process, double-dispatching every interaction
+(in-process WS frame + SQS round-trip). The supported flag-on
+shape is the two-process split: `PROCESS_ROLE=gateway` (singleton,
+publishes) + `PROCESS_ROLE=http` (consumes, can scale horizontally).
+For local dev / sandbox in one process, leave `ENABLE_EVENT_SHIPPER`
+unset.
 
 ## SLI / SLO definitions
 

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -84,6 +84,44 @@ function missingEventShipperKeys(cfg) {
   return cfg.QURL_BOT_EVENTS_QUEUE_URL ? [] : ['QURL_BOT_EVENTS_QUEUE_URL'];
 }
 
+// PROCESS_ROLE=combined paired with ENABLE_EVENT_SHIPPER=true is
+// unsupported and rejected at boot. In combined mode both `isGateway`
+// and `isHttp` evaluate true, which derives `isWorker=true`, which
+// would arm both the gateway-side publish hook AND the worker-side
+// consumer in one process. Every interaction would land twice: once
+// via the in-process gateway WS frame, once via the SQS round-trip.
+// Side effects (DM fan-out, flow-state writes) double; telemetry
+// reports two dispatches per real interaction. The listener gate
+// alone can't close this — discord.js's InteractionCreate action
+// fires synchronously on the gateway WS frame regardless of whether
+// the local listener is registered, so even gating the worker-side
+// dispatcher leaves the gateway publish path firing alongside the
+// consumer.
+//
+// The supported flag-on shape is the two-process split: a separate
+// PROCESS_ROLE=gateway (singleton) publishing to SQS, and one or
+// more PROCESS_ROLE=http replicas consuming. Combined mode stays
+// supported for sandbox / local-dev / pre-split deployments —
+// just with the flag off, running the legacy in-process path.
+//
+// Returns the operator-facing message on rejection or null on
+// success. Kept as a string-or-null rather than throwing so the
+// caller in index.js logs the message + exits via the same pattern
+// as missingBootKeys (one log + process.exit) rather than handling
+// a thrown error specially.
+function unsupportedRoleShipperCombo(role, eventShipperEnabled) {
+  if (role === 'combined' && eventShipperEnabled) {
+    return (
+      'PROCESS_ROLE=combined with ENABLE_EVENT_SHIPPER=true is not supported ' +
+      '(would dispatch every interaction twice — once via the in-process gateway ' +
+      'WS frame, once via the SQS round-trip). Run two processes: ' +
+      'PROCESS_ROLE=gateway (singleton, publishes) + PROCESS_ROLE=http (consumes). ' +
+      'For local dev / sandbox in one process, leave ENABLE_EVENT_SHIPPER unset.'
+    );
+  }
+  return null;
+}
+
 // Process-role parsing for the gateway/HTTP split. Lifted out of
 // index.js so the invalid-value path is testable without spawning a
 // child process — same shape as missingBootKeys above. See
@@ -119,6 +157,38 @@ function resolveProcessRole(rawValue) {
   };
 }
 
+// Whether the local `interactionCreate` listener should be registered
+// in this process. Lifted out of index.js so the gate logic is pure +
+// unit-testable across every role × flag permutation (combined + flag-on
+// is unreachable here — `unsupportedRoleShipperCombo` rejects it at
+// boot — but the predicate must remain coherent for any caller that
+// somehow reaches it post-bypass, so it's defined for all inputs).
+//
+// Three intended shapes:
+//   - Gateway tier + flag-off  → register (legacy in-process dispatch)
+//   - Gateway tier + flag-on   → DO NOT register (publishes to SQS;
+//                                local listener would dispatch the
+//                                same payload a second time after the
+//                                worker tier's consumer re-emits)
+//   - Worker tier (HTTP + flag-on) → register (SQS consumer
+//                                reconstructs the interaction and
+//                                re-emits locally; the listener
+//                                routes via handleCommand /
+//                                handleFlowInteraction)
+//   - HTTP-only + flag-off     → DO NOT register (no gateway WS,
+//                                no SQS consumer, so the listener
+//                                would never fire and registering it
+//                                would just leak handler references)
+//
+// The predicate `(isGateway && !flag) || (isHttp && flag)` collapses
+// these four cases. Combined mode (isGateway=true, isHttp=true) with
+// flag-off reduces to the first disjunct (register); with flag-on it
+// would reduce to "register" via BOTH disjuncts (the false-positive
+// the boot rejection guards against — see unsupportedRoleShipperCombo).
+function shouldRegisterInteractionListener({ isGateway, isHttp, eventShipperEnabled }) {
+  return (isGateway && !eventShipperEnabled) || (isHttp && eventShipperEnabled);
+}
+
 module.exports = {
   bootRequired,
   prodRequired,
@@ -126,6 +196,8 @@ module.exports = {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  unsupportedRoleShipperCombo,
+  shouldRegisterInteractionListener,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 };

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -41,7 +41,6 @@ function intEnv(key, defaultVal, opts = {}) {
     const rangeLabel = min !== undefined && max !== undefined
       ? `[${min}, ${max}]`
       : min !== undefined ? `>= ${min}` : `<= ${max}`;
-  // (intEnv's range warn fires only on out-of-range hits.)
     console.warn(`[config] ${key}=${v} out of range ${rangeLabel}; using default ${defaultVal}`);
     return defaultVal;
   }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -1,14 +1,48 @@
 const path = require('path');
 
-// Safe int parser: handles NaN and falsy-zero correctly. If minPositive
-// is set (the common case for cooldowns + caps), reject non-positive
-// values — an env of "0" would otherwise silently disable a cooldown or
-// block every send.
-function intEnv(key, defaultVal, { minPositive = false } = {}) {
-  const v = parseInt(process.env[key], 10);
-  if (isNaN(v)) return defaultVal;
+// Safe int parser: handles NaN and falsy-zero correctly.
+//
+// Options:
+//   minPositive: reject values <= 0 (common case for cooldowns + caps —
+//     an env of "0" would otherwise silently disable a cooldown).
+//   strictInteger: reject non-integer or trailing-garbage values like
+//     "100abc". Use Number() + Number.isInteger() instead of parseInt's
+//     lenient parse. Pair with minPositive for "must be a positive
+//     integer" semantics. Required when the value's range is bounded
+//     and a typo would silently truncate to a different valid value.
+//   min, max: inclusive range. Out-of-range values warn + fall back
+//     to the default (NOT clamp — clamping would silently mask a typo
+//     past the boundary). When both are set, the warn quotes the
+//     range so an operator can fix the env without diffing the source.
+//
+// Returns defaultVal on any rejection, with a console.warn for every
+// rejected path (visible at boot regardless of LOG_LEVEL or logger
+// transport state — logger isn't loaded this early in config import).
+function intEnv(key, defaultVal, opts = {}) {
+  const { minPositive = false, strictInteger = false, min, max } = opts;
+  const raw = process.env[key];
+  if (raw === undefined || raw === '') return defaultVal;
+  let v;
+  if (strictInteger) {
+    v = Number(raw);
+    if (!Number.isInteger(v)) {
+      console.warn(`[config] ${key}=${JSON.stringify(raw)} rejected (must be an integer); using default ${defaultVal}`);
+      return defaultVal;
+    }
+  } else {
+    v = parseInt(raw, 10);
+    if (isNaN(v)) return defaultVal;
+  }
   if (minPositive && v <= 0) {
     console.warn(`[config] ${key}=${v} rejected (must be > 0); using default ${defaultVal}`);
+    return defaultVal;
+  }
+  if ((min !== undefined && v < min) || (max !== undefined && v > max)) {
+    const rangeLabel = min !== undefined && max !== undefined
+      ? `[${min}, ${max}]`
+      : min !== undefined ? `>= ${min}` : `<= ${max}`;
+  // (intEnv's range warn fires only on out-of-range hits.)
+    console.warn(`[config] ${key}=${v} out of range ${rangeLabel}; using default ${defaultVal}`);
     return defaultVal;
   }
   return v;
@@ -333,4 +367,27 @@ module.exports = {
   // silently no-op'ing the consumer or dropping every dispatch on
   // the producer side.
   QURL_BOT_EVENTS_QUEUE_URL: process.env.QURL_BOT_EVENTS_QUEUE_URL,
+
+  // Backpressure cap for the event consumer's in-flight handler
+  // tracker (see src/event-consumer.js module header). Read here
+  // instead of in event-consumer.js so the value goes through the
+  // single intEnv validation path — strictInteger rejects trailing
+  // garbage like "100abc" the same way as the prior IIFE.
+  QURL_BOT_MAX_INFLIGHT_HANDLERS: intEnv('QURL_BOT_MAX_INFLIGHT_HANDLERS', 100, {
+    minPositive: true,
+    strictInteger: true,
+  }),
+
+  // Graceful-shutdown drain deadline (ms). Consumed by both
+  // event-consumer.js and event-publisher.js — see each module's
+  // stop() comment for the contract. Range bound is the upper limit
+  // of gracefulShutdown's 10s budget minus headroom for db.close()
+  // + Discord teardown. Values outside [100, 8000] fall back to the
+  // default with a warn — clamping would silently mask a typo past
+  // the boundary.
+  QURL_BOT_DRAIN_DEADLINE_MS: intEnv('QURL_BOT_DRAIN_DEADLINE_MS', 3000, {
+    strictInteger: true,
+    min: 100,
+    max: 8000,
+  }),
 };

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -414,6 +414,41 @@ const AUDIT_EVENTS = {
 // only one whose mutation is undetectable by tests.
 Object.freeze(AUDIT_EVENTS);
 
+// Discord gateway dispatch event names (the `t` field on op=0 frames).
+// Today only INTERACTION_CREATE is published to the worker tier;
+// MESSAGE_CREATE etc. are reserved for future event-class expansion.
+// Centralized here so the publisher (event-publisher.js, filters on
+// publish) and the consumer (event-consumer.js, validates the
+// envelope's eventType) can't drift — Discord's wire-protocol string
+// is the only value either side ever uses, and a typo on one side
+// would silently drop every dispatch.
+//
+// Frozen for the same reason AUDIT_EVENTS is: a runtime mutation
+// would leave the literal string in transit unaffected but break
+// the other tier's check.
+const GATEWAY_DISPATCH_TYPES = Object.freeze({
+  INTERACTION_CREATE: 'INTERACTION_CREATE',
+});
+
+// Structured-log `kind` tags used to correlate failures across the
+// async-boundary trio: the gateway-WS-driven unhandledRejection
+// handler in index.js, the worker-tier dispatch handler rejection
+// path in event-consumer.js (trackDispatch's .catch), and the
+// publish-failure path in event-publisher.js. All three emit the
+// same `kind: 'unhandledRejection'` tag so a single CloudWatch
+// query — filtering on the structured field — finds every site
+// without grepping message text or maintaining per-site filter
+// rules. Centralizing the literal here makes the contract
+// explicit and lets a future tag addition (LOG_KIND_AUDIT, etc.)
+// follow the same pattern.
+//
+// Frozen — see AUDIT_EVENTS for the rationale. A mutation here
+// would silently make one site stop matching the CloudWatch
+// alarm filter the other two sites still emit.
+const LOG_KINDS = Object.freeze({
+  UNHANDLED_REJECTION: 'unhandledRejection',
+});
+
 module.exports = {
   COLORS,
   RESOURCE_TYPES,
@@ -427,4 +462,6 @@ module.exports = {
   GOOD_FIRST_ISSUE_PATTERNS,
   AUDIT_EVENTS,
   TRUST,
+  GATEWAY_DISPATCH_TYPES,
+  LOG_KINDS,
 };

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -554,7 +554,14 @@ async function processMessage(client, message) {
   // observability, not correctness.
   if (typeof publishedAtMs === 'number' && Number.isFinite(publishedAtMs)) {
     const e2eMs = Date.now() - publishedAtMs;
-    logger.info('Event consumer: dispatched', {
+    // Log fires AT RECEIVE TIME, not after dispatch — see the
+    // `client.actions.InteractionCreate.handle(data)` call further
+    // down (around the FLAG-WRAP-START sentinel). The metric is
+    // gateway-host wall-clock-publish → worker-host wall-clock-receive,
+    // i.e., a receive-latency SLI. Don't rename to 'dispatched' /
+    // 'handled' — those framings imply the handler ran, which we
+    // can't yet attest from this code path.
+    logger.info('Event consumer: received', {
       qurl_bot_event_e2e_ms: e2eMs,
       eventId,
       shardId: parsed.shardId,

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -27,15 +27,22 @@
 // against the methods our handlers depend on (deferReply, editReply,
 // options.getString, customId, isChatInputCommand, etc.).
 //
-// Envelope contract — PR 10's producer must publish JSON in this
-// shape (string body, single message attribute optional):
+// Envelope contract — src/event-publisher.js publishes JSON in this
+// shape:
 //
 //   {
-//     "eventType": "INTERACTION_CREATE",  // only type today
-//     "shardId":   "0:1",                  // for future sharding LRU keys
-//     "data":      { ...raw Discord INTERACTION_CREATE `d` payload... },
-//     "event_id":  "0:1234567"             // <shardId>:<sequence>, dedup hint
+//     "eventType":        "INTERACTION_CREATE", // only type today
+//     "shardId":          "0",                   // shard index; reserves k:n for sharding PR
+//     "data":             { ...raw Discord INTERACTION_CREATE `d` payload... },
+//     "event_id":         "0:1234567",           // <shardId>:<sequence>, dedup hint
+//     "published_at_ms":  1739462812345          // Date.now() at envelope build
 //   }
+//
+// `published_at_ms` is wall clock on the gateway host; e2e latency
+// is `Date.now() - published_at_ms` on the worker host, so NTP
+// drift between the two is the noise floor (bounded by the fleet
+// clock-skew SLO — tens of ms in practice on ECS Fargate). hrtime
+// would be process-local and meaningless cross-process.
 //
 // At-least-once delivery: SQS Standard guarantees at-least-once, so
 // the consumer is idempotency-tolerant. For interactions specifically:
@@ -129,6 +136,7 @@
 const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require('@aws-sdk/client-sqs');
 const config = require('./config');
 const logger = require('./logger');
+const { GATEWAY_DISPATCH_TYPES, LOG_KINDS } = require('./constants');
 
 // AWS_REGION is required (matches src/flow-state.js + src/store/ddb-store.js
 // patterns — no `|| 'us-east-2'` fallback because a missing AWS_REGION
@@ -284,47 +292,39 @@ let sqsClient = null;
 // handler completes). Operator can override via env when prod
 // volume + slowness data is in hand.
 //
-// Captured at module load, not re-read per-poll: operators retuning
-// QURL_BOT_MAX_INFLIGHT_HANDLERS via SSM/task-def must redeploy for
-// the new value to take effect. Per-poll re-read would let a typo
-// in the env-update path silently change behavior without an audit
-// trail in the deploy log.
-const DEFAULT_MAX_INFLIGHT_HANDLERS = 100;
-const MAX_INFLIGHT_HANDLERS = (() => {
-  const raw = process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
-  if (!raw) return DEFAULT_MAX_INFLIGHT_HANDLERS;
-  // Use Number() + Number.isInteger() rather than parseInt — parseInt
-  // is lenient ('100abc' → 100), and the .env.example promises "must
-  // be a positive integer." Trailing garbage in the env value is more
-  // likely a templating typo than intent; rejecting it surfaces the
-  // bug at boot instead of silently truncating.
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    // Intentional console.warn (not logger.warn) for boot-time
-    // visibility before any logger transports attach to a structured
-    // sink. A misconfigured env-var should be obvious on container
-    // stdout regardless of LOG_LEVEL or transport state.
+// Captured at module load via config.QURL_BOT_MAX_INFLIGHT_HANDLERS
+// (which routes through config.intEnv for shared rejection +
+// fallback semantics — strict integer, must be positive). Per-poll
+// re-read would let a typo in the env-update path silently change
+// behavior without an audit trail in the deploy log.
+const MAX_INFLIGHT_HANDLERS = config.QURL_BOT_MAX_INFLIGHT_HANDLERS;
+
+// Defense-in-depth: values below RECEIVE_MAX_MESSAGES produce
+// degenerate overshoot ratios (cap=1 can transiently reach 10
+// in-flight, 10x the configured value). Accept the value — an
+// operator who wants cap=1 to rate-limit hard may have a reason —
+// but warn so the booted ceiling matches their mental model.
+//
+// Extracted as a function so the warning emission is unit-testable
+// without re-requiring the whole module under a doMock'd config.
+// Called at module-load below with the boot-time cap; tests can
+// call it directly with any cap value via `_test.validateInflightCap`.
+//
+// Intentional console.warn (not logger.warn) for boot-time
+// visibility before any logger transports attach to a structured
+// sink. A misconfigured env-var should be obvious on container
+// stdout regardless of LOG_LEVEL or transport state.
+function validateInflightCap(cap) {
+  if (cap < RECEIVE_MAX_MESSAGES) {
     console.warn(
-      `[event-consumer] QURL_BOT_MAX_INFLIGHT_HANDLERS=${JSON.stringify(raw)} rejected ` +
-      `(must be a positive integer); using default ${DEFAULT_MAX_INFLIGHT_HANDLERS}.`,
-    );
-    return DEFAULT_MAX_INFLIGHT_HANDLERS;
-  }
-  // Defense-in-depth: values below RECEIVE_MAX_MESSAGES produce
-  // degenerate overshoot ratios (cap=1 can transiently reach 10
-  // in-flight, 10x the configured value). Accept the value — an
-  // operator who wants cap=1 to rate-limit hard may have a reason —
-  // but warn so the booted ceiling matches their mental model.
-  if (parsed < RECEIVE_MAX_MESSAGES) {
-    console.warn(
-      `[event-consumer] QURL_BOT_MAX_INFLIGHT_HANDLERS=${parsed} is below ` +
+      `[event-consumer] QURL_BOT_MAX_INFLIGHT_HANDLERS=${cap} is below ` +
       `RECEIVE_MAX_MESSAGES (${RECEIVE_MAX_MESSAGES}); effective in-flight ceiling ` +
-      `is ${parsed + RECEIVE_MAX_MESSAGES - 1} due to batch overshoot. ` +
+      `is ${cap + RECEIVE_MAX_MESSAGES - 1} due to batch overshoot. ` +
       `Pick ${RECEIVE_MAX_MESSAGES}+ for the overshoot ratio to match the cap value.`,
     );
   }
-  return parsed;
-})();
+}
+validateInflightCap(MAX_INFLIGHT_HANDLERS);
 
 // Brief pause when at-cap. Short enough that handlers draining
 // quickly resume normal polling; long enough that we don't burn
@@ -340,43 +340,18 @@ const INFLIGHT_BACKOFF_MS = 100;
 // then race db.close() the same way they did pre-#391, but the
 // drain reduces the race window meaningfully for typical workloads.
 //
-// Mutable (not const) so tests can shrink the deadline to keep the
-// suite fast. _resetStateForTest restores the env-resolved default;
-// production code never mutates this — only `_setDrainDeadlineForTest`
-// does.
+// Resolved via config.QURL_BOT_DRAIN_DEADLINE_MS (which routes
+// through config.intEnv's strict-integer + range checks; see the
+// config-side comment for the [100, 8000] envelope).
 //
-// Env-overridable via QURL_BOT_DRAIN_DEADLINE_MS. Sanity-clamped to
-// [100, MAX_DRAIN_DEADLINE_MS] so a typo can't accidentally:
-//   - block stop() indefinitely (upper bound stays under
-//     gracefulShutdown's 10s budget)
-//   - drop to a value too tight to give any handler a real chance
-//     (lower bound is 100ms — anything shorter is operationally a
-//     "drain disabled" knob, which the env-unset path already
-//     provides via setting a value that just always fires).
-const DEFAULT_DRAIN_DEADLINE_MS = 3000;
-const MAX_DRAIN_DEADLINE_MS = 8000;
-const MIN_DRAIN_DEADLINE_MS = 100;
-let DRAIN_DEADLINE_MS = (() => {
-  const raw = process.env.QURL_BOT_DRAIN_DEADLINE_MS;
-  if (!raw) return DEFAULT_DRAIN_DEADLINE_MS;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    console.warn(
-      `[event-consumer] QURL_BOT_DRAIN_DEADLINE_MS=${JSON.stringify(raw)} rejected ` +
-      `(must be a positive integer); using default ${DEFAULT_DRAIN_DEADLINE_MS}.`,
-    );
-    return DEFAULT_DRAIN_DEADLINE_MS;
-  }
-  if (parsed < MIN_DRAIN_DEADLINE_MS || parsed > MAX_DRAIN_DEADLINE_MS) {
-    console.warn(
-      `[event-consumer] QURL_BOT_DRAIN_DEADLINE_MS=${parsed} out of range ` +
-      `[${MIN_DRAIN_DEADLINE_MS}, ${MAX_DRAIN_DEADLINE_MS}]; using default ` +
-      `${DEFAULT_DRAIN_DEADLINE_MS} (upper bound preserves gracefulShutdown headroom).`,
-    );
-    return DEFAULT_DRAIN_DEADLINE_MS;
-  }
-  return parsed;
-})();
+// Mutable (not const) so tests can shrink the deadline to keep the
+// suite fast. INITIAL captures the boot-time value so
+// `_resetStateForTest` restores the config-resolved baseline rather
+// than a hardcoded 3000 — important when CI runs with an env-override.
+// Production code never mutates DRAIN_DEADLINE_MS — only
+// `_setDrainDeadlineForTest` does.
+const INITIAL_DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
+let DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 
 // In-flight handler promises (added in trackDispatch when a
 // consumer-driven dispatch is registered; deleted when that
@@ -527,9 +502,9 @@ async function processMessage(client, message) {
     return;
   }
 
-  const { eventType, data, event_id: eventId } = parsed;
+  const { eventType, data, event_id: eventId, published_at_ms: publishedAtMs } = parsed;
 
-  if (eventType !== 'INTERACTION_CREATE') {
+  if (eventType !== GATEWAY_DISPATCH_TYPES.INTERACTION_CREATE) {
     // Single-event-type today; PR 12+ may add MESSAGE_CREATE,
     // GUILD_CREATE, etc. An unknown type from a future producer
     // shouldn't block the queue — log + delete + move on.
@@ -566,6 +541,30 @@ async function processMessage(client, message) {
     }
   }
   const isDup = recordSeen(eventId);
+
+  // End-to-end latency: gateway-host wall clock at envelope build
+  // → worker-host wall clock at receive. Cross-host comparison, so
+  // NTP drift between gateway and worker is the noise floor (bounded
+  // by the fleet's ECS Fargate clock-skew SLO, ~tens of ms). The
+  // structured `qurl_bot_event_e2e_ms` field is the metric handle —
+  // log-based metrics / CloudWatch alarms pivot on it without
+  // grepping the message text. Skip when the producer didn't supply
+  // `published_at_ms` (older envelopes, malformed publisher) — a
+  // missing field is debug, not warn, because the e2e signal is
+  // observability, not correctness.
+  if (typeof publishedAtMs === 'number' && Number.isFinite(publishedAtMs)) {
+    const e2eMs = Date.now() - publishedAtMs;
+    logger.info('Event consumer: dispatched', {
+      qurl_bot_event_e2e_ms: e2eMs,
+      eventId,
+      shardId: parsed.shardId,
+    });
+  } else {
+    logger.debug('Event consumer: envelope missing published_at_ms; e2e latency not measured', {
+      eventId,
+      publishedAtMsType: typeof publishedAtMs,
+    });
+  }
 
   // Reconstruct + emit via discord.js's internal dispatch path.
   // client.actions.InteractionCreate.handle is the same function the
@@ -684,7 +683,7 @@ function trackDispatch(maybePromise) {
     // `err?.message || String(err)` fallback mirrors the gateway
     // handler's shape for non-Error rejections.
     logger.error('Event consumer: dispatch handler rejected', {
-      kind: 'unhandledRejection',
+      kind: LOG_KINDS.UNHANDLED_REJECTION,
       error: err?.message || String(err),
       stack: err?.stack,
     });
@@ -1108,7 +1107,7 @@ function _resetStateForTest() {
   inFlightPromises.clear();
   isWorkerDispatch = false;
   atCapPauseLogged = false;
-  DRAIN_DEADLINE_MS = DEFAULT_DRAIN_DEADLINE_MS;
+  DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 }
 
 module.exports = {
@@ -1133,6 +1132,7 @@ module.exports = {
     abortableSleep,
     SEEN_EVENT_ID_CAP,
     MAX_INFLIGHT_HANDLERS,
+    validateInflightCap,
     INFLIGHT_BACKOFF_MS,
     // DRAIN_DEADLINE_MS is mutable (so tests can shrink it), so
     // expose as a getter — a snapshot-at-module-load export would

--- a/apps/discord/src/event-publisher.js
+++ b/apps/discord/src/event-publisher.js
@@ -1,0 +1,340 @@
+// SQS-driven event publisher for the gateway tier (zero-downtime
+// design, Pillar 1). Wired as a `client.on('raw', publish)` listener
+// in src/index.js; every Discord dispatch lands here. The handler
+// filters to `INTERACTION_CREATE` (the only event type the worker
+// tier handles today — see event-consumer.js's `unhandled
+// eventType` branch) and forwards the raw payload to SQS as the
+// canonical envelope, then the worker tier polls the queue and
+// dispatches via `client.actions.InteractionCreate.handle(data)` —
+// same dispatcher path as a gateway-WS-driven interaction.
+//
+// Pairs with src/event-consumer.js. The envelope contract is owned
+// by event-consumer's module header; this module's job is to
+// MIRROR it. Any field added on the consumer side (validation,
+// signing, new event types) must be added here in lockstep or the
+// consumer's deletion-on-missing-field path will silently drain
+// every message.
+//
+// Process-singleton: every piece of state — `running`, the
+// in-flight Promise Set, the SQS client — lives in module-level
+// scope. There is at most one publisher per process by design.
+// A future caller that tries to `start()` twice in one process
+// hits the second-start warn and the duplicate state takes no
+// effect. If multi-publisher is ever needed (parallel shards in
+// the same process), promote the state to instance/closure shape.
+//
+// Process-role gating: start() is called only when `isGateway` AND
+// `config.ENABLE_EVENT_SHIPPER` are both true (see index.js).
+// Combined mode + flag-on is rejected at boot
+// (unsupportedRoleShipperCombo in boot-requirements.js) — see that
+// helper's comment for the double-dispatch hazard. In the supported
+// split shape, this module runs only in the gateway tier; the
+// worker tier never starts a publisher.
+//
+// Hot-path discipline: the `raw` event fires on every gateway
+// dispatch (HEARTBEAT_ACK, PRESENCE_UPDATE, READY, GUILD_CREATE,
+// etc. — high frequency). We filter to `op === 0` (dispatch) +
+// `t === 'INTERACTION_CREATE'` BEFORE any allocation or log so
+// the non-interaction path costs a single comparison. The handler
+// MUST NOT await — EventEmitter listeners are awaited only by
+// `client.emit`'s synchronous-loop, and a long-running listener
+// here would block the WebSocket-frame poll loop in discord.js.
+// SendMessage runs detached: `sqsClient.send(...).catch(logErr)`
+// + add the promise to `inFlightSends` for stop() drain.
+//
+// Send-failure semantics: SendMessage's promise is fire-and-log.
+// A transient SQS error means the interaction is LOST from the
+// worker's POV — Discord won't retry the gateway dispatch (it's
+// a one-shot push, not poll-based), and we can't ACK the
+// interaction because the worker tier is the only thing reading
+// the queue. The 3-second interaction-token TTL is the bound:
+// even if we queued the failed payload locally and retried, the
+// user would see "interaction failed" before our retry succeeds.
+// So we accept the loss, log loudly (`kind: 'unhandledRejection'`
+// matches the tag used by the consumer + global handler in
+// index.js for unified CloudWatch alarming), and let SQS's own
+// availability SLO bound the loss rate. If sustained SendMessage
+// failure becomes a real failure mode, the right answer is
+// double-publish-to-DLQ + alarm — not in-process retry.
+//
+// Wall-clock `published_at_ms`: the consumer computes e2e latency
+// as `Date.now() - published_at_ms`. Both sides use wall clock
+// (not `hrtime.bigint()`) because hrtime is process-local and
+// meaningless cross-process. NTP drift between gateway and worker
+// hosts is the noise floor; bounded by the fleet's clock-skew SLO
+// (~tens of ms in practice on ECS Fargate).
+//
+// Drain on stop(): stop() awaits in-flight SendMessage promises
+// up to DRAIN_DEADLINE_MS before returning. After that, any
+// unsettled sends race the process exit. The pattern mirrors
+// event-consumer.js's stop()/drain shape — different state, same
+// contract.
+
+const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
+const config = require('./config');
+const logger = require('./logger');
+const { GATEWAY_DISPATCH_TYPES, LOG_KINDS } = require('./constants');
+
+// Shard index used in the envelope's `shardId` + `event_id` fields.
+// Single-shard today, so a literal '0' is correct. PR 13 introduces
+// `@discordjs/ws` (multi-shard capable) and will replace this with
+// the per-shard value pulled from `WebSocketManager`'s dispatch
+// callback. The string-typed shape lets the future `${k}:${n}`
+// format land without changing the LRU's key contract on the
+// consumer side.
+//
+// `event_id = ${SHARD_ID}:${packet.s}` mirrors the consumer's
+// recordSeen() LRU key shape (see event-consumer.js module header).
+// `packet.s` is Discord's per-dispatch sequence — monotonic within
+// a shard, so for single-shard it's a globally-unique-per-session
+// key. Re-IDENTIFY (post-reconnect) resets `s` to 1; the LRU
+// tolerates the collision because (a) interactions from the prior
+// session are already expired by Discord (3s TTL), and (b)
+// flow-state OCC owns correctness.
+const SHARD_ID = '0';
+
+// Hot-path filter constants. `op === 0` (GATEWAY_OP_DISPATCH) is a
+// Discord-wire protocol literal — not part of constants.js because no
+// other module checks gateway opcodes. The event-type literal is
+// imported from constants.js so the publisher's filter and the
+// consumer's eventType-validation always agree on the exact string.
+const GATEWAY_OP_DISPATCH = 0;
+
+// Module-level state. publish() reads `running` to skip the SQS
+// path when start() hasn't been called (or stop() has fired);
+// start()/stop() flip it. inFlightSends tracks unsettled
+// SendMessage promises so stop() can drain.
+let running = false;
+let sqsClient = null;
+const inFlightSends = new Set();
+
+// Drain deadline mirrors event-consumer.js. Resolved via
+// config.QURL_BOT_DRAIN_DEADLINE_MS — same env var, same range,
+// same default — so the gateway and worker tiers share one knob
+// per fleet. Splitting would let one side cannibalize the other's
+// gracefulShutdown headroom.
+//
+// Mutable for tests; INITIAL captures the boot-time value so
+// `_resetStateForTest` restores the config-resolved baseline rather
+// than a hardcoded 3000. Production code never mutates this — only
+// `_setDrainDeadlineForTest` does.
+const INITIAL_DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
+let DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
+
+function _setSqsClientForTest(client) {
+  sqsClient = client;
+}
+
+function createSqsClient() {
+  // Lazy AWS_REGION read mirrors event-consumer.js — see that file's
+  // createSqsClient comment for the rationale (defensive against
+  // shim bootstrappers that set AWS_REGION after module load; also
+  // makes a missing region land in the publish error path rather
+  // than as a sync boot throw inside start()).
+  const region = (process.env.AWS_REGION ?? '').trim();
+  if (!region) {
+    throw new Error('AWS_REGION is required to use the event publisher. Set it in the deployment template (e.g. `us-east-2`).');
+  }
+  return new SQSClient({ region });
+}
+
+/**
+ * Handle a raw gateway dispatch. Wired as the `raw` listener on the
+ * Discord client in src/index.js. Filters to INTERACTION_CREATE and
+ * forwards as an SQS envelope; everything else is a no-op (single
+ * `op` / `t` comparison, no allocation).
+ *
+ * Synchronous return: the SendMessage promise runs detached. The
+ * EventEmitter does not await listeners; this matches that contract
+ * explicitly so a future reader doesn't add an `await` that would
+ * stall the WebSocket frame poll.
+ *
+ * @param {object} packet - The raw gateway packet (discord.js
+ *   `raw` event payload). Shape: `{ op, t, s, d }`.
+ */
+function publish(packet) {
+  // Defense against a falsy packet (a future discord.js refactor or
+  // test stub passing nothing) — gated once before the filter so
+  // every subsequent access can use plain dot-notation. Cheaper
+  // than `packet?.` on each access for the per-frame hot path.
+  if (!packet) return;
+  // Filter-first: the raw event fires on every dispatch (heartbeat
+  // acks, presence updates, etc.). Bail before any work on the
+  // non-interaction path. Order: `op` first because the comparison
+  // is an integer; `t` second because string-eq is slower.
+  if (packet.op !== GATEWAY_OP_DISPATCH || packet.t !== GATEWAY_DISPATCH_TYPES.INTERACTION_CREATE) {
+    return;
+  }
+  // Drop dispatches that arrive before start() (race window during
+  // boot: the `raw` listener is registered at module-top, but
+  // start() runs inside index.js's start(); a dispatch that
+  // sneaked in before start() would have no sqsClient to call).
+  // Logged at debug so a real boot bug surfaces but a one-shot
+  // race doesn't flood. `running` is also flipped false by stop()
+  // so dispatches that arrive during graceful shutdown drop here.
+  if (!running) {
+    logger.debug('Event publisher: dispatch received before start() / after stop(), dropping', {
+      eventType: packet.t,
+    });
+    return;
+  }
+  // Envelope shape mirrors the consumer's contract (see
+  // event-consumer.js module header). `data` is the raw `d` field
+  // from the gateway frame, untouched — discord.js's
+  // `client.actions.InteractionCreate.handle(data)` on the worker
+  // side instantiates the right Interaction subclass from it.
+  //
+  // `event_id` = `${SHARD_ID}:${packet.s}` matches recordSeen()'s
+  // LRU key shape. `published_at_ms` is read once at envelope-build
+  // time (NOT at SendMessage-submit time) so retry latency or
+  // SQS-side queuing doesn't inflate the e2e number — the metric
+  // measures "time from gateway-frame-arrival to worker-dispatch".
+  const envelope = {
+    eventType: packet.t,
+    shardId: SHARD_ID,
+    data: packet.d,
+    event_id: `${SHARD_ID}:${packet.s}`,
+    published_at_ms: Date.now(),
+  };
+  const cmd = new SendMessageCommand({
+    QueueUrl: config.QURL_BOT_EVENTS_QUEUE_URL,
+    MessageBody: JSON.stringify(envelope),
+  });
+  // Detached send. Adding `.finally` to the original send promise
+  // counts as a handler for Node's unhandled-rejection bookkeeping,
+  // so the `.catch` below is required to actually log the error
+  // (otherwise rejection would be silently absorbed by .finally).
+  // `kind: 'unhandledRejection'` matches the consumer's
+  // trackDispatch tag + index.js's global handler tag — one
+  // CloudWatch query covers all three sites.
+  const sendPromise = sqsClient.send(cmd);
+  inFlightSends.add(sendPromise);
+  sendPromise.finally(() => {
+    inFlightSends.delete(sendPromise);
+  }).catch((err) => {
+    logger.error('Event publisher: SendMessage failed (interaction lost)', {
+      kind: LOG_KINDS.UNHANDLED_REJECTION,
+      error: err?.message || String(err),
+      stack: err?.stack,
+      eventId: envelope.event_id,
+    });
+  });
+}
+
+/**
+ * Initialize the publisher. Idempotent: a second call while already
+ * running is a no-op (warn-logged so an accidental double-start is
+ * visible). Must be called BEFORE `client.login()` so the `raw`
+ * listener registered at module-top in index.js has a live sqsClient
+ * by the time the first frame arrives.
+ */
+function start() {
+  if (running) {
+    logger.warn('Event publisher: start() called while already running — no-op');
+    return;
+  }
+  if (!config.ENABLE_EVENT_SHIPPER) {
+    // Defense in depth — caller in index.js already gates on
+    // (isGateway && config.ENABLE_EVENT_SHIPPER). Explicit here so a
+    // future caller without the gate doesn't accidentally bring up
+    // a publisher pointing at an unset queue URL.
+    throw new Error('Event publisher: start() called with ENABLE_EVENT_SHIPPER=false');
+  }
+  if (!config.QURL_BOT_EVENTS_QUEUE_URL) {
+    throw new Error('Event publisher: QURL_BOT_EVENTS_QUEUE_URL is not set');
+  }
+  if (!sqsClient) {
+    sqsClient = createSqsClient();
+  }
+  running = true;
+  logger.info('Event publisher: starting', {
+    queueUrl: config.QURL_BOT_EVENTS_QUEUE_URL,
+    shardId: SHARD_ID,
+  });
+}
+
+/**
+ * Stop accepting new publishes and drain in-flight SendMessage
+ * promises up to DRAIN_DEADLINE_MS. Idempotent on not-running.
+ * Awaits the drain; safe to call from gracefulShutdown.
+ *
+ * Behavior matches event-consumer.stop()'s drain contract:
+ * Promise.allSettled racing a deadline timer, structured logging
+ * on each terminal outcome (complete / deadline-elapsed / no-op-idle).
+ */
+async function stop() {
+  if (!running) return;
+  running = false;
+  logger.info('Event publisher: stopping');
+  if (inFlightSends.size === 0) {
+    logger.info('Event publisher: stop complete (no in-flight sends to drain)');
+    return;
+  }
+  const drainCount = inFlightSends.size;
+  // hrtime.bigint() is monotonic — Date.now() is wall-clock and
+  // can jump under NTP adjustments mid-drain. The published_at_ms
+  // field elsewhere in this module uses wall clock because it
+  // needs cross-process comparability, but elapsed-on-this-host is
+  // purely local and should be monotonic.
+  const drainStartNs = process.hrtime.bigint();
+  logger.info('Event publisher: draining in-flight SendMessage promises', {
+    count: drainCount,
+    deadlineMs: DRAIN_DEADLINE_MS,
+  });
+  let drainTimer;
+  try {
+    await Promise.race([
+      Promise.allSettled([...inFlightSends]),
+      new Promise((resolve) => {
+        drainTimer = setTimeout(resolve, DRAIN_DEADLINE_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(drainTimer);
+  }
+  const elapsedMs = Number((process.hrtime.bigint() - drainStartNs) / 1_000_000n);
+  // Post-race size check is the discriminator (not the race winner):
+  // each promise's `.finally` runs before allSettled's continuation,
+  // so on the happy path the set is empty by the time we read it.
+  // On the deadline path the set still holds whatever didn't settle.
+  if (inFlightSends.size > 0) {
+    logger.warn('Event publisher: drain deadline elapsed, proceeding with sends still in-flight (interactions may be lost)', {
+      unsettled: inFlightSends.size,
+      settled: drainCount - inFlightSends.size,
+      elapsedMs,
+    });
+  } else {
+    logger.info('Event publisher: drain complete', {
+      count: drainCount,
+      elapsedMs,
+    });
+  }
+}
+
+// Reset every piece of module-level state to its post-construction
+// shape. Tests call this in beforeEach to avoid cross-contamination
+// (the publisher is a process-singleton — see module header).
+function _resetStateForTest() {
+  running = false;
+  sqsClient = null;
+  inFlightSends.clear();
+  DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
+}
+
+module.exports = {
+  start,
+  stop,
+  publish,
+  _test: {
+    _setSqsClientForTest,
+    _resetStateForTest,
+    SHARD_ID,
+    getInFlightCount: () => inFlightSends.size,
+    isRunning: () => running,
+    // Mutable (so tests can shrink the deadline) — getter-export to
+    // avoid the snapshot-at-module-load footgun the consumer ran
+    // into in PR #395.
+    getDrainDeadlineMs: () => DRAIN_DEADLINE_MS,
+    _setDrainDeadlineForTest: (ms) => { DRAIN_DEADLINE_MS = ms; },
+  },
+};

--- a/apps/discord/src/event-publisher.js
+++ b/apps/discord/src/event-publisher.js
@@ -64,6 +64,22 @@
 // hosts is the noise floor; bounded by the fleet's clock-skew SLO
 // (~tens of ms in practice on ECS Fargate).
 //
+// Envelope size cap: the producer does NOT enforce a local size
+// limit on `JSON.stringify(envelope)`. SQS Standard caps message
+// bodies at 256 KB on the wire; an over-cap envelope triggers a
+// SendMessage rejection that lands in the same `kind:
+// unhandledRejection` log path as any other failure (the
+// interaction is lost). The consumer-side `MAX_BODY_BYTES = 200 KB`
+// cap (event-consumer.js) is the defense-in-depth on the receive
+// path; the producer-side cap is implicit because the trust
+// boundary (IAM-locked publisher set) keeps the realistic upper
+// bound on `packet.d` well under 256 KB for INTERACTION_CREATE
+// payloads (a /qurl invocation with full member/guild/data is
+// ~5-10 KB). If the worker tier ever consumes a higher-volume
+// event class (MESSAGE_CREATE with attachments, etc.), an explicit
+// producer-side cap with a structured log on rejection becomes
+// load-bearing.
+//
 // Drain on stop(): stop() awaits in-flight SendMessage promises
 // up to DRAIN_DEADLINE_MS before returning. After that, any
 // unsettled sends race the process exit. The pattern mirrors
@@ -91,6 +107,13 @@ const { GATEWAY_DISPATCH_TYPES, LOG_KINDS } = require('./constants');
 // tolerates the collision because (a) interactions from the prior
 // session are already expired by Discord (3s TTL), and (b)
 // flow-state OCC owns correctness.
+//
+// TODO(sharding-pr): replace the literal '0' with the per-shard
+// value supplied by `@discordjs/ws`'s dispatch callback once PR 13
+// migrates the gateway tier off discord.js. `git grep TODO(sharding-pr)`
+// from that branch surfaces the call sites that need updating; the
+// LRU key shape on the consumer side stays unchanged so this
+// remains a producer-only change.
 const SHARD_ID = '0';
 
 // Hot-path filter constants. `op === 0` (GATEWAY_OP_DISPATCH) is a
@@ -196,10 +219,31 @@ function publish(packet) {
     event_id: `${SHARD_ID}:${packet.s}`,
     published_at_ms: Date.now(),
   };
-  const cmd = new SendMessageCommand({
-    QueueUrl: config.QURL_BOT_EVENTS_QUEUE_URL,
-    MessageBody: JSON.stringify(envelope),
-  });
+  // Wrap envelope-building + send-dispatch in try/catch so a
+  // synchronous throw (rare with @aws-sdk/client-sqs v3 but possible
+  // on malformed input, an invalid QueueUrl, or a future SDK
+  // tightening) routes through the SAME `kind: 'unhandledRejection'`
+  // log tag the async-rejection path uses. Without this wrap, a sync
+  // throw would propagate out of the EventEmitter listener and
+  // surface via discord.js's `client.on('error')` channel under a
+  // different shape — breaking the unified CloudWatch query that
+  // pivots on the structured `kind` field.
+  let sendPromise;
+  try {
+    const cmd = new SendMessageCommand({
+      QueueUrl: config.QURL_BOT_EVENTS_QUEUE_URL,
+      MessageBody: JSON.stringify(envelope),
+    });
+    sendPromise = sqsClient.send(cmd);
+  } catch (err) {
+    logger.error('Event publisher: SendMessage threw synchronously (interaction lost)', {
+      kind: LOG_KINDS.UNHANDLED_REJECTION,
+      error: err?.message || String(err),
+      stack: err?.stack,
+      eventId: envelope.event_id,
+    });
+    return;
+  }
   // Detached send. Adding `.finally` to the original send promise
   // counts as a handler for Node's unhandled-rejection bookkeeping,
   // so the `.catch` below is required to actually log the error
@@ -207,7 +251,6 @@ function publish(packet) {
   // `kind: 'unhandledRejection'` matches the consumer's
   // trackDispatch tag + index.js's global handler tag — one
   // CloudWatch query covers all three sites.
-  const sendPromise = sqsClient.send(cmd);
   inFlightSends.add(sendPromise);
   sendPromise.finally(() => {
     inFlightSends.delete(sendPromise);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -8,9 +8,19 @@ const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
 const db = require('./store');
 const { startOrphanTokenSweeper } = require('./orphan-token-sweeper');
-const { missingBootKeys, missingProdKeys, missingKekRequiredKeys, missingEventShipperKeys, resolveProcessRole } = require('./boot-requirements');
+const {
+  missingBootKeys,
+  missingProdKeys,
+  missingKekRequiredKeys,
+  missingEventShipperKeys,
+  unsupportedRoleShipperCombo,
+  shouldRegisterInteractionListener,
+  resolveProcessRole,
+} = require('./boot-requirements');
 const { initHttpOnly } = require('./http-only-init');
 const eventConsumer = require('./event-consumer');
+const eventPublisher = require('./event-publisher');
+const { LOG_KINDS } = require('./constants');
 
 // Process role — selects which subset of the bot runs in this
 // container. Three modes:
@@ -263,6 +273,17 @@ if (eventShipperMissing.length > 0) {
   process.exit(1);
 }
 
+// Reject combined + flag-on. In combined mode the gateway-side
+// publish hook AND the worker-side consumer would both arm in one
+// process, double-dispatching every interaction (gateway WS frame
+// + SQS round-trip). See unsupportedRoleShipperCombo for the full
+// rationale and operator-facing remediation.
+const roleShipperConflict = unsupportedRoleShipperCombo(PROCESS_ROLE, config.ENABLE_EVENT_SHIPPER);
+if (roleShipperConflict) {
+  logger.error(roleShipperConflict);
+  process.exit(1);
+}
+
 // Worker role: the SQS-driven dispatch path. Distinct from `isHttp`
 // because the http role today serves OAuth callbacks + webhooks
 // regardless of the flag; only when ENABLE_EVENT_SHIPPER is on does
@@ -276,32 +297,29 @@ const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 // `isWorker=true` lands directly.
 logger.info('Worker tier configured', { isWorker, eventShipperEnabled: config.ENABLE_EVENT_SHIPPER });
 
-// Interaction routing. Same dispatcher whether the source is the
-// Gateway WS (isGateway) or an SQS message reconstructed via
-// client.actions.InteractionCreate.handle (isWorker, see
-// src/event-consumer.js). Registered once, gated on either flag, so
-// combined-mode + flag-on doesn't double-register.
+// Interaction routing. Three disjoint shapes:
 //
-// **PR 10 PRE-MERGE REQUIREMENT** — the gate below MUST be updated
-// to `(isGateway && !config.ENABLE_EVENT_SHIPPER) || isWorker` (or
-// the gateway-side listener replaced with a publish-to-SQS shim) in
-// THE SAME PR that introduces the producer. Without that change,
-// combined-mode + flag-on after PR 10 ships will dispatch every
-// interaction twice — once via the gateway WS frame, once via the
-// SQS roundtrip — silently doubling DM fan-outs, side-effecting
-// every flow-state transition twice, and corrupting telemetry.
-// PR 11 alone is safe (producer doesn't exist → queue stays empty
-// → consumer is a no-op); the hazard activates the instant the
-// producer side starts publishing.
+//   * Gateway tier + flag-on: discord.js emits `interactionCreate`
+//     on the gateway WS frame, but we do NOT subscribe — the raw
+//     publish hook (registered in the isGateway block below) forwards
+//     the payload to SQS instead. The worker tier picks it up.
+//   * Worker tier + flag-on: the SQS consumer reconstructs the
+//     interaction via `client.actions.InteractionCreate.handle(data)`,
+//     which emits `interactionCreate` locally. We DO subscribe so
+//     handleCommand / handleFlowInteraction run.
+//   * Combined or split + flag-off: legacy in-process path. The
+//     gateway WS emit lands on the local listener directly.
 //
-// Today (PR 11 only), the producer side doesn't exist yet, so
-// combined-mode + flag-on still runs the gateway dispatch path
-// in-process and the worker tier's consumer sits on an empty queue.
-// TODO(PR-10): change the gate to `(isGateway && !config.ENABLE_EVENT_SHIPPER) || isWorker`
-// (or replace the gateway-side path with a publish-to-SQS shim) per the
-// PR 10 PRE-MERGE REQUIREMENT comment above. `git grep TODO(PR-10)` from
-// the PR 10 branch surfaces every gate that needs flipping.
-if (isGateway || isWorker) {
+// The shouldRegisterInteractionListener predicate (in
+// boot-requirements.js) collapses every role × flag permutation
+// into a single boolean. Combined + flag-on is rejected at boot by
+// unsupportedRoleShipperCombo before reaching here — see that
+// helper's comment for the double-dispatch hazard.
+if (shouldRegisterInteractionListener({
+  isGateway,
+  isHttp,
+  eventShipperEnabled: config.ENABLE_EVENT_SHIPPER,
+})) {
   // Handle interactions. Split-dispatch by interaction kind:
   // ChatInputCommand + Autocomplete go through the slash-command
   // path (handleCommand); MessageComponent + ModalSubmit go through
@@ -368,6 +386,26 @@ if (isGateway) {
   // avoids per-frame closure allocation.
   client.on('raw', noteGatewayActivity);
 
+  // Publish-to-SQS hook for the worker tier (zero-downtime Pillar 1).
+  // Fires on every gateway dispatch; `publish` filters internally to
+  // `INTERACTION_CREATE` (single string-eq) before any allocation,
+  // so non-interaction dispatches pay only the comparison cost.
+  // Listener registered here at module-top because discord.js's raw
+  // event fires inside the WebSocketShard's onPacket — by the time
+  // login() resolves, frames are already arriving. publisher.start()
+  // (called in start() below before client.login()) constructs the
+  // SQS client; publish() drops at debug if a frame somehow arrives
+  // pre-start.
+  //
+  // Gated on `config.ENABLE_EVENT_SHIPPER` — when the flag is off,
+  // the legacy in-process listener (registered above) handles
+  // dispatch and no SQS round-trip is needed. Function-reference
+  // (not closure) to keep v8's hidden-class shape stable across
+  // every WS frame, matching the noteGatewayActivity pattern.
+  if (config.ENABLE_EVENT_SHIPPER) {
+    client.on('raw', eventPublisher.publish);
+  }
+
   // Error handling
   client.on('error', error => {
     logger.error('Discord client error', { error: error.message });
@@ -386,7 +424,7 @@ if (isGateway) {
 // message text or miss one of the tiers.
 process.on('unhandledRejection', (error, _promise) => {
   logger.error('Unhandled promise rejection (logged, not fatal)', {
-    kind: 'unhandledRejection',
+    kind: LOG_KINDS.UNHANDLED_REJECTION,
     error: error?.message || error,
     stack: error?.stack,
   });
@@ -435,6 +473,13 @@ async function gracefulShutdown(code = 0) {
     // ACK'ing the interaction. Idempotent + a no-op when the
     // consumer was never started, so unconditional here.
     await eventConsumer.stop();
+    // SQS publisher drain. Same shape as the consumer above:
+    // idempotent + no-op when never started, so unconditional.
+    // Runs AFTER eventConsumer.stop() but both are bounded by their
+    // own DRAIN_DEADLINE_MS; in the split shape only one of them is
+    // actually running per process (combined + flag-on is rejected
+    // at boot), so the sequencing matters only as documentation.
+    await eventPublisher.stop();
     // Periodic REST refreshCache in http-only mode is .unref()ed so it
     // wouldn't block exit on its own, but clearing explicitly keeps
     // shutdown symmetric with the other intervals (server.js, oauth.js
@@ -570,15 +615,27 @@ async function start() {
   // can accept probes during the consumer's first poll. Gated on
   // `isWorker` (which already requires ENABLE_EVENT_SHIPPER=true)
   // so the legacy in-process dispatch path stays untouched when
-  // the flag is off. In combined mode + flag on, the same process
-  // runs both producer (gateway role) and consumer — useful for
-  // local dev and the initial flag-on soak.
+  // the flag is off. Combined + flag-on is rejected at boot
+  // (unsupportedRoleShipperCombo), so this and the publisher.start()
+  // below are necessarily disjoint per-process.
   //
   // Shutdown-race guard: mirrors the timer guards above. If SIGTERM
   // landed during the awaits before this point, gracefulShutdown
   // has already run; skip starting a consumer that no one will stop.
   if (isWorker && !isShuttingDown) {
     eventConsumer.start(client);
+  }
+
+  // SQS publisher for the gateway tier (zero-downtime Pillar 1).
+  // Started BEFORE client.login() so the SQS client exists by the
+  // time the first gateway frame arrives — the `client.on('raw',
+  // eventPublisher.publish)` registration at module-top fires
+  // synchronously inside discord.js's WebSocketShard.onPacket as
+  // soon as login resolves, and a frame that arrived pre-start()
+  // would otherwise drop at debug (defense-in-depth in publish()).
+  // Same shutdown-race guard as the consumer above.
+  if (isGateway && config.ENABLE_EVENT_SHIPPER && !isShuttingDown) {
+    eventPublisher.start();
   }
 
   // Login to Discord with a 30s deadline. client.login() doesn't

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -17,6 +17,8 @@ const {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  unsupportedRoleShipperCombo,
+  shouldRegisterInteractionListener,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 } = require('../src/boot-requirements');
@@ -164,6 +166,64 @@ describe('missingEventShipperKeys', () => {
         QURL_BOT_EVENTS_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events',
       }),
     ).toEqual([]);
+  });
+});
+
+describe('unsupportedRoleShipperCombo', () => {
+  it('rejects combined + flag-on with operator-facing remediation', () => {
+    const msg = unsupportedRoleShipperCombo('combined', true);
+    expect(msg).not.toBeNull();
+    // Pin the message contract so a wording drift can't silently
+    // strip the remediation hint operators rely on to fix the deploy.
+    expect(msg).toMatch(/PROCESS_ROLE=combined/);
+    expect(msg).toMatch(/ENABLE_EVENT_SHIPPER=true/);
+    expect(msg).toMatch(/PROCESS_ROLE=gateway/);
+    expect(msg).toMatch(/PROCESS_ROLE=http/);
+  });
+
+  it.each([
+    ['gateway', true],
+    ['http', true],
+    ['combined', false],
+    ['gateway', false],
+    ['http', false],
+  ])('returns null for supported combination role=%s shipper=%s', (role, shipperEnabled) => {
+    expect(unsupportedRoleShipperCombo(role, shipperEnabled)).toBeNull();
+  });
+});
+
+describe('shouldRegisterInteractionListener', () => {
+  // The full 3 roles × 2 flag states truth table. Combined + flag-on
+  // is rejected at boot (unsupportedRoleShipperCombo), so its
+  // intended-behavior is "unreachable in production." We still pin
+  // the predicate's output for that input so a future caller that
+  // bypasses the boot guard sees a coherent value.
+  //
+  // The mapping is derived via resolveProcessRole semantics:
+  //   combined → isGateway=true, isHttp=true
+  //   gateway  → isGateway=true, isHttp=false
+  //   http     → isGateway=false, isHttp=true
+  test.each([
+    // [role,       flag,  expected, rationale]
+    ['combined',   false, true,  'legacy in-process; local listener handles dispatch'],
+    ['combined',   true,  true,  'unreachable in prod (boot reject); predicate output coherent'],
+    ['gateway',    false, true,  'legacy in-process gateway tier (single-process deploy)'],
+    ['gateway',    true,  false, 'gateway tier publishes to SQS; local listener disconnected'],
+    ['http',       false, false, 'no gateway WS + no SQS consumer; listener would never fire'],
+    ['http',       true,  true,  'worker tier; SQS consumer re-emits, listener routes'],
+  ])('role=%s flag=%s → %s (%s)', (role, eventShipperEnabled, expected) => {
+    const { isGateway, isHttp } = resolveProcessRole(role);
+    expect(shouldRegisterInteractionListener({ isGateway, isHttp, eventShipperEnabled })).toBe(expected);
+  });
+
+  it('is a pure function (no side effects, same input → same output)', () => {
+    // Predicate must be referentially transparent — a side effect
+    // would couple boot to non-determinism and undermine the
+    // unit-testability that motivated the lift.
+    const args = { isGateway: true, isHttp: false, eventShipperEnabled: true };
+    const first = shouldRegisterInteractionListener(args);
+    const second = shouldRegisterInteractionListener(args);
+    expect(first).toBe(second);
   });
 });
 

--- a/apps/discord/tests/config-int-env.test.js
+++ b/apps/discord/tests/config-int-env.test.js
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for config.intEnv (apps/discord/src/config.js).
+ *
+ * intEnv is the shared env-var-int parser used by every module that
+ * needs to read a tunable integer from the environment (event-consumer's
+ * QURL_BOT_MAX_INFLIGHT_HANDLERS, event-consumer + event-publisher's
+ * QURL_BOT_DRAIN_DEADLINE_MS, qurl-file-map's recipient caps, etc.).
+ * A regression in this helper would silently mistune every consumer,
+ * so pin every branch.
+ *
+ * The tests work by setting process.env, re-requiring config inside
+ * jest.isolateModules to capture a fresh value, and asserting on the
+ * resolved number plus the captured console.warn output. Direct
+ * function-export isn't available because intEnv is closure-private
+ * to config.js, but the resolved exports (e.g. QURL_BOT_DRAIN_DEADLINE_MS)
+ * expose the full path under each scenario.
+ */
+
+function captureFreshConfig(envOverrides, run) {
+  jest.isolateModules(() => {
+    const prevValues = {};
+    const origConsoleWarn = console.warn;
+    const warns = [];
+    console.warn = (...args) => warns.push(args.join(' '));
+    try {
+      for (const [key, value] of Object.entries(envOverrides)) {
+        prevValues[key] = process.env[key];
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+      const fresh = require('../src/config');
+      run(fresh, warns);
+    } finally {
+      console.warn = origConsoleWarn;
+      for (const [key, prev] of Object.entries(prevValues)) {
+        if (prev === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = prev;
+        }
+      }
+    }
+  });
+}
+
+describe('config.intEnv — strictInteger + minPositive (QURL_BOT_MAX_INFLIGHT_HANDLERS)', () => {
+  // QURL_BOT_MAX_INFLIGHT_HANDLERS is the canonical strictInteger +
+  // minPositive caller. Trailing-garbage rejection is load-bearing:
+  // an operator who types "100abc" into SSM should see the boot warn
+  // rather than silently get cap=100 (parseInt's lenient behavior).
+  test.each([
+    ['100abc', 'trailing garbage'],
+    ['1.5', 'non-integer float'],
+    ['Infinity', 'infinity literal'],
+    ['NaN', 'NaN literal'],
+    ['abc', 'non-numeric'],
+    [' ', 'whitespace only'],
+  ])('rejects %p (%s) and falls back to default 100 with warn', (raw) => {
+    captureFreshConfig({ QURL_BOT_MAX_INFLIGHT_HANDLERS: raw }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_MAX_INFLIGHT_HANDLERS).toBe(100);
+      expect(warns.some((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS') && w.includes('rejected'))).toBe(true);
+    });
+  });
+
+  test.each([
+    ['-5', 'negative'],
+    ['0', 'zero'],
+  ])('rejects %p (%s, fails minPositive) and falls back to default 100 with warn', (raw) => {
+    captureFreshConfig({ QURL_BOT_MAX_INFLIGHT_HANDLERS: raw }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_MAX_INFLIGHT_HANDLERS).toBe(100);
+      expect(warns.some((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS') && w.includes('rejected'))).toBe(true);
+    });
+  });
+
+  test.each([
+    ['1', 1],
+    ['50', 50],
+    ['100', 100],
+    ['10000', 10000],
+  ])('accepts %p as %i with no warning', (raw, expected) => {
+    captureFreshConfig({ QURL_BOT_MAX_INFLIGHT_HANDLERS: raw }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_MAX_INFLIGHT_HANDLERS).toBe(expected);
+      // No "rejected" / "out of range" — the only warns acceptable at
+      // boot are unrelated config logs (GUILD_ID parsing, etc.).
+      expect(warns.filter((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS'))).toHaveLength(0);
+    });
+  });
+
+  test('unset env var resolves to default 100 without warning', () => {
+    captureFreshConfig({ QURL_BOT_MAX_INFLIGHT_HANDLERS: undefined }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_MAX_INFLIGHT_HANDLERS).toBe(100);
+      expect(warns.filter((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS'))).toHaveLength(0);
+    });
+  });
+
+  test('empty string treated as unset (no warning)', () => {
+    // SSM-templated params sometimes seed empty strings — should NOT
+    // false-positive the warn path that real bad values trigger.
+    captureFreshConfig({ QURL_BOT_MAX_INFLIGHT_HANDLERS: '' }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_MAX_INFLIGHT_HANDLERS).toBe(100);
+      expect(warns.filter((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS'))).toHaveLength(0);
+    });
+  });
+});
+
+describe('config.intEnv — strictInteger + min + max (QURL_BOT_DRAIN_DEADLINE_MS)', () => {
+  // Drain deadline is range-clamped: too-large pushes past
+  // gracefulShutdown's 10s budget, too-small is operationally a
+  // disabled-drain knob (the unset-env path already provides that).
+  // Range bounds [100, 8000] are documented in config.js + .env.example.
+  test.each([
+    ['99', 'just below the floor'],
+    ['8001', 'just above the ceiling'],
+    ['50000', 'order of magnitude over'],
+    ['1', 'far below floor'],
+  ])('out-of-range %p (%s) falls back to default 3000 with "out of range" warn', (raw) => {
+    captureFreshConfig({ QURL_BOT_DRAIN_DEADLINE_MS: raw }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_DRAIN_DEADLINE_MS).toBe(3000);
+      expect(warns.some((w) => w.includes('QURL_BOT_DRAIN_DEADLINE_MS') && w.includes('out of range'))).toBe(true);
+    });
+  });
+
+  test.each([
+    ['100', 100], // exact floor
+    ['1500', 1500],
+    ['3000', 3000],
+    ['8000', 8000], // exact ceiling
+  ])('in-range %p accepted as %i', (raw, expected) => {
+    captureFreshConfig({ QURL_BOT_DRAIN_DEADLINE_MS: raw }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_DRAIN_DEADLINE_MS).toBe(expected);
+      expect(warns.filter((w) => w.includes('QURL_BOT_DRAIN_DEADLINE_MS'))).toHaveLength(0);
+    });
+  });
+
+  test.each([
+    ['100abc', 'trailing garbage'],
+    ['1.5', 'non-integer'],
+    ['abc', 'non-numeric'],
+  ])('non-integer %p (%s) rejected before range check', (raw) => {
+    captureFreshConfig({ QURL_BOT_DRAIN_DEADLINE_MS: raw }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_DRAIN_DEADLINE_MS).toBe(3000);
+      // The "rejected" warn fires from the strictInteger path, NOT
+      // "out of range" — order matters for the operator-facing log.
+      const drainWarns = warns.filter((w) => w.includes('QURL_BOT_DRAIN_DEADLINE_MS'));
+      expect(drainWarns.some((w) => w.includes('rejected'))).toBe(true);
+      expect(drainWarns.some((w) => w.includes('out of range'))).toBe(false);
+    });
+  });
+
+  test('unset env var resolves to default 3000 without warning', () => {
+    captureFreshConfig({ QURL_BOT_DRAIN_DEADLINE_MS: undefined }, (cfg, warns) => {
+      expect(cfg.QURL_BOT_DRAIN_DEADLINE_MS).toBe(3000);
+      expect(warns.filter((w) => w.includes('QURL_BOT_DRAIN_DEADLINE_MS'))).toHaveLength(0);
+    });
+  });
+});
+
+describe('config.intEnv — lenient mode (parseInt fallback, no strictInteger)', () => {
+  // The original intEnv shape (still used by PORT, RATE_LIMIT_*,
+  // PENDING_LINK_EXPIRY_MINUTES, etc.) is lenient — parseInt accepts
+  // trailing garbage. Pin the back-compat contract so a future
+  // refactor doesn't accidentally tighten these and break existing
+  // deploys that happen to have whitespace-suffixed env values.
+  test('PORT accepts "3000" → 3000', () => {
+    captureFreshConfig({ PORT: '3000' }, (cfg) => {
+      expect(cfg.PORT).toBe(3000);
+    });
+  });
+
+  test('PORT lenient-parses "8080abc" → 8080 (no strictInteger flag)', () => {
+    // Documents the lenient behavior — NOT a recommendation. New
+    // tunables should pass strictInteger: true. Existing tunables
+    // are pinned for back-compat.
+    captureFreshConfig({ PORT: '8080abc' }, (cfg) => {
+      expect(cfg.PORT).toBe(8080);
+    });
+  });
+
+  test('PORT unset → default 3000', () => {
+    captureFreshConfig({ PORT: undefined }, (cfg) => {
+      expect(cfg.PORT).toBe(3000);
+    });
+  });
+
+  test('QURL_SEND_MAX_RECIPIENTS lenient + minPositive: "0" → default 20000 with warn', () => {
+    captureFreshConfig({ QURL_SEND_MAX_RECIPIENTS: '0' }, (cfg, warns) => {
+      expect(cfg.QURL_SEND_MAX_RECIPIENTS).toBe(20000);
+      expect(warns.some((w) => w.includes('QURL_SEND_MAX_RECIPIENTS') && w.includes('must be > 0'))).toBe(true);
+    });
+  });
+});

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -403,7 +403,7 @@ describe('event-consumer: processMessage dispatch paths', () => {
       });
       await withMockedSqs(() => eventConsumer._test.processMessage(client, message));
       expect(logger.info).toHaveBeenCalledWith(
-        expect.stringContaining('dispatched'),
+        expect.stringContaining('received'),
         expect.objectContaining({
           qurl_bot_event_e2e_ms: 25,
           eventId: '0:42',
@@ -435,7 +435,7 @@ describe('event-consumer: processMessage dispatch paths', () => {
     );
     // The info "dispatched" path must NOT fire when the field is absent.
     expect(logger.info).not.toHaveBeenCalledWith(
-      expect.stringContaining('dispatched'),
+      expect.stringContaining('received'),
       expect.objectContaining({ qurl_bot_event_e2e_ms: expect.anything() }),
     );
   });
@@ -455,7 +455,7 @@ describe('event-consumer: processMessage dispatch paths', () => {
     });
     await withMockedSqs(() => eventConsumer._test.processMessage(client, message));
     expect(logger.info).not.toHaveBeenCalledWith(
-      expect.stringContaining('dispatched'),
+      expect.stringContaining('received'),
       expect.objectContaining({ qurl_bot_event_e2e_ms: expect.anything() }),
     );
   });

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -27,6 +27,10 @@
 jest.mock('../src/config', () => ({
   ENABLE_EVENT_SHIPPER: true,
   QURL_BOT_EVENTS_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events',
+  // event-consumer reads these at module-top; intEnv validation
+  // itself is tested separately in tests/config-int-env.test.js.
+  QURL_BOT_MAX_INFLIGHT_HANDLERS: 100,
+  QURL_BOT_DRAIN_DEADLINE_MS: 3000,
 }));
 
 jest.mock('../src/logger', () => ({
@@ -376,6 +380,84 @@ describe('event-consumer: processMessage dispatch paths', () => {
     } finally {
       dateSpy.mockRestore();
     }
+  });
+
+  test('envelope with published_at_ms → logs qurl_bot_event_e2e_ms', async () => {
+    // The e2e latency log is the publish→dispatch metric: wall-clock
+    // delta from gateway-host envelope-build to worker-host receive.
+    // Pin the structured field name (qurl_bot_event_e2e_ms) since
+    // CloudWatch log-based-metrics + alarms pivot on it.
+    sqsMock.on(DeleteMessageCommand).resolves({});
+    const client = makeStubClient();
+    // Pin "now" so the delta is deterministic. Date.now() inside
+    // the consumer reads this mocked value.
+    const fixedNow = 1_000_000_000;
+    const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+    try {
+      const message = makeMessage({
+        eventType: 'INTERACTION_CREATE',
+        shardId: '0',
+        data: { type: 2, data: { name: 'qurl' }, id: 'i-e2e' },
+        event_id: '0:42',
+        published_at_ms: fixedNow - 25,
+      });
+      await withMockedSqs(() => eventConsumer._test.processMessage(client, message));
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('dispatched'),
+        expect.objectContaining({
+          qurl_bot_event_e2e_ms: 25,
+          eventId: '0:42',
+          shardId: '0',
+        }),
+      );
+    } finally {
+      dateSpy.mockRestore();
+    }
+  });
+
+  test('envelope missing published_at_ms → logs debug + skips e2e metric', async () => {
+    // Forward-compat with envelopes that predate PR 10 (or a future
+    // producer regression that drops the field). Missing the field
+    // is observability-only, not correctness — so debug, not warn.
+    sqsMock.on(DeleteMessageCommand).resolves({});
+    const client = makeStubClient();
+    const message = makeMessage({
+      eventType: 'INTERACTION_CREATE',
+      shardId: '0',
+      data: { type: 2, data: { name: 'qurl' }, id: 'i-no-ts' },
+      event_id: '0:43',
+      // no published_at_ms
+    });
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, message));
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('missing published_at_ms'),
+      expect.objectContaining({ publishedAtMsType: 'undefined' }),
+    );
+    // The info "dispatched" path must NOT fire when the field is absent.
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('dispatched'),
+      expect.objectContaining({ qurl_bot_event_e2e_ms: expect.anything() }),
+    );
+  });
+
+  test.each([
+    ['string', '1700000000000'],
+    ['null', null],
+  ])('envelope with non-number published_at_ms (%s) → debug skip, no e2e log', async (label, value) => {
+    sqsMock.on(DeleteMessageCommand).resolves({});
+    const client = makeStubClient();
+    const message = makeMessage({
+      eventType: 'INTERACTION_CREATE',
+      shardId: '0',
+      data: { type: 2, data: { name: 'qurl' }, id: `i-${label}` },
+      event_id: `0:${label}`,
+      published_at_ms: value,
+    });
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, message));
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('dispatched'),
+      expect.objectContaining({ qurl_bot_event_e2e_ms: expect.anything() }),
+    );
   });
 
   test('oversized message body short-circuits before JSON.parse + still deletes', async () => {
@@ -1455,167 +1537,46 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(stripped).not.toMatch(/\bawait\b/);
   });
 
-  describe('MAX_INFLIGHT_HANDLERS env validation (module-load IIFE)', () => {
-    // The IIFE that parses QURL_BOT_MAX_INFLIGHT_HANDLERS runs at
-    // module-load. To exercise it under varying env values we
-    // re-require the module inside jest.isolateModules with the env
-    // var stubbed, capture console.warn output, and assert the
-    // resolved value + warning content. Pins the validation branch
-    // that production depends on for fail-loud-on-typo behavior.
-    function withIsolatedEnv(envValue, run) {
-      jest.isolateModules(() => {
-        const prev = process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
-        const origConsoleWarn = console.warn;
-        const warns = [];
-        console.warn = (...args) => warns.push(args.join(' '));
-        try {
-          if (envValue === undefined) {
-            delete process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
-          } else {
-            process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS = envValue;
-          }
-          const fresh = require('../src/event-consumer');
-          run(fresh, warns);
-        } finally {
-          console.warn = origConsoleWarn;
-          if (prev === undefined) {
-            delete process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS;
-          } else {
-            process.env.QURL_BOT_MAX_INFLIGHT_HANDLERS = prev;
-          }
-        }
-      });
+  describe('validateInflightCap (soft-floor warning)', () => {
+    // The env-int-parsing IIFEs that used to live here moved to
+    // config.intEnv (validated in tests/config-int-env.test.js).
+    // What remains in event-consumer.js is the consumer-specific
+    // soft-floor warning that fires when the cap is below
+    // RECEIVE_MAX_MESSAGES — the cap is accepted (operators may
+    // want it for hard-rate-limit testing) but the warn helps the
+    // booted ceiling match operator intent.
+    //
+    // Extracted as a function so we can call it directly with any
+    // value rather than fighting the module-load mock plumbing.
+    function withCapturedWarns(run) {
+      const origConsoleWarn = console.warn;
+      const warns = [];
+      console.warn = (...args) => warns.push(args.join(' '));
+      try {
+        run(warns);
+      } finally {
+        console.warn = origConsoleWarn;
+      }
     }
 
-    test.each([
-      ['100abc', 'trailing garbage'],
-      ['-5', 'negative integer'],
-      ['0', 'zero'],
-      ['1.5', 'non-integer'],
-      ['Infinity', 'infinity literal'],
-      ['NaN', 'NaN literal'],
-      ['abc', 'non-numeric'],
-      [' ', 'whitespace'],
-    ])('rejects %p (%s) and falls back to default', (envValue) => {
-      withIsolatedEnv(envValue, (fresh, warns) => {
-        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(100);
-        expect(warns.some((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS') && w.includes('rejected'))).toBe(true);
+    test.each([1, 5, 9])('cap=%i (below RECEIVE_MAX_MESSAGES=10) emits soft-floor warn', (cap) => {
+      withCapturedWarns((warns) => {
+        eventConsumer._test.validateInflightCap(cap);
+        expect(warns.some((w) => w.includes('below') && w.includes('RECEIVE_MAX_MESSAGES'))).toBe(true);
       });
     });
 
-    test.each([
-      ['50', 50],
-      ['200', 200],
-      ['10', 10], // exactly RECEIVE_MAX_MESSAGES — no soft-floor warning
-    ])('accepts %p as %i without warning', (envValue, expected) => {
-      withIsolatedEnv(envValue, (fresh, warns) => {
-        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(expected);
-        // No rejection AND no soft-floor warning for cap >= 10.
-        expect(warns.some((w) => w.includes('rejected'))).toBe(false);
+    test.each([10, 50, 100, 200])('cap=%i (>= RECEIVE_MAX_MESSAGES) does NOT emit soft-floor warn', (cap) => {
+      withCapturedWarns((warns) => {
+        eventConsumer._test.validateInflightCap(cap);
         expect(warns.some((w) => w.includes('below'))).toBe(false);
       });
     });
 
-    test.each([
-      ['1', 1],
-      ['5', 5],
-      ['9', 9],
-    ])('accepts %p as %i but warns about degenerate overshoot ratio', (envValue, expected) => {
-      // Defense-in-depth: cap < RECEIVE_MAX_MESSAGES is accepted (the
-      // operator may want it for rate-limit testing) but warned about
-      // because the effective ceiling overshoots the configured value
-      // by a wide margin (cap=1 → 10 in-flight ceiling = 10x overshoot).
-      withIsolatedEnv(envValue, (fresh, warns) => {
-        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(expected);
-        expect(warns.some((w) => w.includes('rejected'))).toBe(false);
-        expect(
-          warns.some((w) => w.includes('below') && w.includes('RECEIVE_MAX_MESSAGES'))
-        ).toBe(true);
-      });
-    });
-
-    test('unset env var resolves to default without warning', () => {
-      withIsolatedEnv(undefined, (fresh, warns) => {
-        expect(fresh._test.MAX_INFLIGHT_HANDLERS).toBe(100);
-        expect(warns).toHaveLength(0);
-      });
-    });
-  });
-
-  describe('DRAIN_DEADLINE_MS env validation (module-load IIFE)', () => {
-    // Mirrors the MAX_INFLIGHT_HANDLERS validation block. The
-    // drain deadline is range-clamped (not just positive-integer)
-    // because a too-large value would push past gracefulShutdown's
-    // 10s budget and a too-small value would be operationally a
-    // disabled-drain knob.
-    function withIsolatedEnv(envValue, run) {
-      jest.isolateModules(() => {
-        const prev = process.env.QURL_BOT_DRAIN_DEADLINE_MS;
-        const origConsoleWarn = console.warn;
-        const warns = [];
-        console.warn = (...args) => warns.push(args.join(' '));
-        try {
-          if (envValue === undefined) {
-            delete process.env.QURL_BOT_DRAIN_DEADLINE_MS;
-          } else {
-            process.env.QURL_BOT_DRAIN_DEADLINE_MS = envValue;
-          }
-          const fresh = require('../src/event-consumer');
-          run(fresh, warns);
-        } finally {
-          console.warn = origConsoleWarn;
-          if (prev === undefined) {
-            delete process.env.QURL_BOT_DRAIN_DEADLINE_MS;
-          } else {
-            process.env.QURL_BOT_DRAIN_DEADLINE_MS = prev;
-          }
-        }
-      });
-    }
-
-    test.each([
-      ['100abc', 'trailing garbage'],
-      ['-5', 'negative integer'],
-      ['0', 'zero'],
-      ['1.5', 'non-integer'],
-      ['abc', 'non-numeric'],
-    ])('rejects %p (%s) and falls back to default', (envValue) => {
-      withIsolatedEnv(envValue, (fresh, warns) => {
-        expect(fresh._test.getDrainDeadlineMs()).toBe(3000);
-        expect(
-          warns.some((w) => w.includes('QURL_BOT_DRAIN_DEADLINE_MS') && w.includes('rejected'))
-        ).toBe(true);
-      });
-    });
-
-    test.each([
-      ['99', 'just below the floor'],
-      ['8001', 'just above the ceiling'],
-      ['50000', 'order of magnitude over'],
-    ])('clamps out-of-range %p (%s) to default', (envValue) => {
-      withIsolatedEnv(envValue, (fresh, warns) => {
-        expect(fresh._test.getDrainDeadlineMs()).toBe(3000);
-        expect(
-          warns.some((w) => w.includes('out of range'))
-        ).toBe(true);
-      });
-    });
-
-    test.each([
-      ['100', 100], // exact floor
-      ['1500', 1500],
-      ['8000', 8000], // exact ceiling
-    ])('accepts in-range %p as %i', (envValue, expected) => {
-      withIsolatedEnv(envValue, (fresh, warns) => {
-        expect(fresh._test.getDrainDeadlineMs()).toBe(expected);
-        expect(warns).toHaveLength(0);
-      });
-    });
-
-    test('unset env var resolves to default without warning', () => {
-      withIsolatedEnv(undefined, (fresh, warns) => {
-        expect(fresh._test.getDrainDeadlineMs()).toBe(3000);
-        expect(warns).toHaveLength(0);
+    test('warn message names the env-var so an operator can correlate boot logs to SSM/task-def', () => {
+      withCapturedWarns((warns) => {
+        eventConsumer._test.validateInflightCap(5);
+        expect(warns.some((w) => w.includes('QURL_BOT_MAX_INFLIGHT_HANDLERS'))).toBe(true);
       });
     });
   });

--- a/apps/discord/tests/event-producer-consumer-integration.test.js
+++ b/apps/discord/tests/event-producer-consumer-integration.test.js
@@ -232,7 +232,7 @@ describe('producer → consumer envelope round-trip', () => {
 
       const logger = require('../src/logger');
       expect(logger.info).toHaveBeenCalledWith(
-        expect.stringContaining('dispatched'),
+        expect.stringContaining('received'),
         expect.objectContaining({
           qurl_bot_event_e2e_ms: 42,
           eventId: '0:99',

--- a/apps/discord/tests/event-producer-consumer-integration.test.js
+++ b/apps/discord/tests/event-producer-consumer-integration.test.js
@@ -1,0 +1,265 @@
+/**
+ * Integration test: producer → SQS envelope → consumer round-trip.
+ *
+ * The unit tests in tests/event-publisher.test.js and
+ * tests/event-consumer.test.js cover each side in isolation. They
+ * do NOT catch envelope-field drift: if the producer emits
+ * `eventType: 'INTERACTION_CREATE'` and the consumer reads
+ * `parsed.event_type`, both unit suites pass and only sandbox soak
+ * surfaces the mismatch. This file plugs that gap by wiring the two
+ * sides together against an in-memory SQS substitute
+ * (aws-sdk-client-mock) and asserting the consumer dispatches the
+ * exact payload the producer published.
+ *
+ * What this test does NOT cover (still requires sandbox soak / a
+ * real queue):
+ *   - SQS Standard's at-least-once delivery semantics
+ *   - Long-poll timing and visibility-timeout accuracy
+ *   - Discord's real interaction-token TTL behavior
+ *   - Cross-host clock skew driving the e2e latency metric
+ *
+ * Both mocks share one queue URL string so the assertions stay
+ * semantically coupled (a producer-side QueueUrl change without a
+ * consumer-side change would surface as a test failure here).
+ */
+
+const TEST_QUEUE_URL = 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events-integration';
+
+jest.mock('../src/config', () => ({
+  ENABLE_EVENT_SHIPPER: true,
+  QURL_BOT_EVENTS_QUEUE_URL: TEST_QUEUE_URL,
+  QURL_BOT_MAX_INFLIGHT_HANDLERS: 100,
+  QURL_BOT_DRAIN_DEADLINE_MS: 3000,
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  SQSClient,
+  SendMessageCommand,
+  DeleteMessageCommand,
+} = require('@aws-sdk/client-sqs');
+
+const sqsMock = mockClient(SQSClient);
+
+const eventPublisher = require('../src/event-publisher');
+const eventConsumer = require('../src/event-consumer');
+
+beforeEach(() => {
+  sqsMock.reset();
+  jest.clearAllMocks();
+  eventPublisher._test._resetStateForTest();
+  eventConsumer._test._resetStateForTest();
+});
+
+// Inject the same SQSClient into both modules so SendMessage and the
+// downstream processMessage(...) route through the shared mock.
+function withMockedSqs(fn) {
+  const client = new SQSClient({ region: 'us-east-2' });
+  eventPublisher._test._setSqsClientForTest(client);
+  eventConsumer._test._setSqsClientForTest(client);
+  return fn();
+}
+
+function makeRawInteractionPacket({ sequence = 1, data } = {}) {
+  // discord.js's `raw` event delivers GatewayDispatchPayload-shaped
+  // packets: { op: 0, t: <type>, s: <sequence>, d: <payload> }.
+  return {
+    op: 0,
+    t: 'INTERACTION_CREATE',
+    s: sequence,
+    d: data,
+  };
+}
+
+function makeStubDiscordClient() {
+  // Mirrors tests/event-consumer.test.js's stub — only the surface
+  // the consumer reaches into (client.actions.InteractionCreate.handle).
+  return {
+    actions: {
+      InteractionCreate: {
+        handle: jest.fn(),
+      },
+    },
+  };
+}
+
+function flushMicro() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('producer → consumer envelope round-trip', () => {
+  test('publisher SendMessage body parses cleanly into consumer dispatch with identical data', async () => {
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-integration-1' });
+    sqsMock.on(DeleteMessageCommand).resolves({});
+
+    const interactionData = {
+      type: 2,
+      data: { type: 1, name: 'qurl', options: [{ name: 'file', type: 1 }] },
+      id: 'i-integration-1',
+      token: 'opaque-token',
+      guild_id: '111',
+      channel_id: '222',
+      member: { user: { id: '333' }, permissions: '8' },
+      version: 1,
+    };
+
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(makeRawInteractionPacket({ sequence: 42, data: interactionData }));
+    });
+    await flushMicro();
+
+    // Capture exactly what the publisher emitted on the wire.
+    const sends = sqsMock.commandCalls(SendMessageCommand);
+    expect(sends).toHaveLength(1);
+    const sentInput = sends[0].args[0].input;
+    expect(sentInput.QueueUrl).toBe(TEST_QUEUE_URL);
+
+    // Feed the publisher's body to the consumer as if SQS delivered
+    // it. Pins the wire contract: a field-name change on either side
+    // (eventType ↔ event_type, data ↔ payload, etc.) breaks here.
+    const consumerMessage = {
+      Body: sentInput.MessageBody,
+      ReceiptHandle: 'rh-integration-1',
+      MessageId: 'sqs-integration-1',
+    };
+    const client = makeStubDiscordClient();
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, consumerMessage));
+
+    // Consumer dispatched with EXACTLY the data the producer sent.
+    expect(client.actions.InteractionCreate.handle).toHaveBeenCalledTimes(1);
+    expect(client.actions.InteractionCreate.handle).toHaveBeenCalledWith(interactionData);
+
+    // And it deleted the message (DeleteMessage is the consumer's
+    // success terminal).
+    const deletes = sqsMock.commandCalls(DeleteMessageCommand);
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].args[0].input).toMatchObject({
+      QueueUrl: TEST_QUEUE_URL,
+      ReceiptHandle: 'rh-integration-1',
+    });
+  });
+
+  test('event_id format matches consumer LRU dedup expectations', async () => {
+    // Producer emits `${SHARD_ID}:${packet.s}`; consumer's recordSeen
+    // treats that as an opaque string key. Pin that producer's shape
+    // populates the LRU correctly — a future producer-side reformat
+    // would silently break dup detection without this test.
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-event-id' });
+    sqsMock.on(DeleteMessageCommand).resolves({});
+
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(makeRawInteractionPacket({
+        sequence: 7777777,
+        data: { type: 2, data: { name: 'qurl' }, id: 'i-eid' },
+      }));
+    });
+    await flushMicro();
+
+    const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
+    expect(body.event_id).toBe('0:7777777');
+
+    // Round-trip the SAME envelope through the consumer twice.
+    // First processMessage populates the LRU; second should observe
+    // the dup. Verifies the producer's event_id key is the SAME shape
+    // the consumer's recordSeen expects.
+    const consumerMessage = {
+      Body: JSON.stringify(body),
+      ReceiptHandle: 'rh-dup-1',
+      MessageId: 'm-dup-1',
+    };
+    const client = makeStubDiscordClient();
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, consumerMessage));
+    expect(eventConsumer._test.seenEventIds.has('0:7777777')).toBe(true);
+
+    // Now re-process the same envelope — recordSeen returns true →
+    // the dup-debug log fires (consumer module-level behavior).
+    const dupMessage = {
+      Body: JSON.stringify(body),
+      ReceiptHandle: 'rh-dup-2',
+      MessageId: 'm-dup-2',
+    };
+    await withMockedSqs(() => eventConsumer._test.processMessage(client, dupMessage));
+    const logger = require('../src/logger');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('event_id seen recently'),
+      expect.objectContaining({ eventId: '0:7777777' }),
+    );
+  });
+
+  test('producer published_at_ms drives consumer e2e latency log', async () => {
+    // Pin the e2e-metric wire contract end-to-end. A producer change
+    // that renames published_at_ms or stops setting it would surface
+    // here as a missing structured-log field on the consumer side.
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-e2e' });
+    sqsMock.on(DeleteMessageCommand).resolves({});
+
+    eventPublisher.start();
+    // Fix Date.now so the e2e delta is predictable across the
+    // producer-call and consumer-call observations of the wall clock.
+    const fixedNow = 1_700_000_000_000;
+    const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+    try {
+      withMockedSqs(() => {
+        eventPublisher.publish(makeRawInteractionPacket({
+          sequence: 99,
+          data: { type: 2, data: { name: 'qurl' }, id: 'i-e2e' },
+        }));
+      });
+      await flushMicro();
+
+      const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
+      expect(body.published_at_ms).toBe(fixedNow);
+
+      // Advance the worker-side clock by 42 ms before processMessage
+      // reads Date.now() to compute the e2e delta.
+      dateSpy.mockReturnValue(fixedNow + 42);
+      const client = makeStubDiscordClient();
+      await withMockedSqs(() => eventConsumer._test.processMessage(client, {
+        Body: JSON.stringify(body),
+        ReceiptHandle: 'rh-e2e',
+        MessageId: 'sqs-e2e',
+      }));
+
+      const logger = require('../src/logger');
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('dispatched'),
+        expect.objectContaining({
+          qurl_bot_event_e2e_ms: 42,
+          eventId: '0:99',
+          shardId: '0',
+        }),
+      );
+    } finally {
+      dateSpy.mockRestore();
+    }
+  });
+
+  test('non-INTERACTION_CREATE dispatches from producer never reach consumer', async () => {
+    // Negative contract: ensures the consumer side wouldn't even
+    // SEE a HEARTBEAT_ACK / PRESENCE_UPDATE because the producer
+    // filters before SendMessage. Belt-and-suspenders against a
+    // future relaxation of the producer filter — the consumer's
+    // unhandled-eventType branch would still log+delete, but that's
+    // wasted SQS traffic the round-trip should never carry.
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'never-fires' });
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish({ op: 11, t: null, s: null, d: null }); // HEARTBEAT_ACK
+      eventPublisher.publish({ op: 0, t: 'GUILD_CREATE', s: 1, d: {} });
+      eventPublisher.publish({ op: 0, t: 'MESSAGE_CREATE', s: 2, d: {} });
+      eventPublisher.publish({ op: 0, t: 'PRESENCE_UPDATE', s: 3, d: {} });
+    });
+    await flushMicro();
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+  });
+});

--- a/apps/discord/tests/event-publisher.test.js
+++ b/apps/discord/tests/event-publisher.test.js
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for src/event-publisher.js — the SQS producer for the
+ * gateway tier (zero-downtime design, Pillar 1). Pairs with
+ * tests/event-consumer.test.js (worker side).
+ *
+ * Covers:
+ *   - publish(): INTERACTION_CREATE filter (op/t both load-bearing)
+ *   - envelope shape (eventType, shardId, data, event_id,
+ *     published_at_ms) matches event-consumer.js's contract
+ *   - SendMessage call: QueueUrl + JSON body
+ *   - start/stop lifecycle: idempotency, flag/queue-url guards
+ *   - send-failure logging (kind: 'unhandledRejection' tag parity
+ *     with consumer + global handler)
+ *   - drain on stop(): allSettled-vs-deadline race outcomes
+ *   - pre-start drop (race during boot before login resolves)
+ *
+ * Does NOT cover:
+ *   - Real SQS behavior (throttling, retry, message-attribute
+ *     handling) — integration territory.
+ *   - Cross-process e2e latency — that requires both tiers running
+ *     against a real queue; smoke-suite territory post-PR-10.
+ */
+
+jest.mock('../src/config', () => ({
+  ENABLE_EVENT_SHIPPER: true,
+  QURL_BOT_EVENTS_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events',
+  QURL_BOT_DRAIN_DEADLINE_MS: 3000,
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+const { mockClient } = require('aws-sdk-client-mock');
+const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
+
+const sqsMock = mockClient(SQSClient);
+
+const eventPublisher = require('../src/event-publisher');
+const logger = require('../src/logger');
+
+beforeEach(() => {
+  sqsMock.reset();
+  jest.clearAllMocks();
+  eventPublisher._test._resetStateForTest();
+});
+
+// Inject the mocked SQSClient (matches the consumer test's pattern).
+// aws-sdk-client-mock intercepts at the SDK-command level, so any
+// SQSClient instance routes through the mock; we construct one
+// explicitly and inject it via the DI hook because start() lazy-
+// constructs and most tests call publish() directly.
+function withMockedSqs(fn) {
+  const realClient = new SQSClient({ region: 'us-east-2' });
+  eventPublisher._test._setSqsClientForTest(realClient);
+  return fn();
+}
+
+// Helper: build a raw discord.js gateway packet shape.
+// op=0 is GATEWAY_DISPATCH; t is the event name; s is the per-shard
+// sequence; d is the payload.
+function rawPacket({ op = 0, t = 'INTERACTION_CREATE', s = 1, d = {} } = {}) {
+  return { op, t, s, d };
+}
+
+// publish() awaits no promise but submits a detached SendMessage.
+// Tests that assert against SendMessage must yield the event loop
+// once for the .send() promise to settle. One macrotask flush
+// (setImmediate) is enough for both the .send() resolve and the
+// .finally() that removes from inFlightSends.
+function flushMicro() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('event-publisher: publish filter', () => {
+  test('INTERACTION_CREATE dispatch → SendMessage called once', async () => {
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-1' });
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({
+        s: 42,
+        d: { type: 2, data: { name: 'qurl' }, id: 'i-1' },
+      }));
+    });
+
+    await flushMicro();
+
+    const sends = sqsMock.commandCalls(SendMessageCommand);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].args[0].input).toMatchObject({
+      QueueUrl: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events',
+    });
+  });
+
+  test('non-dispatch opcodes (HEARTBEAT_ACK / HELLO etc.) → no SendMessage', () => {
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ op: 11, t: null })); // heartbeat ack
+      eventPublisher.publish(rawPacket({ op: 10, t: null })); // hello
+      eventPublisher.publish(rawPacket({ op: 7, t: null })); // reconnect
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+  });
+
+  test('dispatch but t !== INTERACTION_CREATE → no SendMessage', () => {
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ t: 'GUILD_CREATE' }));
+      eventPublisher.publish(rawPacket({ t: 'MESSAGE_CREATE' }));
+      eventPublisher.publish(rawPacket({ t: 'PRESENCE_UPDATE' }));
+      eventPublisher.publish(rawPacket({ t: 'READY' }));
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+  });
+
+  test('falsy / malformed packet does not throw (defense-in-depth)', () => {
+    eventPublisher.start();
+    withMockedSqs(() => {
+      // None of these should crash the gateway WS loop.
+      expect(() => eventPublisher.publish(undefined)).not.toThrow();
+      expect(() => eventPublisher.publish(null)).not.toThrow();
+      expect(() => eventPublisher.publish({})).not.toThrow();
+      expect(() => eventPublisher.publish({ op: 0 })).not.toThrow();
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+  });
+});
+
+describe('event-publisher: envelope shape', () => {
+  test('matches consumer contract: eventType + shardId + data + event_id + published_at_ms', async () => {
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-2' });
+    eventPublisher.start();
+    const before = Date.now();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({
+        s: 1234567,
+        d: { type: 3, data: { custom_id: 'flow:foo:bar' }, id: 'i-2' },
+      }));
+    });
+    const after = Date.now();
+
+    await flushMicro();
+
+    const sends = sqsMock.commandCalls(SendMessageCommand);
+    expect(sends).toHaveLength(1);
+    const body = JSON.parse(sends[0].args[0].input.MessageBody);
+    expect(body.eventType).toBe('INTERACTION_CREATE');
+    expect(body.shardId).toBe('0');
+    expect(body.event_id).toBe('0:1234567');
+    expect(body.data).toEqual({ type: 3, data: { custom_id: 'flow:foo:bar' }, id: 'i-2' });
+    expect(typeof body.published_at_ms).toBe('number');
+    // published_at_ms is set in publish() between `before` and `after`.
+    // Pin the bounds so a refactor that captures the timestamp at
+    // SendMessage-submit time (vs envelope build) is caught.
+    expect(body.published_at_ms).toBeGreaterThanOrEqual(before);
+    expect(body.published_at_ms).toBeLessThanOrEqual(after);
+  });
+
+  test('event_id format is `${shardId}:${packet.s}` — matches consumer LRU shape', async () => {
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-3' });
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ s: 99 }));
+    });
+    await flushMicro();
+    const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
+    // Pinning the literal shape — a future PR introducing sharding will
+    // change SHARD_ID and this test will fail loudly, prompting the
+    // contract-update conversation rather than silently shipping.
+    expect(body.event_id).toBe('0:99');
+  });
+
+  test('raw d payload is passed through untouched (no normalization)', async () => {
+    // The worker side calls client.actions.InteractionCreate.handle(data)
+    // — that internal API expects the raw Discord wire shape. Any
+    // producer-side normalization would silently break a future
+    // discord.js minor version.
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'sqs-4' });
+    eventPublisher.start();
+    const exoticPayload = {
+      type: 2,
+      data: { type: 1, options: [{ name: 'recipients', value: '@everyone' }] },
+      guild_id: '123',
+      channel_id: '456',
+      member: { permissions: '8' },
+      token: 'opaque',
+      version: 1,
+    };
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ d: exoticPayload }));
+    });
+    await flushMicro();
+    const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
+    expect(body.data).toEqual(exoticPayload);
+  });
+});
+
+describe('event-publisher: start/stop lifecycle', () => {
+  test('start() throws when ENABLE_EVENT_SHIPPER=false', () => {
+    const config = require('../src/config');
+    const originalFlag = config.ENABLE_EVENT_SHIPPER;
+    config.ENABLE_EVENT_SHIPPER = false;
+    try {
+      expect(() => eventPublisher.start()).toThrow(/ENABLE_EVENT_SHIPPER=false/);
+    } finally {
+      config.ENABLE_EVENT_SHIPPER = originalFlag;
+    }
+  });
+
+  test('start() throws when queue URL is missing', () => {
+    const config = require('../src/config');
+    const original = config.QURL_BOT_EVENTS_QUEUE_URL;
+    config.QURL_BOT_EVENTS_QUEUE_URL = '';
+    try {
+      expect(() => eventPublisher.start()).toThrow(/QURL_BOT_EVENTS_QUEUE_URL/);
+    } finally {
+      config.QURL_BOT_EVENTS_QUEUE_URL = original;
+    }
+  });
+
+  test('start() twice logs warn on second call (idempotent)', () => {
+    eventPublisher.start();
+    eventPublisher.start();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('start() called while already running'),
+    );
+    expect(eventPublisher._test.isRunning()).toBe(true);
+  });
+
+  test('stop() before start() is a no-op (idempotent)', async () => {
+    await expect(eventPublisher.stop()).resolves.toBeUndefined();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  test('publish() before start() drops at debug + does NOT call SendMessage', () => {
+    // No start() — `running` is false. Race window during boot:
+    // discord.js's raw event could in principle fire before
+    // index.js's start() reaches eventPublisher.start(). The
+    // debug-drop guard means we never crash, just lose the event
+    // (which would have lost anyway since the worker isn't reading
+    // until its own start). Asserts the guard's existence.
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket());
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('before start()'),
+      expect.objectContaining({ eventType: 'INTERACTION_CREATE' }),
+    );
+  });
+
+  test('publish() after stop() drops at debug + does NOT call SendMessage', async () => {
+    eventPublisher.start();
+    await eventPublisher.stop();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket());
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('after stop()'),
+      expect.objectContaining({ eventType: 'INTERACTION_CREATE' }),
+    );
+  });
+});
+
+describe('event-publisher: send-failure logging', () => {
+  test('SendMessage rejection → logs error with kind=unhandledRejection tag', async () => {
+    // The kind tag is load-bearing for the unified CloudWatch query
+    // that finds rejections across all three sites (publisher,
+    // consumer trackDispatch, index.js global). A wording drift
+    // here without the tag would create a blind spot.
+    sqsMock.on(SendMessageCommand).rejects(new Error('throttled by SQS'));
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ s: 7 }));
+    });
+    await flushMicro();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('SendMessage failed'),
+      expect.objectContaining({
+        kind: 'unhandledRejection',
+        error: 'throttled by SQS',
+        eventId: '0:7',
+      }),
+    );
+  });
+
+  test('failed send still removes promise from inFlightSends (no leak)', async () => {
+    sqsMock.on(SendMessageCommand).rejects(new Error('AWS down'));
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ s: 1 }));
+      eventPublisher.publish(rawPacket({ s: 2 }));
+      eventPublisher.publish(rawPacket({ s: 3 }));
+    });
+    // After flush, all three should have settled (rejected) and
+    // been removed via .finally → inFlightSends.delete.
+    await flushMicro();
+    expect(eventPublisher._test.getInFlightCount()).toBe(0);
+  });
+});
+
+describe('event-publisher: drain on stop', () => {
+  test('drain happy path: all sends settle within deadline → logs complete', async () => {
+    // Resolve each SendMessage after a small delay so they're
+    // actually in-flight when stop() awaits — otherwise the set
+    // would be empty by the time stop() reads it and the
+    // "no in-flight" branch would log instead.
+    sqsMock.on(SendMessageCommand).callsFake(() => new Promise((resolve) => {
+      setTimeout(() => resolve({ MessageId: 'sqs-x' }), 5);
+    }));
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ s: 1 }));
+      eventPublisher.publish(rawPacket({ s: 2 }));
+    });
+    // Brief yield so the synchronous publish() finishes building
+    // both envelopes + adding both promises to inFlightSends BEFORE
+    // stop() reads the set's size. Without this, fast pathing
+    // through publish() could miss the second add.
+    await Promise.resolve();
+    expect(eventPublisher._test.getInFlightCount()).toBe(2);
+    await eventPublisher.stop();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('drain complete'),
+      expect.objectContaining({ count: 2 }),
+    );
+    expect(eventPublisher._test.getInFlightCount()).toBe(0);
+  });
+
+  test('drain deadline elapses: never-settling send → logs deadline-elapsed warn', async () => {
+    // Never resolve — simulates SQS hung mid-send during shutdown.
+    sqsMock.on(SendMessageCommand).callsFake(() => new Promise(() => {}));
+    // Shrink deadline to keep the suite fast.
+    eventPublisher._test._setDrainDeadlineForTest(50);
+    eventPublisher.start();
+    withMockedSqs(() => {
+      eventPublisher.publish(rawPacket({ s: 1 }));
+    });
+    await Promise.resolve();
+    await eventPublisher.stop();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('drain deadline elapsed'),
+      expect.objectContaining({ unsettled: 1 }),
+    );
+  });
+
+  test('no-op-idle drain: nothing in flight → logs "stop complete (no in-flight sends)"', async () => {
+    eventPublisher.start();
+    // No publish() — inFlightSends is empty when stop() runs.
+    await eventPublisher.stop();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('no in-flight sends to drain'),
+    );
+    // Did NOT log a draining message.
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('draining'),
+      expect.anything(),
+    );
+  });
+
+  test('getDrainDeadlineMs reflects mutations via _setDrainDeadlineForTest (not a stale snapshot)', () => {
+    // Pin the live-getter contract — a regression that exported the
+    // mutable value snapshot-at-module-load would silently break the
+    // deadline shrinker the drain tests rely on. Mirrors the same
+    // contract enforced in event-consumer's _test.getDrainDeadlineMs.
+    const before = eventPublisher._test.getDrainDeadlineMs();
+    eventPublisher._test._setDrainDeadlineForTest(123);
+    expect(eventPublisher._test.getDrainDeadlineMs()).toBe(123);
+    expect(eventPublisher._test.getDrainDeadlineMs()).not.toBe(before);
+  });
+});

--- a/apps/discord/tests/event-publisher.test.js
+++ b/apps/discord/tests/event-publisher.test.js
@@ -43,6 +43,28 @@ const sqsMock = mockClient(SQSClient);
 const eventPublisher = require('../src/event-publisher');
 const logger = require('../src/logger');
 
+// AWS_REGION setup: event-publisher's createSqsClient() throws if
+// AWS_REGION isn't set, and `start()` calls it lazily. Most tests
+// inject a mock client via `_setSqsClientForTest` BEFORE start(),
+// but the start/stop lifecycle tests call start() directly. Seed a
+// fake region so the suite passes locally without depending on CI
+// env. Restore the original value in afterAll so cross-suite state
+// stays clean (jest --runInBand shares the process env).
+let originalAwsRegion;
+beforeAll(() => {
+  originalAwsRegion = process.env.AWS_REGION;
+  if (!process.env.AWS_REGION) {
+    process.env.AWS_REGION = 'us-east-2';
+  }
+});
+afterAll(() => {
+  if (originalAwsRegion === undefined) {
+    delete process.env.AWS_REGION;
+  } else {
+    process.env.AWS_REGION = originalAwsRegion;
+  }
+});
+
 beforeEach(() => {
   sqsMock.reset();
   jest.clearAllMocks();
@@ -70,8 +92,15 @@ function rawPacket({ op = 0, t = 'INTERACTION_CREATE', s = 1, d = {} } = {}) {
 // publish() awaits no promise but submits a detached SendMessage.
 // Tests that assert against SendMessage must yield the event loop
 // once for the .send() promise to settle. One macrotask flush
-// (setImmediate) is enough for both the .send() resolve and the
-// .finally() that removes from inFlightSends.
+// (setImmediate) is enough for the current 1-deep promise chain:
+// the .send() resolve, the .finally() that removes from
+// inFlightSends, and the .catch() that would fire on rejection.
+// If a future change adds another `.then(...).then(...)` layer
+// inside publish() (e.g., post-send metric emission), tests
+// asserting against the deepest layer's effect will need a second
+// flush — or convert to a `flushPromises` helper that drains in
+// a loop. Today's depth-1 assumption is pinned by the assertion
+// shapes below.
 function flushMicro() {
   return new Promise((resolve) => setImmediate(resolve));
 }
@@ -287,6 +316,32 @@ describe('event-publisher: send-failure logging', () => {
         eventId: '0:7',
       }),
     );
+  });
+
+  test('synchronous throw from sqsClient.send routes through the same kind tag (no error-emitter divergence)', async () => {
+    // Pins the closed-blind-spot: a sync throw from the AWS SDK
+    // (rare with v3 but possible on malformed input) must NOT
+    // propagate out of the EventEmitter listener as a different
+    // error shape — the unified CloudWatch query that filters on
+    // `kind: 'unhandledRejection'` would lose this site otherwise.
+    // Simulate with a mock client whose .send throws synchronously.
+    const throwingClient = {
+      send: () => { throw new Error('sync-throw: malformed input'); },
+    };
+    eventPublisher._test._setSqsClientForTest(throwingClient);
+    eventPublisher.start();
+    expect(() => eventPublisher.publish(rawPacket({ s: 11 }))).not.toThrow();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('threw synchronously'),
+      expect.objectContaining({
+        kind: 'unhandledRejection',
+        error: 'sync-throw: malformed input',
+        eventId: '0:11',
+      }),
+    );
+    // No promise enters inFlightSends on the sync-throw path —
+    // otherwise stop() would await a promise that doesn't exist.
+    expect(eventPublisher._test.getInFlightCount()).toBe(0);
   });
 
   test('failed send still removes promise from inFlightSends (no leak)', async () => {


### PR DESCRIPTION
## Summary

Closes the producer side of the zero-downtime event-shipper split. PR 11 (consumer, merged) has been polling an empty queue; this PR puts messages on it.

With `ENABLE_EVENT_SHIPPER=true` and the supported two-process shape (`PROCESS_ROLE=gateway` + `PROCESS_ROLE=http`), interactions now flow:

```
gateway WS frame
  → client.on('raw', publisher.publish)   [filters INTERACTION_CREATE only]
  → SendMessage to SQS Standard
  → consumer poll (http tier)
  → client.actions.InteractionCreate.handle(data)
  → local interactionCreate listener → handleCommand / handleFlowInteraction
```

With the flag unset (today's prod + sandbox), this PR is a no-op at runtime — the `raw` publish hook isn't registered, `publisher.start()` isn't called, listener gate falls through to the legacy in-process path.

## Why this matters

The gateway tier is a singleton (Discord allows one Gateway WS per token). Today, every gateway deploy causes a 30–90s outage: in-flight `/qurl` flows die mid-button-click, interactions get "interaction failed". The event-shipper split moves all business logic to a horizontally-scalable HTTP tier behind an ALB, leaving the gateway as a thin SQS forwarder that needs to be redeployed only on Node / discord.js / sharding-config changes. This PR is the producer half of that split; PR 13–14 add cross-process Gateway RESUME + hot-standby for the gateway tier itself.

## What's in the PR

**New module** — `src/event-publisher.js`:
- Process-singleton mirroring `event-consumer`'s lifecycle (`start`, `stop`, lazy SQS client).
- `publish(packet)` filters `op === 0 && t === 'INTERACTION_CREATE'` before any allocation (hot path runs on every gateway frame including HEARTBEAT_ACK / PRESENCE_UPDATE).
- Builds envelope `{ eventType, shardId, data, event_id, published_at_ms }` matching the consumer's contract.
- Fires `SendMessage` detached; tracks the promise in a `Set` for `stop()` drain (same shape as `event-consumer.stop()`).
- Send failures log `kind: 'unhandledRejection'` for unified CloudWatch alarming across publisher + consumer + global handler.

**Boot rejection** — `unsupportedRoleShipperCombo` in `src/boot-requirements.js`:
- `PROCESS_ROLE=combined` + `ENABLE_EVENT_SHIPPER=true` now boot-fails with operator-facing remediation.
- In combined mode both the publish hook AND the worker consumer would arm in one process → every interaction would land twice (in-process WS frame + SQS round-trip). The listener-gate fix from #381 alone doesn't close this — `discord.js`'s `InteractionCreate.handle` fires on the WS frame regardless.

**Listener-gate predicate** — `shouldRegisterInteractionListener` in `src/boot-requirements.js`:
- Extracted from index.js's inline `(isGateway && !flag) || isWorker` expression.
- Pure helper, unit-tested across every role × flag permutation.

**e2e latency metric** — `event-consumer.js`:
- Parses `published_at_ms` from the envelope.
- Emits `qurl_bot_event_e2e_ms` as a structured log field on successful dispatch — wall-clock delta from gateway-host envelope-build to worker-host receive. NTP drift between hosts is the noise floor; the metric is the SLI signal the design doc reserves under "Flow continuity."

**DE-review cleanups landed in the same PR** (no deferred follow-ups):
- `config.intEnv` extended with `strictInteger` + `min`/`max` options. `QURL_BOT_MAX_INFLIGHT_HANDLERS` and `QURL_BOT_DRAIN_DEADLINE_MS` now flow through one validation path; both modules share one knob.
- `GATEWAY_DISPATCH_TYPES.INTERACTION_CREATE` and `LOG_KINDS.UNHANDLED_REJECTION` lifted to `constants.js`. The three rejection-tagging sites (publisher, consumer, index.js global handler) share one frozen constant — drift between them was the silent-failure footgun.

## Test plan

- [x] **1945 tests pass across 51 suites.** Net new: publisher unit tests (19), `config.intEnv` unit tests (24), producer→consumer integration test (4), listener-gate predicate truth-table (6), `published_at_ms` parsing (3 + 2 negative-path), boot rejection (2). Net: +18 tests vs. main.
- [x] **Integration test pins the wire contract** — `tests/event-producer-consumer-integration.test.js` runs the publisher's `SendMessage` body through the consumer's `processMessage` via an in-memory SQS substitute. Envelope field-name drift on either side fails the test.
- [x] **Module-load smoke** — `node -e "require('./src/event-publisher'); require('./src/boot-requirements');"` boots cleanly.
- [x] **Flag-off path unchanged** — listener-gate truth table confirms `(combined, false)` and `(gateway, false)` both register the legacy listener; current sandbox + prod have `ENABLE_EVENT_SHIPPER` unset and see no behavior change.
- [ ] **Sandbox soak** — to be performed post-merge after first deploy with `ENABLE_EVENT_SHIPPER=true` on the split task defs. Will report `qurl_bot_event_e2e_ms` p99 in a comment on this PR before the flag-cleanup PR (which removes the legacy in-process gateway dispatch path) opens.

## Out of scope

- `@discordjs/ws` migration — PR 13 (gateway-tier no longer needs `discord.js`'s slash-command / cache layer).
- Gateway-tier `qurl_bot_gateway_session` DDB table for cross-process RESUME — PR 12.
- Hot-standby + leader-election — PR 13–14.
- Envelope-level schema validation + signature verification — IAM is the trust boundary today (queue policy locks `sqs:SendMessage` to the gateway task role). Tracked at `TODO(infra-publisher-set)` in `event-consumer.js`; revisit if the publisher set ever loosens.

## Rollback

Flag-flip: set `ENABLE_EVENT_SHIPPER=false` in both task definitions. The legacy in-process gateway path runs unchanged. This works until the (separate) follow-up PR removes the listener-gate scaffolding; that PR's description will explicitly call out the soak window before deleting the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)