### PR TITLE
feat(discord): pillar 3 lock + peer-heartbeat primitives (pure modules)

### DIFF
--- a/apps/discord/src/gateway-lock.js
+++ b/apps/discord/src/gateway-lock.js
@@ -9,6 +9,31 @@
 // version cursor. Tests run isolated; a future multi-shard caller can
 // construct one per shard.
 //
+// ── Concurrency: single-caller only ──
+//
+// `currentVersion` is closure state mutated by acquireLock / renewLock
+// / transferLock / adoptLockFromHandoff. JS's single-threaded event
+// loop makes each read-then-write atomic at the await boundary, but
+// two concurrent renewLock invocations (e.g., a scheduled tick
+// overlapping a watchdog-triggered renew) would both read version
+// `N`, both attempt to write `N+1`, and the second's CAS fails —
+// clearing `currentVersion=null` even though the lock is still held.
+// The leader-coordinator in PR 13b.2 must serialize all mutator
+// calls (one outstanding renew at a time; transfer/release run only
+// from the SIGTERM path which has the loop stopped). The diagnostic
+// `readCurrentHolder` is the only safe overlap.
+//
+// ── Release semantics ──
+//
+// `releaseLock` is intended for the no-peer SIGTERM path (active dies
+// with no standby to hand to). Both transport errors and CAS failures
+// clear `currentVersion=null` so the caller's state doesn't outlive
+// the lock. This is correct on the SIGTERM path (process is exiting)
+// but would be over-aggressive on a voluntary-step-down path — a
+// future watchdog-driven release would need to distinguish "lock is
+// gone" from "DDB transient error, retry" rather than zero the
+// cursor on either. Today's only caller is gracefulShutdown.
+//
 // ── Load-bearing contracts ──
 //
 // 1. Conditional-write is the lock primitive, NOT DDB TTL. The TTL
@@ -160,15 +185,20 @@ function createGatewayLock({
     const now = nowSeconds();
     const nextVersion = currentVersion + 1;
     try {
+      // No `lock_holder = :holder` in SET — we already hold the
+      // lock, so lock_holder is unchanged. Including it would
+      // burn ~1 WCU byte per renew with no semantic effect.
+      // (acquireLock writes the full row; transferLock writes
+      // the new holder. Both code paths that need to set
+      // lock_holder do so explicitly.)
       await ddbClient.send(new UpdateCommand({
         TableName: tableName,
         Key: { shard_id: shardId },
-        UpdateExpression: 'SET version = :next, expires_at = :exp, lock_holder = :holder',
+        UpdateExpression: 'SET version = :next, expires_at = :exp',
         ConditionExpression: 'instance_id = :self AND version = :expected',
         ExpressionAttributeValues: {
           ':next': nextVersion,
           ':exp': now + ttlSeconds,
-          ':holder': lockHolder,
           ':self': instanceId,
           ':expected': currentVersion,
         },

--- a/apps/discord/src/gateway-lock.js
+++ b/apps/discord/src/gateway-lock.js
@@ -37,6 +37,18 @@
 //    take it while the legitimate holder is still heartbeating;
 //    their write hits a ConditionalCheckFailedException.
 //
+//    Scope note: `version` is scoped to the CURRENT lock tenancy.
+//    Each `acquireLock` after a release / lapse / transfer resets
+//    the counter to 1; it is NOT a globally monotonic fencing token
+//    in the Kleppmann-treats-it-as-external sense. The internal-CAS
+//    use is sound because every CAS pairs `version` with `instance_id`,
+//    and `instance_id` is unique per process. If any downstream
+//    system ever consumes `version` as an EXTERNAL fencing token
+//    (e.g., a separate storage system that wants "is this fence
+//    number ahead of the last one we saw"), the per-acquire reset
+//    breaks that assumption and the consumer would need to pair
+//    `version` with `instance_id` or read the holder row.
+//
 // 4. Release uses `DeleteItem`, not `UpdateItem REMOVE lock_holder`.
 //    A REMOVE would leave `expires_at` populated, so a peer's next
 //    acquire couldn't take the `attribute_not_exists(lock_holder)`
@@ -189,6 +201,17 @@ function createGatewayLock({
       });
       return { transferred: false };
     }
+    if (targetInstanceId === instanceId) {
+      // Self-handoff is meaningless and would still bump the version
+      // (the CAS would succeed, since we're a holder). Reject at the
+      // API boundary so a caller bug (e.g., a peer-discovery lookup
+      // that accidentally returns our own row) doesn't silently churn
+      // the version counter.
+      logger.warn('gateway-lock: transferLock called with self as target (no-op)', {
+        shardId, instanceId,
+      });
+      return { transferred: false };
+    }
     const now = nowSeconds();
     const nextVersion = currentVersion + 1;
     try {
@@ -264,6 +287,31 @@ function createGatewayLock({
     }
   }
 
+  // Bootstrap the local version cursor after receiving a lock via
+  // cross-process handoff. The producer of this call is PR 13b.2's
+  // control-channel handler: after HMAC-verifying a `POST /control/yours`
+  // body and observing that the active's `transferLock` succeeded
+  // (DDB row now shows this replica as `instance_id`, version=`v`),
+  // the standby must seed its own gateway-lock instance's version
+  // cursor with `v` so the next `renewLock` finds a non-null
+  // `currentVersion` and passes its CAS guard.
+  //
+  // No DDB write. The active's transferLock already wrote the row;
+  // this call just synchronizes local state with what already
+  // exists in DDB. Safe to call multiple times — the cursor just
+  // re-anchors.
+  function adoptLockFromHandoff(versionAfterTransfer) {
+    if (!Number.isInteger(versionAfterTransfer) || versionAfterTransfer < 1) {
+      throw new Error(
+        `gateway-lock: adoptLockFromHandoff requires a positive integer version (got ${versionAfterTransfer})`
+      );
+    }
+    currentVersion = versionAfterTransfer;
+    logger.info('gateway-lock: adopted from handoff', {
+      shardId, instanceId, version: versionAfterTransfer,
+    });
+  }
+
   // Read the current holder row for diagnostics (/health, debug logs).
   // NOT a correctness primitive — the conditional writes above are
   // the lock contract. Returns the row or null if absent.
@@ -279,6 +327,7 @@ function createGatewayLock({
     acquireLock,
     renewLock,
     transferLock,
+    adoptLockFromHandoff,
     releaseLock,
     readCurrentHolder,
     // Inspection seam for tests. Production callers track version

--- a/apps/discord/src/gateway-lock.js
+++ b/apps/discord/src/gateway-lock.js
@@ -1,0 +1,295 @@
+// DDB-backed per-shard leader-election lock for Pillar 3's hot-standby
+// gateway pair. Exactly one of the two `bot_gateway` replicas holds the
+// lock for a given shard at any time; the non-holder boots fully (DDB
+// clients open, control-channel bound, `/health` returning 200) but
+// skips `WebSocketManager.connect()` so Discord only sees one active
+// WS per shard.
+//
+// Factory `createGatewayLock` returns a per-shard instance with its own
+// version cursor. Tests run isolated; a future multi-shard caller can
+// construct one per shard.
+//
+// ── Load-bearing contracts ──
+//
+// 1. Conditional-write is the lock primitive, NOT DDB TTL. The TTL
+//    attribute (`expires_at`) is a background janitor that reaps
+//    long-decommissioned shard rows. Lock correctness lives in the
+//    `ConditionExpression` on every acquire/renew/transfer — DDB TTL
+//    deletion is asynchronous (AWS publishes "typically within a few
+//    days") and a row with `now > expires_at` that hasn't been reaped
+//    is still returned by GetItem.
+//
+// 2. TTL writer shape: epoch SECONDS, not milliseconds. DDB TTL only
+//    understands seconds-since-epoch; a ms-encoded value would land
+//    ~50,000 years in the future to the reaper, leaving rows alive
+//    forever. Matches the convention on `flow_state` and
+//    `gateway_session`. ALL writers (acquire, renew, transfer) MUST
+//    pass `Math.floor(clock() / 1000) + ttlSeconds`.
+//
+// 3. `instance_id` + `version` are the CAS guard. Renew/transfer use
+//    `ConditionExpression = "instance_id = :self AND version =
+//    :expected"`. A stale process whose lease expired and was re-
+//    acquired by a peer cannot accidentally succeed on a delayed
+//    renew — the version moved underneath it. This is the fencing-
+//    token primitive (cf. Martin Kleppmann's "How to do distributed
+//    locking") that makes the TTL clock-skew tolerant: even a clock-
+//    skewed peer that thinks the lock has expired cannot actually
+//    take it while the legitimate holder is still heartbeating;
+//    their write hits a ConditionalCheckFailedException.
+//
+// 4. Release uses `DeleteItem`, not `UpdateItem REMOVE lock_holder`.
+//    A REMOVE would leave `expires_at` populated, so a peer's next
+//    acquire couldn't take the `attribute_not_exists(lock_holder)`
+//    branch and would have to wait for the (now-stale) `expires_at`
+//    to lapse — adding lease-duration latency to a clean handoff.
+//    DeleteItem re-arms the `attribute_not_exists` branch so the
+//    peer acquires immediately. Crash-without-release falls back to
+//    lease expiry (~6 s) which is the design's worst-case floor.
+//
+// 5. acquire uses `PutItem`, not `UpdateItem`. PutItem cleanly handles
+//    the post-DeleteItem "row absent" case in one round-trip
+//    (UpdateItem would need a follow-up to write the full row); it
+//    also makes acquire idempotent on ConditionalCheckFailedException.
+//    Caveat: PutItem replaces the entire item, so any future non-CAS-
+//    managed attribute (e.g., a diagnostic `last_acquired_at`) MUST
+//    be included in every acquire's PutItem payload or moved to a
+//    sibling table — otherwise acquire silently wipes it.
+
+const {
+  PutCommand,
+  GetCommand,
+  UpdateCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+
+// Lease duration in seconds. 6 s sets the cold-fallback floor at
+// ~6 s + RESUME RTT ≈ 7 s. Paired with the 2 s renew cadence elsewhere
+// — three missed renewals = lock becomes acquirable by a peer.
+const DEFAULT_TTL_SECONDS = 6;
+
+function createGatewayLock({
+  ddbClient,
+  tableName,
+  shardId,
+  instanceId,
+  lockHolder,
+  logger,
+  // Injected for deterministic tests. Production uses Date.now.
+  clock = () => Date.now(),
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+} = {}) {
+  if (!ddbClient) throw new Error('createGatewayLock: ddbClient is required');
+  if (!tableName) throw new Error('createGatewayLock: tableName is required');
+  if (!shardId) throw new Error('createGatewayLock: shardId is required');
+  if (!instanceId) throw new Error('createGatewayLock: instanceId is required');
+  if (!lockHolder) throw new Error('createGatewayLock: lockHolder is required');
+  if (!logger) throw new Error('createGatewayLock: logger is required');
+
+  // Tracks the version cursor across renew/transfer ops. Set on
+  // successful acquire/renew (we always know what version we just
+  // wrote); used as :expected on the next CAS. null when we don't
+  // hold the lock.
+  let currentVersion = null;
+
+  function nowSeconds() {
+    return Math.floor(clock() / 1000);
+  }
+
+  // Acquire the lock for this instance. Returns { acquired: true,
+  // version } on success, { acquired: false } when a peer holds a
+  // live lease. Throws on transport errors (caller decides retry).
+  async function acquireLock() {
+    const now = nowSeconds();
+    const newVersion = 1;
+    try {
+      await ddbClient.send(new PutCommand({
+        TableName: tableName,
+        Item: {
+          shard_id: shardId,
+          lock_holder: lockHolder,
+          instance_id: instanceId,
+          version: newVersion,
+          expires_at: now + ttlSeconds,
+        },
+        ConditionExpression:
+          'attribute_not_exists(lock_holder) ' +
+          'OR attribute_not_exists(expires_at) ' +
+          'OR expires_at < :now',
+        ExpressionAttributeValues: { ':now': now },
+      }));
+      currentVersion = newVersion;
+      logger.info('gateway-lock: acquired', {
+        shardId, instanceId, version: newVersion, ttlSeconds,
+      });
+      return { acquired: true, version: newVersion };
+    } catch (err) {
+      if (err.name === 'ConditionalCheckFailedException') {
+        logger.debug('gateway-lock: acquire failed (peer holds live lease)', {
+          shardId, instanceId,
+        });
+        return { acquired: false };
+      }
+      throw err;
+    }
+  }
+
+  // Renew the lease. Returns { renewed: true, version } on success,
+  // { renewed: false } if the CAS guard fails (we lost the lock, or a
+  // version-collision race). Caller should treat renewed=false as
+  // "you no longer hold the lock" and stop the WS / release downstream
+  // resources.
+  async function renewLock() {
+    if (currentVersion === null) {
+      logger.warn('gateway-lock: renew called without prior acquire', {
+        shardId, instanceId,
+      });
+      return { renewed: false };
+    }
+    const now = nowSeconds();
+    const nextVersion = currentVersion + 1;
+    try {
+      await ddbClient.send(new UpdateCommand({
+        TableName: tableName,
+        Key: { shard_id: shardId },
+        UpdateExpression: 'SET version = :next, expires_at = :exp, lock_holder = :holder',
+        ConditionExpression: 'instance_id = :self AND version = :expected',
+        ExpressionAttributeValues: {
+          ':next': nextVersion,
+          ':exp': now + ttlSeconds,
+          ':holder': lockHolder,
+          ':self': instanceId,
+          ':expected': currentVersion,
+        },
+      }));
+      currentVersion = nextVersion;
+      return { renewed: true, version: nextVersion };
+    } catch (err) {
+      if (err.name === 'ConditionalCheckFailedException') {
+        logger.warn('gateway-lock: renew CAS failed — lock lost', {
+          shardId, instanceId, expectedVersion: currentVersion,
+        });
+        currentVersion = null;
+        return { renewed: false };
+      }
+      throw err;
+    }
+  }
+
+  // Atomic ownership transfer to a peer. Used by the SIGTERM push-
+  // handoff path: the active hands the lock over in one DDB op, with
+  // no lock-released-but-not-acquired-yet window. Returns { transferred:
+  // true, version } on success. On CAS failure (we don't hold the lock,
+  // or version moved), returns { transferred: false } and the caller
+  // should fall through to a clean exit — the peer will acquire via
+  // the cold-fallback path.
+  async function transferLock(targetInstanceId, targetLockHolder) {
+    if (currentVersion === null) {
+      logger.warn('gateway-lock: transfer called without prior acquire', {
+        shardId, instanceId,
+      });
+      return { transferred: false };
+    }
+    const now = nowSeconds();
+    const nextVersion = currentVersion + 1;
+    try {
+      await ddbClient.send(new UpdateCommand({
+        TableName: tableName,
+        Key: { shard_id: shardId },
+        UpdateExpression:
+          'SET instance_id = :peer, lock_holder = :peerHolder, ' +
+          'version = :next, expires_at = :exp',
+        ConditionExpression: 'instance_id = :self AND version = :expected',
+        ExpressionAttributeValues: {
+          ':peer': targetInstanceId,
+          ':peerHolder': targetLockHolder,
+          ':next': nextVersion,
+          ':exp': now + ttlSeconds,
+          ':self': instanceId,
+          ':expected': currentVersion,
+        },
+      }));
+      logger.info('gateway-lock: transferred', {
+        shardId, fromInstanceId: instanceId, toInstanceId: targetInstanceId,
+        version: nextVersion,
+      });
+      currentVersion = null;
+      return { transferred: true, version: nextVersion };
+    } catch (err) {
+      if (err.name === 'ConditionalCheckFailedException') {
+        logger.warn('gateway-lock: transfer CAS failed', {
+          shardId, instanceId, expectedVersion: currentVersion,
+        });
+        return { transferred: false };
+      }
+      throw err;
+    }
+  }
+
+  // Best-effort release. Used by the no-peer SIGTERM path (active dies
+  // with no standby to hand to) so a future replacement task can
+  // acquire immediately rather than wait for the ~6 s lease lapse.
+  // The CAS guard on `instance_id` prevents us from deleting a row
+  // owned by a peer that took over while we were tearing down. Logs
+  // but doesn't throw — the worst case is the lease lapses naturally.
+  async function releaseLock() {
+    if (currentVersion === null) {
+      logger.debug('gateway-lock: release called without prior acquire (no-op)', {
+        shardId, instanceId,
+      });
+      return { released: false };
+    }
+    try {
+      await ddbClient.send(new DeleteCommand({
+        TableName: tableName,
+        Key: { shard_id: shardId },
+        ConditionExpression: 'instance_id = :self',
+        ExpressionAttributeValues: { ':self': instanceId },
+      }));
+      logger.info('gateway-lock: released', { shardId, instanceId });
+      currentVersion = null;
+      return { released: true };
+    } catch (err) {
+      if (err.name === 'ConditionalCheckFailedException') {
+        logger.warn('gateway-lock: release CAS failed (peer took over)', {
+          shardId, instanceId,
+        });
+        currentVersion = null;
+        return { released: false };
+      }
+      logger.error('gateway-lock: release failed', {
+        shardId, instanceId, error: err.message,
+      });
+      currentVersion = null;
+      return { released: false };
+    }
+  }
+
+  // Read the current holder row for diagnostics (/health, debug logs).
+  // NOT a correctness primitive — the conditional writes above are
+  // the lock contract. Returns the row or null if absent.
+  async function readCurrentHolder() {
+    const result = await ddbClient.send(new GetCommand({
+      TableName: tableName,
+      Key: { shard_id: shardId },
+    }));
+    return result.Item ?? null;
+  }
+
+  return {
+    acquireLock,
+    renewLock,
+    transferLock,
+    releaseLock,
+    readCurrentHolder,
+    // Inspection seam for tests. Production callers track version
+    // through acquire/renew/transfer return values instead.
+    _getVersionForTest() {
+      return currentVersion;
+    },
+  };
+}
+
+module.exports = {
+  createGatewayLock,
+  DEFAULT_TTL_SECONDS,
+};

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -69,7 +69,13 @@ function createPeerHeartbeat({
   if (!tableName) throw new Error('createPeerHeartbeat: tableName is required');
   if (!instanceId) throw new Error('createPeerHeartbeat: instanceId is required');
   if (!ip) throw new Error('createPeerHeartbeat: ip is required');
-  if (typeof port !== 'number') throw new Error('createPeerHeartbeat: port (number) is required');
+  // Validate port as a TCP port (positive integer, 1-65535) rather
+  // than just `typeof === 'number'` — the latter accepts NaN, 0,
+  // negatives, fractionals, and >65535 (all of which would produce
+  // an unreachable peer entry that's invalid even before DDB sees it).
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error('createPeerHeartbeat: port (integer 1-65535) is required');
+  }
   if (!shardId) throw new Error('createPeerHeartbeat: shardId is required');
   if (!logger) throw new Error('createPeerHeartbeat: logger is required');
 

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -42,8 +42,20 @@
 //    lag, well inside the 6 s freshness window, and ConsistentRead
 //    doubles RCU cost for no correctness benefit). If a future
 //    sharded topology pushes peer row count past ~100, revisit
-//    with a GSI on `shard_id`.
+//    with a GSI on `shard_id` AND a `LastEvaluatedKey` pagination
+//    loop (the current call assumes the entire result fits in one
+//    1 MB ScanCommand response — fine at 2 replicas, broken at
+//    ~1000+).
+//
+//    Client-side filter vs DDB FilterExpression: we apply the
+//    freshness / shard / self filters in Node, not as a
+//    FilterExpression on the Scan. FilterExpressions still consume
+//    RCU for filtered-out rows (post-Scan, pre-response — no
+//    cost-side win), and the network-byte savings are negligible
+//    at this row count. If row count ever grows past ~1000 the
+//    network bytes start to matter; revisit then.
 
+const net = require('node:net');
 const {
   PutCommand,
   ScanCommand,
@@ -68,7 +80,14 @@ function createPeerHeartbeat({
   if (!ddbClient) throw new Error('createPeerHeartbeat: ddbClient is required');
   if (!tableName) throw new Error('createPeerHeartbeat: tableName is required');
   if (!instanceId) throw new Error('createPeerHeartbeat: instanceId is required');
-  if (!ip) throw new Error('createPeerHeartbeat: ip is required');
+  // Validate as a parseable IPv4/IPv6 literal rather than just
+  // truthy. A misconfig that env-stringifies an undefined (passing
+  // the string `"undefined"`) would otherwise write a row whose
+  // `ip` field looks valid to DDB but is unreachable from the
+  // active's POST. `net.isIP` returns 0 for non-IPs, 4/6 otherwise.
+  if (!ip || net.isIP(ip) === 0) {
+    throw new Error('createPeerHeartbeat: ip (IPv4 or IPv6 literal) is required');
+  }
   // Validate port as a TCP port (positive integer, 1-65535) rather
   // than just `typeof === 'number'` — the latter accepts NaN, 0,
   // negatives, fractionals, and >65535 (all of which would produce

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -1,0 +1,153 @@
+// DDB-backed per-replica heartbeat for Pillar 3 standby discovery.
+// `gateway_lock` answers "who holds the lock"; this table answers
+// "where do I reach the *other* replica to hand off to" at SIGTERM.
+// The active replica scans this table, filters by freshness, picks
+// the row whose `instance_id != self`, and POSTs the push-handoff
+// HMAC body to `http://<ip>:<port>/control/yours`.
+//
+// Factory `createPeerHeartbeat` returns a per-replica instance. Tests
+// run isolated.
+//
+// ── Load-bearing contracts ──
+//
+// 1. Freshness filter is the correctness primitive, NOT DDB TTL.
+//    DDB TTL deletion is asynchronous (AWS publishes "typically within
+//    a few days"). A row visible past `expires_at` would cause the
+//    active to POST to a dead peer's IP and miss the handoff window.
+//    The application MUST filter peer rows by
+//    `updated_at > now - freshnessWindowSeconds` at READ time.
+//    Six seconds because the writer cadence is 2 s — three missed
+//    heartbeats = peer presumed dead. Do NOT treat TTL absence as
+//    a correctness signal; do NOT tighten the TTL to 6 s expecting
+//    it to substitute for the freshness filter (deletion lag would
+//    still leave stale rows visible).
+//
+// 2. Single PutItem per renewal — `updated_at` AND `expires_at`
+//    written together. Splitting them into separate ops creates a
+//    window where a partial write leaves the freshness signal and
+//    the TTL out of sync. One write per renewal.
+//
+// 3. TTL writer shape: epoch SECONDS, not milliseconds. Same
+//    convention as flow_state / gateway_lock — DDB TTL only
+//    understands seconds-since-epoch, ms would land ~50,000 years
+//    in the future to the reaper. `expires_at = floor(clock()/1000)
+//    + ttlSeconds`. TTL is 10× the freshness window (60 s default
+//    vs 6 s freshness) — long enough that a transient DDB write
+//    hiccup doesn't reap a live row.
+//
+// 4. Scan is the correct access pattern for this table. The single
+//    read use case is "find my peer" — one scan, sub-second on a
+//    table with at most a handful of rows. ConsistentRead is NOT
+//    needed (eventually-consistent reads have sub-second replication
+//    lag, well inside the 6 s freshness window, and ConsistentRead
+//    doubles RCU cost for no correctness benefit). If a future
+//    sharded topology pushes peer row count past ~100, revisit
+//    with a GSI on `shard_id`.
+
+const {
+  PutCommand,
+  ScanCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+
+const DEFAULT_FRESHNESS_WINDOW_SECONDS = 6;
+const DEFAULT_TTL_SECONDS = 60;
+
+function createPeerHeartbeat({
+  ddbClient,
+  tableName,
+  instanceId,
+  ip,
+  port,
+  shardId,
+  logger,
+  clock = () => Date.now(),
+  freshnessWindowSeconds = DEFAULT_FRESHNESS_WINDOW_SECONDS,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+} = {}) {
+  if (!ddbClient) throw new Error('createPeerHeartbeat: ddbClient is required');
+  if (!tableName) throw new Error('createPeerHeartbeat: tableName is required');
+  if (!instanceId) throw new Error('createPeerHeartbeat: instanceId is required');
+  if (!ip) throw new Error('createPeerHeartbeat: ip is required');
+  if (typeof port !== 'number') throw new Error('createPeerHeartbeat: port (number) is required');
+  if (!shardId) throw new Error('createPeerHeartbeat: shardId is required');
+  if (!logger) throw new Error('createPeerHeartbeat: logger is required');
+
+  function nowSeconds() {
+    return Math.floor(clock() / 1000);
+  }
+
+  // Write the heartbeat row. Called every ~2 s from the leader
+  // coordinator alongside `gateway-lock.renewLock` (regardless of
+  // whether THIS replica holds the lock — both active and standby
+  // heartbeat continuously so each can find the other). Idempotent
+  // PutItem; no CAS — heartbeats from this replica should always
+  // win against any earlier write. Throws on transport errors; the
+  // caller decides whether a missed heartbeat is fatal (it isn't —
+  // the freshness window absorbs up to three misses).
+  async function writeHeartbeat() {
+    const now = nowSeconds();
+    await ddbClient.send(new PutCommand({
+      TableName: tableName,
+      Item: {
+        instance_id: instanceId,
+        ip,
+        port,
+        shard_id: shardId,
+        updated_at: now,
+        expires_at: now + ttlSeconds,
+      },
+    }));
+  }
+
+  // Scan-and-filter for peers eligible to receive a push-handoff.
+  // Excludes self by `instance_id`, filters by
+  // `updated_at > now - freshnessWindowSeconds`, AND filters by
+  // `shard_id` so a future sharded topology routes correctly. Sorts
+  // freshest-first — the caller takes the head of the list. Returns
+  // [] if no fresh peer exists (caller falls through to the
+  // cold-fallback path).
+  async function listFreshPeers() {
+    const cutoff = nowSeconds() - freshnessWindowSeconds;
+    const result = await ddbClient.send(new ScanCommand({
+      TableName: tableName,
+    }));
+    const items = result.Items ?? [];
+    return items
+      .filter((row) => row.instance_id !== instanceId)
+      .filter((row) => row.shard_id === shardId)
+      .filter((row) => typeof row.updated_at === 'number' && row.updated_at > cutoff)
+      .sort((a, b) => b.updated_at - a.updated_at);
+  }
+
+  // Best-effort delete of this replica's own row at clean shutdown.
+  // The freshness filter at read time keeps stale rows invisible
+  // anyway, so this is a courtesy that closes the discovery window
+  // immediately rather than waiting up to `freshnessWindowSeconds`.
+  // Logs but doesn't throw on failure.
+  async function deleteOwnRow() {
+    try {
+      await ddbClient.send(new DeleteCommand({
+        TableName: tableName,
+        Key: { instance_id: instanceId },
+      }));
+      logger.debug('gateway-peer-heartbeat: deleted own row', { instanceId });
+    } catch (err) {
+      logger.warn('gateway-peer-heartbeat: delete own row failed', {
+        instanceId, error: err.message,
+      });
+    }
+  }
+
+  return {
+    writeHeartbeat,
+    listFreshPeers,
+    deleteOwnRow,
+  };
+}
+
+module.exports = {
+  createPeerHeartbeat,
+  DEFAULT_FRESHNESS_WINDOW_SECONDS,
+  DEFAULT_TTL_SECONDS,
+};

--- a/apps/discord/tests/gateway-lock.test.js
+++ b/apps/discord/tests/gateway-lock.test.js
@@ -1,0 +1,445 @@
+// Unit tests for src/gateway-lock.js — Pillar 3 leader-election
+// lock primitive. Pins the five load-bearing contracts:
+//
+//   1. Conditional-write IS the lock (TTL is janitor only).
+//   2. TTL writer shape is epoch SECONDS, never milliseconds.
+//   3. instance_id + version CAS guards renew/transfer against a
+//      stale-process-vs-peer-took-over race.
+//   4. Release uses DeleteItem (re-arms attribute_not_exists for
+//      clean handoff), not UpdateItem REMOVE.
+//   5. Acquire uses PutItem (single round-trip for the post-Delete
+//      row-absent case; idempotent on cond fail).
+//
+// Each contract has a real failure mode the test would catch in
+// production: a writer that sends ms-as-N TTL would leave rows
+// alive forever; a missing version CAS would let a zombie task
+// renew a lock peer has taken; etc.
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  UpdateCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+
+const {
+  createGatewayLock,
+  DEFAULT_TTL_SECONDS,
+} = require('../src/gateway-lock');
+
+// Synthesize a ConditionalCheckFailedException matching the AWS SDK
+// shape so the lock module's `err.name === 'ConditionalCheckFailedException'`
+// branches hit. Real DDB returns this; aws-sdk-client-mock's
+// `.rejects(err)` carries the .name through faithfully.
+function ccfe() {
+  const err = new Error('The conditional request failed');
+  err.name = 'ConditionalCheckFailedException';
+  return err;
+}
+
+function makeLock({ clock, ttlSeconds, instanceId = 'inst-A', lockHolder = 'task-A/inst-A' } = {}) {
+  const rawClient = new DynamoDBClient({});
+  const docClient = DynamoDBDocumentClient.from(rawClient);
+  const ddbMock = mockClient(docClient);
+  const logger = {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+  const lock = createGatewayLock({
+    ddbClient: docClient,
+    tableName: 'test-gateway-lock',
+    shardId: '0:1',
+    instanceId,
+    lockHolder,
+    logger,
+    clock,
+    ttlSeconds,
+  });
+  return { lock, ddbMock, logger };
+}
+
+describe('createGatewayLock — factory validation', () => {
+  it('throws when required args are missing', () => {
+    expect(() => createGatewayLock()).toThrow(/ddbClient is required/);
+    expect(() => createGatewayLock({ ddbClient: {} })).toThrow(/tableName is required/);
+    expect(() => createGatewayLock({ ddbClient: {}, tableName: 't' }))
+      .toThrow(/shardId is required/);
+    expect(() => createGatewayLock({ ddbClient: {}, tableName: 't', shardId: '0:1' }))
+      .toThrow(/instanceId is required/);
+    expect(() => createGatewayLock({ ddbClient: {}, tableName: 't', shardId: '0:1', instanceId: 'i' }))
+      .toThrow(/lockHolder is required/);
+    expect(() => createGatewayLock({
+      ddbClient: {}, tableName: 't', shardId: '0:1', instanceId: 'i', lockHolder: 'h',
+    })).toThrow(/logger is required/);
+  });
+});
+
+describe('acquireLock', () => {
+  it('writes the row with PutItem (not UpdateItem) and the documented condition expression', async () => {
+    // PutItem-vs-UpdateItem matters: the post-Delete row-absent case
+    // is a single round-trip with PutItem; UpdateItem would need a
+    // follow-up to write the full row. Contract 5.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await lock.acquireLock();
+
+    expect(result).toEqual({ acquired: true, version: 1 });
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input.ConditionExpression).toBe(
+      'attribute_not_exists(lock_holder) ' +
+      'OR attribute_not_exists(expires_at) ' +
+      'OR expires_at < :now'
+    );
+    // No UpdateItem on the cold acquire path.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('writes expires_at as epoch SECONDS (not milliseconds)', async () => {
+    // Contract 2 — DDB TTL only understands seconds-since-epoch. A
+    // ms-encoded value would land ~50,000 years in the future to the
+    // reaper and rows would live forever, breaking lock recovery.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000, ttlSeconds: 6 });
+    ddbMock.on(PutCommand).resolves({});
+
+    await lock.acquireLock();
+
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item.expires_at).toBe(1_700_000_006); // ms→s + 6s TTL
+    expect(item.expires_at).toBeLessThan(2_000_000_000); // sanity: not ms
+  });
+
+  it('returns acquired:false (not a throw) on ConditionalCheckFailedException', async () => {
+    // Peer holds the lock — we observe a cond fail and treat it as
+    // a soft "not yours yet" signal. Caller retries on the next
+    // heartbeat cycle.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).rejects(ccfe());
+
+    const result = await lock.acquireLock();
+
+    expect(result).toEqual({ acquired: false });
+    expect(logger.debug).toHaveBeenCalledWith(
+      'gateway-lock: acquire failed (peer holds live lease)',
+      expect.objectContaining({ shardId: '0:1' }),
+    );
+  });
+
+  it('propagates non-CCFE errors (transport failure → caller decides retry)', async () => {
+    // A throughput-exceeded or network blip is NOT "peer holds the
+    // lock." We want it to surface so the leader loop logs and
+    // retries on the next tick rather than silently thinking we
+    // acquired.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    const transportErr = new Error('ThroughputExceededException');
+    transportErr.name = 'ThroughputExceededException';
+    ddbMock.on(PutCommand).rejects(transportErr);
+
+    await expect(lock.acquireLock()).rejects.toThrow(/ThroughputExceededException/);
+  });
+
+  it('embeds expires_at < :now in the cond — :now is the caller wall clock at acquire time', async () => {
+    // The lock primitive's correctness over a clock-skewed peer
+    // depends on `:now` being self-evaluated (we trust our own clock
+    // for the freshness check; the `version` CAS catches misuse). If
+    // a refactor moved :now to a stored value, a stuck process
+    // could observe an old `:now` and re-acquire wrongly.
+    let nowMs = 1_700_000_000_000;
+    const { lock, ddbMock } = makeLock({ clock: () => nowMs });
+    ddbMock.on(PutCommand).resolves({});
+
+    await lock.acquireLock();
+    expect(ddbMock.commandCalls(PutCommand)[0].args[0].input.ExpressionAttributeValues[':now'])
+      .toBe(1_700_000_000);
+
+    nowMs = 1_700_000_010_000; // 10s later
+    await lock.acquireLock();
+    expect(ddbMock.commandCalls(PutCommand)[1].args[0].input.ExpressionAttributeValues[':now'])
+      .toBe(1_700_000_010);
+  });
+});
+
+describe('renewLock', () => {
+  it('uses UpdateItem with the CAS guard on instance_id + version', async () => {
+    // Contract 3 — version is the fencing token. Without `version =
+    // :expected`, a stale process whose lease expired and was re-
+    // acquired by a peer could accidentally succeed on a delayed
+    // renew (clock skew + a peer that took the cond branch). The
+    // CAS guard makes the renewer fail loud rather than silently
+    // overwrite a peer's row.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await lock.acquireLock(); // version → 1
+    const result = await lock.renewLock(); // version → 2
+
+    expect(result).toEqual({ renewed: true, version: 2 });
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ConditionExpression).toBe(
+      'instance_id = :self AND version = :expected'
+    );
+    expect(updateCall.ExpressionAttributeValues[':self']).toBe('inst-A');
+    expect(updateCall.ExpressionAttributeValues[':expected']).toBe(1);
+    expect(updateCall.ExpressionAttributeValues[':next']).toBe(2);
+  });
+
+  it('returns renewed:false and clears version on CAS fail (lock lost)', async () => {
+    // The peer took over (clock skew + we tarried, or we got network-
+    // partitioned past the lease). The renew CAS fails; we treat this
+    // as "you no longer hold the lock" so the leader-coordinator can
+    // tear down its WS rather than keep trying to renew a lock it
+    // doesn't own.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    await lock.acquireLock();
+    const result = await lock.renewLock();
+
+    expect(result).toEqual({ renewed: false });
+    expect(lock._getVersionForTest()).toBe(null);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-lock: renew CAS failed — lock lost',
+      expect.objectContaining({ shardId: '0:1', expectedVersion: 1 }),
+    );
+  });
+
+  it('returns renewed:false and warns if called before acquire', async () => {
+    // Defensive: a caller bug that calls renew without acquire would
+    // otherwise sit in an unreachable cond-fail branch. Surface it
+    // as a warn log so it shows up in observability.
+    const { lock, logger } = makeLock();
+    const result = await lock.renewLock();
+
+    expect(result).toEqual({ renewed: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-lock: renew called without prior acquire',
+      expect.objectContaining({ shardId: '0:1' }),
+    );
+  });
+
+  it('writes expires_at as epoch seconds on every renewal', async () => {
+    // Same TTL writer-shape contract as acquire — every write must
+    // be seconds, not ms.
+    let nowMs = 1_700_000_000_000;
+    const { lock, ddbMock } = makeLock({ clock: () => nowMs, ttlSeconds: 6 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await lock.acquireLock();
+    nowMs += 2000;
+    await lock.renewLock();
+
+    const renewExp = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+      .ExpressionAttributeValues[':exp'];
+    expect(renewExp).toBe(1_700_000_008); // (1_700_000_000_000 + 2000)ms→s + 6
+  });
+
+  it('uses the latest version as :expected across consecutive renews', async () => {
+    // Pins the version cursor advancing. Without this, a refactor
+    // that forgot to update `currentVersion` would cause the second
+    // renew to use stale :expected=1 instead of :expected=2, and
+    // the CAS would fail spuriously.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await lock.acquireLock(); // v1
+    await lock.renewLock(); // v2
+    await lock.renewLock(); // v3
+
+    expect(ddbMock.commandCalls(UpdateCommand)[1].args[0].input
+      .ExpressionAttributeValues[':expected']).toBe(2);
+    expect(ddbMock.commandCalls(UpdateCommand)[1].args[0].input
+      .ExpressionAttributeValues[':next']).toBe(3);
+  });
+});
+
+describe('transferLock', () => {
+  it('atomically rewrites instance_id + lock_holder + version in one UpdateItem', async () => {
+    // The whole point of transferLock vs release-then-acquire is no
+    // lock-released-but-not-acquired-yet window. One atomic
+    // UpdateItem with the CAS guard on `self` instance_id swaps
+    // ownership cleanly.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await lock.acquireLock();
+    const result = await lock.transferLock('inst-B', 'task-B/inst-B');
+
+    expect(result).toEqual({ transferred: true, version: 2 });
+    const updateInput = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateInput.ConditionExpression).toBe(
+      'instance_id = :self AND version = :expected'
+    );
+    expect(updateInput.ExpressionAttributeValues[':self']).toBe('inst-A');
+    expect(updateInput.ExpressionAttributeValues[':peer']).toBe('inst-B');
+    expect(updateInput.ExpressionAttributeValues[':peerHolder']).toBe('task-B/inst-B');
+    expect(updateInput.ExpressionAttributeValues[':next']).toBe(2);
+  });
+
+  it('clears the local version cursor on success (this process no longer holds the lock)', async () => {
+    // After transferLock, this process must stop heartbeating and
+    // tear down the WS. The version-null state is the local signal:
+    // subsequent renew/release calls become no-ops, and a future
+    // re-acquire would correctly start from version=1.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await lock.acquireLock();
+    await lock.transferLock('inst-B', 'task-B/inst-B');
+
+    expect(lock._getVersionForTest()).toBe(null);
+  });
+
+  it('returns transferred:false on CAS fail (caller falls through to clean exit)', async () => {
+    // Edge case the design doc names explicitly: version moved
+    // underneath us (peer crashed and the replacement acquired via
+    // the lease-lapse path) OR we don't actually hold the lock. The
+    // active falls through to a clean exit; the new peer reaches
+    // steady state via the ~7 s cold-fallback floor.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).rejects(ccfe());
+
+    await lock.acquireLock();
+    const result = await lock.transferLock('inst-B', 'task-B/inst-B');
+
+    expect(result).toEqual({ transferred: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-lock: transfer CAS failed',
+      expect.objectContaining({ shardId: '0:1', expectedVersion: 1 }),
+    );
+  });
+
+  it('returns transferred:false and warns if called before acquire', async () => {
+    const { lock, logger } = makeLock();
+    const result = await lock.transferLock('inst-B', 'task-B/inst-B');
+
+    expect(result).toEqual({ transferred: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-lock: transfer called without prior acquire',
+      expect.anything(),
+    );
+  });
+});
+
+describe('releaseLock', () => {
+  it('issues DeleteItem (not UpdateItem REMOVE) so the next acquire takes attribute_not_exists', async () => {
+    // Contract 4 — DeleteItem re-arms the attribute_not_exists branch
+    // on the cond expression, so a peer's next acquire is immediate.
+    // UpdateItem REMOVE would leave expires_at populated, forcing
+    // the peer to wait for it to lapse.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).resolves({});
+
+    await lock.acquireLock();
+    const result = await lock.releaseLock();
+
+    expect(result).toEqual({ released: true });
+    const deleteInput = ddbMock.commandCalls(DeleteCommand)[0].args[0].input;
+    expect(deleteInput.Key).toEqual({ shard_id: '0:1' });
+    expect(deleteInput.ConditionExpression).toBe('instance_id = :self');
+    expect(deleteInput.ExpressionAttributeValues[':self']).toBe('inst-A');
+    // No REMOVE-style UpdateItem.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('treats CAS fail as released:false (a peer took over while we were tearing down)', async () => {
+    // The CAS guard on instance_id prevents us from deleting a row
+    // a peer now owns. If this fired during a busy handoff window
+    // (transfer succeeded; the peer then re-acquired with a new
+    // version), our release CAS would fail and we want a soft
+    // released:false rather than an error — the lock is gone from
+    // our perspective, which is what we wanted.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(DeleteCommand).rejects(ccfe());
+
+    await lock.acquireLock();
+    const result = await lock.releaseLock();
+
+    expect(result).toEqual({ released: false });
+    expect(lock._getVersionForTest()).toBe(null);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-lock: release CAS failed (peer took over)',
+      expect.anything(),
+    );
+  });
+
+  it('best-effort on transport errors (logs error, returns released:false, does not throw)', async () => {
+    // Release is on the SIGTERM teardown path. We must not throw —
+    // the process is exiting and a throw would mask the cleaner
+    // released:false signal. The fallback is the lease lapse, which
+    // is the design's documented worst-case path.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    const transportErr = new Error('NetworkingError');
+    transportErr.name = 'NetworkingError';
+    ddbMock.on(DeleteCommand).rejects(transportErr);
+
+    await lock.acquireLock();
+    const result = await lock.releaseLock();
+
+    expect(result).toEqual({ released: false });
+    expect(lock._getVersionForTest()).toBe(null);
+    expect(logger.error).toHaveBeenCalledWith(
+      'gateway-lock: release failed',
+      expect.objectContaining({ error: 'NetworkingError' }),
+    );
+  });
+
+  it('is a no-op when called before acquire', async () => {
+    // The control-channel watchdog may call release on a path where
+    // acquire never succeeded. We should NOT attempt a DDB delete
+    // (it would do nothing anyway, but spending the call costs PPR
+    // read+write).
+    const { lock, ddbMock } = makeLock();
+    const result = await lock.releaseLock();
+
+    expect(result).toEqual({ released: false });
+    expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(0);
+  });
+});
+
+describe('readCurrentHolder', () => {
+  it('returns the row for diagnostic / health reads', async () => {
+    // Used by /health endpoint output and debug logs. Not in the
+    // lock-correctness path.
+    const { lock, ddbMock } = makeLock();
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        shard_id: '0:1', lock_holder: 'task-A/inst-A', instance_id: 'inst-A',
+        version: 3, expires_at: 1_700_000_006,
+      },
+    });
+
+    const result = await lock.readCurrentHolder();
+    expect(result.lock_holder).toBe('task-A/inst-A');
+    expect(result.version).toBe(3);
+  });
+
+  it('returns null when the row is absent', async () => {
+    const { lock, ddbMock } = makeLock();
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    expect(await lock.readCurrentHolder()).toBeNull();
+  });
+});
+
+describe('default TTL', () => {
+  it('exports the documented 6 second lease', () => {
+    // Pinning this constant matters: the cold-fallback floor math
+    // (~6 s + RESUME RTT ≈ 7 s) lives in the design doc. A silent
+    // bump to 15 s would push the floor out and invalidate the
+    // SLO arithmetic.
+    expect(DEFAULT_TTL_SECONDS).toBe(6);
+  });
+});

--- a/apps/discord/tests/gateway-lock.test.js
+++ b/apps/discord/tests/gateway-lock.test.js
@@ -227,6 +227,13 @@ describe('renewLock', () => {
     expect(updateCall.ExpressionAttributeValues[':self']).toBe('inst-A');
     expect(updateCall.ExpressionAttributeValues[':expected']).toBe(1);
     expect(updateCall.ExpressionAttributeValues[':next']).toBe(2);
+    // renew updates version + expires_at only — lock_holder is
+    // unchanged because we already hold the lock. Including it
+    // would waste a WCU byte per renew. Pin against accidental
+    // reintroduction.
+    expect(updateCall.UpdateExpression).toBe('SET version = :next, expires_at = :exp');
+    expect(updateCall.UpdateExpression).not.toMatch(/lock_holder/);
+    expect(updateCall.ExpressionAttributeValues[':holder']).toBeUndefined();
   });
 
   it('returns renewed:false and clears version on CAS fail (lock lost)', async () => {

--- a/apps/discord/tests/gateway-lock.test.js
+++ b/apps/discord/tests/gateway-lock.test.js
@@ -141,6 +141,48 @@ describe('acquireLock', () => {
     await expect(lock.acquireLock()).rejects.toThrow(/ThroughputExceededException/);
   });
 
+  it('treats expires_at === :now as still-live (strict < boundary)', async () => {
+    // The cond uses strict `expires_at < :now`. A peer whose lease
+    // expires at exactly `:now` should NOT be takeable yet — DDB
+    // rejects the cond and we return acquired:false. Pins the
+    // boundary against a refactor to `<=` that would shave 1s off
+    // the steady-state cold-fallback floor at the cost of a clock-
+    // skew race against the legitimate holder.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).rejects(ccfe()); // simulate DDB rejecting because expires_at == :now
+
+    const result = await lock.acquireLock();
+
+    expect(result).toEqual({ acquired: false });
+    // Pin that we're checking the right condition by inspecting the
+    // request payload — the cond text must say `<`, not `<=`.
+    const condText = ddbMock.commandCalls(PutCommand)[0].args[0].input.ConditionExpression;
+    expect(condText).toContain('expires_at < :now');
+    expect(condText).not.toContain('expires_at <= :now');
+  });
+
+  it('re-acquire while already holding is a soft no-op (DDB cond fails on live lease)', async () => {
+    // A caller bug that double-calls acquireLock without a release
+    // in between should NOT be treated as a renewal (which would
+    // require a CAS on the existing instance_id/version). The cond
+    // `expires_at < :now` fails against our own live lease, DDB
+    // rejects, we return acquired:false. The local `currentVersion`
+    // stays at the first acquire's value — important so the next
+    // renewLock CAS still works.
+    const { lock, ddbMock } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand)
+      .resolvesOnce({}) // first acquire wins
+      .rejects(ccfe()); // second acquire hits cond fail
+
+    const first = await lock.acquireLock();
+    expect(first).toEqual({ acquired: true, version: 1 });
+
+    const second = await lock.acquireLock();
+    expect(second).toEqual({ acquired: false });
+    // Cursor unchanged — the first acquire's version=1 is still valid.
+    expect(lock._getVersionForTest()).toBe(1);
+  });
+
   it('embeds expires_at < :now in the cond — :now is the caller wall clock at acquire time', async () => {
     // The lock primitive's correctness over a clock-skewed peer
     // depends on `:now` being self-evaluated (we trust our own clock
@@ -327,6 +369,92 @@ describe('transferLock', () => {
       'gateway-lock: transfer called without prior acquire',
       expect.anything(),
     );
+  });
+
+  it('rejects self-handoff (target === self) as no-op with warn', async () => {
+    // A caller bug — e.g., peer-discovery accidentally returns our
+    // own row — that called transferLock(self → self) would otherwise
+    // bump the version counter while keeping ownership, churning
+    // DDB for nothing. Reject at the API boundary so the failure
+    // surfaces as a warn log rather than silent state churn.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await lock.acquireLock();
+    const result = await lock.transferLock('inst-A', 'task-A/inst-A'); // same as constructor instanceId
+
+    expect(result).toEqual({ transferred: false });
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0); // no DDB write
+    expect(lock._getVersionForTest()).toBe(1); // cursor unchanged
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-lock: transferLock called with self as target (no-op)',
+      expect.anything(),
+    );
+  });
+});
+
+describe('adoptLockFromHandoff', () => {
+  it('seeds currentVersion so the new holder\'s next renewLock CAS passes', async () => {
+    // The load-bearing case: PR 13b.2's control-channel handler
+    // receives an HMAC-verified push, the active calls transferLock
+    // (DDB row now shows this replica as holder, version=v), and
+    // this call synchronizes the local cursor with that DDB state.
+    // Without it, the first renewLock hits the currentVersion===null
+    // guard and returns renewed:false — the standby would think it
+    // lost the lock it just received.
+    const { lock, ddbMock, logger } = makeLock({ clock: () => 1_700_000_000_000 });
+    ddbMock.on(UpdateCommand).resolves({});
+
+    lock.adoptLockFromHandoff(7); // active's prior version was 6, transferLock bumped to 7
+
+    expect(lock._getVersionForTest()).toBe(7);
+    expect(logger.info).toHaveBeenCalledWith(
+      'gateway-lock: adopted from handoff',
+      expect.objectContaining({ shardId: '0:1', instanceId: 'inst-A', version: 7 }),
+    );
+
+    // The next renewLock uses the adopted version as :expected.
+    await lock.renewLock();
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':expected']).toBe(7);
+    expect(updateCall.ExpressionAttributeValues[':next']).toBe(8);
+  });
+
+  it('does NOT write to DDB (caller is responsible for the prior transferLock)', async () => {
+    // Pure local-state-sync. The active's transferLock already
+    // wrote DDB; this call is just the new holder catching up its
+    // in-memory cursor.
+    const { lock, ddbMock } = makeLock();
+    lock.adoptLockFromHandoff(5);
+
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('throws on non-positive-integer version (defends against null/undefined/0/string from a malformed HMAC body)', () => {
+    // The HMAC body upstream carries the version as JSON-decoded number.
+    // A buggy upstream (or a forged body that passed the HMAC check
+    // somehow) could pass garbage. Fail loud so the standby's handler
+    // bubbles a clear error to the active rather than silently
+    // adopting an invalid cursor.
+    const { lock } = makeLock();
+    expect(() => lock.adoptLockFromHandoff(null)).toThrow(/positive integer version/);
+    expect(() => lock.adoptLockFromHandoff(undefined)).toThrow(/positive integer version/);
+    expect(() => lock.adoptLockFromHandoff(0)).toThrow(/positive integer version/);
+    expect(() => lock.adoptLockFromHandoff(-1)).toThrow(/positive integer version/);
+    expect(() => lock.adoptLockFromHandoff(1.5)).toThrow(/positive integer version/);
+    expect(() => lock.adoptLockFromHandoff('5')).toThrow(/positive integer version/);
+  });
+
+  it('is safe to call multiple times — cursor just re-anchors', async () => {
+    // Idempotency lets the control-channel handler retry-on-error
+    // without worrying about double-anchor side effects.
+    const { lock } = makeLock();
+    lock.adoptLockFromHandoff(5);
+    lock.adoptLockFromHandoff(5);
+    lock.adoptLockFromHandoff(7);
+    expect(lock._getVersionForTest()).toBe(7);
   });
 });
 

--- a/apps/discord/tests/gateway-peer-heartbeat.test.js
+++ b/apps/discord/tests/gateway-peer-heartbeat.test.js
@@ -52,7 +52,7 @@ describe('createPeerHeartbeat — factory validation', () => {
     })).toThrow(/ip is required/);
     expect(() => createPeerHeartbeat({
       ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1',
-    })).toThrow(/port \(number\) is required/);
+    })).toThrow(/port \(integer 1-65535\) is required/);
     expect(() => createPeerHeartbeat({
       ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1', port: 9876,
     })).toThrow(/shardId is required/);
@@ -61,15 +61,29 @@ describe('createPeerHeartbeat — factory validation', () => {
     })).toThrow(/logger is required/);
   });
 
-  it('rejects a non-number port (defends against string-from-env bug)', () => {
+  it('rejects invalid ports (string, NaN, 0, negative, >65535, fractional)', () => {
     // The control-channel port comes from config (env). A bug that
-    // forgot to parseInt would surface as a string "9876" which would
-    // serialize into DDB as an S-type, and DDB readers expecting N
-    // would skip it. Catch at construction.
-    expect(() => createPeerHeartbeat({
+    // forgot to parseInt would surface as a string; an off-by-one in
+    // a port-allocator could overflow 65535; a leftover sentinel could
+    // pass 0 or -1. All of these would produce an unreachable peer
+    // entry; catch them at construction so a misconfig fails boot
+    // rather than failing the first handoff POST.
+    const base = {
       ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1',
-      port: '9876', shardId: '0:1', logger: {},
-    })).toThrow(/port \(number\) is required/);
+      shardId: '0:1', logger: {},
+    };
+    expect(() => createPeerHeartbeat({ ...base, port: '9876' }))
+      .toThrow(/port \(integer 1-65535\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, port: NaN }))
+      .toThrow(/port \(integer 1-65535\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, port: 0 }))
+      .toThrow(/port \(integer 1-65535\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, port: -1 }))
+      .toThrow(/port \(integer 1-65535\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, port: 65536 }))
+      .toThrow(/port \(integer 1-65535\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, port: 9876.5 }))
+      .toThrow(/port \(integer 1-65535\) is required/);
   });
 });
 

--- a/apps/discord/tests/gateway-peer-heartbeat.test.js
+++ b/apps/discord/tests/gateway-peer-heartbeat.test.js
@@ -49,7 +49,7 @@ describe('createPeerHeartbeat — factory validation', () => {
       .toThrow(/instanceId is required/);
     expect(() => createPeerHeartbeat({
       ddbClient: {}, tableName: 't', instanceId: 'i',
-    })).toThrow(/ip is required/);
+    })).toThrow(/ip \(IPv4 or IPv6 literal\) is required/);
     expect(() => createPeerHeartbeat({
       ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1',
     })).toThrow(/port \(integer 1-65535\) is required/);
@@ -59,6 +59,39 @@ describe('createPeerHeartbeat — factory validation', () => {
     expect(() => createPeerHeartbeat({
       ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1', port: 9876, shardId: '0:1',
     })).toThrow(/logger is required/);
+  });
+
+  it('rejects invalid IPs (literal "undefined" from env-stringification, garbage strings, IPs masked as identifiers)', () => {
+    // The classic failure mode: a misconfigured Fargate task that
+    // env-stringifies an undefined IP-resolution result lands the
+    // literal string `"undefined"` on the row. To DDB it's a valid
+    // S value, to the active's POST it's an unreachable hostname.
+    // net.isIP() returns 0 for non-IPs, 4/6 for valid literals.
+    const base = {
+      ddbClient: {}, tableName: 't', instanceId: 'i', port: 9876,
+      shardId: '0:1', logger: {},
+    };
+    expect(() => createPeerHeartbeat({ ...base, ip: 'undefined' }))
+      .toThrow(/ip \(IPv4 or IPv6 literal\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, ip: 'not.an.ip' }))
+      .toThrow(/ip \(IPv4 or IPv6 literal\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, ip: '999.999.999.999' }))
+      .toThrow(/ip \(IPv4 or IPv6 literal\) is required/);
+    expect(() => createPeerHeartbeat({ ...base, ip: 'fe80::1::2' })) // malformed v6
+      .toThrow(/ip \(IPv4 or IPv6 literal\) is required/);
+  });
+
+  it('accepts both IPv4 and IPv6 literals', () => {
+    // Fargate tasks today get IPv4 from the awsvpc network mode,
+    // but ECS supports IPv6-only assigments and the field should
+    // accept either.
+    const base = {
+      ddbClient: {}, tableName: 't', instanceId: 'i', port: 9876,
+      shardId: '0:1', logger: {},
+    };
+    expect(() => createPeerHeartbeat({ ...base, ip: '10.0.0.1' })).not.toThrow();
+    expect(() => createPeerHeartbeat({ ...base, ip: 'fe80::1' })).not.toThrow();
+    expect(() => createPeerHeartbeat({ ...base, ip: '::1' })).not.toThrow();
   });
 
   it('rejects invalid ports (string, NaN, 0, negative, >65535, fractional)', () => {

--- a/apps/discord/tests/gateway-peer-heartbeat.test.js
+++ b/apps/discord/tests/gateway-peer-heartbeat.test.js
@@ -1,0 +1,335 @@
+// Unit tests for src/gateway-peer-heartbeat.js — Pillar 3 standby
+// discovery. Pins the four load-bearing contracts:
+//
+//   1. Freshness filter is the correctness primitive, NOT DDB TTL.
+//   2. Single PutItem per renewal — updated_at + expires_at together.
+//   3. TTL writer shape is epoch SECONDS, never milliseconds.
+//   4. Scan + filter is the correct access pattern (consistency at
+//      6s freshness; small row count).
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  ScanCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+
+const {
+  createPeerHeartbeat,
+  DEFAULT_FRESHNESS_WINDOW_SECONDS,
+  DEFAULT_TTL_SECONDS,
+} = require('../src/gateway-peer-heartbeat');
+
+function makeHeartbeat({
+  clock, freshnessWindowSeconds, ttlSeconds,
+  instanceId = 'inst-A', ip = '10.0.1.5', port = 9876, shardId = '0:1',
+} = {}) {
+  const rawClient = new DynamoDBClient({});
+  const docClient = DynamoDBDocumentClient.from(rawClient);
+  const ddbMock = mockClient(docClient);
+  const logger = {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+  const heartbeat = createPeerHeartbeat({
+    ddbClient: docClient,
+    tableName: 'test-gateway-peer-heartbeat',
+    instanceId, ip, port, shardId, logger, clock,
+    freshnessWindowSeconds, ttlSeconds,
+  });
+  return { heartbeat, ddbMock, logger };
+}
+
+describe('createPeerHeartbeat — factory validation', () => {
+  it('throws when required args are missing', () => {
+    expect(() => createPeerHeartbeat()).toThrow(/ddbClient is required/);
+    expect(() => createPeerHeartbeat({ ddbClient: {} })).toThrow(/tableName is required/);
+    expect(() => createPeerHeartbeat({ ddbClient: {}, tableName: 't' }))
+      .toThrow(/instanceId is required/);
+    expect(() => createPeerHeartbeat({
+      ddbClient: {}, tableName: 't', instanceId: 'i',
+    })).toThrow(/ip is required/);
+    expect(() => createPeerHeartbeat({
+      ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1',
+    })).toThrow(/port \(number\) is required/);
+    expect(() => createPeerHeartbeat({
+      ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1', port: 9876,
+    })).toThrow(/shardId is required/);
+    expect(() => createPeerHeartbeat({
+      ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1', port: 9876, shardId: '0:1',
+    })).toThrow(/logger is required/);
+  });
+
+  it('rejects a non-number port (defends against string-from-env bug)', () => {
+    // The control-channel port comes from config (env). A bug that
+    // forgot to parseInt would surface as a string "9876" which would
+    // serialize into DDB as an S-type, and DDB readers expecting N
+    // would skip it. Catch at construction.
+    expect(() => createPeerHeartbeat({
+      ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1',
+      port: '9876', shardId: '0:1', logger: {},
+    })).toThrow(/port \(number\) is required/);
+  });
+});
+
+describe('writeHeartbeat', () => {
+  it('writes updated_at AND expires_at in the SAME PutItem (contract 2)', async () => {
+    // Splitting these into two ops creates a window where the
+    // freshness signal (updated_at) and the TTL marker (expires_at)
+    // disagree — a partial write could leave a row visible past its
+    // intended reap, or reap a row whose freshness is still good.
+    // Single PutItem keeps them lock-step.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_000_000, ttlSeconds: 60,
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    await heartbeat.writeHeartbeat();
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    const item = putCalls[0].args[0].input.Item;
+    expect(item.updated_at).toBe(1_700_000_000);
+    expect(item.expires_at).toBe(1_700_000_060); // updated_at + ttl
+  });
+
+  it('writes expires_at as epoch SECONDS (not milliseconds)', async () => {
+    // Contract 3 — same TTL writer shape as gateway-session-store /
+    // gateway-lock. Pinning this catches a refactor that introduces
+    // a `clock()` change (returns seconds instead of ms) without
+    // updating the divide-by-1000.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_000_000,
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    await heartbeat.writeHeartbeat();
+
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item.expires_at).toBeLessThan(2_000_000_000); // sanity: not ms
+    expect(item.updated_at).toBeLessThan(2_000_000_000);
+  });
+
+  it('persists ip, port, shard_id alongside the timestamps', async () => {
+    // The handoff path POSTs to http://<ip>:<port>/control/yours.
+    // Missing any of these on the row makes the peer unreachable
+    // even after a fresh write.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_000_000,
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    await heartbeat.writeHeartbeat();
+
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item).toMatchObject({
+      instance_id: 'inst-A',
+      ip: '10.0.1.5',
+      port: 9876,
+      shard_id: '0:1',
+    });
+  });
+
+  it('uses no condition expression — idempotent overwrite is the desired shape', async () => {
+    // Heartbeats from THIS replica should always win against any
+    // earlier write. No CAS, no version. A retry of a same-second
+    // heartbeat just overwrites the previous one with identical
+    // fields — harmless.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_000_000,
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    await heartbeat.writeHeartbeat();
+
+    const putInput = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(putInput.ConditionExpression).toBeUndefined();
+  });
+
+  it('throws on transport error (caller decides whether a missed beat is fatal)', async () => {
+    // A single missed heartbeat is fine — the freshness window
+    // absorbs three. The leader coordinator catches this and
+    // continues. The module's contract is "throw on transport
+    // failure so the caller can log + count" rather than
+    // silently swallow.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_000_000,
+    });
+    ddbMock.on(PutCommand).rejects(new Error('throughput exceeded'));
+
+    await expect(heartbeat.writeHeartbeat()).rejects.toThrow(/throughput exceeded/);
+  });
+});
+
+describe('listFreshPeers', () => {
+  it('returns peers whose updated_at is within the freshness window', async () => {
+    // Contract 1 — freshness filter at read time. A row past
+    // `updated_at + freshnessWindowSeconds` must be invisible to
+    // the active even if DDB TTL hasn't reaped it.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_010_000, // now = 1700000010
+      freshnessWindowSeconds: 6,
+    });
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { instance_id: 'inst-A', shard_id: '0:1', updated_at: 1_700_000_009, ip: '10.0.0.1', port: 9876 }, // self — excluded
+        { instance_id: 'inst-B', shard_id: '0:1', updated_at: 1_700_000_008, ip: '10.0.0.2', port: 9876 }, // fresh (2s ago)
+        { instance_id: 'inst-C', shard_id: '0:1', updated_at: 1_700_000_003, ip: '10.0.0.3', port: 9876 }, // stale (7s ago)
+        { instance_id: 'inst-D', shard_id: '0:1', updated_at: 1_700_000_005, ip: '10.0.0.4', port: 9876 }, // fresh edge (5s ago)
+      ],
+    });
+
+    const peers = await heartbeat.listFreshPeers();
+    const ids = peers.map((p) => p.instance_id);
+    expect(ids).toEqual(['inst-B', 'inst-D']); // self excluded; inst-C stale; freshest first
+  });
+
+  it('excludes the active replica\'s own row by instance_id', async () => {
+    // Even if our own heartbeat is fresh (it always is — we wrote
+    // it 2s ago), we don't push-handoff to ourselves.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_010_000, freshnessWindowSeconds: 6,
+    });
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { instance_id: 'inst-A', shard_id: '0:1', updated_at: 1_700_000_009, ip: '10.0.0.1', port: 9876 },
+      ],
+    });
+
+    expect(await heartbeat.listFreshPeers()).toEqual([]);
+  });
+
+  it('filters by shard_id so a future sharded topology routes correctly', async () => {
+    // Today every replica carries `"0:1"` so this is a no-op, but
+    // the filter must be in place for the sharded future — otherwise
+    // shard 0's active would scan shard 5's standby and POST to
+    // the wrong target.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_010_000, freshnessWindowSeconds: 6,
+    });
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { instance_id: 'inst-B', shard_id: '0:1', updated_at: 1_700_000_009, ip: '10.0.0.2', port: 9876 },
+        { instance_id: 'inst-C', shard_id: '5:8', updated_at: 1_700_000_009, ip: '10.0.0.3', port: 9876 },
+      ],
+    });
+
+    const peers = await heartbeat.listFreshPeers();
+    expect(peers.map((p) => p.instance_id)).toEqual(['inst-B']);
+  });
+
+  it('sorts freshest-first so the caller takes the head of the list', async () => {
+    // Multiple fresh peers (a transient overlap during deploy) —
+    // the active picks the most recently heartbeating one because
+    // it's the most likely to still be alive when the POST lands.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_010_000, freshnessWindowSeconds: 6,
+    });
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { instance_id: 'inst-B', shard_id: '0:1', updated_at: 1_700_000_006, ip: '10.0.0.2', port: 9876 },
+        { instance_id: 'inst-C', shard_id: '0:1', updated_at: 1_700_000_009, ip: '10.0.0.3', port: 9876 },
+        { instance_id: 'inst-D', shard_id: '0:1', updated_at: 1_700_000_008, ip: '10.0.0.4', port: 9876 },
+      ],
+    });
+
+    const peers = await heartbeat.listFreshPeers();
+    expect(peers.map((p) => p.instance_id)).toEqual(['inst-C', 'inst-D', 'inst-B']);
+  });
+
+  it('drops rows whose updated_at is missing or non-numeric (defensive against partial writes)', async () => {
+    // A corrupted row from a manual operator write, or a partial
+    // failure in some future updater, should not surface as a
+    // peer candidate. Same defense shape as gateway-session-store's
+    // malformed-row hydrate path.
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_010_000, freshnessWindowSeconds: 6,
+    });
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { instance_id: 'inst-B', shard_id: '0:1', updated_at: 1_700_000_009, ip: '10.0.0.2', port: 9876 },
+        { instance_id: 'inst-C', shard_id: '0:1', ip: '10.0.0.3', port: 9876 }, // missing updated_at
+        { instance_id: 'inst-D', shard_id: '0:1', updated_at: 'recently', ip: '10.0.0.4', port: 9876 }, // string
+      ],
+    });
+
+    const peers = await heartbeat.listFreshPeers();
+    expect(peers.map((p) => p.instance_id)).toEqual(['inst-B']);
+  });
+
+  it('returns [] when the scan returns no Items (empty table cold start)', async () => {
+    // Standby hasn't booted yet. The active falls through to the
+    // cold-fallback path (~7 s floor).
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => 1_700_000_010_000,
+    });
+    ddbMock.on(ScanCommand).resolves({}); // no Items key at all
+
+    expect(await heartbeat.listFreshPeers()).toEqual([]);
+  });
+
+  it('cutoff is computed from caller-wall-clock, not stored value', async () => {
+    // Symmetric to the lock module's `:now` contract — the freshness
+    // boundary depends on OUR clock. A refactor that cached `cutoff`
+    // somewhere would let the boundary drift and stale peers
+    // re-appear.
+    let nowMs = 1_700_000_010_000;
+    const { heartbeat, ddbMock } = makeHeartbeat({
+      clock: () => nowMs, freshnessWindowSeconds: 6,
+    });
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { instance_id: 'inst-B', shard_id: '0:1', updated_at: 1_700_000_005, ip: '10.0.0.2', port: 9876 },
+      ],
+    });
+
+    expect(await heartbeat.listFreshPeers()).toHaveLength(1); // 5s ago: still fresh
+
+    nowMs = 1_700_000_020_000; // 15s later
+    expect(await heartbeat.listFreshPeers()).toEqual([]); // 15s ago: stale
+  });
+});
+
+describe('deleteOwnRow', () => {
+  it('issues DeleteItem keyed by self instance_id (best-effort, no CAS)', async () => {
+    // Called at clean shutdown to close the discovery window
+    // immediately rather than waiting for the freshness boundary.
+    // No CAS — this row is ours by construction (PK).
+    const { heartbeat, ddbMock } = makeHeartbeat();
+    ddbMock.on(DeleteCommand).resolves({});
+
+    await heartbeat.deleteOwnRow();
+
+    const deleteCalls = ddbMock.commandCalls(DeleteCommand);
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].args[0].input.Key).toEqual({ instance_id: 'inst-A' });
+    expect(deleteCalls[0].args[0].input.ConditionExpression).toBeUndefined();
+  });
+
+  it('logs but does not throw on transport error (SIGTERM path must stay clean)', async () => {
+    // Called from gracefulShutdown. A throw would unwind into the
+    // shutdown handler and mask the cleaner exit path. The freshness
+    // filter is the actual safety net — this delete is hygiene.
+    const { heartbeat, ddbMock, logger } = makeHeartbeat();
+    ddbMock.on(DeleteCommand).rejects(new Error('network blip'));
+
+    await expect(heartbeat.deleteOwnRow()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-peer-heartbeat: delete own row failed',
+      expect.objectContaining({ instanceId: 'inst-A', error: 'network blip' }),
+    );
+  });
+});
+
+describe('default constants', () => {
+  it('exports the documented freshness window (6s) and TTL (60s, 10x the window)', () => {
+    // Pinning these matters: 6 s freshness is what bounds the
+    // "three missed heartbeats = dead" semantic; 60 s TTL is 10×
+    // the window per the table comment so a transient write hiccup
+    // doesn't reap a live row.
+    expect(DEFAULT_FRESHNESS_WINDOW_SECONDS).toBe(6);
+    expect(DEFAULT_TTL_SECONDS).toBe(60);
+    expect(DEFAULT_TTL_SECONDS).toBe(DEFAULT_FRESHNESS_WINDOW_SECONDS * 10);
+  });
+});


### PR DESCRIPTION
## Summary

First of three PRs splitting Pillar 3 (hot-standby gateway pair). This one adds two pure DDB modules — `gateway-lock.js` and `gateway-peer-heartbeat.js` — with **no wiring**. Flag-off, flag-on, and runtime behavior are unchanged. The leader coordinator (PR 13b.2) composes them; the index.js integration (PR 13b.3) puts the whole stack behind a default-off `ENABLE_GATEWAY_HOT_STANDBY` flag.

## Why split

Pillar 3's app side is genuinely bigger than Pillar 2 — lock primitive + heartbeat primitive + HMAC control-channel HTTP server + leader coordinator with watchdog + index.js wiring + boot-requirements. As one PR it lands as 3-5k LOC and a cr loop nightmare. The split lets each surface ship with focused review.

## Modules

### `src/gateway-lock.js`
Per-shard leader-election lock over the `gateway_lock` DDB table (PK = `shard_id`). Five load-bearing contracts:

1. **Conditional-write IS the lock primitive** (TTL is janitor only). DDB TTL deletion is async with a multi-day SLA — every code path must trust the `ConditionExpression` on every write, never trust TTL absence.
2. **TTL writer shape is epoch SECONDS**, never milliseconds. A ms-encoded value would land ~50,000 years in the future to the DDB reaper.
3. **`instance_id` + `version` CAS guards renew/transfer** against the stale-task-vs-peer-took-over race. Version is the fencing token (cf. Kleppmann).
4. **Release uses `DeleteItem`**, not `UpdateItem REMOVE`. REMOVE would leave `expires_at` populated, forcing a peer's next acquire to wait for the lease to lapse. DeleteItem re-arms the `attribute_not_exists` branch.
5. **Acquire uses `PutItem`** (single round-trip for the post-Delete row-absent case; idempotent on cond fail).

### `src/gateway-peer-heartbeat.js`
Per-replica heartbeat over the `gateway_peer_heartbeat` DDB table (PK = `instance_id`). Four load-bearing contracts:

1. **Freshness filter at READ time IS the correctness primitive**, NOT DDB TTL. A row past `updated_at + freshnessWindowSeconds` must be invisible to the active even if DDB TTL hasn't reaped it.
2. **Single PutItem per renewal** — `updated_at` + `expires_at` written together. Splitting them creates a partial-state window.
3. **TTL writer shape is epoch SECONDS** (same convention as `flow_state` / `gateway_lock`).
4. **Scan + filter is the correct access pattern** (small row count, sub-second consistency, ConsistentRead doubles RCU for no correctness benefit).

## Test plan

- [x] Full local jest suite green (2075 tests, +41 new in this PR)
- [x] Lint clean
- [ ] PR 13b.2 (control-channel + leader coordinator) consumes these modules
- [ ] PR 13b.3 (index.js wiring) puts the whole stack behind `ENABLE_GATEWAY_HOT_STANDBY` (default off)

## Architecture

This PR is **pure additive code** — two new src modules, two new test files, zero imports from existing src. Module pre-tested in isolation; integration validation arrives with PR 13b.2.

The conditional-write contracts mirror the table comments in [qurl-integrations-infra PR #617](https://github.com/layervai/qurl-integrations-infra/pull/617) (lock table) and [PR #620](https://github.com/layervai/qurl-integrations-infra/pull/620) (peer-heartbeat table) — see those for the field-by-field rationale. The design doc at `apps/discord/docs/zero-downtime-design.md` §Pillar 3 is the authoritative source for the lease cadence (2s renew / 6s TTL) and freshness window (6s).

## Pillar 3 PR sequence

- **PR 13b.1 (this PR)**: `gateway-lock.js` + `gateway-peer-heartbeat.js` (pure modules)
- **PR 13b.2**: control-channel HTTP server (HMAC verify + nonce LRU + freshness check) + leader coordinator + connection-watchdog
- **PR 13b.3**: `index.js` wiring + `boot-requirements` combo guards + `.env.example` + flag default-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)