### PR TITLE
feat(discord): pillar 2 cross-process gateway RESUME via @discordjs/ws

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -112,6 +112,33 @@ ENABLE_OPENNHP_FEATURES=false
 # ENABLE_EVENT_SHIPPER=false
 # QURL_BOT_EVENTS_QUEUE_URL=https://sqs.us-east-2.amazonaws.com/000000000000/qurl-bot-events-sandbox
 
+# Gateway RESUME (zero-downtime design, Pillar 2). When set to the
+# literal string "true" AND PROCESS_ROLE=gateway, the gateway tier
+# replaces the discord.js Client + client.login() with a direct
+# @discordjs/ws WebSocketManager whose session callbacks point at
+# the `${DDB_TABLE_PREFIX}gateway-session` DDB table. On every
+# restart the new gateway boots, reads the persisted session, and
+# Discord's RESUME (op 6) replays buffered events since the last
+# sequence — eliminating the ~10 s IDENTIFY cold-start the legacy
+# single-process deploy carries today.
+#
+# Requires ENABLE_EVENT_SHIPPER=true (the shim only has a forward-
+# to-SQS dispatch path; in-process dispatchers are unreachable).
+# Combined mode is rejected at boot (the legacy Client owns the WS
+# in combined mode; the shim conflicts).
+#
+# Single-replica behavior is unchanged at this layer — desired_count
+# stays at 1. PR 14 adds the second replica + push handoff (Pillar 3).
+#
+# No-op when PROCESS_ROLE=http (worker tier doesn't open a WS); the
+# flag may be uniform across the gateway and worker task defs.
+#
+# Rollback: unset the flag (or set to anything other than "true")
+# and redeploy. The gateway tier reverts to client.login() and the
+# DDB session row goes stale (next "true" boot RESUMEs back to it
+# if Discord's 60 s buffer still has it, otherwise IDENTIFYs).
+# ENABLE_GATEWAY_RESUME=false
+
 # Maximum number of in-flight detached handlers the SQS consumer
 # tolerates before pausing receives (backpressure). When the count
 # reaches the cap, pollOnce returns early and waits 100ms before

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -122,6 +122,50 @@ function unsupportedRoleShipperCombo(role, eventShipperEnabled) {
   return null;
 }
 
+// Parallel to unsupportedRoleShipperCombo for ENABLE_GATEWAY_RESUME.
+// Two unsupported shapes:
+//
+//   1. resume=true with shipper=false — the resume shim
+//      (@discordjs/ws WebSocketManager) replaces discord.js's Client
+//      entirely, so the in-process interaction dispatcher has no
+//      `client.on('interactionCreate')` emitter to attach to. The
+//      flag-on path is only coherent when the shipper has already
+//      moved dispatch to SQS.
+//   2. resume=true with role=combined — combined mode runs both
+//      tiers in one process, which the legacy discord.js Client
+//      owns end-to-end. The resume shim would conflict with the
+//      Client's WS ownership.
+//
+// (combined + shipper=true is independently rejected by
+// unsupportedRoleShipperCombo; resume's combined-mode rejection
+// catches the remaining combined+shipper-off+resume-on case.)
+//
+// Returns the operator-facing message on rejection or null on
+// success. Same string-or-null shape as unsupportedRoleShipperCombo.
+function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled) {
+  if (!resumeEnabled) return null;
+  if (role === 'combined') {
+    return (
+      'PROCESS_ROLE=combined with ENABLE_GATEWAY_RESUME=true is not supported ' +
+      '(the resume shim owns the WebSocket and conflicts with the legacy ' +
+      'discord.js Client that combined mode runs). Run two processes: ' +
+      'PROCESS_ROLE=gateway (singleton, owns the resume shim) + ' +
+      'PROCESS_ROLE=http (consumes from SQS). For local dev / sandbox in ' +
+      'one process, leave ENABLE_GATEWAY_RESUME unset.'
+    );
+  }
+  if (!eventShipperEnabled) {
+    return (
+      'ENABLE_GATEWAY_RESUME=true requires ENABLE_EVENT_SHIPPER=true ' +
+      '(the resume shim replaces discord.js Client with @discordjs/ws ' +
+      'WebSocketManager, which forwards every frame to SQS — the ' +
+      'in-process dispatcher path is unreachable from the shim). ' +
+      'Enable the shipper first, or leave ENABLE_GATEWAY_RESUME unset.'
+    );
+  }
+  return null;
+}
+
 // PLACEHOLDER is treated as missing because the SSM parameter
 // ships with that literal sentinel value; remediation ("seed a
 // real key") is identical to the empty-key case.
@@ -219,6 +263,7 @@ module.exports = {
   missingKekRequiredKeys,
   missingEventShipperKeys,
   unsupportedRoleShipperCombo,
+  unsupportedRoleResumeCombo,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -123,26 +123,29 @@ function unsupportedRoleShipperCombo(role, eventShipperEnabled) {
 }
 
 // Parallel to unsupportedRoleShipperCombo for ENABLE_GATEWAY_RESUME.
-// Two unsupported shapes:
+// Three unsupported shapes:
 //
-//   1. resume=true with shipper=false — the resume shim
+//   1. resume=true with role=combined — combined mode runs both
+//      tiers in one process, which the legacy discord.js Client
+//      owns end-to-end. The resume shim would conflict with the
+//      Client's WS ownership.
+//   2. resume=true with shipper=false — the resume shim
 //      (@discordjs/ws WebSocketManager) replaces discord.js's Client
 //      entirely, so the in-process interaction dispatcher has no
 //      `client.on('interactionCreate')` emitter to attach to. The
 //      flag-on path is only coherent when the shipper has already
 //      moved dispatch to SQS.
-//   2. resume=true with role=combined — combined mode runs both
-//      tiers in one process, which the legacy discord.js Client
-//      owns end-to-end. The resume shim would conflict with the
-//      Client's WS ownership.
-//
-// (combined + shipper=true is independently rejected by
-// unsupportedRoleShipperCombo; resume's combined-mode rejection
-// catches the remaining combined+shipper-off+resume-on case.)
+//   3. resume=true with storeType!=ddb — the resume guarantee only
+//      holds when session state is persisted across processes.
+//      The default sqlite backend writes a local file that the
+//      next ECS task won't see; a resume against the previous
+//      sequence would fail every restart. Rejecting at boot is
+//      preferable to a silent IDENTIFY-every-restart degradation
+//      that mimics flag-off behavior.
 //
 // Returns the operator-facing message on rejection or null on
 // success. Same string-or-null shape as unsupportedRoleShipperCombo.
-function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled) {
+function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled, storeType) {
   if (!resumeEnabled) return null;
   if (role === 'combined') {
     return (
@@ -161,6 +164,14 @@ function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled) {
       'WebSocketManager, which forwards every frame to SQS — the ' +
       'in-process dispatcher path is unreachable from the shim). ' +
       'Enable the shipper first, or leave ENABLE_GATEWAY_RESUME unset.'
+    );
+  }
+  if (storeType !== 'ddb') {
+    return (
+      `ENABLE_GATEWAY_RESUME=true requires STORE_TYPE=ddb (got '${storeType ?? 'unset (defaults to sqlite)'}'). ` +
+      'Cross-process RESUME persists session state to the gateway-session DDB ' +
+      'table; sqlite would write a local file the next process never sees. Set ' +
+      'STORE_TYPE=ddb in the deployment template, or leave ENABLE_GATEWAY_RESUME unset.'
     );
   }
   return null;

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -158,12 +158,17 @@ function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled, st
     );
   }
   if (!eventShipperEnabled) {
+    // Role-neutral framing: the same env may be applied uniformly
+    // across gateway + http task defs, and an http operator reading
+    // this message shouldn't see gateway-tier-specific language
+    // (the shim is never constructed on http; the rejection here
+    // is a consistency canary, not a description of what http does).
     return (
-      'ENABLE_GATEWAY_RESUME=true requires ENABLE_EVENT_SHIPPER=true ' +
-      '(the resume shim replaces discord.js Client with @discordjs/ws ' +
-      'WebSocketManager, which forwards every frame to SQS — the ' +
-      'in-process dispatcher path is unreachable from the shim). ' +
-      'Enable the shipper first, or leave ENABLE_GATEWAY_RESUME unset.'
+      'ENABLE_GATEWAY_RESUME=true requires ENABLE_EVENT_SHIPPER=true. ' +
+      'The two flags co-design: the gateway tier forwards every Discord ' +
+      'frame to SQS while the worker tier consumes it, so a resume path ' +
+      'without the shipper-shape split has nowhere to dispatch. Enable ' +
+      'the shipper first, or leave ENABLE_GATEWAY_RESUME unset.'
     );
   }
   if (storeType !== 'ddb') {

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -168,7 +168,7 @@ function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled, st
   }
   if (storeType !== 'ddb') {
     return (
-      `ENABLE_GATEWAY_RESUME=true requires STORE_TYPE=ddb (got '${storeType ?? 'unset (defaults to sqlite)'}'). ` +
+      `ENABLE_GATEWAY_RESUME=true requires STORE_TYPE=ddb (got '${storeType}'). ` +
       'Cross-process RESUME persists session state to the gateway-session DDB ' +
       'table; sqlite would write a local file the next process never sees. Set ' +
       'STORE_TYPE=ddb in the deployment template, or leave ENABLE_GATEWAY_RESUME unset.'

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -14,6 +14,7 @@ const {
   TextInputStyle,
   AttachmentBuilder,
 } = require('discord.js');
+const { Routes } = require('discord-api-types/v10');
 const crypto = require('crypto');
 const config = require('./config');
 const db = require('./store');
@@ -8045,25 +8046,25 @@ function getActiveCommands() {
 
 // Proactively clear stale guild-scoped command registrations from any
 // guild the bot is in. Discord's guild and global command namespaces do
-// not purge each other on a fresh .set() call, so a bot that previously
+// not purge each other on a fresh PUT call, so a bot that previously
 // ran in OpenNHP mode (GUILD_ID=X, full command set registered to guild
 // X) and is now redeployed in multi-tenant or single-guild-plain mode
 // will leave /link, /leaderboard, etc. visible in X's slash-command
 // autocomplete until Discord's cache ages out. The dispatch-time filter
 // in handleCommand prevents those stale commands from doing anything
 // harmful, but users still see dead commands in the picker. Issuing
-// .set([], guildId) clears the guild-scoped set; any ALIVE guild-scoped
-// registration for the CURRENT mode gets reinstalled by the main
-// registerCommands path below.
+// PUT-with-empty-body on the guild-commands endpoint clears the
+// guild-scoped set; any ALIVE guild-scoped registration for the
+// CURRENT mode gets reinstalled by the main registerCommands path
+// below.
 //
 // Scoped to non-OpenNHP modes: in OpenNHP mode we intentionally register
 // guild-scoped commands to config.GUILD_ID, so purging there would
-// race with the upcoming set(). Only iterates guilds the bot is
-// actually in (client.guilds.cache) — we can't and shouldn't enumerate
-// guilds we've never joined.
-async function purgeStaleGuildCommands(client) {
+// race with the upcoming PUT. Only iterates guildIds the caller passes
+// in — we can't and shouldn't enumerate guilds we've never joined.
+async function purgeStaleGuildCommands({ rest, appId, guildIds, guildNames = {} }) {
   if (config.isOpenNHPActive) return; // guild-scoped register is the goal in OpenNHP mode
-  // Parallelize the per-guild fetch+set. Sequentializing makes boot
+  // Parallelize the per-guild fetch+put. Sequentializing makes boot
   // time O(guilds) at ~500ms per round-trip, which scales badly for
   // the public-bot install path this PR targets. Promise.allSettled
   // so one slow/failing guild doesn't block the others, and so a
@@ -8072,17 +8073,20 @@ async function purgeStaleGuildCommands(client) {
   // per guild, so parallel fans out cleanly until the global
   // app-command rate limit (~200/min) — well above any realistic
   // boot-time burst.
-  const guilds = [...client.guilds.cache.values()];
-  await Promise.allSettled(guilds.map(async (guild) => {
+  await Promise.allSettled(guildIds.map(async (guildId) => {
     try {
-      const existing = await client.application.commands.fetch({ guildId: guild.id });
-      if (existing.size === 0) return;
-      await client.application.commands.set([], guild.id);
-      logger.info(`Purged ${existing.size} stale guild-scoped commands from ${guild.name} (${guild.id})`);
+      const existing = await rest.get(Routes.applicationGuildCommands(appId, guildId));
+      // REST returns an array of Command objects; falsy / zero-length
+      // means no stale registrations to purge (skip the PUT).
+      const existingCount = Array.isArray(existing) ? existing.length : 0;
+      if (existingCount === 0) return;
+      await rest.put(Routes.applicationGuildCommands(appId, guildId), { body: [] });
+      const displayName = guildNames[guildId] ?? guildId;
+      logger.info(`Purged ${existingCount} stale guild-scoped commands from ${displayName} (${guildId})`);
     } catch (error) {
       // Don't fail boot on a purge error — the dispatch-time filter in
       // handleCommand is the correctness guarantee; purge is UX polish.
-      logger.warn(`Could not purge stale commands from guild ${guild.id}`, { error: error.message });
+      logger.warn(`Could not purge stale commands from guild ${guildId}`, { error: error.message });
     }
   }));
 }
@@ -8090,11 +8094,21 @@ async function purgeStaleGuildCommands(client) {
 // Register commands with Discord. `config.isOpenNHPActive` is the
 // single source of truth for "this deployment exercises the OpenNHP
 // community surface" — see config.js for the derivation.
-async function registerCommands(client) {
+//
+// Signature decoupled from discord.js Client so both the legacy
+// `client.login()` path AND the Pillar 2 `@discordjs/ws` shim path
+// can call this with the same shape: pass REST + appId + the guild
+// list the caller already has.
+//   - Legacy path: rest=client.rest, appId=client.application.id,
+//     guildIds=[...client.guilds.cache.keys()], guildNames map.
+//   - Shim path: rest=shim.rest, appId=shim.getAppId() (READY-derived),
+//     guildIds=[] (gateway-tier shim doesn't track guild cache;
+//     purge is non-load-bearing UX polish in the shim path).
+async function registerCommands({ rest, appId, guildIds = [], guildNames = {} }) {
   // Purge first — prevents stale OpenNHP-era registrations in guilds the
   // bot is still in. See purgeStaleGuildCommands for details + why this
   // is scoped to non-OpenNHP modes.
-  await purgeStaleGuildCommands(client);
+  await purgeStaleGuildCommands({ rest, appId, guildIds, guildNames });
 
   const activeCommands = getActiveCommands();
   const commandData = activeCommands.map(cmd => cmd.data.toJSON());
@@ -8105,14 +8119,14 @@ async function registerCommands(client) {
       // guild. Used by the single-guild OpenNHP deployment where fast command
       // iteration matters more than appearing in other guilds.
       logger.info(`Registering ${activeCommands.length} slash commands to guild ${config.GUILD_ID}...`);
-      await client.application.commands.set(commandData, config.GUILD_ID);
+      await rest.put(Routes.applicationGuildCommands(appId, config.GUILD_ID), { body: commandData });
     } else {
       // Global registration: commands appear in every guild the bot joins.
       // Discord caches global commands for up to 1 hour, so newly-added
       // commands may take that long to propagate. Used for multi-tenant
       // deployments (customers invite the bot to their own servers).
       logger.info(`Registering ${activeCommands.length} slash commands globally (multi-tenant mode): ${activeCommands.map(c => c.data.name).join(', ')}`);
-      await client.application.commands.set(commandData);
+      await rest.put(Routes.applicationCommands(appId), { body: commandData });
     }
     logger.info('Slash commands registered.');
   } catch (error) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -8054,41 +8054,30 @@ function getActiveCommands() {
 // in handleCommand prevents those stale commands from doing anything
 // harmful, but users still see dead commands in the picker. Issuing
 // PUT-with-empty-body on the guild-commands endpoint clears the
-// guild-scoped set; any ALIVE guild-scoped registration for the
-// CURRENT mode gets reinstalled by the main registerCommands path
-// below.
+// guild-scoped set.
 //
 // Scoped to non-OpenNHP modes: in OpenNHP mode we intentionally register
 // guild-scoped commands to config.GUILD_ID, so purging there would
-// race with the upcoming PUT. Only iterates guildIds the caller passes
-// in — we can't and shouldn't enumerate guilds we've never joined.
-async function purgeStaleGuildCommands({ rest, appId, guildIds, guildNames = {} }) {
+// race with the upcoming PUT. Only iterates the `guilds` map the caller
+// passes in — we can't and shouldn't enumerate guilds we've never joined.
+async function purgeStaleGuildCommands({ rest, appId, guilds }) {
   if (config.isOpenNHPActive) return; // guild-scoped register is the goal in OpenNHP mode
-  // Parallelize the per-guild fetch+put. Sequentializing makes boot
-  // time O(guilds) at ~500ms per round-trip, which scales badly for
-  // the public-bot install path this PR targets. Promise.allSettled
-  // so one slow/failing guild doesn't block the others, and so a
-  // single rejection doesn't bubble and abort registerCommands.
-  // Discord's guild-commands endpoint has a separate rate bucket
-  // per guild, so parallel fans out cleanly until the global
-  // app-command rate limit (~200/min) — well above any realistic
-  // boot-time burst.
-  await Promise.allSettled(guildIds.map(async (guildId) => {
+  // Parallelize the per-guild fetch+put. Promise.allSettled so one
+  // slow/failing guild doesn't block the others; Discord's guild-
+  // commands endpoint uses a separate rate bucket per guild.
+  await Promise.allSettled(Array.from(guilds, ([guildId, guildName]) => (async () => {
     try {
       const existing = await rest.get(Routes.applicationGuildCommands(appId, guildId));
-      // REST returns an array of Command objects; falsy / zero-length
-      // means no stale registrations to purge (skip the PUT).
       const existingCount = Array.isArray(existing) ? existing.length : 0;
       if (existingCount === 0) return;
       await rest.put(Routes.applicationGuildCommands(appId, guildId), { body: [] });
-      const displayName = guildNames[guildId] ?? guildId;
-      logger.info(`Purged ${existingCount} stale guild-scoped commands from ${displayName} (${guildId})`);
+      logger.info(`Purged ${existingCount} stale guild-scoped commands from ${guildName ?? guildId} (${guildId})`);
     } catch (error) {
       // Don't fail boot on a purge error — the dispatch-time filter in
       // handleCommand is the correctness guarantee; purge is UX polish.
       logger.warn(`Could not purge stale commands from guild ${guildId}`, { error: error.message });
     }
-  }));
+  })()));
 }
 
 // Register commands with Discord. `config.isOpenNHPActive` is the
@@ -8096,19 +8085,14 @@ async function purgeStaleGuildCommands({ rest, appId, guildIds, guildNames = {} 
 // community surface" — see config.js for the derivation.
 //
 // Signature decoupled from discord.js Client so both the legacy
-// `client.login()` path AND the Pillar 2 `@discordjs/ws` shim path
-// can call this with the same shape: pass REST + appId + the guild
-// list the caller already has.
-//   - Legacy path: rest=client.rest, appId=client.application.id,
-//     guildIds=[...client.guilds.cache.keys()], guildNames map.
-//   - Shim path: rest=shim.rest, appId=shim.getAppId() (READY-derived),
-//     guildIds=[] (gateway-tier shim doesn't track guild cache;
-//     purge is non-load-bearing UX polish in the shim path).
-async function registerCommands({ rest, appId, guildIds = [], guildNames = {} }) {
-  // Purge first — prevents stale OpenNHP-era registrations in guilds the
-  // bot is still in. See purgeStaleGuildCommands for details + why this
-  // is scoped to non-OpenNHP modes.
-  await purgeStaleGuildCommands({ rest, appId, guildIds, guildNames });
+// Client path AND the @discordjs/ws shim path can call this:
+//   - Legacy path: build `guilds` as `Map<guildId, guildName>` from
+//     client.guilds.cache.
+//   - Shim path: empty Map — gateway-tier shim doesn't track guild
+//     cache, and the handleCommand dispatch-time filter remains the
+//     correctness guarantee for stale registrations.
+async function registerCommands({ rest, appId, guilds = new Map() }) {
+  await purgeStaleGuildCommands({ rest, appId, guilds });
 
   const activeCommands = getActiveCommands();
   const commandData = activeCommands.map(cmd => cmd.data.toJSON());

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -410,6 +410,14 @@ module.exports = {
   // src/store/index.js's selection precedence.
   STORE_TYPE: (process.env.STORE_TYPE ?? '').trim() || 'sqlite',
 
+  // DDB table-name prefix shared by every per-table consumer
+  // (ddb-store.js + gateway-session-store.js construction in
+  // index.js). Trimmed here so a whitespace-padded env value
+  // doesn't compute a different table name at one call site than
+  // the others — ddb-store.js's `.trim()` was the original
+  // normalization point.
+  DDB_TABLE_PREFIX: (process.env.DDB_TABLE_PREFIX ?? '').trim(),
+
   // SQS Standard queue the gateway publishes to and the worker
   // consumes from (provisioned by qurl-integrations-infra PR B).
   // Required when ENABLE_EVENT_SHIPPER=true; validated at boot in

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -403,6 +403,13 @@ module.exports = {
   // silently flip the gateway path.
   ENABLE_GATEWAY_RESUME: process.env.ENABLE_GATEWAY_RESUME === 'true',
 
+  // Persistence backend selector. Lifted from raw env into config
+  // so the boot-guard (`unsupportedRoleResumeCombo`) and the
+  // gateway-shim wiring both read through the same parsed shape.
+  // Unset / empty / whitespace-only falls back to 'sqlite', matching
+  // src/store/index.js's selection precedence.
+  STORE_TYPE: (process.env.STORE_TYPE ?? '').trim() || 'sqlite',
+
   // SQS Standard queue the gateway publishes to and the worker
   // consumes from (provisioned by qurl-integrations-infra PR B).
   // Required when ENABLE_EVENT_SHIPPER=true; validated at boot in

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -376,6 +376,33 @@ module.exports = {
   // → "Rollback cliff: ENABLE_EVENT_SHIPPER".
   ENABLE_EVENT_SHIPPER: process.env.ENABLE_EVENT_SHIPPER === 'true',
 
+  // Gateway RESUME (zero-downtime design, Pillar 2). When true and
+  // PROCESS_ROLE=gateway, the gateway tier replaces the discord.js
+  // `Client` with `@discordjs/ws` `WebSocketManager` and persists
+  // session state (session_id / resume_url / sequence) to the
+  // `${DDB_TABLE_PREFIX}gateway-session` DDB table. On a process
+  // restart the new gateway boots, reads the persisted session, and
+  // Discord's `RESUME` (op 6) replays buffered events from the last
+  // sequence — eliminating the ~10 s IDENTIFY cold-start that the
+  // legacy single-process deploy carried on every restart.
+  //
+  // Requires `ENABLE_EVENT_SHIPPER=true` because the @discordjs/ws
+  // shim doesn't run the in-process dispatcher; it forwards every
+  // frame to SQS (same path Pillar 1 set up). `ENABLE_GATEWAY_RESUME=true`
+  // with the shipper off is rejected at boot — the shim would have
+  // nowhere to send dispatches. Combined mode is also rejected
+  // because the legacy Client owns the WS in that shape.
+  //
+  // No-op when role is http/worker (those tiers don't open a WS).
+  // Default off so a deploy without the flag set behaves identically
+  // to the pre-Pillar-2 codebase — matches the ENABLE_EVENT_SHIPPER
+  // rollout pattern.
+  //
+  // Literal-'true' string check (not truthy parsing) for the same
+  // reason as ENABLE_EVENT_SHIPPER: a typo (TRUE/1/yes) must not
+  // silently flip the gateway path.
+  ENABLE_GATEWAY_RESUME: process.env.ENABLE_GATEWAY_RESUME === 'true',
+
   // SQS Standard queue the gateway publishes to and the worker
   // consumes from (provisioned by qurl-integrations-infra PR B).
   // Required when ENABLE_EVENT_SHIPPER=true; validated at boot in

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -83,6 +83,14 @@ assertNoIntent(intents, GatewayIntentBits.DirectMessages, 'DirectMessages');
 
 const client = new Client({ intents });
 
+// Bitfield form of the same `intents` array, for the Pillar 2
+// @discordjs/ws shim path (which takes a number, not an array).
+// Single source of truth: both the legacy Client construction
+// above AND the shim subscribe to identical events. Bitwise OR
+// across the intent constants is the standard discord-api-types
+// shape — see discord-api-types/v10 docs.
+const GATEWAY_INTENTS_BITFIELD = intents.reduce((acc, bit) => acc | bit, 0);
+
 // Cache for quick lookups
 let guild = null;
 let roles = {
@@ -914,6 +922,7 @@ async function shutdown() {
 
 module.exports = {
   client,
+  GATEWAY_INTENTS_BITFIELD,
   assignContributorRole,
   notifyPRMerge,
   notifyBadgeEarned,

--- a/apps/discord/src/discord.js
+++ b/apps/discord/src/discord.js
@@ -84,11 +84,17 @@ assertNoIntent(intents, GatewayIntentBits.DirectMessages, 'DirectMessages');
 const client = new Client({ intents });
 
 // Bitfield form of the same `intents` array, for the Pillar 2
-// @discordjs/ws shim path (which takes a number, not an array).
+// @discordjs/ws shim path (which takes a bitfield, not an array).
 // Single source of truth: both the legacy Client construction
-// above AND the shim subscribe to identical events. Bitwise OR
-// across the intent constants is the standard discord-api-types
-// shape — see discord-api-types/v10 docs.
+// above AND the shim subscribe to identical events.
+//
+// Int32 bitwise OR is safe today — Discord's highest declared
+// intent bit (GuildVoiceStates = 128, GuildMessageTyping = 16384,
+// AutoModerationConfiguration = 1048576, etc.) is well under
+// 2³⁰. If Discord ever adds an intent bit ≥ 2³¹, switch to
+// `new IntentsBitField(intents).bitfield` (BigInt-backed) — the
+// @discordjs/ws WebSocketManager constructor accepts both number
+// and bigint forms.
 const GATEWAY_INTENTS_BITFIELD = intents.reduce((acc, bit) => acc | bit, 0);
 
 // Cache for quick lookups

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -1,67 +1,41 @@
-// DDB-backed @discordjs/ws session store for the gateway tier
-// (zero-downtime design, Pillar 2 — cross-process RESUME).
+// DDB-backed @discordjs/ws session store. Persists
+// `WebSocketShard.sessionInfo` (`{sessionId, resumeURL, sequence}`)
+// so a process restart can RESUME from the last observed sequence
+// instead of IDENTIFYing fresh — Discord replays buffered events
+// from the last sequence within its ~60 s resume buffer window.
 //
-// Persists `WebSocketShard.sessionInfo` (`{sessionId, resumeURL,
-// sequence}`) to DDB so a process restart can RESUME from the last
-// observed sequence instead of IDENTIFYing fresh. Without this
-// persistence, every restart costs the cold-start window
-// (~5-10 s of WebSocket handshake + READY + GUILD_CREATE bursts);
-// with it, Discord replays buffered events from the last sequence
-// within the ~60 s resume buffer window and the bot misses no
-// interactions across the deploy boundary.
-//
-// Module shape: factory `createGatewaySessionStore({ ddbClient,
-// tableName, shardId, logger, clock })` returns a store instance
-// with its own mirror + throttle state. The factory shape (vs
-// module-level singleton like event-publisher.js) lets tests run
-// in parallel without resetting shared state and generalizes when
-// PR 14+ scales beyond single-shard.
+// Factory `createGatewaySessionStore` returns a store instance with
+// its own mirror + throttle state, so tests run isolated and a
+// future multi-shard caller can construct one per shard.
 //
 // ── Load-bearing contracts ──
 //
 // 1. In-memory mirror, not DDB-per-callback. `retrieveSessionInfo`
-//    is called by @discordjs/ws every reconnect — possibly inside
-//    a tight IDENTIFY-reject loop. Reading DDB on each call would
-//    introduce ~10-100 ms of latency per loop iteration AND
-//    couldn't observe in-process state changes made by an earlier
-//    `updateSessionInfo(null)` (DDB writes are visible only after
-//    SDK round-trip; mirror updates are visible immediately).
-//    The mirror is hydrated from DDB once at boot via `hydrate()`;
-//    subsequent reads from `retrieveSessionInfo` are pure-local.
+//    is called by @discordjs/ws every reconnect — possibly in a
+//    tight IDENTIFY-reject loop. Reading DDB on each call adds
+//    ~10-100 ms per iteration AND can't observe in-process state
+//    changes made by an earlier `updateSessionInfo(null)`. Mirror
+//    is hydrated once at boot; subsequent reads are pure-local.
 //
 // 2. Null-clear respected. When @discordjs/ws calls
 //    `updateSessionInfo(shardId, null)` (Discord rejected the
 //    RESUME), the mirror MUST be set to null AND the DDB row MUST
 //    be deleted. Returning the stale session from the next
-//    `retrieveSessionInfo` produces an infinite RESUME-reject loop
-//    that the spike's first sandbox run reproduced. The DDB delete
-//    is load-bearing for the cross-process case: a process that
-//    crashes between IDENTIFY and the next READY would otherwise
-//    leave the dead session row visible to the next boot's
-//    hydrate(), and the next process would try to RESUME on a
-//    session Discord has already invalidated.
+//    `retrieveSessionInfo` produces an infinite RESUME-reject
+//    loop. The DDB delete is load-bearing across processes too:
+//    a crash between IDENTIFY and the next READY would otherwise
+//    leave the dead row visible to the next boot's hydrate().
 //
 // 3. Write throttling. `updateSessionInfo` fires on every gateway
-//    dispatch (HEARTBEAT_ACK + PRESENCE_UPDATE + READY + every
-//    INTERACTION_CREATE — high rate). DDB-write per dispatch would
-//    burn ~$50/month at typical interaction volume AND introduce
-//    write-rate-limit risk. We write immediately only when:
-//      - the session_id changes (READY just fired), OR
-//      - the prior write is more than WRITE_THROTTLE_MS old.
-//    Otherwise the update is deferred via a single scheduled flush
-//    that fires at most every WRITE_THROTTLE_MS. Mirror always
-//    reflects the latest dispatch (so retrieveSessionInfo is
-//    fresh); DDB lags by at most WRITE_THROTTLE_MS, which the
-//    Discord 60 s resume window absorbs trivially.
+//    dispatch (high rate). We write immediately on session_id
+//    change (READY) or when the prior write is older than
+//    WRITE_THROTTLE_MS; other updates defer to a single scheduled
+//    flush. Mirror always reflects the latest dispatch; DDB lags
+//    by at most WRITE_THROTTLE_MS, well inside the resume window.
 //
-// 4. Final flush on SIGTERM. The throttle defers writes; on
-//    shutdown we must ensure the latest sequence reaches DDB
-//    before exit. `flushFinal()` cancels any pending timer and
-//    issues a synchronous write of the mirror's current state.
-//    Skipping this drops the last (up to WRITE_THROTTLE_MS) worth
-//    of sequence on the floor; the next boot's RESUME starts from
-//    a too-old sequence and Discord replays those events (or
-//    rejects the resume if it's older than the buffer).
+// 4. Final flush on SIGTERM. `flushFinal()` cancels any pending
+//    timer and writes the mirror's current state synchronously
+//    so the next process's hydrate sees the latest sequence.
 
 const { PutCommand, GetCommand, DeleteCommand } = require('@aws-sdk/lib-dynamodb');
 
@@ -99,6 +73,13 @@ function createGatewaySessionStore({
   let lastWriteAt = 0;
   let pendingFlush = null;
   let stopped = false;
+  // Tracks the most recently fired DDB write so flushFinal can await
+  // its settlement before exit. Writes are fire-and-forget (see
+  // updateSessionInfo) — `await ddb.send(...)` inside the @discordjs/
+  // ws callback would back-pressure the WS dispatch loop on every
+  // sequence update, undoing the Pillar 1 win of keeping the gateway
+  // forwarder responsive under load.
+  let inFlightWrite = Promise.resolve();
 
   async function persistRow(info) {
     // Wall-clock epoch ms for `updated_at`. Matches the design
@@ -130,38 +111,39 @@ function createGatewaySessionStore({
     }
   }
 
+  // Fire-and-forget DDB write. Cursor (lastWrittenSessionId +
+  // lastWriteAt) updates synchronously so the next call's
+  // sessionChanged + throttleExpired checks reflect the in-flight
+  // write — without it, two same-sessionId updates in quick
+  // succession would both fire immediate writes (each sees a
+  // stale cursor). On failure the cursor isn't rolled back; the
+  // throttle's next flush retries, and SIGTERM's flushFinal is
+  // the backstop. Sustained failure logs every retry.
+  function firePersist(info) {
+    lastWrittenSessionId = info.sessionId;
+    lastWriteAt = clock();
+    inFlightWrite = persistRow(info).catch((err) => {
+      logger.warn('gateway-session-store: write failed', { error: err.message });
+    });
+  }
+
   // Schedule a deferred write at (lastWriteAt + writeThrottleMs).
   // Idempotent — if a timer is already pending, leave it; the
-  // existing timer will pick up whatever's in the mirror at fire
-  // time, which is the latest dispatch. .unref() so a process
-  // exit doesn't get pinned by a pending session-flush timer
-  // (gracefulShutdown's flushFinal handles the final write).
+  // existing timer fires `firePersist(mirror)` with whatever's
+  // current at the time. .unref() so a process exit isn't pinned
+  // by a pending session-flush timer (flushFinal handles the
+  // final write at SIGTERM).
   function scheduleFlush() {
     if (pendingFlush) return;
     if (stopped) return;
     const delay = Math.max(0, writeThrottleMs - (clock() - lastWriteAt));
-    pendingFlush = setTimeout(async () => {
+    pendingFlush = setTimeout(() => {
       pendingFlush = null;
-      // Re-check mirror at fire time: an interleaved null-clear
-      // would have set mirror=null and cancelled this timer. If
-      // the clear fired AFTER this callback was queued by the
-      // event loop but BEFORE it ran, mirror is now null and we
-      // shouldn't write the stale info. The null-clear path
-      // already deleted the row directly, so there's nothing left
-      // to do here.
+      // Mirror may have been null-cleared between schedule and
+      // fire; if so, the null-clear path already issued a Delete
+      // and there's nothing to write here.
       if (!mirror || stopped) return;
-      try {
-        await persistRow(mirror);
-        lastWrittenSessionId = mirror.sessionId;
-        lastWriteAt = clock();
-      } catch (err) {
-        // Deferred write failure is non-fatal: the mirror still
-        // holds the latest info, and the next dispatch will either
-        // re-throttle (and retry on the next firing) or trigger an
-        // immediate write (sessionId change). Final flush on
-        // SIGTERM is the backstop for "throttle never recovers."
-        logger.warn('gateway-session-store: deferred write failed', { error: err.message });
-      }
+      firePersist(mirror);
     }, delay);
     pendingFlush.unref();
   }
@@ -180,70 +162,41 @@ function createGatewaySessionStore({
     },
 
     // `updateSessionInfo(shardId, info)` — info=null means Discord
-    // rejected the RESUME (session expired / version skew / etc.)
-    // and @discordjs/ws fell back to IDENTIFY. Async so the
-    // immediate-write paths can await the DDB call; @discordjs/ws
-    // accepts async callbacks.
-    async updateSessionInfo(_shardId, info) {
-      if (stopped) {
-        // Race: SIGTERM landed mid-dispatch. Don't issue new DDB
-        // writes; flushFinal already wrote (or about to write) the
-        // mirror state captured before stop().
-        return;
-      }
+    // rejected the RESUME and @discordjs/ws fell back to IDENTIFY.
+    //
+    // Synchronous resolution from @discordjs/ws's perspective:
+    // returns before DDB I/O completes so a slow DDB write doesn't
+    // back-pressure the per-frame WS dispatch loop. Writes fire-
+    // and-forget; flushFinal awaits the most recent one before
+    // exit so the next process's hydrate sees current state.
+    updateSessionInfo(_shardId, info) {
+      if (stopped) return;
 
       if (info === null) {
-        // Null-clear path. Mirror cleared first so any in-flight
-        // retrieveSessionInfo on a tight loop never observes the
-        // dead session. Pending throttle is cancelled (it would
-        // have re-written the dead row). DDB delete completes the
-        // cross-process clear so the next boot's hydrate() returns
-        // null and the new process IDENTIFYs cleanly.
         mirror = null;
         lastWrittenSessionId = null;
         cancelPendingFlush();
-        try {
-          await deleteRow();
-          lastWriteAt = clock();
-        } catch (err) {
-          // Delete failure is recoverable: the in-process mirror
-          // is already cleared (correctness for this process is
-          // preserved), and the next dispatch's putItem (after
-          // READY) will overwrite the stale row. Log loudly so
-          // a sustained delete-fail surfaces in metrics.
+        // Fire-and-forget delete. The next boot's hydrate() must
+        // not observe the dead session row, hence the cross-
+        // process clear — but waiting on DDB here would stall the
+        // WS dispatch loop.
+        inFlightWrite = deleteRow().catch((err) => {
           logger.warn('gateway-session-store: null-clear delete failed', { error: err.message });
-        }
+        });
+        lastWriteAt = clock();
         return;
       }
 
-      // Non-null update. Mirror always updated first so
-      // retrieveSessionInfo sees the latest sequence even if the
-      // DDB write is throttled.
+      // Mirror always updated synchronously so retrieveSessionInfo
+      // sees the latest sequence even if the DDB write is throttled.
       mirror = info;
 
       const sessionChanged = info.sessionId !== lastWrittenSessionId;
       const throttleExpired = (clock() - lastWriteAt) >= writeThrottleMs;
       if (sessionChanged || throttleExpired) {
-        // Immediate-write path. Cancel any pending flush since we're
-        // about to persist a newer value.
         cancelPendingFlush();
-        try {
-          await persistRow(info);
-          lastWrittenSessionId = info.sessionId;
-          lastWriteAt = clock();
-        } catch (err) {
-          // Immediate-write failure is the same recoverability
-          // story as the deferred path: mirror holds the truth,
-          // next dispatch retries. Log loudly so a sustained
-          // write-fail surfaces — without it, the gateway runs
-          // happily until restart and then RESUMEs on a too-old
-          // sequence (or hits the resume-rejection IDENTIFY
-          // fallback, which is at least observable).
-          logger.warn('gateway-session-store: write failed', { error: err.message });
-        }
+        firePersist(info);
       } else {
-        // Throttle still cooling. Schedule a deferred flush so the
-        // latest sequence reaches DDB within writeThrottleMs.
         scheduleFlush();
       }
     },
@@ -307,28 +260,31 @@ function createGatewaySessionStore({
       }
     },
 
-    // Final flush on SIGTERM. Cancels any pending throttle timer
-    // and synchronously writes the mirror's current state. If
-    // mirror is null (session was cleared mid-flight), nothing to
-    // write — the null-clear path already issued the DDB delete.
-    // Idempotent: safe to call multiple times (stop() guards
-    // re-entry).
+    // Final flush on SIGTERM. Cancels any pending throttle timer,
+    // awaits the most recently fired DDB write (write or null-
+    // clear), then writes the mirror's current state synchronously
+    // so the next process's hydrate sees current state.
+    //
+    // Failure here is the worst case for the migration: the next
+    // boot's hydrate returns a stale sequence and Discord replays
+    // a few seconds of events (best case) or rejects the RESUME
+    // and the new process IDENTIFYs (acceptable degradation). Log
+    // error-level so operators can correlate a failed flush with
+    // a degraded RESUME on the next boot.
     async flushFinal() {
       stopped = true;
       cancelPendingFlush();
+      // Settle the most recent fire-and-forget write before our
+      // own synchronous write so we don't race it with a stale
+      // value of `mirror`. Errors were already logged by the
+      // .catch inside firePersist/null-clear; swallow here.
+      try { await inFlightWrite; } catch (_) { /* logged */ }
       if (!mirror) return;
       try {
         await persistRow(mirror);
         lastWrittenSessionId = mirror.sessionId;
         lastWriteAt = clock();
       } catch (err) {
-        // Final-flush failure is the worst case for Pillar 2: the
-        // next boot's hydrate() returns a stale sequence, and
-        // Discord either replays a few seconds of events (best
-        // case) or rejects the RESUME and the next process
-        // IDENTIFYs (acceptable degradation). Log loudly so the
-        // operator can correlate a failed flush with a degraded-
-        // RESUME observation on the next boot.
         logger.error('gateway-session-store: final flush failed', { error: err.message });
       }
     },
@@ -355,6 +311,13 @@ function createGatewaySessionStore({
     },
     _getLastWriteAtForTest() {
       return lastWriteAt;
+    },
+    // Synchronizes a test on the most recent fire-and-forget DDB
+    // write. Production callers never await this (the WS dispatch
+    // loop must remain non-blocking); flushFinal handles the
+    // pre-exit synchronization.
+    async _awaitInFlightForTest() {
+      try { await inFlightWrite; } catch (_) { /* swallowed in production .catch */ }
     },
   };
 }

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -73,13 +73,9 @@ function createGatewaySessionStore({
   let lastWriteAt = 0;
   let pendingFlush = null;
   let stopped = false;
-  // Set of in-flight fire-and-forget DDB write promises. flushFinal
-  // awaits Promise.allSettled on every entry so SIGTERM doesn't exit
-  // mid-write. Each entry removes itself from the set on settle, so
-  // the steady-state size is at most one (the throttle keeps writes
-  // from overlapping under normal traffic). A simple "track only the
-  // latest" reference would lose the earlier write's settlement
-  // guarantee when a second fire-and-forget lands quickly behind it.
+  // Set of in-flight fire-and-forget DDB write promises. Each entry
+  // self-removes on settle; flushFinal awaits Promise.allSettled
+  // across the live set so SIGTERM never exits mid-write.
   const inFlightWrites = new Set();
 
   async function persistRow(info) {
@@ -120,6 +116,11 @@ function createGatewaySessionStore({
   // stale cursor). On failure the cursor isn't rolled back; the
   // throttle's next flush retries, and SIGTERM's flushFinal is
   // the backstop. Sustained failure logs every retry.
+  // Tracks a promise in `inFlightWrites` until it settles. Callers
+  // MUST pre-wrap their promise with `.catch()` so a rejection
+  // doesn't become an unhandled rejection — `p.finally` here
+  // preserves the rejected state, and `Promise.allSettled` inside
+  // flushFinal would mask the rejection silently.
   function fireWrite(promise) {
     const p = promise.finally(() => inFlightWrites.delete(p));
     inFlightWrites.add(p);

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -73,6 +73,7 @@ function createGatewaySessionStore({
   let lastWriteAt = 0;
   let pendingFlush = null;
   let stopped = false;
+  let flushed = false;
   // Set of in-flight fire-and-forget DDB write promises. Each entry
   // self-removes on settle; flushFinal awaits Promise.allSettled
   // across the live set so SIGTERM never exits mid-write.
@@ -127,12 +128,16 @@ function createGatewaySessionStore({
   // within ~1s. Burst-retrying on every dispatch would amplify
   // a DDB outage into a hot loop without changing the eventual
   // outcome.
-  // Tracks a promise in `inFlightWrites` until it settles. The
-  // .catch wrapper guarantees the tracked promise never carries a
-  // rejected state — without it, a caller that forgot to pre-catch
-  // would leak unhandled rejections, and Promise.allSettled in
-  // flushFinal would silently consume the rejection. Callers still
-  // attach their own .catch for per-write error logging.
+  // Tracks a promise in `inFlightWrites` until it settles. Two
+  // layers of catch by design: callers (firePersist, null-clear)
+  // attach an inner .catch that LOGS the rejection — that's the
+  // only place the failure surfaces to operators. The outer .catch
+  // here is purely a shape guarantee that the tracked promise
+  // never carries a rejected state, so a caller who forgot to
+  // pre-catch can't leak an unhandled rejection. Don't drop the
+  // outer catch and lean on the inner one: a future call site that
+  // passes a raw persistRow/deleteRow promise without wrapping
+  // would silently break.
   function fireWrite(promise) {
     const wrapped = Promise.resolve(promise).catch(() => { /* shape guarantee */ });
     const p = wrapped.finally(() => inFlightWrites.delete(p));
@@ -176,8 +181,15 @@ function createGatewaySessionStore({
     // the value @discordjs/ws sees). The (shardId) arg is unused
     // today — single-shard means we always serve the one row —
     // but accepted for forward-compat when sharding lands.
+    //
+    // Returns a shallow copy. @discordjs/ws's contract doesn't
+    // explicitly forbid mutation of the returned object, and if a
+    // future minor mutates `sequence` in place between dispatches
+    // the mirror would silently desync. Cost is one 3-field object
+    // per reconnect (not per dispatch), so the defensive copy is
+    // free.
     retrieveSessionInfo(_shardId) {
-      return mirror;
+      return mirror ? { ...mirror } : null;
     },
 
     // `updateSessionInfo(shardId, info)` — info=null means Discord
@@ -300,6 +312,13 @@ function createGatewaySessionStore({
     // error-level so operators can correlate a failed flush with
     // a degraded RESUME on the next boot.
     async flushFinal() {
+      // Idempotent: a second SIGTERM/SIGINT racing the first must
+      // not re-write the mirror to DDB. The shim's stop() is also
+      // idempotent and is the production caller, but a test or a
+      // future caller that drops the shim coordinator could call
+      // flushFinal directly twice — this is the backstop.
+      if (flushed) return;
+      flushed = true;
       stopped = true;
       cancelPendingFlush();
       // Settle every in-flight fire-and-forget write before our

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -116,13 +116,15 @@ function createGatewaySessionStore({
   // stale cursor). On failure the cursor isn't rolled back; the
   // throttle's next flush retries, and SIGTERM's flushFinal is
   // the backstop. Sustained failure logs every retry.
-  // Tracks a promise in `inFlightWrites` until it settles. Callers
-  // MUST pre-wrap their promise with `.catch()` so a rejection
-  // doesn't become an unhandled rejection — `p.finally` here
-  // preserves the rejected state, and `Promise.allSettled` inside
-  // flushFinal would mask the rejection silently.
+  // Tracks a promise in `inFlightWrites` until it settles. The
+  // .catch wrapper guarantees the tracked promise never carries a
+  // rejected state — without it, a caller that forgot to pre-catch
+  // would leak unhandled rejections, and Promise.allSettled in
+  // flushFinal would silently consume the rejection. Callers still
+  // attach their own .catch for per-write error logging.
   function fireWrite(promise) {
-    const p = promise.finally(() => inFlightWrites.delete(p));
+    const wrapped = Promise.resolve(promise).catch(() => { /* shape guarantee */ });
+    const p = wrapped.finally(() => inFlightWrites.delete(p));
     inFlightWrites.add(p);
   }
   function firePersist(info) {

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -1,0 +1,365 @@
+// DDB-backed @discordjs/ws session store for the gateway tier
+// (zero-downtime design, Pillar 2 — cross-process RESUME).
+//
+// Persists `WebSocketShard.sessionInfo` (`{sessionId, resumeURL,
+// sequence}`) to DDB so a process restart can RESUME from the last
+// observed sequence instead of IDENTIFYing fresh. Without this
+// persistence, every restart costs the cold-start window
+// (~5-10 s of WebSocket handshake + READY + GUILD_CREATE bursts);
+// with it, Discord replays buffered events from the last sequence
+// within the ~60 s resume buffer window and the bot misses no
+// interactions across the deploy boundary.
+//
+// Module shape: factory `createGatewaySessionStore({ ddbClient,
+// tableName, shardId, logger, clock })` returns a store instance
+// with its own mirror + throttle state. The factory shape (vs
+// module-level singleton like event-publisher.js) lets tests run
+// in parallel without resetting shared state and generalizes when
+// PR 14+ scales beyond single-shard.
+//
+// ── Load-bearing contracts ──
+//
+// 1. In-memory mirror, not DDB-per-callback. `retrieveSessionInfo`
+//    is called by @discordjs/ws every reconnect — possibly inside
+//    a tight IDENTIFY-reject loop. Reading DDB on each call would
+//    introduce ~10-100 ms of latency per loop iteration AND
+//    couldn't observe in-process state changes made by an earlier
+//    `updateSessionInfo(null)` (DDB writes are visible only after
+//    SDK round-trip; mirror updates are visible immediately).
+//    The mirror is hydrated from DDB once at boot via `hydrate()`;
+//    subsequent reads from `retrieveSessionInfo` are pure-local.
+//
+// 2. Null-clear respected. When @discordjs/ws calls
+//    `updateSessionInfo(shardId, null)` (Discord rejected the
+//    RESUME), the mirror MUST be set to null AND the DDB row MUST
+//    be deleted. Returning the stale session from the next
+//    `retrieveSessionInfo` produces an infinite RESUME-reject loop
+//    that the spike's first sandbox run reproduced. The DDB delete
+//    is load-bearing for the cross-process case: a process that
+//    crashes between IDENTIFY and the next READY would otherwise
+//    leave the dead session row visible to the next boot's
+//    hydrate(), and the next process would try to RESUME on a
+//    session Discord has already invalidated.
+//
+// 3. Write throttling. `updateSessionInfo` fires on every gateway
+//    dispatch (HEARTBEAT_ACK + PRESENCE_UPDATE + READY + every
+//    INTERACTION_CREATE — high rate). DDB-write per dispatch would
+//    burn ~$50/month at typical interaction volume AND introduce
+//    write-rate-limit risk. We write immediately only when:
+//      - the session_id changes (READY just fired), OR
+//      - the prior write is more than WRITE_THROTTLE_MS old.
+//    Otherwise the update is deferred via a single scheduled flush
+//    that fires at most every WRITE_THROTTLE_MS. Mirror always
+//    reflects the latest dispatch (so retrieveSessionInfo is
+//    fresh); DDB lags by at most WRITE_THROTTLE_MS, which the
+//    Discord 60 s resume window absorbs trivially.
+//
+// 4. Final flush on SIGTERM. The throttle defers writes; on
+//    shutdown we must ensure the latest sequence reaches DDB
+//    before exit. `flushFinal()` cancels any pending timer and
+//    issues a synchronous write of the mirror's current state.
+//    Skipping this drops the last (up to WRITE_THROTTLE_MS) worth
+//    of sequence on the floor; the next boot's RESUME starts from
+//    a too-old sequence and Discord replays those events (or
+//    rejects the resume if it's older than the buffer).
+
+const { PutCommand, GetCommand, DeleteCommand } = require('@aws-sdk/lib-dynamodb');
+
+// 1 Hz throttle on sequence updates. Tighter than the design doc's
+// "at most once per second" guidance only insofar as the actual
+// dispatch rate determines the steady-state — a low-traffic bot
+// writes less often than 1/s anyway. The cap protects against the
+// busy case (interaction storm during a feature launch).
+const DEFAULT_WRITE_THROTTLE_MS = 1000;
+
+function createGatewaySessionStore({
+  ddbClient,
+  tableName,
+  shardId,
+  logger,
+  // Injected for deterministic throttle tests. Production uses Date.now.
+  clock = () => Date.now(),
+  writeThrottleMs = DEFAULT_WRITE_THROTTLE_MS,
+} = {}) {
+  if (!ddbClient) throw new Error('createGatewaySessionStore: ddbClient is required');
+  if (!tableName) throw new Error('createGatewaySessionStore: tableName is required');
+  if (!shardId) throw new Error('createGatewaySessionStore: shardId is required');
+  if (!logger) throw new Error('createGatewaySessionStore: logger is required');
+
+  // ── Mirror state ──
+  //
+  // `mirror` holds the latest SessionInfo (or null after a clear).
+  // `lastWrittenSessionId` lets us detect a READY-fresh-session
+  // transition cheaply (sessionId change → write immediately) vs a
+  // sequence-only update (defer to throttle). `lastWriteAt` is the
+  // throttle anchor. `pendingFlush` is the deferred-write timer
+  // handle, cleared by every immediate-write path AND by stop().
+  let mirror = null;
+  let lastWrittenSessionId = null;
+  let lastWriteAt = 0;
+  let pendingFlush = null;
+  let stopped = false;
+
+  async function persistRow(info) {
+    // Wall-clock epoch ms for `updated_at`. Matches the design
+    // doc's table schema. DDB Number type takes JS Number directly;
+    // no marshaling concerns up to 2^53.
+    await ddbClient.send(new PutCommand({
+      TableName: tableName,
+      Item: {
+        shard_id: shardId,
+        session_id: info.sessionId,
+        resume_url: info.resumeURL,
+        sequence: info.sequence,
+        updated_at: clock(),
+      },
+    }));
+  }
+
+  async function deleteRow() {
+    await ddbClient.send(new DeleteCommand({
+      TableName: tableName,
+      Key: { shard_id: shardId },
+    }));
+  }
+
+  function cancelPendingFlush() {
+    if (pendingFlush) {
+      clearTimeout(pendingFlush);
+      pendingFlush = null;
+    }
+  }
+
+  // Schedule a deferred write at (lastWriteAt + writeThrottleMs).
+  // Idempotent — if a timer is already pending, leave it; the
+  // existing timer will pick up whatever's in the mirror at fire
+  // time, which is the latest dispatch. .unref() so a process
+  // exit doesn't get pinned by a pending session-flush timer
+  // (gracefulShutdown's flushFinal handles the final write).
+  function scheduleFlush() {
+    if (pendingFlush) return;
+    if (stopped) return;
+    const delay = Math.max(0, writeThrottleMs - (clock() - lastWriteAt));
+    pendingFlush = setTimeout(async () => {
+      pendingFlush = null;
+      // Re-check mirror at fire time: an interleaved null-clear
+      // would have set mirror=null and cancelled this timer. If
+      // the clear fired AFTER this callback was queued by the
+      // event loop but BEFORE it ran, mirror is now null and we
+      // shouldn't write the stale info. The null-clear path
+      // already deleted the row directly, so there's nothing left
+      // to do here.
+      if (!mirror || stopped) return;
+      try {
+        await persistRow(mirror);
+        lastWrittenSessionId = mirror.sessionId;
+        lastWriteAt = clock();
+      } catch (err) {
+        // Deferred write failure is non-fatal: the mirror still
+        // holds the latest info, and the next dispatch will either
+        // re-throttle (and retry on the next firing) or trigger an
+        // immediate write (sessionId change). Final flush on
+        // SIGTERM is the backstop for "throttle never recovers."
+        logger.warn('gateway-session-store: deferred write failed', { error: err.message });
+      }
+    }, delay);
+    pendingFlush.unref();
+  }
+
+  return {
+    // ── @discordjs/ws callback surface ──
+    //
+    // `retrieveSessionInfo` is documented sync-or-async in
+    // @discordjs/ws; we keep it sync to make the null-clear race
+    // analysis trivial (no await between the callback firing and
+    // the value @discordjs/ws sees). The (shardId) arg is unused
+    // today — single-shard means we always serve the one row —
+    // but accepted for forward-compat when sharding lands.
+    retrieveSessionInfo(_shardId) {
+      return mirror;
+    },
+
+    // `updateSessionInfo(shardId, info)` — info=null means Discord
+    // rejected the RESUME (session expired / version skew / etc.)
+    // and @discordjs/ws fell back to IDENTIFY. Async so the
+    // immediate-write paths can await the DDB call; @discordjs/ws
+    // accepts async callbacks.
+    async updateSessionInfo(_shardId, info) {
+      if (stopped) {
+        // Race: SIGTERM landed mid-dispatch. Don't issue new DDB
+        // writes; flushFinal already wrote (or about to write) the
+        // mirror state captured before stop().
+        return;
+      }
+
+      if (info === null) {
+        // Null-clear path. Mirror cleared first so any in-flight
+        // retrieveSessionInfo on a tight loop never observes the
+        // dead session. Pending throttle is cancelled (it would
+        // have re-written the dead row). DDB delete completes the
+        // cross-process clear so the next boot's hydrate() returns
+        // null and the new process IDENTIFYs cleanly.
+        mirror = null;
+        lastWrittenSessionId = null;
+        cancelPendingFlush();
+        try {
+          await deleteRow();
+          lastWriteAt = clock();
+        } catch (err) {
+          // Delete failure is recoverable: the in-process mirror
+          // is already cleared (correctness for this process is
+          // preserved), and the next dispatch's putItem (after
+          // READY) will overwrite the stale row. Log loudly so
+          // a sustained delete-fail surfaces in metrics.
+          logger.warn('gateway-session-store: null-clear delete failed', { error: err.message });
+        }
+        return;
+      }
+
+      // Non-null update. Mirror always updated first so
+      // retrieveSessionInfo sees the latest sequence even if the
+      // DDB write is throttled.
+      mirror = info;
+
+      const sessionChanged = info.sessionId !== lastWrittenSessionId;
+      const throttleExpired = (clock() - lastWriteAt) >= writeThrottleMs;
+      if (sessionChanged || throttleExpired) {
+        // Immediate-write path. Cancel any pending flush since we're
+        // about to persist a newer value.
+        cancelPendingFlush();
+        try {
+          await persistRow(info);
+          lastWrittenSessionId = info.sessionId;
+          lastWriteAt = clock();
+        } catch (err) {
+          // Immediate-write failure is the same recoverability
+          // story as the deferred path: mirror holds the truth,
+          // next dispatch retries. Log loudly so a sustained
+          // write-fail surfaces — without it, the gateway runs
+          // happily until restart and then RESUMEs on a too-old
+          // sequence (or hits the resume-rejection IDENTIFY
+          // fallback, which is at least observable).
+          logger.warn('gateway-session-store: write failed', { error: err.message });
+        }
+      } else {
+        // Throttle still cooling. Schedule a deferred flush so the
+        // latest sequence reaches DDB within writeThrottleMs.
+        scheduleFlush();
+      }
+    },
+
+    // ── Lifecycle ──
+    //
+    // Hydrate the mirror from DDB at boot. Called once before
+    // `manager.connect()` so the first `retrieveSessionInfo` call
+    // (inside @discordjs/ws's identify-or-resume decision) sees
+    // the persisted session if one exists. Returns the hydrated
+    // info or null — caller may log it as a "RESUME path vs cold
+    // start" SLI.
+    async hydrate() {
+      try {
+        const result = await ddbClient.send(new GetCommand({
+          TableName: tableName,
+          Key: { shard_id: shardId },
+        }));
+        if (!result.Item) {
+          logger.info('gateway-session-store: hydrate found no row (cold start)');
+          return null;
+        }
+        // Validate the shape: a malformed row (missing field, wrong
+        // type) is treated as "no session" rather than throwing —
+        // the bot must boot even if the DDB row is corrupted, and
+        // IDENTIFY recovers the session on the next READY.
+        const { session_id, resume_url, sequence } = result.Item;
+        if (typeof session_id !== 'string'
+            || typeof resume_url !== 'string'
+            || typeof sequence !== 'number') {
+          logger.warn('gateway-session-store: hydrate found malformed row, treating as cold start', {
+            row: result.Item,
+          });
+          return null;
+        }
+        mirror = {
+          sessionId: session_id,
+          resumeURL: resume_url,
+          sequence,
+        };
+        lastWrittenSessionId = session_id;
+        // Note: NOT setting lastWriteAt here — the next dispatch
+        // should hit the immediate-write path (throttleExpired=true
+        // since lastWriteAt=0) so the first post-RESUME sequence
+        // update lands in DDB without delay.
+        logger.info('gateway-session-store: hydrated session from DDB', {
+          sessionIdPrefix: session_id.slice(0, 8),
+          sequence,
+        });
+        return mirror;
+      } catch (err) {
+        // Hydrate failure is non-fatal: the bot boots into IDENTIFY
+        // mode and rebuilds the session from scratch. Log loudly
+        // so a sustained read-fail surfaces — without it, every
+        // deploy silently regresses to IDENTIFY and the operator
+        // can't tell.
+        logger.warn('gateway-session-store: hydrate failed, treating as cold start', {
+          error: err.message,
+        });
+        return null;
+      }
+    },
+
+    // Final flush on SIGTERM. Cancels any pending throttle timer
+    // and synchronously writes the mirror's current state. If
+    // mirror is null (session was cleared mid-flight), nothing to
+    // write — the null-clear path already issued the DDB delete.
+    // Idempotent: safe to call multiple times (stop() guards
+    // re-entry).
+    async flushFinal() {
+      stopped = true;
+      cancelPendingFlush();
+      if (!mirror) return;
+      try {
+        await persistRow(mirror);
+        lastWrittenSessionId = mirror.sessionId;
+        lastWriteAt = clock();
+      } catch (err) {
+        // Final-flush failure is the worst case for Pillar 2: the
+        // next boot's hydrate() returns a stale sequence, and
+        // Discord either replays a few seconds of events (best
+        // case) or rejects the RESUME and the next process
+        // IDENTIFYs (acceptable degradation). Log loudly so the
+        // operator can correlate a failed flush with a degraded-
+        // RESUME observation on the next boot.
+        logger.error('gateway-session-store: final flush failed', { error: err.message });
+      }
+    },
+
+    // Test-only / shutdown-only: drop all timers without flushing.
+    // Used by gracefulShutdown when flushFinal has already run, OR
+    // by tests that want to assert "no timers leak." Distinct from
+    // flushFinal so the call-sites stay readable (the spec is
+    // "flush then stop", which reads as `flushFinal()` followed by
+    // `stop()`; the latter is implicit because flushFinal sets
+    // `stopped=true`).
+    stop() {
+      stopped = true;
+      cancelPendingFlush();
+    },
+
+    // ── Test-only inspection ──
+    //
+    // Exposed for unit tests to assert mirror state without
+    // round-tripping through DDB. Production code should NOT use
+    // this — `retrieveSessionInfo` is the public API.
+    _getMirrorForTest() {
+      return mirror;
+    },
+    _getLastWriteAtForTest() {
+      return lastWriteAt;
+    },
+  };
+}
+
+module.exports = {
+  createGatewaySessionStore,
+  DEFAULT_WRITE_THROTTLE_MS,
+};

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -73,13 +73,14 @@ function createGatewaySessionStore({
   let lastWriteAt = 0;
   let pendingFlush = null;
   let stopped = false;
-  // Tracks the most recently fired DDB write so flushFinal can await
-  // its settlement before exit. Writes are fire-and-forget (see
-  // updateSessionInfo) — `await ddb.send(...)` inside the @discordjs/
-  // ws callback would back-pressure the WS dispatch loop on every
-  // sequence update, undoing the Pillar 1 win of keeping the gateway
-  // forwarder responsive under load.
-  let inFlightWrite = Promise.resolve();
+  // Set of in-flight fire-and-forget DDB write promises. flushFinal
+  // awaits Promise.allSettled on every entry so SIGTERM doesn't exit
+  // mid-write. Each entry removes itself from the set on settle, so
+  // the steady-state size is at most one (the throttle keeps writes
+  // from overlapping under normal traffic). A simple "track only the
+  // latest" reference would lose the earlier write's settlement
+  // guarantee when a second fire-and-forget lands quickly behind it.
+  const inFlightWrites = new Set();
 
   async function persistRow(info) {
     // Wall-clock epoch ms for `updated_at`. Matches the design
@@ -119,12 +120,16 @@ function createGatewaySessionStore({
   // stale cursor). On failure the cursor isn't rolled back; the
   // throttle's next flush retries, and SIGTERM's flushFinal is
   // the backstop. Sustained failure logs every retry.
+  function fireWrite(promise) {
+    const p = promise.finally(() => inFlightWrites.delete(p));
+    inFlightWrites.add(p);
+  }
   function firePersist(info) {
     lastWrittenSessionId = info.sessionId;
     lastWriteAt = clock();
-    inFlightWrite = persistRow(info).catch((err) => {
+    fireWrite(persistRow(info).catch((err) => {
       logger.warn('gateway-session-store: write failed', { error: err.message });
-    });
+    }));
   }
 
   // Schedule a deferred write at (lastWriteAt + writeThrottleMs).
@@ -180,9 +185,9 @@ function createGatewaySessionStore({
         // not observe the dead session row, hence the cross-
         // process clear — but waiting on DDB here would stall the
         // WS dispatch loop.
-        inFlightWrite = deleteRow().catch((err) => {
+        fireWrite(deleteRow().catch((err) => {
           logger.warn('gateway-session-store: null-clear delete failed', { error: err.message });
-        });
+        }));
         lastWriteAt = clock();
         return;
       }
@@ -274,11 +279,13 @@ function createGatewaySessionStore({
     async flushFinal() {
       stopped = true;
       cancelPendingFlush();
-      // Settle the most recent fire-and-forget write before our
-      // own synchronous write so we don't race it with a stale
-      // value of `mirror`. Errors were already logged by the
-      // .catch inside firePersist/null-clear; swallow here.
-      try { await inFlightWrite; } catch (_) { /* logged */ }
+      // Settle every in-flight fire-and-forget write before our
+      // own synchronous write — Promise.allSettled covers the
+      // case where multiple writes are concurrently outstanding
+      // (e.g. null-clear delete chased by a fresh-session put).
+      // Inner .catch handlers in firePersist/null-clear already
+      // logged each error.
+      await Promise.allSettled([...inFlightWrites]);
       if (!mirror) return;
       try {
         await persistRow(mirror);
@@ -312,12 +319,12 @@ function createGatewaySessionStore({
     _getLastWriteAtForTest() {
       return lastWriteAt;
     },
-    // Synchronizes a test on the most recent fire-and-forget DDB
+    // Synchronizes a test on every in-flight fire-and-forget DDB
     // write. Production callers never await this (the WS dispatch
     // loop must remain non-blocking); flushFinal handles the
     // pre-exit synchronization.
     async _awaitInFlightForTest() {
-      try { await inFlightWrite; } catch (_) { /* swallowed in production .catch */ }
+      await Promise.allSettled([...inFlightWrites]);
     },
   };
 }

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -116,6 +116,17 @@ function createGatewaySessionStore({
   // stale cursor). On failure the cursor isn't rolled back; the
   // throttle's next flush retries, and SIGTERM's flushFinal is
   // the backstop. Sustained failure logs every retry.
+  //
+  // Intentional design choice: a failed READY write (sessionId
+  // change → immediate write → DDB rejects) does NOT get a high-
+  // priority retry. The cursor's lastWrittenSessionId has already
+  // advanced to the new sessionId, so the next dispatch's
+  // sessionChanged check is false and the write defers to the
+  // throttle's 1Hz flush. This is the desired behavior — the
+  // mirror holds the correct in-memory state, and DDB catches up
+  // within ~1s. Burst-retrying on every dispatch would amplify
+  // a DDB outage into a hot loop without changing the eventual
+  // outcome.
   // Tracks a promise in `inFlightWrites` until it settles. The
   // .catch wrapper guarantees the tracked promise never carries a
   // rejected state — without it, a caller that forgot to pre-catch

--- a/apps/discord/src/gateway-session-store.js
+++ b/apps/discord/src/gateway-session-store.js
@@ -235,8 +235,17 @@ function createGatewaySessionStore({
         if (typeof session_id !== 'string'
             || typeof resume_url !== 'string'
             || typeof sequence !== 'number') {
+          // Log only the type signature, not the row contents. The
+          // session_id and resume_url are session-bound credentials —
+          // a Discord-side gateway endpoint reachable by anyone holding
+          // resume_url within the ~60 s resume window. CloudWatch
+          // shouldn't carry them in plaintext from a malformed-row path.
           logger.warn('gateway-session-store: hydrate found malformed row, treating as cold start', {
-            row: result.Item,
+            types: {
+              session_id: typeof session_id,
+              resume_url: typeof resume_url,
+              sequence: typeof sequence,
+            },
           });
           return null;
         }

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -384,10 +384,15 @@ function createGatewayWsShim({
       return () => dispatchHandlers.delete(handler);
     },
 
+    // Null until the first READY in this process. Pure-RESUMED boots
+    // (no IDENTIFY → no READY) leave this null for the process
+    // lifetime — appId isn't persisted alongside the session row.
+    // Callers MUST null-check before templating into a REST endpoint.
     getAppId() {
       return appId;
     },
 
+    // Null until start() resolves.
     getRest() {
       return restInstance;
     },

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -281,6 +281,9 @@ function createGatewayWsShim({
     },
 
     async stop({ flushFinal: shouldFlush = true } = {}) {
+      // Idempotent: a second SIGTERM/SIGINT racing the first shouldn't
+      // re-flush the store or re-strip listeners. Cheap early return.
+      if (stopped) return;
       stopped = true;
       // Drop dispatch handlers so any late dispatch arriving on
       // the way out doesn't trigger a downstream side effect.
@@ -296,12 +299,12 @@ function createGatewayWsShim({
       // NO manager.destroy() — see SIGTERM contract in module header.
       // The caller's process.exit() drops the TCP socket; Discord
       // holds the session in its 60 s buffer for the next process's
-      // RESUME. removeAllListeners detaches the Dispatch/Error
-      // handlers we installed so a test that calls stop() without
-      // immediately exiting doesn't leak the listeners (production
-      // exits right after, so this is hygiene rather than correctness).
+      // RESUME. Detach only the listeners we installed; an
+      // unscoped removeAllListeners() could strip @discordjs/ws's
+      // own internal listeners on the same emitter.
       if (manager) {
-        manager.removeAllListeners();
+        manager.removeAllListeners(WebSocketShardEvents.Dispatch);
+        manager.removeAllListeners(WebSocketShardEvents.Error);
       }
       manager = null;
     },

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -47,23 +47,23 @@
 //   - getAppId()         — application id from READY, or null
 //                          before READY fires. Used by
 //                          registerCommands.
-//   - rest               — the REST instance (constructed with the
+//   - getRest()          — REST instance (constructed with the
 //                          token); exposed for registerCommands.
 //
 // ── SIGTERM contract: do NOT call manager.destroy() ──
 //
-// @discordjs/ws@1.2.3's `destroy()` (dist/index.js around line 733)
-// calls `updateSessionInfo(shardId, null)` and sends a close-1000
-// frame unless `recover: Resume` is passed. Both signals invalidate
-// the session on Discord's side. For Pillar 2 cross-process RESUME,
-// we need Discord to PRESERVE the session in its 60 s resume buffer
-// past our exit, so the next process can RESUME (op 6) on it. The
-// only way to achieve that is to drop the TCP connection without a
-// clean close: persist final state, then `process.exit()` from the
-// caller. Discord sees a network-level disconnect (not a clean
-// close), holds the session for ~60 s, and the new process's
-// IDENTIFY-or-RESUME decision goes through retrieveSessionInfo →
-// returns the persisted row → @discordjs/ws issues RESUME.
+// @discordjs/ws's `destroy()` calls `updateSessionInfo(shardId, null)`
+// and sends a close-1000 frame unless `recover: Resume` is passed.
+// Both signals invalidate the session on Discord's side. Cross-
+// process RESUME requires Discord to PRESERVE the session in its
+// ~60 s resume buffer past our exit, so the next process can
+// RESUME (op 6) on it. The only way to achieve that is to drop the
+// TCP connection without a clean close: persist final state, then
+// `process.exit()` from the caller. Discord sees a network-level
+// disconnect (not a clean close), holds the session, and the new
+// process's IDENTIFY-or-RESUME decision goes through
+// retrieveSessionInfo → returns the persisted row → @discordjs/ws
+// issues RESUME.
 //
 // stop() therefore flushes the store's mirror to DDB and clears
 // internal timers, but does not touch manager state. Caller is
@@ -167,14 +167,9 @@ function createGatewayWsShim({
   }
 
   function buildUpdateCallback() {
-    // Pass-through to the store. Whether the store throttles,
-    // writes immediately, or deletes is its own concern; the shim
-    // doesn't second-guess.
-    //
-    // Bound to preserve `this` semantics if the store ever moves
-    // to a class shape. Factory closure today, but the bind is
-    // belt-and-suspenders.
-    return store.updateSessionInfo.bind(store);
+    // Pass-through to the store. Throttle / write / delete behavior
+    // is the store's concern; the shim doesn't second-guess.
+    return (shardId, info) => store.updateSessionInfo(shardId, info);
   }
 
   return {
@@ -196,8 +191,8 @@ function createGatewayWsShim({
       }
 
       // REST is lazy-constructed if the caller didn't inject one.
-      // The single token-bound instance is reused for registerCommands
-      // (commit 6 will refactor registerCommands to accept REST + appId).
+      // The single token-bound instance is reused by registerCommands
+      // (which accepts REST + appId rather than a discord.js Client).
       if (!restInstance) {
         restInstance = new RESTCtor().setToken(token);
       }
@@ -318,7 +313,7 @@ function createGatewayWsShim({
       return appId;
     },
 
-    get rest() {
+    getRest() {
       return restInstance;
     },
 

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -74,23 +74,24 @@
 // Discord enforces a per-bot identify quota of 1000 per 24 h. An
 // unexpected churn loop (e.g., another process contending for the
 // same token, a malformed RESUME bouncing fresh sessions) can
-// burn the entire budget in minutes. MAX_IDENTIFY_ATTEMPTS=1 caps
-// in-process IDENTIFYs at one — after a single failed attempt,
-// retrieveSessionInfo throws and the manager's connect()
-// rejects. The caller (start()) propagates the rejection up to
-// gracefulShutdown(1), which crash-loops the task via ECS.
-// ECS replaces the task and the budget guard resets in the new
-// process — bounding burn to ~1 IDENTIFY per task lifetime
-// rather than 1000 per pathological loop.
+// burn the entire budget in minutes. MAX_IDENTIFY_ATTEMPTS bounds
+// the count of CONSECUTIVE IDENTIFYs without an intervening READY
+// — when a successful READY lands the counter resets to zero.
 //
-// The cap = 1 is intentional: a real cold start always IDENTIFYs
-// successfully on the first try (Discord's IDENTIFY → READY
-// handshake is reliable absent infra issues). A second attempt
-// would only happen if the first IDENTIFY succeeded but the
-// resulting session was immediately invalidated — which signals
-// either token revocation or another process colliding on the
-// same identity, both of which are operator-action items, not
-// "retry quietly" items.
+// Reset-on-READY is what makes cap=1 safe for long-lived processes.
+// Without it, the only IDENTIFY a task could ever do is its cold-
+// start one — a network blip >60s (resume buffer expires on
+// Discord's side) would burn the budget and ECS would crash-loop
+// the task while Discord refused to accept fresh IDENTIFYs from
+// the replacement. With reset-on-READY, every successful session
+// gets a fresh budget for the next reconnect.
+//
+// What the cap still catches: IDENTIFY-without-READY loops. A
+// token-contention scenario (two processes claiming the same
+// identity) produces fast IDENTIFY-reject churn with no READY
+// arriving between attempts — the counter never resets, the cap
+// trips on the second attempt, and the task exits cleanly
+// instead of burning Discord's per-bot quota.
 
 const { WebSocketManager, WebSocketShardEvents } = require('@discordjs/ws');
 const { REST } = require('@discordjs/rest');
@@ -217,6 +218,10 @@ function createGatewayWsShim({
           // commands or guild-commands endpoint.
           appId = data?.d?.application?.id ?? null;
           isReady = true;
+          // Reset the IDENTIFY budget: every successful READY
+          // restores a fresh allowance for the next reconnect.
+          // See module header.
+          identifyAttempts = 0;
           logger.info('gateway-ws-shim: READY received', {
             shardId,
             appIdPrefix: appId ? appId.slice(0, 6) : null,
@@ -278,9 +283,7 @@ function createGatewayWsShim({
     async stop({ flushFinal: shouldFlush = true } = {}) {
       stopped = true;
       // Drop dispatch handlers so any late dispatch arriving on
-      // the way out doesn't trigger a downstream side effect
-      // (the event-publisher's drain handles its own in-flight
-      // sends).
+      // the way out doesn't trigger a downstream side effect.
       dispatchHandlers.clear();
       if (shouldFlush) {
         // Persists the latest sequence so the next process's
@@ -293,7 +296,13 @@ function createGatewayWsShim({
       // NO manager.destroy() — see SIGTERM contract in module header.
       // The caller's process.exit() drops the TCP socket; Discord
       // holds the session in its 60 s buffer for the next process's
-      // RESUME.
+      // RESUME. removeAllListeners detaches the Dispatch/Error
+      // handlers we installed so a test that calls stop() without
+      // immediately exiting doesn't leak the listeners (production
+      // exits right after, so this is hygiene rather than correctness).
+      if (manager) {
+        manager.removeAllListeners();
+      }
       manager = null;
     },
 

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -211,7 +211,8 @@ function createGatewayWsShim({
       // user-registered handlers (the event-publisher, the
       // gateway-activity ticker).
       manager.on(WebSocketShardEvents.Dispatch, ({ data, shardId }) => {
-        if (data?.t === 'READY') {
+        const eventType = data?.t;
+        if (eventType === 'READY') {
           // application.id is the OAuth2 application snowflake —
           // identical to client.application.id in the legacy path.
           // RegisterCommands needs this to address the global-
@@ -226,6 +227,24 @@ function createGatewayWsShim({
             shardId,
             appIdPrefix: appId ? appId.slice(0, 6) : null,
           });
+        } else if (eventType === 'RESUMED') {
+          // RESUMED is Discord's ACK that a `RESUME` op succeeded —
+          // the production happy path for Pillar 2 (cross-process
+          // resume from a persisted DDB row). Without flipping
+          // isReady on this path, /health would stay 503, ECS would
+          // replace the task after --start-period elapses, and the
+          // resume win would be defeated.
+          //
+          // No appId update on resume — the application id doesn't
+          // change between processes for the same bot identity, so
+          // the value hydrated from the previous READY (or null if
+          // we never observed one in this process) is fine. Reset
+          // the IDENTIFY budget so a subsequent disconnect-then-
+          // reconnect path gets a fresh allowance the same way
+          // READY would.
+          isReady = true;
+          identifyAttempts = 0;
+          logger.info('gateway-ws-shim: RESUMED received', { shardId });
         }
         // Fan-out. Each handler runs synchronously; any thrown error
         // is caught and logged so one bad handler doesn't break the
@@ -257,6 +276,14 @@ function createGatewayWsShim({
       // (same hazard the legacy client.login() timeout closed).
       // .unref() prevents the dangling timer from pinning the
       // event loop after a successful connect.
+      //
+      // On timeout, the losing side of Promise.race leaves
+      // manager.connect()'s in-flight WS attempt pending. We don't
+      // call manager.destroy() here (see SIGTERM contract in
+      // module header); manager lifecycle is owned by stop().
+      // The caller's gracefulShutdown(1) → process.exit() unwinds
+      // the dangling promise as the process tears down — acceptable
+      // because the boot is failing anyway.
       let timeoutHandle;
       try {
         await Promise.race([

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -211,6 +211,13 @@ function createGatewayWsShim({
       // user-registered handlers (the event-publisher, the
       // gateway-activity ticker).
       manager.on(WebSocketShardEvents.Dispatch, ({ data, shardId }) => {
+        // Guard against the connect-timeout-then-late-WS-open race:
+        // start() attaches listeners before Promise.race against the
+        // connect timeout. If the race rejects but manager.connect()
+        // continues opening the WS, dispatches arriving during the
+        // gracefulShutdown(1) teardown window would otherwise trigger
+        // downstream side effects (publish-to-SQS, registerCommands).
+        if (stopped) return;
         const eventType = data?.t;
         if (eventType === 'READY') {
           // application.id is the OAuth2 application snowflake —
@@ -298,9 +305,17 @@ function createGatewayWsShim({
         ]);
       } catch (err) {
         // Connect failed (timeout, identify budget exhaustion, or
-        // a Discord-side rejection). Leave the manager intact so
-        // the caller's exception handler can interrogate state if
-        // needed; stop() is the cleanup path.
+        // a Discord-side rejection). Set `stopped=true` so the
+        // Dispatch listener's guard drops any frames that arrive
+        // in the race window between this throw and the caller's
+        // gracefulShutdown → shim.stop() call (the legacy
+        // gracefulShutdown awaits db.close() etc. before reaching
+        // stop()). Without the early flip, a WS that finishes
+        // opening mid-teardown would still side-effect through
+        // registerCommands / eventPublisher / gateway-activity.
+        // Leave the manager handle intact so stop() can clean
+        // it up.
+        stopped = true;
         if (timeoutHandle) clearTimeout(timeoutHandle);
         throw err;
       }

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -129,7 +129,23 @@ function createGatewayWsShim({
   let isReady = false;
   let appId = null;
   let identifyAttempts = 0;
+  // Two distinct flags:
+  //
+  //   `stopped`       — "drop late dispatches." Set by start()'s
+  //                     catch on connect failure AND by stop(). The
+  //                     Dispatch listener guards on this to ignore
+  //                     frames arriving in the boot-teardown race
+  //                     or after stop().
+  //   `stopCompleted` — "stop() has already run cleanup once." stop()
+  //                     idempotency gate; without splitting these,
+  //                     start()-fail → stopped=true → gracefulShutdown
+  //                     calls shim.stop() → stop() short-circuits on
+  //                     stopped=true → flushFinal + listener detach
+  //                     never run. The split keeps the dispatch guard
+  //                     wide AND lets stop() actually clean up on
+  //                     the failed-start path.
   let stopped = false;
+  let stopCompleted = false;
   // Set rather than array for O(1) unsubscribe. The fan-out path
   // (Dispatch listener) iterates this once per gateway frame; Set
   // iteration is fine at expected handler counts (~2-3 today:
@@ -324,8 +340,13 @@ function createGatewayWsShim({
 
     async stop({ flushFinal: shouldFlush = true } = {}) {
       // Idempotent: a second SIGTERM/SIGINT racing the first shouldn't
-      // re-flush the store or re-strip listeners. Cheap early return.
-      if (stopped) return;
+      // re-flush the store or re-strip listeners.
+      if (stopCompleted) return;
+      stopCompleted = true;
+      // Also flip `stopped` so the Dispatch listener drops any
+      // frames that may still arrive on the way out. (start() may
+      // have already set this on a failed-connect path; the flip
+      // here is idempotent.)
       stopped = true;
       // Drop dispatch handlers so any late dispatch arriving on
       // the way out doesn't trigger a downstream side effect.

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -1,0 +1,339 @@
+// @discordjs/ws-backed gateway shim for the gateway tier (zero-
+// downtime design, Pillar 2). Replaces the discord.js `Client` +
+// `client.login()` shape with a direct `WebSocketManager` whose
+// session callbacks point at the DDB-backed store
+// (src/gateway-session-store.js).
+//
+// Why drop discord.js: under the event-shipper split (Pillar 1),
+// the gateway tier doesn't run handlers in-process — it forwards
+// every dispatch to SQS, and the worker tier reconstructs the
+// interaction via `client.actions.InteractionCreate.handle`. The
+// gateway's only job becomes "open a WebSocket, persist session,
+// forward frames." discord.js's `Client` adds significant surface
+// (REST cache, voice, presence, role/channel events, sharding
+// helpers) that the gateway tier never uses. Dropping it shrinks
+// the gateway's process to its essential role and removes the
+// in-memory `WebSocketShard.sessionInfo` storage that prevents
+// cross-process RESUME today.
+//
+// What stays in discord.js: the worker tier (PROCESS_ROLE=http +
+// ENABLE_EVENT_SHIPPER=true) still constructs a Client for the
+// reconstruction-and-dispatch path. So this shim is gateway-tier-
+// only — flag-off keeps the legacy Client-on-gateway shape.
+//
+// Module shape: factory `createGatewayWsShim(...)` so tests inject
+// dependencies (store mock, manager constructor mock) cleanly and
+// multi-shard generalization in PR 14+ is a parameter change.
+//
+// ── Surface (called by index.js in the flag-on path) ──
+//
+//   - hydrate()          — read persisted session from DDB into the
+//                          store's mirror; returns the hydrated info
+//                          or null. Called once before start().
+//   - start({ timeoutMs }) — wire callbacks, register dispatch
+//                          listener, call manager.connect(). Resolves
+//                          after the WS is open; rejects on timeout.
+//   - stop({ flushFinal }) — cancel the budget guard, flush the
+//                          session store, do NOT call
+//                          manager.destroy() (see SIGTERM contract
+//                          below).
+//   - isReady()          — true after the first READY dispatch.
+//   - onDispatch(handler) — register a (payload) => void listener
+//                          for every gateway dispatch. Returns an
+//                          unsubscribe function. Multiple listeners
+//                          supported (the event-publisher in
+//                          commit 4 attaches one; the gateway-
+//                          activity ticker attaches another).
+//   - getAppId()         — application id from READY, or null
+//                          before READY fires. Used by
+//                          registerCommands.
+//   - rest               — the REST instance (constructed with the
+//                          token); exposed for registerCommands.
+//
+// ── SIGTERM contract: do NOT call manager.destroy() ──
+//
+// @discordjs/ws@1.2.3's `destroy()` (dist/index.js around line 733)
+// calls `updateSessionInfo(shardId, null)` and sends a close-1000
+// frame unless `recover: Resume` is passed. Both signals invalidate
+// the session on Discord's side. For Pillar 2 cross-process RESUME,
+// we need Discord to PRESERVE the session in its 60 s resume buffer
+// past our exit, so the next process can RESUME (op 6) on it. The
+// only way to achieve that is to drop the TCP connection without a
+// clean close: persist final state, then `process.exit()` from the
+// caller. Discord sees a network-level disconnect (not a clean
+// close), holds the session for ~60 s, and the new process's
+// IDENTIFY-or-RESUME decision goes through retrieveSessionInfo →
+// returns the persisted row → @discordjs/ws issues RESUME.
+//
+// stop() therefore flushes the store's mirror to DDB and clears
+// internal timers, but does not touch manager state. Caller is
+// responsible for the `process.exit()` that drops the TCP socket.
+//
+// ── IDENTIFY budget guard ──
+//
+// Discord enforces a per-bot identify quota of 1000 per 24 h. An
+// unexpected churn loop (e.g., another process contending for the
+// same token, a malformed RESUME bouncing fresh sessions) can
+// burn the entire budget in minutes. MAX_IDENTIFY_ATTEMPTS=1 caps
+// in-process IDENTIFYs at one — after a single failed attempt,
+// retrieveSessionInfo throws and the manager's connect()
+// rejects. The caller (start()) propagates the rejection up to
+// gracefulShutdown(1), which crash-loops the task via ECS.
+// ECS replaces the task and the budget guard resets in the new
+// process — bounding burn to ~1 IDENTIFY per task lifetime
+// rather than 1000 per pathological loop.
+//
+// The cap = 1 is intentional: a real cold start always IDENTIFYs
+// successfully on the first try (Discord's IDENTIFY → READY
+// handshake is reliable absent infra issues). A second attempt
+// would only happen if the first IDENTIFY succeeded but the
+// resulting session was immediately invalidated — which signals
+// either token revocation or another process colliding on the
+// same identity, both of which are operator-action items, not
+// "retry quietly" items.
+
+const { WebSocketManager, WebSocketShardEvents } = require('@discordjs/ws');
+const { REST } = require('@discordjs/rest');
+
+// Tightly bounded per the budget rationale above.
+const MAX_IDENTIFY_ATTEMPTS = 1;
+
+// Default connect-timeout matches the legacy client.login() timeout
+// (30 s in index.js). Discord's IDENTIFY → READY round-trip is
+// typically under 5 s; 30 s is a generous ceiling that surfaces
+// "Discord API unreachable" as a fast-fail rather than a hang.
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+
+function createGatewayWsShim({
+  token,
+  intents,
+  store,
+  logger,
+  // Test seam: injectable WebSocketManager constructor + REST class.
+  // Production passes neither and the @discordjs/ws/@discordjs/rest
+  // imports above are used. Tests inject mocks to assert
+  // construction args + emit fake dispatch events.
+  WebSocketManagerCtor = WebSocketManager,
+  RESTCtor = REST,
+  rest, // pre-built REST instance (test seam); production constructs internally
+} = {}) {
+  if (!token) throw new Error('createGatewayWsShim: token is required');
+  if (typeof intents !== 'number') throw new Error('createGatewayWsShim: intents (number) is required');
+  if (!store) throw new Error('createGatewayWsShim: store is required');
+  if (!logger) throw new Error('createGatewayWsShim: logger is required');
+
+  // ── Internal state ──
+  let manager = null;
+  let restInstance = rest;
+  let isReady = false;
+  let appId = null;
+  let identifyAttempts = 0;
+  let stopped = false;
+  // Set rather than array for O(1) unsubscribe. The fan-out path
+  // (Dispatch listener) iterates this once per gateway frame; Set
+  // iteration is fine at expected handler counts (~2-3 today:
+  // event-publisher + noteGatewayActivity).
+  const dispatchHandlers = new Set();
+
+  function buildRetrieveCallback() {
+    // Wraps store.retrieveSessionInfo with the IDENTIFY budget
+    // guard. When the store mirror is non-null, the wrapper is a
+    // pass-through (no budget impact — we're RESUMing). When the
+    // mirror is null, every call is a pending IDENTIFY; throw past
+    // MAX_IDENTIFY_ATTEMPTS so a churn loop fails fast.
+    return (shardId) => {
+      const info = store.retrieveSessionInfo(shardId);
+      if (info !== null) {
+        return info;
+      }
+      identifyAttempts += 1;
+      if (identifyAttempts > MAX_IDENTIFY_ATTEMPTS) {
+        // The thrown error propagates through @discordjs/ws's
+        // identify path and rejects the in-flight connect()
+        // promise; start() surfaces it to the caller, which
+        // routes through gracefulShutdown(1). After ECS task
+        // replacement, the new process's budget counter resets
+        // — a fresh shot at the resume window.
+        const err = new Error(`gateway-ws-shim: IDENTIFY budget exhausted (${identifyAttempts} attempts; cap ${MAX_IDENTIFY_ATTEMPTS})`);
+        err.code = 'GATEWAY_IDENTIFY_BUDGET';
+        throw err;
+      }
+      logger.info('gateway-ws-shim: IDENTIFY pending', {
+        attempt: identifyAttempts,
+        cap: MAX_IDENTIFY_ATTEMPTS,
+      });
+      return null;
+    };
+  }
+
+  function buildUpdateCallback() {
+    // Pass-through to the store. Whether the store throttles,
+    // writes immediately, or deletes is its own concern; the shim
+    // doesn't second-guess.
+    //
+    // Bound to preserve `this` semantics if the store ever moves
+    // to a class shape. Factory closure today, but the bind is
+    // belt-and-suspenders.
+    return store.updateSessionInfo.bind(store);
+  }
+
+  return {
+    // Pre-flight hydration. Called once by the caller before
+    // start() so the manager's first retrieveSessionInfo invocation
+    // sees the mirror, not null. Returns whatever the store
+    // returned (info or null) so the caller can log the RESUME-
+    // path-vs-cold-start SLI.
+    async hydrate() {
+      return store.hydrate();
+    },
+
+    async start({ timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS } = {}) {
+      if (manager) {
+        throw new Error('gateway-ws-shim: start() called twice (manager already constructed)');
+      }
+      if (stopped) {
+        throw new Error('gateway-ws-shim: start() after stop() is unsupported');
+      }
+
+      // REST is lazy-constructed if the caller didn't inject one.
+      // The single token-bound instance is reused for registerCommands
+      // (commit 6 will refactor registerCommands to accept REST + appId).
+      if (!restInstance) {
+        restInstance = new RESTCtor().setToken(token);
+      }
+
+      manager = new WebSocketManagerCtor({
+        token,
+        intents,
+        rest: restInstance,
+        retrieveSessionInfo: buildRetrieveCallback(),
+        updateSessionInfo: buildUpdateCallback(),
+      });
+
+      // Dispatch listener: pluck the appId from READY, mirror the
+      // legacy `client.once('ready')` semantics, and fan out to
+      // user-registered handlers (the event-publisher, the
+      // gateway-activity ticker).
+      manager.on(WebSocketShardEvents.Dispatch, ({ data, shardId }) => {
+        if (data?.t === 'READY') {
+          // application.id is the OAuth2 application snowflake —
+          // identical to client.application.id in the legacy path.
+          // RegisterCommands needs this to address the global-
+          // commands or guild-commands endpoint.
+          appId = data?.d?.application?.id ?? null;
+          isReady = true;
+          logger.info('gateway-ws-shim: READY received', {
+            shardId,
+            appIdPrefix: appId ? appId.slice(0, 6) : null,
+          });
+        }
+        // Fan-out. Each handler runs synchronously; any thrown error
+        // is caught and logged so one bad handler doesn't break the
+        // others (matches discord.js's EventEmitter forgiveness shape).
+        for (const handler of dispatchHandlers) {
+          try {
+            handler({ data, shardId });
+          } catch (err) {
+            logger.warn('gateway-ws-shim: dispatch handler threw', {
+              error: err.message,
+              eventType: data?.t,
+            });
+          }
+        }
+      });
+
+      // Shard errors aren't fatal — @discordjs/ws reconnects
+      // automatically on most failure shapes. Logging at warn
+      // matches the legacy client.on('error') level.
+      manager.on(WebSocketShardEvents.Error, ({ error, shardId }) => {
+        logger.warn('gateway-ws-shim: shard error', {
+          shardId,
+          error: error?.message ?? String(error),
+        });
+      });
+
+      // Race connect() against a deadline. Without this, an
+      // unreachable Discord API would hang the boot indefinitely
+      // (same hazard the legacy client.login() timeout closed).
+      // .unref() prevents the dangling timer from pinning the
+      // event loop after a successful connect.
+      let timeoutHandle;
+      try {
+        await Promise.race([
+          manager.connect(),
+          new Promise((_, reject) => {
+            timeoutHandle = setTimeout(
+              () => reject(new Error(`gateway-ws-shim: connect timed out after ${timeoutMs}ms`)),
+              timeoutMs,
+            );
+            timeoutHandle.unref();
+          }),
+        ]);
+      } catch (err) {
+        // Connect failed (timeout, identify budget exhaustion, or
+        // a Discord-side rejection). Leave the manager intact so
+        // the caller's exception handler can interrogate state if
+        // needed; stop() is the cleanup path.
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        throw err;
+      }
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    },
+
+    async stop({ flushFinal: shouldFlush = true } = {}) {
+      stopped = true;
+      // Drop dispatch handlers so any late dispatch arriving on
+      // the way out doesn't trigger a downstream side effect
+      // (the event-publisher's drain handles its own in-flight
+      // sends).
+      dispatchHandlers.clear();
+      if (shouldFlush) {
+        // Persists the latest sequence so the next process's
+        // RESUME picks up cleanly. After this, the store transitions
+        // to stopped=true and rejects further updates.
+        await store.flushFinal();
+      } else {
+        store.stop();
+      }
+      // NO manager.destroy() — see SIGTERM contract in module header.
+      // The caller's process.exit() drops the TCP socket; Discord
+      // holds the session in its 60 s buffer for the next process's
+      // RESUME.
+      manager = null;
+    },
+
+    isReady() {
+      return isReady;
+    },
+
+    onDispatch(handler) {
+      if (typeof handler !== 'function') {
+        throw new Error('gateway-ws-shim: onDispatch handler must be a function');
+      }
+      dispatchHandlers.add(handler);
+      return () => dispatchHandlers.delete(handler);
+    },
+
+    getAppId() {
+      return appId;
+    },
+
+    get rest() {
+      return restInstance;
+    },
+
+    // ── Test-only inspection ──
+    _getManagerForTest() {
+      return manager;
+    },
+    _getIdentifyAttemptsForTest() {
+      return identifyAttempts;
+    },
+  };
+}
+
+module.exports = {
+  createGatewayWsShim,
+  MAX_IDENTIFY_ATTEMPTS,
+  DEFAULT_CONNECT_TIMEOUT_MS,
+};

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -96,7 +96,11 @@
 const { WebSocketManager, WebSocketShardEvents } = require('@discordjs/ws');
 const { REST } = require('@discordjs/rest');
 
-// Tightly bounded per the budget rationale above.
+// Tightly bounded per the budget rationale above. Assumes
+// @discordjs/ws invokes retrieveSessionInfo exactly once per
+// IDENTIFY decision — a future minor that adds a pre-flight
+// retrieve would make a cold-start throw GATEWAY_IDENTIFY_BUDGET
+// before READY ever lands. Pinned in package.json (~1.2.x).
 const MAX_IDENTIFY_ATTEMPTS = 1;
 
 // Default connect-timeout matches the legacy client.login() timeout
@@ -330,8 +334,11 @@ function createGatewayWsShim({
         // opening mid-teardown would still side-effect through
         // registerCommands / eventPublisher / gateway-activity.
         // Leave the manager handle intact so stop() can clean
-        // it up.
+        // it up. Null restInstance: a future caller that retries
+        // start() should hit the proper construction path, not
+        // inherit a half-initialized REST.
         stopped = true;
+        restInstance = null;
         if (timeoutHandle) clearTimeout(timeoutHandle);
         throw err;
       }

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -349,11 +349,6 @@ const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 // tables) so a future env-name rename touches one var, not many.
 // Both this module and the qurl-integrations-infra qurl-bot-ddb
 // module pin the `gateway-session` suffix.
-// Single-shard topology today. Matches the `"k:n"` convention in
-// modules/qurl-bot-ddb's gateway-session schema. Reshard generalization
-// computes this from a SHARD_ID/SHARD_COUNT env pair.
-const DEFAULT_SHARD_ID = '0:1';
-
 let gatewayShim = null;
 if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   // DDB_TABLE_PREFIX and AWS_REGION are validated upstream: the
@@ -373,7 +368,7 @@ if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   const sessionStore = createGatewaySessionStore({
     ddbClient,
     tableName: `${ddbTablePrefix}gateway-session`,
-    shardId: DEFAULT_SHARD_ID,
+    shardId: config.SHARD_ID,
     logger,
   });
   gatewayShim = createGatewayWsShim({
@@ -384,7 +379,7 @@ if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   });
   logger.info('gateway-resume shim constructed', {
     tableName: `${ddbTablePrefix}gateway-session`,
-    shardId: DEFAULT_SHARD_ID,
+    shardId: config.SHARD_ID,
   });
 }
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1,7 +1,11 @@
 const config = require('./config');
 const logger = require('./logger');
-const { client, refreshCache, shutdown: discordShutdown } = require('./discord');
+const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
+const { createGatewayWsShim } = require('./gateway-ws-shim');
+const { createGatewaySessionStore } = require('./gateway-session-store');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
 const { handleFlowInteraction } = require('./flow-dispatch');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const { startGatewayHealthServer } = require('./gateway-health');
@@ -327,6 +331,69 @@ if (mapCommandMissing.length > 0) {
 // consumer-startup and event-listener registration sites stay in sync.
 const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 
+// Pillar 2 gateway-resume shim. Constructed once at module load when
+// PROCESS_ROLE=gateway AND ENABLE_GATEWAY_RESUME=true. Owns its own
+// @discordjs/ws WebSocketManager (replacing the legacy
+// `client.login()` path), persists session state to DDB, and
+// forwards every dispatch to local subscribers via shim.onDispatch.
+// Stays null in every other configuration (flag-off, http tier,
+// worker tier) so the legacy code paths run unchanged.
+//
+// Constructed at module load rather than inside start() because the
+// gracefulShutdown path needs a reference to it for the SIGTERM
+// store-flush; lazy construction would race the shutdown handler.
+//
+// The DDB session-table name is derived from `DDB_TABLE_PREFIX` (the
+// same env-specific prefix the rest of the bot uses for its DDB
+// tables) so a future env-name rename touches one var, not many.
+// Both this module and the qurl-integrations-infra qurl-bot-ddb
+// module pin the `gateway-session` suffix.
+let gatewayShim = null;
+if (isGateway && config.ENABLE_GATEWAY_RESUME) {
+  const ddbTablePrefix = (process.env.DDB_TABLE_PREFIX ?? '').trim();
+  const awsRegion = (process.env.AWS_REGION ?? '').trim();
+  if (!ddbTablePrefix || !ddbTablePrefix.endsWith('-')) {
+    logger.error(
+      'ENABLE_GATEWAY_RESUME=true requires DDB_TABLE_PREFIX (with trailing "-"). ' +
+      `Got '${ddbTablePrefix}'. The gateway-session table is at ` +
+      '`${DDB_TABLE_PREFIX}gateway-session`; without a prefix the bot cannot ' +
+      'address its DDB session row.',
+    );
+    process.exit(1);
+  }
+  if (!awsRegion) {
+    logger.error('ENABLE_GATEWAY_RESUME=true requires AWS_REGION. Set it to the env-specific region in the deployment template.');
+    process.exit(1);
+  }
+  const rawDdbClient = new DynamoDBClient({
+    region: awsRegion,
+    ...(process.env.DDB_TEST_ENDPOINT ? { endpoint: process.env.DDB_TEST_ENDPOINT } : {}),
+  });
+  const ddbClient = DynamoDBDocumentClient.from(rawDdbClient, {
+    marshallOptions: { removeUndefinedValues: true },
+  });
+  const sessionStore = createGatewaySessionStore({
+    ddbClient,
+    tableName: `${ddbTablePrefix}gateway-session`,
+    // Single-shard topology in PR 13a — matches the "0:1" convention
+    // in modules/qurl-bot-ddb's gateway-session schema comment. Reshard
+    // generalization (PR 14+) flips this to `${shardId}:${total}`
+    // computed from a SHARD_ID/SHARD_COUNT env pair.
+    shardId: '0:1',
+    logger,
+  });
+  gatewayShim = createGatewayWsShim({
+    token: config.DISCORD_TOKEN,
+    intents: GATEWAY_INTENTS_BITFIELD,
+    store: sessionStore,
+    logger,
+  });
+  logger.info('Pillar 2 gateway-resume shim constructed', {
+    tableName: `${ddbTablePrefix}gateway-session`,
+    shardId: '0:1',
+  });
+}
+
 // Log isWorker on its own so an operator triaging a no-dispatch
 // incident sees the full picture without having to mentally combine
 // the role log (line 86) with the flag. Distinct line so a grep for
@@ -403,7 +470,16 @@ if (shouldRegisterInteractionListener({
 // they never login() and so the client never fires these events —
 // but the `.on()` registrations would still leak handler references
 // and register no-op listeners, so gate them for clarity.
-if (isGateway) {
+//
+// Two disjoint subpaths inside the isGateway branch:
+//   - !ENABLE_GATEWAY_RESUME (legacy): register listeners on the
+//     discord.js Client; client.login() opens the WS in start().
+//   - ENABLE_GATEWAY_RESUME (Pillar 2): register listeners on the
+//     shim's onDispatch fan-out; shim.start() opens the WS via
+//     @discordjs/ws WebSocketManager in start(). The Client object
+//     still exists at module load (legacy modules depend on its
+//     symbol exports) but client.login() never runs.
+if (isGateway && !config.ENABLE_GATEWAY_RESUME) {
   // Register commands when ready
   client.once('ready', async () => {
     // registerCommands accepts REST + appId + guildIds (rather than
@@ -460,6 +536,65 @@ if (isGateway) {
   client.on('error', error => {
     logger.error('Discord client error', { error: error.message });
   });
+}
+
+// Pillar 2 shim listeners. Symmetric with the legacy block above
+// but every subscription routes through gatewayShim.onDispatch (a
+// fan-out wrapping the underlying @discordjs/ws WebSocketShardEvents.
+// Dispatch event) instead of client.on('raw').
+//
+// The shim only fires for op=0 dispatches (HEARTBEAT_ACK / Hello /
+// etc. don't reach this code path; @discordjs/ws absorbs them
+// internally). Every legacy `raw` listener that used the op-filter
+// (eventPublisher.publish) still works correctly: its op check is
+// trivially satisfied, and the t-filter (INTERACTION_CREATE)
+// remains the load-bearing branch.
+//
+// registerCommands is triggered on the first READY dispatch — same
+// semantics as the legacy `client.once('ready')` listener above.
+// Discord delivers RESUMED (not READY) on a successful resume, so
+// this handler doesn't re-register commands on every reconnect.
+if (isGateway && config.ENABLE_GATEWAY_RESUME && gatewayShim) {
+  gatewayShim.onDispatch(({ data }) => {
+    if (data?.t === 'READY') {
+      // Fire-and-log: registerCommands does its own try/catch on the
+      // rest.put failure path, but a thrown promise outside that
+      // (defensive: e.g. shim.getAppId() returning null past the
+      // READY guard) would bubble to unhandledRejection. Add a
+      // .catch here for completeness.
+      registerCommands({
+        rest: gatewayShim.rest,
+        appId: gatewayShim.getAppId(),
+        // Gateway tier under the shim doesn't maintain a guild
+        // cache — that's the worker tier's job. Skip the
+        // purgeStaleGuildCommands branch by passing an empty
+        // list. The dispatch-time filter in handleCommand
+        // remains the correctness guarantee; purge is UX polish
+        // that PR 13a defers. Multi-tenant deploys land on the
+        // global-commands endpoint regardless of guild count.
+        guildIds: [],
+        guildNames: {},
+      }).catch((err) => {
+        logger.error('registerCommands (shim path) failed', { error: err.message });
+      });
+    }
+  });
+
+  // Activity ticker — same observability gauge as the legacy block.
+  // The arrow wraps noteGatewayActivity to discard the dispatch
+  // payload (noteGatewayActivity's signature expects no real args).
+  gatewayShim.onDispatch(() => noteGatewayActivity());
+
+  // Publish-to-SQS hook. The shim's dispatch payload is `{data,
+  // shardId}` where `data` is the raw gateway packet (`{op, t, s,
+  // d}`) — same shape eventPublisher.publish() consumes from the
+  // legacy client.on('raw') wiring.
+  //
+  // Always armed when the shim is active because shim-on requires
+  // shipper-on at boot (unsupportedRoleResumeCombo rejects the
+  // shim-on + shipper-off combo). The conditional in the legacy
+  // block is therefore unnecessary here.
+  gatewayShim.onDispatch(({ data }) => eventPublisher.publish(data));
 }
 
 // Log and continue on unhandled rejections. The old behavior killed the
@@ -553,7 +688,22 @@ async function gracefulShutdown(code = 0) {
     // role. HTTP-only replicas never called login(), so there's no
     // WebSocket to close — discordShutdown() on an un-logged-in
     // client just releases the event emitter handles.
-    if (isGateway) {
+    //
+    // Pillar 2 shim path is structurally different: the shim owns
+    // the WebSocket (the legacy Client never logged in). stop()
+    // flushes the session store synchronously then drops manager
+    // state WITHOUT calling manager.destroy() — that's the
+    // load-bearing SIGTERM contract that keeps Discord's resume
+    // buffer alive for the next process. The TCP socket drops when
+    // process.exit() fires below, which Discord treats as a network
+    // disconnect rather than a clean close.
+    if (isGateway && config.ENABLE_GATEWAY_RESUME && gatewayShim) {
+      try {
+        await gatewayShim.stop();
+      } catch (err) {
+        logger.error('gateway shim stop failed', { error: err.message });
+      }
+    } else if (isGateway) {
       await discordShutdown();
     }
     await db.close();
@@ -630,10 +780,21 @@ async function start() {
   if (isHttp) {
     httpServer = startServer();
   } else if (isGateway) {
-    // Returns 503 until client.isReady() flips true (after READY
-    // from the Discord gateway). Dockerfile --start-period=30s
-    // covers this boot window so ECS doesn't replace the task early.
-    httpServer = startGatewayHealthServer(() => client.isReady(), () => {
+    // Returns 503 until isReady() flips true (after READY from the
+    // Discord gateway). Dockerfile --start-period=30s covers this
+    // boot window so ECS doesn't replace the task early.
+    //
+    // Pillar 2 shim path: poll shim.isReady() instead of
+    // client.isReady() — the legacy Client never logs in under the
+    // shim, so client.isReady() always returns false there. The
+    // shim's flag flips to true on the first READY dispatch
+    // (cold-start path) or on the first RESUMED dispatch (cross-
+    // process resume path); both are equivalent for "health check
+    // should pass."
+    const isReadyFn = (config.ENABLE_GATEWAY_RESUME && gatewayShim)
+      ? () => gatewayShim.isReady()
+      : () => client.isReady();
+    httpServer = startGatewayHealthServer(isReadyFn, () => {
       // Null out so gracefulShutdown doesn't try to .close() a server
       // that's in an error state. Covers both the listen-window race
       // (server never finished listening — close() would log
@@ -694,14 +855,38 @@ async function start() {
     eventPublisher.start();
   }
 
-  // Login to Discord with a 30s deadline. client.login() doesn't
-  // expose a native timeout; if the Discord API is unreachable
-  // the call can hang indefinitely and block boot without any
-  // log line pointing at the cause. Gated on `isGateway` — the
-  // HTTP-only replica must NOT open a second Gateway connection
-  // on the same bot token; Discord would flap session identity
-  // between the two WebSockets every few seconds.
-  if (isGateway) {
+  // Open the Discord gateway WebSocket. Two disjoint paths:
+  //
+  //   - Pillar 2 (ENABLE_GATEWAY_RESUME=true): hydrate the persisted
+  //     session from DDB, then start the @discordjs/ws shim. On the
+  //     RESUME path the shim's `retrieveSessionInfo` returns the
+  //     hydrated row and Discord replays buffered events since the
+  //     last sequence (no IDENTIFY). On the cold-start path
+  //     (sandbox fresh boot / resume window expired) the mirror is
+  //     null and @discordjs/ws falls back to IDENTIFY.
+  //   - Legacy (flag-off): client.login() with the same 30s timeout
+  //     that the pre-Pillar-2 code carried.
+  //
+  // Both are gated on `isGateway`. HTTP-only replicas never open a
+  // second Gateway connection on the bot token (Discord would flap
+  // session identity between the two WebSockets).
+  if (isGateway && config.ENABLE_GATEWAY_RESUME && gatewayShim) {
+    const hydrated = await gatewayShim.hydrate();
+    logger.info('gateway-resume hydrate complete', {
+      // Log "resume" vs "cold start" as an SLI — operators can
+      // correlate restart frequency with successful-resume rate.
+      mode: hydrated ? 'resume' : 'cold-start',
+    });
+    await gatewayShim.start();
+    // No equivalent of startGatewayHeartbeat / startActiveGuildCount
+    // under the shim today — those probe discord.js Client's
+    // WebSocketManager shape (client.ws.shards[*].lastPingTimestamp)
+    // which doesn't exist when the shim owns the WS. Tracked as a
+    // follow-up: port the heartbeat / active-guild observability to
+    // a shim-aware snapshot. The gateway-health server's /health
+    // endpoint (isReady() probe) remains the load-bearing
+    // ECS-replacement signal in the interim.
+  } else if (isGateway) {
     await Promise.race([
       client.login(config.DISCORD_TOKEN),
       new Promise((_, reject) => {

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -649,7 +649,13 @@ async function gracefulShutdown(code = 0) {
       } catch (err) {
         logger.error('gateway shim stop failed', { error: err.message });
       }
-    } else if (isGateway) {
+    } else if (isGateway && !config.ENABLE_GATEWAY_RESUME) {
+      // Explicit !ENABLE_GATEWAY_RESUME (vs bare `else if (isGateway)`)
+      // so a future refactor that wraps shim construction in try/catch
+      // (leaving `gatewayShim` null when the flag is on) can't silently
+      // fall through to discordShutdown() — the legacy path would
+      // call .destroy() on an un-logged-in Client, which is harmless
+      // today but masks the underlying construction failure.
       await discordShutdown();
     }
     await db.close();

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -356,14 +356,11 @@ const DEFAULT_SHARD_ID = '0:1';
 
 let gatewayShim = null;
 if (isGateway && config.ENABLE_GATEWAY_RESUME) {
-  // DDB_TABLE_PREFIX and AWS_REGION are validated by src/store/ddb-store.js
-  // at module load when STORE_TYPE=ddb. unsupportedRoleResumeCombo above
-  // guarantees STORE_TYPE=ddb when ENABLE_GATEWAY_RESUME=true, and the
-  // `const db = require('./store')` import at the top of this file
-  // resolves to ddb-store.js — which throws before we reach this branch
-  // if either env var is missing. Keep that import ordering invariant
-  // when refactoring: removing the early `require('./store')` would
-  // silently regress the validation here.
+  // DDB_TABLE_PREFIX and AWS_REGION are validated upstream: the
+  // STORE_TYPE=ddb requirement comes from unsupportedRoleResumeCombo
+  // (above), and ddb-store.js throws on either env-var missing when
+  // it loads via `require('./store')` at the top of this file —
+  // before this branch runs.
   const ddbTablePrefix = process.env.DDB_TABLE_PREFIX;
   const awsRegion = process.env.AWS_REGION;
   const rawDdbClient = new DynamoDBClient({

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -519,24 +519,37 @@ if (isGateway && !config.ENABLE_GATEWAY_RESUME) {
 // eventPublisher.publish remains the load-bearing INTERACTION_CREATE
 // gate.
 //
-// READY triggers registerCommands once (Discord delivers RESUMED
-// rather than READY on a successful resume, so commands don't
-// re-register on every reconnect). The shim-on + shipper-on
-// invariant is enforced at boot (unsupportedRoleResumeCombo).
+// registerCommands fires only on the FIRST READY in this process.
+// Discord delivers RESUMED (not READY) on a successful resume,
+// but READY *can* land twice: a >60s outage expires the resume
+// buffer, RESUME is rejected, fresh IDENTIFY yields a fresh READY.
+// The once-flag mirrors the legacy path's `client.once('ready', …)`.
 if (isGateway && config.ENABLE_GATEWAY_RESUME && gatewayShim) {
+  let commandsRegistered = false;
   gatewayShim.onDispatch(({ data }) => {
-    if (data?.t === 'READY') {
-      // Gateway-tier shim doesn't maintain a guild cache (that's
-      // the worker tier's job); empty map skips purge. The
-      // handleCommand dispatch-time filter remains the correctness
-      // guarantee for stale registrations.
-      registerCommands({
-        rest: gatewayShim.getRest(),
-        appId: gatewayShim.getAppId(),
-        guilds: new Map(),
-      }).catch((err) => {
-        logger.error('registerCommands (shim path) failed', { error: err.message });
-      });
+    if (data?.t === 'READY' && !commandsRegistered) {
+      const appId = gatewayShim.getAppId();
+      if (!appId) {
+        // READY without application.id is a degenerate Discord shape
+        // (the spec requires it). Skip registration rather than
+        // route a request through `/applications/null/commands`,
+        // and don't latch commandsRegistered so a subsequent
+        // well-formed READY can recover.
+        logger.warn('registerCommands (shim path) skipped: appId not populated by READY');
+      } else {
+        commandsRegistered = true;
+        // Gateway-tier shim doesn't maintain a guild cache (that's
+        // the worker tier's job); empty map skips purge. The
+        // handleCommand dispatch-time filter remains the correctness
+        // guarantee for stale registrations.
+        registerCommands({
+          rest: gatewayShim.getRest(),
+          appId,
+          guilds: new Map(),
+        }).catch((err) => {
+          logger.error('registerCommands (shim path) failed', { error: err.message });
+        });
+      }
     }
     noteGatewayActivity();
     eventPublisher.publish(data);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -15,6 +15,7 @@ const {
   missingEventShipperKeys,
   missingMapCommandKeys,
   unsupportedRoleShipperCombo,
+  unsupportedRoleResumeCombo,
   shouldRegisterInteractionListener,
   resolveProcessRole,
 } = require('./boot-requirements');
@@ -282,6 +283,27 @@ if (eventShipperMissing.length > 0) {
 const roleShipperConflict = unsupportedRoleShipperCombo(PROCESS_ROLE, config.ENABLE_EVENT_SHIPPER);
 if (roleShipperConflict) {
   logger.error(roleShipperConflict);
+  process.exit(1);
+}
+
+// Gateway-RESUME (Pillar 2) precondition check. Rejects two shapes:
+//   1. ENABLE_GATEWAY_RESUME=true with ENABLE_EVENT_SHIPPER=false
+//      (the resume shim replaces discord.js Client and only has a
+//      forward-to-SQS path; the in-process dispatcher would be
+//      unreachable).
+//   2. ENABLE_GATEWAY_RESUME=true with PROCESS_ROLE=combined (the
+//      legacy Client owns the WS in combined mode; the shim would
+//      conflict).
+// Sequenced AFTER unsupportedRoleShipperCombo so the operator sees
+// the shipper-first remediation when both are misconfigured, rather
+// than chasing a downstream resume error.
+const roleResumeConflict = unsupportedRoleResumeCombo(
+  PROCESS_ROLE,
+  config.ENABLE_GATEWAY_RESUME,
+  config.ENABLE_EVENT_SHIPPER,
+);
+if (roleResumeConflict) {
+  logger.error(roleResumeConflict);
   process.exit(1);
 }
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -406,7 +406,21 @@ if (shouldRegisterInteractionListener({
 if (isGateway) {
   // Register commands when ready
   client.once('ready', async () => {
-    await registerCommands(client);
+    // registerCommands accepts REST + appId + guildIds (rather than
+    // the discord.js Client) so the Pillar 2 shim path can call the
+    // same function without constructing a Client. In the legacy
+    // flag-off path here, lift the same three pieces out of the
+    // discord.js client — semantics identical to the pre-refactor
+    // shape (single PUT to global or guild-scoped commands, with
+    // stale-guild-purge for non-OpenNHP deploys).
+    await registerCommands({
+      rest: client.rest,
+      appId: client.application.id,
+      guildIds: [...client.guilds.cache.keys()],
+      guildNames: Object.fromEntries(
+        [...client.guilds.cache.values()].map((g) => [g.id, g.name]),
+      ),
+    });
   });
 
   // interactionCreate listener is registered above (isGateway || isWorker

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -305,7 +305,7 @@ const roleResumeConflict = unsupportedRoleResumeCombo(
   PROCESS_ROLE,
   config.ENABLE_GATEWAY_RESUME,
   config.ENABLE_EVENT_SHIPPER,
-  (process.env.STORE_TYPE ?? '').trim() || 'sqlite',
+  config.STORE_TYPE,
 );
 if (roleResumeConflict) {
   logger.error(roleResumeConflict);
@@ -357,8 +357,13 @@ const DEFAULT_SHARD_ID = '0:1';
 let gatewayShim = null;
 if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   // DDB_TABLE_PREFIX and AWS_REGION are validated by src/store/ddb-store.js
-  // at module load when STORE_TYPE=ddb (which gateway-resume implies in
-  // practice). Re-checking here would duplicate the upstream guard.
+  // at module load when STORE_TYPE=ddb. unsupportedRoleResumeCombo above
+  // guarantees STORE_TYPE=ddb when ENABLE_GATEWAY_RESUME=true, and the
+  // `const db = require('./store')` import at the top of this file
+  // resolves to ddb-store.js — which throws before we reach this branch
+  // if either env var is missing. Keep that import ordering invariant
+  // when refactoring: removing the early `require('./store')` would
+  // silently regress the validation here.
   const ddbTablePrefix = process.env.DDB_TABLE_PREFIX;
   const awsRegion = process.env.AWS_REGION;
   const rawDdbClient = new DynamoDBClient({

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -355,8 +355,10 @@ if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   // STORE_TYPE=ddb requirement comes from unsupportedRoleResumeCombo
   // (above), and ddb-store.js throws on either env-var missing when
   // it loads via `require('./store')` at the top of this file —
-  // before this branch runs.
-  const ddbTablePrefix = process.env.DDB_TABLE_PREFIX;
+  // before this branch runs. Use config.DDB_TABLE_PREFIX (already
+  // trimmed) so the table-name computation matches every other
+  // DDB call site.
+  const ddbTablePrefix = config.DDB_TABLE_PREFIX;
   const awsRegion = process.env.AWS_REGION;
   const rawDdbClient = new DynamoDBClient({
     region: awsRegion,

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -305,6 +305,7 @@ const roleResumeConflict = unsupportedRoleResumeCombo(
   PROCESS_ROLE,
   config.ENABLE_GATEWAY_RESUME,
   config.ENABLE_EVENT_SHIPPER,
+  (process.env.STORE_TYPE ?? '').trim() || 'sqlite',
 );
 if (roleResumeConflict) {
   logger.error(roleResumeConflict);
@@ -348,23 +349,18 @@ const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 // tables) so a future env-name rename touches one var, not many.
 // Both this module and the qurl-integrations-infra qurl-bot-ddb
 // module pin the `gateway-session` suffix.
+// Single-shard topology today. Matches the `"k:n"` convention in
+// modules/qurl-bot-ddb's gateway-session schema. Reshard generalization
+// computes this from a SHARD_ID/SHARD_COUNT env pair.
+const DEFAULT_SHARD_ID = '0:1';
+
 let gatewayShim = null;
 if (isGateway && config.ENABLE_GATEWAY_RESUME) {
-  const ddbTablePrefix = (process.env.DDB_TABLE_PREFIX ?? '').trim();
-  const awsRegion = (process.env.AWS_REGION ?? '').trim();
-  if (!ddbTablePrefix || !ddbTablePrefix.endsWith('-')) {
-    logger.error(
-      'ENABLE_GATEWAY_RESUME=true requires DDB_TABLE_PREFIX (with trailing "-"). ' +
-      `Got '${ddbTablePrefix}'. The gateway-session table is at ` +
-      '`${DDB_TABLE_PREFIX}gateway-session`; without a prefix the bot cannot ' +
-      'address its DDB session row.',
-    );
-    process.exit(1);
-  }
-  if (!awsRegion) {
-    logger.error('ENABLE_GATEWAY_RESUME=true requires AWS_REGION. Set it to the env-specific region in the deployment template.');
-    process.exit(1);
-  }
+  // DDB_TABLE_PREFIX and AWS_REGION are validated by src/store/ddb-store.js
+  // at module load when STORE_TYPE=ddb (which gateway-resume implies in
+  // practice). Re-checking here would duplicate the upstream guard.
+  const ddbTablePrefix = process.env.DDB_TABLE_PREFIX;
+  const awsRegion = process.env.AWS_REGION;
   const rawDdbClient = new DynamoDBClient({
     region: awsRegion,
     ...(process.env.DDB_TEST_ENDPOINT ? { endpoint: process.env.DDB_TEST_ENDPOINT } : {}),
@@ -375,11 +371,7 @@ if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   const sessionStore = createGatewaySessionStore({
     ddbClient,
     tableName: `${ddbTablePrefix}gateway-session`,
-    // Single-shard topology in PR 13a — matches the "0:1" convention
-    // in modules/qurl-bot-ddb's gateway-session schema comment. Reshard
-    // generalization (PR 14+) flips this to `${shardId}:${total}`
-    // computed from a SHARD_ID/SHARD_COUNT env pair.
-    shardId: '0:1',
+    shardId: DEFAULT_SHARD_ID,
     logger,
   });
   gatewayShim = createGatewayWsShim({
@@ -388,9 +380,9 @@ if (isGateway && config.ENABLE_GATEWAY_RESUME) {
     store: sessionStore,
     logger,
   });
-  logger.info('Pillar 2 gateway-resume shim constructed', {
+  logger.info('gateway-resume shim constructed', {
     tableName: `${ddbTablePrefix}gateway-session`,
-    shardId: '0:1',
+    shardId: DEFAULT_SHARD_ID,
   });
 }
 
@@ -466,36 +458,18 @@ if (shouldRegisterInteractionListener({
   });
 }
 
-// Gateway-only event wiring. HTTP-only replicas skip these because
-// they never login() and so the client never fires these events —
-// but the `.on()` registrations would still leak handler references
-// and register no-op listeners, so gate them for clarity.
-//
-// Two disjoint subpaths inside the isGateway branch:
-//   - !ENABLE_GATEWAY_RESUME (legacy): register listeners on the
-//     discord.js Client; client.login() opens the WS in start().
-//   - ENABLE_GATEWAY_RESUME (Pillar 2): register listeners on the
-//     shim's onDispatch fan-out; shim.start() opens the WS via
-//     @discordjs/ws WebSocketManager in start(). The Client object
-//     still exists at module load (legacy modules depend on its
-//     symbol exports) but client.login() never runs.
+// Gateway-only client event wiring. Skipped on HTTP-only replicas
+// (the client never logs in there) and on the shim path (the shim
+// owns the WS — listeners attach via shim.onDispatch instead).
 if (isGateway && !config.ENABLE_GATEWAY_RESUME) {
   // Register commands when ready
   client.once('ready', async () => {
-    // registerCommands accepts REST + appId + guildIds (rather than
-    // the discord.js Client) so the Pillar 2 shim path can call the
-    // same function without constructing a Client. In the legacy
-    // flag-off path here, lift the same three pieces out of the
-    // discord.js client — semantics identical to the pre-refactor
-    // shape (single PUT to global or guild-scoped commands, with
-    // stale-guild-purge for non-OpenNHP deploys).
+    // registerCommands takes REST + appId + a guilds map so the
+    // shim path can call the same function without a Client.
     await registerCommands({
       rest: client.rest,
       appId: client.application.id,
-      guildIds: [...client.guilds.cache.keys()],
-      guildNames: Object.fromEntries(
-        [...client.guilds.cache.values()].map((g) => [g.id, g.name]),
-      ),
+      guilds: new Map([...client.guilds.cache.values()].map((g) => [g.id, g.name])),
     });
   });
 
@@ -538,63 +512,36 @@ if (isGateway && !config.ENABLE_GATEWAY_RESUME) {
   });
 }
 
-// Pillar 2 shim listeners. Symmetric with the legacy block above
-// but every subscription routes through gatewayShim.onDispatch (a
-// fan-out wrapping the underlying @discordjs/ws WebSocketShardEvents.
-// Dispatch event) instead of client.on('raw').
+// Shim-path dispatch listener. One handler, three branches —
+// keeping a single closure on the per-dispatch hot path instead of
+// fanning out to three. The shim fires only for op=0 dispatches
+// (@discordjs/ws absorbs the control frames internally), so the
+// publish op-filter is trivially satisfied; the t-filter inside
+// eventPublisher.publish remains the load-bearing INTERACTION_CREATE
+// gate.
 //
-// The shim only fires for op=0 dispatches (HEARTBEAT_ACK / Hello /
-// etc. don't reach this code path; @discordjs/ws absorbs them
-// internally). Every legacy `raw` listener that used the op-filter
-// (eventPublisher.publish) still works correctly: its op check is
-// trivially satisfied, and the t-filter (INTERACTION_CREATE)
-// remains the load-bearing branch.
-//
-// registerCommands is triggered on the first READY dispatch — same
-// semantics as the legacy `client.once('ready')` listener above.
-// Discord delivers RESUMED (not READY) on a successful resume, so
-// this handler doesn't re-register commands on every reconnect.
+// READY triggers registerCommands once (Discord delivers RESUMED
+// rather than READY on a successful resume, so commands don't
+// re-register on every reconnect). The shim-on + shipper-on
+// invariant is enforced at boot (unsupportedRoleResumeCombo).
 if (isGateway && config.ENABLE_GATEWAY_RESUME && gatewayShim) {
   gatewayShim.onDispatch(({ data }) => {
     if (data?.t === 'READY') {
-      // Fire-and-log: registerCommands does its own try/catch on the
-      // rest.put failure path, but a thrown promise outside that
-      // (defensive: e.g. shim.getAppId() returning null past the
-      // READY guard) would bubble to unhandledRejection. Add a
-      // .catch here for completeness.
+      // Gateway-tier shim doesn't maintain a guild cache (that's
+      // the worker tier's job); empty map skips purge. The
+      // handleCommand dispatch-time filter remains the correctness
+      // guarantee for stale registrations.
       registerCommands({
-        rest: gatewayShim.rest,
+        rest: gatewayShim.getRest(),
         appId: gatewayShim.getAppId(),
-        // Gateway tier under the shim doesn't maintain a guild
-        // cache — that's the worker tier's job. Skip the
-        // purgeStaleGuildCommands branch by passing an empty
-        // list. The dispatch-time filter in handleCommand
-        // remains the correctness guarantee; purge is UX polish
-        // that PR 13a defers. Multi-tenant deploys land on the
-        // global-commands endpoint regardless of guild count.
-        guildIds: [],
-        guildNames: {},
+        guilds: new Map(),
       }).catch((err) => {
         logger.error('registerCommands (shim path) failed', { error: err.message });
       });
     }
+    noteGatewayActivity();
+    eventPublisher.publish(data);
   });
-
-  // Activity ticker — same observability gauge as the legacy block.
-  // The arrow wraps noteGatewayActivity to discard the dispatch
-  // payload (noteGatewayActivity's signature expects no real args).
-  gatewayShim.onDispatch(() => noteGatewayActivity());
-
-  // Publish-to-SQS hook. The shim's dispatch payload is `{data,
-  // shardId}` where `data` is the raw gateway packet (`{op, t, s,
-  // d}`) — same shape eventPublisher.publish() consumes from the
-  // legacy client.on('raw') wiring.
-  //
-  // Always armed when the shim is active because shim-on requires
-  // shipper-on at boot (unsupportedRoleResumeCombo rejects the
-  // shim-on + shipper-off combo). The conditional in the legacy
-  // block is therefore unnecessary here.
-  gatewayShim.onDispatch(({ data }) => eventPublisher.publish(data));
 }
 
 // Log and continue on unhandled rejections. The old behavior killed the

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -232,7 +232,12 @@ describe('unsupportedRoleResumeCombo', () => {
       const msg = unsupportedRoleResumeCombo(role, true, false, 'ddb');
       expect(msg).not.toBeNull();
       expect(msg).toMatch(/ENABLE_GATEWAY_RESUME=true requires ENABLE_EVENT_SHIPPER=true/);
-      expect(msg).toMatch(/@discordjs\/ws/);
+      // Role-neutral framing: the rejection should not mention
+      // gateway-tier-specific implementation details (the shim is
+      // never constructed on http, so an http operator reading the
+      // message wouldn't see "the shim replaces Client" verbiage).
+      expect(msg).not.toMatch(/replaces discord\.js Client/);
+      expect(msg).not.toMatch(/@discordjs\/ws/);
     }
   });
 

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -197,55 +197,63 @@ describe('unsupportedRoleShipperCombo', () => {
 
 describe('unsupportedRoleResumeCombo', () => {
   it('returns null when resume=false regardless of other inputs', () => {
-    // Flag-off is the legacy path — every (role, shipper) combination
-    // is supported (or rejected by unsupportedRoleShipperCombo, not
-    // this function). Pin every input as null so a future shape
-    // change to this helper can't accidentally start rejecting
-    // legacy deploys.
+    // Flag-off is the legacy path — every (role, shipper, storeType)
+    // combination is supported (or rejected by
+    // unsupportedRoleShipperCombo). Pin every input as null so a
+    // future shape change can't accidentally start rejecting legacy
+    // deploys.
     for (const role of ['combined', 'gateway', 'http']) {
       for (const shipper of [true, false]) {
-        expect(unsupportedRoleResumeCombo(role, false, shipper)).toBeNull();
+        for (const storeType of ['sqlite', 'ddb', undefined]) {
+          expect(unsupportedRoleResumeCombo(role, false, shipper, storeType)).toBeNull();
+        }
       }
     }
   });
 
   it('rejects resume=true with combined role and surfaces shim/Client conflict', () => {
-    // combined+resume is rejected ahead of the shipper check because
-    // combined mode is the higher-order failure: even with the
-    // shipper on, the legacy Client owns the WS. Pinning the
-    // message contract so a future wording drift can't strip the
-    // remediation hint operators rely on.
-    const msg = unsupportedRoleResumeCombo('combined', true, true);
+    // combined+resume is rejected ahead of every other check because
+    // combined mode is the higher-order failure. Pin the message
+    // contract so a future wording drift can't strip the operator
+    // remediation hint.
+    const msg = unsupportedRoleResumeCombo('combined', true, true, 'ddb');
     expect(msg).not.toBeNull();
     expect(msg).toMatch(/PROCESS_ROLE=combined/);
     expect(msg).toMatch(/ENABLE_GATEWAY_RESUME=true/);
     expect(msg).toMatch(/PROCESS_ROLE=gateway/);
     expect(msg).toMatch(/PROCESS_ROLE=http/);
-    // combined+resume with shipper=false hits the same message
-    // (combined-mode check is sequenced first inside the helper).
-    expect(unsupportedRoleResumeCombo('combined', true, false)).toBe(msg);
+    // combined-mode check is sequenced first so it dominates the
+    // shipper/store-type rejections.
+    expect(unsupportedRoleResumeCombo('combined', true, false, 'sqlite')).toBe(msg);
   });
 
   it('rejects resume=true with shipper=false on supported roles', () => {
-    // The "resume needs shipper" rejection path. Surfaces a different
-    // remediation than the combined case — enable the shipper, not
-    // un-set combined mode.
     for (const role of ['gateway', 'http']) {
-      const msg = unsupportedRoleResumeCombo(role, true, false);
+      const msg = unsupportedRoleResumeCombo(role, true, false, 'ddb');
       expect(msg).not.toBeNull();
       expect(msg).toMatch(/ENABLE_GATEWAY_RESUME=true requires ENABLE_EVENT_SHIPPER=true/);
       expect(msg).toMatch(/@discordjs\/ws/);
     }
   });
 
-  it('returns null for resume=true on supported roles with shipper=true', () => {
-    // The production-shape path: PROCESS_ROLE=gateway + both flags on
-    // is the configuration this PR is enabling. Also accepts
-    // PROCESS_ROLE=http (where resume is a no-op — http tier doesn't
-    // open a WS), so the operator can ship one task-def with uniform
-    // env across both tiers.
-    expect(unsupportedRoleResumeCombo('gateway', true, true)).toBeNull();
-    expect(unsupportedRoleResumeCombo('http', true, true)).toBeNull();
+  it('rejects resume=true with storeType!=ddb (sqlite would lose state across processes)', () => {
+    // Default sqlite backend writes a local file that the next ECS
+    // task can't see. Without rejecting at boot, the bot would
+    // silently IDENTIFY on every restart — mimicking flag-off
+    // behavior and burning Discord's per-bot IDENTIFY budget.
+    for (const storeType of ['sqlite', undefined, '']) {
+      const msg = unsupportedRoleResumeCombo('gateway', true, true, storeType);
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/STORE_TYPE=ddb/);
+      expect(msg).toMatch(/gateway-session/);
+    }
+  });
+
+  it('returns null for the production-shape path (gateway + shipper + ddb)', () => {
+    expect(unsupportedRoleResumeCombo('gateway', true, true, 'ddb')).toBeNull();
+    // http tier accepts resume=true as a no-op so the operator can
+    // ship one task-def with uniform env across both tiers.
+    expect(unsupportedRoleResumeCombo('http', true, true, 'ddb')).toBeNull();
   });
 });
 

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -18,6 +18,7 @@ const {
   missingKekRequiredKeys,
   missingEventShipperKeys,
   unsupportedRoleShipperCombo,
+  unsupportedRoleResumeCombo,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
@@ -191,6 +192,60 @@ describe('unsupportedRoleShipperCombo', () => {
     ['http', false],
   ])('returns null for supported combination role=%s shipper=%s', (role, shipperEnabled) => {
     expect(unsupportedRoleShipperCombo(role, shipperEnabled)).toBeNull();
+  });
+});
+
+describe('unsupportedRoleResumeCombo', () => {
+  it('returns null when resume=false regardless of other inputs', () => {
+    // Flag-off is the legacy path — every (role, shipper) combination
+    // is supported (or rejected by unsupportedRoleShipperCombo, not
+    // this function). Pin every input as null so a future shape
+    // change to this helper can't accidentally start rejecting
+    // legacy deploys.
+    for (const role of ['combined', 'gateway', 'http']) {
+      for (const shipper of [true, false]) {
+        expect(unsupportedRoleResumeCombo(role, false, shipper)).toBeNull();
+      }
+    }
+  });
+
+  it('rejects resume=true with combined role and surfaces shim/Client conflict', () => {
+    // combined+resume is rejected ahead of the shipper check because
+    // combined mode is the higher-order failure: even with the
+    // shipper on, the legacy Client owns the WS. Pinning the
+    // message contract so a future wording drift can't strip the
+    // remediation hint operators rely on.
+    const msg = unsupportedRoleResumeCombo('combined', true, true);
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/PROCESS_ROLE=combined/);
+    expect(msg).toMatch(/ENABLE_GATEWAY_RESUME=true/);
+    expect(msg).toMatch(/PROCESS_ROLE=gateway/);
+    expect(msg).toMatch(/PROCESS_ROLE=http/);
+    // combined+resume with shipper=false hits the same message
+    // (combined-mode check is sequenced first inside the helper).
+    expect(unsupportedRoleResumeCombo('combined', true, false)).toBe(msg);
+  });
+
+  it('rejects resume=true with shipper=false on supported roles', () => {
+    // The "resume needs shipper" rejection path. Surfaces a different
+    // remediation than the combined case — enable the shipper, not
+    // un-set combined mode.
+    for (const role of ['gateway', 'http']) {
+      const msg = unsupportedRoleResumeCombo(role, true, false);
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/ENABLE_GATEWAY_RESUME=true requires ENABLE_EVENT_SHIPPER=true/);
+      expect(msg).toMatch(/@discordjs\/ws/);
+    }
+  });
+
+  it('returns null for resume=true on supported roles with shipper=true', () => {
+    // The production-shape path: PROCESS_ROLE=gateway + both flags on
+    // is the configuration this PR is enabling. Also accepts
+    // PROCESS_ROLE=http (where resume is a no-op — http tier doesn't
+    // open a WS), so the operator can ship one task-def with uniform
+    // env across both tiers.
+    expect(unsupportedRoleResumeCombo('gateway', true, true)).toBeNull();
+    expect(unsupportedRoleResumeCombo('http', true, true)).toBeNull();
   });
 });
 

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -204,7 +204,7 @@ describe('unsupportedRoleResumeCombo', () => {
     // deploys.
     for (const role of ['combined', 'gateway', 'http']) {
       for (const shipper of [true, false]) {
-        for (const storeType of ['sqlite', 'ddb', undefined]) {
+        for (const storeType of ['sqlite', 'ddb']) {
           expect(unsupportedRoleResumeCombo(role, false, shipper, storeType)).toBeNull();
         }
       }
@@ -236,17 +236,18 @@ describe('unsupportedRoleResumeCombo', () => {
     }
   });
 
-  it('rejects resume=true with storeType!=ddb (sqlite would lose state across processes)', () => {
+  it('rejects resume=true with storeType=sqlite (would lose state across processes)', () => {
     // Default sqlite backend writes a local file that the next ECS
     // task can't see. Without rejecting at boot, the bot would
     // silently IDENTIFY on every restart — mimicking flag-off
     // behavior and burning Discord's per-bot IDENTIFY budget.
-    for (const storeType of ['sqlite', undefined, '']) {
-      const msg = unsupportedRoleResumeCombo('gateway', true, true, storeType);
-      expect(msg).not.toBeNull();
-      expect(msg).toMatch(/STORE_TYPE=ddb/);
-      expect(msg).toMatch(/gateway-session/);
-    }
+    // config.STORE_TYPE always coerces unset to 'sqlite' so we
+    // only test the resolved string (not undefined/empty).
+    const msg = unsupportedRoleResumeCombo('gateway', true, true, 'sqlite');
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/STORE_TYPE=ddb/);
+    expect(msg).toMatch(/gateway-session/);
+    expect(msg).toMatch(/'sqlite'/);
   });
 
   it('returns null for the production-shape path (gateway + shipper + ddb)', () => {

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -353,16 +353,14 @@ describe('commands module exports', () => {
 });
 
 describe('registerCommands', () => {
-  // Post-refactor signature: ({rest, appId, guildIds, guildNames}).
-  // Both legacy (client.login) and Pillar 2 shim paths share this
-  // signature; tests assert the REST-call shape that the production
-  // wire calls produce.
+  // Signature: ({rest, appId, guilds: Map<id, name>}). Tests assert
+  // the REST-call shape that production wire calls produce.
   it('issues rest.put for the global commands endpoint when GUILD_ID is unset', async () => {
     const rest = {
       put: jest.fn().mockResolvedValue([]),
       get: jest.fn().mockResolvedValue([]),
     };
-    await registerCommands({ rest, appId: 'app-123', guildIds: [], guildNames: {} });
+    await registerCommands({ rest, appId: 'app-123', guilds: new Map() });
     expect(rest.put).toHaveBeenCalled();
   });
 
@@ -372,7 +370,7 @@ describe('registerCommands', () => {
       put: jest.fn().mockRejectedValue(new Error('fail')),
       get: jest.fn().mockResolvedValue([]),
     };
-    await registerCommands({ rest, appId: 'app-123', guildIds: [], guildNames: {} });
+    await registerCommands({ rest, appId: 'app-123', guilds: new Map() });
     expect(logger.error).toHaveBeenCalledWith(
       'Failed to register commands',
       expect.objectContaining({ error: 'fail' }),

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -353,28 +353,26 @@ describe('commands module exports', () => {
 });
 
 describe('registerCommands', () => {
-  it('calls client.application.commands.set', async () => {
-    const client = {
-      application: {
-        commands: {
-          set: jest.fn().mockResolvedValue([]),
-        },
-      },
+  // Post-refactor signature: ({rest, appId, guildIds, guildNames}).
+  // Both legacy (client.login) and Pillar 2 shim paths share this
+  // signature; tests assert the REST-call shape that the production
+  // wire calls produce.
+  it('issues rest.put for the global commands endpoint when GUILD_ID is unset', async () => {
+    const rest = {
+      put: jest.fn().mockResolvedValue([]),
+      get: jest.fn().mockResolvedValue([]),
     };
-    await registerCommands(client);
-    expect(client.application.commands.set).toHaveBeenCalled();
+    await registerCommands({ rest, appId: 'app-123', guildIds: [], guildNames: {} });
+    expect(rest.put).toHaveBeenCalled();
   });
 
-  it('logs error when set() fails', async () => {
+  it('logs error when rest.put rejects', async () => {
     const logger = require('../src/logger');
-    const client = {
-      application: {
-        commands: {
-          set: jest.fn().mockRejectedValue(new Error('fail')),
-        },
-      },
+    const rest = {
+      put: jest.fn().mockRejectedValue(new Error('fail')),
+      get: jest.fn().mockResolvedValue([]),
     };
-    await registerCommands(client);
+    await registerCommands({ rest, appId: 'app-123', guildIds: [], guildNames: {} });
     expect(logger.error).toHaveBeenCalledWith(
       'Failed to register commands',
       expect.objectContaining({ error: 'fail' }),

--- a/apps/discord/tests/gateway-resume-integration.test.js
+++ b/apps/discord/tests/gateway-resume-integration.test.js
@@ -133,7 +133,10 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
     expect(shim._getIdentifyAttemptsForTest()).toBe(1);
 
     // READY arrives — updateSessionInfo fires with the new session.
-    await updateSessionInfo('0:1', {
+    // The callback returns synchronously (writes are fire-and-forget);
+    // aws-sdk-client-mock counts the .send() call at invocation time,
+    // not on settle, so the Put-count assertion is reliable here.
+    updateSessionInfo('0:1', {
       sessionId: 'sess-fresh',
       resumeURL: 'wss://resume.discord.gg/?v=10&encoding=json',
       sequence: 1,
@@ -153,7 +156,7 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
     // 5. INTERACTION_CREATE: updateSessionInfo fires with bumped
     //    sequence; publisher receives the dispatch.
     now += 100;
-    await updateSessionInfo('0:1', {
+    updateSessionInfo('0:1', {
       sessionId: 'sess-fresh',
       resumeURL: 'wss://resume.discord.gg/?v=10&encoding=json',
       sequence: 2,
@@ -169,11 +172,11 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
     // 6. More dispatches inside the throttle window — mirror updates,
     //    DDB writes deferred.
     now += 100;
-    await updateSessionInfo('0:1', {
+    updateSessionInfo('0:1', {
       sessionId: 'sess-fresh', resumeURL: 'wss://r/', sequence: 3,
     });
     now += 100;
-    await updateSessionInfo('0:1', {
+    updateSessionInfo('0:1', {
       sessionId: 'sess-fresh', resumeURL: 'wss://r/', sequence: 42,
     });
     expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1); // still just the initial.
@@ -245,7 +248,8 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
     });
 
     await shim.start();
-    const { retrieveSessionInfo } = instances[0]._args;
+    const mgr = instances[0];
+    const { retrieveSessionInfo } = mgr._args;
 
     // Critical: retrieveSessionInfo returns the persisted row.
     // @discordjs/ws sees a non-null SessionInfo and chooses RESUME.
@@ -257,6 +261,18 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
       sequence: 42,
     });
     expect(shim._getIdentifyAttemptsForTest()).toBe(0);
+    // Pre-RESUMED: isReady stays false (the WS is open but the
+    // session-replay handshake hasn't completed).
+    expect(shim.isReady()).toBe(false);
+
+    // Discord ACKs the successful resume — health flips green.
+    // Without this assertion, the cr-r3-caught "isReady never
+    // flips on RESUMED" bug could regress unnoticed.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { op: 0, t: 'RESUMED', s: 43, d: {} },
+      shardId: 0,
+    });
+    expect(shim.isReady()).toBe(true);
 
     await shim.stop();
   });
@@ -299,7 +315,7 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
     expect(retrieveSessionInfo('0:1')).not.toBeNull();
 
     // 2. Discord rejects RESUME — library calls updateSessionInfo(null).
-    await updateSessionInfo('0:1', null);
+    updateSessionInfo('0:1', null);
 
     // 3. Library calls retrieveSessionInfo again — MUST return null
     //    to break the loop. If this returned the stored session

--- a/apps/discord/tests/gateway-resume-integration.test.js
+++ b/apps/discord/tests/gateway-resume-integration.test.js
@@ -1,0 +1,315 @@
+// End-to-end integration test for the Pillar 2 stack: gateway-ws-shim
+// composed with gateway-session-store, driven through the full
+// hydrate → start → READY → INTERACTION_CREATE → SIGTERM lifecycle.
+//
+// Unit tests in tests/gateway-session-store.test.js and tests/
+// gateway-ws-shim.test.js cover each module's contracts in isolation.
+// This test pins the composition: the shim's callback wiring lands in
+// the store correctly, READY detection flips isReady AND persists,
+// final-flush on stop writes the latest sequence (without calling
+// manager.destroy()).
+//
+// Real-world failure mode this test would catch: a refactor renaming
+// the store's `updateSessionInfo` signature without updating the
+// shim's wiring would silently break cross-process RESUME in
+// production (in-process unit tests both still pass; the integration
+// surface fails). One test here covers the contract that no unit
+// test alone can.
+
+const { EventEmitter } = require('node:events');
+const { mockClient } = require('aws-sdk-client-mock');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const { WebSocketShardEvents } = require('@discordjs/ws');
+
+const { createGatewaySessionStore } = require('../src/gateway-session-store');
+const { createGatewayWsShim } = require('../src/gateway-ws-shim');
+
+// FakeWebSocketManager — replays the shape @discordjs/ws emits when
+// driven by real Discord traffic. Tests construct one via the
+// `WebSocketManagerCtor` injection seam on createGatewayWsShim.
+function makeFakeManagerCtor() {
+  const instances = [];
+  function FakeManager(args) {
+    const inst = new EventEmitter();
+    inst._args = args;
+    inst.connect = jest.fn().mockResolvedValue(undefined);
+    inst.destroy = jest.fn().mockResolvedValue(undefined);
+    instances.push(inst);
+    return inst;
+  }
+  return { FakeManager, instances };
+}
+
+// FakeREST — the shim lazy-constructs a REST instance when none is
+// injected. Production uses @discordjs/rest; we stub so the test
+// doesn't depend on the real REST surface.
+function makeFakeRESTCtor() {
+  function FakeREST() {
+    const inst = { token: null };
+    inst.setToken = jest.fn().mockImplementation((t) => { inst.token = t; return inst; });
+    return inst;
+  }
+  return { FakeREST };
+}
+
+function makeLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+describe('Pillar 2 integration — shim + store full lifecycle', () => {
+  it('cold start → READY → INTERACTION_CREATE → SIGTERM persists final sequence', async () => {
+    jest.useFakeTimers();
+    let now = 1_700_000_000_000;
+    const clock = () => now;
+
+    // ── DDB setup ──
+    const rawClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(rawClient);
+    const ddbMock = mockClient(docClient);
+    ddbMock.on(GetCommand).resolves({ Item: undefined }); // cold start
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).resolves({});
+
+    // ── Shim setup ──
+    const logger = makeLogger();
+    const store = createGatewaySessionStore({
+      ddbClient: docClient,
+      tableName: 'qurl-bot-discord-test-gateway-session',
+      shardId: '0:1',
+      logger,
+      clock,
+      writeThrottleMs: 1000,
+    });
+    const { FakeManager, instances } = makeFakeManagerCtor();
+    const { FakeREST } = makeFakeRESTCtor();
+    const shim = createGatewayWsShim({
+      token: 'test-token',
+      intents: 1,
+      store,
+      logger,
+      WebSocketManagerCtor: FakeManager,
+      RESTCtor: FakeREST,
+    });
+
+    // ── Lifecycle ──
+    // 1. Hydrate (cold start — no persisted session).
+    const hydrated = await shim.hydrate();
+    expect(hydrated).toBeNull();
+    expect(shim.isReady()).toBe(false);
+
+    // 2. Start — shim wires callbacks into the (fake) manager. With
+    //    mirror still null, retrieveSessionInfo will return null
+    //    once (IDENTIFY budget burns one); after that the throw
+    //    would surface. We don't trigger that path here because
+    //    the cold-start cycle has the library invoke retrieve
+    //    exactly once on the way to IDENTIFY → READY.
+    await shim.start();
+    expect(instances).toHaveLength(1);
+    const mgr = instances[0];
+
+    // Subscribe a fake event-publisher to verify dispatch fan-out.
+    const publisher = jest.fn();
+    shim.onDispatch(({ data }) => publisher(data));
+
+    // 3. Fake the IDENTIFY path: @discordjs/ws calls retrieveSessionInfo,
+    //    sees null, identifies, then on READY calls
+    //    updateSessionInfo(shardId, sessionInfo). Simulate by directly
+    //    calling the wired callback (the manager's `_args`).
+    const { retrieveSessionInfo, updateSessionInfo } = mgr._args;
+
+    expect(retrieveSessionInfo('0:1')).toBeNull();
+    // IDENTIFY pending (budget=1/1 — one IDENTIFY is OK on cold start).
+    expect(shim._getIdentifyAttemptsForTest()).toBe(1);
+
+    // READY arrives — updateSessionInfo fires with the new session.
+    await updateSessionInfo('0:1', {
+      sessionId: 'sess-fresh',
+      resumeURL: 'wss://resume.discord.gg/?v=10&encoding=json',
+      sequence: 1,
+    });
+    // First write is immediate (sessionId change from null → real).
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+
+    // 4. Dispatch the READY event so isReady flips and the publisher fan-out fires.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { op: 0, t: 'READY', s: 1, d: { application: { id: '999000111222333444' } } },
+      shardId: 0,
+    });
+    expect(shim.isReady()).toBe(true);
+    expect(shim.getAppId()).toBe('999000111222333444');
+    expect(publisher).toHaveBeenLastCalledWith(expect.objectContaining({ t: 'READY' }));
+
+    // 5. INTERACTION_CREATE: updateSessionInfo fires with bumped
+    //    sequence; publisher receives the dispatch.
+    now += 100;
+    await updateSessionInfo('0:1', {
+      sessionId: 'sess-fresh',
+      resumeURL: 'wss://resume.discord.gg/?v=10&encoding=json',
+      sequence: 2,
+    });
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { op: 0, t: 'INTERACTION_CREATE', s: 2, d: { id: 'interaction-1' } },
+      shardId: 0,
+    });
+    expect(publisher).toHaveBeenLastCalledWith(expect.objectContaining({ t: 'INTERACTION_CREATE' }));
+    // Throttled (within 1 s window, same sessionId) — no new Put yet.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+
+    // 6. More dispatches inside the throttle window — mirror updates,
+    //    DDB writes deferred.
+    now += 100;
+    await updateSessionInfo('0:1', {
+      sessionId: 'sess-fresh', resumeURL: 'wss://r/', sequence: 3,
+    });
+    now += 100;
+    await updateSessionInfo('0:1', {
+      sessionId: 'sess-fresh', resumeURL: 'wss://r/', sequence: 42,
+    });
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1); // still just the initial.
+    expect(store._getMirrorForTest()).toEqual(expect.objectContaining({ sequence: 42 }));
+
+    // 7. SIGTERM: flush + stop. The final-flush MUST persist the
+    //    latest sequence (42) without calling manager.destroy().
+    //    Without flushFinal, the deferred write would land later
+    //    (or get cancelled), and the next process's hydrate() would
+    //    see sequence=1 — Discord would replay all events between
+    //    seq 1 and the truth at exit time.
+    await shim.stop();
+
+    // manager.destroy MUST NOT have been called — the load-bearing
+    // SIGTERM contract that keeps Discord's 60 s resume buffer alive.
+    expect(mgr.destroy).not.toHaveBeenCalled();
+
+    // Final-flush wrote the latest mirror state (sequence 42).
+    const puts = ddbMock.commandCalls(PutCommand);
+    expect(puts).toHaveLength(2);
+    expect(puts[1].args[0].input.Item.sequence).toBe(42);
+    expect(puts[1].args[0].input.Item.session_id).toBe('sess-fresh');
+
+    jest.useRealTimers();
+  });
+
+  it('warm start → hydrate returns persisted session → RESUME path', async () => {
+    // Simulates the next-process boot after a SIGTERM. The DDB row
+    // exists from the prior process; hydrate populates the mirror;
+    // retrieveSessionInfo returns the row instead of null — so
+    // @discordjs/ws issues RESUME (op 6) rather than IDENTIFY (op 2)
+    // and the IDENTIFY budget stays at zero.
+    const rawClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(rawClient);
+    const ddbMock = mockClient(docClient);
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        shard_id: '0:1',
+        session_id: 'sess-prior',
+        resume_url: 'wss://r.discord/prior',
+        sequence: 42,
+        updated_at: 1_700_000_000_000,
+      },
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    const logger = makeLogger();
+    const store = createGatewaySessionStore({
+      ddbClient: docClient,
+      tableName: 't',
+      shardId: '0:1',
+      logger,
+    });
+    const { FakeManager, instances } = makeFakeManagerCtor();
+    const shim = createGatewayWsShim({
+      token: 't',
+      intents: 1,
+      store,
+      logger,
+      WebSocketManagerCtor: FakeManager,
+      RESTCtor: makeFakeRESTCtor().FakeREST,
+    });
+
+    const hydrated = await shim.hydrate();
+    expect(hydrated).toEqual({
+      sessionId: 'sess-prior',
+      resumeURL: 'wss://r.discord/prior',
+      sequence: 42,
+    });
+
+    await shim.start();
+    const { retrieveSessionInfo } = instances[0]._args;
+
+    // Critical: retrieveSessionInfo returns the persisted row.
+    // @discordjs/ws sees a non-null SessionInfo and chooses RESUME.
+    // The IDENTIFY counter stays zero — exactly the win Pillar 2
+    // unlocks (no IDENTIFY budget burn on a restart).
+    expect(retrieveSessionInfo('0:1')).toEqual({
+      sessionId: 'sess-prior',
+      resumeURL: 'wss://r.discord/prior',
+      sequence: 42,
+    });
+    expect(shim._getIdentifyAttemptsForTest()).toBe(0);
+
+    await shim.stop();
+  });
+
+  it('Discord rejects RESUME → updateSessionInfo(null) → next retrieve returns null (no infinite loop)', async () => {
+    // The spike's first sandbox run encountered this: if the mirror
+    // is not honored, the standby loops forever. Discord rejects
+    // the RESUME, library calls updateSessionInfo(null), library
+    // calls retrieveSessionInfo again, our store hands back the
+    // stale session, Discord rejects again, repeat every ~200 ms.
+    // The fix is mirror-respect-null; this test pins it across the
+    // composed surface.
+    const rawClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(rawClient);
+    const ddbMock = mockClient(docClient);
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        shard_id: '0:1', session_id: 'sess-X', resume_url: 'wss://r/', sequence: 1,
+      },
+    });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).resolves({});
+
+    const logger = makeLogger();
+    const store = createGatewaySessionStore({
+      ddbClient: docClient, tableName: 't', shardId: '0:1', logger,
+    });
+    const { FakeManager, instances } = makeFakeManagerCtor();
+    const shim = createGatewayWsShim({
+      token: 't', intents: 1, store, logger,
+      WebSocketManagerCtor: FakeManager,
+      RESTCtor: makeFakeRESTCtor().FakeREST,
+    });
+
+    await shim.hydrate();
+    await shim.start();
+    const { retrieveSessionInfo, updateSessionInfo } = instances[0]._args;
+
+    // 1. Mirror holds the persisted session; first retrieve returns it.
+    expect(retrieveSessionInfo('0:1')).not.toBeNull();
+
+    // 2. Discord rejects RESUME — library calls updateSessionInfo(null).
+    await updateSessionInfo('0:1', null);
+
+    // 3. Library calls retrieveSessionInfo again — MUST return null
+    //    to break the loop. If this returned the stored session
+    //    (mirror miss), we'd be in the infinite-loop hazard.
+    expect(retrieveSessionInfo('0:1')).toBeNull();
+
+    // 4. DDB Delete was issued so the NEXT process's hydrate() also
+    //    sees null (cross-process consistency, not just in-process).
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(1);
+
+    await shim.stop({ flushFinal: false });
+  });
+});

--- a/apps/discord/tests/gateway-resume-integration.test.js
+++ b/apps/discord/tests/gateway-resume-integration.test.js
@@ -37,7 +37,7 @@ function makeFakeManagerCtor() {
   const instances = [];
   function FakeManager(args) {
     const inst = new EventEmitter();
-    inst._args = args;
+    inst._constructorArgs = args;
     inst.connect = jest.fn().mockResolvedValue(undefined);
     inst.destroy = jest.fn().mockResolvedValue(undefined);
     instances.push(inst);
@@ -125,8 +125,8 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
     // 3. Fake the IDENTIFY path: @discordjs/ws calls retrieveSessionInfo,
     //    sees null, identifies, then on READY calls
     //    updateSessionInfo(shardId, sessionInfo). Simulate by directly
-    //    calling the wired callback (the manager's `_args`).
-    const { retrieveSessionInfo, updateSessionInfo } = mgr._args;
+    //    calling the wired callback (the manager's `_constructorArgs`).
+    const { retrieveSessionInfo, updateSessionInfo } = mgr._constructorArgs;
 
     expect(retrieveSessionInfo('0:1')).toBeNull();
     // IDENTIFY pending (budget=1/1 — one IDENTIFY is OK on cold start).
@@ -249,7 +249,7 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
 
     await shim.start();
     const mgr = instances[0];
-    const { retrieveSessionInfo } = mgr._args;
+    const { retrieveSessionInfo } = mgr._constructorArgs;
 
     // Critical: retrieveSessionInfo returns the persisted row.
     // @discordjs/ws sees a non-null SessionInfo and chooses RESUME.
@@ -309,7 +309,7 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
 
     await shim.hydrate();
     await shim.start();
-    const { retrieveSessionInfo, updateSessionInfo } = instances[0]._args;
+    const { retrieveSessionInfo, updateSessionInfo } = instances[0]._constructorArgs;
 
     // 1. Mirror holds the persisted session; first retrieve returns it.
     expect(retrieveSessionInfo('0:1')).not.toBeNull();

--- a/apps/discord/tests/gateway-resume-integration.test.js
+++ b/apps/discord/tests/gateway-resume-integration.test.js
@@ -328,4 +328,72 @@ describe('Pillar 2 integration — shim + store full lifecycle', () => {
 
     await shim.stop({ flushFinal: false });
   });
+
+  it('registerCommands fires only on the first READY per process, not on RESUMED or a later READY', async () => {
+    // The load-bearing case: a >60s outage expires Discord's resume
+    // buffer, RESUME is rejected, fresh IDENTIFY yields a fresh READY
+    // in the same process. Without the once-flag, registerCommands
+    // would re-PUT ~150 global commands and burn the global-commands
+    // rate budget. Mirrors the legacy `client.once('ready', …)`.
+    const rawClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(rawClient);
+    const ddbMock = mockClient(docClient);
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).resolves({});
+
+    const logger = makeLogger();
+    const store = createGatewaySessionStore({
+      ddbClient: docClient, tableName: 't', shardId: '0:1', logger,
+    });
+    const { FakeManager, instances } = makeFakeManagerCtor();
+    const shim = createGatewayWsShim({
+      token: 't', intents: 1, store, logger,
+      WebSocketManagerCtor: FakeManager,
+      RESTCtor: makeFakeRESTCtor().FakeREST,
+    });
+
+    await shim.hydrate();
+    await shim.start();
+    const mgr = instances[0];
+
+    // Replicate the production wiring from src/index.js: a
+    // commandsRegistered closure-flag gates the registerCommands
+    // call to fire exactly once.
+    const registerCommandsCalls = [];
+    let commandsRegistered = false;
+    shim.onDispatch(({ data }) => {
+      if (data?.t === 'READY' && !commandsRegistered) {
+        const appId = shim.getAppId();
+        if (appId) {
+          commandsRegistered = true;
+          registerCommandsCalls.push({ appId });
+        }
+      }
+    });
+
+    // (1) First READY → registerCommands fires.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: 'app-1' }, session_id: 's1', resume_gateway_url: 'wss://r1/' } },
+      shardId: '0:1',
+    });
+    expect(registerCommandsCalls).toHaveLength(1);
+    expect(registerCommandsCalls[0]).toEqual({ appId: 'app-1' });
+
+    // RESUMED dispatch — must not trigger the t==='READY' branch.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'RESUMED', d: {} },
+      shardId: '0:1',
+    });
+    expect(registerCommandsCalls).toHaveLength(1);
+
+    // Second READY (resume-buffer-expired path). Once-flag holds.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: 'app-1' }, session_id: 's2', resume_gateway_url: 'wss://r2/' } },
+      shardId: '0:1',
+    });
+    expect(registerCommandsCalls).toHaveLength(1);
+
+    await shim.stop({ flushFinal: false });
+  });
 });

--- a/apps/discord/tests/gateway-session-store.test.js
+++ b/apps/discord/tests/gateway-session-store.test.js
@@ -495,6 +495,53 @@ describe('flushFinal', () => {
     expect(flushSettled).toBe(true);
   });
 
+  it('awaits an in-flight null-clear delete chased by a fresh-session put', async () => {
+    // The other "awaits every in-flight write" test exercises
+    // two consecutive puts. This one pins the more operationally
+    // relevant shape: a RESUME rejection (updateSessionInfo(null)
+    // → Delete) immediately followed by a fresh IDENTIFY's READY
+    // (updateSessionInfo({...}) → Put). Both writes have to settle
+    // before flushFinal returns, otherwise SIGTERM could exit
+    // mid-delete and the next process would hydrate a row that
+    // should have been cleared.
+    let resolveDelete;
+    let putFired = false;
+
+    const rawClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(rawClient);
+    const ddbMock = mockClient(docClient);
+    ddbMock.on(DeleteCommand).callsFake(() => new Promise((resolve) => { resolveDelete = resolve; }));
+    ddbMock.on(PutCommand).callsFake(() => { putFired = true; return Promise.resolve({}); });
+
+    const logger = {
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+    };
+    const store = createGatewaySessionStore({
+      ddbClient: docClient, tableName: 't', shardId: '0:1', logger,
+    });
+
+    // Prime mirror with a session, then null-clear (Delete starts,
+    // blocked on resolveDelete).
+    store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    store.updateSessionInfo('0:1', null);
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(1);
+    // Fresh IDENTIFY's READY fires while Delete is still in-flight.
+    store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-B', sequence: 1 }));
+    expect(putFired).toBe(true);
+
+    // flushFinal awaits BOTH the in-flight Delete AND the in-flight
+    // Put. It can't resolve until we unblock the Delete.
+    const flushPromise = store.flushFinal();
+    let flushSettled = false;
+    flushPromise.then(() => { flushSettled = true; });
+    await new Promise((r) => setImmediate(r));
+    expect(flushSettled).toBe(false);
+
+    resolveDelete({});
+    await flushPromise;
+    expect(flushSettled).toBe(true);
+  });
+
   it('after flushFinal, subsequent updateSessionInfo calls are dropped', async () => {
     // SIGTERM lands; flushFinal runs and sets stopped=true. A late
     // dispatch arriving on the way out shouldn't trigger another

--- a/apps/discord/tests/gateway-session-store.test.js
+++ b/apps/discord/tests/gateway-session-store.test.js
@@ -1,0 +1,481 @@
+// Unit tests for src/gateway-session-store.js — Pillar 2 DDB-backed
+// session store. Pins the four load-bearing contracts the module
+// header enumerates:
+//
+//   1. In-memory mirror (retrieveSessionInfo never hits DDB after
+//      hydrate).
+//   2. Null-clear respected (mirror set to null AND DDB row deleted).
+//   3. Write throttling (READY/sessionId-change writes immediately;
+//      sequence-only updates within throttle window defer).
+//   4. Final flush on SIGTERM (cancels pending timer; persists mirror).
+//
+// Failure of any of these contracts produced a real incident class:
+//   - Mirror miss → infinite RESUME-reject loop (spike's first run).
+//   - Null-clear miss → same infinite loop on the next process boot.
+//   - Throttle miss → DDB write burn at dispatch rate ($50/mo+ at
+//     interaction-storm volume).
+//   - Final-flush miss → stale-sequence RESUME after every restart,
+//     observable as "Discord replays the last few seconds of events."
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+
+const {
+  createGatewaySessionStore,
+  DEFAULT_WRITE_THROTTLE_MS,
+} = require('../src/gateway-session-store');
+
+// Helper to build the standard test store + mocks. Each test calls
+// this fresh so state isolation is automatic (vs reusing a top-level
+// store across tests, which would leak mirror state).
+function makeStore({ clock, writeThrottleMs } = {}) {
+  const rawClient = new DynamoDBClient({});
+  const docClient = DynamoDBDocumentClient.from(rawClient);
+  const ddbMock = mockClient(docClient);
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  const store = createGatewaySessionStore({
+    ddbClient: docClient,
+    tableName: 'test-gateway-session',
+    shardId: '0:1',
+    logger,
+    clock,
+    writeThrottleMs,
+  });
+  return { store, ddbMock, logger };
+}
+
+// Realistic SessionInfo shape that @discordjs/ws would hand to
+// updateSessionInfo. The three fields (sessionId, resumeURL,
+// sequence) are the ones the design-doc DDB row carries; any
+// other fields @discordjs/ws may add are dropped on write (the
+// store doesn't pass info through verbatim).
+function sessionInfo({ sessionId = 'sess-abc', resumeURL = 'wss://r.discord/abc', sequence = 1 } = {}) {
+  return { sessionId, resumeURL, sequence };
+}
+
+describe('createGatewaySessionStore — factory validation', () => {
+  it('throws when required args are missing', () => {
+    // Pin every required-arg name so a refactor renaming one fails
+    // loudly rather than silently dropping a guard.
+    expect(() => createGatewaySessionStore()).toThrow(/ddbClient is required/);
+    expect(() => createGatewaySessionStore({ ddbClient: {} })).toThrow(/tableName is required/);
+    expect(() => createGatewaySessionStore({ ddbClient: {}, tableName: 't' }))
+      .toThrow(/shardId is required/);
+    expect(() => createGatewaySessionStore({ ddbClient: {}, tableName: 't', shardId: '0:1' }))
+      .toThrow(/logger is required/);
+  });
+});
+
+describe('hydrate', () => {
+  it('returns null and logs cold-start when no row exists', async () => {
+    const { store, ddbMock, logger } = makeStore();
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const result = await store.hydrate();
+
+    expect(result).toBeNull();
+    expect(store._getMirrorForTest()).toBeNull();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringMatching(/cold start/i),
+    );
+  });
+
+  it('parses a well-formed row into mirror and returns it', async () => {
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        shard_id: '0:1',
+        session_id: 'sess-xyz',
+        resume_url: 'wss://r.discord/xyz',
+        sequence: 42,
+        updated_at: 1700000000000,
+      },
+    });
+
+    const result = await store.hydrate();
+
+    // Mirror is hydrated with the @discordjs/ws-facing shape
+    // (sessionId/resumeURL/sequence camelCase) — distinct from
+    // the snake_case DDB column names.
+    expect(result).toEqual({
+      sessionId: 'sess-xyz',
+      resumeURL: 'wss://r.discord/xyz',
+      sequence: 42,
+    });
+    expect(store._getMirrorForTest()).toEqual(result);
+  });
+
+  it('treats malformed rows as cold start (does not throw)', async () => {
+    // Production bot MUST boot even if the DDB row is corrupted.
+    // The recovery path is IDENTIFY-from-scratch, which the
+    // mirror=null state surfaces to @discordjs/ws on the first
+    // retrieveSessionInfo call.
+    const { store, ddbMock, logger } = makeStore();
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        shard_id: '0:1',
+        session_id: 'sess-xyz',
+        // resume_url missing
+        sequence: 42,
+      },
+    });
+
+    const result = await store.hydrate();
+
+    expect(result).toBeNull();
+    expect(store._getMirrorForTest()).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/malformed/i),
+      expect.any(Object),
+    );
+  });
+
+  it('treats DDB read errors as cold start (does not throw)', async () => {
+    const { store, ddbMock, logger } = makeStore();
+    ddbMock.on(GetCommand).rejects(new Error('DDB unavailable'));
+
+    const result = await store.hydrate();
+
+    expect(result).toBeNull();
+    expect(store._getMirrorForTest()).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/hydrate failed/i),
+      expect.objectContaining({ error: 'DDB unavailable' }),
+    );
+  });
+});
+
+describe('retrieveSessionInfo — in-memory mirror contract', () => {
+  it('returns null before hydrate runs', () => {
+    const { store } = makeStore();
+    expect(store.retrieveSessionInfo('0:1')).toBeNull();
+  });
+
+  it('returns hydrated mirror without a fresh DDB read', async () => {
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        shard_id: '0:1',
+        session_id: 'sess-1',
+        resume_url: 'wss://r/1',
+        sequence: 10,
+      },
+    });
+    await store.hydrate();
+
+    // Call retrieveSessionInfo 100 times — DDB Get count stays at 1
+    // (the single hydrate). Pinning this rules out a regression
+    // where a future refactor reads DDB inside retrieveSessionInfo
+    // (which would re-introduce the infinite-loop hazard the
+    // spike documented).
+    for (let i = 0; i < 100; i++) {
+      store.retrieveSessionInfo('0:1');
+    }
+
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1);
+  });
+});
+
+describe('updateSessionInfo — null-clear contract', () => {
+  it('clears mirror, cancels pending flush, and issues DDB delete', async () => {
+    let now = 1_000_000;
+    const clock = () => now;
+    const { store, ddbMock } = makeStore({ clock, writeThrottleMs: 1000 });
+
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).resolves({});
+
+    // Prime mirror with a session via the immediate-write path.
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    expect(store._getMirrorForTest()).not.toBeNull();
+
+    // Issue a sequence-only update while still inside the throttle
+    // window so a deferred flush gets scheduled.
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 2 }));
+
+    // Now null-clear — mirror flips to null, DDB delete fires,
+    // and the pending timer is cancelled (no second Put after the
+    // null-clear settles).
+    await store.updateSessionInfo('0:1', null);
+
+    expect(store._getMirrorForTest()).toBeNull();
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(1);
+
+    // Advance past the throttle window and yield to the event loop
+    // — if the pending timer wasn't cancelled, a second Put would
+    // fire here. We assert it did NOT.
+    now += 2000;
+    await new Promise((r) => setImmediate(r));
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1); // only the initial prime
+  });
+
+  it('after null-clear, retrieveSessionInfo returns null (the contract)', async () => {
+    // This is the contract the spike's first sandbox run discovered:
+    // if retrieveSessionInfo returns the old session post-null-clear,
+    // Discord rejects RESUME, library calls updateSessionInfo(null)
+    // again, infinite loop.
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).resolves({});
+
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A' }));
+    expect(store.retrieveSessionInfo('0:1')).not.toBeNull();
+
+    await store.updateSessionInfo('0:1', null);
+    expect(store.retrieveSessionInfo('0:1')).toBeNull();
+  });
+
+  it('logs but does not throw when DDB delete fails', async () => {
+    const { store, ddbMock, logger } = makeStore();
+    ddbMock.on(DeleteCommand).rejects(new Error('throughput exceeded'));
+
+    // Should resolve cleanly — mirror is the in-process source of
+    // truth, and the in-flight gateway must stay running.
+    await expect(store.updateSessionInfo('0:1', null)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/null-clear delete failed/i),
+      expect.objectContaining({ error: 'throughput exceeded' }),
+    );
+  });
+});
+
+describe('updateSessionInfo — immediate-write path (sessionId change)', () => {
+  it('writes immediately when sessionId changes (READY-fresh-session)', async () => {
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(PutCommand).resolves({});
+
+    // First call: lastWrittenSessionId=null, change detected, write fires.
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 5 }));
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+
+    // Second call with same sessionId but different sequence: throttle
+    // path (no immediate write, since throttle hasn't expired). We
+    // assert this in the throttle test below; here we focus on the
+    // sessionId-change path.
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-B', sequence: 6 }));
+    // sessionId changed → immediate write again.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2);
+  });
+
+  it('persists the @discordjs/ws shape as DDB snake_case columns', async () => {
+    const { store, ddbMock } = makeStore({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+
+    await store.updateSessionInfo('0:1', sessionInfo({
+      sessionId: 'sess-Z',
+      resumeURL: 'wss://r.discord/z',
+      sequence: 99,
+    }));
+
+    // Pin the column-name contract — a rename to camelCase on the
+    // DDB side would diverge from infra (modules/qurl-bot-ddb's
+    // schema uses snake_case shard_id PK + the attribute names
+    // here as the bot's payload).
+    const calls = ddbMock.commandCalls(PutCommand);
+    expect(calls[0].args[0].input).toEqual({
+      TableName: 'test-gateway-session',
+      Item: {
+        shard_id: '0:1',
+        session_id: 'sess-Z',
+        resume_url: 'wss://r.discord/z',
+        sequence: 99,
+        updated_at: 1_700_000_000_000,
+      },
+    });
+  });
+});
+
+describe('updateSessionInfo — throttle path', () => {
+  it('defers writes within throttle window; one flush at boundary', async () => {
+    let now = 1_000_000;
+    const clock = () => now;
+    const { store, ddbMock } = makeStore({ clock, writeThrottleMs: 1000 });
+
+    ddbMock.on(PutCommand).resolves({});
+
+    // Prime with the first update — immediate write because
+    // lastWriteAt=0 → throttleExpired=true.
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+
+    // Rapid sequence updates inside the throttle window — no new
+    // writes should fire synchronously.
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 2 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 3 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 4 }));
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+
+    // Mirror reflects the latest sequence even though DDB hasn't
+    // caught up — pins the "mirror is fresh, DDB lags" contract.
+    expect(store._getMirrorForTest()).toEqual(expect.objectContaining({ sequence: 4 }));
+
+    // Fire the deferred flush by advancing the fake timers.
+    now += 1000;
+    jest.useFakeTimers();
+    // Re-create the store with fake timers active — the scheduleFlush
+    // path already armed a setTimeout above using the real timers,
+    // so this test is more naturally written with explicit fake-time
+    // up-front. Pivoting: rely on real timers + wait. The point is
+    // pinned by the previous assertions; the deferred-flush firing
+    // is covered by the explicit-fake-timer test below.
+    jest.useRealTimers();
+  });
+
+  it('issues exactly one deferred write after rapid updates', async () => {
+    jest.useFakeTimers();
+    let now = 1_000_000;
+    const clock = () => now;
+    const { store, ddbMock } = makeStore({ clock, writeThrottleMs: 1000 });
+
+    ddbMock.on(PutCommand).resolves({});
+
+    // Prime: immediate write (throttleExpired=true at lastWriteAt=0).
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    // Burst of in-window updates.
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 2 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 3 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 4 }));
+
+    // Advance fake timers past the throttle boundary. The deferred
+    // flush should fire once with the latest sequence (4).
+    now += 1000;
+    await jest.advanceTimersByTimeAsync(1000);
+    // One additional Put beyond the prime — total 2.
+    const puts = ddbMock.commandCalls(PutCommand);
+    expect(puts).toHaveLength(2);
+    expect(puts[1].args[0].input.Item.sequence).toBe(4);
+
+    jest.useRealTimers();
+  });
+
+  it('logs but does not throw when deferred write fails', async () => {
+    jest.useFakeTimers();
+    let now = 1_000_000;
+    const clock = () => now;
+    const { store, ddbMock, logger } = makeStore({ clock, writeThrottleMs: 1000 });
+
+    // First Put succeeds (the prime); second Put (deferred) fails.
+    ddbMock.on(PutCommand)
+      .resolvesOnce({})
+      .rejects(new Error('throttling'));
+
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 2 }));
+    now += 1000;
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/deferred write failed/i),
+      expect.objectContaining({ error: 'throttling' }),
+    );
+    jest.useRealTimers();
+  });
+});
+
+describe('flushFinal', () => {
+  it('cancels pending flush and writes the mirror state', async () => {
+    jest.useFakeTimers();
+    let now = 1_000_000;
+    const clock = () => now;
+    const { store, ddbMock } = makeStore({ clock, writeThrottleMs: 1000 });
+
+    ddbMock.on(PutCommand).resolves({});
+
+    // Prime + schedule a deferred flush.
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 99 }));
+
+    // flushFinal cancels the timer AND writes synchronously.
+    await store.flushFinal();
+    const puts = ddbMock.commandCalls(PutCommand);
+    // Prime + flushFinal = 2 puts total. The most recent carries
+    // the latest sequence (99).
+    expect(puts).toHaveLength(2);
+    expect(puts[1].args[0].input.Item.sequence).toBe(99);
+
+    // Advance past the original throttle boundary — the cancelled
+    // deferred flush must NOT fire (would be a 3rd Put).
+    now += 2000;
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2);
+
+    jest.useRealTimers();
+  });
+
+  it('is a no-op when mirror is null (already cleared)', async () => {
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(PutCommand).resolves({});
+
+    await store.flushFinal();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  it('after flushFinal, subsequent updateSessionInfo calls are dropped', async () => {
+    // SIGTERM lands; flushFinal runs and sets stopped=true. A late
+    // dispatch arriving on the way out shouldn't trigger another
+    // DDB write — the process is exiting, the next process will
+    // pick up state from the row we just wrote.
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(PutCommand).resolves({});
+
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    await store.flushFinal();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2); // prime + flushFinal
+
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-B', sequence: 2 }));
+    // No additional Put — stopped=true short-circuits.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2);
+  });
+});
+
+describe('stop()', () => {
+  it('cancels pending flush without writing', async () => {
+    jest.useFakeTimers();
+    let now = 1_000_000;
+    const clock = () => now;
+    const { store, ddbMock } = makeStore({ clock, writeThrottleMs: 1000 });
+
+    ddbMock.on(PutCommand).resolves({});
+
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    now += 100;
+    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 99 }));
+
+    store.stop();
+    now += 2000;
+    await jest.advanceTimersByTimeAsync(2000);
+    // Only the prime — stop() neither wrote NOR fired the deferred.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+
+    jest.useRealTimers();
+  });
+});
+
+describe('throttle default', () => {
+  it('exposes DEFAULT_WRITE_THROTTLE_MS at 1000', () => {
+    // Pin the design-doc-derived value. Changing it would be a
+    // visible operational decision (cost vs cross-process lag);
+    // pin so the change requires a test update.
+    expect(DEFAULT_WRITE_THROTTLE_MS).toBe(1000);
+  });
+});

--- a/apps/discord/tests/gateway-session-store.test.js
+++ b/apps/discord/tests/gateway-session-store.test.js
@@ -241,9 +241,11 @@ describe('updateSessionInfo — null-clear contract', () => {
     const { store, ddbMock, logger } = makeStore();
     ddbMock.on(DeleteCommand).rejects(new Error('throughput exceeded'));
 
-    // Should resolve cleanly — mirror is the in-process source of
-    // truth, and the in-flight gateway must stay running.
-    await expect(store.updateSessionInfo('0:1', null)).resolves.toBeUndefined();
+    // updateSessionInfo returns synchronously; the DDB delete is
+    // fire-and-forget. Settle the in-flight promise via the test
+    // seam before asserting on the warn log.
+    store.updateSessionInfo('0:1', null);
+    await store._awaitInFlightForTest();
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringMatching(/null-clear delete failed/i),
       expect.objectContaining({ error: 'throughput exceeded' }),
@@ -366,25 +368,27 @@ describe('updateSessionInfo — throttle path', () => {
     jest.useRealTimers();
   });
 
-  it('logs but does not throw when deferred write fails', async () => {
+  it('logs but does not throw when a fire-and-forget write fails', async () => {
     jest.useFakeTimers();
     let now = 1_000_000;
     const clock = () => now;
     const { store, ddbMock, logger } = makeStore({ clock, writeThrottleMs: 1000 });
 
-    // First Put succeeds (the prime); second Put (deferred) fails.
+    // First Put succeeds (the prime); second Put (deferred fire-
+    // and-forget after the throttle elapses) fails.
     ddbMock.on(PutCommand)
       .resolvesOnce({})
       .rejects(new Error('throttling'));
 
-    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
     now += 100;
-    await store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 2 }));
+    store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 2 }));
     now += 1000;
     await jest.advanceTimersByTimeAsync(1000);
+    await store._awaitInFlightForTest();
 
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringMatching(/deferred write failed/i),
+      expect.stringMatching(/write failed/i),
       expect.objectContaining({ error: 'throttling' }),
     );
     jest.useRealTimers();

--- a/apps/discord/tests/gateway-session-store.test.js
+++ b/apps/discord/tests/gateway-session-store.test.js
@@ -443,6 +443,24 @@ describe('flushFinal', () => {
     expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
   });
 
+  it('is idempotent — a second call does not re-write the mirror', async () => {
+    // Backstop for the case where a caller drops the shim's stop()
+    // coordinator and invokes flushFinal directly more than once (a
+    // SIGTERM-then-SIGINT race in a non-shim caller, or a test that
+    // double-flushes). The shim's stop() is already idempotent in
+    // production; this guard makes the store safe regardless.
+    const { store, ddbMock } = makeStore();
+    ddbMock.on(PutCommand).resolves({});
+
+    store.updateSessionInfo('0:1', sessionInfo({ sessionId: 'sess-A', sequence: 1 }));
+    await store.flushFinal();
+    const firstCount = ddbMock.commandCalls(PutCommand).length;
+
+    await store.flushFinal();
+    await store.flushFinal();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(firstCount);
+  });
+
   it('awaits every in-flight fire-and-forget write before exit (not just the most recent)', async () => {
     // Without Promise.allSettled across the full set, a SIGTERM
     // that lands between a null-clear delete and a fresh-session

--- a/apps/discord/tests/gateway-session-store.test.js
+++ b/apps/discord/tests/gateway-session-store.test.js
@@ -116,18 +116,23 @@ describe('hydrate', () => {
     expect(store._getMirrorForTest()).toEqual(result);
   });
 
-  it('treats malformed rows as cold start (does not throw)', async () => {
+  it('treats malformed rows as cold start (does not throw or leak session credentials)', async () => {
     // Production bot MUST boot even if the DDB row is corrupted.
     // The recovery path is IDENTIFY-from-scratch, which the
     // mirror=null state surfaces to @discordjs/ws on the first
     // retrieveSessionInfo call.
+    //
+    // Security: the warn log must NOT include the actual session_id
+    // or resume_url values — those are session-bound credentials
+    // reachable from CloudWatch. Pin the type-signature-only shape.
     const { store, ddbMock, logger } = makeStore();
     ddbMock.on(GetCommand).resolves({
       Item: {
         shard_id: '0:1',
-        session_id: 'sess-xyz',
-        // resume_url missing
-        sequence: 42,
+        session_id: 'sess-leaky-secret',
+        resume_url: 'wss://r.discord/leaky-resume-url',
+        // sequence is missing/non-number to trigger the malformed branch
+        sequence: 'not-a-number',
       },
     });
 
@@ -135,10 +140,23 @@ describe('hydrate', () => {
 
     expect(result).toBeNull();
     expect(store._getMirrorForTest()).toBeNull();
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringMatching(/malformed/i),
-      expect.any(Object),
+    const warnCall = logger.warn.mock.calls.find(
+      (call) => /malformed/i.test(call[0]),
     );
+    expect(warnCall).toBeDefined();
+    const payload = warnCall[1];
+    // Type signature is logged...
+    expect(payload).toEqual(expect.objectContaining({
+      types: expect.objectContaining({
+        session_id: 'string',
+        resume_url: 'string',
+        sequence: 'string',
+      }),
+    }));
+    // ...but the actual credential values are NOT in the payload.
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toMatch(/sess-leaky-secret/);
+    expect(serialized).not.toMatch(/leaky-resume-url/);
   });
 
   it('treats DDB read errors as cold start (does not throw)', async () => {
@@ -324,18 +342,9 @@ describe('updateSessionInfo — throttle path', () => {
 
     // Mirror reflects the latest sequence even though DDB hasn't
     // caught up — pins the "mirror is fresh, DDB lags" contract.
+    // Deferred-flush firing is covered by the explicit-fake-timer
+    // test immediately below.
     expect(store._getMirrorForTest()).toEqual(expect.objectContaining({ sequence: 4 }));
-
-    // Fire the deferred flush by advancing the fake timers.
-    now += 1000;
-    jest.useFakeTimers();
-    // Re-create the store with fake timers active — the scheduleFlush
-    // path already armed a setTimeout above using the real timers,
-    // so this test is more naturally written with explicit fake-time
-    // up-front. Pivoting: rely on real timers + wait. The point is
-    // pinned by the previous assertions; the deferred-flush firing
-    // is covered by the explicit-fake-timer test below.
-    jest.useRealTimers();
   });
 
   it('issues exactly one deferred write after rapid updates', async () => {

--- a/apps/discord/tests/gateway-session-store.test.js
+++ b/apps/discord/tests/gateway-session-store.test.js
@@ -434,6 +434,58 @@ describe('flushFinal', () => {
     expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
   });
 
+  it('awaits every in-flight fire-and-forget write before exit (not just the most recent)', async () => {
+    // Without Promise.allSettled across the full set, a SIGTERM
+    // that lands between a null-clear delete and a fresh-session
+    // put could exit while the earlier delete is still in flight.
+    // The Set-based tracker keeps all outstanding writes pending
+    // until flushFinal settles them.
+    let resolveFirstWrite;
+    let secondWriteFired = false;
+
+    const rawClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(rawClient);
+    const ddbMock = mockClient(docClient);
+    // First Put blocks until we resolve it; second Put resolves
+    // immediately. Without the Set tracker, awaiting only the
+    // second would lose the first's settlement signal.
+    ddbMock.on(PutCommand)
+      .callsFakeOnce(() => new Promise((resolve) => { resolveFirstWrite = resolve; }))
+      .callsFake(() => { secondWriteFired = true; return Promise.resolve({}); });
+
+    const logger = {
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+    };
+    const store = createGatewaySessionStore({
+      ddbClient: docClient,
+      tableName: 't',
+      shardId: '0:1',
+      logger,
+    });
+
+    // Fire two writes back-to-back (sessionId change → immediate
+    // writes both times).
+    store.updateSessionInfo('0:1', { sessionId: 'sess-A', resumeURL: 'wss://r/a', sequence: 1 });
+    store.updateSessionInfo('0:1', { sessionId: 'sess-B', resumeURL: 'wss://r/b', sequence: 2 });
+    expect(secondWriteFired).toBe(true);
+
+    // Kick off flushFinal — it must NOT resolve until the still-
+    // pending first write completes.
+    const flushPromise = store.flushFinal();
+    let flushSettled = false;
+    flushPromise.then(() => { flushSettled = true; });
+
+    // Drain the microtask queue — flush is still pending on the
+    // blocked write.
+    await new Promise((r) => setImmediate(r));
+    expect(flushSettled).toBe(false);
+
+    // Now unblock and verify flush completes.
+    resolveFirstWrite({});
+    await flushPromise;
+    expect(flushSettled).toBe(true);
+  });
+
   it('after flushFinal, subsequent updateSessionInfo calls are dropped', async () => {
     // SIGTERM lands; flushFinal runs and sets stopped=true. A late
     // dispatch arriving on the way out shouldn't trigger another

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -416,20 +416,37 @@ describe('SIGTERM contract — stop() does NOT call manager.destroy()', () => {
     expect(h).not.toHaveBeenCalled();
   });
 
-  it('removes manager listeners so non-exiting callers (tests, future shapes) do not leak handler refs', async () => {
-    // Hygiene check: production exits immediately after stop(), so
-    // listener-leak is harmless there. But a test cleanup path
-    // (stop({flushFinal:false}) without process.exit) shouldn't
-    // strand the Dispatch/Error listeners on the manager.
+  it('removes only the listeners the shim installed (does not strip foreign listeners)', async () => {
+    // The shim installs Dispatch + Error listeners; stop() must
+    // detach those and leave any other listeners alone. An unscoped
+    // manager.removeAllListeners() would also strip @discordjs/ws's
+    // own internal listeners on the same emitter.
     const { shim, managerInstances } = makeShim();
     await shim.start();
     const mgr = managerInstances[0];
-    const beforeCount = mgr.listenerCount(WebSocketShardEvents.Dispatch);
-    expect(beforeCount).toBeGreaterThan(0);
+    const foreign = jest.fn();
+    mgr.on('SomeOtherEvent', foreign);
+    expect(mgr.listenerCount(WebSocketShardEvents.Dispatch)).toBeGreaterThan(0);
+    expect(mgr.listenerCount('SomeOtherEvent')).toBe(1);
 
     await shim.stop();
     expect(mgr.listenerCount(WebSocketShardEvents.Dispatch)).toBe(0);
     expect(mgr.listenerCount(WebSocketShardEvents.Error)).toBe(0);
+    expect(mgr.listenerCount('SomeOtherEvent')).toBe(1); // unaffected
+  });
+
+  it('stop() is idempotent — second call is a no-op (does not double-flush)', async () => {
+    // A graceful-shutdown signal arriving twice (SIGTERM then SIGINT
+    // racing) shouldn't double-flush the store or otherwise re-enter
+    // teardown. Single-flush also matters for cost — flushFinal
+    // issues a synchronous DDB PUT; a second one is wasted.
+    const { shim, store } = makeShim();
+    await shim.start();
+
+    await shim.stop();
+    await shim.stop();
+
+    expect(store.flushFinal).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -147,20 +147,54 @@ describe('start — wiring + connect', () => {
     await expect(shim.start()).rejects.toThrow(/start\(\) after stop\(\)/);
   });
 
-  it('rejects on connect timeout', async () => {
-    const { FakeManager } = makeFakeManagerCtor();
-    // Override connect to never resolve.
-    const slowFakeManager = function (args) {
-      const inst = new (function () {})();
-      Object.assign(inst, new EventEmitter());
-      inst.connect = jest.fn(() => new Promise(() => { /* never resolves */ }));
-      inst.destroy = jest.fn().mockResolvedValue(undefined);
-      inst.on = EventEmitter.prototype.on.bind(inst);
-      inst.emit = EventEmitter.prototype.emit.bind(inst);
-      inst._constructorArgs = args;
+  // Factory for a manager whose connect() never resolves — drives
+  // the Promise.race against the deadline to fire. Constructor
+  // form (not arrow) so `new WebSocketManagerCtor(...)` works.
+  function makeSlowManagerCtor() {
+    const instances = [];
+    function SlowFakeManager(args) {
+      const inst = Object.assign(new EventEmitter(), {
+        _constructorArgs: args,
+        connect: jest.fn(() => new Promise(() => { /* never resolves */ })),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      });
+      instances.push(inst);
       return inst;
-    };
-    const { shim } = makeShim({ WebSocketManagerCtor: slowFakeManager });
+    }
+    return { SlowFakeManager, instances };
+  }
+
+  it('drops late dispatches that arrive after connect timeout (start-failure teardown race)', async () => {
+    // start() attaches Dispatch/Error listeners BEFORE racing
+    // connect() against the timeout. If connect times out but the
+    // underlying WS still opens before gracefulShutdown finishes,
+    // dispatches arriving during the teardown window shouldn't
+    // fire downstream side effects (registerCommands, eventPublisher,
+    // gateway-activity ticker). start()'s catch sets stopped=true
+    // before throwing, so the in-listener guard drops the frame.
+    const { SlowFakeManager, instances: lateInstances } = makeSlowManagerCtor();
+    const { shim } = makeShim({ WebSocketManagerCtor: SlowFakeManager });
+    const handler = jest.fn();
+    shim.onDispatch(handler);
+
+    // Race the connect-timeout. start() rejects AND flips
+    // `stopped=true` in its catch before rethrowing.
+    await expect(shim.start({ timeoutMs: 10 })).rejects.toThrow(/timed out/);
+
+    // Simulate the racing WS opening mid-teardown: emit a Dispatch
+    // on the manager handle the shim attached its listener to.
+    // The handler MUST NOT fire — stopped guard drops the frame.
+    const mgr = lateInstances[0];
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'INTERACTION_CREATE', d: {} },
+      shardId: 0,
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('rejects on connect timeout', async () => {
+    const { SlowFakeManager } = makeSlowManagerCtor();
+    const { shim } = makeShim({ WebSocketManagerCtor: SlowFakeManager });
 
     await expect(shim.start({ timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
   });

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -1,0 +1,413 @@
+// Unit tests for src/gateway-ws-shim.js — the @discordjs/ws shim
+// that replaces discord.js Client in the Pillar 2 gateway tier.
+//
+// Coverage focuses on the load-bearing contracts called out in the
+// module header:
+//
+//   1. SIGTERM contract: stop() does NOT call manager.destroy().
+//      Discord's 60 s resume buffer relies on a TCP drop, not a
+//      clean close frame. A regression here breaks cross-process
+//      RESUME.
+//   2. IDENTIFY budget guard: MAX_IDENTIFY_ATTEMPTS = 1 enforced
+//      via thrown error from the retrieveSessionInfo wrapper. A
+//      future bump to 2+ would change the Discord-quota burn
+//      profile — pin so it requires explicit test update.
+//   3. READY detection: appId plucked from data.d.application.id,
+//      isReady flips true after first READY dispatch.
+//   4. Dispatch fan-out: multiple onDispatch handlers all fire;
+//      a throwing handler doesn't break the others.
+
+const { EventEmitter } = require('node:events');
+const {
+  createGatewayWsShim,
+  MAX_IDENTIFY_ATTEMPTS,
+  DEFAULT_CONNECT_TIMEOUT_MS,
+} = require('../src/gateway-ws-shim');
+const { WebSocketShardEvents } = require('@discordjs/ws');
+
+// Fake WebSocketManager built on EventEmitter. Captures construction
+// args so tests can interrogate the callback wiring and emit fake
+// Dispatch / Error events to drive the shim's listeners.
+function makeFakeManagerCtor() {
+  const instances = [];
+  function FakeManager(args) {
+    const inst = new EventEmitter();
+    inst._constructorArgs = args;
+    inst._destroyCalls = [];
+    inst.connect = jest.fn().mockResolvedValue(undefined);
+    inst.destroy = jest.fn().mockImplementation((opts) => {
+      inst._destroyCalls.push(opts);
+      return Promise.resolve();
+    });
+    instances.push(inst);
+    return inst;
+  }
+  return { FakeManager, instances };
+}
+
+function makeFakeRESTCtor() {
+  const instances = [];
+  function FakeREST() {
+    const inst = { token: null, setToken: jest.fn() };
+    inst.setToken.mockImplementation((t) => {
+      inst.token = t;
+      return inst;
+    });
+    instances.push(inst);
+    return inst;
+  }
+  return { FakeREST, instances };
+}
+
+function makeFakeStore() {
+  let mirror = null;
+  return {
+    hydrate: jest.fn().mockResolvedValue(null),
+    retrieveSessionInfo: jest.fn(() => mirror),
+    updateSessionInfo: jest.fn(async (_shardId, info) => { mirror = info; }),
+    flushFinal: jest.fn().mockResolvedValue(undefined),
+    stop: jest.fn(),
+    _setMirror: (val) => { mirror = val; },
+  };
+}
+
+function makeFakeLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+function makeShim(overrides = {}) {
+  const { FakeManager, instances: managerInstances } = makeFakeManagerCtor();
+  const { FakeREST, instances: restInstances } = makeFakeRESTCtor();
+  const store = makeFakeStore();
+  const logger = makeFakeLogger();
+  const shim = createGatewayWsShim({
+    token: 'test-token',
+    intents: 1,
+    store,
+    logger,
+    WebSocketManagerCtor: FakeManager,
+    RESTCtor: FakeREST,
+    ...overrides,
+  });
+  return { shim, store, logger, managerInstances, restInstances };
+}
+
+describe('createGatewayWsShim — factory validation', () => {
+  it('throws when required args are missing', () => {
+    expect(() => createGatewayWsShim()).toThrow(/token is required/);
+    expect(() => createGatewayWsShim({ token: 't' })).toThrow(/intents/);
+    expect(() => createGatewayWsShim({ token: 't', intents: 0 })).toThrow(/store is required/);
+    expect(() => createGatewayWsShim({ token: 't', intents: 0, store: {} })).toThrow(/logger is required/);
+  });
+});
+
+describe('hydrate', () => {
+  it('delegates to store.hydrate', async () => {
+    const { shim, store } = makeShim();
+    store.hydrate.mockResolvedValue({ sessionId: 'sess-A', resumeURL: 'wss://r/a', sequence: 5 });
+
+    const result = await shim.hydrate();
+
+    expect(result).toEqual({ sessionId: 'sess-A', resumeURL: 'wss://r/a', sequence: 5 });
+    expect(store.hydrate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('start — wiring + connect', () => {
+  it('constructs the manager with token, intents, rest, and callbacks', async () => {
+    const { shim, managerInstances, restInstances } = makeShim();
+    await shim.start();
+
+    expect(managerInstances).toHaveLength(1);
+    const args = managerInstances[0]._constructorArgs;
+    expect(args.token).toBe('test-token');
+    expect(args.intents).toBe(1);
+    // REST was lazy-constructed since `rest` wasn't injected.
+    expect(restInstances).toHaveLength(1);
+    expect(restInstances[0].setToken).toHaveBeenCalledWith('test-token');
+    expect(args.rest).toBe(restInstances[0]);
+    expect(typeof args.retrieveSessionInfo).toBe('function');
+    expect(typeof args.updateSessionInfo).toBe('function');
+  });
+
+  it('rejects when start() is called twice', async () => {
+    const { shim } = makeShim();
+    await shim.start();
+    await expect(shim.start()).rejects.toThrow(/start\(\) called twice/);
+  });
+
+  it('rejects when start() is called after stop()', async () => {
+    const { shim } = makeShim();
+    await shim.stop();
+    await expect(shim.start()).rejects.toThrow(/start\(\) after stop\(\)/);
+  });
+
+  it('rejects on connect timeout', async () => {
+    const { FakeManager } = makeFakeManagerCtor();
+    // Override connect to never resolve.
+    const slowFakeManager = function (args) {
+      const inst = new (function () {})();
+      Object.assign(inst, new EventEmitter());
+      inst.connect = jest.fn(() => new Promise(() => { /* never resolves */ }));
+      inst.destroy = jest.fn().mockResolvedValue(undefined);
+      inst.on = EventEmitter.prototype.on.bind(inst);
+      inst.emit = EventEmitter.prototype.emit.bind(inst);
+      inst._constructorArgs = args;
+      return inst;
+    };
+    const { shim } = makeShim({ WebSocketManagerCtor: slowFakeManager });
+
+    await expect(shim.start({ timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
+  });
+});
+
+describe('IDENTIFY budget guard', () => {
+  it('passes through when mirror is non-null (RESUME path; no budget impact)', async () => {
+    const { shim, store, managerInstances } = makeShim();
+    store._setMirror({ sessionId: 'sess-A', resumeURL: 'wss://r/a', sequence: 1 });
+
+    await shim.start();
+    const { retrieveSessionInfo } = managerInstances[0]._constructorArgs;
+
+    // 100 calls, all return the mirror, identifyAttempts stays 0.
+    for (let i = 0; i < 100; i++) {
+      expect(retrieveSessionInfo('0:1')).not.toBeNull();
+    }
+    expect(shim._getIdentifyAttemptsForTest()).toBe(0);
+  });
+
+  it('throws on second null-mirror call (cap = 1)', async () => {
+    const { shim, managerInstances } = makeShim();
+    // Default store mirror is null.
+
+    await shim.start();
+    const { retrieveSessionInfo } = managerInstances[0]._constructorArgs;
+
+    // First call: budget=1, returns null (IDENTIFY pending).
+    expect(retrieveSessionInfo('0:1')).toBeNull();
+    expect(shim._getIdentifyAttemptsForTest()).toBe(1);
+
+    // Second call: budget exhausted, throws.
+    let thrown;
+    try {
+      retrieveSessionInfo('0:1');
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.code).toBe('GATEWAY_IDENTIFY_BUDGET');
+    expect(thrown.message).toMatch(/cap 1/);
+  });
+
+  it('exposes MAX_IDENTIFY_ATTEMPTS = 1 as a pinned constant', () => {
+    expect(MAX_IDENTIFY_ATTEMPTS).toBe(1);
+  });
+});
+
+describe('READY detection', () => {
+  it('flips isReady true and captures appId on READY dispatch', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    expect(shim.isReady()).toBe(false);
+    expect(shim.getAppId()).toBeNull();
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: '123456789012345678' } } },
+      shardId: 0,
+    });
+
+    expect(shim.isReady()).toBe(true);
+    expect(shim.getAppId()).toBe('123456789012345678');
+  });
+
+  it('handles READY without an application id (logs but stays ready)', async () => {
+    // Defensive: Discord's READY shape always includes application.id,
+    // but if a future API change moves it, we want isReady=true to
+    // still flip (the WS is open) — appId stays null and registerCommands
+    // can detect+report the missing piece rather than the bot looking
+    // wedged.
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: {} },
+      shardId: 0,
+    });
+
+    expect(shim.isReady()).toBe(true);
+    expect(shim.getAppId()).toBeNull();
+  });
+
+  it('non-READY dispatches do not flip isReady', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'GUILD_CREATE', d: { id: 'guild-1' } },
+      shardId: 0,
+    });
+
+    expect(shim.isReady()).toBe(false);
+  });
+});
+
+describe('onDispatch fan-out', () => {
+  it('fires every registered handler on each dispatch', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    const h1 = jest.fn();
+    const h2 = jest.fn();
+    shim.onDispatch(h1);
+    shim.onDispatch(h2);
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'INTERACTION_CREATE', d: {} },
+      shardId: 0,
+    });
+
+    expect(h1).toHaveBeenCalledTimes(1);
+    expect(h2).toHaveBeenCalledTimes(1);
+    // Pin the payload contract — handlers receive the full {data, shardId}
+    // payload identical to the underlying Dispatch event. This matches
+    // what discord.js's `raw` listeners (the legacy event-publisher
+    // wiring point) get, so commit 4's migration is a near-mechanical
+    // re-pointing.
+    expect(h1).toHaveBeenCalledWith({
+      data: { t: 'INTERACTION_CREATE', d: {} },
+      shardId: 0,
+    });
+  });
+
+  it('a throwing handler does not break sibling handlers', async () => {
+    // Defensive isolation — one bad handler (e.g., the event-publisher
+    // throwing on a malformed envelope) shouldn't blackhole the
+    // gateway-activity ticker.
+    const { shim, managerInstances, logger } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    const thrower = jest.fn(() => { throw new Error('boom'); });
+    const good = jest.fn();
+    shim.onDispatch(thrower);
+    shim.onDispatch(good);
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'HEARTBEAT_ACK' },
+      shardId: 0,
+    });
+
+    expect(thrower).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/dispatch handler threw/i),
+      expect.objectContaining({ error: 'boom' }),
+    );
+  });
+
+  it('unsubscribe stops future deliveries to that handler', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    const h = jest.fn();
+    const unsubscribe = shim.onDispatch(h);
+
+    mgr.emit(WebSocketShardEvents.Dispatch, { data: { t: 'X' }, shardId: 0 });
+    expect(h).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    mgr.emit(WebSocketShardEvents.Dispatch, { data: { t: 'X' }, shardId: 0 });
+    expect(h).toHaveBeenCalledTimes(1); // still 1
+  });
+
+  it('throws when handler is not a function', () => {
+    const { shim } = makeShim();
+    expect(() => shim.onDispatch(null)).toThrow(/must be a function/);
+    expect(() => shim.onDispatch('hi')).toThrow(/must be a function/);
+  });
+});
+
+describe('SIGTERM contract — stop() does NOT call manager.destroy()', () => {
+  it('flushes store but never invokes manager.destroy()', async () => {
+    const { shim, store, managerInstances } = makeShim();
+    await shim.start();
+
+    await shim.stop();
+
+    // Single most-load-bearing assertion in this file. The 60 s
+    // Discord resume buffer relies on a TCP drop; manager.destroy()
+    // sends a clean close that invalidates the session.
+    expect(managerInstances[0].destroy).not.toHaveBeenCalled();
+    // flushFinal should have run by default.
+    expect(store.flushFinal).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop({ flushFinal: false }) routes through store.stop()', async () => {
+    // Test seam for the case where the caller wants to bail without
+    // a final write (test cleanup, error paths). Still no
+    // manager.destroy().
+    const { shim, store, managerInstances } = makeShim();
+    await shim.start();
+
+    await shim.stop({ flushFinal: false });
+
+    expect(store.flushFinal).not.toHaveBeenCalled();
+    expect(store.stop).toHaveBeenCalledTimes(1);
+    expect(managerInstances[0].destroy).not.toHaveBeenCalled();
+  });
+
+  it('clears dispatch handlers so late dispatches are dropped', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    const h = jest.fn();
+    shim.onDispatch(h);
+    await shim.stop();
+
+    // Late dispatch after stop() — handler should NOT fire.
+    mgr.emit(WebSocketShardEvents.Dispatch, { data: { t: 'X' }, shardId: 0 });
+    expect(h).not.toHaveBeenCalled();
+  });
+});
+
+describe('exposed REST instance', () => {
+  it('reuses an injected REST when provided', async () => {
+    const injectedRest = { setToken: jest.fn().mockReturnThis(), token: 'pre-bound' };
+    const { shim, restInstances } = makeShim({ rest: injectedRest });
+
+    await shim.start();
+    expect(shim.rest).toBe(injectedRest);
+    // No internal REST was constructed when one was injected.
+    expect(restInstances).toHaveLength(0);
+  });
+
+  it('lazy-constructs and binds token when REST is not injected', async () => {
+    const { shim, restInstances } = makeShim();
+    await shim.start();
+
+    expect(restInstances).toHaveLength(1);
+    expect(shim.rest).toBe(restInstances[0]);
+    expect(restInstances[0].token).toBe('test-token');
+  });
+});
+
+describe('constants are pinned', () => {
+  it('DEFAULT_CONNECT_TIMEOUT_MS = 30_000', () => {
+    // Matches the legacy client.login() timeout in index.js. A drift
+    // in this constant changes the boot-fail latency observably and
+    // should require a deliberate test update.
+    expect(DEFAULT_CONNECT_TIMEOUT_MS).toBe(30_000);
+  });
+});

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -28,6 +28,23 @@ const { WebSocketShardEvents } = require('@discordjs/ws');
 // Fake WebSocketManager built on EventEmitter. Captures construction
 // args so tests can interrogate the callback wiring and emit fake
 // Dispatch / Error events to drive the shim's listeners.
+// Factory for a manager whose connect() never resolves — drives
+// the Promise.race against the deadline to fire. Function form
+// (not arrow) so `new WebSocketManagerCtor(...)` works.
+function makeSlowManagerCtor() {
+  const instances = [];
+  function SlowFakeManager(args) {
+    const inst = Object.assign(new EventEmitter(), {
+      _constructorArgs: args,
+      connect: jest.fn(() => new Promise(() => { /* never resolves */ })),
+      destroy: jest.fn().mockResolvedValue(undefined),
+    });
+    instances.push(inst);
+    return inst;
+  }
+  return { SlowFakeManager, instances };
+}
+
 function makeFakeManagerCtor() {
   const instances = [];
   function FakeManager(args) {
@@ -146,23 +163,6 @@ describe('start — wiring + connect', () => {
     await shim.stop();
     await expect(shim.start()).rejects.toThrow(/start\(\) after stop\(\)/);
   });
-
-  // Factory for a manager whose connect() never resolves — drives
-  // the Promise.race against the deadline to fire. Constructor
-  // form (not arrow) so `new WebSocketManagerCtor(...)` works.
-  function makeSlowManagerCtor() {
-    const instances = [];
-    function SlowFakeManager(args) {
-      const inst = Object.assign(new EventEmitter(), {
-        _constructorArgs: args,
-        connect: jest.fn(() => new Promise(() => { /* never resolves */ })),
-        destroy: jest.fn().mockResolvedValue(undefined),
-      });
-      instances.push(inst);
-      return inst;
-    }
-    return { SlowFakeManager, instances };
-  }
 
   it('drops late dispatches that arrive after connect timeout (start-failure teardown race)', async () => {
     // start() attaches Dispatch/Error listeners BEFORE racing
@@ -532,6 +532,31 @@ describe('SIGTERM contract — stop() does NOT call manager.destroy()', () => {
     await shim.stop();
 
     expect(store.flushFinal).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() after a failed start still runs cleanup (listener detach + flushFinal)', async () => {
+    // Regression guard for the cr-r5-caught flag-conflation bug:
+    // start()'s catch sets `stopped=true` for the dispatch-race
+    // guard. A naive single-flag impl would make stop()'s
+    // idempotency check (`if (stopped) return`) short-circuit on
+    // the failed-start path — so manager.removeAllListeners() and
+    // store.flushFinal() would never run. Splitting into
+    // `stopped` (drop-dispatches) and `stopCompleted` (idempotency)
+    // keeps cleanup reachable.
+    const { SlowFakeManager, instances: lateInstances } = makeSlowManagerCtor();
+    const { shim, store } = makeShim({ WebSocketManagerCtor: SlowFakeManager });
+    await expect(shim.start({ timeoutMs: 10 })).rejects.toThrow(/timed out/);
+    const mgr = lateInstances[0];
+    expect(mgr.listenerCount(WebSocketShardEvents.Dispatch)).toBeGreaterThan(0);
+
+    // Caller (gracefulShutdown) now calls stop() after the throw.
+    // It must reach flushFinal AND detach listeners despite
+    // start()-fail having flipped `stopped` first.
+    await shim.stop();
+
+    expect(store.flushFinal).toHaveBeenCalledTimes(1);
+    expect(mgr.listenerCount(WebSocketShardEvents.Dispatch)).toBe(0);
+    expect(mgr.listenerCount(WebSocketShardEvents.Error)).toBe(0);
   });
 });
 

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -534,6 +534,42 @@ describe('SIGTERM contract — stop() does NOT call manager.destroy()', () => {
     expect(store.flushFinal).toHaveBeenCalledTimes(1);
   });
 
+  it('drops dispatches that arrive during stop() teardown (between flag-flip and listener detach)', async () => {
+    // Symmetric to the connect-timeout late-dispatch test: a successful
+    // start() can have dispatches in flight when SIGTERM lands. stop()'s
+    // first lines set stopped=true and clear dispatchHandlers — but
+    // flushFinal awaits a DDB round-trip, leaving a window where the
+    // manager's Dispatch listener is still attached. A frame arriving
+    // mid-flush must NOT reach downstream handlers, otherwise SQS would
+    // see a stray INTERACTION_CREATE after the worker has already begun
+    // its own shutdown. Belt-and-suspenders coverage: both the
+    // stopped-flag guard AND the cleared handlers-set must hold.
+    const { shim, store, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    const h = jest.fn();
+    shim.onDispatch(h);
+
+    // Make flushFinal block until we say go.
+    let resolveFlush;
+    store.flushFinal.mockImplementation(() => new Promise((r) => { resolveFlush = r; }));
+
+    const stopPromise = shim.stop();
+    await Promise.resolve(); // let stop() run up to the await
+
+    // Fire a dispatch during the teardown window. The handler must
+    // not be called.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'INTERACTION_CREATE', d: {} },
+      shardId: 0,
+    });
+    expect(h).not.toHaveBeenCalled();
+
+    resolveFlush();
+    await stopPromise;
+  });
+
   it('stop() after a failed start still runs cleanup (listener detach + flushFinal)', async () => {
     // Regression guard for the cr-r5-caught flag-conflation bug:
     // start()'s catch sets `stopped=true` for the dispatch-race

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -388,7 +388,7 @@ describe('exposed REST instance', () => {
     const { shim, restInstances } = makeShim({ rest: injectedRest });
 
     await shim.start();
-    expect(shim.rest).toBe(injectedRest);
+    expect(shim.getRest()).toBe(injectedRest);
     // No internal REST was constructed when one was injected.
     expect(restInstances).toHaveLength(0);
   });
@@ -398,7 +398,7 @@ describe('exposed REST instance', () => {
     await shim.start();
 
     expect(restInstances).toHaveLength(1);
-    expect(shim.rest).toBe(restInstances[0]);
+    expect(shim.getRest()).toBe(restInstances[0]);
     expect(restInstances[0].token).toBe('test-token');
   });
 });

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -207,6 +207,41 @@ describe('IDENTIFY budget guard', () => {
   it('exposes MAX_IDENTIFY_ATTEMPTS = 1 as a pinned constant', () => {
     expect(MAX_IDENTIFY_ATTEMPTS).toBe(1);
   });
+
+  it('resets the counter on READY so a later resume-rejection still gets an IDENTIFY', async () => {
+    // The cap=1 alone would crash-loop a long-lived task whose
+    // Discord resume buffer expires (>60s outage): cold-start
+    // IDENTIFY burns the budget, then the post-outage RESUME
+    // rejection would throw on the very next retrieve. Reset-on-
+    // READY restores the budget after every successful session
+    // so reconnects-after-outage stay healthy.
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+    const { retrieveSessionInfo } = mgr._constructorArgs;
+
+    // Cold start: retrieve → null → IDENTIFY pending (count=1).
+    expect(retrieveSessionInfo('0:1')).toBeNull();
+    expect(shim._getIdentifyAttemptsForTest()).toBe(1);
+
+    // READY arrives — counter resets.
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+      shardId: 0,
+    });
+    expect(shim._getIdentifyAttemptsForTest()).toBe(0);
+
+    // Later, Discord drops the session past its resume buffer.
+    // Library calls retrieve → mirror is null → another IDENTIFY
+    // is permitted (count=1, still under cap).
+    expect(retrieveSessionInfo('0:1')).toBeNull();
+    expect(shim._getIdentifyAttemptsForTest()).toBe(1);
+
+    // A second consecutive null-mirror retrieve (no READY between)
+    // does trip the cap — the loop-without-READY hazard the cap
+    // exists to catch.
+    expect(() => retrieveSessionInfo('0:1')).toThrow(/IDENTIFY budget exhausted/);
+  });
 });
 
 describe('READY detection', () => {
@@ -379,6 +414,22 @@ describe('SIGTERM contract — stop() does NOT call manager.destroy()', () => {
     // Late dispatch after stop() — handler should NOT fire.
     mgr.emit(WebSocketShardEvents.Dispatch, { data: { t: 'X' }, shardId: 0 });
     expect(h).not.toHaveBeenCalled();
+  });
+
+  it('removes manager listeners so non-exiting callers (tests, future shapes) do not leak handler refs', async () => {
+    // Hygiene check: production exits immediately after stop(), so
+    // listener-leak is harmless there. But a test cleanup path
+    // (stop({flushFinal:false}) without process.exit) shouldn't
+    // strand the Dispatch/Error listeners on the manager.
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+    const beforeCount = mgr.listenerCount(WebSocketShardEvents.Dispatch);
+    expect(beforeCount).toBeGreaterThan(0);
+
+    await shim.stop();
+    expect(mgr.listenerCount(WebSocketShardEvents.Dispatch)).toBe(0);
+    expect(mgr.listenerCount(WebSocketShardEvents.Error)).toBe(0);
   });
 });
 

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -281,7 +281,7 @@ describe('READY detection', () => {
     expect(shim.getAppId()).toBeNull();
   });
 
-  it('non-READY dispatches do not flip isReady', async () => {
+  it('non-READY / non-RESUMED dispatches do not flip isReady', async () => {
     const { shim, managerInstances } = makeShim();
     await shim.start();
     const mgr = managerInstances[0];
@@ -292,6 +292,57 @@ describe('READY detection', () => {
     });
 
     expect(shim.isReady()).toBe(false);
+  });
+
+  it('flips isReady true on RESUMED — the cross-process resume happy path', async () => {
+    // Discord delivers RESUMED (not READY) on a successful resume,
+    // which is the entire Pillar 2 win. Without this branch, the
+    // shim's isReady() stays false through a successful resume, the
+    // health server stays 503, and ECS would replace the task —
+    // defeating the optimization.
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+
+    expect(shim.isReady()).toBe(false);
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'RESUMED', d: {} },
+      shardId: 0,
+    });
+
+    expect(shim.isReady()).toBe(true);
+    // appId stays whatever it was before RESUMED — the prior
+    // process's READY populated it via DDB hydration (or it's
+    // null if this process never observed a READY directly,
+    // which is correct: a pure-resume process never re-registers
+    // commands).
+    expect(shim.getAppId()).toBeNull();
+  });
+
+  it('RESUMED resets the IDENTIFY budget so a later disconnect-reconnect cycle gets a fresh allowance', async () => {
+    // Symmetric with the READY-reset path: every successful session
+    // (whether first-time READY or warm-start RESUMED) restores
+    // the IDENTIFY counter. Otherwise a process that boots via
+    // RESUME and later sees its session age out (>60s outage)
+    // would have count=1 stuck since the prior process's READY
+    // and would trip the cap on the very next reconnect.
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    const mgr = managerInstances[0];
+    const { retrieveSessionInfo } = mgr._constructorArgs;
+
+    // Synthesize a non-zero counter as if a prior reconnect
+    // attempt had landed.
+    retrieveSessionInfo('0:1'); // mirror is null → count=1
+    expect(shim._getIdentifyAttemptsForTest()).toBe(1);
+
+    mgr.emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'RESUMED', d: {} },
+      shardId: 0,
+    });
+
+    expect(shim._getIdentifyAttemptsForTest()).toBe(0);
   });
 });
 

--- a/apps/discord/tests/multi-tenant.test.js
+++ b/apps/discord/tests/multi-tenant.test.js
@@ -138,63 +138,79 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     jest.resetModules();
   });
 
-  it('multi-tenant: registers only /qurl globally (no guildId arg)', async () => {
+  // The post-refactor registerCommands signature is
+  // `({rest, appId, guildIds, guildNames})`, so these tests assert the
+  // REST call shape (rest.put with the right Route URL) rather than the
+  // legacy `client.application.commands.set(data, guildId?)` shape.
+  // Route URLs follow discord-api-types/v10's Routes module:
+  //   global  → /applications/{appId}/commands
+  //   guild   → /applications/{appId}/guilds/{guildId}/commands
+  it('multi-tenant: registers only /qurl on the global commands endpoint', async () => {
     const commandsModule = require('../src/commands');
 
-    const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = {
-      application: { commands: { set: mockSet, fetch: jest.fn().mockResolvedValue(new Map()) } },
-      guilds: { cache: new Map() },
-    };
-    await commandsModule.registerCommands(mockClient);
+    const mockPut = jest.fn().mockResolvedValue(undefined);
+    const mockGet = jest.fn().mockResolvedValue([]);
+    const rest = { put: mockPut, get: mockGet };
+    await commandsModule.registerCommands({
+      rest,
+      appId: 'app-123',
+      guildIds: [],
+      guildNames: {},
+    });
 
-    expect(mockSet).toHaveBeenCalledTimes(1);
-    const [data, guildArg] = mockSet.mock.calls[0];
-    expect(guildArg).toBeUndefined();
+    expect(mockPut).toHaveBeenCalledTimes(1);
+    const [route, opts] = mockPut.mock.calls[0];
+    expect(route).toBe('/applications/app-123/commands');
     // Only /qurl is customer-safe
-    expect(data.map(c => c.name).sort()).toEqual(['qurl']);
+    expect(opts.body.map(c => c.name).sort()).toEqual(['qurl']);
   });
 
-  it('single-guild + ENABLE_OPENNHP_FEATURES=true: registers ALL commands scoped to the guild', async () => {
+  it('single-guild + ENABLE_OPENNHP_FEATURES=true: registers ALL commands on the guild endpoint', async () => {
     process.env.GUILD_ID = '123456789012345678';
     process.env.ENABLE_OPENNHP_FEATURES = 'true';
     jest.resetModules();
     const commandsModule = require('../src/commands');
 
-    const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = {
-      application: { commands: { set: mockSet, fetch: jest.fn().mockResolvedValue(new Map()) } },
-      guilds: { cache: new Map() },
-    };
-    await commandsModule.registerCommands(mockClient);
+    const mockPut = jest.fn().mockResolvedValue(undefined);
+    const mockGet = jest.fn().mockResolvedValue([]);
+    const rest = { put: mockPut, get: mockGet };
+    await commandsModule.registerCommands({
+      rest,
+      appId: 'app-123',
+      guildIds: [],
+      guildNames: {},
+    });
 
-    expect(mockSet).toHaveBeenCalledTimes(1);
-    const [data, guildArg] = mockSet.mock.calls[0];
-    expect(guildArg).toBe('123456789012345678');
-    expect(data.length).toBeGreaterThan(1);
-    expect(data.map(c => c.name)).toContain('qurl');
+    expect(mockPut).toHaveBeenCalledTimes(1);
+    const [route, opts] = mockPut.mock.calls[0];
+    expect(route).toBe('/applications/app-123/guilds/123456789012345678/commands');
+    expect(opts.body.length).toBeGreaterThan(1);
+    expect(opts.body.map(c => c.name)).toContain('qurl');
     // OpenNHP commands register alongside /qurl in the OpenNHP guild
-    expect(data.map(c => c.name)).toContain('link');
+    expect(opts.body.map(c => c.name)).toContain('link');
   });
 
-  it('single-guild + ENABLE_OPENNHP_FEATURES unset: registers only customer-safe commands scoped to the guild', async () => {
+  it('single-guild + ENABLE_OPENNHP_FEATURES unset: registers only customer-safe commands on the guild endpoint', async () => {
     process.env.GUILD_ID = '123456789012345678';
     jest.resetModules();
     const commandsModule = require('../src/commands');
 
-    const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = {
-      application: { commands: { set: mockSet, fetch: jest.fn().mockResolvedValue(new Map()) } },
-      guilds: { cache: new Map() },
-    };
-    await commandsModule.registerCommands(mockClient);
+    const mockPut = jest.fn().mockResolvedValue(undefined);
+    const mockGet = jest.fn().mockResolvedValue([]);
+    const rest = { put: mockPut, get: mockGet };
+    await commandsModule.registerCommands({
+      rest,
+      appId: 'app-123',
+      guildIds: [],
+      guildNames: {},
+    });
 
-    expect(mockSet).toHaveBeenCalledTimes(1);
-    const [data, guildArg] = mockSet.mock.calls[0];
-    expect(guildArg).toBe('123456789012345678');
+    expect(mockPut).toHaveBeenCalledTimes(1);
+    const [route, opts] = mockPut.mock.calls[0];
+    expect(route).toBe('/applications/app-123/guilds/123456789012345678/commands');
     // Only /qurl, even in single-guild mode, because OpenNHP features are off
-    expect(data.map(c => c.name).sort()).toEqual(['qurl']);
-    expect(data.map(c => c.name)).not.toContain('link');
+    expect(opts.body.map(c => c.name).sort()).toEqual(['qurl']);
+    expect(opts.body.map(c => c.name)).not.toContain('link');
   });
 });
 
@@ -223,35 +239,39 @@ describe('registerCommands stale-command purge (issue #86)', () => {
     delete process.env.ENABLE_OPENNHP_FEATURES;
     const commandsModule = require('../src/commands');
 
-    // Two guilds with stale registrations, one empty guild (should not be purged)
-    const mockFetch = jest.fn()
-      .mockResolvedValueOnce(new Map([['cmd-1', {}], ['cmd-2', {}], ['cmd-3', {}]])) // guild A: 3 stale
-      .mockResolvedValueOnce(new Map([['cmd-4', {}]]))                                 // guild B: 1 stale
-      .mockResolvedValueOnce(new Map());                                               // guild C: empty — skip
-    const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = {
-      application: { commands: { set: mockSet, fetch: mockFetch } },
-      guilds: { cache: new Map([
-        ['ga', { id: 'ga', name: 'A' }],
-        ['gb', { id: 'gb', name: 'B' }],
-        ['gc', { id: 'gc', name: 'C' }],
-      ]) },
-    };
+    // Two guilds with stale registrations, one empty guild (should not be purged).
+    // Post-refactor: REST returns arrays of Command objects (was discord.js Map
+    // before). The purge helper uses Array.length, so the mock returns arrays.
+    const mockGet = jest.fn()
+      .mockResolvedValueOnce([{ id: 'cmd-1' }, { id: 'cmd-2' }, { id: 'cmd-3' }]) // guild A: 3 stale
+      .mockResolvedValueOnce([{ id: 'cmd-4' }])                                    // guild B: 1 stale
+      .mockResolvedValueOnce([]);                                                  // guild C: empty — skip
+    const mockPut = jest.fn().mockResolvedValue(undefined);
+    const rest = { get: mockGet, put: mockPut };
 
-    await commandsModule.registerCommands(mockClient);
+    await commandsModule.registerCommands({
+      rest,
+      appId: 'app-1',
+      guildIds: ['ga', 'gb', 'gc'],
+      guildNames: { ga: 'A', gb: 'B', gc: 'C' },
+    });
 
-    // fetch called once per guild (3)
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-    // set called 3 times total: 2 purges (empty array + guildId) + 1 final global register
-    expect(mockSet).toHaveBeenCalledTimes(3);
-    // Verify purge args: empty array, guildId
-    const purgeCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length === 0);
+    // get called once per guild (3) — the per-guild fetch.
+    expect(mockGet).toHaveBeenCalledTimes(3);
+    // put called 3 times total: 2 purges (empty body, guild route) + 1 final global register.
+    expect(mockPut).toHaveBeenCalledTimes(3);
+    // Verify purge routes: applicationGuildCommands(appId, guildId), body=[].
+    const purgeCalls = mockPut.mock.calls.filter(([, opts]) => Array.isArray(opts.body) && opts.body.length === 0);
     expect(purgeCalls).toHaveLength(2);
-    expect(purgeCalls.map(c => c[1]).sort()).toEqual(['ga', 'gb']);
-    // Verify registration: the qurl command, no guildId (global)
-    const registerCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length > 0);
+    const purgedRoutes = purgeCalls.map(c => c[0]).sort();
+    expect(purgedRoutes).toEqual([
+      '/applications/app-1/guilds/ga/commands',
+      '/applications/app-1/guilds/gb/commands',
+    ]);
+    // Verify registration route: applicationCommands(appId), body=non-empty.
+    const registerCalls = mockPut.mock.calls.filter(([, opts]) => Array.isArray(opts.body) && opts.body.length > 0);
     expect(registerCalls).toHaveLength(1);
-    expect(registerCalls[0][1]).toBeUndefined();
+    expect(registerCalls[0][0]).toBe('/applications/app-1/commands');
   });
 
   it('OpenNHP mode: does NOT purge (guild-scoped registration is the goal)', async () => {
@@ -259,20 +279,22 @@ describe('registerCommands stale-command purge (issue #86)', () => {
     process.env.ENABLE_OPENNHP_FEATURES = 'true';
     const commandsModule = require('../src/commands');
 
-    const mockFetch = jest.fn();
-    const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = {
-      application: { commands: { set: mockSet, fetch: mockFetch } },
-      guilds: { cache: new Map([['ga', { id: 'ga', name: 'A' }]]) },
-    };
+    const mockGet = jest.fn();
+    const mockPut = jest.fn().mockResolvedValue(undefined);
+    const rest = { get: mockGet, put: mockPut };
 
-    await commandsModule.registerCommands(mockClient);
+    await commandsModule.registerCommands({
+      rest,
+      appId: 'app-1',
+      guildIds: ['ga'],
+      guildNames: { ga: 'A' },
+    });
 
-    // fetch never called — purge skipped in OpenNHP mode
-    expect(mockFetch).not.toHaveBeenCalled();
-    // set called once for the register, no preceding empty-array purge
-    expect(mockSet).toHaveBeenCalledTimes(1);
-    expect(mockSet.mock.calls[0][0].length).toBeGreaterThan(0);
+    // get never called — purge skipped in OpenNHP mode.
+    expect(mockGet).not.toHaveBeenCalled();
+    // put called once for the register, no preceding empty-body purge.
+    expect(mockPut).toHaveBeenCalledTimes(1);
+    expect(mockPut.mock.calls[0][1].body.length).toBeGreaterThan(0);
   });
 
   it('non-OpenNHP mode: purge failure in one guild does not block registration', async () => {
@@ -280,27 +302,26 @@ describe('registerCommands stale-command purge (issue #86)', () => {
     delete process.env.ENABLE_OPENNHP_FEATURES;
     const commandsModule = require('../src/commands');
 
-    const mockFetch = jest.fn()
+    const mockGet = jest.fn()
       .mockRejectedValueOnce(new Error('Missing Access'))     // guild A: can't enumerate
-      .mockResolvedValueOnce(new Map([['cmd-1', {}]]));      // guild B: succeeds
-    const mockSet = jest.fn().mockResolvedValue(undefined);
-    const mockClient = {
-      application: { commands: { set: mockSet, fetch: mockFetch } },
-      guilds: { cache: new Map([
-        ['ga', { id: 'ga', name: 'A' }],
-        ['gb', { id: 'gb', name: 'B' }],
-      ]) },
-    };
+      .mockResolvedValueOnce([{ id: 'cmd-1' }]);              // guild B: succeeds
+    const mockPut = jest.fn().mockResolvedValue(undefined);
+    const rest = { get: mockGet, put: mockPut };
 
-    await commandsModule.registerCommands(mockClient);
+    await commandsModule.registerCommands({
+      rest,
+      appId: 'app-1',
+      guildIds: ['ga', 'gb'],
+      guildNames: { ga: 'A', gb: 'B' },
+    });
 
-    // Guild A's fetch failed but we still tried guild B
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    // Only guild B got purged (A failed before reaching set)
-    const purgeCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length === 0);
-    expect(purgeCalls.map(c => c[1])).toEqual(['gb']);
-    // Final register still ran despite guild A's purge failure
-    const registerCalls = mockSet.mock.calls.filter(([data]) => Array.isArray(data) && data.length > 0);
+    // Guild A's get failed but we still tried guild B.
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    // Only guild B got purged (A failed before reaching put).
+    const purgeCalls = mockPut.mock.calls.filter(([, opts]) => Array.isArray(opts.body) && opts.body.length === 0);
+    expect(purgeCalls.map(c => c[0])).toEqual(['/applications/app-1/guilds/gb/commands']);
+    // Final register still ran despite guild A's purge failure.
+    const registerCalls = mockPut.mock.calls.filter(([, opts]) => Array.isArray(opts.body) && opts.body.length > 0);
     expect(registerCalls).toHaveLength(1);
   });
 });

--- a/apps/discord/tests/multi-tenant.test.js
+++ b/apps/discord/tests/multi-tenant.test.js
@@ -154,8 +154,7 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     await commandsModule.registerCommands({
       rest,
       appId: 'app-123',
-      guildIds: [],
-      guildNames: {},
+      guilds: new Map(),
     });
 
     expect(mockPut).toHaveBeenCalledTimes(1);
@@ -177,8 +176,7 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     await commandsModule.registerCommands({
       rest,
       appId: 'app-123',
-      guildIds: [],
-      guildNames: {},
+      guilds: new Map(),
     });
 
     expect(mockPut).toHaveBeenCalledTimes(1);
@@ -201,8 +199,7 @@ describe('multi-tenant mode — registerCommands command filtering', () => {
     await commandsModule.registerCommands({
       rest,
       appId: 'app-123',
-      guildIds: [],
-      guildNames: {},
+      guilds: new Map(),
     });
 
     expect(mockPut).toHaveBeenCalledTimes(1);
@@ -252,8 +249,7 @@ describe('registerCommands stale-command purge (issue #86)', () => {
     await commandsModule.registerCommands({
       rest,
       appId: 'app-1',
-      guildIds: ['ga', 'gb', 'gc'],
-      guildNames: { ga: 'A', gb: 'B', gc: 'C' },
+      guilds: new Map([['ga', 'A'], ['gb', 'B'], ['gc', 'C']]),
     });
 
     // get called once per guild (3) — the per-guild fetch.
@@ -286,8 +282,7 @@ describe('registerCommands stale-command purge (issue #86)', () => {
     await commandsModule.registerCommands({
       rest,
       appId: 'app-1',
-      guildIds: ['ga'],
-      guildNames: { ga: 'A' },
+      guilds: new Map([['ga', 'A']]),
     });
 
     // get never called — purge skipped in OpenNHP mode.
@@ -311,8 +306,7 @@ describe('registerCommands stale-command purge (issue #86)', () => {
     await commandsModule.registerCommands({
       rest,
       appId: 'app-1',
-      guildIds: ['ga', 'gb'],
-      guildNames: { ga: 'A', gb: 'B' },
+      guilds: new Map([['ga', 'A'], ['gb', 'B']]),
     });
 
     // Guild A's get failed but we still tried guild B.


### PR DESCRIPTION
## Summary

Adds the app-side of Pillar 2 in the zero-downtime gateway migration. Under a new `ENABLE_GATEWAY_RESUME` flag, the gateway tier replaces `discord.js Client` + `client.login()` with a direct `@discordjs/ws WebSocketManager` whose session callbacks point at a new `qurl-bot-discord-<env>-gateway-session` DDB table. On every restart the new gateway boots, reads the persisted `{sessionId, resumeURL, sequence}` row, and Discord's `RESUME` (op 6) replays buffered events from the last sequence — eliminating the ~10 s IDENTIFY cold-start the legacy single-process deploy carries today.

**Flag default off.** No behavior change in any env until an operator flips `ENABLE_GATEWAY_RESUME=true`. Single-replica behavior is unchanged at this layer (desired_count stays at 1); the second replica + push handoff arrives in PR 13b (Pillar 3).

## Why now

The bot today is `desired_count=1` on a Discord token (Discord allows one active WS per bot identity). Every ECS deploy → ~10 s WebSocket reconnect → `/qurl` command surface dark for that window. With Pillar 1 (PR 10/11) the gateway tier is now a thin SQS forwarder; with Pillar 2 we cross-process-RESUME instead of IDENTIFYing, dropping the visible blackout to a few hundred ms of TCP drop. Pillar 3 (PR 13b) then adds a hot standby with HMAC push-handoff for near-zero observable disruption.

## Architecture

**API shape note**: the shim exposes `getRest()` and `getAppId()` as methods (no property getters). A future port from an earlier "shim.rest" callsite shape will get `undefined is not a function`, not a silent undefined — grep `getRest()` in `src/index.js` when wiring new callers.


The `ENABLE_GATEWAY_RESUME=true` + `PROCESS_ROLE=gateway` path:

1. Boot: `gatewayShim.hydrate()` reads the persisted DDB row into an in-memory mirror.
2. `gatewayShim.start()` constructs a `WebSocketManager` with `retrieveSessionInfo` (mirror-only) and `updateSessionInfo` (mirror + fire-and-forget DDB write) callbacks. `manager.connect()` either RESUMEs (mirror is populated) or IDENTIFYs (cold start).
3. On every gateway frame: shim's `onDispatch` fans out to a single coalesced handler that (a) triggers `registerCommands` on the first READY, (b) ticks the `gateway-activity` observability gauge, (c) forwards INTERACTION_CREATE to SQS via `event-publisher.publish`.
4. SIGTERM: shim's `stop()` flushes the latest sequence to DDB synchronously, then exits **without** calling `manager.destroy()` — the TCP drop is load-bearing for Discord's ~60 s resume buffer (a clean close frame would invalidate the session).
5. Next process boots, hydrates the row, RESUMEs cleanly.

## Boot guards

Three combinations are rejected at boot (new `unsupportedRoleResumeCombo`):
- `ENABLE_GATEWAY_RESUME=true` + `PROCESS_ROLE=combined` — legacy `Client` owns the WS in combined mode.
- `ENABLE_GATEWAY_RESUME=true` + `ENABLE_EVENT_SHIPPER=false` — shim has no in-process dispatcher.
- `ENABLE_GATEWAY_RESUME=true` + `STORE_TYPE!=ddb` — sqlite can't share state across processes.

## Load-bearing contracts (all unit-tested)

1. **In-memory mirror, not DDB-per-callback.** `retrieveSessionInfo` is called by `@discordjs/ws` on every reconnect — a DDB read per call would surface as ~10-100 ms loop latency AND couldn't observe the in-process state changes that a prior `updateSessionInfo(null)` makes.
2. **Null-clear respected.** When Discord rejects a RESUME, `@discordjs/ws` calls `updateSessionInfo(shardId, null)` and the mirror MUST flip to null AND the DDB row MUST be deleted — otherwise the next `retrieveSessionInfo` hands back the dead session and the bot enters an infinite RESUME-reject loop (this is the contract the PR 0 spike's first sandbox run encountered).
3. **Write throttling.** `updateSessionInfo` fires on every dispatch (high rate). Immediate writes only on sessionId change or after 1 s elapses; other updates defer to a single scheduled flush. Mirror always reflects the latest dispatch; DDB lags by at most 1 s.
4. **Final flush on SIGTERM.** `flushFinal()` awaits any in-flight fire-and-forget write, then synchronously writes the mirror so the next process's hydrate sees the latest sequence.
5. **SIGTERM does NOT call `manager.destroy()`.** Destroy sends close-1000 + clears the session on Discord's side; we need the session preserved for the next process's RESUME.
6. **`MAX_IDENTIFY_ATTEMPTS = 1`** — caps Discord's 1000/24h IDENTIFY budget burn at one per task lifetime; ECS task replacement gives a fresh budget.

## Commit order (each independently reviewable)

1. `feat(discord): add ENABLE_GATEWAY_RESUME flag + boot guards` — flag only, no behavior change.
2. `feat(discord): add DDB-backed gateway session store with mirror` — the persistence + throttle + mirror; pure module, no wiring yet.
3. `feat(discord): add WebSocketManager shim with IDENTIFY budget guard` — wraps @discordjs/ws; not yet wired in.
4. `refactor(discord): registerCommands accepts REST + appId` — pure refactor; both legacy + shim paths can call it.
5. `feat(discord): wire Pillar 2 shim into gateway tier under flag` — the integration; flag-off keeps every existing wire.
6. `test(discord): pillar 2 shim+store end-to-end integration` — composes the two modules through the full lifecycle.
7. `docs(discord): .env.example entry for ENABLE_GATEWAY_RESUME`
8. `refactor(discord): /simplify pass on pillar 2 stack` — decouples DDB writes from WS dispatch loop, collapses dispatch fan-out, drops rot-prone comments.

## Test plan

- [x] Full local jest suite green (2033 tests, +75 new in this PR)
- [x] Lint clean
- [ ] Deploy to sandbox with flag off — verify no behavior change vs current main
- [ ] Flip `ENABLE_GATEWAY_RESUME=true` in sandbox (DDB tables provisioned by qurl-integrations-infra PR #498) — observe READY dispatch + DDB session row populated
- [ ] Force-redeploy sandbox gateway task — observe RESUMED dispatch + sequence carried forward (no IDENTIFY budget burn)
- [ ] Verify `/qurl send` end-to-end during the redeploy (interactions reach the worker via SQS without loss)
- [ ] Sandbox soak: confirm no stale guild-scoped slash commands surface under the shim path — `registerCommands` is now invoked from the shim's first READY (not `client.once('ready')`), so any regression in that wiring would show up as commands from a prior deploy lingering in guild scope
- [ ] Sandbox soak ≥48h before recommending prod flag-on
- [ ] PR 13b lands the second replica before any env raises `gateway_desired_count` above 1

## Known follow-ups

- gateway-heartbeat / active-guild-count timers skip when shim is active (they probe `client.ws.shards[*].lastPingTimestamp` which doesn't exist under @discordjs/ws). Port to shim-aware health snapshot once PR 13b ships.
- Cap `inFlightWrites` Set + add a `gateway_session_store_writes_total` observability counter (issue #411) — currently unbounded under pathological per-dispatch sessionId churn (not a real-world Discord shape, but worth hardening before prod flag-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
