### PR TITLE
feat(discord): fail-fast on permanent AWS misconfig in event consumer

### DIFF
--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -868,7 +868,11 @@ function isAbortError(err) {
 //   - SignatureDoesNotMatch — usually clock skew, which also self-heals
 //     once chrony catches up.
 // Re-classify if prod data shows these recur past a fail-fast threshold;
-// today they belong with throttling.
+// today they belong with throttling. AccessDenied is in the permanent
+// set on the bet that misconfig (typo'd queue ARN, missing IAM grant)
+// dominates over deploy-time IAM eventual-consistency gaps. If prod
+// telemetry ever shows AccessDenied spikes correlated with deploys
+// rather than config changes, demote it back to transient.
 const PERMANENT_AWS_ERROR_CODES = new Set([
   // Queue doesn't exist (typo'd URL or wrong region in queue URL).
   'QueueDoesNotExist',
@@ -886,6 +890,13 @@ const PERMANENT_AWS_ERROR_CODES = new Set([
   'InvalidClientTokenId',
 ]);
 
+// Returns the matched permanent-error code from anywhere in err's
+// cause chain, or null if none. Any matching key at any layer wins —
+// if an error has both .name = 'TimeoutError' (transient) and
+// .code = 'QueueDoesNotExist' (permanent), this returns
+// 'QueueDoesNotExist'. The conservative cut is "if any layer says
+// permanent, treat as permanent" — under SDK wrapping a real
+// misconfig can surface anywhere in the chain.
 function permanentAwsErrorCode(err) {
   const visited = new Set();
   let current = err;
@@ -954,6 +965,31 @@ function abortableSleep(ms) {
   });
 }
 
+// Dispatch the fatal-shutdown route. If onFatalCb is wired, call it
+// (sync throws AND async rejections both fall back to process.exit(1)).
+// If not, exit directly. Does NOT await — the caller's defensive
+// return must stay synchronous so pollLoop exits before the next
+// iteration (under test mocks an await would let it iterate).
+function invokeOnFatal() {
+  if (!onFatalCb) {
+    process.exit(1);
+    return;
+  }
+  try {
+    Promise.resolve(onFatalCb()).catch((cbErr) => {
+      logger.error('Event consumer: onFatal rejected, falling back to process.exit', {
+        error: cbErr?.message,
+      });
+      process.exit(1);
+    });
+  } catch (cbErr) {
+    logger.error('Event consumer: onFatal threw, falling back to process.exit', {
+      error: cbErr?.message,
+    });
+    process.exit(1);
+  }
+}
+
 async function pollLoop(client) {
   // Null-guard symmetric with abortableSleep + stop(). Paranoia, not
   // a real path: start() always assigns stopController before invoking
@@ -988,32 +1024,7 @@ async function pollLoop(client) {
         logger.error('Event consumer: permanent AWS failure, exiting', {
           error: err.message, code: permanentCode,
         });
-        if (onFatalCb) {
-          // gracefulShutdown is async, so both sync throws AND async
-          // rejections must route to the fallback exit. try/catch
-          // catches only sync; Promise.resolve(...).catch() covers
-          // the async leg by normalizing the return value first.
-          // We do NOT await here — the return below must stay
-          // synchronous so the loop exits before the next iteration
-          // (under test mocks, an await would let pollLoop iterate).
-          // The fallback exit fires later via the .catch().
-          try {
-            Promise.resolve(onFatalCb()).catch((cbErr) => {
-              logger.error('Event consumer: onFatal rejected, falling back to process.exit', {
-                error: cbErr?.message,
-              });
-              process.exit(1);
-            });
-          } catch (cbErr) {
-            // Sync throw from onFatal — same fallback shape.
-            logger.error('Event consumer: onFatal threw, falling back to process.exit', {
-              error: cbErr?.message,
-            });
-            process.exit(1);
-          }
-        } else {
-          process.exit(1);
-        }
+        invokeOnFatal();
         // Defensive return: stops the loop from iterating again into
         // the same failure under test mocks AND during the async
         // gap before gracefulShutdown's drain awaits this loop.
@@ -1303,6 +1314,7 @@ module.exports = {
     // Set. Kept under the historical name for test-site stability;
     // semantically still "how many handlers are tracked right now."
     getInFlightCount: () => inFlightPromises.size,
+    isRunning: () => running,
     isWorkerDispatching: () => isWorkerDispatch,
     isAtCapPauseLogged: () => atCapPauseLogged,
     // Test-only setter. trackDispatch reads the module-level

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -123,6 +123,14 @@
 // (Strict ceiling is cap + RECEIVE_MAX_MESSAGES - 1; the .env.example
 // rounds up by 1 for headroom math.)
 //
+// Error classification: pollLoop's catch routes errors into three
+// buckets — abort (silent continue, stop()-triggered), permanent
+// (fatal log + process.exit(1) so ECS surfaces the misconfig in
+// deploy-time monitoring), and transient (log + POLL_ERROR_BACKOFF_MS
+// backoff). Permanent codes are typo'd queue URL, missing IAM perm,
+// region drift, and bad creds — anything a retry won't fix. See
+// PERMANENT_AWS_ERROR_CODES for the full set.
+//
 // How tracking works without coupling to handler internals: the
 // consumer sets `isWorkerDispatch = true` synchronously around the
 // `client.actions.InteractionCreate.handle(data)` call. The listener
@@ -836,6 +844,48 @@ function isAbortError(err) {
   return false;
 }
 
+// AWS error codes that indicate permanent misconfiguration rather than
+// transient flakiness. Retrying these forever just spams logs without
+// resolving the underlying problem — better to crash so ECS surfaces
+// the misconfig as a high task-restart rate in deploy-time monitoring.
+// The boot-time `missingEventShipperKeys` check catches the *missing*
+// queue URL case; this catches the *misconfigured-but-set* URL,
+// missing IAM perms, region mismatch, and bad-credential cases.
+//
+// Names include both AWS-API-layer codes (v2-style, still present in
+// error.Code on some SDK paths) and SDK-v3 error class names
+// (error.name). Walking err.cause matches the isAbortError pattern
+// for parity with how @aws-sdk wraps errors across versions.
+const PERMANENT_AWS_ERROR_CODES = new Set([
+  // Queue doesn't exist (typo'd URL or wrong region in queue URL).
+  'QueueDoesNotExist',
+  'AWS.SimpleQueueService.NonExistentQueue',
+  // IAM lacks sqs:ReceiveMessage on the queue.
+  'AccessDenied',
+  'AccessDeniedException',
+  // Malformed queue URL.
+  'InvalidAddress',
+  'InvalidQueueUrl',
+  // Bad endpoint (typically AWS_REGION drift between deploy + queue).
+  'UnknownEndpoint',
+  // Bad/expired credentials.
+  'UnrecognizedClientException',
+  'InvalidClientTokenId',
+]);
+
+function permanentAwsErrorCode(err) {
+  const visited = new Set();
+  let current = err;
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    if (PERMANENT_AWS_ERROR_CODES.has(current.name)) return current.name;
+    if (PERMANENT_AWS_ERROR_CODES.has(current.code)) return current.code;
+    if (PERMANENT_AWS_ERROR_CODES.has(current.Code)) return current.Code;
+    current = current.cause;
+  }
+  return null;
+}
+
 // Sleep that resolves either when the timeout fires OR when
 // stopController.signal fires. Without the early-out, a stop() call
 // during the error-backoff would block for the full
@@ -905,6 +955,22 @@ async function pollLoop(client) {
         // signal.aborted check exits next iteration; no logging or
         // backoff (this is a clean interruption, not a failure).
         continue;
+      }
+      const permanentCode = permanentAwsErrorCode(err);
+      if (permanentCode) {
+        // Permanent AWS misconfig (typo'd queue URL, missing IAM
+        // perm, region drift, bad creds). Crash so ECS surfaces it
+        // as a high task-restart rate in deploy-time monitoring —
+        // retrying would just spam logs and bleed the misconfig
+        // into runtime noise. The boot check catches the missing-
+        // URL case; this catches the misconfigured-but-set ones.
+        logger.error('Event consumer: permanent AWS failure, exiting', {
+          error: err.message, code: permanentCode,
+        });
+        process.exit(1);
+        // Defensive return: test mocks process.exit, so without this
+        // the loop would iterate again into the same failure.
+        return;
       }
       // ReceiveMessage failure (transient AWS, throttling, etc.) —
       // brief backoff so we don't burn CPU on a sustained outage.
@@ -1145,6 +1211,7 @@ module.exports = {
     processMessage,
     pollOnce,
     isAbortError,
+    permanentAwsErrorCode,
     abortableSleep,
     SEEN_EVENT_ID_CAP,
     MAX_INFLIGHT_HANDLERS,

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -989,11 +989,23 @@ async function pollLoop(client) {
           error: err.message, code: permanentCode,
         });
         if (onFatalCb) {
+          // gracefulShutdown is async, so both sync throws AND async
+          // rejections must route to the fallback exit. try/catch
+          // catches only sync; Promise.resolve(...).catch() covers
+          // the async leg by normalizing the return value first.
+          // We do NOT await here — the return below must stay
+          // synchronous so the loop exits before the next iteration
+          // (under test mocks, an await would let pollLoop iterate).
+          // The fallback exit fires later via the .catch().
           try {
-            onFatalCb();
+            Promise.resolve(onFatalCb()).catch((cbErr) => {
+              logger.error('Event consumer: onFatal rejected, falling back to process.exit', {
+                error: cbErr?.message,
+              });
+              process.exit(1);
+            });
           } catch (cbErr) {
-            // If gracefulShutdown itself throws, fall through to
-            // direct exit so a misconfig still terminates the task.
+            // Sync throw from onFatal — same fallback shape.
             logger.error('Event consumer: onFatal threw, falling back to process.exit', {
               error: cbErr?.message,
             });
@@ -1027,14 +1039,21 @@ async function pollLoop(client) {
  *   .actions.InteractionCreate.handle available (i.e., a real
  *   discord.js Client, not a stub).
  * @param {object} [opts]
- * @param {() => void} [opts.onFatal] - Invoked when pollLoop hits a
- *   permanent AWS error. index.js wires `() => gracefulShutdown(1)`
- *   so in-flight handlers, WAL checkpoints, and WebSocket sessions
- *   get torn down before exit. Default (no callback) crashes via
- *   `process.exit(1)` directly — keeps the standalone-test contract.
+ * @param {() => void | Promise<void>} [opts.onFatal] - Invoked when
+ *   pollLoop hits a permanent AWS error. index.js wires
+ *   `() => gracefulShutdown(1)` so in-flight handlers, WAL checkpoints,
+ *   and WebSocket sessions get torn down before exit. May return a
+ *   Promise — both sync throws and async rejections fall back to
+ *   `process.exit(1)`. Default (no callback) crashes directly via
+ *   `process.exit(1)`, preserving the standalone-test contract.
  */
 function start(client, { onFatal } = {}) {
   if (running) {
+    // Double-start no-op preserves the existing onFatalCb (the
+    // assignment below is unreachable on this path), so the callback
+    // wired by the first start() stays in effect. Intentional — a
+    // racing caller shouldn't be able to silently swap the fatal
+    // route by calling start() again.
     logger.warn('Event consumer: start() called while already running — no-op');
     return;
   }

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -295,6 +295,10 @@ let running = false;
 let loopPromise = null;
 let stopController = null;
 let sqsClient = null;
+// onFatal callback supplied at start() — invoked when pollLoop hits a
+// permanent AWS error. Default (null) crashes via process.exit(1);
+// index.js wires `() => gracefulShutdown(1)` so cleanup runs first.
+let onFatalCb = null;
 
 // Backpressure cap (see module header). pollOnce early-returns
 // when inFlightCount >= MAX_INFLIGHT_HANDLERS and waits
@@ -856,6 +860,15 @@ function isAbortError(err) {
 // error.Code on some SDK paths) and SDK-v3 error class names
 // (error.name). Walking err.cause matches the isAbortError pattern
 // for parity with how @aws-sdk wraps errors across versions.
+//
+// Intentionally NOT classified as permanent (kept in the transient
+// path):
+//   - ExpiredToken / ExpiredTokenException — IRSA/ECS task-role STS
+//     creds rotate every ~6h; a brief gap during refresh self-heals.
+//   - SignatureDoesNotMatch — usually clock skew, which also self-heals
+//     once chrony catches up.
+// Re-classify if prod data shows these recur past a fail-fast threshold;
+// today they belong with throttling.
 const PERMANENT_AWS_ERROR_CODES = new Set([
   // Queue doesn't exist (typo'd URL or wrong region in queue URL).
   'QueueDoesNotExist',
@@ -959,17 +972,39 @@ async function pollLoop(client) {
       const permanentCode = permanentAwsErrorCode(err);
       if (permanentCode) {
         // Permanent AWS misconfig (typo'd queue URL, missing IAM
-        // perm, region drift, bad creds). Crash so ECS surfaces it
-        // as a high task-restart rate in deploy-time monitoring —
-        // retrying would just spam logs and bleed the misconfig
-        // into runtime noise. The boot check catches the missing-
-        // URL case; this catches the misconfigured-but-set ones.
+        // perm, region drift, bad creds). Surface to the caller so
+        // ECS sees a high task-restart rate in deploy-time monitoring
+        // — retrying would spam logs and bleed the misconfig into
+        // runtime noise. The boot check catches the missing-URL
+        // case; this catches the misconfigured-but-set ones.
+        //
+        // Routing: if start() received an onFatal callback (index.js
+        // wires `() => gracefulShutdown(1)`), call it so in-flight
+        // handlers, the WAL checkpoint, and the WebSocket session
+        // get torn down before exit. Otherwise fall back to direct
+        // process.exit(1) — keeps the standalone-test contract and
+        // is the safer default if a future caller forgets to wire
+        // onFatal.
         logger.error('Event consumer: permanent AWS failure, exiting', {
           error: err.message, code: permanentCode,
         });
-        process.exit(1);
-        // Defensive return: test mocks process.exit, so without this
-        // the loop would iterate again into the same failure.
+        if (onFatalCb) {
+          try {
+            onFatalCb();
+          } catch (cbErr) {
+            // If gracefulShutdown itself throws, fall through to
+            // direct exit so a misconfig still terminates the task.
+            logger.error('Event consumer: onFatal threw, falling back to process.exit', {
+              error: cbErr?.message,
+            });
+            process.exit(1);
+          }
+        } else {
+          process.exit(1);
+        }
+        // Defensive return: stops the loop from iterating again into
+        // the same failure under test mocks AND during the async
+        // gap before gracefulShutdown's drain awaits this loop.
         return;
       }
       // ReceiveMessage failure (transient AWS, throttling, etc.) —
@@ -991,8 +1026,14 @@ async function pollLoop(client) {
  * @param {import('discord.js').Client} client - Discord client with
  *   .actions.InteractionCreate.handle available (i.e., a real
  *   discord.js Client, not a stub).
+ * @param {object} [opts]
+ * @param {() => void} [opts.onFatal] - Invoked when pollLoop hits a
+ *   permanent AWS error. index.js wires `() => gracefulShutdown(1)`
+ *   so in-flight handlers, WAL checkpoints, and WebSocket sessions
+ *   get torn down before exit. Default (no callback) crashes via
+ *   `process.exit(1)` directly — keeps the standalone-test contract.
  */
-function start(client) {
+function start(client, { onFatal } = {}) {
   if (running) {
     logger.warn('Event consumer: start() called while already running — no-op');
     return;
@@ -1022,6 +1063,7 @@ function start(client) {
   }
   running = true;
   stopController = new AbortController();
+  onFatalCb = typeof onFatal === 'function' ? onFatal : null;
   logger.info('Event consumer: starting', {
     queueUrl: config.QURL_BOT_EVENTS_QUEUE_URL,
     waitSeconds: RECEIVE_WAIT_SECONDS,
@@ -1155,6 +1197,7 @@ async function stop() {
     // unaffected; clearing here also ensures _resetStateForTest's
     // null contract holds without a second branch.
     stopController = null;
+    onFatalCb = null;
     // Reset the at-cap log gate so a `start → at-cap → stop → start`
     // round-trip doesn't inherit a stale `true` and miss the next
     // streak's transition warn. Production never restarts after stop,
@@ -1184,6 +1227,7 @@ function _resetStateForTest() {
   loopPromise = null;
   stopController = null;
   sqsClient = null;
+  onFatalCb = null;
   seenEventIds.clear();
   lastMissingEventIdWarnMs = 0;
   inFlightPromises.clear();

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -637,7 +637,13 @@ async function start() {
   // landed during the awaits before this point, gracefulShutdown
   // has already run; skip starting a consumer that no one will stop.
   if (isWorker && !isShuttingDown) {
-    eventConsumer.start(client);
+    // onFatal routes pollLoop's permanent-AWS-error path through
+    // gracefulShutdown(1) so in-flight handler drain, db.close() WAL
+    // checkpoint, and the discord WebSocket close all run before
+    // exit. Without this, a direct process.exit(1) from event-consumer
+    // would leak the same partial state the `start().catch()` comment
+    // below explicitly calls out.
+    eventConsumer.start(client, { onFatal: () => gracefulShutdown(1) });
   }
 
   // SQS publisher for the gateway tier (zero-downtime Pillar 1).

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -907,9 +907,16 @@ describe('event-consumer: pollLoop error backoff', () => {
         expect.stringContaining('poll iteration failed'),
         expect.anything(),
       );
+      // running stays true after pollLoop's defensive return — pollLoop
+      // doesn't manipulate the flag itself; stop() owns that. Explicit
+      // assertion locks the contract so a future refactor that flips
+      // running inside the error branch (and breaks stop()'s
+      // already-stopped guard) fails loudly here.
+      expect(eventConsumer._test.isRunning()).toBe(true);
       // stop() returns cleanly even though pollLoop already returned
       // on its own (running is still true; stop() flips it + aborts).
       await eventConsumer.stop();
+      expect(eventConsumer._test.isRunning()).toBe(false);
     } finally {
       exitSpy.mockRestore();
     }

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -870,7 +870,7 @@ describe('event-consumer: pollLoop error backoff', () => {
     expect(elapsedMs).toBeLessThan(100);
   });
 
-  test('pollLoop exits on permanent AWS error (NonExistentQueue) — fatal log + process.exit(1)', async () => {
+  test('pollLoop exits on permanent AWS error (QueueDoesNotExist) — fatal log + process.exit(1)', async () => {
     // Misconfigured-but-set queue URL (typo, wrong region, etc.) was
     // the gap the boot check couldn't catch. Retrying forever would
     // spam logs without resolving anything; fail-fast surfaces the
@@ -1003,6 +1003,42 @@ describe('event-consumer: pollLoop error backoff', () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('onFatal threw, falling back to process.exit'),
         expect.objectContaining({ error: 'shutdown failed' }),
+      );
+      await eventConsumer.stop();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test('onFatal async rejection falls back to process.exit(1)', async () => {
+    // Sister to the sync-throw test. The wired callback in production
+    // is `() => gracefulShutdown(1)` which returns a Promise — a
+    // sync try/catch alone would miss an async rejection from inside
+    // gracefulShutdown. The .catch() on Promise.resolve(onFatalCb())
+    // covers that leg.
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+    const onFatal = jest.fn(() => Promise.reject(new Error('async shutdown failed')));
+    sqsMock.on(ReceiveMessageCommand).callsFake(() => {
+      const err = new Error('q gone');
+      err.name = 'QueueDoesNotExist';
+      throw err;
+    });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    const client = makeStubClient();
+
+    try {
+      eventConsumer.start(client, { onFatal });
+      // Two setImmediate yields: first for pollOnce to throw + catch
+      // to call onFatal, second for the rejection's microtask to land
+      // on the .catch() and trigger the fallback exit.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      expect(onFatal).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('onFatal rejected, falling back to process.exit'),
+        expect.objectContaining({ error: 'async shutdown failed' }),
       );
       await eventConsumer.stop();
     } finally {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -869,6 +869,47 @@ describe('event-consumer: pollLoop error backoff', () => {
     // toward the 1s budget and surface here.
     expect(elapsedMs).toBeLessThan(100);
   });
+
+  test('pollLoop exits on permanent AWS error (NonExistentQueue) — fatal log + process.exit(1)', async () => {
+    // Misconfigured-but-set queue URL (typo, wrong region, etc.) was
+    // the gap the boot check couldn't catch. Retrying forever would
+    // spam logs without resolving anything; fail-fast surfaces the
+    // misconfig as ECS task-restart noise in deploy-time monitoring.
+    // Test mocks process.exit so the test runner survives; pollLoop's
+    // defensive `return` after exit(1) prevents the loop from
+    // iterating into the same failure under the mock.
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+    sqsMock.on(ReceiveMessageCommand).callsFake(() => {
+      const err = new Error('Specified queue does not exist');
+      err.name = 'QueueDoesNotExist';
+      throw err;
+    });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    const client = makeStubClient();
+
+    try {
+      eventConsumer.start(client);
+      // Yield so pollOnce throws + catch routes through exit().
+      await new Promise((r) => setImmediate(r));
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('permanent AWS failure'),
+        expect.objectContaining({ code: 'QueueDoesNotExist' }),
+      );
+      // Transient error log MUST NOT fire on this path — we want one
+      // fatal line, not the same misconfig spammed.
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('poll iteration failed'),
+        expect.anything(),
+      );
+      // stop() returns cleanly even though pollLoop already returned
+      // on its own (running is still true; stop() flips it + aborts).
+      await eventConsumer.stop();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
 });
 
 describe('event-consumer: start/stop lifecycle', () => {
@@ -964,6 +1005,57 @@ describe('event-consumer: start/stop lifecycle', () => {
     const e10 = new Error('cyclic');
     e10.cause = e10;
     expect(isAbortError(e10)).toBe(false);
+  });
+
+  test('permanentAwsErrorCode recognizes misconfig shapes, returns null for transient', () => {
+    const { permanentAwsErrorCode } = eventConsumer._test;
+    // Non-error inputs degrade cleanly.
+    expect(permanentAwsErrorCode(null)).toBeNull();
+    expect(permanentAwsErrorCode(undefined)).toBeNull();
+    expect(permanentAwsErrorCode(new Error('boom'))).toBeNull();
+
+    // SDK-v3 error-class names (error.name).
+    const queueGone = Object.assign(new Error('q gone'), { name: 'QueueDoesNotExist' });
+    expect(permanentAwsErrorCode(queueGone)).toBe('QueueDoesNotExist');
+    const accessDenied = Object.assign(new Error('AD'), { name: 'AccessDeniedException' });
+    expect(permanentAwsErrorCode(accessDenied)).toBe('AccessDeniedException');
+
+    // AWS-API-layer codes (error.Code, v2-style, still present on some
+    // v3 paths).
+    const v2NonExistent = Object.assign(new Error('q gone'), {
+      Code: 'AWS.SimpleQueueService.NonExistentQueue',
+    });
+    expect(permanentAwsErrorCode(v2NonExistent)).toBe('AWS.SimpleQueueService.NonExistentQueue');
+    const invalidUrl = Object.assign(new Error('bad url'), { code: 'InvalidQueueUrl' });
+    expect(permanentAwsErrorCode(invalidUrl)).toBe('InvalidQueueUrl');
+
+    // Region mismatch surfaces as UnknownEndpoint.
+    const badRegion = Object.assign(new Error('endpoint'), { name: 'UnknownEndpoint' });
+    expect(permanentAwsErrorCode(badRegion)).toBe('UnknownEndpoint');
+
+    // Bad creds.
+    const badCreds = Object.assign(new Error('creds'), { name: 'UnrecognizedClientException' });
+    expect(permanentAwsErrorCode(badCreds)).toBe('UnrecognizedClientException');
+
+    // Wrapped error: SDK-style err.cause chain still matches via the walk.
+    const wrapped = Object.assign(new Error('wrap'), {
+      cause: { name: 'QueueDoesNotExist' },
+    });
+    expect(permanentAwsErrorCode(wrapped)).toBe('QueueDoesNotExist');
+
+    // Transient errors (throttling, network, timeout) must NOT match —
+    // the existing error-backoff handles those.
+    const throttle = Object.assign(new Error('rate'), { name: 'ThrottlingException' });
+    expect(permanentAwsErrorCode(throttle)).toBeNull();
+    const networkErr = Object.assign(new Error('econnreset'), { code: 'ECONNRESET' });
+    expect(permanentAwsErrorCode(networkErr)).toBeNull();
+    const timeoutErr = Object.assign(new Error('t/o'), { name: 'TimeoutError' });
+    expect(permanentAwsErrorCode(timeoutErr)).toBeNull();
+
+    // Cyclic cause chain — bounded by visited-set, doesn't hang.
+    const cyclic = new Error('cyclic');
+    cyclic.cause = cyclic;
+    expect(permanentAwsErrorCode(cyclic)).toBeNull();
   });
 
   test('pollOnce passes the stopController.signal in the SDK send options', async () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -892,7 +892,11 @@ describe('event-consumer: pollLoop error backoff', () => {
       // Yield so pollOnce throws + catch routes through exit().
       await new Promise((r) => setImmediate(r));
 
+      // toHaveBeenCalledTimes(1) — if the defensive return after exit
+      // ever gets dropped, the test mock would let the loop iterate
+      // into the same failure and exit would be called repeatedly.
       expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(exitSpy).toHaveBeenCalledTimes(1);
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('permanent AWS failure'),
         expect.objectContaining({ code: 'QueueDoesNotExist' }),
@@ -905,6 +909,101 @@ describe('event-consumer: pollLoop error backoff', () => {
       );
       // stop() returns cleanly even though pollLoop already returned
       // on its own (running is still true; stop() flips it + aborts).
+      await eventConsumer.stop();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test('pollLoop exits on err.cause-wrapped permanent error (SDK wrapping)', async () => {
+    // The unit test for permanentAwsErrorCode pins the cause-walk
+    // shape; this pins that the integration path actually invokes
+    // the walk, not just the top-level name check. A future SDK
+    // refresh that wraps errors in an extra layer must still trip
+    // fail-fast — without this, the regression would only surface
+    // in prod when the misconfig fires.
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+    sqsMock.on(ReceiveMessageCommand).callsFake(() => {
+      const inner = Object.assign(new Error('access denied'), {
+        name: 'AccessDeniedException',
+      });
+      const outer = new Error('SDK wrapper');
+      outer.cause = inner;
+      throw outer;
+    });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    const client = makeStubClient();
+
+    try {
+      eventConsumer.start(client);
+      await new Promise((r) => setImmediate(r));
+
+      expect(exitSpy).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('permanent AWS failure'),
+        expect.objectContaining({ code: 'AccessDeniedException' }),
+      );
+      await eventConsumer.stop();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test('onFatal callback routes permanent-error path away from process.exit', async () => {
+    // index.js wires `onFatal: () => gracefulShutdown(1)` so the
+    // permanent-error path runs the same teardown SIGTERM does
+    // (in-flight handler drain, db.close() WAL checkpoint, WebSocket
+    // close). Without this, a direct process.exit truncates all of
+    // it. Pin that an onFatal callback intercepts; process.exit is
+    // NOT called.
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+    const onFatal = jest.fn();
+    sqsMock.on(ReceiveMessageCommand).callsFake(() => {
+      const err = new Error('q gone');
+      err.name = 'QueueDoesNotExist';
+      throw err;
+    });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    const client = makeStubClient();
+
+    try {
+      eventConsumer.start(client, { onFatal });
+      await new Promise((r) => setImmediate(r));
+
+      expect(onFatal).toHaveBeenCalledTimes(1);
+      expect(exitSpy).not.toHaveBeenCalled();
+      await eventConsumer.stop();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test('onFatal throw falls back to process.exit(1)', async () => {
+    // Defense in depth: if gracefulShutdown itself throws (rare —
+    // its own try/catch covers routine errors), we still want the
+    // task to terminate so ECS surfaces the misconfig. Pin the
+    // fallback so a future onFatal regression doesn't silently
+    // leave the process running after the fatal log.
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+    const onFatal = jest.fn(() => { throw new Error('shutdown failed'); });
+    sqsMock.on(ReceiveMessageCommand).callsFake(() => {
+      const err = new Error('q gone');
+      err.name = 'QueueDoesNotExist';
+      throw err;
+    });
+    eventConsumer._test._setSqsClientForTest(new SQSClient({ region: 'us-east-2' }));
+    const client = makeStubClient();
+
+    try {
+      eventConsumer.start(client, { onFatal });
+      await new Promise((r) => setImmediate(r));
+
+      expect(onFatal).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('onFatal threw, falling back to process.exit'),
+        expect.objectContaining({ error: 'shutdown failed' }),
+      );
       await eventConsumer.stop();
     } finally {
       exitSpy.mockRestore();


### PR DESCRIPTION
Closes #385.

## Summary

The event consumer's \`pollLoop\` previously treated every non-abort \`ReceiveMessageCommand\` failure as transient and applied the 1s error backoff. If the deploy is misconfigured (typo'd queue URL, missing IAM permission, region drift, bad credentials), the loop retries forever — flooding logs without escalating.

This PR adds a permanent-vs-transient AWS error classifier. Permanent failures now log fatal + \`process.exit(1)\`; ECS surfaces them as a high task-restart rate in deploy-time monitoring rather than letting the misconfig bleed into runtime noise. Transient errors (throttling, timeouts, network blips) continue through the existing 1s backoff.

## Why

The fail-closed boot check (\`missingEventShipperKeys\`) catches the *missing* queue URL case — the most likely misconfig. This PR hardens the *next-most-likely* shape: a misconfigured-but-set queue URL or an IAM regression. Both are silent failures today; both are loud after this change.

## How

- New \`PERMANENT_AWS_ERROR_CODES\` set covering AWS-API-layer codes (v2-style, \`error.Code\`) and SDK-v3 error class names (\`error.name\`).
- New \`permanentAwsErrorCode(err)\` classifier — parallel to \`isAbortError\`: walks \`err.cause\` with a visited-set (bounded memory, handles cyclic chains), checks \`.name\` / \`.code\` / \`.Code\` on each layer. Returns the matched code or null.
- \`pollLoop\`'s catch routes errors into three buckets:
  - **abort** (silent continue, stop()-triggered) — existing
  - **permanent** (fatal log + \`process.exit(1)\` + defensive \`return\`) — new
  - **transient** (log + \`POLL_ERROR_BACKOFF_MS\`) — existing
- Module header documents the classification scheme.

Defensive \`return\` after \`process.exit(1)\`: in tests \`process.exit\` is mocked to a no-op, so without the return the loop would iterate into the same failure. In prod the return is unreachable.

## Classification (PERMANENT — fail-fast)

| Code / name                                       | Cause                                                    |
| ------------------------------------------------- | -------------------------------------------------------- |
| \`QueueDoesNotExist\`                             | Typo'd queue URL                                         |
| \`AWS.SimpleQueueService.NonExistentQueue\`       | v2-style alias of above                                  |
| \`AccessDenied\` / \`AccessDeniedException\`      | IAM lacks \`sqs:ReceiveMessage\` on the queue            |
| \`InvalidAddress\` / \`InvalidQueueUrl\`          | Malformed queue URL                                      |
| \`UnknownEndpoint\`                               | Region mismatch between \`AWS_REGION\` and queue URL     |
| \`UnrecognizedClientException\` / \`InvalidClientTokenId\` | Bad/expired credentials                                  |

Everything else (Throttling, RequestTimeout, ECONNRESET, etc.) stays in the transient path.

## Test plan

- [x] \`permanentAwsErrorCode\` unit test: matches by \`.name\` / \`.code\` / \`.Code\`, walks \`err.cause\` chains, handles cyclic chains, returns null for transient shapes (Throttling, ECONNRESET, TimeoutError).
- [x] Integration test in \`pollLoop error backoff\` describe: SDK mock throws \`QueueDoesNotExist\` → \`process.exit(1)\` called once (mocked), fatal log fires with \`code: 'QueueDoesNotExist'\`, transient \"poll iteration failed\" log does NOT fire.
- [x] 1960/1960 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)