### PR TITLE
refactor(discord): rename Show All button to Show Recipients

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1888,7 +1888,7 @@ async function executeSendPipeline(interaction, {
   const confirmRendered = buildConfirmMsg(false);
   let confirmMsg = confirmRendered.content;
   // In attachment mode the file IS the full list, so suppress the
-  // Show All toggle — the same shape the post-revoke flow uses.
+  // Show Recipients toggle — the same shape the post-revoke flow uses.
   const needsExpand = confirmRendered.needsExpand;
 
   const buttonRow = new ActionRowBuilder().addComponents(
@@ -1905,7 +1905,7 @@ async function executeSendPipeline(interaction, {
     buttonRow.addComponents(
       new ButtonBuilder()
         .setCustomId(`qurl_expand_${sendId}`)
-        .setLabel('Show All')
+        .setLabel('Show Recipients')
         .setStyle(ButtonStyle.Secondary),
     );
   }
@@ -2035,14 +2035,14 @@ async function executeSendPipeline(interaction, {
         const updatedRow = new ActionRowBuilder().addComponents(
           new ButtonBuilder().setCustomId(`qurl_add_${sendId}`).setLabel('Add Recipients').setStyle(ButtonStyle.Primary),
           new ButtonBuilder().setCustomId(`qurl_revoke_${sendId}`).setLabel('Revoke All').setStyle(ButtonStyle.Danger),
-          new ButtonBuilder().setCustomId(`qurl_expand_${sendId}`).setLabel(showAllRecipients ? 'Show Less' : 'Show All').setStyle(ButtonStyle.Secondary),
+          new ButtonBuilder().setCustomId(`qurl_expand_${sendId}`).setLabel(showAllRecipients ? 'Hide Recipients' : 'Show Recipients').setStyle(ButtonStyle.Secondary),
         );
         await interaction.editReply({ content: fullMsg, components: [updatedRow] }).catch(logIgnoredDiscordErr);
         return;
       }
 
       if (btnInteraction.customId === `qurl_revoke_expand_${sendId}`) {
-        // Toggle Show All / Show Less on the post-revoke recipient list.
+        // Toggle Show Recipients / Hide Recipients on the post-revoke list.
         await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
         revokeShowAll = !revokeShowAll;
         const updated = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, revokeShowAll, revokeResultSuccess);
@@ -2208,7 +2208,7 @@ async function executeSendPipeline(interaction, {
         // message ("Failed to revoke links…") isn't overwritten with
         // a stale "Revoked 0/0 links" line.
         if (revokeSucceeded) {
-          // Terminal state: re-render content (Show All may have
+          // Terminal state: re-render content (Show Recipients may have
           // toggled), strip components. Omit `files`/`attachments`
           // so Discord keeps the existing revoked-users.txt without
           // re-uploading the same blob 15min later.
@@ -3171,7 +3171,7 @@ const SEND_STAGE_AWAITING_CONFIRM = 'awaiting_send_confirm';
 // dispatcher routes against the new literal. See
 // SEND_STAGE_AWAITING_CONFIRM above for the matching stage-value drain.
 //
-// The post-send Add Recipients / Revoke / Show All buttons live on
+// The post-send Add Recipients / Revoke / Show Recipients buttons live on
 // different customId prefixes (`qurl_add_*`, `qurl_revoke_*`,
 // `qurl_expand_*`) — they are NOT affected by renaming the confirm-
 // card literals here, so the 180s flow_state TTL is the only drain
@@ -6865,7 +6865,7 @@ const {
 // Builds the editReply payload from a `renderRevokeMsg` result. When
 // the rendered names list overflowed the Discord content cap,
 // `attachmentText` is populated → wrap in a `revoked-users.txt`
-// attachment and drop the Show All button (the file IS the full list).
+// attachment and drop the Show Recipients button (the file IS the full list).
 function revokeReplyPayload(rendered) {
   const payload = { content: rendered.content };
   payload.components = rendered.row ? [rendered.row] : [];
@@ -6878,7 +6878,8 @@ function revokeReplyPayload(rendered) {
 }
 
 // Wraps `renderRevokeContent` (pure data) and adds the discord.js
-// ActionRowBuilder/ButtonBuilder for the Show All / Show Less toggle.
+// ActionRowBuilder/ButtonBuilder for the Show Recipients / Hide
+// Recipients toggle on the post-revoke "Revoked for: ..." list.
 // All wording assertions live against `renderRevokeContent` directly
 // (see `apps/discord/src/revoke-render.js` + the e2e smoke).
 function renderRevokeMsg(sendId, names, total, showAll, success = names.length) {
@@ -6887,7 +6888,7 @@ function renderRevokeMsg(sendId, names, total, showAll, success = names.length) 
     ? new ActionRowBuilder().addComponents(
       new ButtonBuilder()
         .setCustomId(`qurl_revoke_expand_${sendId}`)
-        .setLabel(showAll ? 'Show Less' : 'Show All')
+        .setLabel(showAll ? 'Hide Recipients' : 'Show Recipients')
         .setStyle(ButtonStyle.Secondary),
     )
     : null;

--- a/apps/discord/src/revoke-render.js
+++ b/apps/discord/src/revoke-render.js
@@ -10,8 +10,8 @@ const REVOKE_TRUNC_LIMIT = 5;
 // Discord message content cap is 2000 chars. Leave headroom for the
 // header + "Revoked for: " prefix; force truncation in renderRevokeContent
 // even when showAll=true if the full names list would push the total
-// over this. Without it, a Show All on ~80+ recipients would exceed
-// Discord's limit and the editReply would error.
+// over this. Without it, a Show Recipients click on ~80+ recipients
+// would exceed Discord's limit and the editReply would error.
 const REVOKE_CONTENT_SAFE_MAX = 1900;
 
 const REVOKE_FOR_PREFIX = '\nRevoked for: ';
@@ -31,8 +31,8 @@ function buildRevokeHeader(success, total) {
 // site). Returns `attachmentText` (newline-joined full list) when the
 // inline rendering would exceed Discord's 2000-char content cap —
 // caller wraps in an AttachmentBuilder. In attachment mode
-// `needsExpand=false` so the caller suppresses the Show All button
-// (the file IS the full list).
+// `needsExpand=false` so the caller suppresses the Show Recipients
+// button (the file IS the full list).
 //
 // `success` defaults to `names.length`. Pass it explicitly when the
 // authoritative count (e.g. DDB strict-success) may exceed the names
@@ -59,7 +59,7 @@ function renderRevokeContent({ names, total, showAll, success = names.length }) 
     return { content, needsExpand: false, attachmentText: names.join('\n') };
   }
 
-  // Full list fits inline — current Show All / Show Less behavior.
+  // Full list fits inline — current Show Recipients / Hide Recipients behavior.
   if (showAll || names.length <= REVOKE_TRUNC_LIMIT) {
     content += fullLine;
   } else {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1492,7 +1492,7 @@ describe('renderSendConfirm — post-send confirmation overflow', () => {
     failedNamesPlain: [], successNames: [], showAll: false,
   };
 
-  it('small list: full inline + Show All toggle when >TRUNC_LIMIT', () => {
+  it('small list: full inline + Show Recipients toggle when >TRUNC_LIMIT', () => {
     const successNames = Array.from({ length: REVOKE_TRUNC_LIMIT + 2 }, (_, i) => `u${i}`);
     const r = renderSendConfirm({ ...baseArgs, delivered: successNames.length, successNames });
     expect(r.content).toMatch(/^Sent to \d+ users? \| /);
@@ -1530,7 +1530,7 @@ describe('renderSendConfirm — post-send confirmation overflow', () => {
     expect(r.attachmentText).toBeNull();
   });
 
-  it('overflow: full list >2000 chars triggers attachment + suppresses Show All', () => {
+  it('overflow: full list >2000 chars triggers attachment + suppresses Show Recipients', () => {
     // 200 long names ~= ~6kB inline; well over Discord's 2000-char cap.
     const successNames = Array.from({ length: 200 }, (_, i) => `verylongusername${String(i).padStart(4, '0')}`);
     const r = renderSendConfirm({ ...baseArgs, delivered: successNames.length, successNames, showAll: true });
@@ -1650,22 +1650,26 @@ describe('renderRevokeMsg', () => {
     expect(r.row).toBeNull();
   });
 
-  it('truncates with "+N more" + adds Show All button when count > TRUNC_LIMIT', () => {
+  it('truncates with "+N more" + adds Show Recipients button when count > TRUNC_LIMIT', () => {
     const names = Array.from({ length: REVOKE_TRUNC_LIMIT + 3 }, (_, i) => `u${i}`);
     const r = renderRevokeMsg('send-2', names, names.length, false);
     expect(r.content).toContain(`+${3} more`);
     expect(r.content).not.toContain(names.at(-1)); // last name truncated off
     expect(r.needsExpand).toBe(true);
     expect(r.row).not.toBeNull();
+    // Pin the renamed label so a regression that flips it back to the
+    // ambiguous "Show All" (which users misread as a permissions
+    // action next to "Revoke All") fails here.
+    expect(r.row.components[0].setLabel).toHaveBeenCalledWith('Show Recipients');
   });
 
-  it('shows full list + Show Less button when showAll=true', () => {
+  it('shows full list + Hide Recipients button when showAll=true', () => {
     const names = Array.from({ length: REVOKE_TRUNC_LIMIT + 2 }, (_, i) => `u${i}`);
     const r = renderRevokeMsg('send-3', names, names.length, true);
     expect(r.content).toContain(names.at(-1));
     expect(r.content).not.toMatch(/\+\d+ more/);
     expect(r.needsExpand).toBe(true);
-    expect(r.row.components[0].setLabel).toHaveBeenCalledWith('Show Less');
+    expect(r.row.components[0].setLabel).toHaveBeenCalledWith('Hide Recipients');
   });
 
   it('omits the names line when no successful revokes (e.g. all already-opened)', () => {
@@ -1686,7 +1690,7 @@ describe('renderRevokeMsg', () => {
     expect(r.content).not.toContain('already-opened');
   });
 
-  it('emits attachmentText + suppresses Show All when full list would exceed Discord 2000-char cap', () => {
+  it('emits attachmentText + suppresses Show Recipients when full list would exceed Discord 2000-char cap', () => {
     // 200 long usernames (~30 chars each) → ~6000 chars uncapped.
     const names = Array.from({ length: 200 }, (_, i) => `verylongusername${String(i).padStart(4, '0')}`);
     const r = renderRevokeMsg('send-cap', names, names.length, /* showAll */ true);
@@ -1696,7 +1700,7 @@ describe('renderRevokeMsg', () => {
     // Newline-separated full list — every name present.
     expect(r.attachmentText.split('\n')).toHaveLength(200);
     expect(r.attachmentText).toContain(names[199]);
-    // Show All button suppressed — file IS the full list.
+    // Show Recipients button suppressed — file IS the full list.
     expect(r.needsExpand).toBe(false);
     expect(r.row).toBeNull();
   });


### PR DESCRIPTION
## Summary

User feedback: *"The 'show all' button could be confusing and has given me pause before. ... Since it comes right after 'revoke all', I feel it implies that send all is giving permissions rather than showing recipients."*

The adjacency to **Revoke All** was the actual ambiguity — \"Show All\" parses as a permissions/visibility action (\"show qURL to all participants\") when read in sequence with the danger button. New labels make the action object explicit.

## Before / after

```
Before:  [Add Recipients] [Revoke All] [Show All]
After:   [Add Recipients] [Revoke All] [Show Recipients]

After click — before:  [Add Recipients] [Revoke All] [Show Less]
After click — after:   [Add Recipients] [Revoke All] [Hide Recipients]
```

## Scope

Renamed at three render sites for consistency across pre- and post-revoke surfaces:
- `executeSendPipeline` initial render
- `executeSendPipeline` post-click re-render
- `renderRevokeMsg` post-revoke list expansion

CustomIds (`qurl_expand_*`, `qurl_revoke_expand_*`) are unchanged — only the user-visible label moves. Dispatcher routing, flow_state TTL, and inflight-button-press handling are all keyed on the customId, so the rename has zero ripple effect on those surfaces.

## Test plan

- [x] Updated `renderRevokeMsg` label assertion (`Show Less` → `Hide Recipients`) + added a positive pin for `Show Recipients` so a future revert to the ambiguous label fails with a clear diff.
- [x] Updated 4 inline test-description strings to match the renamed button.
- [x] Full suite: 2383/2383 pass.
- [x] Lint clean.
- [ ] Live verification — send to >7 recipients (triggers the truncation/expand path) and confirm the button label reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)