### PR TITLE
feat(discord): pillar 3 hot-standby wiring layer

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -139,6 +139,51 @@ ENABLE_OPENNHP_FEATURES=false
 # if Discord's 60 s buffer still has it, otherwise IDENTIFYs).
 # ENABLE_GATEWAY_RESUME=false
 
+# Gateway hot-standby (zero-downtime design, Pillar 3). When set to
+# the literal string "true" AND PROCESS_ROLE=gateway AND
+# ENABLE_GATEWAY_RESUME=true, two gateway replicas run: one holds
+# the DDB-backed lock and owns the live WebSocket (active), the
+# other heartbeats and waits (standby). On SIGTERM the active
+# pushes ownership via an HMAC-authenticated POST to the standby,
+# which drives manager.connect() inside the push window — the
+# next Discord dispatch lands without an IDENTIFY/RESUME cold-start.
+#
+# Requires:
+#   * ENABLE_GATEWAY_RESUME=true (cross-process session continuity)
+#   * PROCESS_ROLE=gateway (only the gateway tier constructs the
+#     manager that hot-standby drives)
+#   * INSTANCE_ID, INSTANCE_IP, GATEWAY_HANDOFF_HMAC (below)
+#
+# Default off. The boot-requirements check rejects every unsupported
+# combination at startup (see src/boot-requirements.js).
+# ENABLE_GATEWAY_HOT_STANDBY=false
+
+# Per-replica identity for the hot-standby control plane. Each task
+# must see a unique value — the DDB lock + peer-heartbeat rows key
+# on this. ECS task-defs inject the task's ARN suffix (or task
+# metadata GUID) here at boot. Required when
+# ENABLE_GATEWAY_HOT_STANDBY=true, unused otherwise.
+# INSTANCE_ID=
+# INSTANCE_IP=
+
+# Bind + listen ports for the in-VPC control channel that receives
+# pushHandoff envelopes from the outgoing leader. 0.0.0.0 binds to
+# all interfaces (awsvpc-routable IP); 127.0.0.1 would be unreachable
+# from peer tasks. Restrict the listening port to peer tasks via the
+# task's security group (see qurl-integrations-infra terraform).
+# Defaults: 7800 / 0.0.0.0.
+# GATEWAY_CONTROL_PORT=7800
+# GATEWAY_CONTROL_BIND_ADDR=0.0.0.0
+
+# HMAC secret for the control channel. JSON-shaped string:
+# `{"current":"<64-char-hex>","previous":"<64-char-hex>"}`. Each
+# value is a 32-byte HMAC-SHA256 key in lowercase hex. `previous`
+# is optional and covers the rolling-deploy rotation window
+# (dual-accept). Production: SSM SecureString
+# /qurl-bot-discord/GATEWAY_HANDOFF_HMAC, injected via the task-def
+# `secrets =` block — never set in .env files on real deploys.
+# GATEWAY_HANDOFF_HMAC=
+
 # Maximum number of in-flight detached handlers the SQS consumer
 # tolerates before pausing receives (backpressure). When the count
 # reaches the cap, pollOnce returns early and waits 100ms before

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -246,6 +246,47 @@ function missingHotStandbyKeys(cfg) {
   return missing;
 }
 
+// Shape checks for INSTANCE_ID + INSTANCE_IP (run AFTER missing-keys
+// passes). Matches the secret-loader's "fail at boot, not at first
+// use" posture: a misconfigured task-def that injects the literal
+// `${ECS_TASK_ARN}` (unsubstituted shell expansion) or
+// `INSTANCE_IP=10.0.0.999` (non-IPv4) would pass the presence gate
+// and surface as a baffling DDB-lock-can't-acquire or peer-
+// unreachable error at runtime. A cheap regex catches both.
+//
+// INSTANCE_ID: rejects the `${...}` template-literal pattern (the
+// common ECS task-def substitution-failure footgun). Otherwise
+// permissive — the downstream lock/heartbeat code does not require
+// a specific format.
+//
+// INSTANCE_IP: must parse as an IPv4 dotted-quad. The hot-standby
+// awsvpc deployment puts each task on a unique ENI with a v4
+// address; v6 is not in scope for Pillar 3 today (the control
+// channel binds to the v4 ENI, peers reach each other over v4 SG
+// rules). If v6 ever lands, this check loosens.
+//
+// Returns an array of operator-facing message strings (one per
+// problem) or [] when all values are well-shaped. Hot-standby off
+// → skip entirely.
+const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+function invalidHotStandbyValues(cfg) {
+  if (!cfg.ENABLE_GATEWAY_HOT_STANDBY) return [];
+  const problems = [];
+  if (cfg.INSTANCE_ID && cfg.INSTANCE_ID.includes('${')) {
+    problems.push(
+      `INSTANCE_ID looks like an unsubstituted template literal ('${cfg.INSTANCE_ID}'). ` +
+      'Check the ECS task-def is resolving the placeholder against the task metadata endpoint.'
+    );
+  }
+  if (cfg.INSTANCE_IP && !IPV4_RE.test(cfg.INSTANCE_IP)) {
+    problems.push(
+      `INSTANCE_IP must be a valid IPv4 address (got '${cfg.INSTANCE_IP}'). ` +
+      'Hot-standby uses v4 for the control-channel binding + peer reach; v6 is not in scope today.'
+    );
+  }
+  return problems;
+}
+
 // PLACEHOLDER is treated as missing because the SSM parameter
 // ships with that literal sentinel value; remediation ("seed a
 // real key") is identical to the empty-key case.
@@ -346,6 +387,7 @@ module.exports = {
   unsupportedRoleResumeCombo,
   unsupportedRoleHotStandbyCombo,
   missingHotStandbyKeys,
+  invalidHotStandbyValues,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -183,6 +183,11 @@ function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled, st
 }
 
 // Parallel to unsupportedRoleResumeCombo for ENABLE_GATEWAY_HOT_STANDBY.
+// Caller guarantees the upstream resume combo check has already run
+// (resumeEnabled=true → shipper+ddb already validated upstream), so
+// the 3-arg signature here is sufficient — no need to re-check
+// shipper/storeType.
+//
 // Two unsupported shapes:
 //
 //   1. hotStandby=true with role!=gateway — the leader coordinator

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -265,10 +265,16 @@ function missingHotStandbyKeys(cfg) {
 // channel binds to the v4 ENI, peers reach each other over v4 SG
 // rules). If v6 ever lands, this check loosens.
 //
+// Leading-zero octets are rejected (`01.02.03.04` would parse as
+// octal under some resolvers); each octet is `0` alone, `1-9`, or
+// `1[0-9]-25[0-5]` with no leading zero. ECS task-def injection
+// produces canonical no-leading-zero v4 strings; this just closes
+// the operator-typo door.
+//
 // Returns an array of operator-facing message strings (one per
 // problem) or [] when all values are well-shaped. Hot-standby off
 // → skip entirely.
-const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)$/;
 function invalidHotStandbyValues(cfg) {
   if (!cfg.ENABLE_GATEWAY_HOT_STANDBY) return [];
   const problems = [];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -242,7 +242,12 @@ function missingHotStandbyKeys(cfg) {
   const missing = [];
   if (!cfg.INSTANCE_ID) missing.push('INSTANCE_ID');
   if (!cfg.INSTANCE_IP) missing.push('INSTANCE_IP');
-  if (!cfg.GATEWAY_HANDOFF_HMAC) missing.push('GATEWAY_HANDOFF_HMAC');
+  // GATEWAY_HANDOFF_HMAC presence is surfaced via `hasGatewayHandoffHmac`
+  // (boolean flag) rather than the raw value — the secret string is
+  // never exposed as a config-object property to keep it unreachable
+  // through heap-dump-accessible references. See config.js's
+  // `takeGatewayHandoffHmac` for the security rationale.
+  if (!cfg.hasGatewayHandoffHmac) missing.push('GATEWAY_HANDOFF_HMAC');
   return missing;
 }
 

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -182,6 +182,65 @@ function unsupportedRoleResumeCombo(role, resumeEnabled, eventShipperEnabled, st
   return null;
 }
 
+// Parallel to unsupportedRoleResumeCombo for ENABLE_GATEWAY_HOT_STANDBY.
+// Two unsupported shapes:
+//
+//   1. hotStandby=true with role!=gateway — the leader coordinator
+//      drives the gateway-ws-shim's manager handle; only the gateway
+//      tier constructs the shim, so http/combined have nothing to
+//      hand off. Rejecting at boot avoids a deploy where the hot-
+//      standby flag is set in a uniform env block but the role isn't
+//      gateway — which would silently no-op the leader path and
+//      mask the misconfig as "the lock never gets acquired."
+//   2. hotStandby=true with resume=false — pushHandoff hands the
+//      incoming task a snapshot of session_id + sequence so it can
+//      RESUME without dropping events. Without the cross-process
+//      RESUME path, "handoff" degenerates to "both replicas
+//      IDENTIFY against the same token" — Discord rejects the
+//      second IDENTIFY and the second replica flaps the session.
+//
+// Returns the operator-facing message on rejection or null on
+// success. Same string-or-null shape as unsupportedRoleResumeCombo.
+function unsupportedRoleHotStandbyCombo(role, hotStandbyEnabled, resumeEnabled) {
+  if (!hotStandbyEnabled) return null;
+  if (role !== 'gateway') {
+    return (
+      `ENABLE_GATEWAY_HOT_STANDBY=true requires PROCESS_ROLE=gateway (got '${role}'). ` +
+      'The hot-standby control plane (leader election + push handoff) drives the ' +
+      'gateway-ws-shim manager, which only the gateway tier constructs. http and ' +
+      'combined roles have no manager to hand off. Set PROCESS_ROLE=gateway on the ' +
+      'gateway task def, or leave ENABLE_GATEWAY_HOT_STANDBY unset on http/combined.'
+    );
+  }
+  if (!resumeEnabled) {
+    return (
+      'ENABLE_GATEWAY_HOT_STANDBY=true requires ENABLE_GATEWAY_RESUME=true. ' +
+      'Push handoff transfers session_id + sequence from the outgoing task to the ' +
+      'incoming task; without cross-process RESUME the incoming task would IDENTIFY ' +
+      'against the same bot token and Discord would flap the session. Enable RESUME ' +
+      'first, or leave ENABLE_GATEWAY_HOT_STANDBY unset.'
+    );
+  }
+  return null;
+}
+
+// Required env vars when ENABLE_GATEWAY_HOT_STANDBY=true on a gateway
+// replica. Returns the array of missing keys (parallel shape to
+// missingMapCommandKeys / missingEventShipperKeys). Each value is
+// load-bearing: INSTANCE_ID keys the lock row + peer-heartbeat row;
+// INSTANCE_IP is the address peers reach this replica on; the HMAC
+// secret authenticates every control-channel envelope. A boot with
+// any of these unset would either crash at first use or — worse —
+// run with a zero-knowledge HMAC that fails every verify silently.
+function missingHotStandbyKeys(cfg) {
+  if (!cfg.ENABLE_GATEWAY_HOT_STANDBY) return [];
+  const missing = [];
+  if (!cfg.INSTANCE_ID) missing.push('INSTANCE_ID');
+  if (!cfg.INSTANCE_IP) missing.push('INSTANCE_IP');
+  if (!cfg.GATEWAY_HANDOFF_HMAC) missing.push('GATEWAY_HANDOFF_HMAC');
+  return missing;
+}
+
 // PLACEHOLDER is treated as missing because the SSM parameter
 // ships with that literal sentinel value; remediation ("seed a
 // real key") is identical to the empty-key case.
@@ -280,6 +339,8 @@ module.exports = {
   missingEventShipperKeys,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
+  unsupportedRoleHotStandbyCombo,
+  missingHotStandbyKeys,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -188,6 +188,32 @@ const isDiscordInstallConfigured = Boolean(
 // export point so a future grep-and-replace doesn't miss a callsite.
 const SHARD_ID = process.env.SHARD_ID || '0:1';
 
+// One-shot getter for the GATEWAY_HANDOFF_HMAC secret. The raw value
+// is captured into a module-private binding at require time, then
+// surfaced exactly once via takeGatewayHandoffHmac() which nulls the
+// binding before returning.
+//
+// Defense in depth against heap-dump key exposure: even if a future
+// caller adds telemetry that captures the config object wholesale,
+// or a debugger attaches mid-process, the secret string is no longer
+// reachable through any module-level reference once startHotStandby
+// has consumed it. The live HMAC instance created by createGatewayHmac
+// still holds the parsed bytes (necessary for sign/verify) — that's
+// the only retained reference.
+//
+// Why a private binding rather than a config-object property: the
+// `config` object is exported and any module can capture it at
+// require time. A `delete config.GATEWAY_HANDOFF_HMAC` after the
+// secret is consumed does NOT remove already-captured references.
+// A private binding inside this module is unreachable to anything
+// except this getter.
+let _gatewayHandoffHmacRaw = process.env.GATEWAY_HANDOFF_HMAC;
+function takeGatewayHandoffHmac() {
+  const value = _gatewayHandoffHmacRaw;
+  _gatewayHandoffHmacRaw = undefined;
+  return value;
+}
+
 // Configuration from environment variables
 module.exports = {
   // Discord
@@ -461,13 +487,24 @@ module.exports = {
   }),
   GATEWAY_CONTROL_BIND_ADDR: process.env.GATEWAY_CONTROL_BIND_ADDR || '0.0.0.0',
 
-  // JSON-shaped HMAC secret for the control channel. Injected as a
-  // string by the task-def `secrets = []` block from SSM
-  // `/${project}/GATEWAY_HANDOFF_HMAC`. The actual parse + hex-shape
-  // validation runs in src/gateway-hmac-secret-loader.js at boot;
-  // we surface the raw string here so the loader sees the same
-  // value the env var carries.
-  GATEWAY_HANDOFF_HMAC: process.env.GATEWAY_HANDOFF_HMAC,
+  // JSON-shaped HMAC secret for the control channel. NOT a direct
+  // property — read once via the `takeGatewayHandoffHmac` helper
+  // exported below. The boot-presence check
+  // (`missingHotStandbyKeys`) reads from `_gatewayHandoffHmacRaw` via
+  // a separate `hasGatewayHandoffHmac` flag exposed below so the
+  // gate can fire before takeGatewayHandoffHmac is called.
+  //
+  // Surfaced this way (not as a property on the exported config
+  // object) so a heap dump after secret consumption can't recover
+  // the raw value through `config.GATEWAY_HANDOFF_HMAC`. See the
+  // takeGatewayHandoffHmac definition near the top of this file
+  // for the security rationale.
+  //
+  // Operator note: the boot-presence check below uses
+  // `process.env.GATEWAY_HANDOFF_HMAC` directly (via the flag), so
+  // an unset env var still surfaces the same "required key missing"
+  // error message as before — no observable behavior change.
+  hasGatewayHandoffHmac: Boolean(process.env.GATEWAY_HANDOFF_HMAC),
 
   // Persistence backend selector. Lifted from raw env into config
   // so the boot-guard (`unsupportedRoleResumeCombo`) and the
@@ -514,4 +551,10 @@ module.exports = {
     min: 100,
     max: 8000,
   }),
+
+  // One-shot getter for the GATEWAY_HANDOFF_HMAC raw value (see the
+  // takeGatewayHandoffHmac definition near the top of this file).
+  // Exposed as a function, NOT a property — second call returns
+  // undefined.
+  takeGatewayHandoffHmac,
 };

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -403,6 +403,72 @@ module.exports = {
   // silently flip the gateway path.
   ENABLE_GATEWAY_RESUME: process.env.ENABLE_GATEWAY_RESUME === 'true',
 
+  // Gateway hot-standby (zero-downtime design, Pillar 3). When true
+  // and PROCESS_ROLE=gateway, the gateway tier runs two replicas
+  // (active + standby) that elect a leader via the DDB lock table,
+  // exchange heartbeats via the peer-heartbeat table, and push
+  // ownership of the live WebSocket via an HMAC-authenticated control
+  // channel on SIGTERM. Eliminates the IDENTIFY/RESUME gap on every
+  // deploy — the incoming task `manager.connect()`s synchronously
+  // inside the outgoing task's pushHandoff so the next dispatch
+  // lands without a cold start. See `apps/discord/docs/zero-downtime-design.md`
+  // → "Pillar 3: hot-standby + push handoff".
+  //
+  // Requires ENABLE_GATEWAY_RESUME=true AND PROCESS_ROLE=gateway —
+  // the hot-standby control plane drives the gateway-ws-shim's
+  // manager handle, so neither the legacy single-process shape nor
+  // the http/worker tiers have a manager to hand off. Combined +
+  // hot-standby is rejected for the same reason as combined + RESUME
+  // (the legacy Client owns the WS). Boot-requirements rejects every
+  // unsupported combo at startup.
+  //
+  // Default off so a deploy without the flag set behaves identically
+  // to the pre-Pillar-3 codebase — single replica, single-process
+  // gateway, no control channel listening. Literal-'true' check for
+  // the same typo-rejection reason as ENABLE_EVENT_SHIPPER.
+  ENABLE_GATEWAY_HOT_STANDBY: process.env.ENABLE_GATEWAY_HOT_STANDBY === 'true',
+
+  // Per-replica identity. The leader coordinator writes this into the
+  // DDB lock row as the holder; the control-channel server logs it on
+  // every handoff; the peer-heartbeat row keys on it. Injected by the
+  // ECS task-def `environment = []` block from `${ECS_TASK_ARN}` or
+  // the task metadata endpoint — the deploy is responsible for
+  // ensuring two replicas never share the same value (the lock would
+  // otherwise short-circuit and both replicas would think they hold
+  // it). When unset (hot-standby off), the leader code path doesn't
+  // run, so the value is never read.
+  INSTANCE_ID: process.env.INSTANCE_ID || null,
+
+  // The IPv4 address peers reach this replica on (`http://<ip>:<port>/control/yours`).
+  // ECS awsvpc mode assigns a routable VPC IP per task and exposes it
+  // on the ECS metadata endpoint `$ECS_CONTAINER_METADATA_URI_V4`;
+  // the task-def `environment = []` block plumbs that into INSTANCE_IP
+  // at boot. Used by the peer-heartbeat row's `address_v4` field so
+  // the active replica's pushHandoff client knows where to connect.
+  INSTANCE_IP: process.env.INSTANCE_IP || null,
+
+  // Bind/listen ports for the in-VPC control channel that receives
+  // pushHandoff envelopes from the outgoing leader. The bind address
+  // defaults to 0.0.0.0 (awsvpc-routable) rather than 127.0.0.1
+  // because the peer reaches it via the task's VPC IP. The security
+  // posture is HMAC-on-every-request (gateway-hmac) plus a security-
+  // group rule that restricts the listening port to peer tasks in the
+  // same service — see qurl-integrations-infra `qurl-bot-discord/terraform/control-channel.tf`.
+  GATEWAY_CONTROL_PORT: intEnv('GATEWAY_CONTROL_PORT', 7800, {
+    strictInteger: true,
+    min: 1024,
+    max: 65535,
+  }),
+  GATEWAY_CONTROL_BIND_ADDR: process.env.GATEWAY_CONTROL_BIND_ADDR || '0.0.0.0',
+
+  // JSON-shaped HMAC secret for the control channel. Injected as a
+  // string by the task-def `secrets = []` block from SSM
+  // `/${project}/GATEWAY_HANDOFF_HMAC`. The actual parse + hex-shape
+  // validation runs in src/gateway-hmac-secret-loader.js at boot;
+  // we surface the raw string here so the loader sees the same
+  // value the env var carries.
+  GATEWAY_HANDOFF_HMAC: process.env.GATEWAY_HANDOFF_HMAC,
+
   // Persistence backend selector. Lifted from raw env into config
   // so the boot-guard (`unsupportedRoleResumeCombo`) and the
   // gateway-shim wiring both read through the same parsed shape.

--- a/apps/discord/src/gateway-hmac-secret-loader.js
+++ b/apps/discord/src/gateway-hmac-secret-loader.js
@@ -78,10 +78,17 @@ function loadGatewayHmacSecret(raw) {
     if (typeof previous !== 'string' || !HEX64.test(previous)) {
       fail('GATEWAY_HANDOFF_HMAC.previous, if present, must be a 64-char hex string');
     }
-    normalizedPrevious = previous;
+    normalizedPrevious = previous.toLowerCase();
   }
 
-  return { current, previous: normalizedPrevious };
+  // Normalize case on the way out. crypto.createHmac keys on UTF-8
+  // bytes, so a rotation that re-serializes the same logical key
+  // with different case ('A1B2…' → 'a1b2…') would silently break
+  // dual-accept across the rolling deploy: the active and standby
+  // would compute different HMACs for the same payload. Eliminating
+  // the case-as-identity hazard at the loader is cheaper than relying
+  // on operator discipline.
+  return { current: current.toLowerCase(), previous: normalizedPrevious };
 }
 
 module.exports = {

--- a/apps/discord/src/gateway-hmac-secret-loader.js
+++ b/apps/discord/src/gateway-hmac-secret-loader.js
@@ -1,0 +1,87 @@
+// Parses + validates the Pillar 3 control-channel HMAC secret.
+//
+// Wire shape: the SSM SecureString
+// `/${project}/GATEWAY_HANDOFF_HMAC` is injected by the ECS task-def
+// `secrets =` block as the env var `GATEWAY_HANDOFF_HMAC`. The decoded
+// value is the JSON string `{"current": "<hex>", "previous": "<hex>"}`
+// where each hex value is a 32-byte (64-char) HMAC-SHA256 key.
+// `previous` is optional — null/undefined/missing all mean "no
+// rotation window active" (single-key mode).
+//
+// Why hex-64 specifically:
+//   - `crypto.createHmac('sha256', secret)` accepts any string and
+//     keys on its UTF-8 bytes, so the gateway-hmac module itself
+//     does not enforce hex.
+//   - Operator tooling (rotation scripts, key generation,
+//     break-glass procedures) standardize on 64-char hex (i.e. 32
+//     raw bytes). Enforcing the shape at the loader is the
+//     single chokepoint where a malformed/short secret gets caught
+//     at boot rather than silently weakening the HMAC posture or
+//     surfacing as a baffling verify-mismatch in prod.
+//   - 32 bytes matches the SHA-256 block size; shorter keys
+//     would still HMAC but reduce the brute-force space.
+//
+// Failure mode: throw at boot. The caller (boot in index.js) wraps
+// this in the existing gracefulShutdown(1) path so the ECS task
+// exits with status 1 and the task definition's restart policy
+// surfaces it as a CrashLoopBackOff — the same posture every other
+// secret-misconfig in this app already has.
+
+const HEX64 = /^[0-9a-f]{64}$/i;
+
+function fail(reason) {
+  // Single error class so callers can pattern-match on .name if
+  // they need to distinguish boot-misconfig from runtime errors
+  // — production currently does not, but keeping the shape stable
+  // future-proofs the boot-fail observability work.
+  const err = new Error(`gateway-hmac-secret-loader: ${reason}`);
+  err.code = 'GATEWAY_HMAC_SECRET_MALFORMED';
+  throw err;
+}
+
+// `raw` is the env-var string — typically `process.env.GATEWAY_HANDOFF_HMAC`,
+// injected at task launch from SSM. Tests pass it directly to
+// avoid global env mutation. Returns `{current, previous}` ready
+// to forward to createGatewayHmac.
+function loadGatewayHmacSecret(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    fail('GATEWAY_HANDOFF_HMAC env var is empty or missing');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    // The raw value is a secret — never echo it into the error
+    // string. We surface ONLY the JSON.parse error message, which
+    // discloses the parse-failure position but not the bytes.
+    fail(`GATEWAY_HANDOFF_HMAC is not valid JSON: ${err.message}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail('GATEWAY_HANDOFF_HMAC must decode to a JSON object');
+  }
+
+  const { current, previous } = parsed;
+
+  if (typeof current !== 'string' || !HEX64.test(current)) {
+    fail('GATEWAY_HANDOFF_HMAC.current must be a 64-char hex string (32-byte HMAC key)');
+  }
+
+  // previous is optional. Accept null, undefined, or missing — all
+  // mean "single-key mode" (no active rotation window). Any other
+  // type is a config mistake worth failing on.
+  let normalizedPrevious = null;
+  if (previous != null) {
+    if (typeof previous !== 'string' || !HEX64.test(previous)) {
+      fail('GATEWAY_HANDOFF_HMAC.previous, if present, must be a 64-char hex string');
+    }
+    normalizedPrevious = previous;
+  }
+
+  return { current, previous: normalizedPrevious };
+}
+
+module.exports = {
+  loadGatewayHmacSecret,
+};

--- a/apps/discord/src/gateway-hmac-secret-loader.js
+++ b/apps/discord/src/gateway-hmac-secret-loader.js
@@ -51,11 +51,13 @@ function loadGatewayHmacSecret(raw) {
   let parsed;
   try {
     parsed = JSON.parse(raw);
-  } catch (err) {
-    // The raw value is a secret — never echo it into the error
-    // string. We surface ONLY the JSON.parse error message, which
-    // discloses the parse-failure position but not the bytes.
-    fail(`GATEWAY_HANDOFF_HMAC is not valid JSON: ${err.message}`);
+  } catch (_err) {
+    // The raw value is a secret — never echo it (or any prefix of it)
+    // into the error string. Node 19+ V8 JSON.parse error messages
+    // include a truncated snippet of the source: a misconfig where an
+    // operator pasted raw hex without JSON wrapping would otherwise
+    // leak the first ~13 hex chars of a 64-char key into CloudWatch.
+    fail('GATEWAY_HANDOFF_HMAC is not valid JSON (raw value omitted to avoid leaking the secret)');
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -714,8 +714,8 @@ function createGatewayLeader({
   // renew, heartbeat write, peer-cache refresh) would still report
   // healthy here. Acceptable for now — the 2 s renew + 60 s lock
   // TTL means a hung loop loses the lock to a peer's cold-acquire
-  // within ~1 min anyway. Follow-up to add a `lastTickAt`
-  // freshness check tracked in the post-13b.3 polish list.
+  // within ~1 min anyway. Tracked: issue #420 (lastTickAt
+  // freshness check follow-up).
   function hasStartedTickLoop() {
     return loopPromise !== null;
   }

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -702,14 +702,20 @@ function createGatewayLeader({
     return knownPeerInstanceIds.has(instanceId);
   }
 
-  // True once `start()` has spun up the tick loop and false again
-  // after `stop()` (or after pushHandoff sets `closed=true` and the
-  // loop drains). Consumed by index.js's /health probe on the
-  // standby path: a standby with no WS by design needs SOME liveness
-  // signal to keep ECS from replacing it, and "tick loop running"
-  // is the simplest correct one — if the loop dies, lock renew /
-  // heartbeat write / peer-cache refresh all stop, and the standby
-  // has lost the ability to take over on the next handoff.
+  // True when the tick loop has been started AND has not yet
+  // exited (loopPromise nulls itself via `.finally` when the loop
+  // returns — start-fail, stop(), or post-pushHandoff drain all
+  // clear it). Consumed by index.js's /health probe on the standby
+  // path so a standby that has no WS by design isn't reported as
+  // unhealthy.
+  //
+  // Limitation worth knowing: this is loop-exists, NOT loop-is-
+  // progressing. A tick wedged inside a hanging DDB call (lock
+  // renew, heartbeat write, peer-cache refresh) would still report
+  // healthy here. Acceptable for now — the 2 s renew + 60 s lock
+  // TTL means a hung loop loses the lock to a peer's cold-acquire
+  // within ~1 min anyway. Follow-up to add a `lastTickAt`
+  // freshness check tracked in the post-13b.3 polish list.
   function hasStartedTickLoop() {
     return loopPromise !== null;
   }

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -702,6 +702,18 @@ function createGatewayLeader({
     return knownPeerInstanceIds.has(instanceId);
   }
 
+  // True once `start()` has spun up the tick loop and false again
+  // after `stop()` (or after pushHandoff sets `closed=true` and the
+  // loop drains). Consumed by index.js's /health probe on the
+  // standby path: a standby with no WS by design needs SOME liveness
+  // signal to keep ECS from replacing it, and "tick loop running"
+  // is the simplest correct one — if the loop dies, lock renew /
+  // heartbeat write / peer-cache refresh all stop, and the standby
+  // has lost the ability to take over on the next handoff.
+  function hasStartedTickLoop() {
+    return loopPromise !== null;
+  }
+
   return {
     start,
     stop,
@@ -711,6 +723,7 @@ function createGatewayLeader({
     isHoldingLock,
     isConnecting,
     isKnownPeer,
+    hasStartedTickLoop,
     // Inspection seams for tests.
     _stepForTest: () => runSerialized('tick', step),
     _getKnownPeersForTest: () => new Set(knownPeerInstanceIds),

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -186,6 +186,13 @@ async function runPushHandoffShutdown({
     exit(forcedExitCode);
   }, ceilingMs);
   if (hardExit && typeof hardExit.unref === 'function') {
+    // `.unref()` so the timer can't pin shutdown past the explicit
+    // `exit()` below. Safe against "loop idles out early before
+    // the ceiling fires" because pushHandoff itself holds DDB +
+    // HTTP socket handles open during its await, and we exit
+    // synchronously after `await drainPromise` resolves — there's
+    // no window where the unref'd timer is the only loop handle
+    // before we call exit() explicitly.
     hardExit.unref();
   }
   // Kick the publisher drain in parallel — tryStop is null-safe,

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -77,25 +77,45 @@ async function tryClose(name, server, logger) {
 }
 
 // Push-handoff SIGTERM body. Distinct from gracefulShutdown because
-// the active replica's job is to transfer ownership ASAP — not drain
-// SQS / close DB / flush its own session row — the standby is already
-// doing all of that. Skipping `gatewayShim.stop()` here is load-
-// bearing: shim.stop()'s flushFinal=true would clobber the (newer)
-// session row that the standby has already advanced past our snapshot.
+// the active replica's job is to transfer ownership ASAP — not run
+// the full drain (close DB, flush its own session row, etc.) — the
+// standby is already doing the steady-state work. Three load-bearing
+// skips:
 //
-// The caller manages the `isShuttingDown` re-entry gate; this function
-// is purely "what runs inside the gate". Deps are injected so the
-// timeout / exit-code / handoff-result contracts are unit-testable
-// without process.exit side effects.
+//   * gatewayShim.stop() — flushFinal=true would clobber the (newer)
+//     session row the standby has advanced past our snapshot.
+//   * controlChannelServer close + leader/watchdog stop — leader's
+//     `closed=true` sentinel (set by pushHandoff itself) short-
+//     circuits any late inbound-handoff envelopes the still-listening
+//     server delivers in the ~ms window before process.exit fires.
+//     Calling tryClose/tryStop symmetrically would add latency to
+//     the active SIGTERM critical path with no correctness gain.
+//
+// One NON-skip: `eventPublisher.stop()` runs in parallel with
+// pushHandoff. The publisher's in-flight SQS sends are the outgoing
+// process's responsibility — those frames arrived on OUR WebSocket,
+// the standby cannot replay them. Draining in parallel (not before)
+// means the publisher's DRAIN_DEADLINE_MS doesn't extend the
+// pushHandoff critical path.
+//
+// The caller manages the `isShuttingDown` re-entry gate; this
+// function is purely "what runs inside the gate". Deps are injected
+// so the timeout / exit-code / handoff-result / drain contracts are
+// unit-testable without process.exit side effects.
 async function runPushHandoffShutdown({
   code = 0,
   gatewayLeader,
+  // Optional. When provided, `.stop()` runs in parallel with
+  // pushHandoff so in-flight SQS sends drain inside the 12 s ceiling
+  // instead of being truncated at process.exit. Production wires
+  // src/event-publisher.js; tests can omit or pass a spy.
+  eventPublisher = null,
   logger,
   ceilingMs = 12_000,
-  // Forced exit code when the outer ceiling fires. Hard-coded to 1
-  // (not the incoming `code`) so ECS / dashboards can distinguish
-  // "clean transfer, exit 0" from "timeout, standby cold-acquired,
-  // exit 1" even when the SIGTERM that triggered us was code 0.
+  // Forced exit code when the outer ceiling fires. Defaults to 1
+  // so ECS / dashboards can distinguish "clean transfer, exit 0"
+  // from "timeout, standby cold-acquired, exit 1" even when the
+  // SIGTERM that triggered us was code 0. Configurable for tests.
   forcedExitCode = 1,
   // Injected for tests; production uses node:timers + process.
   exit = (c) => process.exit(c),
@@ -109,6 +129,12 @@ async function runPushHandoffShutdown({
   if (hardExit && typeof hardExit.unref === 'function') {
     hardExit.unref();
   }
+  // Kick the publisher drain in parallel — tryStop is null-safe,
+  // catches both sync throws and async rejects, and harmonizes log
+  // shape with the rest of the shutdown surface. Capturing the
+  // promise (instead of awaiting here) lets pushHandoff run
+  // concurrently; we await both before exit below.
+  const drainPromise = tryStop('event-publisher', eventPublisher, logger);
   try {
     const result = await gatewayLeader.pushHandoff();
     logger.info('pushHandoff complete', {
@@ -122,6 +148,11 @@ async function runPushHandoffShutdown({
       error: err.message,
     });
   }
+  // Wait for the in-parallel publisher drain to finish before
+  // exit, so any SQS send that was almost-flushed gets its last
+  // round-trip. Best-effort; the outer ceiling absorbs the worst
+  // case.
+  await drainPromise;
   exit(code);
 }
 

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -62,6 +62,40 @@ async function tryStop(name, handle, logger) {
   }
 }
 
+// Waits for an http.Server-shaped handle to fire its `listening`
+// event, with three-way unwind: resolve on `listening`, reject on
+// `error`, reject on `close`. The `close` clause closes the
+// SIGTERM-during-listen-await hang: if gracefulShutdown calls
+// `server.close()` while we're still waiting for the listener to
+// come up, Node fires `close` (not `error` or `listening`) and the
+// Promise would otherwise hang until gracefulShutdown's force-exit
+// timer fires.
+//
+// Mutual listener removal — leaving idle `error → reject` /
+// `close → reject` listeners attached after a `listening` resolve
+// would surface unhandled rejections on every runtime listener-
+// error; the caller's `onListenError` hook routes those to
+// gracefulShutdown(1) and we don't need a duplicate path.
+function awaitServerListening(server) {
+  return new Promise((resolve, reject) => {
+    if (server.listening) {
+      resolve();
+      return;
+    }
+    const cleanup = () => {
+      server.off('listening', onListening);
+      server.off('error', onError);
+      server.off('close', onClose);
+    };
+    const onListening = () => { cleanup(); resolve(); };
+    const onError = (err) => { cleanup(); reject(err); };
+    const onClose = () => { cleanup(); reject(new Error('control-channel server closed before listening')); };
+    server.once('listening', onListening);
+    server.once('error', onError);
+    server.once('close', onClose);
+  });
+}
+
 // Symmetric to tryStop, but for net.Server-shaped handles (callback-
 // based close instead of Promise-based stop). Null-safe, awaits the
 // close callback, surfaces any close error at warn. Resolves cleanly
@@ -184,6 +218,7 @@ async function runPushHandoffShutdown({
 module.exports = {
   shouldUsePushHandoffShutdown,
   selectGatewayReadinessProbe,
+  awaitServerListening,
   tryStop,
   tryClose,
   runPushHandoffShutdown,

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -111,6 +111,11 @@ async function runPushHandoffShutdown({
   // src/event-publisher.js; tests can omit or pass a spy.
   eventPublisher = null,
   logger,
+  // 12 s = 9 s pushHandoff internal ceiling (enforced in
+  // gateway-leader.js's DEFAULT_INBOUND_CONNECT_TIMEOUT_MS /
+  // pushHandoff race) + ~3 s headroom for the post-handoff log,
+  // publisher drain, and process.exit unwind. Well under ECS's 30 s
+  // SIGTERM deadline.
   ceilingMs = 12_000,
   // Forced exit code when the outer ceiling fires. Defaults to 1
   // so ECS / dashboards can distinguish "clean transfer, exit 0"
@@ -120,6 +125,7 @@ async function runPushHandoffShutdown({
   // Injected for tests; production uses node:timers + process.
   exit = (c) => process.exit(c),
   scheduleHardExit = setTimeout,
+  clearHardExit = clearTimeout,
 }) {
   logger.info('Hot-standby shutdown initiated; attempting pushHandoff');
   const hardExit = scheduleHardExit(() => {
@@ -135,6 +141,13 @@ async function runPushHandoffShutdown({
   // promise (instead of awaiting here) lets pushHandoff run
   // concurrently; we await both before exit below.
   const drainPromise = tryStop('event-publisher', eventPublisher, logger);
+  // Track whether pushHandoff threw — we still exit (so the standby
+  // cold-acquires after lock TTL) but with `forcedExitCode` instead
+  // of the incoming `code` so deploy dashboards can distinguish three
+  // outcomes by exit code: clean transfer (code), pushHandoff threw
+  // (forcedExitCode), pushHandoff timed out (forcedExitCode, via the
+  // hard-exit timer above).
+  let handoffThrew = false;
   try {
     const result = await gatewayLeader.pushHandoff();
     logger.info('pushHandoff complete', {
@@ -144,6 +157,7 @@ async function runPushHandoffShutdown({
       pushReason: result?.pushReason,
     });
   } catch (err) {
+    handoffThrew = true;
     logger.error('pushHandoff threw — exiting anyway so the standby can cold-acquire', {
       error: err.message,
     });
@@ -153,7 +167,14 @@ async function runPushHandoffShutdown({
   // round-trip. Best-effort; the outer ceiling absorbs the worst
   // case.
   await drainPromise;
-  exit(code);
+  // Clear the hard-exit timer on the success path. In prod
+  // process.exit kills the process so the pending timer is moot
+  // (and .unref'd so it can't pin shutdown anyway), but a
+  // non-terminal injected `exit` (tests, future metric-emitting
+  // wrappers) would observe a spurious second exit-code-1 ~12 s
+  // later without this clear.
+  clearHardExit(hardExit);
+  exit(handoffThrew ? forcedExitCode : code);
 }
 
 module.exports = {

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -70,7 +70,11 @@ async function tryClose(name, server, logger) {
   if (!server) return;
   await new Promise(resolve => {
     server.close(err => {
-      if (err) logger.warn(`${name} close reported error`, { error: err.message });
+      // Stack alongside message — symmetric with tryStop. Most
+      // net.Server.close errors are low-information ("listener
+      // already detached"), but the next failure mode introduced
+      // here will benefit from the call-site trace.
+      if (err) logger.warn(`${name} close reported error`, { error: err.message, stack: err.stack });
       resolve();
     });
   });

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -137,6 +137,12 @@ async function tryClose(name, server, logger) {
 //     by the standby. Holding up SIGTERM for a Knex pool drain
 //     would extend the handoff critical path with no correctness
 //     gain.
+//   * eventConsumer — never runs on the gateway tier (isWorker is
+//     derived as isHttp && ENABLE_EVENT_SHIPPER, so hot-standby
+//     gateways have no consumer to drain). Skipped implicitly by
+//     never being constructed; called out here so a future role-
+//     shape refactor doesn't quietly re-introduce a consumer on
+//     the gateway path without re-thinking this list.
 //
 // One NON-skip: `eventPublisher.stop()` runs in parallel with
 // pushHandoff. The publisher's in-flight SQS sends are the outgoing

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -28,6 +28,9 @@ function selectGatewayReadinessProbe({
   client,
 }) {
   if (enableHotStandby) {
+    // gatewayShim is guaranteed non-null on this branch — the
+    // boot-requirements gate rejects hot-standby without RESUME
+    // (which requires the shim's construction). No null-check needed.
     return () => {
       const gatewayLeader = getGatewayLeader();
       if (!gatewayLeader) return false;
@@ -53,12 +56,79 @@ async function tryStop(name, handle, logger) {
   try {
     await handle.stop();
   } catch (err) {
-    logger.warn(`${name} stop failed`, { error: err.message });
+    // Include the stack so a stuck SIGTERM drain log has both the
+    // symptom and the call site.
+    logger.warn(`${name} stop failed`, { error: err.message, stack: err.stack });
   }
+}
+
+// Symmetric to tryStop, but for net.Server-shaped handles (callback-
+// based close instead of Promise-based stop). Null-safe, awaits the
+// close callback, surfaces any close error at warn. Resolves cleanly
+// in every case so teardown doesn't stall.
+async function tryClose(name, server, logger) {
+  if (!server) return;
+  await new Promise(resolve => {
+    server.close(err => {
+      if (err) logger.warn(`${name} close reported error`, { error: err.message });
+      resolve();
+    });
+  });
+}
+
+// Push-handoff SIGTERM body. Distinct from gracefulShutdown because
+// the active replica's job is to transfer ownership ASAP — not drain
+// SQS / close DB / flush its own session row — the standby is already
+// doing all of that. Skipping `gatewayShim.stop()` here is load-
+// bearing: shim.stop()'s flushFinal=true would clobber the (newer)
+// session row that the standby has already advanced past our snapshot.
+//
+// The caller manages the `isShuttingDown` re-entry gate; this function
+// is purely "what runs inside the gate". Deps are injected so the
+// timeout / exit-code / handoff-result contracts are unit-testable
+// without process.exit side effects.
+async function runPushHandoffShutdown({
+  code = 0,
+  gatewayLeader,
+  logger,
+  ceilingMs = 12_000,
+  // Forced exit code when the outer ceiling fires. Hard-coded to 1
+  // (not the incoming `code`) so ECS / dashboards can distinguish
+  // "clean transfer, exit 0" from "timeout, standby cold-acquired,
+  // exit 1" even when the SIGTERM that triggered us was code 0.
+  forcedExitCode = 1,
+  // Injected for tests; production uses node:timers + process.
+  exit = (c) => process.exit(c),
+  scheduleHardExit = setTimeout,
+}) {
+  logger.info('Hot-standby shutdown initiated; attempting pushHandoff');
+  const hardExit = scheduleHardExit(() => {
+    logger.error('PushHandoff shutdown timed out, forcing exit');
+    exit(forcedExitCode);
+  }, ceilingMs);
+  if (hardExit && typeof hardExit.unref === 'function') {
+    hardExit.unref();
+  }
+  try {
+    const result = await gatewayLeader.pushHandoff();
+    logger.info('pushHandoff complete', {
+      transferred: result?.transferred,
+      pushAcked: result?.pushAcked,
+      reason: result?.reason,
+      pushReason: result?.pushReason,
+    });
+  } catch (err) {
+    logger.error('pushHandoff threw — exiting anyway so the standby can cold-acquire', {
+      error: err.message,
+    });
+  }
+  exit(code);
 }
 
 module.exports = {
   shouldUsePushHandoffShutdown,
   selectGatewayReadinessProbe,
   tryStop,
+  tryClose,
+  runPushHandoffShutdown,
 };

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -1,0 +1,64 @@
+// Pure helpers for the Pillar 3 hot-standby gateway tier's shutdown
+// branching + /health probe selection. Extracted from index.js so the
+// contracts are unit-testable without the full bot bootstrap.
+
+// True when this replica's SIGTERM should invoke pushHandoff-then-exit
+// (active branch). Reads `gatewayLeader.isHoldingLock()` at call time
+// so an inbound handoff that already moved the lock to our peer
+// correctly routes us into gracefulShutdown instead.
+function shouldUsePushHandoffShutdown({ enableHotStandby, gatewayLeader }) {
+  if (!enableHotStandby) return false;
+  if (!gatewayLeader) return false;
+  return gatewayLeader.isHoldingLock();
+}
+
+// Returns the /health readiness probe closure for the gateway tier:
+// hot-standby = active reports shim.isReady, standby reports tick-loop
+// liveness; Pillar 2 = shim.isReady; legacy = client.isReady.
+//
+// `getGatewayLeader` is a callback (NOT the handle) because the probe
+// is wired before startHotStandby runs, when the leader is still null;
+// the callback closes over the caller's mutable binding so each probe
+// firing reads the current value.
+function selectGatewayReadinessProbe({
+  enableHotStandby,
+  enableGatewayResume,
+  gatewayShim,
+  getGatewayLeader,
+  client,
+}) {
+  if (enableHotStandby) {
+    return () => {
+      const gatewayLeader = getGatewayLeader();
+      if (!gatewayLeader) return false;
+      if (gatewayLeader.isHoldingLock()) {
+        return gatewayShim.isReady();
+      }
+      return gatewayLeader.hasStartedTickLoop();
+    };
+  }
+  if (enableGatewayResume && gatewayShim) {
+    return () => gatewayShim.isReady();
+  }
+  return () => client.isReady();
+}
+
+// Best-effort stop() invoker for shutdown teardown. Null-safe so
+// callers can pass a handle that was never constructed (e.g.
+// hot-standby off). Failures log at warn and resolve — teardown is
+// already on the failure path; a stop() error shouldn't stall the
+// rest of the drain.
+async function tryStop(name, handle, logger) {
+  if (!handle) return;
+  try {
+    await handle.stop();
+  } catch (err) {
+    logger.warn(`${name} stop failed`, { error: err.message });
+  }
+}
+
+module.exports = {
+  shouldUsePushHandoffShutdown,
+  selectGatewayReadinessProbe,
+  tryStop,
+};

--- a/apps/discord/src/gateway-shutdown-helpers.js
+++ b/apps/discord/src/gateway-shutdown-helpers.js
@@ -128,6 +128,15 @@ async function tryClose(name, server, logger) {
 //     server delivers in the ~ms window before process.exit fires.
 //     Calling tryClose/tryStop symmetrically would add latency to
 //     the active SIGTERM critical path with no correctness gain.
+//   * db.close() — the 12 s ceiling + process.exit() forces socket
+//     cleanup at the OS level. The active replica is not the system
+//     of record for any uncommitted DB state during the SIGTERM
+//     window: writes to qurl_bot_flow_state run on the worker tier
+//     (separate process), and the gateway's only DB interactions
+//     are lock / heartbeat reads that are idempotent and re-driven
+//     by the standby. Holding up SIGTERM for a Knex pool drain
+//     would extend the handoff critical path with no correctness
+//     gain.
 //
 // One NON-skip: `eventPublisher.stop()` runs in parallel with
 // pushHandoff. The publisher's in-flight SQS sends are the outgoing

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -203,13 +203,19 @@ function createGatewayWsShim({
       return store.hydrate();
     },
 
-    async start({ timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS } = {}) {
+    async start({ timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS, connect = true } = {}) {
       if (manager) {
         throw new Error('gateway-ws-shim: start() called twice (manager already constructed)');
       }
       if (stopped) {
         throw new Error('gateway-ws-shim: start() after stop() is unsupported');
       }
+      // `connect: false` is the Pillar 3 hot-standby seam: construct
+      // the manager + attach listeners without opening a WS, so both
+      // replicas can boot without racing to IDENTIFY against the same
+      // bot token (which Discord would resolve by flapping the session
+      // identity). The watchdog/leader drives manager.connect() later
+      // after winning the DDB lock or receiving an inbound handoff.
 
       // REST is lazy-constructed if the caller didn't inject one.
       // The single token-bound instance is reused by registerCommands
@@ -297,6 +303,10 @@ function createGatewayWsShim({
           error: error?.message ?? String(error),
         });
       });
+
+      if (!connect) {
+        return;
+      }
 
       // Race connect() against a deadline. Without this, an
       // unreachable Discord API would hang the boot indefinitely
@@ -404,10 +414,16 @@ function createGatewayWsShim({
       return restInstance;
     },
 
-    // ── Test-only inspection ──
-    _getManagerForTest() {
+    // Null until start() constructs the WebSocketManager. Pillar 3
+    // wiring (leader coordinator + connection watchdog) needs the
+    // manager handle to call .connect() / .isConnected() — exposed as
+    // a getter rather than a stored reference so callers always see
+    // the current value (the field is reassigned inside start()).
+    getManager() {
       return manager;
     },
+
+    // ── Test-only inspection ──
     _getIdentifyAttemptsForTest() {
       return identifyAttempts;
     },

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -12,6 +12,11 @@ const { createControlClient } = require('./gateway-control-client');
 const { createConnectionWatchdog } = require('./gateway-connection-watchdog');
 const { startControlChannelServer } = require('./gateway-control-channel');
 const { loadGatewayHmacSecret } = require('./gateway-hmac-secret-loader');
+const {
+  shouldUsePushHandoffShutdown,
+  selectGatewayReadinessProbe,
+  tryStop,
+} = require('./gateway-shutdown-helpers');
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
 const { handleFlowInteraction } = require('./flow-dispatch');
@@ -640,20 +645,6 @@ let gatewayHeartbeatTimer = null;
 let activeGuildCountTimer = null;
 let isShuttingDown = false;
 
-// Best-effort stop() invoker for shutdown teardown. Null-safe so
-// callers can pass a handle that was never constructed (e.g.
-// hot-standby off). Failures log at warn and resolve — teardown is
-// already on the failure path; a stop() error shouldn't stall the
-// rest of the drain.
-async function tryStop(name, handle) {
-  if (!handle) return;
-  try {
-    await handle.stop();
-  } catch (err) {
-    logger.warn(`${name} stop failed`, { error: err.message });
-  }
-}
-
 async function gracefulShutdown(code = 0) {
   if (isShuttingDown) return;
   isShuttingDown = true;
@@ -719,8 +710,8 @@ async function gracefulShutdown(code = 0) {
     // ECS rolling deploy). Neither is on the SIGTERM critical path
     // for Discord-session continuity because the active peer (if
     // any) owns the WS.
-    await tryStop('connection-watchdog', connectionWatchdog);
-    await tryStop('gateway-leader', gatewayLeader);
+    await tryStop('connection-watchdog', connectionWatchdog, logger);
+    await tryStop('gateway-leader', gatewayLeader, logger);
     if (controlChannelServer) {
       await new Promise(resolve => {
         controlChannelServer.close(err => {
@@ -796,8 +787,13 @@ async function pushHandoffShutdown(code = 0) {
   isShuttingDown = true;
   logger.info('Hot-standby shutdown initiated; attempting pushHandoff');
   const hardExit = setTimeout(() => {
+    // Force exit(1) on timeout — even when the SIGTERM that triggered
+    // us was code 0. A timed-out pushHandoff is a deploy-time failure
+    // (peer unreachable, hung connect, HMAC mismatch); dashboards and
+    // ECS observability need to distinguish "clean transfer" from
+    // "timeout, standby cold-acquired" via the exit code.
     logger.error('PushHandoff shutdown timed out, forcing exit');
-    process.exit(code);
+    process.exit(1);
   }, 12_000);
   hardExit.unref();
   try {
@@ -816,14 +812,16 @@ async function pushHandoffShutdown(code = 0) {
   process.exit(code);
 }
 
-// Handle shutdown signals. The hot-standby active replica takes the
-// pushHandoff path (transfer-then-exit); every other shape runs the
-// legacy gracefulShutdown drain. The branch reads the lock state at
-// signal time so an inbound handoff that already moved the lock onto
-// our peer doesn't drag us through pushHandoff when we have nothing
-// to push.
+// Handle shutdown signals. Branches between the pushHandoff path
+// (active replica with the lock) and the legacy gracefulShutdown
+// drain (every other shape). Decision is made via the pure helper
+// in gateway-shutdown-helpers so the branching contract is unit-
+// testable independent of the boot-state mutations here.
 function signalShutdown(code) {
-  if (config.ENABLE_GATEWAY_HOT_STANDBY && gatewayLeader && gatewayLeader.isHoldingLock()) {
+  if (shouldUsePushHandoffShutdown({
+    enableHotStandby: config.ENABLE_GATEWAY_HOT_STANDBY,
+    gatewayLeader,
+  })) {
     pushHandoffShutdown(code);
   } else {
     gracefulShutdown(code);
@@ -938,6 +936,18 @@ async function startHotStandby() {
     controlChannelServer.once('error', reject);
   });
 
+  // SIGTERM-during-boot race guard. If a signal landed while we were
+  // awaiting the `listening` event, gracefulShutdown has already
+  // started tearing down the partial state (it sees a non-null
+  // gatewayLeader + controlChannelServer because they're assigned
+  // synchronously above). Continuing past this point would call
+  // .start() on the leader / watchdog after their gracefulShutdown
+  // .stop() already ran, leaving an unsupervised tick loop that
+  // process.exit() doesn't reap until SIGKILL.
+  if (isShuttingDown) {
+    return;
+  }
+
   // Watchdog drives the active path's manager.connect() on lock
   // acquisition + monitors the connection during the active lifetime.
   // `releaseLock` is wired to leader.releaseLockForImmediateExit
@@ -1032,25 +1042,13 @@ async function start() {
     // (cold-start path) or on the first RESUMED dispatch (cross-
     // process resume path); both are equivalent for "health check
     // should pass."
-    // Hot-standby probe handles the active/standby split per-request
-    // so a lock flip (acquire / lose to a peer's pushHandoff) doesn't
-    // need a re-wire. Standby has no WS by design — tick-loop liveness
-    // is its readiness signal; without it, ECS would replace the
-    // standby on the first --start-period lapse.
-    let isReadyFn;
-    if (config.ENABLE_GATEWAY_HOT_STANDBY) {
-      isReadyFn = () => {
-        if (!gatewayLeader) return false; // Pre-startHotStandby window.
-        if (gatewayLeader.isHoldingLock()) {
-          return gatewayShim.isReady();
-        }
-        return gatewayLeader.hasStartedTickLoop();
-      };
-    } else if (config.ENABLE_GATEWAY_RESUME && gatewayShim) {
-      isReadyFn = () => gatewayShim.isReady();
-    } else {
-      isReadyFn = () => client.isReady();
-    }
+    const isReadyFn = selectGatewayReadinessProbe({
+      enableHotStandby: config.ENABLE_GATEWAY_HOT_STANDBY,
+      enableGatewayResume: config.ENABLE_GATEWAY_RESUME,
+      gatewayShim,
+      getGatewayLeader: () => gatewayLeader,
+      client,
+    });
     httpServer = startGatewayHealthServer(isReadyFn, () => {
       // Null out so gracefulShutdown doesn't try to .close() a server
       // that's in an error state. Covers both the listen-window race

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -16,6 +16,8 @@ const {
   shouldUsePushHandoffShutdown,
   selectGatewayReadinessProbe,
   tryStop,
+  tryClose,
+  runPushHandoffShutdown,
 } = require('./gateway-shutdown-helpers');
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
@@ -353,6 +355,21 @@ if (hotStandbyMissing.length > 0) {
   process.exit(1);
 }
 
+// Parse + validate the HMAC secret AT BOOT, not inside startHotStandby.
+// All hot-standby misconfigs (env-var presence AND secret-format validity)
+// surface upfront before any I/O — same posture as missingHotStandbyKeys.
+// Stashed in a module-level so startHotStandby can read the parsed value
+// without re-parsing (and without drifting if the parse logic changes).
+let gatewayHmacSecrets = null;
+if (config.ENABLE_GATEWAY_HOT_STANDBY) {
+  try {
+    gatewayHmacSecrets = loadGatewayHmacSecret(config.GATEWAY_HANDOFF_HMAC);
+  } catch (err) {
+    logger.error(err.message);
+    process.exit(1);
+  }
+}
+
 // Symmetric with the eventShipper check above — fail fast on
 // inconsistent flag-vs-secret state. The error message is the
 // operator-facing source of truth for the remediation steps.
@@ -659,14 +676,7 @@ async function gracefulShutdown(code = 0) {
     // process.exit() called immediately after would truncate OAuth callbacks
     // mid-flight and leave users with a consumed pending_link but no GitHub
     // link created.
-    if (httpServer) {
-      await new Promise(resolve => {
-        httpServer.close(err => {
-          if (err) logger.warn('HTTP server close reported error', { error: err.message });
-          resolve();
-        });
-      });
-    }
+    await tryClose('HTTP server', httpServer, logger);
     stopServerIntervals();
     // SQS consumer drain. Stops new ReceiveMessage calls, then
     // awaits the current poll iteration's in-flight `processMessage`
@@ -704,22 +714,19 @@ async function gracefulShutdown(code = 0) {
     // Pillar 3 standby-path teardown. Active replicas take the
     // pushHandoffShutdown branch instead; this code only runs when
     // hot-standby is off, OR hot-standby is on but THIS replica is
-    // the standby (no lock to push). Closing the leader first stops
-    // new heartbeat / renew writes; the control-channel server close
-    // is best-effort (the peer would also be exiting in a typical
-    // ECS rolling deploy). Neither is on the SIGTERM critical path
-    // for Discord-session continuity because the active peer (if
-    // any) owns the WS.
+    // the standby (no lock to push).
+    //
+    // Order matters: close the control-channel server FIRST so no
+    // late inbound handoff envelope can land on a half-stopped
+    // leader (handleInboundHandoff against a leader whose tick loop
+    // has already exited is technically a no-op, but the explicit
+    // ordering makes the no-inbound-during-teardown invariant load-
+    // bearing rather than incidental). Watchdog stops next so its
+    // tick can't fire a manager.connect() during teardown. Leader
+    // last so any in-flight tick observes running=false and exits.
+    await tryClose('control-channel server', controlChannelServer, logger);
     await tryStop('connection-watchdog', connectionWatchdog, logger);
     await tryStop('gateway-leader', gatewayLeader, logger);
-    if (controlChannelServer) {
-      await new Promise(resolve => {
-        controlChannelServer.close(err => {
-          if (err) logger.warn('control-channel server close reported error', { error: err.message });
-          resolve();
-        });
-      });
-    }
 
     // Discord client shutdown only meaningful when we're the gateway
     // role. HTTP-only replicas never called login(), so there's no
@@ -758,58 +765,14 @@ async function gracefulShutdown(code = 0) {
   process.exit(code);
 }
 
-// Hot-standby push-handoff shutdown path. Distinct from gracefulShutdown
-// because the active replica's job is to transfer ownership ASAP, not
-// drain SQS / close DB / flush its own session row — the standby is
-// already doing all of that.
-//
-// Skipping eventConsumer/publisher drain + db.close is intentional: this
-// process never owned the inbound interaction surface (it published
-// frames to SQS; the worker tier consumed them). Any in-flight publish
-// is bounded by SQS's at-least-once guarantee. The bot's at-least-once
-// semantics carry through.
-//
-// gatewayShim.stop() is also skipped on this path — load-bearing.
-// shim.stop()'s flushFinal=true writes our (now-stale) session row
-// to DDB; after pushHandoff the standby is the live WS and its
-// updates have already advanced the row past our snapshot. A late
-// flush here would clobber the newer state and the standby's next
-// dispatch would land with a wrong sequence (Discord buffer
-// invalidated). The TCP socket drops when process.exit() fires
-// below, which is exactly what the SIGTERM contract wants —
-// Discord treats it as a network disconnect, not a clean close.
-//
-// 12 s outer setTimeout = 9 s pushHandoff ceiling + ~3 s headroom for
-// the post-handoff log + process.exit unwind. Well under the 30 s ECS
-// SIGTERM deadline.
+// Hot-standby push-handoff SIGTERM path. The body lives in
+// `runPushHandoffShutdown` (gateway-shutdown-helpers.js) so the
+// timeout / exit-code / handoff-result contracts are unit-testable;
+// this wrapper owns the `isShuttingDown` re-entry gate.
 async function pushHandoffShutdown(code = 0) {
   if (isShuttingDown) return;
   isShuttingDown = true;
-  logger.info('Hot-standby shutdown initiated; attempting pushHandoff');
-  const hardExit = setTimeout(() => {
-    // Force exit(1) on timeout — even when the SIGTERM that triggered
-    // us was code 0. A timed-out pushHandoff is a deploy-time failure
-    // (peer unreachable, hung connect, HMAC mismatch); dashboards and
-    // ECS observability need to distinguish "clean transfer" from
-    // "timeout, standby cold-acquired" via the exit code.
-    logger.error('PushHandoff shutdown timed out, forcing exit');
-    process.exit(1);
-  }, 12_000);
-  hardExit.unref();
-  try {
-    const result = await gatewayLeader.pushHandoff();
-    logger.info('pushHandoff complete', {
-      transferred: result?.transferred,
-      pushAcked: result?.pushAcked,
-      reason: result?.reason,
-      pushReason: result?.pushReason,
-    });
-  } catch (err) {
-    logger.error('pushHandoff threw — exiting anyway so the standby can cold-acquire', {
-      error: err.message,
-    });
-  }
-  process.exit(code);
+  await runPushHandoffShutdown({ code, gatewayLeader, logger });
 }
 
 // Handle shutdown signals. Branches between the pushHandoff path
@@ -881,8 +844,9 @@ async function startHotStandby() {
     logger,
   });
 
-  const secrets = loadGatewayHmacSecret(config.GATEWAY_HANDOFF_HMAC);
-  const hmac = createGatewayHmac({ secrets, logger });
+  // Secrets were parsed + validated at module load (see boot chain
+  // adjacent to missingHotStandbyKeys). Read the stash here.
+  const hmac = createGatewayHmac({ secrets: gatewayHmacSecrets, logger });
 
   const controlClient = createControlClient({ hmac, logger });
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -796,6 +796,13 @@ function signalShutdown(code) {
   }
 }
 
+// SIGTERM/SIGINT can land BEFORE startHotStandby has assigned
+// `gatewayLeader` (e.g. ECS task replacement mid-boot, ctrl-c during
+// `npm start`). Applies to BOTH handlers below.
+// `shouldUsePushHandoffShutdown` handles the null-leader case by
+// falling through to gracefulShutdown — the contract is pinned by
+// the "returns false when leader is null" test in
+// gateway-shutdown-helpers.test.js.
 process.on('SIGTERM', () => {
   logger.info('Received SIGTERM');
   signalShutdown(0);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -802,27 +802,10 @@ async function pushHandoffShutdown(code = 0) {
 
 // Handle shutdown signals. Branches between the pushHandoff path
 // (active replica with the lock) and the legacy gracefulShutdown
-// drain (every other shape). Decision is made via the pure helper
-// in gateway-shutdown-helpers so the branching contract is unit-
-// testable independent of the boot-state mutations here.
-//
-// Async + .catch on the call sites — both shutdown branches are
-// async fire-and-forget from the signal handler. Either is supposed
-// to handle its own errors internally (both wrap their critical
-// work in try/catch), but a future refactor that introduces an
-// uncaught reject path (e.g., adds a new await above the try)
-// would otherwise surface as an unhandledRejection on the process.
-// The explicit .catch is defense-in-depth.
-//
-// No `code` parameter — both call sites always pass 0 (the signal
-// itself never carries a "fault" semantic; it's ECS asking us to
-// drain). The non-zero exit codes come from `runPushHandoffShutdown`
-// (pushHandoff threw / 12 s ceiling fired) or from explicit
-// `gracefulShutdown(1)` calls on the boot-failure / onListenError
-// paths. So in production the dual-knob `code` was always 0, and
-// the third observable outcome lives in the runPushHandoffShutdown
-// unit-test surface + the existing `gracefulShutdown(1)` direct
-// callers (boot-failure path, onListenError).
+// drain (every other shape). `shouldUsePushHandoffShutdown` handles
+// the null-leader case (SIGTERM during boot) by falling through to
+// gracefulShutdown — pinned by the "returns false when leader is
+// null" test in gateway-shutdown-helpers.test.js.
 async function signalShutdown() {
   if (shouldUsePushHandoffShutdown({
     enableHotStandby: config.ENABLE_GATEWAY_HOT_STANDBY,
@@ -834,28 +817,19 @@ async function signalShutdown() {
   }
 }
 
-// SIGTERM/SIGINT can land BEFORE startHotStandby has assigned
-// `gatewayLeader` (e.g. ECS task replacement mid-boot, ctrl-c during
-// `npm start`). Applies to BOTH handlers below.
-// `shouldUsePushHandoffShutdown` handles the null-leader case by
-// falling through to gracefulShutdown — the contract is pinned by
-// the "returns false when leader is null" test in
-// gateway-shutdown-helpers.test.js.
-process.on('SIGTERM', () => {
-  logger.info('Received SIGTERM');
-  signalShutdown().catch(err => {
-    logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
-    process.exit(1);
+// `.catch` is defense-in-depth: both shutdown branches handle their
+// own errors today, but a future refactor that introduces an
+// uncaught reject path would otherwise surface as an
+// unhandledRejection on the process.
+for (const sig of ['SIGTERM', 'SIGINT']) {
+  process.on(sig, () => {
+    logger.info(`Received ${sig}`);
+    signalShutdown().catch(err => {
+      logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
+      process.exit(1);
+    });
   });
-});
-
-process.on('SIGINT', () => {
-  logger.info('Received SIGINT');
-  signalShutdown().catch(err => {
-    logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
-    process.exit(1);
-  });
-});
+}
 
 // Pillar 3 hot-standby wiring. Called from start() AFTER the shim is
 // constructed and started in connect-deferred mode. Sequencing matters:

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -767,12 +767,17 @@ async function gracefulShutdown(code = 0) {
 
 // Hot-standby push-handoff SIGTERM path. The body lives in
 // `runPushHandoffShutdown` (gateway-shutdown-helpers.js) so the
-// timeout / exit-code / handoff-result contracts are unit-testable;
-// this wrapper owns the `isShuttingDown` re-entry gate.
+// timeout / exit-code / handoff-result / publisher-drain contracts
+// are unit-testable; this wrapper owns the `isShuttingDown` gate.
+//
+// eventPublisher is passed in so its DRAIN_DEADLINE_MS bounded
+// `.stop()` runs in parallel with pushHandoff — the outgoing
+// process's in-flight SQS sends carry dispatches the standby
+// can't replay (they arrived on OUR WebSocket).
 async function pushHandoffShutdown(code = 0) {
   if (isShuttingDown) return;
   isShuttingDown = true;
-  await runPushHandoffShutdown({ code, gatewayLeader, logger });
+  await runPushHandoffShutdown({ code, gatewayLeader, eventPublisher, logger });
 }
 
 // Handle shutdown signals. Branches between the pushHandoff path
@@ -896,8 +901,15 @@ async function startHotStandby() {
       resolve();
       return;
     }
-    controlChannelServer.once('listening', resolve);
-    controlChannelServer.once('error', reject);
+    // Remove the OTHER listener on first event — leaving an idle
+    // `error → reject` listener after resolve would .reject() on
+    // every runtime listener-error and surface a noisy
+    // unhandled-rejection (the onListenError handler already routes
+    // those to gracefulShutdown(1); we don't need a duplicate path).
+    const onListening = () => { controlChannelServer.off('error', onError); resolve(); };
+    const onError = (err) => { controlChannelServer.off('listening', onListening); reject(err); };
+    controlChannelServer.once('listening', onListening);
+    controlChannelServer.once('error', onError);
   });
 
   // SIGTERM-during-boot race guard. If a signal landed while we were

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -4,6 +4,14 @@ const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdow
 const { registerCommands, handleCommand } = require('./commands');
 const { createGatewayWsShim } = require('./gateway-ws-shim');
 const { createGatewaySessionStore } = require('./gateway-session-store');
+const { createGatewayLock } = require('./gateway-lock');
+const { createPeerHeartbeat } = require('./gateway-peer-heartbeat');
+const { createGatewayHmac } = require('./gateway-hmac');
+const { createGatewayLeader } = require('./gateway-leader');
+const { createControlClient } = require('./gateway-control-client');
+const { createConnectionWatchdog } = require('./gateway-connection-watchdog');
+const { startControlChannelServer } = require('./gateway-control-channel');
+const { loadGatewayHmacSecret } = require('./gateway-hmac-secret-loader');
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
 const { handleFlowInteraction } = require('./flow-dispatch');
@@ -20,6 +28,8 @@ const {
   missingMapCommandKeys,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
+  unsupportedRoleHotStandbyCombo,
+  missingHotStandbyKeys,
   shouldRegisterInteractionListener,
   resolveProcessRole,
 } = require('./boot-requirements');
@@ -312,6 +322,32 @@ if (roleResumeConflict) {
   process.exit(1);
 }
 
+// Pillar 3 hot-standby — sequenced AFTER unsupportedRoleResumeCombo
+// so an operator who turned both flags on but forgot the prerequisites
+// sees the RESUME-side fix first (the hot-standby gate then becomes a
+// derivative of "RESUME is on"). Same boot-fail shape as the others
+// above: log + exit(1), no partial-state teardown.
+const roleHotStandbyConflict = unsupportedRoleHotStandbyCombo(
+  PROCESS_ROLE,
+  config.ENABLE_GATEWAY_HOT_STANDBY,
+  config.ENABLE_GATEWAY_RESUME,
+);
+if (roleHotStandbyConflict) {
+  logger.error(roleHotStandbyConflict);
+  process.exit(1);
+}
+
+const hotStandbyMissing = missingHotStandbyKeys(config);
+if (hotStandbyMissing.length > 0) {
+  logger.error(
+    `ENABLE_GATEWAY_HOT_STANDBY=true but required env vars missing: ${hotStandbyMissing.join(', ')}. ` +
+    'INSTANCE_ID + INSTANCE_IP are injected by the ECS task-def from the task metadata endpoint; ' +
+    'GATEWAY_HANDOFF_HMAC is the SSM-decrypted JSON `{current, previous?}` secret. Verify the ' +
+    'qurl-integrations-infra/qurl-bot-discord/terraform/main.tf wiring and re-deploy.'
+  );
+  process.exit(1);
+}
+
 // Symmetric with the eventShipper check above — fail fast on
 // inconsistent flag-vs-secret state. The error message is the
 // operator-facing source of truth for the remediation steps.
@@ -349,6 +385,23 @@ const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 // tables) so a future env-name rename touches one var, not many.
 // Both this module and the qurl-integrations-infra qurl-bot-ddb
 // module pin the `gateway-session` suffix.
+// Pillar 3 hot-standby plumbing. These are constructed inside start()
+// — not here at module load — because the leader factory requires the
+// shim's WebSocketManager handle (`shim.getManager()`), which doesn't
+// exist until `await gatewayShim.start({ connect: false })` resolves.
+// We hoist the locals here so gracefulShutdown + SIGTERM branching can
+// see them. Both stay null when hot-standby is off.
+let gatewayLeader = null;
+let controlChannelServer = null;
+let connectionWatchdog = null;
+
+// Shared DDB client. Constructed at module load when ENABLE_GATEWAY_RESUME=true
+// so the Pillar 2 gateway-session store AND the Pillar 3 lock + peer-
+// heartbeat tables can share a single connection pool. Building two
+// clients would double the SDK's HTTPS keep-alive sockets to the
+// same DDB endpoint with no upside.
+let sharedGatewayDdbClient = null;
+
 let gatewayShim = null;
 if (isGateway && config.ENABLE_GATEWAY_RESUME) {
   // DDB_TABLE_PREFIX and AWS_REGION are validated upstream: the
@@ -364,11 +417,11 @@ if (isGateway && config.ENABLE_GATEWAY_RESUME) {
     region: awsRegion,
     ...(process.env.DDB_TEST_ENDPOINT ? { endpoint: process.env.DDB_TEST_ENDPOINT } : {}),
   });
-  const ddbClient = DynamoDBDocumentClient.from(rawDdbClient, {
+  sharedGatewayDdbClient = DynamoDBDocumentClient.from(rawDdbClient, {
     marshallOptions: { removeUndefinedValues: true },
   });
   const sessionStore = createGatewaySessionStore({
-    ddbClient,
+    ddbClient: sharedGatewayDdbClient,
     tableName: `${ddbTablePrefix}gateway-session`,
     shardId: config.SHARD_ID,
     logger,
@@ -587,6 +640,20 @@ let gatewayHeartbeatTimer = null;
 let activeGuildCountTimer = null;
 let isShuttingDown = false;
 
+// Best-effort stop() invoker for shutdown teardown. Null-safe so
+// callers can pass a handle that was never constructed (e.g.
+// hot-standby off). Failures log at warn and resolve — teardown is
+// already on the failure path; a stop() error shouldn't stall the
+// rest of the drain.
+async function tryStop(name, handle) {
+  if (!handle) return;
+  try {
+    await handle.stop();
+  } catch (err) {
+    logger.warn(`${name} stop failed`, { error: err.message });
+  }
+}
+
 async function gracefulShutdown(code = 0) {
   if (isShuttingDown) return;
   isShuttingDown = true;
@@ -643,6 +710,26 @@ async function gracefulShutdown(code = 0) {
     if (activeGuildCountTimer) {
       clearInterval(activeGuildCountTimer);
     }
+    // Pillar 3 standby-path teardown. Active replicas take the
+    // pushHandoffShutdown branch instead; this code only runs when
+    // hot-standby is off, OR hot-standby is on but THIS replica is
+    // the standby (no lock to push). Closing the leader first stops
+    // new heartbeat / renew writes; the control-channel server close
+    // is best-effort (the peer would also be exiting in a typical
+    // ECS rolling deploy). Neither is on the SIGTERM critical path
+    // for Discord-session continuity because the active peer (if
+    // any) owns the WS.
+    await tryStop('connection-watchdog', connectionWatchdog);
+    await tryStop('gateway-leader', gatewayLeader);
+    if (controlChannelServer) {
+      await new Promise(resolve => {
+        controlChannelServer.close(err => {
+          if (err) logger.warn('control-channel server close reported error', { error: err.message });
+          resolve();
+        });
+      });
+    }
+
     // Discord client shutdown only meaningful when we're the gateway
     // role. HTTP-only replicas never called login(), so there's no
     // WebSocket to close — discordShutdown() on an un-logged-in
@@ -680,16 +767,205 @@ async function gracefulShutdown(code = 0) {
   process.exit(code);
 }
 
-// Handle shutdown signals
+// Hot-standby push-handoff shutdown path. Distinct from gracefulShutdown
+// because the active replica's job is to transfer ownership ASAP, not
+// drain SQS / close DB / flush its own session row — the standby is
+// already doing all of that.
+//
+// Skipping eventConsumer/publisher drain + db.close is intentional: this
+// process never owned the inbound interaction surface (it published
+// frames to SQS; the worker tier consumed them). Any in-flight publish
+// is bounded by SQS's at-least-once guarantee. The bot's at-least-once
+// semantics carry through.
+//
+// gatewayShim.stop() is also skipped on this path — load-bearing.
+// shim.stop()'s flushFinal=true writes our (now-stale) session row
+// to DDB; after pushHandoff the standby is the live WS and its
+// updates have already advanced the row past our snapshot. A late
+// flush here would clobber the newer state and the standby's next
+// dispatch would land with a wrong sequence (Discord buffer
+// invalidated). The TCP socket drops when process.exit() fires
+// below, which is exactly what the SIGTERM contract wants —
+// Discord treats it as a network disconnect, not a clean close.
+//
+// 12 s outer setTimeout = 9 s pushHandoff ceiling + ~3 s headroom for
+// the post-handoff log + process.exit unwind. Well under the 30 s ECS
+// SIGTERM deadline.
+async function pushHandoffShutdown(code = 0) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  logger.info('Hot-standby shutdown initiated; attempting pushHandoff');
+  const hardExit = setTimeout(() => {
+    logger.error('PushHandoff shutdown timed out, forcing exit');
+    process.exit(code);
+  }, 12_000);
+  hardExit.unref();
+  try {
+    const result = await gatewayLeader.pushHandoff();
+    logger.info('pushHandoff complete', {
+      transferred: result?.transferred,
+      pushAcked: result?.pushAcked,
+      reason: result?.reason,
+      pushReason: result?.pushReason,
+    });
+  } catch (err) {
+    logger.error('pushHandoff threw — exiting anyway so the standby can cold-acquire', {
+      error: err.message,
+    });
+  }
+  process.exit(code);
+}
+
+// Handle shutdown signals. The hot-standby active replica takes the
+// pushHandoff path (transfer-then-exit); every other shape runs the
+// legacy gracefulShutdown drain. The branch reads the lock state at
+// signal time so an inbound handoff that already moved the lock onto
+// our peer doesn't drag us through pushHandoff when we have nothing
+// to push.
+function signalShutdown(code) {
+  if (config.ENABLE_GATEWAY_HOT_STANDBY && gatewayLeader && gatewayLeader.isHoldingLock()) {
+    pushHandoffShutdown(code);
+  } else {
+    gracefulShutdown(code);
+  }
+}
+
 process.on('SIGTERM', () => {
   logger.info('Received SIGTERM');
-  gracefulShutdown(0);
+  signalShutdown(0);
 });
 
 process.on('SIGINT', () => {
   logger.info('Received SIGINT');
-  gracefulShutdown(0);
+  signalShutdown(0);
 });
+
+// Pillar 3 hot-standby wiring. Called from start() AFTER the shim is
+// constructed and started in connect-deferred mode. Sequencing matters:
+//
+//   1. Construct lock + peer-heartbeat (DDB-backed, no manager dep).
+//   2. Load + validate the HMAC secret (JSON shape + hex format).
+//   3. Construct hmac, controlClient, leader (leader needs the manager
+//      handle from shim.getManager()).
+//   4. Start the control-channel HTTP server. AWAIT `listening` event
+//      before continuing — if we start the leader first, the peer could
+//      acquire the lock and pushHandoff to us before our listener is
+//      up, dropping the connection.
+//   5. Start the leader tick loop. The watchdog wakes inside the tick
+//      flow on the active path; standby just heartbeats and waits.
+//
+// Errors propagate to start().catch() → gracefulShutdown(1). Constructing
+// inside a single function (vs. spreading across start()) keeps the
+// chain of dependencies legible and the rollback ordering implicit.
+async function startHotStandby() {
+  const ddbTablePrefix = config.DDB_TABLE_PREFIX;
+  const lockTableName = `${ddbTablePrefix}gateway-lock`;
+  const peerHeartbeatTableName = `${ddbTablePrefix}gateway-peer-heartbeat`;
+  const lockHolder = `${config.SHARD_ID}#gateway`;
+
+  const lock = createGatewayLock({
+    ddbClient: sharedGatewayDdbClient,
+    tableName: lockTableName,
+    shardId: config.SHARD_ID,
+    instanceId: config.INSTANCE_ID,
+    lockHolder,
+    logger,
+  });
+
+  const peerHeartbeat = createPeerHeartbeat({
+    ddbClient: sharedGatewayDdbClient,
+    tableName: peerHeartbeatTableName,
+    instanceId: config.INSTANCE_ID,
+    ip: config.INSTANCE_IP,
+    port: config.GATEWAY_CONTROL_PORT,
+    shardId: config.SHARD_ID,
+    lockHolder,
+    logger,
+  });
+
+  const secrets = loadGatewayHmacSecret(config.GATEWAY_HANDOFF_HMAC);
+  const hmac = createGatewayHmac({ secrets, logger });
+
+  const controlClient = createControlClient({ hmac, logger });
+
+  const manager = gatewayShim.getManager();
+  if (!manager) {
+    // Belt-and-suspenders: shim.start({ connect: false }) constructs
+    // the manager synchronously inside its await, so by the time we
+    // get here it should always be non-null. If a future refactor
+    // moves construction later (e.g. lazy on first connect), this
+    // guard surfaces the wiring regression at boot rather than as a
+    // confusing leader-factory error.
+    throw new Error('startHotStandby: gatewayShim.getManager() returned null — shim.start() ordering regression');
+  }
+
+  gatewayLeader = createGatewayLeader({
+    lock,
+    peerHeartbeat,
+    controlClient,
+    manager,
+    selfInstanceId: config.INSTANCE_ID,
+    shardId: config.SHARD_ID,
+    logger,
+  });
+
+  // Wait for `listening` before starting the leader. server.listen()
+  // is async; if we don't await it, the leader can win the lock and
+  // its peer can pushHandoff to us before we accept TCP connections.
+  controlChannelServer = startControlChannelServer({
+    hmac,
+    selfInstanceId: config.INSTANCE_ID,
+    isKnownPeer: gatewayLeader.isKnownPeer,
+    onHandoff: gatewayLeader.handleInboundHandoff,
+    logger,
+    port: config.GATEWAY_CONTROL_PORT,
+    bindAddr: config.GATEWAY_CONTROL_BIND_ADDR,
+    onListenError: (err) => {
+      // Listener failure is fatal. The peer can't reach us, so no
+      // pushHandoff will succeed — we'd block the next deploy
+      // indefinitely. Route through gracefulShutdown(1) to clean up
+      // the leader / lock release / etc.
+      logger.error('control-channel listener fatal error; shutting down', { error: err.message });
+      gracefulShutdown(1);
+    },
+  });
+  await new Promise((resolve, reject) => {
+    if (controlChannelServer.listening) {
+      resolve();
+      return;
+    }
+    controlChannelServer.once('listening', resolve);
+    controlChannelServer.once('error', reject);
+  });
+
+  // Watchdog drives the active path's manager.connect() on lock
+  // acquisition + monitors the connection during the active lifetime.
+  // `releaseLock` is wired to leader.releaseLockForImmediateExit
+  // (not lock.releaseLock directly) so the watchdog's failure-replace
+  // path goes through the same serialization chain that pushHandoff /
+  // inbound-handoff use. Without this, the watchdog could release the
+  // lock concurrently with an in-flight transferLock and the DDB
+  // row would land in a state neither replica expects.
+  connectionWatchdog = createConnectionWatchdog({
+    manager,
+    isHoldingLock: gatewayLeader.isHoldingLock,
+    isConnecting: gatewayLeader.isConnecting,
+    releaseLock: gatewayLeader.releaseLockForImmediateExit,
+    deleteOwnRow: peerHeartbeat.deleteOwnRow,
+    logger,
+  });
+
+  gatewayLeader.start();
+  connectionWatchdog.start();
+
+  logger.info('Pillar 3 hot-standby wired', {
+    instanceId: config.INSTANCE_ID,
+    instanceIp: config.INSTANCE_IP,
+    controlPort: config.GATEWAY_CONTROL_PORT,
+    lockTable: lockTableName,
+    peerHeartbeatTable: peerHeartbeatTableName,
+  });
+}
 
 // Start everything
 async function start() {
@@ -756,9 +1032,25 @@ async function start() {
     // (cold-start path) or on the first RESUMED dispatch (cross-
     // process resume path); both are equivalent for "health check
     // should pass."
-    const isReadyFn = (config.ENABLE_GATEWAY_RESUME && gatewayShim)
-      ? () => gatewayShim.isReady()
-      : () => client.isReady();
+    // Hot-standby probe handles the active/standby split per-request
+    // so a lock flip (acquire / lose to a peer's pushHandoff) doesn't
+    // need a re-wire. Standby has no WS by design — tick-loop liveness
+    // is its readiness signal; without it, ECS would replace the
+    // standby on the first --start-period lapse.
+    let isReadyFn;
+    if (config.ENABLE_GATEWAY_HOT_STANDBY) {
+      isReadyFn = () => {
+        if (!gatewayLeader) return false; // Pre-startHotStandby window.
+        if (gatewayLeader.isHoldingLock()) {
+          return gatewayShim.isReady();
+        }
+        return gatewayLeader.hasStartedTickLoop();
+      };
+    } else if (config.ENABLE_GATEWAY_RESUME && gatewayShim) {
+      isReadyFn = () => gatewayShim.isReady();
+    } else {
+      isReadyFn = () => client.isReady();
+    }
     httpServer = startGatewayHealthServer(isReadyFn, () => {
       // Null out so gracefulShutdown doesn't try to .close() a server
       // that's in an error state. Covers both the listen-window race
@@ -840,9 +1132,24 @@ async function start() {
     logger.info('gateway-resume hydrate complete', {
       // Log "resume" vs "cold start" as an SLI — operators can
       // correlate restart frequency with successful-resume rate.
+      // Under hot-standby, the standby's hydrated mirror is largely
+      // wasted (any inbound push-handoff carries a fresh snapshot
+      // that replaces it). The boot sequence stays symmetric across
+      // active/standby so the hydrate path remains a single code path
+      // worth one log line for SLI parity.
       mode: hydrated ? 'resume' : 'cold-start',
     });
-    await gatewayShim.start();
+    // Under hot-standby, both replicas construct the manager + attach
+    // listeners but only the lock-holder calls manager.connect().
+    // gateway-leader (active path) and the inbound-handoff handler
+    // (standby-becoming-active path) drive connect() themselves —
+    // see gateway-ws-shim.js's `start({ connect })` comment for the
+    // session-flap hazard the seam prevents.
+    await gatewayShim.start({ connect: !config.ENABLE_GATEWAY_HOT_STANDBY });
+
+    if (config.ENABLE_GATEWAY_HOT_STANDBY && !isShuttingDown) {
+      await startHotStandby();
+    }
     // No equivalent of startGatewayHeartbeat / startActiveGuildCount
     // under the shim today — those probe discord.js Client's
     // WebSocketManager shape (client.ws.shards[*].lastPingTimestamp)

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -38,6 +38,7 @@ const {
   unsupportedRoleResumeCombo,
   unsupportedRoleHotStandbyCombo,
   missingHotStandbyKeys,
+  invalidHotStandbyValues,
   shouldRegisterInteractionListener,
   resolveProcessRole,
 } = require('./boot-requirements');
@@ -356,6 +357,14 @@ if (hotStandbyMissing.length > 0) {
   process.exit(1);
 }
 
+const hotStandbyInvalid = invalidHotStandbyValues(config);
+if (hotStandbyInvalid.length > 0) {
+  for (const problem of hotStandbyInvalid) {
+    logger.error(problem);
+  }
+  process.exit(1);
+}
+
 // Parse + validate the HMAC secret AT BOOT, not inside startHotStandby.
 // All hot-standby misconfigs (env-var presence AND secret-format validity)
 // surface upfront before any I/O — same posture as missingHotStandbyKeys.
@@ -408,22 +417,13 @@ const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 // tables) so a future env-name rename touches one var, not many.
 // Both this module and the qurl-integrations-infra qurl-bot-ddb
 // module pin the `gateway-session` suffix.
-// Pillar 3 hot-standby plumbing. These are constructed inside start()
-// — not here at module load — because the leader factory requires the
-// shim's WebSocketManager handle (`shim.getManager()`), which doesn't
-// exist until `await gatewayShim.start({ connect: false })` resolves.
-// We hoist the locals here so gracefulShutdown + SIGTERM branching can
-// see them. Both stay null when hot-standby is off.
-//
-// Concurrency invariant: these three `let`s are written only inside
-// `startHotStandby` (one ECS-task-lifetime initialization path) and
-// read from `gracefulShutdown` + the SIGTERM handler. Node's single
-// event loop guarantees read/write atomicity here — no two tasks
-// can be mid-mutation while a signal handler reads. The tryClose /
-// tryStop calls in gracefulShutdown are `!= null`-guarded, so a
-// SIGTERM landing mid-startHotStandby (before the assignment) is
-// safe; the `isShuttingDown` re-check after the listen-await closes
-// the inverse race (assignment done, but `.start()` not yet called).
+// Pillar 3 hot-standby plumbing. Constructed inside startHotStandby
+// (the leader factory needs the shim's WebSocketManager handle, which
+// only exists after `gatewayShim.start({ connect: false })` resolves).
+// Hoisted to module scope so gracefulShutdown + signal handlers can
+// see them; tryClose/tryStop are null-guarded so a SIGTERM mid-
+// construction is safe, and the `isShuttingDown` re-check in
+// startHotStandby closes the inverse race.
 let gatewayLeader = null;
 let controlChannelServer = null;
 let connectionWatchdog = null;
@@ -742,6 +742,14 @@ async function gracefulShutdown(code = 0) {
     // but skipping the gate would still pay 3 microtask hops per
     // teardown across every HTTP-only / combined replica that never
     // built the hot-standby surface.
+    //
+    // No per-call timeout on tryStop/tryClose: a wedged
+    // gatewayLeader.stop() (e.g., DDB hanging in the final renew)
+    // is bounded by the 10 s `force-exit` setTimeout at the top of
+    // this function — which itself sits inside ECS's 30 s SIGTERM
+    // deadline. That layered ceiling is the deliberate outermost
+    // belt; introducing a third per-call timeout here would just
+    // multiply the moving parts without changing the worst-case.
     if (config.ENABLE_GATEWAY_HOT_STANDBY) {
       await tryClose('control-channel server', controlChannelServer, logger);
       await tryStop('connection-watchdog', connectionWatchdog, logger);
@@ -794,18 +802,21 @@ async function gracefulShutdown(code = 0) {
 // `.stop()` runs in parallel with pushHandoff — the outgoing
 // process's in-flight SQS sends carry dispatches the standby
 // can't replay (they arrived on OUR WebSocket).
+//
+// Defaults left implicit (forcedExitCode=1, ceilingMs=12_000): the
+// 12 s ceiling = 9 s pushHandoff race + 3 s headroom, comfortably
+// inside ECS's 30 s SIGTERM-to-SIGKILL window. If that deadline
+// ever changes, runPushHandoffShutdown's DEFAULT_CEILING_MS is
+// the load-bearing knob to revisit.
 async function pushHandoffShutdown(code = 0) {
   if (isShuttingDown) return;
   isShuttingDown = true;
   await runPushHandoffShutdown({ code, gatewayLeader, eventPublisher, logger });
 }
 
-// Handle shutdown signals. Branches between the pushHandoff path
-// (active replica with the lock) and the legacy gracefulShutdown
-// drain (every other shape). `shouldUsePushHandoffShutdown` handles
-// the null-leader case (SIGTERM during boot) by falling through to
-// gracefulShutdown — pinned by the "returns false when leader is
-// null" test in gateway-shutdown-helpers.test.js.
+// SIGTERM during boot (gatewayLeader still null) falls through to
+// gracefulShutdown via shouldUsePushHandoffShutdown's null-leader
+// check — pinned in gateway-shutdown-helpers.test.js.
 async function signalShutdown() {
   if (shouldUsePushHandoffShutdown({
     enableHotStandby: config.ENABLE_GATEWAY_HOT_STANDBY,
@@ -817,10 +828,6 @@ async function signalShutdown() {
   }
 }
 
-// `.catch` is defense-in-depth: both shutdown branches handle their
-// own errors today, but a future refactor that introduces an
-// uncaught reject path would otherwise surface as an
-// unhandledRejection on the process.
 for (const sig of ['SIGTERM', 'SIGINT']) {
   process.on(sig, () => {
     logger.info(`Received ${sig}`);
@@ -852,6 +859,11 @@ async function startHotStandby() {
   const ddbTablePrefix = config.DDB_TABLE_PREFIX;
   const lockTableName = `${ddbTablePrefix}gateway-lock`;
   const peerHeartbeatTableName = `${ddbTablePrefix}gateway-peer-heartbeat`;
+  // `lockHolder` identifies the ROLE-owning entity (one shard, one
+  // gateway role), NOT the replica. Both active + standby replicas
+  // of the same shard share the same lockHolder string — replica
+  // disambiguation lives on `instanceId` (passed separately to the
+  // lock primitive, used in the heartbeat row + DDB CAS attribution).
   const lockHolder = `${config.SHARD_ID}#gateway`;
 
   const lock = createGatewayLock({
@@ -875,8 +887,17 @@ async function startHotStandby() {
   });
 
   // Secrets were parsed + validated at module load (see boot chain
-  // adjacent to missingHotStandbyKeys). Read the stash here.
+  // adjacent to missingHotStandbyKeys). Read the stash here, then
+  // scrub both the parsed-secret stash and the raw env value off
+  // `config` once createGatewayHmac has captured the material
+  // internally. Defense in depth against a heap dump (CloudWatch
+  // crash diagnostics, debugger attach, future memory-profiling
+  // tools) surfacing the key from a long-lived module-scope ref.
+  // The live HMAC instance still holds the strings for sign/verify
+  // — that's unavoidable — but the redundant references are not.
   const hmac = createGatewayHmac({ secrets: gatewayHmacSecrets, logger });
+  gatewayHmacSecrets = null;
+  delete config.GATEWAY_HANDOFF_HMAC;
 
   const controlClient = createControlClient({ hmac, logger });
 
@@ -918,11 +939,17 @@ async function startHotStandby() {
       // indefinitely. Route through gracefulShutdown(1) to clean up
       // the leader / lock release / etc.
       //
+      // Null out controlChannelServer so gracefulShutdown's
+      // `tryClose` skips a server that's in an error state.
+      // Mirrors the same defensive null-out in
+      // startGatewayHealthServer's error callback below.
+      //
       // `.catch` mirrors the SIGTERM/SIGINT handlers' defense-in-depth:
       // gracefulShutdown handles its own errors internally, but a
       // future refactor that introduces an uncaught reject path would
       // otherwise surface as an unhandledRejection on the process.
       logger.error('control-channel listener fatal error; shutting down', { error: err.message });
+      controlChannelServer = null;
       gracefulShutdown(1).catch(shutdownErr => {
         logger.error('gracefulShutdown rejected unexpectedly from onListenError', {
           error: shutdownErr.message, stack: shutdownErr.stack,
@@ -944,6 +971,13 @@ async function startHotStandby() {
   if (isShuttingDown) {
     return;
   }
+
+  // INVARIANT: no `await` below this guard. Everything from here to
+  // the function's return runs synchronously, so a SIGTERM can't
+  // preempt — the OS-level signal is queued until the JS micro-
+  // tasks settle and signalShutdown observes `isShuttingDown=true`
+  // via the `gracefulShutdown` re-entry gate. Adding an async hop
+  // here silently reopens the SIGTERM-mid-startup race.
 
   // Watchdog drives the active path's manager.connect() on lock
   // acquisition + monitors the connection during the active lifetime.

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -370,10 +370,15 @@ if (hotStandbyInvalid.length > 0) {
 // surface upfront before any I/O — same posture as missingHotStandbyKeys.
 // Stashed in a module-level so startHotStandby can read the parsed value
 // without re-parsing (and without drifting if the parse logic changes).
+//
+// `config.takeGatewayHandoffHmac()` reads the raw value from the
+// module-private binding in config.js and nulls that binding — see
+// the takeGatewayHandoffHmac definition for the heap-dump rationale.
+// Called once at boot here; calling again would return undefined.
 let gatewayHmacSecrets = null;
 if (config.ENABLE_GATEWAY_HOT_STANDBY) {
   try {
-    gatewayHmacSecrets = loadGatewayHmacSecret(config.GATEWAY_HANDOFF_HMAC);
+    gatewayHmacSecrets = loadGatewayHmacSecret(config.takeGatewayHandoffHmac());
   } catch (err) {
     logger.error(err.message);
     process.exit(1);
@@ -897,16 +902,15 @@ async function startHotStandby() {
 
   // Secrets were parsed + validated at module load (see boot chain
   // adjacent to missingHotStandbyKeys). Read the stash here, then
-  // scrub both the parsed-secret stash and the raw env value off
-  // `config` once createGatewayHmac has captured the material
-  // internally. Defense in depth against a heap dump (CloudWatch
-  // crash diagnostics, debugger attach, future memory-profiling
-  // tools) surfacing the key from a long-lived module-scope ref.
-  // The live HMAC instance still holds the strings for sign/verify
-  // — that's unavoidable — but the redundant references are not.
+  // null it once createGatewayHmac has captured the material
+  // internally. The raw env value is already unreachable — the
+  // one-shot config.takeGatewayHandoffHmac() at boot nulled the
+  // private binding in config.js — so nulling gatewayHmacSecrets
+  // here closes the remaining module-scope reference. The live
+  // HMAC instance still holds the strings for sign/verify (the
+  // only retained reference, unavoidable).
   const hmac = createGatewayHmac({ secrets: gatewayHmacSecrets, logger });
   gatewayHmacSecrets = null;
-  delete config.GATEWAY_HANDOFF_HMAC;
 
   const controlClient = createControlClient({ hmac, logger });
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -735,9 +735,18 @@ async function gracefulShutdown(code = 0) {
     // bearing rather than incidental). Watchdog stops next so its
     // tick can't fire a manager.connect() during teardown. Leader
     // last so any in-flight tick observes running=false and exits.
-    await tryClose('control-channel server', controlChannelServer, logger);
-    await tryStop('connection-watchdog', connectionWatchdog, logger);
-    await tryStop('gateway-leader', gatewayLeader, logger);
+    //
+    // Gated on ENABLE_GATEWAY_HOT_STANDBY for symmetry with the
+    // Pillar 2 shim block below: all three handles are null when
+    // hot-standby is off, so the tryClose/tryStop calls are no-ops,
+    // but skipping the gate would still pay 3 microtask hops per
+    // teardown across every HTTP-only / combined replica that never
+    // built the hot-standby surface.
+    if (config.ENABLE_GATEWAY_HOT_STANDBY) {
+      await tryClose('control-channel server', controlChannelServer, logger);
+      await tryStop('connection-watchdog', connectionWatchdog, logger);
+      await tryStop('gateway-leader', gatewayLeader, logger);
+    }
 
     // Discord client shutdown only meaningful when we're the gateway
     // role. HTTP-only replicas never called login(), so there's no
@@ -804,14 +813,24 @@ async function pushHandoffShutdown(code = 0) {
 // uncaught reject path (e.g., adds a new await above the try)
 // would otherwise surface as an unhandledRejection on the process.
 // The explicit .catch is defense-in-depth.
-async function signalShutdown(code) {
+//
+// No `code` parameter — both call sites always pass 0 (the signal
+// itself never carries a "fault" semantic; it's ECS asking us to
+// drain). The non-zero exit codes come from `runPushHandoffShutdown`
+// (pushHandoff threw / 12 s ceiling fired) or from explicit
+// `gracefulShutdown(1)` calls on the boot-failure / onListenError
+// paths. So in production the dual-knob `code` was always 0, and
+// the third observable outcome lives in the runPushHandoffShutdown
+// unit-test surface + the existing `gracefulShutdown(1)` direct
+// callers (boot-failure path, onListenError).
+async function signalShutdown() {
   if (shouldUsePushHandoffShutdown({
     enableHotStandby: config.ENABLE_GATEWAY_HOT_STANDBY,
     gatewayLeader,
   })) {
-    await pushHandoffShutdown(code);
+    await pushHandoffShutdown(0);
   } else {
-    await gracefulShutdown(code);
+    await gracefulShutdown(0);
   }
 }
 
@@ -822,20 +841,9 @@ async function signalShutdown(code) {
 // falling through to gracefulShutdown — the contract is pinned by
 // the "returns false when leader is null" test in
 // gateway-shutdown-helpers.test.js.
-//
-// `signalShutdown(0)` always passes 0 here — the signal received is
-// "container scheduled for replacement", which is a clean transfer,
-// not a fault. The non-zero exit codes (the `forcedExitCode` knob in
-// runPushHandoffShutdown) signal in-process failures: pushHandoff
-// threw, or the 12 s ceiling fired. So in production today the
-// three-outcome contract collapses to two observable outcomes
-// (0 = clean transfer, 1 = anything else). The third knob exists
-// for the unit-test surface and for the next caller that wants to
-// distinguish "explicit fault exit" from "signal-driven exit" (e.g.
-// a future health-probe-driven self-restart path).
 process.on('SIGTERM', () => {
   logger.info('Received SIGTERM');
-  signalShutdown(0).catch(err => {
+  signalShutdown().catch(err => {
     logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
     process.exit(1);
   });
@@ -843,7 +851,7 @@ process.on('SIGTERM', () => {
 
 process.on('SIGINT', () => {
   logger.info('Received SIGINT');
-  signalShutdown(0).catch(err => {
+  signalShutdown().catch(err => {
     logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
     process.exit(1);
   });
@@ -935,8 +943,18 @@ async function startHotStandby() {
       // pushHandoff will succeed — we'd block the next deploy
       // indefinitely. Route through gracefulShutdown(1) to clean up
       // the leader / lock release / etc.
+      //
+      // `.catch` mirrors the SIGTERM/SIGINT handlers' defense-in-depth:
+      // gracefulShutdown handles its own errors internally, but a
+      // future refactor that introduces an uncaught reject path would
+      // otherwise surface as an unhandledRejection on the process.
       logger.error('control-channel listener fatal error; shutting down', { error: err.message });
-      gracefulShutdown(1);
+      gracefulShutdown(1).catch(shutdownErr => {
+        logger.error('gracefulShutdown rejected unexpectedly from onListenError', {
+          error: shutdownErr.message, stack: shutdownErr.stack,
+        });
+        process.exit(1);
+      });
     },
   });
   await awaitServerListening(controlChannelServer);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -828,15 +828,24 @@ async function signalShutdown() {
   }
 }
 
-for (const sig of ['SIGTERM', 'SIGINT']) {
-  process.on(sig, () => {
-    logger.info(`Received ${sig}`);
-    signalShutdown().catch(err => {
-      logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
-      process.exit(1);
-    });
-  });
-}
+// SIGTERM vs SIGINT split: only SIGTERM routes through signalShutdown
+// → pushHandoffShutdown. SIGINT (dev ctrl-c, manual `kill -2` from an
+// operator) goes straight to plain gracefulShutdown. Triggering a
+// real DDB CAS + cross-AZ HTTP round-trip on a developer's ctrl-c
+// is overkill, and ECS sends SIGTERM for production replacement —
+// so push-handoff lives on the production-deploy signal exclusively.
+const onShutdownReject = (label) => (err) => {
+  logger.error(`${label} rejected unexpectedly`, { error: err.message, stack: err.stack });
+  process.exit(1);
+};
+process.on('SIGTERM', () => {
+  logger.info('Received SIGTERM');
+  signalShutdown().catch(onShutdownReject('signalShutdown'));
+});
+process.on('SIGINT', () => {
+  logger.info('Received SIGINT');
+  gracefulShutdown(0).catch(onShutdownReject('gracefulShutdown'));
+});
 
 // Pillar 3 hot-standby wiring. Called from start() AFTER the shim is
 // constructed and started in connect-deferred mode. Sequencing matters:

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -785,14 +785,22 @@ async function pushHandoffShutdown(code = 0) {
 // drain (every other shape). Decision is made via the pure helper
 // in gateway-shutdown-helpers so the branching contract is unit-
 // testable independent of the boot-state mutations here.
-function signalShutdown(code) {
+//
+// Async + .catch on the call sites — both shutdown branches are
+// async fire-and-forget from the signal handler. Either is supposed
+// to handle its own errors internally (both wrap their critical
+// work in try/catch), but a future refactor that introduces an
+// uncaught reject path (e.g., adds a new await above the try)
+// would otherwise surface as an unhandledRejection on the process.
+// The explicit .catch is defense-in-depth.
+async function signalShutdown(code) {
   if (shouldUsePushHandoffShutdown({
     enableHotStandby: config.ENABLE_GATEWAY_HOT_STANDBY,
     gatewayLeader,
   })) {
-    pushHandoffShutdown(code);
+    await pushHandoffShutdown(code);
   } else {
-    gracefulShutdown(code);
+    await gracefulShutdown(code);
   }
 }
 
@@ -805,12 +813,18 @@ function signalShutdown(code) {
 // gateway-shutdown-helpers.test.js.
 process.on('SIGTERM', () => {
   logger.info('Received SIGTERM');
-  signalShutdown(0);
+  signalShutdown(0).catch(err => {
+    logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
+    process.exit(1);
+  });
 });
 
 process.on('SIGINT', () => {
   logger.info('Received SIGINT');
-  signalShutdown(0);
+  signalShutdown(0).catch(err => {
+    logger.error('signalShutdown rejected unexpectedly', { error: err.message, stack: err.stack });
+    process.exit(1);
+  });
 });
 
 // Pillar 3 hot-standby wiring. Called from start() AFTER the shim is
@@ -948,6 +962,14 @@ async function startHotStandby() {
     logger,
   });
 
+  // gatewayLeader.start() and connectionWatchdog.start() are
+  // sync-by-design: each schedules its own tick loop via
+  // setTimeout, captures the loop promise in a closure (so it
+  // can be awaited by stop()), and returns. Awaiting here would
+  // hang — the loop only resolves on stop(). If a future refactor
+  // adds an async pre-flight (e.g., warming a connection), that
+  // pre-flight should resolve BEFORE `.start()` returns so any
+  // thrown error still routes through `start().catch()`.
   gatewayLeader.start();
   connectionWatchdog.start();
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -15,6 +15,7 @@ const { loadGatewayHmacSecret } = require('./gateway-hmac-secret-loader');
 const {
   shouldUsePushHandoffShutdown,
   selectGatewayReadinessProbe,
+  awaitServerListening,
   tryStop,
   tryClose,
   runPushHandoffShutdown,
@@ -413,6 +414,16 @@ const isWorker = isHttp && config.ENABLE_EVENT_SHIPPER;
 // exist until `await gatewayShim.start({ connect: false })` resolves.
 // We hoist the locals here so gracefulShutdown + SIGTERM branching can
 // see them. Both stay null when hot-standby is off.
+//
+// Concurrency invariant: these three `let`s are written only inside
+// `startHotStandby` (one ECS-task-lifetime initialization path) and
+// read from `gracefulShutdown` + the SIGTERM handler. Node's single
+// event loop guarantees read/write atomicity here — no two tasks
+// can be mid-mutation while a signal handler reads. The tryClose /
+// tryStop calls in gracefulShutdown are `!= null`-guarded, so a
+// SIGTERM landing mid-startHotStandby (before the assignment) is
+// safe; the `isShuttingDown` re-check after the listen-await closes
+// the inverse race (assignment done, but `.start()` not yet called).
 let gatewayLeader = null;
 let controlChannelServer = null;
 let connectionWatchdog = null;
@@ -811,6 +822,17 @@ async function signalShutdown(code) {
 // falling through to gracefulShutdown — the contract is pinned by
 // the "returns false when leader is null" test in
 // gateway-shutdown-helpers.test.js.
+//
+// `signalShutdown(0)` always passes 0 here — the signal received is
+// "container scheduled for replacement", which is a clean transfer,
+// not a fault. The non-zero exit codes (the `forcedExitCode` knob in
+// runPushHandoffShutdown) signal in-process failures: pushHandoff
+// threw, or the 12 s ceiling fired. So in production today the
+// three-outcome contract collapses to two observable outcomes
+// (0 = clean transfer, 1 = anything else). The third knob exists
+// for the unit-test surface and for the next caller that wants to
+// distinguish "explicit fault exit" from "signal-driven exit" (e.g.
+// a future health-probe-driven self-restart path).
 process.on('SIGTERM', () => {
   logger.info('Received SIGTERM');
   signalShutdown(0).catch(err => {
@@ -917,21 +939,7 @@ async function startHotStandby() {
       gracefulShutdown(1);
     },
   });
-  await new Promise((resolve, reject) => {
-    if (controlChannelServer.listening) {
-      resolve();
-      return;
-    }
-    // Remove the OTHER listener on first event — leaving an idle
-    // `error → reject` listener after resolve would .reject() on
-    // every runtime listener-error and surface a noisy
-    // unhandled-rejection (the onListenError handler already routes
-    // those to gracefulShutdown(1); we don't need a duplicate path).
-    const onListening = () => { controlChannelServer.off('error', onError); resolve(); };
-    const onError = (err) => { controlChannelServer.off('listening', onListening); reject(err); };
-    controlChannelServer.once('listening', onListening);
-    controlChannelServer.once('error', onError);
-  });
+  await awaitServerListening(controlChannelServer);
 
   // SIGTERM-during-boot race guard. If a signal landed while we were
   // awaiting the `listening` event, gracefulShutdown has already

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -21,6 +21,7 @@ const {
   unsupportedRoleResumeCombo,
   unsupportedRoleHotStandbyCombo,
   missingHotStandbyKeys,
+  invalidHotStandbyValues,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
@@ -503,5 +504,83 @@ describe('missingHotStandbyKeys', () => {
       GATEWAY_HANDOFF_HMAC: undefined,
     }));
     expect(missing).toEqual(['INSTANCE_ID', 'INSTANCE_IP', 'GATEWAY_HANDOFF_HMAC']);
+  });
+});
+
+describe('invalidHotStandbyValues', () => {
+  function cfg(overrides = {}) {
+    return {
+      ENABLE_GATEWAY_HOT_STANDBY: true,
+      INSTANCE_ID: 'task-abc-123',
+      INSTANCE_IP: '10.0.1.42',
+      ...overrides,
+    };
+  }
+
+  it('returns empty when the flag is off (no shape requirements)', () => {
+    expect(invalidHotStandbyValues({
+      ENABLE_GATEWAY_HOT_STANDBY: false,
+      INSTANCE_ID: '${LITERALLY_UNRESOLVED}',
+      INSTANCE_IP: 'not-an-ip',
+    })).toEqual([]);
+  });
+
+  it('returns empty when both values are well-shaped', () => {
+    expect(invalidHotStandbyValues(cfg())).toEqual([]);
+  });
+
+  it('flags unsubstituted template literal in INSTANCE_ID — the ECS task-def footgun', () => {
+    // The specific scenario: a task-def with
+    // `INSTANCE_ID: "${ECS_TASK_ARN}"` that the metadata-resolution
+    // layer fails to substitute. Without this check the literal
+    // `${ECS_TASK_ARN}` would key the lock + heartbeat rows and
+    // every replica would think it owns the same identifier.
+    const problems = invalidHotStandbyValues(cfg({ INSTANCE_ID: '${ECS_TASK_ARN}' }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/INSTANCE_ID looks like an unsubstituted template literal/);
+    expect(problems[0]).toContain('${ECS_TASK_ARN}');
+  });
+
+  it('flags non-IPv4 INSTANCE_IP (string)', () => {
+    const problems = invalidHotStandbyValues(cfg({ INSTANCE_IP: 'not-an-ip' }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/INSTANCE_IP must be a valid IPv4 address/);
+    expect(problems[0]).toContain("'not-an-ip'");
+  });
+
+  it('flags out-of-range octets in INSTANCE_IP (10.0.0.999)', () => {
+    const problems = invalidHotStandbyValues(cfg({ INSTANCE_IP: '10.0.0.999' }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('10.0.0.999');
+  });
+
+  it('flags IPv6 INSTANCE_IP (out of scope for Pillar 3)', () => {
+    const problems = invalidHotStandbyValues(cfg({ INSTANCE_IP: '::1' }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/must be a valid IPv4/);
+  });
+
+  it('accepts every octet boundary (0, 9, 10, 99, 100, 199, 200, 249, 255)', () => {
+    const ips = ['0.0.0.0', '255.255.255.255', '10.99.100.249', '1.9.199.200'];
+    for (const ip of ips) {
+      expect(invalidHotStandbyValues(cfg({ INSTANCE_IP: ip }))).toEqual([]);
+    }
+  });
+
+  it('reports every problem on a single call (one-shot operator remediation)', () => {
+    const problems = invalidHotStandbyValues(cfg({
+      INSTANCE_ID: '${ECS_TASK_ARN}',
+      INSTANCE_IP: '999.999.999.999',
+    }));
+    expect(problems).toHaveLength(2);
+  });
+
+  it('does not trip on present-but-empty INSTANCE_IP (the missingHotStandbyKeys check catches that)', () => {
+    // Separation of concerns: missing-key checks are presence-only,
+    // shape checks only run on present values. An empty string is
+    // "missing" from the perspective of the upstream check and is
+    // skipped here to avoid duplicate operator-facing messages.
+    expect(invalidHotStandbyValues(cfg({ INSTANCE_IP: '' }))).toEqual([]);
+    expect(invalidHotStandbyValues(cfg({ INSTANCE_ID: '' }))).toEqual([]);
   });
 });

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -493,11 +493,15 @@ describe('missingHotStandbyKeys', () => {
   });
 
   it('returns every missing key (not just the first) for one-shot remediation', () => {
+    // Order is the function's natural push order (INSTANCE_ID,
+    // INSTANCE_IP, GATEWAY_HANDOFF_HMAC); pinning it documents that
+    // contract so a refactor that reorders the pushes flags the
+    // operator-facing log-message ordering as a change.
     const missing = missingHotStandbyKeys(cfg({
       INSTANCE_ID: undefined,
       INSTANCE_IP: undefined,
       GATEWAY_HANDOFF_HMAC: undefined,
     }));
-    expect(missing.sort()).toEqual(['GATEWAY_HANDOFF_HMAC', 'INSTANCE_ID', 'INSTANCE_IP']);
+    expect(missing).toEqual(['INSTANCE_ID', 'INSTANCE_IP', 'GATEWAY_HANDOFF_HMAC']);
   });
 });

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -560,6 +560,19 @@ describe('invalidHotStandbyValues', () => {
     expect(problems[0]).toMatch(/must be a valid IPv4/);
   });
 
+  it('flags leading-zero IPv4 octets (octal-parse hazard under some resolvers)', () => {
+    // `01.02.03.04` parses as octal under glibc's `inet_aton` and a
+    // handful of resolvers — a typo'd "010.0.0.1" would resolve as
+    // 8.0.0.1, silently routing the control channel to a wrong host.
+    // The closed-door fix is to require canonical no-leading-zero
+    // octets, which the ECS task-def injection always produces.
+    for (const ip of ['01.0.0.1', '10.01.0.1', '10.0.01.1', '10.0.0.01']) {
+      const problems = invalidHotStandbyValues(cfg({ INSTANCE_IP: ip }));
+      expect(problems).toHaveLength(1);
+      expect(problems[0]).toMatch(/must be a valid IPv4/);
+    }
+  });
+
   it('accepts every octet boundary (0, 9, 10, 99, 100, 199, 200, 249, 255)', () => {
     const ips = ['0.0.0.0', '255.255.255.255', '10.99.100.249', '1.9.199.200'];
     for (const ip of ips) {

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -19,6 +19,8 @@ const {
   missingEventShipperKeys,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
+  unsupportedRoleHotStandbyCombo,
+  missingHotStandbyKeys,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
@@ -397,5 +399,105 @@ describe('resolveProcessRole', () => {
     // 'GATEWAY' should fail loud, not silently coerce.
     expect(() => resolveProcessRole('GATEWAY')).toThrow(/GATEWAY/);
     expect(() => resolveProcessRole('Combined')).toThrow(/Combined/);
+  });
+});
+
+describe('unsupportedRoleHotStandbyCombo', () => {
+  it('returns null when hot-standby=false regardless of other inputs', () => {
+    for (const role of ['combined', 'gateway', 'http']) {
+      for (const resume of [true, false]) {
+        expect(unsupportedRoleHotStandbyCombo(role, false, resume)).toBeNull();
+      }
+    }
+  });
+
+  it('rejects hot-standby=true on combined role with operator-facing remediation', () => {
+    const msg = unsupportedRoleHotStandbyCombo('combined', true, true);
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/ENABLE_GATEWAY_HOT_STANDBY=true/);
+    expect(msg).toMatch(/PROCESS_ROLE=gateway/);
+    // Names the actual role so an operator pasting the log line into
+    // a ticket sees their misconfiguration immediately.
+    expect(msg).toMatch(/'combined'/);
+  });
+
+  it('rejects hot-standby=true on http role', () => {
+    const msg = unsupportedRoleHotStandbyCombo('http', true, true);
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/'http'/);
+    expect(msg).toMatch(/no manager to hand off/);
+  });
+
+  it('rejects hot-standby=true with resume=false (would session-flap)', () => {
+    // The push-handoff path adopts the outgoing leader's
+    // session_id+sequence on the standby — without RESUME, the
+    // standby would IDENTIFY against the same token and Discord
+    // would flap the session identity.
+    const msg = unsupportedRoleHotStandbyCombo('gateway', true, false);
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/requires ENABLE_GATEWAY_RESUME=true/);
+    expect(msg).toMatch(/flap the session/);
+  });
+
+  it('returns null on the supported combo (gateway + resume + hot-standby)', () => {
+    expect(unsupportedRoleHotStandbyCombo('gateway', true, true)).toBeNull();
+  });
+
+  it('sequences role check before resume check (operator sees the dominant fix first)', () => {
+    // combined+hot-standby+resume-off is doubly broken. The role
+    // check fires first because PROCESS_ROLE is the higher-order
+    // misconfig — fixing the role + leaving resume off would leave
+    // the second rejection still firing; fixing resume + leaving
+    // combined would re-fire the role rejection. Sequencing the
+    // role check first means the first redeploy lands the higher-
+    // order fix.
+    const msg = unsupportedRoleHotStandbyCombo('combined', true, false);
+    expect(msg).toMatch(/PROCESS_ROLE=gateway/);
+    expect(msg).not.toMatch(/ENABLE_GATEWAY_RESUME=true/);
+  });
+});
+
+describe('missingHotStandbyKeys', () => {
+  function cfg(overrides = {}) {
+    return {
+      ENABLE_GATEWAY_HOT_STANDBY: true,
+      INSTANCE_ID: 'task-abc-123',
+      INSTANCE_IP: '10.0.1.42',
+      GATEWAY_HANDOFF_HMAC: '{"current":"' + 'a'.repeat(64) + '"}',
+      ...overrides,
+    };
+  }
+
+  it('returns empty when the flag is off (no requirements)', () => {
+    expect(missingHotStandbyKeys({
+      ENABLE_GATEWAY_HOT_STANDBY: false,
+      // Everything else unset — must still be empty.
+    })).toEqual([]);
+  });
+
+  it('returns empty when every required key is present', () => {
+    expect(missingHotStandbyKeys(cfg())).toEqual([]);
+  });
+
+  it('surfaces missing INSTANCE_ID', () => {
+    expect(missingHotStandbyKeys(cfg({ INSTANCE_ID: undefined }))).toEqual(['INSTANCE_ID']);
+  });
+
+  it('surfaces missing INSTANCE_IP', () => {
+    expect(missingHotStandbyKeys(cfg({ INSTANCE_IP: null }))).toEqual(['INSTANCE_IP']);
+  });
+
+  it('surfaces missing GATEWAY_HANDOFF_HMAC', () => {
+    expect(missingHotStandbyKeys(cfg({ GATEWAY_HANDOFF_HMAC: '' })))
+      .toEqual(['GATEWAY_HANDOFF_HMAC']);
+  });
+
+  it('returns every missing key (not just the first) for one-shot remediation', () => {
+    const missing = missingHotStandbyKeys(cfg({
+      INSTANCE_ID: undefined,
+      INSTANCE_IP: undefined,
+      GATEWAY_HANDOFF_HMAC: undefined,
+    }));
+    expect(missing.sort()).toEqual(['GATEWAY_HANDOFF_HMAC', 'INSTANCE_ID', 'INSTANCE_IP']);
   });
 });

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -464,7 +464,7 @@ describe('missingHotStandbyKeys', () => {
       ENABLE_GATEWAY_HOT_STANDBY: true,
       INSTANCE_ID: 'task-abc-123',
       INSTANCE_IP: '10.0.1.42',
-      GATEWAY_HANDOFF_HMAC: '{"current":"' + 'a'.repeat(64) + '"}',
+      hasGatewayHandoffHmac: true,
       ...overrides,
     };
   }
@@ -488,8 +488,11 @@ describe('missingHotStandbyKeys', () => {
     expect(missingHotStandbyKeys(cfg({ INSTANCE_IP: null }))).toEqual(['INSTANCE_IP']);
   });
 
-  it('surfaces missing GATEWAY_HANDOFF_HMAC', () => {
-    expect(missingHotStandbyKeys(cfg({ GATEWAY_HANDOFF_HMAC: '' })))
+  it('surfaces missing GATEWAY_HANDOFF_HMAC (via hasGatewayHandoffHmac flag)', () => {
+    // The presence check reads `hasGatewayHandoffHmac` (boolean) rather
+    // than the raw secret string — see config.js's
+    // `takeGatewayHandoffHmac` for the heap-dump security rationale.
+    expect(missingHotStandbyKeys(cfg({ hasGatewayHandoffHmac: false })))
       .toEqual(['GATEWAY_HANDOFF_HMAC']);
   });
 
@@ -501,7 +504,7 @@ describe('missingHotStandbyKeys', () => {
     const missing = missingHotStandbyKeys(cfg({
       INSTANCE_ID: undefined,
       INSTANCE_IP: undefined,
-      GATEWAY_HANDOFF_HMAC: undefined,
+      hasGatewayHandoffHmac: false,
     }));
     expect(missing).toEqual(['INSTANCE_ID', 'INSTANCE_IP', 'GATEWAY_HANDOFF_HMAC']);
   });

--- a/apps/discord/tests/config-take-gateway-handoff-hmac.test.js
+++ b/apps/discord/tests/config-take-gateway-handoff-hmac.test.js
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for config.takeGatewayHandoffHmac (apps/discord/src/config.js).
+ *
+ * The one-shot getter is defense in depth against heap-dump key
+ * exposure. After the first call, the raw GATEWAY_HANDOFF_HMAC
+ * string must be unreachable through any reference in the config
+ * module — `config.GATEWAY_HANDOFF_HMAC` no longer exists, the
+ * module-private binding is nulled, and a second call returns
+ * undefined.
+ *
+ * Each test uses jest.isolateModules to get a fresh config module
+ * (with a fresh module-private binding) so the one-shot semantics
+ * don't bleed across tests.
+ */
+
+function withFreshConfig(envValue, run) {
+  jest.isolateModules(() => {
+    const prev = process.env.GATEWAY_HANDOFF_HMAC;
+    if (envValue === undefined) {
+      delete process.env.GATEWAY_HANDOFF_HMAC;
+    } else {
+      process.env.GATEWAY_HANDOFF_HMAC = envValue;
+    }
+    try {
+      const config = require('../src/config');
+      run(config);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.GATEWAY_HANDOFF_HMAC;
+      } else {
+        process.env.GATEWAY_HANDOFF_HMAC = prev;
+      }
+    }
+  });
+}
+
+describe('config.takeGatewayHandoffHmac (one-shot getter)', () => {
+  it('returns the raw env value on first call', () => {
+    const raw = '{"current":"' + 'a'.repeat(64) + '"}';
+    withFreshConfig(raw, (config) => {
+      expect(config.takeGatewayHandoffHmac()).toBe(raw);
+    });
+  });
+
+  it('returns undefined on second call (binding nulled)', () => {
+    // The load-bearing contract. After consumption, the secret string
+    // is unreachable through the config module — a callback that
+    // captures the config object at require-time and re-reads later
+    // would get undefined, NOT a stale captured copy.
+    const raw = '{"current":"' + 'b'.repeat(64) + '"}';
+    withFreshConfig(raw, (config) => {
+      expect(config.takeGatewayHandoffHmac()).toBe(raw);
+      expect(config.takeGatewayHandoffHmac()).toBeUndefined();
+      expect(config.takeGatewayHandoffHmac()).toBeUndefined();
+    });
+  });
+
+  it('returns undefined immediately when env var is unset', () => {
+    withFreshConfig(undefined, (config) => {
+      expect(config.takeGatewayHandoffHmac()).toBeUndefined();
+    });
+  });
+
+  it('returns empty string on first call when env var is set to empty string', () => {
+    // The env-var-present check (missingHotStandbyKeys → hasGatewayHandoffHmac)
+    // is what rejects an empty value at boot; the getter itself
+    // doesn't filter empty strings. Pin the contract so a future
+    // refactor that adds empty-string filtering here doesn't
+    // silently shift the "missing" semantic.
+    withFreshConfig('', (config) => {
+      expect(config.takeGatewayHandoffHmac()).toBe('');
+      expect(config.takeGatewayHandoffHmac()).toBeUndefined();
+    });
+  });
+
+  it('does NOT expose the raw value as a config-object property', () => {
+    // Closes the heap-dump vector. `config.GATEWAY_HANDOFF_HMAC` MUST
+    // NOT exist on the exported object — that property is what a
+    // future contributor would grep for, and finding it would
+    // silently re-open the redundant-reference hazard.
+    const raw = '{"current":"' + 'c'.repeat(64) + '"}';
+    withFreshConfig(raw, (config) => {
+      expect(Object.prototype.hasOwnProperty.call(config, 'GATEWAY_HANDOFF_HMAC')).toBe(false);
+      expect(config.GATEWAY_HANDOFF_HMAC).toBeUndefined();
+    });
+  });
+
+  it('hasGatewayHandoffHmac reflects env-var presence without exposing the value', () => {
+    const raw = '{"current":"' + 'd'.repeat(64) + '"}';
+    withFreshConfig(raw, (config) => {
+      expect(config.hasGatewayHandoffHmac).toBe(true);
+    });
+    withFreshConfig(undefined, (config) => {
+      expect(config.hasGatewayHandoffHmac).toBe(false);
+    });
+    withFreshConfig('', (config) => {
+      expect(config.hasGatewayHandoffHmac).toBe(false);
+    });
+  });
+
+  it('hasGatewayHandoffHmac stays true after the value is taken', () => {
+    // The flag captures env-var presence at module-load time and
+    // doesn't track consumption. The boot-presence check runs BEFORE
+    // takeGatewayHandoffHmac is called, so the flag's frozen-at-load
+    // semantic is intentional. Pinning so a future refactor that
+    // flips the flag on take() flags itself as a behavior change.
+    const raw = '{"current":"' + 'e'.repeat(64) + '"}';
+    withFreshConfig(raw, (config) => {
+      expect(config.hasGatewayHandoffHmac).toBe(true);
+      config.takeGatewayHandoffHmac();
+      expect(config.hasGatewayHandoffHmac).toBe(true);
+    });
+  });
+});

--- a/apps/discord/tests/gateway-hmac-secret-loader.test.js
+++ b/apps/discord/tests/gateway-hmac-secret-loader.test.js
@@ -21,10 +21,16 @@ describe('loadGatewayHmacSecret', () => {
       });
     });
 
-    it('accepts uppercase hex (case-insensitive)', () => {
+    it('accepts uppercase hex and normalizes to lowercase on the way out', () => {
+      // Lowercase normalization eliminates the case-as-identity
+      // hazard during rotation: the same logical key re-serialized
+      // with different case would otherwise key createHmac on
+      // different UTF-8 bytes and silently break dual-accept across
+      // the rolling deploy.
       const upper = 'A'.repeat(64);
-      const result = loadGatewayHmacSecret(JSON.stringify({ current: upper }));
-      expect(result.current).toBe(upper);
+      const result = loadGatewayHmacSecret(JSON.stringify({ current: upper, previous: 'B'.repeat(64) }));
+      expect(result.current).toBe('a'.repeat(64));
+      expect(result.previous).toBe('b'.repeat(64));
     });
 
     it('treats `previous: null` the same as missing — single-key mode', () => {

--- a/apps/discord/tests/gateway-hmac-secret-loader.test.js
+++ b/apps/discord/tests/gateway-hmac-secret-loader.test.js
@@ -136,16 +136,21 @@ describe('loadGatewayHmacSecret', () => {
       }
     });
 
-    it('does not echo the raw secret in the JSON-parse-failure path', () => {
-      // The secret is the env var contents — never log it verbatim.
-      // We mention "not valid JSON" + the JSON.parse error message
-      // (which discloses the parse position, not the bytes).
-      const raw = 'SECRET_SHOULD_NOT_APPEAR_HERE';
+    it('does not leak any prefix of the raw secret in the JSON-parse-failure path', () => {
+      // V8's JSON.parse error message truncates the source to a
+      // ~13-char snippet, so a substring leak is the real hazard
+      // (not the full string). Operator-realistic misconfig: raw hex
+      // pasted without JSON wrapping. Any 8+ char substring of the
+      // raw value appearing in the surfaced error message would leak
+      // key material to CloudWatch.
+      const raw = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
       try {
         loadGatewayHmacSecret(raw);
         throw new Error('expected throw');
       } catch (err) {
-        expect(err.message).not.toContain('SECRET_SHOULD_NOT_APPEAR_HERE');
+        for (let i = 0; i + 8 <= raw.length; i += 1) {
+          expect(err.message).not.toContain(raw.slice(i, i + 8));
+        }
       }
     });
   });

--- a/apps/discord/tests/gateway-hmac-secret-loader.test.js
+++ b/apps/discord/tests/gateway-hmac-secret-loader.test.js
@@ -1,0 +1,152 @@
+const { loadGatewayHmacSecret } = require('../src/gateway-hmac-secret-loader');
+
+const VALID_HEX_A = 'a'.repeat(64);
+const VALID_HEX_B = 'b'.repeat(64);
+
+describe('loadGatewayHmacSecret', () => {
+  describe('happy path', () => {
+    it('parses {current, previous} and returns both', () => {
+      const raw = JSON.stringify({ current: VALID_HEX_A, previous: VALID_HEX_B });
+      expect(loadGatewayHmacSecret(raw)).toEqual({
+        current: VALID_HEX_A,
+        previous: VALID_HEX_B,
+      });
+    });
+
+    it('parses {current} alone (no rotation window) — previous normalizes to null', () => {
+      const raw = JSON.stringify({ current: VALID_HEX_A });
+      expect(loadGatewayHmacSecret(raw)).toEqual({
+        current: VALID_HEX_A,
+        previous: null,
+      });
+    });
+
+    it('accepts uppercase hex (case-insensitive)', () => {
+      const upper = 'A'.repeat(64);
+      const result = loadGatewayHmacSecret(JSON.stringify({ current: upper }));
+      expect(result.current).toBe(upper);
+    });
+
+    it('treats `previous: null` the same as missing — single-key mode', () => {
+      const raw = JSON.stringify({ current: VALID_HEX_A, previous: null });
+      expect(loadGatewayHmacSecret(raw).previous).toBeNull();
+    });
+  });
+
+  describe('shape validation', () => {
+    it('rejects undefined env var', () => {
+      expect(() => loadGatewayHmacSecret(undefined)).toThrow(/empty or missing/);
+    });
+
+    it('rejects empty string env var', () => {
+      expect(() => loadGatewayHmacSecret('')).toThrow(/empty or missing/);
+    });
+
+    it('rejects non-string input (defense-in-depth for a future caller mistake)', () => {
+      expect(() => loadGatewayHmacSecret(42)).toThrow(/empty or missing/);
+      expect(() => loadGatewayHmacSecret(null)).toThrow(/empty or missing/);
+    });
+
+    it('rejects malformed JSON', () => {
+      expect(() => loadGatewayHmacSecret('not json')).toThrow(/not valid JSON/);
+      expect(() => loadGatewayHmacSecret('{"unterminated')).toThrow(/not valid JSON/);
+    });
+
+    it('rejects a JSON array', () => {
+      expect(() => loadGatewayHmacSecret('[1,2,3]')).toThrow(/must decode to a JSON object/);
+    });
+
+    it('rejects a JSON primitive (number / null / true)', () => {
+      expect(() => loadGatewayHmacSecret('42')).toThrow(/must decode to a JSON object/);
+      expect(() => loadGatewayHmacSecret('null')).toThrow(/must decode to a JSON object/);
+      expect(() => loadGatewayHmacSecret('true')).toThrow(/must decode to a JSON object/);
+    });
+  });
+
+  describe('current validation', () => {
+    it('rejects missing current', () => {
+      expect(() => loadGatewayHmacSecret('{}')).toThrow(/current must be a 64-char hex/);
+    });
+
+    it('rejects current as non-string', () => {
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: 42 })))
+        .toThrow(/current must be a 64-char hex/);
+    });
+
+    it('rejects current with wrong length (63 chars)', () => {
+      const short = 'a'.repeat(63);
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: short })))
+        .toThrow(/current must be a 64-char hex/);
+    });
+
+    it('rejects current with wrong length (65 chars)', () => {
+      const long = 'a'.repeat(65);
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: long })))
+        .toThrow(/current must be a 64-char hex/);
+    });
+
+    it('rejects current with non-hex chars', () => {
+      const bad = 'g'.repeat(64);
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: bad })))
+        .toThrow(/current must be a 64-char hex/);
+    });
+
+    it('rejects current with mid-string non-hex char', () => {
+      const bad = `${'a'.repeat(63)}z`;
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: bad })))
+        .toThrow(/current must be a 64-char hex/);
+    });
+  });
+
+  describe('previous validation', () => {
+    it('rejects previous as non-string non-null', () => {
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: VALID_HEX_A, previous: 42 })))
+        .toThrow(/previous, if present, must be a 64-char hex/);
+    });
+
+    it('rejects previous with wrong length', () => {
+      const short = 'b'.repeat(60);
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: VALID_HEX_A, previous: short })))
+        .toThrow(/previous, if present, must be a 64-char hex/);
+    });
+
+    it('rejects previous with non-hex chars', () => {
+      const bad = 'z'.repeat(64);
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: VALID_HEX_A, previous: bad })))
+        .toThrow(/previous, if present, must be a 64-char hex/);
+    });
+
+    it('rejects previous = empty string (would silently disable dual-accept)', () => {
+      // An empty-string `previous` would parse as truthy-falsy in
+      // gateway-hmac's `if (!matched && secrets.previous)` gate,
+      // silently disabling dual-accept during a rotation. The loader
+      // is the chokepoint that catches this misconfig at boot.
+      expect(() => loadGatewayHmacSecret(JSON.stringify({ current: VALID_HEX_A, previous: '' })))
+        .toThrow(/previous, if present, must be a 64-char hex/);
+    });
+  });
+
+  describe('error shape', () => {
+    it('attaches code GATEWAY_HMAC_SECRET_MALFORMED on every throw', () => {
+      try {
+        loadGatewayHmacSecret('not json');
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err.code).toBe('GATEWAY_HMAC_SECRET_MALFORMED');
+      }
+    });
+
+    it('does not echo the raw secret in the JSON-parse-failure path', () => {
+      // The secret is the env var contents — never log it verbatim.
+      // We mention "not valid JSON" + the JSON.parse error message
+      // (which discloses the parse position, not the bytes).
+      const raw = 'SECRET_SHOULD_NOT_APPEAR_HERE';
+      try {
+        loadGatewayHmacSecret(raw);
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err.message).not.toContain('SECRET_SHOULD_NOT_APPEAR_HERE');
+      }
+    });
+  });
+});

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -1143,10 +1143,11 @@ describe('hasStartedTickLoop — /health probe seam', () => {
   });
 
   it('returns false again after stop() drains the loop', async () => {
-    // The /health probe on the standby path relies on this predicate
-    // as its liveness signal. If `stop()` leaves it stuck at `true`,
-    // a standby whose tick loop crashed would still report healthy —
-    // exactly the failure mode the predicate exists to surface.
+    // The /health probe on the standby path relies on this predicate.
+    // The crashed-loop case (loop body throws) and the stop() case
+    // both null `loopPromise` via the .finally — so both report
+    // unhealthy via this predicate. (A *hung* tick — DDB call that
+    // never resolves — does NOT flip this; see the helper comment.)
     const sleepResolvers = [];
     const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
     const { leader } = makeLeader({ sleep });

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -1126,3 +1126,37 @@ describe('start / stop lifecycle', () => {
     expect(sleep).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('hasStartedTickLoop — /health probe seam', () => {
+  it('returns false before start()', () => {
+    const sleep = jest.fn(() => new Promise(() => {}));
+    const { leader } = makeLeader({ sleep });
+    expect(leader.hasStartedTickLoop()).toBe(false);
+  });
+
+  it('returns true after start()', async () => {
+    const sleep = jest.fn(() => new Promise(() => {}));
+    const { leader } = makeLeader({ sleep });
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(leader.hasStartedTickLoop()).toBe(true);
+  });
+
+  it('returns false again after stop() drains the loop', async () => {
+    // The /health probe on the standby path relies on this predicate
+    // as its liveness signal. If `stop()` leaves it stuck at `true`,
+    // a standby whose tick loop crashed would still report healthy —
+    // exactly the failure mode the predicate exists to surface.
+    const sleepResolvers = [];
+    const sleep = jest.fn(() => new Promise((resolve) => { sleepResolvers.push(resolve); }));
+    const { leader } = makeLeader({ sleep });
+    leader.start();
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(leader.hasStartedTickLoop()).toBe(true);
+
+    const stopPromise = leader.stop();
+    sleepResolvers[0]();
+    await stopPromise;
+    expect(leader.hasStartedTickLoop()).toBe(false);
+  });
+});

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -266,6 +266,41 @@ describe('handleInboundHandoff', () => {
     expect(mocks.manager.connect).not.toHaveBeenCalled();
   });
 
+  it('inbound handoff on a never-started leader: adopts + connects without start()', async () => {
+    // Pins the SIGTERM-during-startHotStandby race contract. The
+    // control-channel server starts listening BEFORE leader.start()
+    // runs, so an in-flight handoff envelope can land on a leader
+    // whose tick loop has not begun. The runSerialized chain is
+    // primed at factory time (inFlight = Promise.resolve()), so the
+    // adopt → flag → connect ordering must hold without start()
+    // having ever fired.
+    const callOrder = [];
+    const mocks = makeMocks();
+    mocks.lock.adoptLockFromHandoff = jest.fn(() => callOrder.push('adopt'));
+    const { leader } = makeLeader({ mocks });
+
+    let flagAtConnect = null;
+    let tickLoopStartedAtConnect = null;
+    mocks.manager.connect = jest.fn(async () => {
+      flagAtConnect = leader.isHoldingLock();
+      tickLoopStartedAtConnect = leader.hasStartedTickLoop();
+      callOrder.push('connect');
+    });
+
+    // Pre-condition: no tick loop yet.
+    expect(leader.hasStartedTickLoop()).toBe(false);
+
+    await leader.handleInboundHandoff({
+      activeInstanceId: 'inst-A', expectedVersion: 7,
+    });
+
+    expect(callOrder).toEqual(['adopt', 'connect']);
+    expect(flagAtConnect).toBe(true);
+    expect(tickLoopStartedAtConnect).toBe(false); // confirms the loop never ran
+    expect(leader.isHoldingLock()).toBe(true);
+    expect(mocks.peerHeartbeat.writeHeartbeat).not.toHaveBeenCalled();
+  });
+
   it('adopt throw — heldLock + connecting both stay false; runSerialized chain stays intact for next call', async () => {
     // Adopt is the first step of the handoff. If it throws, NO
     // flag mutations must happen (heldLock=false, connecting=false),

--- a/apps/discord/tests/gateway-leader.test.js
+++ b/apps/discord/tests/gateway-leader.test.js
@@ -1102,6 +1102,37 @@ describe('loop backstop — survives unexpected throws from step()', () => {
 });
 
 describe('start / stop lifecycle', () => {
+  it('stop() before start() is a safe no-op (returns resolved promise, no side effects)', async () => {
+    // Load-bearing for startHotStandby's partial-construction
+    // teardown path: if startControlChannelServer throws after
+    // gatewayLeader is assigned but before .start() runs,
+    // gracefulShutdown calls leader.stop() on a never-started
+    // leader. This must resolve cleanly, NOT throw, and must not
+    // call any of the injected mocks — there's no loop to halt yet.
+    const mocks = makeMocks();
+    const { leader } = makeLeader({ mocks });
+
+    await expect(leader.stop()).resolves.toBeUndefined();
+
+    expect(mocks.lock.acquireLock).not.toHaveBeenCalled();
+    expect(mocks.lock.releaseLock).not.toHaveBeenCalled();
+    expect(mocks.peerHeartbeat.writeHeartbeat).not.toHaveBeenCalled();
+    expect(leader.isHoldingLock()).toBe(false);
+    expect(leader.hasStartedTickLoop()).toBe(false);
+  });
+
+  it('stop() is idempotent across repeated pre-start calls', async () => {
+    const mocks = makeMocks();
+    const { leader } = makeLeader({ mocks });
+
+    await leader.stop();
+    await leader.stop();
+    await leader.stop();
+
+    expect(mocks.lock.acquireLock).not.toHaveBeenCalled();
+    expect(leader.hasStartedTickLoop()).toBe(false);
+  });
+
   it('start is idempotent', async () => {
     const sleep = jest.fn(() => new Promise(() => {}));
     const { leader } = makeLeader({ sleep });

--- a/apps/discord/tests/gateway-shutdown-helpers.test.js
+++ b/apps/discord/tests/gateway-shutdown-helpers.test.js
@@ -308,6 +308,7 @@ describe('runPushHandoffShutdown', () => {
       gatewayLeader: { pushHandoff: jest.fn().mockResolvedValue({ transferred: true, pushAcked: true }) },
       exit: jest.fn(),
       scheduleHardExit: makeTimerSpy(),
+      clearHardExit: jest.fn(),
       ...overrides,
     };
   }
@@ -323,16 +324,58 @@ describe('runPushHandoffShutdown', () => {
     );
   });
 
-  it('on a thrown pushHandoff, still exits with the incoming code (standby cold-acquires)', async () => {
+  it('on a thrown pushHandoff, exits with forcedExitCode so deploy metrics distinguish clean transfer from throw', async () => {
+    // Three observable outcomes, three exit codes:
+    //   * clean transfer       → exit(code)            (typically 0)
+    //   * pushHandoff threw    → exit(forcedExitCode)  (defaults to 1)
+    //   * pushHandoff timed out → exit(forcedExitCode)  (via hard-exit timer)
+    // Collapsing throw + clean would hide deploy-time peer-reachability
+    // failures behind clean-transfer SLI metrics.
     const deps = makeDeps({
       gatewayLeader: { pushHandoff: jest.fn().mockRejectedValue(new Error('peer unreachable')) },
     });
     await runPushHandoffShutdown({ code: 0, ...deps });
-    expect(deps.exit).toHaveBeenCalledWith(0);
+    expect(deps.exit).toHaveBeenCalledWith(1);
     expect(deps.logger.error).toHaveBeenCalledWith(
       'pushHandoff threw — exiting anyway so the standby can cold-acquire',
       expect.objectContaining({ error: 'peer unreachable' }),
     );
+  });
+
+  it('forcedExitCode is configurable for the throw path too', async () => {
+    const deps = makeDeps({
+      gatewayLeader: { pushHandoff: jest.fn().mockRejectedValue(new Error('hmac mismatch')) },
+    });
+    await runPushHandoffShutdown({ code: 0, forcedExitCode: 42, ...deps });
+    expect(deps.exit).toHaveBeenCalledWith(42);
+  });
+
+  it('clears the hard-exit timer on the success path so a non-terminal injected exit does not see a spurious second exit', async () => {
+    // In prod process.exit kills the process so the .unref'd timer
+    // is moot. But a non-terminal injected exit (tests, future
+    // metric-emitting wrapper) would observe a spurious exit-code-1
+    // ~12 s later without the clear.
+    const deps = makeDeps();
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.clearHardExit).toHaveBeenCalledTimes(1);
+    expect(deps.clearHardExit).toHaveBeenCalledWith(deps.scheduleHardExit.timers[0]);
+    // Sanity: exit fired exactly once (the success-path exit), NOT
+    // a second time from the timer callback.
+    expect(deps.exit).toHaveBeenCalledTimes(1);
+    expect(deps.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('clears the hard-exit timer on the throw path too (and exits with forcedExitCode)', async () => {
+    const deps = makeDeps({
+      gatewayLeader: { pushHandoff: jest.fn().mockRejectedValue(new Error('peer down')) },
+    });
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.clearHardExit).toHaveBeenCalledTimes(1);
+    // Assert the exit code here too (not just call count) so a
+    // regression that swaps the throw path back to `code` is caught
+    // by this test independently of the dedicated throw-code test.
+    expect(deps.exit).toHaveBeenCalledTimes(1);
+    expect(deps.exit).toHaveBeenCalledWith(1);
   });
 
   it('schedules a hard-exit timer with the configured ceiling', async () => {

--- a/apps/discord/tests/gateway-shutdown-helpers.test.js
+++ b/apps/discord/tests/gateway-shutdown-helpers.test.js
@@ -266,14 +266,14 @@ describe('tryClose', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('logs at warn and resolves cleanly when close yields an error', async () => {
+  it('logs at warn (with error + stack) and resolves cleanly when close yields an error', async () => {
     const logger = makeFakeLogger();
     const err = new Error('listener already detached');
     const server = { close: jest.fn((cb) => cb(err)) };
     await expect(tryClose('control-channel server', server, logger)).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
       'control-channel server close reported error',
-      { error: 'listener already detached' },
+      { error: 'listener already detached', stack: err.stack },
     );
   });
 

--- a/apps/discord/tests/gateway-shutdown-helpers.test.js
+++ b/apps/discord/tests/gateway-shutdown-helpers.test.js
@@ -1,6 +1,8 @@
+const { EventEmitter } = require('events');
 const {
   shouldUsePushHandoffShutdown,
   selectGatewayReadinessProbe,
+  awaitServerListening,
   tryStop,
   tryClose,
   runPushHandoffShutdown,
@@ -205,6 +207,99 @@ describe('selectGatewayReadinessProbe', () => {
     // After inbound handoff transfers ownership away: now standby.
     currentLeader = makeFakeLeader({ holdingLock: false, ticking: true });
     expect(probe()).toBe(true); // standby is still healthy via tick loop
+  });
+});
+
+describe('awaitServerListening', () => {
+  // Fake http.Server: an EventEmitter with a mutable `listening`
+  // flag. Models the three relevant terminal events (`listening`,
+  // `error`, `close`) without binding an actual socket.
+  function makeFakeServer({ listening = false } = {}) {
+    const s = new EventEmitter();
+    s.listening = listening;
+    return s;
+  }
+
+  it('resolves immediately when server.listening is already true (fast path)', async () => {
+    const server = makeFakeServer({ listening: true });
+    await expect(awaitServerListening(server)).resolves.toBeUndefined();
+  });
+
+  it('resolves on the `listening` event when server starts not-yet-listening', async () => {
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('listening');
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('rejects on the `error` event with the emitted error', async () => {
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('error', new Error('EADDRINUSE'));
+    await expect(promise).rejects.toThrow(/EADDRINUSE/);
+  });
+
+  it('rejects on the `close` event — closes the SIGTERM-during-listen-await hang', async () => {
+    // Load-bearing contract. If gracefulShutdown calls server.close()
+    // while we're still awaiting `listening`, Node fires `close` (not
+    // `error` or `listening`) — without this reject the promise would
+    // hang until gracefulShutdown's force-exit timer fires.
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('close');
+    await expect(promise).rejects.toThrow(/closed before listening/);
+  });
+
+  it('removes all three listeners on `listening` resolve (no late-event leakage)', async () => {
+    // Idle listeners would .reject() on every runtime listener-error
+    // and surface a noisy unhandled-rejection. The caller's
+    // onListenError hook already routes runtime errors to graceful-
+    // Shutdown(1); we don't need a duplicate path.
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('listening');
+    await promise;
+    expect(server.listenerCount('listening')).toBe(0);
+    expect(server.listenerCount('error')).toBe(0);
+    expect(server.listenerCount('close')).toBe(0);
+  });
+
+  it('removes all three listeners on `error` reject', async () => {
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('error', new Error('bind failed'));
+    await expect(promise).rejects.toThrow();
+    expect(server.listenerCount('listening')).toBe(0);
+    expect(server.listenerCount('error')).toBe(0);
+    expect(server.listenerCount('close')).toBe(0);
+  });
+
+  it('removes all three listeners on `close` reject', async () => {
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('close');
+    await expect(promise).rejects.toThrow();
+    expect(server.listenerCount('listening')).toBe(0);
+    expect(server.listenerCount('error')).toBe(0);
+    expect(server.listenerCount('close')).toBe(0);
+  });
+
+  it('a second `error` after `listening` does not surface an unhandled rejection', async () => {
+    // Defense against the idle-listener hazard: after resolve(), any
+    // subsequent `error` event from the server's runtime lifetime
+    // must NOT bubble through our Promise.
+    const server = makeFakeServer();
+    const promise = awaitServerListening(server);
+    server.emit('listening');
+    await promise;
+    // This must not throw and must not bubble — if our cleanup
+    // missed a listener, jest would surface the unhandled rejection
+    // at the next tick.
+    expect(() => server.emit('error', new Error('runtime listener-error'))).toThrow(/runtime listener-error/);
+    // (EventEmitter's default error-without-listener behavior is to
+    // re-throw synchronously — the throw above PROVES no idle
+    // `error → reject` listener remained, since a remaining listener
+    // would have swallowed it.)
   });
 });
 
@@ -490,6 +585,19 @@ describe('runPushHandoffShutdown', () => {
     // helper doesn't blow up trying to call .stop() on null.
     await runPushHandoffShutdown({ code: 0, ...deps });
     expect(deps.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('eventPublisher explicit null is fine (SIGTERM before publisher.start() ran)', async () => {
+    // Different from the "omitted" case in that the caller is
+    // explicitly passing the unset binding rather than relying on
+    // the parameter default. Models the SIGTERM-during-boot path
+    // where startHotStandby's publisher construction has not yet
+    // happened. tryStop is null-safe; the helper must not throw
+    // and must still complete the pushHandoff + clean exit.
+    const deps = makeDeps();
+    await runPushHandoffShutdown({ code: 0, eventPublisher: null, ...deps });
+    expect(deps.exit).toHaveBeenCalledWith(0);
+    expect(deps.gatewayLeader.pushHandoff).toHaveBeenCalledTimes(1);
   });
 
   it('eventPublisher.stop() failure is absorbed via tryStop (not propagated)', async () => {

--- a/apps/discord/tests/gateway-shutdown-helpers.test.js
+++ b/apps/discord/tests/gateway-shutdown-helpers.test.js
@@ -1,0 +1,241 @@
+const {
+  shouldUsePushHandoffShutdown,
+  selectGatewayReadinessProbe,
+  tryStop,
+} = require('../src/gateway-shutdown-helpers');
+
+function makeFakeLeader({ holdingLock = false, ticking = false } = {}) {
+  return {
+    isHoldingLock: jest.fn(() => holdingLock),
+    hasStartedTickLoop: jest.fn(() => ticking),
+  };
+}
+
+function makeFakeLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+describe('shouldUsePushHandoffShutdown', () => {
+  it('returns false when hot-standby is off (legacy / Pillar 2 only)', () => {
+    expect(shouldUsePushHandoffShutdown({
+      enableHotStandby: false,
+      gatewayLeader: makeFakeLeader({ holdingLock: true }),
+    })).toBe(false);
+  });
+
+  it('returns false when leader is null (pre-startHotStandby boot window)', () => {
+    // SIGTERM-during-startup window: the user-facing CTL+C or ECS
+    // task-replacement signal can fire before startHotStandby has
+    // constructed the leader. Falling back to gracefulShutdown is
+    // correct — there's no lock to push.
+    expect(shouldUsePushHandoffShutdown({
+      enableHotStandby: true,
+      gatewayLeader: null,
+    })).toBe(false);
+  });
+
+  it('returns false when leader is not holding the lock (standby branch)', () => {
+    expect(shouldUsePushHandoffShutdown({
+      enableHotStandby: true,
+      gatewayLeader: makeFakeLeader({ holdingLock: false }),
+    })).toBe(false);
+  });
+
+  it('returns true only when hot-standby + leader + holding-lock all hold', () => {
+    expect(shouldUsePushHandoffShutdown({
+      enableHotStandby: true,
+      gatewayLeader: makeFakeLeader({ holdingLock: true }),
+    })).toBe(true);
+  });
+
+  it('re-reads lock state per call (no caching)', () => {
+    // The lock can flip between SIGTERM landings if an inbound
+    // handoff already moved ownership onto our peer. A first call
+    // returning true must not lock in that answer.
+    let holding = true;
+    const leader = {
+      isHoldingLock: jest.fn(() => holding),
+    };
+    expect(shouldUsePushHandoffShutdown({
+      enableHotStandby: true, gatewayLeader: leader,
+    })).toBe(true);
+    holding = false;
+    expect(shouldUsePushHandoffShutdown({
+      enableHotStandby: true, gatewayLeader: leader,
+    })).toBe(false);
+  });
+});
+
+describe('selectGatewayReadinessProbe', () => {
+  it('legacy mode (flag-off): probe reports client.isReady()', () => {
+    const client = { isReady: jest.fn(() => true) };
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: false,
+      enableGatewayResume: false,
+      gatewayShim: null,
+      getGatewayLeader: () => null,
+      client,
+    });
+    expect(probe()).toBe(true);
+    expect(client.isReady).toHaveBeenCalled();
+  });
+
+  it('Pillar 2 mode: probe reports shim.isReady()', () => {
+    const gatewayShim = { isReady: jest.fn(() => true) };
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: false,
+      enableGatewayResume: true,
+      gatewayShim,
+      getGatewayLeader: () => null,
+      client: { isReady: jest.fn() },
+    });
+    expect(probe()).toBe(true);
+    expect(gatewayShim.isReady).toHaveBeenCalled();
+  });
+
+  it('Pillar 2 mode without a shim (e.g. flag-on http tier): falls back to client.isReady()', () => {
+    // ENABLE_GATEWAY_RESUME=true but no shim was constructed —
+    // happens on the http tier where the flag is uniform across
+    // task defs but only the gateway role actually constructs the
+    // shim. client.isReady() preserves legacy behavior there.
+    const client = { isReady: jest.fn(() => false) };
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: false,
+      enableGatewayResume: true,
+      gatewayShim: null,
+      getGatewayLeader: () => null,
+      client,
+    });
+    expect(probe()).toBe(false);
+    expect(client.isReady).toHaveBeenCalled();
+  });
+
+  it('hot-standby + pre-startHotStandby window (leader null): probe returns false', () => {
+    // The probe is wired BEFORE startHotStandby runs; until the
+    // leader is assigned the probe must report unhealthy so --start-period
+    // covers the gap.
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: true,
+      enableGatewayResume: true,
+      gatewayShim: { isReady: jest.fn() },
+      getGatewayLeader: () => null,
+      client: { isReady: jest.fn() },
+    });
+    expect(probe()).toBe(false);
+  });
+
+  it('hot-standby + active replica: probe reports shim.isReady()', () => {
+    const gatewayShim = { isReady: jest.fn(() => true) };
+    const leader = makeFakeLeader({ holdingLock: true, ticking: true });
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: true,
+      enableGatewayResume: true,
+      gatewayShim,
+      getGatewayLeader: () => leader,
+      client: { isReady: jest.fn() },
+    });
+    expect(probe()).toBe(true);
+    expect(gatewayShim.isReady).toHaveBeenCalled();
+    // Tick-loop liveness is NOT consulted on the active path.
+    expect(leader.hasStartedTickLoop).not.toHaveBeenCalled();
+  });
+
+  it('hot-standby + standby replica: probe reports hasStartedTickLoop()', () => {
+    const gatewayShim = { isReady: jest.fn(() => false) }; // Standby has no WS.
+    const leader = makeFakeLeader({ holdingLock: false, ticking: true });
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: true,
+      enableGatewayResume: true,
+      gatewayShim,
+      getGatewayLeader: () => leader,
+      client: { isReady: jest.fn() },
+    });
+    expect(probe()).toBe(true);
+    // The standby reports tick-loop liveness, NOT WS-readiness —
+    // otherwise it would 503 forever and ECS would replace it.
+    expect(gatewayShim.isReady).not.toHaveBeenCalled();
+    expect(leader.hasStartedTickLoop).toHaveBeenCalled();
+  });
+
+  it('hot-standby + standby with dead tick loop: probe returns false', () => {
+    // The tick loop dying is the standby's failure mode — the
+    // probe flipping to false here is the load-bearing signal
+    // that lets ECS replace the standby task.
+    const leader = makeFakeLeader({ holdingLock: false, ticking: false });
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: true,
+      enableGatewayResume: true,
+      gatewayShim: { isReady: jest.fn() },
+      getGatewayLeader: () => leader,
+      client: { isReady: jest.fn() },
+    });
+    expect(probe()).toBe(false);
+  });
+
+  it('hot-standby probe re-reads gatewayLeader via the callback (lock flip mid-deploy)', () => {
+    // The active/standby flip happens between requests — the
+    // outgoing leader pushHandoffs to the peer, the peer adopts
+    // the lock. If the probe captured the leader handle at wire
+    // time, it would keep reporting the stale role. The callback
+    // indirection means every probe firing re-reads the current
+    // module-level reference.
+    let currentLeader = null;
+    const probe = selectGatewayReadinessProbe({
+      enableHotStandby: true,
+      enableGatewayResume: true,
+      gatewayShim: { isReady: jest.fn(() => true) },
+      getGatewayLeader: () => currentLeader,
+      client: { isReady: jest.fn() },
+    });
+
+    // Before startHotStandby: leader null → false.
+    expect(probe()).toBe(false);
+
+    // After startHotStandby completes: leader set, holding lock.
+    currentLeader = makeFakeLeader({ holdingLock: true });
+    expect(probe()).toBe(true);
+
+    // After inbound handoff transfers ownership away: now standby.
+    currentLeader = makeFakeLeader({ holdingLock: false, ticking: true });
+    expect(probe()).toBe(true); // standby is still healthy via tick loop
+  });
+});
+
+describe('tryStop', () => {
+  it('is a no-op for null handle (hot-standby off — leader never constructed)', async () => {
+    const logger = makeFakeLogger();
+    await tryStop('connection-watchdog', null, logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('awaits the handle.stop() promise', async () => {
+    const logger = makeFakeLogger();
+    const handle = { stop: jest.fn().mockResolvedValue(undefined) };
+    await tryStop('leader', handle, logger);
+    expect(handle.stop).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs at warn and swallows the error if stop() rejects', async () => {
+    // Teardown is already on the failure path; one component's
+    // stop() error shouldn't stall the rest of the drain (which
+    // is why we wrap each in tryStop rather than chaining bare
+    // awaits).
+    const logger = makeFakeLogger();
+    const handle = { stop: jest.fn().mockRejectedValue(new Error('ddb down')) };
+    await expect(tryStop('leader', handle, logger)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith('leader stop failed', { error: 'ddb down' });
+  });
+
+  it('embeds the component name in the warn message for triage', async () => {
+    const logger = makeFakeLogger();
+    const handle = { stop: jest.fn().mockRejectedValue(new Error('boom')) };
+    await tryStop('connection-watchdog', handle, logger);
+    expect(logger.warn).toHaveBeenCalledWith('connection-watchdog stop failed', { error: 'boom' });
+  });
+});

--- a/apps/discord/tests/gateway-shutdown-helpers.test.js
+++ b/apps/discord/tests/gateway-shutdown-helpers.test.js
@@ -410,4 +410,57 @@ describe('runPushHandoffShutdown', () => {
       pushReason: 'push_threw',
     });
   });
+
+  it('drains eventPublisher concurrently with pushHandoff (publisher.stop called before pushHandoff resolves)', async () => {
+    // The active received Discord dispatches that may be in-flight to
+    // SQS. The standby cannot replay these — they arrived on OUR
+    // WebSocket. The contract is concurrent (not sequential) so
+    // publisher's DRAIN_DEADLINE_MS doesn't extend the pushHandoff
+    // critical path. Prove the ordering with a pending pushHandoff:
+    // publisher.stop must already have been invoked by the time the
+    // test releases pushHandoff.
+    const handoffResolvers = {};
+    const handoffPromise = new Promise((resolve) => { handoffResolvers.resolve = resolve; });
+    const eventPublisher = { stop: jest.fn().mockResolvedValue(undefined) };
+    const deps = makeDeps({
+      eventPublisher,
+      gatewayLeader: { pushHandoff: jest.fn().mockReturnValue(handoffPromise) },
+    });
+
+    const shutdownPromise = runPushHandoffShutdown({ code: 0, ...deps });
+    // Yield the microtask queue once so the helper's body runs up to
+    // the `await gatewayLeader.pushHandoff()` await point. The
+    // publisher drain is kicked off synchronously before that await,
+    // so the stop spy must already have fired.
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
+    expect(deps.exit).not.toHaveBeenCalled(); // pushHandoff still pending
+
+    handoffResolvers.resolve({ transferred: true, pushAcked: true });
+    await shutdownPromise;
+    expect(deps.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('eventPublisher omitted is fine (legacy / flag-off / test setups)', async () => {
+    const deps = makeDeps();
+    // Default makeDeps doesn't include eventPublisher — verify the
+    // helper doesn't blow up trying to call .stop() on null.
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('eventPublisher.stop() failure is absorbed via tryStop (not propagated)', async () => {
+    // The SIGTERM handler invokes pushHandoffShutdown asynchronously
+    // (awaited); an unhandled-rejection bubble from the publisher
+    // drain would be a runtime hazard. tryStop catches both sync
+    // throws (async-function semantics) and async rejects.
+    const eventPublisher = { stop: jest.fn().mockRejectedValue(new Error('sqs unreachable')) };
+    const deps = makeDeps({ eventPublisher });
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      'event-publisher stop failed',
+      expect.objectContaining({ error: 'sqs unreachable' }),
+    );
+    expect(deps.exit).toHaveBeenCalledWith(0);
+  });
 });

--- a/apps/discord/tests/gateway-shutdown-helpers.test.js
+++ b/apps/discord/tests/gateway-shutdown-helpers.test.js
@@ -2,6 +2,8 @@ const {
   shouldUsePushHandoffShutdown,
   selectGatewayReadinessProbe,
   tryStop,
+  tryClose,
+  runPushHandoffShutdown,
 } = require('../src/gateway-shutdown-helpers');
 
 function makeFakeLeader({ holdingLock = false, ticking = false } = {}) {
@@ -221,21 +223,191 @@ describe('tryStop', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('logs at warn and swallows the error if stop() rejects', async () => {
+  it('logs at warn (with error + stack) and swallows the error if stop() rejects', async () => {
     // Teardown is already on the failure path; one component's
     // stop() error shouldn't stall the rest of the drain (which
     // is why we wrap each in tryStop rather than chaining bare
-    // awaits).
+    // awaits). Stack is included for triage on a stuck drain
+    // where the message alone doesn't tell the operator which
+    // call site threw.
     const logger = makeFakeLogger();
-    const handle = { stop: jest.fn().mockRejectedValue(new Error('ddb down')) };
+    const err = new Error('ddb down');
+    const handle = { stop: jest.fn().mockRejectedValue(err) };
     await expect(tryStop('leader', handle, logger)).resolves.toBeUndefined();
-    expect(logger.warn).toHaveBeenCalledWith('leader stop failed', { error: 'ddb down' });
+    expect(logger.warn).toHaveBeenCalledWith('leader stop failed', {
+      error: 'ddb down',
+      stack: err.stack,
+    });
   });
 
   it('embeds the component name in the warn message for triage', async () => {
     const logger = makeFakeLogger();
     const handle = { stop: jest.fn().mockRejectedValue(new Error('boom')) };
     await tryStop('connection-watchdog', handle, logger);
-    expect(logger.warn).toHaveBeenCalledWith('connection-watchdog stop failed', { error: 'boom' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'connection-watchdog stop failed',
+      expect.objectContaining({ error: 'boom' }),
+    );
+  });
+});
+
+describe('tryClose', () => {
+  it('is a no-op for null server handle', async () => {
+    const logger = makeFakeLogger();
+    await tryClose('HTTP server', null, logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('awaits the server.close() callback', async () => {
+    const logger = makeFakeLogger();
+    const server = { close: jest.fn((cb) => cb()) };
+    await tryClose('HTTP server', server, logger);
+    expect(server.close).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs at warn and resolves cleanly when close yields an error', async () => {
+    const logger = makeFakeLogger();
+    const err = new Error('listener already detached');
+    const server = { close: jest.fn((cb) => cb(err)) };
+    await expect(tryClose('control-channel server', server, logger)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'control-channel server close reported error',
+      { error: 'listener already detached' },
+    );
+  });
+
+  it('embeds the component name in the warn message', async () => {
+    const logger = makeFakeLogger();
+    const server = { close: jest.fn((cb) => cb(new Error('boom'))) };
+    await tryClose('HTTP server', server, logger);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'HTTP server close reported error',
+      expect.objectContaining({ error: 'boom' }),
+    );
+  });
+});
+
+describe('runPushHandoffShutdown', () => {
+  // Captures every scheduleHardExit call so a test can fire the
+  // pending timer callback to simulate the ceiling elapsing.
+  function makeTimerSpy() {
+    const timers = [];
+    const fn = jest.fn((cb, ms) => {
+      const timer = { cb, ms, unref: jest.fn() };
+      timers.push(timer);
+      return timer;
+    });
+    fn.timers = timers;
+    return fn;
+  }
+
+  function makeDeps(overrides = {}) {
+    return {
+      logger: makeFakeLogger(),
+      gatewayLeader: { pushHandoff: jest.fn().mockResolvedValue({ transferred: true, pushAcked: true }) },
+      exit: jest.fn(),
+      scheduleHardExit: makeTimerSpy(),
+      ...overrides,
+    };
+  }
+
+  it('on a successful pushHandoff, exits with the incoming code', async () => {
+    const deps = makeDeps();
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.gatewayLeader.pushHandoff).toHaveBeenCalledTimes(1);
+    expect(deps.exit).toHaveBeenCalledWith(0);
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      'pushHandoff complete',
+      expect.objectContaining({ transferred: true, pushAcked: true }),
+    );
+  });
+
+  it('on a thrown pushHandoff, still exits with the incoming code (standby cold-acquires)', async () => {
+    const deps = makeDeps({
+      gatewayLeader: { pushHandoff: jest.fn().mockRejectedValue(new Error('peer unreachable')) },
+    });
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.exit).toHaveBeenCalledWith(0);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'pushHandoff threw — exiting anyway so the standby can cold-acquire',
+      expect.objectContaining({ error: 'peer unreachable' }),
+    );
+  });
+
+  it('schedules a hard-exit timer with the configured ceiling', async () => {
+    const deps = makeDeps();
+    await runPushHandoffShutdown({ code: 0, ceilingMs: 9999, ...deps });
+    expect(deps.scheduleHardExit).toHaveBeenCalledWith(expect.any(Function), 9999);
+  });
+
+  it('default ceiling is 12_000 ms (9s pushHandoff + 3s headroom)', async () => {
+    const deps = makeDeps();
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.scheduleHardExit).toHaveBeenCalledWith(expect.any(Function), 12_000);
+  });
+
+  it('unrefs the hard-exit timer so it does not pin the event loop', async () => {
+    const deps = makeDeps();
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.scheduleHardExit.timers[0].unref).toHaveBeenCalledTimes(1);
+  });
+
+  it('hard-exit firing uses forcedExitCode=1 even when the incoming SIGTERM was code 0', async () => {
+    // Load-bearing contract — dashboards/ECS need to distinguish
+    // "clean transfer, exit 0" from "timeout, standby cold-acquired,
+    // exit 1" so a stuck handoff doesn't masquerade as a clean
+    // shutdown in the deploy metrics.
+    const handoffResolvers = {};
+    const handoffPromise = new Promise((resolve) => { handoffResolvers.resolve = resolve; });
+    const deps = makeDeps({
+      gatewayLeader: { pushHandoff: jest.fn().mockReturnValue(handoffPromise) },
+    });
+
+    const shutdown = runPushHandoffShutdown({ code: 0, ...deps });
+    // Yield once so scheduleHardExit has been called.
+    await new Promise((resolve) => { setImmediate(resolve); });
+    expect(deps.scheduleHardExit.timers).toHaveLength(1);
+
+    // Fire the timer callback synchronously — represents the 12s
+    // ceiling elapsing in real time.
+    deps.scheduleHardExit.timers[0].cb();
+    expect(deps.exit).toHaveBeenCalledWith(1);
+    expect(deps.logger.error).toHaveBeenCalledWith('PushHandoff shutdown timed out, forcing exit');
+
+    // Release the never-resolving handoff so the orphan shutdown
+    // promise settles, then await it so Jest doesn't warn about
+    // an open async-context.
+    handoffResolvers.resolve({ transferred: true, pushAcked: true });
+    await shutdown;
+  });
+
+  it('forcedExitCode is configurable', async () => {
+    const handoffResolvers = {};
+    const handoffPromise = new Promise((resolve) => { handoffResolvers.resolve = resolve; });
+    const deps = makeDeps({
+      gatewayLeader: { pushHandoff: jest.fn().mockReturnValue(handoffPromise) },
+    });
+    const shutdown = runPushHandoffShutdown({ code: 0, forcedExitCode: 42, ...deps });
+    await new Promise((resolve) => { setImmediate(resolve); });
+    deps.scheduleHardExit.timers[0].cb();
+    expect(deps.exit).toHaveBeenCalledWith(42);
+    handoffResolvers.resolve({});
+    await shutdown;
+  });
+
+  it('forwards every pushHandoff result field into the log line for observability', async () => {
+    const deps = makeDeps({
+      gatewayLeader: { pushHandoff: jest.fn().mockResolvedValue({
+        transferred: false, pushAcked: false, reason: 'no_peer', pushReason: 'push_threw',
+      }) },
+    });
+    await runPushHandoffShutdown({ code: 0, ...deps });
+    expect(deps.logger.info).toHaveBeenCalledWith('pushHandoff complete', {
+      transferred: false,
+      pushAcked: false,
+      reason: 'no_peer',
+      pushReason: 'push_threw',
+    });
   });
 });

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -198,6 +198,63 @@ describe('start — wiring + connect', () => {
 
     await expect(shim.start({ timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
   });
+
+  it('connect:false skips manager.connect() — Pillar 3 hot-standby seam', async () => {
+    // Both replicas call start({ connect: false }) at boot so the
+    // manager is constructed + listeners attached, but only the
+    // lock-holder eventually drives connect(). Without this seam,
+    // both replicas would IDENTIFY at boot and Discord would flap
+    // the session identity every few seconds.
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+
+    expect(managerInstances).toHaveLength(1);
+    // Manager was constructed (listeners attached) but connect() was
+    // NOT called by the shim — the caller drives it later.
+    expect(managerInstances[0].connect).not.toHaveBeenCalled();
+  });
+
+  it('connect:false still attaches Dispatch listener (fan-out works after a later connect)', async () => {
+    // Standby flow: start({connect:false}) at boot, then later the
+    // leader drives manager.connect() inside handleInboundHandoff.
+    // The first READY/RESUMED that arrives after that connect MUST
+    // fan out to onDispatch handlers — otherwise the standby's event
+    // pipeline is dead.
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    const handler = jest.fn();
+    shim.onDispatch(handler);
+
+    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'MESSAGE_CREATE', d: {} },
+      shardId: 0,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getManager — Pillar 3 leader handle', () => {
+  it('returns null before start()', () => {
+    const { shim } = makeShim();
+    expect(shim.getManager()).toBeNull();
+  });
+
+  it('returns the WebSocketManager instance after start()', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start();
+    expect(shim.getManager()).toBe(managerInstances[0]);
+  });
+
+  it('returns the manager after start({ connect: false }) too', async () => {
+    // Critical for the hot-standby wiring path: the leader needs the
+    // manager handle BEFORE driving connect(). If getManager() only
+    // returned non-null after a successful connect, the wiring chain
+    // would deadlock (leader needs manager → manager needs leader to
+    // call connect → loop).
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    expect(shim.getManager()).toBe(managerInstances[0]);
+  });
 });
 
 describe('IDENTIFY budget guard', () => {


### PR DESCRIPTION
## Summary

Wires the Pillar 3 modules (lock, peer-heartbeat, hmac, control-channel, leader, watchdog) into the gateway bootstrap path, gated by `ENABLE_GATEWAY_HOT_STANDBY`. Ships flag-off everywhere — single-replica gateway stays the production default until PR 14 flips `desired_count=2`.

## Why

This is the application-side completion of the zero-downtime deploy story. With both replicas running and the flag on, every deploy push-handoffs the live WebSocket from the outgoing task to the incoming task inside the SIGTERM window — eliminating the IDENTIFY/RESUME cold-start gap that today drops dispatches on every deploy.

The lock + peer-heartbeat (PR 13b.1) and HMAC + control-channel + leader (PR 13b.2 / #414) primitives have already landed. PR 13b.3 is the wiring layer that makes them load-bearing in `index.js`.

## What changed

**Shim seam (`connect: false`)** — Both replicas boot the shim without opening a WebSocket. The leader/watchdog drives `manager.connect()` after winning the DDB lock or receiving an inbound handoff. Without this, both replicas would race to IDENTIFY against the same bot token and Discord would flap the session identity. Also adds a public `getManager()` accessor (replaces `_getManagerForTest`).

**Leader API** — new `hasStartedTickLoop()` predicate consumed by the standby `/health` probe.

**Boot guards** — `unsupportedRoleHotStandbyCombo` rejects hot-standby on non-gateway roles or with RESUME=false; `missingHotStandbyKeys` surfaces missing `INSTANCE_ID` / `INSTANCE_IP` / `GATEWAY_HANDOFF_HMAC`.

**Secret loader (new module)** — `gateway-hmac-secret-loader.js` parses + validates the SSM-injected `GATEWAY_HANDOFF_HMAC` env var (`{current, previous?}` JSON with 64-char hex values). Fail-loud at boot.

**Wiring (`startHotStandby` in `index.js`)** — constructs the chain after `gatewayShim.start({ connect: false })` resolves; awaits the control-channel server's `listening` event before starting the leader so the peer can never pushHandoff to a not-yet-listening port.

**`/health` probe split** — active path returns `shim.isReady()`; standby returns `leader.hasStartedTickLoop()`. Without this, the standby would 503 forever and get ECS-replaced on the first `--start-period` lapse.

**SIGTERM branching** — `pushHandoffShutdown` (active path: pushHandoff with 9 s ceiling + 12 s outer belt-and-suspenders, then `process.exit`) vs the legacy `gracefulShutdown` (standby / flag-off). `tryStop()` helper de-duplicates the new teardown call sites.

**Config + `.env.example`** — new entries: `ENABLE_GATEWAY_HOT_STANDBY`, `INSTANCE_ID`, `INSTANCE_IP`, `GATEWAY_CONTROL_PORT`, `GATEWAY_CONTROL_BIND_ADDR`, `GATEWAY_HANDOFF_HMAC`.

## Test plan

- [x] 22 new cases for the secret loader (shape + hex + previous-optional + error-shape contracts)
- [x] 16 new cases for the boot-requirements gates (synergy combos + missing-keys)
- [x] 5 new cases for shim `connect: false` + `getManager()`
- [x] 3 new cases for `leader.hasStartedTickLoop()`
- [x] Full suite: 2320 tests pass / lint clean
- [ ] Sandbox deploy: flag-off boot is identical to current behavior (Pillar 2 only)
- [ ] Sandbox deploy: flag-on with `desired_count=1` boots clean — leader cold-acquires, watchdog drives connect, /health returns 200
- [ ] Sandbox deploy: flag-on with `desired_count=2` — active/standby split, pushHandoff during rolling deploy keeps session continuity (requires PR 14)

## Rollout

1. Merge PR 13b.3 (this PR) — flag-off, no behavior change.
2. Bake on prod for 24-48 h to confirm no regression in Pillar 2 path.
3. PR 14 lands infra change to `desired_count=2` + AZ-spread placement.
4. Flip `ENABLE_GATEWAY_HOT_STANDBY=true` on the gateway task def.
5. PR 15 runs chaos validation (deploy-during-flow + RESUME-fail + queue-backpressure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)