### PR TITLE
test(discord): pillar 3 chaos validation suite (PR 15)

### DIFF
--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -67,7 +67,9 @@ function tableNamesTargeted(cmdInput) {
   if (Array.isArray(cmdInput.TransactItems)) {
     return cmdInput.TransactItems
       .map((entry) => {
-        const op = entry.Put || entry.Update || entry.Delete || entry.ConditionCheck;
+        // Includes Get for TransactGet (read-side) so the allowlist
+        // gate doesn't miss it if a future read-side refactor lands.
+        const op = entry.Put || entry.Update || entry.Delete || entry.ConditionCheck || entry.Get;
         return op?.TableName;
       })
       .filter(Boolean);
@@ -247,8 +249,28 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     // can't distinguish parallel from serialized at the timescales
     // mocked-DDB pushHandoff runs at (single-digit ms); call-order is
     // the right signal.
-    const pushHandoffSpy = jest.spyOn(leader, 'pushHandoff');
-    const eventPublisher = makeControllableEventPublisher();
+    //
+    // Timeline-based check (in addition to "both called within one
+    // tick"): record both `stop()` invoke and `pushHandoff()` resolve
+    // as ordered events, then assert stop-invoke landed BEFORE
+    // pushHandoff-resolve. A regression that serializes the drain
+    // (`await pushHandoff(); then stop()`) would resolve pushHandoff
+    // first, then invoke stop — failing the ordering check.
+    const timeline = [];
+    const origPushHandoff = leader.pushHandoff.bind(leader);
+    const pushHandoffSpy = jest.spyOn(leader, 'pushHandoff').mockImplementation(async (...args) => {
+      const result = await origPushHandoff(...args);
+      timeline.push('pushHandoff-resolved');
+      return result;
+    });
+    const baseEventPublisher = makeControllableEventPublisher();
+    const eventPublisher = {
+      stop: jest.fn(() => {
+        timeline.push('stop-invoked');
+        return baseEventPublisher.stop();
+      }),
+      releaseStop: baseEventPublisher.releaseStop,
+    };
     const exit = jest.fn();
     const { schedule, clearHardExit, timers } = makeScheduleHardExit();
 
@@ -266,6 +288,16 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
 
     expect(pushHandoffSpy).toHaveBeenCalled();
     expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
+
+    // Ordering check: stop-invoke must come before pushHandoff-resolve.
+    // Tighter than "both called within one tick" — a serialized
+    // `await pushHandoff(); then stop()` would resolve pushHandoff
+    // first, then invoke stop, flipping the order.
+    const stopIdx = timeline.indexOf('stop-invoked');
+    const pushResolvedIdx = timeline.indexOf('pushHandoff-resolved');
+    expect(stopIdx).toBeGreaterThanOrEqual(0);
+    expect(pushResolvedIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeLessThan(pushResolvedIdx);
 
     // Release the pending stop() so runPushHandoffShutdown's
     // `await drainPromise` resolves and exit() fires.

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -43,6 +43,14 @@
 //      ~6s longer (waiting for TTL lapse vs immediate DDB Delete). The
 //      no-peer case below asserts the DDB DeleteCommand lands on the
 //      lock table within the SIGTERM window.
+//
+// Out of chaos scope (covered by unit tests, intentionally not duplicated):
+//   - pushHandoff throwing synchronously (handoffThrew path → forcedExitCode):
+//     runPushHandoffShutdown's unit tests pin the exit-code semantics;
+//     test #3 below covers the symmetric hung-controlClient timeout path.
+//   - exact backoff-ladder timing (200/400/800/1600 ms): the watchdog's
+//     unit test pins the cadence; chaos tests stub sleep to a no-op.
+//   - per-attempt log shape: also in unit tests.
 
 const { createGatewayLock } = require('../src/gateway-lock');
 const { createPeerHeartbeat } = require('../src/gateway-peer-heartbeat');
@@ -250,6 +258,17 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     // mocked-DDB pushHandoff runs at (single-digit ms); call-order is
     // the right signal.
     //
+    // Brittleness note: this spy works because runPushHandoffShutdown
+    // calls `gatewayLeader.pushHandoff()` through the object property
+    // (`createGatewayLeader` returns an object literal of closures).
+    // If a future refactor destructures or caches the method elsewhere
+    // (e.g. `const { pushHandoff } = gatewayLeader`), this spy would
+    // silently bypass and the ordering assertion would mysteriously
+    // fail. If that lands, switch the spy target to `lock.transferLock`
+    // (the seam between real primitives that pushHandoff awaits
+    // internally) — same call-order signal, decoupled from the
+    // leader's surface shape.
+    //
     // Timeline-based check (in addition to "both called within one
     // tick"): record both `stop()` invoke and `pushHandoff()` resolve
     // as ordered events, then assert stop-invoke landed BEFORE
@@ -278,13 +297,27 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       code: 0, gatewayLeader: leader, eventPublisher, logger,
       exit, scheduleHardExit: schedule, clearHardExit,
     });
-    // Yield once so runPushHandoffShutdown enters its body. The
-    // parallel call to eventPublisher.stop() lands synchronously
-    // inside that body — regardless of whether pushHandoff has
-    // resolved yet — IF they're issued in parallel. If they were
-    // serialized (stop() awaited AFTER pushHandoff returns), the
-    // spy would not yet be called at this observation point.
-    await new Promise((r) => { setImmediate(r); });
+    // Wait for pushHandoff to fully resolve. A single setImmediate
+    // yield is enough today (the body's awaits drain in microtasks
+    // ahead of setImmediate), but bounding by a yield counter
+    // mirrors test #3's MAX_YIELDS_FOR_TRANSFER pattern — robust if
+    // a future refactor adds another await inside pushHandoff (e.g.
+    // a metric flush or extra DDB round-trip). The diagnostic throw
+    // turns a future flake into a clear failure message.
+    const MAX_YIELDS_FOR_PUSH_RESOLVE = 50;
+    let yields = 0;
+    while (!timeline.includes('pushHandoff-resolved')) {
+      if (yields++ >= MAX_YIELDS_FOR_PUSH_RESOLVE) {
+        throw new Error(
+          `chaos: pushHandoff did not resolve within ${MAX_YIELDS_FOR_PUSH_RESOLVE} setImmediate yields; ` +
+          `timeline: ${JSON.stringify(timeline)}. ` +
+          `If pushHandoff grew an extra await hop, raise the bound; if it now hangs, ` +
+          `that's a real regression (test #3 covers the timeout path).`
+        );
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => { setImmediate(r); });
+    }
 
     expect(pushHandoffSpy).toHaveBeenCalled();
     expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
@@ -423,6 +456,13 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       code: 0, gatewayLeader: leader, eventPublisher, logger,
       exit, scheduleHardExit: schedule, clearHardExit,
     });
+    // Park the orphan shutdown promise immediately — it stays pending
+    // forever in prod (process.exit kills it), but in jest a failure
+    // in any later assertion would early-return without attaching this
+    // handler and the pending promise could surface as an unhandled
+    // rejection that masks the real failure. Attach now so any
+    // assertion failure below has clean output.
+    shutdownPromise.catch(() => {});
 
     // Wait until transferLock has landed (state.lockRow.instance_id
     // flipped to B). This indicates the pushHandoff body has cleared
@@ -454,11 +494,6 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     expect(state.lockRow.instance_id).toBe(INSTANCE_B);
     expect(state.lockRow.version).toBe(8);
     assertNoUnexpectedTableCalls(ddbMock);
-
-    // Park the orphan shutdown promise — it stays pending forever in
-    // prod (process.exit kills it), but in jest it'd surface as an
-    // unhandled rejection if pushHandoff ever rejects (it can't, since
-    // it's the new Promise(() => {}) hang — but defense in depth).
-    shutdownPromise.catch(() => {});
+    // (shutdownPromise.catch was attached up front; see above.)
   });
 });

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -55,18 +55,38 @@ const {
   INSTANCE_A, INSTANCE_B, HOLDER_A, HOLDER_B,
 } = require('./helpers/chaos-ddb');
 
+// Pull every TableName an SDK command targets, including the nested
+// shapes (BatchGet/BatchWrite use `RequestItems`; TransactGet/
+// TransactWrite use `TransactItems`). Single-item shapes (Put/Get/
+// Update/Delete/Scan/Query) carry `input.TableName` directly. Returns
+// a flat string[] so callers can filter against an allowlist.
+function tableNamesTargeted(cmdInput) {
+  if (!cmdInput) return [];
+  if (cmdInput.TableName) return [cmdInput.TableName];
+  if (cmdInput.RequestItems) return Object.keys(cmdInput.RequestItems);
+  if (Array.isArray(cmdInput.TransactItems)) {
+    return cmdInput.TransactItems
+      .map((entry) => {
+        const op = entry.Put || entry.Update || entry.Delete || entry.ConditionCheck;
+        return op?.TableName;
+      })
+      .filter(Boolean);
+  }
+  return [];
+}
+
 // Post-hoc inspection: every DDB command issued during the test must
 // have a TableName in the allowlist. Unrouted commands in mockClient
 // silently resolve, so a future refactor that writes to e.g.
 // qurl_bot_flow_state from the gateway-tier SIGTERM path would not
-// throw at runtime — this assertion is the catch. Uses ddbMock.calls()
-// rather than per-command enumeration so a future BatchGet / Query /
-// TransactWrite against a forbidden table also surfaces.
+// throw at runtime — this assertion is the catch. Walks every shape
+// (single-item, BatchGet/Write RequestItems, TransactGet/Write
+// TransactItems) so the regression surface is exhaustive.
 function assertNoUnexpectedTableCalls(ddbMock) {
   const allowed = new Set([LOCK_TABLE, HEARTBEAT_TABLE]);
-  const offenders = ddbMock.calls()
-    .map((c) => c.args[0]?.input?.TableName)
-    .filter((t) => t && !allowed.has(t));
+  const allTables = ddbMock.calls()
+    .flatMap((c) => tableNamesTargeted(c.args[0]?.input));
+  const offenders = allTables.filter((t) => !allowed.has(t));
   if (offenders.length > 0) {
     throw new Error(
       `chaos: gateway-tier SIGTERM path wrote to forbidden tables: ${[...new Set(offenders)].join(', ')}. ` +
@@ -81,9 +101,7 @@ function assertNoUnexpectedTableCalls(ddbMock) {
   // fire — this expect catches that drift specifically, since the
   // flow_state-on-gateway prohibition is the primary regression
   // target this whole file exists to protect.
-  const flowStateCalls = ddbMock.calls()
-    .filter((c) => c.args[0]?.input?.TableName === FLOW_STATE_TABLE_NAME);
-  expect(flowStateCalls).toHaveLength(0);
+  expect(allTables.filter((t) => t === FLOW_STATE_TABLE_NAME)).toHaveLength(0);
 }
 
 function makeFakeManager() {

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -250,13 +250,11 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     eventPublisher.releaseStop();
     await shutdownPromise;
 
-    // Lock row: ownership flipped, version bumped.
     expect(state.lockRow).not.toBeNull();
     expect(state.lockRow.instance_id).toBe(INSTANCE_B);
     expect(state.lockRow.lock_holder).toBe(HOLDER_B);
     expect(state.lockRow.version).toBe(4);
 
-    // Heartbeat: A's row deleted (best-effort SIGTERM cleanup).
     const remainingPeerIds = state.peerRows.map((r) => r.instance_id);
     expect(remainingPeerIds).not.toContain(INSTANCE_A);
     expect(remainingPeerIds).toContain(INSTANCE_B);
@@ -303,20 +301,16 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       exit, scheduleHardExit: schedule, clearHardExit,
     });
 
-    // Lock row deleted (releaseLockBestEffort CAS-Delete).
     expect(state.lockRow).toBeNull();
-    // No push attempted on the no-peer branch.
     expect(controlClient.pushHandoff).not.toHaveBeenCalled();
-    // Heartbeat row for A deleted (post-handoff cleanup runs on the
-    // no_peer branch too).
     expect(state.peerRows).toEqual([]);
-    // exit(0) — the no-peer outcome is still "clean" (the standby
-    // will cold-acquire via the TTL floor); exit(0) vs exit(1)
-    // distinguishes that from the timeout path for deploy SLI.
+    // exit(0): no-peer outcome is still "clean" (standby cold-acquires
+    // via the TTL floor). exit(0) vs exit(1) distinguishes from the
+    // timeout path for deploy SLI.
     expect(exit).toHaveBeenCalledWith(0);
     assertNoUnexpectedTableCalls(ddbMock);
-    // Pin the documented no-peer log so a future regression that
-    // silently swaps the branch (e.g. always-transferLock) surfaces.
+    // Pin the documented no-peer log against a future branch swap
+    // (e.g. always-transferLock).
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('no fresh peer for handoff'),
     );

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -1,0 +1,436 @@
+// Pillar 3 chaos validation — SIGTERM mid-flow (deploy-during-flow).
+//
+// Composes REAL primitives at the seams the existing unit/integration
+// tests don't reach:
+//
+//   - real createGatewayLock against a mockClient(docClient) so DDB
+//     row-state transitions (instance_id flip, version bump, expires_at
+//     refresh) are asserted against the actual UpdateCommand inputs,
+//     not a `jest.fn().mockResolvedValue(...)` stub.
+//   - real createPeerHeartbeat so listFreshPeers' Scan + filters land
+//     on the real shape (the unit test for the leader bypasses this
+//     via `peerHeartbeat: { listFreshPeers: () => [...] }`).
+//   - real createGatewayLeader with the full runSerialized chain and
+//     the pushHandoff body; the existing leader unit test exercises
+//     individual ops, not the SIGTERM-through-handoff trajectory.
+//   - real runPushHandoffShutdown so the eventPublisher-drain-in-
+//     parallel contract is exercised end-to-end, not just the
+//     gatewayLeader mock's resolve.
+//
+// Three regression modes this guards against:
+//
+//   1. A future refactor wires flow-state writes into the gateway
+//      tier's SIGTERM path. The design forbids it: writes to
+//      qurl_bot_flow_state run on the WORKER tier, which is a
+//      separate process — gateway-shutdown-helpers.js calls this out
+//      explicitly in the runPushHandoffShutdown header. The Table-
+//      Name allowlist assertion below catches the regression at PR
+//      time via post-hoc inspection of `ddbMock.commandCalls()` —
+//      unrouted commands silently resolve, so the protection is the
+//      end-of-test assertion, not a runtime throw.
+//
+//   2. A future refactor accidentally serializes eventPublisher.stop()
+//      AFTER pushHandoff instead of in parallel. The publisher's
+//      DRAIN_DEADLINE_MS (3s default) would then extend the SIGTERM
+//      critical path past the 12s ceiling. Asserts both run in parallel
+//      via call-order spies: eventPublisher.stop() is observed to enter
+//      before pushHandoff's await landed, not via wall-clock measurement
+//      (the latter is too noisy to distinguish parallel from serialized
+//      at the timescales mocked-DDB pushHandoff runs at).
+//
+//   3. A future refactor changes pushHandoff to skip releaseLockBestEffort
+//      on the no_peer path. The cold-fallback floor would then become
+//      ~6s longer (waiting for TTL lapse vs immediate DDB Delete). The
+//      no-peer case below asserts the DDB DeleteCommand lands on the
+//      lock table within the SIGTERM window.
+
+const {
+  PutCommand, GetCommand, UpdateCommand, DeleteCommand, ScanCommand,
+} = require('@aws-sdk/lib-dynamodb');
+
+const { createGatewayLock } = require('../src/gateway-lock');
+const { createPeerHeartbeat } = require('../src/gateway-peer-heartbeat');
+const { createGatewayLeader } = require('../src/gateway-leader');
+const { runPushHandoffShutdown } = require('../src/gateway-shutdown-helpers');
+const { __TABLE_NAME: FLOW_STATE_TABLE_NAME } = require('../src/flow-state');
+const {
+  setupChaosDdb, makeChaosLogger,
+  LOCK_TABLE, HEARTBEAT_TABLE, SHARD_ID,
+  INSTANCE_A, INSTANCE_B, HOLDER_A, HOLDER_B,
+} = require('./helpers/chaos-ddb');
+
+// Post-hoc inspection: every DDB command issued during the test must
+// have a TableName in the allowlist. Unrouted commands in mockClient
+// silently resolve, so a future refactor that writes to e.g.
+// qurl_bot_flow_state from the gateway-tier SIGTERM path would not
+// throw at runtime — this assertion is the catch.
+function assertNoUnexpectedTableCalls(ddbMock) {
+  const allowed = new Set([LOCK_TABLE, HEARTBEAT_TABLE]);
+  const allCalls = [
+    ...ddbMock.commandCalls(PutCommand),
+    ...ddbMock.commandCalls(GetCommand),
+    ...ddbMock.commandCalls(UpdateCommand),
+    ...ddbMock.commandCalls(DeleteCommand),
+    ...ddbMock.commandCalls(ScanCommand),
+  ];
+  const offenders = allCalls
+    .map((c) => c.args[0].input.TableName)
+    .filter((t) => t && !allowed.has(t));
+  if (offenders.length > 0) {
+    throw new Error(
+      `chaos: gateway-tier SIGTERM path wrote to forbidden tables: ${[...new Set(offenders)].join(', ')}. ` +
+      `Allowed: ${[...allowed].join(', ')}. ` +
+      `If this test starts failing because the gateway tier legitimately needs ` +
+      `another table, add it here AND update gateway-shutdown-helpers.js's header ` +
+      `to document the new write surface.`
+    );
+  }
+  // Belt-and-suspenders: if a future change adds flow_state to
+  // `allowed` (mistakenly or otherwise), the throw above wouldn't
+  // fire — this expect catches that drift specifically, since the
+  // flow_state-on-gateway prohibition is the primary regression
+  // target this whole file exists to protect.
+  const flowStateCalls = allCalls.filter(
+    (c) => c.args[0].input.TableName === FLOW_STATE_TABLE_NAME,
+  );
+  expect(flowStateCalls).toHaveLength(0);
+}
+
+function makeFakeManager() {
+  return {
+    isConnected: jest.fn(() => true),
+    connect: jest.fn(async () => {}),
+  };
+}
+
+function makeFakeControlClient() {
+  return {
+    pushHandoff: jest.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+// A publisher whose stop() resolves after the test releases it. The
+// caller observes WHEN stop() was entered (relative to other calls)
+// via the spy's call-order, then releases the pending promise so the
+// parallel drain in runPushHandoffShutdown's `await drainPromise`
+// resolves before exit().
+function makeControllableEventPublisher() {
+  let resolveStop;
+  const stopped = new Promise((resolve) => { resolveStop = resolve; });
+  return {
+    stop: jest.fn().mockImplementation(() => stopped),
+    releaseStop: () => resolveStop(),
+  };
+}
+
+function makeScheduleHardExit() {
+  const timers = [];
+  const schedule = jest.fn((cb, ms) => {
+    const timer = { cb, ms, unref: jest.fn(), cleared: false };
+    timers.push(timer);
+    return timer;
+  });
+  const clearHardExit = jest.fn((timer) => {
+    if (timer) timer.cleared = true;
+  });
+  return { schedule, clearHardExit, timers };
+}
+
+// Assembles a fully wired leader against the real lock + heartbeat
+// primitives and the mock control-client/manager. clock is a mutable
+// closure so peer rows can be seeded with `updated_at` in the
+// freshness window for the SIGTERM-time clock value. controlClient is
+// optional — defaults to an always-ACK fake; test #3 injects a hung
+// stub to exercise the timeout path without re-implementing the
+// surrounding wiring.
+function assembleLeader({ docClient, clock, controlClient } = {}) {
+  const logger = makeChaosLogger();
+  const lock = createGatewayLock({
+    ddbClient: docClient,
+    tableName: LOCK_TABLE,
+    shardId: SHARD_ID,
+    instanceId: INSTANCE_A,
+    lockHolder: HOLDER_A,
+    logger,
+    clock,
+  });
+  const peerHeartbeat = createPeerHeartbeat({
+    ddbClient: docClient,
+    tableName: HEARTBEAT_TABLE,
+    instanceId: INSTANCE_A,
+    ip: '10.0.0.10',
+    port: 7800,
+    shardId: SHARD_ID,
+    lockHolder: HOLDER_A,
+    logger,
+    clock,
+  });
+  const resolvedControlClient = controlClient ?? makeFakeControlClient();
+  const manager = makeFakeManager();
+  const leader = createGatewayLeader({
+    lock,
+    peerHeartbeat,
+    controlClient: resolvedControlClient,
+    manager,
+    selfInstanceId: INSTANCE_A,
+    shardId: SHARD_ID,
+    logger,
+    tickIntervalMs: 1_000,
+  });
+  return {
+    leader, lock, peerHeartbeat, controlClient: resolvedControlClient, manager, logger,
+  };
+}
+
+describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
+  let now = 1_700_000_000_000;
+  const clock = () => now;
+
+  beforeEach(() => { now = 1_700_000_000_000; });
+
+  it('SIGTERM with healthy standby peer → transferLock + push ACK + clean exit(0)', async () => {
+    // Pre-seed: A holds the lock (version=3), B has a fresh
+    // heartbeat row in the same shard inside the 6 s freshness
+    // window. A's heartbeat is also present (the production wiring
+    // writes one every tick from both replicas).
+    const nowSeconds = Math.floor(now / 1000);
+    const { docClient, ddbMock, state } = setupChaosDdb({
+      initialLockRow: {
+        shard_id: SHARD_ID,
+        instance_id: INSTANCE_A,
+        lock_holder: HOLDER_A,
+        version: 3,
+        expires_at: nowSeconds + 6,
+      },
+      initialPeerRows: [
+        // A's own row.
+        {
+          instance_id: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+          shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+          lock_holder: HOLDER_A,
+        },
+        // B's row — fresh (updated_at within freshness window).
+        {
+          instance_id: INSTANCE_B, ip: '10.0.0.20', port: 7800,
+          shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+          lock_holder: HOLDER_B,
+        },
+      ],
+    });
+
+    const { leader, lock, logger } = assembleLeader({ docClient, clock });
+    // Synthesize A's prior acquisition: prime the lock's version cursor
+    // to 3 so transferLock's CAS sees the matching :expected. In
+    // production the tick loop's renewLock would have done this; we
+    // skip the tick churn here because the chaos test is scoped to
+    // the SIGTERM body, not the tick loop.
+    lock.adoptLockFromHandoff(3);
+    // The leader's `heldLock` flag is private and set by tick or
+    // handleInboundHandoff. For the SIGTERM-only path we drive
+    // through handleInboundHandoff so heldLock flips true without
+    // running the full tick loop. (gateway-leader's handleInboundHandoff
+    // body documents the adopt-then-flag-then-connect ordering that
+    // makes this safe.)
+    await leader.handleInboundHandoff({
+      activeInstanceId: 'predecessor', expectedVersion: 3,
+    });
+
+    // Spy on the leader's pushHandoff so we can observe call ORDER vs
+    // eventPublisher.stop. Wall-clock measurement was tried first but
+    // can't distinguish parallel from serialized at the timescales
+    // mocked-DDB pushHandoff runs at (single-digit ms); call-order is
+    // the right signal.
+    const pushHandoffSpy = jest.spyOn(leader, 'pushHandoff');
+    const eventPublisher = makeControllableEventPublisher();
+    const exit = jest.fn();
+    const { schedule, clearHardExit, timers } = makeScheduleHardExit();
+
+    const shutdownPromise = runPushHandoffShutdown({
+      code: 0, gatewayLeader: leader, eventPublisher, logger,
+      exit, scheduleHardExit: schedule, clearHardExit,
+    });
+    // Yield once so runPushHandoffShutdown enters its body. The
+    // parallel call to eventPublisher.stop() lands synchronously
+    // inside that body — regardless of whether pushHandoff has
+    // resolved yet — IF they're issued in parallel. If they were
+    // serialized (stop() awaited AFTER pushHandoff returns), the
+    // spy would not yet be called at this observation point.
+    await new Promise((r) => { setImmediate(r); });
+
+    expect(pushHandoffSpy).toHaveBeenCalled();
+    expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
+
+    // Release the pending stop() so runPushHandoffShutdown's
+    // `await drainPromise` resolves and exit() fires.
+    eventPublisher.releaseStop();
+    await shutdownPromise;
+
+    // ── Steady-state assertions ──
+
+    // (a) Lock row in DDB: ownership flipped to B; version bumped to 4.
+    expect(state.lockRow).not.toBeNull();
+    expect(state.lockRow.instance_id).toBe(INSTANCE_B);
+    expect(state.lockRow.lock_holder).toBe(HOLDER_B);
+    expect(state.lockRow.version).toBe(4);
+
+    // (b) Heartbeat: A's row was deleted (best-effort cleanup at SIGTERM).
+    const remainingPeerIds = state.peerRows.map((r) => r.instance_id);
+    expect(remainingPeerIds).not.toContain(INSTANCE_A);
+    expect(remainingPeerIds).toContain(INSTANCE_B);
+
+    // (c) Clean exit code path.
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(clearHardExit).toHaveBeenCalledWith(timers[0]);
+
+    // (d) No flow_state table writes/reads.
+    assertNoUnexpectedTableCalls(ddbMock);
+  });
+
+  it('SIGTERM with no peer (no_peer fallback) → releaseLock + clean exit(0)', async () => {
+    const nowSeconds = Math.floor(now / 1000);
+    // Only A's own heartbeat row exists. listFreshPeers will filter
+    // it out (instance_id !== self), returning []. pushHandoff hits
+    // the no_peer branch.
+    const { docClient, ddbMock, state } = setupChaosDdb({
+      initialLockRow: {
+        shard_id: SHARD_ID,
+        instance_id: INSTANCE_A,
+        lock_holder: HOLDER_A,
+        version: 5,
+        expires_at: nowSeconds + 6,
+      },
+      initialPeerRows: [{
+        instance_id: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+        shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+        lock_holder: HOLDER_A,
+      }],
+    });
+
+    const { leader, lock, controlClient, logger } = assembleLeader({ docClient, clock });
+    lock.adoptLockFromHandoff(5);
+    await leader.handleInboundHandoff({
+      activeInstanceId: 'predecessor', expectedVersion: 5,
+    });
+
+    const eventPublisher = makeControllableEventPublisher();
+    eventPublisher.releaseStop(); // resolve immediately — no-peer path doesn't gate on it.
+    const exit = jest.fn();
+    const { schedule, clearHardExit } = makeScheduleHardExit();
+
+    await runPushHandoffShutdown({
+      code: 0, gatewayLeader: leader, eventPublisher, logger,
+      exit, scheduleHardExit: schedule, clearHardExit,
+    });
+
+    // (a) Lock row deleted (releaseLockBestEffort's CAS-Delete).
+    expect(state.lockRow).toBeNull();
+    // (b) No transferLock attempted — controlClient.pushHandoff never called.
+    expect(controlClient.pushHandoff).not.toHaveBeenCalled();
+    // (c) Heartbeat row for A deleted (post-handoff cleanup runs on
+    //     the no_peer branch too).
+    expect(state.peerRows).toEqual([]);
+    // (d) Exit(0) — the no-peer outcome is still "clean" (the
+    //     standby will cold-acquire via the TTL floor). exit(0)
+    //     vs exit(1) signals dashboards.
+    expect(exit).toHaveBeenCalledWith(0);
+    // (e) No flow_state touches.
+    assertNoUnexpectedTableCalls(ddbMock);
+    // (f) Documented no-peer log fires so a future regression that
+    //     silently swaps the branch under us (e.g. always-transferLock)
+    //     surfaces here.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('no fresh peer for handoff'),
+    );
+  });
+
+  it('SIGTERM with hung controlClient.pushHandoff → hard-exit fires with forcedExitCode=1', async () => {
+    // Pins the dashboard contract: a stuck push exits with the forced
+    // code (1), not the incoming code (0), so the deploy SLI
+    // distinguishes "clean transfer + ACK" from "transfer happened but
+    // ACK timed out" — same DDB outcome, different operator signal.
+    // Lock is ALREADY transferred in DDB before pushHandoff hangs
+    // (transferLock is awaited first in gateway-leader's pushHandoff
+    // body); the standby's watchdog covers the no-ACK case via
+    // lock-held + WS-disconnected within ~1 s.
+    const nowSeconds = Math.floor(now / 1000);
+    const { docClient, ddbMock, state } = setupChaosDdb({
+      initialLockRow: {
+        shard_id: SHARD_ID, instance_id: INSTANCE_A, lock_holder: HOLDER_A,
+        version: 7, expires_at: nowSeconds + 6,
+      },
+      initialPeerRows: [
+        {
+          instance_id: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+          shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+          lock_holder: HOLDER_A,
+        },
+        {
+          instance_id: INSTANCE_B, ip: '10.0.0.20', port: 7800,
+          shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+          lock_holder: HOLDER_B,
+        },
+      ],
+    });
+
+    // Override the default ACK'ing controlClient with a hung one —
+    // simulates B's process being unresponsive. All other wiring
+    // (lock/heartbeat/manager/leader) is the same as the healthy-peer
+    // path; reuse assembleLeader so a future ctor-arg addition can't
+    // silently miss this test.
+    const hungControlClient = {
+      pushHandoff: jest.fn(() => new Promise(() => {})),
+    };
+    const { leader, lock, logger } = assembleLeader({
+      docClient, clock, controlClient: hungControlClient,
+    });
+    lock.adoptLockFromHandoff(7);
+    await leader.handleInboundHandoff({
+      activeInstanceId: 'predecessor', expectedVersion: 7,
+    });
+
+    const eventPublisher = makeControllableEventPublisher();
+    eventPublisher.releaseStop(); // drain resolves immediately; not what we're testing
+    const exit = jest.fn();
+    const { schedule, timers, clearHardExit } = makeScheduleHardExit();
+
+    const shutdownPromise = runPushHandoffShutdown({
+      code: 0, gatewayLeader: leader, eventPublisher, logger,
+      exit, scheduleHardExit: schedule, clearHardExit,
+    });
+
+    // Wait until transferLock has landed (state.lockRow.instance_id
+    // flipped to B). This indicates the pushHandoff body has cleared
+    // listFreshPeers + transferLock and is now awaiting the hung
+    // controlClient.pushHandoff — the exact state we want to time
+    // the hard-exit fire against. Polling on observable DDB state is
+    // deterministic where setImmediate-counting would be fragile.
+    const transferredBy = Date.now() + 1_000;
+    while (state.lockRow.instance_id !== INSTANCE_B) {
+      if (Date.now() > transferredBy) {
+        throw new Error('chaos: transferLock never landed within 1 s');
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => { setImmediate(r); });
+    }
+    expect(timers).toHaveLength(1);
+    expect(timers[0].ms).toBe(12_000);
+    timers[0].cb();
+
+    // The hard-exit path calls exit(forcedExitCode) and the shutdown
+    // promise itself remains pending (its inner await never resolves);
+    // that's the prod shape — process.exit kills the process and the
+    // pending await is moot.
+    expect(exit).toHaveBeenCalledWith(1);
+
+    expect(state.lockRow.instance_id).toBe(INSTANCE_B);
+    expect(state.lockRow.version).toBe(8);
+    assertNoUnexpectedTableCalls(ddbMock);
+
+    // Park the orphan shutdown promise — it stays pending forever in
+    // prod (process.exit kills it), but in jest it'd surface as an
+    // unhandled rejection if pushHandoff ever rejects (it can't, since
+    // it's the new Promise(() => {}) hang — but defense in depth).
+    shutdownPromise.catch(() => {});
+  });
+});

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -132,7 +132,11 @@ function makeScheduleHardExit() {
 // freshness window for the SIGTERM-time clock value. controlClient is
 // optional — defaults to an always-ACK fake; test #3 injects a hung
 // stub to exercise the timeout path without re-implementing the
-// surrounding wiring.
+// surrounding wiring. Hard-codes the from-A perspective (instanceId:
+// INSTANCE_A, lockHolder: HOLDER_A) since every SIGTERM chaos
+// scenario here drives the SIGTERM-on-A leg of the handoff; a future
+// chaos test that needs the from-B viewpoint will need a `selfInstance`
+// knob added here.
 function assembleLeader({ docClient, clock, controlClient } = {}) {
   const logger = makeChaosLogger();
   const lock = createGatewayLock({

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -56,63 +56,12 @@ const { createGatewayLock } = require('../src/gateway-lock');
 const { createPeerHeartbeat } = require('../src/gateway-peer-heartbeat');
 const { createGatewayLeader } = require('../src/gateway-leader');
 const { runPushHandoffShutdown } = require('../src/gateway-shutdown-helpers');
-const { __TABLE_NAME: FLOW_STATE_TABLE_NAME } = require('../src/flow-state');
 const {
   setupChaosDdb, makeChaosLogger,
   LOCK_TABLE, HEARTBEAT_TABLE, SHARD_ID,
   INSTANCE_A, INSTANCE_B, HOLDER_A, HOLDER_B,
+  MAX_MICROTASK_YIELDS, assertNoUnexpectedTableCalls,
 } = require('./helpers/chaos-ddb');
-
-// Pull every TableName an SDK command targets, including the nested
-// shapes (BatchGet/BatchWrite use `RequestItems`; TransactGet/
-// TransactWrite use `TransactItems`). Single-item shapes (Put/Get/
-// Update/Delete/Scan/Query) carry `input.TableName` directly. Returns
-// a flat string[] so callers can filter against an allowlist.
-function tableNamesTargeted(cmdInput) {
-  if (!cmdInput) return [];
-  if (cmdInput.TableName) return [cmdInput.TableName];
-  if (cmdInput.RequestItems) return Object.keys(cmdInput.RequestItems);
-  if (Array.isArray(cmdInput.TransactItems)) {
-    return cmdInput.TransactItems
-      .map((entry) => {
-        // Includes Get for TransactGet (read-side) so the allowlist
-        // gate doesn't miss it if a future read-side refactor lands.
-        const op = entry.Put || entry.Update || entry.Delete || entry.ConditionCheck || entry.Get;
-        return op?.TableName;
-      })
-      .filter(Boolean);
-  }
-  return [];
-}
-
-// Post-hoc inspection: every DDB command issued during the test must
-// have a TableName in the allowlist. Unrouted commands in mockClient
-// silently resolve, so a future refactor that writes to e.g.
-// qurl_bot_flow_state from the gateway-tier SIGTERM path would not
-// throw at runtime — this assertion is the catch. Walks every shape
-// (single-item, BatchGet/Write RequestItems, TransactGet/Write
-// TransactItems) so the regression surface is exhaustive.
-function assertNoUnexpectedTableCalls(ddbMock) {
-  const allowed = new Set([LOCK_TABLE, HEARTBEAT_TABLE]);
-  const allTables = ddbMock.calls()
-    .flatMap((c) => tableNamesTargeted(c.args[0]?.input));
-  const offenders = allTables.filter((t) => !allowed.has(t));
-  if (offenders.length > 0) {
-    throw new Error(
-      `chaos: gateway-tier SIGTERM path wrote to forbidden tables: ${[...new Set(offenders)].join(', ')}. ` +
-      `Allowed: ${[...allowed].join(', ')}. ` +
-      `If this test starts failing because the gateway tier legitimately needs ` +
-      `another table, add it here AND update gateway-shutdown-helpers.js's header ` +
-      `to document the new write surface.`
-    );
-  }
-  // Belt-and-suspenders: if a future change adds flow_state to
-  // `allowed` (mistakenly or otherwise), the throw above wouldn't
-  // fire — this expect catches that drift specifically, since the
-  // flow_state-on-gateway prohibition is the primary regression
-  // target this whole file exists to protect.
-  expect(allTables.filter((t) => t === FLOW_STATE_TABLE_NAME)).toHaveLength(0);
-}
 
 function makeFakeManager() {
   return {
@@ -283,6 +232,11 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     // first, then invoke stop — failing the ordering check.
     const timeline = [];
     const origPushHandoff = leader.pushHandoff.bind(leader);
+    // Brittleness alert: this spy attaches via object-property
+    // dispatch. See the spy-brittleness paragraph in the file
+    // header — if pushHandoff is ever cached/destructured by the
+    // caller, swap this spy for `lock.transferLock` (the seam
+    // between real primitives) to preserve the call-order signal.
     const pushHandoffSpy = jest.spyOn(leader, 'pushHandoff').mockImplementation(async (...args) => {
       const result = await origPushHandoff(...args);
       timeline.push('pushHandoff-resolved');
@@ -306,16 +260,15 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     // Wait for pushHandoff to fully resolve. A single setImmediate
     // yield is enough today (the body's awaits drain in microtasks
     // ahead of setImmediate), but bounding by a yield counter
-    // mirrors test #3's MAX_YIELDS_FOR_TRANSFER pattern — robust if
-    // a future refactor adds another await inside pushHandoff (e.g.
-    // a metric flush or extra DDB round-trip). The diagnostic throw
-    // turns a future flake into a clear failure message.
-    const MAX_YIELDS_FOR_PUSH_RESOLVE = 50;
-    let yields = 0;
+    // (`MAX_MICROTASK_YIELDS`) is robust if a future refactor adds
+    // another await inside pushHandoff (e.g. a metric flush or extra
+    // DDB round-trip). The diagnostic throw turns a future flake
+    // into a clear failure message.
+    let yieldsForPushResolve = 0;
     while (!timeline.includes('pushHandoff-resolved')) {
-      if (yields++ >= MAX_YIELDS_FOR_PUSH_RESOLVE) {
+      if (yieldsForPushResolve++ >= MAX_MICROTASK_YIELDS) {
         throw new Error(
-          `chaos: pushHandoff did not resolve within ${MAX_YIELDS_FOR_PUSH_RESOLVE} setImmediate yields; ` +
+          `chaos: pushHandoff did not resolve within ${MAX_MICROTASK_YIELDS} setImmediate yields; ` +
           `timeline: ${JSON.stringify(timeline)}. ` +
           `If pushHandoff grew an extra await hop, raise the bound; if it now hangs, ` +
           `that's a real regression (test #3 covers the timeout path).`
@@ -476,13 +429,13 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     // controlClient.pushHandoff — the exact state we want to time
     // the hard-exit fire against. setImmediate-counter (vs wall-clock)
     // so the bound doesn't drift with CI runner load: with mocked
-    // DDB, transferLock settles in ≤ 3 microtask hops; 50 yields is
-    // generous defense without depending on Date.now().
-    const MAX_YIELDS_FOR_TRANSFER = 50;
-    let yields = 0;
+    // DDB, transferLock settles in ≤ 3 microtask hops; the
+    // MAX_MICROTASK_YIELDS bound is generous defense without
+    // depending on Date.now().
+    let yieldsForTransfer = 0;
     while (state.lockRow.instance_id !== INSTANCE_B) {
-      if (yields++ >= MAX_YIELDS_FOR_TRANSFER) {
-        throw new Error(`chaos: transferLock never landed within ${MAX_YIELDS_FOR_TRANSFER} event-loop yields`);
+      if (yieldsForTransfer++ >= MAX_MICROTASK_YIELDS) {
+        throw new Error(`chaos: transferLock never landed within ${MAX_MICROTASK_YIELDS} event-loop yields`);
       }
       // eslint-disable-next-line no-await-in-loop
       await new Promise((r) => { setImmediate(r); });

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -93,6 +93,15 @@ function makeControllableEventPublisher() {
 function makeScheduleHardExit() {
   const timers = [];
   const schedule = jest.fn((cb, ms) => {
+    // Pin the zero-arity callback contract — production `setTimeout`
+    // (the default scheduleHardExit) invokes its callback with no
+    // args, and test #3's `timers[0].cb()` matches that shape. If a
+    // future refactor changes scheduleHardExit's callback signature
+    // (e.g. passing the deadline as an arg), the test would still
+    // call `cb()` and silently take the wrong branch.
+    if (typeof cb !== 'function' || cb.length !== 0) {
+      throw new Error(`chaos: scheduleHardExit callback must be zero-arity, got arity=${cb?.length}`);
+    }
     const timer = { cb, ms, unref: jest.fn(), cleared: false };
     timers.push(timer);
     return timer;

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -44,10 +44,6 @@
 //      no-peer case below asserts the DDB DeleteCommand lands on the
 //      lock table within the SIGTERM window.
 
-const {
-  PutCommand, GetCommand, UpdateCommand, DeleteCommand, ScanCommand,
-} = require('@aws-sdk/lib-dynamodb');
-
 const { createGatewayLock } = require('../src/gateway-lock');
 const { createPeerHeartbeat } = require('../src/gateway-peer-heartbeat');
 const { createGatewayLeader } = require('../src/gateway-leader');
@@ -63,18 +59,13 @@ const {
 // have a TableName in the allowlist. Unrouted commands in mockClient
 // silently resolve, so a future refactor that writes to e.g.
 // qurl_bot_flow_state from the gateway-tier SIGTERM path would not
-// throw at runtime — this assertion is the catch.
+// throw at runtime — this assertion is the catch. Uses ddbMock.calls()
+// rather than per-command enumeration so a future BatchGet / Query /
+// TransactWrite against a forbidden table also surfaces.
 function assertNoUnexpectedTableCalls(ddbMock) {
   const allowed = new Set([LOCK_TABLE, HEARTBEAT_TABLE]);
-  const allCalls = [
-    ...ddbMock.commandCalls(PutCommand),
-    ...ddbMock.commandCalls(GetCommand),
-    ...ddbMock.commandCalls(UpdateCommand),
-    ...ddbMock.commandCalls(DeleteCommand),
-    ...ddbMock.commandCalls(ScanCommand),
-  ];
-  const offenders = allCalls
-    .map((c) => c.args[0].input.TableName)
+  const offenders = ddbMock.calls()
+    .map((c) => c.args[0]?.input?.TableName)
     .filter((t) => t && !allowed.has(t));
   if (offenders.length > 0) {
     throw new Error(
@@ -90,9 +81,8 @@ function assertNoUnexpectedTableCalls(ddbMock) {
   // fire — this expect catches that drift specifically, since the
   // flow_state-on-gateway prohibition is the primary regression
   // target this whole file exists to protect.
-  const flowStateCalls = allCalls.filter(
-    (c) => c.args[0].input.TableName === FLOW_STATE_TABLE_NAME,
-  );
+  const flowStateCalls = ddbMock.calls()
+    .filter((c) => c.args[0]?.input?.TableName === FLOW_STATE_TABLE_NAME);
   expect(flowStateCalls).toHaveLength(0);
 }
 
@@ -218,19 +208,14 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       ],
     });
 
-    const { leader, lock, logger } = assembleLeader({ docClient, clock });
-    // Synthesize A's prior acquisition: prime the lock's version cursor
-    // to 3 so transferLock's CAS sees the matching :expected. In
-    // production the tick loop's renewLock would have done this; we
-    // skip the tick churn here because the chaos test is scoped to
-    // the SIGTERM body, not the tick loop.
-    lock.adoptLockFromHandoff(3);
-    // The leader's `heldLock` flag is private and set by tick or
-    // handleInboundHandoff. For the SIGTERM-only path we drive
-    // through handleInboundHandoff so heldLock flips true without
-    // running the full tick loop. (gateway-leader's handleInboundHandoff
-    // body documents the adopt-then-flag-then-connect ordering that
-    // makes this safe.)
+    const { leader, logger } = assembleLeader({ docClient, clock });
+    // handleInboundHandoff is the production path that flips heldLock
+    // true; it internally calls lock.adoptLockFromHandoff(expectedVersion)
+    // (adopt-then-flag-then-connect ordering). Driving it here primes
+    // the lock cursor without running the full tick loop, AND keeps
+    // the test honest — if a future refactor removed the internal
+    // adopt call, the test would fail (vs. silently passing if we
+    // pre-primed the cursor ourselves).
     await leader.handleInboundHandoff({
       activeInstanceId: 'predecessor', expectedVersion: 3,
     });
@@ -265,25 +250,21 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     eventPublisher.releaseStop();
     await shutdownPromise;
 
-    // ── Steady-state assertions ──
-
-    // (a) Lock row in DDB: ownership flipped to B; version bumped to 4.
+    // Lock row: ownership flipped, version bumped.
     expect(state.lockRow).not.toBeNull();
     expect(state.lockRow.instance_id).toBe(INSTANCE_B);
     expect(state.lockRow.lock_holder).toBe(HOLDER_B);
     expect(state.lockRow.version).toBe(4);
 
-    // (b) Heartbeat: A's row was deleted (best-effort cleanup at SIGTERM).
+    // Heartbeat: A's row deleted (best-effort SIGTERM cleanup).
     const remainingPeerIds = state.peerRows.map((r) => r.instance_id);
     expect(remainingPeerIds).not.toContain(INSTANCE_A);
     expect(remainingPeerIds).toContain(INSTANCE_B);
 
-    // (c) Clean exit code path.
     expect(exit).toHaveBeenCalledWith(0);
     expect(exit).toHaveBeenCalledTimes(1);
     expect(clearHardExit).toHaveBeenCalledWith(timers[0]);
 
-    // (d) No flow_state table writes/reads.
     assertNoUnexpectedTableCalls(ddbMock);
   });
 
@@ -307,8 +288,7 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       }],
     });
 
-    const { leader, lock, controlClient, logger } = assembleLeader({ docClient, clock });
-    lock.adoptLockFromHandoff(5);
+    const { leader, controlClient, logger } = assembleLeader({ docClient, clock });
     await leader.handleInboundHandoff({
       activeInstanceId: 'predecessor', expectedVersion: 5,
     });
@@ -323,22 +303,20 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       exit, scheduleHardExit: schedule, clearHardExit,
     });
 
-    // (a) Lock row deleted (releaseLockBestEffort's CAS-Delete).
+    // Lock row deleted (releaseLockBestEffort CAS-Delete).
     expect(state.lockRow).toBeNull();
-    // (b) No transferLock attempted — controlClient.pushHandoff never called.
+    // No push attempted on the no-peer branch.
     expect(controlClient.pushHandoff).not.toHaveBeenCalled();
-    // (c) Heartbeat row for A deleted (post-handoff cleanup runs on
-    //     the no_peer branch too).
+    // Heartbeat row for A deleted (post-handoff cleanup runs on the
+    // no_peer branch too).
     expect(state.peerRows).toEqual([]);
-    // (d) Exit(0) — the no-peer outcome is still "clean" (the
-    //     standby will cold-acquire via the TTL floor). exit(0)
-    //     vs exit(1) signals dashboards.
+    // exit(0) — the no-peer outcome is still "clean" (the standby
+    // will cold-acquire via the TTL floor); exit(0) vs exit(1)
+    // distinguishes that from the timeout path for deploy SLI.
     expect(exit).toHaveBeenCalledWith(0);
-    // (e) No flow_state touches.
     assertNoUnexpectedTableCalls(ddbMock);
-    // (f) Documented no-peer log fires so a future regression that
-    //     silently swaps the branch under us (e.g. always-transferLock)
-    //     surfaces here.
+    // Pin the documented no-peer log so a future regression that
+    // silently swaps the branch (e.g. always-transferLock) surfaces.
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('no fresh peer for handoff'),
     );
@@ -381,10 +359,9 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     const hungControlClient = {
       pushHandoff: jest.fn(() => new Promise(() => {})),
     };
-    const { leader, lock, logger } = assembleLeader({
+    const { leader, logger } = assembleLeader({
       docClient, clock, controlClient: hungControlClient,
     });
-    lock.adoptLockFromHandoff(7);
     await leader.handleInboundHandoff({
       activeInstanceId: 'predecessor', expectedVersion: 7,
     });
@@ -403,12 +380,15 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
     // flipped to B). This indicates the pushHandoff body has cleared
     // listFreshPeers + transferLock and is now awaiting the hung
     // controlClient.pushHandoff — the exact state we want to time
-    // the hard-exit fire against. Polling on observable DDB state is
-    // deterministic where setImmediate-counting would be fragile.
-    const transferredBy = Date.now() + 1_000;
+    // the hard-exit fire against. setImmediate-counter (vs wall-clock)
+    // so the bound doesn't drift with CI runner load: with mocked
+    // DDB, transferLock settles in ≤ 3 microtask hops; 50 yields is
+    // generous defense without depending on Date.now().
+    const MAX_YIELDS_FOR_TRANSFER = 50;
+    let yields = 0;
     while (state.lockRow.instance_id !== INSTANCE_B) {
-      if (Date.now() > transferredBy) {
-        throw new Error('chaos: transferLock never landed within 1 s');
+      if (yields++ >= MAX_YIELDS_FOR_TRANSFER) {
+        throw new Error(`chaos: transferLock never landed within ${MAX_YIELDS_FOR_TRANSFER} event-loop yields`);
       }
       // eslint-disable-next-line no-await-in-loop
       await new Promise((r) => { setImmediate(r); });

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -248,16 +248,24 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       code: 0, gatewayLeader: leader, eventPublisher, logger,
       exit, scheduleHardExit: schedule, clearHardExit,
     });
+    // Pin the exact stop() call count BEFORE releasing — runPushHandoffShutdown's
+    // synchronous prefix calls eventPublisher.stop() once. If a future
+    // refactor re-entered stop() (e.g. a retry on the drain), the
+    // makeControllableEventPublisher fake would coalesce both calls
+    // into the same settled promise and a `toHaveBeenCalledTimes(1)`
+    // at end-of-test wouldn't catch it. Asserting here pins the
+    // single-invocation contract at the right moment.
+    expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
     // Release the pending stop() so runPushHandoffShutdown's
     // `await drainPromise` can resolve once it's reached. Order doesn't
-    // matter — the timeline observes both events regardless.
+    // matter for the timeline observation — both events are recorded
+    // regardless.
     eventPublisher.releaseStop();
     // Drive the full shutdown to completion (pushHandoff body runs,
     // transferLock resolves, drainPromise resolves, exit fires). With
     // mocked DDB this is a few microtask hops; no polling needed.
     await shutdownPromise;
 
-    expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
     expect(lock.transferLock).toHaveBeenCalledTimes(1);
 
     // Ordering check: stop-invoke must come before transferLock-resolve.

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -159,10 +159,12 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
 
   beforeEach(() => { now = 1_700_000_000_000; });
   // Cheap defense against an un-restored spy leaking between tests
-  // (jest.spyOn(leader, 'pushHandoff') in test #1 below). Works today
-  // because assembleLeader() builds a fresh leader per test, but if a
-  // future refactor pulls leader assembly into beforeAll, the
-  // unrestored spy would leak.
+  // (jest.spyOn(lock, 'transferLock') in test #1 below). Works today
+  // because assembleLeader() builds a fresh leader+lock per test, but
+  // if a future refactor pulls assembly into beforeAll, the
+  // unrestored spy would leak. Note this does NOT reset the per-test
+  // ddbMock — each test gets its own via setupChaosDdb(), so the
+  // afterEach is a no-op for the mock client.
   afterEach(() => { jest.restoreAllMocks(); });
 
   it('SIGTERM with healthy standby peer → transferLock + push ACK + clean exit(0)', async () => {
@@ -195,7 +197,7 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       ],
     });
 
-    const { leader, logger } = assembleLeader({ docClient, clock });
+    const { leader, lock, logger } = assembleLeader({ docClient, clock });
     // handleInboundHandoff is the production path that flips heldLock
     // true; it internally calls lock.adoptLockFromHandoff(expectedVersion)
     // (adopt-then-flag-then-connect ordering). Driving it here primes
@@ -207,39 +209,28 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       activeInstanceId: 'predecessor', expectedVersion: 3,
     });
 
-    // Spy on the leader's pushHandoff so we can observe call ORDER vs
-    // eventPublisher.stop. Wall-clock measurement was tried first but
-    // can't distinguish parallel from serialized at the timescales
-    // mocked-DDB pushHandoff runs at (single-digit ms); call-order is
-    // the right signal.
+    // Spy on `lock.transferLock` (the real primitive seam invoked by
+    // pushHandoff) so we can observe call ORDER vs eventPublisher.stop.
+    // Wall-clock measurement was tried first but can't distinguish
+    // parallel from serialized at the timescales mocked-DDB
+    // transferLock runs at (single-digit ms); call-order is the right
+    // signal. Spying on transferLock (rather than the leader's
+    // pushHandoff) keeps the test decoupled from the leader's surface
+    // shape — if a future refactor destructures or caches pushHandoff,
+    // the closure still holds the same `lock` reference and the spy
+    // still fires.
     //
-    // Brittleness note: this spy works because runPushHandoffShutdown
-    // calls `gatewayLeader.pushHandoff()` through the object property
-    // (`createGatewayLeader` returns an object literal of closures).
-    // If a future refactor destructures or caches the method elsewhere
-    // (e.g. `const { pushHandoff } = gatewayLeader`), this spy would
-    // silently bypass and the ordering assertion would mysteriously
-    // fail. If that lands, switch the spy target to `lock.transferLock`
-    // (the seam between real primitives that pushHandoff awaits
-    // internally) — same call-order signal, decoupled from the
-    // leader's surface shape.
-    //
-    // Timeline-based check (in addition to "both called within one
-    // tick"): record both `stop()` invoke and `pushHandoff()` resolve
-    // as ordered events, then assert stop-invoke landed BEFORE
-    // pushHandoff-resolve. A regression that serializes the drain
-    // (`await pushHandoff(); then stop()`) would resolve pushHandoff
+    // Timeline-based check (in addition to "stop was called"): record
+    // both `stop()` invoke and `transferLock()` resolve as ordered
+    // events, then assert stop-invoke landed BEFORE
+    // transferLock-resolve. A regression that serializes the drain
+    // (`await pushHandoff(); then stop()`) would resolve transferLock
     // first, then invoke stop — failing the ordering check.
     const timeline = [];
-    const origPushHandoff = leader.pushHandoff.bind(leader);
-    // Brittleness alert: this spy attaches via object-property
-    // dispatch. See the spy-brittleness paragraph in the file
-    // header — if pushHandoff is ever cached/destructured by the
-    // caller, swap this spy for `lock.transferLock` (the seam
-    // between real primitives) to preserve the call-order signal.
-    const pushHandoffSpy = jest.spyOn(leader, 'pushHandoff').mockImplementation(async (...args) => {
-      const result = await origPushHandoff(...args);
-      timeline.push('pushHandoff-resolved');
+    const origTransferLock = lock.transferLock.bind(lock);
+    jest.spyOn(lock, 'transferLock').mockImplementation(async (...args) => {
+      const result = await origTransferLock(...args);
+      timeline.push('transferLock-resolved');
       return result;
     });
     const baseEventPublisher = makeControllableEventPublisher();
@@ -257,44 +248,27 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       code: 0, gatewayLeader: leader, eventPublisher, logger,
       exit, scheduleHardExit: schedule, clearHardExit,
     });
-    // Wait for pushHandoff to fully resolve. A single setImmediate
-    // yield is enough today (the body's awaits drain in microtasks
-    // ahead of setImmediate), but bounding by a yield counter
-    // (`MAX_MICROTASK_YIELDS`) is robust if a future refactor adds
-    // another await inside pushHandoff (e.g. a metric flush or extra
-    // DDB round-trip). The diagnostic throw turns a future flake
-    // into a clear failure message.
-    let yieldsForPushResolve = 0;
-    while (!timeline.includes('pushHandoff-resolved')) {
-      if (yieldsForPushResolve++ >= MAX_MICROTASK_YIELDS) {
-        throw new Error(
-          `chaos: pushHandoff did not resolve within ${MAX_MICROTASK_YIELDS} setImmediate yields; ` +
-          `timeline: ${JSON.stringify(timeline)}. ` +
-          `If pushHandoff grew an extra await hop, raise the bound; if it now hangs, ` +
-          `that's a real regression (test #3 covers the timeout path).`
-        );
-      }
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise((r) => { setImmediate(r); });
-    }
+    // Release the pending stop() so runPushHandoffShutdown's
+    // `await drainPromise` can resolve once it's reached. Order doesn't
+    // matter — the timeline observes both events regardless.
+    eventPublisher.releaseStop();
+    // Drive the full shutdown to completion (pushHandoff body runs,
+    // transferLock resolves, drainPromise resolves, exit fires). With
+    // mocked DDB this is a few microtask hops; no polling needed.
+    await shutdownPromise;
 
-    expect(pushHandoffSpy).toHaveBeenCalled();
     expect(eventPublisher.stop).toHaveBeenCalledTimes(1);
+    expect(lock.transferLock).toHaveBeenCalledTimes(1);
 
-    // Ordering check: stop-invoke must come before pushHandoff-resolve.
-    // Tighter than "both called within one tick" — a serialized
-    // `await pushHandoff(); then stop()` would resolve pushHandoff
+    // Ordering check: stop-invoke must come before transferLock-resolve.
+    // Tighter than "both called". A serialized refactor
+    // (`await pushHandoff(); then stop()`) would resolve transferLock
     // first, then invoke stop, flipping the order.
     const stopIdx = timeline.indexOf('stop-invoked');
-    const pushResolvedIdx = timeline.indexOf('pushHandoff-resolved');
+    const transferResolvedIdx = timeline.indexOf('transferLock-resolved');
     expect(stopIdx).toBeGreaterThanOrEqual(0);
-    expect(pushResolvedIdx).toBeGreaterThanOrEqual(0);
-    expect(stopIdx).toBeLessThan(pushResolvedIdx);
-
-    // Release the pending stop() so runPushHandoffShutdown's
-    // `await drainPromise` resolves and exit() fires.
-    eventPublisher.releaseStop();
-    await shutdownPromise;
+    expect(transferResolvedIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeLessThan(transferResolvedIdx);
 
     expect(state.lockRow).not.toBeNull();
     expect(state.lockRow.instance_id).toBe(INSTANCE_B);
@@ -441,7 +415,12 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
       await new Promise((r) => { setImmediate(r); });
     }
     expect(timers).toHaveLength(1);
-    expect(timers[0].ms).toBe(12_000);
+    // A hard-exit timer was scheduled with a positive deadline; the
+    // exact `ceilingMs` value (12 s default) is pinned by
+    // gateway-shutdown-helpers' unit test. Asserting a positive bound
+    // here keeps the chaos check resilient to a future ceiling tune
+    // without losing the "a hard-exit was armed" signal.
+    expect(timers[0].ms).toBeGreaterThan(0);
     timers[0].cb();
 
     // The hard-exit path calls exit(forcedExitCode) and the shutdown

--- a/apps/discord/tests/deploy-during-flow.chaos.test.js
+++ b/apps/discord/tests/deploy-during-flow.chaos.test.js
@@ -209,6 +209,12 @@ describe('Pillar 3 chaos — deploy-during-flow (SIGTERM mid-handoff)', () => {
   const clock = () => now;
 
   beforeEach(() => { now = 1_700_000_000_000; });
+  // Cheap defense against an un-restored spy leaking between tests
+  // (jest.spyOn(leader, 'pushHandoff') in test #1 below). Works today
+  // because assembleLeader() builds a fresh leader per test, but if a
+  // future refactor pulls leader assembly into beforeAll, the
+  // unrestored spy would leak.
+  afterEach(() => { jest.restoreAllMocks(); });
 
   it('SIGTERM with healthy standby peer → transferLock + push ACK + clean exit(0)', async () => {
     // Pre-seed: A holds the lock (version=3), B has a fresh

--- a/apps/discord/tests/event-publisher.test.js
+++ b/apps/discord/tests/event-publisher.test.js
@@ -357,6 +357,33 @@ describe('event-publisher: send-failure logging', () => {
     await flushMicro();
     expect(eventPublisher._test.getInFlightCount()).toBe(0);
   });
+
+  test('sustained SendMessage failure → inFlightSends stays bounded, no retry buffer accumulates (fire-and-log invariant)', async () => {
+    // Pins the documented fire-and-log design (this file's module
+    // header explicitly rejects in-process retry / accumulation). A
+    // future "let's add a retry buffer" refactor would break the
+    // invariant — inFlightSends would grow unboundedly with drained-
+    // but-pending sends. Publishing N packets against a throwing SQS
+    // and asserting post-settle count is zero catches both the
+    // .finally→delete-bypassed and .catch-bypassed regressions in
+    // one shot. N=20 is enough — every iteration takes the same
+    // code path; 200 added no extra coverage and made the test
+    // visibly slower.
+    sqsMock.on(SendMessageCommand).rejects(new Error('persistent SQS outage'));
+    eventPublisher.start();
+    const N = 20;
+    withMockedSqs(() => {
+      for (let i = 0; i < N; i += 1) {
+        eventPublisher.publish(rawPacket({ s: i + 1 }));
+      }
+    });
+    await flushMicro();
+    expect(eventPublisher._test.getInFlightCount()).toBe(0);
+    const failureLogs = logger.error.mock.calls.filter(
+      ([, ctx]) => ctx && ctx.kind === 'unhandledRejection',
+    );
+    expect(failureLogs).toHaveLength(N);
+  });
 });
 
 describe('event-publisher: drain on stop', () => {

--- a/apps/discord/tests/event-publisher.test.js
+++ b/apps/discord/tests/event-publisher.test.js
@@ -378,11 +378,15 @@ describe('event-publisher: send-failure logging', () => {
       }
     });
     await flushMicro();
+    // The load-bearing invariant: no in-memory accumulation. A future
+    // batch/coalesce optimization could legitimately reduce the
+    // per-publish log ratio, so the count assertion is `> 0` (must
+    // log SOMETHING per failure) — the count-to-zero is what matters.
     expect(eventPublisher._test.getInFlightCount()).toBe(0);
     const failureLogs = logger.error.mock.calls.filter(
       ([, ctx]) => ctx && ctx.kind === 'unhandledRejection',
     );
-    expect(failureLogs).toHaveLength(N);
+    expect(failureLogs.length).toBeGreaterThan(0);
   });
 });
 

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -37,6 +37,11 @@ const HEARTBEAT_TABLE = 'test-gateway-peer-heartbeat';
 
 // Stable identifiers shared by the chaos tests. A two-replica shard
 // is sufficient for every Pillar 3 SIGTERM scenario this suite covers.
+// HOLDER_A/B are opaque strings — gateway-lock and peer-heartbeat
+// treat lock_holder as operational metadata for logs/debug only and
+// don't parse it (e.g. as an ARN). The literal `task-arn:.../...`
+// shape is shorthand for "looks like a real ECS task ARN" without
+// committing to a parseable schema.
 const SHARD_ID = '0:1';
 const INSTANCE_A = 'inst-A';
 const INSTANCE_B = 'inst-B';
@@ -75,14 +80,26 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     state.lockRow = { ...cmd.Item };
     return {};
   });
+  // The CAS guards below mirror what production DDB enforces. Without
+  // them, a regression that ships a corrupted `:expected` or `:self`
+  // value would silently write through the mock when production would
+  // reject — defeating the whole point of composing real primitives.
+  // gateway-lock.js's renew/transfer/release all share the
+  // `instance_id = :self AND version = :expected` (or just :self for
+  // delete) condition shape.
   ddbMock.on(UpdateCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
-    // The lock module issues UpdateCommand for renew + transfer.
-    // Both update version + expires_at; transfer also flips
+    if (!state.lockRow) throw makeCcfe();
+    const v = cmd.ExpressionAttributeValues || {};
+    if (v[':self'] !== undefined && v[':self'] !== state.lockRow.instance_id) {
+      throw makeCcfe();
+    }
+    if (v[':expected'] !== undefined && v[':expected'] !== state.lockRow.version) {
+      throw makeCcfe();
+    }
+    // Renew writes version + expires_at; transfer also flips
     // instance_id + lock_holder. Apply whichever fields the caller's
     // ExpressionAttributeValues include — matches gateway-lock.js's
     // shape without re-implementing the SET expression parser.
-    if (!state.lockRow) throw makeCcfe();
-    const v = cmd.ExpressionAttributeValues || {};
     if (v[':peer'] !== undefined) {
       state.lockRow.instance_id = v[':peer'];
       state.lockRow.lock_holder = v[':peerHolder'];
@@ -91,7 +108,15 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     if (v[':exp'] !== undefined) state.lockRow.expires_at = v[':exp'];
     return {};
   });
-  ddbMock.on(DeleteCommand, { TableName: LOCK_TABLE }).callsFake(() => {
+  ddbMock.on(DeleteCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
+    // gateway-lock.releaseLock's condition is `instance_id = :self`.
+    // Enforce it so a stale-cursor regression (e.g. delete from the
+    // wrong instance) surfaces as CCFE here too.
+    const v = cmd.ExpressionAttributeValues || {};
+    if (!state.lockRow) throw makeCcfe();
+    if (v[':self'] !== undefined && v[':self'] !== state.lockRow.instance_id) {
+      throw makeCcfe();
+    }
     state.lockRow = null;
     return {};
   });

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -1,0 +1,131 @@
+// Shared DDB scaffolding for Pillar 3 chaos tests
+// (deploy-during-flow.chaos.test.js, resume-fail.chaos.test.js).
+//
+// Each chaos test composes the REAL `createGatewayLock` +
+// `createPeerHeartbeat` primitives against a `mockClient(docClient)`
+// and exercises a SIGTERM-class scenario. The setup boilerplate
+// (table-routed mock handlers + in-memory row state so subsequent
+// reads see prior writes) is identical between files; this helper
+// owns it.
+//
+// Why an in-memory `state` map vs static `.resolves({})`: the
+// transferLock → readCurrentHolder sequence inside `pushHandoff`
+// expects the row's `instance_id` to reflect the transferred owner.
+// Static resolves would always return the seeded row, masking
+// transfer regressions.
+//
+// Scope limit: only the lock + heartbeat tables are wired. The
+// flow-state table is intentionally UN-routed so any write to it
+// surfaces as an uncaught throw, catching the gateway-tier-touches-
+// flow-state regression on the spot. Callers running tests that
+// legitimately need additional tables should extend the mock at
+// call-site, not in this helper.
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  UpdateCommand,
+  DeleteCommand,
+  ScanCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+
+const LOCK_TABLE = 'test-gateway-lock';
+const HEARTBEAT_TABLE = 'test-gateway-peer-heartbeat';
+
+// Stable identifiers shared by the chaos tests. A two-replica shard
+// is sufficient for every Pillar 3 SIGTERM scenario this suite covers.
+const SHARD_ID = '0:1';
+const INSTANCE_A = 'inst-A';
+const INSTANCE_B = 'inst-B';
+const HOLDER_A = 'task-arn:.../inst-A';
+const HOLDER_B = 'task-arn:.../inst-B';
+
+function makeChaosLogger() {
+  return {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  };
+}
+
+function makeCcfe() {
+  const err = new Error('conditional check failed');
+  err.name = 'ConditionalCheckFailedException';
+  return err;
+}
+
+// Build a docClient + mockClient + mutable in-memory `state` map
+// representing the lock + heartbeat tables. Seeds the state with
+// the initial rows from the caller and wires Put/Get/Update/Delete/
+// Scan handlers that read and write through `state` so a CAS-by-
+// version pattern is visible to subsequent reads.
+function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
+  const rawClient = new DynamoDBClient({});
+  const docClient = DynamoDBDocumentClient.from(rawClient);
+  const ddbMock = mockClient(docClient);
+
+  const state = {
+    lockRow: initialLockRow ? { ...initialLockRow } : null,
+    peerRows: initialPeerRows.map((r) => ({ ...r })),
+  };
+
+  // ── Lock table ──
+  ddbMock.on(PutCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
+    state.lockRow = { ...cmd.Item };
+    return {};
+  });
+  ddbMock.on(UpdateCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
+    // The lock module issues UpdateCommand for renew + transfer.
+    // Both update version + expires_at; transfer also flips
+    // instance_id + lock_holder. Apply whichever fields the caller's
+    // ExpressionAttributeValues include — matches gateway-lock.js's
+    // shape without re-implementing the SET expression parser.
+    if (!state.lockRow) throw makeCcfe();
+    const v = cmd.ExpressionAttributeValues || {};
+    if (v[':peer'] !== undefined) {
+      state.lockRow.instance_id = v[':peer'];
+      state.lockRow.lock_holder = v[':peerHolder'];
+    }
+    if (v[':next'] !== undefined) state.lockRow.version = v[':next'];
+    if (v[':exp'] !== undefined) state.lockRow.expires_at = v[':exp'];
+    return {};
+  });
+  ddbMock.on(DeleteCommand, { TableName: LOCK_TABLE }).callsFake(() => {
+    state.lockRow = null;
+    return {};
+  });
+  ddbMock.on(GetCommand, { TableName: LOCK_TABLE }).callsFake(() => ({
+    Item: state.lockRow ?? undefined,
+  }));
+
+  // ── Heartbeat table ──
+  ddbMock.on(PutCommand, { TableName: HEARTBEAT_TABLE }).callsFake((cmd) => {
+    const idx = state.peerRows.findIndex((r) => r.instance_id === cmd.Item.instance_id);
+    if (idx >= 0) state.peerRows[idx] = { ...cmd.Item };
+    else state.peerRows.push({ ...cmd.Item });
+    return {};
+  });
+  ddbMock.on(ScanCommand, { TableName: HEARTBEAT_TABLE }).callsFake(() => ({
+    Items: state.peerRows.slice(),
+  }));
+  ddbMock.on(DeleteCommand, { TableName: HEARTBEAT_TABLE }).callsFake((cmd) => {
+    state.peerRows = state.peerRows.filter((r) => r.instance_id !== cmd.Key.instance_id);
+    return {};
+  });
+
+  return { docClient, ddbMock, state };
+}
+
+module.exports = {
+  setupChaosDdb,
+  makeChaosLogger,
+  LOCK_TABLE,
+  HEARTBEAT_TABLE,
+  SHARD_ID,
+  INSTANCE_A,
+  INSTANCE_B,
+  HOLDER_A,
+  HOLDER_B,
+  makeCcfe,
+};

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -35,13 +35,8 @@ const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const LOCK_TABLE = 'test-gateway-lock';
 const HEARTBEAT_TABLE = 'test-gateway-peer-heartbeat';
 
-// Stable identifiers shared by the chaos tests. A two-replica shard
-// is sufficient for every Pillar 3 SIGTERM scenario this suite covers.
-// HOLDER_A/B are opaque strings — gateway-lock and peer-heartbeat
-// treat lock_holder as operational metadata for logs/debug only and
-// don't parse it (e.g. as an ARN). The literal `task-arn:.../...`
-// shape is shorthand for "looks like a real ECS task ARN" without
-// committing to a parseable schema.
+// Stable identifiers shared by the chaos tests. HOLDER_A/B are
+// opaque (lock/heartbeat treat lock_holder as unparsed debug metadata).
 const SHARD_ID = '0:1';
 const INSTANCE_A = 'inst-A';
 const INSTANCE_B = 'inst-B';
@@ -75,31 +70,37 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     peerRows: initialPeerRows.map((r) => ({ ...r })),
   };
 
-  // ── Lock table ──
-  ddbMock.on(PutCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
-    state.lockRow = { ...cmd.Item };
-    return {};
-  });
-  // The CAS guards below mirror what production DDB enforces. Without
-  // them, a regression that ships a corrupted `:expected` or `:self`
-  // value would silently write through the mock when production would
-  // reject — defeating the whole point of composing real primitives.
-  // gateway-lock.js's renew/transfer/release all share the
-  // `instance_id = :self AND version = :expected` (or just :self for
-  // delete) condition shape.
-  ddbMock.on(UpdateCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
+  // CAS guard for the lock row. Mirrors what production DDB enforces
+  // on gateway-lock's `instance_id = :self [AND version = :expected]`
+  // condition shape (renew/transfer use both; release uses :self only).
+  // Without these checks a regression that ships a corrupted :expected
+  // or :self would silently write through the mock when production
+  // would reject — defeating the whole point of composing real
+  // primitives. `checkVersion` is opt-in because DeleteCommand
+  // (releaseLock) doesn't guard on version.
+  function assertLockCas(cmd, { checkVersion }) {
     if (!state.lockRow) throw makeCcfe();
     const v = cmd.ExpressionAttributeValues || {};
     if (v[':self'] !== undefined && v[':self'] !== state.lockRow.instance_id) {
       throw makeCcfe();
     }
-    if (v[':expected'] !== undefined && v[':expected'] !== state.lockRow.version) {
+    if (checkVersion && v[':expected'] !== undefined && v[':expected'] !== state.lockRow.version) {
       throw makeCcfe();
     }
+  }
+
+  // ── Lock table ──
+  ddbMock.on(PutCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
+    state.lockRow = { ...cmd.Item };
+    return {};
+  });
+  ddbMock.on(UpdateCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
+    assertLockCas(cmd, { checkVersion: true });
     // Renew writes version + expires_at; transfer also flips
     // instance_id + lock_holder. Apply whichever fields the caller's
     // ExpressionAttributeValues include — matches gateway-lock.js's
-    // shape without re-implementing the SET expression parser.
+    // SET expression without re-implementing the parser.
+    const v = cmd.ExpressionAttributeValues || {};
     if (v[':peer'] !== undefined) {
       state.lockRow.instance_id = v[':peer'];
       state.lockRow.lock_holder = v[':peerHolder'];
@@ -109,14 +110,7 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     return {};
   });
   ddbMock.on(DeleteCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
-    // gateway-lock.releaseLock's condition is `instance_id = :self`.
-    // Enforce it so a stale-cursor regression (e.g. delete from the
-    // wrong instance) surfaces as CCFE here too.
-    const v = cmd.ExpressionAttributeValues || {};
-    if (!state.lockRow) throw makeCcfe();
-    if (v[':self'] !== undefined && v[':self'] !== state.lockRow.instance_id) {
-      throw makeCcfe();
-    }
+    assertLockCas(cmd, { checkVersion: false });
     state.lockRow = null;
     return {};
   });

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -44,8 +44,12 @@ const HOLDER_A = 'task-arn:.../inst-A';
 const HOLDER_B = 'task-arn:.../inst-B';
 
 function makeChaosLogger() {
+  // Mirrors src/logger.js's exported methods so a future chaos
+  // composition that invokes logger.audit doesn't throw on an
+  // undefined method.
   return {
-    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(),
+    debug: jest.fn(), audit: jest.fn(),
   };
 }
 
@@ -76,11 +80,13 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
   // Without these checks a regression that ships a corrupted :expected
   // or :self would silently write through the mock when production
   // would reject — defeating the whole point of composing real
-  // primitives. `checkVersion` is opt-in because DeleteCommand
-  // (releaseLock) doesn't guard on version.
-  function assertLockCas(cmd, { checkVersion }) {
+  // primitives. `requireSelf` is on for Update/Delete (a stripped-CAS
+  // regression should fail here too); `checkVersion` is on for Update
+  // only since Delete (releaseLock) doesn't guard on version.
+  function assertLockCas(cmd, { requireSelf = true, checkVersion = false } = {}) {
     if (!state.lockRow) throw makeCcfe();
     const v = cmd.ExpressionAttributeValues || {};
+    if (requireSelf && v[':self'] === undefined) throw makeCcfe();
     if (v[':self'] !== undefined && v[':self'] !== state.lockRow.instance_id) {
       throw makeCcfe();
     }
@@ -95,7 +101,7 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     return {};
   });
   ddbMock.on(UpdateCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
-    assertLockCas(cmd, { checkVersion: true });
+    assertLockCas(cmd, { requireSelf: true, checkVersion: true });
     // Renew writes version + expires_at; transfer also flips
     // instance_id + lock_holder. Apply whichever fields the caller's
     // ExpressionAttributeValues include — matches gateway-lock.js's
@@ -110,7 +116,7 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     return {};
   });
   ddbMock.on(DeleteCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
-    assertLockCas(cmd, { checkVersion: false });
+    assertLockCas(cmd, { requireSelf: true, checkVersion: false });
     state.lockRow = null;
     return {};
   });

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -56,6 +56,10 @@ function makeChaosLogger() {
 function makeCcfe() {
   const err = new Error('conditional check failed');
   err.name = 'ConditionalCheckFailedException';
+  // Match the real AWS error shape so any future branch on
+  // err.$metadata.httpStatusCode (e.g. distinguishing 4xx vs 5xx)
+  // behaves the same against the mock as against prod DDB.
+  err.$metadata = { httpStatusCode: 400 };
   return err;
 }
 
@@ -100,13 +104,30 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
     state.lockRow = { ...cmd.Item };
     return {};
   });
+  // The known set of `:`-keys this mock recognizes. If gateway-lock's
+  // SET expression ever renames one (e.g. :peer → :newOwner), the
+  // mock would silently no-op the state mutation and downstream
+  // assertions would fail with "the row never flipped" instead of a
+  // clear "your rename broke the mock contract" error. Throw on any
+  // unknown key to surface drift at the point of breakage.
+  const KNOWN_UPDATE_KEYS = new Set([
+    ':self', ':expected',                        // CAS guards
+    ':next', ':exp',                             // renew
+    ':peer', ':peerHolder',                      // transfer
+  ]);
   ddbMock.on(UpdateCommand, { TableName: LOCK_TABLE }).callsFake((cmd) => {
     assertLockCas(cmd, { requireSelf: true, checkVersion: true });
-    // Renew writes version + expires_at; transfer also flips
-    // instance_id + lock_holder. Apply whichever fields the caller's
-    // ExpressionAttributeValues include — matches gateway-lock.js's
-    // SET expression without re-implementing the parser.
     const v = cmd.ExpressionAttributeValues || {};
+    for (const key of Object.keys(v)) {
+      if (!KNOWN_UPDATE_KEYS.has(key)) {
+        throw new Error(
+          `chaos-ddb: UpdateCommand on ${LOCK_TABLE} carried unknown ExpressionAttributeValues key "${key}". ` +
+          `If gateway-lock.js added or renamed an expression key, update KNOWN_UPDATE_KEYS + the SET-apply switch below.`
+        );
+      }
+    }
+    // Renew writes version + expires_at; transfer also flips
+    // instance_id + lock_holder.
     if (v[':peer'] !== undefined) {
       state.lockRow.instance_id = v[':peer'];
       state.lockRow.lock_holder = v[':peerHolder'];

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -31,6 +31,14 @@ const {
   ScanCommand,
 } = require('@aws-sdk/lib-dynamodb');
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { __TABLE_NAME: FLOW_STATE_TABLE_NAME } = require('../../src/flow-state');
+
+// Bound for microtask-yield polling loops (`while (!condition) await
+// setImmediate(...)`). Used by chaos tests that wait for an
+// observable DDB state mutation to land. Set generously above the
+// observed need (≤ 3 hops with mocked DDB); the diagnostic throw on
+// overflow turns a future flake into a clear failure message.
+const MAX_MICROTASK_YIELDS = 50;
 
 const LOCK_TABLE = 'test-gateway-lock';
 const HEARTBEAT_TABLE = 'test-gateway-peer-heartbeat';
@@ -163,15 +171,72 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
   return { docClient, ddbMock, state };
 }
 
+// Pull every TableName an SDK command targets, including the nested
+// shapes (BatchGet/BatchWrite use `RequestItems`; TransactGet/
+// TransactWrite use `TransactItems`). Single-item shapes (Put/Get/
+// Update/Delete/Scan/Query) carry `input.TableName` directly. Returns
+// a flat string[] so callers can filter against an allowlist.
+function tableNamesTargeted(cmdInput) {
+  if (!cmdInput) return [];
+  if (cmdInput.TableName) return [cmdInput.TableName];
+  if (cmdInput.RequestItems) return Object.keys(cmdInput.RequestItems);
+  if (Array.isArray(cmdInput.TransactItems)) {
+    return cmdInput.TransactItems
+      .map((entry) => {
+        // Includes Get for TransactGet (read-side) so the allowlist
+        // gate doesn't miss it if a future read-side refactor lands.
+        const op = entry.Put || entry.Update || entry.Delete || entry.ConditionCheck || entry.Get;
+        return op?.TableName;
+      })
+      .filter(Boolean);
+  }
+  return [];
+}
+
+// Post-hoc inspection: every DDB command issued during the test must
+// have a TableName in the allowlist. Unrouted commands in mockClient
+// silently resolve, so a future refactor that writes to e.g.
+// qurl_bot_flow_state from the gateway-tier SIGTERM path would not
+// throw at runtime — this assertion is the catch. Walks every shape
+// (single-item, BatchGet/Write RequestItems, TransactGet/Write
+// TransactItems) so the regression surface is exhaustive. Used by
+// both deploy-during-flow and resume-fail chaos tests (both
+// gateway-tier paths that must not touch flow_state).
+function assertNoUnexpectedTableCalls(ddbMock) {
+  const allowed = new Set([LOCK_TABLE, HEARTBEAT_TABLE]);
+  const allTables = ddbMock.calls()
+    .flatMap((c) => tableNamesTargeted(c.args[0]?.input));
+  const offenders = allTables.filter((t) => !allowed.has(t));
+  if (offenders.length > 0) {
+    throw new Error(
+      `chaos: gateway-tier path wrote to forbidden tables: ${[...new Set(offenders)].join(', ')}. ` +
+      `Allowed: ${[...allowed].join(', ')}. ` +
+      `If this test starts failing because the gateway tier legitimately needs ` +
+      `another table, add it here AND update the relevant source module's header ` +
+      `to document the new write surface.`
+    );
+  }
+  // Belt-and-suspenders: if a future change adds flow_state to
+  // `allowed` (mistakenly or otherwise), the throw above wouldn't
+  // fire — this expect catches that drift specifically, since the
+  // flow_state-on-gateway prohibition is the primary regression
+  // target these chaos tests exist to protect.
+  expect(allTables.filter((t) => t === FLOW_STATE_TABLE_NAME)).toHaveLength(0);
+}
+
 module.exports = {
   setupChaosDdb,
   makeChaosLogger,
   LOCK_TABLE,
   HEARTBEAT_TABLE,
+  FLOW_STATE_TABLE_NAME,
   SHARD_ID,
   INSTANCE_A,
   INSTANCE_B,
   HOLDER_A,
   HOLDER_B,
+  MAX_MICROTASK_YIELDS,
   makeCcfe,
+  tableNamesTargeted,
+  assertNoUnexpectedTableCalls,
 };

--- a/apps/discord/tests/helpers/chaos-ddb.js
+++ b/apps/discord/tests/helpers/chaos-ddb.js
@@ -97,6 +97,14 @@ function setupChaosDdb({ initialLockRow = null, initialPeerRows = [] } = {}) {
   // only since Delete (releaseLock) doesn't guard on version.
   function assertLockCas(cmd, { requireSelf = true, checkVersion = false } = {}) {
     if (!state.lockRow) throw makeCcfe();
+    // Production DDB enforces CAS on the ConditionExpression itself,
+    // not on the values bound to it. A regression that strips
+    // ConditionExpression but keeps ExpressionAttributeValues would
+    // pass a values-only check; require the expression text too so
+    // the mock matches prod's enforcement boundary.
+    if (requireSelf && !(cmd.ConditionExpression && cmd.ConditionExpression.includes('instance_id = :self'))) {
+      throw makeCcfe();
+    }
     const v = cmd.ExpressionAttributeValues || {};
     if (requireSelf && v[':self'] === undefined) throw makeCcfe();
     if (v[':self'] !== undefined && v[':self'] !== state.lockRow.instance_id) {

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -112,9 +112,14 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
     expect(cap).toBe(10);
 
+    // `new Promise(() => {})` never settles — these references are
+    // released by `_resetStateForTest` in beforeEach (which calls
+    // .clear() on the inflight Set), not by GC. --detectOpenHandles
+    // doesn't flag promise references (only timers/sockets), so the
+    // suite stays clean.
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
-        eventConsumer.trackDispatch(new Promise(() => {})); // never settles
+        eventConsumer.trackDispatch(new Promise(() => {}));
       }
     });
     expect(eventConsumer._test.getInFlightCount()).toBe(cap);
@@ -153,13 +158,20 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     expect(entryWarns).toHaveLength(1);
   });
 
-  it('SIGTERM during at-cap pause wakes abortableSleep + stop() resolves inside drain deadline', async () => {
+  it('SIGTERM during at-cap pause wakes abortableSleep without timer fire (signal-wake invariant)', async () => {
     // The load-bearing chaos invariant. Without the abortableSleep-
     // signal-wired refactor, an at-cap stop() would wait out the full
     // backoff sleep on each pollLoop iteration — and at the ceiling
     // (1.6 s/iter), a multi-iteration drain would breach the 3 s
-    // deadline. This test pins that a stop() during a backoff sleep
-    // resolves within a tight window.
+    // deadline. Asserted deterministically here via fake timers: if
+    // stop() wakes via signal, the loop terminates WITHOUT any
+    // backoff setTimeout firing.
+    //
+    // Drives the production lifecycle (start() → pollLoop → pollOnce
+    // parks → stop()). Using _test.pollOnce directly bypasses start()
+    // which sets `running=true` — stop()'s first guard short-circuits
+    // when !running, so a direct-pollOnce setup would silently no-op
+    // stop() and pass for the wrong reason.
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
@@ -167,40 +179,47 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
       }
     });
 
-    // Shrink the drain deadline so a regression that fails to wake
-    // abortableSleep doesn't wall-clock the suite. 50 ms is generous
-    // vs the few-ms microtask drain a working signal-wake produces.
+    // Shrink the drain deadline so stop()'s post-loop wait on the
+    // never-settling inflight promises doesn't wall-clock the test.
+    // The drain timer is real (not the abortable backoff sleep we're
+    // testing), so even under fake-timers it'd otherwise consume
+    // DRAIN_DEADLINE_MS of real time.
     eventConsumer._test._setDrainDeadlineForTest(50);
 
-    // Inject a pollLoop that's parked inside the at-cap abortableSleep
-    // by calling pollOnce directly (cap is already saturated) and
-    // racing stop() against it.
-    const client = makeStubClient();
-    const pollPromise = eventConsumer._test.pollOnce(client);
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      const client = makeStubClient();
+      await eventConsumer.start(client);
 
-    // Yield one event-loop turn so pollOnce enters the at-cap branch
-    // and reaches the abortableSleep.
-    await new Promise((r) => { setImmediate(r); });
+      // Drain microtasks so pollLoop enters and the first pollOnce
+      // iteration parks inside abortableSleep.
+      await new Promise((r) => { setImmediate(r); });
 
-    // Stop the consumer. signalShutdown→stop()→stopController.abort()
-    // fires the signal, which wakes the in-flight abortableSleep so
-    // pollOnce returns. Without the wire-up, stop() would wait the
-    // full INFLIGHT_BACKOFF_BASE_MS (100 ms) before pollOnce returned —
-    // not catastrophic in this tiny test but a regression mode that
-    // compounds with the doubling ladder.
-    const stopStart = Date.now();
-    await eventConsumer.stop();
-    const stopElapsed = Date.now() - stopStart;
+      // The loop is parked on a (fake) backoff timer. If this fails,
+      // the test would be vacuously passing on a no-op pollLoop.
+      expect(jest.getTimerCount()).toBeGreaterThan(0);
 
-    // The pollPromise itself resolves (it's been awoken).
-    await pollPromise;
+      // Capture the signal NOW — stop() nulls stopController in its
+      // finally block, so a post-stop read would see null.
+      const { signal } = eventConsumer._test.getStopController();
 
-    // Stop landed inside the drain deadline. With a properly wired
-    // abort-signal, this is a few ms; with a regression that breaks
-    // the wire-up, it'd wait the full INFLIGHT_BACKOFF_BASE_MS (100 ms)
-    // per iteration. 200 ms threshold gives GC-pause headroom on slow
-    // CI runners while still catching a wire-up regression.
-    expect(stopElapsed).toBeLessThan(200);
+      // Stop. signal abort wakes abortableSleep via its event
+      // listener — no timer advancement needed for the at-cap sleep.
+      // stop()'s drain phase DOES use a real setTimeout so the
+      // never-settling inflight promises don't pin the test; advance
+      // timers to release that drain.
+      const stopPromise = eventConsumer.stop();
+      await new Promise((r) => { setImmediate(r); });
+      await jest.runAllTimersAsync();
+      await stopPromise;
+
+      // The signal aborted via stop()'s call — proves the at-cap
+      // abortableSleep was wired to observe this signal (otherwise
+      // pollLoop would not have unwound for stop to complete).
+      expect(signal.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('capacity released → release-info log + backoff reset (pause-end half of the bracket)', async () => {

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -114,6 +114,12 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
 
     // `new Promise(() => {})` never settles; _resetStateForTest in
     // beforeEach .clear()s the inflight Set, releasing the references.
+    // withWorkerDispatch wraps the pre-fill only. The flag flips back
+    // to false before pollOnce runs, so any handler pollOnce would
+    // try to track via processMessage's trackDispatch is a no-op (the
+    // gate skips). That's intentional — we want the cap saturated and
+    // pollOnce's at-cap branch to fire; pollOnce shouldn't ADD to
+    // inflight during the test.
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         eventConsumer.trackDispatch(new Promise(() => {}));
@@ -170,6 +176,12 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     // when !running, so a direct-pollOnce setup would silently no-op
     // stop() and pass for the wrong reason.
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    // withWorkerDispatch wraps the pre-fill only. The flag flips back
+    // to false before pollOnce runs, so any handler pollOnce would
+    // try to track via processMessage's trackDispatch is a no-op (the
+    // gate skips). That's intentional — we want the cap saturated and
+    // pollOnce's at-cap branch to fire; pollOnce shouldn't ADD to
+    // inflight during the test.
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         eventConsumer.trackDispatch(new Promise(() => {}));
@@ -198,9 +210,13 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
       // iteration parks inside abortableSleep.
       await new Promise((r) => { setImmediate(r); });
 
-      // The loop is parked on a (fake) backoff timer. If this fails,
-      // the test would be vacuously passing on a no-op pollLoop.
-      expect(jest.getTimerCount()).toBeGreaterThan(0);
+      // Loop parked on a single (fake) backoff timer — exactly one
+      // is the structural shape. If start() ever schedules a setTimeout
+      // before its first internal await (a future metrics tick, say),
+      // this would catch the new timer and force us to revisit the
+      // load-bearing `=== 0` assertion below (which would need to
+      // account for the extra one).
+      expect(jest.getTimerCount()).toBe(1);
 
       // Capture the signal NOW — stop() nulls stopController in its
       // finally block, so a post-stop read would see null.
@@ -271,7 +287,7 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
       // Backoff doubled to 200 ms post-iteration.
       expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
 
-      // Settle a handler — capacity drops to cap-1 (= 4).
+      // Settle a handler — capacity drops to cap-1 (= 9).
       resolveOne();
       // Yield so the .then(remove) cleanup runs.
       await new Promise((r) => { setImmediate(r); });
@@ -281,22 +297,48 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
       p = eventConsumer._test.pollOnce(client);
       await jest.runOnlyPendingTimersAsync();
       await p;
+
+      // Release-side post-conditions land here, before the follow-on
+      // streak rewrites them. atCapPauseLogged is now false, backoff
+      // back to base, release-info logged.
+      expect(logger.info).toHaveBeenCalledWith(
+        eventConsumer._test.AT_CAP_RELEASED_INFO_MSG,
+        // The release log snapshots the inflight count that triggered
+        // the release (necessarily below cap). Don't assert exact value
+        // — cap-1 at log time is what we'd see today, but the contract
+        // is "< cap", not "= cap-1".
+        expect.objectContaining({ inFlight: expect.any(Number), cap }),
+      );
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(
+        eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS,
+      );
+      expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
+
+      // ── Follow-on at-cap streak: entry-warn must re-fire ──
+      // Re-saturate to cap and run one more pollOnce. The entry warn
+      // must fire a SECOND time — a regression that fails to clear
+      // atCapPauseLogged on release would silently suppress every
+      // subsequent at-cap warning, costing operators the signal.
+      // isAtCapPauseLogged()=false above is the necessary condition;
+      // this iteration is the sufficient one (closes the bracketing
+      // contract on a real second entry, not just the flag flip).
+      withWorkerDispatch(() => {
+        eventConsumer.trackDispatch(new Promise(() => {}));
+      });
+      expect(eventConsumer._test.getInFlightCount()).toBe(cap);
+
+      p = eventConsumer._test.pollOnce(client);
+      await jest.runOnlyPendingTimersAsync();
+      await p;
     } finally {
       jest.useRealTimers();
     }
 
-    expect(logger.info).toHaveBeenCalledWith(
-      eventConsumer._test.AT_CAP_RELEASED_INFO_MSG,
-      // The release log snapshots the inflight count that triggered the
-      // release (necessarily below cap). Don't assert exact value —
-      // cap=4 at log time is what we'd see today, but the contract is
-      // "< cap", not "= cap-1".
-      expect.objectContaining({ inFlight: expect.any(Number), cap }),
+    // Entry-warn fired on the first AND on the follow-on streak —
+    // exactly two over the test.
+    const entryWarns = logger.warn.mock.calls.filter(
+      ([msg]) => msg === eventConsumer._test.AT_CAP_PAUSE_WARN_MSG,
     );
-    // Backoff reset to base.
-    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(
-      eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS,
-    );
-    expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
+    expect(entryWarns).toHaveLength(2);
   });
 });

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -222,11 +222,11 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
       await new Promise((r) => { setImmediate(r); });
 
       // Loop parked on exactly one (fake) backoff timer — the
-      // structural shape. If start() ever schedules an additional
+      // structural shape. If this fails (count=2), the regression
+      // likely lives in event-consumer.js's start(): it added a
       // setTimeout before its first internal await (a future metrics
-      // tick, say), this would catch the new timer as a count of 2
-      // and force a revisit of the load-bearing `=== 0` post-stop
-      // assertion below (which would need to subtract the extra one).
+      // tick, say), and the load-bearing `=== 0` post-stop assertion
+      // below needs to be revisited.
       expect(jest.getTimerCount()).toBe(1);
 
       // Capture the signal NOW — stop() nulls stopController in its

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -1,0 +1,267 @@
+// Pillar 1 chaos validation — consumer-side queue backpressure under
+// sustained at-cap load + SIGTERM mid-pause.
+//
+// The producer (event-publisher) is intentionally fire-and-log per its
+// module header + the design doc — no in-process retry. The real
+// backpressure mechanism lives in the consumer's MAX_INFLIGHT_HANDLERS
+// cap (see event-consumer.js: validateInflightCap + the at-cap branch
+// of pollOnce). This chaos test pins the composition-level invariants:
+//
+//   1. Inflight count is BOUNDED under sustained pressure. A sustained
+//      at-cap streak shouldn't grow the inFlightPromises Set beyond
+//      MAX_INFLIGHT_HANDLERS + (RECEIVE_MAX_MESSAGES - 1) — no OOM.
+//      Unit test `pollOnce early-returns + backs off when in-flight at
+//      cap` pins ONE pause; this test pins SUSTAINED behavior.
+//
+//   2. SIGTERM during at-cap pause exits inside DRAIN_DEADLINE_MS.
+//      The abortableSleep refactor (PR #387) wired stopController.signal
+//      into the at-cap sleep so a stop() call wakes the sleep
+//      immediately. Without this, an at-cap pause of up to
+//      INFLIGHT_BACKOFF_MAX_MS (1.6 s) per iteration would push the
+//      total drain past the 3 s ceiling on a multi-iteration pause.
+//      The unit test for abortableSleep tests the signal-wake in
+//      isolation; this test composes it with a real pollLoop +
+//      backoff ladder mid-streak.
+//
+//   3. Capacity-released: when slow handlers settle, the at-cap
+//      release log fires, currentBackoffMs resets, and inflight count
+//      returns to zero. Pins the symmetric "pause-end" half of the
+//      pause-bracketing contract.
+//
+// What this test does NOT cover (already pinned by unit tests):
+//   - exact backoff sequence (100/200/400/800/1600 ms ladder)
+//   - log throttling (one warn per streak, one info on release)
+//   - cap-skew metric / underflow log shape
+
+// MUST mock config + logger BEFORE requiring event-consumer (top-level
+// requires). Mirror tests/event-consumer.test.js so the env shape
+// matches what the rest of the suite exercises.
+jest.mock('../src/config', () => ({
+  ENABLE_EVENT_SHIPPER: true,
+  QURL_BOT_EVENTS_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-events',
+  // Tight cap for fast chaos-runs. Production default is 100. Set to
+  // RECEIVE_MAX_MESSAGES (10) — the floor for which validateInflightCap
+  // doesn't emit the "effective ceiling is cap+overshoot" warn (which
+  // would pollute test output without representing a real misconfig).
+  QURL_BOT_MAX_INFLIGHT_HANDLERS: 10,
+  QURL_BOT_DRAIN_DEADLINE_MS: 3000,
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(),
+  debug: jest.fn(), audit: jest.fn(),
+}));
+
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  SQSClient, ReceiveMessageCommand, DeleteMessageCommand,
+} = require('@aws-sdk/client-sqs');
+
+const logger = require('../src/logger');
+
+// Re-require event-consumer AFTER mocks so the config snapshot is
+// the one above. Each describe block needs `_resetStateForTest` to
+// clear module-level state (inflight set, atCapPauseLogged, backoff)
+// since the consumer is a process-singleton.
+const eventConsumer = require('../src/event-consumer');
+
+const sqsMock = mockClient(SQSClient);
+
+function makeStubClient() {
+  return {
+    actions: {
+      InteractionCreate: { handle: jest.fn(() => Promise.resolve()) },
+    },
+  };
+}
+
+// Pre-mock with an empty receive so the unit-level tests' stubs apply
+// here too. Individual tests override as needed.
+beforeEach(() => {
+  sqsMock.reset();
+  sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+  sqsMock.on(DeleteMessageCommand).resolves({});
+  eventConsumer._test._resetStateForTest();
+  eventConsumer._test._setSqsClientForTest(new SQSClient({}));
+  eventConsumer._test._setStopControllerForTest();
+  logger.info.mockClear();
+  logger.warn.mockClear();
+  logger.error.mockClear();
+  logger.debug.mockClear();
+});
+
+afterAll(() => sqsMock.restore());
+
+// trackDispatch is gated by isWorkerDispatch; flip the flag via the
+// test-only setter so calls from this test land in the inflight Set
+// the way pollOnce's production dispatch would.
+function withWorkerDispatch(fn) {
+  eventConsumer._test._setWorkerDispatchingForTest(true);
+  try { return fn(); } finally {
+    eventConsumer._test._setWorkerDispatchingForTest(false);
+  }
+}
+
+describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => {
+  it('inflight is bounded across many at-cap iterations (no OOM growth)', async () => {
+    // Saturate inflight at the cap with pending Promises that never
+    // settle. Then iterate pollOnce 10 times. Inflight count must stay
+    // at exactly cap — pollOnce's early-return must NOT accidentally
+    // enqueue a new handler each iteration (which would grow the Set
+    // unbounded → OOM under sustained load).
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    expect(cap).toBe(10);
+
+    withWorkerDispatch(() => {
+      for (let i = 0; i < cap; i += 1) {
+        eventConsumer.trackDispatch(new Promise(() => {})); // never settles
+      }
+    });
+    expect(eventConsumer._test.getInFlightCount()).toBe(cap);
+
+    // Even when ReceiveMessage WOULD return work, the cap blocks it.
+    sqsMock.on(ReceiveMessageCommand).resolves({
+      Messages: [{ Body: JSON.stringify({ data: { t: 'INTERACTION_CREATE' } }), ReceiptHandle: 'h' }],
+    });
+    const client = makeStubClient();
+
+    // Run 10 at-cap pollOnce iterations. Backoff sleeps are real
+    // setTimeouts; with the cap immediately hit, each iteration only
+    // awaits the abortableSleep which we shorten via fake timers.
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      for (let i = 0; i < 10; i += 1) {
+        const p = eventConsumer._test.pollOnce(client);
+        // Drain the timer + microtasks each iteration.
+        // eslint-disable-next-line no-await-in-loop
+        await jest.runOnlyPendingTimersAsync();
+        // eslint-disable-next-line no-await-in-loop
+        await p;
+      }
+    } finally {
+      jest.useRealTimers();
+    }
+
+    // Inflight stayed at cap; no growth.
+    expect(eventConsumer._test.getInFlightCount()).toBe(cap);
+    // Receive was never called — the cap blocked every iteration.
+    expect(sqsMock.commandCalls(ReceiveMessageCommand)).toHaveLength(0);
+    // Entry-warn fired exactly once (transition-loud, steady-state-quiet).
+    const entryWarns = logger.warn.mock.calls.filter(
+      ([msg]) => msg === eventConsumer._test.AT_CAP_PAUSE_WARN_MSG,
+    );
+    expect(entryWarns).toHaveLength(1);
+  });
+
+  it('SIGTERM during at-cap pause wakes abortableSleep + stop() resolves inside drain deadline', async () => {
+    // The load-bearing chaos invariant. Without the abortableSleep-
+    // signal-wired refactor, an at-cap stop() would wait out the full
+    // backoff sleep on each pollLoop iteration — and at the ceiling
+    // (1.6 s/iter), a multi-iteration drain would breach the 3 s
+    // deadline. This test pins that a stop() during a backoff sleep
+    // resolves within a tight window.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+    withWorkerDispatch(() => {
+      for (let i = 0; i < cap; i += 1) {
+        eventConsumer.trackDispatch(new Promise(() => {}));
+      }
+    });
+
+    // Shrink the drain deadline so a regression that fails to wake
+    // abortableSleep doesn't wall-clock the suite. 50 ms is generous
+    // vs the few-ms microtask drain a working signal-wake produces.
+    eventConsumer._test._setDrainDeadlineForTest(50);
+
+    // Inject a pollLoop that's parked inside the at-cap abortableSleep
+    // by calling pollOnce directly (cap is already saturated) and
+    // racing stop() against it.
+    const client = makeStubClient();
+    const pollPromise = eventConsumer._test.pollOnce(client);
+
+    // Yield one event-loop turn so pollOnce enters the at-cap branch
+    // and reaches the abortableSleep.
+    await new Promise((r) => { setImmediate(r); });
+
+    // Stop the consumer. signalShutdown→stop()→stopController.abort()
+    // fires the signal, which wakes the in-flight abortableSleep so
+    // pollOnce returns. Without the wire-up, stop() would wait the
+    // full INFLIGHT_BACKOFF_BASE_MS (100 ms) before pollOnce returned —
+    // not catastrophic in this tiny test but a regression mode that
+    // compounds with the doubling ladder.
+    const stopStart = Date.now();
+    await eventConsumer.stop();
+    const stopElapsed = Date.now() - stopStart;
+
+    // The pollPromise itself resolves (it's been awoken).
+    await pollPromise;
+
+    // Stop landed inside the drain deadline. With a properly wired
+    // abort-signal, this is a few ms; with a regression that breaks
+    // the wire-up, it'd wait the full INFLIGHT_BACKOFF_BASE_MS (100 ms)
+    // per iteration. 200 ms threshold gives GC-pause headroom on slow
+    // CI runners while still catching a wire-up regression.
+    expect(stopElapsed).toBeLessThan(200);
+  });
+
+  it('capacity released → release-info log + backoff reset (pause-end half of the bracket)', async () => {
+    // The symmetric assertion: when slow handlers settle and inflight
+    // drops below cap, the pause-end log fires AND
+    // currentBackoffMs resets to base. A regression that fails to
+    // reset would leave the next at-cap streak entering at the
+    // ceiling backoff (1.6 s) instead of base (100 ms), inflating
+    // dwell time at the cap by 16× on the FIRST iteration of every
+    // subsequent streak.
+    const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
+
+    // Settle one of the handlers controllably; the others stay pending.
+    let resolveOne;
+    const settleable = new Promise((r) => { resolveOne = r; });
+    withWorkerDispatch(() => {
+      eventConsumer.trackDispatch(settleable);
+      for (let i = 0; i < cap - 1; i += 1) {
+        eventConsumer.trackDispatch(new Promise(() => {}));
+      }
+    });
+    expect(eventConsumer._test.getInFlightCount()).toBe(cap);
+
+    const client = makeStubClient();
+
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+      // First iteration: at-cap → entry warn + base backoff sleep.
+      let p = eventConsumer._test.pollOnce(client);
+      await jest.runOnlyPendingTimersAsync();
+      await p;
+      expect(eventConsumer._test.isAtCapPauseLogged()).toBe(true);
+      // Backoff doubled to 200 ms post-iteration.
+      expect(eventConsumer._test.getCurrentBackoffMs()).toBe(200);
+
+      // Settle a handler — capacity drops to cap-1 (= 4).
+      resolveOne();
+      // Yield so the .then(remove) cleanup runs.
+      await new Promise((r) => { setImmediate(r); });
+      expect(eventConsumer._test.getInFlightCount()).toBe(cap - 1);
+
+      // Next iteration: below-cap path fires release-info log + resets backoff.
+      p = eventConsumer._test.pollOnce(client);
+      await jest.runOnlyPendingTimersAsync();
+      await p;
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(logger.info).toHaveBeenCalledWith(
+      eventConsumer._test.AT_CAP_RELEASED_INFO_MSG,
+      // The release log snapshots the inflight count that triggered the
+      // release (necessarily below cap). Don't assert exact value —
+      // cap=4 at log time is what we'd see today, but the contract is
+      // "< cap", not "= cap-1".
+      expect.objectContaining({ inFlight: expect.any(Number), cap }),
+    );
+    // Backoff reset to base.
+    expect(eventConsumer._test.getCurrentBackoffMs()).toBe(
+      eventConsumer._test.INFLIGHT_BACKOFF_BASE_MS,
+    );
+    expect(eventConsumer._test.isAtCapPauseLogged()).toBe(false);
+  });
+});

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -83,6 +83,11 @@ beforeEach(() => {
   sqsMock.on(DeleteMessageCommand).resolves({});
   eventConsumer._test._resetStateForTest();
   eventConsumer._test._setSqsClientForTest(new SQSClient({}));
+  // _setStopControllerForTest is needed by tests #1 and #3 which
+  // drive pollOnce directly and read stopController.signal without
+  // going through start() (start() re-creates the controller, so
+  // test #2 overwrites this seed harmlessly). Run unconditionally
+  // here so all three tests get a fresh AbortController.
   eventConsumer._test._setStopControllerForTest();
   logger.info.mockClear();
   logger.warn.mockClear();

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -95,6 +95,13 @@ afterAll(() => sqsMock.restore());
 // trackDispatch is gated by isWorkerDispatch; flip the flag via the
 // test-only setter so calls from this test land in the inflight Set
 // the way pollOnce's production dispatch would.
+//
+// Scoping: this helper wraps the cap-pre-fill ONLY. The flag flips
+// back to false before any subsequent pollOnce runs, so anything
+// pollOnce would try to track via processMessage's trackDispatch is
+// a no-op (the gate skips). That's intentional — we want the cap
+// saturated by the pre-fill and pollOnce's at-cap branch to fire;
+// pollOnce shouldn't ADD to inflight during the test.
 function withWorkerDispatch(fn) {
   eventConsumer._test._setWorkerDispatchingForTest(true);
   try { return fn(); } finally {
@@ -103,6 +110,14 @@ function withWorkerDispatch(fn) {
 }
 
 describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => {
+  // Pin the floor cap once. Mocked config sets MAX_INFLIGHT_HANDLERS=10
+  // (matches RECEIVE_MAX_MESSAGES so validateInflightCap stays quiet).
+  // If the mocked value drifts, this surfaces it once at the describe
+  // boundary instead of per-test.
+  beforeAll(() => {
+    expect(eventConsumer._test.MAX_INFLIGHT_HANDLERS).toBe(10);
+  });
+
   it('inflight is bounded across many at-cap iterations (no OOM growth)', async () => {
     // Saturate inflight at the cap with pending Promises that never
     // settle. Then iterate pollOnce 10 times. Inflight count must stay
@@ -110,16 +125,11 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     // enqueue a new handler each iteration (which would grow the Set
     // unbounded → OOM under sustained load).
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    expect(cap).toBe(10);
 
     // `new Promise(() => {})` never settles; _resetStateForTest in
     // beforeEach .clear()s the inflight Set, releasing the references.
-    // withWorkerDispatch wraps the pre-fill only. The flag flips back
-    // to false before pollOnce runs, so any handler pollOnce would
-    // try to track via processMessage's trackDispatch is a no-op (the
-    // gate skips). That's intentional — we want the cap saturated and
-    // pollOnce's at-cap branch to fire; pollOnce shouldn't ADD to
-    // inflight during the test.
+    // (See withWorkerDispatch's docstring for why the flag scoping is
+    // pre-fill only.)
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         eventConsumer.trackDispatch(new Promise(() => {}));
@@ -176,12 +186,7 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     // when !running, so a direct-pollOnce setup would silently no-op
     // stop() and pass for the wrong reason.
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
-    // withWorkerDispatch wraps the pre-fill only. The flag flips back
-    // to false before pollOnce runs, so any handler pollOnce would
-    // try to track via processMessage's trackDispatch is a no-op (the
-    // gate skips). That's intentional — we want the cap saturated and
-    // pollOnce's at-cap branch to fire; pollOnce shouldn't ADD to
-    // inflight during the test.
+    // (See withWorkerDispatch's docstring for the flag scoping rationale.)
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         eventConsumer.trackDispatch(new Promise(() => {}));
@@ -198,24 +203,25 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
     try {
       const client = makeStubClient();
-      // start() builds promises but schedules no timer before its
-      // first internal await. The first timer this test sees is the
-      // backoff setTimeout inside pollOnce → abortableSleep. The
-      // load-bearing `getTimerCount() === 0` post-stop assertion
-      // assumes this — if start() ever schedules a setTimeout up
-      // front, that pre-existing timer would land in the count.
+      // start() is synchronous (kicks off pollLoop as a detached
+      // promise). The `await` consumes one microtask tick, which is
+      // enough for pollLoop to enter its first pollOnce → at-cap →
+      // schedule a backoff setTimeout via abortableSleep. So by the
+      // time start() resolves to the test, the loop is already
+      // parked on exactly one (fake) backoff timer.
       await eventConsumer.start(client);
 
-      // Drain microtasks so pollLoop enters and the first pollOnce
-      // iteration parks inside abortableSleep.
+      // One more setImmediate yield to flush any straggling
+      // microtasks pollLoop may have queued; not load-bearing —
+      // the post-await timer count is already 1.
       await new Promise((r) => { setImmediate(r); });
 
-      // Loop parked on a single (fake) backoff timer — exactly one
-      // is the structural shape. If start() ever schedules a setTimeout
-      // before its first internal await (a future metrics tick, say),
-      // this would catch the new timer and force us to revisit the
-      // load-bearing `=== 0` assertion below (which would need to
-      // account for the extra one).
+      // Loop parked on exactly one (fake) backoff timer — the
+      // structural shape. If start() ever schedules an additional
+      // setTimeout before its first internal await (a future metrics
+      // tick, say), this would catch the new timer as a count of 2
+      // and force a revisit of the load-bearing `=== 0` post-stop
+      // assertion below (which would need to subtract the extra one).
       expect(jest.getTimerCount()).toBe(1);
 
       // Capture the signal NOW — stop() nulls stopController in its

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -112,11 +112,8 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     const cap = eventConsumer._test.MAX_INFLIGHT_HANDLERS;
     expect(cap).toBe(10);
 
-    // `new Promise(() => {})` never settles — these references are
-    // released by `_resetStateForTest` in beforeEach (which calls
-    // .clear() on the inflight Set), not by GC. --detectOpenHandles
-    // doesn't flag promise references (only timers/sockets), so the
-    // suite stays clean.
+    // `new Promise(() => {})` never settles; _resetStateForTest in
+    // beforeEach .clear()s the inflight Set, releasing the references.
     withWorkerDispatch(() => {
       for (let i = 0; i < cap; i += 1) {
         eventConsumer.trackDispatch(new Promise(() => {}));
@@ -203,20 +200,33 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
       // finally block, so a post-stop read would see null.
       const { signal } = eventConsumer._test.getStopController();
 
-      // Stop. signal abort wakes abortableSleep via its event
-      // listener — no timer advancement needed for the at-cap sleep.
-      // stop()'s drain phase DOES use a real setTimeout so the
-      // never-settling inflight promises don't pin the test; advance
-      // timers to release that drain.
+      // Call stop. Its synchronous prefix (before the first internal
+      // await) calls stopController.abort(), which fires the abort
+      // event listeners — including abortableSleep's, which calls
+      // clearTimeout(t) on the parked backoff timer.
       const stopPromise = eventConsumer.stop();
+
+      // ── Load-bearing assertion ──
+      // At this point, abort() has already run synchronously. If
+      // abortableSleep is signal-wired (current contract), its
+      // listener fired and cleared the backoff timer. stop()'s drain
+      // timer hasn't been scheduled yet (it lives after `await
+      // loopPromise` inside stop). Pending fake timer count must be 0.
+      //
+      // If a regression strips the addEventListener wiring from
+      // abortableSleep, the backoff timer would still be parked here,
+      // getTimerCount() would be 1, and this assertion fails — even
+      // though runAllTimersAsync below would later fire the orphan
+      // timer and let the loop unwind via the timeout branch (which
+      // is exactly the regression mode this test exists to catch).
+      expect(jest.getTimerCount()).toBe(0);
+      expect(signal.aborted).toBe(true);
+
+      // Let stop() finish its drain (which schedules + awaits a
+      // real-but-faked setTimeout(DRAIN_DEADLINE_MS)) and unwind.
       await new Promise((r) => { setImmediate(r); });
       await jest.runAllTimersAsync();
       await stopPromise;
-
-      // The signal aborted via stop()'s call — proves the at-cap
-      // abortableSleep was wired to observe this signal (otherwise
-      // pollLoop would not have unwound for stop to complete).
-      expect(signal.aborted).toBe(true);
     } finally {
       jest.useRealTimers();
     }

--- a/apps/discord/tests/queue-backpressure.chaos.test.js
+++ b/apps/discord/tests/queue-backpressure.chaos.test.js
@@ -186,6 +186,12 @@ describe('Pillar 1 chaos — sustained backpressure + SIGTERM-mid-pause', () => 
     jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
     try {
       const client = makeStubClient();
+      // start() builds promises but schedules no timer before its
+      // first internal await. The first timer this test sees is the
+      // backoff setTimeout inside pollOnce → abortableSleep. The
+      // load-bearing `getTimerCount() === 0` post-stop assertion
+      // assumes this — if start() ever schedules a setTimeout up
+      // front, that pre-existing timer would land in the count.
       await eventConsumer.start(client);
 
       // Drain microtasks so pollLoop enters and the first pollOnce

--- a/apps/discord/tests/resume-fail.chaos.test.js
+++ b/apps/discord/tests/resume-fail.chaos.test.js
@@ -123,10 +123,9 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
     //     immediately because the row is gone, not just expired.
     expect(state.lockRow).toBeNull();
     // Confirm via DDB call inspection: a DeleteCommand against the
-    // lock table landed exactly once.
-    const lockDeletes = ddbMock.commandCalls(DeleteCommand).filter(
-      (c) => c.args[0].input.TableName === LOCK_TABLE,
-    );
+    // lock table landed exactly once. `commandCalls`' second arg is
+    // a per-input filter — the same shape mockClient uses for routing.
+    const lockDeletes = ddbMock.commandCalls(DeleteCommand, { TableName: LOCK_TABLE });
     expect(lockDeletes).toHaveLength(1);
     // CAS guard MUST be present — without it, a peer that already
     // cold-acquired would have its row clobbered.
@@ -198,6 +197,11 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
       isConnecting: () => false,
       releaseLock: () => lock.releaseLock(),
       deleteOwnRow: () => heartbeat.deleteOwnRow(),
+      // maxAttempts=3 (vs 5 in test #1) because this test pins the
+      // exhaustion-branch outcome under CAS-failure, not the ladder
+      // depth. The 200/400/800/1600 ms ladder is covered by the
+      // watchdog's unit test; 3 attempts is enough to enter the
+      // exhaustion exit and faster than the 5-attempt setup.
       logger, maxAttempts: 3,
       sleep: jest.fn(async () => {}),
       exit,

--- a/apps/discord/tests/resume-fail.chaos.test.js
+++ b/apps/discord/tests/resume-fail.chaos.test.js
@@ -36,6 +36,7 @@ const {
   setupChaosDdb, makeChaosLogger, makeCcfe,
   LOCK_TABLE, HEARTBEAT_TABLE, SHARD_ID,
   INSTANCE_A, INSTANCE_B, HOLDER_A,
+  assertNoUnexpectedTableCalls,
 } = require('./helpers/chaos-ddb');
 
 describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
@@ -145,6 +146,11 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
     // (4) Five connect() attempts occurred — the ladder ran to
     //     completion, not short-circuited.
     expect(manager.connect).toHaveBeenCalledTimes(5);
+
+    // Forbidden-table guard: the watchdog's exhaustion-exit path is
+    // gateway-tier and must NOT touch flow_state (or any other table
+    // outside the lock/heartbeat allowlist).
+    assertNoUnexpectedTableCalls(ddbMock);
   });
 
   it('lock-table DeleteCommand mocked to throw CCFE → exit(1) still fires (defensive)', async () => {
@@ -218,7 +224,10 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
     // exit(1) and heartbeat-cleanup both fired despite the lock
     // delete CAS failure.
     expect(state.lockRow).not.toBeNull();
-    expect(state.peerRows.find((r) => r.instance_id === INSTANCE_A)).toBeUndefined();
+    // Heartbeat row for A is gone. Mirror test #1's map+not.toContain
+    // shape so both heartbeat-row assertions read identically.
+    const remainingHeartbeats = state.peerRows.map((r) => r.instance_id);
+    expect(remainingHeartbeats).not.toContain(INSTANCE_A);
     expect(exit).toHaveBeenCalledWith(1);
     // gateway-lock.releaseLock logs `release CAS failed (peer took
     // over)` at warn on CCFE — pinning the log so a future regression
@@ -228,5 +237,10 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
       expect.stringContaining('release CAS failed'),
       expect.any(Object),
     );
+
+    // Forbidden-table guard: same invariant as test #1 — even on the
+    // CAS-failure branch the watchdog must not write outside the
+    // lock/heartbeat allowlist.
+    assertNoUnexpectedTableCalls(ddbMock);
   });
 });

--- a/apps/discord/tests/resume-fail.chaos.test.js
+++ b/apps/discord/tests/resume-fail.chaos.test.js
@@ -229,6 +229,9 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
     // TTL lapse will free it). A future refactor that succeeds the
     // delete via a different path (without throwing) would set
     // state.lockRow=null and silently pass the .not.toBeNull check.
+    // Note: this test does NOT exercise the TTL-lapse itself
+    // (`clock` is frozen at `now`); the cold-acquire-via-TTL
+    // recovery is integration-test territory, out of chaos scope.
     expect(state.lockRow.instance_id).toBe(INSTANCE_A);
     // Heartbeat row for A is gone. Mirror test #1's map+not.toContain
     // shape so both heartbeat-row assertions read identically.

--- a/apps/discord/tests/resume-fail.chaos.test.js
+++ b/apps/discord/tests/resume-fail.chaos.test.js
@@ -1,0 +1,220 @@
+// Pillar 3 chaos validation — RESUME-fail (watchdog retries exhausted).
+//
+// The watchdog's unit test (gateway-connection-watchdog.test.js, the
+// "step() — exhaustion path" describe block) already covers the
+// exhaustion-exit branch at high fidelity with `releaseLock` and
+// `deleteOwnRow` mocked as `jest.fn()`. What this chaos test adds is
+// the COMPOSITION-level guarantee: the watchdog's failure-exit path
+// drives the REAL gateway-lock + REAL peer-heartbeat primitives, and
+// we observe DDB-level row deletion. A future refactor that
+// disconnects the watchdog's releaseLock wiring from the real lock
+// primitive (e.g., passing a no-op closure) would pass the unit test
+// but leave the lock row stuck until TTL — this test catches that.
+//
+// Design-doc acceptance criterion (zero-downtime-design.md lines 607-612):
+//   At maxAttempts (5), the watchdog "releases the lock and exit(1)
+//   so ECS replaces the task". This test pins both effects landing
+//   on the actual DDB row state, not just the spy call counts.
+//
+// What this test does NOT cover (out of scope vs the unit test):
+//   - backoff timing (sleep is injected as a no-op stub here; the
+//     unit test pins 200/400/800/1600 ms)
+//   - per-attempt logging shape
+//   - hung releaseLock with Promise.race ceiling (unit test pins this
+//     with a hand-stubbed releaseLock; replicating with real DDB
+//     would mean a DDB call that never resolves, which is at odds
+//     with mockClient's call-and-respond model)
+//   - the leader's `isConnecting` true case (covered by leader unit
+//     tests; not a chaos scenario)
+
+const { DeleteCommand } = require('@aws-sdk/lib-dynamodb');
+
+const { createGatewayLock } = require('../src/gateway-lock');
+const { createPeerHeartbeat } = require('../src/gateway-peer-heartbeat');
+const { createConnectionWatchdog } = require('../src/gateway-connection-watchdog');
+const {
+  setupChaosDdb, makeChaosLogger, makeCcfe,
+  LOCK_TABLE, HEARTBEAT_TABLE, SHARD_ID,
+  INSTANCE_A, INSTANCE_B, HOLDER_A,
+} = require('./helpers/chaos-ddb');
+
+describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
+  const now = 1_700_000_000_000;
+  const clock = () => now;
+
+  it('5 consecutive connect() failures → DDB lock row deleted + heartbeat row deleted + exit(1)', async () => {
+    const nowSeconds = Math.floor(now / 1000);
+    // A holds the lock (version=3, lease alive). Heartbeat rows for
+    // both A (the dying replica) and B (a peer that won't be reached
+    // before exit anyway). Seeded so the heartbeat-delete on A is
+    // observable as a row-count delta vs an irrelevant peer.
+    const { docClient, ddbMock, state } = setupChaosDdb({
+      initialLockRow: {
+        shard_id: SHARD_ID, instance_id: INSTANCE_A, lock_holder: HOLDER_A,
+        version: 3, expires_at: nowSeconds + 6,
+      },
+      initialPeerRows: [
+        {
+          instance_id: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+          shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+          lock_holder: HOLDER_A,
+        },
+        {
+          instance_id: INSTANCE_B, ip: '10.0.0.20', port: 7800,
+          shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+        },
+      ],
+    });
+
+    const logger = makeChaosLogger();
+    const lock = createGatewayLock({
+      ddbClient: docClient, tableName: LOCK_TABLE, shardId: SHARD_ID,
+      instanceId: INSTANCE_A, lockHolder: HOLDER_A, logger, clock,
+    });
+    // Synthesize prior acquisition (version cursor at 3) so the
+    // watchdog's releaseLock CAS-Delete has a non-null currentVersion
+    // to consume. Mirrors the post-tick state we'd see in production.
+    lock.adoptLockFromHandoff(3);
+
+    const heartbeat = createPeerHeartbeat({
+      ddbClient: docClient, tableName: HEARTBEAT_TABLE,
+      instanceId: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+      shardId: SHARD_ID, lockHolder: HOLDER_A, logger, clock,
+    });
+
+    // Persistent-fail manager — every connect() rejects. Mirrors the
+    // production failure mode where Discord gateway endpoint
+    // resolution / TLS / WS upgrade fails consecutively (e.g., during
+    // a region-wide DNS outage). isConnected stays false throughout.
+    const manager = {
+      isConnected: jest.fn(() => false),
+      connect: jest.fn().mockRejectedValue(new Error('econnrefused')),
+    };
+
+    const exit = jest.fn();
+
+    const watchdog = createConnectionWatchdog({
+      manager,
+      isHoldingLock: () => true,
+      isConnecting: () => false,
+      releaseLock: () => lock.releaseLock(),
+      deleteOwnRow: () => heartbeat.deleteOwnRow(),
+      logger,
+      maxAttempts: 5,
+      // No-op sleep so backoff doesn't wall-clock the test. Backoff
+      // timing is covered by the unit test (200/400/800/1600 ms ladder).
+      sleep: jest.fn(async () => {}),
+      exit,
+    });
+
+    // Drive 5 failed step() iterations — equivalent to 5 watchdog
+    // ticks in production. After the 5th, the exhaustion-exit branch
+    // fires.
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    // ── Real-DDB-level assertions ──
+
+    // (1) The lock row in DDB has been DELETED. This is the strongest
+    //     signal that the cold-fallback floor (~6 s TTL lapse) is
+    //     skipped on the watchdog-exit path — a peer can acquire
+    //     immediately because the row is gone, not just expired.
+    expect(state.lockRow).toBeNull();
+    // Confirm via DDB call inspection: a DeleteCommand against the
+    // lock table landed exactly once.
+    const lockDeletes = ddbMock.commandCalls(DeleteCommand).filter(
+      (c) => c.args[0].input.TableName === LOCK_TABLE,
+    );
+    expect(lockDeletes).toHaveLength(1);
+    // CAS guard MUST be present — without it, a peer that already
+    // cold-acquired would have its row clobbered.
+    expect(lockDeletes[0].args[0].input.ConditionExpression).toContain('instance_id = :self');
+
+    // (2) The heartbeat row for A has been deleted. Closes the peer-
+    //     discovery window immediately so a future replacement's
+    //     listFreshPeers stops returning the dead row.
+    const remainingHeartbeats = state.peerRows.map((r) => r.instance_id);
+    expect(remainingHeartbeats).not.toContain(INSTANCE_A);
+    expect(remainingHeartbeats).toContain(INSTANCE_B); // sanity: didn't nuke the wrong row.
+
+    // (3) Exit fired with code 1 — ECS replaces the task.
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+
+    // (4) Five connect() attempts occurred — the ladder ran to
+    //     completion, not short-circuited.
+    expect(manager.connect).toHaveBeenCalledTimes(5);
+  });
+
+  it('lock-table DeleteCommand mocked to throw CCFE → exit(1) still fires (defensive)', async () => {
+    // Pathological case: the watchdog's releaseLock call hits a CAS
+    // failure (peer already cold-acquired during the failure ladder).
+    // gateway-lock returns { released: false } and logs a warn; the
+    // watchdog catches no throw, proceeds to deleteOwnRow, then exits.
+    // Pinning this so a future refactor that promotes the
+    // releaseLock-returns-false outcome to a throw doesn't silently
+    // skip the heartbeat-row delete + exit(1) — the surviving
+    // failover slot would stay held with no live gateway.
+    const nowSeconds = Math.floor(now / 1000);
+    const { docClient, ddbMock, state } = setupChaosDdb({
+      initialLockRow: {
+        shard_id: SHARD_ID, instance_id: INSTANCE_A, lock_holder: HOLDER_A,
+        version: 3, expires_at: nowSeconds + 6,
+      },
+      initialPeerRows: [{
+        instance_id: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+        shard_id: SHARD_ID, updated_at: nowSeconds, expires_at: nowSeconds + 60,
+        lock_holder: HOLDER_A,
+      }],
+    });
+
+    const logger = makeChaosLogger();
+    const lock = createGatewayLock({
+      ddbClient: docClient, tableName: LOCK_TABLE, shardId: SHARD_ID,
+      instanceId: INSTANCE_A, lockHolder: HOLDER_A, logger, clock,
+    });
+    lock.adoptLockFromHandoff(3);
+    // Override DeleteCommand for the lock table to throw a CAS error
+    // — simulates a peer cold-acquiring during the failure ladder.
+    ddbMock.on(DeleteCommand, { TableName: LOCK_TABLE }).callsFake(() => { throw makeCcfe(); });
+
+    const heartbeat = createPeerHeartbeat({
+      ddbClient: docClient, tableName: HEARTBEAT_TABLE,
+      instanceId: INSTANCE_A, ip: '10.0.0.10', port: 7800,
+      shardId: SHARD_ID, lockHolder: HOLDER_A, logger, clock,
+    });
+
+    const manager = {
+      isConnected: jest.fn(() => false),
+      connect: jest.fn().mockRejectedValue(new Error('econnrefused')),
+    };
+    const exit = jest.fn();
+
+    const watchdog = createConnectionWatchdog({
+      manager,
+      isHoldingLock: () => true,
+      isConnecting: () => false,
+      releaseLock: () => lock.releaseLock(),
+      deleteOwnRow: () => heartbeat.deleteOwnRow(),
+      logger, maxAttempts: 3,
+      sleep: jest.fn(async () => {}),
+      exit,
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await watchdog._stepForTest();
+    }
+
+    // Lock-row Delete CAS failed → row stays in DDB. But heartbeat
+    // row deleted, exit(1) fired. The system is still recoverable
+    // (TTL reaps the row inside 6 s); the assertion is that
+    // exit(1) and heartbeat-cleanup both fired despite the lock
+    // delete CAS failure.
+    expect(state.lockRow).not.toBeNull();
+    expect(state.peerRows.find((r) => r.instance_id === INSTANCE_A)).toBeUndefined();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/discord/tests/resume-fail.chaos.test.js
+++ b/apps/discord/tests/resume-fail.chaos.test.js
@@ -224,6 +224,12 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
     // exit(1) and heartbeat-cleanup both fired despite the lock
     // delete CAS failure.
     expect(state.lockRow).not.toBeNull();
+    // Pin the row's instance_id — recovery story is "TTL reaps the
+    // row inside 6 s" (the lock is still held by A in DDB; only the
+    // TTL lapse will free it). A future refactor that succeeds the
+    // delete via a different path (without throwing) would set
+    // state.lockRow=null and silently pass the .not.toBeNull check.
+    expect(state.lockRow.instance_id).toBe(INSTANCE_A);
     // Heartbeat row for A is gone. Mirror test #1's map+not.toContain
     // shape so both heartbeat-row assertions read identically.
     const remainingHeartbeats = state.peerRows.map((r) => r.instance_id);

--- a/apps/discord/tests/resume-fail.chaos.test.js
+++ b/apps/discord/tests/resume-fail.chaos.test.js
@@ -216,5 +216,13 @@ describe('Pillar 3 chaos — RESUME-fail (watchdog exhausts retries)', () => {
     expect(state.lockRow).not.toBeNull();
     expect(state.peerRows.find((r) => r.instance_id === INSTANCE_A)).toBeUndefined();
     expect(exit).toHaveBeenCalledWith(1);
+    // gateway-lock.releaseLock logs `release CAS failed (peer took
+    // over)` at warn on CCFE — pinning the log so a future regression
+    // that silently swallows the warning (and lose the operational
+    // signal) is caught here.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('release CAS failed'),
+      expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Final piece of the zero-downtime design before flipping `gateway_hot_standby_enabled = true` in prod. Pins the composition-level invariants the existing unit tests can't reach because they mock the seams that matter.

- **deploy-during-flow** (Pillar 3, SIGTERM mid-handoff): real `createGatewayLock` + `createPeerHeartbeat` + `createGatewayLeader` composed against `mockClient(docClient)` + driven through `runPushHandoffShutdown`. Healthy-peer / no_peer / hung-controlClient scenarios.
- **resume-fail** (Pillar 3, watchdog exhaustion): real watchdog wired against real lock + heartbeat primitives; 5 connect-failures land DDB `Delete` on the lock row + heartbeat row + `exit(1)`.
- **queue-backpressure** (Pillar 1, consumer-side): sustained at-cap inflight stays bounded (no OOM growth), SIGTERM mid-pause wakes `abortableSleep` and drains inside `DRAIN_DEADLINE_MS`, capacity-release fires the pause-end log and resets backoff.
- **event-publisher fire-and-log invariant**: 20 publishes against a throwing SQS settle to `inFlightCount=0` — pins the documented fire-and-log design against a future "retry buffer" regression.

Shared scaffolding in `tests/helpers/chaos-ddb.js` (real DDB primitives composed against `mockClient` with in-memory row state so `transferLock → readCurrentHolder` is visible).

## Motivation

Hot-standby in prod is gated by a chaos-test bar (per the zero-downtime design doc). Each test here corresponds to a documented acceptance criterion:
- deploy-during-flow → "SIGTERM mid-handoff doesn't deadlock or kill flows"
- resume-fail → design-doc §"At maxAttempts the watchdog releases the lock and exit(1)"
- queue-backpressure → consumer-side backpressure is what actually exists (producer is intentionally fire-and-log; the producer invariant test pins THAT design)

Why not unit tests: each chaos file composes REAL primitives at the seams the unit tests mock. The watchdog unit test, for example, mocks `releaseLock` as a `jest.fn()` — it'd pass even if the watchdog's `releaseLock` wiring was disconnected from the real lock primitive. The chaos test wires the real one and asserts DDB-level row deletion.

## Test plan

- [x] All 68 suites × 2408 tests pass locally
- [x] `--detectOpenHandles --forceExit` clean (no leaked timers/sockets)
- [x] `/simplify` pass applied: extracted shared `chaos-ddb` helper + chaos constants, replaced wall-clock parallel-drain check with call-order spy, trimmed the publisher invariant loop to N=20
- [x] DE review pass: misleading "loud-fails" comments → post-hoc inspection language, stale source line refs → symbol references, test #2 title fixed (UPDATE → DeleteCommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)