### PR TITLE
feat(discord): exponential-decay backoff at in-flight cap + silent steady-state

### DIFF
--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -342,8 +342,9 @@ function validateInflightCap(cap) {
 }
 validateInflightCap(MAX_INFLIGHT_HANDLERS);
 
-// At-cap pause backoff. Exponential decay from BASE to MAX while
-// the cap stays full, resets to BASE on the first below-cap poll.
+// At-cap pause backoff. Exponential backoff (doubling) from BASE to
+// MAX while the cap stays full; resets to BASE on the first below-cap
+// poll. The wake *rate* decays — the sleep duration grows.
 // A short cap streak (handlers draining within a second) keeps the
 // 100ms responsiveness; a sustained streak (slow downstream + bursty
 // arrivals) drops the wake rate to ~0.6/s instead of 10/s, cutting
@@ -749,7 +750,7 @@ async function pollOnce(client) {
     // Steady-state at-cap is intentionally silent — the entry warn
     // + the exit info already bookend the pause for operators.
     await abortableSleep(currentBackoffMs);
-    // Exponential decay: each consecutive at-cap iteration doubles
+    // Exponential backoff: each consecutive at-cap iteration doubles
     // the wait up to MAX, so a sustained streak drops the wake rate
     // from 10/s to ~0.6/s without significantly delaying recovery.
     currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS);

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -342,12 +342,17 @@ function validateInflightCap(cap) {
 }
 validateInflightCap(MAX_INFLIGHT_HANDLERS);
 
-// Brief pause when at-cap. Short enough that handlers draining
-// quickly resume normal polling; long enough that we don't burn
-// CPU re-checking the cap on every microtask. abortableSleep
-// honors the abort signal so a SIGTERM during a backpressure pause
-// still exits inside the graceful-shutdown budget.
-const INFLIGHT_BACKOFF_MS = 100;
+// At-cap pause backoff. Exponential decay from BASE to MAX while
+// the cap stays full, resets to BASE on the first below-cap poll.
+// A short cap streak (handlers draining within a second) keeps the
+// 100ms responsiveness; a sustained streak (slow downstream + bursty
+// arrivals) drops the wake rate to ~0.6/s instead of 10/s, cutting
+// CPU + log noise without significantly delaying recovery.
+// abortableSleep honors the abort signal so a SIGTERM during a
+// backpressure pause still exits inside the graceful-shutdown budget.
+const INFLIGHT_BACKOFF_BASE_MS = 100;
+const INFLIGHT_BACKOFF_MAX_MS = 1600;
+let currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
 
 // Maximum time stop() waits for in-flight handler promises to
 // settle before proceeding past `await loopPromise`. Stays well
@@ -389,20 +394,17 @@ let DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 const inFlightPromises = new Set();
 let isWorkerDispatch = false;
 
-// State-machine rate-limit on the at-cap log. Sustained at-cap
-// (slow downstream + bursty arrivals) wakes pollOnce every
-// INFLIGHT_BACKOFF_MS, so without throttling a single backlog
-// produces ~10 lines/sec/worker. Pattern matches
-// `lastMissingEventIdWarnMs`: the *transition* into at-cap is the
-// loud signal (warn), steady-state at-cap is debug, and the
-// transition back to below-cap is info. atCapPauseLogged is the
-// "we've already logged the warn for this streak" gate; cleared
-// when pollOnce next observes a below-cap state. Log messages
-// pulled into constants so monitoring alerts that grep for them
-// stay in sync with the call site even if the wording drifts.
+// State-machine rate-limit on the at-cap log. The *transition* into
+// at-cap is the loud signal (warn-on-entry), the transition back to
+// below-cap is the info-on-release. Steady-state at-cap is silent —
+// pairing entry+exit gives the duration of the pause without
+// per-iteration noise. atCapPauseLogged is the "we've logged the
+// warn for this streak" gate; cleared when pollOnce next observes a
+// below-cap state. Log messages live in constants so monitoring
+// alerts that grep for them stay in sync with the call site if the
+// wording drifts.
 let atCapPauseLogged = false;
 const AT_CAP_PAUSE_WARN_MSG = 'Event consumer: in-flight cap reached, pausing receive until handlers drain';
-const AT_CAP_PAUSE_DEBUG_MSG = 'Event consumer: still at in-flight cap, continuing pause';
 const AT_CAP_RELEASED_INFO_MSG = 'Event consumer: in-flight cap released, resuming receive';
 
 // Hook for unit tests: lets the test inject a mock SQSClient
@@ -743,20 +745,26 @@ async function pollOnce(client) {
     if (!atCapPauseLogged) {
       logger.warn(AT_CAP_PAUSE_WARN_MSG, capPayload);
       atCapPauseLogged = true;
-    } else {
-      logger.debug(AT_CAP_PAUSE_DEBUG_MSG, capPayload);
     }
-    await abortableSleep(INFLIGHT_BACKOFF_MS);
+    // Steady-state at-cap is intentionally silent — the entry warn
+    // + the exit info already bookend the pause for operators.
+    await abortableSleep(currentBackoffMs);
+    // Exponential decay: each consecutive at-cap iteration doubles
+    // the wait up to MAX, so a sustained streak drops the wake rate
+    // from 10/s to ~0.6/s without significantly delaying recovery.
+    currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS);
     return;
   }
   // Below-cap path: if we just transitioned out of at-cap, log the
   // release so operators can match "pause started" with "pause ended"
-  // pairs in CloudWatch. Reset the gate so the next at-cap entry
-  // re-fires the warn (each streak gets exactly one warn).
+  // pairs in CloudWatch. Reset both the warn gate and the backoff so
+  // the next at-cap entry re-fires the warn AND starts at the base
+  // wait (each streak gets exactly one warn and starts responsive).
   if (atCapPauseLogged) {
     logger.info(AT_CAP_RELEASED_INFO_MSG, capPayload);
     atCapPauseLogged = false;
   }
+  currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
   const queueUrl = config.QURL_BOT_EVENTS_QUEUE_URL;
   const cmd = new ReceiveMessageCommand({
     QueueUrl: queueUrl,
@@ -1234,6 +1242,7 @@ async function stop() {
     // but integration tests that exercise the lifecycle would
     // otherwise see a phantom suppressed warn.
     atCapPauseLogged = false;
+    currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
     // Intentionally do NOT null `sqsClient`. Production never calls
     // start() after stop() — gracefulShutdown runs once at SIGTERM,
     // then process.exit. Reusing the client across a hypothetical
@@ -1263,6 +1272,7 @@ function _resetStateForTest() {
   inFlightPromises.clear();
   isWorkerDispatch = false;
   atCapPauseLogged = false;
+  currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
   DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 }
 
@@ -1290,14 +1300,15 @@ module.exports = {
     SEEN_EVENT_ID_CAP,
     MAX_INFLIGHT_HANDLERS,
     validateInflightCap,
-    INFLIGHT_BACKOFF_MS,
+    INFLIGHT_BACKOFF_BASE_MS,
+    INFLIGHT_BACKOFF_MAX_MS,
+    getCurrentBackoffMs: () => currentBackoffMs,
     // DRAIN_DEADLINE_MS is mutable (so tests can shrink it), so
     // expose as a getter — a snapshot-at-module-load export would
     // silently read 3000 even after _setDrainDeadlineForTest(50)
     // mutated the live value.
     getDrainDeadlineMs: () => DRAIN_DEADLINE_MS,
     AT_CAP_PAUSE_WARN_MSG,
-    AT_CAP_PAUSE_DEBUG_MSG,
     AT_CAP_RELEASED_INFO_MSG,
     // Live getter for the lifetime abort controller. Was previously
     // `getReceiveAbortController` (per-iteration); the AbortSignal

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -1274,7 +1274,11 @@ async function stop() {
     // stale `true`/ceiling and miss the next streak's transition warn
     // or start the next streak at MAX. Production never restarts
     // after stop, but integration tests that exercise the lifecycle
-    // would otherwise see a phantom suppressed warn.
+    // would otherwise see a phantom suppressed warn. Also: the
+    // post-await doubling line at pollOnce's at-cap branch runs on
+    // an abort-wake (the await resolves, the next line executes
+    // before the loop signal check), so without this reset, the
+    // post-shutdown state would be `currentBackoffMs = prev * 2`.
     clearAtCapState();
     // Intentionally do NOT null `sqsClient`. Production never calls
     // start() after stop() — gracefulShutdown runs once at SIGTERM,

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -408,6 +408,18 @@ let atCapPauseLogged = false;
 const AT_CAP_PAUSE_WARN_MSG = 'Event consumer: in-flight cap reached, pausing receive until handlers drain';
 const AT_CAP_RELEASED_INFO_MSG = 'Event consumer: in-flight cap released, resuming receive';
 
+// Reset the paired at-cap state — backoff value + warn gate. The two
+// always move together: a non-base `currentBackoffMs` implies an
+// in-progress streak (the at-cap branch is the only writer that grows
+// it), which implies `atCapPauseLogged === true`. Three call sites
+// reset both (pollOnce below-cap transition, stop()'s finally,
+// _resetStateForTest); the helper keeps them in lockstep so a future
+// fourth site can't silently break the invariant by forgetting one.
+function clearAtCapState() {
+  atCapPauseLogged = false;
+  currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
+}
+
 // Hook for unit tests: lets the test inject a mock SQSClient
 // (aws-sdk-client-mock'd in tests/event-consumer.test.js) without
 // constructing a real client at module load. Pure DI — production
@@ -752,7 +764,10 @@ async function pollOnce(client) {
     await abortableSleep(currentBackoffMs);
     // Exponential backoff: each consecutive at-cap iteration doubles
     // the wait up to MAX, so a sustained streak drops the wake rate
-    // from 10/s to ~0.6/s without significantly delaying recovery.
+    // from 10/s to ~0.6/s at the ceiling without significantly
+    // delaying recovery. (The first 5 iterations average ~1.6/s
+    // before settling at the 1.6s ceiling — see the cadence table
+    // in PR #407 for the per-iteration breakdown.)
     // Trade-off: a release that lands mid-sleep delays the next
     // below-cap observation (and the paired pause-end log) by up to
     // MAX (1.6s). Operators pairing pause-start/pause-end durations
@@ -773,8 +788,7 @@ async function pollOnce(client) {
   // wait (each streak gets exactly one warn and starts responsive).
   if (atCapPauseLogged) {
     logger.info(AT_CAP_RELEASED_INFO_MSG, capPayload);
-    atCapPauseLogged = false;
-    currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
+    clearAtCapState();
   }
   const queueUrl = config.QURL_BOT_EVENTS_QUEUE_URL;
   const cmd = new ReceiveMessageCommand({
@@ -1247,13 +1261,13 @@ async function stop() {
     // null contract holds without a second branch.
     stopController = null;
     onFatalCb = null;
-    // Reset the at-cap log gate so a `start → at-cap → stop → start`
-    // round-trip doesn't inherit a stale `true` and miss the next
-    // streak's transition warn. Production never restarts after stop,
-    // but integration tests that exercise the lifecycle would
-    // otherwise see a phantom suppressed warn.
-    atCapPauseLogged = false;
-    currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
+    // Reset the at-cap pair (gate + backoff) so a
+    // `start → at-cap → stop → start` round-trip doesn't inherit a
+    // stale `true`/ceiling and miss the next streak's transition warn
+    // or start the next streak at MAX. Production never restarts
+    // after stop, but integration tests that exercise the lifecycle
+    // would otherwise see a phantom suppressed warn.
+    clearAtCapState();
     // Intentionally do NOT null `sqsClient`. Production never calls
     // start() after stop() — gracefulShutdown runs once at SIGTERM,
     // then process.exit. Reusing the client across a hypothetical
@@ -1282,8 +1296,7 @@ function _resetStateForTest() {
   lastMissingEventIdWarnMs = 0;
   inFlightPromises.clear();
   isWorkerDispatch = false;
-  atCapPauseLogged = false;
-  currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
+  clearAtCapState();
   DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 }
 

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -352,6 +352,12 @@ validateInflightCap(MAX_INFLIGHT_HANDLERS);
 // abortableSleep honors the abort signal so a SIGTERM during a
 // backpressure pause still exits inside the graceful-shutdown budget.
 const INFLIGHT_BACKOFF_BASE_MS = 100;
+// 1600 = 4 doublings from BASE (100→200→400→800→1600). Chosen to
+// keep the worst-case stop()-during-backoff wake (a SIGTERM that
+// lands right after entering the ceiling sleep) well inside the
+// gracefulShutdown budget — leaves >8s of the 10s budget for
+// downstream cleanup. Halving to 800ms gives back half the wake-rate
+// win; doubling to 3200ms approaches the shutdown ceiling.
 const INFLIGHT_BACKOFF_MAX_MS = 1600;
 let currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
 

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -757,6 +757,18 @@ async function pollOnce(client) {
     // below-cap observation (and the paired pause-end log) by up to
     // MAX (1.6s). Operators pairing pause-start/pause-end durations
     // in CloudWatch see this as inflated dwell time at the ceiling.
+    //
+    // No jitter: each worker process maintains its own at-cap state
+    // (in-flight handlers are per-process), so synchronized wakes
+    // across workers aren't possible. The downstream wedge isn't
+    // sensitive to wake-time alignment either, so plain doubling is
+    // the right shape.
+    //
+    // stop()-during-sleep race: if signal.abort() fires while we're
+    // parked here, abortableSleep resolves, this line still doubles
+    // currentBackoffMs (one wasted increment), then pollOnce returns,
+    // pollLoop's while-check sees signal.aborted, and stop()'s
+    // finally resets currentBackoffMs to BASE. End state correct.
     currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS);
     return;
   }

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -753,6 +753,10 @@ async function pollOnce(client) {
     // Exponential backoff: each consecutive at-cap iteration doubles
     // the wait up to MAX, so a sustained streak drops the wake rate
     // from 10/s to ~0.6/s without significantly delaying recovery.
+    // Trade-off: a release that lands mid-sleep delays the next
+    // below-cap observation (and the paired pause-end log) by up to
+    // MAX (1.6s). Operators pairing pause-start/pause-end durations
+    // in CloudWatch see this as inflated dwell time at the ceiling.
     currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS);
     return;
   }
@@ -764,8 +768,8 @@ async function pollOnce(client) {
   if (atCapPauseLogged) {
     logger.info(AT_CAP_RELEASED_INFO_MSG, capPayload);
     atCapPauseLogged = false;
+    currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
   }
-  currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS;
   const queueUrl = config.QURL_BOT_EVENTS_QUEUE_URL;
   const cmd = new ReceiveMessageCommand({
     QueueUrl: queueUrl,

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -763,12 +763,6 @@ async function pollOnce(client) {
     // across workers aren't possible. The downstream wedge isn't
     // sensitive to wake-time alignment either, so plain doubling is
     // the right shape.
-    //
-    // stop()-during-sleep race: if signal.abort() fires while we're
-    // parked here, abortableSleep resolves, this line still doubles
-    // currentBackoffMs (one wasted increment), then pollOnce returns,
-    // pollLoop's while-check sees signal.aborted, and stop()'s
-    // finally resets currentBackoffMs to BASE. End state correct.
     currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS);
     return;
   }

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -763,11 +763,11 @@ async function pollOnce(client) {
     // + the exit info already bookend the pause for operators.
     await abortableSleep(currentBackoffMs);
     // Exponential backoff: each consecutive at-cap iteration doubles
-    // the wait up to MAX, so a sustained streak drops the wake rate
+    // the wait up to MAX (cadence: 100→200→400→800→1600ms, then
+    // clamped at 1600ms), so a sustained streak drops the wake rate
     // from 10/s to ~0.6/s at the ceiling without significantly
-    // delaying recovery. (The first 5 iterations average ~1.6/s
-    // before settling at the 1.6s ceiling — see the cadence table
-    // in PR #407 for the per-iteration breakdown.)
+    // delaying recovery. The first 5 iterations average ~1.6/s
+    // before settling at the 1.6s ceiling.
     // Trade-off: a release that lands mid-sleep delays the next
     // below-cap observation (and the paired pause-end log) by up to
     // MAX (1.6s) worst-case, ~MAX/2 (~800ms) average since releases

--- a/apps/discord/src/event-consumer.js
+++ b/apps/discord/src/event-consumer.js
@@ -738,12 +738,12 @@ async function pollOnce(client) {
   // budget.
   //
   // Log throttling: only the transition into at-cap is loud (warn);
-  // subsequent at-cap polls in the same streak are debug. The
-  // transition back to below-cap (handled after this branch) logs
-  // at info. This matches the `lastMissingEventIdWarnMs` pattern
-  // already in this file — transition-loud, steady-state-quiet.
-  // Snapshot capPayload at pollOnce entry. Shared across at-cap
-  // warn/debug AND the release-info branch — so the release log's
+  // steady-state at-cap is silent. The transition back to below-cap
+  // (handled after this branch) logs at info. This matches the
+  // `lastMissingEventIdWarnMs` pattern already in this file —
+  // transition-loud, steady-state-quiet.
+  // Snapshot capPayload at pollOnce entry. Shared across the at-cap
+  // entry-warn AND the release-info branch — so the release log's
   // `inFlight` field is the value that *triggered* the release
   // (necessarily below cap), not "drained to N" at the moment of
   // logging. That's the right framing for pairing pause-start
@@ -770,14 +770,16 @@ async function pollOnce(client) {
     // in PR #407 for the per-iteration breakdown.)
     // Trade-off: a release that lands mid-sleep delays the next
     // below-cap observation (and the paired pause-end log) by up to
-    // MAX (1.6s). Operators pairing pause-start/pause-end durations
-    // in CloudWatch see this as inflated dwell time at the ceiling.
+    // MAX (1.6s) worst-case, ~MAX/2 (~800ms) average since releases
+    // land uniformly within the sleep window. Operators pairing
+    // pause-start/pause-end durations in CloudWatch see this as
+    // inflated dwell time at the ceiling.
     //
-    // No jitter: each worker process maintains its own at-cap state
-    // (in-flight handlers are per-process), so synchronized wakes
-    // across workers aren't possible. The downstream wedge isn't
-    // sensitive to wake-time alignment either, so plain doubling is
-    // the right shape.
+    // No jitter: the downstream wedge isn't sensitive to wake-time
+    // alignment, so even if multiple worker processes hit the cap
+    // at the same wall-clock moment (shared-downstream wedge) and
+    // their doubling ladders align, plain doubling is still the
+    // right shape — there's no thundering-herd surface to spread.
     currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS);
     return;
   }

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1864,49 +1864,57 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
   });
 
   test('stop() finally resets currentBackoffMs to BASE (load-bearing assertion)', async () => {
-    // cr-r5: the lifecycle test in the start/stop describe block
-    // never drove currentBackoffMs away from BASE before stop(), so
-    // its post-stop() assertion was vacuous (BASE === BASE would
-    // pass even if stop()'s finally-reset line were deleted). This
-    // test drives a non-base value first via fake-timer at-cap
-    // iterations, then exercises the real stop() codepath under
-    // real timers (stop()'s drain uses Promise.race with setTimeout;
-    // fake timers would hang the deadline). Resolvable promises so
-    // drain settles cleanly via the inFlightPromises path.
-    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    const resolvers = [];
-    withWorkerDispatch(() => {
-      for (let i = 0; i < cap; i += 1) {
-        let resolve;
-        const p = new Promise((r) => { resolve = r; });
-        resolvers.push(resolve);
-        eventConsumer.trackDispatch(p);
-      }
-    });
-    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
-    const client = makeStubClient();
-
-    // Drive currentBackoffMs to a non-base value via fake-timer
-    // pollOnce. One at-cap iteration: 100 → 200.
-    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    // cr-r5/r10: the cr-r5 fix drove currentBackoffMs to 200 before
+    // stop() but then drained the in-flight handlers, so start()'s
+    // pollLoop took pollOnce's BELOW-cap branch first, which itself
+    // calls clearAtCapState() — meaning stop()'s finally reset was
+    // a no-op by the time it ran. Deleting stop()'s clearAtCapState()
+    // still passed the test (cr-r10 traced this empirically).
+    //
+    // To make the assertion actually load-bearing on stop()'s
+    // finally, the in-flight handlers must STAY at cap throughout
+    // start(): pollLoop enters pollOnce → AT-cap branch → sleeps →
+    // stop() aborts the sleep → doubling runs → pollLoop exits via
+    // signal check → stop()'s finally is the ONLY reset path. Pair
+    // with _setDrainDeadlineForTest(50) so stop()'s drain race
+    // resolves on the deadline-timer side without waiting the full
+    // DRAIN_DEADLINE_MS (handlers never resolve in this test).
+    const originalDeadline = eventConsumer._test.getDrainDeadlineMs();
+    eventConsumer._test._setDrainDeadlineForTest(50);
     try {
-      await pollOnceFast(client);
-      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
+      const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+      withWorkerDispatch(() => {
+        for (let i = 0; i < cap; i += 1) {
+          // Never-resolving promises: keep inFlightCount at cap for
+          // the entire test so pollOnce stays in the at-cap branch.
+          eventConsumer.trackDispatch(new Promise(() => {}));
+        }
+      });
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      const client = makeStubClient();
+
+      // Drive currentBackoffMs to a non-base value via one fake-timer
+      // at-cap iteration (100 → 200).
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+      try {
+        await pollOnceFast(client);
+        expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
+      } finally {
+        jest.useRealTimers();
+      }
+
+      // start() + stop() under real timers. Handlers are at cap, so
+      // pollLoop's first pollOnce takes the at-cap branch, sleeps,
+      // stop()'s abort wakes the sleep, the post-sleep doubling line
+      // runs (currentBackoffMs = 400), pollLoop exits on the signal
+      // check. stop()'s finally is the ONLY reset path remaining:
+      // delete its clearAtCapState() call and this assertion fails.
+      eventConsumer.start(client);
+      await eventConsumer.stop();
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
     } finally {
-      jest.useRealTimers();
+      eventConsumer._test._setDrainDeadlineForTest(originalDeadline);
     }
-
-    // Resolve in-flight promises so stop()'s drain settles via
-    // inFlightPromises (no need to wait the DRAIN_DEADLINE_MS).
-    resolvers.forEach((r) => r('done'));
-    await flushMicrotasks();
-    expect(eventConsumer._test.getInFlightCount()).toBe(0);
-
-    // start() + stop() under real timers. stop()'s finally runs the
-    // reset; without that line, currentBackoffMs would still be 200.
-    eventConsumer.start(client);
-    await eventConsumer.stop();
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });
 
   test('pollOnce: MAX → BASE reset via production below-cap path (not just one doubling)', async () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1293,11 +1293,6 @@ describe('event-consumer: start/stop lifecycle', () => {
     await eventConsumer.stop();
     // Stop is idempotent.
     await eventConsumer.stop();
-
-    // stop()'s finally restores currentBackoffMs to BASE alongside
-    // running/loopPromise/stopController. Pins the contract called
-    // out in the at-cap backoff describe block (#390).
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });
 
   // A "start() actually registers pollOnce" companion test was
@@ -1707,11 +1702,17 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
   // existing flushMicrotasks() + Promise scheduling stay unaffected.
   //
   // Invariant: pollOnce's at-cap branch awaits exactly one timer
-  // (abortableSleep's setTimeout). runOnlyPendingTimersAsync fires
-  // that timer + drains microtasks. If a future change adds a
-  // second `await abortableSleep` in this branch (e.g., a separate
-  // metrics-flush sleep), this helper would silently advance only
-  // the first and the second would hang — convert to a loop then.
+  // (abortableSleep's setTimeout) and yields ONLY on that timer.
+  // runOnlyPendingTimersAsync fires that timer + drains microtasks.
+  // Two failure modes a future change could introduce:
+  //   1. A second `await abortableSleep` in this branch (e.g., a
+  //      separate metrics-flush sleep) — this helper would advance
+  //      only the first and the second would hang in real time.
+  //   2. An `await` before the setTimeout (e.g., `await
+  //      someMetric.flush()`) — runOnlyPendingTimersAsync would
+  //      execute before the setTimeout was even scheduled, advance
+  //      zero timers, and the test would hang.
+  // Convert to a loop + microtask flushes between if either lands.
   async function pollOnceFast(client) {
     const p = withMockedSqs(() => eventConsumer._test.pollOnce(client));
     await jest.runOnlyPendingTimersAsync();
@@ -1859,6 +1860,52 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
       expect.objectContaining({ cap }),
     );
     expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+  });
+
+  test('stop() finally resets currentBackoffMs to BASE (load-bearing assertion)', async () => {
+    // cr-r5: the lifecycle test in the start/stop describe block
+    // never drove currentBackoffMs away from BASE before stop(), so
+    // its post-stop() assertion was vacuous (BASE === BASE would
+    // pass even if stop()'s finally-reset line were deleted). This
+    // test drives a non-base value first via fake-timer at-cap
+    // iterations, then exercises the real stop() codepath under
+    // real timers (stop()'s drain uses Promise.race with setTimeout;
+    // fake timers would hang the deadline). Resolvable promises so
+    // drain settles cleanly via the inFlightPromises path.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    const resolvers = [];
+    withWorkerDispatch(() => {
+      for (let i = 0; i < cap; i += 1) {
+        let resolve;
+        const p = new Promise((r) => { resolve = r; });
+        resolvers.push(resolve);
+        eventConsumer.trackDispatch(p);
+      }
+    });
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    const client = makeStubClient();
+
+    // Drive currentBackoffMs to a non-base value via fake-timer
+    // pollOnce. One at-cap iteration: 100 → 200.
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
+    } finally {
+      jest.useRealTimers();
+    }
+
+    // Resolve in-flight promises so stop()'s drain settles via
+    // inFlightPromises (no need to wait the DRAIN_DEADLINE_MS).
+    resolvers.forEach((r) => r('done'));
+    await flushMicrotasks();
+    expect(eventConsumer._test.getInFlightCount()).toBe(0);
+
+    // start() + stop() under real timers. stop()'s finally runs the
+    // reset; without that line, currentBackoffMs would still be 200.
+    eventConsumer.start(client);
+    await eventConsumer.stop();
     expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });
 

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1756,6 +1756,34 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
   });
 
+  test('pollOnce: post-restart streak starts at BASE (stop()/_resetStateForTest contract)', async () => {
+    // A start → drive-to-max → stop → start lifecycle must not
+    // inherit the doubled value. stop()'s finally + _resetStateForTest
+    // both clear currentBackoffMs, but the asymmetry between
+    // atCapPauseLogged (gated reset) and currentBackoffMs (unconditional)
+    // makes an inversion regression easy. Lock it down explicitly.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    withWorkerDispatch(() => {
+      for (let i = 0; i < cap; i += 1) {
+        eventConsumer.trackDispatch(new Promise(() => {}));
+      }
+    });
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    const client = makeStubClient();
+
+    // Drive to MAX (4 doublings: 100 → 200 → 400 → 800 → 1600).
+    for (let i = 0; i < 4; i += 1) {
+      await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    }
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
+
+    // Full reset, mirroring how _resetStateForTest is wired in
+    // beforeEach. Production never restarts after stop(), but the
+    // test path that the helper covers must observe the contract.
+    eventConsumer._test._resetStateForTest();
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+  });
+
   test('pollOnce logs cap-released info on transition back to below-cap', async () => {
     // Pins the recovery path: after an at-cap streak, dropping
     // below cap fires the release-info log so operators can pair

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1782,11 +1782,13 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     }
   });
 
-  test('pollOnce: post-streak resets via _resetStateForTest restores base', async () => {
+  test('_resetStateForTest restores currentBackoffMs to base', async () => {
     // _resetStateForTest is the beforeEach harness path. stop()'s
     // finally also resets currentBackoffMs — that branch is asserted
     // in the start()+stop() round-trip test in the start/stop
-    // lifecycle describe block.
+    // lifecycle describe block. The cap-release path (below-cap
+    // transition after a streak) is covered by the next test in this
+    // describe block.
     jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
     try {
       const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1293,6 +1293,11 @@ describe('event-consumer: start/stop lifecycle', () => {
     await eventConsumer.stop();
     // Stop is idempotent.
     await eventConsumer.stop();
+
+    // stop()'s finally restores currentBackoffMs to BASE alongside
+    // running/loopPromise/stopController. Pins the contract called
+    // out in the at-cap backoff describe block (#390).
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });
 
   // A "start() actually registers pollOnce" companion test was
@@ -1756,12 +1761,11 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
   });
 
-  test('pollOnce: post-restart streak starts at BASE (stop()/_resetStateForTest contract)', async () => {
-    // A start → drive-to-max → stop → start lifecycle must not
-    // inherit the doubled value. stop()'s finally + _resetStateForTest
-    // both clear currentBackoffMs, but the asymmetry between
-    // atCapPauseLogged (gated reset) and currentBackoffMs (unconditional)
-    // makes an inversion regression easy. Lock it down explicitly.
+  test('pollOnce: post-streak resets via _resetStateForTest restore base', async () => {
+    // _resetStateForTest is the beforeEach harness path. stop()'s
+    // finally also resets currentBackoffMs (asserted in the cap-
+    // released test below, where the stop() lifecycle is exercised
+    // by other tests in the start/stop describe block).
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
@@ -1777,9 +1781,6 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     }
     expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
 
-    // Full reset, mirroring how _resetStateForTest is wired in
-    // beforeEach. Production never restarts after stop(), but the
-    // test path that the helper covers must observe the contract.
     eventConsumer._test._resetStateForTest();
     expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1699,90 +1699,116 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(eventConsumer._test.isAtCapPauseLogged()).toBe(true);
   });
 
+  // Helper: kick off pollOnce and immediately advance fake timers so
+  // the at-cap abortableSleep resolves in test time, not wall time.
+  // Without this, sustained-at-cap tests pay 100+200+400+800+1600 =
+  // 3.1s of real-time sleep per iteration sequence. setImmediate +
+  // queueMicrotask are excluded from fake-timer wrapping so the
+  // existing flushMicrotasks() + Promise scheduling stay unaffected.
+  async function pollOnceFast(client) {
+    const p = withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    await jest.runOnlyPendingTimersAsync();
+    return p;
+  }
+
   test('pollOnce stays silent during a sustained at-cap streak (one warn at entry, no per-iteration noise)', async () => {
     // The entry warn + the eventual exit info already bookend the
     // pause for operators — steady-state at-cap is intentionally
     // silent. Pre-#390, this test asserted a per-iteration debug
     // log; that pattern is gone now (it spammed ~10×/s per worker
     // with no operational value beyond what entry+exit convey).
-    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    withWorkerDispatch(() => {
-      for (let i = 0; i < cap; i += 1) {
-        eventConsumer.trackDispatch(new Promise(() => {})); // never resolves
-      }
-    });
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+      withWorkerDispatch(() => {
+        for (let i = 0; i < cap; i += 1) {
+          eventConsumer.trackDispatch(new Promise(() => {})); // never resolves
+        }
+      });
 
-    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
-    const client = makeStubClient();
-    const warnBaseline = logger.warn.mock.calls.length;
-    const debugBaseline = logger.debug.mock.calls.length;
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      const client = makeStubClient();
+      const warnBaseline = logger.warn.mock.calls.length;
+      const debugBaseline = logger.debug.mock.calls.length;
 
-    // Three consecutive at-cap polls.
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+      await pollOnceFast(client);
+      await pollOnceFast(client);
+      await pollOnceFast(client);
 
-    // Exactly one warn fired (the entry), no debugs across the streak.
-    expect(logger.warn.mock.calls.length - warnBaseline).toBe(1);
-    expect(logger.debug.mock.calls.length - debugBaseline).toBe(0);
+      // Exactly one warn fired (the entry), no debugs across the streak.
+      expect(logger.warn.mock.calls.length - warnBaseline).toBe(1);
+      expect(logger.debug.mock.calls.length - debugBaseline).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('pollOnce: at-cap backoff doubles each iteration up to the ceiling', async () => {
-    // Exponential decay: 100ms → 200 → 400 → 800 → 1600 (max). Cuts
-    // wake rate from 10/s to ~0.6/s under sustained at-cap without
-    // significantly delaying recovery (a release in the middle of a
-    // backoff still wakes via the next iteration's below-cap check).
-    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    withWorkerDispatch(() => {
-      for (let i = 0; i < cap; i += 1) {
-        eventConsumer.trackDispatch(new Promise(() => {}));
-      }
-    });
+    // Exponential backoff: 100ms → 200 → 400 → 800 → 1600 (max).
+    // Cuts wake rate from 10/s to ~0.6/s under sustained at-cap
+    // without significantly delaying recovery (a release in the
+    // middle of a backoff still wakes via the next below-cap check).
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+      withWorkerDispatch(() => {
+        for (let i = 0; i < cap; i += 1) {
+          eventConsumer.trackDispatch(new Promise(() => {}));
+        }
+      });
 
-    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
-    const client = makeStubClient();
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      const client = makeStubClient();
 
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
 
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
 
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(400);
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(400);
 
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(800);
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(800);
 
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
 
-    // One more iteration past the ceiling: still pinned at MAX.
-    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
+      // One more iteration past the ceiling: still pinned at MAX.
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
-  test('pollOnce: post-streak resets via _resetStateForTest restore base', async () => {
+  test('pollOnce: post-streak resets via _resetStateForTest restores base', async () => {
     // _resetStateForTest is the beforeEach harness path. stop()'s
-    // finally also resets currentBackoffMs (asserted in the cap-
-    // released test below, where the stop() lifecycle is exercised
-    // by other tests in the start/stop describe block).
-    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    withWorkerDispatch(() => {
-      for (let i = 0; i < cap; i += 1) {
-        eventConsumer.trackDispatch(new Promise(() => {}));
+    // finally also resets currentBackoffMs — that branch is asserted
+    // in the start()+stop() round-trip test in the start/stop
+    // lifecycle describe block.
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+      withWorkerDispatch(() => {
+        for (let i = 0; i < cap; i += 1) {
+          eventConsumer.trackDispatch(new Promise(() => {}));
+        }
+      });
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      const client = makeStubClient();
+
+      // Drive to MAX (4 doublings: 100 → 200 → 400 → 800 → 1600).
+      for (let i = 0; i < 4; i += 1) {
+        await pollOnceFast(client);
       }
-    });
-    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
-    const client = makeStubClient();
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
 
-    // Drive to MAX (4 doublings: 100 → 200 → 400 → 800 → 1600).
-    for (let i = 0; i < 4; i += 1) {
-      await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+      eventConsumer._test._resetStateForTest();
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+    } finally {
+      jest.useRealTimers();
     }
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
-
-    eventConsumer._test._resetStateForTest();
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });
 
   test('pollOnce logs cap-released info on transition back to below-cap', async () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1705,6 +1705,13 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
   // 3.1s of real-time sleep per iteration sequence. setImmediate +
   // queueMicrotask are excluded from fake-timer wrapping so the
   // existing flushMicrotasks() + Promise scheduling stay unaffected.
+  //
+  // Invariant: pollOnce's at-cap branch awaits exactly one timer
+  // (abortableSleep's setTimeout). runOnlyPendingTimersAsync fires
+  // that timer + drains microtasks. If a future change adds a
+  // second `await abortableSleep` in this branch (e.g., a separate
+  // metrics-flush sleep), this helper would silently advance only
+  // the first and the second would hang — convert to a loop then.
   async function pollOnceFast(client) {
     const p = withMockedSqs(() => eventConsumer._test.pollOnce(client));
     await jest.runOnlyPendingTimersAsync();
@@ -1853,6 +1860,48 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     );
     expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
     expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+  });
+
+  test('pollOnce: MAX → BASE reset via production below-cap path (not just one doubling)', async () => {
+    // Companion to the cap-released test, which only exercises the
+    // single-doubling case (200 → 100). This drives currentBackoffMs
+    // to the ceiling first, then triggers the real below-cap
+    // transition, locking in that the reset works from any step on
+    // the doubling ladder — not just the first.
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+      const resolvers = [];
+      withWorkerDispatch(() => {
+        for (let i = 0; i < cap; i += 1) {
+          let resolve;
+          const p = new Promise((r) => { resolve = r; });
+          resolvers.push(resolve);
+          eventConsumer.trackDispatch(p);
+        }
+      });
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      const client = makeStubClient();
+
+      // Drive to MAX (4 doublings: 100 → 200 → 400 → 800 → 1600).
+      for (let i = 0; i < 4; i += 1) {
+        await pollOnceFast(client);
+      }
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
+
+      // Drain all handlers, then take the production below-cap path.
+      resolvers.forEach((r) => r('done'));
+      // flushMicrotasks uses setImmediate which is excluded from
+      // fake timers, so the .finally chain flushes normally.
+      await flushMicrotasks();
+      expect(eventConsumer._test.getInFlightCount()).toBe(0);
+
+      await pollOnceFast(client);
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+      expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('pollOnce proceeds with receive when below cap', async () => {

--- a/apps/discord/tests/event-consumer.test.js
+++ b/apps/discord/tests/event-consumer.test.js
@@ -1657,9 +1657,9 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
 
   test('pollOnce early-returns + backs off when in-flight at cap', async () => {
     // When inFlightCount >= MAX_INFLIGHT_HANDLERS, pollOnce must
-    // skip the receive call and sleep INFLIGHT_BACKOFF_MS to let
-    // handlers drain. Pins that the cap is enforced + the receive
-    // path is bypassed.
+    // skip the receive call and sleep at least the base backoff to
+    // let handlers drain. Pins that the cap is enforced + the
+    // receive path is bypassed.
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
 
     // Manually crank inFlightCount up to cap via the tracker. Use
@@ -1694,11 +1694,12 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     expect(eventConsumer._test.isAtCapPauseLogged()).toBe(true);
   });
 
-  test('pollOnce only warns once per at-cap streak (debug for subsequent polls)', async () => {
-    // Pins the throttle: a sustained at-cap condition produces one
-    // warn at the entry transition and debug lines for the rest of
-    // the streak. Without this, a slow downstream wedge would spam
-    // logger.warn ~10x/s per worker.
+  test('pollOnce stays silent during a sustained at-cap streak (one warn at entry, no per-iteration noise)', async () => {
+    // The entry warn + the eventual exit info already bookend the
+    // pause for operators — steady-state at-cap is intentionally
+    // silent. Pre-#390, this test asserted a per-iteration debug
+    // log; that pattern is gone now (it spammed ~10×/s per worker
+    // with no operational value beyond what entry+exit convey).
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
@@ -1708,23 +1709,51 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
 
     sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
     const client = makeStubClient();
+    const warnBaseline = logger.warn.mock.calls.length;
+    const debugBaseline = logger.debug.mock.calls.length;
 
-    // First poll: warn fires.
+    // Three consecutive at-cap polls.
     await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.debug).not.toHaveBeenCalledWith(
-      eventConsumer._test.AT_CAP_PAUSE_DEBUG_MSG,
-      expect.anything(),
-    );
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
 
-    // Subsequent polls in the same streak: debug only, no extra warn.
+    // Exactly one warn fired (the entry), no debugs across the streak.
+    expect(logger.warn.mock.calls.length - warnBaseline).toBe(1);
+    expect(logger.debug.mock.calls.length - debugBaseline).toBe(0);
+  });
+
+  test('pollOnce: at-cap backoff doubles each iteration up to the ceiling', async () => {
+    // Exponential decay: 100ms → 200 → 400 → 800 → 1600 (max). Cuts
+    // wake rate from 10/s to ~0.6/s under sustained at-cap without
+    // significantly delaying recovery (a release in the middle of a
+    // backoff still wakes via the next iteration's below-cap check).
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    withWorkerDispatch(() => {
+      for (let i = 0; i < cap; i += 1) {
+        eventConsumer.trackDispatch(new Promise(() => {}));
+      }
+    });
+
+    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+    const client = makeStubClient();
+
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
+
     await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
+
     await withMockedSqs(() => eventConsumer._test.pollOnce(client));
-    expect(logger.warn).toHaveBeenCalledTimes(1); // still 1
-    expect(logger.debug).toHaveBeenCalledWith(
-      eventConsumer._test.AT_CAP_PAUSE_DEBUG_MSG,
-      expect.objectContaining({ inFlight: cap, cap }),
-    );
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(400);
+
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(800);
+
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
+
+    // One more iteration past the ceiling: still pinned at MAX.
+    await withMockedSqs(() => eventConsumer._test.pollOnce(client));
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_MAX_MS);
   });
 
   test('pollOnce logs cap-released info on transition back to below-cap', async () => {
@@ -1747,9 +1776,10 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
     const client = makeStubClient();
 
-    // Enter at-cap state (warn fires, gate is set).
+    // Enter at-cap state (warn fires, gate set, backoff doubled).
     await withMockedSqs(() => eventConsumer._test.pollOnce(client));
     expect(eventConsumer._test.isAtCapPauseLogged()).toBe(true);
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
 
     // Drain all handlers: resolve every tracked promise, then let
     // the .finally microtask chain flush so inFlightCount drops to 0.
@@ -1757,13 +1787,15 @@ describe('event-consumer: backpressure (in-flight handler cap)', () => {
     await flushMicrotasks();
     expect(eventConsumer._test.getInFlightCount()).toBe(0);
 
-    // Below-cap poll: release-info fires, gate clears.
+    // Below-cap poll: release-info fires, gate clears, backoff
+    // resets to base so the next at-cap entry starts responsive.
     await withMockedSqs(() => eventConsumer._test.pollOnce(client));
     expect(logger.info).toHaveBeenCalledWith(
       eventConsumer._test.AT_CAP_RELEASED_INFO_MSG,
       expect.objectContaining({ cap }),
     );
     expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS);
   });
 
   test('pollOnce proceeds with receive when below cap', async () => {


### PR DESCRIPTION
Closes #390.

## Summary

PR #389 landed a fixed 100ms backoff at the in-flight handler cap with a debug log on every iteration of an at-cap streak. cr feedback on that PR noted that under sustained at-cap (slow downstream + bursty arrivals) the loop wakes ~10×/s producing per-worker log noise without operational value — the entry warn + exit info already bookend the pause.

This PR addresses both concerns:

1. **Exponential decay** replaces fixed 100ms.
2. **Silent steady-state**: per-iteration debug log dropped.

## Why

The current shape is correct but over-talks. A wedged downstream can hold the cap for tens of seconds; at 10 wakes/s the worker burns CPU re-checking the cap and emits a debug line each time. The entry warn ("we entered at-cap") and exit info ("we left at-cap") already give operators the pair they need to compute pause duration — the per-iteration debug just trails behind.

Exponential decay keeps the 100ms responsiveness for short streaks (the common case — a brief DM-fan-out spike) and drops sustained-streak wake rate from 10/s to ~0.6/s, cutting CPU + log noise meaningfully.

## How

- `INFLIGHT_BACKOFF_MS = 100` → `INFLIGHT_BACKOFF_BASE_MS = 100` + `INFLIGHT_BACKOFF_MAX_MS = 1600`.
- New module-level `currentBackoffMs`, starts at base.
- pollOnce at-cap path: `await abortableSleep(currentBackoffMs)`, then `currentBackoffMs = Math.min(currentBackoffMs * 2, INFLIGHT_BACKOFF_MAX_MS)`.
- Below-cap path resets `currentBackoffMs = INFLIGHT_BACKOFF_BASE_MS` so the next at-cap entry starts responsive again.
- State resets alongside `atCapPauseLogged` in `stop()` and `_resetStateForTest`.
- Per-iteration debug log removed. `AT_CAP_PAUSE_DEBUG_MSG` constant + export gone.

`abortableSleep` honors the abort signal unchanged, so `stop()` during a 1.6s backoff still exits within the graceful-shutdown budget.

## Cadence

| Iteration  | 1   | 2   | 3   | 4   | 5+   |
|------------|-----|-----|-----|-----|------|
| Backoff ms | 100 | 200 | 400 | 800 | 1600 |

Recovery: a below-cap poll at any iteration resets to 100ms.

## Test plan

- [x] Updated "stays silent during sustained at-cap" test: 3 consecutive at-cap polls produce exactly 1 warn + 0 debugs.
- [x] New "at-cap backoff doubles each iteration up to the ceiling" test: pins 100→200→400→800→1600 and the ceiling clamp.
- [x] Updated cap-released test: asserts `currentBackoffMs` resets to base on below-cap transition.
- [x] Existing tests (entry warn, exit info, abort-during-backoff) unchanged.
- [x] 1971/1971 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)