### PR TITLE
feat(discord): raise picker per-pick cap from 10 to 25

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3957,7 +3957,7 @@ function renderConfirmCardRows({
   if (mode === RECIPIENT_MODE_PICKER) {
     const picker = new MentionableSelectMenuBuilder()
       .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
-      .setPlaceholder(`Pick up to ${maxValues} users/roles`)
+      .setPlaceholder(`Pick up to ${maxValues} ${maxValues === 1 ? 'user/role' : 'users/roles'}`)
       .setMinValues(1)
       .setMaxValues(maxValues);
     if (defaults.length > 0) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -588,11 +588,11 @@ function isValidExpiry(v) {
   return Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, v);
 }
 
-// Per-pick cap on UserSelectMenuBuilder.setMaxValues. Discord's hard
-// limit is 25; capping at 10 bounds the UX. The initial confirm-card
-// UserSelectMenu AND the post-send "Add Recipients" flow both use this
-// — keep them in lockstep so a future bump doesn't drift.
-const USER_SELECT_PER_PICK_CAP = 10;
+// Per-pick cap on UserSelectMenuBuilder.setMaxValues. Set to Discord's
+// hard limit so the picker exposes the full per-pick budget. The initial
+// confirm-card UserSelectMenu AND the post-send "Add Recipients" flow
+// both use this — keep them in lockstep so a future change doesn't drift.
+const USER_SELECT_PER_PICK_CAP = 25;
 
 // Shared render caps for warnings-block bullets that surface user-
 // or admin-controlled strings (invalidTokens, roleMentionsDeniedNames).
@@ -3942,16 +3942,21 @@ function renderConfirmCardRows({
 }) {
   const rows = [];
   const mode = normalizeRecipientMode(recipientMode);
-  const baseCap = Math.min(USER_SELECT_PER_PICK_CAP, config.QURL_SEND_MAX_RECIPIENTS);
-  // When text-resolved recipients are already present, widen max_values
-  // so we can pre-check them via addDefaultUsers (Discord requires
-  // default_values.length ≤ max_values). Widen clamps at the hard cap;
-  // recipientIds past the hard cap are still in payload.recipientIds and
-  // get the send — only the visual pre-check truncates.
+  // Picker opens at the smallest of the per-pick UX cap, the system
+  // recipient cap, and Discord's max_values hard cap. With
+  // USER_SELECT_PER_PICK_CAP set to Discord's hard cap (25) and
+  // QURL_SEND_MAX_RECIPIENTS ≥ 25 in every deployed config, this lands
+  // on 25; the three-way min stays so a future lowering of
+  // USER_SELECT_PER_PICK_CAP (or a tighter QURL_SEND_MAX_RECIPIENTS via
+  // env) continues to clamp correctly. Pre-resolved recipientIds past
+  // maxValues stay in payload.recipientIds and get the send — only the
+  // visual pre-check via addDefaultUsers truncates.
   const defaults = Array.isArray(recipientIds) ? recipientIds : [];
-  const maxValues = defaults.length > 0
-    ? Math.min(DISCORD_SELECT_MAX_VALUES_HARD_CAP, config.QURL_SEND_MAX_RECIPIENTS, Math.max(baseCap, defaults.length))
-    : baseCap;
+  const maxValues = Math.min(
+    USER_SELECT_PER_PICK_CAP,
+    config.QURL_SEND_MAX_RECIPIENTS,
+    DISCORD_SELECT_MAX_VALUES_HARD_CAP,
+  );
   if (mode === RECIPIENT_MODE_PICKER) {
     const picker = new MentionableSelectMenuBuilder()
       .setCustomId(CONFIRM_USER_SELECT_CUSTOM_ID)
@@ -5214,10 +5219,11 @@ async function handleConfirmUserSelect(interaction, { flow_id, row }) {
     return rejectPick(`⚠\u{FE0F} ${reasonText}. Re-pick recipients below.\n\n`);
   }
   // Defense-in-depth — unreachable in production today: the picker's
-  // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,
-  // QURL_SEND_MAX_RECIPIENTS=25) = 10, so the user physically can't
-  // pick more than 25. Kept against a future bump to either constant
-  // (or a forged interaction) so the cap stays honored.
+  // setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=25,
+  // QURL_SEND_MAX_RECIPIENTS) and Discord's own hard cap on max_values
+  // is 25, so the user physically can't pick more than 25. Kept against
+  // a future change to either constant (or a forged interaction) so the
+  // cap stays honored.
   if (valid.length > config.QURL_SEND_MAX_RECIPIENTS) {
     return rejectPick(`⚠\u{FE0F} Pick at most ${config.QURL_SEND_MAX_RECIPIENTS} recipients.\n\n`);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -604,11 +604,9 @@ const USER_SELECT_PER_PICK_CAP = 25;
 const WARNING_LIST_DISPLAY_MAX = 10;
 const WARNING_NAME_CODEPOINT_CAP = 80;
 
-// Discord's hard cap on select-menu max_values. The initial confirm-card
-// renderer widens max_values to fit text-resolved recipientIds (so
-// addDefaultUsers can pre-check them — default_values.length ≤
-// max_values is a Discord-side invariant), and that widen is bounded
-// by this cap so we never construct a menu Discord rejects at validation.
+// Discord's hard cap on select-menu max_values. Both picker call sites
+// clamp against this so we never construct a menu Discord rejects at
+// validation (e.g. if USER_SELECT_PER_PICK_CAP is ever raised above 25).
 const DISCORD_SELECT_MAX_VALUES_HARD_CAP = 25;
 
 // Shared Google Maps URL patterns. `/qurl map`'s slash-option

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -604,9 +604,11 @@ const USER_SELECT_PER_PICK_CAP = 25;
 const WARNING_LIST_DISPLAY_MAX = 10;
 const WARNING_NAME_CODEPOINT_CAP = 80;
 
-// Discord's hard cap on select-menu max_values. Both picker call sites
-// clamp against this so we never construct a menu Discord rejects at
-// validation (e.g. if USER_SELECT_PER_PICK_CAP is ever raised above 25).
+// Discord's protocol-level cap on select-menu max_values. Both picker
+// call sites clamp against this so we never construct a menu Discord
+// rejects at validation — defends against any combination of
+// USER_SELECT_PER_PICK_CAP and QURL_SEND_MAX_RECIPIENTS that would
+// otherwise produce a setMaxValues > 25.
 const DISCORD_SELECT_MAX_VALUES_HARD_CAP = 25;
 
 // Shared Google Maps URL patterns. `/qurl map`'s slash-option

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -588,10 +588,9 @@ function isValidExpiry(v) {
   return Object.prototype.hasOwnProperty.call(EXPIRY_LABELS, v);
 }
 
-// Per-pick cap on UserSelectMenuBuilder.setMaxValues. Set to Discord's
-// hard limit so the picker exposes the full per-pick budget. The initial
-// confirm-card UserSelectMenu AND the post-send "Add Recipients" flow
-// both use this — keep them in lockstep so a future change doesn't drift.
+// Per-pick cap on UserSelectMenuBuilder.setMaxValues, set to Discord's
+// max_values hard limit. Used by both the initial confirm-card picker
+// and the post-send "Add Recipients" flow — keep them in lockstep.
 const USER_SELECT_PER_PICK_CAP = 25;
 
 // Shared render caps for warnings-block bullets that surface user-
@@ -2009,8 +2008,12 @@ async function executeSendPipeline(interaction, {
           }
           setCooldown(interaction.user.id);
 
-          // Show user select menu — collect the response on the REPLY message
-          const maxSelect = Math.min(USER_SELECT_PER_PICK_CAP, remaining);
+          // Show user select menu — collect the response on the REPLY message.
+          const maxSelect = Math.min(
+            USER_SELECT_PER_PICK_CAP,
+            remaining,
+            DISCORD_SELECT_MAX_VALUES_HARD_CAP,
+          );
           const userSelectRow = new ActionRowBuilder().addComponents(
             new UserSelectMenuBuilder()
               .setCustomId(`qurl_addusers_${sendId}`)
@@ -3942,15 +3945,9 @@ function renderConfirmCardRows({
 }) {
   const rows = [];
   const mode = normalizeRecipientMode(recipientMode);
-  // Picker opens at the smallest of the per-pick UX cap, the system
-  // recipient cap, and Discord's max_values hard cap. With
-  // USER_SELECT_PER_PICK_CAP set to Discord's hard cap (25) and
-  // QURL_SEND_MAX_RECIPIENTS ≥ 25 in every deployed config, this lands
-  // on 25; the three-way min stays so a future lowering of
-  // USER_SELECT_PER_PICK_CAP (or a tighter QURL_SEND_MAX_RECIPIENTS via
-  // env) continues to clamp correctly. Pre-resolved recipientIds past
-  // maxValues stay in payload.recipientIds and get the send — only the
-  // visual pre-check via addDefaultUsers truncates.
+  // Pre-resolved recipientIds past maxValues stay in payload.recipientIds
+  // and still get sent — only the visual pre-check via addDefaultUsers
+  // truncates.
   const defaults = Array.isArray(recipientIds) ? recipientIds : [];
   const maxValues = Math.min(
     USER_SELECT_PER_PICK_CAP,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -604,11 +604,10 @@ const USER_SELECT_PER_PICK_CAP = 25;
 const WARNING_LIST_DISPLAY_MAX = 10;
 const WARNING_NAME_CODEPOINT_CAP = 80;
 
-// Discord's protocol-level cap on select-menu max_values. Both picker
-// call sites clamp against this so we never construct a menu Discord
-// rejects at validation — defends against any combination of
-// USER_SELECT_PER_PICK_CAP and QURL_SEND_MAX_RECIPIENTS that would
-// otherwise produce a setMaxValues > 25.
+// Discord's protocol-level cap on select-menu max_values. Authoritative
+// — both picker sites must include this in their Math.min so we never
+// construct a menu Discord rejects at validation regardless of how
+// USER_SELECT_PER_PICK_CAP or QURL_SEND_MAX_RECIPIENTS are configured.
 const DISCORD_SELECT_MAX_VALUES_HARD_CAP = 25;
 
 // Shared Google Maps URL patterns. `/qurl map`'s slash-option

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -6537,8 +6537,10 @@ describe('renderConfirmCardRows', () => {
   });
 
   test('slash-entry with pre-resolved recipients pre-checks all defaults via addDefaultUsers', async () => {
-    // Discord requires default_values.length ≤ max_values; the picker
-    // opens at the full per-pick cap (25) so any defaults ≤25 fit.
+    // Picker always opens at the full per-pick cap (25) regardless of
+    // defaults.length — the prior fit-to-defaults behavior is gone with
+    // the widen branch removal. All 12 pre-resolved defaults stay
+    // pre-checked because addDefaultUsers honors any list ≤25.
     const { MentionableSelectMenuBuilder } = require('discord.js');
     MentionableSelectMenuBuilder.mockClear();
     const ids = Array.from({ length: 12 }, (_, i) => `1000000000000000${String(i + 10)}`);
@@ -6552,6 +6554,61 @@ describe('renderConfirmCardRows', () => {
     const builder = MentionableSelectMenuBuilder.mock.results[0].value;
     expect(builder.setMaxValues).toHaveBeenCalledWith(25);
     expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids);
+  });
+
+  test('renderConfirmCardRows clamps maxValues to QURL_SEND_MAX_RECIPIENTS when env override is tighter than the per-pick cap', async () => {
+    // With a tenant-configured QURL_SEND_MAX_RECIPIENTS below 25, the
+    // three-way Math.min in renderConfirmCardRows must clamp the picker
+    // down so the placeholder and setMaxValues both reflect the system
+    // cap. Without this test the clamp could silently rot — the other
+    // tests run with mocked QSMR=25, where min(25,25,25)=25 makes the
+    // QSMR leg invisible.
+    const config = require('../src/config');
+    const origCap = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 15;
+    try {
+      const { MentionableSelectMenuBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT },  // no recipients → needsPicker
+      });
+      await handleQurlSend(int);
+      const builder = MentionableSelectMenuBuilder.mock.results[0].value;
+      expect(builder.setMaxValues).toHaveBeenCalledWith(15);
+      expect(builder.setPlaceholder).toHaveBeenCalledWith('Pick up to 15 users/roles');
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = origCap;
+    }
+  });
+
+  test('pre-resolved defaults beyond the per-pick cap truncate to the first 25 via addDefaultUsers', async () => {
+    // The slice on `defaults.slice(0, maxValues)` enforces Discord's
+    // default_values.length ≤ max_values invariant when text-resolved
+    // recipientIds overflow the picker's 25-slot cap. Overflow ids stay
+    // in payload.recipientIds and still reach the send — only the
+    // visual pre-check truncates. Mock QSMR=30 to let parseRecipientMentions
+    // surface all 30 ids to the renderer; without the mock parse would
+    // cap at the default 25 and there'd be nothing to slice.
+    const config = require('../src/config');
+    const origCap = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 30;
+    try {
+      const { MentionableSelectMenuBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      const ids = Array.from({ length: 30 }, (_, i) => `1000000000000000${String(i + 10).padStart(2, '0')}`);
+      const mentionList = ids.map((id) => `<@${id}>`).join(' ');
+      const guildMembers = Object.fromEntries(ids.map((id) => [id, {}]));
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT, recipients: mentionList },
+        guildMembers,
+      });
+      await handleQurlSend(int);
+      const builder = MentionableSelectMenuBuilder.mock.results[0].value;
+      expect(builder.setMaxValues).toHaveBeenCalledWith(25);
+      expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids.slice(0, 25));
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = origCap;
+    }
   });
 
   test('voice button label is the fixed "Everyone on voice" form, independent of channel name', async () => {

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -6604,14 +6604,14 @@ describe('renderConfirmCardRows', () => {
     }
   });
 
-  test('pre-resolved defaults beyond the per-pick cap truncate to the first 25 via addDefaultUsers', async () => {
+  test('pre-resolved defaults beyond the per-pick cap truncate to the first 25 via addDefaultUsers, but the full set persists in payload.recipientIds', async () => {
     // The slice on `defaults.slice(0, maxValues)` enforces Discord's
     // default_values.length ≤ max_values invariant when text-resolved
     // recipientIds overflow the picker's 25-slot cap. Overflow ids stay
-    // in payload.recipientIds and still reach the send — only the
-    // visual pre-check truncates. Mock QSMR=30 to let parseRecipientMentions
-    // surface all 30 ids to the renderer; without the mock parse would
-    // cap at the default 25 and there'd be nothing to slice.
+    // in payload.recipientIds and still reach the send — pin both halves
+    // so a future refactor can't silently drop the overflow. Mock QSMR=30
+    // to let parseRecipientMentions surface all 30 ids; without the mock
+    // parse would cap at the default 25 and there'd be nothing to slice.
     const config = require('../src/config');
     const origCap = config.QURL_SEND_MAX_RECIPIENTS;
     config.QURL_SEND_MAX_RECIPIENTS = 30;
@@ -6629,6 +6629,8 @@ describe('renderConfirmCardRows', () => {
       const builder = MentionableSelectMenuBuilder.mock.results[0].value;
       expect(builder.setMaxValues).toHaveBeenCalledWith(25);
       expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids.slice(0, 25));
+      const persistedPayload = mockSupersedeOrCreate.mock.calls[0][0].payload;
+      expect(persistedPayload.recipientIds.sort()).toEqual([...ids].sort());
     } finally {
       config.QURL_SEND_MAX_RECIPIENTS = origCap;
     }

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -4171,13 +4171,9 @@ describe('handleConfirmUserSelect', () => {
   });
 
   test('defense-in-depth: cap-exceeded pick rejected even though picker setMaxValues makes it unreachable today', async () => {
-    // The picker's setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=25,
-    // QURL_SEND_MAX_RECIPIENTS) and Discord's own max_values hard cap of
-    // 25, so production users physically can't pick more than 25. But a
-    // future change to either constant (or a forged interaction) could
-    // trip this branch — pin the guard so a refactor that drops it
-    // produces a visible failure. QURL_SEND_MAX_RECIPIENTS = 25 in the
-    // mocked config; build a pick of 26 to exceed it.
+    // Picker caps at 25; pin the post-pick guard against a forged
+    // interaction or future cap drift. Mocked QURL_SEND_MAX_RECIPIENTS
+    // is 25, so a pick of 26 trips the branch.
     const users = Array.from({ length: 26 }, (_, i) => makeUser(`1000000000000000${String(i).padStart(2, '0')}`));
     const int = makeSelectInteraction({ users });
     await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
@@ -6540,11 +6536,9 @@ describe('renderConfirmCardRows', () => {
     expect(builder.addDefaultUsers).not.toHaveBeenCalled();
   });
 
-  test('slash-entry with pre-resolved recipients opens picker at full per-pick cap with all defaults pre-checked', async () => {
-    // Discord requires default_values.length ≤ max_values. The picker's
-    // per-pick cap equals Discord's hard max_values cap (25), so the
-    // initial render always opens at 25 and any pre-resolved defaults
-    // (≤25) get fully pre-checked via addDefaultUsers.
+  test('slash-entry with pre-resolved recipients pre-checks all defaults via addDefaultUsers', async () => {
+    // Discord requires default_values.length ≤ max_values; the picker
+    // opens at the full per-pick cap (25) so any defaults ≤25 fit.
     const { MentionableSelectMenuBuilder } = require('discord.js');
     MentionableSelectMenuBuilder.mockClear();
     const ids = Array.from({ length: 12 }, (_, i) => `1000000000000000${String(i + 10)}`);

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -4171,13 +4171,13 @@ describe('handleConfirmUserSelect', () => {
   });
 
   test('defense-in-depth: cap-exceeded pick rejected even though picker setMaxValues makes it unreachable today', async () => {
-    // The picker's setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=10,
-    // QURL_SEND_MAX_RECIPIENTS=25) = 10, so production users physically
-    // can't pick more than 25. But a future bump to either constant
-    // (or a forged interaction) could trip this branch — pin the
-    // guard so a refactor that drops it produces a visible failure.
-    // QURL_SEND_MAX_RECIPIENTS = 25 in the mocked config; build a
-    // pick of 26 to exceed it.
+    // The picker's setMaxValues caps at min(USER_SELECT_PER_PICK_CAP=25,
+    // QURL_SEND_MAX_RECIPIENTS) and Discord's own max_values hard cap of
+    // 25, so production users physically can't pick more than 25. But a
+    // future change to either constant (or a forged interaction) could
+    // trip this branch — pin the guard so a refactor that drops it
+    // produces a visible failure. QURL_SEND_MAX_RECIPIENTS = 25 in the
+    // mocked config; build a pick of 26 to exceed it.
     const users = Array.from({ length: 26 }, (_, i) => makeUser(`1000000000000000${String(i).padStart(2, '0')}`));
     const int = makeSelectInteraction({ users });
     await handleConfirmUserSelect(int, { flow_id: 'fid', row: { payload: initialPayload, version: 1 } });
@@ -6540,12 +6540,11 @@ describe('renderConfirmCardRows', () => {
     expect(builder.addDefaultUsers).not.toHaveBeenCalled();
   });
 
-  test('slash-entry with >USER_SELECT_PER_PICK_CAP recipients widens max_values to fit all defaults', async () => {
+  test('slash-entry with pre-resolved recipients opens picker at full per-pick cap with all defaults pre-checked', async () => {
     // Discord requires default_values.length ≤ max_values. The picker's
-    // default per-pick cap is 10; if the user text-resolved 12 valid
-    // recipients, the initial render must widen max_values to 12 so
-    // addDefaultUsers(12 ids) is accepted (bounded by Discord's 25 hard
-    // cap on select-menu max_values).
+    // per-pick cap equals Discord's hard max_values cap (25), so the
+    // initial render always opens at 25 and any pre-resolved defaults
+    // (≤25) get fully pre-checked via addDefaultUsers.
     const { MentionableSelectMenuBuilder } = require('discord.js');
     MentionableSelectMenuBuilder.mockClear();
     const ids = Array.from({ length: 12 }, (_, i) => `1000000000000000${String(i + 10)}`);
@@ -6557,7 +6556,7 @@ describe('renderConfirmCardRows', () => {
     });
     await handleQurlSend(int);
     const builder = MentionableSelectMenuBuilder.mock.results[0].value;
-    expect(builder.setMaxValues).toHaveBeenCalledWith(12);
+    expect(builder.setMaxValues).toHaveBeenCalledWith(25);
     expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids);
   });
 

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -6556,6 +6556,29 @@ describe('renderConfirmCardRows', () => {
     expect(builder.addDefaultUsers).toHaveBeenCalledWith(...ids);
   });
 
+  test('renderConfirmCardRows pluralizes the placeholder text correctly when QURL_SEND_MAX_RECIPIENTS clamps to 1', async () => {
+    // An operator dialing the per-tenant cap to 1 (allowed by the
+    // minPositive validator) would otherwise see "Pick up to 1
+    // users/roles" — wrong English. Singular branch keeps the
+    // placeholder grammatical at the only QSMR value where it matters.
+    const config = require('../src/config');
+    const origCap = config.QURL_SEND_MAX_RECIPIENTS;
+    config.QURL_SEND_MAX_RECIPIENTS = 1;
+    try {
+      const { MentionableSelectMenuBuilder } = require('discord.js');
+      MentionableSelectMenuBuilder.mockClear();
+      const int = makeInteraction({
+        options: { attachment: VALID_ATTACHMENT },
+      });
+      await handleQurlSend(int);
+      const builder = MentionableSelectMenuBuilder.mock.results[0].value;
+      expect(builder.setMaxValues).toHaveBeenCalledWith(1);
+      expect(builder.setPlaceholder).toHaveBeenCalledWith('Pick up to 1 user/role');
+    } finally {
+      config.QURL_SEND_MAX_RECIPIENTS = origCap;
+    }
+  });
+
   test('renderConfirmCardRows clamps maxValues to QURL_SEND_MAX_RECIPIENTS when env override is tighter than the per-pick cap', async () => {
     // With a tenant-configured QURL_SEND_MAX_RECIPIENTS below 25, the
     // three-way Math.min in renderConfirmCardRows must clamp the picker


### PR DESCRIPTION
## Summary

The MentionableSelectMenu on the qURL send confirm card capped per-pick selections at 10, even though Discord's API allows up to 25. Bump to 25 so users can address a full team (~15-25 recipients) in one pick instead of stitching multiple **Add Recipients** clicks. The placeholder ("Pick up to N users/roles") interpolates the cap dynamically, so it now reads "25" without a copy edit.

- Bump `USER_SELECT_PER_PICK_CAP` from 10 → 25 in `apps/discord/src/commands.js`. The post-send **Add Recipients** flow shares this constant, so it gets the same bump (and stays in lockstep per the constant's existing contract).
- Collapse the now-dead widen branch in `renderConfirmCardRows`. With the per-pick cap equal to Discord's `max_values` hard cap (25), the `defaults.length > 0 ? widen : baseCap` ternary always produced 25 regardless of `defaults.length`. Replaced with a single three-way `min(USER_SELECT_PER_PICK_CAP, QURL_SEND_MAX_RECIPIENTS, DISCORD_SELECT_MAX_VALUES_HARD_CAP)`, which still clamps correctly if someone later lowers `USER_SELECT_PER_PICK_CAP` or tightens `QURL_SEND_MAX_RECIPIENTS` via env.
- Add the same three-way `Math.min` clamp at the **Add Recipients** site (`commands.js:2013`) so both picker call sites are symmetric — defends against a future `USER_SELECT_PER_PICK_CAP > 25` from constructing a menu Discord rejects.
- Refresh the stale `"=10"` comments on the defense-in-depth guard in `handleConfirmUserSelect`, on the `DISCORD_SELECT_MAX_VALUES_HARD_CAP` constant (which used to describe the now-removed widen branch), and on the cap-exceeded test. Retarget the former widen-fit test to assert the picker opens at the full per-pick cap (25) with all pre-resolved defaults still pre-checked via `addDefaultUsers`.
- Add two tests pinning the three-way `Math.min` clamp branches: (a) env-override (`QURL_SEND_MAX_RECIPIENTS=15` → `setMaxValues(15)`, placeholder "Pick up to 15 users/roles"); (b) slice truncation (>25 pre-resolved defaults → `addDefaultUsers` receives exactly the first 25; overflow ids still ride in `payload.recipientIds`).

## UX behavior change worth flagging

When a user slash-invokes with 11–24 pre-resolved mentions, the picker previously sized `max_values` to exactly `defaults.length` (the widen branch). After this PR, the picker always opens at 25 — so the user can top up to 25 in one click without re-picking. Matches the PR's stated motivation but is a deliberate delta on the slash-with-mentions path.

## What did not change

- `QURL_SEND_MAX_RECIPIENTS` (the overall cap on a single send, default 20000 in prod) is untouched. The 10→25 bump only affects how many entities the user can select per **single** picker click.
- Role expansion, mass-mention gating, bot filtering, and the confirm card's first-5-name preview all stay as-is; they're recipient-count-independent or already bounded by `QURL_SEND_MAX_RECIPIENTS`.
- The defense-in-depth `valid.length > QURL_SEND_MAX_RECIPIENTS` reject branch is preserved (now reachable only via forged interactions, same as before — the inline comment now says so).

## Test plan

- [x] `npx jest` — 1960/1960 pass (added env-override clamp test + slice truncation test)
- [x] `npx eslint src/commands.js tests/qurl-send-map.test.js` — clean
- [ ] Manual: in sandbox Discord, run `/qurl send`, open the picker on the confirm card, verify the placeholder reads "Pick up to 25 users/roles" and Discord's UI permits up to 25 selections
- [ ] Manual: with `/qurl send recipients:@a @b ... @c` (12 mentions), confirm card renders with all 12 pre-checked in the picker, no truncation
- [ ] Manual: with 15 pre-resolved mentions, verify the picker now allows topping up to 25 in a single re-pick (UX delta vs. pre-PR fit-to-defaults behavior)
- [ ] Manual: on the post-send embed, click **Add Recipients** and verify the same per-pick cap behavior (≤25, narrows as `remaining` shrinks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)