### PR TITLE
feat(slack): wire AliasStore so /qurl setalias and /qurl unsetalias actually work

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -196,7 +196,7 @@ func run() error {
 			slog.Info("aliasstore wired")
 		}
 	} else {
-		slog.Info("aliasstore disabled — " + aliasstore.EnvChannelPoliciesTable + " is unset")
+		slog.Info("aliasstore disabled", "env_var", aliasstore.EnvChannelPoliciesTable, "reason", "unset")
 	}
 
 	// Compose the top-level mux: existing Slack-bot routes (handled

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -182,9 +182,9 @@ func run() error {
 	// aliasPreamble guard, which is more debuggable than a startup
 	// crash on a sandbox without the DDB tables provisioned.
 	if table := os.Getenv(aliasstore.EnvChannelPoliciesTable); table != "" {
-		store, aerr := aliasstore.New(signalCtx)
-		if aerr != nil {
-			slog.Warn("aliasstore init failed; /qurl setalias and /qurl unsetalias will be disabled", "error", aerr)
+		store, err := aliasstore.New(signalCtx, table)
+		if err != nil {
+			slog.Warn("aliasstore init failed; /qurl setalias and /qurl unsetalias will be disabled", "error", err)
 		} else {
 			handler.SetAliasStore(store)
 			// Table name omitted from the log line on purpose: the

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/aliasstore"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
@@ -169,6 +170,34 @@ func run() error {
 			)
 		},
 	})
+
+	// Wire the AliasStore for /qurl setalias and /qurl unsetalias.
+	// Bridging package — when #231's slackdata.Store lands with the
+	// same BindChannelAlias/UnbindChannelAlias methods, swap this for
+	// `handler.SetAliasStore(slackdata.NewStore(...))` and delete the
+	// aliasstore package. Env var name matches slackdata's intended
+	// wiring so the qurl-bot-slack TF (main.tf:245) already sets it.
+	// Missing env or constructor error is non-fatal: the verbs reply
+	// with a "not configured" ephemeral via handler_alias.go's
+	// aliasPreamble guard, which is more debuggable than a startup
+	// crash on a sandbox without the DDB tables provisioned.
+	if table := os.Getenv(aliasstore.EnvChannelPoliciesTable); table != "" {
+		store, aerr := aliasstore.New(signalCtx)
+		if aerr != nil {
+			slog.Warn("aliasstore init failed; /qurl setalias and /qurl unsetalias will be disabled", "error", aerr)
+		} else {
+			handler.SetAliasStore(store)
+			// Table name omitted from the log line on purpose: the
+			// value is tainted (os.Getenv) and even though slog's JSON
+			// handler escapes control bytes, the operator can read the
+			// configured value off the ECS task definition. The
+			// presence of this line is the only signal worth carrying
+			// here — "did the wire succeed at all".
+			slog.Info("aliasstore wired")
+		}
+	} else {
+		slog.Info("aliasstore disabled — " + aliasstore.EnvChannelPoliciesTable + " is unset")
+	}
 
 	// Compose the top-level mux: existing Slack-bot routes (handled
 	// by the internal.Handler.ServeHTTP fall-through) + new OAuth

--- a/apps/slack/internal/aliasstore/aliasstore.go
+++ b/apps/slack/internal/aliasstore/aliasstore.go
@@ -1,0 +1,208 @@
+// Package aliasstore is the DynamoDB-backed implementation of
+// internal.AliasStore that backs the /qurl setalias and
+// /qurl unsetalias verbs (#347). It writes the per-channel
+// `alias_bindings` Map attribute on the `channel_policies` table
+// via two atomic UpdateItem calls (one to lazy-init the Map, one
+// to add/remove the alias key under a conditional expression).
+//
+// This package exists because #347's AliasStore interface landed on
+// main before the larger `slackdata` package (#231/#233) that would
+// otherwise hold the implementation. Once #231 merges and the
+// slackdata Store has BindChannelAlias/UnbindChannelAlias methods,
+// fold this package into slackdata and delete it; the contract here
+// matches the interface in apps/slack/internal/handler_alias.go so
+// the migration is mechanical (move two methods + delete package +
+// update one import).
+//
+// Schema (decided 2026-05-17, recorded in SLACK_QURL_ROLLOUT.md):
+// the row is keyed on (slack_team_id, slack_channel_id); aliases live
+// as an app-managed Map attribute `alias_bindings` with alias name as
+// key and resource id as value. Many aliases coexist on one channel
+// (each is a Map entry). Coexists with the legacy
+// `allowed_resource_ids` String Set used by /qurl admin allow/disallow
+// (orthogonal surface, untouched here).
+//
+// Why two UpdateItem calls per Bind: DynamoDB rejects an
+// UpdateExpression that references both a Map and a sub-path of that
+// Map ("overlapping paths"). The first call seeds an empty Map only
+// when absent (ConditionalCheckFailed on the seed is the "already
+// there" success case and is swallowed). The second call performs the
+// real, race-sensitive write — `SET alias_bindings.#a = :rid`
+// conditional on `attribute_not_exists(alias_bindings.#a)`. Concurrent
+// binds of different alias names succeed; concurrent binds of the same
+// alias name collapse to one success + one ErrAliasAlreadyBound.
+package aliasstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+)
+
+// EnvChannelPoliciesTable is the operator-set env var that names the
+// DDB table. Matches the name slackdata uses on the #231 branch so
+// the eventual merge is wire-compatible — no operator action needed
+// beyond what qurl-bot-slack/terraform/main.tf already sets.
+const EnvChannelPoliciesTable = "QURL_CHANNEL_POLICIES_TABLE"
+
+// DDB attribute and expression-placeholder names. Mirrored on the
+// qurl-bot-slack-infra side in modules/qurl-slack-ddb's TF table
+// schema; changing these here requires a coordinated TF change.
+const (
+	attrSlackTeamID    = "slack_team_id"
+	attrSlackChannelID = "slack_channel_id"
+	attrAliasBindings  = "alias_bindings"
+
+	exprAliasBindings = "#ab"
+	exprAliasName     = "#a"
+	exprResourceID    = ":rid"
+	exprEmptyMap      = ":empty"
+)
+
+// DynamoDBClient is the narrow surface the Store uses. Matched against
+// the live *dynamodb.Client; tests inject a fake. Kept here rather
+// than as a package-public type so a future slackdata fold can drop
+// it without breaking external callers.
+type DynamoDBClient interface {
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+// Store is the DDB-backed AliasStore. Zero value is not usable; use
+// New. Field exported so the slackdata fold can copy it verbatim.
+type Store struct {
+	Client    DynamoDBClient
+	TableName string
+}
+
+// New constructs a Store from the ambient AWS config and the
+// QURL_CHANNEL_POLICIES_TABLE env var. Returns a configuration error
+// when the env var is unset — callers should treat that as "alias
+// verbs disabled" and continue, not fatal startup.
+func New(ctx context.Context) (*Store, error) {
+	table := os.Getenv(EnvChannelPoliciesTable)
+	if table == "" {
+		return nil, fmt.Errorf("%s is unset", EnvChannelPoliciesTable)
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("aws config: %w", err)
+	}
+	return &Store{
+		Client:    dynamodb.NewFromConfig(cfg),
+		TableName: table,
+	}, nil
+}
+
+// Static assertion: Store satisfies internal.AliasStore. Catches an
+// interface drift on either side at compile time rather than at first
+// slash-command invocation.
+var _ internal.AliasStore = (*Store)(nil)
+
+// BindChannelAlias binds aliasName→resourceID on the
+// (teamID, channelID) row. Implements internal.AliasStore.
+//
+// Two-step write: lazy-init the Map if absent, then add the alias
+// entry under a conditional that fences duplicates. See package doc
+// for the rationale on splitting these.
+func (s *Store) BindChannelAlias(ctx context.Context, teamID, channelID, aliasName, resourceID string) error {
+	if err := s.ensureAliasBindingsMap(ctx, teamID, channelID); err != nil {
+		return fmt.Errorf("ensure alias_bindings map: %w", err)
+	}
+
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: teamID},
+			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channelID},
+		},
+		UpdateExpression:    aws.String("SET " + exprAliasBindings + "." + exprAliasName + " = " + exprResourceID),
+		ConditionExpression: aws.String("attribute_not_exists(" + exprAliasBindings + "." + exprAliasName + ")"),
+		ExpressionAttributeNames: map[string]string{
+			exprAliasBindings: attrAliasBindings,
+			exprAliasName:     aliasName,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			exprResourceID: &ddbtypes.AttributeValueMemberS{Value: resourceID},
+		},
+	})
+	if err != nil {
+		var ccfe *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return internal.ErrAliasAlreadyBound
+		}
+		return fmt.Errorf("bind alias: %w", err)
+	}
+	return nil
+}
+
+// UnbindChannelAlias removes aliasName from the (teamID, channelID)
+// row. Implements internal.AliasStore. ErrAliasNotFound when the
+// alias (or the alias_bindings Map itself) is absent — both collapse
+// to the same ConditionalCheckFailedException via the
+// `attribute_exists(alias_bindings.#a)` guard.
+func (s *Store) UnbindChannelAlias(ctx context.Context, teamID, channelID, aliasName string) error {
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: teamID},
+			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channelID},
+		},
+		UpdateExpression:    aws.String("REMOVE " + exprAliasBindings + "." + exprAliasName),
+		ConditionExpression: aws.String("attribute_exists(" + exprAliasBindings + "." + exprAliasName + ")"),
+		ExpressionAttributeNames: map[string]string{
+			exprAliasBindings: attrAliasBindings,
+			exprAliasName:     aliasName,
+		},
+	})
+	if err != nil {
+		var ccfe *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return internal.ErrAliasNotFound
+		}
+		return fmt.Errorf("unbind alias: %w", err)
+	}
+	return nil
+}
+
+// ensureAliasBindingsMap is the lazy-init step of BindChannelAlias.
+// SET-ifs the attribute to an empty Map only when it doesn't already
+// exist; the CCF on the "already there" branch is the success case
+// and is swallowed. The row itself is upserted by the same call
+// (UpdateItem creates the item on first write), so a brand-new
+// channel goes from no row → row with empty map → row with one alias
+// in two atomic round-trips with no partial visible state for any
+// reader (readers see either no row, the empty Map, or the Map with
+// the alias).
+func (s *Store) ensureAliasBindingsMap(ctx context.Context, teamID, channelID string) error {
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: teamID},
+			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channelID},
+		},
+		UpdateExpression:    aws.String("SET " + exprAliasBindings + " = " + exprEmptyMap),
+		ConditionExpression: aws.String("attribute_not_exists(" + exprAliasBindings + ")"),
+		ExpressionAttributeNames: map[string]string{
+			exprAliasBindings: attrAliasBindings,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			exprEmptyMap: &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{}},
+		},
+	})
+	if err != nil {
+		var ccfe *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/apps/slack/internal/aliasstore/aliasstore.go
+++ b/apps/slack/internal/aliasstore/aliasstore.go
@@ -14,13 +14,12 @@
 // the migration is mechanical (move two methods + delete package +
 // update one import).
 //
-// Schema (decided 2026-05-17, recorded in SLACK_QURL_ROLLOUT.md):
-// the row is keyed on (slack_team_id, slack_channel_id); aliases live
-// as an app-managed Map attribute `alias_bindings` with alias name as
-// key and resource id as value. Many aliases coexist on one channel
-// (each is a Map entry). Coexists with the legacy
-// `allowed_resource_ids` String Set used by /qurl admin allow/disallow
-// (orthogonal surface, untouched here).
+// Schema: the row is keyed on (slack_team_id, slack_channel_id);
+// aliases live as an app-managed Map attribute `alias_bindings`
+// with alias name as key and resource id as value. Many aliases
+// coexist on one channel (each is a Map entry). Coexists with the
+// legacy `allowed_resource_ids` String Set used by /qurl admin
+// allow/disallow (orthogonal surface, untouched here).
 //
 // Why two UpdateItem calls per Bind: DynamoDB rejects an
 // UpdateExpression that references both a Map and a sub-path of that
@@ -30,14 +29,37 @@
 // real, race-sensitive write — `SET alias_bindings.#a = :rid`
 // conditional on `attribute_not_exists(alias_bindings.#a)`. Concurrent
 // binds of different alias names succeed; concurrent binds of the same
-// alias name collapse to one success + one ErrAliasAlreadyBound.
+// alias name collapse to one success + one ErrAliasAlreadyBound. The
+// seed call is the steady-state cost (one extra round-trip per Bind),
+// not a one-time setup — the alternatives (try-write-first or a
+// GetItem cache) trade clean CCF semantics or write-races for the
+// extra call, neither worth it for an admin-volume verb.
+//
+// Partial-failure footprint: if the seed succeeds but the write fails
+// with a non-CCF error (throttling, network), the empty
+// `alias_bindings` map is left on the row. Harmless — the next Bind
+// observes it as already-seeded and the seed becomes a no-op. Within
+// a single Bind, readers see no partial state; across attempts, an
+// empty Map can briefly persist.
+//
+// Retry semantics: if a Bind write succeeds but the response is lost
+// (network drop), the caller's retry surfaces as ErrAliasAlreadyBound
+// (→ 409 user copy). That's the correct posture for admin verbs —
+// "you already did this, don't worry about the duplicate" — and the
+// idempotency cost is zero because the Map entry is set to the same
+// resource_id.
+//
+// Alias-name validation is the caller's responsibility — this
+// package writes whatever string it receives as a DDB Map key.
+// `handler_alias.go::aliasCharsetPattern` is the upstream chokepoint
+// for /qurl setalias; a future direct caller (CLI, migration script)
+// MUST pre-validate before calling BindChannelAlias.
 package aliasstore
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -76,28 +98,28 @@ type DynamoDBClient interface {
 }
 
 // Store is the DDB-backed AliasStore. Zero value is not usable; use
-// New. Field exported so the slackdata fold can copy it verbatim.
+// New.
 type Store struct {
-	Client    DynamoDBClient
-	TableName string
+	client    DynamoDBClient
+	tableName string
 }
 
-// New constructs a Store from the ambient AWS config and the
-// QURL_CHANNEL_POLICIES_TABLE env var. Returns a configuration error
-// when the env var is unset — callers should treat that as "alias
-// verbs disabled" and continue, not fatal startup.
-func New(ctx context.Context) (*Store, error) {
-	table := os.Getenv(EnvChannelPoliciesTable)
-	if table == "" {
-		return nil, fmt.Errorf("%s is unset", EnvChannelPoliciesTable)
+// New constructs a Store against the named DDB table from the
+// ambient AWS config. Caller owns the env-var read — keeping it in
+// cmd/main.go next to its sibling wirings (OAuth, DDB provider) means
+// this package stays decoupled from the deployment shape, and the
+// slackdata fold doesn't need a config seam.
+func New(ctx context.Context, tableName string) (*Store, error) {
+	if tableName == "" {
+		return nil, errors.New("aliasstore: tableName is required")
 	}
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("aws config: %w", err)
 	}
 	return &Store{
-		Client:    dynamodb.NewFromConfig(cfg),
-		TableName: table,
+		client:    dynamodb.NewFromConfig(cfg),
+		tableName: tableName,
 	}, nil
 }
 
@@ -117,8 +139,8 @@ func (s *Store) BindChannelAlias(ctx context.Context, teamID, channelID, aliasNa
 		return fmt.Errorf("ensure alias_bindings map: %w", err)
 	}
 
-	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(s.TableName),
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: teamID},
 			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channelID},
@@ -149,8 +171,8 @@ func (s *Store) BindChannelAlias(ctx context.Context, teamID, channelID, aliasNa
 // to the same ConditionalCheckFailedException via the
 // `attribute_exists(alias_bindings.#a)` guard.
 func (s *Store) UnbindChannelAlias(ctx context.Context, teamID, channelID, aliasName string) error {
-	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(s.TableName),
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: teamID},
 			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channelID},
@@ -182,8 +204,8 @@ func (s *Store) UnbindChannelAlias(ctx context.Context, teamID, channelID, alias
 // reader (readers see either no row, the empty Map, or the Map with
 // the alias).
 func (s *Store) ensureAliasBindingsMap(ctx context.Context, teamID, channelID string) error {
-	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(s.TableName),
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: teamID},
 			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channelID},

--- a/apps/slack/internal/aliasstore/aliasstore_test.go
+++ b/apps/slack/internal/aliasstore/aliasstore_test.go
@@ -47,7 +47,7 @@ func (f *fakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ 
 }
 
 func newStore(f *fakeDDB) *Store {
-	return &Store{Client: f, TableName: testTable}
+	return &Store{client: f, tableName: testTable}
 }
 
 func ccf() error {
@@ -182,10 +182,50 @@ func TestUnbindChannelAlias_NonCCFErrorBubbles(t *testing.T) {
 	}
 }
 
-func TestNew_ReturnsErrorWhenEnvVarUnset(t *testing.T) {
-	t.Setenv(EnvChannelPoliciesTable, "")
-	_, err := New(context.Background())
-	if err == nil || !strings.Contains(err.Error(), EnvChannelPoliciesTable) {
-		t.Fatalf("want error naming %s, got %v", EnvChannelPoliciesTable, err)
+// TestBindChannelAlias_TwoAliasesSameChannelCoexist pins the
+// multi-alias promise from the schema-decision recap: a second alias
+// name on the same channel succeeds against the same row, without
+// disturbing the first binding. The fence is on the call sequence
+// (two Binds → four UpdateItems total, all targeting the same key)
+// rather than on observable DDB state, since the fake is stateless;
+// see `handler_alias_test.go::TestSetChannelAlias_SecondAliasOnSameChannelSucceeds`
+// for the end-to-end stateful counterpart.
+func TestBindChannelAlias_TwoAliasesSameChannelCoexist(t *testing.T) {
+	f := &fakeDDB{}
+	s := newStore(f)
+
+	if err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, "grafana", "r_abc"); err != nil {
+		t.Fatalf("first BindChannelAlias: %v", err)
+	}
+	if err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, "logs", "r_def"); err != nil {
+		t.Fatalf("second BindChannelAlias: %v", err)
+	}
+	if len(f.calls) != 4 {
+		t.Fatalf("expected 4 UpdateItem calls (seed+write × 2), got %d", len(f.calls))
+	}
+	// All four calls share the same (team, channel) key — confirms
+	// both Binds target the same DDB row rather than splitting.
+	for i, in := range f.calls {
+		teamAttr, ok := in.Key[attrSlackTeamID].(*ddbtypes.AttributeValueMemberS)
+		if !ok || teamAttr.Value != testTeamID {
+			t.Errorf("call %d: team key = %#v, want S(%q)", i, in.Key[attrSlackTeamID], testTeamID)
+		}
+		chanAttr, ok := in.Key[attrSlackChannelID].(*ddbtypes.AttributeValueMemberS)
+		if !ok || chanAttr.Value != testChannelID {
+			t.Errorf("call %d: channel key = %#v, want S(%q)", i, in.Key[attrSlackChannelID], testChannelID)
+		}
+	}
+	// Confirm the two writes targeted different alias names.
+	w1 := f.calls[1].ExpressionAttributeNames["#a"]
+	w2 := f.calls[3].ExpressionAttributeNames["#a"]
+	if w1 != "grafana" || w2 != "logs" {
+		t.Errorf("write #a substitutions = (%q, %q), want (grafana, logs)", w1, w2)
+	}
+}
+
+func TestNew_RejectsEmptyTableName(t *testing.T) {
+	_, err := New(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "tableName is required") {
+		t.Fatalf("want tableName-required error, got %v", err)
 	}
 }

--- a/apps/slack/internal/aliasstore/aliasstore_test.go
+++ b/apps/slack/internal/aliasstore/aliasstore_test.go
@@ -20,24 +20,18 @@ const (
 	testTable     = "qurl-bot-slack-test-channel_policies"
 )
 
-// recordedCall captures the input handed to UpdateItem so tests can
-// assert on table name, key, expression shape, and substitutions.
-type recordedCall struct {
-	Input *dynamodb.UpdateItemInput
-}
-
 // fakeDDB is a programmable UpdateItem stub. Each call pops one
 // scripted response off `outputs`/`errs`; tests script the seed/write
 // pair separately so the two-step Bind path can be exercised
 // independently from the single-step Unbind path.
 type fakeDDB struct {
-	calls   []recordedCall
+	calls   []*dynamodb.UpdateItemInput
 	errs    []error
 	outputs []*dynamodb.UpdateItemOutput
 }
 
 func (f *fakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
-	f.calls = append(f.calls, recordedCall{Input: in})
+	f.calls = append(f.calls, in)
 	idx := len(f.calls) - 1
 	var err error
 	if idx < len(f.errs) {
@@ -71,7 +65,7 @@ func TestBindChannelAlias_SeedsMapAndWritesEntry(t *testing.T) {
 		t.Fatalf("expected 2 UpdateItem calls (seed + write), got %d", len(f.calls))
 	}
 
-	seed := f.calls[0].Input
+	seed := f.calls[0]
 	if got := *seed.TableName; got != testTable {
 		t.Errorf("seed: TableName = %q, want %q", got, testTable)
 	}
@@ -82,7 +76,7 @@ func TestBindChannelAlias_SeedsMapAndWritesEntry(t *testing.T) {
 		t.Errorf("seed: ConditionExpression = %q, want attribute_not_exists(#ab)", *seed.ConditionExpression)
 	}
 
-	write := f.calls[1].Input
+	write := f.calls[1]
 	if got := *write.UpdateExpression; got != "SET #ab.#a = :rid" {
 		t.Errorf("write: UpdateExpression = %q, want SET #ab.#a = :rid", got)
 	}
@@ -155,7 +149,7 @@ func TestUnbindChannelAlias_HappyPath(t *testing.T) {
 	if len(f.calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(f.calls))
 	}
-	in := f.calls[0].Input
+	in := f.calls[0]
 	if got := *in.UpdateExpression; got != "REMOVE #ab.#a" {
 		t.Errorf("UpdateExpression = %q, want REMOVE #ab.#a", got)
 	}
@@ -187,11 +181,6 @@ func TestUnbindChannelAlias_NonCCFErrorBubbles(t *testing.T) {
 		t.Fatalf("want wrapped unbind error, got %v", err)
 	}
 }
-
-// Compile-time guard: the package-doc claim that *Store satisfies
-// internal.AliasStore should never silently regress. The const-assign
-// to a typed nil var would fail compilation if the contract drifts.
-var _ internal.AliasStore = (*Store)(nil)
 
 func TestNew_ReturnsErrorWhenEnvVarUnset(t *testing.T) {
 	t.Setenv(EnvChannelPoliciesTable, "")

--- a/apps/slack/internal/aliasstore/aliasstore_test.go
+++ b/apps/slack/internal/aliasstore/aliasstore_test.go
@@ -1,0 +1,202 @@
+package aliasstore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+)
+
+const (
+	testTeamID    = "T123ABCDEF"
+	testChannelID = "C456GHIJKL"
+	testAlias     = "grafana"
+	testResource  = "r_abc123"
+	testTable     = "qurl-bot-slack-test-channel_policies"
+)
+
+// recordedCall captures the input handed to UpdateItem so tests can
+// assert on table name, key, expression shape, and substitutions.
+type recordedCall struct {
+	Input *dynamodb.UpdateItemInput
+}
+
+// fakeDDB is a programmable UpdateItem stub. Each call pops one
+// scripted response off `outputs`/`errs`; tests script the seed/write
+// pair separately so the two-step Bind path can be exercised
+// independently from the single-step Unbind path.
+type fakeDDB struct {
+	calls   []recordedCall
+	errs    []error
+	outputs []*dynamodb.UpdateItemOutput
+}
+
+func (f *fakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.calls = append(f.calls, recordedCall{Input: in})
+	idx := len(f.calls) - 1
+	var err error
+	if idx < len(f.errs) {
+		err = f.errs[idx]
+	}
+	var out *dynamodb.UpdateItemOutput
+	if idx < len(f.outputs) {
+		out = f.outputs[idx]
+	} else {
+		out = &dynamodb.UpdateItemOutput{}
+	}
+	return out, err
+}
+
+func newStore(f *fakeDDB) *Store {
+	return &Store{Client: f, TableName: testTable}
+}
+
+func ccf() error {
+	return &ddbtypes.ConditionalCheckFailedException{}
+}
+
+func TestBindChannelAlias_SeedsMapAndWritesEntry(t *testing.T) {
+	f := &fakeDDB{}
+	s := newStore(f)
+
+	if err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias, testResource); err != nil {
+		t.Fatalf("BindChannelAlias: %v", err)
+	}
+	if len(f.calls) != 2 {
+		t.Fatalf("expected 2 UpdateItem calls (seed + write), got %d", len(f.calls))
+	}
+
+	seed := f.calls[0].Input
+	if got := *seed.TableName; got != testTable {
+		t.Errorf("seed: TableName = %q, want %q", got, testTable)
+	}
+	if !strings.Contains(*seed.UpdateExpression, "SET #ab = :empty") {
+		t.Errorf("seed: UpdateExpression = %q, want SET #ab = :empty", *seed.UpdateExpression)
+	}
+	if !strings.Contains(*seed.ConditionExpression, "attribute_not_exists(#ab)") {
+		t.Errorf("seed: ConditionExpression = %q, want attribute_not_exists(#ab)", *seed.ConditionExpression)
+	}
+
+	write := f.calls[1].Input
+	if got := *write.UpdateExpression; got != "SET #ab.#a = :rid" {
+		t.Errorf("write: UpdateExpression = %q, want SET #ab.#a = :rid", got)
+	}
+	if got := *write.ConditionExpression; got != "attribute_not_exists(#ab.#a)" {
+		t.Errorf("write: ConditionExpression = %q, want attribute_not_exists(#ab.#a)", got)
+	}
+	if got := write.ExpressionAttributeNames["#a"]; got != testAlias {
+		t.Errorf("write: #a substitution = %q, want %q", got, testAlias)
+	}
+	rid, ok := write.ExpressionAttributeValues[":rid"].(*ddbtypes.AttributeValueMemberS)
+	if !ok || rid.Value != testResource {
+		t.Errorf("write: :rid substitution = %#v, want S(%q)", write.ExpressionAttributeValues[":rid"], testResource)
+	}
+}
+
+func TestBindChannelAlias_SeedAlreadyExistsIsSwallowed(t *testing.T) {
+	f := &fakeDDB{errs: []error{ccf(), nil}}
+	s := newStore(f)
+
+	if err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias, testResource); err != nil {
+		t.Fatalf("BindChannelAlias: CCF on seed must be swallowed; got %v", err)
+	}
+	if len(f.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(f.calls))
+	}
+}
+
+func TestBindChannelAlias_DuplicateAliasReturnsErrAliasAlreadyBound(t *testing.T) {
+	f := &fakeDDB{errs: []error{nil, ccf()}}
+	s := newStore(f)
+
+	err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias, testResource)
+	if !errors.Is(err, internal.ErrAliasAlreadyBound) {
+		t.Fatalf("want ErrAliasAlreadyBound, got %v", err)
+	}
+}
+
+func TestBindChannelAlias_SeedNonCCFErrorAborts(t *testing.T) {
+	want := errors.New("boom")
+	f := &fakeDDB{errs: []error{want}}
+	s := newStore(f)
+
+	err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias, testResource)
+	if err == nil || !strings.Contains(err.Error(), "ensure alias_bindings map") {
+		t.Fatalf("want wrapped seed error, got %v", err)
+	}
+	if len(f.calls) != 1 {
+		t.Errorf("write call must not fire after seed error; got %d calls", len(f.calls))
+	}
+}
+
+func TestBindChannelAlias_WriteNonCCFErrorBubbles(t *testing.T) {
+	want := errors.New("throttled")
+	f := &fakeDDB{errs: []error{nil, want}}
+	s := newStore(f)
+
+	err := s.BindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias, testResource)
+	if err == nil || !strings.Contains(err.Error(), "bind alias") {
+		t.Fatalf("want wrapped bind error, got %v", err)
+	}
+}
+
+func TestUnbindChannelAlias_HappyPath(t *testing.T) {
+	f := &fakeDDB{}
+	s := newStore(f)
+
+	if err := s.UnbindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias); err != nil {
+		t.Fatalf("UnbindChannelAlias: %v", err)
+	}
+	if len(f.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(f.calls))
+	}
+	in := f.calls[0].Input
+	if got := *in.UpdateExpression; got != "REMOVE #ab.#a" {
+		t.Errorf("UpdateExpression = %q, want REMOVE #ab.#a", got)
+	}
+	if got := *in.ConditionExpression; got != "attribute_exists(#ab.#a)" {
+		t.Errorf("ConditionExpression = %q, want attribute_exists(#ab.#a)", got)
+	}
+	if got := in.ExpressionAttributeNames["#a"]; got != testAlias {
+		t.Errorf("#a substitution = %q, want %q", got, testAlias)
+	}
+}
+
+func TestUnbindChannelAlias_NotPresentReturnsErrAliasNotFound(t *testing.T) {
+	f := &fakeDDB{errs: []error{ccf()}}
+	s := newStore(f)
+
+	err := s.UnbindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias)
+	if !errors.Is(err, internal.ErrAliasNotFound) {
+		t.Fatalf("want ErrAliasNotFound, got %v", err)
+	}
+}
+
+func TestUnbindChannelAlias_NonCCFErrorBubbles(t *testing.T) {
+	want := errors.New("network")
+	f := &fakeDDB{errs: []error{want}}
+	s := newStore(f)
+
+	err := s.UnbindChannelAlias(context.Background(), testTeamID, testChannelID, testAlias)
+	if err == nil || !strings.Contains(err.Error(), "unbind alias") {
+		t.Fatalf("want wrapped unbind error, got %v", err)
+	}
+}
+
+// Compile-time guard: the package-doc claim that *Store satisfies
+// internal.AliasStore should never silently regress. The const-assign
+// to a typed nil var would fail compilation if the contract drifts.
+var _ internal.AliasStore = (*Store)(nil)
+
+func TestNew_ReturnsErrorWhenEnvVarUnset(t *testing.T) {
+	t.Setenv(EnvChannelPoliciesTable, "")
+	_, err := New(context.Background())
+	if err == nil || !strings.Contains(err.Error(), EnvChannelPoliciesTable) {
+		t.Fatalf("want error naming %s, got %v", EnvChannelPoliciesTable, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `apps/slack/internal/aliasstore` — a minimal DynamoDB-backed implementation of the `AliasStore` interface introduced by #347.
- Wires it in `cmd/main.go` against `QURL_CHANNEL_POLICIES_TABLE` (the env var `qurl-bot-slack/terraform/main.tf:245` already sets).
- Unblocks the `/qurl setalias` + `/qurl unsetalias` demo in sandbox without waiting for #228/#231/#233/#234 to land.

## Why

#347 landed the `AliasStore` interface and the handler dispatch but no implementation. On main today, `h.aliasStore` is `nil` and the verbs short-circuit with the operator-visible ephemeral:

> Alias storage is not configured on this Slack bot deployment. Contact the operator.

The original plan was for #231's `slackdata` package to also satisfy the interface, but #231's `slackdata.Store` only carries `ResolvePolicy` / `AllowResource` / `DisallowResource` / `ListPolicies` — the two alias methods (`BindChannelAlias`, `UnbindChannelAlias`) aren't on any branch yet. This is the missing piece.

## What it does

Two methods that map directly to the interface in `apps/slack/internal/handler_alias.go:31-46`:

**`BindChannelAlias(ctx, teamID, channelID, aliasName, resourceID)`** — two DDB `UpdateItem`s:
1. `SET alias_bindings = :empty` conditional on `attribute_not_exists(alias_bindings)` — idempotent seed. CCF on this step is the "Map already there" success branch and is swallowed.
2. `SET alias_bindings.#a = :rid` conditional on `attribute_not_exists(alias_bindings.#a)`. CCF here maps to `internal.ErrAliasAlreadyBound` → 409 in handler copy.

DynamoDB rejects an `UpdateExpression` that references both a Map and a sub-path of that Map (overlapping paths). Two round trips is the standard idiom; each step is atomic, and concurrent binds of different aliases on the same channel succeed (different Map keys). Same-alias-name races collapse to one success + one 409.

**`UnbindChannelAlias(ctx, teamID, channelID, aliasName)`** — single `REMOVE alias_bindings.#a` conditional on `attribute_exists(alias_bindings.#a)`. Missing parent Map and missing alias key both collapse to CCF → `internal.ErrAliasNotFound` → 404 in handler copy.

## Tests

- Seed-then-write call shape (table name, expression strings, name/value substitutions)
- CCF on seed is swallowed (already-seeded case)
- CCF on write → `ErrAliasAlreadyBound`
- Non-CCF on seed aborts before the write
- Non-CCF on write bubbles wrapped
- Unbind happy path, ErrAliasNotFound on CCF, non-CCF bubbles wrapped
- `New()` env-var-unset case
- Compile-time guard that `*Store` satisfies `internal.AliasStore`

Test pattern mirrors `shared/auth/ddb_provider_test.go`'s `fakeDDBClient` (programmable scripted responses).

## Migration path

When #231's `slackdata` package merges, the fold is mechanical:

1. Copy `BindChannelAlias` + `UnbindChannelAlias` (and the related constants/expression placeholders) into `apps/slack/internal/slackdata/policies.go`.
2. Delete the `apps/slack/internal/aliasstore` directory.
3. In `cmd/main.go`, swap `aliasstore.New(...)` for the slackdata store wiring and drop the import.

The interface contract is identical, the env-var name is identical, and the DDB attribute names match #231's `policies.go` (`alias_bindings`, `slack_team_id`, `slack_channel_id`). No data migration needed.

## Demo unblocked

With this PR merged:
- Sandbox bot auto-deploys on push to main (last main push triggered the standard `repository_dispatch slack-bot-deploy` chain).
- `/qurl setalias \$grafana r_abc` writes one Map entry to `qurl-bot-slack-sandbox-channel_policies`.
- `/qurl setalias \$logs r_def` on the same channel writes a second entry (multi-alias proof).
- `/qurl unsetalias \$grafana` removes the first entry; the second is untouched.
- Re-running `/qurl unsetalias \$grafana` returns the "not bound" 404 copy.

Nothing in this PR requires `/qurl create`, qurl-service, NHP/AC plumbing, or the reverse-tunnel stack.

## Test plan

- [x] `go build ./apps/slack/...` — clean
- [x] `go test ./apps/slack/...` — all green including new `aliasstore` package
- [x] `golangci-lint run ./apps/slack/internal/aliasstore/...` — 0 issues
- [x] `golangci-lint run --new-from-rev=origin/main ./apps/slack/...` — 0 issues
- [x] `pre-commit run --files ...` — all hooks pass (TruffleHog, gosec, go fmt, etc.)
- [ ] On merge: confirm sandbox bot redeploys and `/qurl setalias` no longer returns the "not configured" ephemeral
- [ ] Manual demo: create a binding, list via DDB console, clear it

🤖 Generated with [Claude Code](https://claude.com/claude-code)