### PR TITLE
fix(discord): gateway-ws-shim provides connect()/isConnected() for Pillar 3

### DIFF
--- a/apps/discord/src/gateway-connection-watchdog.js
+++ b/apps/discord/src/gateway-connection-watchdog.js
@@ -79,6 +79,11 @@ const RELEASE_LOCK_CEILING_MS = 3_000;
 // like a connect rejection; the attempts ladder advances normally.
 const CONNECT_CEILING_MS = 8_000;
 
+// `manager` is conventionally the gateway-ws-shim instance (passed
+// from startHotStandby), but any object satisfying connect() +
+// sync isConnected() is accepted. The raw @discordjs/ws
+// WebSocketManager does NOT satisfy this contract — it exposes
+// only an async fetchStatus() — which is why the shim wraps it.
 function createConnectionWatchdog({
   manager,
   isHoldingLock,

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -2,7 +2,12 @@
 //   - gateway-lock           (the DDB CAS lock primitive)
 //   - gateway-peer-heartbeat (standby discovery)
 //   - gateway-control-client (outbound push-handoff)
-//   - manager                (the @discordjs/ws shim — connect()/isConnected())
+//   - manager                (the gateway-ws-shim itself — connect()/isConnected();
+//                              the raw @discordjs/ws WebSocketManager
+//                              does NOT expose isConnected(), only
+//                              async fetchStatus(), which is why the
+//                              shim wraps it rather than the leader
+//                              consuming it directly)
 //
 // And exposes the four hooks the wiring layer (index.js, PR 13b.3)
 // plugs into the other Pillar 3 components:

--- a/apps/discord/src/gateway-leader.js
+++ b/apps/discord/src/gateway-leader.js
@@ -88,6 +88,11 @@ const DEFAULT_TICK_INTERVAL_MS = 2_000;
 // than relying on the WS shim's wiring to enforce a timeout.
 const DEFAULT_INBOUND_CONNECT_TIMEOUT_MS = 5_000;
 
+// `manager` is conventionally the gateway-ws-shim instance (passed
+// from startHotStandby), but any object satisfying connect() +
+// sync isConnected() is accepted. The raw @discordjs/ws
+// WebSocketManager does NOT satisfy this contract — it exposes
+// only an async fetchStatus() — which is why the shim wraps it.
 function createGatewayLeader({
   lock,
   peerHeartbeat,

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -331,9 +331,18 @@ function createGatewayWsShim({
       // it would re-call connect() on a shard whose status is
       // already Ready, throwing "Tried to connect a shard that
       // wasn't idle" upstream as an unhandled rejection.
-      manager.on(WebSocketShardEvents.Ready, () => { wsConnected = true; });
-      manager.on(WebSocketShardEvents.Resumed, () => { wsConnected = true; });
+      // `stopped` guard mirrors the Dispatch listener: drops late
+      // shard events between a failed-start catch and shim.stop().
+      manager.on(WebSocketShardEvents.Ready, () => {
+        if (stopped) return;
+        wsConnected = true;
+      });
+      manager.on(WebSocketShardEvents.Resumed, () => {
+        if (stopped) return;
+        wsConnected = true;
+      });
       manager.on(WebSocketShardEvents.Closed, ({ code, reason, shardId }) => {
+        if (stopped) return;
         wsConnected = false;
         logger.info('gateway-ws-shim: shard closed', {
           shardId, code, reason: reason ?? null,
@@ -480,15 +489,19 @@ function createGatewayWsShim({
     // (Ready/Resumed/Closed listeners in start()) — both consumers
     // call it synchronously every tick, so awaiting fetchStatus()
     // there would be wrong.
-    async connect() {
-      // Order matters: stop() nulls `manager`, so a post-stop call
-      // would mis-classify as "never started" if !manager were
-      // checked first.
+    connect() {
+      // `stopped` is set by both stop() AND start()'s failed-connect
+      // catch, so the message covers both terminal states. Check it
+      // before `!manager` since stop() nulls manager.
       if (stopped) {
-        throw new Error('gateway-ws-shim: connect() called after stop()');
+        return Promise.reject(new Error(
+          'gateway-ws-shim: connect() called after stop() or a failed start()',
+        ));
       }
       if (!manager) {
-        throw new Error('gateway-ws-shim: connect() called before start() constructed the manager');
+        return Promise.reject(new Error(
+          'gateway-ws-shim: connect() called before start() constructed the manager',
+        ));
       }
       return manager.connect();
     },

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -118,6 +118,14 @@ const MAX_IDENTIFY_ATTEMPTS = 1;
 // "Discord API unreachable" as a fast-fail rather than a hang.
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
 
+// The @discordjs/ws major.minor range whose WebSocketShard.onMessage
+// dispatch ordering (shard.emit(Ready) BEFORE shard.emit(Dispatch))
+// the Pillar 3 wsConnected mirror depends on. The version-contract
+// test asserts the installed range starts with this string — a
+// minor bump must re-verify the upstream dispatch handler before
+// updating this constant.
+const VERIFIED_DJS_WS_MAJOR_MINOR = '1.2';
+
 function createGatewayWsShim({
   token,
   intents,
@@ -331,6 +339,8 @@ function createGatewayWsShim({
       // it would re-call connect() on a shard whose status is
       // already Ready, throwing "Tried to connect a shard that
       // wasn't idle" upstream as an unhandled rejection.
+      //
+      // Version contract: see VERIFIED_DJS_WS_MAJOR_MINOR above.
       // `stopped` guard mirrors the Dispatch listener: drops late
       // shard events between a failed-start catch and shim.stop().
       manager.on(WebSocketShardEvents.Ready, () => {
@@ -480,9 +490,8 @@ function createGatewayWsShim({
     // with `connect()` + `isConnected()`. @discordjs/ws's
     // WebSocketManager exposes connect() but NOT isConnected() —
     // it has only async fetchStatus(). So the shim itself is the
-    // contract-conforming handle: callers pass `gatewayShim` (not
-    // `gatewayShim.getManager()`) into createGatewayLeader /
-    // createConnectionWatchdog.
+    // contract-conforming handle: callers pass `gatewayShim`
+    // directly into createGatewayLeader / createConnectionWatchdog.
     //
     // `connect()` delegates straight through. `isConnected()`
     // returns a sync mirror flag tracked via shard events
@@ -519,12 +528,12 @@ function createGatewayWsShim({
       return manager !== null;
     },
 
-    // Null until start() constructs the WebSocketManager. Kept for
-    // test introspection only — production callers should use the
-    // shim's connect()/isConnected()/isStarted() above. Exposed as
-    // a getter rather than a stored reference so callers always see
-    // the current value (the field is reassigned inside start()/stop()).
-    getManager() {
+    // Null until start() constructs the WebSocketManager. Name
+    // prefix marks the boundary explicitly: production code uses
+    // connect()/isConnected()/isStarted() above; this exists for
+    // test introspection so suites can interrogate the underlying
+    // manager (e.g. assert listener counts, construction args).
+    _getManagerForTest() {
       return manager;
     },
 
@@ -539,4 +548,5 @@ module.exports = {
   createGatewayWsShim,
   MAX_IDENTIFY_ATTEMPTS,
   DEFAULT_CONNECT_TIMEOUT_MS,
+  VERIFIED_DJS_WS_MAJOR_MINOR,
 };

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -153,6 +153,17 @@ function createGatewayWsShim({
   // flap ECS into replacing the task. `wsConnected` is the Pillar 3
   // leader/watchdog signal — "should I call connect()" — and flips
   // false on Closed so the watchdog re-drives connect after a drop.
+  //
+  // Single-shard assumption: this is a module-level boolean, not
+  // a per-shardId map, because today's deployment has SHARD_ID=
+  // '0:1' (one shard total). A future horizontal scale-out would
+  // need to either (a) track wsConnected as a Map<shardId, boolean>
+  // and have isConnected() return some aggregate ("all-Ready" for
+  // the watchdog's purposes), or (b) split the shim into one
+  // instance per shard. As-is, any shard dropping would flip the
+  // flag false and the watchdog would re-call manager.connect()
+  // on the whole manager — upstream rejects "Tried to connect a
+  // shard that wasn't idle" for the still-Ready shards.
   let wsConnected = false;
   let appId = null;
   let identifyAttempts = 0;
@@ -351,6 +362,10 @@ function createGatewayWsShim({
         if (stopped) return;
         wsConnected = true;
       });
+      // Note: @discordjs/ws v1.2.x Closed payload is `{ code, shardId }`
+      // only. We destructure `reason` defensively against a future
+      // minor adding it (some Discord 4xxx close frames carry one);
+      // today it's always undefined, logged as null.
       manager.on(WebSocketShardEvents.Closed, ({ code, reason, shardId }) => {
         if (stopped) return;
         wsConnected = false;

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -55,6 +55,9 @@
 //                          (Ready/Resumed → true, Closed → false);
 //                          read every tick by the watchdog and
 //                          once per inbound-handoff by the leader.
+//   - isStarted()        — true after start() resolves and before
+//                          stop() runs; used by the Pillar 3 wiring
+//                          for a boot-ordering belt-and-suspenders.
 //
 // ── SIGTERM contract: do NOT call manager.destroy() ──
 //
@@ -264,7 +267,8 @@ function createGatewayWsShim({
           // commands or guild-commands endpoint.
           appId = data?.d?.application?.id ?? null;
           isReady = true;
-          wsConnected = true;
+          // wsConnected is mirrored on the shard-level Ready/Resumed
+          // listeners installed below — not here.
           // Reset the IDENTIFY budget: every successful READY
           // restores a fresh allowance for the next reconnect.
           // See module header.
@@ -289,7 +293,6 @@ function createGatewayWsShim({
           // reconnect path gets a fresh allowance the same way
           // READY would.
           isReady = true;
-          wsConnected = true;
           identifyAttempts = 0;
           logger.info('gateway-ws-shim: RESUMED received', { shardId });
         }
@@ -318,13 +321,23 @@ function createGatewayWsShim({
         });
       });
 
-      // Pillar 3 wsConnected mirror. Flipping false on Closed lets
-      // the leader's inbound-handoff and the watchdog's tick observe
-      // "connection dropped" synchronously and re-drive connect().
-      // The next successful Ready/Resumed dispatch flips it back.
-      manager.on(WebSocketShardEvents.Closed, ({ code, shardId }) => {
+      // Pillar 3 wsConnected mirror. Listen on shard-level
+      // Ready/Resumed (NOT the Dispatch fan-out) — @discordjs/ws's
+      // manager.connect() awaits `once(Ready)` / `once(Resumed)`
+      // and resolves immediately after the shard emits those, but
+      // BEFORE the Dispatch fan-out fires. Mirroring on Dispatch
+      // would leave a 1-tick window where connect() has resolved
+      // and the watchdog sees `!isConnected() && !isConnecting` —
+      // it would re-call connect() on a shard whose status is
+      // already Ready, throwing "Tried to connect a shard that
+      // wasn't idle" upstream as an unhandled rejection.
+      manager.on(WebSocketShardEvents.Ready, () => { wsConnected = true; });
+      manager.on(WebSocketShardEvents.Resumed, () => { wsConnected = true; });
+      manager.on(WebSocketShardEvents.Closed, ({ code, reason, shardId }) => {
         wsConnected = false;
-        logger.info('gateway-ws-shim: shard closed', { shardId, code });
+        logger.info('gateway-ws-shim: shard closed', {
+          shardId, code, reason: reason ?? null,
+        });
       });
 
       if (!connect) {
@@ -410,10 +423,19 @@ function createGatewayWsShim({
       // RESUME. Detach only the listeners we installed; an
       // unscoped removeAllListeners() could strip @discordjs/ws's
       // own internal listeners on the same emitter.
+      //
+      // Strip-safety check: the @discordjs/ws-internal close
+      // handler attaches on the SHARD (the shim only sees events
+      // via the strategy's shard→manager fanout), and the
+      // strategy's own fanout listener attaches on shard.on(...),
+      // not manager.on(...). So the per-event removals below only
+      // strip listeners the shim itself installed.
       if (manager) {
         manager.removeAllListeners(WebSocketShardEvents.Dispatch);
         manager.removeAllListeners(WebSocketShardEvents.Error);
         manager.removeAllListeners(WebSocketShardEvents.Closed);
+        manager.removeAllListeners(WebSocketShardEvents.Ready);
+        manager.removeAllListeners(WebSocketShardEvents.Resumed);
       }
       manager = null;
     },
@@ -475,11 +497,20 @@ function createGatewayWsShim({
       return wsConnected;
     },
 
+    // True once start() has constructed the underlying manager and
+    // before stop() has nulled it. Pillar 3 wiring uses this as a
+    // belt-and-suspenders check at startHotStandby boot to surface
+    // a shim-ordering regression as a clear error rather than a
+    // delayed factory throw.
+    isStarted() {
+      return manager !== null;
+    },
+
     // Null until start() constructs the WebSocketManager. Kept for
     // test introspection only — production callers should use the
-    // shim's connect()/isConnected() above. Exposed as a getter
-    // rather than a stored reference so callers always see the
-    // current value (the field is reassigned inside start()/stop()).
+    // shim's connect()/isConnected()/isStarted() above. Exposed as
+    // a getter rather than a stored reference so callers always see
+    // the current value (the field is reassigned inside start()/stop()).
     getManager() {
       return manager;
     },

--- a/apps/discord/src/gateway-ws-shim.js
+++ b/apps/discord/src/gateway-ws-shim.js
@@ -49,6 +49,12 @@
 //                          registerCommands.
 //   - getRest()          — REST instance (constructed with the
 //                          token); exposed for registerCommands.
+//   - connect()          — drive a Pillar-3 connect from the leader
+//                          / watchdog (start({connect:false}) seam).
+//   - isConnected()      — sync mirror of the WS connection state
+//                          (Ready/Resumed → true, Closed → false);
+//                          read every tick by the watchdog and
+//                          once per inbound-handoff by the leader.
 //
 // ── SIGTERM contract: do NOT call manager.destroy() ──
 //
@@ -131,6 +137,12 @@ function createGatewayWsShim({
   let manager = null;
   let restInstance = rest;
   let isReady = false;
+  // Distinct from `isReady`. `isReady` powers /health — stays true
+  // through transient reconnects so a momentary WS blip doesn't
+  // flap ECS into replacing the task. `wsConnected` is the Pillar 3
+  // leader/watchdog signal — "should I call connect()" — and flips
+  // false on Closed so the watchdog re-drives connect after a drop.
+  let wsConnected = false;
   let appId = null;
   let identifyAttempts = 0;
   // Two distinct flags:
@@ -252,6 +264,7 @@ function createGatewayWsShim({
           // commands or guild-commands endpoint.
           appId = data?.d?.application?.id ?? null;
           isReady = true;
+          wsConnected = true;
           // Reset the IDENTIFY budget: every successful READY
           // restores a fresh allowance for the next reconnect.
           // See module header.
@@ -276,6 +289,7 @@ function createGatewayWsShim({
           // reconnect path gets a fresh allowance the same way
           // READY would.
           isReady = true;
+          wsConnected = true;
           identifyAttempts = 0;
           logger.info('gateway-ws-shim: RESUMED received', { shardId });
         }
@@ -302,6 +316,15 @@ function createGatewayWsShim({
           shardId,
           error: error?.message ?? String(error),
         });
+      });
+
+      // Pillar 3 wsConnected mirror. Flipping false on Closed lets
+      // the leader's inbound-handoff and the watchdog's tick observe
+      // "connection dropped" synchronously and re-drive connect().
+      // The next successful Ready/Resumed dispatch flips it back.
+      manager.on(WebSocketShardEvents.Closed, ({ code, shardId }) => {
+        wsConnected = false;
+        logger.info('gateway-ws-shim: shard closed', { shardId, code });
       });
 
       if (!connect) {
@@ -365,6 +388,11 @@ function createGatewayWsShim({
       // have already set this on a failed-connect path; the flip
       // here is idempotent.)
       stopped = true;
+      // Mirror state for invariant integrity: anything observing
+      // wsConnected post-stop() sees the closed state immediately
+      // rather than waiting on the Closed event from the eventual
+      // socket teardown.
+      wsConnected = false;
       // Drop dispatch handlers so any late dispatch arriving on
       // the way out doesn't trigger a downstream side effect.
       dispatchHandlers.clear();
@@ -385,6 +413,7 @@ function createGatewayWsShim({
       if (manager) {
         manager.removeAllListeners(WebSocketShardEvents.Dispatch);
         manager.removeAllListeners(WebSocketShardEvents.Error);
+        manager.removeAllListeners(WebSocketShardEvents.Closed);
       }
       manager = null;
     },
@@ -414,11 +443,43 @@ function createGatewayWsShim({
       return restInstance;
     },
 
-    // Null until start() constructs the WebSocketManager. Pillar 3
-    // wiring (leader coordinator + connection watchdog) needs the
-    // manager handle to call .connect() / .isConnected() — exposed as
-    // a getter rather than a stored reference so callers always see
-    // the current value (the field is reassigned inside start()).
+    // ── Pillar 3 manager contract ──
+    // The leader (gateway-leader.js) and connection watchdog
+    // (gateway-connection-watchdog.js) require a manager handle
+    // with `connect()` + `isConnected()`. @discordjs/ws's
+    // WebSocketManager exposes connect() but NOT isConnected() —
+    // it has only async fetchStatus(). So the shim itself is the
+    // contract-conforming handle: callers pass `gatewayShim` (not
+    // `gatewayShim.getManager()`) into createGatewayLeader /
+    // createConnectionWatchdog.
+    //
+    // `connect()` delegates straight through. `isConnected()`
+    // returns a sync mirror flag tracked via shard events
+    // (Ready/Resumed/Closed listeners in start()) — both consumers
+    // call it synchronously every tick, so awaiting fetchStatus()
+    // there would be wrong.
+    async connect() {
+      // Order matters: stop() nulls `manager`, so a post-stop call
+      // would mis-classify as "never started" if !manager were
+      // checked first.
+      if (stopped) {
+        throw new Error('gateway-ws-shim: connect() called after stop()');
+      }
+      if (!manager) {
+        throw new Error('gateway-ws-shim: connect() called before start() constructed the manager');
+      }
+      return manager.connect();
+    },
+
+    isConnected() {
+      return wsConnected;
+    },
+
+    // Null until start() constructs the WebSocketManager. Kept for
+    // test introspection only — production callers should use the
+    // shim's connect()/isConnected() above. Exposed as a getter
+    // rather than a stored reference so callers always see the
+    // current value (the field is reassigned inside start()/stop()).
     getManager() {
       return manager;
     },

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -919,12 +919,12 @@ async function startHotStandby() {
 
   // Belt-and-suspenders: shim.start({ connect: false }) constructs
   // the manager synchronously inside its await, so by the time we
-  // get here getManager() should always be non-null. If a future
-  // refactor moves construction later (e.g. lazy on first connect),
-  // this guard surfaces the wiring regression at boot rather than
-  // as a confusing leader-factory error.
-  if (!gatewayShim.getManager()) {
-    throw new Error('startHotStandby: gatewayShim.getManager() returned null — shim.start() ordering regression');
+  // get here isStarted() should always be true. If a future refactor
+  // moves construction later (e.g. lazy on first connect), this
+  // guard surfaces the wiring regression at boot rather than as a
+  // delayed leader/watchdog runtime error.
+  if (!gatewayShim.isStarted()) {
+    throw new Error('startHotStandby: gatewayShim.isStarted() is false — shim.start() ordering regression');
   }
 
   // The shim itself satisfies the leader/watchdog `manager` contract

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -858,8 +858,10 @@ process.on('SIGINT', () => {
 //
 //   1. Construct lock + peer-heartbeat (DDB-backed, no manager dep).
 //   2. Load + validate the HMAC secret (JSON shape + hex format).
-//   3. Construct hmac, controlClient, leader (leader needs the manager
-//      handle from shim.getManager()).
+//   3. Construct hmac, controlClient, leader (leader is wired against
+//      `gatewayShim` itself — the shim provides the connect() +
+//      isConnected() contract that @discordjs/ws's WebSocketManager
+//      lacks isConnected() for).
 //   4. Start the control-channel HTTP server. AWAIT `listening` event
 //      before continuing — if we start the leader first, the peer could
 //      acquire the lock and pushHandoff to us before our listener is
@@ -915,22 +917,26 @@ async function startHotStandby() {
 
   const controlClient = createControlClient({ hmac, logger });
 
-  const manager = gatewayShim.getManager();
-  if (!manager) {
-    // Belt-and-suspenders: shim.start({ connect: false }) constructs
-    // the manager synchronously inside its await, so by the time we
-    // get here it should always be non-null. If a future refactor
-    // moves construction later (e.g. lazy on first connect), this
-    // guard surfaces the wiring regression at boot rather than as a
-    // confusing leader-factory error.
+  // Belt-and-suspenders: shim.start({ connect: false }) constructs
+  // the manager synchronously inside its await, so by the time we
+  // get here getManager() should always be non-null. If a future
+  // refactor moves construction later (e.g. lazy on first connect),
+  // this guard surfaces the wiring regression at boot rather than
+  // as a confusing leader-factory error.
+  if (!gatewayShim.getManager()) {
     throw new Error('startHotStandby: gatewayShim.getManager() returned null — shim.start() ordering regression');
   }
 
+  // The shim itself satisfies the leader/watchdog `manager` contract
+  // (connect() + isConnected()). Passing the raw @discordjs/ws
+  // WebSocketManager would fail the factory's typeof check because
+  // upstream exposes only fetchStatus() (async) — see gateway-ws-shim
+  // module header "Pillar 3 manager contract".
   gatewayLeader = createGatewayLeader({
     lock,
     peerHeartbeat,
     controlClient,
-    manager,
+    manager: gatewayShim,
     selfInstanceId: config.INSTANCE_ID,
     shardId: config.SHARD_ID,
     logger,
@@ -1002,7 +1008,7 @@ async function startHotStandby() {
   // lock concurrently with an in-flight transferLock and the DDB
   // row would land in a state neither replica expects.
   connectionWatchdog = createConnectionWatchdog({
-    manager,
+    manager: gatewayShim,
     isHoldingLock: gatewayLeader.isHoldingLock,
     isConnecting: gatewayLeader.isConnecting,
     releaseLock: gatewayLeader.releaseLockForImmediateExit,

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -923,6 +923,11 @@ async function startHotStandby() {
   // moves construction later (e.g. lazy on first connect), this
   // guard surfaces the wiring regression at boot rather than as a
   // delayed leader/watchdog runtime error.
+  //
+  // Not redundant with the leader/watchdog factory typeof checks:
+  // those pass when called before start() too, because the shim
+  // exposes connect()/isConnected() unconditionally. This catches
+  // the wiring-order regression those checks would miss.
   if (!gatewayShim.isStarted()) {
     throw new Error('startHotStandby: gatewayShim.isStarted() is false — shim.start() ordering regression');
   }

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -310,9 +310,12 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
   });
 
   it('isConnected() flips true on shard Resumed event (Pillar 2 happy path)', async () => {
+    // @discordjs/ws v1.2.x emits Resumed with `(shardId: number)` —
+    // a bare number, not an object. Match upstream shape so the
+    // fixture documents the real contract.
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
-    managerInstances[0].emit(WebSocketShardEvents.Resumed, { shardId: 0 });
+    managerInstances[0].emit(WebSocketShardEvents.Resumed, 0);
     expect(shim.isConnected()).toBe(true);
   });
 
@@ -324,7 +327,10 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
       shardId: 0,
     });
     expect(shim.isConnected()).toBe(true);
-    managerInstances[0].emit(WebSocketShardEvents.Closed, { code: 1006, reason: 'unit-test', shardId: 0 });
+    // @discordjs/ws v1.2.x Closed payload is `{ code, shardId }` —
+    // no `reason`. Listener destructures `reason` defensively
+    // against a future minor adding it; the fallback logs null.
+    managerInstances[0].emit(WebSocketShardEvents.Closed, { code: 1006, shardId: 0 });
     expect(shim.isConnected()).toBe(false);
   });
 
@@ -412,7 +418,7 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
     expect(shim.isConnected()).toBe(false);
     instances[0].emit(WebSocketShardEvents.Ready, { data: {}, shardId: 0 });
     expect(shim.isConnected()).toBe(false);
-    instances[0].emit(WebSocketShardEvents.Resumed, { shardId: 0 });
+    instances[0].emit(WebSocketShardEvents.Resumed, 0);
     expect(shim.isConnected()).toBe(false);
     instances[0].emit(WebSocketShardEvents.Closed, { code: 1006, shardId: 0 });
     expect(shim.isConnected()).toBe(false);
@@ -908,8 +914,15 @@ describe('constants are pinned', () => {
     const path = require('node:path');
     const fs = require('node:fs');
     const wsEntry = require.resolve('@discordjs/ws');
-    const wsRoot = wsEntry.slice(0, wsEntry.indexOf(`${path.sep}@discordjs${path.sep}ws${path.sep}`))
-      + `${path.sep}@discordjs${path.sep}ws`;
+    const marker = `${path.sep}@discordjs${path.sep}ws${path.sep}`;
+    const markerIdx = wsEntry.indexOf(marker);
+    if (markerIdx < 0) {
+      throw new Error(
+        `Could not locate @discordjs/ws install from require.resolve('${wsEntry}'). ` +
+        'Update the path-extraction below to match the new install layout.',
+      );
+    }
+    const wsRoot = wsEntry.slice(0, markerIdx) + marker.slice(0, -1);
     const djsWsVersion = JSON.parse(fs.readFileSync(path.join(wsRoot, 'package.json'), 'utf8')).version;
     const installedMajorMinor = djsWsVersion.split('.').slice(0, 2).join('.');
     expect(installedMajorMinor).toBe(VERIFIED_DJS_WS_MAJOR_MINOR);

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -364,6 +364,20 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
     await expect(shim.connect()).rejects.toThrow(/after stop\(\) or a failed start\(\)/);
   });
 
+  it('concurrent shim.connect() calls both delegate to manager.connect()', async () => {
+    // The shim itself doesn't dedupe concurrent connect() calls —
+    // the upstream WebSocketManager isn't concurrency-safe and the
+    // serialization invariant lives in the leader's `connecting`
+    // latch + the watchdog's `isConnecting` observer. Pinning this
+    // test surfaces a future shim refactor that accidentally adds
+    // a dedup layer (which would break the contract those callers
+    // expect).
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    await Promise.all([shim.connect(), shim.connect()]);
+    expect(managerInstances[0].connect).toHaveBeenCalledTimes(2);
+  });
+
   it('connect() propagates the underlying manager rejection', async () => {
     // The watchdog wraps shim.connect() in raceWithCeiling and
     // surfaces rejections through its failure ladder — they must

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -343,7 +343,35 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
     const { shim } = makeShim();
     await shim.start({ connect: false });
     await shim.stop({ flushFinal: false });
-    await expect(shim.connect()).rejects.toThrow(/connect\(\) called after stop\(\)/);
+    await expect(shim.connect()).rejects.toThrow(/after stop\(\) or a failed start\(\)/);
+  });
+
+  // Drives a start({connect:true}) into the catch arm (stopped=true,
+  // manager still attached) — shared by the connect()-error and
+  // listener-guard tests below.
+  async function makeFailedStartShim() {
+    const { SlowFakeManager, instances } = makeSlowManagerCtor();
+    const { shim } = makeShim({ WebSocketManagerCtor: SlowFakeManager });
+    await expect(shim.start({ timeoutMs: 5 })).rejects.toThrow(/timed out/);
+    return { shim, instances };
+  }
+
+  it('connect() rejects after a failed start() with the same terminal-state error', async () => {
+    // start({connect:true}) sets stopped=true on its failed-connect
+    // catch, but never calls stop(). The connect() error message
+    // must cover that state — without lying about which one happened.
+    const { shim } = await makeFailedStartShim();
+    await expect(shim.connect()).rejects.toThrow(/after stop\(\) or a failed start\(\)/);
+  });
+
+  it('connect() propagates the underlying manager rejection', async () => {
+    // The watchdog wraps shim.connect() in raceWithCeiling and
+    // surfaces rejections through its failure ladder — they must
+    // pass through verbatim, not be wrapped or swallowed.
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    managerInstances[0].connect.mockRejectedValueOnce(new Error('discord 5xx'));
+    await expect(shim.connect()).rejects.toThrow('discord 5xx');
   });
 
   it('stop() removes every shim-installed shard listener (no leak across cycles)', async () => {
@@ -360,6 +388,20 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
     expect(managerInstances[0].listenerCount(WebSocketShardEvents.Closed)).toBe(0);
     expect(managerInstances[0].listenerCount(WebSocketShardEvents.Ready)).toBe(0);
     expect(managerInstances[0].listenerCount(WebSocketShardEvents.Resumed)).toBe(0);
+  });
+
+  it('shard event listeners no-op after a failed start() (stopped guard)', async () => {
+    // Listeners stay attached until gracefulShutdown → shim.stop()
+    // runs. A late shard event in that window must not mutate
+    // wsConnected on a teardown-bound shim.
+    const { shim, instances } = await makeFailedStartShim();
+    expect(shim.isConnected()).toBe(false);
+    instances[0].emit(WebSocketShardEvents.Ready, { data: {}, shardId: 0 });
+    expect(shim.isConnected()).toBe(false);
+    instances[0].emit(WebSocketShardEvents.Resumed, { shardId: 0 });
+    expect(shim.isConnected()).toBe(false);
+    instances[0].emit(WebSocketShardEvents.Closed, { code: 1006, shardId: 0 });
+    expect(shim.isConnected()).toBe(false);
   });
 
   it('isStarted() reflects construction state (false → true → false)', async () => {

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -294,43 +294,45 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
     expect(shim.isConnected()).toBe(false);
   });
 
-  it('isConnected() flips true on READY dispatch', async () => {
+  it('isConnected() flips true on shard Ready event', async () => {
+    // The shard-level Ready event fires BEFORE the Dispatch
+    // fan-out (see @discordjs/ws WebSocketShard.onMessage: it
+    // emits "ready" then "dispatch" on a READY frame). Mirroring
+    // wsConnected here lets it land before manager.connect()
+    // resolves on the Promise.race(once Ready) inside @discordjs/ws.
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
-    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
-      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+    managerInstances[0].emit(WebSocketShardEvents.Ready, {
+      data: { application: { id: 'app-1' } },
       shardId: 0,
     });
     expect(shim.isConnected()).toBe(true);
   });
 
-  it('isConnected() flips true on RESUMED dispatch (Pillar 2 happy path)', async () => {
+  it('isConnected() flips true on shard Resumed event (Pillar 2 happy path)', async () => {
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
-    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
-      data: { t: 'RESUMED' },
-      shardId: 0,
-    });
+    managerInstances[0].emit(WebSocketShardEvents.Resumed, { shardId: 0 });
     expect(shim.isConnected()).toBe(true);
   });
 
   it('isConnected() flips back to false on Closed', async () => {
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
-    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
-      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+    managerInstances[0].emit(WebSocketShardEvents.Ready, {
+      data: { application: { id: 'app-1' } },
       shardId: 0,
     });
     expect(shim.isConnected()).toBe(true);
-    managerInstances[0].emit(WebSocketShardEvents.Closed, { code: 1006, shardId: 0 });
+    managerInstances[0].emit(WebSocketShardEvents.Closed, { code: 1006, reason: 'unit-test', shardId: 0 });
     expect(shim.isConnected()).toBe(false);
   });
 
-  it('isConnected() is false after stop() regardless of prior READY', async () => {
+  it('isConnected() is false after stop() regardless of prior Ready', async () => {
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
-    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
-      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+    managerInstances[0].emit(WebSocketShardEvents.Ready, {
+      data: { application: { id: 'app-1' } },
       shardId: 0,
     });
     await shim.stop({ flushFinal: false });
@@ -344,16 +346,29 @@ describe('Pillar 3 manager contract — connect() + isConnected()', () => {
     await expect(shim.connect()).rejects.toThrow(/connect\(\) called after stop\(\)/);
   });
 
-  it('stop() removes the Closed listener too (no listener leak across cycles)', async () => {
+  it('stop() removes every shim-installed shard listener (no leak across cycles)', async () => {
     // Regression pin for the listener-leak hazard: a future
     // `start()/stop()/start()` cycle would otherwise accumulate
-    // Closed handlers on every new manager instance, each closing
-    // over the previous cycle's wsConnected/logger references.
+    // handlers on every new manager instance, each closing over
+    // the previous cycle's wsConnected/logger references.
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
     expect(managerInstances[0].listenerCount(WebSocketShardEvents.Closed)).toBe(1);
+    expect(managerInstances[0].listenerCount(WebSocketShardEvents.Ready)).toBe(1);
+    expect(managerInstances[0].listenerCount(WebSocketShardEvents.Resumed)).toBe(1);
     await shim.stop({ flushFinal: false });
     expect(managerInstances[0].listenerCount(WebSocketShardEvents.Closed)).toBe(0);
+    expect(managerInstances[0].listenerCount(WebSocketShardEvents.Ready)).toBe(0);
+    expect(managerInstances[0].listenerCount(WebSocketShardEvents.Resumed)).toBe(0);
+  });
+
+  it('isStarted() reflects construction state (false → true → false)', async () => {
+    const { shim } = makeShim();
+    expect(shim.isStarted()).toBe(false);
+    await shim.start({ connect: false });
+    expect(shim.isStarted()).toBe(true);
+    await shim.stop({ flushFinal: false });
+    expect(shim.isStarted()).toBe(false);
   });
 
   it('satisfies the leader/watchdog factory contracts (no TypeError on construction)', () => {

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -22,6 +22,7 @@ const {
   createGatewayWsShim,
   MAX_IDENTIFY_ATTEMPTS,
   DEFAULT_CONNECT_TIMEOUT_MS,
+  VERIFIED_DJS_WS_MAJOR_MINOR,
 } = require('../src/gateway-ws-shim');
 const { WebSocketShardEvents } = require('@discordjs/ws');
 
@@ -233,27 +234,26 @@ describe('start — wiring + connect', () => {
   });
 });
 
-describe('getManager — Pillar 3 leader handle', () => {
+describe('_getManagerForTest — test introspection seam', () => {
   it('returns null before start()', () => {
     const { shim } = makeShim();
-    expect(shim.getManager()).toBeNull();
+    expect(shim._getManagerForTest()).toBeNull();
   });
 
   it('returns the WebSocketManager instance after start()', async () => {
     const { shim, managerInstances } = makeShim();
     await shim.start();
-    expect(shim.getManager()).toBe(managerInstances[0]);
+    expect(shim._getManagerForTest()).toBe(managerInstances[0]);
   });
 
   it('returns the manager after start({ connect: false }) too', async () => {
-    // Critical for the hot-standby wiring path: the leader needs the
-    // manager handle BEFORE driving connect(). If getManager() only
-    // returned non-null after a successful connect, the wiring chain
-    // would deadlock (leader needs manager → manager needs leader to
-    // call connect → loop).
+    // Critical for the hot-standby wiring path: the production
+    // boot guard (isStarted()) and other test assertions depend on
+    // the manager being constructed by the time start() resolves,
+    // regardless of whether connect was driven.
     const { shim, managerInstances } = makeShim();
     await shim.start({ connect: false });
-    expect(shim.getManager()).toBe(managerInstances[0]);
+    expect(shim._getManagerForTest()).toBe(managerInstances[0]);
   });
 });
 
@@ -878,5 +878,26 @@ describe('constants are pinned', () => {
     // in this constant changes the boot-fail latency observably and
     // should require a deliberate test update.
     expect(DEFAULT_CONNECT_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it('VERIFIED_DJS_WS_MAJOR_MINOR matches the installed @discordjs/ws major.minor', () => {
+    // The wsConnected mirror depends on @discordjs/ws's
+    // WebSocketShard.onMessage emitting Ready/Resumed BEFORE the
+    // Dispatch fan-out — verified against the version captured by
+    // VERIFIED_DJS_WS_MAJOR_MINOR. A node_modules bump past that
+    // range fails this test, forcing whoever bumps the dep to
+    // re-read the upstream dispatch handler before merging.
+    // @discordjs/ws's exports field blocks require('.../package.json'),
+    // so locate the install via require.resolve (works regardless of
+    // whether the dep landed in apps/discord/node_modules or got
+    // hoisted to a parent node_modules).
+    const path = require('node:path');
+    const fs = require('node:fs');
+    const wsEntry = require.resolve('@discordjs/ws');
+    const wsRoot = wsEntry.slice(0, wsEntry.indexOf(`${path.sep}@discordjs${path.sep}ws${path.sep}`))
+      + `${path.sep}@discordjs${path.sep}ws`;
+    const djsWsVersion = JSON.parse(fs.readFileSync(path.join(wsRoot, 'package.json'), 'utf8')).version;
+    const installedMajorMinor = djsWsVersion.split('.').slice(0, 2).join('.');
+    expect(installedMajorMinor).toBe(VERIFIED_DJS_WS_MAJOR_MINOR);
   });
 });

--- a/apps/discord/tests/gateway-ws-shim.test.js
+++ b/apps/discord/tests/gateway-ws-shim.test.js
@@ -257,6 +257,147 @@ describe('getManager — Pillar 3 leader handle', () => {
   });
 });
 
+describe('Pillar 3 manager contract — connect() + isConnected()', () => {
+  // The leader (gateway-leader.js) and watchdog
+  // (gateway-connection-watchdog.js) require a manager handle whose
+  // typeof connect === 'function' && typeof isConnected === 'function'.
+  // The raw @discordjs/ws WebSocketManager has connect() but NOT
+  // isConnected() (only async fetchStatus()) — so the SHIM has to be
+  // the contract-conforming handle. These tests pin the surface
+  // shape so a future refactor that drops either method fails CI
+  // instead of crash-looping the gateway task on next deploy.
+
+  it('exposes connect() and isConnected() on the returned shim', () => {
+    const { shim } = makeShim();
+    expect(typeof shim.connect).toBe('function');
+    expect(typeof shim.isConnected).toBe('function');
+  });
+
+  it('connect() throws before start() (no manager yet)', async () => {
+    const { shim } = makeShim();
+    await expect(shim.connect()).rejects.toThrow(/connect\(\) called before start\(\)/);
+  });
+
+  it('connect() delegates to the underlying manager once start() has run', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    await shim.connect();
+    // start({connect:false}) skips the internal connect, so the
+    // count reflects ONLY the shim.connect() call we just made.
+    expect(managerInstances[0].connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('isConnected() is false before any READY/RESUMED', async () => {
+    const { shim } = makeShim();
+    expect(shim.isConnected()).toBe(false);
+    await shim.start({ connect: false });
+    expect(shim.isConnected()).toBe(false);
+  });
+
+  it('isConnected() flips true on READY dispatch', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+      shardId: 0,
+    });
+    expect(shim.isConnected()).toBe(true);
+  });
+
+  it('isConnected() flips true on RESUMED dispatch (Pillar 2 happy path)', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'RESUMED' },
+      shardId: 0,
+    });
+    expect(shim.isConnected()).toBe(true);
+  });
+
+  it('isConnected() flips back to false on Closed', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+      shardId: 0,
+    });
+    expect(shim.isConnected()).toBe(true);
+    managerInstances[0].emit(WebSocketShardEvents.Closed, { code: 1006, shardId: 0 });
+    expect(shim.isConnected()).toBe(false);
+  });
+
+  it('isConnected() is false after stop() regardless of prior READY', async () => {
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    managerInstances[0].emit(WebSocketShardEvents.Dispatch, {
+      data: { t: 'READY', d: { application: { id: 'app-1' } } },
+      shardId: 0,
+    });
+    await shim.stop({ flushFinal: false });
+    expect(shim.isConnected()).toBe(false);
+  });
+
+  it('connect() rejects after stop()', async () => {
+    const { shim } = makeShim();
+    await shim.start({ connect: false });
+    await shim.stop({ flushFinal: false });
+    await expect(shim.connect()).rejects.toThrow(/connect\(\) called after stop\(\)/);
+  });
+
+  it('stop() removes the Closed listener too (no listener leak across cycles)', async () => {
+    // Regression pin for the listener-leak hazard: a future
+    // `start()/stop()/start()` cycle would otherwise accumulate
+    // Closed handlers on every new manager instance, each closing
+    // over the previous cycle's wsConnected/logger references.
+    const { shim, managerInstances } = makeShim();
+    await shim.start({ connect: false });
+    expect(managerInstances[0].listenerCount(WebSocketShardEvents.Closed)).toBe(1);
+    await shim.stop({ flushFinal: false });
+    expect(managerInstances[0].listenerCount(WebSocketShardEvents.Closed)).toBe(0);
+  });
+
+  it('satisfies the leader/watchdog factory contracts (no TypeError on construction)', () => {
+    // Regression guard: the prior wiring passed `shim.getManager()` —
+    // the raw @discordjs/ws WebSocketManager — to createGatewayLeader,
+    // which throws "manager with connect() and isConnected() is
+    // required" because WebSocketManager has no isConnected(). The
+    // production fix passes `gatewayShim` itself; this test asserts
+    // both factories accept it without throwing.
+    const { shim } = makeShim();
+    const { createGatewayLeader } = require('../src/gateway-leader');
+    const { createConnectionWatchdog } = require('../src/gateway-connection-watchdog');
+
+    const minimalDeps = {
+      lock: {
+        acquireLock: async () => ({}),
+        renewLock: async () => ({}),
+        transferLock: async () => ({}),
+        adoptLockFromHandoff: () => {},
+        releaseLock: async () => {},
+      },
+      peerHeartbeat: {
+        writeHeartbeat: async () => {},
+        listFreshPeers: async () => [],
+        deleteOwnRow: async () => {},
+      },
+      controlClient: { pushHandoff: async () => ({ ok: true }) },
+      selfInstanceId: 'i-test',
+      shardId: '0:1',
+      logger: makeFakeLogger(),
+    };
+
+    expect(() => createGatewayLeader({ ...minimalDeps, manager: shim })).not.toThrow();
+    expect(() => createConnectionWatchdog({
+      manager: shim,
+      isHoldingLock: () => false,
+      isConnecting: () => false,
+      releaseLock: async () => {},
+      deleteOwnRow: async () => {},
+      logger: minimalDeps.logger,
+    })).not.toThrow();
+  });
+});
+
 describe('IDENTIFY budget guard', () => {
   it('passes through when mirror is non-null (RESUME path; no budget impact)', async () => {
     const { shim, store, managerInstances } = makeShim();


### PR DESCRIPTION
## Summary

Pillar 3 sandbox deploy 26068476160 crashed gateway tasks at boot with:

```
ERROR: Failed to start {"error":"createGatewayLeader: manager with connect() and isConnected() is required"}
```

Root cause: `gateway-leader.js` and `gateway-connection-watchdog.js` both require a `manager` arg whose `connect` and `isConnected` are functions. The prior wiring at `apps/discord/src/index.js` passed `gatewayShim.getManager()` — the raw `@discordjs/ws` `WebSocketManager`, which exposes `connect()` but NOT `isConnected()` (only async `fetchStatus()`). Existing tests passed because leader/watchdog suites mocked `manager` with `{connect, isConnected}`.

This was the 3rd Pillar 3 boot bug surfaced by deploys this session (env-leak fixed in qurl-integrations-infra#710, HMAC seed prerequisite resolved, this contract-gap).

## Changes

- **`gateway-ws-shim.js`** — adds `connect()` (delegates to underlying manager) and `isConnected()` (sync mirror flag tracked via `Ready`/`Resumed`/`Closed` shard listeners). Distinct from `isReady` (which stays sticky through reconnects so `/health` doesn't flap ECS — `wsConnected` is the leader/watchdog signal).
- **`index.js`** — passes `gatewayShim` (not `getManager()`) to both `createGatewayLeader` and `createConnectionWatchdog`.
- **`gateway-leader.js`** — header comment updated to clarify the shim wraps the manager because upstream `WebSocketManager` lacks a sync `isConnected()`.
- **`gateway-ws-shim.test.js`** — 10 new tests under `Pillar 3 manager contract`:
  - exposes `connect()` + `isConnected()`
  - state transitions: idle → READY → Closed → false, RESUMED → true, etc.
  - `connect()` rejects before `start()` and after `stop()`
  - `stop()` removes the new `Closed` listener (no listener leak across cycles)
  - **regression guard** — constructs the *real* shim and passes it to *real* `createGatewayLeader` + `createConnectionWatchdog`, asserting neither throws (this is the assertion that would have caught this bug)

## Verified

- Audited the full Pillar 3 dep contract for `lock`, `peerHeartbeat`, `controlClient` — all factory return shapes match what the leader/watchdog call. Bug was isolated to `manager`.
- Verified `@discordjs/ws@~1.2.3` exposes `WebSocketShardEvents.Closed` + `Ready`/`Resumed` shard events used by the wsConnected mirror.

## Test plan

- [x] `npx jest tests/gateway-ws-shim.test.js` — 46 tests pass
- [x] `npx jest` — 2419 tests pass across 68 suites
- [x] `npm run lint` — clean (max-warnings 0)
- [ ] Sandbox deploy succeeds + gateway task reaches `runningCount=2` + CloudWatch IDENTIFY-once-per-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)