### PR TITLE
test(ci): switch google-maps e2e assertions to fallback-card shape (infra#726 follow-up)

### DIFF
--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -8,14 +8,21 @@
  * Prior shape (pre-qurl-integrations-infra#726): the fileviewer carried
  * a GOOGLE_MAPS_API_KEY in its .env and rendered an inline Maps Embed
  * API iframe. #726 removed the API key entirely — the iframe path is
- * dormant code and the fallback card (handler.go mapFallbackTmpl) is
- * the steady-state render. mapsURL construction (handler.go:2451-2509)
- * is identical on both paths, so all URL-shape regressions
- * (e.g. the "Erbil restaurant" /maps/place vs /maps/search bug fixed
- * in infra#155) remain testable via the fallback link's href.
+ * dormant code and the fallback card is the steady-state render.
+ * mapsURL construction is identical on both paths, so all URL-shape
+ * regressions (e.g. the "Erbil restaurant" /maps/place vs /maps/search
+ * bug fixed in infra#155) remain testable via the fallback link's href.
  *
  * Also tests edge cases: short URL resolution, coordinates, plain text
  * queries, and non-Maps JSON that should NOT trigger the Maps path.
+ *
+ * TODO(upstream-line-refs): the comments below cite line numbers in
+ * `qurl-s3-connector/internal/handler/handler.go` (a different repo).
+ * The line refs will rot as that file churns — when a test fails in
+ * a way that no longer matches the cited line, search for the symbol
+ * (`mapFallbackTmpl`, `mapEmbedTmpl`, `QueryEscape`, `isGoogleMapsURL`)
+ * rather than trusting the line number. Same convention as the
+ * `TODO(upstream-rebrand)` marker on the qURL error-string match.
  */
 
 // TODO: Add afterAll cleanup to revoke/delete test resources
@@ -206,13 +213,19 @@ describe('Google Maps: Fallback card render', () => {
 
     const html = await fetchViewerPage(upload.viewerUrl);
     // Anchored URL form: the NAME segment must pin the original query
-    // ("Erbil restaurant", with space as %20 or +) followed by the
+    // ("Erbil restaurant", with space as %20) followed by the
     // @lat,lng,17z anchor. Pinning the name — not just `[^/]*` — is
     // what catches a regression that returns the right coords but the
     // wrong place identity. `%.7f` formatting on the server side
     // produces the trailing zeros.
+    //
+    // Strict %20 (not tolerant `(?:%20|\+)`): handler.go normalizes
+    // url.QueryEscape's default '+' to '%20' via
+    // `strings.ReplaceAll(url.QueryEscape(s), "+", "%20")` — so the
+    // contract is firm and matches the strict-`%20` Eiffel + Revoke
+    // assertions below. cr cycle 1 on infra#726 follow-up.
     expect(html).toMatch(
-      /https:\/\/www\.google\.com\/maps\/place\/Erbil(?:%20|\+)restaurant\/@36\.1911000,44\.0094000,17z/,
+      /https:\/\/www\.google\.com\/maps\/place\/Erbil%20restaurant\/@36\.1911000,44\.0094000,17z/,
     );
     // Negative pin: /maps/search/Erbil must appear NOWHERE in the
     // rendered HTML. It's only emitted by the pre-fix fallback path,
@@ -229,15 +242,18 @@ describe('Google Maps: Fallback card render', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    // mapFallbackTmpl markers (handler.go:1513-1532):
+    // mapFallbackTmpl markers:
     // - Centered card layout via `.card` class
     // - "Shared Location" heading
     // - "Open in Google Maps to view this location." body copy
-    // - body CSS still uses `100vh` (min-height) for full-viewport
+    //
+    // Deliberately NOT asserting CSS details (e.g. `100vh`) — viewport
+    // unit refactors (e.g. `100vh` → `100dvh`) would fail the test for
+    // no functional reason. The three markers above pin the template
+    // firmly enough.
     expect(html).toContain('class="card"');
     expect(html).toContain('Shared Location');
     expect(html).toContain('Open in Google Maps to view this location.');
-    expect(html).toContain('100vh');
     // Negative: the iframe-embed template's `map-container` class
     // and `Shared securely by` footer were specific to mapEmbedTmpl
     // (which doesn't fire without an API key). Assert they're absent
@@ -249,15 +265,17 @@ describe('Google Maps: Fallback card render', () => {
 });
 
 describe('Google Maps: Non-Maps JSON', () => {
-  test('regular JSON does NOT render Maps iframe', async () => {
+  test('regular JSON does NOT trigger Maps render path', async () => {
     const upload = await uploadMapLocation(
       { name: 'config.json', version: 1 },
       'config.json',
     );
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    // Should use the canvas/template path, not the Maps iframe
+    // Should use the canvas/template path, not the Maps render (neither
+    // iframe nor fallback card).
     expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('Open in Google Maps to view this location.');
     expect(html).toContain('canvas');
   });
 
@@ -268,8 +286,10 @@ describe('Google Maps: Non-Maps JSON', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    // No valid location data → falls through to template renderer
+    // No valid location data → falls through to template renderer.
+    // Neither Maps render path (iframe nor fallback card) fires.
     expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('Open in Google Maps to view this location.');
   });
 });
 

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -2,10 +2,20 @@
  * Google Maps location sharing E2E tests.
  *
  * Tests the full flow: upload google-map JSON to connector → mint link →
- * access fileviewer → verify Maps iframe embed renders correctly.
+ * access fileviewer → verify the fallback "Open in Google Maps" card
+ * renders with the correctly-constructed mapsURL href.
  *
- * Also tests edge cases: short URL resolution, coordinates, plain text queries,
- * and non-Maps JSON that should NOT trigger the Maps path.
+ * Prior shape (pre-qurl-integrations-infra#726): the fileviewer carried
+ * a GOOGLE_MAPS_API_KEY in its .env and rendered an inline Maps Embed
+ * API iframe. #726 removed the API key entirely — the iframe path is
+ * dormant code and the fallback card (handler.go mapFallbackTmpl) is
+ * the steady-state render. mapsURL construction (handler.go:2451-2509)
+ * is identical on both paths, so all URL-shape regressions
+ * (e.g. the "Erbil restaurant" /maps/place vs /maps/search bug fixed
+ * in infra#155) remain testable via the fallback link's href.
+ *
+ * Also tests edge cases: short URL resolution, coordinates, plain text
+ * queries, and non-Maps JSON that should NOT trigger the Maps path.
  */
 
 // TODO: Add afterAll cleanup to revoke/delete test resources
@@ -101,35 +111,51 @@ async function fetchViewerPage(viewerUrl: string): Promise<string> {
   return res.text();
 }
 
-describe('Google Maps: Iframe Embed', () => {
-  test('google-map with short URL renders Maps iframe', async () => {
+describe('Google Maps: Fallback card render', () => {
+  // GOOGLE_MAPS_API_KEY was removed from the fileviewer deploy in
+  // qurl-integrations-infra#726 — Maps share renders go through
+  // mapFallbackTmpl (handler.go:1513) which shows an "Open in
+  // Google Maps" card with a hyperlink to the resolved Google
+  // Maps URL. The previous "iframe embed" assertions were only
+  // valid when an API key was wired; the URL-construction logic
+  // (mapsURL in handler.go:2451-2509) still runs regardless of
+  // the key, so the underlying URL shape continues to be testable.
+  test('google-map with short URL renders fallback card with original URL', async () => {
+    const originalUrl = 'https://maps.app.goo.gl/DvXv2GW9xc5ZGq3r8';
     const upload = await uploadMapLocation({
       type: 'google-map',
-      url: 'https://maps.app.goo.gl/DvXv2GW9xc5ZGq3r8',
+      url: originalUrl,
     });
     expect(upload.viewerUrl).toContain('/view/');
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('iframe');
-    expect(html).toContain('google.com/maps/embed');
+    // Fallback card: no iframe, no embed; "Open in Google Maps"
+    // link points at the original URL.
+    expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('<iframe');
     expect(html).toContain('Open in Google Maps');
-    // Should NOT contain the canvas/watermark template
+    expect(html).toContain(`href="${originalUrl}"`);
+    // Should NOT contain the canvas/watermark template (the page
+    // is still routed as a Maps share, not as a generic file).
     expect(html).not.toContain('drawWatermark');
   });
 
-  test('google-map with query renders Maps iframe with query', async () => {
+  test('google-map with query renders fallback card with /maps/search URL', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       query: 'Eiffel Tower, Paris',
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('iframe');
-    expect(html).toContain('google.com/maps/embed');
-    expect(html).toContain('Eiffel');
+    expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('<iframe');
+    expect(html).toContain('Open in Google Maps');
+    // /maps/search/<query> with space as %20 (per handler.go's
+    // QueryEscape→%20 normalization at line 2492).
+    expect(html).toContain('https://www.google.com/maps/search/Eiffel%20Tower');
   });
 
-  test('google-map with coordinates renders Maps iframe', async () => {
+  test('google-map with coordinates renders fallback card with /maps/@lat,lng URL', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       lat: 48.8584,
@@ -137,9 +163,12 @@ describe('Google Maps: Iframe Embed', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('iframe');
-    expect(html).toContain('google.com/maps/embed');
-    expect(html).toContain('48.858');
+    expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('<iframe');
+    expect(html).toContain('Open in Google Maps');
+    // /maps/@<lat>,<lng>,17z with %.7f formatting on coords (per
+    // handler.go:2507).
+    expect(html).toContain('https://www.google.com/maps/@48.8584000,2.2945000,17z');
   });
 
   test('google-map page has "Open in Google Maps" link', async () => {
@@ -163,6 +192,11 @@ describe('Google Maps: Iframe Embed', () => {
     // the recipient's side and opens a namesake near THEIR
     // geolocation instead of the place the sender picked. Fixed in
     // qurl-integrations-infra#155.
+    //
+    // This regression class survives the iframe→fallback-card
+    // switch: the mapsURL string is the SAME on both paths (only
+    // the embed iframe goes away). So this test continues to
+    // catch the original bug shape via the fallback link's href.
     const upload = await uploadMapLocation({
       type: 'google-map',
       query: 'Erbil restaurant',
@@ -188,19 +222,29 @@ describe('Google Maps: Iframe Embed', () => {
     expect(html).not.toMatch(/\/maps\/search\/Erbil/);
   });
 
-  test('google-map page has correct styling (map-container, bar)', async () => {
+  test('fallback card has expected layout markers', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       query: 'Central Park',
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('map-container');
-    // Footer text matches the template in qurl-s3-connector handler.go's
-    // mapEmbedTmpl: `📍 <span>Shared securely by <a href="https://layerv.ai/qurl" ...>QURL</a></span>`.
-    expect(html).toContain('Shared securely by');
-    expect(html).toContain('https://layerv.ai/qurl');
+    // mapFallbackTmpl markers (handler.go:1513-1532):
+    // - Centered card layout via `.card` class
+    // - "Shared Location" heading
+    // - "Open in Google Maps to view this location." body copy
+    // - body CSS still uses `100vh` (min-height) for full-viewport
+    expect(html).toContain('class="card"');
+    expect(html).toContain('Shared Location');
+    expect(html).toContain('Open in Google Maps to view this location.');
     expect(html).toContain('100vh');
+    // Negative: the iframe-embed template's `map-container` class
+    // and `Shared securely by` footer were specific to mapEmbedTmpl
+    // (which doesn't fire without an API key). Assert they're absent
+    // so a future re-enable of the iframe path that forgets to
+    // update this test fails loud.
+    expect(html).not.toContain('map-container');
+    expect(html).not.toContain('Shared securely by');
   });
 });
 
@@ -230,7 +274,11 @@ describe('Google Maps: Non-Maps JSON', () => {
 });
 
 describe('Google Maps: Edge Cases', () => {
-  test('google-map with very long query still works', async () => {
+  // mapsURL construction happens regardless of API key (handler.go:2451-2509);
+  // the API-key check at 2516 only gates whether the iframe or the
+  // fallback card renders. So all edge-case assertions are on the
+  // fallback card's "Open in Google Maps" href.
+  test('google-map with very long query renders fallback card', async () => {
     const longQuery = 'A'.repeat(900); // under 1000 char limit
     const upload = await uploadMapLocation({
       type: 'google-map',
@@ -238,11 +286,14 @@ describe('Google Maps: Edge Cases', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('iframe');
-    expect(html).toContain('google.com/maps/embed');
+    expect(html).not.toContain('google.com/maps/embed');
+    expect(html).toContain('Open in Google Maps');
+    // The 900-char A string is QueryEscape-clean, so it appears
+    // verbatim in /maps/search/.
+    expect(html).toContain(`https://www.google.com/maps/search/${longQuery}`);
   });
 
-  test('google-map with query over 1000 chars falls through', async () => {
+  test('google-map with query over 1000 chars falls through (no Maps URL)', async () => {
     const tooLong = 'B'.repeat(1001);
     const upload = await uploadMapLocation({
       type: 'google-map',
@@ -250,10 +301,14 @@ describe('Google Maps: Edge Cases', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
+    // Over the 1000-char cap, handler.go skips the maps render path
+    // entirely — mapsURL stays empty, falls through to the generic
+    // template renderer. Neither embed nor fallback fires.
     expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('Open in Google Maps to view this location.');
   });
 
-  test('google-map with null island (0,0) renders correctly', async () => {
+  test('google-map with null island (0,0) renders fallback card', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       lat: 0,
@@ -261,11 +316,12 @@ describe('Google Maps: Edge Cases', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('iframe');
-    expect(html).toContain('google.com/maps/embed');
+    expect(html).not.toContain('google.com/maps/embed');
+    expect(html).toContain('Open in Google Maps');
+    expect(html).toContain('https://www.google.com/maps/@0.0000000,0.0000000,17z');
   });
 
-  test('google-map with negative coordinates (Sydney) works', async () => {
+  test('google-map with negative coordinates (Sydney) renders fallback card', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       lat: -33.8688,
@@ -273,11 +329,12 @@ describe('Google Maps: Edge Cases', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
-    expect(html).toContain('iframe');
-    expect(html).toContain('-33.868');
+    expect(html).not.toContain('google.com/maps/embed');
+    expect(html).toContain('Open in Google Maps');
+    expect(html).toContain('https://www.google.com/maps/@-33.8688000,151.2093000,17z');
   });
 
-  test('google-map with invalid coordinates falls through', async () => {
+  test('google-map with invalid coordinates falls through (no Maps URL)', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       lat: 999,
@@ -285,10 +342,13 @@ describe('Google Maps: Edge Cases', () => {
     });
 
     const html = await fetchViewerPage(upload.viewerUrl);
+    // Coords outside [-90,90]/[-180,180] are rejected at handler.go:2504-2506,
+    // mapsURL stays empty, falls through to the generic template.
     expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('Open in Google Maps to view this location.');
   });
 
-  test('google-map with URL over 2000 chars falls through', async () => {
+  test('google-map with URL over 2000 chars falls through (no Maps URL)', async () => {
     const upload = await uploadMapLocation({
       type: 'google-map',
       url: 'https://maps.app.goo.gl/' + 'x'.repeat(2000),
@@ -296,6 +356,7 @@ describe('Google Maps: Edge Cases', () => {
 
     const html = await fetchViewerPage(upload.viewerUrl);
     expect(html).not.toContain('google.com/maps/embed');
+    expect(html).not.toContain('Open in Google Maps to view this location.');
   });
 });
 
@@ -315,9 +376,12 @@ describe('Google Maps: Revoke', () => {
   // These tests verify today's revoke contract via `getLinkStatus()` → 404
   // (the canonical post-revoke signal; matches smoke.test.ts:103). Once
   // infra#93 ships, add `(await fetch(upload.viewerUrl)).status === 404`
-  // alongside — marked with a TODO below. The iframe-regression assertion
-  // is preserved in the pre-revoke read so a no-API-key deploy still fails
-  // these tests loudly regardless.
+  // alongside — marked with a TODO below.
+  //
+  // Pre-revoke read also asserts the fallback-card render shape so a
+  // future regression that breaks the map render path (e.g. mapsURL
+  // construction broken) fails these tests loudly regardless of the
+  // revoke pathway.
 
   test('revoke location qURL → getLinkStatus returns 404', async () => {
     const upload = await uploadMapLocation({
@@ -325,12 +389,15 @@ describe('Google Maps: Revoke', () => {
       query: 'Revoke Test, Boston',
     });
 
-    // Status-only check on the viewer would also pass on the no-API-key
-    // fallback page. Assert both status-code AND iframe content so this
-    // test catches the same class of regression as the test below.
+    // Pre-revoke read: fallback-card shape (no API key in deploy).
+    // Status-only check on the viewer would also pass on a generic-
+    // template fallthrough, so assert the fallback card's specific
+    // markers — both that the maps-render path fired AND that the
+    // resolved mapsURL is in the href.
     const before = await fetchViewerPage(upload.viewerUrl);
-    expect(before).toContain('iframe');
-    expect(before).toContain('google.com/maps/embed');
+    expect(before).toContain('Open in Google Maps');
+    expect(before).toContain('Open in Google Maps to view this location.');
+    expect(before).toContain('https://www.google.com/maps/search/Revoke%20Test');
 
     const revoked = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, upload.resourceId);
     expect(revoked).toBe(true);
@@ -343,9 +410,11 @@ describe('Google Maps: Revoke', () => {
     ).rejects.toThrow(/404/);
   });
 
-  test('revoke iframe-rendering location also kills the resource', async () => {
-    // Explicitly targets the mapEmbedTmpl path (coordinates → iframe),
-    // which is the UX regression that motivated PR #86 + today's key wiring.
+  test('revoke coordinate-based location also kills the resource', async () => {
+    // Explicitly targets the lat/lng → /maps/@<lat>,<lng>,17z path.
+    // Previously this asserted the iframe-embed shape (handler's
+    // mapEmbedTmpl); after #726 stripped GOOGLE_MAPS_API_KEY the
+    // assertion is the fallback card's href instead.
     const upload = await uploadMapLocation({
       type: 'google-map',
       lat: 40.7128,
@@ -353,10 +422,8 @@ describe('Google Maps: Revoke', () => {
     });
 
     const beforeHtml = await fetchViewerPage(upload.viewerUrl);
-    // Guard: if `GOOGLE_MAPS_API_KEY` is missing in the deploy, this fails
-    // and flags the regression — which is the whole point of this test.
-    expect(beforeHtml).toContain('iframe');
-    expect(beforeHtml).toContain('google.com/maps/embed');
+    expect(beforeHtml).toContain('Open in Google Maps');
+    expect(beforeHtml).toContain('https://www.google.com/maps/@40.7128000,-74.0060000,17z');
 
     const revoked = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, upload.resourceId);
     expect(revoked).toBe(true);


### PR DESCRIPTION
## Summary
- `qurl-integrations-infra#726` removed `GOOGLE_MAPS_API_KEY` from the fileviewer deploy. The Maps render path falls back to the "Open in Google Maps" card (`mapFallbackTmpl` in `qurl-s3-connector/internal/handler/handler.go:1513`) instead of an iframe embed.
- All `iframe`-asserting tests in `e2e/tests/google-maps.test.ts` were failing on every main deploy after the infra-side merge (e.g. https://github.com/layervai/qurl-integrations-infra/actions/runs/26074595389).
- This PR updates each test to assert the fallback card's shape while preserving every prior regression-guard.

## Test plan
- [x] `tsc --noEmit` on the test file is clean (pre-existing tsconfig deprecation warning is unrelated)
- [ ] CI on this PR runs the e2e-smoke against sandbox and passes the google-maps suite
- [ ] After merge, the next main deploy's e2e-smoke goes green

## Notes
- The `mapsURL` builder (`handler.go:2451-2509`) is shared between the iframe and fallback paths, so URL-shape regressions (most importantly the "Erbil restaurant" `/maps/place` vs `/maps/search` bug, infra#155) remain testable via the fallback link's `href`.
- The fall-through cases (>1000-char query, invalid coords, >2000-char URL) gain a negative-pin on the fallback card's "Open in Google Maps to view this location." body copy — that confirms `mapsURL` stayed empty and the generic template fired, vs. the prior assertion which only checked iframe absence (a too-loose negative).