### PR TITLE
fix(discord): deriveInstanceIp skips link-local 169.254/16 (Pillar 3 push-handoff)

### DIFF
--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -296,6 +296,19 @@ function invalidHotStandbyValues(cfg) {
       'If you set INSTANCE_IP as an env override, unset it to fall back to the derivation from os.networkInterfaces().'
     );
   }
+  // Link-local (169.254.0.0/16) is well-formed IPv4 but not routable
+  // peer-to-peer. config.deriveInstanceIp filters it out of the
+  // os.networkInterfaces walk; the override path must reject it for
+  // the same reason. Common operator paste-error: copying the ECS
+  // task-metadata endpoint URL (169.254.170.2 / 169.254.172.2) out
+  // of AWS docs.
+  if (cfg.INSTANCE_IP && IPV4_RE.test(cfg.INSTANCE_IP) && cfg.INSTANCE_IP.startsWith('169.254.')) {
+    problems.push(
+      `INSTANCE_IP is link-local (got '${cfg.INSTANCE_IP}'). ` +
+      '169.254.0.0/16 is RFC 3927 link-local and not routable peer-to-peer; push-handoff would POST to an unreachable address. ' +
+      'Unset the env override so it falls back to the os.networkInterfaces() derivation, or set it to the task\'s awsvpc-assigned private IP.'
+    );
+  }
   return problems;
 }
 

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -647,10 +647,4 @@ module.exports = {
   // Exposed as a function, NOT a property — second call returns
   // undefined.
   takeGatewayHandoffHmac,
-
-  // Exported for unit-test coverage of the link-local filter (Pillar 3
-  // bug fix: Fargate platform 1.4+ has 169.254.172.2 bound on eth0
-  // alongside the real ENI IP). Production callers read INSTANCE_IP
-  // off the module exports above; this is just the test seam.
-  _deriveInstanceIpForTest: deriveInstanceIp,
 };

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -50,7 +50,17 @@ function deriveInstanceId() {
 }
 
 function isIPv4(addr) {
-  return (addr.family === 'IPv4' || addr.family === 4) && !addr.internal;
+  // `!addr.internal` rejects loopback (127.0.0.0/8) but NOT link-local
+  // (169.254.0.0/16) — node's `internal` flag only flips for loopback
+  // interfaces. Under Fargate platform 1.4+, eth0 has 169.254.172.2
+  // (the task metadata endpoint) bound alongside the real ENI IP, and
+  // a naive eth0-first walk picks the link-local entry. Writing that
+  // to the peer-heartbeat row breaks push-handoff — the standby
+  // POSTs to a link-local address that isn't routable peer-to-peer.
+  // Filter explicitly so the real awsvpc-assigned private IP wins.
+  return (addr.family === 'IPv4' || addr.family === 4)
+    && !addr.internal
+    && !addr.address.startsWith('169.254.');
 }
 
 function deriveInstanceIp() {
@@ -58,7 +68,8 @@ function deriveInstanceIp() {
   if (envOverride) return envOverride;
   const ifaces = os.networkInterfaces();
   // First pass: eth0 (the awsvpc ENI's stable name) gets priority —
-  // under Fargate this always returns on the first candidate.
+  // under Fargate this returns the real ENI private IP once isIPv4
+  // has filtered out the link-local task-metadata address.
   for (const addr of ifaces.eth0 || []) {
     if (isIPv4(addr)) return addr.address;
   }
@@ -636,4 +647,10 @@ module.exports = {
   // Exposed as a function, NOT a property — second call returns
   // undefined.
   takeGatewayHandoffHmac,
+
+  // Exported for unit-test coverage of the link-local filter (Pillar 3
+  // bug fix: Fargate platform 1.4+ has 169.254.172.2 bound on eth0
+  // alongside the real ENI IP). Production callers read INSTANCE_IP
+  // off the module exports above; this is just the test seam.
+  _deriveInstanceIpForTest: deriveInstanceIp,
 };

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -564,6 +564,18 @@ describe('invalidHotStandbyValues', () => {
     expect(problems[0]).toMatch(/must be a valid IPv4/);
   });
 
+  it('flags link-local INSTANCE_IP (paste-error from ECS metadata endpoint URL)', () => {
+    // Mirrors deriveInstanceIp's link-local filter — without this,
+    // an operator pasting `169.254.172.2` (the ECS task metadata
+    // endpoint) into INSTANCE_IP would slip past the shape check
+    // and re-introduce the Pillar 3 push-handoff bug through the
+    // env override path.
+    const problems = invalidHotStandbyValues(cfg({ INSTANCE_IP: '169.254.172.2' }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/link-local/);
+    expect(problems[0]).toContain("'169.254.172.2'");
+  });
+
   it('flags leading-zero IPv4 octets (octal-parse hazard under some resolvers)', () => {
     // `01.02.03.04` parses as octal under glibc's `inet_aton` and a
     // handful of resolvers — a typo'd "010.0.0.1" would resolve as

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -308,10 +308,4 @@ describe('INSTANCE_IP derivation', () => {
       },
     );
   });
-
-  it('_deriveInstanceIpForTest is exposed (test seam contract)', () => {
-    withFreshConfig({ env: {}, networkInterfaces: {} }, (config) => {
-      expect(typeof config._deriveInstanceIpForTest).toBe('function');
-    });
-  });
 });

--- a/apps/discord/tests/config-instance-derivation.test.js
+++ b/apps/discord/tests/config-instance-derivation.test.js
@@ -264,4 +264,54 @@ describe('INSTANCE_IP derivation', () => {
       },
     );
   });
+
+  it('skips link-local 169.254.0.0/16 addresses on eth0 (Fargate platform 1.4+)', () => {
+    // Pillar 3 push-handoff regression pin: under Fargate platform
+    // 1.4+, eth0 has 169.254.172.2 (the task metadata endpoint) bound
+    // alongside the real ENI IP, with the link-local listed first.
+    // `addr.internal` is false for link-local (node only sets that
+    // for loopback), so the prior naive `!internal && family==IPv4`
+    // filter picked 169.254.172.2 and the heartbeat row stored an
+    // unroutable address. Pin the post-fix behavior so a future edit
+    // can't quietly re-introduce the bug.
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          eth0: [
+            { family: 'IPv4', address: '169.254.172.2', internal: false },
+            { family: 'IPv4', address: '172.31.44.139', internal: false },
+          ],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('172.31.44.139');
+      },
+    );
+  });
+
+  it('falls through to non-eth0 when eth0 has only link-local IPv4', () => {
+    // Defense in depth: if a future Fargate platform ships an even
+    // weirder eth0 (only link-local, real IP on a different name),
+    // the second-pass interface scan must also reject link-local
+    // before reaching the real address elsewhere.
+    withFreshConfig(
+      {
+        env: {},
+        networkInterfaces: {
+          eth0: [{ family: 'IPv4', address: '169.254.172.2', internal: false }],
+          eth1: [{ family: 'IPv4', address: '10.0.5.7', internal: false }],
+        },
+      },
+      (config) => {
+        expect(config.INSTANCE_IP).toBe('10.0.5.7');
+      },
+    );
+  });
+
+  it('_deriveInstanceIpForTest is exposed (test seam contract)', () => {
+    withFreshConfig({ env: {}, networkInterfaces: {} }, (config) => {
+      expect(typeof config._deriveInstanceIpForTest).toBe('function');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Post-#437 sandbox deploy verified the shim contract fix worked, but a deeper audit of the peer-heartbeat DDB rows surfaced a separate Pillar 3 bug: both gateway tasks were writing `ip: "169.254.172.2"` (the ECS Fargate task-metadata endpoint, not routable) instead of their actual ENI private IPs.

```
$ aws dynamodb scan --table-name qurl-bot-discord-sandbox-gateway-peer-heartbeat
[
  { "instance_id": "ip-172-31-44-139...", "ip": "169.254.172.2", ... },
  { "instance_id": "ip-172-31-19-244...", "ip": "169.254.172.2", ... }
]
```

`instance_id` correctly shows the real ENI IPs (172.31.44.139 / 172.31.19.244 from the hostname's reverse DNS), but `ip` is the link-local metadata endpoint. Push-handoff would POST to it and fail.

## Root cause

Under Fargate platform 1.4+, eth0 has the link-local 169.254.172.2 bound **alongside** the real ENI IP, with the link-local listed first in `os.networkInterfaces().eth0`. `isIPv4()`'s prior `!addr.internal` filter doesn't catch 169.254/16 — node's `internal` flag is set only for loopback interfaces (RFC 3927 link-local is not "internal" in node's sense).

## Fix

`apps/discord/src/config.js` — add `!addr.address.startsWith('169.254.')` to the IPv4 candidate filter:

```diff
 function isIPv4(addr) {
-  return (addr.family === 'IPv4' || addr.family === 4) && !addr.internal;
+  return (addr.family === 'IPv4' || addr.family === 4)
+    && !addr.internal
+    && !addr.address.startsWith('169.254.');
 }
```

## Coupled fix

This PR alone is **not sufficient** to restore push-handoff. The companion fix in `qurl-integrations-infra` adds `dynamodb:Scan` to the peer-heartbeat IAM policy (which is currently denied at `greenfield.tf:879` with a comment claiming Scan is "intentionally NOT granted" — that comment is wrong; `listFreshPeers` needs it). Both must land for push-handoff to work. PR-B will reference this PR.

Once both land:
- IAM grants `dynamodb:Scan` → `listFreshPeers` returns rows
- Rows now carry real ENI IPs (this PR) → standby POSTs to a routable peer
- Active SIGTERM → push-handoff → ~50ms WS gap (vs ~6s TTL-lapse fallback today)

## Test plan

- [x] `npx jest` — 2428 tests pass (+3 in `config-instance-derivation.test.js`)
- [x] `npm run lint` — clean
- [ ] Post-merge: companion IAM PR lands, redeploy, verify heartbeat rows now show `172.x.x.x` IPs
- [ ] Stop the active replica, observe leader.pushHandoff transfers to standby in <1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)