### PR TITLE
fix(discord): clear cooldown on cancel so user can immediately retry

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -502,11 +502,6 @@ function setCooldown(userId) {
   // LRU-ish behavior: delete first so set() re-inserts at the end of the
   // Map's insertion order. Combined with the bulk 10%-drop eviction below,
   // active users stay resident while stale entries roll out.
-  //
-  // CAUTION: softenCooldown (below) rides on the same insertion-order
-  // contract — if the eviction strategy ever changes (priority-based,
-  // TTL-based, etc.), softenCooldown's iteration-order test will fail
-  // loudly and both helpers will need rethinking together.
   sendCooldowns.delete(userId);
   sendCooldowns.set(userId, Date.now());
   if (sendCooldowns.size > 10000) {
@@ -529,26 +524,6 @@ function setCooldown(userId) {
 
 function clearCooldown(userId) {
   sendCooldowns.delete(userId);
-}
-
-// Soften an existing cooldown so `residualMs` remain. Monotonic SHRINK
-// — only reduces remaining time, never extends. Used by Cancel paths
-// so a legitimate "I changed my mind" doesn't lock the full window
-// out, but rapid /qurl send → Cancel → /qurl send → Cancel spam still
-// pays a small throttle on each iteration (preventing supersedeOrCreate
-// + interaction-reply abuse).
-function softenCooldown(userId, residualMs) {
-  if (!sendCooldowns.has(userId)) return;
-  const target = Date.now() - Math.max(0, config.QURL_SEND_COOLDOWN_MS - residualMs);
-  const existing = sendCooldowns.get(userId);
-  if (target < existing) {
-    // delete-then-set re-inserts at the end of Map iteration order so
-    // the bulk eviction in setCooldown (line ~248) preserves active
-    // users. Matches the same LRU pattern setCooldown uses; a bare
-    // `set` on an existing key would NOT re-order.
-    sendCooldowns.delete(userId);
-    sendCooldowns.set(userId, target);
-  }
 }
 
 async function batchSettled(items, fn, batchSize = 5) {
@@ -3369,12 +3344,6 @@ const SEND_NOTE_MODAL_FIELD_ID = 'message_value';
 // to review the confirm card and click Send/Cancel after invoking
 // /qurl send or /qurl map.
 const SEND_FLOW_TTL_SECONDS = 180;
-
-// On a successful Cancel, soften (don't clear) the cooldown so 5s of
-// throttle remain — defuses the rapid /qurl send → Cancel → /qurl send
-// → Cancel spam vector (which would otherwise rack up supersedeOrCreate
-// DDB writes with zero throttle).
-const CANCEL_SOFTEN_RESIDUAL_MS = 5000;
 
 // Subcommands that require the guild API key resolution + cooldown gate.
 // Single-source allowlist: adding a new send-style subcommand only
@@ -6883,12 +6852,16 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
 //     surfaces that as the dedup-loser path (user re-clicks Cancel on
 //     the new row if they still want to abort).
 //
-// On a successful Cancel, `softenCooldown` retains 5s of throttle
-// instead of fully clearing — a full clear would let a user spam
-// /qurl send → Cancel → /qurl send → Cancel and rack up
-// supersedeOrCreate DDB writes + Discord interactions with zero
-// throttle. The cooldown-loser branch leaves cooldown untouched
-// (Send is mid-fanout; bypassing is the abuse vector).
+// On a successful Cancel, the cooldown is CLEARED so a user who hits
+// "wrong file, retry" doesn't run into a "Please wait before sending
+// again" message on their next /qurl send. The cancel-loser branch
+// (deleted=false) leaves cooldown untouched — Send won the race and is
+// mid-fanout; bypassing it is the abuse vector. Earlier versions used
+// a 5s-residual "soften" to defend against /send→Cancel→/send spam,
+// but the rapid-cancel-spam scenario is bounded by Discord's own
+// slash-command rate limiting AND requires a deliberate human click
+// loop; the UX cost of false-positive blocks on legitimate retries
+// outweighed the abuse defense.
 async function handleConfirmCancelClick(interaction, { flow_id, row }) {
   // Defer-ack within the 3s window. The single deleteFlow call below
   // is fast in the happy path, but a DDB blip or slow region could
@@ -6928,7 +6901,7 @@ async function handleConfirmCancelClick(interaction, { flow_id, row }) {
       ephemeral: true,
     }).catch(logIgnoredDiscordErr);
   }
-  softenCooldown(interaction.user.id, CANCEL_SOFTEN_RESIDUAL_MS);
+  clearCooldown(interaction.user.id);
   return interaction.editReply({
     content: 'Send cancelled.',
     components: [],
@@ -8919,7 +8892,6 @@ module.exports = {
       _resetAutocompleteFailureBurst: () => { autocompleteFailureBurst = 0; },
       AUTOCOMPLETE_FAILURE_LOG_BURST,
       safeDecodeURIComponent,
-      softenCooldown,
       SEND_STAGE_AWAITING_CONFIRM,
       // Every confirm-card customId is exported so the contract test
       // in qurl-send-map.test.js can pin every wire value — a typo

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -6857,9 +6857,9 @@ async function handleConfirmSendClick(interaction, { flow_id, row }) {
 // again" message on their next /qurl send. The cancel-loser branch
 // (deleted=false) leaves cooldown untouched — Send won the race and is
 // mid-fanout; bypassing it is the abuse vector. Earlier versions used
-// a 5s-residual "soften" to defend against /send→Cancel→/send spam,
-// but the rapid-cancel-spam scenario is bounded by Discord's own
-// slash-command rate limiting AND requires a deliberate human click
+// a 5s-residual "soften" to defend against /qurl send → Cancel → /qurl
+// send spam, but the rapid-cancel-spam scenario is bounded by Discord's
+// own slash-command rate limiting AND requires a deliberate human click
 // loop; the UX cost of false-positive blocks on legitimate retries
 // outweighed the abuse defense.
 async function handleConfirmCancelClick(interaction, { flow_id, row }) {

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -195,7 +195,6 @@ const {
   _resetAutocompleteFailureBurst,
   AUTOCOMPLETE_FAILURE_LOG_BURST,
   safeDecodeURIComponent,
-  softenCooldown,
   SEND_STAGE_AWAITING_CONFIRM,
   CONFIRM_USER_SELECT_CUSTOM_ID,
   CONFIRM_SEND_CUSTOM_ID,
@@ -1151,61 +1150,19 @@ describe('resolveRoleNames (#326 helper)', () => {
   });
 });
 
-describe('softenCooldown', () => {
-  // Cancel-path helper: leave `residualMs` of cooldown remaining,
-  // monotonically SHRINK (never extend). Tests use the real
-  // QURL_SEND_COOLDOWN_MS via config (mocked in the test setup).
-  const config = require('../src/config');
-  const COOLDOWN_MS = config.QURL_SEND_COOLDOWN_MS;
-
+describe('clearCooldown', () => {
   beforeEach(() => sendCooldowns.clear());
 
-  test('no-op when no cooldown is set', () => {
-    softenCooldown('u1', 5000);
-    expect(sendCooldowns.has('u1')).toBe(false);
-  });
-
-  test('softens a fresh cooldown so ~5s remain', () => {
-    const now = Date.now();
-    sendCooldowns.set('u1', now);
-    softenCooldown('u1', 5000);
-    expect(sendCooldowns.has('u1')).toBe(true);
-    // Resulting `last` should be approximately now - (COOLDOWN - 5000)
-    // so remaining time is 5000ms.
-    const last = sendCooldowns.get('u1');
-    expect(last).toBeLessThanOrEqual(now - (COOLDOWN_MS - 5000) + 5);
-    expect(last).toBeGreaterThanOrEqual(now - (COOLDOWN_MS - 5000) - 5);
-  });
-
-  test('does NOT extend an already-short remaining cooldown', () => {
-    // existing `last` is older than the soften target → remaining is
-    // already less than 5s. Soften must NOT bump it back up.
-    const ancient = Date.now() - (COOLDOWN_MS - 1000);  // 1s remaining
-    sendCooldowns.set('u1', ancient);
-    softenCooldown('u1', 5000);
-    expect(sendCooldowns.get('u1')).toBe(ancient);
-  });
-
-  test('residualMs=0 effectively clears (last pushed far enough back that remaining=0)', () => {
+  test('removes the cooldown entry entirely', () => {
     sendCooldowns.set('u1', Date.now());
-    softenCooldown('u1', 0);
+    clearCooldown('u1');
+    expect(sendCooldowns.has('u1')).toBe(false);
     expect(isOnCooldown('u1')).toBe(false);
   });
 
-  test('soften reorders the Map: softened entry moves to the end of iteration order', () => {
-    // LRU iteration contract: setCooldown's bulk eviction (commands.js:~248)
-    // drops the oldest N keys in iteration order. softenCooldown deletes-
-    // then-sets so a soften refreshes the user's iteration position to
-    // the end, keeping them resident through bulk evictions. Without
-    // this, a Cancel-then-Cancel sequence would still drop the active
-    // user during the next eviction wave.
-    sendCooldowns.set('uA', Date.now());
-    sendCooldowns.set('uB', Date.now());
-    sendCooldowns.set('uC', Date.now());
-    // Initial iteration order: A, B, C.
-    softenCooldown('uA', 5000);
-    // After softening A, iteration order should be: B, C, A.
-    expect(Array.from(sendCooldowns.keys())).toEqual(['uB', 'uC', 'uA']);
+  test('no-op when no cooldown is set', () => {
+    clearCooldown('u1');
+    expect(sendCooldowns.has('u1')).toBe(false);
   });
 });
 
@@ -4176,40 +4133,37 @@ describe('handleConfirmSendClick', () => {
 // ──────────────────────────────────────────────────────────────
 
 describe('handleConfirmCancelClick', () => {
-  test('happy path → version-gated deleteFlow + cooldown softened to ~5s residual + update', async () => {
-    // softenCooldown leaves 5s of throttle so a user can't spam
-    // /qurl send → Cancel → /qurl send → Cancel and rack up
-    // supersedeOrCreate DDB writes with zero cost. A legitimate
-    // "I changed my mind" still has the cooldown softened from full
-    // QURL_SEND_COOLDOWN_MS down to 5s.
+  test('happy path → version-gated deleteFlow + cooldown CLEARED + update', async () => {
+    // A user who cancels a send and immediately retries should not see
+    // "Please wait before sending again." — the cooldown is meant to
+    // throttle rapid resends of a completed send, not penalize a
+    // user who changed their mind. The earlier soften-to-5s-residual
+    // behavior generated user-reported false-positive blocks; the
+    // abuse-defense it was guarding against is bounded by Discord's
+    // own slash-command rate limiting (the user has to click between
+    // each iteration).
     const int = makeInteraction();
-    const cooldownStart = Date.now();
-    sendCooldowns.set(SENDER_ID, cooldownStart);
+    sendCooldowns.set(SENDER_ID, Date.now());
     await handleConfirmCancelClick(int, { flow_id: 'fid', row: { version: 3 } });
     expect(mockDeleteFlow).toHaveBeenCalledWith('fid', expect.objectContaining({
       stage: SEND_STAGE_AWAITING_CONFIRM,
       reason: 'terminal',
       expectedVersion: 3,
     }));
-    // Cooldown ENTRY still exists (not deleted) — softening pushes
-    // `last` to a value that leaves ~5s remaining. isOnCooldown is
-    // therefore still true (within the 5s residual window).
-    expect(sendCooldowns.has(SENDER_ID)).toBe(true);
-    expect(isOnCooldown(SENDER_ID)).toBe(true);
-    // The new `last` should be older than the original cooldownStart
-    // (softening pushed it back so remaining time is now ~5s).
-    expect(sendCooldowns.get(SENDER_ID)).toBeLessThan(cooldownStart);
+    // Cooldown entry is fully removed — user can immediately retry.
+    expect(sendCooldowns.has(SENDER_ID)).toBe(false);
+    expect(isOnCooldown(SENDER_ID)).toBe(false);
     expect(int.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringMatching(/cancelled/),
     }));
   });
 
-  test('deleteFlow dedup loser → ephemeral message + cooldown PRESERVED (no soften)', async () => {
+  test('deleteFlow dedup loser → ephemeral message + cooldown PRESERVED (no clear)', async () => {
     // Critical: when Send won the race, we must NOT touch the cooldown
-    // — Send is fanning out DMs and a soften would let the user
-    // re-fire /qurl send within 5s of clicking Cancel, before the
-    // first send finishes. The Cancel-loser branch leaves the
-    // original cooldown timestamp intact (no softening).
+    // — Send is fanning out DMs and clearing would let the user
+    // re-fire /qurl send before the first send finishes. The
+    // Cancel-loser branch leaves the original cooldown timestamp
+    // intact.
     mockDeleteFlow.mockResolvedValueOnce({ deleted: false });
     const cooldownAt = Date.now();
     sendCooldowns.set(SENDER_ID, cooldownAt);
@@ -4220,7 +4174,7 @@ describe('handleConfirmCancelClick', () => {
       ephemeral: true,
     }));
     // Cooldown is exactly as the test set it — Cancel-loser must not
-    // soften OR clear it.
+    // touch it (Send is mid-fanout; original throttle stays).
     expect(isOnCooldown(SENDER_ID)).toBe(true);
     expect(sendCooldowns.get(SENDER_ID)).toBe(cooldownAt);
   });

--- a/apps/discord/tests/qurl-send-map.test.js
+++ b/apps/discord/tests/qurl-send-map.test.js
@@ -1166,6 +1166,28 @@ describe('clearCooldown', () => {
   });
 });
 
+describe('setCooldown LRU iteration order', () => {
+  // setCooldown's bulk eviction (commands.js:~510) drops the oldest N
+  // keys in Map iteration order, which JS preserves as insertion order.
+  // setCooldown delete-then-sets on every call so a re-touched user
+  // moves to the end of iteration and survives evictions. This used
+  // to be pinned indirectly via the now-removed `softenCooldown
+  // reorders the Map` test; explicit standalone pin so a future
+  // refactor (e.g., bare `set` on an existing key) doesn't silently
+  // break the LRU contract.
+  beforeEach(() => sendCooldowns.clear());
+
+  test('re-setting an existing key moves it to the end of iteration order', () => {
+    setCooldown('uA');
+    setCooldown('uB');
+    setCooldown('uC');
+    expect(Array.from(sendCooldowns.keys())).toEqual(['uA', 'uB', 'uC']);
+    // Re-touch uA → it should move to the end.
+    setCooldown('uA');
+    expect(Array.from(sendCooldowns.keys())).toEqual(['uB', 'uC', 'uA']);
+  });
+});
+
 describe('parseLocationInput', () => {
   test('Google Maps short URL passes through verbatim', () => {
     const r = parseLocationInput('https://goo.gl/maps/abc123');


### PR DESCRIPTION
## Why

User reported: \"if I start a \`/qurl send\`, cancel it, then immediately try to send again, it says 'Please wait before sending again.' That should not happen.\"

The repro is a routine \"wrong file, retry\" flow — exactly the kind of thing that should NOT trigger a throttle message.

## Root cause

\`handleConfirmCancelClick\` was calling \`softenCooldown(userId, 5000)\`, which leaves a 5-second residual throttle after cancel. The 5s window was designed as an abuse defense against rapid \`/qurl send → Cancel → /qurl send → Cancel\` spam. In practice:

- That spam vector requires a deliberate human click loop (user clicks slash command, sees confirm card, clicks Cancel, repeats).
- Discord's own slash-command rate limiting (~5/sec per user) caps the iteration rate regardless of our cooldown.
- The UX cost — false-positive throttle on every legitimate cancel-retry — was inflicted on every user every time, while the abuse case was theoretical.

## Fix

Replace \`softenCooldown\` with \`clearCooldown\` on the happy Cancel path. The cancel-loser branch (Send won the race, \`deleted=false\`) still preserves the cooldown — Send is mid-fanout, and clearing would let the user re-fire before the first send completes. That race-condition defense stays.

## Cross-command scope

\`sendCooldowns\` is a single Map keyed on user ID, shared between \`/qurl send\` and \`/qurl map\`. The cleared-on-cancel behavior applies transitively: a user who starts \`/qurl send\`, cancels, then immediately runs \`/qurl map\` is also unthrottled. Intended — a cancel is a cancel regardless of which entry point started the flow.

## Code removed (dead after this change)

- \`softenCooldown\` helper function (~20 lines + doc-comment)
- \`CANCEL_SOFTEN_RESIDUAL_MS\` constant
- \`softenCooldown\` from the \`_test\` exports block
- \`describe('softenCooldown', ...)\` test block (5 unit tests on the helper)
- The \`CAUTION: softenCooldown rides on the same insertion-order contract\` comment in \`setCooldown\`

Replaced with:
- A small \`describe('clearCooldown', ...)\` block (2 tests pinning entry-removal + no-op semantics).
- A standalone \`describe('setCooldown LRU iteration order', ...)\` test that pins the delete-then-set re-insertion behavior. The LRU contract still matters for setCooldown's bulk-eviction wave; previously it was pinned only indirectly via the now-removed soften test.
- The Cancel-handler happy-path test now asserts the cooldown is fully cleared instead of softened.

## Test

- All 2382 unit tests pass; lint clean.
- Cancel-handler test suite still covers: happy clear, dedup-loser preservation, throw-path preservation, version fencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)