### PR TITLE
fix(discord): seed client.user via REST in http-only mode (interaction reconstruction)

### DIFF
--- a/apps/discord/src/http-only-init.js
+++ b/apps/discord/src/http-only-init.js
@@ -102,6 +102,35 @@ function formatInterval(ms) {
  */
 async function initHttpOnly({ client, config, refreshCache, logger }) {
   client.rest.setToken(config.DISCORD_TOKEN);
+  // Populate `client.user` from REST GET /users/@me. The Pillar 1
+  // worker tier reconstructs INTERACTION_CREATE dispatches via
+  // `client.actions.InteractionCreate.handle(data)` — the same code
+  // path the legacy Client's WebSocketShard runs on a real gateway
+  // dispatch. discord.js's Action.getChannel reads
+  // `this.client.user.id` to filter the bot itself out of an
+  // interaction's recipient list (discord.js src/client/actions/
+  // Action.js: `if (recipient.id !== this.client.user.id)`). In
+  // gateway mode the READY handler populates `client.user` (READY.js:
+  // `client.user = new ClientUser(client, data.user)`); in http-only
+  // mode `client.login()` is intentionally skipped (Discord admits
+  // exactly one active Gateway connection per bot token, so http-only
+  // replicas must NOT collide with the gateway singleton), so READY
+  // never fires here. Without this REST seed, every interaction
+  // replayed through the worker tier throws "Cannot read properties
+  // of null (reading 'id')" on `client.user.id`.
+  //
+  // Crash-loop on failure (matches the module's fatal-on-REST-error
+  // posture): a worker that can't identify itself can't safely
+  // service interactions. Better to surface the misconfig at boot
+  // than to fail every interaction silently.
+  const ClientUser = require('discord.js').ClientUser;
+  const { Routes } = require('discord-api-types/v10');
+  const me = await client.rest.get(Routes.user('@me'));
+  client.user = new ClientUser(client, me);
+  logger.info('http-only mode: client.user seeded from REST GET /users/@me', {
+    userId: client.user.id,
+    username: client.user.username,
+  });
   // Falsy check is intentional and aligned with config.js's GUILD_ID
   // normalization: anything that isn't a 17-20 digit Discord snowflake
   // (unset env, "PLACEHOLDER", whitespace-only, etc.) lands as `null`

--- a/apps/discord/tests/http-only-init.test.js
+++ b/apps/discord/tests/http-only-init.test.js
@@ -15,10 +15,28 @@
 
 const { initHttpOnly, REFRESH_INTERVAL_MS } = require('../src/http-only-init');
 
+// Avoid constructing a real discord.js ClientUser in tests — it
+// walks the User -> Base inheritance chain and pokes the Client
+// for things like options.makeCache. The mock seeds the same
+// `client.user.{id,username}` shape that initHttpOnly's logger
+// reads + the dispatch-reconstruction path consumes.
+jest.mock('discord.js', () => ({
+  ClientUser: jest.fn().mockImplementation((_client, data) => ({
+    id: data.id,
+    username: data.username,
+    bot: true,
+  })),
+}));
+
 function makeClient() {
   return {
     rest: {
       setToken: jest.fn(),
+      get: jest.fn().mockResolvedValue({
+        id: 'bot-id-123',
+        username: 'qurl-bot-test',
+        bot: true,
+      }),
     },
   };
 }
@@ -28,6 +46,33 @@ function makeLogger() {
 }
 
 describe('initHttpOnly', () => {
+  it('seeds client.user from REST GET /users/@me (worker-tier dispatch reconstruction depends on it)', async () => {
+    // Pre-PR-#444 bug: discord.js's Action.getChannel reads
+    // `client.user.id` to filter the bot from the interaction's
+    // recipient list. http-only mode skips login() (gateway-token
+    // singleton), so without this REST seed, client.user stays null
+    // and every replayed INTERACTION_CREATE throws
+    // "Cannot read properties of null (reading 'id')". This test
+    // pins the seed so a future refactor that drops it fails CI
+    // instead of breaking every interaction in production.
+    const client = makeClient();
+    const refreshCache = jest.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
+    const config = { DISCORD_TOKEN: 'tok-abc', GUILD_ID: '123' };
+
+    await initHttpOnly({ client, config, refreshCache, logger });
+
+    // Routes.user('@me') URI-encodes @ to %40 — assert via includes
+    // so the test doesn't break if upstream Routes ever switches
+    // encoding strategy.
+    expect(client.rest.get).toHaveBeenCalledTimes(1);
+    expect(client.rest.get.mock.calls[0][0]).toMatch(/^\/users\/(@|%40)me$/);
+    expect(client.user).toEqual(expect.objectContaining({
+      id: 'bot-id-123',
+      username: 'qurl-bot-test',
+    }));
+  });
+
   it('sets the bot token on client.rest and warms the cache (single-guild)', async () => {
     const client = makeClient();
     const refreshCache = jest.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

Sandbox interactions are currently failing with:
```
ERROR: Event consumer: dispatch reconstruction failed 
{"error":"Cannot read properties of null (reading 'id')","eventId":"0:4"}
```

Every interaction since the post-#443 deploy has thrown this. Root cause: http-only mode skips `client.login()` (Discord bot tokens admit one active gateway connection per token; http-only replicas must not collide with the gateway singleton). discord.js's `Action.getChannel` reads `this.client.user.id` to filter the bot out of an interaction's recipient list — in gateway mode the READY handler populates `client.user = new ClientUser(...)`, but in http-only mode READY never fires, so every replayed INTERACTION_CREATE null-derefs.

## Fix

In `initHttpOnly`, REST GET `/users/@me` at boot and construct a `ClientUser`, matching the shape the gateway-side READY handler produces. No changes needed downstream.

## Note: this is tactical

The qURL bot only handles slash commands. The gateway → SQS → worker-tier reconstruction model is overkill — and the null-deref class of bugs (this one, plus latent `client.application` nulls, etc.) is structural to that model. **The correct architecture is Discord HTTP Interactions Endpoint**: Discord HTTPS-POSTs interactions directly to the bot's URL, no gateway needed for slash commands. A follow-up issue will track that migration. This PR just restores service so the bot responds again.

## Test plan

- [x] `npx jest tests/http-only-init.test.js` — 13 pass (1 new pinning the REST seed)
- [x] `npx jest` — 2353 pass
- [x] `npm run lint` — clean
- [ ] Post-merge sandbox deploy → verify `client.user seeded from REST GET /users/@me` log appears → ping bot, get a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)