### PR TITLE
test(ci): tighten Google Maps fallback-card assertions (PR #448 cr cycle-2 nits)

### DIFF
--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -141,7 +141,15 @@ describe('Google Maps: Fallback card render', () => {
     expect(html).not.toContain('google.com/maps/embed');
     expect(html).not.toContain('<iframe');
     expect(html).toContain('Open in Google Maps');
-    expect(html).toContain(`href="${originalUrl}"`);
+    // Tolerate either quote style on the href attribute. Go's
+    // html/template emits double quotes today, but the assertion
+    // shouldn't break on a future template-engine swap; what we
+    // actually care about is the URL appearing inside an href.
+    // The originalUrl here is a short maps.app.goo.gl path with no
+    // chars that html/template would entity-escape — if a future
+    // fixture adds `&` or quotes, switch this to a regex that
+    // matches the escaped form as well.
+    expect(html).toMatch(new RegExp(`href=["']${originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']`));
     // Should NOT contain the canvas/watermark template (the page
     // is still routed as a Maps share, not as a generic file).
     expect(html).not.toContain('drawWatermark');
@@ -158,8 +166,11 @@ describe('Google Maps: Fallback card render', () => {
     expect(html).not.toContain('<iframe');
     expect(html).toContain('Open in Google Maps');
     // /maps/search/<query> with space as %20 (per handler.go's
-    // QueryEscape→%20 normalization at line 2492).
-    expect(html).toContain('https://www.google.com/maps/search/Eiffel%20Tower');
+    // QueryEscape→%20 normalization at line 2492). Pin the full
+    // segment including the `, Paris` suffix (comma as %2C) — a
+    // prefix-only check would silently pass on a regression that
+    // truncates the query at the first comma.
+    expect(html).toContain('https://www.google.com/maps/search/Eiffel%20Tower%2C%20Paris');
   });
 
   test('google-map with coordinates renders fallback card with /maps/@lat,lng URL', async () => {
@@ -251,7 +262,11 @@ describe('Google Maps: Fallback card render', () => {
     // unit refactors (e.g. `100vh` → `100dvh`) would fail the test for
     // no functional reason. The three markers above pin the template
     // firmly enough.
-    expect(html).toContain('class="card"');
+    // Tolerate either quote style on the class attribute and a
+    // future addition of co-classes (e.g. `class="card map-card"`)
+    // — what we care about is that the `card` class is applied,
+    // not the exact serialization.
+    expect(html).toMatch(/class=["']card(?:\s[^"']*)?["']/);
     expect(html).toContain('Shared Location');
     expect(html).toContain('Open in Google Maps to view this location.');
     // Negative: the iframe-embed template's `map-container` class
@@ -417,7 +432,10 @@ describe('Google Maps: Revoke', () => {
     const before = await fetchViewerPage(upload.viewerUrl);
     expect(before).toContain('Open in Google Maps');
     expect(before).toContain('Open in Google Maps to view this location.');
-    expect(before).toContain('https://www.google.com/maps/search/Revoke%20Test');
+    // Full-segment pin (incl. `%2C%20Boston` comma+space), same as
+    // the Eiffel assertion above — prefix-only would miss a query-
+    // truncation regression.
+    expect(before).toContain('https://www.google.com/maps/search/Revoke%20Test%2C%20Boston');
 
     const revoked = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, upload.resourceId);
     expect(revoked).toBe(true);

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -141,15 +141,16 @@ describe('Google Maps: Fallback card render', () => {
     expect(html).not.toContain('google.com/maps/embed');
     expect(html).not.toContain('<iframe');
     expect(html).toContain('Open in Google Maps');
-    // Tolerate either quote style on the href attribute. Go's
-    // html/template emits double quotes today, but the assertion
-    // shouldn't break on a future template-engine swap; what we
-    // actually care about is the URL appearing inside an href.
-    // The originalUrl here is a short maps.app.goo.gl path with no
-    // chars that html/template would entity-escape — if a future
-    // fixture adds `&` or quotes, switch this to a regex that
-    // matches the escaped form as well.
-    expect(html).toMatch(new RegExp(`href=["']${originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']`));
+    // Tolerate either quote style on the href attribute, with a
+    // backreference pinning the matched quotes (no mismatched
+    // `href="x'` shape). Go's html/template emits double quotes
+    // today; what we actually care about is the URL appearing
+    // inside a properly-paired href. The originalUrl here is a
+    // short maps.app.goo.gl path with no chars that html/template
+    // would entity-escape — if a future fixture adds `&` or
+    // quotes, switch this to a regex that matches the escaped form
+    // as well.
+    expect(html).toMatch(new RegExp(`href=(["'])${originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\1`));
     // Should NOT contain the canvas/watermark template (the page
     // is still routed as a Maps share, not as a generic file).
     expect(html).not.toContain('drawWatermark');
@@ -262,11 +263,11 @@ describe('Google Maps: Fallback card render', () => {
     // unit refactors (e.g. `100vh` → `100dvh`) would fail the test for
     // no functional reason. The three markers above pin the template
     // firmly enough.
-    // Tolerate either quote style on the class attribute and a
-    // future addition of co-classes (e.g. `class="card map-card"`)
-    // — what we care about is that the `card` class is applied,
-    // not the exact serialization.
-    expect(html).toMatch(/class=["']card(?:\s[^"']*)?["']/);
+    // Tolerate either quote style and any co-class order. Uses
+    // whitespace-or-attribute-edge as the class-name separator —
+    // `\bcard\b` would still match `card-deck` (regex word
+    // boundary, not CSS class boundary).
+    expect(html).toMatch(/class=["'](?:[^"']*\s)?card(?:\s[^"']*)?["']/);
     expect(html).toContain('Shared Location');
     expect(html).toContain('Open in Google Maps to view this location.');
     // Negative: the iframe-embed template's `map-container` class


### PR DESCRIPTION
## Summary

Follow-up to merged PR #448. Addresses cycle-2 cr nits that were
left unaddressed before the squash-merge landed:

- **`class=\"card\"`** brittle to quote style + future co-classes.
  Switched to `/class=[\"']card(?:\s[^\"']*)?[\"']/` so a
  template-engine swap to single-quoted attrs or addition of a
  second class (`class=\"card map-card\"`) won't silently break
  the assertion.
- **`href=\"\${originalUrl}\"`** likewise tolerant of either
  quote style. The short URL fixture has no HTML-escapable chars
  today; comment flags the future-fixture case where `&` would
  need an escaped-form branch.
- **Eiffel + Revoke `/maps/search/` URLs** were prefix-only
  (`...Eiffel%20Tower`, `...Revoke%20Test`). Pinned to the full
  segment including the `%2C%20<rest>` comma+space — a
  prefix-only check would silently pass on a regression that
  truncates the query at the first comma.

## Test plan

- [x] Regexes sanity-checked against representative inputs (single + double quote, multi-class, wrong class, escaped/unescaped URL forms)
- [ ] Wait for `claude-review` cr cycle
- [ ] Wait for required status checks (Validate PR Title, CodeQL, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)