### PR TITLE
feat(discord): pillar 3 control channel + leader coordinator

### DIFF
--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -57,6 +57,16 @@ const BACKOFF_CAP_MS = 5_000;
 function createConnectionWatchdog({
   manager,
   isHoldingLock,
+  // Optional. Returns true when the leader is itself mid-
+  // `manager.connect()` (inbound-handoff path); the watchdog backs
+  // off rather than race a second concurrent connect. Default
+  // `() => false` keeps tests + non-leader callers simple, but
+  // production wiring (PR 13b.3) MUST pass the leader's
+  // `isConnecting()` — without it, an inbound-handoff connect
+  // taking >1 s would race the next watchdog tick and produce
+  // overlapping connect() calls against the non-concurrency-safe
+  // WebSocketManager.
+  isConnecting = () => false,
   releaseLock,
   logger,
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
@@ -71,6 +81,9 @@ function createConnectionWatchdog({
   }
   if (typeof isHoldingLock !== 'function') {
     throw new Error('createConnectionWatchdog: isHoldingLock function is required');
+  }
+  if (typeof isConnecting !== 'function') {
+    throw new Error('createConnectionWatchdog: isConnecting must be a function');
   }
   if (typeof releaseLock !== 'function') {
     throw new Error('createConnectionWatchdog: releaseLock function is required');
@@ -91,6 +104,16 @@ function createConnectionWatchdog({
       return;
     }
     if (manager.isConnected()) {
+      attempts = 0;
+      return;
+    }
+    // Leader is mid-connect (inbound-handoff path). Stand down —
+    // don't race a second concurrent connect against the same
+    // WebSocketManager. Reset attempts so the leader's eventual
+    // success doesn't leave a stale failure ladder behind, and
+    // its eventual failure starts the ladder cleanly from 1 on
+    // the next tick when isConnecting() returns false again.
+    if (isConnecting()) {
       attempts = 0;
       return;
     }

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -118,6 +118,12 @@ function createConnectionWatchdog({
   // calls it from the `start()` loop. Returns once the iteration
   // (including any failure-path backoff sleep) settles.
   async function step() {
+    // Terminal-state guard. After the exhaustion-exit branch sets
+    // closed=true, the production loop stops. But _stepForTest can
+    // still be called manually post-exit; without this guard a
+    // re-entry would re-fire releaseLock + deleteOwnRow. Test-tool
+    // robustness only; production never re-enters.
+    if (closed) return;
     if (!isHoldingLock()) {
       attempts = 0;
       return;

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -53,6 +53,13 @@ const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_ATTEMPTS = 5;
 const BACKOFF_BASE_MS = 100;
 const BACKOFF_CAP_MS = 5_000;
+// Ceilings below bound the WATCHDOG's own failure-replace path —
+// they're NOT on the SIGTERM critical path (which has its own
+// ~200 ms client-side cap in gateway-leader.js's pushHandoff). A
+// stuck standby holding the failover slot is what these protect
+// against; worst-case watchdog tick at exhaustion is CONNECT +
+// RELEASE_LOCK ≈ 11 s, well inside the 30 s ECS graceful-stop.
+//
 // Hard ceiling on the releaseLock-during-exit call. The leader's
 // releaseLockForImmediateExit awaits through `runSerialized`, so a
 // hung inbound-handoff (parked inside manager.connect() with

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -57,16 +57,16 @@ const BACKOFF_CAP_MS = 5_000;
 function createConnectionWatchdog({
   manager,
   isHoldingLock,
-  // Optional. Returns true when the leader is itself mid-
+  // REQUIRED. Returns true when the leader is itself mid-
   // `manager.connect()` (inbound-handoff path); the watchdog backs
-  // off rather than race a second concurrent connect. Default
-  // `() => false` keeps tests + non-leader callers simple, but
-  // production wiring (PR 13b.3) MUST pass the leader's
-  // `isConnecting()` — without it, an inbound-handoff connect
-  // taking >1 s would race the next watchdog tick and produce
-  // overlapping connect() calls against the non-concurrency-safe
-  // WebSocketManager.
-  isConnecting = () => false,
+  // off rather than race a second concurrent connect. Required
+  // because the race is otherwise silent: an inbound-handoff connect
+  // taking >1 s would produce overlapping connect() calls against
+  // the non-concurrency-safe WebSocketManager. A wiring oversight
+  // failing loud at boot is preferable to a rare production race.
+  // Tests that don't exercise the inbound-handoff path can pass
+  // `() => false`.
+  isConnecting,
   releaseLock,
   logger,
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
@@ -83,7 +83,7 @@ function createConnectionWatchdog({
     throw new Error('createConnectionWatchdog: isHoldingLock function is required');
   }
   if (typeof isConnecting !== 'function') {
-    throw new Error('createConnectionWatchdog: isConnecting must be a function');
+    throw new Error('createConnectionWatchdog: isConnecting function is required');
   }
   if (typeof releaseLock !== 'function') {
     throw new Error('createConnectionWatchdog: releaseLock function is required');

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -61,6 +61,16 @@ const BACKOFF_CAP_MS = 5_000;
 // chain forever and exit(1) would never fire. 3 s is generous
 // vs. the 1 s expected DDB RTT; on miss we log and exit anyway.
 const RELEASE_LOCK_CEILING_MS = 3_000;
+// Hard ceiling on the watchdog's `manager.connect()` await. Mirrors
+// the leader's `inboundConnectTimeoutMs` (5 s default) — a hung
+// connect would otherwise pin the tick forever, attempts wouldn't
+// advance, and the `exit(1)` recovery would never fire. 8 s is
+// generous vs. Discord WS cold-connect's 1-3 s typical, slightly
+// wider than the leader's 5 s to leave headroom for the watchdog's
+// fail-loud-then-replace posture (the leader caps tighter because
+// it's gated on the SIGTERM ECS deadline). On timeout we throw
+// like a connect rejection; the attempts ladder advances normally.
+const CONNECT_CEILING_MS = 8_000;
 
 function createConnectionWatchdog({
   manager,
@@ -85,6 +95,9 @@ function createConnectionWatchdog({
   // the ~1 s expected DDB RTT; on miss we log and exit anyway.
   // Injected for tests so the ceiling can be tuned tiny.
   releaseLockCeilingMs = RELEASE_LOCK_CEILING_MS,
+  // Hard ceiling on the inline `manager.connect()` call. See
+  // CONNECT_CEILING_MS above for rationale. Injected for tests.
+  connectCeilingMs = CONNECT_CEILING_MS,
   // Optional. If provided, called best-effort on the exhaustion-exit
   // path alongside releaseLock. Symmetric to gateway-leader.js's
   // SIGTERM pushHandoff path which also deletes the row. Without
@@ -125,6 +138,34 @@ function createConnectionWatchdog({
   if (!Number.isInteger(pollIntervalMs) || pollIntervalMs <= 0) {
     throw new Error('createConnectionWatchdog: pollIntervalMs must be a positive integer');
   }
+  if (!Number.isInteger(releaseLockCeilingMs) || releaseLockCeilingMs <= 0) {
+    throw new Error('createConnectionWatchdog: releaseLockCeilingMs must be a positive integer');
+  }
+  if (!Number.isInteger(connectCeilingMs) || connectCeilingMs <= 0) {
+    throw new Error('createConnectionWatchdog: connectCeilingMs must be a positive integer');
+  }
+
+  // Races `promise` against a `ceilingMs` timer that rejects with a
+  // labeled Error. Used to bound `manager.connect()` and
+  // `releaseLock()` — either could hang and pin the failure-exit
+  // recovery path. Mirrors `gateway-leader.js`'s
+  // `inboundConnectTimeoutMs` pattern.
+  async function raceWithCeiling(promise, ceilingMs, label) {
+    let timer;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`${label}_${ceilingMs}ms`)),
+            ceilingMs,
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
 
   let running = false;
   let loopPromise = null;
@@ -162,7 +203,9 @@ function createConnectionWatchdog({
 
     attempts += 1;
     try {
-      await manager.connect();
+      // Bounded by CONNECT_CEILING_MS — a hung connect would otherwise
+      // pin this tick and the failure-exit recovery would never fire.
+      await raceWithCeiling(manager.connect(), connectCeilingMs, 'watchdog_connect_ceiling');
       attempts = 0;
       logger.info('connection-watchdog: connect succeeded');
     } catch (err) {
@@ -171,24 +214,14 @@ function createConnectionWatchdog({
           error: err.message, attempts,
         });
         try {
-          // Race against a hard ceiling. The leader's
+          // Bounded by RELEASE_LOCK_CEILING_MS — the leader's
           // releaseLockForImmediateExit awaits through its
-          // serialization chain, so a hung inbound-handoff (parked
+          // serialization chain; a hung inbound-handoff (parked
           // inside manager.connect() with `connecting=true` latched)
-          // would block the chain forever. Without the race, exit(1)
-          // would never fire — the failover slot stays held with
-          // no live gateway. On ceiling miss we log and exit anyway;
-          // the row fades via TTL.
-          let releaseTimer;
-          await Promise.race([
-            releaseLock(),
-            new Promise((_, reject) => {
-              releaseTimer = setTimeout(
-                () => reject(new Error(`release_lock_ceiling_${releaseLockCeilingMs}ms`)),
-                releaseLockCeilingMs,
-              );
-            }),
-          ]).finally(() => clearTimeout(releaseTimer));
+          // would block the chain forever and exit(1) would never
+          // fire. On ceiling miss we log and exit anyway; the row
+          // fades via TTL.
+          await raceWithCeiling(releaseLock(), releaseLockCeilingMs, 'release_lock_ceiling');
         } catch (rerr) {
           // Logged-and-swallowed: we're already in the failure-exit
           // path; refusing to exit because of a DDB blip — or the

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -100,6 +100,14 @@ function createConnectionWatchdog({
     throw new Error('createConnectionWatchdog: releaseLock function is required');
   }
   if (!logger) throw new Error('createConnectionWatchdog: logger is required');
+  // maxAttempts=0 would exit(1) on the first tick; pollIntervalMs=0
+  // would saturate the loop. Fail loud at boot.
+  if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
+    throw new Error('createConnectionWatchdog: maxAttempts must be a positive integer');
+  }
+  if (!Number.isInteger(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new Error('createConnectionWatchdog: pollIntervalMs must be a positive integer');
+  }
 
   let running = false;
   let loopPromise = null;

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -175,17 +175,24 @@ function createConnectionWatchdog({
   }
 
   function start() {
-    if (running || exited) return;
+    // Guard on `loopPromise` (NOT just `running`) so a `start()`
+    // after a `stop()` that hasn't yet observed the running=false
+    // flag — the old loop is still inside `await sleep(...)` — does
+    // not spawn a second concurrent loop. Callers that need to
+    // re-start MUST await `stop()` first.
+    if (loopPromise || exited) return;
     running = true;
-    loopPromise = loop();
+    loopPromise = loop().finally(() => { loopPromise = null; });
   }
 
-  // Halts the loop. Idempotent. Does not interrupt an in-flight
+  // Halts the loop and returns a promise that resolves once the
+  // last in-flight tick has completed (including any in-flight
   // `manager.connect()` — the awaiting tick still completes before
-  // the loop check sees running=false. That matches the design's
-  // at-most-one outstanding connect invariant.
+  // the loop check sees running=false). Idempotent. Callers that
+  // want to re-start the watchdog MUST await this.
   function stop() {
     running = false;
+    return loopPromise ?? Promise.resolve();
   }
 
   return {

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -1,0 +1,173 @@
+// Connection watchdog for Pillar 3 — closes the gap where the
+// standby has been handed the lock (or acquired it via cold
+// fallback) but the gateway WebSocket isn't connected to Discord.
+// Without this loop, the active times out on ACK after 200 ms and
+// exits, while the standby sits lock-held-but-no-WS indefinitely.
+//
+// Spec reference: docs/zero-downtime-design.md §Pillar 3
+// "connection-watchdog" (lines ~583-612).
+//
+// ── Loop ──
+// Every `pollIntervalMs` (default 1000):
+//   1. If not holding the lock → reset attempts; continue. The
+//      watchdog runs unconditionally, so a standby waiting to be
+//      promoted enters the loop but no-ops until it acquires the
+//      lock. Resetting attempts here means a previous failure ladder
+//      doesn't carry across a lock-give-up + lock-reacquire cycle.
+//   2. If holding the lock AND the manager reports connected → reset
+//      attempts; continue. Steady-state: 1 s tick, no work, no log.
+//   3. Otherwise: attempts++, try `manager.connect()`. On success,
+//      reset attempts. On failure, log + exponential backoff sleep
+//      (200 ms, 400 ms, 800 ms, 1.6 s — capped at 5 s, see below).
+//      At `attempts >= maxAttempts` (default 5), release the lock
+//      and `exit(1)` so ECS replaces the task.
+//
+// ── Why bounded retry → exit, not infinite retry ──
+// A standby that can't reach Discord but holds the lock blocks the
+// only failover slot. ECS will restart us with fresh DNS / fresh
+// gateway endpoint pinning / fresh networking state; that's the
+// cheapest recovery path. Holding the lock and looping forever
+// merely delays handoff to a new task.
+//
+// ── Backoff cap is dead code ──
+// `Math.min(2^attempts * 100, 5000)` caps at 5 s. At maxAttempts=5,
+// the last backoff that ever sleeps is at attempts=4 → 1600 ms,
+// before the attempts=5 check triggers exit. The 5 s ceiling is
+// unreachable at this cap. Kept literally for future-proofing: if
+// someone bumps maxAttempts to e.g. 8, the cap kicks in (12800 ms
+// → 5000 ms) and they don't have to revisit the formula.
+//
+// ── Concurrency ──
+// The watchdog awaits `manager.connect()` inline. The next 1 s tick
+// does NOT fire until that call settles. Two concurrent connect()
+// invocations would race the @discordjs/ws internal state; the
+// design depends on at-most-one outstanding connect() per watchdog
+// instance. Tests pin this by counting connect() calls under
+// fake-timer advancement.
+//
+// ── Process exit is injected ──
+// Real prod calls `process.exit(1)`. Tests inject a no-op so the
+// retries-exhausted branch is observable without killing jest.
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_ATTEMPTS = 5;
+const BACKOFF_BASE_MS = 100;
+const BACKOFF_CAP_MS = 5_000;
+
+function createConnectionWatchdog({
+  manager,
+  isHoldingLock,
+  releaseLock,
+  logger,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  // Injected for tests. Production: setTimeout-based.
+  sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
+  // Injected for tests. Production: process.exit. Tests pass a spy.
+  exit = (code) => process.exit(code),
+} = {}) {
+  if (!manager || typeof manager.connect !== 'function' || typeof manager.isConnected !== 'function') {
+    throw new Error('createConnectionWatchdog: manager with connect() and isConnected() is required');
+  }
+  if (typeof isHoldingLock !== 'function') {
+    throw new Error('createConnectionWatchdog: isHoldingLock function is required');
+  }
+  if (typeof releaseLock !== 'function') {
+    throw new Error('createConnectionWatchdog: releaseLock function is required');
+  }
+  if (!logger) throw new Error('createConnectionWatchdog: logger is required');
+
+  let running = false;
+  let loopPromise = null;
+  let attempts = 0;
+  let exited = false;
+
+  // Run one iteration of the watchdog. Public for tests; production
+  // calls it from the `start()` loop. Returns once the iteration
+  // (including any failure-path backoff sleep) settles.
+  async function step() {
+    if (!isHoldingLock()) {
+      attempts = 0;
+      return;
+    }
+    if (manager.isConnected()) {
+      attempts = 0;
+      return;
+    }
+
+    attempts += 1;
+    try {
+      await manager.connect();
+      attempts = 0;
+      logger.info('connection-watchdog: connect succeeded');
+    } catch (err) {
+      if (attempts >= maxAttempts) {
+        logger.error('connection-watchdog: connect retries exhausted, releasing lock', {
+          error: err.message, attempts,
+        });
+        try {
+          await releaseLock();
+        } catch (rerr) {
+          // Logged-and-swallowed: we're already in the failure-exit
+          // path; refusing to exit because of a DDB blip would leave
+          // the lock held with no live gateway.
+          logger.error('connection-watchdog: releaseLock failed during exhaustion-exit', {
+            error: rerr.message,
+          });
+        }
+        exited = true;
+        running = false;
+        exit(1);
+        return;
+      }
+      const backoffMs = Math.min((2 ** attempts) * BACKOFF_BASE_MS, BACKOFF_CAP_MS);
+      logger.warn('connection-watchdog: connect failed, backing off', {
+        error: err.message, attempts, backoffMs,
+      });
+      await sleep(backoffMs);
+    }
+  }
+
+  async function loop() {
+    while (running) {
+      // Sleep first so an immediate stop() right after start()
+      // doesn't run a single tick — useful for tests + clean
+      // shutdown semantics.
+      await sleep(pollIntervalMs);
+      if (!running) break;
+      await step();
+    }
+  }
+
+  function start() {
+    if (running || exited) return;
+    running = true;
+    loopPromise = loop();
+  }
+
+  // Halts the loop. Idempotent. Does not interrupt an in-flight
+  // `manager.connect()` — the awaiting tick still completes before
+  // the loop check sees running=false. That matches the design's
+  // at-most-one outstanding connect invariant.
+  function stop() {
+    running = false;
+  }
+
+  return {
+    start,
+    stop,
+    // Inspection + driver seams for tests.
+    _stepForTest: step,
+    _getAttemptsForTest() { return attempts; },
+    _getRunningForTest() { return running; },
+    _getLoopPromiseForTest() { return loopPromise; },
+  };
+}
+
+module.exports = {
+  createConnectionWatchdog,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  BACKOFF_BASE_MS,
+  BACKOFF_CAP_MS,
+};

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -53,6 +53,14 @@ const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_ATTEMPTS = 5;
 const BACKOFF_BASE_MS = 100;
 const BACKOFF_CAP_MS = 5_000;
+// Hard ceiling on the releaseLock-during-exit call. The leader's
+// releaseLockForImmediateExit awaits through `runSerialized`, so a
+// hung inbound-handoff (parked inside manager.connect() with
+// `connecting=true` latched per gateway-leader.js's bounded-
+// settlement comment, tracked in #415) would otherwise block the
+// chain forever and exit(1) would never fire. 3 s is generous
+// vs. the 1 s expected DDB RTT; on miss we log and exit anyway.
+const RELEASE_LOCK_CEILING_MS = 3_000;
 
 function createConnectionWatchdog({
   manager,
@@ -68,6 +76,15 @@ function createConnectionWatchdog({
   // `() => false`.
   isConnecting,
   releaseLock,
+  // Hard ceiling on the releaseLock call during exhaustion-exit. The
+  // leader's releaseLockForImmediateExit awaits through `runSerialized`,
+  // so a hung inbound-handoff (parked inside manager.connect() with
+  // `connecting=true` latched per gateway-leader.js's bounded-
+  // settlement comment, tracked in #415) would otherwise block the
+  // chain forever and exit(1) would never fire. 3 s is generous vs.
+  // the ~1 s expected DDB RTT; on miss we log and exit anyway.
+  // Injected for tests so the ceiling can be tuned tiny.
+  releaseLockCeilingMs = RELEASE_LOCK_CEILING_MS,
   // Optional. If provided, called best-effort on the exhaustion-exit
   // path alongside releaseLock. Symmetric to gateway-leader.js's
   // SIGTERM pushHandoff path which also deletes the row. Without
@@ -154,11 +171,29 @@ function createConnectionWatchdog({
           error: err.message, attempts,
         });
         try {
-          await releaseLock();
+          // Race against a hard ceiling. The leader's
+          // releaseLockForImmediateExit awaits through its
+          // serialization chain, so a hung inbound-handoff (parked
+          // inside manager.connect() with `connecting=true` latched)
+          // would block the chain forever. Without the race, exit(1)
+          // would never fire — the failover slot stays held with
+          // no live gateway. On ceiling miss we log and exit anyway;
+          // the row fades via TTL.
+          let releaseTimer;
+          await Promise.race([
+            releaseLock(),
+            new Promise((_, reject) => {
+              releaseTimer = setTimeout(
+                () => reject(new Error(`release_lock_ceiling_${releaseLockCeilingMs}ms`)),
+                releaseLockCeilingMs,
+              );
+            }),
+          ]).finally(() => clearTimeout(releaseTimer));
         } catch (rerr) {
           // Logged-and-swallowed: we're already in the failure-exit
-          // path; refusing to exit because of a DDB blip would leave
-          // the lock held with no live gateway.
+          // path; refusing to exit because of a DDB blip — or the
+          // ceiling-miss above — would leave the lock held with no
+          // live gateway.
           logger.error('connection-watchdog: releaseLock failed during exhaustion-exit', {
             error: rerr.message,
           });

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -86,17 +86,9 @@ function createConnectionWatchdog({
   // `() => false`.
   isConnecting,
   releaseLock,
-  // Hard ceiling on the releaseLock call during exhaustion-exit. The
-  // leader's releaseLockForImmediateExit awaits through `runSerialized`,
-  // so a hung inbound-handoff (parked inside manager.connect() with
-  // `connecting=true` latched per gateway-leader.js's bounded-
-  // settlement comment, tracked in #415) would otherwise block the
-  // chain forever and exit(1) would never fire. 3 s is generous vs.
-  // the ~1 s expected DDB RTT; on miss we log and exit anyway.
-  // Injected for tests so the ceiling can be tuned tiny.
+  // Ceilings — see RELEASE_LOCK_CEILING_MS / CONNECT_CEILING_MS above
+  // for rationale. Injected for tests so they can be tuned tiny.
   releaseLockCeilingMs = RELEASE_LOCK_CEILING_MS,
-  // Hard ceiling on the inline `manager.connect()` call. See
-  // CONNECT_CEILING_MS above for rationale. Injected for tests.
   connectCeilingMs = CONNECT_CEILING_MS,
   // Optional. If provided, called best-effort on the exhaustion-exit
   // path alongside releaseLock. Symmetric to gateway-leader.js's

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -135,7 +135,19 @@ function createConnectionWatchdog({
       // shutdown semantics.
       await sleep(pollIntervalMs);
       if (!running) break;
-      await step();
+      // Backstop for unexpected throws from `manager.isConnected()`
+      // (contractually non-throwing, but a future shim refactor
+      // could regress) or any other unhandled path. Without this,
+      // a single throw inside step() would exit the loop and
+      // silently disable the watchdog. Log + continue: the next
+      // tick re-tries.
+      try {
+        await step();
+      } catch (err) {
+        logger.error('connection-watchdog: step threw unexpectedly (loop continues)', {
+          error: err && err.message,
+        });
+      }
     }
   }
 

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -68,6 +68,17 @@ function createConnectionWatchdog({
   // `() => false`.
   isConnecting,
   releaseLock,
+  // Optional. If provided, called best-effort on the exhaustion-exit
+  // path alongside releaseLock. Symmetric to gateway-leader.js's
+  // SIGTERM pushHandoff path which also deletes the row. Without
+  // this, the heartbeat row lingers until DDB TTL (default 60s) and
+  // surviving peers keep `isKnownPeer`-ing this dead replica + the
+  // next handoff source may pick this row from listFreshPeers head
+  // and time out the 200 ms ACK. Not a correctness issue (the cold-
+  // fallback floor applies), but a small latency tax during the TTL
+  // window. Optional so existing wiring without peerHeartbeat
+  // visibility doesn't break — the absence is a no-op, not a throw.
+  deleteOwnRow,
   logger,
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
   maxAttempts = DEFAULT_MAX_ATTEMPTS,
@@ -137,6 +148,21 @@ function createConnectionWatchdog({
           logger.error('connection-watchdog: releaseLock failed during exhaustion-exit', {
             error: rerr.message,
           });
+        }
+        // Best-effort heartbeat-row cleanup, symmetric to gateway-
+        // leader.js's pushHandoff path. Closes the discovery window
+        // immediately so a freshly-promoted peer's listFreshPeers
+        // stops returning this dead row. Optional hook — absence is
+        // a no-op; failure is logged and swallowed (we're already
+        // exiting).
+        if (typeof deleteOwnRow === 'function') {
+          try {
+            await deleteOwnRow();
+          } catch (derr) {
+            logger.warn('connection-watchdog: deleteOwnRow failed during exhaustion-exit', {
+              error: derr.message,
+            });
+          }
         }
         closed = true;
         running = false;

--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -93,7 +93,7 @@ function createConnectionWatchdog({
   let running = false;
   let loopPromise = null;
   let attempts = 0;
-  let exited = false;
+  let closed = false;
 
   // Run one iteration of the watchdog. Public for tests; production
   // calls it from the `start()` loop. Returns once the iteration
@@ -138,7 +138,7 @@ function createConnectionWatchdog({
             error: rerr.message,
           });
         }
-        exited = true;
+        closed = true;
         running = false;
         exit(1);
         return;
@@ -180,7 +180,7 @@ function createConnectionWatchdog({
     // flag — the old loop is still inside `await sleep(...)` — does
     // not spawn a second concurrent loop. Callers that need to
     // re-start MUST await `stop()` first.
-    if (loopPromise || exited) return;
+    if (loopPromise || closed) return;
     running = true;
     loopPromise = loop().finally(() => { loopPromise = null; });
   }

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -111,8 +111,14 @@ function startControlChannelServer({
 
   // Cap idle/header timeouts to bound resource usage. Match the
   // ordering constraint Node enforces: headersTimeout < requestTimeout.
+  //
+  // Floor at 1 s: a caller passing a tiny `requestTimeoutMs` (e.g.,
+  // 1 in a test) would otherwise produce `headersTimeout = 0`, which
+  // Node interprets as DISABLED (no header timeout at all) — the
+  // exact opposite of "half." We don't want that footgun on the
+  // production surface.
   server.requestTimeout = requestTimeoutMs;
-  server.headersTimeout = Math.floor(requestTimeoutMs / 2);
+  server.headersTimeout = Math.max(1_000, Math.floor(requestTimeoutMs / 2));
 
   server.on('error', (err) => {
     logger.error('control-channel: listener failed', { error: err.message, code: err.code });

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -53,6 +53,23 @@
 // without re-litigating the cap, but small enough to bound the
 // worst-case memory of an attacker spamming maximally-large bodies.
 //
+// When the cap is hit, `req.pause()` stops further data events and
+// the handler returns a 413 with `Connection: close`. Server-level
+// `requestTimeout` (default 5 s) is the backstop for a misbehaving
+// client that ignores the close and keeps the socket open — the
+// paused stream stays in memory at most 5 s before the timeout
+// reaps it.
+//
+// ── 401 reason leak — intentional tradeoff ──
+// On HMAC verify failure, the 401 response includes the verifier's
+// `reason` field (bad_signature | stale | replay | malformed_body |
+// missing_field). On a VPC-internal HMAC-authenticated channel this
+// is a small information leak — an attacker without the secret can
+// only ever produce `bad_signature`, so the differentiation only
+// helps a legitimate operator triage their own misconfig (clock
+// skew → stale; replay-protection collision → replay). Worth the
+// triage value at this trust boundary.
+//
 // ── Bind address ──
 // Defaults to `0.0.0.0` because in awsvpc mode each Fargate task has
 // its own ENI; binding all interfaces means "this ENI" — there are

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -237,11 +237,13 @@ async function handleRequest(req, res, ctx) {
   // cap is unambiguous — short-circuit before reading any bytes so
   // an obvious bad request doesn't get a per-chunk dance.
   // `parseInt` tolerates leading whitespace; we additionally require
-  // a digits-only value to ignore garbage like `0xFF` or `1KB`.
+  // a digits-only value to ignore garbage like `0xFF` or `1KB`. The
+  // regex pre-check guarantees `parseInt` returns a non-negative
+  // integer, so no further `Number.isFinite` guard is needed.
   const declaredLengthRaw = req.headers['content-length'];
   if (declaredLengthRaw !== undefined && /^\d+$/.test(declaredLengthRaw)) {
     const declaredLength = parseInt(declaredLengthRaw, 10);
-    if (Number.isFinite(declaredLength) && declaredLength > ctx.bodyByteCap) {
+    if (declaredLength > ctx.bodyByteCap) {
       ctx.logger.warn('control-channel: Content-Length exceeds cap', {
         declared: declaredLength, cap: ctx.bodyByteCap,
       });

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -209,16 +209,17 @@ async function handleRequest(req, res, ctx) {
     sendJson(res, 405, { error: 'method_not_allowed' }, { Allow: 'POST', Connection: 'close' });
     return;
   }
-  // Content-Type must be application/json (or absent, since
-  // control-client always sets it and the body is always JSON).
+  // Content-Type must be application/json (required, not optional).
   // 415 unsupported_media_type is the RFC-correct response — and
-  // helps operator triage by distinguishing "probe with wrong
-  // content type" from "real client with a bad envelope" (400).
+  // helps operator triage by distinguishing "probe with wrong /
+  // missing content type" (415) from "real client with a bad
+  // envelope" (400). Our control-client always sets it; rejecting
+  // missing CT also catches `curl` probes without `-H` upfront.
   // We accept charset parameters (`application/json; charset=utf-8`)
   // by matching the prefix, plus RFC 9110-style trailing whitespace
   // after the media type (`application/json `).
   const contentType = req.headers['content-type'];
-  if (contentType !== undefined && !/^application\/json\s*(?:;|$)/i.test(contentType)) {
+  if (contentType === undefined || !/^application\/json\s*(?:;|$)/i.test(contentType)) {
     sendJson(res, 415, { error: 'unsupported_media_type' }, { Connection: 'close' });
     return;
   }

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -348,12 +348,13 @@ function findInvalidHandoffField(payload) {
     return 'peer_instance_id';
   }
   // Upper bound is a sanity ceiling, not a security primitive — the
-  // HMAC has already authenticated the sender. A peer adopting
-  // Number.MAX_SAFE_INTEGER as the version cursor would burn
-  // ~2^53 CAS values before the row could ever match again; reject
-  // anything that's clearly not a real lock-version number.
-  if (typeof payload.expected_version !== 'number'
-      || !Number.isInteger(payload.expected_version)
+  // HMAC has already authenticated the sender. `Number.isInteger`
+  // accepts representable integers past MAX_SAFE_INTEGER (e.g.
+  // `2**53` returns true) where arithmetic loses precision, so the
+  // explicit `> Number.MAX_SAFE_INTEGER` check IS doing work — it's
+  // not redundant with `isInteger`. Reject values that could ever
+  // round-trip lossily via JSON or DDB number marshaling.
+  if (!Number.isInteger(payload.expected_version)
       || payload.expected_version <= 0
       || payload.expected_version > Number.MAX_SAFE_INTEGER) {
     return 'expected_version';

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -1,0 +1,277 @@
+// In-VPC control channel for Pillar 3 push-handoff. Binds an HTTP
+// listener on the task's ENI (default 0.0.0.0 in awsvpc mode) and
+// answers a single endpoint:
+//
+//   POST /control/yours    — peer is handing the lock to us; verify
+//                            HMAC, validate routing, invoke onHandoff,
+//                            ACK.
+//
+// Spec reference: docs/zero-downtime-design.md §Pillar 3 "Control-
+// channel auth: shared HMAC secret" (lines ~436-472) and "Standby on
+// POST /control/yours" (lines ~562-618).
+//
+// ── Wire envelope ──
+// HTTP body = JSON.stringify({
+//   body: "<json-string of the signed payload>",
+//   signature: "<hex sha256>",
+// })
+//
+// The INNER `body` string is the exact UTF-8 bytes that the sender
+// signed (sender: bodyBytes = Buffer.from(JSON.stringify(payload),
+// 'utf8')). Wrapping it as a string inside an outer JSON envelope
+// preserves the inner bytes verbatim across JSON.parse + .toString:
+// JSON-stringified strings round-trip exactly. The alternative —
+// putting `body` as an object — would force the receiver to re-
+// stringify it, canonicalizing key order, which would break HMAC
+// verify on a body whose original stringification used a different
+// key order.
+//
+// ── Verification order ──
+// We hash-verify BEFORE we look at any payload field. Reasons:
+//   1. DoS: parsing a giant unsigned body before verify lets an
+//      attacker burn CPU + memory. The 8 KB cap bounds memory, but
+//      verify-first means we don't even JSON.parse on bad inputs.
+//   2. nonce-burn safety: gateway-hmac burns the nonce when verify
+//      returns ok=true. Burning a nonce on a malformed-payload body
+//      (peer_instance_id mismatch, etc.) is OK — legitimate senders
+//      don't send mis-addressed bodies, and a captured-then-replayed
+//      body addressed to a different peer hits a different replica's
+//      LRU anyway.
+//
+// ── Routing checks (after verify) ──
+//   - `payload.peer_instance_id === self.instance_id` — the body is
+//     addressed to THIS standby. Defends against intra-cluster cross-
+//     shard replay at sharding inflection (PR 15 / 16-ish).
+//   - `isKnownPeer(payload.active_instance_id)` — the sender is a
+//     replica we've seen in the peer-heartbeat table within the
+//     freshness window. Defends against handoff from a stale stopped
+//     task whose container exited but whose body was queued upstream.
+//
+// ── Body cap ──
+// 8 KB. Real handoff payload is ~250 B (4 strings + a number + nonce
+// + ts). 8 KB is 30× over-provisioned — gives room for future fields
+// without re-litigating the cap, but small enough to bound the
+// worst-case memory of an attacker spamming maximally-large bodies.
+//
+// ── Bind address ──
+// Defaults to `0.0.0.0` because in awsvpc mode each Fargate task has
+// its own ENI; binding all interfaces means "this ENI" — there are
+// no other interfaces in the task's network namespace, so this is
+// not actually a broader bind than 127.0.0.1 in the network-namespace
+// sense. The task security group is the perimeter. Tests pass
+// `127.0.0.1` to avoid binding a routable address during the suite.
+
+const http = require('node:http');
+
+const { unwrapEnvelope } = require('./gateway-hmac');
+
+const DEFAULT_BODY_BYTE_CAP = 8 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+
+function startControlChannelServer({
+  hmac,
+  selfInstanceId,
+  isKnownPeer,
+  onHandoff,
+  logger,
+  port,
+  bindAddr = '0.0.0.0',
+  bodyByteCap = DEFAULT_BODY_BYTE_CAP,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  onListenError,
+} = {}) {
+  if (!hmac || typeof hmac.verify !== 'function') {
+    throw new Error('startControlChannelServer: hmac with verify() is required');
+  }
+  if (!selfInstanceId) {
+    throw new Error('startControlChannelServer: selfInstanceId is required');
+  }
+  if (typeof isKnownPeer !== 'function') {
+    throw new Error('startControlChannelServer: isKnownPeer function is required');
+  }
+  if (typeof onHandoff !== 'function') {
+    throw new Error('startControlChannelServer: onHandoff function is required');
+  }
+  if (!logger) throw new Error('startControlChannelServer: logger is required');
+  if (typeof onListenError !== 'function') {
+    throw new Error('startControlChannelServer: onListenError function is required');
+  }
+  if (port == null) {
+    throw new Error('startControlChannelServer: port is required');
+  }
+
+  const server = http.createServer((req, res) => {
+    handleRequest(req, res, {
+      hmac, selfInstanceId, isKnownPeer, onHandoff, logger, bodyByteCap,
+    }).catch((err) => {
+      logger.error('control-channel: unhandled handler error', { error: err.message });
+      sendJson(res, 500, { error: 'internal_error' });
+    });
+  });
+
+  // Cap idle/header timeouts to bound resource usage. Match the
+  // ordering constraint Node enforces: headersTimeout < requestTimeout.
+  server.requestTimeout = requestTimeoutMs;
+  server.headersTimeout = Math.floor(requestTimeoutMs / 2);
+
+  server.on('error', (err) => {
+    logger.error('control-channel: listener failed', { error: err.message, code: err.code });
+    onListenError(err);
+  });
+
+  server.listen(port, bindAddr, () => {
+    logger.info('control-channel: listening', { addr: bindAddr, port: server.address().port });
+  });
+
+  return server;
+}
+
+async function handleRequest(req, res, ctx) {
+  const path = req.url.split('?', 1)[0];
+
+  if (req.method !== 'POST' || path !== '/control/yours') {
+    sendJson(res, 404, { error: 'not_found' });
+    return;
+  }
+
+  let bodyBuf;
+  try {
+    bodyBuf = await readRequestBody(req, ctx.bodyByteCap);
+  } catch (err) {
+    if (err.code === 'BODY_TOO_LARGE') {
+      ctx.logger.warn('control-channel: body exceeded cap', { cap: ctx.bodyByteCap });
+      sendJson(res, 413, { error: 'body_too_large' });
+      return;
+    }
+    ctx.logger.warn('control-channel: body read failed', { error: err.message });
+    sendJson(res, 400, { error: 'body_read_failed' });
+    return;
+  }
+
+  const unwrapped = unwrapEnvelope(bodyBuf);
+  if (!unwrapped) {
+    sendJson(res, 400, { error: 'invalid_envelope' });
+    return;
+  }
+
+  const verifyResult = ctx.hmac.verify(unwrapped);
+  if (!verifyResult.ok) {
+    ctx.logger.warn('control-channel: hmac verify failed', { reason: verifyResult.reason });
+    sendJson(res, 401, { error: 'unauthorized', reason: verifyResult.reason });
+    return;
+  }
+
+  const payload = verifyResult.payload;
+  const invalidField = findInvalidHandoffField(payload);
+  if (invalidField) {
+    ctx.logger.warn('control-channel: payload shape invalid', { field: invalidField });
+    sendJson(res, 400, { error: 'invalid_payload' });
+    return;
+  }
+
+  if (payload.peer_instance_id !== ctx.selfInstanceId) {
+    ctx.logger.warn('control-channel: body addressed to wrong peer', {
+      addressedTo: payload.peer_instance_id, self: ctx.selfInstanceId,
+    });
+    sendJson(res, 400, { error: 'wrong_peer' });
+    return;
+  }
+
+  if (!ctx.isKnownPeer(payload.active_instance_id)) {
+    ctx.logger.warn('control-channel: handoff from unknown peer', {
+      activeInstanceId: payload.active_instance_id,
+    });
+    sendJson(res, 400, { error: 'unknown_peer' });
+    return;
+  }
+
+  try {
+    await ctx.onHandoff({
+      activeInstanceId: payload.active_instance_id,
+      expectedVersion: payload.expected_version,
+    });
+  } catch (err) {
+    ctx.logger.error('control-channel: onHandoff threw', { error: err.message });
+    sendJson(res, 500, { error: 'handoff_failed' });
+    return;
+  }
+
+  ctx.logger.info('control-channel: handoff accepted', {
+    activeInstanceId: payload.active_instance_id,
+    expectedVersion: payload.expected_version,
+  });
+  sendJson(res, 200, { status: 'ok' });
+}
+
+// Per-field validation for the handoff payload. Returns the name of
+// the first invalid field, or null if everything checks out. Named-
+// field-in-log makes a 400 invalid_payload easier to root-cause than
+// a 5-clause boolean expression with a `hasActive: 'string'` log
+// entry that doesn't say which field bad.
+function findInvalidHandoffField(payload) {
+  if (typeof payload.active_instance_id !== 'string' || payload.active_instance_id.length === 0) {
+    return 'active_instance_id';
+  }
+  if (typeof payload.peer_instance_id !== 'string' || payload.peer_instance_id.length === 0) {
+    return 'peer_instance_id';
+  }
+  if (typeof payload.expected_version !== 'number'
+      || !Number.isInteger(payload.expected_version)
+      || payload.expected_version <= 0) {
+    return 'expected_version';
+  }
+  return null;
+}
+
+function readRequestBody(req, byteCap) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let totalLength = 0;
+    let settled = false;
+
+    function settle(fn, arg) {
+      if (settled) return;
+      settled = true;
+      fn(arg);
+    }
+
+    req.on('data', (chunk) => {
+      if (settled) return;
+      totalLength += chunk.length;
+      if (totalLength > byteCap) {
+        const err = new Error('body-too-large');
+        err.code = 'BODY_TOO_LARGE';
+        // Destroy the request to stop further reads. Without this,
+        // a malicious peer could keep streaming past the cap.
+        req.destroy();
+        settle(reject, err);
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => { settle(resolve, Buffer.concat(chunks)); });
+    req.on('error', (err) => { settle(reject, err); });
+    req.on('aborted', () => { settle(reject, new Error('request_aborted')); });
+  });
+}
+
+function sendJson(res, status, body) {
+  if (res.headersSent || res.writableEnded) return;
+  const buf = Buffer.from(JSON.stringify(body), 'utf8');
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': buf.length,
+  });
+  res.end(buf);
+}
+
+module.exports = {
+  startControlChannelServer,
+  // Exported for tests that want to drive the handler without
+  // actually binding a socket.
+  _handleRequestForTest: handleRequest,
+  _readRequestBodyForTest: readRequestBody,
+  DEFAULT_BODY_BYTE_CAP,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+};

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -286,7 +286,17 @@ function readRequestBody(req, byteCap) {
 
     req.on('end', () => { settle(resolve, Buffer.concat(chunks)); });
     req.on('error', (err) => { settle(reject, err); });
-    req.on('aborted', () => { settle(reject, new Error('request_aborted')); });
+    // 'close' fires after the request stream is fully done — either
+    // by 'end' (we already settled resolve) or by abort/transport
+    // error (we may not have settled yet). Use `req.destroyed`
+    // post-close as the abort signal. The older 'aborted' event was
+    // deprecated in Node 17 in favor of this pattern; settling here
+    // makes the abort path forward-compatible.
+    req.on('close', () => {
+      if (req.destroyed) {
+        settle(reject, new Error('request_aborted'));
+      }
+    });
   });
 }
 

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -38,6 +38,13 @@
 //      body addressed to a different peer hits a different replica's
 //      LRU anyway.
 //
+// IMPORTANT: the nonce-burn-on-routing-rejection tradeoff is only
+// safe BECAUSE verify runs first. If a future change moves the
+// routing checks before verify (e.g., to reject early on shard
+// mismatch), the threat model flips — an attacker without the HMAC
+// secret could spam wrong-peer bodies to evict legitimate nonces
+// from the LRU. Verify-first is load-bearing.
+//
 // ── Routing checks (after verify) ──
 //   - `payload.peer_instance_id === self.instance_id` — the body is
 //     addressed to THIS standby. Defends against intra-cluster cross-
@@ -292,7 +299,11 @@ async function handleRequest(req, res, ctx) {
     ctx.logger.warn('control-channel: body addressed to wrong peer', {
       addressedTo: payload.peer_instance_id, self: ctx.selfInstanceId,
     });
-    sendJson(res, 400, { error: 'wrong_peer' }, { Connection: 'close' });
+    // No Connection: close — body fully consumed before this bail.
+    // Matches the posture of other post-verify bails (invalid_payload,
+    // unauthorized, handoff_failed): close is only needed when the
+    // request body is in an indeterminate state.
+    sendJson(res, 400, { error: 'wrong_peer' });
     return;
   }
 
@@ -300,7 +311,9 @@ async function handleRequest(req, res, ctx) {
     ctx.logger.warn('control-channel: handoff from unknown peer', {
       activeInstanceId: payload.active_instance_id,
     });
-    sendJson(res, 400, { error: 'unknown_peer' }, { Connection: 'close' });
+    // No Connection: close — body fully consumed before this bail.
+    // (Same rationale as the wrong_peer branch above.)
+    sendJson(res, 400, { error: 'unknown_peer' });
     return;
   }
 

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -141,10 +141,18 @@ function startControlChannelServer({
 }
 
 async function handleRequest(req, res, ctx) {
-  const path = req.url.split('?', 1)[0];
+  const path = req.url.split('?')[0];
 
-  if (req.method !== 'POST' || path !== '/control/yours') {
+  if (path !== '/control/yours') {
     sendJson(res, 404, { error: 'not_found' });
+    return;
+  }
+  // Path matches but wrong method → 405 with Allow header (RFC 9110
+  // §9.1). The distinction from a 404 matters for triage: it tells
+  // an operator "the endpoint exists but someone is hitting it
+  // with the wrong verb" (e.g., a probe misconfigured).
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'method_not_allowed' }, { Allow: 'POST' });
     return;
   }
 

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -167,8 +167,12 @@ function startControlChannelServer({
 async function handleRequest(req, res, ctx) {
   const path = req.url.split('?')[0];
 
+  // All short-circuit responses below set `Connection: close`. We
+  // bail without reading the request body, so any pending body
+  // bytes would otherwise confuse a keep-alive client's next
+  // request on the same socket. Same shape as the 413 path.
   if (path !== '/control/yours') {
-    sendJson(res, 404, { error: 'not_found' });
+    sendJson(res, 404, { error: 'not_found' }, { Connection: 'close' });
     return;
   }
   // Path matches but wrong method → 405 with Allow header (RFC 9110
@@ -176,7 +180,7 @@ async function handleRequest(req, res, ctx) {
   // an operator "the endpoint exists but someone is hitting it
   // with the wrong verb" (e.g., a probe misconfigured).
   if (req.method !== 'POST') {
-    sendJson(res, 405, { error: 'method_not_allowed' }, { Allow: 'POST' });
+    sendJson(res, 405, { error: 'method_not_allowed' }, { Allow: 'POST', Connection: 'close' });
     return;
   }
   // Content-Type must be application/json (or absent, since
@@ -188,7 +192,7 @@ async function handleRequest(req, res, ctx) {
   // by matching the prefix.
   const contentType = req.headers['content-type'];
   if (contentType !== undefined && !/^application\/json(\s*;|\s*$)/i.test(contentType)) {
-    sendJson(res, 415, { error: 'unsupported_media_type' });
+    sendJson(res, 415, { error: 'unsupported_media_type' }, { Connection: 'close' });
     return;
   }
 

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -134,6 +134,12 @@ function startControlChannelServer({
   if (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs < 1100) {
     throw new Error('startControlChannelServer: requestTimeoutMs must be an integer >= 1100 (see headersTimeout invariant)');
   }
+  // bodyByteCap = 0 would 413 every request; negative / NaN / float
+  // would produce surprising int-coercion behavior in the stream
+  // length check. Fail loud at boot.
+  if (!Number.isInteger(bodyByteCap) || bodyByteCap <= 0) {
+    throw new Error('startControlChannelServer: bodyByteCap must be a positive integer');
+  }
 
   const server = http.createServer((req, res) => {
     handleRequest(req, res, {
@@ -159,7 +165,8 @@ function startControlChannelServer({
   // Math.min then caps at `requestTimeout - 100` so the
   // headersTimeout < requestTimeout invariant holds even when
   // the floor would otherwise push it over the request timeout.
-  // Defaults (5s request, 1s headers) are unaffected.
+  // With defaults (5 s request) this yields 2.5 s headersTimeout —
+  // the floor only kicks in below requestTimeoutMs ≈ 2 s.
   //
   // The factory-level `requestTimeoutMs < 1100` guard above ensures
   // both clauses can produce a meaningful >= 1000 ms — without it,
@@ -208,11 +215,31 @@ async function handleRequest(req, res, ctx) {
   // helps operator triage by distinguishing "probe with wrong
   // content type" from "real client with a bad envelope" (400).
   // We accept charset parameters (`application/json; charset=utf-8`)
-  // by matching the prefix.
+  // by matching the prefix, plus RFC 9110-style trailing whitespace
+  // after the media type (`application/json `).
   const contentType = req.headers['content-type'];
-  if (contentType !== undefined && !/^application\/json(\s*;|\s*$)/i.test(contentType)) {
+  if (contentType !== undefined && !/^application\/json\s*(?:;|$)/i.test(contentType)) {
     sendJson(res, 415, { error: 'unsupported_media_type' }, { Connection: 'close' });
     return;
+  }
+
+  // Pre-check Content-Length against the body cap. The streaming
+  // guard in readRequestBody is the load-bearing check (a client can
+  // omit or lie about Content-Length), but a declared length over
+  // cap is unambiguous — short-circuit before reading any bytes so
+  // an obvious bad request doesn't get a per-chunk dance.
+  // `parseInt` tolerates leading whitespace; we additionally require
+  // a digits-only value to ignore garbage like `0xFF` or `1KB`.
+  const declaredLengthRaw = req.headers['content-length'];
+  if (declaredLengthRaw !== undefined && /^\d+$/.test(declaredLengthRaw)) {
+    const declaredLength = parseInt(declaredLengthRaw, 10);
+    if (Number.isFinite(declaredLength) && declaredLength > ctx.bodyByteCap) {
+      ctx.logger.warn('control-channel: Content-Length exceeds cap', {
+        declared: declaredLength, cap: ctx.bodyByteCap,
+      });
+      sendJson(res, 413, { error: 'body_too_large' }, { Connection: 'close' });
+      return;
+    }
   }
 
   let bodyBuf;

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -140,7 +140,13 @@ async function handleRequest(req, res, ctx) {
   } catch (err) {
     if (err.code === 'BODY_TOO_LARGE') {
       ctx.logger.warn('control-channel: body exceeded cap', { cap: ctx.bodyByteCap });
-      sendJson(res, 413, { error: 'body_too_large' });
+      // `Connection: close` because we never read the rest of the
+      // (paused) request body. Without forcing close, a keep-alive
+      // client could attempt another request on the same socket
+      // and the leftover unread bytes would confuse the HTTP
+      // parser. Forcing close after this response makes the
+      // unread body harmless.
+      sendJson(res, 413, { error: 'body_too_large' }, { Connection: 'close' });
       return;
     }
     ctx.logger.warn('control-channel: body read failed', { error: err.message });
@@ -262,12 +268,13 @@ function readRequestBody(req, byteCap) {
   });
 }
 
-function sendJson(res, status, body) {
+function sendJson(res, status, body, extraHeaders = {}) {
   if (res.headersSent || res.writableEnded) return;
   const buf = Buffer.from(JSON.stringify(body), 'utf8');
   res.writeHead(status, {
     'Content-Type': 'application/json',
     'Content-Length': buf.length,
+    ...extraHeaders,
   });
   res.end(buf);
 }

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -129,7 +129,14 @@ function startControlChannelServer({
     handleRequest(req, res, {
       hmac, selfInstanceId, isKnownPeer, onHandoff, logger, bodyByteCap,
     }).catch((err) => {
-      logger.error('control-channel: unhandled handler error', { error: err.message });
+      // Include req.method + req.url so an operator triaging a 500
+      // can correlate this log line with what the client was
+      // attempting. sendJson is guarded against already-ended
+      // responses, so the 500 write is safe even if the failure
+      // happened after headers were sent.
+      logger.error('control-channel: unhandled handler error', {
+        error: err.message, method: req.method, url: req.url,
+      });
       sendJson(res, 500, { error: 'internal_error' });
     });
   });

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -124,6 +124,16 @@ function startControlChannelServer({
   if (port == null) {
     throw new Error('startControlChannelServer: port is required');
   }
+  // Floor on requestTimeoutMs. The headersTimeout formula below is
+  // `min(max(1000, requestTimeout/2), requestTimeout - 100)`. Below
+  // ~1100 ms the outer min picks `requestTimeout - 100`, and below
+  // 1100 ms entirely it collapses toward 1 ms — effectively
+  // disabling header-read protection. Fail loud at boot rather than
+  // letting a misconfigured caller silently lose the invariant.
+  // 1100 ms is the floor for both clauses to produce ≥ 1000 ms.
+  if (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs < 1100) {
+    throw new Error('startControlChannelServer: requestTimeoutMs must be an integer >= 1100 (see headersTimeout invariant)');
+  }
 
   const server = http.createServer((req, res) => {
     handleRequest(req, res, {
@@ -150,6 +160,11 @@ function startControlChannelServer({
   // headersTimeout < requestTimeout invariant holds even when
   // the floor would otherwise push it over the request timeout.
   // Defaults (5s request, 1s headers) are unaffected.
+  //
+  // The factory-level `requestTimeoutMs < 1100` guard above ensures
+  // both clauses can produce a meaningful >= 1000 ms — without it,
+  // requestTimeoutMs=50 would yield headersTimeout=1ms (effectively
+  // disabling header-read protection).
   server.requestTimeout = requestTimeoutMs;
   server.headersTimeout = Math.min(
     Math.max(1_000, Math.floor(requestTimeoutMs / 2)),
@@ -245,7 +260,7 @@ async function handleRequest(req, res, ctx) {
     ctx.logger.warn('control-channel: body addressed to wrong peer', {
       addressedTo: payload.peer_instance_id, self: ctx.selfInstanceId,
     });
-    sendJson(res, 400, { error: 'wrong_peer' });
+    sendJson(res, 400, { error: 'wrong_peer' }, { Connection: 'close' });
     return;
   }
 
@@ -253,7 +268,7 @@ async function handleRequest(req, res, ctx) {
     ctx.logger.warn('control-channel: handoff from unknown peer', {
       activeInstanceId: payload.active_instance_id,
     });
-    sendJson(res, 400, { error: 'unknown_peer' });
+    sendJson(res, 400, { error: 'unknown_peer' }, { Connection: 'close' });
     return;
   }
 

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -239,11 +239,17 @@ function readRequestBody(req, byteCap) {
       if (settled) return;
       totalLength += chunk.length;
       if (totalLength > byteCap) {
+        // `req.pause()` (NOT `req.destroy()`) stops further data
+        // events without tearing down the socket. Destroying here
+        // would race the 413 response: the handler's
+        // sendJson(res, 413, ...) runs in the next microtask, by
+        // which point the destroyed socket may not be writable,
+        // and legitimate over-cap clients wouldn't see the 413.
+        // Pause keeps the response path alive; TCP backpressure
+        // bounds the attacker's per-connection cost.
+        req.pause();
         const err = new Error('body-too-large');
         err.code = 'BODY_TOO_LARGE';
-        // Destroy the request to stop further reads. Without this,
-        // a malicious peer could keep streaming past the cap.
-        req.destroy();
         settle(reject, err);
         return;
       }

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -259,7 +259,11 @@ async function handleRequest(req, res, ctx) {
       return;
     }
     ctx.logger.warn('control-channel: body read failed', { error: err.message });
-    sendJson(res, 400, { error: 'body_read_failed' });
+    // `Connection: close` for the same reason as 413 above: a body-
+    // read error lands after a partial stream, so any leftover bytes
+    // would confuse a keep-alive client's HTTP parser on the next
+    // request. Force close to make the indeterminate state harmless.
+    sendJson(res, 400, { error: 'body_read_failed' }, { Connection: 'close' });
     return;
   }
 

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -179,6 +179,18 @@ async function handleRequest(req, res, ctx) {
     sendJson(res, 405, { error: 'method_not_allowed' }, { Allow: 'POST' });
     return;
   }
+  // Content-Type must be application/json (or absent, since
+  // control-client always sets it and the body is always JSON).
+  // 415 unsupported_media_type is the RFC-correct response — and
+  // helps operator triage by distinguishing "probe with wrong
+  // content type" from "real client with a bad envelope" (400).
+  // We accept charset parameters (`application/json; charset=utf-8`)
+  // by matching the prefix.
+  const contentType = req.headers['content-type'];
+  if (contentType !== undefined && !/^application\/json(\s*;|\s*$)/i.test(contentType)) {
+    sendJson(res, 415, { error: 'unsupported_media_type' });
+    return;
+  }
 
   let bodyBuf;
   try {
@@ -267,9 +279,15 @@ function findInvalidHandoffField(payload) {
   if (typeof payload.peer_instance_id !== 'string' || payload.peer_instance_id.length === 0) {
     return 'peer_instance_id';
   }
+  // Upper bound is a sanity ceiling, not a security primitive — the
+  // HMAC has already authenticated the sender. A peer adopting
+  // Number.MAX_SAFE_INTEGER as the version cursor would burn
+  // ~2^53 CAS values before the row could ever match again; reject
+  // anything that's clearly not a real lock-version number.
   if (typeof payload.expected_version !== 'number'
       || !Number.isInteger(payload.expected_version)
-      || payload.expected_version <= 0) {
+      || payload.expected_version <= 0
+      || payload.expected_version > Number.MAX_SAFE_INTEGER) {
     return 'expected_version';
   }
   return null;

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -60,6 +60,14 @@
 // not actually a broader bind than 127.0.0.1 in the network-namespace
 // sense. The task security group is the perimeter. Tests pass
 // `127.0.0.1` to avoid binding a routable address during the suite.
+//
+// IPv4-only assumption: this default works on today's Fargate
+// (IPv4 ENI). If the bot ever runs on an IPv6-only ENI, callers
+// MUST pass `bindAddr: '::'` (dual-stack) explicitly — `0.0.0.0`
+// won't bind to v6. The peer-heartbeat module's `net.isIP` write
+// validator and the control-client's read validator both accept
+// IPv6 literals, so the wire is v6-ready; only this bind default
+// is v4-only. Revisit when ECS rolls out v6-only task networking.
 
 const http = require('node:http');
 
@@ -275,7 +283,13 @@ function readRequestBody(req, byteCap) {
 }
 
 function sendJson(res, status, body, extraHeaders = {}) {
-  if (res.headersSent || res.writableEnded) return;
+  // `res.destroyed` covers the client-abort path: the request was
+  // aborted mid-stream, the socket is gone, and a writeHead/end
+  // pair would emit 'error' on the response. Without this guard
+  // that 'error' would propagate to the server-level error handler
+  // (which is scoped to listen errors, not per-request) and
+  // surface a benign client abort as a listener fault.
+  if (res.headersSent || res.writableEnded || res.destroyed) return;
   const buf = Buffer.from(JSON.stringify(body), 'utf8');
   res.writeHead(status, {
     'Content-Type': 'application/json',

--- a/apps/discord/src/gateway-control-channel.js
+++ b/apps/discord/src/gateway-control-channel.js
@@ -144,13 +144,17 @@ function startControlChannelServer({
   // Cap idle/header timeouts to bound resource usage. Match the
   // ordering constraint Node enforces: headersTimeout < requestTimeout.
   //
-  // Floor at 1 s: a caller passing a tiny `requestTimeoutMs` (e.g.,
-  // 1 in a test) would otherwise produce `headersTimeout = 0`, which
-  // Node interprets as DISABLED (no header timeout at all) — the
-  // exact opposite of "half." We don't want that footgun on the
-  // production surface.
+  // Floor at 1 s prevents the `headersTimeout = 0` (= disabled)
+  // footgun for tiny caller-provided requestTimeoutMs. The outer
+  // Math.min then caps at `requestTimeout - 100` so the
+  // headersTimeout < requestTimeout invariant holds even when
+  // the floor would otherwise push it over the request timeout.
+  // Defaults (5s request, 1s headers) are unaffected.
   server.requestTimeout = requestTimeoutMs;
-  server.headersTimeout = Math.max(1_000, Math.floor(requestTimeoutMs / 2));
+  server.headersTimeout = Math.min(
+    Math.max(1_000, Math.floor(requestTimeoutMs / 2)),
+    Math.max(1, requestTimeoutMs - 100),
+  );
 
   server.on('error', (err) => {
     logger.error('control-channel: listener failed', { error: err.message, code: err.code });

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -39,6 +39,7 @@
 // distinction is for observability only.
 
 const http = require('node:http');
+const net = require('node:net');
 
 const { wrapEnvelope } = require('./gateway-hmac');
 
@@ -63,8 +64,15 @@ function createControlClient({
     selfInstanceId,
     expectedVersion,
   }) {
-    if (typeof peerIp !== 'string' || peerIp.length === 0) {
-      throw new Error('pushHandoff: peerIp (non-empty string) required');
+    // Validate as a parseable IPv4/IPv6 literal — same shape as
+    // gateway-peer-heartbeat's write-time check. Defense-in-depth:
+    // if a heartbeat row is ever corrupted or mis-written to carry
+    // a hostname (or the literal "undefined" from env-stringification),
+    // we don't want to do DNS resolution + POST to wherever it
+    // resolves. The heartbeat-side validator and this validator
+    // are deliberately the same so each side fails loud on a bad row.
+    if (typeof peerIp !== 'string' || net.isIP(peerIp) === 0) {
+      throw new Error('pushHandoff: peerIp (IPv4 or IPv6 literal) required');
     }
     if (!Number.isInteger(peerPort) || peerPort <= 0 || peerPort > 65535) {
       throw new Error('pushHandoff: peerPort (integer 1-65535) required');
@@ -130,6 +138,15 @@ function createControlClient({
             peerInstanceId, error: err.message,
           });
           settle({ ok: false, reason: 'http_error', error: err.message });
+        });
+        // Peer crashes mid-response (after headers, before end):
+        // 'aborted' fires but 'end' never will. Without this
+        // handler we'd wait the full timeout before settling.
+        // Settle as http_error so the caller treats it like any
+        // other peer-side failure.
+        res.on('aborted', () => {
+          logger.warn('control-client: response aborted', { peerInstanceId });
+          settle({ ok: false, reason: 'http_error', error: 'response_aborted' });
         });
       });
 

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -108,7 +108,16 @@ function createControlClient({
         resolve(result);
       }
 
-      const req = httpRequest({
+      // Wrap httpRequest + req.write/end in try/catch so a future
+      // Node version tightening validation on hostname/port (or
+      // any other synchronous throw from the http module) doesn't
+      // break the "pushHandoff never throws" contract. Inputs are
+      // pre-validated above, so this is belt-and-braces — but the
+      // contract is load-bearing for the SIGTERM caller, which
+      // cannot handle exceptions cleanly.
+      let req;
+      try {
+        req = httpRequest({
         hostname: peerIp,
         port: peerPort,
         path: '/control/yours',
@@ -187,6 +196,12 @@ function createControlClient({
 
       req.write(wire);
       req.end();
+      } catch (err) {
+        logger.warn('control-client: synchronous http.request failure', {
+          peerInstanceId, error: err.message,
+        });
+        settle({ ok: false, reason: 'http_error', error: err.message });
+      }
     });
   }
 

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -193,8 +193,7 @@ function createControlClient({
           settle({ ok: false, reason: 'http_error', error: err.message });
         });
 
-        req.write(wire);
-        req.end();
+        req.end(wire);
       } catch (err) {
         logger.warn('control-client: synchronous http.request failure', {
           peerInstanceId, error: err.message,

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -106,7 +106,7 @@ function createControlClient({
       }
 
       const req = httpRequest({
-        host: peerIp,
+        hostname: peerIp,
         port: peerPort,
         path: '/control/yours',
         method: 'POST',

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -156,14 +156,20 @@ function createControlClient({
             });
             settle({ ok: false, reason: 'http_error', error: err.message });
           });
-          // Peer crashes mid-response (after headers, before end):
-          // 'aborted' fires but 'end' never will. Without this
+          // Peer crashes mid-response (after headers, before end).
+          // The deprecated `res.on('aborted')` was replaced in Node 17
+          // by `res.on('close')` combined with checking
+          // `res.destroyed` post-close. Matches the receive-side
+          // idiom in gateway-control-channel.js. Without this
           // handler we'd wait the full timeout before settling.
-          // Settle as http_error so the caller treats it like any
-          // other peer-side failure.
-          res.on('aborted', () => {
-            logger.warn('control-client: response aborted', { peerInstanceId });
-            settle({ ok: false, reason: 'http_error', error: 'response_aborted' });
+          res.on('close', () => {
+            if (res.destroyed && res.statusCode !== undefined) {
+              // Aborted after headers but before 'end' fired. The
+              // 'end' arm already settled if the body completed
+              // normally, so settle is idempotent here.
+              logger.warn('control-client: response aborted', { peerInstanceId });
+              settle({ ok: false, reason: 'http_error', error: 'response_aborted' });
+            }
           });
         });
 

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -108,7 +108,7 @@ function createControlClient({
         resolve(result);
       }
 
-      // Wrap httpRequest + req.write/end in try/catch so a future
+      // Wrap httpRequest + req.end(wire) in try/catch so a future
       // Node version tightening validation on hostname/port (or
       // any other synchronous throw from the http module) doesn't
       // break the "pushHandoff never throws" contract. Inputs are

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -1,0 +1,173 @@
+// Outbound control-channel client for Pillar 3 push-handoff. The
+// active replica calls `pushHandoff` from its SIGTERM handler to
+// signal a chosen peer "you're up." The peer's gateway-control-
+// channel server (see gateway-control-channel.js) verifies the HMAC,
+// runs `transferLock` (atomic active→standby), connects its WS to
+// Discord, and ACKs.
+//
+// Spec reference: docs/zero-downtime-design.md §Pillar 3
+// "SIGTERM handoff sequence" (lines ~519-537) and "Standby on POST
+// /control/yours" (lines ~562-618).
+//
+// ── Timeout ──
+// Default 200 ms. The active is shutting down; it cannot block on
+// SIGTERM's ECS-imposed deadline (10 s) waiting for an unresponsive
+// peer. If the standby doesn't ACK in 200 ms, the active gives up
+// and exits anyway — the standby's connection watchdog will catch
+// "lock held but WS disconnected" within ~1 s of the next watchdog
+// tick and bring up the gateway from the cold-fallback path. The
+// ~7 s cold-floor applies but is still better than a stuck active
+// preventing handoff.
+//
+// ── Body shape ──
+// `{active_instance_id, peer_instance_id, expected_version, ts, nonce}`
+// signed with HMAC. `ts` and `nonce` are added by this module
+// (callers don't need to think about them); `expected_version` is
+// the active's currentVersion at the moment of handoff — pre-
+// transfer, the peer uses it via `adoptLockFromHandoff(expected+1)`
+// to bootstrap its own version cursor.
+//
+// ── Return contract ──
+// Returns a result object — never throws. Distinguishes:
+//   { ok: true,  status: 200 }                        — peer ACKed; we're done
+//   { ok: false, reason: 'timeout' }                  — peer didn't reply in time
+//   { ok: false, reason: 'http_error', error }        — connection error
+//   { ok: false, reason: 'rejected', status, body }   — peer returned non-2xx
+//
+// Callers (the leader's SIGTERM path) ignore the difference between
+// failure modes — any non-ok result means "exit anyway." The
+// distinction is for observability only.
+
+const http = require('node:http');
+
+const { wrapEnvelope } = require('./gateway-hmac');
+
+const DEFAULT_TIMEOUT_MS = 200;
+
+function createControlClient({
+  hmac,
+  logger,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  // Injected for tests. Production uses node:http.
+  httpRequest = http.request,
+} = {}) {
+  if (!hmac || typeof hmac.sign !== 'function' || typeof hmac.generateNonce !== 'function') {
+    throw new Error('createControlClient: hmac with sign() and generateNonce() is required');
+  }
+  if (!logger) throw new Error('createControlClient: logger is required');
+
+  async function pushHandoff({
+    peerIp,
+    peerPort,
+    peerInstanceId,
+    selfInstanceId,
+    expectedVersion,
+  }) {
+    if (typeof peerIp !== 'string' || peerIp.length === 0) {
+      throw new Error('pushHandoff: peerIp (non-empty string) required');
+    }
+    if (!Number.isInteger(peerPort) || peerPort <= 0 || peerPort > 65535) {
+      throw new Error('pushHandoff: peerPort (integer 1-65535) required');
+    }
+    if (typeof peerInstanceId !== 'string' || peerInstanceId.length === 0) {
+      throw new Error('pushHandoff: peerInstanceId (non-empty string) required');
+    }
+    if (typeof selfInstanceId !== 'string' || selfInstanceId.length === 0) {
+      throw new Error('pushHandoff: selfInstanceId (non-empty string) required');
+    }
+    if (!Number.isInteger(expectedVersion) || expectedVersion <= 0) {
+      throw new Error('pushHandoff: expectedVersion (positive integer) required');
+    }
+
+    const payload = {
+      active_instance_id: selfInstanceId,
+      peer_instance_id: peerInstanceId,
+      expected_version: expectedVersion,
+      ts: Date.now(),
+      nonce: hmac.generateNonce(),
+    };
+    const signed = hmac.sign(payload);
+    const wire = wrapEnvelope(signed);
+
+    return new Promise((resolve) => {
+      let settled = false;
+      function settle(result) {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      }
+
+      const req = httpRequest({
+        host: peerIp,
+        port: peerPort,
+        path: '/control/yours',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': wire.length,
+        },
+        // Per-call timeout — covers both connect and response phases.
+        timeout: timeoutMs,
+      }, (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            logger.info('control-client: handoff ACKed', {
+              peerInstanceId, status: res.statusCode,
+            });
+            settle({ ok: true, status: res.statusCode });
+          } else {
+            logger.warn('control-client: handoff rejected by peer', {
+              peerInstanceId, status: res.statusCode, body,
+            });
+            settle({ ok: false, reason: 'rejected', status: res.statusCode, body });
+          }
+        });
+        res.on('error', (err) => {
+          logger.warn('control-client: response error', {
+            peerInstanceId, error: err.message,
+          });
+          settle({ ok: false, reason: 'http_error', error: err.message });
+        });
+      });
+
+      req.on('timeout', () => {
+        // `timeout` event fires but doesn't close the socket. We
+        // MUST settle BEFORE destroy: `req.destroy(err)` can emit
+        // 'error' synchronously in some code paths, and the 'error'
+        // handler below would otherwise race ahead and settle with
+        // reason:'http_error' instead of 'timeout'. Settle is
+        // idempotent, so the destroy-induced 'error' becomes a
+        // no-op after this.
+        logger.warn('control-client: handoff timed out', {
+          peerInstanceId, timeoutMs,
+        });
+        settle({ ok: false, reason: 'timeout' });
+        req.destroy(new Error('handoff_timeout'));
+      });
+
+      req.on('error', (err) => {
+        // After `destroy(err)` for the timeout path, 'error' will
+        // fire — settle is already done, so this is a no-op. Other
+        // error paths (connection refused, DNS fail, etc.) settle
+        // here.
+        logger.warn('control-client: request error', {
+          peerInstanceId, error: err.message,
+        });
+        settle({ ok: false, reason: 'http_error', error: err.message });
+      });
+
+      req.write(wire);
+      req.end();
+    });
+  }
+
+  return { pushHandoff };
+}
+
+module.exports = {
+  createControlClient,
+  DEFAULT_TIMEOUT_MS,
+};

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -19,6 +19,19 @@
 // ~7 s cold-floor applies but is still better than a stuck active
 // preventing handoff.
 //
+// ── ACK-vs-timeout regime ──
+// The standby's `onHandoff` handler awaits `manager.connect()` to
+// Discord WS (typically 1-3 s) BEFORE returning 200. The active's
+// 200 ms timeout is much shorter, so the wire-level 200 ACK is
+// essentially never observed by the sender in the happy path.
+// `pushAcked: true` will be rare; `pushAcked: false, pushReason:
+// 'timeout'` is the common case. This is intentional — the wire
+// ACK is only useful for the synchronous-throw / 4xx error path
+// (bad HMAC, malformed body, wrong peer, etc.). For success, we
+// rely on the watchdog's lock-held + WS-disconnected check instead.
+// PR 13b.3 should log `pushAcked` as a metric so the "always times
+// out" regime stays observable vs. a genuinely-broken standby.
+//
 // ── Body shape ──
 // `{active_instance_id, peer_instance_id, expected_version, ts, nonce}`
 // signed with HMAC. `ts` and `nonce` are added by this module
@@ -48,13 +61,15 @@ const net = require('node:net');
 const { wrapEnvelope } = require('./gateway-hmac');
 
 const DEFAULT_TIMEOUT_MS = 200;
-// Symmetric to the server's bodyByteCap (gateway-control-channel.js
-// DEFAULT_BODY_BYTE_CAP = 8 KB). A correctly-behaving peer will reply
-// with a small ACK or a JSON error envelope — kilobytes at most.
-// A misrouted POST hitting an HTML error page (or a hostile in-VPC
-// actor) could otherwise return multi-MB and OOM the active during
-// the SIGTERM critical path. Buffer cap is the bytes we'll keep; on
-// exceeded the request is destroyed and we settle with `http_error`.
+// Expected legitimate responses from the control-channel server are
+// tiny — `{"status":"ok"}` on 2xx (≈ 15 bytes) or a small JSON error
+// envelope on 4xx/5xx (≈ 50 bytes). 8 KB matches the server's request
+// bodyByteCap and is ~150× the expected response size, so the cap
+// only ever fires on pathological inputs: a misrouted POST hitting
+// an HTML error page (e.g., a generic LB 502 with a multi-KB body)
+// or a hostile in-VPC actor returning multi-MB. Defense against OOM
+// of the active during the SIGTERM critical path. On exceeded, the
+// response is destroyed and we settle with reason:'http_error'.
 const DEFAULT_RESPONSE_BYTE_CAP = 8 * 1024;
 
 function createControlClient({

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -33,6 +33,7 @@
 // ── Return contract ──
 // Returns a result object — never throws. Distinguishes:
 //   { ok: true,  status: 200 }                        — peer ACKed; we're done
+//   { ok: false, reason: 'invalid_arg', arg }         — argument validation rejected (also caught at the heartbeat-side validator; this is defense-in-depth)
 //   { ok: false, reason: 'timeout' }                  — peer didn't reply in time
 //   { ok: false, reason: 'http_error', error }        — connection error
 //   { ok: false, reason: 'rejected', status, body }   — peer returned non-2xx
@@ -47,11 +48,20 @@ const net = require('node:net');
 const { wrapEnvelope } = require('./gateway-hmac');
 
 const DEFAULT_TIMEOUT_MS = 200;
+// Symmetric to the server's bodyByteCap (gateway-control-channel.js
+// DEFAULT_BODY_BYTE_CAP = 8 KB). A correctly-behaving peer will reply
+// with a small ACK or a JSON error envelope — kilobytes at most.
+// A misrouted POST hitting an HTML error page (or a hostile in-VPC
+// actor) could otherwise return multi-MB and OOM the active during
+// the SIGTERM critical path. Buffer cap is the bytes we'll keep; on
+// exceeded the request is destroyed and we settle with `http_error`.
+const DEFAULT_RESPONSE_BYTE_CAP = 8 * 1024;
 
 function createControlClient({
   hmac,
   logger,
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  responseByteCap = DEFAULT_RESPONSE_BYTE_CAP,
   // Injected for tests. Production uses node:http.
   httpRequest = http.request,
 } = {}) {
@@ -67,27 +77,29 @@ function createControlClient({
     selfInstanceId,
     expectedVersion,
   }) {
-    // Validate as a parseable IPv4/IPv6 literal — same shape as
-    // gateway-peer-heartbeat's write-time check. Defense-in-depth:
-    // if a heartbeat row is ever corrupted or mis-written to carry
-    // a hostname (or the literal "undefined" from env-stringification),
-    // we don't want to do DNS resolution + POST to wherever it
-    // resolves. The heartbeat-side validator and this validator
-    // are deliberately the same so each side fails loud on a bad row.
-    if (typeof peerIp !== 'string' || net.isIP(peerIp) === 0) {
-      throw new Error('pushHandoff: peerIp (IPv4 or IPv6 literal) required');
-    }
-    if (!Number.isInteger(peerPort) || peerPort <= 0 || peerPort > 65535) {
-      throw new Error('pushHandoff: peerPort (integer 1-65535) required');
-    }
-    if (typeof peerInstanceId !== 'string' || peerInstanceId.length === 0) {
-      throw new Error('pushHandoff: peerInstanceId (non-empty string) required');
-    }
-    if (typeof selfInstanceId !== 'string' || selfInstanceId.length === 0) {
-      throw new Error('pushHandoff: selfInstanceId (non-empty string) required');
-    }
-    if (!Number.isInteger(expectedVersion) || expectedVersion <= 0) {
-      throw new Error('pushHandoff: expectedVersion (positive integer) required');
+    // Validators return a result object rather than throw so the
+    // "never throws" contract documented in the module header holds
+    // unconditionally. Defense-in-depth: if a heartbeat row is ever
+    // corrupted or mis-written to carry a hostname (or the literal
+    // "undefined" from env-stringification), we don't want to do DNS
+    // resolution + POST to wherever it resolves. The heartbeat-side
+    // validator (gateway-peer-heartbeat.js) DOES throw (it's a write-
+    // time config check, not a hot-path runtime check) — this side
+    // mirrors the same shape but at runtime returns a result so the
+    // SIGTERM caller stays exception-free.
+    const invalidArg = (
+      (typeof peerIp !== 'string' || net.isIP(peerIp) === 0) ? 'peerIp'
+      : (!Number.isInteger(peerPort) || peerPort <= 0 || peerPort > 65535) ? 'peerPort'
+      : (typeof peerInstanceId !== 'string' || peerInstanceId.length === 0) ? 'peerInstanceId'
+      : (typeof selfInstanceId !== 'string' || selfInstanceId.length === 0) ? 'selfInstanceId'
+      : (!Number.isInteger(expectedVersion) || expectedVersion <= 0) ? 'expectedVersion'
+      : null
+    );
+    if (invalidArg) {
+      logger.warn('control-client: invalid pushHandoff arg', {
+        arg: invalidArg, peerInstanceId: typeof peerInstanceId === 'string' ? peerInstanceId : null,
+      });
+      return { ok: false, reason: 'invalid_arg', arg: invalidArg };
     }
 
     const payload = {
@@ -129,8 +141,32 @@ function createControlClient({
           timeout: timeoutMs,
         }, (res) => {
           const chunks = [];
-          res.on('data', (chunk) => chunks.push(chunk));
+          let bytesRead = 0;
+          let bodyCapExceeded = false;
+          res.on('data', (chunk) => {
+            if (bodyCapExceeded) return;
+            bytesRead += chunk.length;
+            if (bytesRead > responseByteCap) {
+              // A misrouted POST hitting an HTML error page or a
+              // hostile in-VPC actor could otherwise return multi-MB
+              // and OOM the active during SIGTERM. Destroy the
+              // response so we settle now instead of buffering
+              // forever; the destroy emits an error which the 'error'
+              // handler below maps to http_error. Mark a flag so
+              // subsequent 'data' chunks (already in the pipeline)
+              // are dropped without growing the buffer.
+              bodyCapExceeded = true;
+              logger.warn('control-client: response body exceeded cap', {
+                peerInstanceId, cap: responseByteCap,
+              });
+              settle({ ok: false, reason: 'http_error', error: 'response_body_too_large' });
+              res.destroy();
+              return;
+            }
+            chunks.push(chunk);
+          });
           res.on('end', () => {
+            if (bodyCapExceeded) return;
             const body = Buffer.concat(chunks).toString('utf8');
             if (res.statusCode >= 200 && res.statusCode < 300) {
               logger.info('control-client: handoff ACKed', {
@@ -141,9 +177,8 @@ function createControlClient({
               // Cap the logged body so an unexpectedly large peer
               // response (e.g., a stray HTML error page from a
               // misrouted request) doesn't flood the log line. The
-              // returned `body` field stays uncapped — callers don't
-              // act on it today, but a future debugger reading the
-              // full string from the result object is still ok.
+              // returned `body` field is already cap-bounded by the
+              // streaming guard above.
               logger.warn('control-client: handoff rejected by peer', {
                 peerInstanceId, status: res.statusCode, body: body.slice(0, 512),
               });

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -84,6 +84,12 @@ function createControlClient({
     throw new Error('createControlClient: hmac with sign() and generateNonce() is required');
   }
   if (!logger) throw new Error('createControlClient: logger is required');
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('createControlClient: timeoutMs must be a positive integer');
+  }
+  if (!Number.isInteger(responseByteCap) || responseByteCap <= 0) {
+    throw new Error('createControlClient: responseByteCap must be a positive integer');
+  }
 
   async function pushHandoff({
     peerIp,

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -127,8 +127,14 @@ function createControlClient({
             });
             settle({ ok: true, status: res.statusCode });
           } else {
+            // Cap the logged body so an unexpectedly large peer
+            // response (e.g., a stray HTML error page from a
+            // misrouted request) doesn't flood the log line. The
+            // returned `body` field stays uncapped — callers don't
+            // act on it today, but a future debugger reading the
+            // full string from the result object is still ok.
             logger.warn('control-client: handoff rejected by peer', {
-              peerInstanceId, status: res.statusCode, body,
+              peerInstanceId, status: res.statusCode, body: body.slice(0, 512),
             });
             settle({ ok: false, reason: 'rejected', status: res.statusCode, body });
           }

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -23,9 +23,12 @@
 // `{active_instance_id, peer_instance_id, expected_version, ts, nonce}`
 // signed with HMAC. `ts` and `nonce` are added by this module
 // (callers don't need to think about them); `expected_version` is
-// the active's currentVersion at the moment of handoff — pre-
-// transfer, the peer uses it via `adoptLockFromHandoff(expected+1)`
-// to bootstrap its own version cursor.
+// the POST-transfer version returned by the active's
+// `transferLock` call (DDB version after the CAS-bump). The
+// standby seeds its own `gateway-lock` cursor with this value
+// directly via `adoptLockFromHandoff(expected_version)` — no
+// arithmetic on the receive side. Sender contract: pass the
+// `version` field of a `{transferred: true}` transferLock result.
 //
 // ── Return contract ──
 // Returns a result object — never throws. Distinguishes:

--- a/apps/discord/src/gateway-control-client.js
+++ b/apps/discord/src/gateway-control-client.js
@@ -115,87 +115,86 @@ function createControlClient({
       // pre-validated above, so this is belt-and-braces — but the
       // contract is load-bearing for the SIGTERM caller, which
       // cannot handle exceptions cleanly.
-      let req;
       try {
-        req = httpRequest({
-        hostname: peerIp,
-        port: peerPort,
-        path: '/control/yours',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': wire.length,
-        },
-        // Per-call timeout — covers both connect and response phases.
-        timeout: timeoutMs,
-      }, (res) => {
-        const chunks = [];
-        res.on('data', (chunk) => chunks.push(chunk));
-        res.on('end', () => {
-          const body = Buffer.concat(chunks).toString('utf8');
-          if (res.statusCode >= 200 && res.statusCode < 300) {
-            logger.info('control-client: handoff ACKed', {
-              peerInstanceId, status: res.statusCode,
+        const req = httpRequest({
+          hostname: peerIp,
+          port: peerPort,
+          path: '/control/yours',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': wire.length,
+          },
+          // Per-call timeout — covers both connect and response phases.
+          timeout: timeoutMs,
+        }, (res) => {
+          const chunks = [];
+          res.on('data', (chunk) => chunks.push(chunk));
+          res.on('end', () => {
+            const body = Buffer.concat(chunks).toString('utf8');
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+              logger.info('control-client: handoff ACKed', {
+                peerInstanceId, status: res.statusCode,
+              });
+              settle({ ok: true, status: res.statusCode });
+            } else {
+              // Cap the logged body so an unexpectedly large peer
+              // response (e.g., a stray HTML error page from a
+              // misrouted request) doesn't flood the log line. The
+              // returned `body` field stays uncapped — callers don't
+              // act on it today, but a future debugger reading the
+              // full string from the result object is still ok.
+              logger.warn('control-client: handoff rejected by peer', {
+                peerInstanceId, status: res.statusCode, body: body.slice(0, 512),
+              });
+              settle({ ok: false, reason: 'rejected', status: res.statusCode, body });
+            }
+          });
+          res.on('error', (err) => {
+            logger.warn('control-client: response error', {
+              peerInstanceId, error: err.message,
             });
-            settle({ ok: true, status: res.statusCode });
-          } else {
-            // Cap the logged body so an unexpectedly large peer
-            // response (e.g., a stray HTML error page from a
-            // misrouted request) doesn't flood the log line. The
-            // returned `body` field stays uncapped — callers don't
-            // act on it today, but a future debugger reading the
-            // full string from the result object is still ok.
-            logger.warn('control-client: handoff rejected by peer', {
-              peerInstanceId, status: res.statusCode, body: body.slice(0, 512),
-            });
-            settle({ ok: false, reason: 'rejected', status: res.statusCode, body });
-          }
+            settle({ ok: false, reason: 'http_error', error: err.message });
+          });
+          // Peer crashes mid-response (after headers, before end):
+          // 'aborted' fires but 'end' never will. Without this
+          // handler we'd wait the full timeout before settling.
+          // Settle as http_error so the caller treats it like any
+          // other peer-side failure.
+          res.on('aborted', () => {
+            logger.warn('control-client: response aborted', { peerInstanceId });
+            settle({ ok: false, reason: 'http_error', error: 'response_aborted' });
+          });
         });
-        res.on('error', (err) => {
-          logger.warn('control-client: response error', {
+
+        req.on('timeout', () => {
+          // `timeout` event fires but doesn't close the socket. We
+          // MUST settle BEFORE destroy: `req.destroy(err)` can emit
+          // 'error' synchronously in some code paths, and the 'error'
+          // handler below would otherwise race ahead and settle with
+          // reason:'http_error' instead of 'timeout'. Settle is
+          // idempotent, so the destroy-induced 'error' becomes a
+          // no-op after this.
+          logger.warn('control-client: handoff timed out', {
+            peerInstanceId, timeoutMs,
+          });
+          settle({ ok: false, reason: 'timeout' });
+          req.destroy(new Error('handoff_timeout'));
+        });
+
+        req.on('error', (err) => {
+          // After `destroy(err)` for the timeout path, 'error' will
+          // fire — settle is already done, so this is a no-op. Other
+          // error paths (connection refused, DNS fail, etc.) settle
+          // here.
+          logger.warn('control-client: request error', {
             peerInstanceId, error: err.message,
           });
           settle({ ok: false, reason: 'http_error', error: err.message });
         });
-        // Peer crashes mid-response (after headers, before end):
-        // 'aborted' fires but 'end' never will. Without this
-        // handler we'd wait the full timeout before settling.
-        // Settle as http_error so the caller treats it like any
-        // other peer-side failure.
-        res.on('aborted', () => {
-          logger.warn('control-client: response aborted', { peerInstanceId });
-          settle({ ok: false, reason: 'http_error', error: 'response_aborted' });
-        });
-      });
 
-      req.on('timeout', () => {
-        // `timeout` event fires but doesn't close the socket. We
-        // MUST settle BEFORE destroy: `req.destroy(err)` can emit
-        // 'error' synchronously in some code paths, and the 'error'
-        // handler below would otherwise race ahead and settle with
-        // reason:'http_error' instead of 'timeout'. Settle is
-        // idempotent, so the destroy-induced 'error' becomes a
-        // no-op after this.
-        logger.warn('control-client: handoff timed out', {
-          peerInstanceId, timeoutMs,
-        });
-        settle({ ok: false, reason: 'timeout' });
-        req.destroy(new Error('handoff_timeout'));
-      });
-
-      req.on('error', (err) => {
-        // After `destroy(err)` for the timeout path, 'error' will
-        // fire — settle is already done, so this is a no-op. Other
-        // error paths (connection refused, DNS fail, etc.) settle
-        // here.
-        logger.warn('control-client: request error', {
-          peerInstanceId, error: err.message,
-        });
-        settle({ ok: false, reason: 'http_error', error: err.message });
-      });
-
-      req.write(wire);
-      req.end();
+        req.write(wire);
+        req.end();
       } catch (err) {
         logger.warn('control-client: synchronous http.request failure', {
           peerInstanceId, error: err.message,

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -52,16 +52,25 @@
 // freshness edge and may bounce; the design doc names this as a
 // chrony-failure incident, not an application-level recovery target.
 //
-// ── Nonce LRU ──
+// ── Nonce cache (FIFO-by-insertion) ──
 // Each verified body carries a `nonce` (16 random bytes hex). The
-// verifier maintains a bounded in-memory LRU (default 1024 entries)
+// verifier maintains a bounded in-memory FIFO (default 1024 entries)
 // of seen nonces. Replays within the freshness window are rejected.
-// At 5s freshness and 1024 entries, the LRU absorbs up to ~200
+// At 5s freshness and 1024 entries, the cache absorbs up to ~200
 // handoffs/sec before still-fresh nonces start evicting (which would
 // allow replay within the 5s window). Real-world handoff rate is
 // one-per-deploy, so the size is ~3 orders of magnitude over-
 // provisioned; revisit the size if either freshness or handoff rate
 // changes.
+//
+// FIFO (not LRU): we evict by insertion order, not by access order.
+// True LRU would re-rank on each `has()` hit, but the verify path
+// returns `replay` before `rememberNonce` runs on a duplicate, so
+// the cache never sees an `has()` hit followed by use. Eviction by
+// insertion order == eviction by first-seen, which is what we want
+// for a replay window: an old nonce is more likely to be past
+// freshness than a recently-inserted one. Same behavior either way
+// for this call shape; the name reflects the simpler invariant.
 //
 // The check-then-set MUST be one synchronous microtask. There must
 // be no `await` between Map.has and Map.set, otherwise a concurrent
@@ -111,10 +120,12 @@ function createGatewayHmac({
   }
   if (!logger) throw new Error('createGatewayHmac: logger is required');
 
-  // Map insertion order is preserved per spec — so a Map IS a
-  // size-bounded LRU if we re-insert on access and evict the oldest
-  // (first iterator key) when at capacity. Cheaper than a full
-  // LRU class for our 1k-entry use case.
+  // Map insertion order is preserved per spec — so a Map gives us
+  // a size-bounded FIFO by evicting the oldest (first iterator key)
+  // when at capacity. We do NOT re-insert on access (which would
+  // make this a true LRU) — see the FIFO discussion in the module
+  // header for why insertion-order eviction is correct for the
+  // replay-window invariant.
   const seenNonces = new Map();
 
   function rememberNonce(nonce) {

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -301,6 +301,18 @@ function unwrapEnvelope(wireBytes) {
 //      a same-length-but-non-hex `a` produces a SHORTER buffer than
 //      the proper-hex `b` — re-check buffer byte length before the
 //      timing-safe compare to keep timingSafeEqual from throwing.
+//
+// ── Timing-safety limits ──
+// The string-length and post-Buffer length short-circuits are NOT
+// constant-time — they leak whether the candidate signature was
+// the wrong length. For legitimate inputs the length is always
+// fixed at 64 (sha256 hex), so the leak is bounded to "candidate
+// was wrong length" — which an attacker can already observe from
+// the wire by counting bytes they sent. The constant-time guarantee
+// applies to the BYTE-WISE comparison once both sides are valid
+// sha256-hex; we do not claim "constant time across all inputs."
+// If that stronger property is ever needed, drop the length checks
+// and require the caller to pre-validate the candidate length.
 function timingSafeHexEqual(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {
     return false;

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -227,7 +227,15 @@ function createGatewayHmac({
       return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
     }
 
-    if (typeof payload.ts !== 'number' || typeof payload.nonce !== 'string' || payload.nonce.length === 0) {
+    // `Number.isFinite` (not `typeof === 'number'`) because valid
+    // JSON like `1e1000` parses to `Infinity` and would slip past
+    // `typeof === 'number'`. `Math.abs(now - Infinity) > windowMs`
+    // is true today (so the body falls into the stale branch), but
+    // pinning the rejection at the field-shape gate is cleaner and
+    // doesn't depend on freshness arithmetic. Matches the
+    // `Number.isInteger` posture used elsewhere in the gateway
+    // module.
+    if (!Number.isFinite(payload.ts) || typeof payload.nonce !== 'string' || payload.nonce.length === 0) {
       return { ok: false, reason: VERIFY_REASONS.MISSING_FIELD };
     }
 

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -1,0 +1,294 @@
+// HMAC-SHA256 sign/verify primitive for Pillar 3's control-channel
+// push-handoff. Backed by a JSON-shaped SSM secret
+// `{"current": "<hex>", "previous": "<hex>"}`. Both keys are loaded
+// at boot and held in memory for the task lifetime — no SSM hot-
+// reload (matches every other secret in this app:
+// DISCORD_TOKEN, KEY_ENCRYPTION_KEY, etc.; rotation is via rolling
+// redeploy, see design doc §Pillar 3 "Secret rotation").
+//
+// ── Sign side ──
+// Active always signs with `current`. The signed body is the raw
+// UTF-8 bytes of `JSON.stringify(payload)`; the wire shape is
+// `{ body: <string>, signature: <hex> }`. We sign the bytes once,
+// not the parsed object, so receiver-side JSON-key-reordering or
+// re-stringification never breaks the signature.
+//
+// ── Wire envelope helpers ──
+// `wrapEnvelope({bodyBytes, signature}) → Buffer` and
+// `unwrapEnvelope(wireBytes) → {bodyBytes, signature} | null` are
+// the single source of truth for the on-the-wire shape. The
+// control-channel server, control-channel client, and test fixtures
+// all funnel through these — so a future change to the envelope
+// (rename, version field, etc.) is one edit instead of three
+// drifting copies.
+//
+// ── Verify side ──
+// Standby tries `current` first, then `previous`. The dual-accept
+// window covers the rotation deploy: between the rolling-deploy
+// stages, one replica may still sign with `previous` while the
+// other has loaded `current` as new and `previous` as the old
+// (or vice-versa). At least one of the two HMACs must validate.
+//
+// Verify MUST run on the raw bytes BEFORE `JSON.parse`. Two reasons:
+//   1. Key-order safety: parsing then re-stringifying for verification
+//      would canonicalize the key order, and a body signed with key
+//      order A would fail to verify if the receiver's stringify
+//      produced key order B.
+//   2. DoS protection: parsing an unverified body lets an attacker
+//      OOM the standby by sending a giant JSON payload. The body
+//      cap (enforced upstream in gateway-control-channel) bounds
+//      memory regardless, but verifying first means we don't parse
+//      unauthenticated input at all.
+//
+// Equality is `crypto.timingSafeEqual` — never `===`. We length-check
+// first because timingSafeEqual throws on length mismatch (a property
+// that's load-bearing for the timing-safe guarantee but inconvenient
+// for our "try current then previous" flow where a malformed signature
+// could be any length).
+//
+// ── Freshness window ──
+// Payloads carry a `ts` (epoch ms). Anything outside ±freshnessWindowMs
+// (default 5000) is rejected. Clock skew >±2s pushes bodies into the
+// freshness edge and may bounce; the design doc names this as a
+// chrony-failure incident, not an application-level recovery target.
+//
+// ── Nonce LRU ──
+// Each verified body carries a `nonce` (16 random bytes hex). The
+// verifier maintains a bounded in-memory LRU (default 1024 entries)
+// of seen nonces. Replays within the freshness window are rejected.
+// At 5s freshness and 1024 entries, the LRU absorbs up to ~200
+// handoffs/sec before still-fresh nonces start evicting (which would
+// allow replay within the 5s window). Real-world handoff rate is
+// one-per-deploy, so the size is ~3 orders of magnitude over-
+// provisioned; revisit the size if either freshness or handoff rate
+// changes.
+//
+// The check-then-set MUST be one synchronous microtask. There must
+// be no `await` between Map.has and Map.set, otherwise a concurrent
+// duplicate POST slips through both checks.
+
+const crypto = require('node:crypto');
+
+const DEFAULT_FRESHNESS_WINDOW_MS = 5_000;
+const DEFAULT_NONCE_LRU_SIZE = 1024;
+
+// Verify-rejection reasons. Exported so callers (control-channel
+// server logs, tests) reference the constant rather than the literal
+// — one typo in a literal across modules silently breaks the
+// protocol's observability surface.
+const VERIFY_REASONS = Object.freeze({
+  BAD_SIGNATURE: 'bad_signature',
+  STALE: 'stale',
+  REPLAY: 'replay',
+  MALFORMED_BODY: 'malformed_body',
+  MISSING_FIELD: 'missing_field',
+});
+
+function createGatewayHmac({
+  secrets,
+  logger,
+  // Injected for deterministic tests. Production uses Date.now.
+  clock = () => Date.now(),
+  freshnessWindowMs = DEFAULT_FRESHNESS_WINDOW_MS,
+  nonceLruSize = DEFAULT_NONCE_LRU_SIZE,
+} = {}) {
+  if (!secrets || typeof secrets !== 'object') {
+    throw new Error('createGatewayHmac: secrets ({ current, previous? }) is required');
+  }
+  if (typeof secrets.current !== 'string' || secrets.current.length === 0) {
+    throw new Error('createGatewayHmac: secrets.current (non-empty hex string) is required');
+  }
+  // `previous` is optional — null/undefined accepted, but if present
+  // must be a string. Lets the rotation deploy run with a
+  // single-secret state (post-step-3 "scrub previous") without
+  // forcing every replica to redeploy first.
+  if (secrets.previous != null && typeof secrets.previous !== 'string') {
+    throw new Error('createGatewayHmac: secrets.previous must be a string or null');
+  }
+  if (!logger) throw new Error('createGatewayHmac: logger is required');
+
+  // Map insertion order is preserved per spec — so a Map IS a
+  // size-bounded LRU if we re-insert on access and evict the oldest
+  // (first iterator key) when at capacity. Cheaper than a full
+  // LRU class for our 1k-entry use case.
+  const seenNonces = new Map();
+
+  function rememberNonce(nonce) {
+    // Bump-to-newest on re-insert.
+    if (seenNonces.has(nonce)) {
+      seenNonces.delete(nonce);
+    }
+    seenNonces.set(nonce, true);
+    while (seenNonces.size > nonceLruSize) {
+      const oldest = seenNonces.keys().next().value;
+      seenNonces.delete(oldest);
+    }
+  }
+
+  function hmacHex(secret, bodyBytes) {
+    return crypto.createHmac('sha256', secret).update(bodyBytes).digest('hex');
+  }
+
+  // Signs the payload with `secrets.current` and returns the wire
+  // shape. Caller is responsible for adding `ts` and `nonce` to the
+  // payload before calling — those are part of the freshness +
+  // replay defenses, signed alongside the rest of the body.
+  function sign(payload) {
+    if (payload == null || typeof payload !== 'object') {
+      throw new Error('gateway-hmac: sign requires an object payload');
+    }
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = hmacHex(secrets.current, bodyBytes);
+    return { bodyBytes, signature };
+  }
+
+  // Verify a body + signature pair. `bodyBytes` MUST be the exact
+  // bytes received off the wire, not a re-stringified parsed
+  // representation (see module header).
+  //
+  // Returns one of:
+  //   { ok: true, payload }
+  //   { ok: false, reason: 'bad_signature' | 'stale' | 'replay' | 'malformed_body' | 'missing_field' }
+  //
+  // `payload` on the ok-path is the JSON-parsed body. Parse happens
+  // AFTER successful HMAC verification.
+  function verify({ bodyBytes, signature }) {
+    if (!Buffer.isBuffer(bodyBytes) || typeof signature !== 'string') {
+      return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
+    }
+
+    const expectedCurrent = hmacHex(secrets.current, bodyBytes);
+    let matched = timingSafeHexEqual(signature, expectedCurrent);
+
+    // Try `previous` only if `current` didn't match AND `previous`
+    // is configured. The rotation procedure relies on the standby
+    // accepting both during the rolling-deploy window.
+    if (!matched && secrets.previous) {
+      const expectedPrevious = hmacHex(secrets.previous, bodyBytes);
+      matched = timingSafeHexEqual(signature, expectedPrevious);
+    }
+
+    if (!matched) {
+      return { ok: false, reason: VERIFY_REASONS.BAD_SIGNATURE };
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(bodyBytes.toString('utf8'));
+    } catch (_err) {
+      return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
+    }
+    if (payload == null || typeof payload !== 'object') {
+      return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
+    }
+
+    if (typeof payload.ts !== 'number' || typeof payload.nonce !== 'string' || payload.nonce.length === 0) {
+      return { ok: false, reason: VERIFY_REASONS.MISSING_FIELD };
+    }
+
+    const now = clock();
+    if (Math.abs(now - payload.ts) > freshnessWindowMs) {
+      logger.warn('gateway-hmac: stale body rejected', {
+        ts: payload.ts, now, skewMs: now - payload.ts, freshnessWindowMs,
+      });
+      return { ok: false, reason: VERIFY_REASONS.STALE };
+    }
+
+    // Check-then-set must be ONE microtask — no await between. A
+    // concurrent duplicate POST landing here mid-handler would
+    // otherwise slip through both checks.
+    if (seenNonces.has(payload.nonce)) {
+      logger.warn('gateway-hmac: replayed nonce rejected', { noncePrefix: payload.nonce.slice(0, 8) });
+      return { ok: false, reason: VERIFY_REASONS.REPLAY };
+    }
+    rememberNonce(payload.nonce);
+
+    return { ok: true, payload };
+  }
+
+  // Generates a fresh nonce. Exposed so callers (the handoff body
+  // builder) don't have to reach into `node:crypto` themselves.
+  function generateNonce() {
+    return crypto.randomBytes(16).toString('hex');
+  }
+
+  return {
+    sign,
+    verify,
+    generateNonce,
+    // Inspection seams for tests.
+    _getSeenNoncesSizeForTest() {
+      return seenNonces.size;
+    },
+  };
+}
+
+// Build the wire envelope from `sign()`'s output. The wire shape is
+// `{body: <utf-8 string of signed JSON>, signature: <hex>}`,
+// serialized as JSON. Stringifying the inner body once and embedding
+// it as a STRING (not a parsed object) preserves the inner bytes
+// verbatim across `JSON.parse` on the receiver — JSON-string round-
+// trip is byte-exact, parsed-object round-trip is not (key order
+// canonicalization could break HMAC verify).
+function wrapEnvelope({ bodyBytes, signature }) {
+  if (!Buffer.isBuffer(bodyBytes) || typeof signature !== 'string') {
+    throw new Error('wrapEnvelope: { bodyBytes: Buffer, signature: string } required');
+  }
+  return Buffer.from(JSON.stringify({
+    body: bodyBytes.toString('utf8'),
+    signature,
+  }), 'utf8');
+}
+
+// Parse wire envelope bytes back to `{bodyBytes, signature}`. Returns
+// null on any shape mismatch — caller decides whether to reject with
+// 400 / log / etc. Does NOT verify HMAC; that's `hmac.verify()`'s job.
+function unwrapEnvelope(wireBytes) {
+  if (!Buffer.isBuffer(wireBytes)) return null;
+  let envelope;
+  try {
+    envelope = JSON.parse(wireBytes.toString('utf8'));
+  } catch (_err) {
+    return null;
+  }
+  if (envelope == null
+    || typeof envelope.body !== 'string'
+    || typeof envelope.signature !== 'string') {
+    return null;
+  }
+  return {
+    bodyBytes: Buffer.from(envelope.body, 'utf8'),
+    signature: envelope.signature,
+  };
+}
+
+// Constant-time hex string compare. timingSafeEqual throws on length
+// mismatch (a property that's load-bearing for the timing-safe
+// guarantee but inconvenient here, where a malformed or non-hex
+// candidate signature could be any length). We:
+//   1. Reject up front on string-length mismatch.
+//   2. Parse both sides with Buffer.from(..., 'hex'). Buffer.from
+//      SILENTLY DROPS non-hex characters rather than throwing, so
+//      a same-length-but-non-hex `a` produces a SHORTER buffer than
+//      the proper-hex `b` — re-check buffer byte length before the
+//      timing-safe compare to keep timingSafeEqual from throwing.
+function timingSafeHexEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {
+    return false;
+  }
+  const ba = Buffer.from(a, 'hex');
+  const bb = Buffer.from(b, 'hex');
+  if (ba.length !== bb.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(ba, bb);
+}
+
+module.exports = {
+  createGatewayHmac,
+  wrapEnvelope,
+  unwrapEnvelope,
+  VERIFY_REASONS,
+  DEFAULT_FRESHNESS_WINDOW_MS,
+  DEFAULT_NONCE_LRU_SIZE,
+};

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -105,7 +105,13 @@ function createGatewayHmac({
     throw new Error('createGatewayHmac: secrets ({ current, previous? }) is required');
   }
   if (typeof secrets.current !== 'string' || secrets.current.length === 0) {
-    throw new Error('createGatewayHmac: secrets.current (non-empty hex string) is required');
+    // Format: any non-empty opaque string. Production deploys
+    // load this from SSM as a hex-encoded 32-byte value (matches
+    // operator tooling that assumes hex), but `createHmac` accepts
+    // any string and uses its UTF-8 bytes as the key, so the
+    // module itself does not enforce hex. If you change the SSM
+    // format, audit operator tooling for hex assumptions.
+    throw new Error('createGatewayHmac: secrets.current (non-empty string) is required');
   }
   // `previous` is optional — null/undefined accepted, but if present
   // must be a NON-EMPTY string. The use site at the verify path

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -125,6 +125,22 @@ function createGatewayHmac({
     throw new Error('createGatewayHmac: secrets.previous must be a non-empty string or null');
   }
   if (!logger) throw new Error('createGatewayHmac: logger is required');
+  // freshnessWindowMs <= 0 would reject every body as `stale` (the
+  // freshness check is `now - ts < window`); fractional values
+  // would coerce weirdly. Fail loud at boot.
+  if (!Number.isInteger(freshnessWindowMs) || freshnessWindowMs <= 0) {
+    throw new Error('createGatewayHmac: freshnessWindowMs must be a positive integer');
+  }
+  // nonceLruSize <= 0 SILENTLY DISABLES replay protection: the
+  // `while (seenNonces.size > nonceLruSize)` loop in rememberNonce
+  // would evict the just-inserted nonce immediately, so the next
+  // verify() call sees an empty cache and never finds the replay.
+  // This is the worst possible failure mode — looks like it's
+  // working but the replay window is zero entries. Fail loud at
+  // boot to make the misconfig impossible.
+  if (!Number.isInteger(nonceLruSize) || nonceLruSize <= 0) {
+    throw new Error('createGatewayHmac: nonceLruSize must be a positive integer');
+  }
 
   // Map insertion order is preserved per spec — so a Map gives us
   // a size-bounded FIFO by evicting the oldest (first iterator key)

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -80,6 +80,11 @@ const crypto = require('node:crypto');
 
 const DEFAULT_FRESHNESS_WINDOW_MS = 5_000;
 const DEFAULT_NONCE_LRU_SIZE = 1024;
+// sha256 hex digest length. Used as a cheap pre-check in `verify`
+// to skip the hmacHex compute when the candidate signature can't
+// possibly match (any non-64-char string fails the byte-wise
+// compare in `timingSafeHexEqual` regardless).
+const SHA256_HEX_LENGTH = 64;
 
 // Verify-rejection reasons. Exported so callers (control-channel
 // server logs, tests) reference the constant rather than the literal
@@ -194,6 +199,18 @@ function createGatewayHmac({
   function verify({ bodyBytes, signature }) {
     if (!Buffer.isBuffer(bodyBytes) || typeof signature !== 'string') {
       return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
+    }
+    // Skip the hmacHex compute when the candidate is the wrong
+    // length. sha256 hex is always 64 chars; anything else can't
+    // possibly match `expected*` so the byte-wise compare in
+    // timingSafeHexEqual would short-circuit anyway. Pre-checking
+    // here saves an HMAC compute on every malformed candidate AND
+    // keeps the cost forward-compatible if a future caller swaps
+    // sha256 for a heavier MAC. The "candidate was wrong length"
+    // timing leak is unchanged (already documented above
+    // timingSafeHexEqual).
+    if (signature.length !== SHA256_HEX_LENGTH) {
+      return { ok: false, reason: VERIFY_REASONS.BAD_SIGNATURE };
     }
 
     const expectedCurrent = hmacHex(secrets.current, bodyBytes);

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -184,7 +184,13 @@ function createGatewayHmac({
     } catch (_err) {
       return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
     }
-    if (payload == null || typeof payload !== 'object') {
+    // Reject arrays too — `typeof [] === 'object'`, but a handoff
+    // payload is always a plain object. The downstream
+    // findInvalidHandoffField check would catch an array anyway
+    // (array.active_instance_id is undefined), but rejecting at the
+    // HMAC module boundary keeps this layer's contract less
+    // dependent on receiver-side validation shape.
+    if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) {
       return { ok: false, reason: VERIFY_REASONS.MALFORMED_BODY };
     }
 

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -99,11 +99,15 @@ function createGatewayHmac({
     throw new Error('createGatewayHmac: secrets.current (non-empty hex string) is required');
   }
   // `previous` is optional — null/undefined accepted, but if present
-  // must be a string. Lets the rotation deploy run with a
-  // single-secret state (post-step-3 "scrub previous") without
-  // forcing every replica to redeploy first.
-  if (secrets.previous != null && typeof secrets.previous !== 'string') {
-    throw new Error('createGatewayHmac: secrets.previous must be a string or null');
+  // must be a NON-EMPTY string. The use site at the verify path
+  // (`if (!matched && secrets.previous)`) treats empty string as
+  // "not configured" (falsy); without this validator catching it,
+  // a misconfig that set `previous: ""` would silently disable
+  // dual-accept during the rolling-deploy rotation window. Fail
+  // loud at boot.
+  if (secrets.previous != null
+      && (typeof secrets.previous !== 'string' || secrets.previous.length === 0)) {
+    throw new Error('createGatewayHmac: secrets.previous must be a non-empty string or null');
   }
   if (!logger) throw new Error('createGatewayHmac: logger is required');
 
@@ -114,7 +118,11 @@ function createGatewayHmac({
   const seenNonces = new Map();
 
   function rememberNonce(nonce) {
-    // Bump-to-newest on re-insert.
+    // The `has → delete → set` bump-to-newest pattern. Note that
+    // the `has` branch is unreachable from `verify()` (verify
+    // returns `replay` BEFORE calling rememberNonce on a duplicate),
+    // so this is defensive for any future caller that might insert
+    // without the pre-check. Harmless dead branch via verify.
     if (seenNonces.has(nonce)) {
       seenNonces.delete(nonce);
     }

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -118,14 +118,12 @@ function createGatewayHmac({
   const seenNonces = new Map();
 
   function rememberNonce(nonce) {
-    // The `has → delete → set` bump-to-newest pattern. Note that
-    // the `has` branch is unreachable from `verify()` (verify
-    // returns `replay` BEFORE calling rememberNonce on a duplicate),
-    // so this is defensive for any future caller that might insert
-    // without the pre-check. Harmless dead branch via verify.
-    if (seenNonces.has(nonce)) {
-      seenNonces.delete(nonce);
-    }
+    // Insert-only. The sole caller (`verify`) already returns
+    // `replay` BEFORE reaching here on a duplicate, so this never
+    // sees an existing key — and a defensive bump-to-newest would
+    // be misleading code (it would never run). If a future caller
+    // bypasses the verify path and needs bump semantics, add an
+    // explicit pre-check at that call site.
     seenNonces.set(nonce, true);
     while (seenNonces.size > nonceLruSize) {
       const oldest = seenNonces.keys().next().value;

--- a/apps/discord/src/gateway-hmac.js
+++ b/apps/discord/src/gateway-hmac.js
@@ -142,13 +142,13 @@ function createGatewayHmac({
     throw new Error('createGatewayHmac: nonceLruSize must be a positive integer');
   }
 
-  // Map insertion order is preserved per spec — so a Map gives us
+  // Set insertion order is preserved per spec — so a Set gives us
   // a size-bounded FIFO by evicting the oldest (first iterator key)
   // when at capacity. We do NOT re-insert on access (which would
   // make this a true LRU) — see the FIFO discussion in the module
   // header for why insertion-order eviction is correct for the
   // replay-window invariant.
-  const seenNonces = new Map();
+  const seenNonces = new Set();
 
   function rememberNonce(nonce) {
     // Insert-only. The sole caller (`verify`) already returns
@@ -157,9 +157,9 @@ function createGatewayHmac({
     // be misleading code (it would never run). If a future caller
     // bypasses the verify path and needs bump semantics, add an
     // explicit pre-check at that call site.
-    seenNonces.set(nonce, true);
+    seenNonces.add(nonce);
     while (seenNonces.size > nonceLruSize) {
-      const oldest = seenNonces.keys().next().value;
+      const oldest = seenNonces.values().next().value;
       seenNonces.delete(oldest);
     }
   }

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -467,11 +467,15 @@ function createGatewayLeader({
           }),
         ]);
       } catch (err) {
-        // Sync-throw path (and non-thenable-return path): if the
-        // lifecycle handlers never attached, this catch is the only
-        // clear. The async-rejection path is owned by the .then()
-        // handlers, so we DON'T touch `connecting` there (would
-        // race the next tick's connect; see comment in finally).
+        // Sync-throw path: if `manager.connect()` itself throws OR
+        // returns a non-thenable (in which case `.then` is undefined
+        // on the return value and the call site throws synchronously
+        // BEFORE `lifecycleAttached` flips true), the lifecycle
+        // handlers never registered. This catch is then the only
+        // clear for `connecting=false`. The async-rejection path is
+        // owned by the .then() handlers, so we DON'T touch
+        // `connecting` there (would race the next tick's connect;
+        // see comment in finally).
         if (!lifecycleAttached) connecting = false;
         logger.error('gateway-leader: inbound-handoff connect threw (watchdog will retry)', {
           error: err.message, activeInstanceId,

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -170,13 +170,16 @@ function createGatewayLeader({
     // chain-keeping promise behavior on purpose.
     const next = inFlight.then(() => work(), () => work());
     inFlight = next.then(() => {}, (err) => {
-      // Warn (not debug): every work() should already log its own
-      // failure at warn/error level, so this backstop should never
-      // fire visibly in practice. If it ever does (a future caller
-      // passes a work fn that throws before its own try/catch),
-      // surfacing at warn level makes it visible at default prod
-      // log levels rather than silently swallowing.
-      logger.warn('gateway-leader: serialized op rejected (chain continues)', {
+      // Debug (not warn): every rethrowing op (tick / handleInboundHandoff
+      // / pushHandoff) ALREADY logs at warn/error from its own
+      // try/catch before throwing. Logging again at warn here
+      // double-reports the same failure under a different message,
+      // confusing log readers into thinking two things failed. Drop
+      // to debug so the chain-keeping observability is still
+      // available for whoever ever needs it (e.g., investigating a
+      // backstop firing for a future caller that bypassed the
+      // op-level try/catch) without polluting prod log levels.
+      logger.debug('gateway-leader: serialized op rejected (chain continues)', {
         error: err && err.message,
       });
     });
@@ -297,10 +300,15 @@ function createGatewayLeader({
   // a handoff to us. Already HMAC-verified + routing-checked by the
   // server; this just does the lock-cursor + WS-connect side.
   //
-  // Returns nothing on success. Throws on failure — the server
-  // returns 500 to the active. Either branch is safe: the active
-  // exits on any non-2xx, and the watchdog re-tries the connect
-  // path if heldLock got set before the throw.
+  // @param {object} arg
+  // @param {string} arg.activeInstanceId  who's transferring to us
+  // @param {number} arg.expectedVersion   the lock version to adopt
+  // @returns {Promise<void>}              resolves on success
+  // @throws on adopt failure, connect failure, or stray-handoff
+  //
+  // Server returns 500 to the active on any throw. Either branch is
+  // safe: the active exits on any non-2xx, and the watchdog re-tries
+  // the connect path if heldLock got set before the throw.
   async function handleInboundHandoff({ activeInstanceId, expectedVersion }) {
     return runSerialized(async () => {
       // Stray-handoff guard: if we already hold the lock AND the WS

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -292,6 +292,15 @@ function createGatewayLeader({
         return { pushed: false, reason: 'transfer_failed' };
       }
 
+      // Implicit invariant: caller (SIGTERM handler) MUST exit
+      // after this point. Clearing heldLock here without exiting
+      // would cause the next tick (if `running` got flipped back
+      // on) to observe heldLock=false and try `acquireLock` —
+      // immediately re-acquiring the lock we just transferred.
+      // Stop is already false (set at the top of pushHandoff),
+      // but a future refactor that ever resumes the tick loop
+      // after handoff needs to also clear or re-key heldLock
+      // semantics.
       heldLock = false;
 
       const result = await controlClient.pushHandoff({

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -59,17 +59,20 @@
 // ── pushHandoff (SIGTERM path) ──
 // Stops the tick loop, then:
 //   1. Find a fresh peer in this shard (listFreshPeers, head of list).
-//   2. If no peer → release lock (best-effort) + return {pushed: false,
-//      reason: 'no_peer'}. Cold-fallback floor applies on the other
-//      side.
+//   2. If no peer → release lock (best-effort) + return
+//      {transferred: false, reason: 'no_peer'}. Cold-fallback floor
+//      applies on the other side.
 //   3. transferLock(peer.instance_id, peer.lock_holder) — atomic
 //      DDB ownership move. On CCF (active lost the lock to a cold-
-//      fallback acquire by the peer) → return {pushed: false, reason:
-//      'transfer_failed'}.
+//      fallback acquire by the peer) → return {transferred: false,
+//      reason: 'transfer_failed'}.
 //   4. controlClient.pushHandoff(...) with expectedVersion = the
 //      post-transfer version returned by transferLock.
-//   5. Return the result. Caller (index.js SIGTERM handler) exits
-//      either way.
+//   5. Return {transferred: true, pushAcked: bool, pushReason?}. The
+//      `transferred` field reflects DDB ownership (the standby owns
+//      the lock); `pushAcked` reflects whether the standby's HTTP
+//      ACK arrived. The watchdog covers the !pushAcked case. Caller
+//      (index.js SIGTERM handler) exits either way.
 
 const DEFAULT_TICK_INTERVAL_MS = 2_000;
 // Internal ceiling for an inbound-handoff `manager.connect()` await.
@@ -389,11 +392,15 @@ function createGatewayLeader({
       // `manager.connect()` is inside the try so a synchronous throw
       // (defensive — @discordjs/ws's WebSocketManager.connect contract
       // is async, but a future shim regression or wiring bug could
-      // surface a sync throw) still clears `connecting=false`. If
-      // `connectPromise` is unassigned at catch-time, the lifecycle
-      // attachment never ran, so the catch arm is the only thing that
-      // can clear the flag.
+      // surface a sync throw or a non-thenable return) still clears
+      // `connecting=false`. We track lifecycle attachment success
+      // explicitly (rather than just `!!connectPromise`) because
+      // `.then` itself can throw if `connect()` returned a non-
+      // thenable — in that case `connectPromise` is set but the
+      // settlement handlers never registered, so the catch is the
+      // only clear.
       let connectPromise;
+      let lifecycleAttached = false;
       let connectTimer;
       try {
         connectPromise = manager.connect();
@@ -401,6 +408,7 @@ function createGatewayLeader({
           () => { connecting = false; },
           () => { connecting = false; },
         );
+        lifecycleAttached = true;
         await Promise.race([
           connectPromise,
           new Promise((_, reject) => {
@@ -411,12 +419,12 @@ function createGatewayLeader({
           }),
         ]);
       } catch (err) {
-        // Sync-throw path: no connectPromise means the lifecycle
-        // attachment never ran, so this catch is the only clear. The
-        // async-rejection path is owned by the .then() handlers, so
-        // we DON'T touch `connecting` there (would race the next
-        // tick's connect; see comment in finally).
-        if (!connectPromise) connecting = false;
+        // Sync-throw path (and non-thenable-return path): if the
+        // lifecycle handlers never attached, this catch is the only
+        // clear. The async-rejection path is owned by the .then()
+        // handlers, so we DON'T touch `connecting` there (would
+        // race the next tick's connect; see comment in finally).
+        if (!lifecycleAttached) connecting = false;
         logger.error('gateway-leader: inbound-handoff connect threw (watchdog will retry)', {
           error: err.message, activeInstanceId,
         });
@@ -450,7 +458,7 @@ function createGatewayLeader({
     const result = await runSerialized(async () => {
       if (!heldLock) {
         logger.info('gateway-leader: pushHandoff called without holding lock (no-op)');
-        return { pushed: false, reason: 'not_holding_lock' };
+        return { transferred: false, reason: 'not_holding_lock' };
       }
 
       let peers;
@@ -461,14 +469,14 @@ function createGatewayLeader({
           error: err.message,
         });
         await releaseLockBestEffort('peer_lookup_failed');
-        return { pushed: false, reason: 'peer_lookup_failed' };
+        return { transferred: false, reason: 'peer_lookup_failed' };
       }
 
       const peer = peers[0]; // freshest-first per listFreshPeers contract
       if (!peer) {
         logger.warn('gateway-leader: no fresh peer for handoff — falling through to cold-fallback');
         await releaseLockBestEffort('no_peer');
-        return { pushed: false, reason: 'no_peer' };
+        return { transferred: false, reason: 'no_peer' };
       }
 
       // Defensive: if a heartbeat row exists without lock_holder
@@ -493,7 +501,7 @@ function createGatewayLeader({
       } catch (err) {
         logger.error('gateway-leader: transferLock threw', { error: err.message });
         await releaseLockBestEffort('transfer_threw');
-        return { pushed: false, reason: 'transfer_threw' };
+        return { transferred: false, reason: 'transfer_threw' };
       }
 
       if (!transferResult.transferred) {
@@ -502,7 +510,7 @@ function createGatewayLeader({
         // longer ours, so flip the local flag to match.
         heldLock = false;
         logger.warn('gateway-leader: transferLock CAS failed; skipping push');
-        return { pushed: false, reason: 'transfer_failed' };
+        return { transferred: false, reason: 'transfer_failed' };
       }
 
       heldLock = false;
@@ -530,7 +538,7 @@ function createGatewayLeader({
         logger.error('gateway-leader: controlClient.pushHandoff threw (watchdog will catch)', {
           peerInstanceId: peer.instance_id, error: err && err.message,
         });
-        return { pushed: true, ackReason: 'push_threw' };
+        return { transferred: true, pushAcked: false, pushReason: 'push_threw' };
       }
       // Either ACK branch is fine. The active is exiting anyway; the
       // standby has the lock either way (transferLock already moved
@@ -541,12 +549,12 @@ function createGatewayLeader({
         logger.info('gateway-leader: pushHandoff ACKed', {
           peerInstanceId: peer.instance_id,
         });
-      } else {
-        logger.warn('gateway-leader: pushHandoff did not ACK (watchdog will catch)', {
-          peerInstanceId: peer.instance_id, reason: pushResult.reason,
-        });
+        return { transferred: true, pushAcked: true };
       }
-      return { pushed: true, ackReason: pushResult.ok ? 'ack' : pushResult.reason };
+      logger.warn('gateway-leader: pushHandoff did not ACK (watchdog will catch)', {
+        peerInstanceId: peer.instance_id, reason: pushResult.reason,
+      });
+      return { transferred: true, pushAcked: false, pushReason: pushResult.reason };
     });
 
     // Best-effort heartbeat-row cleanup. Deliberately OUTSIDE the

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -127,13 +127,6 @@ function createGatewayLeader({
   let loopPromise = null;
   let knownPeerInstanceIds = new Set();
 
-  // Mutator serialization. Every call site that touches the
-  // single-caller-only gateway-lock API funnels through this so
-  // tick / inbound-handoff / push-handoff never overlap. Rejections
-  // are caught when chained into `inFlight` so a prior failure
-  // doesn't break the chain — but we log on the catch so an op
-  // failure isn't observable-only-via-caller (the work itself logs
-  // its own failure, this is a backstop for the chain-keeping path).
   // Best-effort lock release for pushHandoff's bail-out paths. The
   // leader is exiting; we want to give up the lock so the next
   // replacement task can cold-acquire immediately instead of waiting
@@ -150,25 +143,30 @@ function createGatewayLeader({
     }
   }
 
+  // ── Mutator serialization ──
+  // Every call site that touches the single-caller-only gateway-lock
+  // API funnels through `runSerialized` so tick / inbound-handoff /
+  // push-handoff never overlap. The serialization chain absorbs
+  // failures so one op's rejection doesn't break the next op's
+  // turn — see the function-level comment for the load-bearing
+  // invariant.
   let inFlight = Promise.resolve();
   function runSerialized(work) {
-    // `.then(work, work)` — both fulfillment AND rejection handlers
-    // invoke `work()`. INTENTIONAL: a prior op rejecting must NOT
-    // skip the next op (that would break the serialization chain
-    // when one op fails). The fulfillment and rejection arms are
-    // distinct thenable handlers but both call the same `work`
-    // callee; `work()` runs exactly once per `runSerialized` call
-    // regardless of the prior outcome.
+    // The load-bearing invariant: `inFlight` is ALWAYS fulfilled
+    // (never rejected) because we assign it below to a `.then` whose
+    // rejection arm returns undefined — turning every prior failure
+    // into a fulfilled chain. That means the NEXT `runSerialized`
+    // call's `inFlight.then(() => work())` reliably runs `work()`
+    // regardless of whether the previous op rejected. This is what
+    // keeps the serialization chain alive across failures; the
+    // dual-arm `.then` we used to have on the consumer side was
+    // over-defending against a state that can't happen.
     //
-    // Subtle: this function returns `next` (which propagates work's
-    // rejection to the caller) but ASSIGNS `inFlight` to a different
-    // promise that swallows the rejection (via the second `.then`
-    // arm below). The caller awaiting the return value can `.catch`
-    // its op's failure; the NEXT `runSerialized` call chains off an
-    // always-fulfilled `inFlight` so a prior op's rejection doesn't
-    // poison the chain. Returned-promise behavior diverges from
-    // chain-keeping promise behavior on purpose.
-    const next = inFlight.then(() => work(), () => work());
+    // The returned `next` DOES propagate the work's rejection to the
+    // caller — so callers can `.catch` their own op's failure — but
+    // the side-effect `inFlight` assignment diverges and absorbs it.
+    // Returned-promise vs chain-keeping behavior differ on purpose.
+    const next = inFlight.then(() => work());
     inFlight = next.then(() => {}, (err) => {
       // Debug (not warn): every rethrowing op (tick / handleInboundHandoff
       // / pushHandoff) ALREADY logs at warn/error from its own
@@ -310,6 +308,17 @@ function createGatewayLeader({
   // safe: the active exits on any non-2xx, and the watchdog re-tries
   // the connect path if heldLock got set before the throw.
   async function handleInboundHandoff({ activeInstanceId, expectedVersion }) {
+    // Terminal-state guard: a post-pushHandoff leader is dead.
+    // A second inbound handoff arriving (e.g., racing the SIGTERM
+    // path) must NOT re-adopt — the process is exiting. Throw so
+    // the control-channel server returns 500 and the active gives
+    // up. Symmetric to start()'s same guard.
+    if (closed) {
+      logger.warn('gateway-leader: inbound handoff rejected — leader closed', {
+        activeInstanceId, expectedVersion,
+      });
+      throw new Error('leader_closed');
+    }
     return runSerialized(async () => {
       // Stray-handoff guard: if we already hold the lock AND the WS
       // is connected, a second inbound handoff is either a duplicate
@@ -395,7 +404,10 @@ function createGatewayLeader({
       // If a future @discordjs/ws version ever drops that contract,
       // either set a hard ceiling here that accepts the concurrent
       // risk, or wire a `manager.destroy()`-on-timeout escape in
-      // the shim layer.
+      // the shim layer. Tracking issue #415 covers a process-level
+      // health check (alert on `connecting=true` duration > 30s
+      // and exit(1) so ECS replaces the task) — preferred recovery
+      // over racing another timer.
       connecting = true;
       // `manager.connect()` is inside the try so a synchronous throw
       // (defensive — @discordjs/ws's WebSocketManager.connect contract
@@ -498,8 +510,7 @@ function createGatewayLeader({
       // TODO(post-13b.2-bake): drop this fallback once all peers
       // have been on >=13b.2 long enough that missing lock_holder
       // is impossible. Target removal: 2026-07-01 (~6 weeks after
-      // 13b.2 lands in prod). Tracked: file a follow-up issue
-      // when 13b.3 lands so the bake window is observable.
+      // 13b.2 lands in prod). Tracked: #416.
       const targetLockHolder = peer.lock_holder
         || `placeholder/${peer.instance_id}`;
 
@@ -592,7 +603,16 @@ function createGatewayLeader({
   // success); the function name surfaces that contract at the
   // call site instead of relying on a comment.
   async function releaseLockForImmediateExit() {
-    return runSerialized(async () => {
+    // Terminal-state guard: if pushHandoff already ran, we've already
+    // released (best-effort) and `heldLock=false`. A subsequent watchdog
+    // call here would no-op anyway, but short-circuiting makes the
+    // closed-state invariant uniform across the API surface (start()
+    // and handleInboundHandoff also guard on closed).
+    if (closed) {
+      logger.debug('gateway-leader: releaseLockForImmediateExit called on closed leader (no-op)');
+      return;
+    }
+    await runSerialized(async () => {
       heldLock = false;
       await lock.releaseLock();
     });

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -199,13 +199,23 @@ function createGatewayLeader({
   }
 
   function start() {
-    if (running) return;
+    // Guard on `loopPromise` (NOT just `running`) so a `start()`
+    // after a `stop()` that hasn't yet observed the running=false
+    // flag — the old loop is still inside `await sleep(...)` — does
+    // not spawn a second concurrent loop. Callers that need to
+    // re-start MUST `await stop()` first; the returned promise
+    // resolves once the loop has actually exited.
+    if (loopPromise) return;
     running = true;
-    loopPromise = loop();
+    loopPromise = loop().finally(() => { loopPromise = null; });
   }
 
+  // Halts the loop and returns a promise that resolves once the
+  // last in-flight tick has completed. Callers that want to
+  // re-start the leader MUST await this. Idempotent.
   function stop() {
     running = false;
+    return loopPromise ?? Promise.resolve();
   }
 
   // Called by the gateway-control-channel server when a peer pushes
@@ -220,8 +230,18 @@ function createGatewayLeader({
     return runSerialized(async () => {
       // Step 1: bootstrap version cursor. THROWS if expectedVersion
       // is malformed — protects against a future control-channel-server
-      // bug that lets bad payloads through.
-      lock.adoptLockFromHandoff(expectedVersion);
+      // bug that lets bad payloads through. Log at error level with
+      // routing context so an unexpected adopt failure is visible
+      // (the catch in runSerialized only logs at debug, which
+      // wouldn't show in default-prod log levels).
+      try {
+        lock.adoptLockFromHandoff(expectedVersion);
+      } catch (err) {
+        logger.error('gateway-leader: adoptLockFromHandoff threw', {
+          error: err.message, activeInstanceId, expectedVersion,
+        });
+        throw err;
+      }
       // Step 2: flag held BEFORE connect. If connect throws, watchdog
       // picks up the retry. If we flipped the flag after connect,
       // the watchdog would race the connect and possibly redundantly

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -333,6 +333,21 @@ function createGatewayLeader({
       throw new Error('leader_closed');
     }
     return runSerialized('inbound-handoff', async () => {
+      // Inner closed re-check: a race window exists between the
+      // outer check above and the moment this closure starts.
+      // Sequence: inbound passes outer check → queued in chain
+      // behind a tick → SIGTERM fires → pushHandoff sets
+      // closed=true AND queues its own work → tick finishes → THIS
+      // closure runs and would adopt/connect against a soon-to-be-
+      // transferred lock. The re-check makes the closed sentinel
+      // load-bearing inside the serial chain, not just at the API
+      // entry point. Throw so the server returns 500.
+      if (closed) {
+        logger.warn('gateway-leader: inbound handoff aborted mid-queue — leader closed', {
+          activeInstanceId, expectedVersion,
+        });
+        throw new Error('leader_closed');
+      }
       // Stray-handoff guard: if we already hold the lock AND the WS
       // is connected, a second inbound handoff is either a duplicate
       // from a retry-ing active or a misrouted body (the server-side
@@ -594,9 +609,16 @@ function createGatewayLeader({
     // state (it's a different DDB table), so serializing it would
     // only add latency to the SIGTERM critical path. Failure is
     // swallowed — the worst case is the row fades naturally inside
-    // the freshness window. Closes the discovery window immediately
-    // so the freshly-promoted standby's listFreshPeers stops
-    // returning this row.
+    // the freshness window.
+    //
+    // Timing note: this runs AFTER the serialized work completes,
+    // so during the window from `closed=true` (set above) through
+    // the end of the serialized chain, our heartbeat row is still
+    // visible. A concurrent inbound from another peer would see
+    // our row in their listFreshPeers head, but the inner closed
+    // re-check (in handleInboundHandoff) makes the leader reject
+    // any work that got queued post-`closed`. After this call
+    // returns, peer-side listFreshPeers stops returning our row.
     await peerHeartbeat.deleteOwnRow().catch(() => {});
 
     return result;

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -648,6 +648,15 @@ function createGatewayLeader({
       return;
     }
     await runSerialized('releaseLockForImmediateExit', async () => {
+      // Inner closed re-check: mirrors handleInboundHandoff's
+      // closure-level guard. The outer check catches the post-
+      // pushHandoff sequential case, but a watchdog call queued
+      // BEFORE pushHandoff flipped closed could still pop here
+      // after closed=true has latched. Consequence in practice is
+      // only a redundant releaseLock call (the sole caller exits
+      // right after), but the inner guard keeps the closed-state
+      // invariant uniform across the API surface.
+      if (closed) return;
       heldLock = false;
       await lock.releaseLock();
     });

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -107,6 +107,16 @@ function createGatewayLeader({
   if (!selfInstanceId) throw new Error('createGatewayLeader: selfInstanceId is required');
   if (!shardId) throw new Error('createGatewayLeader: shardId is required');
   if (!logger) throw new Error('createGatewayLeader: logger is required');
+  // tickIntervalMs=0 would saturate the renew loop; negative would
+  // produce surprising setTimeout behavior. Fail loud at boot.
+  if (!Number.isInteger(tickIntervalMs) || tickIntervalMs <= 0) {
+    throw new Error('createGatewayLeader: tickIntervalMs must be a positive integer');
+  }
+  // inboundConnectTimeoutMs=0 would race the timer against the
+  // connect immediately; negative would be undefined behavior.
+  if (!Number.isInteger(inboundConnectTimeoutMs) || inboundConnectTimeoutMs <= 0) {
+    throw new Error('createGatewayLeader: inboundConnectTimeoutMs must be a positive integer');
+  }
 
   let heldLock = false;
   // Set true around `handleInboundHandoff`'s in-flight
@@ -149,9 +159,12 @@ function createGatewayLeader({
   // push-handoff never overlap. The serialization chain absorbs
   // failures so one op's rejection doesn't break the next op's
   // turn — see the function-level comment for the load-bearing
-  // invariant.
+  // invariant. The `opName` argument is included in the chain-catch
+  // debug log so a future caller that bypasses an op-level try/catch
+  // is trivially recognizable in logs (vs. an unlabeled backstop
+  // firing without context).
   let inFlight = Promise.resolve();
-  function runSerialized(work) {
+  function runSerialized(opName, work) {
     // The load-bearing invariant: `inFlight` is ALWAYS fulfilled
     // (never rejected) because we assign it below to a `.then` whose
     // rejection arm returns undefined — turning every prior failure
@@ -178,7 +191,7 @@ function createGatewayLeader({
       // backstop firing for a future caller that bypassed the
       // op-level try/catch) without polluting prod log levels.
       logger.debug('gateway-leader: serialized op rejected (chain continues)', {
-        error: err && err.message,
+        op: opName, error: err && err.message,
       });
     });
     return next;
@@ -259,7 +272,7 @@ function createGatewayLeader({
       // backstop. Log + continue: the next tick re-tries.
       try {
         // eslint-disable-next-line no-await-in-loop
-        await runSerialized(step);
+        await runSerialized('tick', step);
       } catch (err) {
         logger.error('gateway-leader: tick threw unexpectedly (loop continues)', {
           error: err && err.message,
@@ -319,7 +332,7 @@ function createGatewayLeader({
       });
       throw new Error('leader_closed');
     }
-    return runSerialized(async () => {
+    return runSerialized('inbound-handoff', async () => {
       // Stray-handoff guard: if we already hold the lock AND the WS
       // is connected, a second inbound handoff is either a duplicate
       // from a retry-ing active or a misrouted body (the server-side
@@ -475,7 +488,7 @@ function createGatewayLeader({
     running = false;
     closed = true;
 
-    const result = await runSerialized(async () => {
+    const result = await runSerialized('pushHandoff', async () => {
       if (!heldLock) {
         logger.info('gateway-leader: pushHandoff called without holding lock (no-op)');
         return { transferred: false, reason: 'not_holding_lock' };
@@ -612,7 +625,7 @@ function createGatewayLeader({
       logger.debug('gateway-leader: releaseLockForImmediateExit called on closed leader (no-op)');
       return;
     }
-    await runSerialized(async () => {
+    await runSerialized('releaseLockForImmediateExit', async () => {
       heldLock = false;
       await lock.releaseLock();
     });
@@ -643,7 +656,7 @@ function createGatewayLeader({
     isConnecting,
     isKnownPeer,
     // Inspection seams for tests.
-    _stepForTest: () => runSerialized(step),
+    _stepForTest: () => runSerialized('tick', step),
     _getKnownPeersForTest: () => new Set(knownPeerInstanceIds),
     _getLoopPromiseForTest: () => loopPromise,
   };

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -275,6 +275,23 @@ function createGatewayLeader({
   // path if heldLock got set before the throw.
   async function handleInboundHandoff({ activeInstanceId, expectedVersion }) {
     return runSerialized(async () => {
+      // Stray-handoff guard: if we already hold the lock AND the WS
+      // is connected, a second inbound handoff is either a duplicate
+      // from a retry-ing active or a misrouted body (the server-side
+      // peer_instance_id binding + isKnownPeer check make this
+      // low-probability but not impossible — e.g., a cold-fallback
+      // race where this replica acquired the lock just before the
+      // peer's push body arrived). Re-adopting would re-anchor
+      // currentVersion against a row that may have moved; re-
+      // calling manager.connect() would race the existing WS state
+      // (@discordjs/ws's WebSocketManager is NOT concurrent-safe).
+      // Reject cleanly — the active will exit anyway.
+      if (heldLock && manager.isConnected()) {
+        logger.warn('gateway-leader: inbound handoff rejected — already holding lock + connected', {
+          activeInstanceId, expectedVersion,
+        });
+        throw new Error('already_holding_lock_and_connected');
+      }
       // Step 1: bootstrap version cursor. THROWS if expectedVersion
       // is malformed — protects against a future control-channel-server
       // bug that lets bad payloads through. Log at error level with
@@ -329,6 +346,20 @@ function createGatewayLeader({
       // settlement, then race the timer separately. The handler
       // returns when EITHER settles, but the flag stays held until
       // the underlying connect resolves or rejects.
+      //
+      // Bounded-settlement assumption: @discordjs/ws's
+      // WebSocketManager.connect() is contracted to settle in
+      // bounded time — the shim wraps it and the underlying
+      // WebSocket has its own handshake/heartbeat timeouts. A
+      // truly-never-settling connect would pin `connecting=true`
+      // forever and the watchdog would no-op every tick, leaving
+      // a stuck standby. We trust the upstream contract here
+      // rather than racing ANOTHER timer (which would re-introduce
+      // the concurrent-connect race this guard exists to prevent).
+      // If a future @discordjs/ws version ever drops that contract,
+      // either set a hard ceiling here that accepts the concurrent
+      // risk, or wire a `manager.destroy()`-on-timeout escape in
+      // the shim layer.
       connecting = true;
       const connectPromise = manager.connect();
       connectPromise.then(

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -98,6 +98,14 @@ function createGatewayLeader({
   if (!logger) throw new Error('createGatewayLeader: logger is required');
 
   let heldLock = false;
+  // Set true around `handleInboundHandoff`'s in-flight
+  // `manager.connect()`. The watchdog observes this via
+  // `isConnecting()` and skips its own `manager.connect()` call —
+  // a Discord WS cold-connect routinely takes 1-3 s, longer than
+  // the watchdog's 1 s tick, so without this flag the two would
+  // race and call `connect()` concurrently. @discordjs/ws's
+  // WebSocketManager is NOT safe under concurrent connect().
+  let connecting = false;
   let running = false;
   let loopPromise = null;
   let knownPeerInstanceIds = new Set();
@@ -222,6 +230,17 @@ function createGatewayLeader({
       // Step 3: bring up the WS. The active is waiting for the ACK
       // (200 ms) before exiting; this connect resolving is what
       // makes the 200 "I'm live" semantic true.
+      //
+      // `connecting` is flipped true around the await so the
+      // watchdog's parallel 1 s tick observes it via isConnecting()
+      // and skips its own connect call. Without this guard a
+      // Discord WS cold-connect (1-3 s) would race the watchdog
+      // and produce two concurrent connect() invocations against
+      // @discordjs/ws's WebSocketManager, which is NOT safe under
+      // concurrency. Reset in `finally` so a connect throw still
+      // clears the flag — the watchdog can then validly take over
+      // the retry on the next tick.
+      connecting = true;
       try {
         await manager.connect();
       } catch (err) {
@@ -229,6 +248,8 @@ function createGatewayLeader({
           error: err.message, activeInstanceId,
         });
         throw err;
+      } finally {
+        connecting = false;
       }
       logger.info('gateway-leader: adopted lock + connected via inbound handoff', {
         activeInstanceId, expectedVersion,
@@ -341,6 +362,13 @@ function createGatewayLeader({
     return heldLock;
   }
 
+  // For the connection-watchdog: when the leader is itself mid-
+  // `manager.connect()` (inbound-handoff path), the watchdog must
+  // back off rather than fire its own concurrent connect.
+  function isConnecting() {
+    return connecting;
+  }
+
   function isKnownPeer(instanceId) {
     return knownPeerInstanceIds.has(instanceId);
   }
@@ -352,6 +380,7 @@ function createGatewayLeader({
     handleInboundHandoff,
     releaseLockForExit,
     isHoldingLock,
+    isConnecting,
     isKnownPeer,
     // Inspection seams for tests.
     _stepForTest: () => runSerialized(step),

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -198,6 +198,14 @@ function createGatewayLeader({
   }
 
   async function step() {
+    // Terminal-state guard: mirrors handleInboundHandoff's inner
+    // closed re-check. The production loop already stops via
+    // running=false, but `_stepForTest` enters through the same
+    // serialized chain — without this guard a stray post-close test
+    // call would re-write heartbeat / re-call renewLock / re-acquire,
+    // diverging from the closed-sentinel invariant the rest of the
+    // module enforces.
+    if (closed) return;
     // Heartbeat write + peer-list refresh run in parallel — both are
     // independent DDB ops, neither feeds into the other. Sequencing
     // them adds ~one DDB RTT to every tick for no correctness gain.

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -126,11 +126,12 @@ function createGatewayLeader({
   let inFlight = Promise.resolve();
   function runSerialized(work) {
     // `.then(work, work)` — both fulfillment AND rejection handlers
-    // call work(). INTENTIONAL: a prior op rejecting must NOT skip
-    // the next op (that would break the serialization chain when
-    // one op fails). Same `work` reference in both arms; called
-    // exactly once per `runSerialized` call regardless of the
-    // prior outcome.
+    // invoke `work()`. INTENTIONAL: a prior op rejecting must NOT
+    // skip the next op (that would break the serialization chain
+    // when one op fails). The fulfillment and rejection arms are
+    // distinct thenable handlers but both call the same `work`
+    // callee; `work()` runs exactly once per `runSerialized` call
+    // regardless of the prior outcome.
     const next = inFlight.then(() => work(), () => work());
     inFlight = next.then(() => {}, (err) => {
       // Warn (not debug): every work() should already log its own
@@ -269,9 +270,10 @@ function createGatewayLeader({
       // Step 1: bootstrap version cursor. THROWS if expectedVersion
       // is malformed — protects against a future control-channel-server
       // bug that lets bad payloads through. Log at error level with
-      // routing context so an unexpected adopt failure is visible
-      // (the catch in runSerialized only logs at debug, which
-      // wouldn't show in default-prod log levels).
+      // routing context so an unexpected adopt failure carries the
+      // active_instance_id + expectedVersion in the same line as
+      // the error message — the runSerialized backstop is a generic
+      // warn without that routing context.
       try {
         lock.adoptLockFromHandoff(expectedVersion);
       } catch (err) {

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -312,15 +312,33 @@ function createGatewayLeader({
       // Internal timeout: a hung `manager.connect()` (e.g., Discord
       // WS endpoint resolution black-holed) would otherwise pin
       // `connecting=true` indefinitely and the watchdog would
-      // no-op every tick. Racing connect against a timer keeps
-      // the leader self-sufficient — on timeout we throw, the
-      // catch arm logs, the finally clears the flag, and the
-      // watchdog picks up the retry next tick.
+      // no-op every tick. Racing connect against a timer lets us
+      // throw on timeout so the caller (control-channel server)
+      // returns 500 to the active.
+      //
+      // Critical: `connecting=true` MUST stay true until the
+      // UNDERLYING `manager.connect()` actually settles — not just
+      // until `Promise.race` resolves. Otherwise: timeout fires →
+      // race resolves → flag clears → next watchdog tick (1s) sees
+      // !isConnecting and fires its OWN `manager.connect()` while
+      // the original is STILL pending in @discordjs/ws's internal
+      // state. That's exactly the concurrent-connect race the flag
+      // exists to prevent.
+      //
+      // Pattern: start the connect, attach the flag-clear to its
+      // settlement, then race the timer separately. The handler
+      // returns when EITHER settles, but the flag stays held until
+      // the underlying connect resolves or rejects.
       connecting = true;
+      const connectPromise = manager.connect();
+      connectPromise.then(
+        () => { connecting = false; },
+        () => { connecting = false; },
+      );
       let connectTimer;
       try {
         await Promise.race([
-          manager.connect(),
+          connectPromise,
           new Promise((_, reject) => {
             connectTimer = setTimeout(
               () => reject(new Error(`inbound_connect_timeout_${inboundConnectTimeoutMs}ms`)),
@@ -335,7 +353,10 @@ function createGatewayLeader({
         throw err;
       } finally {
         clearTimeout(connectTimer);
-        connecting = false;
+        // Note: NO `connecting = false` here — that's owned by the
+        // connectPromise settlement handlers above. Clearing it
+        // here on a timeout would race the still-pending connect
+        // against the next watchdog tick's fresh connect().
       }
       logger.info('gateway-leader: adopted lock + connected via inbound handoff', {
         activeInstanceId, expectedVersion,

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -133,7 +133,13 @@ function createGatewayLeader({
     // prior outcome.
     const next = inFlight.then(() => work(), () => work());
     inFlight = next.then(() => {}, (err) => {
-      logger.debug('gateway-leader: serialized op rejected (chain continues)', {
+      // Warn (not debug): every work() should already log its own
+      // failure at warn/error level, so this backstop should never
+      // fire visibly in practice. If it ever does (a future caller
+      // passes a work fn that throws before its own try/catch),
+      // surfacing at warn level makes it visible at default prod
+      // log levels rather than silently swallowing.
+      logger.warn('gateway-leader: serialized op rejected (chain continues)', {
         error: err && err.message,
       });
     });
@@ -292,6 +298,14 @@ function createGatewayLeader({
       // concurrency. Reset in `finally` so a connect throw still
       // clears the flag — the watchdog can then validly take over
       // the retry on the next tick.
+      //
+      // Note: `manager.connect()` is awaited inline with no timeout
+      // here. A hung connect (e.g., Discord WS endpoint resolution
+      // black-holed) would pin `connecting=true` indefinitely and
+      // the watchdog would no-op every tick. PR 13b.3 wiring MUST
+      // ensure the WS shim's connect() either has an internal
+      // timeout OR provide an external timeout wrapper at the
+      // call site.
       connecting = true;
       try {
         await manager.connect();
@@ -353,11 +367,14 @@ function createGatewayLeader({
       // window), build a placeholder so transferLock still has a
       // valid string to write. The lock_holder field is operational
       // metadata; correctness doesn't depend on its value, only its
-      // non-emptiness. TODO(post-13b.2-bake): drop this fallback
-      // once all peers have been on >=13b.2 long enough that
-      // missing lock_holder is impossible.
+      // non-emptiness. Prefix `placeholder/` so the fallback is
+      // obvious in transferLock traces — vs. a real holder string
+      // which is shaped like `task-arn:.../inst-X`.
+      // TODO(post-13b.2-bake): drop this fallback once all peers
+      // have been on >=13b.2 long enough that missing lock_holder
+      // is impossible.
       const targetLockHolder = peer.lock_holder
-        || `peer/${peer.instance_id}`;
+        || `placeholder/${peer.instance_id}`;
 
       let transferResult;
       try {
@@ -418,6 +435,14 @@ function createGatewayLeader({
 
   // For the connection-watchdog's releaseLock hook. Serialized so
   // it can't race a tick's renewLock.
+  //
+  // Order note: heldLock=false is cleared BEFORE awaiting the DDB
+  // release. If releaseLock throws, the local flag is already false
+  // but the DDB row may still belong to us until TTL lapse. This is
+  // OK only because the sole caller (watchdog exhaustion path)
+  // `exit(1)`s immediately afterward — the row fades naturally via
+  // TTL. A future non-exiting caller would need to flip the
+  // ordering (await release first, then clear the flag on success).
   async function releaseLockForExit() {
     return runSerialized(async () => {
       heldLock = false;

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -205,8 +205,22 @@ function createGatewayLeader({
       // refresh don't touch lock state, but bundling the whole step
       // is simpler than splitting the serialization boundary inside
       // it.
-      // eslint-disable-next-line no-await-in-loop
-      await runSerialized(step);
+      //
+      // Backstop for unexpected throws inside step() that escape
+      // its internal try/catch (e.g., a future row-shape regression
+      // that throws inside `peers.map(...)`). Without this, a single
+      // throw would resolve loopPromise as a rejection, the loop
+      // would exit silently, and the leader would stop renewing
+      // without anyone observing it. Mirrors the watchdog's
+      // backstop. Log + continue: the next tick re-tries.
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await runSerialized(step);
+      } catch (err) {
+        logger.error('gateway-leader: tick threw unexpectedly (loop continues)', {
+          error: err && err.message,
+        });
+      }
     }
   }
 

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -321,20 +321,10 @@ function createGatewayLeader({
   async function pushHandoff() {
     running = false;
     closed = true;
-    const cleanupHeartbeatRow = async () => {
-      // Best-effort: close the discovery window immediately so the
-      // freshly-promoted standby's listFreshPeers stops returning
-      // this row, rather than waiting up to `freshnessWindowSeconds`
-      // for the natural fade. Already-warned-and-logged inside
-      // deleteOwnRow; the .catch() is belt-and-braces in case the
-      // module surface changes.
-      await peerHeartbeat.deleteOwnRow().catch(() => {});
-    };
 
-    return runSerialized(async () => {
+    const result = await runSerialized(async () => {
       if (!heldLock) {
         logger.info('gateway-leader: pushHandoff called without holding lock (no-op)');
-        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'not_holding_lock' };
       }
 
@@ -348,7 +338,6 @@ function createGatewayLeader({
         // Best-effort release so the next replacement task can acquire
         // immediately rather than wait for TTL lapse.
         await lock.releaseLock().catch(() => {});
-        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'peer_lookup_failed' };
       }
 
@@ -356,7 +345,6 @@ function createGatewayLeader({
       if (!peer) {
         logger.warn('gateway-leader: no fresh peer for handoff — falling through to cold-fallback');
         await lock.releaseLock().catch(() => {});
-        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'no_peer' };
       }
 
@@ -377,7 +365,6 @@ function createGatewayLeader({
       } catch (err) {
         logger.error('gateway-leader: transferLock threw', { error: err.message });
         await lock.releaseLock().catch(() => {});
-        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'transfer_threw' };
       }
 
@@ -387,13 +374,12 @@ function createGatewayLeader({
         // longer ours, so flip the local flag to match.
         heldLock = false;
         logger.warn('gateway-leader: transferLock CAS failed; skipping push');
-        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'transfer_failed' };
       }
 
       heldLock = false;
 
-      const result = await controlClient.pushHandoff({
+      const pushResult = await controlClient.pushHandoff({
         peerIp: peer.ip,
         peerPort: peer.port,
         peerInstanceId: peer.instance_id,
@@ -405,18 +391,29 @@ function createGatewayLeader({
       // it in DDB). If the push didn't ACK, the standby's watchdog
       // sees lock-held + WS-disconnected within ~1 s and brings
       // up the gateway.
-      if (result.ok) {
+      if (pushResult.ok) {
         logger.info('gateway-leader: pushHandoff ACKed', {
           peerInstanceId: peer.instance_id,
         });
       } else {
         logger.warn('gateway-leader: pushHandoff did not ACK (watchdog will catch)', {
-          peerInstanceId: peer.instance_id, reason: result.reason,
+          peerInstanceId: peer.instance_id, reason: pushResult.reason,
         });
       }
-      await cleanupHeartbeatRow();
-      return { pushed: true, ackReason: result.ok ? 'ack' : result.reason };
+      return { pushed: true, ackReason: pushResult.ok ? 'ack' : pushResult.reason };
     });
+
+    // Best-effort heartbeat-row cleanup. Deliberately OUTSIDE the
+    // serialized chain: deleteOwnRow does not touch gateway-lock
+    // state (it's a different DDB table), so serializing it would
+    // only add latency to the SIGTERM critical path. Failure is
+    // swallowed — the worst case is the row fades naturally inside
+    // the freshness window. Closes the discovery window immediately
+    // so the freshly-promoted standby's listFreshPeers stops
+    // returning this row.
+    await peerHeartbeat.deleteOwnRow().catch(() => {});
+
+    return result;
   }
 
   // For the connection-watchdog's releaseLock hook. Serialized so

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -119,6 +119,12 @@ function createGatewayLeader({
   // its own failure, this is a backstop for the chain-keeping path).
   let inFlight = Promise.resolve();
   function runSerialized(work) {
+    // `.then(work, work)` — both fulfillment AND rejection handlers
+    // call work(). INTENTIONAL: a prior op rejecting must NOT skip
+    // the next op (that would break the serialization chain when
+    // one op fails). Same `work` reference in both arms; called
+    // exactly once per `runSerialized` call regardless of the
+    // prior outcome.
     const next = inFlight.then(() => work(), () => work());
     inFlight = next.then(() => {}, (err) => {
       logger.debug('gateway-leader: serialized op rejected (chain continues)', {
@@ -328,7 +334,14 @@ function createGatewayLeader({
 
       if (!transferResult.transferred) {
         // CAS failed — version moved (peer cold-acquired) or we
-        // weren't actually holding. Either way, nothing to push.
+        // weren't actually holding. Either way the DDB row is no
+        // longer ours, so flip the local flag to match. Without
+        // this, the implicit "caller MUST exit after pushHandoff"
+        // invariant would be load-bearing for a hypothetical caller
+        // that loops back into the tick (where heldLock=true would
+        // attempt renewLock on a row owned by the peer). Making the
+        // flag explicitly match DDB state removes the dependency.
+        heldLock = false;
         logger.warn('gateway-leader: transferLock CAS failed; skipping push');
         return { pushed: false, reason: 'transfer_failed' };
       }

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -543,8 +543,12 @@ function createGatewayLeader({
       // have been on >=13b.2 long enough that missing lock_holder
       // is impossible. Target removal: 2026-07-01 (~6 weeks after
       // 13b.2 lands in prod). Tracked: #416.
+      // `??` (not `||`) so an empty-string or 0-valued row from a
+      // misbehaving writer doesn't silently take the placeholder
+      // branch. heartbeat write-time validation enforces non-empty
+      // string, but defense-in-depth on the read side too.
       const targetLockHolder = peer.lock_holder
-        || `placeholder/${peer.instance_id}`;
+        ?? `placeholder/${peer.instance_id}`;
 
       let transferResult;
       try {
@@ -623,7 +627,16 @@ function createGatewayLeader({
     // re-check (in handleInboundHandoff) makes the leader reject
     // any work that got queued post-`closed`. After this call
     // returns, peer-side listFreshPeers stops returning our row.
-    await peerHeartbeat.deleteOwnRow().catch(() => {});
+    // `peerHeartbeat.deleteOwnRow()` is documented as never-throwing
+    // (logs+swallows internally), but defense-in-depth: belt-and-
+    // braces .catch so a future regression in that contract doesn't
+    // poison the pushHandoff result. Debug-level — a real fault here
+    // is already surfaced by the inner warn log in deleteOwnRow.
+    await peerHeartbeat.deleteOwnRow().catch((err) => {
+      logger.debug('gateway-leader: deleteOwnRow rejected (contract regression?)', {
+        error: err && err.message,
+      });
+    });
 
     return result;
   }

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -97,8 +97,10 @@ function createGatewayLeader({
   if (!lock) throw new Error('createGatewayLeader: lock is required');
   if (!peerHeartbeat) throw new Error('createGatewayLeader: peerHeartbeat is required');
   if (!controlClient) throw new Error('createGatewayLeader: controlClient is required');
-  if (!manager || typeof manager.connect !== 'function') {
-    throw new Error('createGatewayLeader: manager with connect() is required');
+  if (!manager
+      || typeof manager.connect !== 'function'
+      || typeof manager.isConnected !== 'function') {
+    throw new Error('createGatewayLeader: manager with connect() and isConnected() is required');
   }
   if (!selfInstanceId) throw new Error('createGatewayLeader: selfInstanceId is required');
   if (!selfLockHolder) throw new Error('createGatewayLeader: selfLockHolder is required');
@@ -131,6 +133,22 @@ function createGatewayLeader({
   // doesn't break the chain — but we log on the catch so an op
   // failure isn't observable-only-via-caller (the work itself logs
   // its own failure, this is a backstop for the chain-keeping path).
+  // Best-effort lock release for pushHandoff's bail-out paths. The
+  // leader is exiting; we want to give up the lock so the next
+  // replacement task can cold-acquire immediately instead of waiting
+  // for TTL lapse. But a failure here is non-fatal — TTL absorbs it
+  // — so the caller does not propagate. Swallowing silently would
+  // hide a recurring DDB outage, so log at warn instead of `() => {}`.
+  async function releaseLockBestEffort(reason) {
+    try {
+      await lock.releaseLock();
+    } catch (err) {
+      logger.warn('gateway-leader: best-effort releaseLock failed (TTL will reap)', {
+        reason, error: err && err.message,
+      });
+    }
+  }
+
   let inFlight = Promise.resolve();
   function runSerialized(work) {
     // `.then(work, work)` — both fulfillment AND rejection handlers
@@ -421,16 +439,14 @@ function createGatewayLeader({
         logger.error('gateway-leader: listFreshPeers failed during pushHandoff', {
           error: err.message,
         });
-        // Best-effort release so the next replacement task can acquire
-        // immediately rather than wait for TTL lapse.
-        await lock.releaseLock().catch(() => {});
+        await releaseLockBestEffort('peer_lookup_failed');
         return { pushed: false, reason: 'peer_lookup_failed' };
       }
 
       const peer = peers[0]; // freshest-first per listFreshPeers contract
       if (!peer) {
         logger.warn('gateway-leader: no fresh peer for handoff — falling through to cold-fallback');
-        await lock.releaseLock().catch(() => {});
+        await releaseLockBestEffort('no_peer');
         return { pushed: false, reason: 'no_peer' };
       }
 
@@ -455,7 +471,7 @@ function createGatewayLeader({
         transferResult = await lock.transferLock(peer.instance_id, targetLockHolder);
       } catch (err) {
         logger.error('gateway-leader: transferLock threw', { error: err.message });
-        await lock.releaseLock().catch(() => {});
+        await releaseLockBestEffort('transfer_threw');
         return { pushed: false, reason: 'transfer_threw' };
       }
 

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -1,0 +1,357 @@
+// Per-shard leader coordinator for Pillar 3. Composes:
+//   - gateway-lock           (the DDB CAS lock primitive)
+//   - gateway-peer-heartbeat (standby discovery)
+//   - gateway-control-client (outbound push-handoff)
+//   - manager                (the @discordjs/ws shim — connect()/isConnected())
+//
+// And exposes the four hooks the wiring layer (index.js, PR 13b.3)
+// plugs into the other Pillar 3 components:
+//   - `isHoldingLock()` → for gateway-connection-watchdog
+//   - `releaseLockForExit()` → for gateway-connection-watchdog's
+//      exhaustion path
+//   - `handleInboundHandoff(payload)` → for gateway-control-channel's
+//      onHandoff
+//   - `isKnownPeer(instanceId)` → for gateway-control-channel's
+//      isKnownPeer
+//
+// And the two lifecycle entry points the SIGTERM handler hits:
+//   - `start()` — begin the tick loop (renew + heartbeat + acquire)
+//   - `pushHandoff()` — SIGTERM path: find peer, transfer, push, return
+//
+// ── Tick loop ──
+// Every `tickIntervalMs` (default 2_000), in order:
+//   1. Write peer heartbeat (unconditional — active AND standby
+//      heartbeat so each can discover the other for the handoff).
+//   2. Refresh `knownPeerInstanceIds` from `listFreshPeers()`. The
+//      control-channel server's `isKnownPeer` reads this cache
+//      synchronously. Stale-by-at-most-tickIntervalMs is acceptable;
+//      a stale peer reference would just produce a 400 unknown_peer
+//      response, which is safe.
+//   3. If we hold the lock → `renewLock()`. On CCF, peer took over
+//      out-of-band; clear heldLock and let the watchdog observe.
+//   4. If we DON'T hold the lock → `acquireLock()` (cold-fallback).
+//      If acquired, set heldLock=true; the connection watchdog
+//      observes lock-held + WS-not-connected and brings up the WS.
+//
+// ── Single-tick serialization ──
+// gateway-lock's mutators (acquire / renew / transfer / adopt) are
+// single-caller-only — their closure state would race under concurrency.
+// The leader serializes every mutator path through `runSerialized`,
+// which chains each work function onto the previous one. Tick,
+// inbound-handoff, and SIGTERM-handoff all compete for this serial
+// channel; whichever started first finishes first.
+//
+// ── Inbound-handoff ordering (adopt-then-flag-then-connect) ──
+// On `handleInboundHandoff({activeInstanceId, expectedVersion})`:
+//   1. `lock.adoptLockFromHandoff(expectedVersion)` — bootstrap our
+//      local version cursor (the active already wrote the row in DDB).
+//      If this throws, no `heldLock` flag is set; the watchdog never
+//      sees lock-held when we don't actually hold it.
+//   2. Set `heldLock = true`. Watchdog can now observe and act.
+//   3. `manager.connect()`. If this throws, heldLock stays true; the
+//      watchdog picks up next tick and retries the connect. This is
+//      the design's "succeeded transferLock but failed connect"
+//      recovery path.
+// If we flipped heldLock=true BEFORE adopt, a transient adopt failure
+// would leave the watchdog convinced we hold the lock when we don't
+// even have a version cursor. Order matters.
+//
+// ── pushHandoff (SIGTERM path) ──
+// Stops the tick loop, then:
+//   1. Find a fresh peer in this shard (listFreshPeers, head of list).
+//   2. If no peer → release lock (best-effort) + return {pushed: false,
+//      reason: 'no_peer'}. Cold-fallback floor applies on the other
+//      side.
+//   3. transferLock(peer.instance_id, peer.lock_holder) — atomic
+//      DDB ownership move. On CCF (active lost the lock to a cold-
+//      fallback acquire by the peer) → return {pushed: false, reason:
+//      'transfer_failed'}.
+//   4. controlClient.pushHandoff(...) with expectedVersion = the
+//      post-transfer version returned by transferLock.
+//   5. Return the result. Caller (index.js SIGTERM handler) exits
+//      either way.
+
+const DEFAULT_TICK_INTERVAL_MS = 2_000;
+
+function createGatewayLeader({
+  lock,
+  peerHeartbeat,
+  controlClient,
+  manager,
+  selfInstanceId,
+  selfLockHolder,
+  shardId,
+  logger,
+  tickIntervalMs = DEFAULT_TICK_INTERVAL_MS,
+  // Injected for tests. Production: setTimeout-based sleep.
+  sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
+} = {}) {
+  if (!lock) throw new Error('createGatewayLeader: lock is required');
+  if (!peerHeartbeat) throw new Error('createGatewayLeader: peerHeartbeat is required');
+  if (!controlClient) throw new Error('createGatewayLeader: controlClient is required');
+  if (!manager || typeof manager.connect !== 'function') {
+    throw new Error('createGatewayLeader: manager with connect() is required');
+  }
+  if (!selfInstanceId) throw new Error('createGatewayLeader: selfInstanceId is required');
+  if (!selfLockHolder) throw new Error('createGatewayLeader: selfLockHolder is required');
+  if (!shardId) throw new Error('createGatewayLeader: shardId is required');
+  if (!logger) throw new Error('createGatewayLeader: logger is required');
+
+  let heldLock = false;
+  let running = false;
+  let loopPromise = null;
+  let knownPeerInstanceIds = new Set();
+
+  // Mutator serialization. Every call site that touches the
+  // single-caller-only gateway-lock API funnels through this so
+  // tick / inbound-handoff / push-handoff never overlap. Rejections
+  // are caught when chained into `inFlight` so a prior failure
+  // doesn't break the chain — but we log on the catch so an op
+  // failure isn't observable-only-via-caller (the work itself logs
+  // its own failure, this is a backstop for the chain-keeping path).
+  let inFlight = Promise.resolve();
+  function runSerialized(work) {
+    const next = inFlight.then(() => work(), () => work());
+    inFlight = next.then(() => {}, (err) => {
+      logger.debug('gateway-leader: serialized op rejected (chain continues)', {
+        error: err && err.message,
+      });
+    });
+    return next;
+  }
+
+  async function step() {
+    // Heartbeat write + peer-list refresh run in parallel — both are
+    // independent DDB ops, neither feeds into the other. Sequencing
+    // them adds ~one DDB RTT to every tick for no correctness gain.
+    // Each has independent error handling so a failure in one
+    // doesn't sink the other. A heartbeat write failure is
+    // recoverable (freshness window absorbs ~3 misses); a list
+    // failure preserves the prior peer cache.
+    await Promise.all([
+      peerHeartbeat.writeHeartbeat().catch((err) => {
+        logger.warn('gateway-leader: heartbeat write failed (will retry next tick)', {
+          error: err.message,
+        });
+      }),
+      peerHeartbeat.listFreshPeers().then((peers) => {
+        knownPeerInstanceIds = new Set(peers.map((row) => row.instance_id));
+      }).catch((err) => {
+        logger.warn('gateway-leader: listFreshPeers failed (cache stays as-is)', {
+          error: err.message,
+        });
+      }),
+    ]);
+
+    if (heldLock) {
+      try {
+        const renewed = await lock.renewLock();
+        if (!renewed.renewed) {
+          // CAS failed — peer took the lock out-of-band. Watchdog
+          // will see heldLock=false and stop trying to connect; the
+          // next tick will try acquire again.
+          logger.warn('gateway-leader: lost lock (peer took over out-of-band)');
+          heldLock = false;
+        }
+      } catch (err) {
+        // Transient — keep heldLock as-is, retry next tick.
+        logger.error('gateway-leader: renewLock threw, keeping heldLock for retry', {
+          error: err.message,
+        });
+      }
+    } else {
+      try {
+        const result = await lock.acquireLock();
+        if (result.acquired) {
+          logger.info('gateway-leader: cold-acquired lock', {
+            shardId, version: result.version,
+          });
+          heldLock = true;
+          // The connection watchdog will observe lock-held + WS-not-
+          // connected on its next tick and call manager.connect().
+        }
+      } catch (err) {
+        logger.error('gateway-leader: acquireLock threw', { error: err.message });
+      }
+    }
+  }
+
+  async function loop() {
+    while (running) {
+      await sleep(tickIntervalMs);
+      if (!running) break;
+      // Tick mutators (renew / acquire) MUST be serialized against
+      // push-handoff and inbound-handoff. Heartbeat + peer-cache
+      // refresh don't touch lock state, but bundling the whole step
+      // is simpler than splitting the serialization boundary inside
+      // it.
+      // eslint-disable-next-line no-await-in-loop
+      await runSerialized(step);
+    }
+  }
+
+  function start() {
+    if (running) return;
+    running = true;
+    loopPromise = loop();
+  }
+
+  function stop() {
+    running = false;
+  }
+
+  // Called by the gateway-control-channel server when a peer pushes
+  // a handoff to us. Already HMAC-verified + routing-checked by the
+  // server; this just does the lock-cursor + WS-connect side.
+  //
+  // Returns nothing on success. Throws on failure — the server
+  // returns 500 to the active. Either branch is safe: the active
+  // exits on any non-2xx, and the watchdog re-tries the connect
+  // path if heldLock got set before the throw.
+  async function handleInboundHandoff({ activeInstanceId, expectedVersion }) {
+    return runSerialized(async () => {
+      // Step 1: bootstrap version cursor. THROWS if expectedVersion
+      // is malformed — protects against a future control-channel-server
+      // bug that lets bad payloads through.
+      lock.adoptLockFromHandoff(expectedVersion);
+      // Step 2: flag held BEFORE connect. If connect throws, watchdog
+      // picks up the retry. If we flipped the flag after connect,
+      // the watchdog would race the connect and possibly redundantly
+      // re-call it.
+      heldLock = true;
+      // Step 3: bring up the WS. The active is waiting for the ACK
+      // (200 ms) before exiting; this connect resolving is what
+      // makes the 200 "I'm live" semantic true.
+      try {
+        await manager.connect();
+      } catch (err) {
+        logger.error('gateway-leader: inbound-handoff connect threw (watchdog will retry)', {
+          error: err.message, activeInstanceId,
+        });
+        throw err;
+      }
+      logger.info('gateway-leader: adopted lock + connected via inbound handoff', {
+        activeInstanceId, expectedVersion,
+      });
+    });
+  }
+
+  // Called by the SIGTERM handler. Find peer, transfer, push, return.
+  // Stops the tick loop first so the next tick can't race the
+  // transferLock with a renewLock.
+  async function pushHandoff() {
+    running = false;
+    return runSerialized(async () => {
+      if (!heldLock) {
+        logger.info('gateway-leader: pushHandoff called without holding lock (no-op)');
+        return { pushed: false, reason: 'not_holding_lock' };
+      }
+
+      let peers;
+      try {
+        peers = await peerHeartbeat.listFreshPeers();
+      } catch (err) {
+        logger.error('gateway-leader: listFreshPeers failed during pushHandoff', {
+          error: err.message,
+        });
+        // Best-effort release so the next replacement task can acquire
+        // immediately rather than wait for TTL lapse.
+        await lock.releaseLock().catch(() => {});
+        return { pushed: false, reason: 'peer_lookup_failed' };
+      }
+
+      const peer = peers[0]; // freshest-first per listFreshPeers contract
+      if (!peer) {
+        logger.warn('gateway-leader: no fresh peer for handoff — falling through to cold-fallback');
+        await lock.releaseLock().catch(() => {});
+        return { pushed: false, reason: 'no_peer' };
+      }
+
+      // Defensive: if a heartbeat row exists without lock_holder
+      // (back-compat with pre-PR-13b.2 callers or a partial-write
+      // window), build a placeholder so transferLock still has a
+      // valid string to write. The lock_holder field is operational
+      // metadata; correctness doesn't depend on its value, only its
+      // non-emptiness.
+      const targetLockHolder = peer.lock_holder
+        || `peer/${peer.instance_id}`;
+
+      let transferResult;
+      try {
+        transferResult = await lock.transferLock(peer.instance_id, targetLockHolder);
+      } catch (err) {
+        logger.error('gateway-leader: transferLock threw', { error: err.message });
+        await lock.releaseLock().catch(() => {});
+        return { pushed: false, reason: 'transfer_threw' };
+      }
+
+      if (!transferResult.transferred) {
+        // CAS failed — version moved (peer cold-acquired) or we
+        // weren't actually holding. Either way, nothing to push.
+        logger.warn('gateway-leader: transferLock CAS failed; skipping push');
+        return { pushed: false, reason: 'transfer_failed' };
+      }
+
+      heldLock = false;
+
+      const result = await controlClient.pushHandoff({
+        peerIp: peer.ip,
+        peerPort: peer.port,
+        peerInstanceId: peer.instance_id,
+        selfInstanceId,
+        expectedVersion: transferResult.version,
+      });
+      // Either branch is fine. The active is exiting anyway; the
+      // standby has the lock either way (transferLock already moved
+      // it in DDB). If the push didn't ACK, the standby's watchdog
+      // sees lock-held + WS-disconnected within ~1 s and brings
+      // up the gateway.
+      if (result.ok) {
+        logger.info('gateway-leader: pushHandoff ACKed', {
+          peerInstanceId: peer.instance_id,
+        });
+      } else {
+        logger.warn('gateway-leader: pushHandoff did not ACK (watchdog will catch)', {
+          peerInstanceId: peer.instance_id, reason: result.reason,
+        });
+      }
+      return { pushed: true, ackReason: result.ok ? 'ack' : result.reason };
+    });
+  }
+
+  // For the connection-watchdog's releaseLock hook. Serialized so
+  // it can't race a tick's renewLock.
+  async function releaseLockForExit() {
+    return runSerialized(async () => {
+      heldLock = false;
+      await lock.releaseLock();
+    });
+  }
+
+  function isHoldingLock() {
+    return heldLock;
+  }
+
+  function isKnownPeer(instanceId) {
+    return knownPeerInstanceIds.has(instanceId);
+  }
+
+  return {
+    start,
+    stop,
+    pushHandoff,
+    handleInboundHandoff,
+    releaseLockForExit,
+    isHoldingLock,
+    isKnownPeer,
+    // Inspection seams for tests.
+    _stepForTest: () => runSerialized(step),
+    _getKnownPeersForTest: () => new Set(knownPeerInstanceIds),
+    _getLoopPromiseForTest: () => loopPromise,
+  };
+}
+
+module.exports = {
+  createGatewayLeader,
+  DEFAULT_TICK_INTERVAL_MS,
+};

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -7,7 +7,7 @@
 // And exposes the four hooks the wiring layer (index.js, PR 13b.3)
 // plugs into the other Pillar 3 components:
 //   - `isHoldingLock()` → for gateway-connection-watchdog
-//   - `releaseLockForExit()` → for gateway-connection-watchdog's
+//   - `releaseLockForImmediateExit()` → for gateway-connection-watchdog's
 //      exhaustion path
 //   - `handleInboundHandoff(payload)` → for gateway-control-channel's
 //      onHandoff
@@ -72,6 +72,13 @@
 //      either way.
 
 const DEFAULT_TICK_INTERVAL_MS = 2_000;
+// Internal ceiling for an inbound-handoff `manager.connect()` await.
+// Discord WS cold-connects normally complete in 1-3s; 5s is generous
+// headroom while still bounding a hung resolve. On timeout we settle
+// the promise as a connect failure (heldLock stays true, watchdog
+// takes over next tick). Makes the leader self-sufficient rather
+// than relying on the WS shim's wiring to enforce a timeout.
+const DEFAULT_INBOUND_CONNECT_TIMEOUT_MS = 5_000;
 
 function createGatewayLeader({
   lock,
@@ -83,6 +90,7 @@ function createGatewayLeader({
   shardId,
   logger,
   tickIntervalMs = DEFAULT_TICK_INTERVAL_MS,
+  inboundConnectTimeoutMs = DEFAULT_INBOUND_CONNECT_TIMEOUT_MS,
   // Injected for tests. Production: setTimeout-based sleep.
   sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
 } = {}) {
@@ -301,22 +309,32 @@ function createGatewayLeader({
       // clears the flag — the watchdog can then validly take over
       // the retry on the next tick.
       //
-      // Note: `manager.connect()` is awaited inline with no timeout
-      // here. A hung connect (e.g., Discord WS endpoint resolution
-      // black-holed) would pin `connecting=true` indefinitely and
-      // the watchdog would no-op every tick. PR 13b.3 wiring MUST
-      // ensure the WS shim's connect() either has an internal
-      // timeout OR provide an external timeout wrapper at the
-      // call site.
+      // Internal timeout: a hung `manager.connect()` (e.g., Discord
+      // WS endpoint resolution black-holed) would otherwise pin
+      // `connecting=true` indefinitely and the watchdog would
+      // no-op every tick. Racing connect against a timer keeps
+      // the leader self-sufficient — on timeout we throw, the
+      // catch arm logs, the finally clears the flag, and the
+      // watchdog picks up the retry next tick.
       connecting = true;
+      let connectTimer;
       try {
-        await manager.connect();
+        await Promise.race([
+          manager.connect(),
+          new Promise((_, reject) => {
+            connectTimer = setTimeout(
+              () => reject(new Error(`inbound_connect_timeout_${inboundConnectTimeoutMs}ms`)),
+              inboundConnectTimeoutMs,
+            );
+          }),
+        ]);
       } catch (err) {
         logger.error('gateway-leader: inbound-handoff connect threw (watchdog will retry)', {
           error: err.message, activeInstanceId,
         });
         throw err;
       } finally {
+        clearTimeout(connectTimer);
         connecting = false;
       }
       logger.info('gateway-leader: adopted lock + connected via inbound handoff', {
@@ -374,7 +392,9 @@ function createGatewayLeader({
       // which is shaped like `task-arn:.../inst-X`.
       // TODO(post-13b.2-bake): drop this fallback once all peers
       // have been on >=13b.2 long enough that missing lock_holder
-      // is impossible.
+      // is impossible. Target removal: 2026-07-01 (~6 weeks after
+      // 13b.2 lands in prod). Tracked: file a follow-up issue
+      // when 13b.3 lands so the bake window is observable.
       const targetLockHolder = peer.lock_holder
         || `placeholder/${peer.instance_id}`;
 
@@ -438,14 +458,17 @@ function createGatewayLeader({
   // For the connection-watchdog's releaseLock hook. Serialized so
   // it can't race a tick's renewLock.
   //
-  // Order note: heldLock=false is cleared BEFORE awaiting the DDB
-  // release. If releaseLock throws, the local flag is already false
-  // but the DDB row may still belong to us until TTL lapse. This is
-  // OK only because the sole caller (watchdog exhaustion path)
-  // `exit(1)`s immediately afterward — the row fades naturally via
-  // TTL. A future non-exiting caller would need to flip the
-  // ordering (await release first, then clear the flag on success).
-  async function releaseLockForExit() {
+  // Name is deliberately `releaseLockForImmediateExit` (not just
+  // `releaseLock`): the implementation clears `heldLock=false`
+  // BEFORE awaiting the DDB release. If releaseLock throws, the
+  // local flag is already false but the DDB row may still belong
+  // to us until TTL lapse. This is OK ONLY because every documented
+  // caller `exit(1)`s immediately afterward — the row fades
+  // naturally via TTL. A future non-exiting caller would need to
+  // flip the ordering (await release first, then clear the flag on
+  // success); the function name surfaces that contract at the
+  // call site instead of relying on a comment.
+  async function releaseLockForImmediateExit() {
     return runSerialized(async () => {
       heldLock = false;
       await lock.releaseLock();
@@ -472,7 +495,7 @@ function createGatewayLeader({
     stop,
     pushHandoff,
     handleInboundHandoff,
-    releaseLockForExit,
+    releaseLockForImmediateExit,
     isHoldingLock,
     isConnecting,
     isKnownPeer,
@@ -486,4 +509,5 @@ function createGatewayLeader({
 module.exports = {
   createGatewayLeader,
   DEFAULT_TICK_INTERVAL_MS,
+  DEFAULT_INBOUND_CONNECT_TIMEOUT_MS,
 };

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -86,7 +86,6 @@ function createGatewayLeader({
   controlClient,
   manager,
   selfInstanceId,
-  selfLockHolder,
   shardId,
   logger,
   tickIntervalMs = DEFAULT_TICK_INTERVAL_MS,
@@ -103,7 +102,6 @@ function createGatewayLeader({
     throw new Error('createGatewayLeader: manager with connect() and isConnected() is required');
   }
   if (!selfInstanceId) throw new Error('createGatewayLeader: selfInstanceId is required');
-  if (!selfLockHolder) throw new Error('createGatewayLeader: selfLockHolder is required');
   if (!shardId) throw new Error('createGatewayLeader: shardId is required');
   if (!logger) throw new Error('createGatewayLeader: logger is required');
 
@@ -158,6 +156,15 @@ function createGatewayLeader({
     // distinct thenable handlers but both call the same `work`
     // callee; `work()` runs exactly once per `runSerialized` call
     // regardless of the prior outcome.
+    //
+    // Subtle: this function returns `next` (which propagates work's
+    // rejection to the caller) but ASSIGNS `inFlight` to a different
+    // promise that swallows the rejection (via the second `.then`
+    // arm below). The caller awaiting the return value can `.catch`
+    // its op's failure; the NEXT `runSerialized` call chains off an
+    // always-fulfilled `inFlight` so a prior op's rejection doesn't
+    // poison the chain. Returned-promise behavior diverges from
+    // chain-keeping promise behavior on purpose.
     const next = inFlight.then(() => work(), () => work());
     inFlight = next.then(() => {}, (err) => {
       // Warn (not debug): every work() should already log its own
@@ -379,13 +386,21 @@ function createGatewayLeader({
       // risk, or wire a `manager.destroy()`-on-timeout escape in
       // the shim layer.
       connecting = true;
-      const connectPromise = manager.connect();
-      connectPromise.then(
-        () => { connecting = false; },
-        () => { connecting = false; },
-      );
+      // `manager.connect()` is inside the try so a synchronous throw
+      // (defensive — @discordjs/ws's WebSocketManager.connect contract
+      // is async, but a future shim regression or wiring bug could
+      // surface a sync throw) still clears `connecting=false`. If
+      // `connectPromise` is unassigned at catch-time, the lifecycle
+      // attachment never ran, so the catch arm is the only thing that
+      // can clear the flag.
+      let connectPromise;
       let connectTimer;
       try {
+        connectPromise = manager.connect();
+        connectPromise.then(
+          () => { connecting = false; },
+          () => { connecting = false; },
+        );
         await Promise.race([
           connectPromise,
           new Promise((_, reject) => {
@@ -396,16 +411,22 @@ function createGatewayLeader({
           }),
         ]);
       } catch (err) {
+        // Sync-throw path: no connectPromise means the lifecycle
+        // attachment never ran, so this catch is the only clear. The
+        // async-rejection path is owned by the .then() handlers, so
+        // we DON'T touch `connecting` there (would race the next
+        // tick's connect; see comment in finally).
+        if (!connectPromise) connecting = false;
         logger.error('gateway-leader: inbound-handoff connect threw (watchdog will retry)', {
           error: err.message, activeInstanceId,
         });
         throw err;
       } finally {
         clearTimeout(connectTimer);
-        // Note: NO `connecting = false` here — that's owned by the
-        // connectPromise settlement handlers above. Clearing it
-        // here on a timeout would race the still-pending connect
-        // against the next watchdog tick's fresh connect().
+        // Note: NO `connecting = false` here on the async path —
+        // that's owned by the connectPromise settlement handlers.
+        // Clearing it here on a timeout would race the still-pending
+        // connect against the next watchdog tick's fresh connect().
       }
       logger.info('gateway-leader: adopted lock + connected via inbound handoff', {
         activeInstanceId, expectedVersion,
@@ -486,14 +507,32 @@ function createGatewayLeader({
 
       heldLock = false;
 
-      const pushResult = await controlClient.pushHandoff({
-        peerIp: peer.ip,
-        peerPort: peer.port,
-        peerInstanceId: peer.instance_id,
-        selfInstanceId,
-        expectedVersion: transferResult.version,
-      });
-      // Either branch is fine. The active is exiting anyway; the
+      // The control-client's documented contract is "never throws"
+      // (returns a result object). Wrap defensively anyway: the
+      // synchronous validators inside pushHandoff (peerIp/peerPort/
+      // expectedVersion shape) DO throw if a row makes it past
+      // listFreshPeers' filters in a future regression — and the
+      // SIGTERM caller cannot handle exceptions cleanly. Mirrors the
+      // transferLock try/catch posture above. transferLock has
+      // already moved the lock in DDB, so the standby owns it either
+      // way; the watchdog catches lock-held + WS-disconnected within
+      // ~1 s and brings up the gateway from the cold-fallback path.
+      let pushResult;
+      try {
+        pushResult = await controlClient.pushHandoff({
+          peerIp: peer.ip,
+          peerPort: peer.port,
+          peerInstanceId: peer.instance_id,
+          selfInstanceId,
+          expectedVersion: transferResult.version,
+        });
+      } catch (err) {
+        logger.error('gateway-leader: controlClient.pushHandoff threw (watchdog will catch)', {
+          peerInstanceId: peer.instance_id, error: err && err.message,
+        });
+        return { pushed: true, ackReason: 'push_threw' };
+      }
+      // Either ACK branch is fine. The active is exiting anyway; the
       // standby has the lock either way (transferLock already moved
       // it in DDB). If the push didn't ACK, the standby's watchdog
       // sees lock-held + WS-disconnected within ~1 s and brings

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -107,6 +107,12 @@ function createGatewayLeader({
   // WebSocketManager is NOT safe under concurrent connect().
   let connecting = false;
   let running = false;
+  // Terminal-after-pushHandoff sentinel. Once set, `start()` is a
+  // permanent no-op. Mirrors the watchdog's `exited` flag — it's
+  // there to make the "leader is dead after pushHandoff" invariant
+  // explicit at the API surface rather than relying on the SIGTERM
+  // handler to never call start() again.
+  let closed = false;
   let loopPromise = null;
   let knownPeerInstanceIds = new Set();
 
@@ -211,7 +217,13 @@ function createGatewayLeader({
     // not spawn a second concurrent loop. Callers that need to
     // re-start MUST `await stop()` first; the returned promise
     // resolves once the loop has actually exited.
-    if (loopPromise) return;
+    //
+    // `closed` is permanent — once pushHandoff has run, start() is
+    // a no-op. The leader is terminal after handoff (the SIGTERM
+    // handler exits the process shortly after); a stray start()
+    // from a wiring bug would otherwise resume the tick on a dead
+    // task.
+    if (loopPromise || closed) return;
     running = true;
     loopPromise = loop().finally(() => { loopPromise = null; });
   }
@@ -286,11 +298,29 @@ function createGatewayLeader({
   // Called by the SIGTERM handler. Find peer, transfer, push, return.
   // Stops the tick loop first so the next tick can't race the
   // transferLock with a renewLock.
+  //
+  // TERMINAL: after this returns (any branch), the leader is dead.
+  // The `closed` sentinel is latched so a subsequent `start()` is a
+  // no-op — protects against a wiring bug in PR 13b.3 that might
+  // accidentally re-start the leader post-SIGTERM. The SIGTERM
+  // handler is still expected to `process.exit()` shortly after.
   async function pushHandoff() {
     running = false;
+    closed = true;
+    const cleanupHeartbeatRow = async () => {
+      // Best-effort: close the discovery window immediately so the
+      // freshly-promoted standby's listFreshPeers stops returning
+      // this row, rather than waiting up to `freshnessWindowSeconds`
+      // for the natural fade. Already-warned-and-logged inside
+      // deleteOwnRow; the .catch() is belt-and-braces in case the
+      // module surface changes.
+      await peerHeartbeat.deleteOwnRow().catch(() => {});
+    };
+
     return runSerialized(async () => {
       if (!heldLock) {
         logger.info('gateway-leader: pushHandoff called without holding lock (no-op)');
+        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'not_holding_lock' };
       }
 
@@ -304,6 +334,7 @@ function createGatewayLeader({
         // Best-effort release so the next replacement task can acquire
         // immediately rather than wait for TTL lapse.
         await lock.releaseLock().catch(() => {});
+        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'peer_lookup_failed' };
       }
 
@@ -311,6 +342,7 @@ function createGatewayLeader({
       if (!peer) {
         logger.warn('gateway-leader: no fresh peer for handoff — falling through to cold-fallback');
         await lock.releaseLock().catch(() => {});
+        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'no_peer' };
       }
 
@@ -319,7 +351,9 @@ function createGatewayLeader({
       // window), build a placeholder so transferLock still has a
       // valid string to write. The lock_holder field is operational
       // metadata; correctness doesn't depend on its value, only its
-      // non-emptiness.
+      // non-emptiness. TODO(post-13b.2-bake): drop this fallback
+      // once all peers have been on >=13b.2 long enough that
+      // missing lock_holder is impossible.
       const targetLockHolder = peer.lock_holder
         || `peer/${peer.instance_id}`;
 
@@ -329,32 +363,20 @@ function createGatewayLeader({
       } catch (err) {
         logger.error('gateway-leader: transferLock threw', { error: err.message });
         await lock.releaseLock().catch(() => {});
+        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'transfer_threw' };
       }
 
       if (!transferResult.transferred) {
         // CAS failed — version moved (peer cold-acquired) or we
         // weren't actually holding. Either way the DDB row is no
-        // longer ours, so flip the local flag to match. Without
-        // this, the implicit "caller MUST exit after pushHandoff"
-        // invariant would be load-bearing for a hypothetical caller
-        // that loops back into the tick (where heldLock=true would
-        // attempt renewLock on a row owned by the peer). Making the
-        // flag explicitly match DDB state removes the dependency.
+        // longer ours, so flip the local flag to match.
         heldLock = false;
         logger.warn('gateway-leader: transferLock CAS failed; skipping push');
+        await cleanupHeartbeatRow();
         return { pushed: false, reason: 'transfer_failed' };
       }
 
-      // Implicit invariant: caller (SIGTERM handler) MUST exit
-      // after this point. Clearing heldLock here without exiting
-      // would cause the next tick (if `running` got flipped back
-      // on) to observe heldLock=false and try `acquireLock` —
-      // immediately re-acquiring the lock we just transferred.
-      // Stop is already false (set at the top of pushHandoff),
-      // but a future refactor that ever resumes the tick loop
-      // after handoff needs to also clear or re-key heldLock
-      // semantics.
       heldLock = false;
 
       const result = await controlClient.pushHandoff({
@@ -378,6 +400,7 @@ function createGatewayLeader({
           peerInstanceId: peer.instance_id, reason: result.reason,
         });
       }
+      await cleanupHeartbeatRow();
       return { pushed: true, ackReason: result.ok ? 'ack' : result.reason };
     });
   }

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -112,6 +112,13 @@ function createPeerHeartbeat({
   }
   if (!shardId) throw new Error('createPeerHeartbeat: shardId is required');
   if (!logger) throw new Error('createPeerHeartbeat: logger is required');
+  // `lockHolder` is optional but, when provided, must be a non-empty
+  // string. A stray `lockHolder: 42` or `lockHolder: true` would write
+  // a non-string to DDB and surface as a confusing log field at
+  // SIGTERM. Mirrors the `secrets.previous` posture in gateway-hmac.
+  if (lockHolder !== undefined && (typeof lockHolder !== 'string' || lockHolder.length === 0)) {
+    throw new Error('createPeerHeartbeat: lockHolder must be a non-empty string when provided');
+  }
 
   function nowSeconds() {
     return Math.floor(clock() / 1000);

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -152,6 +152,16 @@ function createPeerHeartbeat({
       .filter((row) => row.instance_id !== instanceId)
       .filter((row) => row.shard_id === shardId)
       .filter((row) => typeof row.updated_at === 'number' && row.updated_at > cutoff)
+      // Defense-in-depth: skip any row missing a parseable IPv4/IPv6
+      // `ip` or a valid TCP `port`. The write path already validates
+      // both, but a corrupt or pre-validator row would otherwise reach
+      // the SIGTERM handoff path. The control-client validates again
+      // at POST time and would throw — but the cost of catching a bad
+      // row here is one filter pass, and the win is that the caller
+      // moves on to the next-freshest peer instead of bailing out
+      // with `pushHandoff: peerIp required` and losing the handoff.
+      .filter((row) => typeof row.ip === 'string' && net.isIP(row.ip) !== 0)
+      .filter((row) => Number.isInteger(row.port) && row.port > 0 && row.port <= 65535)
       .sort((a, b) => b.updated_at - a.updated_at);
   }
 

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -91,6 +91,15 @@ function createPeerHeartbeat({
   // the string `"undefined"`) would otherwise write a row whose
   // `ip` field looks valid to DDB but is unreachable from the
   // active's POST. `net.isIP` returns 0 for non-IPs, 4/6 otherwise.
+  //
+  // ── IPv6 zone-id assumption ──
+  // `net.isIP` accepts scoped IPv6 literals (`fe80::1%eth0`) on
+  // some Node versions, but `node:http` doesn't reliably connect
+  // to them across platforms. ECS awsvpc tasks get a non-link-local
+  // ENI address, so zone-ids never reach this row in practice; we
+  // rely on the caller passing a global-scope literal. If a future
+  // deployment surface adds link-local addresses, strip the zone-id
+  // here AND in gateway-control-client's peerIp validator.
   if (!ip || net.isIP(ip) === 0) {
     throw new Error('createPeerHeartbeat: ip (IPv4 or IPv6 literal) is required');
   }

--- a/apps/discord/src/gateway-peer-heartbeat.js
+++ b/apps/discord/src/gateway-peer-heartbeat.js
@@ -72,6 +72,12 @@ function createPeerHeartbeat({
   ip,
   port,
   shardId,
+  // Optional. When set, written as `lock_holder` on the heartbeat
+  // row so the active's SIGTERM `transferLock(target, targetHolder)`
+  // call has a real holder string for the peer instead of inventing
+  // a placeholder. Pure operational-debug metadata; lock correctness
+  // doesn't depend on its value.
+  lockHolder,
   logger,
   clock = () => Date.now(),
   freshnessWindowSeconds = DEFAULT_FRESHNESS_WINDOW_SECONDS,
@@ -112,16 +118,20 @@ function createPeerHeartbeat({
   // the freshness window absorbs up to three misses).
   async function writeHeartbeat() {
     const now = nowSeconds();
+    const item = {
+      instance_id: instanceId,
+      ip,
+      port,
+      shard_id: shardId,
+      updated_at: now,
+      expires_at: now + ttlSeconds,
+    };
+    // Only write lock_holder if provided. DDB rejects undefined
+    // attribute values and back-compat callers may not pass it.
+    if (lockHolder) item.lock_holder = lockHolder;
     await ddbClient.send(new PutCommand({
       TableName: tableName,
-      Item: {
-        instance_id: instanceId,
-        ip,
-        port,
-        shard_id: shardId,
-        updated_at: now,
-        expires_at: now + ttlSeconds,
-      },
+      Item: item,
     }));
   }
 

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -50,6 +50,7 @@ function makeWatchdog({
   deleteOwnRow,
   pollIntervalMs,
   maxAttempts,
+  releaseLockCeilingMs,
   sleep = jest.fn(async () => {}),
   exit = jest.fn(),
 } = {}) {
@@ -59,7 +60,7 @@ function makeWatchdog({
   const watchdog = createConnectionWatchdog({
     manager: manager ?? makeFakeManager(),
     isHoldingLock, isConnecting, releaseLock, deleteOwnRow, logger,
-    pollIntervalMs, maxAttempts, sleep, exit,
+    pollIntervalMs, maxAttempts, releaseLockCeilingMs, sleep, exit,
   });
   return {
     watchdog, logger, releaseLock, deleteOwnRow, sleep, exit,
@@ -393,6 +394,35 @@ describe('step() — exhaustion path', () => {
       await watchdog._stepForTest();
     }
     expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('exits(1) even when releaseLock hangs (Promise.race ceiling kicks in)', async () => {
+    // Defense vs the inbound-handoff-hung-on-manager.connect path
+    // (see #415). releaseLockForImmediateExit awaits through the
+    // leader's serialization chain, which can be stuck behind a
+    // hung connect. Without the race, exit(1) would never fire and
+    // the failover slot stays held with no live gateway. Inject a
+    // tiny ceiling (10ms) so the test runs in real time.
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('persistent-fail'));
+    // releaseLock returns a never-resolving promise — simulates the
+    // serialization chain being stuck behind a hung op.
+    const releaseLock = jest.fn(() => new Promise(() => {}));
+    const exit = jest.fn();
+    const { watchdog, logger } = makeWatchdog({
+      manager, releaseLock, exit, maxAttempts: 3, releaseLockCeilingMs: 10,
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'connection-watchdog: releaseLock failed during exhaustion-exit',
+      expect.objectContaining({ error: expect.stringMatching(/release_lock_ceiling/) }),
+    );
   });
 
   it('still exits(1) when releaseLock throws AND deleteOwnRow is absent (combined-permutation pin)', async () => {

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -45,6 +45,7 @@ function makeFakeManager({ initialConnected = false } = {}) {
 function makeWatchdog({
   manager,
   isHoldingLock = () => true,
+  isConnecting = () => false,
   releaseLock = jest.fn(async () => {}),
   pollIntervalMs,
   maxAttempts,
@@ -56,7 +57,7 @@ function makeWatchdog({
   };
   const watchdog = createConnectionWatchdog({
     manager: manager ?? makeFakeManager(),
-    isHoldingLock, releaseLock, logger,
+    isHoldingLock, isConnecting, releaseLock, logger,
     pollIntervalMs, maxAttempts, sleep, exit,
   });
   return { watchdog, logger, releaseLock, sleep, exit };
@@ -145,6 +146,46 @@ describe('step() — no-op paths', () => {
     manager._setConnected(true);
     await watchdog._stepForTest();
     expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+});
+
+describe('step() — isConnecting backoff (race with leader inbound-handoff)', () => {
+  it('does NOT call manager.connect() when leader reports isConnecting=true', async () => {
+    // Inbound-handoff path: leader is awaiting `manager.connect()`.
+    // Watchdog tick observes !isConnected() and would normally
+    // fire its own connect — that would race against the same
+    // WebSocketManager. The isConnecting hook gates this off.
+    const manager = makeFakeManager();
+    const isConnecting = jest.fn(() => true);
+    const { watchdog } = makeWatchdog({ manager, isConnecting });
+
+    await watchdog._stepForTest();
+
+    expect(manager.connect).not.toHaveBeenCalled();
+    expect(isConnecting).toHaveBeenCalled();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+
+  it('resets attempts when leader transitions to isConnecting=true mid-ladder', async () => {
+    // Failure ladder is at attempt 3; leader then takes over the
+    // connect (inbound-handoff). The watchdog must reset attempts
+    // so the leader's eventual outcome doesn't carry a stale
+    // ladder into the next watchdog-driven retry.
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    let leaderConnecting = false;
+    const { watchdog } = makeWatchdog({
+      manager, isConnecting: () => leaderConnecting, maxAttempts: 10,
+    });
+    await watchdog._stepForTest();
+    await watchdog._stepForTest();
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(3);
+
+    leaderConnecting = true;
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+    expect(manager.connect).toHaveBeenCalledTimes(3); // not 4
   });
 });
 

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -71,6 +71,18 @@ describe('createConnectionWatchdog — factory validation', () => {
     expect(BACKOFF_CAP_MS).toBe(5_000);
   });
 
+  it('BACKOFF_CAP_MS stays above the natural ceiling at DEFAULT_MAX_ATTEMPTS', () => {
+    // Source comment names this the "dead-code branch": at default
+    // maxAttempts=5, the highest pre-exit backoff is 2^4 * 100 =
+    // 1600 ms, well under the 5000 cap. Pin the inequality so a
+    // future bump to maxAttempts that pushes the natural backoff
+    // past the cap surfaces here rather than silently truncating
+    // the failure ladder.
+    const naturalCeiling = (2 ** DEFAULT_MAX_ATTEMPTS) * BACKOFF_BASE_MS;
+    // At maxAttempts=5: ceiling = 32 * 100 = 3200. Cap 5000 > 3200.
+    expect(BACKOFF_CAP_MS).toBeGreaterThan(naturalCeiling);
+  });
+
   it('throws when manager lacks required methods', () => {
     expect(() => createConnectionWatchdog()).toThrow(/manager.*connect.*isConnected/);
     expect(() => createConnectionWatchdog({ manager: {} })).toThrow(/manager.*connect.*isConnected/);
@@ -78,13 +90,18 @@ describe('createConnectionWatchdog — factory validation', () => {
       .toThrow(/manager.*connect.*isConnected/);
   });
 
-  it('throws when isHoldingLock / releaseLock / logger are missing', () => {
+  it('throws when isHoldingLock / isConnecting / releaseLock / logger are missing', () => {
     const manager = makeFakeManager();
     expect(() => createConnectionWatchdog({ manager })).toThrow(/isHoldingLock/);
-    expect(() => createConnectionWatchdog({ manager, isHoldingLock: () => true }))
-      .toThrow(/releaseLock/);
     expect(() => createConnectionWatchdog({
-      manager, isHoldingLock: () => true, releaseLock: async () => {},
+      manager, isHoldingLock: () => true,
+    })).toThrow(/isConnecting/);
+    expect(() => createConnectionWatchdog({
+      manager, isHoldingLock: () => true, isConnecting: () => false,
+    })).toThrow(/releaseLock/);
+    expect(() => createConnectionWatchdog({
+      manager, isHoldingLock: () => true, isConnecting: () => false,
+      releaseLock: async () => {},
     })).toThrow(/logger is required/);
   });
 });

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -1,0 +1,351 @@
+// Unit tests for src/gateway-connection-watchdog.js — Pillar 3
+// connection watchdog that closes the "lock held, WS not connected"
+// gap. Pins the load-bearing contracts:
+//
+//   1. No-op when not holding the lock. Watchdog runs unconditionally;
+//      a standby waiting for promotion ticks but does nothing.
+//   2. No-op when manager.isConnected(). Steady-state: no work, no log.
+//   3. Tries manager.connect() exactly once per failure tick (at-most-
+//      one outstanding connect — the design depends on this).
+//   4. Attempt counter resets on:
+//        - successful connect()
+//        - lock-not-held tick (covers give-up-and-reacquire)
+//        - manager-already-connected tick
+//   5. Exponential backoff sleeps after failure: 200 / 400 / 800 / 1600 ms
+//      (capped at 5 s — dead code at maxAttempts=5, see source).
+//   6. At attempts >= maxAttempts (default 5): releaseLock() then exit(1).
+//      releaseLock failure is logged and swallowed; exit still fires.
+//   7. start() is idempotent; stop() halts the loop; post-exit, start()
+//      cannot re-enter.
+//
+// Each contract maps to a production failure mode:
+//   - (3) two parallel connect() calls would race @discordjs/ws internal state.
+//   - (4) without reset on lock-give-up, a previous task's failure ladder
+//     would carry into a re-acquired lock and prematurely exit.
+//   - (5)/(6) without bounded retry + exit, a standby that can't reach
+//     Discord blocks the only failover slot indefinitely.
+
+const {
+  createConnectionWatchdog,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  BACKOFF_BASE_MS,
+  BACKOFF_CAP_MS,
+} = require('../src/gateway-connection-watchdog');
+
+function makeFakeManager({ initialConnected = false } = {}) {
+  let connected = initialConnected;
+  return {
+    isConnected: jest.fn(() => connected),
+    connect: jest.fn(async () => { connected = true; }),
+    _setConnected(v) { connected = v; },
+  };
+}
+
+function makeWatchdog({
+  manager,
+  isHoldingLock = () => true,
+  releaseLock = jest.fn(async () => {}),
+  pollIntervalMs,
+  maxAttempts,
+  sleep = jest.fn(async () => {}),
+  exit = jest.fn(),
+} = {}) {
+  const logger = {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+  const watchdog = createConnectionWatchdog({
+    manager: manager ?? makeFakeManager(),
+    isHoldingLock, releaseLock, logger,
+    pollIntervalMs, maxAttempts, sleep, exit,
+  });
+  return { watchdog, logger, releaseLock, sleep, exit };
+}
+
+describe('createConnectionWatchdog — factory validation', () => {
+  it('exposes default constants', () => {
+    expect(DEFAULT_POLL_INTERVAL_MS).toBe(1_000);
+    expect(DEFAULT_MAX_ATTEMPTS).toBe(5);
+    expect(BACKOFF_BASE_MS).toBe(100);
+    expect(BACKOFF_CAP_MS).toBe(5_000);
+  });
+
+  it('throws when manager lacks required methods', () => {
+    expect(() => createConnectionWatchdog()).toThrow(/manager.*connect.*isConnected/);
+    expect(() => createConnectionWatchdog({ manager: {} })).toThrow(/manager.*connect.*isConnected/);
+    expect(() => createConnectionWatchdog({ manager: { connect: () => {} } }))
+      .toThrow(/manager.*connect.*isConnected/);
+  });
+
+  it('throws when isHoldingLock / releaseLock / logger are missing', () => {
+    const manager = makeFakeManager();
+    expect(() => createConnectionWatchdog({ manager })).toThrow(/isHoldingLock/);
+    expect(() => createConnectionWatchdog({ manager, isHoldingLock: () => true }))
+      .toThrow(/releaseLock/);
+    expect(() => createConnectionWatchdog({
+      manager, isHoldingLock: () => true, releaseLock: async () => {},
+    })).toThrow(/logger is required/);
+  });
+});
+
+describe('step() — no-op paths', () => {
+  it('does nothing when not holding the lock', async () => {
+    const manager = makeFakeManager();
+    const { watchdog } = makeWatchdog({ manager, isHoldingLock: () => false });
+
+    await watchdog._stepForTest();
+
+    expect(manager.connect).not.toHaveBeenCalled();
+    expect(manager.isConnected).not.toHaveBeenCalled();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+
+  it('does nothing when manager.isConnected() returns true', async () => {
+    const manager = makeFakeManager({ initialConnected: true });
+    const { watchdog, sleep } = makeWatchdog({ manager });
+
+    await watchdog._stepForTest();
+
+    expect(manager.connect).not.toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+
+  it('resets attempts when transitioning lock-held → lock-not-held mid-ladder', async () => {
+    let holding = true;
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const { watchdog, sleep } = makeWatchdog({
+      manager, isHoldingLock: () => holding, maxAttempts: 10, sleep: jest.fn(async () => {}),
+    });
+
+    await watchdog._stepForTest();
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(2);
+
+    // Give up the lock — next tick must reset.
+    holding = false;
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+    // sleep was called on each of the 2 failures, not on the no-op tick.
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets attempts when manager reconnects between ticks', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const { watchdog } = makeWatchdog({ manager, maxAttempts: 10 });
+
+    await watchdog._stepForTest();
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(2);
+
+    // Manager reconnected on its own (e.g., a successful out-of-band
+    // connect from elsewhere). Next tick must reset.
+    manager._setConnected(true);
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+});
+
+describe('step() — connect retries', () => {
+  it('calls manager.connect() when lock held + not connected', async () => {
+    const manager = makeFakeManager();
+    const { watchdog } = makeWatchdog({ manager });
+
+    await watchdog._stepForTest();
+
+    expect(manager.connect).toHaveBeenCalledTimes(1);
+    expect(watchdog._getAttemptsForTest()).toBe(0); // reset after success
+  });
+
+  it('resets attempts on successful connect after prior failures', async () => {
+    const manager = makeFakeManager();
+    let nthCall = 0;
+    manager.connect.mockImplementation(async () => {
+      nthCall += 1;
+      if (nthCall < 3) throw new Error('transient');
+      // Third call succeeds.
+      manager._setConnected(true);
+    });
+    const { watchdog } = makeWatchdog({ manager, maxAttempts: 10 });
+
+    await watchdog._stepForTest();
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(2);
+    await watchdog._stepForTest();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+
+  it('backs off 200/400/800/1600 ms on attempts 1..4', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const sleep = jest.fn(async () => {});
+    const { watchdog } = makeWatchdog({ manager, maxAttempts: 10, sleep });
+
+    await watchdog._stepForTest(); // attempt 1 → 200 ms
+    await watchdog._stepForTest(); // attempt 2 → 400 ms
+    await watchdog._stepForTest(); // attempt 3 → 800 ms
+    await watchdog._stepForTest(); // attempt 4 → 1600 ms
+
+    expect(sleep).toHaveBeenNthCalledWith(1, 200);
+    expect(sleep).toHaveBeenNthCalledWith(2, 400);
+    expect(sleep).toHaveBeenNthCalledWith(3, 800);
+    expect(sleep).toHaveBeenNthCalledWith(4, 1_600);
+  });
+
+  it('caps backoff at 5000 ms (dead-code branch — pins the cap for future maxAttempts bumps)', async () => {
+    // With maxAttempts=10 and BACKOFF_BASE=100, attempt 7 would be
+    // 2^7 * 100 = 12_800 ms → capped at 5000. Validates the cap.
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const sleep = jest.fn(async () => {});
+    const { watchdog } = makeWatchdog({ manager, maxAttempts: 10, sleep });
+
+    for (let i = 0; i < 7; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+    // Last call (attempt 7) should hit the cap.
+    expect(sleep).toHaveBeenLastCalledWith(5_000);
+  });
+
+  it('logs each failed-connect attempt with attempts + backoffMs', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('econnrefused'));
+    const { watchdog, logger } = makeWatchdog({ manager, maxAttempts: 10 });
+
+    await watchdog._stepForTest();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'connection-watchdog: connect failed, backing off',
+      expect.objectContaining({ attempts: 1, backoffMs: 200 }),
+    );
+  });
+});
+
+describe('step() — exhaustion path', () => {
+  it('releases the lock and exits(1) when attempts reaches maxAttempts', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('persistent-fail'));
+    const releaseLock = jest.fn(async () => {});
+    const exit = jest.fn();
+    const sleep = jest.fn(async () => {});
+    const { watchdog, logger } = makeWatchdog({
+      manager, releaseLock, exit, sleep, maxAttempts: 5,
+    });
+
+    // 5 failed attempts.
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    expect(manager.connect).toHaveBeenCalledTimes(5);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'connection-watchdog: connect retries exhausted, releasing lock',
+      expect.objectContaining({ attempts: 5 }),
+    );
+    // On the exhaustion tick, the backoff sleep MUST NOT fire — the
+    // exit path supersedes it. So sleep only fired on attempts 1..4.
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it('still exits(1) when releaseLock itself throws', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const releaseLock = jest.fn(async () => { throw new Error('ddb-blip'); });
+    const exit = jest.fn();
+    const { watchdog, logger } = makeWatchdog({
+      manager, releaseLock, exit, maxAttempts: 5,
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'connection-watchdog: releaseLock failed during exhaustion-exit',
+      expect.objectContaining({ error: 'ddb-blip' }),
+    );
+  });
+
+  it('does not re-enter start() after exhaustion-exit', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const exit = jest.fn();
+    const { watchdog } = makeWatchdog({
+      manager, exit, maxAttempts: 5,
+      // Fast poll interval so the next test setup is quick.
+      pollIntervalMs: 1,
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+    expect(exit).toHaveBeenCalledWith(1);
+
+    // Calling start() after exhaustion is a no-op (the watchdog is
+    // dead; the process is supposed to be exiting).
+    watchdog.start();
+    expect(watchdog._getRunningForTest()).toBe(false);
+  });
+});
+
+describe('start() / stop() lifecycle', () => {
+  it('start() schedules ticks via the injected sleep + stop() halts the loop', async () => {
+    const manager = makeFakeManager({ initialConnected: true });
+    const sleepResolvers = [];
+    // Make sleep a controllable promise — resolve it when the test
+    // wants the next tick to fire.
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { watchdog } = makeWatchdog({ manager, sleep });
+
+    watchdog.start();
+    // First sleep is queued before the first step.
+    await flushMicrotasks();
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    // Release the first poll: a step runs (no-op, isConnected=true)
+    // then the next poll-sleep is queued.
+    sleepResolvers[0]();
+    await flushMicrotasks();
+    expect(manager.isConnected).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledTimes(2);
+
+    watchdog.stop();
+    sleepResolvers[1](); // wake the loop so it observes running=false and exits
+    await flushMicrotasks();
+    expect(watchdog._getRunningForTest()).toBe(false);
+  });
+
+  it('start() is idempotent', async () => {
+    const manager = makeFakeManager({ initialConnected: true });
+    const sleep = jest.fn(() => new Promise(() => {})); // never resolves
+    const { watchdog } = makeWatchdog({ manager, sleep });
+
+    watchdog.start();
+    watchdog.start();
+    watchdog.start();
+    await flushMicrotasks();
+    // Only the first start scheduled a sleep; later starts must no-op.
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    watchdog.stop();
+  });
+
+  it('stop() before start() is safe', () => {
+    const { watchdog } = makeWatchdog();
+    expect(() => watchdog.stop()).not.toThrow();
+  });
+});
+
+// Lets the queued microtasks (await sleep/connect resolutions) flush
+// before the next assertion.
+function flushMicrotasks() {
+  return new Promise((resolve) => { setImmediate(resolve); });
+}

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -51,6 +51,7 @@ function makeWatchdog({
   pollIntervalMs,
   maxAttempts,
   releaseLockCeilingMs,
+  connectCeilingMs,
   sleep = jest.fn(async () => {}),
   exit = jest.fn(),
 } = {}) {
@@ -60,7 +61,7 @@ function makeWatchdog({
   const watchdog = createConnectionWatchdog({
     manager: manager ?? makeFakeManager(),
     isHoldingLock, isConnecting, releaseLock, deleteOwnRow, logger,
-    pollIntervalMs, maxAttempts, releaseLockCeilingMs, sleep, exit,
+    pollIntervalMs, maxAttempts, releaseLockCeilingMs, connectCeilingMs, sleep, exit,
   });
   return {
     watchdog, logger, releaseLock, deleteOwnRow, sleep, exit,
@@ -283,6 +284,22 @@ describe('step() — connect retries', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       'connection-watchdog: connect failed, backing off',
       expect.objectContaining({ attempts: 1, backoffMs: 200 }),
+    );
+  });
+
+  it('treats a hung manager.connect() as a failed attempt (connect-ceiling race)', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockImplementation(() => new Promise(() => {})); // never settles
+    const { watchdog, logger } = makeWatchdog({
+      manager, maxAttempts: 10, connectCeilingMs: 10,
+    });
+
+    await watchdog._stepForTest();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'connection-watchdog: connect failed, backing off',
+      expect.objectContaining({
+        attempts: 1, error: expect.stringMatching(/watchdog_connect_ceiling/),
+      }),
     );
   });
 });

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -395,6 +395,36 @@ describe('step() — exhaustion path', () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
+  it('still exits(1) when releaseLock throws AND deleteOwnRow is absent (combined-permutation pin)', async () => {
+    // Pin the cross-product the individual tests don't cover. Both
+    // best-effort awaits are independent, but a future refactor that
+    // accidentally wires them sequentially (one throw aborting the
+    // other) would still need to surface exit(1).
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const releaseLock = jest.fn(async () => { throw new Error('ddb-blip'); });
+    const exit = jest.fn();
+    const { watchdog, logger } = makeWatchdog({
+      manager, releaseLock, exit, maxAttempts: 3,
+      // deleteOwnRow deliberately omitted.
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'connection-watchdog: releaseLock failed during exhaustion-exit',
+      expect.objectContaining({ error: 'ddb-blip' }),
+    );
+    // No deleteOwnRow log because hook wasn't provided.
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'connection-watchdog: deleteOwnRow failed during exhaustion-exit',
+      expect.anything(),
+    );
+  });
+
   it('does not re-enter start() after exhaustion-exit', async () => {
     const manager = makeFakeManager();
     manager.connect.mockRejectedValue(new Error('fail'));

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -296,6 +296,49 @@ describe('step() — exhaustion path', () => {
   });
 });
 
+describe('loop backstop — survives unexpected throws from step()', () => {
+  it('an isConnected() throw does not exit the loop (logs + retries next tick)', async () => {
+    // Contractually `manager.isConnected()` is non-throwing, but a
+    // future shim refactor could regress. Without a backstop, the
+    // first throw would reject the loop's `await step()` and
+    // silently disable the watchdog. The loop must keep running.
+    const manager = makeFakeManager();
+    let nthCall = 0;
+    manager.isConnected = jest.fn(() => {
+      nthCall += 1;
+      if (nthCall === 1) throw new Error('shim-regression');
+      return true;
+    });
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { watchdog, logger } = makeWatchdog({
+      manager, sleep, pollIntervalMs: 1,
+    });
+
+    watchdog.start();
+    await flushMicrotasks();
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    // Wake the loop for tick #1 — isConnected throws.
+    sleepResolvers[0]();
+    await flushMicrotasks();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/step threw unexpectedly/),
+      expect.objectContaining({ error: 'shim-regression' }),
+    );
+    // Loop must have scheduled the next sleep.
+    expect(sleep).toHaveBeenCalledTimes(2);
+
+    // Wake tick #2 — isConnected succeeds (returns true).
+    sleepResolvers[1]();
+    await flushMicrotasks();
+    expect(manager.isConnected).toHaveBeenCalledTimes(2);
+
+    watchdog.stop();
+    sleepResolvers[2]();
+  });
+});
+
 describe('start() / stop() lifecycle', () => {
   it('start() schedules ticks via the injected sleep + stop() halts the loop', async () => {
     const manager = makeFakeManager({ initialConnected: true });

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -190,6 +190,32 @@ describe('step() — isConnecting backoff (race with leader inbound-handoff)', (
     expect(watchdog._getAttemptsForTest()).toBe(0);
   });
 
+  it('stays at attempts=0 indefinitely while isConnecting=true (escape hatch #415)', async () => {
+    // Pin the *current* failure mode tracked by #415: if @discordjs/ws
+    // ever fails to settle manager.connect(), the leader latches
+    // `connecting=true` forever, isConnecting() returns true on every
+    // tick, the watchdog resets attempts and stands down, and the
+    // exit(1) recovery never fires. The process is permanently broken
+    // without an external process-health monitor. This test pins the
+    // current behavior so the fix (process-level alarm landing later)
+    // is loud about changing it.
+    const manager = makeFakeManager();
+    const isConnecting = jest.fn(() => true);
+    const exit = jest.fn();
+    const releaseLock = jest.fn(async () => {});
+    const { watchdog } = makeWatchdog({
+      manager, isConnecting, exit, releaseLock, maxAttempts: 3,
+    });
+    for (let i = 0; i < 20; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+    expect(manager.connect).not.toHaveBeenCalled();
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+    expect(watchdog._getAttemptsForTest()).toBe(0);
+  });
+
   it('resets attempts when leader transitions to isConnecting=true mid-ladder', async () => {
     // Failure ladder is at attempt 3; leader then takes over the
     // connect (inbound-handoff). The watchdog must reset attempts

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -426,6 +426,46 @@ describe('start() / stop() lifecycle', () => {
     const { watchdog } = makeWatchdog();
     expect(() => watchdog.stop()).not.toThrow();
   });
+
+  it('stop() returns a promise that resolves once the loop exits', async () => {
+    const manager = makeFakeManager({ initialConnected: true });
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { watchdog } = makeWatchdog({ manager, sleep });
+    watchdog.start();
+    await flushMicrotasks();
+
+    const stopPromise = watchdog.stop();
+    sleepResolvers[0](); // wake the loop so it can observe running=false and exit
+    await stopPromise;
+
+    expect(watchdog._getRunningForTest()).toBe(false);
+  });
+
+  it('start() after stop() without awaiting does NOT orphan a second loop', async () => {
+    // Re-start safety: caller must await stop() before start();
+    // a naked start() during the wind-down window is a no-op.
+    const manager = makeFakeManager({ initialConnected: true });
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { watchdog } = makeWatchdog({ manager, sleep });
+
+    watchdog.start();
+    await flushMicrotasks();
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    watchdog.stop();
+    watchdog.start(); // no-op — old loop still pending
+    await flushMicrotasks();
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    // Wake old loop so it exits, then a fresh start is allowed.
+    sleepResolvers[0]();
+    await flushMicrotasks();
+    watchdog.start();
+    await flushMicrotasks();
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
 });
 
 // Lets the queued microtasks (await sleep/connect resolutions) flush

--- a/apps/discord/tests/gateway-connection-watchdog.test.js
+++ b/apps/discord/tests/gateway-connection-watchdog.test.js
@@ -47,6 +47,7 @@ function makeWatchdog({
   isHoldingLock = () => true,
   isConnecting = () => false,
   releaseLock = jest.fn(async () => {}),
+  deleteOwnRow,
   pollIntervalMs,
   maxAttempts,
   sleep = jest.fn(async () => {}),
@@ -57,10 +58,12 @@ function makeWatchdog({
   };
   const watchdog = createConnectionWatchdog({
     manager: manager ?? makeFakeManager(),
-    isHoldingLock, isConnecting, releaseLock, logger,
+    isHoldingLock, isConnecting, releaseLock, deleteOwnRow, logger,
     pollIntervalMs, maxAttempts, sleep, exit,
   });
-  return { watchdog, logger, releaseLock, sleep, exit };
+  return {
+    watchdog, logger, releaseLock, deleteOwnRow, sleep, exit,
+  };
 }
 
 describe('createConnectionWatchdog — factory validation', () => {
@@ -72,14 +75,16 @@ describe('createConnectionWatchdog — factory validation', () => {
   });
 
   it('BACKOFF_CAP_MS stays above the natural ceiling at DEFAULT_MAX_ATTEMPTS', () => {
-    // Source comment names this the "dead-code branch": at default
-    // maxAttempts=5, the highest pre-exit backoff is 2^4 * 100 =
-    // 1600 ms, well under the 5000 cap. Pin the inequality so a
-    // future bump to maxAttempts that pushes the natural backoff
-    // past the cap surfaces here rather than silently truncating
-    // the failure ladder.
-    const naturalCeiling = (2 ** DEFAULT_MAX_ATTEMPTS) * BACKOFF_BASE_MS;
-    // At maxAttempts=5: ceiling = 32 * 100 = 3200. Cap 5000 > 3200.
+    // Source comment names this the "dead-code branch": the highest
+    // backoff that actually sleeps is at `attempts = maxAttempts - 1`
+    // (the next failure tips into the exhaustion-exit path before
+    // sleeping). At default maxAttempts=5 that's 2^4 * 100 = 1600 ms,
+    // well under the 5000 cap. Pin the inequality so a future bump
+    // to maxAttempts that pushes the natural backoff past the cap
+    // surfaces here rather than silently truncating the failure
+    // ladder.
+    const naturalCeiling = (2 ** (DEFAULT_MAX_ATTEMPTS - 1)) * BACKOFF_BASE_MS;
+    // At maxAttempts=5: ceiling = 16 * 100 = 1600. Cap 5000 > 1600.
     expect(BACKOFF_CAP_MS).toBeGreaterThan(naturalCeiling);
   });
 
@@ -329,6 +334,65 @@ describe('step() — exhaustion path', () => {
       'connection-watchdog: releaseLock failed during exhaustion-exit',
       expect.objectContaining({ error: 'ddb-blip' }),
     );
+  });
+
+  it('calls deleteOwnRow on exhaustion when hook is provided (symmetric to pushHandoff)', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('persistent-fail'));
+    const releaseLock = jest.fn(async () => {});
+    const deleteOwnRow = jest.fn(async () => {});
+    const exit = jest.fn();
+    const { watchdog } = makeWatchdog({
+      manager, releaseLock, deleteOwnRow, exit, maxAttempts: 3,
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(deleteOwnRow).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('still exits(1) when deleteOwnRow throws (logged and swallowed)', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const releaseLock = jest.fn(async () => {});
+    const deleteOwnRow = jest.fn(async () => { throw new Error('ddb-blip'); });
+    const exit = jest.fn();
+    const { watchdog, logger } = makeWatchdog({
+      manager, releaseLock, deleteOwnRow, exit, maxAttempts: 3,
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'connection-watchdog: deleteOwnRow failed during exhaustion-exit',
+      expect.objectContaining({ error: 'ddb-blip' }),
+    );
+  });
+
+  it('omits deleteOwnRow call when hook not provided (back-compat with leader-less wiring)', async () => {
+    const manager = makeFakeManager();
+    manager.connect.mockRejectedValue(new Error('fail'));
+    const releaseLock = jest.fn(async () => {});
+    const exit = jest.fn();
+    // No deleteOwnRow injected.
+    const { watchdog } = makeWatchdog({
+      manager, releaseLock, exit, maxAttempts: 3,
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+    expect(exit).toHaveBeenCalledWith(1);
   });
 
   it('does not re-enter start() after exhaustion-exit', async () => {

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -31,6 +31,7 @@ const { Readable } = require('node:stream');
 const {
   startControlChannelServer,
   _handleRequestForTest,
+  _readRequestBodyForTest,
   DEFAULT_BODY_BYTE_CAP,
 } = require('../src/gateway-control-channel');
 
@@ -727,6 +728,43 @@ describe('handleRequest — Connection: close on bail-out paths', () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body)).toEqual({ error: 'unknown_peer' });
     expect(res.headers).not.toMatchObject({ Connection: 'close' });
+  });
+});
+
+describe('readRequestBody — settle idempotence on close-after-end', () => {
+  it('resolves cleanly when close fires after end (Node 17+ destroy-on-end path)', async () => {
+    // Some Node versions emit `close` with `req.destroyed=true` right
+    // after a normal `end` — this is the post-Node-17 stream lifecycle
+    // for cleanly-consumed request streams. The `settle` helper must
+    // be idempotent so the `end` → resolve wins and the trailing
+    // `close` → reject is a no-op. Without idempotence, the body
+    // would correctly resolve then immediately get a reject for
+    // `request_aborted`, which would unhandled-promise-warn or worse.
+    const req = new Readable({ read() {} });
+    const p = _readRequestBodyForTest(req, 1024);
+    req.push(Buffer.from('hello'));
+    req.push(null); // triggers 'end'
+    // Simulate the Node 17+ post-end behavior: close with destroyed.
+    setImmediate(() => {
+      // eslint-disable-next-line no-param-reassign
+      req.destroyed = true;
+      req.emit('close');
+    });
+    await expect(p).resolves.toEqual(Buffer.from('hello'));
+  });
+
+  it('rejects cleanly when close fires WITHOUT a preceding end (true abort)', async () => {
+    // The mirror case: socket dies mid-body, no `end` ever arrives.
+    // The `close` handler sees `req.destroyed=true` and rejects.
+    const req = new Readable({ read() {} });
+    const p = _readRequestBodyForTest(req, 1024);
+    req.push(Buffer.from('partial'));
+    setImmediate(() => {
+      // eslint-disable-next-line no-param-reassign
+      req.destroyed = true;
+      req.emit('close');
+    });
+    await expect(p).rejects.toThrow(/request_aborted/);
   });
 });
 

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -184,6 +184,42 @@ describe('handleRequest — method + path routing', () => {
     await _handleRequestForTest(req, res, ctx);
     expect(res.statusCode).toBe(200);
   });
+
+  it.each([
+    ['application/json-patch+json'],
+    ['application/jsonp'],
+    ['application/jsonish'],
+    ['text/plain'],
+    ['application/octet-stream'],
+  ])('415s POST /control/yours with content-type %s', async (contentType) => {
+    const ctx = makeCtx();
+    const req = makeReq();
+    req.headers['content-type'] = contentType;
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(415);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unsupported_media_type' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['application/json'],
+    ['application/json; charset=utf-8'],
+    ['Application/JSON'],
+    ['application/json;charset=UTF-8'],
+  ])('accepts content-type %s (matched by prefix)', async (contentType) => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ payload });
+
+    const req = makeReq({ body: Buffer.from(envelope) });
+    req.headers['content-type'] = contentType;
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(200);
+  });
 });
 
 describe('handleRequest — body cap', () => {

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -532,6 +532,25 @@ describe('handleRequest — routing checks (after HMAC verify)', () => {
     }
   });
 
+  it('400s when expected_version exceeds Number.MAX_SAFE_INTEGER (sanity ceiling)', async () => {
+    // Defense against a peer adopting an absurd version cursor that
+    // would burn ~2^53 CAS values before the row could match again.
+    // 2^53 is the first integer > MAX_SAFE_INTEGER; isInteger(2^53)
+    // is still true (representable but unsafe), so the ceiling check
+    // is what catches it.
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const payload = makeFreshPayload({ now, expectedVersion: 2 ** 53 });
+    payload.nonce = 'huge'.padEnd(32, 'h');
+    const envelope = makeSignedEnvelope({ payload });
+    const ctx = makeCtx({ hmac });
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'invalid_payload' });
+  });
+
   it('400s when expected_version is missing entirely', async () => {
     const now = 1_700_000_000_000;
     const hmac = makeHmac({ clock: () => now });
@@ -673,10 +692,13 @@ describe('handleRequest — Connection: close on bail-out paths', () => {
     expect(res.headers).toMatchObject({ Connection: 'close' });
   });
 
-  it('sets Connection: close on 400 wrong_peer', async () => {
-    // wrong_peer fires AFTER HMAC verify + envelope parse, so body
-    // is fully consumed. Connection: close is consistency-only here
-    // (no leftover bytes), but matches the rest of the bail paths.
+  it('does NOT set Connection: close on 400 wrong_peer (body fully consumed)', async () => {
+    // wrong_peer fires AFTER HMAC verify + envelope parse, so the
+    // body is fully consumed and the stream is in a determinate
+    // state. Omitting Connection: close matches the posture of
+    // other post-verify bails (invalid_payload, unauthorized,
+    // handoff_failed). Close is only needed when leftover bytes
+    // could confuse a keep-alive parser.
     const now = 1_700_000_000_000;
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({ hmac, selfInstanceId: 'inst-B' });
@@ -687,10 +709,11 @@ describe('handleRequest — Connection: close on bail-out paths', () => {
     await _handleRequestForTest(req, res, ctx);
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body)).toEqual({ error: 'wrong_peer' });
-    expect(res.headers).toMatchObject({ Connection: 'close' });
+    expect(res.headers).not.toMatchObject({ Connection: 'close' });
   });
 
-  it('sets Connection: close on 400 unknown_peer', async () => {
+  it('does NOT set Connection: close on 400 unknown_peer (body fully consumed)', async () => {
+    // Same rationale as wrong_peer above.
     const now = 1_700_000_000_000;
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({
@@ -703,7 +726,7 @@ describe('handleRequest — Connection: close on bail-out paths', () => {
     await _handleRequestForTest(req, res, ctx);
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body)).toEqual({ error: 'unknown_peer' });
-    expect(res.headers).toMatchObject({ Connection: 'close' });
+    expect(res.headers).not.toMatchObject({ Connection: 'close' });
   });
 });
 

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -435,6 +435,65 @@ describe('handleRequest — onHandoff', () => {
   });
 });
 
+describe('handleRequest — body cap response race (real socket)', () => {
+  let server;
+  let port;
+
+  beforeEach(() => new Promise((resolve) => {
+    const hmac = makeHmac();
+    server = startControlChannelServer({
+      hmac,
+      selfInstanceId: 'inst-B',
+      isKnownPeer: () => true,
+      onHandoff: jest.fn(async () => {}),
+      logger: makeLogger(),
+      port: 0,
+      bindAddr: '127.0.0.1',
+      bodyByteCap: 100,
+      onListenError: () => {},
+    });
+    server.on('listening', () => {
+      port = server.address().port;
+      resolve();
+    });
+  }));
+
+  afterEach(() => new Promise((resolve) => {
+    server.close(() => resolve());
+  }));
+
+  it('returns the 413 response to the client even after the body exceeds the cap (no socket-destroy race)', async () => {
+    // Earlier shape used req.destroy() on over-cap which tore down
+    // the socket BEFORE the catch handler could write the 413 —
+    // legitimate over-cap clients never saw the response. The fix
+    // uses req.pause(). Drive a real HTTP request that streams
+    // bytes past the cap and assert we get a 413 status code +
+    // JSON body, not a connection-reset error.
+    const result = await new Promise((resolve, reject) => {
+      const big = Buffer.alloc(500, 0x61); // 5× the cap
+      const req = http.request({
+        host: '127.0.0.1', port, path: '/control/yours', method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': big.length,
+        },
+      }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve({
+          status: res.statusCode,
+          body: Buffer.concat(chunks).toString('utf8'),
+        }));
+      });
+      req.on('error', reject);
+      req.write(big);
+      req.end();
+    });
+    expect(result.status).toBe(413);
+    expect(JSON.parse(result.body)).toEqual({ error: 'body_too_large' });
+  });
+});
+
 describe('end-to-end — real HTTP server on ephemeral port', () => {
   let server;
   let port;

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -57,7 +57,10 @@ function makeReq({ method = 'POST', url = '/control/yours', body = Buffer.alloc(
   const req = Readable.from([body]);
   req.method = method;
   req.url = url;
-  req.headers = {};
+  // Default to a valid Content-Type so tests focused on other behaviors
+  // don't all need to set it. Tests that exercise the 415 path
+  // explicitly delete or override this header.
+  req.headers = { 'content-type': 'application/json' };
   // The handler may call req.destroy() on body-too-large; the
   // Readable.from stream implements destroy as a no-op for our needs.
   return req;
@@ -235,6 +238,20 @@ describe('handleRequest — method + path routing', () => {
     expect(ctx.onHandoff).not.toHaveBeenCalled();
   });
 
+  it('415s POST /control/yours when Content-Type header is missing', async () => {
+    // Required, not optional — catches `curl` probes without `-H` and
+    // any future caller that forgets to set the header. Triage-friendly
+    // 415 vs 400 distinguishes "wrong/missing CT" from "bad envelope".
+    const ctx = makeCtx();
+    const req = makeReq();
+    delete req.headers['content-type'];
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(415);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unsupported_media_type' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['application/json'],
     ['application/json; charset=utf-8'],
@@ -356,7 +373,7 @@ describe('handleRequest — body cap', () => {
     const req = Readable.from([chunk1, chunk2]);
     req.method = 'POST';
     req.url = '/control/yours';
-    req.headers = {};
+    req.headers = { 'content-type': 'application/json' };
     const res = makeRes();
     await _handleRequestForTest(req, res, ctx);
     expect(res.statusCode).toBe(413);

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -198,6 +198,32 @@ describe('handleRequest — body cap', () => {
     expect(ctx.onHandoff).not.toHaveBeenCalled();
   });
 
+  it('accepts a body exactly at bodyByteCap (boundary: cap = "max allowed", not "first rejected")', async () => {
+    // Off-by-one pin: the cap is the largest accepted size. A body
+    // of exactly `cap` bytes must NOT 413. (`> cap` rejects, `>=
+    // cap` would reject the boundary — wrong shape.)
+    const ctx = makeCtx({ bodyByteCap: 100 });
+    // Body must be a valid signed envelope to reach the 200 path,
+    // so we build a tiny payload and verify the envelope fits.
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    ctx.hmac = hmac;
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ payload });
+    // Pin the precondition: the envelope must be longer than cap
+    // for the body-to-cap to mean anything; if not, this is a
+    // useful test of "small envelope passes," which is also fine.
+    const padded = Buffer.alloc(100, 0x20); // 100 bytes of spaces
+    padded.write(envelope.slice(0, Math.min(envelope.length, 100)), 0);
+    // Either case (passes verify or fails verify) reaches a status
+    // code that isn't 413. The contract under test is "at-cap is
+    // not body_too_large."
+    const req = makeReq({ body: padded });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).not.toBe(413);
+  });
+
   it('413s when cumulative chunks exceed bodyByteCap (streaming path)', async () => {
     // Real HTTP streams chunk delivery (~16 KB at a time). A bug in
     // the cumulative-counter that only checked the LAST chunk would

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -101,11 +101,11 @@ function makeCtx({
   };
 }
 
-function makeSignedEnvelope({ hmac, payload }) {
-  // `hmac` arg kept for clarity/future use; we recompute with the
-  // same SECRET to avoid coupling to the hmac module's nonce LRU
-  // state during fixture construction.
-  void hmac;
+function makeSignedEnvelope({ payload }) {
+  // Recompute the signature directly with the shared SECRET rather
+  // than calling into a `makeHmac()` instance — that would couple
+  // the fixture to the hmac module's nonce LRU state and require
+  // careful clock injection on every call site.
   const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
   const signature = crypto.createHmac('sha256', SECRET).update(bodyBytes).digest('hex');
   return wrapEnvelope({ bodyBytes, signature }).toString('utf8');
@@ -177,7 +177,7 @@ describe('handleRequest — method + path routing', () => {
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({ hmac });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     const req = makeReq({ url: '/control/yours?cachebust=1', body: Buffer.from(envelope) });
     const res = makeRes();
@@ -246,7 +246,7 @@ describe('handleRequest — HMAC verify', () => {
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({ hmac });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -283,7 +283,7 @@ describe('handleRequest — HMAC verify', () => {
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({ hmac });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
     now += 10_000; // 10s past freshness window
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -297,7 +297,7 @@ describe('handleRequest — HMAC verify', () => {
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({ hmac });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     // First call succeeds.
     const req1 = makeReq({ body: Buffer.from(envelope) });
@@ -320,7 +320,7 @@ describe('handleRequest — routing checks (after HMAC verify)', () => {
     const hmac = makeHmac({ clock: () => now });
     const ctx = makeCtx({ hmac, selfInstanceId: 'inst-B' });
     const payload = makeFreshPayload({ now, peerInstanceId: 'inst-C' });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -336,7 +336,7 @@ describe('handleRequest — routing checks (after HMAC verify)', () => {
     const isKnownPeer = jest.fn(() => false);
     const ctx = makeCtx({ hmac, isKnownPeer });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -357,7 +357,7 @@ describe('handleRequest — routing checks (after HMAC verify)', () => {
       // iterations as replay.
       i += 1;
       payload.nonce = `bad${i}`.padEnd(32, 'x');
-      const envelope = makeSignedEnvelope({ hmac, payload });
+      const envelope = makeSignedEnvelope({ payload });
       const ctx = makeCtx({ hmac });
       const req = makeReq({ body: Buffer.from(envelope) });
       const res = makeRes();
@@ -379,7 +379,7 @@ describe('handleRequest — routing checks (after HMAC verify)', () => {
       active_instance_id: 'inst-A',
       peer_instance_id: 'inst-B',
     };
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
     const ctx = makeCtx({ hmac });
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -401,7 +401,7 @@ describe('handleRequest — onHandoff', () => {
     });
     const ctx = makeCtx({ hmac, onHandoff });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -423,7 +423,7 @@ describe('handleRequest — onHandoff', () => {
     const onHandoff = jest.fn(async () => { throw new Error('connect-rejected'); });
     const ctx = makeCtx({ hmac, onHandoff });
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
 
     const req = makeReq({ body: Buffer.from(envelope) });
     const res = makeRes();
@@ -547,7 +547,7 @@ describe('end-to-end — real HTTP server on ephemeral port', () => {
     await start({ hmac, onHandoff });
 
     const payload = makeFreshPayload({ now });
-    const envelope = makeSignedEnvelope({ hmac, payload });
+    const envelope = makeSignedEnvelope({ payload });
     const result = await post('/control/yours', envelope);
     expect(result.status).toBe(200);
     expect(onHandoff).toHaveBeenCalledWith({

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -1,0 +1,503 @@
+// Unit tests for src/gateway-control-channel.js — Pillar 3 push-
+// handoff receiver. Pins the load-bearing contracts:
+//
+//   1. Only POST /control/yours is accepted; everything else → 404.
+//   2. Body cap enforced before parse; oversize → 413 with no parse,
+//      no onHandoff call, no nonce burn.
+//   3. Invalid envelope (non-JSON / missing body+signature) → 400
+//      without invoking hmac.verify (so an attacker can't even
+//      probe whether a key matches without a well-formed envelope).
+//   4. HMAC verify runs BEFORE payload-shape / routing checks.
+//      Bad signature → 401; stale/replay → 401 with the verifier's
+//      reason field surfaced.
+//   5. Routing checks (peer_instance_id binding + isKnownPeer)
+//      enforced AFTER verify; 400 for mismatch.
+//   6. onHandoff is awaited; thrown errors → 500. ACK 200 only
+//      after onHandoff resolves (the "I'm live" semantic from the
+//      design doc).
+//   7. expected_version is validated as a positive integer; non-
+//      integer / negative / zero → 400 invalid_payload.
+//
+// Test architecture: most tests drive the exported _handleRequestForTest
+// with stub req/res to keep them fast and deterministic. A small set
+// of end-to-end tests bind a real ephemeral port + send via
+// http.request to pin the listen path, body-cap streaming, and
+// header timeouts.
+
+const http = require('node:http');
+const crypto = require('node:crypto');
+const { Readable } = require('node:stream');
+
+const {
+  startControlChannelServer,
+  _handleRequestForTest,
+  DEFAULT_BODY_BYTE_CAP,
+} = require('../src/gateway-control-channel');
+
+const { createGatewayHmac, wrapEnvelope } = require('../src/gateway-hmac');
+
+const SECRET = 'a'.repeat(64);
+
+function makeHmac({ clock } = {}) {
+  return createGatewayHmac({
+    secrets: { current: SECRET },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    clock,
+  });
+}
+
+function makeLogger() {
+  return {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+}
+
+// Build a stub IncomingMessage from an in-memory Buffer body.
+function makeReq({ method = 'POST', url = '/control/yours', body = Buffer.alloc(0) } = {}) {
+  const req = Readable.from([body]);
+  req.method = method;
+  req.url = url;
+  req.headers = {};
+  // The handler may call req.destroy() on body-too-large; the
+  // Readable.from stream implements destroy as a no-op for our needs.
+  return req;
+}
+
+function makeRes() {
+  const chunks = [];
+  const res = {
+    headersSent: false,
+    writableEnded: false,
+    statusCode: null,
+    headers: null,
+    body: null,
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.headers = headers;
+      this.headersSent = true;
+    },
+    end(buf) {
+      if (buf) chunks.push(buf);
+      this.body = Buffer.concat(chunks).toString('utf8');
+      this.writableEnded = true;
+    },
+  };
+  return res;
+}
+
+function makeCtx({
+  hmac, selfInstanceId = 'inst-B',
+  isKnownPeer = () => true,
+  onHandoff = jest.fn(async () => {}),
+  bodyByteCap = DEFAULT_BODY_BYTE_CAP,
+} = {}) {
+  return {
+    hmac: hmac ?? makeHmac(),
+    selfInstanceId,
+    isKnownPeer,
+    onHandoff,
+    logger: makeLogger(),
+    bodyByteCap,
+  };
+}
+
+function makeSignedEnvelope({ hmac, payload }) {
+  // `hmac` arg kept for clarity/future use; we recompute with the
+  // same SECRET to avoid coupling to the hmac module's nonce LRU
+  // state during fixture construction.
+  void hmac;
+  const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+  const signature = crypto.createHmac('sha256', SECRET).update(bodyBytes).digest('hex');
+  return wrapEnvelope({ bodyBytes, signature }).toString('utf8');
+}
+
+function makeFreshPayload({
+  now = 1_700_000_000_000,
+  activeInstanceId = 'inst-A',
+  peerInstanceId = 'inst-B',
+  expectedVersion = 7,
+  nonceChar = 'n',
+} = {}) {
+  return {
+    ts: now,
+    nonce: nonceChar.repeat(32),
+    active_instance_id: activeInstanceId,
+    peer_instance_id: peerInstanceId,
+    expected_version: expectedVersion,
+  };
+}
+
+describe('startControlChannelServer — factory validation', () => {
+  it('throws on missing required deps', () => {
+    expect(() => startControlChannelServer()).toThrow(/hmac/);
+    expect(() => startControlChannelServer({ hmac: { verify() {} } }))
+      .toThrow(/selfInstanceId/);
+    expect(() => startControlChannelServer({ hmac: { verify() {} }, selfInstanceId: 'a' }))
+      .toThrow(/isKnownPeer/);
+    expect(() => startControlChannelServer({
+      hmac: { verify() {} }, selfInstanceId: 'a', isKnownPeer: () => true,
+    })).toThrow(/onHandoff/);
+    expect(() => startControlChannelServer({
+      hmac: { verify() {} }, selfInstanceId: 'a', isKnownPeer: () => true, onHandoff: () => {},
+    })).toThrow(/logger/);
+    expect(() => startControlChannelServer({
+      hmac: { verify() {} }, selfInstanceId: 'a', isKnownPeer: () => true, onHandoff: () => {},
+      logger: makeLogger(),
+    })).toThrow(/onListenError/);
+    expect(() => startControlChannelServer({
+      hmac: { verify() {} }, selfInstanceId: 'a', isKnownPeer: () => true, onHandoff: () => {},
+      logger: makeLogger(), onListenError: () => {},
+    })).toThrow(/port/);
+  });
+});
+
+describe('handleRequest — method + path routing', () => {
+  it('404s any path other than /control/yours', async () => {
+    const ctx = makeCtx();
+    const req = makeReq({ method: 'POST', url: '/control/other' });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'not_found' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('404s GET /control/yours (only POST is allowed)', async () => {
+    const ctx = makeCtx();
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('strips query string before matching path', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    const req = makeReq({ url: '/control/yours?cachebust=1', body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('handleRequest — body cap', () => {
+  it('413s when body exceeds bodyByteCap (and never calls onHandoff)', async () => {
+    const ctx = makeCtx({ bodyByteCap: 100 });
+    const big = Buffer.alloc(200, 0x61); // 200 bytes
+    const req = makeReq({ body: big });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(413);
+    expect(JSON.parse(res.body)).toEqual({ error: 'body_too_large' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('413s when cumulative chunks exceed bodyByteCap (streaming path)', async () => {
+    // Real HTTP streams chunk delivery (~16 KB at a time). A bug in
+    // the cumulative-counter that only checked the LAST chunk would
+    // miss a body where each individual chunk is under cap but the
+    // sum is over. Drive that path with a multi-chunk stream.
+    const ctx = makeCtx({ bodyByteCap: 100 });
+    const chunk1 = Buffer.alloc(60, 0x61); // 60 bytes — under cap on its own
+    const chunk2 = Buffer.alloc(60, 0x62); // 60 bytes — but 120 cumulative
+    const req = Readable.from([chunk1, chunk2]);
+    req.method = 'POST';
+    req.url = '/control/yours';
+    req.headers = {};
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(413);
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleRequest — envelope shape', () => {
+  it('400s non-JSON body', async () => {
+    const ctx = makeCtx();
+    const req = makeReq({ body: Buffer.from('not-json') });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'invalid_envelope' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('400s envelope missing body or signature', async () => {
+    const ctx = makeCtx();
+    for (const env of [{}, { body: 'x' }, { signature: 'y' }, { body: 42, signature: 'y' }]) {
+      const req = makeReq({ body: Buffer.from(JSON.stringify(env)) });
+      const res = makeRes();
+      // eslint-disable-next-line no-await-in-loop
+      await _handleRequestForTest(req, res, ctx);
+      expect(res.statusCode).toBe(400);
+    }
+  });
+});
+
+describe('handleRequest — HMAC verify', () => {
+  it('200s a well-formed signed body with valid routing', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    expect(ctx.onHandoff).toHaveBeenCalledWith({
+      activeInstanceId: 'inst-A',
+      expectedVersion: 7,
+    });
+  });
+
+  it('401s a tampered signature with the verifier reason', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac });
+    const payload = makeFreshPayload({ now });
+    const bodyStr = JSON.stringify(payload);
+    const envelope = JSON.stringify({
+      body: bodyStr,
+      signature: 'f'.repeat(64),
+    });
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unauthorized', reason: 'bad_signature' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('401s a stale body with reason=stale', async () => {
+    let now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+    now += 10_000; // 10s past freshness window
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unauthorized', reason: 'stale' });
+  });
+
+  it('401s a replay with reason=replay', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    // First call succeeds.
+    const req1 = makeReq({ body: Buffer.from(envelope) });
+    const res1 = makeRes();
+    await _handleRequestForTest(req1, res1, ctx);
+    expect(res1.statusCode).toBe(200);
+
+    // Second call (same envelope, same nonce) is rejected as replay.
+    const req2 = makeReq({ body: Buffer.from(envelope) });
+    const res2 = makeRes();
+    await _handleRequestForTest(req2, res2, ctx);
+    expect(res2.statusCode).toBe(401);
+    expect(JSON.parse(res2.body)).toEqual({ error: 'unauthorized', reason: 'replay' });
+  });
+});
+
+describe('handleRequest — routing checks (after HMAC verify)', () => {
+  it('400s when peer_instance_id does not match self', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac, selfInstanceId: 'inst-B' });
+    const payload = makeFreshPayload({ now, peerInstanceId: 'inst-C' });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'wrong_peer' });
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('400s when active_instance_id is not a known peer', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const isKnownPeer = jest.fn(() => false);
+    const ctx = makeCtx({ hmac, isKnownPeer });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unknown_peer' });
+    expect(isKnownPeer).toHaveBeenCalledWith('inst-A');
+    expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('400s when expected_version is non-positive-integer or wrong type', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    let i = 0;
+    for (const bad of [0, -1, 1.5, '7']) {
+      const payload = makeFreshPayload({ now, expectedVersion: bad });
+      // Distinct nonce per case so the LRU doesn't false-fail later
+      // iterations as replay.
+      i += 1;
+      payload.nonce = `bad${i}`.padEnd(32, 'x');
+      const envelope = makeSignedEnvelope({ hmac, payload });
+      const ctx = makeCtx({ hmac });
+      const req = makeReq({ body: Buffer.from(envelope) });
+      const res = makeRes();
+      // eslint-disable-next-line no-await-in-loop
+      await _handleRequestForTest(req, res, ctx);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toEqual({ error: 'invalid_payload' });
+    }
+  });
+
+  it('400s when expected_version is missing entirely', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    // Build the payload directly so we can omit expected_version
+    // without going through makeFreshPayload's default.
+    const payload = {
+      ts: now,
+      nonce: 'miss'.padEnd(32, 'y'),
+      active_instance_id: 'inst-A',
+      peer_instance_id: 'inst-B',
+    };
+    const envelope = makeSignedEnvelope({ hmac, payload });
+    const ctx = makeCtx({ hmac });
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'invalid_payload' });
+  });
+});
+
+describe('handleRequest — onHandoff', () => {
+  it('awaits onHandoff before ACKing (200 means "standby is live")', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    let resolvedAt = null;
+    let respondedAt = null;
+    const onHandoff = jest.fn(async () => {
+      await new Promise((resolve) => { setImmediate(resolve); });
+      resolvedAt = Date.now();
+    });
+    const ctx = makeCtx({ hmac, onHandoff });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    const originalEnd = res.end.bind(res);
+    res.end = (buf) => {
+      respondedAt = Date.now();
+      return originalEnd(buf);
+    };
+
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(200);
+    expect(resolvedAt).not.toBeNull();
+    expect(respondedAt).toBeGreaterThanOrEqual(resolvedAt);
+  });
+
+  it('500s when onHandoff throws', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const onHandoff = jest.fn(async () => { throw new Error('connect-rejected'); });
+    const ctx = makeCtx({ hmac, onHandoff });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({ error: 'handoff_failed' });
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      'control-channel: onHandoff threw',
+      expect.objectContaining({ error: 'connect-rejected' }),
+    );
+  });
+});
+
+describe('end-to-end — real HTTP server on ephemeral port', () => {
+  let server;
+  let port;
+
+  function start({ hmac, selfInstanceId = 'inst-B', isKnownPeer = () => true, onHandoff }) {
+    const logger = makeLogger();
+    server = startControlChannelServer({
+      hmac, selfInstanceId, isKnownPeer, onHandoff,
+      logger, port: 0, bindAddr: '127.0.0.1',
+      onListenError: () => {},
+    });
+    return new Promise((resolve) => {
+      server.on('listening', () => {
+        port = server.address().port;
+        resolve();
+      });
+    });
+  }
+
+  afterEach(() => new Promise((resolve) => {
+    if (!server) { resolve(); return; }
+    server.close(() => resolve());
+    server = null;
+  }));
+
+  function post(path, body) {
+    return new Promise((resolve, reject) => {
+      const req = http.request({
+        host: '127.0.0.1', port, path, method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+      }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve({
+          status: res.statusCode,
+          body: Buffer.concat(chunks).toString('utf8'),
+        }));
+      });
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  it('round-trips a valid signed handoff body to onHandoff', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const onHandoff = jest.fn(async () => {});
+    await start({ hmac, onHandoff });
+
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ hmac, payload });
+    const result = await post('/control/yours', envelope);
+    expect(result.status).toBe(200);
+    expect(onHandoff).toHaveBeenCalledWith({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    });
+  });
+
+  it('404s an unknown path', async () => {
+    const hmac = makeHmac();
+    await start({ hmac, onHandoff: jest.fn() });
+    const result = await post('/health', '{}');
+    expect(result.status).toBe(404);
+  });
+});

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -162,12 +162,14 @@ describe('handleRequest — method + path routing', () => {
     expect(ctx.onHandoff).not.toHaveBeenCalled();
   });
 
-  it('404s GET /control/yours (only POST is allowed)', async () => {
+  it('405s GET /control/yours with an Allow: POST header (only POST is allowed)', async () => {
     const ctx = makeCtx();
     const req = makeReq({ method: 'GET' });
     const res = makeRes();
     await _handleRequestForTest(req, res, ctx);
-    expect(res.statusCode).toBe(404);
+    expect(res.statusCode).toBe(405);
+    expect(JSON.parse(res.body)).toEqual({ error: 'method_not_allowed' });
+    expect(res.headers).toMatchObject({ Allow: 'POST' });
   });
 
   it('strips query string before matching path', async () => {

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -601,6 +601,112 @@ describe('handleRequest — onHandoff', () => {
   });
 });
 
+describe('handleRequest — Connection: close on bail-out paths', () => {
+  // Keep-alive-safety contract: every bail path that leaves the
+  // request body in an indeterminate state MUST set Connection:
+  // close so the parser doesn't see leftover unread bytes on the
+  // next keep-alive request. Pin each bail path here so a future
+  // refactor doesn't silently drop the header.
+
+  it('sets Connection: close on 404 (wrong path)', async () => {
+    const ctx = makeCtx();
+    const req = makeReq({ url: '/control/other' });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(404);
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+
+  it('sets Connection: close on 405 (wrong method)', async () => {
+    const ctx = makeCtx();
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(405);
+    expect(res.headers).toMatchObject({ Allow: 'POST', Connection: 'close' });
+  });
+
+  it('sets Connection: close on 415 (wrong content-type)', async () => {
+    const ctx = makeCtx();
+    const req = makeReq();
+    req.headers['content-type'] = 'text/plain';
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(415);
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+
+  it('sets Connection: close on 415 (missing content-type)', async () => {
+    const ctx = makeCtx();
+    const req = makeReq();
+    delete req.headers['content-type'];
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(415);
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+
+  it('sets Connection: close on 413 (body cap exceeded)', async () => {
+    const ctx = makeCtx({ bodyByteCap: 100 });
+    const big = Buffer.alloc(200, 0x61);
+    const req = makeReq({ body: big });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(413);
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+
+  it('sets Connection: close on 400 body_read_failed', async () => {
+    // Drive a stream error by emitting an error mid-read.
+    const ctx = makeCtx();
+    const req = new (require('node:stream').Readable)({ read() {} });
+    req.method = 'POST';
+    req.url = '/control/yours';
+    req.headers = { 'content-type': 'application/json' };
+    const res = makeRes();
+    const handlePromise = _handleRequestForTest(req, res, ctx);
+    // Emit error after one tick so readRequestBody is listening.
+    setImmediate(() => req.emit('error', new Error('socket reset')));
+    await handlePromise;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'body_read_failed' });
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+
+  it('sets Connection: close on 400 wrong_peer', async () => {
+    // wrong_peer fires AFTER HMAC verify + envelope parse, so body
+    // is fully consumed. Connection: close is consistency-only here
+    // (no leftover bytes), but matches the rest of the bail paths.
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ hmac, selfInstanceId: 'inst-B' });
+    const payload = makeFreshPayload({ now, peerInstanceId: 'inst-OTHER' });
+    const envelope = makeSignedEnvelope({ payload });
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'wrong_peer' });
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+
+  it('sets Connection: close on 400 unknown_peer', async () => {
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({
+      hmac, selfInstanceId: 'inst-B', isKnownPeer: () => false,
+    });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ payload });
+    const req = makeReq({ body: Buffer.from(envelope) });
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unknown_peer' });
+    expect(res.headers).toMatchObject({ Connection: 'close' });
+  });
+});
+
 describe('handleRequest — body cap response race (real socket)', () => {
   let server;
   let port;

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -167,6 +167,21 @@ describe('startControlChannelServer — factory validation', () => {
     expect(() => startControlChannelServer({ ...baseArgs, requestTimeoutMs: '5000' }))
       .toThrow(/requestTimeoutMs.*1100/);
   });
+
+  it('throws on non-positive bodyByteCap (every request would 413)', () => {
+    const baseArgs = {
+      hmac: { verify() {} }, selfInstanceId: 'a', isKnownPeer: () => true,
+      onHandoff: () => {}, logger: makeLogger(), onListenError: () => {}, port: 0,
+    };
+    expect(() => startControlChannelServer({ ...baseArgs, bodyByteCap: 0 }))
+      .toThrow(/bodyByteCap.*positive integer/);
+    expect(() => startControlChannelServer({ ...baseArgs, bodyByteCap: -1 }))
+      .toThrow(/bodyByteCap.*positive integer/);
+    expect(() => startControlChannelServer({ ...baseArgs, bodyByteCap: 1.5 }))
+      .toThrow(/bodyByteCap.*positive integer/);
+    expect(() => startControlChannelServer({ ...baseArgs, bodyByteCap: '8192' }))
+      .toThrow(/bodyByteCap.*positive integer/);
+  });
 });
 
 describe('handleRequest — method + path routing', () => {
@@ -250,6 +265,58 @@ describe('handleRequest — body cap', () => {
     expect(res.statusCode).toBe(413);
     expect(JSON.parse(res.body)).toEqual({ error: 'body_too_large' });
     expect(ctx.onHandoff).not.toHaveBeenCalled();
+  });
+
+  it('413s on Content-Length over cap WITHOUT reading body chunks (short-circuit)', async () => {
+    // A declared length over cap is unambiguous — short-circuit before
+    // any stream work. Body chunks must NOT be consumed; verify that
+    // by tracking data emissions.
+    const ctx = makeCtx({ bodyByteCap: 100 });
+    const big = Buffer.alloc(200, 0x61);
+    const req = makeReq({ body: big });
+    req.headers['content-length'] = '200';
+    // Spy: track whether anyone read from the stream.
+    let dataEmitted = false;
+    req.on('data', () => { dataEmitted = true; });
+
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(413);
+    expect(JSON.parse(res.body)).toEqual({ error: 'body_too_large' });
+    // The pre-check fires before readRequestBody starts the data
+    // listener, so no chunks were drained.
+    expect(dataEmitted).toBe(false);
+  });
+
+  it('ignores malformed Content-Length and falls through to streaming check', async () => {
+    // "1KB", "0xFF", negative, multi-value-like — anything not pure
+    // digits is ignored, the streaming cap still catches over-cap.
+    const ctx = makeCtx({ bodyByteCap: 100 });
+    const big = Buffer.alloc(200, 0x61);
+    for (const bad of ['1KB', '-50', '0xFF', '1, 2']) {
+      // eslint-disable-next-line no-await-in-loop
+      const req = makeReq({ body: big });
+      req.headers['content-length'] = bad;
+      const res = makeRes();
+      // eslint-disable-next-line no-await-in-loop
+      await _handleRequestForTest(req, res, ctx);
+      expect(res.statusCode).toBe(413); // streaming cap caught it
+    }
+  });
+
+  it('accepts request when Content-Length is under cap (no pre-check trigger)', async () => {
+    // Sanity: under-cap declared length passes the pre-check, then
+    // streaming runs normally.
+    const now = 1_700_000_000_000;
+    const hmac = makeHmac({ clock: () => now });
+    const ctx = makeCtx({ bodyByteCap: 8192, hmac });
+    const payload = makeFreshPayload({ now });
+    const envelope = makeSignedEnvelope({ payload });
+    const req = makeReq({ body: Buffer.from(envelope) });
+    req.headers['content-length'] = String(envelope.length);
+    const res = makeRes();
+    await _handleRequestForTest(req, res, ctx);
+    expect(res.statusCode).toBe(200);
   });
 
   it('accepts a body exactly at bodyByteCap (boundary: cap = "max allowed", not "first rejected")', async () => {

--- a/apps/discord/tests/gateway-control-channel.test.js
+++ b/apps/discord/tests/gateway-control-channel.test.js
@@ -149,6 +149,24 @@ describe('startControlChannelServer — factory validation', () => {
       logger: makeLogger(), onListenError: () => {},
     })).toThrow(/port/);
   });
+
+  it('throws on requestTimeoutMs < 1100 (headersTimeout invariant)', () => {
+    // For requestTimeoutMs = 50, the headersTimeout formula yields 1ms,
+    // effectively disabling header-read protection. The factory rejects
+    // the misconfig rather than letting it silently lose the invariant.
+    const baseArgs = {
+      hmac: { verify() {} }, selfInstanceId: 'a', isKnownPeer: () => true,
+      onHandoff: () => {}, logger: makeLogger(), onListenError: () => {}, port: 0,
+    };
+    expect(() => startControlChannelServer({ ...baseArgs, requestTimeoutMs: 50 }))
+      .toThrow(/requestTimeoutMs.*1100/);
+    expect(() => startControlChannelServer({ ...baseArgs, requestTimeoutMs: 1099 }))
+      .toThrow(/requestTimeoutMs.*1100/);
+    expect(() => startControlChannelServer({ ...baseArgs, requestTimeoutMs: 1.5 }))
+      .toThrow(/requestTimeoutMs.*1100/);
+    expect(() => startControlChannelServer({ ...baseArgs, requestTimeoutMs: '5000' }))
+      .toThrow(/requestTimeoutMs.*1100/);
+  });
 });
 
 describe('handleRequest — method + path routing', () => {

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -47,7 +47,8 @@ function makeFakeHttpRequest({ behavior }) {
     const req = new EventEmitter();
     const writtenChunks = [];
     req.write = (chunk) => { writtenChunks.push(chunk); };
-    req.end = () => {
+    req.end = (chunk) => {
+      if (chunk) writtenChunks.push(chunk);
       const ctx = {
         options,
         body: Buffer.concat(writtenChunks),

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -317,6 +317,55 @@ describe('pushHandoff — result mapping', () => {
     );
   });
 
+  it('drops in-flight chunks AFTER bodyCapExceeded fires (synchronous-destroy + flag-mark)', async () => {
+    // The cap path settles synchronously on the over-cap chunk AND
+    // calls res.destroy(), but subsequent 'data' events already in
+    // the event-loop pipeline still arrive. The bodyCapExceeded
+    // flag must drop them without growing the buffer or re-firing
+    // settle (which is idempotent but a second log/state mutation
+    // would be a regression). Pin this contract.
+    const hmac = makeHmac();
+    let capturedRes;
+    const fakeRequest = (options, responseHandler) => {
+      const req = new EventEmitter();
+      req.write = () => {};
+      req.end = () => {
+        const res = new EventEmitter();
+        res.statusCode = 200;
+        res.destroyed = false;
+        res.destroy = () => { res.destroyed = true; };
+        capturedRes = res;
+        responseHandler(res);
+        // First chunk: under cap. Second chunk: trips cap. Third
+        // chunk: arrives AFTER cap-exceeded → must be dropped.
+        setImmediate(() => {
+          res.emit('data', Buffer.from('A'.repeat(30), 'utf8'));
+          res.emit('data', Buffer.from('B'.repeat(30), 'utf8')); // 60 > 50 cap
+          res.emit('data', Buffer.from('C'.repeat(30), 'utf8')); // post-cap drop
+          res.emit('end');
+        });
+      };
+      req.destroy = () => {};
+      return req;
+    };
+    const logger = makeLogger();
+    const client = createControlClient({
+      hmac, logger, httpRequest: fakeRequest, responseByteCap: 50,
+    });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({
+      ok: false, reason: 'http_error', error: 'response_body_too_large',
+    });
+    // res.destroy() fires synchronously on the over-cap chunk.
+    expect(capturedRes.destroyed).toBe(true);
+    // Cap-exceeded log fires exactly once (not three times — the
+    // post-cap drops must be silent).
+    const capLogs = logger.warn.mock.calls.filter(
+      ([msg]) => msg === 'control-client: response body exceeded cap',
+    );
+    expect(capLogs).toHaveLength(1);
+  });
+
   it('returns reason:http_error when the response is aborted mid-stream', async () => {
     // Peer sends headers then crashes — `aborted` event fires but
     // `end` never will. Without an aborted handler we'd block on

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -154,7 +154,7 @@ describe('pushHandoff — request shape', () => {
     expect(result).toEqual({ ok: true, status: 200 });
     expect(calls).toHaveLength(1);
     expect(calls[0].options).toMatchObject({
-      host: '10.0.1.5',
+      hostname: '10.0.1.5',
       port: 9876,
       path: '/control/yours',
       method: 'POST',

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -336,3 +336,77 @@ describe('end-to-end — client → server', () => {
     });
   });
 });
+
+describe('end-to-end — IPv6 loopback (::1)', () => {
+  // peer-heartbeat rows can carry IPv6 literals; pushHandoff's
+  // validator accepts ::1, and node:http handles bare-IPv6 hostname
+  // correctly. This test closes the loop end-to-end on v6 so a
+  // future deploy onto an IPv6-only ENI doesn't surface an
+  // untested wire path.
+  //
+  // Some CI environments disable IPv6 entirely. Probe ::1 bindability
+  // in beforeAll and skip the suite cleanly if unavailable.
+  let server;
+  let port;
+  let ipv6Available = false;
+  const onHandoff = jest.fn(async () => {});
+
+  beforeAll(async () => {
+    ipv6Available = await new Promise((resolve) => {
+      const probe = require('node:http').createServer();
+      probe.once('error', () => resolve(false));
+      probe.listen(0, '::1', () => {
+        probe.close(() => resolve(true));
+      });
+    });
+  });
+
+  beforeEach(() => {
+    if (!ipv6Available) return undefined;
+    return new Promise((resolve) => {
+      const hmac = makeHmac();
+      server = startControlChannelServer({
+        hmac,
+        selfInstanceId: 'inst-B',
+        isKnownPeer: (id) => id === 'inst-A',
+        onHandoff,
+        logger: makeLogger(),
+        port: 0,
+        bindAddr: '::1',
+        onListenError: () => {},
+      });
+      server.on('listening', () => {
+        port = server.address().port;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(() => new Promise((resolve) => {
+    onHandoff.mockClear();
+    if (!server) { resolve(); return; }
+    server.close(() => resolve());
+    server = null;
+  }));
+
+  it('round-trips a handoff over ::1', async () => {
+    if (!ipv6Available) {
+      // eslint-disable-next-line no-console
+      console.warn('IPv6 loopback unavailable; skipping ::1 e2e test');
+      return;
+    }
+    const hmac = makeHmac();
+    const client = createControlClient({ hmac, logger: makeLogger() });
+    const result = await client.pushHandoff({
+      peerIp: '::1',
+      peerPort: port,
+      peerInstanceId: 'inst-B',
+      selfInstanceId: 'inst-A',
+      expectedVersion: 7,
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(onHandoff).toHaveBeenCalledWith({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    });
+  });
+});

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -1,0 +1,282 @@
+// Unit tests for src/gateway-control-client.js — Pillar 3 outbound
+// push-handoff. Pins the load-bearing contracts:
+//
+//   1. Builds a signed envelope via hmac.sign + wrapEnvelope. ts +
+//      nonce are added by the client; caller passes only routing
+//      + version.
+//   2. POSTs to peer's /control/yours with the wire envelope as
+//      body and a Content-Length header.
+//   3. Returns a result OBJECT, never throws. 2xx → ok:true;
+//      timeout → reason:'timeout'; non-2xx → reason:'rejected';
+//      transport/error → reason:'http_error'.
+//   4. Per-call timeout (default 200 ms) bounds the SIGTERM stall.
+//   5. End-to-end with the real control-channel server: the
+//      generated envelope is accepted by hmac.verify and routed
+//      to onHandoff with the right activeInstanceId + expectedVersion.
+
+const { EventEmitter } = require('node:events');
+
+const { createGatewayHmac, unwrapEnvelope } = require('../src/gateway-hmac');
+const { createControlClient, DEFAULT_TIMEOUT_MS } = require('../src/gateway-control-client');
+const { startControlChannelServer } = require('../src/gateway-control-channel');
+
+const SECRET = 'a'.repeat(64);
+
+function makeHmac({ clock } = {}) {
+  return createGatewayHmac({
+    secrets: { current: SECRET },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    clock,
+  });
+}
+
+function makeLogger() {
+  return {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+}
+
+// Build a fake http.request that captures the options + body and
+// drives the (response, timeout, error) lifecycle via test hooks.
+function makeFakeHttpRequest({ behavior }) {
+  // `behavior` is invoked with the captured call context and decides
+  // how to settle: respond, timeout, or error.
+  const calls = [];
+
+  function fakeRequest(options, responseHandler) {
+    const req = new EventEmitter();
+    const writtenChunks = [];
+    req.write = (chunk) => { writtenChunks.push(chunk); };
+    req.end = () => {
+      const ctx = {
+        options,
+        body: Buffer.concat(writtenChunks),
+        respond(status, body) {
+          const res = new EventEmitter();
+          res.statusCode = status;
+          responseHandler(res);
+          setImmediate(() => {
+            res.emit('data', Buffer.from(body ?? '', 'utf8'));
+            res.emit('end');
+          });
+        },
+        timeout() { req.emit('timeout'); },
+        error(err) { req.emit('error', err); },
+      };
+      calls.push(ctx);
+      behavior(ctx);
+    };
+    req.destroy = (err) => { if (err) req.emit('error', err); };
+    return req;
+  }
+
+  return { fakeRequest, calls };
+}
+
+const validArgs = {
+  peerIp: '10.0.1.5',
+  peerPort: 9876,
+  peerInstanceId: 'inst-B',
+  selfInstanceId: 'inst-A',
+  expectedVersion: 7,
+};
+
+describe('createControlClient — factory validation', () => {
+  it('exposes default timeout', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(200);
+  });
+
+  it('throws on missing hmac or logger', () => {
+    expect(() => createControlClient()).toThrow(/hmac/);
+    expect(() => createControlClient({ hmac: {} })).toThrow(/hmac/);
+    expect(() => createControlClient({ hmac: { sign() {}, generateNonce() {} } }))
+      .toThrow(/logger/);
+  });
+});
+
+describe('pushHandoff — argument validation', () => {
+  it('rejects missing required args', async () => {
+    const hmac = makeHmac();
+    const client = createControlClient({ hmac, logger: makeLogger() });
+    await expect(client.pushHandoff({})).rejects.toThrow(/required/);
+    await expect(client.pushHandoff({ ...validArgs, peerIp: '' })).rejects.toThrow(/required/);
+    await expect(client.pushHandoff({ ...validArgs, expectedVersion: 0 })).rejects.toThrow(/required/);
+  });
+});
+
+describe('pushHandoff — request shape', () => {
+  it('POSTs /control/yours with a signed envelope to the peer IP+port', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest, calls } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respond(200, '{"status":"ok"}'),
+    });
+    const client = createControlClient({
+      hmac, logger: makeLogger(), httpRequest: fakeRequest,
+    });
+
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options).toMatchObject({
+      host: '10.0.1.5',
+      port: 9876,
+      path: '/control/yours',
+      method: 'POST',
+    });
+    expect(calls[0].options.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'Content-Length': calls[0].body.length,
+    });
+    // The body should unwrap cleanly into bodyBytes + signature.
+    const unwrapped = unwrapEnvelope(calls[0].body);
+    expect(unwrapped).not.toBeNull();
+    expect(typeof unwrapped.signature).toBe('string');
+    expect(unwrapped.signature).toHaveLength(64);
+  });
+
+  it('payload includes selfInstanceId, peerInstanceId, expectedVersion, ts, nonce', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest, calls } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respond(200, '{}'),
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    await client.pushHandoff(validArgs);
+
+    const unwrapped = unwrapEnvelope(calls[0].body);
+    const payload = JSON.parse(unwrapped.bodyBytes.toString('utf8'));
+    expect(payload).toMatchObject({
+      active_instance_id: 'inst-A',
+      peer_instance_id: 'inst-B',
+      expected_version: 7,
+    });
+    expect(typeof payload.ts).toBe('number');
+    expect(typeof payload.nonce).toBe('string');
+    expect(payload.nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('passes the per-call timeout (default 200 ms) to httpRequest', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest, calls } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respond(200, '{}'),
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    await client.pushHandoff(validArgs);
+    expect(calls[0].options.timeout).toBe(200);
+
+    const fastClient = createControlClient({
+      hmac, logger: makeLogger(), httpRequest: fakeRequest, timeoutMs: 50,
+    });
+    await fastClient.pushHandoff(validArgs);
+    expect(calls[1].options.timeout).toBe(50);
+  });
+});
+
+describe('pushHandoff — result mapping', () => {
+  it('returns ok:true on 2xx', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respond(200, '{}'),
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({ ok: true, status: 200 });
+  });
+
+  it('returns reason:rejected on non-2xx (with body)', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respond(401, '{"error":"unauthorized"}'),
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({
+      ok: false, reason: 'rejected', status: 401, body: '{"error":"unauthorized"}',
+    });
+  });
+
+  it('returns reason:timeout when peer is unresponsive', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.timeout(),
+    });
+    const logger = makeLogger();
+    const client = createControlClient({ hmac, logger, httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({ ok: false, reason: 'timeout' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'control-client: handoff timed out',
+      expect.objectContaining({ peerInstanceId: 'inst-B' }),
+    );
+  });
+
+  it('returns reason:http_error on transport error', async () => {
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.error(new Error('ECONNREFUSED')),
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({ ok: false, reason: 'http_error', error: 'ECONNREFUSED' });
+  });
+
+  it('settles exactly once when timeout + error both fire', async () => {
+    // Real http: timeout event fires THEN we destroy(err) THEN the
+    // 'error' event fires. Result must be timeout, not http_error.
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => {
+        ctx.timeout();
+        // simulate the post-destroy error event
+        setImmediate(() => ctx.error(new Error('handoff_timeout')));
+      },
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result.reason).toBe('timeout');
+  });
+});
+
+describe('end-to-end — client → server', () => {
+  let server;
+  let port;
+  const onHandoff = jest.fn(async () => {});
+
+  beforeEach(() => new Promise((resolve) => {
+    const hmac = makeHmac();
+    server = startControlChannelServer({
+      hmac,
+      selfInstanceId: 'inst-B',
+      isKnownPeer: (id) => id === 'inst-A',
+      onHandoff,
+      logger: makeLogger(),
+      port: 0,
+      bindAddr: '127.0.0.1',
+      onListenError: () => {},
+    });
+    server.on('listening', () => {
+      port = server.address().port;
+      resolve();
+    });
+  }));
+
+  afterEach(() => new Promise((resolve) => {
+    onHandoff.mockClear();
+    server.close(() => resolve());
+  }));
+
+  it('round-trips a real handoff through the real HTTP path', async () => {
+    const hmac = makeHmac();
+    const client = createControlClient({ hmac, logger: makeLogger() });
+    const result = await client.pushHandoff({
+      peerIp: '127.0.0.1',
+      peerPort: port,
+      peerInstanceId: 'inst-B',
+      selfInstanceId: 'inst-A',
+      expectedVersion: 7,
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(onHandoff).toHaveBeenCalledWith({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    });
+  });
+});

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -62,12 +62,20 @@ function makeFakeHttpRequest({ behavior }) {
           });
         },
         respondThenAbort(status) {
-          // Headers + partial body arrive, then peer crashes — emit
-          // 'aborted' instead of 'end'.
+          // Headers + partial body arrive, then peer crashes. Node 17+
+          // (after `aborted` was deprecated) signals this as `close`
+          // on the response with `destroyed=true` and a statusCode
+          // already set from headers — that's what the client listens
+          // for now. See the comment in gateway-control-client.js's
+          // res.on('close') handler for why.
           const res = new EventEmitter();
           res.statusCode = status;
+          res.destroyed = false;
           responseHandler(res);
-          setImmediate(() => res.emit('aborted'));
+          setImmediate(() => {
+            res.destroyed = true;
+            res.emit('close');
+          });
         },
         timeout() { req.emit('timeout'); },
         error(err) { req.emit('error', err); },

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -337,6 +337,21 @@ describe('pushHandoff — result mapping', () => {
     );
   });
 
+  it('returns reason:http_error when the connection aborts BEFORE headers (req error path)', async () => {
+    // Pin the pre-headers abort contract. If the socket dies before
+    // any response headers arrive, `statusCode` is undefined and the
+    // `close` handler intentionally does NOT settle (its gate is
+    // `res.destroyed && res.statusCode !== undefined`). Settlement
+    // is owned by req.on('error') in that case.
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.error(new Error('ECONNRESET')),
+    });
+    const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({ ok: false, reason: 'http_error', error: 'ECONNRESET' });
+  });
+
   it('settles exactly once when timeout + error both fire', async () => {
     // Real http: timeout event fires THEN we destroy(err) THEN the
     // 'error' event fires. Result must be timeout, not http_error.

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -55,6 +55,10 @@ function makeFakeHttpRequest({ behavior }) {
         respond(status, body) {
           const res = new EventEmitter();
           res.statusCode = status;
+          res.destroyed = false;
+          // Real http.IncomingMessage exposes .destroy() — the client
+          // calls it on body-cap-exceeded to stop the stream.
+          res.destroy = () => { res.destroyed = true; };
           responseHandler(res);
           setImmediate(() => {
             res.emit('data', Buffer.from(body ?? '', 'utf8'));
@@ -112,12 +116,24 @@ describe('createControlClient — factory validation', () => {
 });
 
 describe('pushHandoff — argument validation', () => {
-  it('rejects missing required args', async () => {
+  it('returns ok:false reason:invalid_arg on missing required args (never throws)', async () => {
+    // The "never throws" contract documented in the module header is
+    // load-bearing for the SIGTERM caller. Validators must surface as
+    // result objects, not rejected promises.
     const hmac = makeHmac();
     const client = createControlClient({ hmac, logger: makeLogger() });
-    await expect(client.pushHandoff({})).rejects.toThrow(/required/);
-    await expect(client.pushHandoff({ ...validArgs, peerIp: '' })).rejects.toThrow(/required/);
-    await expect(client.pushHandoff({ ...validArgs, expectedVersion: 0 })).rejects.toThrow(/required/);
+    await expect(client.pushHandoff({}))
+      .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'peerIp' });
+    await expect(client.pushHandoff({ ...validArgs, peerIp: '' }))
+      .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'peerIp' });
+    await expect(client.pushHandoff({ ...validArgs, peerPort: 0 }))
+      .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'peerPort' });
+    await expect(client.pushHandoff({ ...validArgs, peerInstanceId: '' }))
+      .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'peerInstanceId' });
+    await expect(client.pushHandoff({ ...validArgs, selfInstanceId: '' }))
+      .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'selfInstanceId' });
+    await expect(client.pushHandoff({ ...validArgs, expectedVersion: 0 }))
+      .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'expectedVersion' });
   });
 
   it('rejects peerIp that is not an IPv4/IPv6 literal (defense-in-depth vs corrupted heartbeat row)', async () => {
@@ -126,13 +142,14 @@ describe('pushHandoff — argument validation', () => {
     // env-stringification. The client mirrors that check so a
     // corrupted row (or pre-13b.2 callers that bypassed the write-
     // time validator) doesn't get a free DNS resolution + POST to
-    // an arbitrary host.
+    // an arbitrary host. Returned as result object (see "never
+    // throws" contract in the module header).
     const hmac = makeHmac();
     const client = createControlClient({ hmac, logger: makeLogger() });
     for (const bad of ['discord.com', 'localhost', 'undefined', 'not-an-ip', '10.0.0', '10.0.0.0.0']) {
       // eslint-disable-next-line no-await-in-loop
       await expect(client.pushHandoff({ ...validArgs, peerIp: bad }))
-        .rejects.toThrow(/IPv4 or IPv6 literal/);
+        .resolves.toMatchObject({ ok: false, reason: 'invalid_arg', arg: 'peerIp' });
     }
     // IPv4 + IPv6 literals pass validation. Use a fake httpRequest
     // so the assertion runs without actually opening a socket.
@@ -262,6 +279,42 @@ describe('pushHandoff — result mapping', () => {
     const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
     const result = await client.pushHandoff(validArgs);
     expect(result).toEqual({ ok: false, reason: 'http_error', error: 'ECONNREFUSED' });
+  });
+
+  it('caps response body and returns reason:http_error on cap exceeded', async () => {
+    // Defense vs OOM during SIGTERM: a misrouted POST hitting an
+    // HTML error page (or hostile in-VPC actor) could otherwise
+    // return multi-MB. The client must settle as http_error before
+    // buffering grows unbounded.
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => {
+        // Simulate a streaming response of chunks that together
+        // exceed the configured cap. We send via the 'respond'
+        // helper which fires data + end, but we want to drive
+        // multiple data chunks. Reach inside to do it manually.
+        const res = new (require('events').EventEmitter)();
+        res.statusCode = 200;
+        ctx.options; // no-op — keep ctx referenced
+        // The responseHandler lives in the closure of httpRequest;
+        // simplest path is to use the 'respond' helper with a giant
+        // body so the single data emit > cap.
+        ctx.respond(200, 'X'.repeat(100));
+      },
+    });
+    const logger = makeLogger();
+    // Set a tiny cap so a 100-byte response trips it.
+    const client = createControlClient({
+      hmac, logger, httpRequest: fakeRequest, responseByteCap: 50,
+    });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({
+      ok: false, reason: 'http_error', error: 'response_body_too_large',
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'control-client: response body exceeded cap',
+      expect.objectContaining({ peerInstanceId: 'inst-B', cap: 50 }),
+    );
   });
 
   it('returns reason:http_error when the response is aborted mid-stream', async () => {

--- a/apps/discord/tests/gateway-control-client.test.js
+++ b/apps/discord/tests/gateway-control-client.test.js
@@ -60,6 +60,14 @@ function makeFakeHttpRequest({ behavior }) {
             res.emit('end');
           });
         },
+        respondThenAbort(status) {
+          // Headers + partial body arrive, then peer crashes — emit
+          // 'aborted' instead of 'end'.
+          const res = new EventEmitter();
+          res.statusCode = status;
+          responseHandler(res);
+          setImmediate(() => res.emit('aborted'));
+        },
         timeout() { req.emit('timeout'); },
         error(err) { req.emit('error', err); },
       };
@@ -101,6 +109,34 @@ describe('pushHandoff — argument validation', () => {
     await expect(client.pushHandoff({})).rejects.toThrow(/required/);
     await expect(client.pushHandoff({ ...validArgs, peerIp: '' })).rejects.toThrow(/required/);
     await expect(client.pushHandoff({ ...validArgs, expectedVersion: 0 })).rejects.toThrow(/required/);
+  });
+
+  it('rejects peerIp that is not an IPv4/IPv6 literal (defense-in-depth vs corrupted heartbeat row)', async () => {
+    // The heartbeat-side validator (gateway-peer-heartbeat.js) uses
+    // net.isIP() to reject hostnames + the literal "undefined" from
+    // env-stringification. The client mirrors that check so a
+    // corrupted row (or pre-13b.2 callers that bypassed the write-
+    // time validator) doesn't get a free DNS resolution + POST to
+    // an arbitrary host.
+    const hmac = makeHmac();
+    const client = createControlClient({ hmac, logger: makeLogger() });
+    for (const bad of ['discord.com', 'localhost', 'undefined', 'not-an-ip', '10.0.0', '10.0.0.0.0']) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(client.pushHandoff({ ...validArgs, peerIp: bad }))
+        .rejects.toThrow(/IPv4 or IPv6 literal/);
+    }
+    // IPv4 + IPv6 literals pass validation. Use a fake httpRequest
+    // so the assertion runs without actually opening a socket.
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respond(200, '{}'),
+    });
+    const okClient = createControlClient({
+      hmac, logger: makeLogger(), httpRequest: fakeRequest,
+    });
+    await expect(okClient.pushHandoff({ ...validArgs, peerIp: '10.0.0.1' }))
+      .resolves.toEqual({ ok: true, status: 200 });
+    await expect(okClient.pushHandoff({ ...validArgs, peerIp: '::1' }))
+      .resolves.toEqual({ ok: true, status: 200 });
   });
 });
 
@@ -217,6 +253,26 @@ describe('pushHandoff — result mapping', () => {
     const client = createControlClient({ hmac, logger: makeLogger(), httpRequest: fakeRequest });
     const result = await client.pushHandoff(validArgs);
     expect(result).toEqual({ ok: false, reason: 'http_error', error: 'ECONNREFUSED' });
+  });
+
+  it('returns reason:http_error when the response is aborted mid-stream', async () => {
+    // Peer sends headers then crashes — `aborted` event fires but
+    // `end` never will. Without an aborted handler we'd block on
+    // the 200 ms timeout; with it we settle immediately.
+    const hmac = makeHmac();
+    const { fakeRequest } = makeFakeHttpRequest({
+      behavior: (ctx) => ctx.respondThenAbort(200),
+    });
+    const logger = makeLogger();
+    const client = createControlClient({ hmac, logger, httpRequest: fakeRequest });
+    const result = await client.pushHandoff(validArgs);
+    expect(result).toEqual({
+      ok: false, reason: 'http_error', error: 'response_aborted',
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'control-client: response aborted',
+      expect.objectContaining({ peerInstanceId: 'inst-B' }),
+    );
   });
 
   it('settles exactly once when timeout + error both fire', async () => {

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -429,13 +429,11 @@ describe('verify — nonce LRU', () => {
     expect(signAndVerify('1').ok).toBe(true);
   });
 
-  it('bumps a nonce to newest on re-access (would not happen via verify but exercised via the size cap)', () => {
-    // We can't directly call rememberNonce; but bump-to-newest is an
-    // internal property that only matters via the size cap. Since
-    // verify rejects duplicates, the bump-on-re-insert path is only
-    // reached by the explicit `seenNonces.has(...) → delete → set`
-    // dance. We approximate by checking the inspection seam reports
-    // a stable size after many distinct nonces with capacity.
+  it('enforces the size cap — verifying more nonces than the LRU holds settles at cap, not above', () => {
+    // rememberNonce is insert-only and verify rejects duplicates,
+    // so this test exercises only the eviction-at-capacity path:
+    // after many distinct nonces, the LRU size settles at the cap
+    // rather than growing unbounded.
     const now = 1_700_000_000_000;
     const { hmac } = makeHmac({ clock: () => now, nonceLruSize: 5 });
     for (let i = 0; i < 50; i += 1) {

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -1,0 +1,547 @@
+// Unit tests for src/gateway-hmac.js — Pillar 3 push-handoff
+// HMAC primitive. Pins the load-bearing contracts:
+//
+//   1. Sign produces { bodyBytes, signature } with HMAC computed
+//      over the exact UTF-8 bytes of JSON.stringify(payload).
+//   2. Verify runs HMAC check BEFORE JSON.parse. A malformed body
+//      with a valid HMAC is reported as malformed_body AFTER parse;
+//      an unsigned/bad-sig body never reaches parse.
+//   3. Dual-secret accept: verify tries `current`, then `previous`
+//      iff configured. `previous` may be null/undefined.
+//   4. Timing-safe equality — length mismatches MUST NOT throw
+//      (since timingSafeEqual itself throws on length mismatch).
+//   5. Freshness window: bodies outside ±freshnessWindowMs of clock()
+//      are rejected with reason 'stale'.
+//   6. Nonce LRU: duplicate nonce within freshness window is rejected
+//      with reason 'replay'. LRU is bounded; oldest evicts when full.
+//      Check-then-set must be synchronous (one microtask).
+//   7. Wire shape: { bodyBytes: Buffer, signature: hex-string };
+//      anything else is malformed_body.
+//
+// Each contract maps to a concrete production failure mode:
+//   - (1) parsing-then-re-stringifying would canonicalize key order
+//     and break verification on a sig produced for the original order.
+//   - (2) parsing first lets an attacker OOM the standby with a
+//     giant unsigned JSON body.
+//   - (3) without dual-accept, every rotation deploy would lose
+//     handoffs across the rolling-deploy window.
+//   - (4) timingSafeEqual throws on length mismatch — a naive caller
+//     would crash the verifier on any malformed signature.
+//   - (5)/(6) without freshness+nonce, a replayed body from a prior
+//     handoff could trigger a second standby takeover.
+
+const crypto = require('node:crypto');
+const {
+  createGatewayHmac,
+  wrapEnvelope,
+  unwrapEnvelope,
+  DEFAULT_FRESHNESS_WINDOW_MS,
+  DEFAULT_NONCE_LRU_SIZE,
+} = require('../src/gateway-hmac');
+
+const SECRET_CURRENT = 'a'.repeat(64);
+const SECRET_PREVIOUS = 'b'.repeat(64);
+
+function makeHmac({
+  secrets = { current: SECRET_CURRENT, previous: SECRET_PREVIOUS },
+  clock,
+  freshnessWindowMs,
+  nonceLruSize,
+} = {}) {
+  const logger = {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+  const hmac = createGatewayHmac({
+    secrets, logger, clock, freshnessWindowMs, nonceLruSize,
+  });
+  return { hmac, logger };
+}
+
+// Builds a fresh handoff-shaped payload pinned to a clock tick.
+function freshPayload({ now = 1_700_000_000_000, nonce = 'n'.repeat(32), extras = {} } = {}) {
+  return { ts: now, nonce, ...extras };
+}
+
+describe('createGatewayHmac — factory validation', () => {
+  it('throws when secrets is missing or wrong shape', () => {
+    const logger = { info() {}, warn() {}, error() {}, debug() {} };
+    expect(() => createGatewayHmac()).toThrow(/secrets/);
+    expect(() => createGatewayHmac({ logger })).toThrow(/secrets/);
+    expect(() => createGatewayHmac({ secrets: 'string', logger })).toThrow(/secrets/);
+    expect(() => createGatewayHmac({ secrets: {}, logger })).toThrow(/secrets\.current/);
+    expect(() => createGatewayHmac({ secrets: { current: '' }, logger })).toThrow(/secrets\.current/);
+    expect(() => createGatewayHmac({ secrets: { current: 'x', previous: 42 }, logger }))
+      .toThrow(/secrets\.previous must be a string/);
+  });
+
+  it('throws when logger is missing', () => {
+    expect(() => createGatewayHmac({ secrets: { current: 'x' } })).toThrow(/logger is required/);
+  });
+
+  it('accepts secrets with null/undefined previous (single-secret post-rotation state)', () => {
+    const logger = { info() {}, warn() {}, error() {}, debug() {} };
+    expect(() => createGatewayHmac({ secrets: { current: 'x' }, logger })).not.toThrow();
+    expect(() => createGatewayHmac({ secrets: { current: 'x', previous: null }, logger })).not.toThrow();
+    expect(() => createGatewayHmac({ secrets: { current: 'x', previous: undefined }, logger })).not.toThrow();
+  });
+
+  it('exposes default constants', () => {
+    expect(DEFAULT_FRESHNESS_WINDOW_MS).toBe(5_000);
+    expect(DEFAULT_NONCE_LRU_SIZE).toBe(1024);
+  });
+
+  it('exposes frozen VERIFY_REASONS to keep cross-module reason codes typo-safe', () => {
+    // eslint-disable-next-line global-require
+    const { VERIFY_REASONS } = require('../src/gateway-hmac');
+    expect(VERIFY_REASONS).toEqual({
+      BAD_SIGNATURE: 'bad_signature',
+      STALE: 'stale',
+      REPLAY: 'replay',
+      MALFORMED_BODY: 'malformed_body',
+      MISSING_FIELD: 'missing_field',
+    });
+    expect(Object.isFrozen(VERIFY_REASONS)).toBe(true);
+  });
+});
+
+describe('sign', () => {
+  it('signs the raw UTF-8 bytes of JSON.stringify(payload) with `current`', () => {
+    const { hmac } = makeHmac();
+    const payload = freshPayload({ extras: { hello: 'world' } });
+    const { bodyBytes, signature } = hmac.sign(payload);
+
+    expect(Buffer.isBuffer(bodyBytes)).toBe(true);
+    expect(bodyBytes.toString('utf8')).toBe(JSON.stringify(payload));
+
+    // Recompute deterministically using `current` and confirm equality.
+    const expected = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes)
+      .digest('hex');
+    expect(signature).toBe(expected);
+  });
+
+  it('rejects non-object payloads', () => {
+    const { hmac } = makeHmac();
+    expect(() => hmac.sign(null)).toThrow(/object payload/);
+    expect(() => hmac.sign('string')).toThrow(/object payload/);
+    expect(() => hmac.sign(42)).toThrow(/object payload/);
+  });
+
+  it('produces a signature distinct from the one `previous` would produce', () => {
+    // If the sign path ever drifted to using `previous`, the standby
+    // would never verify a fresh handoff body in steady state.
+    const { hmac } = makeHmac();
+    const payload = freshPayload();
+    const { bodyBytes, signature } = hmac.sign(payload);
+    const previousSig = crypto.createHmac('sha256', SECRET_PREVIOUS)
+      .update(bodyBytes).digest('hex');
+    expect(signature).not.toBe(previousSig);
+  });
+});
+
+describe('verify — happy path', () => {
+  it('verifies a fresh body+signature pair signed by `current`', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+    const result = hmac.verify({ bodyBytes, signature });
+    expect(result.ok).toBe(true);
+    expect(result.payload).toEqual(payload);
+  });
+
+  it('verifies a body signed by `previous` (dual-accept during rotation)', () => {
+    // Simulate: peer is on `previous`, this replica has rotated to
+    // a new `current` with the old now in `previous`.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({
+      secrets: { current: 'new'.repeat(20), previous: SECRET_CURRENT },
+      clock: () => now,
+    });
+    const payload = freshPayload({ now });
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+
+    const result = hmac.verify({ bodyBytes, signature });
+    expect(result.ok).toBe(true);
+    expect(result.payload).toEqual(payload);
+  });
+});
+
+describe('verify — rejection reasons', () => {
+  it('rejects bodyBytes that is not a Buffer', () => {
+    const { hmac } = makeHmac();
+    expect(hmac.verify({ bodyBytes: '{"ts":1,"nonce":"x"}', signature: 'ab' }))
+      .toEqual({ ok: false, reason: 'malformed_body' });
+  });
+
+  it('rejects signature that is not a string', () => {
+    const { hmac } = makeHmac();
+    expect(hmac.verify({ bodyBytes: Buffer.from('{}'), signature: 12345 }))
+      .toEqual({ ok: false, reason: 'malformed_body' });
+  });
+
+  it('rejects a tampered signature (bad_signature)', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const { bodyBytes } = hmac.sign(freshPayload({ now }));
+    const badSig = 'f'.repeat(64);
+    expect(hmac.verify({ bodyBytes, signature: badSig }))
+      .toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a signature with wrong length WITHOUT throwing', () => {
+    // crypto.timingSafeEqual throws on length mismatch — the module's
+    // timingSafeHexEqual MUST length-check first or this throws and
+    // takes the verifier down.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const { bodyBytes } = hmac.sign(freshPayload({ now }));
+    expect(() => hmac.verify({ bodyBytes, signature: 'short' })).not.toThrow();
+    expect(hmac.verify({ bodyBytes, signature: 'short' }))
+      .toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects non-hex signature WITHOUT throwing', () => {
+    // Buffer.from(s, 'hex') silently drops non-hex chars rather than
+    // throwing. Length check guards us against panic, but a same-
+    // length-non-hex signature still must return bad_signature.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const { bodyBytes } = hmac.sign(freshPayload({ now }));
+    const nonHex = 'z'.repeat(64);
+    expect(() => hmac.verify({ bodyBytes, signature: nonHex })).not.toThrow();
+    expect(hmac.verify({ bodyBytes, signature: nonHex }))
+      .toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a body with a valid HMAC but non-JSON content (malformed_body AFTER parse)', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const bodyBytes = Buffer.from('not-json', 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'malformed_body' });
+  });
+
+  it('rejects a body whose JSON parses to a non-object', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const bodyBytes = Buffer.from('42', 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'malformed_body' });
+  });
+
+  it('rejects a body missing ts (missing_field)', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = { nonce: 'n'.repeat(32) };
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'missing_field' });
+  });
+
+  it('rejects a body missing nonce (missing_field)', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = { ts: now };
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'missing_field' });
+  });
+
+  it('rejects a body where ts is not a number', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = { ts: String(now), nonce: 'n'.repeat(32) };
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'missing_field' });
+  });
+
+  it('rejects a body where nonce is empty', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = { ts: now, nonce: '' };
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'missing_field' });
+  });
+
+  it('does not try `previous` when not configured (and bad_signature when current fails)', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({
+      secrets: { current: SECRET_CURRENT },
+      clock: () => now,
+    });
+    const payload = freshPayload({ now });
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_PREVIOUS)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'bad_signature' });
+  });
+});
+
+describe('verify — freshness window', () => {
+  it('accepts ts inside ±freshnessWindowMs', () => {
+    let now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    // Body signed at t=now, verified at t=now+4999 (just inside 5s window).
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+    now += 4_999;
+    expect(hmac.verify({ bodyBytes, signature })).toEqual({ ok: true, payload });
+  });
+
+  it('rejects ts older than freshnessWindowMs (stale)', () => {
+    let now = 1_700_000_000_000;
+    const { hmac, logger } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+    now += 5_001;
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'stale' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-hmac: stale body rejected', expect.objectContaining({ ts: payload.ts }),
+    );
+  });
+
+  it('rejects ts far in the future (clock-skew on sender side) as stale', () => {
+    // Symmetric window: a sender whose clock is way ahead is also rejected.
+    let now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now: now + 5_001 });
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'stale' });
+  });
+
+  it('honors a custom freshnessWindowMs', () => {
+    let now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now, freshnessWindowMs: 100 });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+    now += 101;
+    expect(hmac.verify({ bodyBytes, signature })).toEqual({ ok: false, reason: 'stale' });
+  });
+});
+
+describe('verify — nonce LRU', () => {
+  it('rejects a replayed nonce within the freshness window', () => {
+    const now = 1_700_000_000_000;
+    const { hmac, logger } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+
+    const first = hmac.verify({ bodyBytes, signature });
+    const second = hmac.verify({ bodyBytes, signature });
+    expect(first.ok).toBe(true);
+    expect(second).toEqual({ ok: false, reason: 'replay' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'gateway-hmac: replayed nonce rejected', expect.objectContaining({ noncePrefix: 'nnnnnnnn' }),
+    );
+  });
+
+  it('rejects replay only AFTER signature passes — bad-signature replays do not poison the LRU', () => {
+    // Verifying a body with a bad signature must NOT add its nonce
+    // to the LRU; otherwise an attacker could pre-burn legitimate
+    // nonces with garbage signatures and DoS the standby.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+    // First call: valid body, bad signature → bad_signature
+    expect(hmac.verify({ bodyBytes, signature: 'f'.repeat(64) }))
+      .toEqual({ ok: false, reason: 'bad_signature' });
+    // Now the legitimate signed body must still verify (nonce not burned).
+    const goodSig = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature: goodSig })).toEqual({ ok: true, payload });
+  });
+
+  it('does not burn the nonce when stale (freshness rejection precedes nonce remember)', () => {
+    // A stale body shouldn't burn its nonce; otherwise a clock-skew
+    // bounce could permanently lock out a still-valid retry.
+    let now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+
+    now += 5_001;
+    expect(hmac.verify({ bodyBytes, signature })).toEqual({ ok: false, reason: 'stale' });
+
+    now -= 5_001; // clock recovers; same body now in-window again
+    expect(hmac.verify({ bodyBytes, signature })).toEqual({ ok: true, payload });
+  });
+
+  it('evicts oldest nonce when LRU is full (bounded memory)', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now, nonceLruSize: 3 });
+
+    function signAndVerify(nonceChar) {
+      const payload = { ts: now, nonce: nonceChar.repeat(32) };
+      const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+      const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+        .update(bodyBytes).digest('hex');
+      return hmac.verify({ bodyBytes, signature });
+    }
+
+    // Fill the LRU with 3 distinct nonces.
+    expect(signAndVerify('1').ok).toBe(true);
+    expect(signAndVerify('2').ok).toBe(true);
+    expect(signAndVerify('3').ok).toBe(true);
+
+    // Oldest nonce (nonce='1') is still pinned. Add a 4th — now '1' evicts.
+    expect(signAndVerify('4').ok).toBe(true);
+
+    // Replaying nonce='2' (still in LRU) is rejected.
+    expect(signAndVerify('2')).toEqual({ ok: false, reason: 'replay' });
+
+    // Replaying nonce='1' (evicted) is ACCEPTED — bounded LRU semantics.
+    // (At default LRU size of 1024 + 5s freshness, real-world traffic
+    // never approaches eviction; this only validates the bound.)
+    expect(signAndVerify('1').ok).toBe(true);
+  });
+
+  it('bumps a nonce to newest on re-access (would not happen via verify but exercised via the size cap)', () => {
+    // We can't directly call rememberNonce; but bump-to-newest is an
+    // internal property that only matters via the size cap. Since
+    // verify rejects duplicates, the bump-on-re-insert path is only
+    // reached by the explicit `seenNonces.has(...) → delete → set`
+    // dance. We approximate by checking the inspection seam reports
+    // a stable size after many distinct nonces with capacity.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now, nonceLruSize: 5 });
+    for (let i = 0; i < 50; i += 1) {
+      const payload = { ts: now, nonce: `nonce-${i}`.padEnd(32, '0') };
+      const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+      const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+        .update(bodyBytes).digest('hex');
+      hmac.verify({ bodyBytes, signature });
+    }
+    expect(hmac._getSeenNoncesSizeForTest()).toBe(5);
+  });
+
+  it('check-then-set is synchronous — two parallel verifies of the same nonce produce exactly one ok:true', async () => {
+    // The check-then-set MUST run as one microtask. A future refactor
+    // that drops an `await` between `seenNonces.has(nonce)` and
+    // `rememberNonce(nonce)` would let two parallel verifies BOTH
+    // observe "not seen" before either sets — and both would return
+    // ok:true on the same body. We drive two parallel `verify()`
+    // calls of the same body+signature and assert exactly one wins.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+
+    const results = await Promise.all([
+      Promise.resolve().then(() => hmac.verify({ bodyBytes, signature })),
+      Promise.resolve().then(() => hmac.verify({ bodyBytes, signature })),
+    ]);
+    const oks = results.filter((r) => r.ok);
+    const replays = results.filter((r) => !r.ok && r.reason === 'replay');
+    expect(oks).toHaveLength(1);
+    expect(replays).toHaveLength(1);
+  });
+});
+
+describe('generateNonce', () => {
+  it('returns a 32-char hex string (16 random bytes)', () => {
+    const { hmac } = makeHmac();
+    const a = hmac.generateNonce();
+    const b = hmac.generateNonce();
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+    expect(b).toMatch(/^[0-9a-f]{32}$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('wrapEnvelope / unwrapEnvelope', () => {
+  it('round-trips bodyBytes + signature byte-exact', () => {
+    const bodyBytes = Buffer.from('{"a":1,"b":"hello"}', 'utf8');
+    const signature = 'a'.repeat(64);
+    const wire = wrapEnvelope({ bodyBytes, signature });
+    expect(Buffer.isBuffer(wire)).toBe(true);
+    const unwrapped = unwrapEnvelope(wire);
+    expect(unwrapped).not.toBeNull();
+    expect(unwrapped.bodyBytes.equals(bodyBytes)).toBe(true);
+    expect(unwrapped.signature).toBe(signature);
+  });
+
+  it('preserves inner JSON key order across the round-trip (HMAC-verify-safe)', () => {
+    // The wire wrapping must preserve the inner body verbatim. If
+    // it ever JSON.parsed and re-stringified the inner body, a
+    // sender that signed `{"b":1,"a":2}` would have its key-order
+    // canonicalized to `{"a":2,"b":1}` on the receiver and HMAC
+    // verify would fail.
+    const innerStr = '{"z":1,"a":2,"m":3}';
+    const bodyBytes = Buffer.from(innerStr, 'utf8');
+    const wire = wrapEnvelope({ bodyBytes, signature: 'sig' });
+    const unwrapped = unwrapEnvelope(wire);
+    expect(unwrapped.bodyBytes.toString('utf8')).toBe(innerStr);
+  });
+
+  it('wrapEnvelope throws on bad input', () => {
+    expect(() => wrapEnvelope({})).toThrow();
+    expect(() => wrapEnvelope({ bodyBytes: 'string', signature: 'sig' })).toThrow();
+    expect(() => wrapEnvelope({ bodyBytes: Buffer.from(''), signature: 42 })).toThrow();
+  });
+
+  it('unwrapEnvelope returns null on shape mismatch (does not throw)', () => {
+    expect(unwrapEnvelope(null)).toBeNull();
+    expect(unwrapEnvelope('string')).toBeNull();
+    expect(unwrapEnvelope(Buffer.from('not-json'))).toBeNull();
+    expect(unwrapEnvelope(Buffer.from('42'))).toBeNull();
+    expect(unwrapEnvelope(Buffer.from('{}'))).toBeNull();
+    expect(unwrapEnvelope(Buffer.from('{"body":"x"}'))).toBeNull();
+    expect(unwrapEnvelope(Buffer.from('{"signature":"y"}'))).toBeNull();
+    expect(unwrapEnvelope(Buffer.from('{"body":42,"signature":"y"}'))).toBeNull();
+  });
+
+  it('wrap + verify end-to-end — sign → wrap → unwrap → verify', () => {
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const payload = freshPayload({ now });
+    const { bodyBytes, signature } = hmac.sign(payload);
+    const wire = wrapEnvelope({ bodyBytes, signature });
+    const unwrapped = unwrapEnvelope(wire);
+    const result = hmac.verify(unwrapped);
+    expect(result.ok).toBe(true);
+    expect(result.payload).toEqual(payload);
+  });
+});
+
+describe('round-trip integration — sign then verify (steady-state handoff)', () => {
+  it('signs a full handoff body and verifies it on the receiver side', () => {
+    const now = 1_700_000_000_000;
+    const { hmac: sender } = makeHmac({ clock: () => now });
+    const { hmac: receiver } = makeHmac({ clock: () => now });
+
+    const payload = {
+      ts: now,
+      nonce: sender.generateNonce(),
+      active_instance_id: 'inst-A',
+      peer_instance_id: 'inst-B',
+      expected_version: 7,
+    };
+    const { bodyBytes, signature } = sender.sign(payload);
+    const result = receiver.verify({ bodyBytes, signature });
+    expect(result.ok).toBe(true);
+    expect(result.payload).toEqual(payload);
+  });
+});

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -483,6 +483,20 @@ describe('generateNonce', () => {
 });
 
 describe('wrapEnvelope / unwrapEnvelope', () => {
+  it('wire envelope key order is exactly [body, signature]', () => {
+    // Pin the on-the-wire key order. V8 preserves insertion order
+    // per the JSON spec, so the order depends entirely on how
+    // wrapEnvelope spells the literal. A refactor that reorders
+    // the keys would change the byte representation across versions
+    // and break consumers that parse strictly. Pin the contract.
+    const wire = wrapEnvelope({
+      bodyBytes: Buffer.from('{"a":1}', 'utf8'),
+      signature: 'sig',
+    });
+    const parsed = JSON.parse(wire.toString('utf8'));
+    expect(Object.keys(parsed)).toEqual(['body', 'signature']);
+  });
+
   it('round-trips bodyBytes + signature byte-exact', () => {
     const bodyBytes = Buffer.from('{"a":1,"b":"hello"}', 'utf8');
     const signature = 'a'.repeat(64);

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -85,6 +85,32 @@ describe('createGatewayHmac — factory validation', () => {
     expect(() => createGatewayHmac({ secrets: { current: 'x', previous: undefined }, logger })).not.toThrow();
   });
 
+  it('throws on non-positive freshnessWindowMs (every body would 401-stale)', () => {
+    const logger = { info() {}, warn() {}, error() {}, debug() {} };
+    const baseArgs = { secrets: { current: 'x' }, logger };
+    expect(() => createGatewayHmac({ ...baseArgs, freshnessWindowMs: 0 }))
+      .toThrow(/freshnessWindowMs.*positive integer/);
+    expect(() => createGatewayHmac({ ...baseArgs, freshnessWindowMs: -1 }))
+      .toThrow(/freshnessWindowMs.*positive integer/);
+    expect(() => createGatewayHmac({ ...baseArgs, freshnessWindowMs: 1.5 }))
+      .toThrow(/freshnessWindowMs.*positive integer/);
+    expect(() => createGatewayHmac({ ...baseArgs, freshnessWindowMs: '5000' }))
+      .toThrow(/freshnessWindowMs.*positive integer/);
+  });
+
+  it('throws on non-positive nonceLruSize — would silently disable replay protection', () => {
+    const logger = { info() {}, warn() {}, error() {}, debug() {} };
+    const baseArgs = { secrets: { current: 'x' }, logger };
+    expect(() => createGatewayHmac({ ...baseArgs, nonceLruSize: 0 }))
+      .toThrow(/nonceLruSize.*positive integer/);
+    expect(() => createGatewayHmac({ ...baseArgs, nonceLruSize: -1 }))
+      .toThrow(/nonceLruSize.*positive integer/);
+    expect(() => createGatewayHmac({ ...baseArgs, nonceLruSize: 1.5 }))
+      .toThrow(/nonceLruSize.*positive integer/);
+    expect(() => createGatewayHmac({ ...baseArgs, nonceLruSize: '1024' }))
+      .toThrow(/nonceLruSize.*positive integer/);
+  });
+
   it('rejects secrets.previous = "" (empty string) — would silently disable dual-accept', () => {
     // The verify use site treats falsy `previous` as "not configured"
     // and skips the second hmac check. Without this validator, a

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -446,6 +446,38 @@ describe('verify — nonce LRU', () => {
     expect(hmac._getSeenNoncesSizeForTest()).toBe(5);
   });
 
+  it('an evicted nonce is accepted again (size cap is a deliberate ceiling, not a correctness primitive)', async () => {
+    // Module header explicitly notes: at 5s freshness and 1024
+    // entries, the LRU absorbs ~200 handoffs/sec before still-
+    // fresh nonces start evicting (which would allow replay
+    // within the 5s window). Real rate is 1/deploy, so this
+    // never happens in practice — but the eviction-allows-replay
+    // semantic is intentional. Pin it so a future refactor that
+    // makes eviction equivalent to permanent rejection (e.g.,
+    // appending to a separate "burned" set) doesn't silently
+    // change behavior.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now, nonceLruSize: 3 });
+
+    function verifyNonce(nonceChar) {
+      const payload = { ts: now, nonce: nonceChar.repeat(32) };
+      const bodyBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+      const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+        .update(bodyBytes).digest('hex');
+      return hmac.verify({ bodyBytes, signature });
+    }
+
+    // Fill the LRU. State after each verify (FIFO, oldest first):
+    expect(verifyNonce('1').ok).toBe(true);   // [1]
+    expect(verifyNonce('2').ok).toBe(true);   // [1, 2]
+    expect(verifyNonce('3').ok).toBe(true);   // [1, 2, 3]
+    expect(verifyNonce('4').ok).toBe(true);   // [2, 3, 4] (evicted 1)
+    // '1' is now evicted — verifying it AGAIN succeeds.
+    expect(verifyNonce('1').ok).toBe(true);   // [3, 4, 1] (evicted 2)
+    // '3' is still in the LRU — replay rejection.
+    expect(verifyNonce('3')).toEqual({ ok: false, reason: 'replay' });
+  });
+
   it('check-then-set is synchronous — two parallel verifies of the same nonce produce exactly one ok:true', async () => {
     // The check-then-set MUST run as one microtask. A future refactor
     // that drops an `await` between `seenNonces.has(nonce)` and

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -306,6 +306,22 @@ describe('verify — rejection reasons', () => {
       .toEqual({ ok: false, reason: 'missing_field' });
   });
 
+  it('rejects a body where ts is Infinity (JSON.parse of `1e1000` → Infinity, typeof === number)', () => {
+    // `1e1000` is valid JSON but V8 parses it to Infinity (double-
+    // precision overflow). `Number.isFinite` rejects this; a bare
+    // `typeof === "number"` check would accept it and fall through
+    // to the stale branch — works today but the contract should be
+    // pinned at the field-shape gate, not the freshness arithmetic.
+    const now = 1_700_000_000_000;
+    const { hmac } = makeHmac({ clock: () => now });
+    const bodyBytes = Buffer.from('{"ts":1e1000,"nonce":"nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"}', 'utf8');
+    expect(JSON.parse(bodyBytes.toString('utf8')).ts).toBe(Infinity); // sanity
+    const signature = crypto.createHmac('sha256', SECRET_CURRENT)
+      .update(bodyBytes).digest('hex');
+    expect(hmac.verify({ bodyBytes, signature }))
+      .toEqual({ ok: false, reason: 'missing_field' });
+  });
+
   it('rejects a body where nonce is empty', () => {
     const now = 1_700_000_000_000;
     const { hmac } = makeHmac({ clock: () => now });

--- a/apps/discord/tests/gateway-hmac.test.js
+++ b/apps/discord/tests/gateway-hmac.test.js
@@ -71,7 +71,7 @@ describe('createGatewayHmac — factory validation', () => {
     expect(() => createGatewayHmac({ secrets: {}, logger })).toThrow(/secrets\.current/);
     expect(() => createGatewayHmac({ secrets: { current: '' }, logger })).toThrow(/secrets\.current/);
     expect(() => createGatewayHmac({ secrets: { current: 'x', previous: 42 }, logger }))
-      .toThrow(/secrets\.previous must be a string/);
+      .toThrow(/secrets\.previous must be a non-empty string/);
   });
 
   it('throws when logger is missing', () => {
@@ -83,6 +83,17 @@ describe('createGatewayHmac — factory validation', () => {
     expect(() => createGatewayHmac({ secrets: { current: 'x' }, logger })).not.toThrow();
     expect(() => createGatewayHmac({ secrets: { current: 'x', previous: null }, logger })).not.toThrow();
     expect(() => createGatewayHmac({ secrets: { current: 'x', previous: undefined }, logger })).not.toThrow();
+  });
+
+  it('rejects secrets.previous = "" (empty string) — would silently disable dual-accept', () => {
+    // The verify use site treats falsy `previous` as "not configured"
+    // and skips the second hmac check. Without this validator, a
+    // misconfig writing `previous: ""` would pass at boot and silently
+    // disable the rotation window's dual-accept. Fail loud.
+    const logger = { info() {}, warn() {}, error() {}, debug() {} };
+    expect(() => createGatewayHmac({
+      secrets: { current: 'x', previous: '' }, logger,
+    })).toThrow(/non-empty string or null/);
   });
 
   it('exposes default constants', () => {

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -471,6 +471,90 @@ describe('serialization — no two mutators interleave', () => {
   });
 });
 
+describe('isConnecting — race protection between inbound-handoff and watchdog', () => {
+  it('is true ONLY while handleInboundHandoff awaits manager.connect()', async () => {
+    let resolveConnect;
+    const mocks = makeMocks();
+    mocks.manager.connect = jest.fn(() => new Promise((resolve) => {
+      resolveConnect = resolve;
+    }));
+    const { leader } = makeLeader({ mocks });
+    expect(leader.isConnecting()).toBe(false);
+
+    const handoffPromise = leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 5,
+    });
+    // Give the serialized fn a microtask to start.
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(leader.isConnecting()).toBe(true);
+
+    resolveConnect();
+    await handoffPromise;
+    expect(leader.isConnecting()).toBe(false);
+  });
+
+  it('isConnecting clears even when manager.connect() throws', async () => {
+    const mocks = makeMocks();
+    mocks.manager.connect = jest.fn(async () => { throw new Error('discord-down'); });
+    const { leader } = makeLeader({ mocks });
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 5,
+    })).rejects.toThrow(/discord-down/);
+    // finally{} block must clear the flag so the watchdog can take
+    // over the retry on its next tick.
+    expect(leader.isConnecting()).toBe(false);
+  });
+});
+
+describe('pushHandoff — re-entry safety', () => {
+  it('a second pushHandoff call after the first transferred returns not_holding_lock', async () => {
+    // SIGTERM fires twice (rare but possible: ECS retry + signal
+    // bounce). Second call must observe heldLock=false (cleared by
+    // the first push's transfer) and no-op cleanly rather than
+    // attempt to re-transfer.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, lock } = makeLeader({ mocks });
+    await leader._stepForTest(); // heldLock=true via acquire
+
+    const first = await leader.pushHandoff();
+    expect(first).toEqual({ pushed: true, ackReason: 'ack' });
+
+    const second = await leader.pushHandoff();
+    expect(second).toEqual({ pushed: false, reason: 'not_holding_lock' });
+
+    // Critical: transferLock was called once, not twice.
+    expect(lock.transferLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('two parallel pushHandoff calls serialize — only one transfers', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, lock } = makeLeader({ mocks });
+    await leader._stepForTest(); // heldLock=true
+
+    const [a, b] = await Promise.all([
+      leader.pushHandoff(),
+      leader.pushHandoff(),
+    ]);
+    expect(lock.transferLock).toHaveBeenCalledTimes(1);
+    // First call transfers, second sees not_holding_lock.
+    const transferred = [a, b].filter((r) => r.pushed === true);
+    const noOps = [a, b].filter((r) => r.pushed === false);
+    expect(transferred).toHaveLength(1);
+    expect(noOps).toHaveLength(1);
+    expect(noOps[0]).toEqual({ pushed: false, reason: 'not_holding_lock' });
+  });
+});
+
 describe('hooks for watchdog + control-channel', () => {
   it('isHoldingLock reflects internal state', async () => {
     const { leader } = makeLeader();

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -73,7 +73,6 @@ function makeLeader({ mocks, sleep, tickIntervalMs } = {}) {
     controlClient: m.controlClient,
     manager: m.manager,
     selfInstanceId: 'inst-A',
-    selfLockHolder: 'task-arn:.../inst-A',
     shardId: '0:1',
     logger: m.logger,
     tickIntervalMs, sleep,
@@ -103,14 +102,10 @@ describe('createGatewayLeader — factory validation', () => {
     expect(() => createGatewayLeader({
       lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
       selfInstanceId: 'a',
-    })).toThrow(/selfLockHolder/);
-    expect(() => createGatewayLeader({
-      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
-      selfInstanceId: 'a', selfLockHolder: 'h',
     })).toThrow(/shardId/);
     expect(() => createGatewayLeader({
       lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
-      selfInstanceId: 'a', selfLockHolder: 'h', shardId: 's',
+      selfInstanceId: 'a', shardId: 's',
     })).toThrow(/logger/);
   });
 });
@@ -322,6 +317,23 @@ describe('handleInboundHandoff', () => {
       expect.objectContaining({ error: 'discord-down' }),
     );
   });
+
+  it('synchronous manager.connect throw clears connecting flag (defensive)', async () => {
+    // @discordjs/ws's WebSocketManager.connect contract is async, but
+    // a future shim regression could surface a sync throw. The flag
+    // must clear so the watchdog can take over the retry — otherwise
+    // it would no-op forever.
+    const mocks = makeMocks();
+    mocks.manager.connect = jest.fn(() => { throw new Error('sync-shim-bug'); });
+    const { leader } = makeLeader({ mocks });
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    })).rejects.toThrow(/sync-shim-bug/);
+
+    expect(leader.isConnecting()).toBe(false);
+    expect(leader.isHoldingLock()).toBe(true);
+  });
 });
 
 describe('pushHandoff', () => {
@@ -396,6 +408,33 @@ describe('pushHandoff', () => {
 
     const result = await leader.pushHandoff();
     expect(result).toEqual({ pushed: true, ackReason: 'timeout' });
+  });
+
+  it('returns pushed:true, ackReason:push_threw when controlClient.pushHandoff throws', async () => {
+    // The control-client's documented contract is "never throws", but
+    // its synchronous argument validators DO throw if a row makes it
+    // past listFreshPeers' filters in a future regression. transferLock
+    // has already moved the lock in DDB at this point, so the standby
+    // owns it either way; the standby's watchdog catches lock-held +
+    // WS-disconnected and brings up the gateway from the cold path.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.controlClient.pushHandoff = jest.fn(async () => {
+      throw new Error('pushHandoff: peerIp (IPv4 or IPv6 literal) required');
+    });
+    const { leader, logger } = makeLeader({ mocks });
+    await preHoldLock(leader);
+
+    const result = await leader.pushHandoff();
+    expect(result).toEqual({ pushed: true, ackReason: 'push_threw' });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/controlClient\.pushHandoff threw/),
+      expect.objectContaining({ peerInstanceId: 'inst-B' }),
+    );
   });
 
   it('falls back to placeholder lock_holder when peer row lacks the field', async () => {
@@ -654,7 +693,6 @@ describe('isConnecting — race protection between inbound-handoff and watchdog'
       controlClient: mocks.controlClient,
       manager: mocks.manager,
       selfInstanceId: 'inst-A',
-      selfLockHolder: 'task-arn:.../inst-A',
       shardId: '0:1',
       logger: mocks.logger,
       inboundConnectTimeoutMs: 50,

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -838,6 +838,66 @@ describe('pushHandoff — terminal contract (closed sentinel)', () => {
     expect(lock.adoptLockFromHandoff).not.toHaveBeenCalled();
   });
 
+  it('inner closed re-check: inbound-handoff queued BEFORE pushHandoff aborts when its turn comes', async () => {
+    // The race: an inbound-handoff arrives, passes the outer closed
+    // check, and is queued in runSerialized behind a tick. SIGTERM
+    // fires DURING the queue wait: pushHandoff sets closed=true and
+    // queues its own work behind the inbound. When the inbound work
+    // pops off the chain and starts running, it must observe
+    // closed=true and throw — otherwise it would adopt + connect
+    // against a soon-to-be-transferred lock.
+    //
+    // Construct: gate a tick on a slow renewLock so the chain blocks,
+    // kick inbound, kick pushHandoff, then release renewLock and
+    // verify inbound throws leader_closed and adoptLockFromHandoff
+    // never ran.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, lock } = makeLeader({ mocks });
+    // Acquire the lock first (heldLock=true) via a tick before we
+    // install the blocking renewLock mock — otherwise the lock
+    // module would be the one stuck.
+    await leader._stepForTest();
+    expect(leader.isHoldingLock()).toBe(true);
+
+    // Now swap renewLock to block on a held promise. The next tick
+    // will queue and never settle until we release.
+    let releaseRenew;
+    mocks.lock.renewLock = jest.fn(() => new Promise((resolve) => {
+      releaseRenew = () => resolve({ renewed: true, version: 7 });
+    }));
+
+    // Kick a tick (queued #1, will block on renewLock).
+    const tickPromise = leader._stepForTest();
+    // Yield microtasks so the tick reaches the blocking renewLock.
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(typeof releaseRenew).toBe('function');
+
+    // Kick the inbound (queued #2, will wait for tick to finish).
+    const inboundPromise = leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 99,
+    });
+    // SIGTERM fires (queued #3 + sets closed=true). pushHandoff's
+    // outer side-effect is `closed = true; running = false`, so by
+    // the time the inbound work pops, closed has latched.
+    const pushPromise = leader.pushHandoff();
+
+    // Let the tick complete so the chain drains.
+    releaseRenew();
+    await tickPromise;
+
+    // Inbound must reject with leader_closed and never call adopt.
+    await expect(inboundPromise).rejects.toThrow(/leader_closed/);
+    expect(lock.adoptLockFromHandoff).not.toHaveBeenCalled();
+
+    // pushHandoff still proceeds to transfer.
+    await pushPromise;
+  });
+
   it('releaseLockForImmediateExit after pushHandoff is a no-op (closed)', async () => {
     const mocks = makeMocks({
       initialPeers: [{

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -1,0 +1,535 @@
+// Unit tests for src/gateway-leader.js — the Pillar 3 orchestrator
+// that ties gateway-lock + peer-heartbeat + control-client + manager
+// into one state machine. Pins the load-bearing contracts:
+//
+//   1. Tick writes heartbeat unconditionally + refreshes peer cache.
+//      Heartbeat failure doesn't block lock op; peer-cache fetch
+//      failure keeps the prior cache (don't blank it on transients).
+//   2. Tick lock op:
+//        - heldLock=false → tries acquireLock; success flips flag.
+//        - heldLock=true  → tries renewLock; CCF flips flag off.
+//        - throw on either → keeps flag as-is (retry next tick).
+//   3. handleInboundHandoff ordering: adopt → flag → connect. Adopt
+//      throw never flips the flag; connect throw flips it (watchdog
+//      retries).
+//   4. pushHandoff:
+//        - not holding → no-op.
+//        - no fresh peer → releaseLock + reason:'no_peer'.
+//        - transferLock CAS fail → reason:'transfer_failed', no release
+//          (peer cold-acquired; the CCF IS the release).
+//        - transferLock success + push success → pushed:true.
+//        - transferLock success + push timeout → pushed:true, ackReason:
+//          'timeout' (active still exits; standby's watchdog recovers).
+//   5. Serialization: tick + inbound-handoff + push-handoff funnel
+//      through the same in-flight chain. No two lock mutators ever
+//      run concurrently.
+//   6. Hooks: isHoldingLock + isKnownPeer + releaseLockForExit
+//      reflect internal state; releaseLockForExit clears flag +
+//      calls lock.releaseLock.
+
+const {
+  createGatewayLeader,
+  DEFAULT_TICK_INTERVAL_MS,
+} = require('../src/gateway-leader');
+
+function makeMocks({
+  initialPeers = [],
+  ...overrides
+} = {}) {
+  const lock = {
+    acquireLock: jest.fn(async () => ({ acquired: true, version: 1 })),
+    renewLock: jest.fn(async () => ({ renewed: true, version: 2 })),
+    transferLock: jest.fn(async () => ({ transferred: true, version: 3 })),
+    adoptLockFromHandoff: jest.fn(),
+    releaseLock: jest.fn(async () => ({ released: true })),
+    ...overrides.lock,
+  };
+  const peerHeartbeat = {
+    writeHeartbeat: jest.fn(async () => {}),
+    listFreshPeers: jest.fn(async () => initialPeers),
+    ...overrides.peerHeartbeat,
+  };
+  const controlClient = {
+    pushHandoff: jest.fn(async () => ({ ok: true, status: 200 })),
+    ...overrides.controlClient,
+  };
+  const manager = {
+    connect: jest.fn(async () => {}),
+    isConnected: jest.fn(() => false),
+    ...overrides.manager,
+  };
+  const logger = {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+  return { lock, peerHeartbeat, controlClient, manager, logger };
+}
+
+function makeLeader({ mocks, sleep, tickIntervalMs } = {}) {
+  const m = mocks ?? makeMocks();
+  const leader = createGatewayLeader({
+    lock: m.lock,
+    peerHeartbeat: m.peerHeartbeat,
+    controlClient: m.controlClient,
+    manager: m.manager,
+    selfInstanceId: 'inst-A',
+    selfLockHolder: 'task-arn:.../inst-A',
+    shardId: '0:1',
+    logger: m.logger,
+    tickIntervalMs, sleep,
+  });
+  return { leader, ...m };
+}
+
+describe('createGatewayLeader — factory validation', () => {
+  it('exposes default tick interval', () => {
+    expect(DEFAULT_TICK_INTERVAL_MS).toBe(2_000);
+  });
+
+  it('throws on missing required deps', () => {
+    expect(() => createGatewayLeader()).toThrow(/lock/);
+    expect(() => createGatewayLeader({ lock: {} })).toThrow(/peerHeartbeat/);
+    expect(() => createGatewayLeader({ lock: {}, peerHeartbeat: {} }))
+      .toThrow(/controlClient/);
+    expect(() => createGatewayLeader({
+      lock: {}, peerHeartbeat: {}, controlClient: {},
+    })).toThrow(/manager/);
+    expect(() => createGatewayLeader({
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: {},
+    })).toThrow(/manager/);
+    expect(() => createGatewayLeader({
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+    })).toThrow(/selfInstanceId/);
+    expect(() => createGatewayLeader({
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      selfInstanceId: 'a',
+    })).toThrow(/selfLockHolder/);
+    expect(() => createGatewayLeader({
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      selfInstanceId: 'a', selfLockHolder: 'h',
+    })).toThrow(/shardId/);
+    expect(() => createGatewayLeader({
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      selfInstanceId: 'a', selfLockHolder: 'h', shardId: 's',
+    })).toThrow(/logger/);
+  });
+});
+
+describe('step (tick) — heartbeat + peer cache', () => {
+  it('writes heartbeat unconditionally', async () => {
+    const { leader, peerHeartbeat } = makeLeader();
+    await leader._stepForTest();
+    expect(peerHeartbeat.writeHeartbeat).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes peer cache from listFreshPeers each tick', async () => {
+    const mocks = makeMocks({
+      initialPeers: [
+        { instance_id: 'inst-B', ip: '10.0.0.2', port: 9876, updated_at: 100 },
+      ],
+    });
+    const { leader, peerHeartbeat } = makeLeader({ mocks });
+    expect(leader.isKnownPeer('inst-B')).toBe(false);
+    await leader._stepForTest();
+    expect(leader.isKnownPeer('inst-B')).toBe(true);
+    expect(leader.isKnownPeer('inst-X')).toBe(false);
+    expect(peerHeartbeat.listFreshPeers).toHaveBeenCalledTimes(1);
+  });
+
+  it('heartbeat write failure does not block the lock op', async () => {
+    const mocks = makeMocks();
+    mocks.peerHeartbeat.writeHeartbeat = jest.fn(async () => { throw new Error('throttled'); });
+    const { leader, lock, logger } = makeLeader({ mocks });
+
+    await leader._stepForTest();
+
+    // Lock acquire still attempted (heldLock=false initial state).
+    expect(lock.acquireLock).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/heartbeat write failed/),
+      expect.objectContaining({ error: 'throttled' }),
+    );
+  });
+
+  it('listFreshPeers failure preserves prior peer cache (no blanking on transients)', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{ instance_id: 'inst-B', updated_at: 100 }],
+    });
+    const { leader, peerHeartbeat } = makeLeader({ mocks });
+    await leader._stepForTest(); // populate cache
+    expect(leader.isKnownPeer('inst-B')).toBe(true);
+
+    // Next tick: listFreshPeers throws — cache must not be blanked.
+    peerHeartbeat.listFreshPeers.mockRejectedValueOnce(new Error('ddb-throttled'));
+    await leader._stepForTest();
+    expect(leader.isKnownPeer('inst-B')).toBe(true);
+  });
+});
+
+describe('step (tick) — lock state machine', () => {
+  it('not-holding → tries acquireLock; success flips heldLock to true', async () => {
+    const { leader, lock } = makeLeader();
+    expect(leader.isHoldingLock()).toBe(false);
+    await leader._stepForTest();
+    expect(lock.acquireLock).toHaveBeenCalledTimes(1);
+    expect(leader.isHoldingLock()).toBe(true);
+  });
+
+  it('not-holding → acquired=false keeps flag false', async () => {
+    const mocks = makeMocks();
+    mocks.lock.acquireLock = jest.fn(async () => ({ acquired: false }));
+    const { leader } = makeLeader({ mocks });
+    await leader._stepForTest();
+    expect(leader.isHoldingLock()).toBe(false);
+  });
+
+  it('holding → tries renewLock; success keeps flag true', async () => {
+    const { leader, lock } = makeLeader();
+    await leader._stepForTest(); // acquire
+    expect(leader.isHoldingLock()).toBe(true);
+
+    await leader._stepForTest(); // renew
+    expect(lock.renewLock).toHaveBeenCalledTimes(1);
+    expect(leader.isHoldingLock()).toBe(true);
+  });
+
+  it('holding → renewLock CCF flips flag to false', async () => {
+    const mocks = makeMocks();
+    mocks.lock.renewLock = jest.fn(async () => ({ renewed: false }));
+    const { leader, logger } = makeLeader({ mocks });
+    // Pre-arm heldLock by stepping once with successful acquire (default).
+    await leader._stepForTest();
+    expect(leader.isHoldingLock()).toBe(true);
+
+    await leader._stepForTest();
+    expect(leader.isHoldingLock()).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/lost lock/),
+    );
+  });
+
+  it('holding → renewLock throw keeps flag true (retry next tick)', async () => {
+    const mocks = makeMocks();
+    mocks.lock.renewLock = jest.fn(async () => { throw new Error('throttled'); });
+    const { leader, logger } = makeLeader({ mocks });
+    await leader._stepForTest(); // acquire
+    expect(leader.isHoldingLock()).toBe(true);
+
+    await leader._stepForTest(); // renew throws
+    expect(leader.isHoldingLock()).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/renewLock threw/),
+      expect.objectContaining({ error: 'throttled' }),
+    );
+  });
+});
+
+describe('handleInboundHandoff', () => {
+  it('order: adopt → set heldLock → connect', async () => {
+    const callOrder = [];
+    const mocks = makeMocks();
+    mocks.lock.adoptLockFromHandoff = jest.fn(() => callOrder.push('adopt'));
+    mocks.manager.connect = jest.fn(async () => callOrder.push('connect'));
+    const { leader } = makeLeader({ mocks });
+
+    // Spy the flag flip by checking inside connect()'s call.
+    let flagAtConnect = null;
+    mocks.manager.connect = jest.fn(async () => {
+      flagAtConnect = leader.isHoldingLock();
+      callOrder.push('connect');
+    });
+
+    await leader.handleInboundHandoff({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    });
+
+    expect(callOrder).toEqual(['adopt', 'connect']);
+    expect(flagAtConnect).toBe(true); // flag set BEFORE connect
+    expect(mocks.lock.adoptLockFromHandoff).toHaveBeenCalledWith(7);
+    expect(leader.isHoldingLock()).toBe(true);
+  });
+
+  it('adopt throw → flag NOT set; rethrows so server returns 500', async () => {
+    const mocks = makeMocks();
+    mocks.lock.adoptLockFromHandoff = jest.fn(() => {
+      throw new Error('bad-version');
+    });
+    const { leader, manager } = makeLeader({ mocks });
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-A', expectedVersion: 0,
+    })).rejects.toThrow(/bad-version/);
+
+    expect(leader.isHoldingLock()).toBe(false);
+    expect(manager.connect).not.toHaveBeenCalled();
+  });
+
+  it('connect throw → flag IS set (watchdog will retry); rethrows', async () => {
+    const mocks = makeMocks();
+    mocks.manager.connect = jest.fn(async () => { throw new Error('discord-down'); });
+    const { leader, logger } = makeLeader({ mocks });
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    })).rejects.toThrow(/discord-down/);
+
+    expect(leader.isHoldingLock()).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/inbound-handoff connect threw/),
+      expect.objectContaining({ error: 'discord-down' }),
+    );
+  });
+});
+
+describe('pushHandoff', () => {
+  function preHoldLock(leader) {
+    // Drive a tick to flip heldLock=true via successful acquireLock.
+    return leader._stepForTest();
+  }
+
+  it('returns not_holding_lock when called without the lock', async () => {
+    const { leader } = makeLeader();
+    const result = await leader.pushHandoff();
+    expect(result).toEqual({ pushed: false, reason: 'not_holding_lock' });
+  });
+
+  it('returns no_peer + best-effort release when no fresh peer exists', async () => {
+    const mocks = makeMocks({ initialPeers: [] });
+    const { leader, lock } = makeLeader({ mocks });
+    await preHoldLock(leader);
+
+    const result = await leader.pushHandoff();
+    expect(result).toEqual({ pushed: false, reason: 'no_peer' });
+    expect(lock.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns transfer_failed when transferLock CAS fails (does NOT release — CCF IS the release)', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.lock.transferLock = jest.fn(async () => ({ transferred: false }));
+    const { leader, lock, controlClient } = makeLeader({ mocks });
+    await preHoldLock(leader);
+
+    const result = await leader.pushHandoff();
+    expect(result).toEqual({ pushed: false, reason: 'transfer_failed' });
+    expect(controlClient.pushHandoff).not.toHaveBeenCalled();
+    expect(lock.releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('returns pushed:true, ackReason:ack on successful transfer + ACKed push', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, lock, controlClient } = makeLeader({ mocks });
+    await preHoldLock(leader);
+
+    const result = await leader.pushHandoff();
+    expect(result).toEqual({ pushed: true, ackReason: 'ack' });
+    expect(lock.transferLock).toHaveBeenCalledWith('inst-B', 'task-B/inst-B');
+    expect(controlClient.pushHandoff).toHaveBeenCalledWith({
+      peerIp: '10.0.0.2', peerPort: 9876, peerInstanceId: 'inst-B',
+      selfInstanceId: 'inst-A', expectedVersion: 3,
+    });
+    expect(leader.isHoldingLock()).toBe(false);
+  });
+
+  it('returns pushed:true, ackReason:timeout when transferred but peer did not ACK', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.controlClient.pushHandoff = jest.fn(async () => ({ ok: false, reason: 'timeout' }));
+    const { leader } = makeLeader({ mocks });
+    await preHoldLock(leader);
+
+    const result = await leader.pushHandoff();
+    expect(result).toEqual({ pushed: true, ackReason: 'timeout' });
+  });
+
+  it('falls back to placeholder lock_holder when peer row lacks the field', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        // no lock_holder
+        updated_at: 100,
+      }],
+    });
+    const { leader, lock } = makeLeader({ mocks });
+    await preHoldLock(leader);
+
+    await leader.pushHandoff();
+    expect(lock.transferLock).toHaveBeenCalledWith('inst-B', 'peer/inst-B');
+  });
+
+  it('stops the tick loop before the transferLock', async () => {
+    // Without stop, a tick could race the transferLock with a renewLock.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const sleep = jest.fn(() => new Promise(() => {})); // never resolves
+    const { leader } = makeLeader({ mocks, sleep, tickIntervalMs: 1 });
+    leader.start();
+    await preHoldLock(leader);
+
+    await leader.pushHandoff();
+    // The loop's running flag must be false after pushHandoff. We
+    // can't observe `running` directly; we observe that no further
+    // step is fired by checking sleep was called only once
+    // (the initial start's first sleep).
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('serialization — no two mutators interleave', () => {
+  it('a tick during an in-flight pushHandoff waits for the push to settle', async () => {
+    let resolvePush;
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.controlClient.pushHandoff = jest.fn(() => new Promise((resolve) => {
+      resolvePush = resolve;
+    }));
+    const { leader, lock } = makeLeader({ mocks });
+    await leader._stepForTest(); // heldLock=true
+
+    // Reset transfer mock to count fresh calls.
+    lock.transferLock.mockClear();
+    const firstAcquireCalls = lock.acquireLock.mock.calls.length;
+
+    // Kick off pushHandoff but don't await yet.
+    const pushPromise = leader.pushHandoff();
+    // Immediately schedule a tick — should queue behind the push.
+    const tickPromise = leader._stepForTest();
+
+    // Give microtasks a chance to run.
+    await new Promise((resolve) => { setImmediate(resolve); });
+
+    // Push is still in flight (controlClient.pushHandoff hasn't
+    // resolved). Tick should NOT have run a lock op yet.
+    expect(lock.transferLock).toHaveBeenCalledTimes(1); // from push
+    // acquireLock not called again past the pre-step.
+    expect(lock.acquireLock.mock.calls.length).toBe(firstAcquireCalls);
+
+    // Resolve the push; tick should then run.
+    resolvePush({ ok: true, status: 200 });
+    await pushPromise;
+    await tickPromise;
+
+    // After push completes, heldLock=false, so the tick's branch
+    // calls acquireLock again.
+    expect(lock.acquireLock.mock.calls.length).toBe(firstAcquireCalls + 1);
+  });
+
+  it('two concurrent inbound handoffs serialize through adopt + connect', async () => {
+    const callOrder = [];
+    const mocks = makeMocks();
+    mocks.lock.adoptLockFromHandoff = jest.fn((v) => {
+      callOrder.push(`adopt-${v}`);
+    });
+    let connectResolves = [];
+    mocks.manager.connect = jest.fn(() => new Promise((resolve) => {
+      connectResolves.push(resolve);
+      callOrder.push(`connect-start-${connectResolves.length}`);
+    }));
+    const { leader } = makeLeader({ mocks });
+
+    const p1 = leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 5,
+    });
+    const p2 = leader.handleInboundHandoff({
+      activeInstanceId: 'inst-Y', expectedVersion: 9,
+    });
+
+    await new Promise((resolve) => { setImmediate(resolve); });
+    // Only the FIRST handoff's adopt + connect should have started.
+    expect(callOrder).toEqual(['adopt-5', 'connect-start-1']);
+
+    connectResolves[0]();
+    await p1;
+    await new Promise((resolve) => { setImmediate(resolve); });
+    // Now the second handoff runs.
+    expect(callOrder).toEqual([
+      'adopt-5', 'connect-start-1',
+      'adopt-9', 'connect-start-2',
+    ]);
+    connectResolves[1]();
+    await p2;
+  });
+});
+
+describe('hooks for watchdog + control-channel', () => {
+  it('isHoldingLock reflects internal state', async () => {
+    const { leader } = makeLeader();
+    expect(leader.isHoldingLock()).toBe(false);
+    await leader._stepForTest(); // cold acquire
+    expect(leader.isHoldingLock()).toBe(true);
+  });
+
+  it('isKnownPeer uses the cache from listFreshPeers', async () => {
+    const mocks = makeMocks({
+      initialPeers: [
+        { instance_id: 'inst-B', updated_at: 100 },
+        { instance_id: 'inst-C', updated_at: 100 },
+      ],
+    });
+    const { leader } = makeLeader({ mocks });
+    await leader._stepForTest();
+    expect(leader.isKnownPeer('inst-B')).toBe(true);
+    expect(leader.isKnownPeer('inst-C')).toBe(true);
+    expect(leader.isKnownPeer('inst-Z')).toBe(false);
+  });
+
+  it('releaseLockForExit clears flag + calls lock.releaseLock', async () => {
+    const { leader, lock } = makeLeader();
+    await leader._stepForTest();
+    expect(leader.isHoldingLock()).toBe(true);
+
+    await leader.releaseLockForExit();
+    expect(leader.isHoldingLock()).toBe(false);
+    expect(lock.releaseLock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('start / stop lifecycle', () => {
+  it('start is idempotent', async () => {
+    const sleep = jest.fn(() => new Promise(() => {}));
+    const { leader } = makeLeader({ sleep });
+    leader.start();
+    leader.start();
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop halts the loop', async () => {
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { leader, peerHeartbeat } = makeLeader({ sleep });
+    leader.start();
+
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    leader.stop();
+    sleepResolvers[0](); // wake the loop so it observes running=false
+    await new Promise((resolve) => { setImmediate(resolve); });
+
+    // After stop, the loop must not have called writeHeartbeat (the
+    // first tick's work — running=false check skips step).
+    expect(peerHeartbeat.writeHeartbeat).not.toHaveBeenCalled();
+  });
+});

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -249,6 +249,49 @@ describe('handleInboundHandoff', () => {
     expect(leader.isHoldingLock()).toBe(true);
   });
 
+  it('rejects a stray inbound handoff when already holding lock + connected', async () => {
+    // Defense against a duplicate or misrouted handoff body that
+    // passed the server's HMAC + routing checks. Re-adopting would
+    // re-anchor currentVersion against a possibly-moved row;
+    // re-calling manager.connect() would race the existing WS
+    // (WebSocketManager is NOT concurrent-safe).
+    const mocks = makeMocks();
+    mocks.manager.isConnected = jest.fn(() => true);
+    const { leader } = makeLeader({ mocks });
+    await leader._stepForTest(); // heldLock=true via cold acquire
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 99,
+    })).rejects.toThrow(/already_holding_lock_and_connected/);
+
+    // Critical: must NOT have called adopt or connect on the stray.
+    expect(mocks.lock.adoptLockFromHandoff).not.toHaveBeenCalled();
+    expect(mocks.manager.connect).not.toHaveBeenCalled();
+  });
+
+  it('adopt throw — heldLock + connecting both stay false; runSerialized chain stays intact for next call', async () => {
+    // Adopt is the first step of the handoff. If it throws, NO
+    // flag mutations must happen (heldLock=false, connecting=false),
+    // and the serialization chain must still accept the next op.
+    const mocks = makeMocks();
+    mocks.lock.adoptLockFromHandoff = jest.fn(() => {
+      throw new Error('bad-version');
+    });
+    const { leader, manager } = makeLeader({ mocks });
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 0,
+    })).rejects.toThrow(/bad-version/);
+
+    expect(leader.isHoldingLock()).toBe(false);
+    expect(leader.isConnecting()).toBe(false);
+    expect(manager.connect).not.toHaveBeenCalled();
+
+    // Chain still works: a subsequent tick must run cleanly.
+    await leader._stepForTest();
+    expect(mocks.lock.acquireLock).toHaveBeenCalledTimes(1);
+  });
+
   it('adopt throw → flag NOT set; rethrows so server returns 500', async () => {
     const mocks = makeMocks();
     mocks.lock.adoptLockFromHandoff = jest.fn(() => {

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -815,6 +815,45 @@ describe('pushHandoff — terminal contract (closed sentinel)', () => {
     // Push still succeeds; cleanup is best-effort.
     expect(result).toEqual({ transferred: true, pushAcked: true });
   });
+
+  it('handleInboundHandoff after pushHandoff rejects with leader_closed', async () => {
+    // A race where the SIGTERM path ran AND an inbound handoff hits
+    // the control-channel server BEFORE the process exits. The leader
+    // is dead — must not re-adopt. Uniform terminal-state invariant
+    // alongside start() and releaseLockForImmediateExit.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, lock } = makeLeader({ mocks });
+    await leader._stepForTest();
+    await leader.pushHandoff();
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 99,
+    })).rejects.toThrow(/leader_closed/);
+    // adoptLockFromHandoff must NOT have run.
+    expect(lock.adoptLockFromHandoff).not.toHaveBeenCalled();
+  });
+
+  it('releaseLockForImmediateExit after pushHandoff is a no-op (closed)', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, lock } = makeLeader({ mocks });
+    await leader._stepForTest();
+    await leader.pushHandoff();
+    const releaseCallsBefore = lock.releaseLock.mock.calls.length;
+
+    await leader.releaseLockForImmediateExit();
+    // releaseLock NOT called again — the closed sentinel short-circuits.
+    expect(lock.releaseLock.mock.calls.length).toBe(releaseCallsBefore);
+  });
 });
 
 describe('pushHandoff — re-entry safety', () => {

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -591,13 +591,20 @@ describe('isConnecting — race protection between inbound-handoff and watchdog'
     expect(leader.isConnecting()).toBe(false);
   });
 
-  it('inbound handoff connect times out internally and throws (watchdog takes over)', async () => {
-    // A hung Discord WS connect (never resolves) would pin
-    // connecting=true forever without the internal timeout. The
-    // leader races connect against a timer; on timeout it throws
-    // and the finally clears the flag so the watchdog can retry.
+  it('inbound handoff connect times out internally; isConnecting stays true until underlying connect settles', async () => {
+    // A hung Discord WS connect would pin connecting=true forever
+    // without the internal timeout. The leader races connect
+    // against a timer and THROWS on timeout — but critically,
+    // `isConnecting()` stays true until the UNDERLYING connect
+    // promise actually settles. Otherwise the next watchdog tick
+    // (1s) would fire its OWN manager.connect() while the original
+    // is still pending in @discordjs/ws — exactly the concurrent-
+    // connect race the flag exists to prevent.
     const mocks = makeMocks();
-    mocks.manager.connect = jest.fn(() => new Promise(() => {})); // never resolves
+    let resolveUnderlying;
+    mocks.manager.connect = jest.fn(() => new Promise((resolve) => {
+      resolveUnderlying = resolve;
+    }));
     const leader = createGatewayLeader({
       lock: mocks.lock,
       peerHeartbeat: mocks.peerHeartbeat,
@@ -607,20 +614,26 @@ describe('isConnecting — race protection between inbound-handoff and watchdog'
       selfLockHolder: 'task-arn:.../inst-A',
       shardId: '0:1',
       logger: mocks.logger,
-      inboundConnectTimeoutMs: 50, // fast timeout for the test
+      inboundConnectTimeoutMs: 50,
     });
 
     await expect(leader.handleInboundHandoff({
       activeInstanceId: 'inst-X', expectedVersion: 5,
     })).rejects.toThrow(/inbound_connect_timeout/);
 
-    // Critical: connecting must be cleared after the timeout so
-    // the watchdog can take over on the next tick.
-    expect(leader.isConnecting()).toBe(false);
-    // heldLock must still be true (adopt + flag-set happened before
-    // the connect await) so the watchdog observes lock-held + WS-
-    // not-connected and retries.
+    // Post-timeout-throw: connecting MUST still be true. The
+    // underlying connect is still pending — the watchdog must
+    // back off, not race a second connect.
+    expect(leader.isConnecting()).toBe(true);
+    // heldLock stays true so the watchdog observes lock-held but
+    // is held off by isConnecting until the underlying settles.
     expect(leader.isHoldingLock()).toBe(true);
+
+    // Resolve the underlying connect — flag clears, watchdog
+    // can take over.
+    resolveUnderlying();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(leader.isConnecting()).toBe(false);
   });
 
   it('isConnecting clears even when manager.connect() throws', async () => {

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -17,9 +17,11 @@
 //        - no fresh peer → releaseLock + reason:'no_peer'.
 //        - transferLock CAS fail → reason:'transfer_failed', no release
 //          (peer cold-acquired; the CCF IS the release).
-//        - transferLock success + push success → pushed:true.
-//        - transferLock success + push timeout → pushed:true, ackReason:
-//          'timeout' (active still exits; standby's watchdog recovers).
+//        - transferLock success + push success → transferred:true,
+//          pushAcked:true.
+//        - transferLock success + push timeout → transferred:true,
+//          pushAcked:false, pushReason:'timeout' (active still exits;
+//          standby's watchdog recovers).
 //   5. Serialization: tick + inbound-handoff + push-handoff funnel
 //      through the same in-flight chain. No two lock mutators ever
 //      run concurrently.
@@ -334,6 +336,23 @@ describe('handleInboundHandoff', () => {
     expect(leader.isConnecting()).toBe(false);
     expect(leader.isHoldingLock()).toBe(true);
   });
+
+  it('non-thenable manager.connect return clears connecting flag (defensive)', async () => {
+    // Even stronger defensive: if connect() returns a non-thenable
+    // (i.e., the .then attachment itself throws synchronously after
+    // connectPromise is already assigned), the lifecycle handlers
+    // never register. The catch must still clear `connecting=false`.
+    const mocks = makeMocks();
+    mocks.manager.connect = jest.fn(() => 'not-a-promise');
+    const { leader } = makeLeader({ mocks });
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    })).rejects.toThrow();
+
+    expect(leader.isConnecting()).toBe(false);
+    expect(leader.isHoldingLock()).toBe(true);
+  });
 });
 
 describe('pushHandoff', () => {
@@ -345,7 +364,7 @@ describe('pushHandoff', () => {
   it('returns not_holding_lock when called without the lock', async () => {
     const { leader } = makeLeader();
     const result = await leader.pushHandoff();
-    expect(result).toEqual({ pushed: false, reason: 'not_holding_lock' });
+    expect(result).toEqual({ transferred: false, reason: 'not_holding_lock' });
   });
 
   it('returns no_peer + best-effort release when no fresh peer exists', async () => {
@@ -354,7 +373,7 @@ describe('pushHandoff', () => {
     await preHoldLock(leader);
 
     const result = await leader.pushHandoff();
-    expect(result).toEqual({ pushed: false, reason: 'no_peer' });
+    expect(result).toEqual({ transferred: false, reason: 'no_peer' });
     expect(lock.releaseLock).toHaveBeenCalledTimes(1);
   });
 
@@ -370,12 +389,12 @@ describe('pushHandoff', () => {
     await preHoldLock(leader);
 
     const result = await leader.pushHandoff();
-    expect(result).toEqual({ pushed: false, reason: 'transfer_failed' });
+    expect(result).toEqual({ transferred: false, reason: 'transfer_failed' });
     expect(controlClient.pushHandoff).not.toHaveBeenCalled();
     expect(lock.releaseLock).not.toHaveBeenCalled();
   });
 
-  it('returns pushed:true, ackReason:ack on successful transfer + ACKed push', async () => {
+  it('returns transferred:true, pushAcked:true on successful transfer + ACKed push', async () => {
     const mocks = makeMocks({
       initialPeers: [{
         instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
@@ -386,7 +405,7 @@ describe('pushHandoff', () => {
     await preHoldLock(leader);
 
     const result = await leader.pushHandoff();
-    expect(result).toEqual({ pushed: true, ackReason: 'ack' });
+    expect(result).toEqual({ transferred: true, pushAcked: true });
     expect(lock.transferLock).toHaveBeenCalledWith('inst-B', 'task-B/inst-B');
     expect(controlClient.pushHandoff).toHaveBeenCalledWith({
       peerIp: '10.0.0.2', peerPort: 9876, peerInstanceId: 'inst-B',
@@ -395,7 +414,7 @@ describe('pushHandoff', () => {
     expect(leader.isHoldingLock()).toBe(false);
   });
 
-  it('returns pushed:true, ackReason:timeout when transferred but peer did not ACK', async () => {
+  it('returns transferred:true, pushAcked:false, pushReason:timeout when transferred but peer did not ACK', async () => {
     const mocks = makeMocks({
       initialPeers: [{
         instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
@@ -407,10 +426,10 @@ describe('pushHandoff', () => {
     await preHoldLock(leader);
 
     const result = await leader.pushHandoff();
-    expect(result).toEqual({ pushed: true, ackReason: 'timeout' });
+    expect(result).toEqual({ transferred: true, pushAcked: false, pushReason: 'timeout' });
   });
 
-  it('returns pushed:true, ackReason:push_threw when controlClient.pushHandoff throws', async () => {
+  it('returns transferred:true, pushAcked:false, pushReason:push_threw when controlClient.pushHandoff throws', async () => {
     // The control-client's documented contract is "never throws", but
     // its synchronous argument validators DO throw if a row makes it
     // past listFreshPeers' filters in a future regression. transferLock
@@ -430,7 +449,7 @@ describe('pushHandoff', () => {
     await preHoldLock(leader);
 
     const result = await leader.pushHandoff();
-    expect(result).toEqual({ pushed: true, ackReason: 'push_threw' });
+    expect(result).toEqual({ transferred: true, pushAcked: false, pushReason: 'push_threw' });
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringMatching(/controlClient\.pushHandoff threw/),
       expect.objectContaining({ peerInstanceId: 'inst-B' }),
@@ -794,7 +813,7 @@ describe('pushHandoff — terminal contract (closed sentinel)', () => {
     await leader._stepForTest();
     const result = await leader.pushHandoff();
     // Push still succeeds; cleanup is best-effort.
-    expect(result).toEqual({ pushed: true, ackReason: 'ack' });
+    expect(result).toEqual({ transferred: true, pushAcked: true });
   });
 });
 
@@ -814,10 +833,10 @@ describe('pushHandoff — re-entry safety', () => {
     await leader._stepForTest(); // heldLock=true via acquire
 
     const first = await leader.pushHandoff();
-    expect(first).toEqual({ pushed: true, ackReason: 'ack' });
+    expect(first).toEqual({ transferred: true, pushAcked: true });
 
     const second = await leader.pushHandoff();
-    expect(second).toEqual({ pushed: false, reason: 'not_holding_lock' });
+    expect(second).toEqual({ transferred: false, reason: 'not_holding_lock' });
 
     // Critical: transferLock was called once, not twice.
     expect(lock.transferLock).toHaveBeenCalledTimes(1);
@@ -839,11 +858,11 @@ describe('pushHandoff — re-entry safety', () => {
     ]);
     expect(lock.transferLock).toHaveBeenCalledTimes(1);
     // First call transfers, second sees not_holding_lock.
-    const transferred = [a, b].filter((r) => r.pushed === true);
-    const noOps = [a, b].filter((r) => r.pushed === false);
+    const transferred = [a, b].filter((r) => r.transferred === true);
+    const noOps = [a, b].filter((r) => r.transferred === false);
     expect(transferred).toHaveLength(1);
     expect(noOps).toHaveLength(1);
-    expect(noOps[0]).toEqual({ pushed: false, reason: 'not_holding_lock' });
+    expect(noOps[0]).toEqual({ transferred: false, reason: 'not_holding_lock' });
   });
 });
 

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -47,6 +47,7 @@ function makeMocks({
   const peerHeartbeat = {
     writeHeartbeat: jest.fn(async () => {}),
     listFreshPeers: jest.fn(async () => initialPeers),
+    deleteOwnRow: jest.fn(async () => {}),
     ...overrides.peerHeartbeat,
   };
   const controlClient = {
@@ -549,6 +550,74 @@ describe('isConnecting — race protection between inbound-handoff and watchdog'
     // finally{} block must clear the flag so the watchdog can take
     // over the retry on its next tick.
     expect(leader.isConnecting()).toBe(false);
+  });
+});
+
+describe('pushHandoff — terminal contract (closed sentinel)', () => {
+  it('after pushHandoff, start() is a permanent no-op', async () => {
+    const sleep = jest.fn(() => new Promise(() => {})); // never resolves
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader } = makeLeader({ mocks, sleep });
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    await leader._stepForTest(); // heldLock=true
+    await leader.pushHandoff();
+
+    // After pushHandoff, start() must NOT schedule another tick —
+    // the leader is terminal (SIGTERM handler is about to exit).
+    const sleepCallsBeforeRestart = sleep.mock.calls.length;
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep.mock.calls.length).toBe(sleepCallsBeforeRestart);
+  });
+
+  it('calls peerHeartbeat.deleteOwnRow on the happy path', async () => {
+    // SIGTERM cleanup: the dying replica should close its discovery
+    // window immediately rather than wait the freshness window for
+    // the row to fade naturally.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.peerHeartbeat.deleteOwnRow = jest.fn(async () => {});
+    const { leader, peerHeartbeat } = makeLeader({ mocks });
+    await leader._stepForTest();
+    await leader.pushHandoff();
+    expect(peerHeartbeat.deleteOwnRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls deleteOwnRow on the no_peer branch too', async () => {
+    const mocks = makeMocks({ initialPeers: [] });
+    mocks.peerHeartbeat.deleteOwnRow = jest.fn(async () => {});
+    const { leader, peerHeartbeat } = makeLeader({ mocks });
+    await leader._stepForTest();
+    const result = await leader.pushHandoff();
+    expect(result.reason).toBe('no_peer');
+    expect(peerHeartbeat.deleteOwnRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('a deleteOwnRow failure does NOT bubble into the pushHandoff result', async () => {
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.peerHeartbeat.deleteOwnRow = jest.fn(async () => { throw new Error('ddb-throttle'); });
+    const { leader } = makeLeader({ mocks });
+    await leader._stepForTest();
+    const result = await leader.pushHandoff();
+    // Push still succeeds; cleanup is best-effort.
+    expect(result).toEqual({ pushed: true, ackReason: 'ack' });
   });
 });
 

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -577,9 +577,14 @@ describe('serialization — no two mutators interleave', () => {
     await pushPromise;
     await tickPromise;
 
-    // After push completes, heldLock=false, so the tick's branch
-    // calls acquireLock again.
-    expect(lock.acquireLock.mock.calls.length).toBe(firstAcquireCalls + 1);
+    // After push completes, `closed=true` is latched — the queued
+    // tick's closed-guard now bails before touching the lock. This
+    // matches handleInboundHandoff's closed-state invariant: any
+    // work queued behind pushHandoff is a no-op once the leader is
+    // terminal. The serialization contract is still pinned (the
+    // tick waited; transferLock was called exactly once).
+    expect(lock.acquireLock.mock.calls.length).toBe(firstAcquireCalls);
+    expect(lock.transferLock).toHaveBeenCalledTimes(1);
   });
 
   it('a SIGTERM pushHandoff during an in-flight inbound-handoff queues behind it', async () => {
@@ -750,6 +755,28 @@ describe('isConnecting — race protection between inbound-handoff and watchdog'
 });
 
 describe('pushHandoff — terminal contract (closed sentinel)', () => {
+  it('step() is a no-op after pushHandoff (closed-guard mirrors handleInboundHandoff)', async () => {
+    // Mirrors the closed-guard contract: handleInboundHandoff has an
+    // inner closed re-check inside the serialized closure; step() now
+    // has its own closed-guard so a stray post-close `_stepForTest`
+    // call doesn't re-write heartbeat / re-acquire / re-renew. The
+    // production loop guards via running=false, but the seam needs
+    // to match the rest of the module's invariants.
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    const { leader, peerHeartbeat } = makeLeader({ mocks });
+    await leader._stepForTest();
+    await leader.pushHandoff();
+    const writeCallsBefore = peerHeartbeat.writeHeartbeat.mock.calls.length;
+    await leader._stepForTest();
+    // No new heartbeat, no new peer-list refresh, no new lock work.
+    expect(peerHeartbeat.writeHeartbeat).toHaveBeenCalledTimes(writeCallsBefore);
+  });
+
   it('after pushHandoff, start() is a permanent no-op', async () => {
     const sleep = jest.fn(() => new Promise(() => {})); // never resolves
     const mocks = makeMocks({

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -23,8 +23,8 @@
 //   5. Serialization: tick + inbound-handoff + push-handoff funnel
 //      through the same in-flight chain. No two lock mutators ever
 //      run concurrently.
-//   6. Hooks: isHoldingLock + isKnownPeer + releaseLockForExit
-//      reflect internal state; releaseLockForExit clears flag +
+//   6. Hooks: isHoldingLock + isKnownPeer + releaseLockForImmediateExit
+//      reflect internal state; releaseLockForImmediateExit clears flag +
 //      calls lock.releaseLock.
 
 const {
@@ -591,6 +591,38 @@ describe('isConnecting — race protection between inbound-handoff and watchdog'
     expect(leader.isConnecting()).toBe(false);
   });
 
+  it('inbound handoff connect times out internally and throws (watchdog takes over)', async () => {
+    // A hung Discord WS connect (never resolves) would pin
+    // connecting=true forever without the internal timeout. The
+    // leader races connect against a timer; on timeout it throws
+    // and the finally clears the flag so the watchdog can retry.
+    const mocks = makeMocks();
+    mocks.manager.connect = jest.fn(() => new Promise(() => {})); // never resolves
+    const leader = createGatewayLeader({
+      lock: mocks.lock,
+      peerHeartbeat: mocks.peerHeartbeat,
+      controlClient: mocks.controlClient,
+      manager: mocks.manager,
+      selfInstanceId: 'inst-A',
+      selfLockHolder: 'task-arn:.../inst-A',
+      shardId: '0:1',
+      logger: mocks.logger,
+      inboundConnectTimeoutMs: 50, // fast timeout for the test
+    });
+
+    await expect(leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 5,
+    })).rejects.toThrow(/inbound_connect_timeout/);
+
+    // Critical: connecting must be cleared after the timeout so
+    // the watchdog can take over on the next tick.
+    expect(leader.isConnecting()).toBe(false);
+    // heldLock must still be true (adopt + flag-set happened before
+    // the connect await) so the watchdog observes lock-held + WS-
+    // not-connected and retries.
+    expect(leader.isHoldingLock()).toBe(true);
+  });
+
   it('isConnecting clears even when manager.connect() throws', async () => {
     const mocks = makeMocks();
     mocks.manager.connect = jest.fn(async () => { throw new Error('discord-down'); });
@@ -743,12 +775,12 @@ describe('hooks for watchdog + control-channel', () => {
     expect(leader.isKnownPeer('inst-Z')).toBe(false);
   });
 
-  it('releaseLockForExit clears flag + calls lock.releaseLock', async () => {
+  it('releaseLockForImmediateExit clears flag + calls lock.releaseLock', async () => {
     const { leader, lock } = makeLeader();
     await leader._stepForTest();
     expect(leader.isHoldingLock()).toBe(true);
 
-    await leader.releaseLockForExit();
+    await leader.releaseLockForImmediateExit();
     expect(leader.isHoldingLock()).toBe(false);
     expect(lock.releaseLock).toHaveBeenCalledTimes(1);
   });

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -599,7 +599,7 @@ describe('start / stop lifecycle', () => {
     expect(sleep).toHaveBeenCalledTimes(1);
   });
 
-  it('stop halts the loop', async () => {
+  it('stop halts the loop and returns a promise that resolves when the loop exits', async () => {
     const sleepResolvers = [];
     const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
     const { leader, peerHeartbeat } = makeLeader({ sleep });
@@ -608,12 +608,43 @@ describe('start / stop lifecycle', () => {
     await new Promise((resolve) => { setImmediate(resolve); });
     expect(sleep).toHaveBeenCalledTimes(1);
 
-    leader.stop();
+    const stopPromise = leader.stop();
     sleepResolvers[0](); // wake the loop so it observes running=false
-    await new Promise((resolve) => { setImmediate(resolve); });
+    await stopPromise;
 
     // After stop, the loop must not have called writeHeartbeat (the
     // first tick's work — running=false check skips step).
     expect(peerHeartbeat.writeHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it('start after stop without awaiting does NOT orphan a second loop', async () => {
+    // Lifecycle correctness: a re-start must wait for the prior
+    // loop to fully exit, otherwise the in-flight `await sleep(...)`
+    // in the OLD loop resumes after a `start()` toggles running=true
+    // again, and we get two concurrent ticks against the same
+    // single-caller-only gateway-lock. Guard: start() is a no-op
+    // while loopPromise is still pending.
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { leader } = makeLeader({ sleep });
+
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    // stop() does NOT immediately resolve — the old loop is still
+    // inside the sleep promise. Calling start() now must NOT spawn
+    // a second loop.
+    leader.stop();
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(1); // still only 1, not 2
+
+    // Wake the old loop so it can exit, then start fresh.
+    sleepResolvers[0]();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    leader.start(); // now safe — loopPromise resolved
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -391,6 +391,52 @@ describe('pushHandoff', () => {
   });
 });
 
+describe('serialization — SIGTERM-during-tick (pushHandoff while a tick is in-flight)', () => {
+  it('pushHandoff queues behind an in-flight tick and runs after the tick settles', async () => {
+    // Real production race: SIGTERM fires mid-tick. The tick is
+    // awaiting renewLock (DDB RTT ~10-30ms); pushHandoff must
+    // queue behind it on `inFlight`, not race the same lock
+    // mutator. The serialization chain pins this — but until now
+    // only the inbound-handoff-vs-tick and parallel-handoff cases
+    // had explicit tests.
+    const callOrder = [];
+    let resolveRenew;
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-B', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-B/inst-B', updated_at: 100,
+      }],
+    });
+    mocks.lock.renewLock = jest.fn(() => new Promise((resolve) => {
+      callOrder.push('renew-start');
+      resolveRenew = resolve;
+    }));
+    mocks.lock.transferLock = jest.fn(async () => {
+      callOrder.push('transfer');
+      return { transferred: true, version: 3 };
+    });
+    const { leader } = makeLeader({ mocks });
+    // Pre-hold the lock so the tick path enters renewLock branch.
+    await leader._stepForTest(); // heldLock=true via acquire
+
+    // Now start a SECOND tick (will go into renew); it'll block.
+    const tick2 = leader._stepForTest();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(callOrder).toEqual(['renew-start']);
+
+    // SIGTERM fires: pushHandoff. Queues behind tick2.
+    const push = leader.pushHandoff();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(callOrder).toEqual(['renew-start']); // still blocked
+
+    // Resolve the renew; tick2 settles, then push runs.
+    resolveRenew({ renewed: true, version: 2 });
+    await tick2;
+    await push;
+    expect(callOrder).toEqual(['renew-start', 'transfer']);
+  });
+});
+
 describe('serialization — no two mutators interleave', () => {
   it('a tick during an in-flight pushHandoff waits for the push to settle', async () => {
     let resolvePush;

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -703,6 +703,47 @@ describe('hooks for watchdog + control-channel', () => {
   });
 });
 
+describe('loop backstop — survives unexpected throws from step()', () => {
+  it('a synchronous throw from peerHeartbeat.listFreshPeers does not kill the loop', async () => {
+    // Symmetric to the watchdog's loop backstop. A synchronous throw
+    // (NOT a rejecting promise) from any awaited operation inside
+    // step() escapes the inner try/catch arms — `Promise.all([...])`
+    // captures sync rejections, but the array-element construction
+    // itself can throw synchronously and that's not caught by the
+    // inner .catch() arms. Without the loop-level backstop, the
+    // loop's `await runSerialized(step)` would reject and exit.
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const mocks = makeMocks();
+    let throwCount = 0;
+    mocks.peerHeartbeat.listFreshPeers = jest.fn(() => {
+      throwCount += 1;
+      // Synchronous throw, NOT a rejecting promise.
+      throw new Error('sync-list-throw');
+    });
+
+    const { leader, logger } = makeLeader({ mocks, sleep });
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    // Tick #1: throws synchronously → backstop catches → loop
+    // schedules tick #2 sleep.
+    sleepResolvers[0]();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(throwCount).toBeGreaterThanOrEqual(1);
+    // Loop must NOT have exited — another sleep was scheduled.
+    expect(sleep.mock.calls.length).toBeGreaterThan(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/tick threw unexpectedly/),
+      expect.objectContaining({ error: 'sync-list-throw' }),
+    );
+
+    leader.stop();
+    while (sleepResolvers.length > 0) sleepResolvers.shift()();
+  });
+});
+
 describe('start / stop lifecycle', () => {
   it('start is idempotent', async () => {
     const sleep = jest.fn(() => new Promise(() => {}));

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -367,7 +367,7 @@ describe('pushHandoff', () => {
     await preHoldLock(leader);
 
     await leader.pushHandoff();
-    expect(lock.transferLock).toHaveBeenCalledWith('inst-B', 'peer/inst-B');
+    expect(lock.transferLock).toHaveBeenCalledWith('inst-B', 'placeholder/inst-B');
   });
 
   it('stops the tick loop before the transferLock', async () => {
@@ -479,6 +479,57 @@ describe('serialization — no two mutators interleave', () => {
     // After push completes, heldLock=false, so the tick's branch
     // calls acquireLock again.
     expect(lock.acquireLock.mock.calls.length).toBe(firstAcquireCalls + 1);
+  });
+
+  it('a SIGTERM pushHandoff during an in-flight inbound-handoff queues behind it', async () => {
+    // Real race: handleInboundHandoff is awaiting manager.connect()
+    // when SIGTERM fires. pushHandoff must queue behind the inbound
+    // handoff on the serialization chain — otherwise both would
+    // touch the lock state concurrently.
+    const callOrder = [];
+    const mocks = makeMocks({
+      initialPeers: [{
+        instance_id: 'inst-X', ip: '10.0.0.2', port: 9876,
+        lock_holder: 'task-X/inst-X', updated_at: 100,
+      }],
+    });
+    let resolveConnect;
+    mocks.lock.adoptLockFromHandoff = jest.fn(() => callOrder.push('adopt'));
+    mocks.manager.connect = jest.fn(() => new Promise((resolve) => {
+      callOrder.push('connect-start');
+      resolveConnect = resolve;
+    }));
+    mocks.lock.transferLock = jest.fn(async () => {
+      callOrder.push('transfer');
+      return { transferred: true, version: 3 };
+    });
+    const { leader } = makeLeader({ mocks });
+
+    // Pre-hold lock via a tick so pushHandoff has something to do.
+    // (Note: this acquires; handleInboundHandoff below will overwrite
+    // the version cursor via adoptLockFromHandoff. That's a slight
+    // semantic stretch — in reality we wouldn't have both — but the
+    // test is about serialization ordering.)
+    await leader._stepForTest();
+    callOrder.length = 0;
+
+    // Kick off inbound handoff; blocks at connect-start.
+    const inbound = leader.handleInboundHandoff({
+      activeInstanceId: 'inst-X', expectedVersion: 5,
+    });
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(callOrder).toEqual(['adopt', 'connect-start']);
+
+    // SIGTERM fires now: pushHandoff queues.
+    const push = leader.pushHandoff();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(callOrder).toEqual(['adopt', 'connect-start']); // still blocked
+
+    // Release the inbound handoff; push then runs.
+    resolveConnect();
+    await inbound;
+    await push;
+    expect(callOrder).toEqual(['adopt', 'connect-start', 'transfer']);
   });
 
   it('two concurrent inbound handoffs serialize through adopt + connect', async () => {

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -98,18 +98,18 @@ describe('createGatewayLeader — factory validation', () => {
       lock: {}, peerHeartbeat: {}, controlClient: {}, manager: {},
     })).toThrow(/manager/);
     expect(() => createGatewayLeader({
-      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
     })).toThrow(/selfInstanceId/);
     expect(() => createGatewayLeader({
-      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
       selfInstanceId: 'a',
     })).toThrow(/selfLockHolder/);
     expect(() => createGatewayLeader({
-      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
       selfInstanceId: 'a', selfLockHolder: 'h',
     })).toThrow(/shardId/);
     expect(() => createGatewayLeader({
-      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {} },
+      lock: {}, peerHeartbeat: {}, controlClient: {}, manager: { connect() {}, isConnected() {} },
       selfInstanceId: 'a', selfLockHolder: 'h', shardId: 's',
     })).toThrow(/logger/);
   });

--- a/apps/discord/tests/gateway-peer-heartbeat.test.js
+++ b/apps/discord/tests/gateway-peer-heartbeat.test.js
@@ -95,6 +95,29 @@ describe('createPeerHeartbeat — factory validation', () => {
     expect(() => createPeerHeartbeat({ ...base, ip: '::1' })).not.toThrow();
   });
 
+  it('rejects non-string or empty-string lockHolder when provided', () => {
+    // `lockHolder` is optional but, when provided, must be a non-
+    // empty string. A stray non-string would write a non-S value to
+    // DDB and surface as a confusing log field at SIGTERM transfer
+    // time. Mirrors the secrets.previous posture in gateway-hmac.
+    const base = {
+      ddbClient: {}, tableName: 't', instanceId: 'i', ip: '10.0.0.1',
+      port: 9876, shardId: '0:1', logger: {},
+    };
+    expect(() => createPeerHeartbeat({ ...base, lockHolder: '' }))
+      .toThrow(/lockHolder must be a non-empty string when provided/);
+    expect(() => createPeerHeartbeat({ ...base, lockHolder: 42 }))
+      .toThrow(/lockHolder must be a non-empty string when provided/);
+    expect(() => createPeerHeartbeat({ ...base, lockHolder: true }))
+      .toThrow(/lockHolder must be a non-empty string when provided/);
+    expect(() => createPeerHeartbeat({ ...base, lockHolder: {} }))
+      .toThrow(/lockHolder must be a non-empty string when provided/);
+    // Omitted and undefined both fine.
+    expect(() => createPeerHeartbeat({ ...base })).not.toThrow();
+    expect(() => createPeerHeartbeat({ ...base, lockHolder: undefined })).not.toThrow();
+    expect(() => createPeerHeartbeat({ ...base, lockHolder: 'task-arn:..../inst-A' })).not.toThrow();
+  });
+
   it('rejects invalid ports (string, NaN, 0, negative, >65535, fractional)', () => {
     // The control-channel port comes from config (env). A bug that
     // forgot to parseInt would surface as a string; an off-by-one in

--- a/apps/discord/tests/gateway-peer-heartbeat.test.js
+++ b/apps/discord/tests/gateway-peer-heartbeat.test.js
@@ -25,6 +25,7 @@ const {
 function makeHeartbeat({
   clock, freshnessWindowSeconds, ttlSeconds,
   instanceId = 'inst-A', ip = '10.0.1.5', port = 9876, shardId = '0:1',
+  lockHolder,
 } = {}) {
   const rawClient = new DynamoDBClient({});
   const docClient = DynamoDBDocumentClient.from(rawClient);
@@ -35,7 +36,7 @@ function makeHeartbeat({
   const heartbeat = createPeerHeartbeat({
     ddbClient: docClient,
     tableName: 'test-gateway-peer-heartbeat',
-    instanceId, ip, port, shardId, logger, clock,
+    instanceId, ip, port, shardId, logger, clock, lockHolder,
     freshnessWindowSeconds, ttlSeconds,
   });
   return { heartbeat, ddbMock, logger };
@@ -176,6 +177,30 @@ describe('writeHeartbeat', () => {
       port: 9876,
       shard_id: '0:1',
     });
+  });
+
+  it('writes lock_holder when supplied, omits when absent', async () => {
+    // The leader's SIGTERM path needs the peer's lockHolder string
+    // to call transferLock(targetInstanceId, targetLockHolder).
+    // Carrying it on the heartbeat row keeps the active from having
+    // to invent or look it up. Absent — back-compat with cold-only
+    // callers, no `lock_holder: undefined` on the DDB write.
+    const { heartbeat: withHolder, ddbMock: m1 } = makeHeartbeat({
+      clock: () => 1_700_000_000_000,
+      lockHolder: 'task-arn:.../inst-A',
+    });
+    m1.on(PutCommand).resolves({});
+    await withHolder.writeHeartbeat();
+    expect(m1.commandCalls(PutCommand)[0].args[0].input.Item.lock_holder)
+      .toBe('task-arn:.../inst-A');
+
+    const { heartbeat: noHolder, ddbMock: m2 } = makeHeartbeat({
+      clock: () => 1_700_000_000_000,
+    });
+    m2.on(PutCommand).resolves({});
+    await noHolder.writeHeartbeat();
+    expect(m2.commandCalls(PutCommand)[0].args[0].input.Item)
+      .not.toHaveProperty('lock_holder');
   });
 
   it('uses no condition expression — idempotent overwrite is the desired shape', async () => {


### PR DESCRIPTION
## Why

Pillar 3 of the zero-downtime gateway rollout: hot-standby leader election with sub-second push-handoff on deploy. The current bot's single-replica Discord gateway means every deploy + every task replacement = ~7 s of gateway downtime, which under burst load can shed user-visible interactions. This PR adds the control-plane machinery so a second replica can immediately take over the WS session via in-VPC handoff instead of waiting for the cold-fallback floor.

Builds on the lock + peer-heartbeat primitives from #412 (PR 13b.1). No wiring into `index.js` yet — that ships in **PR 13b.3** alongside the `ENABLE_GATEWAY_HOT_STANDBY` flag (default off), so this PR is a pure-addition no-runtime-effect change. Design doc: `apps/discord/docs/zero-downtime-design.md` §Pillar 3.

## What

### Five new modules

| Module | Role |
|---|---|
| `gateway-hmac.js` | SHA-256 sign/verify with dual-secret accept (rolling-rotation window), 5 s freshness, 1024-entry nonce LRU. Exports wrap/unwrap envelope helpers as the single source of truth for the wire shape across server + client + tests. Frozen `VERIFY_REASONS` for cross-module typo safety. |
| `gateway-connection-watchdog.js` | 1 s-tick loop that closes the "lock held but WS disconnected" gap. Exponential backoff (200/400/800/1600 ms); at 5 attempts → release lock + `exit(1)` so ECS replaces the task. |
| `gateway-control-channel.js` | `node:http` server for `POST /control/yours`. 8 KB body cap (streaming), HMAC-verify-before-parse, routing checks (peer_instance_id binding + isKnownPeer), awaits onHandoff before ACKing. |
| `gateway-control-client.js` | Outbound POST with 200 ms timeout to match the SIGTERM ACK deadline. Returns result objects — never throws. Settles before destroy on timeout to prevent the destroy-induced `error` event from racing the timeout reason. |
| `gateway-leader.js` | Orchestrator that ties lock + heartbeat + control-client + manager into the state machine. Exposes hooks (`isHoldingLock` / `isKnownPeer` / `handleInboundHandoff` / `releaseLockForExit`) for the wiring layer in PR 13b.3. Serializes all lock mutators through a single in-flight promise chain — `gateway-lock` is single-caller-only by contract. |

### One modification

- `gateway-peer-heartbeat.js`: optional `lockHolder` arg, written as `lock_holder` on the heartbeat row. The active's SIGTERM `transferLock(target, targetHolder)` needs the peer's holder string; carrying it on the heartbeat row keeps the active from inventing or looking it up. Falls back to a placeholder for pre-13b.2 callers.

## Load-bearing design choices

1. **HMAC verify runs BEFORE JSON.parse** (DoS + key-order safety). The wire envelope wraps the inner signed body as a JSON STRING so its bytes round-trip verbatim — parsing it as an object would canonicalize key order and break verify.
2. **Synchronous check-then-set in the nonce LRU.** Tested with a parallel-verify concurrency test that asserts exactly one of two simultaneous verifies of the same nonce wins.
3. **Watchdog exhaustion → `exit(1)`** rather than infinite retry. A standby that can't reach Discord but holds the lock blocks the only failover slot — ECS-restart is the cheaper recovery.
4. **Single-caller-only serialization.** `tick` / `inbound-handoff` / `push-handoff` all touch `gateway-lock`'s closure state (currentVersion). The leader funnels every mutator through one in-flight promise chain so two never overlap. Pinned by a concurrency test.
5. **Adopt → flag → connect ordering** on inbound handoff. Adopt failure leaves heldLock=false (watchdog stays quiet). Connect failure flips heldLock=true (watchdog retries). Reversing the order would mis-key the watchdog under transient DDB failures.
6. **Heartbeat + peer-list in parallel** per tick — independent DDB ops with independent error handling. Halves tick DDB-RTT cost.

## Testing

137 new unit tests across 5 new files + extensions to `gateway-peer-heartbeat.test.js`. Full discord suite (61 files, 2202 tests) green.

Test categories:
- Factory validation (every module)
- Contract pins (HMAC dual-secret, freshness window, nonce LRU bounds, verify-before-parse)
- Routing checks (peer_instance_id binding, isKnownPeer)
- Failure modes (timeout, http_error, transferLock CAS fail, adopt throw, connect throw)
- Serialization invariants (no two mutators interleave; concurrent inbound handoffs serialize)
- End-to-end client → server round-trip

## What's NOT in this PR

- No `index.js` wiring (PR 13b.3)
- No `ENABLE_GATEWAY_HOT_STANDBY` flag (PR 13b.3)
- No `gateway_desired_count=2` / AZ-spread infra (PR 14)
- No chaos validation (PR 15)

## Test plan

- [x] Unit tests for all new modules
- [x] End-to-end real-HTTP test for control-channel server + control-client
- [x] Concurrency test for nonce LRU check-then-set
- [x] Full discord suite (2202 tests) green
- [x] /simplify across all new files (code reuse, code quality, efficiency — applied findings)
- [x] Lint clean on all changed files
- [ ] Runtime smoke (deferred to PR 13b.3 wiring)