### PR TITLE
fix(discord): enable @everyone button in http-only worker mode

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -4038,7 +4038,16 @@ function formatPersonalMessagePreview(message) {
 const everyoneCountMemo = new WeakMap();
 function computeEveryoneDisplayCount(guild) {
   const cache = guild?.members?.cache;
-  const memberCount = guild?.memberCount;
+  // discord.js Guild._patch only sets `memberCount` from the gateway
+  // GUILD_CREATE payload's `member_count` field. The REST
+  // `GET /guilds/:id?with_counts=true` returns `approximate_member_count`
+  // instead, which discord.js stores under a different property
+  // (`approximateMemberCount`). HTTP-only worker mode never sees a
+  // GUILD_CREATE, so `memberCount` stays undefined despite the
+  // event-consumer pre-fetch succeeding. Without this fallback every
+  // @everyone button render in http-tier hits the `displayCount-null`
+  // disable branch (CloudWatch warn-log evidence in sandbox).
+  const memberCount = guild?.memberCount ?? guild?.approximateMemberCount;
   if (cache && typeof cache.size === 'number' && memberCount != null && cache.size >= memberCount) {
     const fingerprint = `${cache.size}:${memberCount}`;
     const cached = everyoneCountMemo.get(guild);

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -7582,6 +7582,45 @@ describe('computeEveryoneDisplayCount', () => {
     expect(computeEveryoneDisplayCount(guild)).toEqual({ count: null, accurate: false });
   });
 
+  // discord.js Guild._patch sets `memberCount` ONLY from gateway
+  // GUILD_CREATE's `member_count`. The REST `?with_counts=true` shape
+  // returns `approximate_member_count`, stored as
+  // `approximateMemberCount`. HTTP-only worker mode has no gateway, so
+  // the pre-fetched guild has approximateMemberCount set but
+  // memberCount undefined — pre-fix, every http-tier @everyone button
+  // rendered disabled. CloudWatch sandbox evidence (2026-05-19):
+  // displayCount-null branch firing on every http-tier render.
+  test('http-tier shape (memberCount undefined + approximateMemberCount set) → falls back to approximate count', () => {
+    const guild = {
+      id: 'g-http-tier',
+      approximateMemberCount: 42,
+      members: { cache: new Map([['bot', { user: { id: 'bot', bot: true } }]]) },
+      // memberCount intentionally absent — mirrors what discord.js stores
+      // after client.guilds.fetch(id) when withCounts defaults to true.
+    };
+    _everyoneCountMemo.delete(guild);
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: 42, accurate: false });
+  });
+
+  test('memberCount wins over approximateMemberCount when both are set (gateway mode preserves precedence)', () => {
+    // Gateway mode populates `memberCount` from GUILD_CREATE; the REST
+    // pre-fetch path may have also fired earlier and set
+    // `approximateMemberCount`. The live gateway value is more
+    // current — pin precedence so a future refactor doesn't accidentally
+    // swap the fallback order.
+    const guild = {
+      id: 'g-both',
+      memberCount: 10,            // live (from gateway)
+      approximateMemberCount: 9,  // stale (from earlier REST fetch)
+      members: { cache: new Map([['u1', { user: { id: 'u1', bot: false } }]]) },
+    };
+    _everyoneCountMemo.delete(guild);
+    // Cold-cache branch (cache.size=1 < memberCount=10) returns the
+    // memberCount value with accurate=false. Pin that the count is 10
+    // (memberCount), not 9 (approximateMemberCount).
+    expect(computeEveryoneDisplayCount(guild)).toEqual({ count: 10, accurate: false });
+  });
+
   test('partial-cache row (no .user) does not inflate count', () => {
     // The `m?.user && !isBotMember(m)` guard aligns the render-time
     // count with the click-time partition filter — a degraded row


### PR DESCRIPTION
## Summary

User report: *"@everyone is disabled in the general channel while trying to send a qurl."* PR #451's diagnostic warn-log captured the actual state in sandbox CloudWatch on every http-tier render:

```
WARN: @everyone button rendered disabled
  branch:            displayCount-null
  guildMemberCount:  null
  cacheSize:         1 (just the bot)
  accurate:          false
```

## Root cause

discord.js's `Guild._patch` sets `guild.memberCount` ONLY from the gateway `GUILD_CREATE` payload's `member_count` field. The REST `GET /guilds/:id?with_counts=true` returns `approximate_member_count` instead, which discord.js stores under a different property (`guild.approximateMemberCount`).

The http-only worker tier never sees a `GUILD_CREATE` (no gateway connection), so `guild.memberCount` stays `undefined` even after the event-consumer.js pre-fetch succeeds — and `approximateMemberCount` IS populated by that pre-fetch but our code didn't read it.

`computeEveryoneDisplayCount` only consulted `memberCount`, so `displayCount` resolved to `null` on every http-tier render → button disabled.

## Fix

One-line fallback: `guild.memberCount ?? guild.approximateMemberCount`. Precedence preserved (memberCount wins when both are set — the live gateway value over the slightly-stale REST approximate).

## Test plan

- [x] **http-tier shape** (memberCount undefined + approximateMemberCount=42) → returns `{count: 42, accurate: false}`. Pins the fix.
- [x] **Both set** (gateway + REST both populated) → memberCount wins precedence. Pin against a future refactor swapping the fallback order.
- [x] Existing displayCount-null + over-cap tests still pass (mocks omit both fields when null state is intended).
- [x] Full suite: 2385/2385 pass.
- [x] Lint clean.
- [ ] **Live verification**: after deploy, run `/qurl send` in #general — the 📢 @everyone button should be enabled. The PR #451 diagnostic warn-log should stop firing on this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)