### PR TITLE
fix(slack,shared): mint-by-resource_id calls /v1/resources/{id}/qurls

### DIFF
--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -50,7 +50,7 @@ func writeAPIError(t *testing.T, w http.ResponseWriter, status int, code, title 
 func TestHandleGet_HappyPath(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -102,7 +102,7 @@ func TestHandleGet_AliasNotFound(t *testing.T) {
 func TestHandleGet_MintTunnelDisabled(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 		writeAPIError(t, w, http.StatusForbidden, "tunnel_disabled", "Forbidden")
 	})
 	h := newAdminTestHandler(t, ts)
@@ -119,7 +119,7 @@ func TestHandleGet_MintTunnelDisabled(t *testing.T) {
 func TestHandleGet_MintRateLimit(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Retry-After", "30")
 		writeAPIError(t, w, http.StatusTooManyRequests, "rate_limited", "Too Many Requests")
 	})
@@ -141,7 +141,7 @@ func TestHandleGet_MintRateLimit(t *testing.T) {
 func TestHandleGet_MintTransportError(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 		writeAPIError(t, w, http.StatusBadGateway, "upstream_error", "Bad Gateway")
 	})
 	h := newAdminTestHandler(t, ts)
@@ -293,7 +293,7 @@ func TestHandleGet_DMVariantRefusedWhenPostDMNil(t *testing.T) {
 func TestHandleGet_DMVariantPostDMSuccess(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 		writeCreateFixture(t, w, "https://qurl.link/dm-secret", testResourceIDFix)
 	})
 
@@ -353,15 +353,16 @@ func TestHumanizeRetry(t *testing.T) {
 	}
 }
 
-// TestCreateInputJSON_ResourceID fences the wire shape:
-// CreateInput{ResourceID: "r_x"} marshals without a target_url key
-// (mutually_exclusive_fields with the server). Captured by a
-// recording httptest server.
+// TestCreateInputJSON_ResourceID fences the wire shape for the
+// alias-form mint: the bot calls POST /v1/resources/{id}/qurls, the
+// resource id rides in the path, and the body carries neither
+// target_url nor resource_id (both repeat the path id and would
+// trip the server's exclusivity rules).
 func TestCreateInputJSON_ResourceID(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
 	var capturedBody []byte
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, r *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		capturedBody = b
 		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
@@ -376,21 +377,22 @@ func TestCreateInputJSON_ResourceID(t *testing.T) {
 		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
 	}
 	if _, ok := parsed["target_url"]; ok {
-		t.Errorf("target_url present on resource-id mint (mutually-exclusive): %v", parsed)
+		t.Errorf("target_url present on alias-form mint body (path-bound id, target_url is rejected): %v", parsed)
 	}
-	if got, _ := parsed["resource_id"].(string); got != testResourceIDFix {
-		t.Errorf("resource_id = %v, want r_prod_db", parsed["resource_id"])
+	if _, ok := parsed["resource_id"]; ok {
+		t.Errorf("resource_id present on alias-form mint body (rides in URL path): %v", parsed)
 	}
 }
 
 // TestCreateInputJSON_Reason fences the wire shape: reason flag
 // flows through to the JSON body when set, and is absent when
-// unset.
+// unset. Alias-form mint, so the path is the resource-scoped
+// endpoint.
 func TestCreateInputJSON_Reason(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
 	var capturedBody []byte
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, r *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		capturedBody = b
 		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
@@ -411,12 +413,13 @@ func TestCreateInputJSON_Reason(t *testing.T) {
 
 // TestCreateInputJSON_IdempotencyKeyHeader fences that the
 // Idempotency-Key header lands on the wire (not in the JSON body)
-// and is the sha256(team\x00channel\x00user\x00trigger).
+// and is the sha256(team\x00channel\x00user\x00trigger). Alias-form,
+// so the request lands at the resource-scoped endpoint.
 func TestCreateInputJSON_IdempotencyKeyHeader(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
 	var capturedHeader string
-	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, r *http.Request) {
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
 		capturedHeader = r.Header.Get("Idempotency-Key")
 		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
 	})
@@ -437,6 +440,8 @@ func TestCreateInputJSON_IdempotencyKeyHeader(t *testing.T) {
 // TestMapMintError_Unmapped5xx fences the catch-all transport-class
 // branch: 503 + 504 + bare network errors all surface
 // serviceUnreachableMessage and never the generic "Failed to mint".
+// Alias-form, so the upstream serves 5xx at the resource-scoped
+// endpoint.
 func TestMapMintError_Unmapped5xx(t *testing.T) {
 	statuses := []int{
 		http.StatusBadGateway,
@@ -446,7 +451,7 @@ func TestMapMintError_Unmapped5xx(t *testing.T) {
 	for _, s := range statuses {
 		ts := newAdminTestServers(t)
 		ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-		ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
+		ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 			writeAPIError(t, w, s, "upstream_error", "Upstream Error")
 		})
 		h := newAdminTestHandler(t, ts)

--- a/apps/slack/internal/handler_test_helpers_test.go
+++ b/apps/slack/internal/handler_test_helpers_test.go
@@ -12,14 +12,19 @@ import (
 // constants in tests because goconst would otherwise flag the 4+
 // duplications across fixture builders.
 const (
-	testKeyData         = "data"
-	testKeyError        = "error"
-	testKeyResourceID   = "resource_id"
-	testKeyTitle        = "title"
-	testResourceIDFix   = "r_prod_db" // canonical test resource_id
-	testCmdSlash        = "/qurl"
-	testCmdAdminClaim   = "admin claim"
-	testFieldCallbackID = "callback_id"
+	testKeyData       = "data"
+	testKeyError      = "error"
+	testKeyResourceID = "resource_id"
+	testKeyTitle      = "title"
+	testResourceIDFix = "r_prod_db" // canonical test resource_id
+	// mintByTestResourcePath is the resource-scoped mint endpoint
+	// that `client.Create` hits when given a ResourceID (alias-form
+	// /qurl get). Lifted so the alias-form tests register their
+	// httptest mock at the same path the bot actually calls.
+	mintByTestResourcePath = "/v1/resources/" + testResourceIDFix + "/qurls"
+	testCmdSlash           = "/qurl"
+	testCmdAdminClaim      = "admin claim"
+	testFieldCallbackID    = "callback_id"
 )
 
 // writeResourceFixtureWithTarget writes the resource envelope used

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -335,12 +335,18 @@ func validateIdempotencyKey(key string) error {
 
 // Create creates a new qURL.
 //
-// Exactly one of input.TargetURL or input.ResourceID must be set. The client
-// fails fast on both the both-empty and both-populated cases (saves a
-// round-trip and yields a Go-typed error rather than a deserialized
-// *APIError); the server-side `mutually_exclusive_fields` rule is the
-// enforcement of last resort. Empty fields elide from the wire payload via
-// `omitempty`, so a ResourceID-only call doesn't accidentally trip the rule.
+// Exactly one of input.TargetURL or input.ResourceID must be set. The
+// client routes to a different qURL service endpoint per case:
+//
+//   - TargetURL → POST /v1/qurls (CreateQurl). The handler accepts
+//     target_url in the request body and auto-creates the underlying
+//     resource if one doesn't already exist for that URL.
+//   - ResourceID → POST /v1/resources/{id}/qurls (CreateQurlForResource).
+//     The resource id rides in the URL path; the body is the policy
+//     subset (no target_url, no resource_id). The /v1/qurls handler
+//     does NOT accept resource_id in its body — a body-keyed call
+//     surfaces as 400 invalid_target_url because target_url is
+//     required for that endpoint.
 //
 // Note: Create takes a value receiver for backward-compat with the existing
 // callers in apps/slack and apps/cli; the new methods ([Client.CreateResource],
@@ -359,12 +365,38 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 		return nil, err
 	}
 
-	body, err := json.Marshal(input)
+	var (
+		endpoint string
+		logLabel string
+		body     []byte
+		err      error
+	)
+	if input.ResourceID != "" {
+		// /v1/resources/{id}/qurls — id rides in the path; the body
+		// drops target_url + resource_id and ships the policy subset.
+		// Reason ships in the body too (silently dropped by the server
+		// if not in its schema; harmless either way and matches the
+		// URL-form posture).
+		endpoint = c.baseURL + "/v1/resources/" + url.PathEscape(input.ResourceID) + "/qurls"
+		logLabel = "POST /v1/resources/:id/qurls"
+		body, err = json.Marshal(createForResourceBody{
+			Description:  input.Description,
+			ExpiresIn:    input.ExpiresIn,
+			OneTimeUse:   input.OneTimeUse,
+			MaxSessions:  input.MaxSessions,
+			AccessPolicy: input.AccessPolicy,
+			Reason:       input.Reason,
+		})
+	} else {
+		endpoint = c.baseURL + "/v1/qurls"
+		logLabel = "POST /v1/qurls"
+		body, err = json.Marshal(input)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("marshal create input: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/qurls", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -377,10 +409,24 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 	}
 
 	var out CreateOutput
-	if _, err := c.do(req, &out, "POST /v1/qurls"); err != nil {
+	if _, err := c.do(req, &out, logLabel); err != nil {
 		return nil, err
 	}
 	return &out, nil
+}
+
+// createForResourceBody is the wire shape for `POST
+// /v1/resources/{id}/qurls`. Mirrors the qURL service's
+// `CreateQurlForResourceRequest` schema (resource id rides in the URL
+// path, so it doesn't repeat in the body; target_url is absent for
+// the same reason — the resource already owns it).
+type createForResourceBody struct {
+	Description  string        `json:"description,omitempty"`
+	ExpiresIn    string        `json:"expires_in,omitempty"`
+	OneTimeUse   bool          `json:"one_time_use,omitempty"`
+	MaxSessions  int           `json:"max_sessions,omitempty"`
+	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+	Reason       string        `json:"reason,omitempty"`
 }
 
 // Get retrieves a qURL by ID.

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -859,12 +859,15 @@ func TestCreatePathIsPlural(t *testing.T) {
 }
 
 func TestCreateResourceIDFlow(t *testing.T) {
-	// When ResourceID is set and TargetURL is empty, the wire payload
-	// must contain `resource_id` and must NOT contain `target_url`.
-	// Server-side `mutually_exclusive_fields` rejects bodies that
-	// serialize an empty `target_url` alongside a `resource_id`.
+	// When ResourceID is set, Create hits the resource-scoped mint
+	// endpoint (POST /v1/resources/{id}/qurls). The id rides in the
+	// URL path, so the request body MUST NOT carry resource_id or
+	// target_url — qURL service's CreateQurlForResourceRequest schema
+	// has neither (the path identifies the resource).
+	var gotPath string
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
 		var err error
 		gotBody, err = io.ReadAll(r.Body)
 		if err != nil {
@@ -882,16 +885,18 @@ func TestCreateResourceIDFlow(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	// Decode into a generic map so omitempty behavior is observable.
+	if got, want := gotPath, "/v1/resources/"+testResourceID+"/qurls"; got != want {
+		t.Errorf("path: got %q, want %q", got, want)
+	}
 	var raw map[string]any
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v (body=%s)", err, gotBody)
 	}
-	if got := raw["resource_id"]; got != testResourceID {
-		t.Errorf("resource_id: got %v, want %q", got, testResourceID)
+	if _, ok := raw["resource_id"]; ok {
+		t.Errorf("resource_id must NOT appear in body (rides in URL path); body=%s", gotBody)
 	}
-	if _, hasTargetURL := raw["target_url"]; hasTargetURL {
-		t.Errorf("target_url must be omitted when empty (server-side mutually_exclusive_fields rule); body=%s", gotBody)
+	if _, ok := raw["target_url"]; ok {
+		t.Errorf("target_url must NOT appear in body on resource-scoped mint; body=%s", gotBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

`client.Create` was hitting the wrong qURL service endpoint when given a `ResourceID`. The bot was sending `{resource_id: r_…}` to `POST /v1/qurls`, but that endpoint's `CreateQurlRequest` schema only accepts `target_url`. The service silently dropped the unknown `resource_id` field, then rejected the request with **400 invalid_target_url** because `target_url` was empty — which the slack bot mapped to the generic "Failed to mint qURL. Please try again."

This was a latent bug. Pre-#447, the alias resolution path always 404'd at `GetResourceByAlias` (admins write aliases via `setalias` → DDB, but the customer API never saw them), so the bot never reached this mint call. #447 made alias resolution actually succeed via DDB lookup, which is now exposing the wrong-endpoint bug downstream.

## Fix

Route `ResourceID`-only `Create` calls to `POST /v1/resources/{id}/qurls` (the resource-scoped mint endpoint, where the id rides in the URL path and the body is the policy subset). URL-form mints (`POST /v1/qurls` with `target_url` in body) are unchanged.

## Test plan

- [x] `go test ./shared/client/... ./apps/slack/...` clean
- [x] `golangci-lint run --new-from-rev=origin/main` clean (0 new issues)
- [x] `pre-commit run --files …` clean
- [x] Updated assertions:
  - `TestCreateResourceIDFlow` now asserts the path is `/v1/resources/{id}/qurls` and the body has neither `resource_id` nor `target_url`
  - Slack alias-form tests register their mocks at the new `mintByTestResourcePath` constant
  - URL-form tests still register at `/v1/qurls`
- [ ] Manual sandbox verification after redeploy: `/qurl-sandbox setalias $demo r_…` then `/qurl-sandbox get $demo` → minted (was the failure path repro'd from Kevin's screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)