### PR TITLE
feat(discord): derive INSTANCE_ID/INSTANCE_IP from os module

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -160,9 +160,12 @@ ENABLE_OPENNHP_FEATURES=false
 
 # Per-replica identity for the hot-standby control plane. Each task
 # must see a unique value — the DDB lock + peer-heartbeat rows key
-# on this. ECS task-defs inject the task's ARN suffix (or task
-# metadata GUID) here at boot. Required when
-# ENABLE_GATEWAY_HOT_STANDBY=true, unused otherwise.
+# on this. Derived in-process at boot:
+#   INSTANCE_ID ← os.hostname()           (Fargate per-task hostname)
+#   INSTANCE_IP ← first non-internal IPv4 (Fargate awsvpc eth0 ENI)
+# Setting either here is an override (tests, local docker, debugging);
+# under normal ECS Fargate operation leave both blank. Required when
+# ENABLE_GATEWAY_HOT_STANDBY=true.
 # INSTANCE_ID=
 # INSTANCE_IP=
 

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -253,14 +253,14 @@ function missingHotStandbyKeys(cfg) {
 
 // Shape checks for INSTANCE_ID + INSTANCE_IP (run AFTER missing-keys
 // passes). Matches the secret-loader's "fail at boot, not at first
-// use" posture: a misconfigured task-def that injects the literal
-// `${ECS_TASK_ARN}` (unsubstituted shell expansion) or
+// use" posture: an env override like `INSTANCE_ID=${ECS_TASK_ARN}`
+// (unsubstituted shell expansion an operator pasted by mistake) or
 // `INSTANCE_IP=10.0.0.999` (non-IPv4) would pass the presence gate
 // and surface as a baffling DDB-lock-can't-acquire or peer-
 // unreachable error at runtime. A cheap regex catches both.
 //
 // INSTANCE_ID: rejects the `${...}` template-literal pattern (the
-// common ECS task-def substitution-failure footgun). Otherwise
+// classic env-override substitution-failure footgun). Otherwise
 // permissive — the downstream lock/heartbeat code does not require
 // a specific format.
 //
@@ -286,7 +286,7 @@ function invalidHotStandbyValues(cfg) {
   if (cfg.INSTANCE_ID && cfg.INSTANCE_ID.includes('${')) {
     problems.push(
       `INSTANCE_ID looks like an unsubstituted template literal ('${cfg.INSTANCE_ID}'). ` +
-      'Check the ECS task-def is resolving the placeholder against the task metadata endpoint.'
+      'INSTANCE_ID is derived from os.hostname() by default; an env override here was set to an unresolved placeholder.'
     );
   }
   if (cfg.INSTANCE_IP && !IPV4_RE.test(cfg.INSTANCE_IP)) {

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -292,7 +292,8 @@ function invalidHotStandbyValues(cfg) {
   if (cfg.INSTANCE_IP && !IPV4_RE.test(cfg.INSTANCE_IP)) {
     problems.push(
       `INSTANCE_IP must be a valid IPv4 address (got '${cfg.INSTANCE_IP}'). ` +
-      'Hot-standby uses v4 for the control-channel binding + peer reach; v6 is not in scope today.'
+      'Hot-standby uses v4 for the control-channel binding + peer reach; v6 is not in scope today. ' +
+      'If you set INSTANCE_IP as an env override, unset it to fall back to the derivation from os.networkInterfaces().'
     );
   }
   return problems;

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -68,7 +68,7 @@ function deriveInstanceIp() {
   // but yield nothing (the first pass already rejected every candidate),
   // so a separate skip isn't worth the noise.
   for (const addrs of Object.values(ifaces)) {
-    for (const addr of addrs) {
+    for (const addr of addrs || []) {
       if (isIPv4(addr)) return addr.address;
     }
   }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -41,7 +41,12 @@ const os = require('os');
 // Fargate boot (which would surface as a misleading "no IPv4 found"
 // diagnostic at 3am).
 function deriveInstanceId() {
-  return process.env.INSTANCE_ID?.trim() || os.hostname();
+  // `|| null` normalizes the rare empty-hostname case (chroot or
+  // misconfigured init namespace) for symmetry with deriveInstanceIp.
+  // missingHotStandbyKeys catches both null and '' via its falsy
+  // check, so behavior is unchanged — the symmetry is for callers
+  // reading config.INSTANCE_ID and reasoning about its possible shapes.
+  return process.env.INSTANCE_ID?.trim() || os.hostname() || null;
 }
 
 function isIPv4(addr) {
@@ -529,8 +534,11 @@ module.exports = {
   // every handoff; the peer-heartbeat row keys on it. Derived from
   // `os.hostname()` (Fargate sets this to a short alphanumeric per
   // task — distinct across replicas in the same service); env override
-  // wins. When hot-standby is off, the leader code path doesn't run,
-  // so the value is never read. LOAD-BEARING INVARIANT (full rationale
+  // wins. Populated unconditionally at module-load (even when
+  // hot-standby is off) — safe because every consumer in index.js
+  // lives inside `startHotStandby()`, which only runs when the flag
+  // is on. A non-null `config.INSTANCE_ID` is NOT a hot-standby
+  // indicator on its own. LOAD-BEARING INVARIANT (full rationale
   // above `deriveInstanceId`): two replicas in the same ECS service
   // MUST see different values, or the DDB lock short-circuits.
   INSTANCE_ID: deriveInstanceId(),

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -22,8 +22,11 @@ function deriveInstanceIp() {
   for (const addr of ifaces.eth0 || []) {
     if (addr.family === 'IPv4' && !addr.internal) return addr.address;
   }
-  for (const name of Object.keys(ifaces)) {
-    if (name === 'eth0') continue;
+  // Fallback for local/dev (macOS `en0`, stripped containers without
+  // `eth0`, etc.). Iteration order is whatever `os.networkInterfaces()`
+  // returns — best-effort only; under Fargate awsvpc the eth0 path
+  // above always wins, so this branch never runs in prod.
+  for (const name of Object.keys(ifaces).filter(n => n !== 'eth0')) {
     for (const addr of ifaces[name] || []) {
       if (addr.family === 'IPv4' && !addr.internal) return addr.address;
     }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -42,15 +42,17 @@ function deriveInstanceIp() {
   const envOverride = process.env.INSTANCE_IP?.trim();
   if (envOverride) return envOverride;
   const ifaces = os.networkInterfaces();
+  // First pass: eth0 (the awsvpc ENI's stable name) gets priority —
+  // under Fargate this always returns on the first candidate.
   for (const addr of ifaces.eth0 || []) {
     if (addr.family === 'IPv4' && !addr.internal) return addr.address;
   }
   // Fallback for local/dev (macOS `en0`, stripped containers without
   // `eth0`, etc.). Iteration order is whatever `os.networkInterfaces()`
-  // returns — best-effort only; under Fargate awsvpc the eth0 path
-  // above always wins, so this branch never runs in prod.
-  for (const [name, addrs] of Object.entries(ifaces)) {
-    if (name === 'eth0') continue;
+  // returns — best-effort only. Re-walking eth0 here is a no-op (the
+  // first pass already returned on any usable candidate), so we don't
+  // bother skipping it.
+  for (const addrs of Object.values(ifaces)) {
     for (const addr of addrs) {
       if (addr.family === 'IPv4' && !addr.internal) return addr.address;
     }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -2,6 +2,9 @@ const path = require('path');
 const os = require('os');
 
 // Sync derivation for INSTANCE_ID / INSTANCE_IP (hot-standby identity).
+// Each helper runs once at module-load and is cached into the exported
+// config object — readers of `config.INSTANCE_ID` see a frozen value,
+// not a re-evaluation on access.
 //
 // ECS Fargate awsvpc gives each task its own hostname and ENI, but it
 // does NOT substitute `${ECS_TASK_ARN}` into task-def env-var values
@@ -12,6 +15,15 @@ const os = require('os');
 // module, which is sync, network-free, and works identically in ECS,
 // local docker, and unit tests. Per-field semantics are commented at
 // the call sites below.
+//
+// LOAD-BEARING INVARIANT for the lock primitive: two replicas in the
+// same ECS service MUST see different INSTANCE_ID values. Fargate
+// assigns a unique short alphanumeric hostname per task, which
+// satisfies this — but if a future runtime ever reused hostnames
+// across replicas in the same service, the DDB lock would short-
+// circuit and both replicas would believe they hold leadership.
+// The peer-heartbeat row collision (two writers on the same composite
+// key) would surface post-deploy as a telemetry signal.
 function deriveInstanceId() {
   return process.env.INSTANCE_ID || os.hostname();
 }
@@ -27,7 +39,7 @@ function deriveInstanceIp() {
   // returns — best-effort only; under Fargate awsvpc the eth0 path
   // above always wins, so this branch never runs in prod.
   for (const name of Object.keys(ifaces).filter(n => n !== 'eth0')) {
-    for (const addr of ifaces[name] || []) {
+    for (const addr of ifaces[name]) {
       if (addr.family === 'IPv4' && !addr.internal) return addr.address;
     }
   }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -1,4 +1,35 @@
 const path = require('path');
+const os = require('os');
+
+// Sync derivation for INSTANCE_ID / INSTANCE_IP (hot-standby identity).
+//
+// ECS Fargate awsvpc gives each task its own hostname and ENI, but it
+// does NOT substitute `${ECS_TASK_ARN}` into task-def env-var values
+// (only `command = []` and `entryPoint = []` see that interpolation).
+// Rather than spin up an async ECS-metadata-endpoint fetch at boot —
+// which would push the missing-env guard past module load and add an
+// HTTP dependency to startup — derive both values from Node's `os`
+// module, which is sync, network-free, and works identically in ECS,
+// local docker, and unit tests. Per-field semantics are commented at
+// the call sites below.
+function deriveInstanceId() {
+  return process.env.INSTANCE_ID || os.hostname();
+}
+
+function deriveInstanceIp() {
+  if (process.env.INSTANCE_IP) return process.env.INSTANCE_IP;
+  const ifaces = os.networkInterfaces();
+  for (const addr of ifaces.eth0 || []) {
+    if (addr.family === 'IPv4' && !addr.internal) return addr.address;
+  }
+  for (const name of Object.keys(ifaces)) {
+    if (name === 'eth0') continue;
+    for (const addr of ifaces[name] || []) {
+      if (addr.family === 'IPv4' && !addr.internal) return addr.address;
+    }
+  }
+  return null;
+}
 
 // Safe int parser: handles NaN and falsy-zero correctly.
 //
@@ -456,22 +487,21 @@ module.exports = {
 
   // Per-replica identity. The leader coordinator writes this into the
   // DDB lock row as the holder; the control-channel server logs it on
-  // every handoff; the peer-heartbeat row keys on it. Injected by the
-  // ECS task-def `environment = []` block from `${ECS_TASK_ARN}` or
-  // the task metadata endpoint — the deploy is responsible for
-  // ensuring two replicas never share the same value (the lock would
-  // otherwise short-circuit and both replicas would think they hold
-  // it). When unset (hot-standby off), the leader code path doesn't
-  // run, so the value is never read.
-  INSTANCE_ID: process.env.INSTANCE_ID || null,
+  // every handoff; the peer-heartbeat row keys on it. Derived from
+  // `os.hostname()` (Fargate sets this to a short alphanumeric per
+  // task — distinct across replicas in the same service); env override
+  // wins. When hot-standby is off, the leader code path doesn't run,
+  // so the value is never read.
+  INSTANCE_ID: deriveInstanceId(),
 
   // The IPv4 address peers reach this replica on (`http://<ip>:<port>/control/yours`).
-  // ECS awsvpc mode assigns a routable VPC IP per task and exposes it
-  // on the ECS metadata endpoint `$ECS_CONTAINER_METADATA_URI_V4`;
-  // the task-def `environment = []` block plumbs that into INSTANCE_IP
-  // at boot. Used by the peer-heartbeat row's `address_v4` field so
-  // the active replica's pushHandoff client knows where to connect.
-  INSTANCE_IP: process.env.INSTANCE_IP || null,
+  // ECS awsvpc mode assigns a routable VPC IP per task on the task's
+  // eth0 ENI; `os.networkInterfaces()` exposes it sync at boot. Used
+  // by the peer-heartbeat row's `address_v4` field so the active
+  // replica's pushHandoff client knows where to connect. Env override
+  // wins; if no non-internal IPv4 exists, this is null and
+  // invalidHotStandbyValues rejects boot.
+  INSTANCE_IP: deriveInstanceIp(),
 
   // Bind/listen ports for the in-VPC control channel that receives
   // pushHandoff envelopes from the outgoing leader. The bind address

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -24,12 +24,23 @@ const os = require('os');
 // circuit and both replicas would believe they hold leadership.
 // The peer-heartbeat row collision (two writers on the same composite
 // key) would surface post-deploy as a telemetry signal.
+// Env overrides are trimmed for parity with GUILD_ID / STORE_TYPE /
+// ALLOWED_GITHUB_ORGS upstream — a trailing space on INSTANCE_ID
+// would otherwise silently key into the DDB lock and a replica
+// mismatch would be hard to spot.
+//
+// `addr.family === 'IPv4'` matches Node 22's `os.networkInterfaces()`
+// string-form contract (the brief Node 18 numeric experiment was
+// reverted). If a future Node major flips back to numeric, this
+// returns null on every Fargate boot and invalidHotStandbyValues
+// catches it — fail-loud, but the diagnostic would be misleading.
 function deriveInstanceId() {
-  return process.env.INSTANCE_ID || os.hostname();
+  return process.env.INSTANCE_ID?.trim() || os.hostname();
 }
 
 function deriveInstanceIp() {
-  if (process.env.INSTANCE_IP) return process.env.INSTANCE_IP;
+  const envOverride = process.env.INSTANCE_IP?.trim();
+  if (envOverride) return envOverride;
   const ifaces = os.networkInterfaces();
   for (const addr of ifaces.eth0 || []) {
     if (addr.family === 'IPv4' && !addr.internal) return addr.address;
@@ -38,8 +49,9 @@ function deriveInstanceIp() {
   // `eth0`, etc.). Iteration order is whatever `os.networkInterfaces()`
   // returns — best-effort only; under Fargate awsvpc the eth0 path
   // above always wins, so this branch never runs in prod.
-  for (const name of Object.keys(ifaces).filter(n => n !== 'eth0')) {
-    for (const addr of ifaces[name]) {
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (name === 'eth0') continue;
+    for (const addr of addrs) {
       if (addr.family === 'IPv4' && !addr.internal) return addr.address;
     }
   }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -29,13 +29,23 @@ const os = require('os');
 // would otherwise silently key into the DDB lock and a replica
 // mismatch would be hard to spot.
 //
+// Shape validation for env overrides lives in `invalidHotStandbyValues`
+// (boot-requirements.js): this helper trusts env values verbatim,
+// the boot-time validator catches malformed IPv4 / template-literal
+// pastes via a single source of truth.
+//
 // `addr.family === 'IPv4'` matches Node 22's `os.networkInterfaces()`
-// string-form contract (the brief Node 18 numeric experiment was
-// reverted). If a future Node major flips back to numeric, this
-// returns null on every Fargate boot and invalidHotStandbyValues
-// catches it — fail-loud, but the diagnostic would be misleading.
+// string-form contract. Node 18.0.0 briefly returned numeric `4`/`6`
+// before that was reverted; we accept both shapes so a future Node
+// major regressing back to numeric doesn't return null on every
+// Fargate boot (which would surface as a misleading "no IPv4 found"
+// diagnostic at 3am).
 function deriveInstanceId() {
   return process.env.INSTANCE_ID?.trim() || os.hostname();
+}
+
+function isIPv4(addr) {
+  return (addr.family === 'IPv4' || addr.family === 4) && !addr.internal;
 }
 
 function deriveInstanceIp() {
@@ -45,16 +55,16 @@ function deriveInstanceIp() {
   // First pass: eth0 (the awsvpc ENI's stable name) gets priority —
   // under Fargate this always returns on the first candidate.
   for (const addr of ifaces.eth0 || []) {
-    if (addr.family === 'IPv4' && !addr.internal) return addr.address;
+    if (isIPv4(addr)) return addr.address;
   }
   // Fallback for local/dev (macOS `en0`, stripped containers without
   // `eth0`, etc.). Iteration order is whatever `os.networkInterfaces()`
-  // returns — best-effort only. Re-walking eth0 here is a no-op (the
-  // first pass already returned on any usable candidate), so we don't
-  // bother skipping it.
+  // returns — best-effort only. The eth0 entries get re-walked here
+  // but yield nothing (the first pass already rejected every candidate),
+  // so a separate skip isn't worth the noise.
   for (const addrs of Object.values(ifaces)) {
     for (const addr of addrs) {
-      if (addr.family === 'IPv4' && !addr.internal) return addr.address;
+      if (isIPv4(addr)) return addr.address;
     }
   }
   return null;
@@ -520,7 +530,9 @@ module.exports = {
   // `os.hostname()` (Fargate sets this to a short alphanumeric per
   // task — distinct across replicas in the same service); env override
   // wins. When hot-standby is off, the leader code path doesn't run,
-  // so the value is never read.
+  // so the value is never read. LOAD-BEARING INVARIANT (full rationale
+  // above `deriveInstanceId`): two replicas in the same ECS service
+  // MUST see different values, or the DDB lock short-circuits.
   INSTANCE_ID: deriveInstanceId(),
 
   // The IPv4 address peers reach this replica on (`http://<ip>:<port>/control/yours`).

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -351,7 +351,7 @@ if (hotStandbyMissing.length > 0) {
   logger.error(
     `ENABLE_GATEWAY_HOT_STANDBY=true but required env vars missing: ${hotStandbyMissing.join(', ')}. ` +
     'INSTANCE_ID + INSTANCE_IP are derived in-process from `os.hostname()` and `os.networkInterfaces()` ' +
-    '(env overrides accepted) — a null value means the container has no hostname or no non-internal IPv4. ' +
+    '(env overrides accepted) — null or empty means the container has no hostname or no non-internal IPv4. ' +
     'GATEWAY_HANDOFF_HMAC is the SSM-decrypted JSON `{current, previous?}` secret. Verify the ' +
     'qurl-integrations-infra/qurl-bot-discord/terraform/main.tf wiring and re-deploy.'
   );

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -350,7 +350,8 @@ const hotStandbyMissing = missingHotStandbyKeys(config);
 if (hotStandbyMissing.length > 0) {
   logger.error(
     `ENABLE_GATEWAY_HOT_STANDBY=true but required env vars missing: ${hotStandbyMissing.join(', ')}. ` +
-    'INSTANCE_ID + INSTANCE_IP are injected by the ECS task-def from the task metadata endpoint; ' +
+    'INSTANCE_ID + INSTANCE_IP are derived in-process from `os.hostname()` and `os.networkInterfaces()` ' +
+    '(env overrides accepted) — a null value means the container has no hostname or no non-internal IPv4. ' +
     'GATEWAY_HANDOFF_HMAC is the SSM-decrypted JSON `{current, previous?}` secret. Verify the ' +
     'qurl-integrations-infra/qurl-bot-discord/terraform/main.tf wiring and re-deploy.'
   );

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -532,12 +532,13 @@ describe('invalidHotStandbyValues', () => {
     expect(invalidHotStandbyValues(cfg())).toEqual([]);
   });
 
-  it('flags unsubstituted template literal in INSTANCE_ID — the ECS task-def footgun', () => {
-    // The specific scenario: a task-def with
-    // `INSTANCE_ID: "${ECS_TASK_ARN}"` that the metadata-resolution
-    // layer fails to substitute. Without this check the literal
-    // `${ECS_TASK_ARN}` would key the lock + heartbeat rows and
-    // every replica would think it owns the same identifier.
+  it('flags unsubstituted template literal in INSTANCE_ID — env-override paste footgun', () => {
+    // The specific scenario: an operator sets
+    // `INSTANCE_ID=${ECS_TASK_ARN}` as an env override (e.g. pasted
+    // from a runbook) and the surrounding shell fails to expand it.
+    // Without this check the literal `${ECS_TASK_ARN}` would key the
+    // lock + heartbeat rows and every replica would think it owns
+    // the same identifier.
     const problems = invalidHotStandbyValues(cfg({ INSTANCE_ID: '${ECS_TASK_ARN}' }));
     expect(problems).toHaveLength(1);
     expect(problems[0]).toMatch(/INSTANCE_ID looks like an unsubstituted template literal/);

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -69,6 +69,32 @@ describe('INSTANCE_ID derivation', () => {
 });
 
 describe('INSTANCE_IP derivation', () => {
+  it('falls back to interface scan when INSTANCE_IP is empty string', () => {
+    withFreshConfig(
+      {
+        env: { INSTANCE_IP: '' },
+        networkInterfaces: {
+          eth0: [{ family: 'IPv4', address: '10.0.0.7', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.0.0.7');
+      },
+    );
+  });
+
+  it('trims whitespace from env overrides (parity with other env-derived values)', () => {
+    withFreshConfig(
+      {
+        env: { INSTANCE_ID: '  pinned  ', INSTANCE_IP: ' 10.0.0.5 ' },
+      },
+      (config) => {
+        expect(config.INSTANCE_ID).toBe('pinned');
+        expect(config.INSTANCE_IP).toBe('10.0.0.5');
+      },
+    );
+  });
+
   it('uses INSTANCE_IP env override when set (wins over interfaces)', () => {
     withFreshConfig(
       {

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -143,6 +143,24 @@ describe('INSTANCE_IP derivation', () => {
     );
   });
 
+  it('accepts numeric addr.family (defensive against historical Node 18 regression)', () => {
+    // Node 18.0.0 briefly returned `family: 4`/`6` before that was
+    // reverted to the string form. Pinning both shapes here so a
+    // future Node major regressing back to numeric doesn't return
+    // null on every Fargate boot.
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          eth0: [{ family: 4, address: '10.0.0.55', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.0.0.55');
+      },
+    );
+  });
+
   it('falls back to non-eth0 when eth0 has only internal IPv4 addresses', () => {
     // The branch the previous tests missed: eth0 exists and has IPv4
     // addresses, but all are internal (e.g., loopback aliased). The

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -58,6 +58,19 @@ describe('INSTANCE_ID derivation', () => {
     );
   });
 
+  it('returns null when both env override and os.hostname() are empty', () => {
+    // Pins the `|| null` branch in deriveInstanceId: rare chroot or
+    // misconfigured-init-ns where os.hostname() returns ''. Without
+    // the null normalization, callers branching on `=== null` would
+    // see an empty string instead.
+    withFreshConfig(
+      { env: {}, hostname: '' },
+      (config) => {
+        expect(config.INSTANCE_ID).toBeNull();
+      },
+    );
+  });
+
   it('falls back to os.hostname() when INSTANCE_ID is empty string', () => {
     withFreshConfig(
       { env: { INSTANCE_ID: '' }, hostname: 'fargate-empty-env' },

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -131,14 +131,37 @@ describe('INSTANCE_IP derivation', () => {
     );
   });
 
-  it('skips internal IPv4 addresses', () => {
+  it('passes a bad env override through to invalidHotStandbyValues (contract end-to-end)', () => {
+    // Env override wins over derivation, so a malformed value
+    // (10.0.0.999 — non-IPv4) lands in config.INSTANCE_IP unmodified.
+    // The boot-time validator must then catch it. Locks the contract
+    // that override-path values still flow through the shape gate.
+    const { invalidHotStandbyValues } = require('../src/boot-requirements');
+    withFreshConfig(
+      { env: { INSTANCE_IP: '10.0.0.999' } },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.0.0.999');
+        const problems = invalidHotStandbyValues({
+          ...config,
+          ENABLE_GATEWAY_HOT_STANDBY: true,
+        });
+        expect(problems.some((p) => p.includes('INSTANCE_IP must be a valid IPv4'))).toBe(true);
+      },
+    );
+  });
+
+  it('skips internal IPv4 addresses on eth0 (loopback aliased)', () => {
+    // Eth0 has both an internal address (127.0.0.1 — a misconfigured
+    // alias) AND the real non-internal IP. Without the `!addr.internal`
+    // guard this would return 127.0.0.1 because it appears first.
     withFreshConfig(
       {
         env: {},
         networkInterfaces: {
-          lo: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
-          docker0: [{ family: 'IPv4', address: '172.17.0.1', internal: true }],
-          eth0: [{ family: 'IPv4', address: '10.0.0.1', internal: false }],
+          eth0: [
+            { family: 'IPv4', address: '127.0.0.1', internal: true },
+            { family: 'IPv4', address: '10.0.0.1', internal: false },
+          ],
         },
       },
       (config) => {

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -95,6 +95,22 @@ describe('INSTANCE_IP derivation', () => {
     );
   });
 
+  it('whitespace-only env overrides fall through to derivation', () => {
+    withFreshConfig(
+      {
+        env: { INSTANCE_ID: '   ', INSTANCE_IP: '\t\t' },
+        hostname: 'derived-host',
+        networkInterfaces: {
+          eth0: [{ family: 'IPv4', address: '10.0.0.99', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_ID).toBe('derived-host');
+        expect(config.INSTANCE_IP).toBe('10.0.0.99');
+      },
+    );
+  });
+
   it('uses INSTANCE_IP env override when set (wins over interfaces)', () => {
     withFreshConfig(
       {
@@ -123,6 +139,25 @@ describe('INSTANCE_IP derivation', () => {
       },
       (config) => {
         expect(config.INSTANCE_IP).toBe('10.0.0.42');
+      },
+    );
+  });
+
+  it('falls back to non-eth0 when eth0 has only internal IPv4 addresses', () => {
+    // The branch the previous tests missed: eth0 exists and has IPv4
+    // addresses, but all are internal (e.g., loopback aliased). The
+    // first-pass eth0 loop must walk through without returning, then
+    // the fallback must pick up the non-internal address on en0.
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          eth0: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+          en0: [{ family: 'IPv4', address: '192.168.5.10', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('192.168.5.10');
       },
     );
   });

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -1,0 +1,149 @@
+// Each test uses jest.isolateModules with `os` mocked BEFORE config
+// is required — config caches the derived values into the exported
+// object at require-time, so a fresh module graph is required per
+// test to exercise different `os` shapes.
+
+function withFreshConfig({ env = {}, hostname, networkInterfaces }, run) {
+  jest.isolateModules(() => {
+    const prevEnv = {};
+    for (const key of ['INSTANCE_ID', 'INSTANCE_IP']) {
+      prevEnv[key] = process.env[key];
+      if (env[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = env[key];
+      }
+    }
+    jest.doMock('os', () => {
+      const actual = jest.requireActual('os');
+      return {
+        ...actual,
+        hostname: () => (hostname !== undefined ? hostname : actual.hostname()),
+        networkInterfaces: () =>
+          networkInterfaces !== undefined ? networkInterfaces : actual.networkInterfaces(),
+      };
+    });
+    try {
+      const config = require('../src/config');
+      run(config);
+    } finally {
+      for (const key of Object.keys(prevEnv)) {
+        if (prevEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = prevEnv[key];
+        }
+      }
+      jest.dontMock('os');
+    }
+  });
+}
+
+describe('INSTANCE_ID derivation', () => {
+  it('uses INSTANCE_ID env override when set (wins over hostname)', () => {
+    withFreshConfig(
+      { env: { INSTANCE_ID: 'pinned-override' }, hostname: 'ip-10-0-0-7' },
+      (config) => {
+        expect(config.INSTANCE_ID).toBe('pinned-override');
+      },
+    );
+  });
+
+  it('falls back to os.hostname() when INSTANCE_ID is unset', () => {
+    withFreshConfig(
+      { env: {}, hostname: 'fargate-abc123def456' },
+      (config) => {
+        expect(config.INSTANCE_ID).toBe('fargate-abc123def456');
+      },
+    );
+  });
+
+  it('falls back to os.hostname() when INSTANCE_ID is empty string', () => {
+    withFreshConfig(
+      { env: { INSTANCE_ID: '' }, hostname: 'fargate-empty-env' },
+      (config) => {
+        expect(config.INSTANCE_ID).toBe('fargate-empty-env');
+      },
+    );
+  });
+});
+
+describe('INSTANCE_IP derivation', () => {
+  it('uses INSTANCE_IP env override when set (wins over interfaces)', () => {
+    withFreshConfig(
+      {
+        env: { INSTANCE_IP: '10.99.99.99' },
+        networkInterfaces: {
+          eth0: [{ family: 'IPv4', address: '10.0.0.5', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.99.99.99');
+      },
+    );
+  });
+
+  it('picks first non-internal IPv4 from eth0 when env unset', () => {
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          lo: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+          eth0: [
+            { family: 'IPv6', address: 'fe80::1', internal: false },
+            { family: 'IPv4', address: '10.0.0.42', internal: false },
+          ],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.0.0.42');
+      },
+    );
+  });
+
+  it('falls back to non-eth0 interfaces when eth0 has no usable IPv4', () => {
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          lo: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+          en0: [{ family: 'IPv4', address: '192.168.1.42', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('192.168.1.42');
+      },
+    );
+  });
+
+  it('returns null when no non-internal IPv4 exists', () => {
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          lo: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+          eth0: [{ family: 'IPv6', address: 'fe80::1', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBeNull();
+      },
+    );
+  });
+
+  it('skips internal IPv4 addresses', () => {
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          lo: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+          docker0: [{ family: 'IPv4', address: '172.17.0.1', internal: true }],
+          eth0: [{ family: 'IPv4', address: '10.0.0.1', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.0.0.1');
+      },
+    );
+  });
+});

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -136,10 +136,13 @@ describe('INSTANCE_IP derivation', () => {
     // (10.0.0.999 — non-IPv4) lands in config.INSTANCE_IP unmodified.
     // The boot-time validator must then catch it. Locks the contract
     // that override-path values still flow through the shape gate.
-    const { invalidHotStandbyValues } = require('../src/boot-requirements');
     withFreshConfig(
       { env: { INSTANCE_IP: '10.0.0.999' } },
       (config) => {
+        // Require inside isolateModules so boot-requirements sees the
+        // same module graph as config — future-proofs against a graph
+        // dependency on the `os` mock.
+        const { invalidHotStandbyValues } = require('../src/boot-requirements');
         expect(config.INSTANCE_IP).toBe('10.0.0.999');
         const problems = invalidHotStandbyValues({
           ...config,


### PR DESCRIPTION
## Summary

Hot-standby identity (Pillar 3, shipped in #417) requires `INSTANCE_ID` + `INSTANCE_IP` to be populated on every gateway replica. ECS Fargate awsvpc gives each task its own hostname and ENI, but it does **not** substitute `${ECS_TASK_ARN}` into task-def env-var values (only `command` and `entryPoint` see that interpolation) — so plumbing identity through env vars alone is a dead end on Fargate.

This PR derives both fields sync from Node's `os` module at config require-time:
- `INSTANCE_ID` ← trimmed env override || `os.hostname()`
- `INSTANCE_IP` ← trimmed env override || first non-internal IPv4 from `os.networkInterfaces()`, preferring `eth0` (the awsvpc ENI's stable name)

Env overrides are trimmed for parity with other env-derived values in `config.js` (GUILD_ID, STORE_TYPE, ALLOWED_GITHUB_ORGS) and remain for test pinning and debugging; under normal Fargate operation both run unset and the derivation produces correct values without any task-def coupling.

## Why this matters

This is the prereq for PR 14 (`gateway_desired_count=2` + AZ-spread placement). Without populated `INSTANCE_ID`/`INSTANCE_IP`, flipping `ENABLE_GATEWAY_HOT_STANDBY=true` would fail boot at the `missingHotStandbyKeys` gate.

The alternative — async fetch from `$ECS_CONTAINER_METADATA_URI_V4` — would push the missing-env guard past module load, add an HTTP dependency to startup, and create a network failure mode for boot. Sync derivation has none of those tradeoffs and works identically in ECS, local docker, and unit tests.

## Load-bearing invariant

The lock primitive depends on **two replicas in the same ECS service seeing different `INSTANCE_ID` values**. Fargate assigns a unique short alphanumeric hostname per task, which satisfies this. The invariant is called out at the `deriveInstanceId` call site so future readers don't have to reconstruct it.

## What changed

- `src/config.js`: `deriveInstanceId()` + `deriveInstanceIp()` helpers; both called once at module-load and cached into `module.exports`. Hostname-uniqueness invariant + module-load caching + `addr.family` Node-version assumption documented inline. Env overrides trimmed for parity with the rest of the file.
- `src/boot-requirements.js`: updated comments + error message (template-literal check still catches env-override paste mistakes)
- `src/index.js`: updated operator-facing boot error to reflect new derivation source
- `.env.example`: documents the new derivation semantics; both vars are overrides, not required
- `tests/config-instance-derivation.test.js`: 13 new tests (env-set wins, env-unset→derived, empty-string env for both ID + IP, whitespace-trim, whitespace-only fall-through, eth0 preferred, fallback when eth0 has only internal IPv4, fallback to non-eth0 when eth0 has no IPv4, IPv6-only returns null, internal IPv4 skipped on aliased eth0, env-override-passes-through contract end-to-end)
- `tests/boot-requirements.test.js`: updated one comment + test title to reflect env-override-paste failure mode

## Test plan

- [x] `npx jest` — all 2397 tests pass (13 new)
- [x] `npx eslint` — clean
- [x] /simplify pass — applied: eth0 skip on fallback loop, trimmed duplicate comments
- [x] cr-r1 + cr-r2 + cr-r3 + cr-r4 feedback applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)