### PR TITLE
fix(discord): restore channel notification on @everyone / voice mode sends

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -81,7 +81,7 @@ function largeSendThreshold() {
 // one-liners across this file.
 const logIgnoredDiscordErr = (err) => logger.warn('Discord API op failed (ignored)', { error: err.message });
 const { sendDM } = require('./discord');
-const { editDM } = require('./discord-rest');
+const { editDM, sendChannelMessage } = require('./discord-rest');
 
 
 // Generate an OAuth state token bound to the initiating Discord user.
@@ -1390,6 +1390,11 @@ async function executeSendPipeline(interaction, {
   selfDestructSeconds,
   personalMessage,
   sendNonce,
+  // 'picker' | 'voice' | 'everyone'. Drives the post-send channel
+  // notification (voice + everyone modes only). Optional — defaults
+  // to RECIPIENT_MODE_PICKER via normalizeRecipientMode for legacy
+  // callers and the picker happy path.
+  recipientMode,
 }) {
   // Shared cancel-edit for every entry gate. Fire-and-forget — the
   // throw is the load-bearing signal (test pins + logger.error in
@@ -1858,6 +1863,39 @@ async function executeSendPipeline(interaction, {
     ];
   }
   const response = await interaction.editReply(initialPayload);
+
+  // Non-ephemeral channel notification when sending to @everyone or the
+  // voice-channel population. Recipients on voice or scrolling on mobile
+  // miss the DM ping otherwise — this post is the only chat signal that
+  // a fan-out send happened. Picker-mode skips: recipient list is
+  // explicit and small, DM ping suffices. Routed via REST not
+  // `interaction.channel.send()` because http-only worker mode has an
+  // empty `client.channels.cache` (no GUILD_CREATE without login()), so
+  // the discord.js getter resolves to null and `.send()` would throw.
+  // Logged-and-continued on failure: a missing Send Messages permission
+  // in a customer server must NOT fail a send whose DMs already
+  // delivered. Fire-and-forget so the collector below arms in parallel
+  // with the REST flush.
+  const mode = normalizeRecipientMode(recipientMode);
+  if (delivered > 0 && (mode === RECIPIENT_MODE_EVERYONE || mode === RECIPIENT_MODE_VOICE)) {
+    // sanitizeDisplayName is load-bearing here, not in the DM embed:
+    // public-channel post is a wider blast radius than a DM, so a
+    // U+202E in the nickname would flip the announcement RTL for
+    // every viewer.
+    const safeName = sanitizeDisplayName(senderAlias);
+    const audience = mode === RECIPIENT_MODE_VOICE
+      ? 'everyone in this voice channel'
+      : 'everyone in this server';
+    const notifyMsg = `📩 **${safeName}** shared something with ${audience} via **qURL Bot** — check your DMs from qURL Bot.`;
+    sendChannelMessage(interaction.channelId, { content: notifyMsg })
+      .then((result) => {
+        if (!result.ok) {
+          logger.warn('Failed to send channel notification', {
+            sendId, channelId: interaction.channelId, status: result.status, error: result.error,
+          });
+        }
+      });
+  }
 
   logger.info('qurl send pipeline completed', {
     sender: interaction.user.id, sendId, resourceType, delivered, failed, expiresIn,
@@ -6635,6 +6673,7 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
     selfDestructSeconds: payload.selfDestructSeconds,
     personalMessage: payload.personalMessage,
     sendNonce: payload.sendNonce,
+    recipientMode: payload.recipientMode,
   });
 }
 

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -166,6 +166,33 @@ async function editDM(channelId, messageId, message) {
 }
 
 /**
+ * Post a message to a guild channel via REST (no Gateway).
+ *
+ * Why REST and not `interaction.channel.send()`: http-only worker
+ * mode skips `client.login()`, so no GUILD_CREATE events fire and
+ * `client.channels.cache` stays empty. The discord.js
+ * `interaction.channel` getter resolves to null on the cache miss and
+ * `.send()` throws synchronously. `interaction.channelId` is set
+ * straight from the payload, so REST works in both modes.
+ *
+ * Returns `{ ok: true, messageId }` on success, `{ ok: false, error,
+ * status }` on failure. Caller decides whether to surface or swallow.
+ */
+async function sendChannelMessage(channelId, message) {
+  try {
+    const sent = await client.rest.post(Routes.channelMessages(channelId), {
+      body: message,
+    });
+    return { ok: true, messageId: sent.id };
+  } catch (err) {
+    logger.warn('sendChannelMessage via REST failed', {
+      channelId, status: err.status, errorMessage: err.message,
+    });
+    return { ok: false, error: err.message, status: err.status };
+  }
+}
+
+/**
  * Add a role to a guild member via REST (no Gateway).
  * Idempotent on the Discord side — re-adding an existing role is
  * a no-op.
@@ -209,6 +236,7 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 module.exports = {
   sendDM,
   editDM,
+  sendChannelMessage,
   addRoleToMember,
   removeRoleFromMember,
 };

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -42,7 +42,7 @@ jest.mock('../src/discord', () => {
 
 const restMock = require('../src/discord').__mockRestInstance;
 
-const { sendDM, editDM, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
+const { sendDM, editDM, sendChannelMessage, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
 
 beforeEach(() => {
   restMock.post.mockReset();
@@ -238,5 +238,37 @@ describe('removeRoleFromMember via REST', () => {
     expect(restMock.delete).toHaveBeenCalledTimes(1);
     // DELETE /guilds/:guild/members/:user/roles/:role — same path shape as PUT.
     expect(restMock.delete.mock.calls[0][0]).toBe('/guilds/guild-1/members/user-1/roles/role-1');
+  });
+});
+
+describe('sendChannelMessage via REST', () => {
+  it('POSTs to /channels/:cid/messages with the message body, returns ok:true with messageId', async () => {
+    restMock.post.mockResolvedValueOnce({ id: 'message-7' });
+    const result = await sendChannelMessage('channel-1', { content: 'hello room' });
+    expect(result).toEqual({ ok: true, messageId: 'message-7' });
+    expect(restMock.post).toHaveBeenCalledTimes(1);
+    expect(restMock.post.mock.calls[0][0]).toBe('/channels/channel-1/messages');
+    expect(restMock.post.mock.calls[0][1]).toEqual({ body: { content: 'hello room' } });
+  });
+
+  it('returns ok:false on 403 (Missing Permissions) — caller decides whether to surface', async () => {
+    // The /qURL channel-notification call site treats this as
+    // logged-and-swallowed: a customer server without "Send Messages"
+    // for the bot must NOT fail a send whose DMs already delivered.
+    const err = new Error('Missing Permissions');
+    err.status = 403;
+    restMock.post.mockRejectedValueOnce(err);
+    const result = await sendChannelMessage('channel-1', { content: 'x' });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  it('returns ok:false on transient 5xx', async () => {
+    const err = new Error('Bad Gateway');
+    err.status = 502;
+    restMock.post.mockRejectedValueOnce(err);
+    const result = await sendChannelMessage('channel-1', { content: 'x' });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(502);
   });
 });

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -143,6 +143,7 @@ jest.mock('../src/store', () => mockDb);
 
 const mockSendDM = jest.fn().mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 const mockEditDM = jest.fn().mockResolvedValue({ ok: true });
+const mockSendChannelMessage = jest.fn().mockResolvedValue({ ok: true, messageId: 'ch-m' });
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
   notifyPRMerge: jest.fn(),
@@ -155,6 +156,7 @@ jest.mock('../src/discord', () => ({
 }));
 jest.mock('../src/discord-rest', () => ({
   editDM: mockEditDM,
+  sendChannelMessage: mockSendChannelMessage,
 }));
 
 jest.mock('../src/utils/admin', () => ({
@@ -2309,6 +2311,101 @@ describe('executeSendPipeline — truncForLog applies to value-rendering gates',
     const huge = 'y'.repeat(1024);
     await expect(executeSendPipeline(interaction, makePipelineParams({ expiresIn: huge })))
       .rejects.toThrow(/expiresIn must be one of .* \(got y{64}…\)/);
+  });
+});
+
+// Channel-notification on @everyone / voice mode. Each test drives
+// executeSendPipeline through the full file-prep + mint + DM happy
+// path so the post-send notification site is actually reached; the
+// collector setup that runs after the notification throws because
+// the editReply mock returns undefined, but the throw is caught
+// inside the pipeline and is not load-bearing for these assertions.
+//
+// The channel post is fire-and-forget — the call to sendChannelMessage
+// is synchronous (so `.toHaveBeenCalled()` reads true immediately after
+// the pipeline resolves), but the `.then` callback that emits the
+// failure warn-log runs on the microtask queue. Tests that assert on
+// the warn-log flush microtasks with `await Promise.resolve()` first.
+describe('executeSendPipeline — channel notification on @everyone / voice mode', () => {
+  beforeEach(() => {
+    mockDownloadAndUpload.mockResolvedValue({ resource_id: 'res-1', fileBuffer: new ArrayBuffer(10) });
+    mockMintLinks.mockResolvedValue([{ qurl_link: 'https://q.test/1', resource_id: 'res-1' }]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+  });
+
+  test('posts non-ephemeral channel notification when recipientMode is "everyone"', async () => {
+    const interaction = makeInteraction({ channelId: 'channel-everyone' });
+    await executeSendPipeline(interaction, makePipelineParams({ recipientMode: 'everyone' }));
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendChannelMessage).toHaveBeenCalledWith(
+      'channel-everyone',
+      expect.objectContaining({
+        content: expect.stringMatching(/shared something with everyone in this server.*qURL Bot/),
+      }),
+    );
+  });
+
+  test('posts notification with voice-channel copy when recipientMode is "voice"', async () => {
+    const interaction = makeInteraction({ channelId: 'channel-voice' });
+    await executeSendPipeline(interaction, makePipelineParams({ recipientMode: 'voice' }));
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendChannelMessage).toHaveBeenCalledWith(
+      'channel-voice',
+      expect.objectContaining({
+        content: expect.stringMatching(/shared something with everyone in this voice channel.*qURL Bot/),
+      }),
+    );
+  });
+
+  // 'picker' is the gate's explicit no-notify branch; `undefined`
+  // exercises the normalizeRecipientMode fallback that maps stale
+  // pre-field flow rows + any future off-set drift to picker. Two
+  // distinct branches, not two framings of the same one.
+  test.each([
+    ['picker', 'picker'],
+    ['undefined (stale flow row, normalizeRecipientMode fallback)', undefined],
+  ])('does NOT post channel notification when recipientMode is %s', async (_label, recipientMode) => {
+    const interaction = makeInteraction();
+    await executeSendPipeline(interaction, makePipelineParams({ recipientMode }));
+    expect(mockSendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  test('does NOT post channel notification when delivered === 0 (every DM failed)', async () => {
+    // Without this gate, a public "X shared something with everyone"
+    // would post even though nobody actually got the DM.
+    mockSendDM.mockResolvedValue({ ok: false, error: 'all DMs blocked' });
+    const interaction = makeInteraction();
+    await executeSendPipeline(interaction, makePipelineParams({ recipientMode: 'everyone' }));
+    expect(mockSendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  test('logs warn on REST failure without failing the send (a missing Send Messages permission cannot fail a send whose DMs already delivered)', async () => {
+    mockSendChannelMessage.mockResolvedValueOnce({ ok: false, error: 'Missing Permissions', status: 403 });
+    logger.warn.mockClear();
+    const interaction = makeInteraction({ channelId: 'channel-no-perm' });
+    await expect(
+      executeSendPipeline(interaction, makePipelineParams({ recipientMode: 'everyone' })),
+    ).resolves.not.toThrow();
+    // Flush the fire-and-forget `.then` so the warn-log assertion sees it.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to send channel notification',
+      expect.objectContaining({ channelId: 'channel-no-perm', status: 403 }),
+    );
+  });
+
+  test('sanitizes the sender display name before posting (bidi/RTL spoof defense)', async () => {
+    // U+202E (RIGHT-TO-LEFT OVERRIDE) in a public post would flip the
+    // announcement RTL for every viewer in the channel.
+    const interaction = makeInteraction({
+      member: { displayName: 'Alice‮Evil' },
+      user: { id: 'sender-1', username: 'Alice' },
+    });
+    await executeSendPipeline(interaction, makePipelineParams({ recipientMode: 'everyone' }));
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+    const [, message] = mockSendChannelMessage.mock.calls[0];
+    expect(message.content).not.toMatch(/‮/);
   });
 });
 


### PR DESCRIPTION
## Summary

Restores the non-ephemeral channel notification that posts when a user sends a qURL to `@everyone` or the voice-channel population. Hard-removed in PR #313's front-half refactor; this PR re-wires it onto the new `RECIPIENT_MODE_*` shape.

**User feedback motivating the restore:** *"I miss there being the message to chat saying a qurl was sent to all. This is because some of us are on voice or in chat and on mobile."* Without the public chat post, teammates who are on voice or scrolling on mobile have no signal in the channel that anything was shared — they miss the DM ping, and the ephemeral "Sent to N users" confirmation is only visible to the sender.

## What changed

- **commands.js** — thread `payload.recipientMode` through `handleConfirmSendClick` into `executeSendPipeline`. After `editReply` renders the sender's ephemeral confirmation, post a non-ephemeral channel message gated on `delivered > 0 && mode is EVERYONE or VOICE`. Picker-mode stays silent (explicit small list, DM ping suffices). Audience-specific copy distinguishes whole-guild from voice. Sender name runs through `sanitizeDisplayName` (load-bearing for public posts — a U+202E in a nickname would flip the announcement RTL for every viewer).
- **discord-rest.js** — new `sendChannelMessage(channelId, message)` helper. The historical code at `a43d45e` called `interaction.channel.send()` directly, but in http-only worker mode the discord.js `interaction.channel` getter resolves null because `client.channels.cache` stays empty without `login()`. Routing via REST works in both gateway and http-only modes (same fix shape as #444 / #445).
- Fire-and-forget so the post-send collector arms in parallel with the REST round-trip. Failure → warn-log + continue: a customer server without "Send Messages" permission for the bot must not fail a send whose DMs already delivered.

## Test plan

- [x] `apps/discord/tests/send-pipeline-back-half.test.js` — 6 new specs: EVERYONE post + copy, VOICE post + copy, picker silent, stale-row undefined silent (`normalizeRecipientMode` fallback), `delivered === 0` silent, REST failure swallowed-and-warned, bidi-sanitize on sender name.
- [x] `apps/discord/tests/discord-rest.test.js` — 3 new specs for the helper: POST route shape, 403, 5xx.
- [x] Full suite: 2368/2368 pass.
- [x] Lint clean.
- [ ] **Not smoke-tested against a live Discord guild** — reviewer should confirm the message actually appears in chat before merging. Unit tests verify code correctness; a live send verifies feature correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)