### PR TITLE
refactor(discord): rename /qurl file subcommand to /qurl send

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -185,7 +185,7 @@ ADMIN_USER_IDS=
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_MAX_REQUESTS=30
 
-# qURL sharing operational knobs (apply to /qurl file + /qurl map)
+# qURL sharing operational knobs (apply to /qurl send + /qurl map)
 # QURL_SEND_MAX_RECIPIENTS=50
 # QURL_SEND_COOLDOWN_MS=30000
 

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -5,7 +5,7 @@ linking and auto Contributor-role assignment for community members.
 
 ## Features
 
-- **`/qurl file`** — share a file as a one-time qURL link, delivered to each
+- **`/qurl send`** — share a file as a one-time qURL link, delivered to each
   recipient via DM. Recipients picked via @mentions or a user-select menu.
 - **`/qurl map`** — share a Google Maps location as a one-time qURL link,
   delivered to each recipient via DM.
@@ -26,7 +26,7 @@ linking and auto Contributor-role assignment for community members.
 
 | Command | Description |
 |---------|-------------|
-| `/qurl file` | Send a file as one-time qURL links to picked recipients |
+| `/qurl send` | Send a file as one-time qURL links to picked recipients |
 | `/qurl map` | Send a Google Maps location as one-time qURL links to picked recipients |
 | `/qurl revoke` | Revoke links from a previous send |
 | `/qurl help` | Usage reference |

--- a/apps/discord/docs/zero-downtime-design.md
+++ b/apps/discord/docs/zero-downtime-design.md
@@ -2,11 +2,14 @@
 
 **Status:** front-half analysis superseded by PR 7b.3 — see banner; full
 rewrite tracked in [#314](https://github.com/layervai/qurl-integrations/issues/314). Gateway-tier RESUME design (PR 10–15) still applies.
-> ⚠️ This doc still references `/qurl send` and the legacy `await*Component` /
-> `awaitMessages` patterns. As of PR 7b.3 those are gone — `/qurl file` and
-> `/qurl map` are the live entry points and the flow is flow_state-backed
-> (no in-process Promise-on-Gateway-event coupling). The MESSAGE_CREATE-on-DM
-> constraint cited below is no longer load-bearing.
+> ⚠️ This doc still references the legacy multi-step `/qurl send` wizard and
+> the `await*Component` / `awaitMessages` patterns. As of PR 7b.3 those are
+> gone — the live entry points are `/qurl send` (renamed from `/qurl file`)
+> and `/qurl map`, and the flow is flow_state-backed (no in-process
+> Promise-on-Gateway-event coupling). The MESSAGE_CREATE-on-DM constraint
+> cited below is no longer load-bearing. NOTE: the live `/qurl send` is
+> distinct from the legacy `/qurl send` wizard — same name, different
+> implementation.
 
 **Tracking:** `qurl-integrations-infra#122` (deploy outage), `qurl-integrations#TBD` (this PR)
 **Owners:** posey + reviewers

--- a/apps/discord/jest.config.js
+++ b/apps/discord/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
   coverageThreshold: {
     // 78/68/78/78 floors. Current commands.js coverage: 81.23/77.27/
     // 83.93/81.98 — held by five files, each owning a distinct slice:
-    //   - qurl-file-map.test.js: /qurl file + /qurl map front-half
+    //   - qurl-send-map.test.js: /qurl send + /qurl map front-half
     //     (slash-option parsing, recipient resolution, confirm-card
     //     render/dispatch, forgery-rejection gates).
     //   - send-pipeline-back-half.test.js: executeSendPipeline + back-half

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qurl-discord-bot",
   "version": "2.1.0",
-  "description": "qURL Discord bot — /qurl file + /qurl map for secure one-time resource sharing, GitHub OAuth linking, auto Contributor role",
+  "description": "qURL Discord bot — /qurl send + /qurl map for secure one-time resource sharing, GitHub OAuth linking, auto Contributor role",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -29,7 +29,7 @@ function bootRequired(isOpenNHPActive) {
 }
 
 // Additionally required when NODE_ENV=production. QURL_API_KEY is the
-// global-fallback for /qurl file + /qurl map; single-guild-plain and
+// global-fallback for /qurl send + /qurl map; single-guild-plain and
 // multi-tenant deployments both rely on per-guild /qurl setup, so it's
 // optional outside the OpenNHP community server.
 //

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -269,7 +269,7 @@ const ROLE_MENTION_HINT_RE = /<@&\d+>/u;
 // gateway event delivery causes drift.
 //
 // In-flight de-duplication via the `prewarmInFlight` map below: two
-// concurrent `/qurl file @everyone` invocations in the same guild from
+// concurrent `/qurl send @everyone` invocations in the same guild from
 // a cold cache share the same underlying `members.fetch()` promise.
 // Without coalescing, abuse via concurrent invocations could burn
 // chunk-request budget linearly. discord.js may also coalesce the
@@ -429,7 +429,7 @@ function clearCooldown(userId) {
 // Soften an existing cooldown so `residualMs` remain. Monotonic SHRINK
 // — only reduces remaining time, never extends. Used by Cancel paths
 // so a legitimate "I changed my mind" doesn't lock the full window
-// out, but rapid /qurl file → Cancel → /qurl file → Cancel spam still
+// out, but rapid /qurl send → Cancel → /qurl send → Cancel spam still
 // pays a small throttle on each iteration (preventing supersedeOrCreate
 // + interaction-reply abuse).
 function softenCooldown(userId, residualMs) {
@@ -864,7 +864,7 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
   // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
   // and "1 hour ago" once expired. No bot-side editing needed.
   //
-  // CONTRACT: `personalMessage` arrives pre-sanitized. `/qurl file`
+  // CONTRACT: `personalMessage` arrives pre-sanitized. `/qurl send`
   // and `/qurl map` pipe raw input through `sanitizeMessage`
   // (markdown escape + @-mention strip) before constructing this
   // payload, and the addRecipients path reads from
@@ -1022,7 +1022,7 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
 }
 
 // --- Link status monitor ---
-// Track live monitors so a burst of `/qurl file` + `/qurl map` commands
+// Track live monitors so a burst of `/qurl send` + `/qurl map` commands
 // can't stack more than MAX_CONCURRENT_MONITORS setIntervals. When we
 // cross the cap, the oldest monitor is stopped to make room (the user
 // can still `/qurl revoke`; they just stop seeing live status updates in
@@ -1248,7 +1248,7 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   return control;
 }
 
-// --- qurl send pipeline (back-half shared by /qurl file + /qurl map) ---
+// --- qurl send pipeline (back-half shared by /qurl send + /qurl map) ---
 // TODO(#55): Split commands.js into focused modules — see https://github.com/layervai/qurl-integrations/issues/55
 //
 // REVIEW NOTE: The size of commands.js is tracked as a follow-up in
@@ -1296,7 +1296,7 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
 }
 
 // executeSendPipeline — back-half of the qurl send lifecycle, shared
-// by `/qurl file` and `/qurl map` after the user clicks the Send
+// by `/qurl send` and `/qurl map` after the user clicks the Send
 // button on the confirm card. The destructure signature is the
 // authoritative param surface; the notes below capture only non-obvious
 // contract guarantees that a reader couldn't infer from the call sites
@@ -1417,7 +1417,7 @@ async function executeSendPipeline(interaction, {
     throw new ErrorCtor(msg);
   }
 
-  // Defense-in-depth SSRF re-check. `/qurl file`'s front-half
+  // Defense-in-depth SSRF re-check. `/qurl send`'s front-half
   // validates attachment.url against isAllowedSourceUrl BEFORE
   // calling the pipeline; this gate catches a future caller that
   // forgets.
@@ -1458,7 +1458,7 @@ async function executeSendPipeline(interaction, {
   }
 
   // `recipients` shape + cap gates. The docstring's "non-empty,
-  // ≤ QURL_SEND_MAX_RECIPIENTS" contract is enforced by the `/qurl file`
+  // ≤ QURL_SEND_MAX_RECIPIENTS" contract is enforced by the `/qurl send`
   // + `/qurl map` front-half today; this is defense-in-depth for a
   // future caller (deserialized payload, programmatic retry, admin tool)
   // that skips those checks. Trips here would otherwise surface deep
@@ -1689,10 +1689,10 @@ async function executeSendPipeline(interaction, {
       resourceId: link.resourceId, resourceType, qurlLink: link.qurlLink,
       // CONTRACT: targetType is always 'user' for new rows post-PR
       // #313 (the only caller is executeSendPipeline via the confirm
-      // card on /qurl file + /qurl map, both of which DM individual
+      // card on /qurl send + /qurl map, both of which DM individual
       // recipients). The column is kept because the revoke-list
       // renderer's branch on `s.target_type` still has to handle
-      // historical /qurl send rows ('channel') during the TTL drain
+      // historical legacy /qurl send wizard rows ('channel') during the TTL drain
       // window. #318 drops the formatRevokeLabel non-'user' branch
       // once no revoke-visible row has `target_type !== 'user'` — the
       // drain happens naturally as the revoke renderer filters on
@@ -2734,8 +2734,8 @@ const SETUP_API_KEY_MAX_LENGTH = 64;
 const SETUP_SUCCESS_MSG =
   '✅ **qURL is now configured for this server!**\n\n'
   + (config.MAP_COMMAND_ENABLED
-    ? 'Your team can use `/qurl file` and `/qurl map` to share files and locations securely.\n'
-    : 'Your team can use `/qurl file` to share files securely.\n')
+    ? 'Your team can use `/qurl send` and `/qurl map` to share files and locations securely.\n'
+    : 'Your team can use `/qurl send` to share files securely.\n')
   + 'All qURL usage will be billed to your API key.';
 
 // Button-stage handler. Routed by flow-dispatch when the admin
@@ -3003,12 +3003,12 @@ async function handleSetupModal(interaction, { flow_id }) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// /qurl file + /qurl map — slash-driven sends.
+// /qurl send + /qurl map — slash-driven sends.
 //
 // All-options-up-front slash commands that render an in-channel
 // ephemeral confirm card. The flow:
 //
-//   /qurl file recipients:<text> attachment:<file> [expires-in]
+//   /qurl send recipients:<text> attachment:<file> [expires-in]
 //                                                  [self-destruct]
 //                                                  [personal-message]
 //   /qurl map  recipients:<text> location:<text>   [location-name]
@@ -3054,7 +3054,7 @@ const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
 const CONFIRM_USER_SELECT_CUSTOM_ID = 'qurl_confirm_user_select';
 const CONFIRM_SEND_CUSTOM_ID = 'qurl_confirm_send';
 const CONFIRM_CANCEL_CUSTOM_ID = 'qurl_confirm_cancel';
-// Confirm-card menus / button — slash options on /qurl file + /qurl map
+// Confirm-card menus / button — slash options on /qurl send + /qurl map
 // remain as initial defaults (one-shot for power users), but a user who
 // didn't fill them in can still adjust expiry, self-destruct, and note
 // inline on the card.
@@ -3069,14 +3069,16 @@ const CONFIRM_NOTE_MODAL_CUSTOM_ID = 'qurl_confirm_note_modal';
 // non-bot members via `channel.members` AT CLICK TIME, not render time,
 // so a 30s-old member snapshot doesn't silently send to people who
 // left. PR #174's "voice-connected only" semantics are restored here
-// (replacing the legacy `/qurl send`'s wizard option deleted in
-// PR #313 alongside `getChannelMembers`).
+// (replacing the legacy multi-step `/qurl send` wizard's option,
+// deleted in PR #313 alongside `getChannelMembers`. Note: the
+// current `/qurl send` is the renamed `/qurl file` subcommand,
+// NOT the deleted wizard — the name was reused after rename).
 //
 // STAGE-CHANNEL SEMANTICS: discord.js's `channel.members` for stage
 // channels includes BOTH speakers and audience (everyone currently
 // connected to the voice gateway in that stage). This is the
 // "voice-connected" contract carried over from PR #174 and matches
-// the legacy `/qurl send` behavior. A future stage-specific UX
+// the legacy multi-step `/qurl send` wizard's behavior. A future stage-specific UX
 // might want speakers-only (filter by `member.voice.suppress ===
 // false`) — that's a separate affordance, not a regression in this
 // path. Today the live `(N)` count on the button label is the user's
@@ -3163,11 +3165,11 @@ const SEND_NOTE_MODAL_FIELD_ID = 'message_value';
 
 // 3-minute confirm-card window — the time-to-finish budget a user has
 // to review the confirm card and click Send/Cancel after invoking
-// /qurl file or /qurl map.
+// /qurl send or /qurl map.
 const SEND_FLOW_TTL_SECONDS = 180;
 
 // On a successful Cancel, soften (don't clear) the cooldown so 5s of
-// throttle remain — defuses the rapid /qurl file → Cancel → /qurl file
+// throttle remain — defuses the rapid /qurl send → Cancel → /qurl send
 // → Cancel spam vector (which would otherwise rack up supersedeOrCreate
 // DDB writes with zero throttle).
 const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
@@ -3183,7 +3185,7 @@ const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
 // would hit "qURL is not configured for this server" instead of
 // QURL_MAP_DISABLED_REPLY.
 const API_KEY_GATED_SUBCOMMANDS = new Set(
-  config.MAP_COMMAND_ENABLED ? ['file', 'map', 'revoke'] : ['file', 'revoke'],
+  config.MAP_COMMAND_ENABLED ? ['send', 'map', 'revoke'] : ['send', 'revoke'],
 );
 
 // User-facing reply for stale /qurl map submissions when the toggle
@@ -3191,7 +3193,7 @@ const API_KEY_GATED_SUBCOMMANDS = new Set(
 // submission after the registration has dropped it. Copy mirrors
 // the flag-off branch of SETUP_SUCCESS_MSG so both surfaces describe
 // the same remaining capability.
-const QURL_MAP_DISABLED_REPLY = '❌ `/qurl map` is currently disabled. Use `/qurl file` to share files securely.';
+const QURL_MAP_DISABLED_REPLY = '❌ `/qurl map` is currently disabled. Use `/qurl send` to share files securely.';
 
 // Slash-option choice arrays. The same wording flows into both the
 // slash-command autocomplete and the confirm-card dropdowns so users
@@ -4182,7 +4184,7 @@ function renderConfirmCardRows({
   return rows;
 }
 
-// Shared entry point — both `/qurl file` and `/qurl map` route here
+// Shared entry point — both `/qurl send` and `/qurl map` route here
 // after collecting their resource-specific options. `params` carries:
 //   resourceType: RESOURCE_TYPES.FILE | RESOURCE_TYPES.MAPS
 //   attachment:   {url, name, contentType, size} | null  (file path)
@@ -4203,7 +4205,7 @@ async function handleQurlSlashSend(interaction, params) {
       ephemeral: true,
     });
   }
-  // Cooldown gate is owned by the front-half handlers (handleQurlFile /
+  // Cooldown gate is owned by the front-half handlers (handleQurlSend /
   // handleQurlMap) so invalid inputs are throttled too. By the time we
   // get here the cooldown is already set; legitimate clearCooldown calls
   // on individual error branches below still unlock retry.
@@ -4297,7 +4299,7 @@ async function handleQurlSlashSend(interaction, params) {
         resolved = await resolveRecipientUsers(interaction, parsed.ids);
       } catch (err) {
         clearCooldown(interaction.user.id);
-        logger.error('qurl file/map: resolveRecipientUsers threw', {
+        logger.error('qurl send/map: resolveRecipientUsers threw', {
           user_id: interaction.user.id, error: err && err.message,
         });
         return interaction.editReply({
@@ -4393,7 +4395,7 @@ async function handleQurlSlashSend(interaction, params) {
     //     ephemeral message lives in, which DOES match invocation
     //     channel in practice — but pinning via payload is the durable
     //     contract and matches the rest of the flow-state pattern.
-    //   - A user who opens /qurl file from a voice channel, then
+    //   - A user who opens /qurl send from a voice channel, then
     //     drags themselves into a different channel mid-confirm,
     //     should still see "Everyone on voice" target
     //     the channel they invoked from, not the channel they're now
@@ -4407,7 +4409,7 @@ async function handleQurlSlashSend(interaction, params) {
     // Voice-everyone auto-default. When the slash command was invoked
     // from a voice channel AND `recipients:` was omitted, resolve to
     // voice-connected members (excluding sender + bots) and render the
-    // card in voice-mode. This makes "/qurl file" from inside #voice
+    // card in voice-mode. This makes "/qurl send" from inside #voice
     // behave the way users naturally expect — the room is the audience.
     //
     // Sender is filtered pre-validity via partitionRecipients's
@@ -4424,7 +4426,7 @@ async function handleQurlSlashSend(interaction, params) {
     //
     // SNAPSHOT vs. CLICK-TIME asymmetry: this slash-entry path freezes
     // `recipientIds` at command receipt — someone joining the channel
-    // between `/qurl file` and the Send click is NOT added. The "🔊
+    // between `/qurl send` and the Send click is NOT added. The "🔊
     // Everyone on voice" button (handleConfirmVoiceEveryone) goes the
     // other way: re-resolves `channel.members` at click time. The two
     // shapes are reachable from the same UI but produce different
@@ -4574,7 +4576,7 @@ async function handleQurlSlashSend(interaction, params) {
     const needsPicker = recipientMode === RECIPIENT_MODE_PICKER && recipientsOmitted;
     const recipientIds = finalValid.map((u) => u.id);
 
-    // supersedeOrCreate handles the "another /qurl file/map is open"
+    // supersedeOrCreate handles the "another /qurl send/map is open"
     // case — sibling-flow disambig surfaces a stage-specific message;
     // same-stage rerun atomically claims the slot. Mirrors /qurl
     // revoke's pattern.
@@ -4731,7 +4733,7 @@ async function handleQurlSlashSend(interaction, params) {
   }
 }
 
-async function handleQurlFile(interaction) {
+async function handleQurlSend(interaction) {
   // DM rejection first — no cooldown burned on a guild-only invocation
   // attempted from DMs.
   if (!interaction.guildId || !interaction.guild) {
@@ -4748,7 +4750,7 @@ async function handleQurlFile(interaction) {
     // Log at INFO so capacity-tuning has a trend signal — a sudden
     // burst of these would indicate either MAX_CONCURRENT_FILE_SENDS
     // is undersized or a downstream pipeline is stuck holding slots.
-    logger.info('handleQurlFile: capacity backpressure', {
+    logger.info('handleQurlSend: capacity backpressure', {
       user_id: interaction.user.id,
       active_file_sends: activeFileSends,
       max_concurrent: MAX_CONCURRENT_FILE_SENDS,
@@ -4785,7 +4787,7 @@ async function handleQurlFile(interaction) {
   try {
     attachment = interaction.options.getAttachment('attachment', true);
   } catch (err) {
-    logger.warn('handleQurlFile: required attachment option missing', {
+    logger.warn('handleQurlSend: required attachment option missing', {
       user_id: interaction.user.id, error: err && err.message,
     });
     clearCooldown(interaction.user.id);
@@ -4803,7 +4805,7 @@ async function handleQurlFile(interaction) {
     });
   }
   if (!isAllowedSourceUrl(attachment.url)) {
-    logger.warn('handleQurlFile: attachment.url failed SSRF gate', {
+    logger.warn('handleQurlSend: attachment.url failed SSRF gate', {
       user_id: interaction.user.id, host: safeUrlHost(attachment.url),
     });
     return interaction.reply({
@@ -4859,12 +4861,12 @@ async function handleQurlMap(interaction) {
       ephemeral: true,
     });
   }
-  // NOTE: No `activeFileSends` capacity gate here (unlike handleQurlFile).
+  // NOTE: No `activeFileSends` capacity gate here (unlike handleQurlSend).
   // The capacity gate guards the connector upload path that file sends
   // hit during back-half dispatch; map sends never touch that resource.
   // Sharing the gate would punish maps for file-pipeline saturation.
   //
-  // Cooldown gate — cross-command bucket shared with /qurl file
+  // Cooldown gate — cross-command bucket shared with /qurl send
   // (sendCooldowns Map). Tests pin the contract.
   if (isOnCooldown(interaction.user.id)) {
     return interaction.reply({
@@ -4878,7 +4880,7 @@ async function handleQurlMap(interaction) {
   // enforces required server-side; the more likely cause in production
   // is a client/schema desync (redeploy timing) than abuse. Clear
   // cooldown on the throw catch so the user can retry once the deploy
-  // stabilizes — same rationale as handleQurlFile's required-option
+  // stabilizes — same rationale as handleQurlSend's required-option
   // throw branch.
   let locationValue;
   try {
@@ -4906,7 +4908,7 @@ async function handleQurlMap(interaction) {
   if (locationValue.length === 0) {
     // Honest user error (pasted only whitespace, or empty string) —
     // unlock retry. Same shape as the file-type / size cap branches
-    // in handleQurlFile.
+    // in handleQurlSend.
     clearCooldown(interaction.user.id);
     return interaction.reply({
       content: '❌ Location is empty.',
@@ -4916,7 +4918,7 @@ async function handleQurlMap(interaction) {
 
   // Shared parser: see `parseLocationInput` near the top of this file.
   // Wrap in try/catch as a defensive symmetry with
-  // handleQurlFile's catches: a future regex change in parseLocationInput
+  // handleQurlSend's catches: a future regex change in parseLocationInput
   // or a pathological input could throw synchronously before reaching
   // handleQurlSlashSend's safety net, leaving cooldown set with no
   // visible response.
@@ -4996,7 +4998,7 @@ async function handleQurlMap(interaction) {
   });
 }
 
-// --- Confirm-card handlers for `/qurl file` + `/qurl map` ---
+// --- Confirm-card handlers for `/qurl send` + `/qurl map` ---
 // Any future rename of the `qurl_confirm_*` wire literals (or these
 // handler names, since they're paired with them via registerFlow)
 // needs a SEND_FLOW_TTL_SECONDS (180s) drain on the prior deploy so
@@ -5113,7 +5115,7 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
   // warning banner prepended. Replacing card content with just the
   // warning string strips the resource header ("Sending file:
   // report.pdf / Expires: 24h / Self-destruct: …") that the user
-  // chose at /qurl file time — they shouldn't have to scroll back to
+  // chose at /qurl send time — they shouldn't have to scroll back to
   // remember what they're sending. needsPicker:true keeps the "Pick
   // recipients below" prompt; sendDisabled:true keeps Send greyed.
   const rejectPick = (warning) => interaction.editReply({
@@ -5972,7 +5974,7 @@ async function handleConfirmEveryone(interaction, { flow_id, row }) {
 // handlers drifting on `sendDisabled` / content flags.
 //
 // `sendDisabled` is derived from recipientIds — without it, a user
-// who opened /qurl file without `recipients:` could change expiry
+// who opened /qurl send without `recipients:` could change expiry
 // before picking and see an enabled Send button against an empty
 // recipient set.
 // All four entry paths (picker, expiry, self-destruct, note modal)
@@ -6558,7 +6560,7 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
   // for the two buckets — "left the server" is stable, "lookup
   // blipped" encourages a fresh rerun if they want to include the
   // missed recipients. The rerun hint names the actual subcommand
-  // they invoked (resourceType drives /qurl file vs /qurl map).
+  // they invoked (resourceType drives /qurl send vs /qurl map).
   //
   // followUp (not edited into the "Preparing send…" editReply) is
   // INTENTIONAL: executeSendPipeline will rewrite editReply to
@@ -6567,7 +6569,7 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
   // message. followUp is a separate ephemeral that persists past
   // the back-half's editReply rewrites.
   if (partialLeftCount > 0 || partialTransientCount > 0) {
-    const rerunCommand = payload.resourceType === RESOURCE_TYPES.MAPS ? '/qurl map' : '/qurl file';
+    const rerunCommand = payload.resourceType === RESOURCE_TYPES.MAPS ? '/qurl map' : '/qurl send';
     const parts = [];
     if (partialLeftCount > 0) {
       parts.push(`${partialLeftCount} recipient${partialLeftCount === 1 ? '' : 's'} had left the server`);
@@ -6613,7 +6615,7 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
 //
 // On a successful Cancel, `softenCooldown` retains 5s of throttle
 // instead of fully clearing — a full clear would let a user spam
-// /qurl file → Cancel → /qurl file → Cancel and rack up
+// /qurl send → Cancel → /qurl send → Cancel and rack up
 // supersedeOrCreate DDB writes + Discord interactions with zero
 // throttle. The cooldown-loser branch leaves cooldown untouched
 // (Send is mid-fanout; bypassing is the abuse vector).
@@ -7545,13 +7547,13 @@ const commands = [
     // based on config.MAP_COMMAND_ENABLED — a plain fluent chain
     // can't host an `if`. The order of `addSubcommand` calls below
     // matches the chain we'd write inline, with `map` inserted
-    // between `file` and `revoke` when the flag is on.
+    // between `send` and `revoke` when the flag is on.
     data: (() => {
       const builder = new SlashCommandBuilder()
         .setName('qurl')
         .setDescription('Share resources securely via qURL')
         .addSubcommand(sub =>
-          sub.setName('file')
+          sub.setName('send')
             .setDescription('Share a file via one-time qURL links')
             .addAttachmentOption(opt =>
               opt.setName('attachment')
@@ -7860,10 +7862,27 @@ const commands = [
         });
       }
 
-      // Gate: require guild API key for file/map/revoke (the set
+      // Stale-client rename reply — `/qurl file` was renamed to
+      // `/qurl send`. Discord clients cache slash registrations and
+      // can submit the old name for up to ~1h after a global rollout
+      // (near-instant on guild-scoped registration). Caught here
+      // BEFORE API_KEY_GATED_SUBCOMMANDS so unconfigured guilds get
+      // the rename hint instead of "qURL is not configured".
+      if (sub === 'file') {
+        logger.debug('qurl_file_renamed_reply: stale-client /qurl file submission caught by rename gate', {
+          user_id: interaction.user?.id,
+          guild_id: interaction.guildId,
+        });
+        return interaction.reply({
+          content: '⚠️ `/qurl file` has been renamed to `/qurl send`. Please use `/qurl send` instead — your Discord client may take up to an hour to refresh the command list.',
+          ephemeral: true,
+        });
+      }
+
+      // Gate: require guild API key for send/map/revoke (the set
       // in API_KEY_GATED_SUBCOMMANDS, hoisted to module scope).
       //
-      // For /qurl file + /qurl map this read is a fail-fast presence
+      // For /qurl send + /qurl map this read is a fail-fast presence
       // check — the resolved value is intentionally NOT threaded
       // through to the back-half. handleConfirmSendClick re-fetches at
       // Send-click time so a key rotation during the 3-minute confirm-
@@ -7886,12 +7905,12 @@ const commands = [
         resolvedApiKey = guildApiKey || config.QURL_API_KEY;
       }
 
-      // /qurl file and /qurl map deliberately don't accept the
+      // /qurl send and /qurl map deliberately don't accept the
       // dispatcher-resolved apiKey — handleConfirmSendClick re-fetches
       // at Send time so a mid-flow rotation still uses the live key.
       // The dispatcher's API_KEY_GATED_SUBCOMMANDS gate above is the
       // fail-fast presence check.
-      if (sub === 'file') return handleQurlFile(interaction);
+      if (sub === 'send') return handleQurlSend(interaction);
       if (sub === 'map') {
         if (!config.MAP_COMMAND_ENABLED) {
           // Debug (not warn) — expected post-deploy traffic from
@@ -7933,21 +7952,21 @@ const commands = [
           ? {
             sectionVerb: 'Share resources',
             bullet: '  `/qurl map` — share a Google Maps location via one-time qURL links\n',
-            runLine: '\t1. Run `/qurl file` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n',
+            runLine: '\t1. Run `/qurl send` (attach a file) or `/qurl map` (paste a Google Maps URL or address)\n',
             resource: 'the file or location',
-            cmd: '`/qurl file` or `/qurl map`',
+            cmd: '`/qurl send` or `/qurl map`',
           }
           : {
             sectionVerb: 'Share files',
             bullet: '',
-            runLine: '\t1. Run `/qurl file` (attach a file)\n',
+            runLine: '\t1. Run `/qurl send` (attach a file)\n',
             resource: 'the file',
-            cmd: '`/qurl file`',
+            cmd: '`/qurl send`',
           };
         return interaction.reply({
           content: '**qURL Bot — Help**\n\n' +
             `**Getting started — ${mapCopy.sectionVerb} securely via one-time links:**\n` +
-            '  `/qurl file` — share a file with users via one-time qURL links\n' +
+            '  `/qurl send` — share a file with users via one-time qURL links\n' +
             mapCopy.bullet +
             '  `/qurl revoke` — revoke links from a previous send\n' +
             '  `/qurl help` — show this message\n\n' +
@@ -8395,7 +8414,7 @@ registerFlow(SETUP_MODAL_CUSTOM_ID, {
   siblingMessage: 'You already have a `/qurl setup` modal open — finish that one, or wait for it to expire.',
 });
 
-// /qurl file + /qurl map confirm-card components. All three customIds
+// /qurl send + /qurl map confirm-card components. All three customIds
 // share the same expectedStage — they're three component types
 // (button + user-select + button) attached to the same confirm-card
 // message, all routed by stage. siblingMessage is registered on the
@@ -8404,14 +8423,14 @@ registerFlow(SETUP_MODAL_CUSTOM_ID, {
 registerFlow(CONFIRM_USER_SELECT_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmUserSelect,
-  siblingMessage: 'You have a `/qurl file` or `/qurl map` confirm card open in this channel — finish or cancel it first.',
+  siblingMessage: 'You have a `/qurl send` or `/qurl map` confirm card open in this channel — finish or cancel it first.',
 });
 // siblingMessage intentionally omitted on the SEND + CANCEL custom-
 // id registrations below — flow-dispatch's `siblingMessages` map is
 // keyed by stage (not by customId), so the message registered on
 // USER_SELECT above is reachable from any of the three customIds
 // at SEND_STAGE_AWAITING_CONFIRM. The "siblingMessage keyed by stage"
-// test in qurl-file-map.test.js pins this contract.
+// test in qurl-send-map.test.js pins this contract.
 registerFlow(CONFIRM_SEND_CUSTOM_ID, {
   expectedStage: SEND_STAGE_AWAITING_CONFIRM,
   handler: handleConfirmSendClick,
@@ -8501,7 +8520,7 @@ module.exports = {
       sendCooldowns,
       // Renderer exposed so tests can pin the bottom-row button
       // composition directly (e.g., the DM-context @everyone-gate
-      // assertion) without driving through handleQurlFile's entry path.
+      // assertion) without driving through handleQurlSend's entry path.
       renderConfirmCardRows,
       // Memo for the @everyone non-bot count is module-scoped. Tests
       // that reuse a guild reference across cases could otherwise get
@@ -8523,7 +8542,7 @@ module.exports = {
       safeUrlHost,
       // Back-half functions exposed for direct unit testing. Without these
       // hooks, coverage of the polling/revoke/add-recipients code paths
-      // can only be reached via full /qurl file + /qurl map integration
+      // can only be reached via full /qurl send + /qurl map integration
       // tests, which require mocking the entire state-machine front-half
       // before the back-half even runs. Direct exposure means each
       // function gets a focused spec without that setup overhead.
@@ -8537,7 +8556,7 @@ module.exports = {
       // The top-level back-half driver. Exported here so PR 7b's
       // tests (and the follow-up direct unit spec in #278) can pin
       // its contract against a constructed param object — without
-      // re-driving the full /qurl file + /qurl map confirm-card flow.
+      // re-driving the full /qurl send + /qurl map confirm-card flow.
       executeSendPipeline,
       // Test-only file-concurrency hooks. The slot counter is module-
       // private (live state) and exposing a setter lets the cap branch
@@ -8564,10 +8583,10 @@ module.exports = {
       SETUP_API_KEY_MIN_LENGTH,
       SETUP_API_KEY_MAX_LENGTH,
       SETUP_SUCCESS_MSG,
-      // /qurl file + /qurl map handlers + flow constants. Tests pin
+      // /qurl send + /qurl map handlers + flow constants. Tests pin
       // against production values via these exports rather than
       // re-stating the strings.
-      handleQurlFile,
+      handleQurlSend,
       handleQurlMap,
       resolveRecipientUsers,
       partitionRecipients,
@@ -8592,7 +8611,7 @@ module.exports = {
       softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
       // Every confirm-card customId is exported so the contract test
-      // in qurl-file-map.test.js can pin every wire value — a typo
+      // in qurl-send-map.test.js can pin every wire value — a typo
       // in any of these silently breaks routing for in-flight confirm
       // cards, so they need to be test-asserted.
       CONFIRM_USER_SELECT_CUSTOM_ID,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -291,7 +291,7 @@ module.exports = {
   // (ECS rolls fresh tasks on every task-def revision).
   MAP_COMMAND_ENABLED: process.env.MAP_COMMAND_ENABLED === 'true',
 
-  // qURL send limits (/qurl file + /qurl map) — both must be > 0. A
+  // qURL send limits (/qurl send + /qurl map) — both must be > 0. A
   // cooldown of 0 would silently disable the rate limit; a recipients
   // cap of 0 would reject every send.
   //

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -156,7 +156,7 @@ const AUDIT_EVENTS = {
   // both file and location prep paths. The meta `kind` field carries
   // the composition: 'file' | 'location' | 'mixed'. Collapsing to one
   // event prevents UploadCount from double-counting mixed sends if the
-  // CloudWatch filter doesn't dimension on kind. /qurl file and
+  // CloudWatch filter doesn't dimension on kind. /qurl send and
   // /qurl map are mutually exclusive so 'mixed' only ever shows up
   // from handleAddRecipients on a sendConfig that has both file +
   // location.

--- a/apps/discord/src/database.js
+++ b/apps/discord/src/database.js
@@ -164,7 +164,7 @@ const SAFE_ALTERS = {
   // dropdown so users don't re-select a no-op and see "0/0 links revoked".
   revoked_at: 'ALTER TABLE qurl_send_configs ADD COLUMN revoked_at TEXT',
   // Self-destruct timer (seconds) — one of the SELF_DESTRUCT_PRESETS the
-  // user picked on the /qurl file + /qurl map confirm card, forwarded to
+  // user picked on the /qurl send + /qurl map confirm card, forwarded to
   // the connector as `viewer_ttl_seconds` so the rendered viewer page
   // wipes content after N seconds. REAL because the smallest preset is
   // 0.5. NULL ⇒ no timer (default). Persisted so the Add Recipients flow

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -37,8 +37,8 @@ function assertIntent(intentsList, bit, requiredFor) {
   }
 }
 assertIntent(intents, GatewayIntentBits.Guilds, 'guild bootstrap (caches guilds the bot is in)');
-assertIntent(intents, GatewayIntentBits.GuildMembers, '/qurl file + /qurl map recipient resolution (members.cache for role-mention expansion + members.fetch for selected-user backfill)');
-assertIntent(intents, GatewayIntentBits.GuildVoiceStates, '/qurl file + /qurl map voice-channel-everyone resolution (channel.members for voice-connected snapshot in the confirm card button + <#voice> mention expansion in the recipients string)');
+assertIntent(intents, GatewayIntentBits.GuildMembers, '/qurl send + /qurl map recipient resolution (members.cache for role-mention expansion + members.fetch for selected-user backfill)');
+assertIntent(intents, GatewayIntentBits.GuildVoiceStates, '/qurl send + /qurl map voice-channel-everyone resolution (channel.members for voice-connected snapshot in the confirm card button + <#voice> mention expansion in the recipients string)');
 
 // Negative-intent canaries — pin that the bot has NOT silently
 // re-broadened gateway scope. Every intent listed here is either:

--- a/apps/discord/src/flow-state.js
+++ b/apps/discord/src/flow-state.js
@@ -221,7 +221,7 @@ function decryptPayload(ciphertext) {
 //
 // Why caller-supplied `expires_at` rather than computing it here:
 // different flow types have different lifecycle bounds (a
-// `/qurl setup` modal has a 15-minute window; a `/qurl file` or
+// `/qurl setup` modal has a 15-minute window; a `/qurl send` or
 // `/qurl map` confirm card has a 3-minute window). The caller knows;
 // this module just persists.
 //
@@ -840,7 +840,7 @@ async function deleteFlow(flow_id, { stage, reason, expectedVersion } = {}) {
 // Open a fresh flow row, superseding a same-flow_id predecessor at
 // the SAME stage if one exists. The supersede-and-retry pattern was
 // duplicated across /qurl revoke and /qurl setup (and recurs in
-// /qurl file + /qurl map); extracting it here closes #272 (OCC on
+// /qurl send + /qurl map); extracting it here closes #272 (OCC on
 // deleteFlow against the prior version), #273 (include_expired so
 // a stuck-orphan past its logical TTL is still observable), and
 // #274 (the duplication itself).

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -125,7 +125,7 @@ if (isMultiTenant) {
 // workflows stay convenient. Keep this list in sync with the production
 // comments in .env.example.
 if (process.env.NODE_ENV === 'production') {
-  // QURL_API_KEY is the global-fallback key for /qurl file + /qurl map.
+  // QURL_API_KEY is the global-fallback key for /qurl send + /qurl map.
   // Only the OpenNHP community server demands it at boot; single-guild-
   // plain and multi-tenant deployments rely on per-guild /qurl setup.
   // List is in boot-requirements.js for testability.

--- a/apps/discord/src/recipient-parser.js
+++ b/apps/discord/src/recipient-parser.js
@@ -1,7 +1,7 @@
 // recipient-parser — extracts user/role mentions from the `recipients:`
 // slash-command option string and resolves them to a flat user-ID list.
 //
-// `/qurl file` and `/qurl map` expose `recipients:` as a STRING option
+// `/qurl send` and `/qurl map` expose `recipients:` as a STRING option
 // rather than a list of mentionables because Discord's slash-command
 // `mentionable` option type is single-value — a power-user one-shot
 // path needs a free-form text that can carry many mentions, role
@@ -198,7 +198,7 @@ const VIEW_CHANNEL_PERMISSION = 1n << 10n;
 // pasted formatting without ever hitting the parser cap.
 const MAX_INPUT_LENGTH = 4000;
 
-// Max length applied to `/qurl file` / `/qurl map` `recipients:`
+// Max length applied to `/qurl send` / `/qurl map` `recipients:`
 // slash options. Discord enforces this server-side, so anything past
 // it never reaches the parser — the parser's MAX_INPUT_LENGTH cap
 // (above) is genuine defense-in-depth, only reachable via a forged
@@ -207,7 +207,7 @@ const MAX_INPUT_LENGTH = 4000;
 // Picked at half of MAX_INPUT_LENGTH so the headroom relationship is
 // load-bearing: a future bump to MAX_INPUT_LENGTH (e.g. for a larger
 // guild's role-expansion needs) preserves the 2× gap automatically.
-// Both /qurl file and /qurl map builders read this; 7b.3+ should
+// Both /qurl send and /qurl map builders read this; 7b.3+ should
 // continue to honor the gap.
 const SLASH_OPTION_HEADROOM_DIVISOR = 2;
 const MAX_SLASH_OPTION_LENGTH = Math.floor(MAX_INPUT_LENGTH / SLASH_OPTION_HEADROOM_DIVISOR);
@@ -454,7 +454,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // Permission gate (issue #326): non-mentionable roles require
     // MENTION_EVERYONE — same rule Discord enforces for in-chat role
     // mentions. Without this gate, a non-admin sender could
-    // `/qurl file recipients:<@&adminRoleId>` to fan a send to admin-
+    // `/qurl send recipients:<@&adminRoleId>` to fan a send to admin-
     // role members, bypassing the same protection the @everyone path
     // got in #323. `role.mentionable === true` is the per-role bypass
     // (set explicitly by a role owner). Lands in `roleMentionsDenied`
@@ -546,7 +546,7 @@ function parseRecipientMentions(raw, interaction, opts = {}) {
     // it has visibility into, so without this check a user who
     // discovers a private voice channel's snowflake (audit logs,
     // mod-tool exports, leaked URLs) could DM-blast its connected
-    // members via `/qurl file recipients:<#hidden-voice-id>` even
+    // members via `/qurl send recipients:<#hidden-voice-id>` even
     // when they themselves can't see the channel in the client.
     // Fail-closed: a missing `interaction.member` (DM context the
     // outer guild check already eliminated; defense-in-depth here

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -59,7 +59,7 @@ function renderNotConfigured(res) {
 // if attacker pre-runs Discord install in their browser then forwards
 // the chained Auth0-redirect URL to a victim, the readout shows
 // (attacker's guild + victim's qURL email) so the victim can spot the
-// mismatch before /qurl file or /qurl map usage starts. PR #177 follow-up C.5 —
+// mismatch before /qurl send or /qurl map usage starts. PR #177 follow-up C.5 —
 // upgraded from the prior grey-prose subtext for visual prominence.
 function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   const details = [];
@@ -75,7 +75,7 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
     // CTA folded into message so the "confirm before closing" cue
     // always rides next to the binding readout, including when the
     // qURL-account-email line is missing (JWKS verify failure).
-    message: 'Confirm the binding below matches your server, then close this tab and return to Discord. /qurl file and /qurl map are ready.',
+    message: 'Confirm the binding below matches your server, then close this tab and return to Discord. /qurl send and /qurl map are ready.',
     details,
     type: 'success',
   }));
@@ -441,7 +441,7 @@ router.get('/callback', rateLimit, async (req, res) => {
   //    `/qurl status` and against the layerv.ai dashboard, which
   //    matters for spotting binding mismatches in the rare confused-
   //    deputy edge case (see PR #177 review item 3).
-  const dmLines = ['✅ **qURL is connected to your Discord server.** Your team can now use `/qurl file` and `/qurl map`. All usage will be billed to your qURL account.'];
+  const dmLines = ['✅ **qURL is connected to your Discord server.** Your team can now use `/qurl send` and `/qurl map`. All usage will be billed to your qURL account.'];
   if (keyPrefix) dmLines.push(`Key prefix: \`${keyPrefix}\``);
   sendDM(discordUserId, dmLines.join('\n'))
     .catch((err) => logger.warn('Failed to DM admin after qURL setup', { error: err?.message, discordUserId }));

--- a/apps/discord/src/utils/sanitize.js
+++ b/apps/discord/src/utils/sanitize.js
@@ -70,7 +70,7 @@ function stripControlAndBidi(s, maxCodepoints = 64, fallback = DISPLAY_NAME_FALL
  * `maxCodepoints`, then escape markdown so a crafted label can't
  * inject `**bold**` / `[masked-link](https://evil)` / spoilers.
  *
- * Callers: /qurl map's `locationName`, /qurl file's
+ * Callers: /qurl map's `locationName`, /qurl send's
  * `attachment.name`-derived `resourceLabel`. Returns '' on empty /
  * all-strip-char input (NOT the 'Someone' display-name fallback) so
  * the caller can render its own empty-state.

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -30,7 +30,7 @@ function expiryToMs(expiresIn) {
 }
 
 // Self-destruct timer presets — the 7 durations exposed in the
-// /qurl file + /qurl map confirm-card dropdown. Curated narrow set so
+// /qurl send + /qurl map confirm-card dropdown. Curated narrow set so
 // creators don't ship a 0.7s viewer that hits the 500ms-floor edge
 // case in the connector by accident; every preset is a value we'd
 // recommend out loud.
@@ -65,7 +65,7 @@ function findPresetBySeconds(n) {
 }
 
 // selfDestructSelectValueToSeconds — converts a StringSelectMenu value
-// from the /qurl file + /qurl map confirm card into the seconds the
+// from the /qurl send + /qurl map confirm card into the seconds the
 // bot persists and forwards.
 // The select's option set is fixed: the no-timer sentinel, or
 // `String(preset.seconds)` for each preset. Strict string equality (not

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -291,7 +291,7 @@ function makeInteraction(overrides = {}) {
   const base = {
     user: { id: 'user-1', username: 'TestUser' },
     options: {
-      getSubcommand: jest.fn(() => 'file'),
+      getSubcommand: jest.fn(() => 'send'),
       getString: jest.fn(() => null),
       getUser: jest.fn(() => null),
       getAttachment: jest.fn(() => null),
@@ -2211,7 +2211,7 @@ describe('handleSetupModal (dispatcher path)', () => {
 // set MAP_COMMAND_ENABLED, so the bot's strict `=== 'true'` parser
 // resolves it to false — matching the production default. Every test
 // in this block verifies a surface that should be inert when the flag
-// is off. The flag-on path is covered by qurl-file-map.test.js (whose
+// is off. The flag-on path is covered by qurl-send-map.test.js (whose
 // config mock sets MAP_COMMAND_ENABLED: true).
 describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
   const { mockSearchPlaces } = require('./helpers/places-mock');
@@ -2221,7 +2221,7 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
     // production string via _test so a future copy edit can't drift
     // this assertion from reality.
     expect(_test.SETUP_SUCCESS_MSG).not.toContain('/qurl map');
-    expect(_test.SETUP_SUCCESS_MSG).toContain('/qurl file');
+    expect(_test.SETUP_SUCCESS_MSG).toContain('/qurl send');
   });
 
   it('/qurl help reply omits /qurl map references', async () => {
@@ -2238,7 +2238,7 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
     // Sanity: the help reply is still rendered (we want absence of
     // map, not absence of help). Catches a regression where the
     // entire help branch goes silent.
-    expect(replyArg.content).toContain('/qurl file');
+    expect(replyArg.content).toContain('/qurl send');
     expect(replyArg.content).toContain('qURL Bot — Help');
     // Pin the flag-off `sectionVerb` swap — a regression that drops
     // the conditional verb would render "Share resources" against a
@@ -2290,6 +2290,31 @@ describe('MAP_COMMAND_ENABLED=false (flag-off behavior)', () => {
     await handleCommand(interaction);
     expect(interaction.respond).toHaveBeenCalledWith([]);
     expect(mockSearchPlaces).not.toHaveBeenCalled();
+  });
+
+  it('dispatcher replies with rename hint for stale `/qurl file` submissions (post-rename to /qurl send)', async () => {
+    // Discord won't normally route a `file` submission after the
+    // rename propagates, but a stale client carrying the pre-rename
+    // command definition can still submit one for up to ~1h (global
+    // registration cache TTL). The dispatcher's defensive branch
+    // turns that into an ephemeral rename hint instead of falling
+    // through to an unknown-subcommand void.
+    const interaction = makeInteraction({
+      options: {
+        ...makeInteraction().options,
+        getSubcommand: jest.fn(() => 'file'),
+      },
+    });
+    await handleCommand(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringMatching(/`\/qurl file` has been renamed to `\/qurl send`/),
+      ephemeral: true,
+    });
+    // The hint must fire BEFORE handleQurlSend's defer path; if the
+    // dispatcher ever routed through it by mistake, deferReply would
+    // fire and the user would see a spurious "thinking..." then the
+    // rename hint. Negative assertion guards against that regression.
+    expect(interaction.deferReply).not.toHaveBeenCalled();
   });
 
   it('stale /qurl map in an unconfigured guild hits disabled reply BEFORE the API-key gate (routing order)', async () => {

--- a/apps/discord/tests/coverage-boost.test.js
+++ b/apps/discord/tests/coverage-boost.test.js
@@ -1,6 +1,6 @@
 /**
  * Residual coverage tests for commands.js — narrow branches that aren't
- * covered by the focused specs (qurl-file-map, send-pipeline-back-half,
+ * covered by the focused specs (qurl-send-map, send-pipeline-back-half,
  * commands-comprehensive, send-pipeline-helpers).
  *
  * Covers:
@@ -248,7 +248,7 @@ function makeInteraction(overrides = {}) {
   const base = {
     user: { id: 'user-1', username: 'TestUser' },
     options: {
-      getSubcommand: jest.fn(() => 'file'),
+      getSubcommand: jest.fn(() => 'send'),
       getString: jest.fn(() => null),
       getUser: jest.fn(() => null),
       getAttachment: jest.fn(() => null),
@@ -346,7 +346,7 @@ describe('handleCommand — autocomplete edge cases', () => {
       isChatInputCommand: jest.fn(() => false),
       options: {
         ...makeInteraction().options,
-        getSubcommand: jest.fn(() => 'file'),
+        getSubcommand: jest.fn(() => 'send'),
         getFocused: jest.fn(() => ({ name: 'location', value: 'query' })),
       },
     });

--- a/apps/discord/tests/discord.test.js
+++ b/apps/discord/tests/discord.test.js
@@ -105,7 +105,7 @@ const mockClient = {
 jest.mock('discord.js', () => ({
   Client: jest.fn(() => mockClient),
   // GuildVoiceStates (=128 in production discord.js) is load-bearing
-  // for the /qurl file + /qurl map voice-channel-everyone path —
+  // for the /qurl send + /qurl map voice-channel-everyone path —
   // channel.members for voice channels reads the voice-state cache
   // which is only populated when the intent is declared. The discord.js
   // module's assertIntent at boot would throw if this bit is missing
@@ -638,9 +638,8 @@ describe('discord module', () => {
     // Pins the actual production canary description strings so a future
     // refactor of the `assertIntent(..., '<feature>')` arg at discord.js:
     // 38–39 fails this test instead of silently shipping a stale error
-    // message at boot. The prior version of this spec pinned a `/qurl send`
-    // description; this version tracks the live `/qurl file + /qurl map`
-    // wording.
+    // message at boot. Tracks the live `/qurl send + /qurl map` wording
+    // (the subcommand was renamed from `/qurl file` to `/qurl send`).
     it('production assertIntent invocations surface the live recipient-resolution feature label', () => {
       // Construct the same intentsList shape src/discord.js declares (the
       // numeric values are mocked at the top of this file — see the
@@ -648,8 +647,8 @@ describe('discord module', () => {
       // canary; the throw message MUST embed the production label so an
       // oncall engineer reading boot logs gets the actionable feature.
       expect(() => discord.assertIntent([1 /* Guilds */], 2 /* GuildMembers */,
-        '/qurl file + /qurl map recipient resolution (members.cache for role-mention expansion + members.fetch for selected-user backfill)'))
-        .toThrow(/\/qurl file \+ \/qurl map recipient resolution/);
+        '/qurl send + /qurl map recipient resolution (members.cache for role-mention expansion + members.fetch for selected-user backfill)'))
+        .toThrow(/\/qurl send \+ \/qurl map recipient resolution/);
     });
 
     // GuildVoiceStates is the second load-bearing intent: its boot
@@ -659,7 +658,7 @@ describe('discord module', () => {
     // must trip this assertion at module load.
     it('production assertIntent for GuildVoiceStates surfaces the voice-everyone resolution feature label', () => {
       expect(() => discord.assertIntent([1 /* Guilds */, 2 /* GuildMembers */], 128 /* GuildVoiceStates */,
-        '/qurl file + /qurl map voice-channel-everyone resolution (channel.members for voice-connected snapshot in the confirm card button + <#voice> mention expansion in the recipients string)'))
+        '/qurl send + /qurl map voice-channel-everyone resolution (channel.members for voice-connected snapshot in the confirm card button + <#voice> mention expansion in the recipients string)'))
         .toThrow(/voice-channel-everyone resolution/);
     });
   });

--- a/apps/discord/tests/helpers/places-mock.js
+++ b/apps/discord/tests/helpers/places-mock.js
@@ -6,7 +6,7 @@
  * file mocks it, but the mock contract has crept up over time —
  * encode/decode, shape regex, buildPlaceUrl — and the duplicate
  * implementations across `commands-comprehensive.test.js`,
- * `coverage-boost.test.js`, and `qurl-file-map.test.js` were a real
+ * `coverage-boost.test.js`, and `qurl-send-map.test.js` were a real
  * drift risk (one file's regex tightens, the other two silently
  * accept the looser shape).
  *

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -1,7 +1,8 @@
 /**
- * Tests for /qurl file + /qurl map slash commands (PR 7b.2).
+ * Tests for /qurl send + /qurl map slash commands (PR 7b.2;
+ * `/qurl file` renamed to `/qurl send` in a later PR).
  *
- * Covers the new handlers from src/commands.js — handleQurlFile,
+ * Covers the new handlers from src/commands.js — handleQurlSend,
  * handleQurlMap, the shared confirm-card pipeline, the flow-dispatch
  * handlers (UserSelect / Send / Cancel) — plus the pure helpers
  * (resolveRecipientUsers, partitionRecipients, selfDestructOptionToSeconds,
@@ -180,7 +181,7 @@ const commands = require('../src/commands');
 const { _test } = commands;
 const logger = require('../src/logger');
 const {
-  handleQurlFile,
+  handleQurlSend,
   handleQurlMap,
   resolveRecipientUsers,
   partitionRecipients,
@@ -297,7 +298,7 @@ function makeInteraction({
     options: {
       getString: optGetString,
       getAttachment: optGetAttachment,
-      getSubcommand: () => options._sub || 'file',
+      getSubcommand: () => options._sub || 'send',
     },
     reply: jest.fn().mockResolvedValue(undefined),
     editReply: jest.fn().mockResolvedValue(undefined),
@@ -1451,8 +1452,8 @@ describe('handleAutocomplete', () => {
     expect(mockSearchPlaces).not.toHaveBeenCalled();
   });
 
-  test('responds empty for /qurl file (only /qurl map has suggestions)', async () => {
-    const int = makeAutocompleteInteraction({ subcommand: 'file' });
+  test('responds empty for /qurl send (only /qurl map has suggestions)', async () => {
+    const int = makeAutocompleteInteraction({ subcommand: 'send' });
     await handleAutocomplete(int);
     expect(int.respond).toHaveBeenCalledWith([]);
     expect(mockSearchPlaces).not.toHaveBeenCalled();
@@ -1749,7 +1750,7 @@ describe('safeDecodeURIComponent', () => {
 });
 
 describe('cross-command cooldown contract', () => {
-  // /qurl file and /qurl map share the sendCooldowns Map. setCooldown
+  // /qurl send and /qurl map share the sendCooldowns Map. setCooldown
   // from one MUST block the other — without this contract, a user
   // could bypass the per-user throttle by alternating entry points.
   beforeEach(() => sendCooldowns.clear());
@@ -2229,16 +2230,16 @@ describe('renderConfirmCardContent', () => {
 });
 
 // ──────────────────────────────────────────────────────────────
-// handleQurlFile — front half
+// handleQurlSend — front half
 // ──────────────────────────────────────────────────────────────
 
-describe('handleQurlFile — slash entry', () => {
+describe('handleQurlSend — slash entry', () => {
   test('rejects in DM context', async () => {
     const int = makeInteraction({
       guildId: null,
       options: { attachment: VALID_ATTACHMENT },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/in a server/),
       ephemeral: true,
@@ -2256,7 +2257,7 @@ describe('handleQurlFile — slash entry', () => {
     try {
       setActiveFileSends(99);  // any value ≥ MAX_CONCURRENT_FILE_SENDS
       const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
         content: expect.stringMatching(/too many file sends/i),
         ephemeral: true,
@@ -2274,7 +2275,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, url: 'https://evil.com/x.png' } },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/source not allowed/),
       ephemeral: true,
@@ -2288,7 +2289,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, contentType: 'application/x-evil-macroenabled' } },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/File type not allowed/),
     }));
@@ -2301,7 +2302,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: { ...VALID_ATTACHMENT, size: 999_999_999 } },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/too large/),
     }));
@@ -2318,7 +2319,7 @@ describe('handleQurlFile — slash entry', () => {
       },
       guildMembers: { [u1]: {}, [u2]: {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.deferReply).toHaveBeenCalled();
     expect(mockSupersedeOrCreate).toHaveBeenCalledWith(expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
@@ -2346,7 +2347,7 @@ describe('handleQurlFile — slash entry', () => {
     expect(reply.components.length).toBeGreaterThan(0);
   });
 
-  test('/qurl map slash entry persists recipientAliases (parity with /qurl file)', async () => {
+  test('/qurl map slash entry persists recipientAliases (parity with /qurl send)', async () => {
     // Both entry points share handleQurlSlashSend's payload-construction
     // path. This sanity test pins that the alias-persistence guarantee
     // covers /qurl map as well — without it, a regression that only
@@ -2375,7 +2376,7 @@ describe('handleQurlFile — slash entry', () => {
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Pick recipients/);
@@ -2391,7 +2392,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: `<@${u1}> <@${u2}>` },
       guildMembers: { [u1]: { bot: true }, [u2]: { bot: true } },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
@@ -2406,7 +2407,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: `<@${SENDER_ID}>` },
       guildMembers: { [SENDER_ID]: {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Send includes you/);
@@ -2429,7 +2430,7 @@ describe('handleQurlFile — slash entry', () => {
       guildId: null, // → guild = null in makeInteraction
       options: { attachment: VALID_ATTACHMENT, recipients: `@everyone <@${SENDER_ID}>` },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     // Whatever editReply lands, the @everyone permission warning
     // must not appear. (The flow itself may hard-fail downstream
     // because resolveRecipientUsers needs guild context — that's a
@@ -2455,7 +2456,7 @@ describe('handleQurlFile — slash entry', () => {
     // Default memberPermissions is undefined (no Mention Everyone) —
     // matches the existing "no permission" assumption across this
     // test suite.
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const lastEdit = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(lastEdit.content).toMatch(/Mention Everyone\b/);
@@ -2484,7 +2485,7 @@ describe('handleQurlFile — slash entry', () => {
       mentionable: false,
       members: new Map([[bobId, { user: { id: bobId, bot: false } }]]),
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     // Alice (directly mentioned) IS in recipients; Bob (role member) is NOT.
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
@@ -2516,7 +2517,7 @@ describe('handleQurlFile — slash entry', () => {
       mentionable: false,
       members: new Map([[aliceId, { user: { id: aliceId, bot: false } }]]),
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     // Permission-specific copy present.
@@ -2552,7 +2553,7 @@ describe('handleQurlFile — slash entry', () => {
       ]),
     });
     int.memberPermissions = { has: jest.fn(() => true) };
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.recipientIds.sort()).toEqual([aliceId, bobId].sort());
@@ -2574,7 +2575,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { [aliceId]: {}, [bobId]: {} },
     });
     int.memberPermissions = { has: jest.fn(() => true) };
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const lastEdit = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     // Permission warning must NOT fire.
@@ -2596,7 +2597,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: {},
       guildFetchByID: { [flaky1]: 'ratelimit', [flaky2]: 'ratelimit' },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Could not look up recipients right now.*Try again/i);
@@ -2611,7 +2612,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { [known]: {} },
       guildFetchByID: { [gone]: 'unknown' },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.recipientIds).toEqual([known]);
@@ -2627,7 +2628,7 @@ describe('handleQurlFile — slash entry', () => {
     // Force cooldown
     sendCooldowns.set(SENDER_ID, Date.now());
     expect(isOnCooldown(SENDER_ID)).toBe(true);
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/wait before sending/),
     }));
@@ -2643,7 +2644,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/revoke.*menu open/);
   });
@@ -2659,7 +2660,7 @@ describe('handleQurlFile — slash entry', () => {
       },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
     expect(payload.expiresIn).toBe('7d');
@@ -2672,7 +2673,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>', 'expires-in': '99y' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Unrecognized expiry/);
@@ -2705,7 +2706,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: {},  // ALL cache-miss
       guildFetchByID: fetchByID,
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/No valid recipients/);
@@ -2724,7 +2725,7 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(isOnCooldown(SENDER_ID)).toBe(false);
     const reply = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(reply.content).toMatch(/Could not start a send/);
@@ -2747,7 +2748,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     int.deferReply.mockRejectedValueOnce(new Error('token expired'));
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(isOnCooldown(SENDER_ID)).toBe(false);
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringMatching(/unexpected throw/),
@@ -2760,7 +2761,7 @@ describe('handleQurlFile — slash entry', () => {
     // (renderConfirmCardContent, renderConfirmCardRows, the final
     // editReply, etc.) throws, the DDB row we just claimed would
     // sit orphaned until TTL eviction — blocking the user's next
-    // /qurl file or /qurl map under the sibling-flow guard.
+    // /qurl send or /qurl map under the sibling-flow guard.
     //
     // Reproduce: let supersedeOrCreate resolve `created: true`, then
     // force editReply to throw on its first call (the
@@ -2772,7 +2773,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     int.editReply.mockRejectedValueOnce(new Error('Discord 500'));
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     expect(mockDeleteFlow).toHaveBeenCalledWith(
       expect.any(String),
@@ -2801,7 +2802,7 @@ describe('handleQurlFile — slash entry', () => {
       guildMembers: { '100000000000000001': {} },
     });
     int.deferReply.mockRejectedValueOnce(new Error('token expired'));
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).not.toHaveBeenCalled();
     expect(mockDeleteFlow).not.toHaveBeenCalled();
   });
@@ -2818,13 +2819,13 @@ describe('handleQurlFile — slash entry', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     expect(mockDeleteFlow).not.toHaveBeenCalled();
   });
 
   describe('voice-channel slash entry (auto voice-everyone default)', () => {
-    // When `/qurl file` is invoked from a voice channel WITHOUT a
+    // When `/qurl send` is invoked from a voice channel WITHOUT a
     // `recipients:` value, the front half auto-resolves the voice-
     // connected members (minus sender + bots) and lands in voice-mode.
     // These tests pin (a) the recipient set excludes the sender,
@@ -2858,7 +2859,7 @@ describe('handleQurlFile — slash entry', () => {
 
     test('happy path: voice members minus sender land in payload, recipientMode:"voice"', async () => {
       const int = makeVoiceEntryInteraction({ members: [SENDER_ID, u1, u2] });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('voice');
       expect(payload.recipientIds.sort()).toEqual([u1, u2].sort());
@@ -2871,7 +2872,7 @@ describe('handleQurlFile — slash entry', () => {
         members: [u1, bot, u2],
         botIds: [bot],
       });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('voice');
       expect(payload.recipientIds.sort()).toEqual([u1, u2].sort());
@@ -2888,7 +2889,7 @@ describe('handleQurlFile — slash entry', () => {
         members: [bot],
         botIds: [bot],
       });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');
       expect(payload.recipientIds).toEqual([]);
@@ -2900,7 +2901,7 @@ describe('handleQurlFile — slash entry', () => {
       // warning; the user didn't ask for voice-everyone, so falling
       // back to the picker UX is the quiet path.
       const int = makeVoiceEntryInteraction({ members: [SENDER_ID] });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');
       expect(payload.recipientIds).toEqual([]);
@@ -2908,7 +2909,7 @@ describe('handleQurlFile — slash entry', () => {
 
     test('empty voice channel → falls back to picker-mode', async () => {
       const int = makeVoiceEntryInteraction({ members: [] });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');
       expect(payload.recipientIds).toEqual([]);
@@ -2925,7 +2926,7 @@ describe('handleQurlFile — slash entry', () => {
       config.QURL_SEND_MAX_RECIPIENTS = 1;  // force over-cap with 2 members
       try {
         const int = makeVoiceEntryInteraction({ members: [u1, u2] });
-        await handleQurlFile(int);
+        await handleQurlSend(int);
         const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
         expect(payload.recipientMode).toBe('picker');
         expect(payload.recipientIds).toEqual([]);
@@ -2951,7 +2952,7 @@ describe('handleQurlFile — slash entry', () => {
       // Inject the channel id WITHOUT registering it in the cache —
       // makes guild.channels.cache.get(id) return undefined, the cache-
       // miss shape.
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');
       expect(payload.warningsBlock).toMatch(/Couldn't read voice channel members/);
@@ -2968,7 +2969,7 @@ describe('handleQurlFile — slash entry', () => {
       int.options.getString.mockImplementation((key) =>
         (key === 'recipients' ? `<@${u1}>` : null)
       );
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('picker');
       expect(payload.recipientIds).toEqual([u1]);
@@ -2992,7 +2993,7 @@ describe('handleQurlFile — slash entry', () => {
       });
       int.memberPermissions = { has: jest.fn(() => true) };
       int.guild.memberCount = 3;
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('everyone');
       // Fan-out includes the sender (selfIncluded=true), matching
@@ -3026,7 +3027,7 @@ describe('handleQurlFile — slash entry', () => {
       });
       int.memberPermissions = { has: jest.fn(() => true) };
       int.guild.memberCount = 3;
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const payload = mockSupersedeOrCreate.mock.calls[0][0].payload;
       expect(payload.recipientMode).toBe('everyone');
       expect(payload.selfIncluded).toBe(false);
@@ -3044,7 +3045,7 @@ describe('handleQurlFile — slash entry', () => {
         guildMembers: { [SENDER_ID]: {} },
       });
       // Default permission shape → no MENTION_EVERYONE.
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const supersedeCalls = mockSupersedeOrCreate.mock.calls;
       // No confirm card persisted (recipientsOmitted=false + valid=0 →
       // the "no valid recipients" early-return fires before
@@ -3091,7 +3092,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       guildMembers: { [aliceId]: {} },
     });
     int.memberPermissions = { has: jest.fn(() => true) };
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
   });
 
@@ -3108,7 +3109,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       id: '7100', name: 'team', mentionable: true,
       members: new Map([[aliceId, { user: { id: aliceId, bot: false } }]]),
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
   });
 
@@ -3121,7 +3122,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: `<@${aliceId}>` },
       guildMembers: { [aliceId]: {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
@@ -3131,7 +3132,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT }, // no recipients
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
@@ -3145,7 +3146,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '@everyone' },
     });
     // No memberPermissions set → has(MentionEveryone) returns undefined → falsy.
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
@@ -3164,7 +3165,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       members: new Map([[aliceId, { user: { id: aliceId, bot: false } }]]),
     });
     // No memberPermissions set → has(MentionEveryone) returns undefined → falsy.
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.find(isPrewarmCall)).toBeTruthy();
   });
 
@@ -3178,7 +3179,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT, recipients: '@everyonefoo' },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
@@ -3195,12 +3196,12 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     });
     int.memberPermissions = { has: jest.fn(() => true) };
     int.guild.memberCount = 2; // matches cache.size from guildMembers above
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(int.guild.members.fetch.mock.calls.filter(isPrewarmCall)).toEqual([]);
   });
 
   test('concurrent invocations in the same guild share one in-flight fetch', async () => {
-    // Two simultaneous /qurl file @everyone calls against a cold cache
+    // Two simultaneous /qurl send @everyone calls against a cold cache
     // should NOT each fire their own chunk request. The prewarm helper's
     // in-flight Map<guildId, Promise> coalesces them — abuse via
     // concurrent invocations otherwise burns chunk-request budget
@@ -3209,7 +3210,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
     const aliceId = '500000000000000010';
     // A controllable fetch — caller resolves `release` after the
     // assertion so both handlers complete cleanly. Without the resolve,
-    // the two awaiting `handleQurlFile` calls would leak through to
+    // the two awaiting `handleQurlSend` calls would leak through to
     // process exit and Jest's `--detectOpenHandles` would surface them.
     let release;
     const fetchGate = new Promise((r) => { release = r; });
@@ -3231,8 +3232,8 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       int.memberPermissions = { has: jest.fn(() => true) };
       return int;
     }
-    const p1 = handleQurlFile(makeShared());
-    const p2 = handleQurlFile(makeShared());
+    const p1 = handleQurlSend(makeShared());
+    const p2 = handleQurlSend(makeShared());
     // Microtask flush so both handlers reach the prewarm await.
     await new Promise((r) => setImmediate(r));
     const prewarmCalls = sharedFetch.mock.calls.filter(isPrewarmCall);
@@ -3260,7 +3261,7 @@ describe('handleQurlSlashSend — guild.members cache pre-warm', () => {
       }
       return { user: makeUser(arg) };
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(mockSupersedeOrCreate).toHaveBeenCalled();
     const logger = require('../src/logger');
     const warnCall = logger.warn.mock.calls.find(
@@ -3485,7 +3486,7 @@ describe('handleQurlMap — slash entry', () => {
     }));
     // Honest user error (whitespace-only paste) — don't strand them
     // for 30s. Same shape as the file-type / size-cap branches in
-    // handleQurlFile.
+    // handleQurlSend.
     expect(isOnCooldown(SENDER_ID)).toBe(false);
   });
 
@@ -3705,7 +3706,7 @@ describe('handleConfirmSendClick', () => {
     );
   });
 
-  test('partial transient lookup at Send click — Send proceeds with remaining, transient drop surfaced with retry copy (/qurl file)', async () => {
+  test('partial transient lookup at Send click — Send proceeds with remaining, transient drop surfaced with retry copy (/qurl send)', async () => {
     // transientFailureIds must be surfaced with retry-encouraging
     // copy (NOT "left the server" wording) — the buckets are split
     // + threaded so a 429/gateway blip doesn't read as "they're gone".
@@ -3723,7 +3724,7 @@ describe('handleConfirmSendClick', () => {
     // followUp distinguishes transient from "left" — retry copy. The
     // rerun command name is derived from payload.resourceType.
     expect(int.followUp).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/1 couldn't be looked up.*rerun \/qurl file/),
+      content: expect.stringMatching(/1 couldn't be looked up.*rerun \/qurl send/),
       ephemeral: true,
     }));
     expect(logger.info).toHaveBeenCalledWith(
@@ -3733,8 +3734,8 @@ describe('handleConfirmSendClick', () => {
   });
 
   test('partial transient lookup at Send click — /qurl map payload produces /qurl map rerun hint', async () => {
-    // The same handler serves /qurl file and /qurl map. A user who
-    // invoked /qurl map should NOT be told to "rerun /qurl file" in
+    // The same handler serves /qurl send and /qurl map. A user who
+    // invoked /qurl map should NOT be told to "rerun /qurl send" in
     // the transient-lookup followUp. resourceType=MAPS in the payload
     // drives the hint.
     const flaky = '100000000000000099';
@@ -3757,9 +3758,9 @@ describe('handleConfirmSendClick', () => {
       content: expect.stringMatching(/rerun \/qurl map/),
       ephemeral: true,
     }));
-    // Must NOT say /qurl file when the user invoked /qurl map.
+    // Must NOT say /qurl send when the user invoked /qurl map.
     expect(int.followUp).not.toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringMatching(/rerun \/qurl file/),
+      content: expect.stringMatching(/rerun \/qurl send/),
     }));
   });
 
@@ -3963,7 +3964,7 @@ describe('handleConfirmSendClick', () => {
 describe('handleConfirmCancelClick', () => {
   test('happy path → version-gated deleteFlow + cooldown softened to ~5s residual + update', async () => {
     // softenCooldown leaves 5s of throttle so a user can't spam
-    // /qurl file → Cancel → /qurl file → Cancel and rack up
+    // /qurl send → Cancel → /qurl send → Cancel and rack up
     // supersedeOrCreate DDB writes with zero cost. A legitimate
     // "I changed my mind" still has the cooldown softened from full
     // QURL_SEND_COOLDOWN_MS down to 5s.
@@ -3992,7 +3993,7 @@ describe('handleConfirmCancelClick', () => {
   test('deleteFlow dedup loser → ephemeral message + cooldown PRESERVED (no soften)', async () => {
     // Critical: when Send won the race, we must NOT touch the cooldown
     // — Send is fanning out DMs and a soften would let the user
-    // re-fire /qurl file within 5s of clicking Cancel, before the
+    // re-fire /qurl send within 5s of clicking Cancel, before the
     // first send finishes. The Cancel-loser branch leaves the
     // original cooldown timestamp intact (no softening).
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
@@ -4156,7 +4157,7 @@ describe('handleConfirmUserSelect', () => {
     // keeps the pick prompt and the picker stays attached. Replacing
     // the content with just the warning string would strip the
     // "Sending file: report.pdf / Expires: 24h" header the user
-    // chose at /qurl file time.
+    // chose at /qurl send time.
     const int = makeSelectInteraction({
       users: [makeUser(u1, { bot: true })],
     });
@@ -6399,7 +6400,7 @@ describe('renderConfirmCardRows', () => {
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT },  // no `recipients` → needsPicker
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const editReplyCalls = int.editReply.mock.calls;
     const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
     expect(lastCall.components).toHaveLength(4);
@@ -6429,7 +6430,7 @@ describe('renderConfirmCardRows', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const editReplyCalls = int.editReply.mock.calls;
     const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
     expect(lastCall.components).toHaveLength(4);
@@ -6447,7 +6448,7 @@ describe('renderConfirmCardRows', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     // 3 buttons constructed for the bottom row of the confirm card.
     expect(ButtonBuilder).toHaveBeenCalledTimes(3);
     const customIds = ButtonBuilder.mock.results.map(
@@ -6467,7 +6468,7 @@ describe('renderConfirmCardRows', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const noteBtn = ButtonBuilder.mock.results[0].value;
     expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Add a note/));
   });
@@ -6488,7 +6489,7 @@ describe('renderConfirmCardRows', () => {
       },
       guildMembers: { '100000000000000001': {} },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const noteBtn = ButtonBuilder.mock.results[0].value;
     expect(noteBtn.setLabel).toHaveBeenCalledWith(expect.stringMatching(/Edit note/));
   });
@@ -6514,7 +6515,7 @@ describe('renderConfirmCardRows', () => {
         '100000000000000002': {},
       },
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(MentionableSelectMenuBuilder).toHaveBeenCalledTimes(1);
     const builder = MentionableSelectMenuBuilder.mock.results[0].value;
     expect(builder.addDefaultUsers).toHaveBeenCalledWith(
@@ -6533,7 +6534,7 @@ describe('renderConfirmCardRows', () => {
     const int = makeInteraction({
       options: { attachment: VALID_ATTACHMENT },  // no recipients → needsPicker
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     expect(MentionableSelectMenuBuilder).toHaveBeenCalledTimes(1);
     const builder = MentionableSelectMenuBuilder.mock.results[0].value;
     expect(builder.addDefaultUsers).not.toHaveBeenCalled();
@@ -6554,7 +6555,7 @@ describe('renderConfirmCardRows', () => {
       options: { attachment: VALID_ATTACHMENT, recipients: mentionList },
       guildMembers,
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const builder = MentionableSelectMenuBuilder.mock.results[0].value;
     expect(builder.setMaxValues).toHaveBeenCalledWith(12);
     expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids);
@@ -6582,7 +6583,7 @@ describe('renderConfirmCardRows', () => {
       id: 'voice-fixed', name: adversarialName, type: 2,
       members: new Map([['111', { user: { id: '111', bot: false } }]]),
     });
-    await handleQurlFile(int);
+    await handleQurlSend(int);
     const voiceBtn = ButtonBuilder.mock.results.find(
       (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_voice_everyone'
     );
@@ -6604,7 +6605,7 @@ describe('renderConfirmCardRows', () => {
   });
 
   describe('voice-mode layout (recipientMode:"voice")', () => {
-    // Round-trip the render layout via handleQurlFile invoked from a
+    // Round-trip the render layout via handleQurlSend invoked from a
     // voice channel WITHOUT `recipients:`. The slash-entry voice-mode
     // auto-default lands the card in voice-mode, which:
     //   - HIDES the MentionableSelect picker row
@@ -6633,7 +6634,7 @@ describe('renderConfirmCardRows', () => {
       MentionableSelectMenuBuilder.mockClear();
       const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
       setupVoice(int);
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       // The literal "one or the other" contract — voice-mode kills the
       // picker. A test that asserted on `editReply.components.length`
       // alone would silently drift if rows were added/removed elsewhere.
@@ -6645,7 +6646,7 @@ describe('renderConfirmCardRows', () => {
       ButtonBuilder.mockClear();
       const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
       setupVoice(int);
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const customIds = ButtonBuilder.mock.results.map(
         (r) => r.value.setCustomId.mock.calls[0]?.[0]
       );
@@ -6663,7 +6664,7 @@ describe('renderConfirmCardRows', () => {
       ButtonBuilder.mockClear();
       const int = makeInteraction({ options: { attachment: VALID_ATTACHMENT } });
       setupVoice(int);
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const customIds = ButtonBuilder.mock.results.map(
         (r) => r.value.setCustomId.mock.calls[0]?.[0]
       );
@@ -6689,7 +6690,7 @@ describe('renderConfirmCardRows', () => {
         name: '**inject** _under_ ||hide||',
         members: new Map([[u1, member]]),
       });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const editReplyCalls = int.editReply.mock.calls;
       const lastCall = editReplyCalls[editReplyCalls.length - 1][0];
       expect(lastCall.content).toContain(`<#${VOICE_CH}>`);
@@ -6882,7 +6883,7 @@ describe('renderConfirmCardRows', () => {
       });
       int.memberPermissions = { has: jest.fn(() => true) };
       int.guild.memberCount = 5;
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
       expect(customIds).toContain('qurl_confirm_everyone');
     });
@@ -6897,7 +6898,7 @@ describe('renderConfirmCardRows', () => {
         options: { attachment: VALID_ATTACHMENT, recipients: '<@100000000000000001>' },
         guildMembers: { '100000000000000001': {} },
       });
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
       expect(customIds).not.toContain('qurl_confirm_everyone');
     });
@@ -6921,7 +6922,7 @@ describe('renderConfirmCardRows', () => {
       });
       int.memberPermissions = { has: jest.fn(() => true) };
       int.guild.memberCount = 3;
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const everyoneBtn = ButtonBuilder.mock.results.find(
         (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
       );
@@ -6950,7 +6951,7 @@ describe('renderConfirmCardRows', () => {
       int.memberPermissions = { has: jest.fn(() => true) };
       // Leave memberCount unset → undefined.
       delete int.guild.memberCount;
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const everyoneBtn = ButtonBuilder.mock.results.find(
         (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
       );
@@ -6960,7 +6961,7 @@ describe('renderConfirmCardRows', () => {
 
     test('does NOT render in DM context — direct renderer assertion', () => {
       // Pin the renderer's `interaction.guild` gate directly (not via
-      // handleQurlFile's entry-point DM-rejection). Without a direct
+      // handleQurlSend's entry-point DM-rejection). Without a direct
       // assertion, a future refactor that loosens the renderer gate
       // would only fail tests via the entry-point guard, leaving the
       // renderer-only contract under-pinned.
@@ -7127,7 +7128,7 @@ describe('renderConfirmCardRows', () => {
         });
         int.memberPermissions = { has: jest.fn(() => true) };
         int.guild.memberCount = 4;  // matches cache.size → warm + accurate
-        await handleQurlFile(int);
+        await handleQurlSend(int);
         const everyoneBtn = ButtonBuilder.mock.results.find(
           (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
         );
@@ -7158,7 +7159,7 @@ describe('renderConfirmCardRows', () => {
         });
         int.memberPermissions = { has: jest.fn(() => true) };
         int.guild.memberCount = 500;  // cache.size < memberCount → cold
-        await handleQurlFile(int);
+        await handleQurlSend(int);
         const everyoneBtn = ButtonBuilder.mock.results.find(
           (r) => r.value.setCustomId.mock.calls[0]?.[0] === 'qurl_confirm_everyone'
         );
@@ -7197,7 +7198,7 @@ describe('renderConfirmCardRows', () => {
         members: new Map([['100000000000000001', { user: makeUser('100000000000000001') }]]),
       };
       int.guild.channels.cache.set(voiceChannelId, int.channel);
-      await handleQurlFile(int);
+      await handleQurlSend(int);
       const customIds = ButtonBuilder.mock.results.map((r) => r.value.setCustomId.mock.calls[0]?.[0]);
       // Both affordances present; full bottom row = Voice + @everyone +
       // Note + Send + Cancel = 5 components (Discord's hard cap).
@@ -7486,7 +7487,7 @@ describe('constants + exports', () => {
     // accidentally keys siblingMessage by customId breaks here.
     const { siblingMessageForStage } = require('../src/flow-dispatch');
     const msg = siblingMessageForStage(SEND_STAGE_AWAITING_CONFIRM);
-    expect(msg).toMatch(/qurl file.*qurl map.*confirm card/i);
+    expect(msg).toMatch(/qurl send.*qurl map.*confirm card/i);
     // Defense-in-depth: confirm-card customIds for SEND + CANCEL,
     // although registered without their own siblingMessage, still
     // reach the same registered message through the stage lookup.

--- a/apps/discord/tests/recipient-parser.test.js
+++ b/apps/discord/tests/recipient-parser.test.js
@@ -1,6 +1,6 @@
 /**
  * Unit tests for src/recipient-parser.js — the `recipients:` slash-
- * option mention parser used by /qurl file and /qurl map.
+ * option mention parser used by /qurl send and /qurl map.
  *
  * Mocks config (just QURL_SEND_MAX_RECIPIENTS) and uses synthetic
  * `interaction` objects with the guild.members.cache / guild.roles.cache
@@ -394,7 +394,7 @@ describe('parseRecipientMentions — role-mention permission gate (#326)', () =>
   // Issue #326 parity: <@&roleId> for a non-mentionable role requires
   // MENTION_EVERYONE (allowMassMention). Mirrors Discord's in-chat
   // gate; closes the privilege-escalation surface where a non-admin
-  // could `/qurl file recipients:<@&adminRoleId>` to fan-out to an
+  // could `/qurl send recipients:<@&adminRoleId>` to fan-out to an
   // admin-only role.
 
   test('mentionable: false WITHOUT allowMassMention → roleMentionsDenied entry, NOT expanded', () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1,7 +1,7 @@
 /**
  * Send-pipeline back-half tests — monitorLinkStatus polling,
  * revokeAllLinks direct path, and handleAddRecipients flow. Covers the
- * code paths exercised after `/qurl file` or `/qurl map` reaches the
+ * code paths exercised after `/qurl send` or `/qurl map` reaches the
  * "Sent to N" confirmation:
  *   - monitorLinkStatus's setInterval body (init, status diff, pending →
  *     opened/expired transitions, addRecipients() generation bump,
@@ -2135,7 +2135,7 @@ describe('executeSendPipeline — personalMessage shape gate', () => {
 });
 
 // Defensive guards for the `recipients` invariants — non-empty and
-// ≤ config.QURL_SEND_MAX_RECIPIENTS. The `/qurl file` + `/qurl map`
+// ≤ config.QURL_SEND_MAX_RECIPIENTS. The `/qurl send` + `/qurl map`
 // front-half already enforces these before the pipeline call; the
 // gates are defense-in-depth for a future caller (deserialized
 // payload, programmatic retry) that skips those checks. Without

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -1,5 +1,5 @@
 /**
- * Tests for shared send-pipeline helpers used by /qurl file + /qurl map:
+ * Tests for shared send-pipeline helpers used by /qurl send + /qurl map:
  * helper functions, the qURL client, connector client, places client, and
  * database methods. The polling/back-half coverage lives in
  * send-pipeline-back-half.test.js.

--- a/e2e/tests/discord-commands.smoke.test.ts
+++ b/e2e/tests/discord-commands.smoke.test.ts
@@ -155,14 +155,14 @@ describe('Discord command registration (smoke)', () => {
       // eslint-disable-next-line no-console
       console.log(`smoke: MAP_COMMAND_ENABLED resolved to "${rawMapFlag}" (mapEnabled=${mapEnabled})`);
       const expectedSubcommands = mapEnabled
-        ? ['file', 'help', 'map', 'revoke', 'setup', 'status']
-        : ['file', 'help', 'revoke', 'setup', 'status'];
+        ? ['help', 'map', 'revoke', 'send', 'setup', 'status']
+        : ['help', 'revoke', 'send', 'setup', 'status'];
       expect({ scope: qurl._scope, subcommands })
         .toEqual({ scope: qurl._scope, subcommands: expectedSubcommands });
     }
   });
 
-  it('has no ghost subcommands from the Python-bot era or the pre-/qurl-file flow', () => {
+  it('has no ghost subcommands from the Python-bot era or the pre-rename flow', () => {
     // Intentional overlap with the exact-set assertion above: that
     // test is the correctness invariant, this one is living
     // documentation for subcommands that USED to exist and must
@@ -170,11 +170,19 @@ describe('Discord command registration (smoke)', () => {
     //
     // - `list`, `clear`: Python bot's catalog-era commands, removed
     //   when the bot was rewritten in Node.js.
-    // - `send`: legacy multi-step "Send File / Send Location" wizard,
-    //   replaced by `/qurl file` + `/qurl map` which provide the same
-    //   capabilities with explicit slash options + inline confirm-card
-    //   menus. Removed in PR 7b.3 (no grace period — file/map ship
-    //   the same UX).
+    // - `file`: the post-7b.3 subcommand name for "share a file" before
+    //   it was renamed to `/qurl send`. The dispatcher's stale-client
+    //   arm in commands.js intentionally handles `sub === 'file'`
+    //   submissions to surface a rename hint to clients with cached
+    //   command defs (~1h global cache TTL); that's a runtime path,
+    //   not a registration. The Discord registration must NEVER carry
+    //   `file` again — Discord would route to a real arm and bypass
+    //   the rename hint entirely.
+    //
+    // NOTE on `send`: there was an older legacy multi-step wizard
+    // named `/qurl send` (removed in PR 7b.3). The CURRENT `/qurl send`
+    // is the renamed `/qurl file` and is the expected active
+    // registration — it's in the positive-set assertion above, not here.
     for (const qurl of registrations) {
       const subcommandNames = (qurl.options ?? [])
         .filter((o) => o.type === SUBCOMMAND_OPTION_TYPE)
@@ -188,7 +196,7 @@ describe('Discord command registration (smoke)', () => {
       // regression that also changes the full set.
       expect(subcommandNames).not.toContain('list');
       expect(subcommandNames).not.toContain('clear');
-      expect(subcommandNames).not.toContain('send');
+      expect(subcommandNames).not.toContain('file');
     }
   });
 });

--- a/e2e/tests/qurl-oauth-setup.smoke.test.ts
+++ b/e2e/tests/qurl-oauth-setup.smoke.test.ts
@@ -34,7 +34,7 @@
  *      Discord server."
  *   7. Verify DDB row exists: `aws dynamodb get-item --table-name
  *      <table_prefix>guild-configs --key '{"guild_id":{"S":"<id>"}}'`.
- *   8. Run `/qurl file` (or `/qurl map`) with a test recipient — confirm
+ *   8. Run `/qurl send` (or `/qurl map`) with a test recipient — confirm
  *      it succeeds (proves the persisted key works through the connector
  *      + mint).
  *   9. Run `/qurl status` — confirm it shows the key prefix.


### PR DESCRIPTION
## Summary
- Renames `/qurl file` → `/qurl send` end-to-end: slash registration, dispatcher, handler (`handleQurlFile → handleQurlSend`), help copy, error messages, README, OAuth-success DM, and ~150 comments / log keys / test mocks.
- Adds a stale-client safety arm in the dispatcher so cached Discord clients submitting the old `/qurl file` name (up to ~1h on global registration, near-instant guild-scoped) get an ephemeral rename hint instead of falling through silently. Mirrors `qurl_map_disabled_reply`.
- Smoke-test ghost-list flipped: `'send'` removed (now active); `'file'` added (must never return in the registration).

## What stays literal (intentional)
Domain-model values, not subcommand names — unchanged on purpose:
- `resource_type = 'file'` (DDB column value)
- `RESOURCE_TYPES.FILE` constant, audit-event `kind: 'file'`
- `activeFileSends` / `fileSendSlotClaimed` (attachment-upload capacity slots — `/qurl send` still uploads files)

## Note on the legacy `/qurl send`
There was a previous multi-step wizard named `/qurl send` removed in PR 7b.3 (on the smoke ghost-list until this PR). The current `/qurl send` is the renamed `/qurl file`, not a restoration of that wizard. The disambiguating comments in `commands.js` and `docs/zero-downtime-design.md` make this explicit so a future reader doesn't try to "restore" the wizard's UX.

## Test plan
- [x] `npm run lint` clean in `apps/discord/`
- [x] `npm test` in `apps/discord/`: 48 suites / 1903 tests pass (includes new test for the rename-hint dispatcher arm)
- [x] `git mv` preserved test-file history (99% similarity reported)
- [ ] e2e smoke (`discord-commands.smoke.test.ts`) — runs in CI with real Discord credentials; ghost-list flip + expected-set update unverified locally
- [ ] Post-deploy: confirm cached clients submitting `/qurl file` see the rename-hint ephemeral (debug-log filter: `qurl_file_renamed_reply`)
- [ ] Post-deploy: confirm `/qurl send` registers globally and propagates within ~1h (Discord's documented cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)