### PR TITLE
feat(discord): voice-everyone success-path audit log

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5598,19 +5598,11 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
-  // Mirrors the audit log in handleConfirmEveryone — a successful
-  // voice-channel fan-out is comparably load-bearing for ops ("did
-  // someone fan to N members of #voice-channel?") and shouldn't
-  // require a DDB scan of qurl_send_configs to surface in logs.
-  //
-  // Asymmetry with handleConfirmEveryone: that log emits both
-  // cache_size and member_count (cache vs guild-total; the gap is
-  // the partial-cache signal at guild scope). The voice path has
-  // no guild-total peer — Discord doesn't expose a "total ever-
-  // could-connect" count for a voice channel — so one field
-  // (voice_member_count = channel.members.size) is sufficient. The
-  // (voice_member_count - valid_count) gap captures the same
-  // forensic signal at voice-channel scope.
+  // Audit-log parity with handleConfirmEveryone — voice fan-outs
+  // need to be findable in logs without a qurl_send_configs scan.
+  // Asymmetry: no guild-total peer at voice scope (Discord doesn't
+  // expose one), so one channel-size field —
+  // (voice_member_count - valid_count) = partial-cache + filter gap.
   logger.info('handleConfirmVoiceEveryone: voice @everyone expansion succeeded', {
     flow_id, guild_id: interaction.guildId, user_id: interaction.user.id,
     voice_channel_id: voiceChannelId,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5600,8 +5600,8 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
 
   // Audit-log parity with handleConfirmEveryone — voice fan-outs
   // need to be findable in logs without a qurl_send_configs scan.
-  // Asymmetry: no guild-total peer at voice scope (Discord doesn't
-  // expose one), so one channel-size field —
+  // Asymmetry: no guild-total peer at voice scope (channel.userLimit
+  // is a capacity cap, not a count), so one channel-size field —
   // (voice_member_count - valid_count) = partial-cache + filter gap.
   logger.info('handleConfirmVoiceEveryone: voice @everyone expansion succeeded', {
     flow_id, guild_id: interaction.guildId, user_id: interaction.user.id,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5598,6 +5598,18 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
     }).catch(logIgnoredDiscordErr);
   }
 
+  // Mirrors the audit log in handleConfirmEveryone — a successful
+  // voice-channel fan-out is comparably load-bearing for ops ("did
+  // someone fan to N members of #voice-channel?") and shouldn't
+  // require a DDB scan of qurl_send_configs to surface in logs.
+  logger.info('handleConfirmVoiceEveryone: voice @everyone expansion succeeded', {
+    flow_id, guild_id: interaction.guildId, user_id: interaction.user.id,
+    voice_channel_id: voiceChannelId,
+    valid_count: valid.length, dropped_bots: droppedBots,
+    partial_cache_drops: partialCacheDrops, self_included: false,
+    voice_member_count: channel.members.size,
+  });
+
   const content = renderConfirmCardContent({
     resourceType: payload.resourceType,
     resourceLabel: payload.resourceLabel,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -5602,6 +5602,15 @@ async function handleConfirmVoiceEveryone(interaction, { flow_id, row }) {
   // voice-channel fan-out is comparably load-bearing for ops ("did
   // someone fan to N members of #voice-channel?") and shouldn't
   // require a DDB scan of qurl_send_configs to surface in logs.
+  //
+  // Asymmetry with handleConfirmEveryone: that log emits both
+  // cache_size and member_count (cache vs guild-total; the gap is
+  // the partial-cache signal at guild scope). The voice path has
+  // no guild-total peer — Discord doesn't expose a "total ever-
+  // could-connect" count for a voice channel — so one field
+  // (voice_member_count = channel.members.size) is sufficient. The
+  // (voice_member_count - valid_count) gap captures the same
+  // forensic signal at voice-channel scope.
   logger.info('handleConfirmVoiceEveryone: voice @everyone expansion succeeded', {
     flow_id, guild_id: interaction.guildId, user_id: interaction.user.id,
     voice_channel_id: voiceChannelId,

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -5116,6 +5116,30 @@ describe('handleConfirmVoiceEveryone', () => {
       }),
     );
   });
+
+  test('success-log: voice_member_count tracks channel.members.size, NOT valid.length, under partial-cache drops', async () => {
+    // Locks down the voice_member_count semantic: it's the *raw* size
+    // of channel.members BEFORE the partial-cache + bot filter drop
+    // members. A regression that swaps it to `valid.length` would
+    // pass the happy-path test (counts match when no drops) but lose
+    // the audit signal — operators would no longer see the shrinkage
+    // gap (voice_member_count - valid_count = drops).
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    // Inject a partial-cache row so channel.members.size = 3 but
+    // valid.length stays at 2 after the partial-cache drop.
+    const channel = int.guild.channels.cache.get(VOICE_CH);
+    channel.members.set('partial-cache-id', {});
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const logger = require('../src/logger');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('voice @everyone expansion succeeded'),
+      expect.objectContaining({
+        valid_count: 2,
+        partial_cache_drops: 1,
+        voice_member_count: 3,
+      }),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -5140,6 +5140,52 @@ describe('handleConfirmVoiceEveryone', () => {
       }),
     );
   });
+
+  test('success-log does NOT fire on transitionFlow conflict / not_found / throw', async () => {
+    // The audit log is reserved for the actual flow-advancement path.
+    // Surfacing it on conflict / not_found / throw would mislead
+    // operators auditing fan-outs ("did this admin send to N members?")
+    // — the answer is NO on those branches. Pin the negative spec so
+    // a future log-placement refactor that moves the .info() ahead of
+    // the early-returns regresses loudly.
+    const logger = require('../src/logger');
+
+    // conflict (OCC race)
+    logger.info.mockClear();
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'conflict' });
+    await handleConfirmVoiceEveryone(
+      makeVoiceInteraction({ members: [u1, u2] }),
+      { flow_id: 'fid', row: { payload: basePayload, version: 1 } }
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('voice @everyone expansion succeeded'),
+      expect.anything(),
+    );
+
+    // not_found (row TTL elapsed)
+    logger.info.mockClear();
+    mockTransitionFlow.mockResolvedValueOnce({ result: 'not_found' });
+    await handleConfirmVoiceEveryone(
+      makeVoiceInteraction({ members: [u1, u2] }),
+      { flow_id: 'fid', row: { payload: basePayload, version: 1 } }
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('voice @everyone expansion succeeded'),
+      expect.anything(),
+    );
+
+    // synchronous throw (DDB blip)
+    logger.info.mockClear();
+    mockTransitionFlow.mockRejectedValueOnce(new Error('DDB unavailable'));
+    await handleConfirmVoiceEveryone(
+      makeVoiceInteraction({ members: [u1, u2] }),
+      { flow_id: 'fid', row: { payload: basePayload, version: 1 } }
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('voice @everyone expansion succeeded'),
+      expect.anything(),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -5126,7 +5126,9 @@ describe('handleConfirmVoiceEveryone', () => {
     // gap (voice_member_count - valid_count = drops).
     const int = makeVoiceInteraction({ members: [u1, u2] });
     // Inject a partial-cache row so channel.members.size = 3 but
-    // valid.length stays at 2 after the partial-cache drop.
+    // valid.length stays at 2 after the partial-cache drop. The
+    // empty object `{}` triggers the no-`.user` branch in the voice
+    // resolution loop (commands.js: `if (m?.user) ... else partialCacheDrops++`).
     const channel = int.guild.channels.cache.get(VOICE_CH);
     channel.members.set('partial-cache-id', {});
     await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -5088,10 +5088,16 @@ describe('handleConfirmVoiceEveryone', () => {
   });
 
   test('success-path emits info-level audit log with counts', async () => {
-    // Mirror handleConfirmEveryone's success-log test (#376) — a
-    // successful voice-channel fan-out is a load-bearing audit signal
-    // ("did someone fan to N members of #voice-channel?") and should
-    // be findable in logs without a DDB scan of qurl_send_configs.
+    // Mirror handleConfirmEveryone's success-log test — a successful
+    // voice-channel fan-out is a load-bearing audit signal ("did
+    // someone fan to N members of #voice-channel?") and should be
+    // findable in logs without a DDB scan of qurl_send_configs.
+    //
+    // Exact-value asserts (vs expect.any) catch regressions where
+    // the bot filter double-counts, partial-cache rows leak into the
+    // valid set, or voice_member_count drifts away from
+    // channel.members.size. guild_id + user_id pinned so a future
+    // forensics consumer that greps by them is protected by the spec.
     const int = makeVoiceInteraction({ members: [u1, u2] });
     await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
     const logger = require('../src/logger');
@@ -5099,12 +5105,14 @@ describe('handleConfirmVoiceEveryone', () => {
       expect.stringContaining('voice @everyone expansion succeeded'),
       expect.objectContaining({
         flow_id: 'fid',
+        guild_id: int.guildId,
+        user_id: int.user.id,
         voice_channel_id: VOICE_CH,
         valid_count: 2,
-        dropped_bots: expect.any(Number),
-        partial_cache_drops: expect.any(Number),
+        dropped_bots: 0,
+        partial_cache_drops: 0,
         self_included: false,
-        voice_member_count: expect.any(Number),
+        voice_member_count: 2,
       }),
     );
   });

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -5086,6 +5086,28 @@ describe('handleConfirmVoiceEveryone', () => {
     const lastCall = int.editReply.mock.calls[int.editReply.mock.calls.length - 1][0];
     expect(lastCall.content).toMatch(/Card data is corrupted/);
   });
+
+  test('success-path emits info-level audit log with counts', async () => {
+    // Mirror handleConfirmEveryone's success-log test (#376) — a
+    // successful voice-channel fan-out is a load-bearing audit signal
+    // ("did someone fan to N members of #voice-channel?") and should
+    // be findable in logs without a DDB scan of qurl_send_configs.
+    const int = makeVoiceInteraction({ members: [u1, u2] });
+    await handleConfirmVoiceEveryone(int, { flow_id: 'fid', row: { payload: basePayload, version: 1 } });
+    const logger = require('../src/logger');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('voice @everyone expansion succeeded'),
+      expect.objectContaining({
+        flow_id: 'fid',
+        voice_channel_id: VOICE_CH,
+        valid_count: 2,
+        dropped_bots: expect.any(Number),
+        partial_cache_drops: expect.any(Number),
+        self_included: false,
+        voice_member_count: expect.any(Number),
+      }),
+    );
+  });
 });
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #376.

## Summary

\`handleConfirmEveryone\` (PR #371) emits an info-level audit log on a successful @everyone expansion — \"did someone fan out to N users?\" findable in logs without a DDB scan of \`qurl_send_configs\`. \`handleConfirmVoiceEveryone\` is the voice-channel analog button-handler and was silent on its success path; a 99-member voice-channel fan-out is comparably interesting to ops.

## Why

Audit-log parity. The two handlers do the same job (resolve a population, fan a send to it) for different scopes — guild-wide vs voice-channel. Logging success in one but not the other leaves a blind spot in ops dashboards: dispute/audit responses that grep for \"who fanned out and to whom\" miss voice-channel sends.

## How

Add \`logger.info\` after the successful \`transitionFlow\` in \`handleConfirmVoiceEveryone\`, before the \`renderConfirmCardContent\` re-render. Same structured-log shape as the @everyone analog plus two voice-specific fields:

- \`voice_channel_id\` — the channel that drove the resolution
- \`voice_member_count\` — \`channel.members.size\` (the cache-shape forensic field, analog of \`cache_size\` + \`member_count\` in handleConfirmEveryone)

\`self_included\` is structurally \`false\` on this path: voice-everyone passes \`{ excludeSender: true }\` to \`partitionRecipients\` (matching the slash-command auto-default at \`handleQurlSlashSend\`'s voice-mode override). Hard-coded rather than read from \`payload\` to defend against a future \`...payload\` spread carrying a stale flag forward.

Log fires AFTER \`transitionFlow\` returns \`ok\` — NOT on \`conflict\` / \`not_found\` / throw (those have their own paths today).

## Test plan

- [x] New test in \`tests/qurl-send-map.test.js\` mirrors \`handleConfirmEveryone\`'s success-path test: pins the structured-log shape with \`valid_count: 2\`, \`self_included: false\`, voice_channel_id present.
- [x] All 1959 tests pass locally (1958 → 1959 with the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)