### PR TITLE
feat(discord): qurl.accessed webhook receiver + restore view counter UI

### DIFF
--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -1,0 +1,93 @@
+# qURL webhook rollout — operator runbook
+
+Powers the `👀 N viewed / M pending` counter on `/qurl send` + `/qurl map`
+confirmation messages. The counter was stripped in
+[`qurl-integrations#455`](https://github.com/layervai/qurl-integrations/pull/455)
+because the upstream polling approach broke when `qurl-service` started
+stripping the `qurls` array from `GET /v1/qurls/:id` responses for
+type=transit resources (every Discord bot send is transit).
+
+This rollout replaces the poll with a `qurl.accessed` webhook receiver.
+
+## Rollout order
+
+Each step blocks the next — do not skip ahead.
+
+1. **`qurl-views` DDB table.** Terraform-managed in
+   `qurl-integrations-infra/qurl-bot-discord/terraform`. Without it, the
+   bot's monitor `BatchGet` returns the empty map and the counter
+   silently stays at `0 viewed / N pending` forever. Confirm with:
+   ```
+   aws dynamodb describe-table \
+     --table-name <DDB_TABLE_PREFIX>qurl-views \
+     --region <env-region>
+   ```
+2. **Deploy the bot.** Code mounts `/webhooks/qurl` unconditionally and
+   warns on boot if `QURL_WEBHOOK_SECRET` is unset — that's the operator
+   signal that step 3 hasn't happened yet.
+3. **Set the SSM secret.**
+   ```
+   aws ssm put-parameter \
+     --name "/<project>/QURL_WEBHOOK_SECRET" \
+     --type SecureString \
+     --value "$(openssl rand -hex 32)" \
+     --overwrite \
+     --region <env-region>
+   ```
+   Then restart the task so the secret is picked up:
+   ```
+   aws ecs update-service --service <svc> --force-new-deployment ...
+   ```
+4. **Register the subscription with qurl-service.** The subscription's
+   `secret` field MUST be the same hex string as step 3 — the bot's
+   verifySignature pins bare-hex HMAC-SHA256 over the raw body.
+   ```
+   curl -X POST https://<qurl-service-host>/v1/webhooks \
+     -H 'Authorization: Bearer <qurl-service-admin-token>' \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "url": "https://<bot-host>/webhooks/qurl",
+       "event_types": ["qurl.accessed"],
+       "secret": "<same-hex-as-step-3>"
+     }'
+   ```
+
+## Wire shape (pinned)
+
+- Header: `QURL-Signature` = bare-hex HMAC-SHA256 over the raw body.
+  No `sha256=` prefix — that's the GitHub wire shape, NOT this one.
+- Body: `{event, event_id, data:{qurl_id, resource_id, access_count, consumed}}`
+- `src_ip` + `user_agent` are stripped server-side for type=transit
+  resources (the connector-owned privacy boundary). Discord bot sends
+  are always transit; we don't read those fields.
+
+## Failure modes
+
+- **Bot starts, but no secret set.** Boot log emits `QURL_WEBHOOK_SECRET
+  unset — qURL webhook receiver mounted but will reject all inbound
+  traffic with 503`. The view counter renders `0 viewed / N pending`
+  on every send (the monitor's `BatchGet` returns the default empty
+  map). Recover via step 3 above.
+- **Secret rotates without restarting qurl-service subscription.**
+  All inbound webhooks return 401 (signature mismatch). The bot's
+  per-IP `BAD_SIG_MAX=30` rate limit kicks in after 30 attempts and
+  switches to 429. Recover by updating the subscription's `secret`
+  field (PATCH the subscription).
+- **`qurl-views` table missing.** The bot's monitor `BatchGet` throws
+  `ResourceNotFoundException`. The setInterval's try/catch swallows
+  it and logs `Link monitor poll failed` — the counter sticks at
+  `0 viewed / N pending`. Recover by applying the terraform.
+- **Some links missing `qurl_id`.** Upstream connector pre `qurl-s3-connector#747`
+  doesn't surface `qurl_id` from `MintLink`. The bot's empty-`qurlId`
+  boundary guard degrades the WHOLE monitor to the bare base message
+  (no `👀` line at all) and emits one WARN per affected send. Recover
+  by deploying the connector forward.
+
+## What the bot does NOT need
+
+- A webhook auto-registration handshake — subscriptions are managed
+  out-of-band (curl above). Adding an admin slash command for this is
+  out of scope.
+- The full `qurl.accessed` payload's `src_ip` / `user_agent` fields —
+  they're stripped for transit resources at the qurl-service boundary,
+  per the connector-owned redaction policy.

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -13,10 +13,10 @@ This rollout replaces the poll with a `qurl.accessed` webhook receiver.
 
 Each step blocks the next — do not skip ahead.
 
-1. **`qurl-views` DDB table.** Terraform-managed in
-   `qurl-integrations-infra/qurl-bot-discord/terraform`. Without it, the
-   bot's monitor `BatchGet` returns the empty map and the counter
-   silently stays at `0 viewed / N pending` forever. Confirm with:
+1. **`qurl-views` DDB table.** Provisioned by the deploying organization's
+   infrastructure (separate from this repo). Without it, the bot's
+   monitor `BatchGet` returns the empty map and the counter silently
+   stays at `0 viewed / N pending` forever. Confirm with:
    ```
    aws dynamodb describe-table \
      --table-name <DDB_TABLE_PREFIX>qurl-views \
@@ -57,10 +57,11 @@ Each step blocks the next — do not skip ahead.
 - Header: `QURL-Signature` = bare-hex HMAC-SHA256 over the raw body.
   No `sha256=` prefix — that's the GitHub wire shape, NOT this one.
 - Body: `{id, type, data:{qurl_id, resource_id, access_count, consumed}, owner_id, timestamp, api_version}`
-  (peer is `qurl-service:internal/domain/webhook.go::WebhookEvent`).
-  Field names matter: `type` is the event type, `id` is the per-event
-  replay key. Receiver does NOT accept `event` / `event_id` as
-  synonyms — see the regression test in `tests/qurl-webhook.test.js`.
+  (peer is qurl-service's `WebhookEvent` payload shape per its
+  published API contract). Field names matter: `type` is the event
+  type, `id` is the per-event replay key. Receiver does NOT accept
+  `event` / `event_id` as synonyms — see the regression test in
+  `tests/qurl-webhook.test.js`.
 - `src_ip` + `user_agent` are stripped server-side for type=transit
   resources (the connector-owned privacy boundary). Discord bot sends
   are always transit; we don't read those fields.
@@ -92,11 +93,11 @@ Each step blocks the next — do not skip ahead.
   `ResourceNotFoundException`. The setInterval's try/catch swallows
   it and logs `Link monitor poll failed` — the counter sticks at
   `0 viewed / N pending`. Recover by applying the terraform.
-- **Some links missing `qurl_id`.** Upstream connector pre `qurl-s3-connector#747`
-  doesn't surface `qurl_id` from `MintLink`. The bot's empty-`qurlId`
-  boundary guard degrades the WHOLE monitor to the bare base message
-  (no `👀` line at all) and emits one WARN per affected send. Recover
-  by deploying the connector forward.
+- **Some links missing `qurl_id`.** Connector running an older
+  version (before `qurl_id` was surfaced from `MintLink`) — the bot's
+  empty-`qurlId` boundary guard degrades the WHOLE monitor to the
+  bare base message (no `👀` line at all) and emits one WARN per
+  affected send. Recover by deploying the connector forward.
 
 ## Known operator-burden tradeoffs
 

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -56,7 +56,11 @@ Each step blocks the next — do not skip ahead.
 
 - Header: `QURL-Signature` = bare-hex HMAC-SHA256 over the raw body.
   No `sha256=` prefix — that's the GitHub wire shape, NOT this one.
-- Body: `{event, event_id, data:{qurl_id, resource_id, access_count, consumed}}`
+- Body: `{id, type, data:{qurl_id, resource_id, access_count, consumed}, owner_id, timestamp, api_version}`
+  (peer is `qurl-service:internal/domain/webhook.go::WebhookEvent`).
+  Field names matter: `type` is the event type, `id` is the per-event
+  replay key. Receiver does NOT accept `event` / `event_id` as
+  synonyms — see the regression test in `tests/qurl-webhook.test.js`.
 - `src_ip` + `user_agent` are stripped server-side for type=transit
   resources (the connector-owned privacy boundary). Discord bot sends
   are always transit; we don't read those fields.
@@ -83,11 +87,23 @@ Each step blocks the next — do not skip ahead.
   (no `👀` line at all) and emits one WARN per affected send. Recover
   by deploying the connector forward.
 
+## Known operator-burden tradeoffs
+
+- **Secret coupled in two places.** Step 3's SSM value and step 4's
+  subscription `secret` field must match by hand; rotation is a
+  coordinated edit, not a single command. Auto-register-at-boot
+  (bot POSTs the subscription on startup with the same value it
+  read from SSM) would collapse this to one source of truth —
+  deferred because giving the bot a qurl-service admin token
+  widens the bot's blast radius beyond the per-guild `QURL_API_KEY`
+  it has today. Revisit when the admin-token surface has tighter
+  scoping (per-subscription instead of org-wide).
+
 ## What the bot does NOT need
 
 - A webhook auto-registration handshake — subscriptions are managed
-  out-of-band (curl above). Adding an admin slash command for this is
-  out of scope.
+  out-of-band (curl above). See "operator-burden tradeoffs" for
+  why this isn't automated today.
 - The full `qurl.accessed` payload's `src_ip` / `user_agent` fields —
   they're stripped for transit resources at the qurl-service boundary,
   per the connector-owned redaction policy.

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -82,6 +82,12 @@ Each step blocks the next — do not skip ahead.
   Operators rotating in production should pre-stage both the SSM
   update and the subscription PATCH so the failed-sig window is as
   narrow as possible.
+  - **Paging note**: a >10-min rotation gap will fire both alarms
+    in sequence — `qurl-bot-discord-qurl-webhook-signature-invalid`
+    at ~5min, then `…-rate-limited` at ~10min — with the same root
+    cause. If `signature_invalid` already paged for the same time
+    window, ack `rate_limited` as the tail of that incident; do not
+    treat it as a new event.
 - **`qurl-views` table missing.** The bot's monitor `BatchGet` throws
   `ResourceNotFoundException`. The setInterval's try/catch swallows
   it and logs `Link monitor poll failed` — the counter sticks at

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -76,7 +76,12 @@ Each step blocks the next — do not skip ahead.
   All inbound webhooks return 401 (signature mismatch). The bot's
   per-IP `BAD_SIG_MAX=30` rate limit kicks in after 30 attempts and
   switches to 429. Recover by updating the subscription's `secret`
-  field (PATCH the subscription).
+  field (PATCH the subscription) — but if the lockout already
+  triggered, expect a **~1 min blackout** before legit traffic
+  unsticks (the rate-limit window is 60s from the last failed sig).
+  Operators rotating in production should pre-stage both the SSM
+  update and the subscription PATCH so the failed-sig window is as
+  narrow as possible.
 - **`qurl-views` table missing.** The bot's monitor `BatchGet` throws
   `ResourceNotFoundException`. The setInterval's try/catch swallows
   it and logs `Link monitor poll failed` — the counter sticks at

--- a/apps/discord/scripts/provision-ddb-local.js
+++ b/apps/discord/scripts/provision-ddb-local.js
@@ -232,10 +232,12 @@ const tables = [
   {
     // Webhook-fed view counter; multi-instance bridge between the
     // /webhooks/qurl receiver and the per-send monitor. No GSI —
-    // read path is BatchGet by qurlLinks set.
+    // read path is BatchGet by qurlLinks set. 30d TTL on `expires_at`
+    // (canonical attribute name) refreshed on every webhook write.
     name: 'qurl-views',
     keySchema: [{ AttributeName: 'qurl_id', KeyType: 'HASH' }],
     attributes: [{ AttributeName: 'qurl_id', AttributeType: 'S' }],
+    ttlAttribute: 'expires_at',
   },
   {
     name: 'orphaned-oauth-tokens',

--- a/apps/discord/scripts/provision-ddb-local.js
+++ b/apps/discord/scripts/provision-ddb-local.js
@@ -230,12 +230,9 @@ const tables = [
     attributes: [{ AttributeName: 'send_id', AttributeType: 'S' }],
   },
   {
-    // Webhook-fed view counter for /qurl send + /qurl map. Populated by
-    // the qurl.accessed webhook receiver via conditional MAX-merge
-    // update; read by the live monitor's setInterval as the
-    // multi-instance bridge (a webhook lands on instance A while the
-    // originating monitor runs on instance B). No GSI — read path is
-    // always BatchGet by the in-memory qurlLinks set.
+    // Webhook-fed view counter; multi-instance bridge between the
+    // /webhooks/qurl receiver and the per-send monitor. No GSI —
+    // read path is BatchGet by qurlLinks set.
     name: 'qurl-views',
     keySchema: [{ AttributeName: 'qurl_id', KeyType: 'HASH' }],
     attributes: [{ AttributeName: 'qurl_id', AttributeType: 'S' }],

--- a/apps/discord/scripts/provision-ddb-local.js
+++ b/apps/discord/scripts/provision-ddb-local.js
@@ -230,6 +230,17 @@ const tables = [
     attributes: [{ AttributeName: 'send_id', AttributeType: 'S' }],
   },
   {
+    // Webhook-fed view counter for /qurl send + /qurl map. Populated by
+    // the qurl.accessed webhook receiver via conditional MAX-merge
+    // update; read by the live monitor's setInterval as the
+    // multi-instance bridge (a webhook lands on instance A while the
+    // originating monitor runs on instance B). No GSI — read path is
+    // always BatchGet by the in-memory qurlLinks set.
+    name: 'qurl-views',
+    keySchema: [{ AttributeName: 'qurl_id', KeyType: 'HASH' }],
+    attributes: [{ AttributeName: 'qurl_id', AttributeType: 'S' }],
+  },
+  {
     name: 'orphaned-oauth-tokens',
     keySchema: [{ AttributeName: 'token_hash', KeyType: 'HASH' }],
     attributes: [{ AttributeName: 'token_hash', AttributeType: 'S' }],

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1169,7 +1169,17 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       if (Array.isArray(newLinks)) {
         for (const item of newLinks) {
           const qid = item && item.qurlId;
-          if (!qid) { viewCounterDegraded = true; continue; }
+          if (!qid) {
+            // Mirror the construction-time warn — an operator chasing
+            // "why is the counter blank?" needs a breadcrumb when the
+            // degraded flip happens mid-life via /qurl add, not just
+            // at the original send.
+            if (!viewCounterDegraded) {
+              logger.warn('Monitor view counter degraded mid-life — addRecipients link missing qurl_id', { sendId });
+            }
+            viewCounterDegraded = true;
+            continue;
+          }
           if (!trackedQurlIds.has(qid)) {
             trackedQurlIds.add(qid);
             linkStatus.set(qid, { status: 'pending', username: item.username || 'unknown' });
@@ -1311,6 +1321,18 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       }
       if (changed) {
         const pending = Math.max(0, expectedCount - viewed);
+        // Render-order analysis: two concurrent ticks both reaching
+        // this branch is bounded by the `=== 'opened' continue` guard
+        // at the flip site. A slower tick whose snapshot pre-dates a
+        // faster tick's flip can't double-flip the same qurl_id, so
+        // `viewed` never regresses across ticks. A truly stale tick
+        // would observe all-opened and exit with `changed=false`
+        // (no safeEdit). The remaining theoretical flicker — DDB
+        // eventual-consistency returning newer data to the older
+        // tick than to the newer one — is sub-ms in practice and
+        // self-corrects on the next tick. Acceptable cost for not
+        // adding a render-generation counter on top of the existing
+        // trackingGeneration.
         await safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] });
         if (pending === 0) { allDone = true; clearInterval(timer); }
       }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1180,10 +1180,13 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       // If the monitor had already settled (all initial recipients viewed
       // → setInterval cleared), re-arm it so the new recipients' views
       // get a chance to flip. Without this, /qurl add on an already-
-      // resolved send leaves the counter frozen at `N viewed / M pending`
-      // for the rest of the 1h monitor lifetime.
+      // resolved send leaves the counter frozen for the rest of the 1h
+      // monitor lifetime. Reset pollCount too — the throttling decay
+      // (every-other / every-4th) is meant for an idle send; /qurl add
+      // is the explicit signal that the send is NOT steady-state.
       if (allDone && !stopped) {
         allDone = false;
+        pollCount = 0;
         clearInterval(timer);
         timer = setInterval(runTick, pollInterval);
         if (timer && timer.unref) timer.unref();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1107,23 +1107,23 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
 // the original message).
 const activeMonitors = new Set();
 
-// Interaction tokens (webhook tokens) expire 15 minutes after the
-// originating interaction. The monitor outlives that for any send with
-// expiry > 15 min (capped at 1h), so we capture the channel message ID
-// after the initial editReply and switch to bot-token PATCH edits once
-// we're inside the TTL danger zone. 14-minute cutover leaves slack for
-// clock drift between this process and Discord's edge.
-const INTERACTION_TOKEN_TTL_CUTOVER_MS = 14 * 60 * 1000;
+// Discord ephemeral messages can ONLY be edited via the interaction
+// webhook token (which expires 15 min after the interaction is created),
+// not via bot-token channel PATCH. Both /qurl send and /qurl map
+// deferReply ephemeral, so the confirmation is unreachable once the
+// token expires. There's no cross-token fallback — we just cap the
+// monitor below the 15-min cliff so we don't waste setIntervals
+// against a dead token.
 
 function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, expiresIn, baseMsg, buttonRowArg, delivered) {
   // Rebind params as closure-mutable so stop() can null them out for GC.
-  // Long-running monitors (up to 1h × MAX_CONCURRENT_MONITORS=50) otherwise
-  // pin interaction/recipients/buttonRow in the setInterval closure.
+  // Long-running monitors (up to MAX_MONITOR_DURATION_MS ×
+  // MAX_CONCURRENT_MONITORS=50) otherwise pin interaction/recipients/
+  // buttonRow in the setInterval closure.
   let interaction = interactionArg;
   let qurlLinks = qurlLinksArg;
   let recipients = recipientsArg;
   let buttonRow = buttonRowArg;
-  let messageId = null;
   let currentBaseMsg = baseMsg;
   let stopped = false;
   let timer = null;
@@ -1180,19 +1180,27 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       // If the monitor had already settled (all initial recipients viewed
       // → setInterval cleared), re-arm it so the new recipients' views
       // get a chance to flip. Without this, /qurl add on an already-
-      // resolved send leaves the counter frozen for the rest of the 1h
+      // resolved send leaves the counter frozen for the rest of the
       // monitor lifetime. Reset pollCount too — the throttling decay
       // (every-other / every-4th) is meant for an idle send; /qurl add
       // is the explicit signal that the send is NOT steady-state.
+      // Re-uses the construction-time setTimeout→setInterval pattern
+      // so the first post-add tick fires at FIRST_POLL_DELAY_MS (3s),
+      // not at pollInterval (15-60s) — the same sub-second-click
+      // catching rationale applies to /qurl add recipients too.
       if (allDone && !stopped) {
         allDone = false;
         pollCount = 0;
         clearInterval(timer);
-        timer = setInterval(runTick, pollInterval);
+        timer = setTimeout(async () => {
+          await runTick();
+          if (isTerminated()) return;
+          timer = setInterval(runTick, pollInterval);
+          if (timer && timer.unref) timer.unref();
+        }, FIRST_POLL_DELAY_MS);
         if (timer && timer.unref) timer.unref();
       }
     },
-    setMessageId(id) { messageId = id; },
     stop() {
       if (stopped) return;
       stopped = true;
@@ -1210,9 +1218,16 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   };
 
   const expiryMs = expiryToMs(expiresIn);
-  // 1h cap regardless of link expiry — avoids multi-day setIntervals
-  // for 7d expiries. Links themselves still expire at the API level.
-  const MAX_MONITOR_DURATION_MS = 60 * 60 * 1000;
+  // 14-min cap matches the practical edit window. The interaction
+  // webhook token expires at ~15 min from interaction creation; both
+  // /qurl send + /qurl map deferReply ephemeral, and ephemeral
+  // messages can't be edited via any other token. Past the cap the
+  // setInterval would only burn cycles against a dead token. Store-
+  // side view recording (recordQurlView) is unaffected — webhooks
+  // keep landing for the link's full lifetime; the sender's confirm-
+  // message counter just freezes after the cap. Links themselves
+  // still expire at the API level regardless of the monitor cap.
+  const MAX_MONITOR_DURATION_MS = 14 * 60 * 1000;
   const maxMonitorMs = Math.min(expiryMs + 60000, MAX_MONITOR_DURATION_MS);
 
   const pollInterval = Math.max(15000, Math.min(60000, expiryMs / 10));
@@ -1222,19 +1237,13 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   const startTime = Date.now();
   const isTerminated = () => stopped || allDone || Date.now() - startTime > maxMonitorMs;
 
-  // Bot-token PATCH (editDM) bypasses the 15-min interaction-token TTL.
-  // Null messageId is bounded by FIRST_POLL_DELAY_MS (3s) <
-  // INTERACTION_TOKEN_TTL_CUTOVER_MS (14min), so a tick before
-  // setMessageId resolves always falls through to interaction.editReply
-  // — safe by construction. Best-effort: Discord errors don't crash
-  // the setInterval (recipients see status from their DM).
+  // Best-effort edit through the interaction webhook token. After the
+  // 14-min monitor cap, this would 401 against an expired token —
+  // logIgnoredDiscordErr swallows it. Recipients see status from
+  // their DM, so the sender's frozen counter past cap is just a
+  // dashboard nicety, not a load-bearing surface.
   async function safeEdit(payload) {
     if (!interaction) return;
-    const useChannelEdit = Date.now() - startTime >= INTERACTION_TOKEN_TTL_CUTOVER_MS;
-    if (useChannelEdit && messageId && interaction.channelId) {
-      await editDM(interaction.channelId, messageId, payload).catch(logIgnoredDiscordErr);
-      return;
-    }
     await interaction.editReply(payload).catch(logIgnoredDiscordErr);
   }
 
@@ -1256,11 +1265,21 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   }
 
   let pollCount = 0;
+  // Concurrent-tick safety: runTick has one `await` (db.getQurlViews).
+  // Two ticks queued from setInterval can both be in-flight, both
+  // iterating `views` after their respective resolves. The
+  // `if (current.status === 'opened') continue;` guard at the flip
+  // site is synchronous JS, so the second tick observes the first
+  // tick's flip and no-ops — `viewed++` doesn't double-count, the
+  // BatchGet path is idempotent on already-flipped status.
   const runTick = async () => {
     pollCount++;
-    // Decay tick rate after the first 5 / 20 ticks to bound the
-    // sustained cost of an idle 1h monitor (5 fast, then every-other,
-    // then every-4th).
+    // Decay tick rate to bound sustained cost of an idle monitor.
+    //   pollCount 1–5:    every tick fires (fast ramp)
+    //   pollCount 6–20:   every other tick (even-only)
+    //   pollCount 21+:    every 4th tick (multiple-of-4)
+    // The else-if chain reads in the same order: 21+ throttle first,
+    // then 6–20 throttle.
     if (pollCount > 20 && pollCount % 4 !== 0) return;
     else if (pollCount > 5 && pollCount % 2 !== 0) return;
     if (isTerminated()) {
@@ -1965,8 +1984,6 @@ async function executeSendPipeline(interaction, {
     if (monitor) monitor.stop();
     throw err;
   }
-  // Channel message ID for the >14min interaction-token-TTL fallback.
-  if (monitor && response && response.id) monitor.setMessageId(response.id);
 
   // Non-ephemeral channel notification when sending to @everyone or the
   // voice-channel population. Recipients on voice or scrolling on mobile

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1123,41 +1123,62 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   let qurlLinks = qurlLinksArg;
   let recipients = recipientsArg;
   let buttonRow = buttonRowArg;
-  let messageId = null; // set via control.setMessageId after initial editReply
-  // Returns a control object: call monitor.addRecipients(count) when new recipients are added
+  let messageId = null;
   let currentBaseMsg = baseMsg;
   let stopped = false;
-  let timer = null; // assigned after control object
+  let timer = null;
+  let expectedCount = delivered;
 
-  // Empty-qurl_id boundary guard. If ANY recipient's link lacks a
-  // qurl_id (upstream qurl-service / connector hasn't rolled past
-  // qurl-service #598 yet), degrade the WHOLE monitor to base-msg
-  // mode rather than partial counting — a "3 of 10 viewed" rendering
-  // built from a partial-attribution set would mislead the sender
-  // worse than no counter at all.
-  const viewCounterDegraded = qurlLinks.some(l => !l.qurlId);
+  // Seed tracked qurl_ids from the in-memory qurlLinks. Each linkStatus
+  // entry pre-populates with the recipient's username so the first
+  // webhook-fed tick can flip status → 'opened' without losing the
+  // label. Empty qurlId on ANY link degrades the whole monitor — a
+  // partial-attribution counter would mislead worse than no counter.
+  const trackedQurlIds = new Set();
+  const linkStatus = new Map();
+  let degradedAtConstruction = false;
+  for (let i = 0; i < qurlLinks.length; i++) {
+    const qid = qurlLinks[i].qurlId;
+    if (!qid) { degradedAtConstruction = true; continue; }
+    trackedQurlIds.add(qid);
+    const username = recipients[i] ? recipients[i].username : `user-${i + 1}`;
+    linkStatus.set(qid, { status: 'pending', username });
+  }
+  // Re-derived each tick so addRecipients() with a missing qurlId can
+  // re-degrade the monitor mid-life. Set during addRecipients too.
+  let viewCounterDegraded = degradedAtConstruction;
   if (viewCounterDegraded) {
-    logger.warn('Monitor view counter degraded — some links missing qurl_id (check upstream qurl-s3-connector version + qurl-service #598 rollout)', {
+    logger.warn('Monitor view counter degraded — some links missing qurl_id', {
       sendId, missing: qurlLinks.filter(l => !l.qurlId).length, total: qurlLinks.length,
     });
   }
 
+  // Bumped by addRecipients. A tick whose getQurlViews resolves after
+  // generation advanced must skip its render — the views map was built
+  // against the pre-add tracked set and could under-report.
+  let trackingGeneration = 0;
+  let allDone = false;
+
   const control = {
-    addRecipients(count, newQurlIds) {
+    // newLinks: Array<{qurlId, username}> aligned per-recipient. Must
+    // seed `linkStatus` AND `trackedQurlIds` together — extending only
+    // the tracked set means runTick's view-flip lookup misses the new
+    // qurl_ids and the counter never advances for /qurl add recipients.
+    addRecipients(count, newLinks) {
       expectedCount += count;
-      if (Array.isArray(newQurlIds)) {
-        for (const qid of newQurlIds) {
-          if (qid && !trackedQurlIds.has(qid)) trackedQurlIds.add(qid);
+      if (Array.isArray(newLinks)) {
+        for (const item of newLinks) {
+          const qid = item && item.qurlId;
+          if (!qid) { viewCounterDegraded = true; continue; }
+          if (!trackedQurlIds.has(qid)) {
+            trackedQurlIds.add(qid);
+            linkStatus.set(qid, { status: 'pending', username: item.username || 'unknown' });
+          }
         }
       }
-      // Bump the generation so an in-flight tick's snapshot knows to
-      // discard its result — the post-add tracked set is wider than
-      // the pre-add snapshot it was built against.
       trackingGeneration++;
     },
-    setMessageId(id) {
-      messageId = id;
-    },
+    setMessageId(id) { messageId = id; },
     stop() {
       if (stopped) return;
       stopped = true;
@@ -1165,68 +1186,34 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       activeMonitors.delete(control);
       linkStatus.clear();
       trackedQurlIds.clear();
-      // Drop the big closure-captured objects so GC can reclaim them — an
-      // idle timer that was already cleared above holds the closure frame
-      // alive until the control object itself is GC'd.
       interaction = null;
       qurlLinks = null;
       recipients = null;
       buttonRow = null;
     },
-    updateBaseMsg(msg) {
-      currentBaseMsg = msg;
-    },
-    getFullMsg() {
-      return buildStatusMsg();
-    },
+    updateBaseMsg(msg) { currentBaseMsg = msg; },
+    getFullMsg() { return buildStatusMsg(); },
   };
+
   const expiryMs = expiryToMs(expiresIn);
-  // Cap monitor lifetime at 1h regardless of link expiry. Links still expire
-  // normally at the API level; we just stop updating the Discord message
-  // after an hour to avoid multi-day setIntervals for 7d expiries.
+  // 1h cap regardless of link expiry — avoids multi-day setIntervals
+  // for 7d expiries. Links themselves still expire at the API level.
   const MAX_MONITOR_DURATION_MS = 60 * 60 * 1000;
   const maxMonitorMs = Math.min(expiryMs + 60000, MAX_MONITOR_DURATION_MS);
 
-  let expectedCount = delivered;
-
-  // Seed tracked qurl_ids synchronously from the in-memory qurlLinks. No
-  // first-tick upstream discovery pass needed (the pre-PR-455 monitor
-  // walked GET /v1/qurls/:id; that endpoint strips the qurls array for
-  // type=transit, so the discovery never returned anything anyway).
-  // Each linkStatus entry seeds with the recipient's username so the
-  // first tick's webhook-fed access_count update can flip status →
-  // 'opened' without losing the label.
-  const trackedQurlIds = new Set(qurlLinks.map(l => l.qurlId).filter(Boolean));
-  const linkStatus = new Map();
-  for (let i = 0; i < qurlLinks.length; i++) {
-    const qid = qurlLinks[i].qurlId;
-    if (!qid) continue;
-    const username = recipients[i] ? recipients[i].username : `user-${i + 1}`;
-    linkStatus.set(qid, { status: 'pending', username });
-  }
-  // Monotonic counter bumped by addRecipients(). A tick that begins
-  // reading while generation=N and finishes after generation advanced
-  // to N+1 must skip its render — its accessCount map was built against
-  // the pre-add trackedQurlIds set and could under-report.
-  let trackingGeneration = 0;
-  let allDone = false;
-
   const pollInterval = Math.max(15000, Math.min(60000, expiryMs / 10));
-  // First poll fires fast so the live view counter catches sub-second
-  // self-destruct sends where the recipient opens + burns the link
-  // before the standard pollInterval tick would have fired. Reader is
-  // a single DDB BatchGet (no upstream qurl-service round trip), so
-  // the t=3s vs. t=15s shift is a tiny RCU delta — much cheaper than
-  // the pre-PR-455 N-resource-fanout this replaced.
+  // Fast first tick catches sub-second self-destruct sends where the
+  // recipient burns the link before the standard interval would fire.
   const FIRST_POLL_DELAY_MS = 3000;
   const startTime = Date.now();
   const isTerminated = () => stopped || allDone || Date.now() - startTime > maxMonitorMs;
 
-  // Bot-token PATCH bypasses the 15-min interaction-token TTL by
-  // editing the channel message directly. Returns silently on Discord
-  // errors so a stale interaction can't crash the setInterval — every
-  // edit attempt is best-effort, the link itself is the durable
-  // surface (recipients see status from their DM, not this message).
+  // Bot-token PATCH (editDM) bypasses the 15-min interaction-token TTL.
+  // Null messageId is bounded by FIRST_POLL_DELAY_MS (3s) <
+  // INTERACTION_TOKEN_TTL_CUTOVER_MS (14min), so a tick before
+  // setMessageId resolves always falls through to interaction.editReply
+  // — safe by construction. Best-effort: Discord errors don't crash
+  // the setInterval (recipients see status from their DM).
   async function safeEdit(payload) {
     if (!interaction) return;
     const useChannelEdit = Date.now() - startTime >= INTERACTION_TOKEN_TTL_CUTOVER_MS;
@@ -1237,20 +1224,29 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     await interaction.editReply(payload).catch(logIgnoredDiscordErr);
   }
 
+  // `viewed` counter is closure-tracked so we don't re-walk linkStatus
+  // on each render. Incremented when a link flips pending → opened in
+  // runTick; never decreases.
+  let viewed = 0;
+
+  // No explicit `expired` state in the rendered counter: qurl.accessed
+  // is the only event we receive, and the 1h monitor cap covers the
+  // practical "user never opened it" window. Pre-PR-455 modelled
+  // expired explicitly via upstream polling; the webhook-only world
+  // can't observe expiration without a separate qurl.expired
+  // subscription (out of scope).
   function buildStatusMsg() {
     if (viewCounterDegraded) return currentBaseMsg;
-    const viewed = [...linkStatus.values()].filter(s => s.status === 'opened').length;
-    const pending = expectedCount - viewed;
-    // `👀 N viewed / M pending` matches the pre-PR-455 wire format the
-    // sender already knows; restoring the same string keeps muscle
-    // memory intact rather than introducing a new format alongside the
-    // webhook backend swap.
-    return `${currentBaseMsg}\n👀 ${viewed} viewed / ${Math.max(0, pending)} pending`;
+    const pending = Math.max(0, expectedCount - viewed);
+    return `${currentBaseMsg}\n👀 ${viewed} viewed / ${pending} pending`;
   }
 
   let pollCount = 0;
   const runTick = async () => {
     pollCount++;
+    // Decay tick rate after the first 5 / 20 ticks to bound the
+    // sustained cost of an idle 1h monitor (5 fast, then every-other,
+    // then every-4th).
     if (pollCount > 20 && pollCount % 4 !== 0) return;
     else if (pollCount > 5 && pollCount % 2 !== 0) return;
     if (isTerminated()) {
@@ -1264,25 +1260,24 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     try {
       const genAtStart = trackingGeneration;
       const views = await db.getQurlViews([...trackedQurlIds]);
-      if (trackingGeneration !== genAtStart) {
-        // addRecipients ran during the BatchGet — the views map was
-        // built against a stale tracked set. Next tick re-reads
-        // against the widened set.
-        return;
-      }
-      if (!interaction) return; // stop() raced the await
+      // addRecipients during the await invalidates this snapshot.
+      if (trackingGeneration !== genAtStart) return;
+      if (!interaction) return;
 
+      // Iterate the (sparse) views map instead of the full linkStatus
+      // set — usually only a handful of qurls have actually been
+      // accessed, vs. up to 50 tracked links.
       let changed = false;
-      for (const [qurlId, current] of linkStatus.entries()) {
-        const v = views.get(qurlId);
-        if (!v) continue;
-        if (v.accessCount > 0 && current.status !== 'opened') {
-          linkStatus.set(qurlId, { ...current, status: 'opened' });
-          changed = true;
-        }
+      for (const [qurlId, v] of views) {
+        if (!(v.accessCount > 0)) continue;
+        const current = linkStatus.get(qurlId);
+        if (!current || current.status === 'opened') continue;
+        linkStatus.set(qurlId, { ...current, status: 'opened' });
+        viewed++;
+        changed = true;
       }
       if (changed) {
-        const pending = [...linkStatus.values()].filter(s => s.status === 'pending').length;
+        const pending = Math.max(0, expectedCount - viewed);
         await safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] });
         if (pending === 0) { allDone = true; clearInterval(timer); }
       }
@@ -1360,10 +1355,8 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
     const batchSize = Math.min(TOKENS_PER_RESOURCE, recipientCount - i);
     const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey);
     for (const link of minted) {
-      // qurl_id is the per-link join key against the qurl.accessed webhook
-      // payload — empty string means the upstream connector was speaking
-      // the pre qurl-service #598 wire and the view counter will degrade
-      // to the bare base message (see monitorLinkStatus' empty-id guard).
+      // qurl_id is the join key against qurl.accessed webhooks; empty
+      // string degrades the whole monitor to bare base-msg.
       allLinks.push({ qurl_link: link.qurl_link, qurl_id: link.qurl_id || '', resourceId: currentResourceId });
     }
     tokensUsed += batchSize;
@@ -1958,10 +1951,7 @@ async function executeSendPipeline(interaction, {
     if (monitor) monitor.stop();
     throw err;
   }
-  // Feed the monitor the channel message ID so it can fall back to bot-
-  // token PATCH once the 15-min interaction token expires. response.id
-  // is populated by interaction.editReply's Message return — without
-  // this hand-off the past-14-min ticks land on a dead webhook token.
+  // Channel message ID for the >14min interaction-token-TTL fallback.
   if (monitor && response && response.id) monitor.setMessageId(response.id);
 
   // Non-ephemeral channel notification when sending to @everyone or the
@@ -2188,11 +2178,7 @@ async function executeSendPipeline(interaction, {
 
             if (addResult.delivered > 0) {
               addRecipientsCount += addResult.delivered;
-              // Tell the monitor to track the new links — feed the new
-              // per-recipient qurl_ids so the next webhook-fed tick can
-              // count their views (newResourceIds was the pre-PR-455
-              // shape; the monitor reads via DDB BatchGet on qurl_id now).
-              monitor.addRecipients(addResult.delivered, addResult.newQurlIds);
+              monitor.addRecipients(addResult.delivered, addResult.newLinks);
               const totalSent = delivered + addRecipientsCount;
               confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | ${formatSelfDestructSegment(selfDestructSeconds)}`;
               if (failed > 0) confirmMsg += `\n${failed} could not be reached`;
@@ -2257,7 +2243,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const senderDiscordId = originalInteraction.user.id;
   const sendConfig = await db.getSendConfig(sendId, senderDiscordId);
   if (!sendConfig) {
-    return { msg: 'Send configuration not found.', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: [] };
+    return { msg: 'Send configuration not found.', newLinks: [], delivered: 0, failed: 0, newRecipients: [] };
   }
 
   // #352 entry gate. Shares the same `EXPIRY_LABELS` membership
@@ -2279,7 +2265,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     logger.warn('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
       msg: `Cannot add recipients — this send's saved expiry is invalid (the original send's links still work; create a new send to reach additional recipients).`,
-      newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: [],
+      newLinks: [], delivered: 0, failed: 0, newRecipients: [],
     };
   }
 
@@ -2297,7 +2283,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const resolvedRecipients = newRecipients.map(u => ({ id: u.id, username: u.username }));
 
   if (newRecipients.length === 0) {
-    return { msg: 'No valid recipients selected (bots and yourself are excluded).', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg: 'No valid recipients selected (bots and yourself are excluded).', newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Create new QURL links for each resource type in the send config
@@ -2307,7 +2293,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const hasLocation = sendConfig.actual_url;
 
   if (!hasFile && !hasLocation) {
-    return { msg: 'Cannot add recipients — send configuration is incomplete.', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg: 'Cannot add recipients — send configuration is incomplete.', newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Tracks which prep paths actually completed so we can emit a single
@@ -2334,7 +2320,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       if (!sendConfig.attachment_url) {
         return {
           msg: 'Cannot add file recipients — original attachment is no longer available. Please create a new send.',
-          newResourceIds: [], newQurlIds: [], newRecipients: resolvedRecipients,
+          newLinks: [], newRecipients: resolvedRecipients,
           delivered: 0,
           failed: 0,
         };
@@ -2347,7 +2333,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         logger.error('addRecipients refused non-Discord attachment_url', { sendId });
         return {
           msg: 'Cannot add file recipients — original attachment URL is no longer valid. Please create a new send.',
-          newResourceIds: [], newQurlIds: [], newRecipients: resolvedRecipients,
+          newLinks: [], newRecipients: resolvedRecipients,
           delivered: 0,
           failed: 0,
         };
@@ -2380,14 +2366,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
-        return { msg, newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+        return { msg, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
 
       if (allLinks.length < newRecipients.length) {
         logger.error('mintLinks returned fewer links than expected in addRecipients', { expected: newRecipients.length, got: allLinks.length });
-        const newResourceIds = [...new Set(allLinks.map(l => l.resourceId))];
-        const newQurlIds = allLinks.map(l => l.qurl_id).filter(Boolean);
-        return { msg: `Only ${allLinks.length} of ${newRecipients.length} links created. Try again.`, newResourceIds, newQurlIds, delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+        return { msg: `Only ${allLinks.length} of ${newRecipients.length} links created. Try again.`, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
       // Iterate by allLinks length so an off-by-one can never index out of bounds.
       // The guard above ensures allLinks.length >= newRecipients.length.
@@ -2419,7 +2403,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
       if (allLinks.length < newRecipients.length) {
         logger.error('mintLinks returned fewer links than expected in addRecipients (location)', { expected: newRecipients.length, got: allLinks.length });
-        return { msg: `Only ${allLinks.length} of ${newRecipients.length} location links created. Try again.`, newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+        return { msg: `Only ${allLinks.length} of ${newRecipients.length} location links created. Try again.`, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
       newRecipients.forEach((r, i) => {
         if (!recipientLinks[r.id]) recipientLinks[r.id] = [];
@@ -2438,7 +2422,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
-    return { msg, newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Single emission per send. `kind` carries the composition so a future
@@ -2451,7 +2435,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
   const recipientIds = Object.keys(recipientLinks);
   if (recipientIds.length === 0) {
-    return { msg: 'Failed to create any links.', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg: 'Failed to create any links.', newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Hoist payload-shared inputs to the top of the dispatch block so
@@ -2504,7 +2488,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     });
     return {
       msg: 'Failed to save link records. Recipients were not messaged. Please try again.',
-      newResourceIds: [], newQurlIds: [], newRecipients: resolvedRecipients,
+      newLinks: [], newRecipients: resolvedRecipients,
       delivered: 0,
       failed: 0,
     };
@@ -2580,14 +2564,23 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     else failed++;
   }
 
-  const allLinks = Object.values(recipientLinks).flat();
-  const newResourceIds = [...new Set(allLinks.map(l => l.resourceId))];
-  const newQurlIds = allLinks.map(l => l.qurlId).filter(Boolean);
+  // newLinks pairs each qurlId with the recipient's username so the
+  // monitor can seed linkStatus correctly. Walking recipientLinks
+  // (rather than the flattened list) preserves the per-recipient
+  // association — a /qurl add user opening their link must surface
+  // under their username, not a positional guess.
+  const newLinks = [];
+  for (const [rid, links] of Object.entries(recipientLinks)) {
+    const recip = resolvedRecipients.find(r => r.id === rid);
+    const username = recip?.username || 'unknown';
+    for (const link of links) {
+      if (link.qurlId) newLinks.push({ qurlId: link.qurlId, username });
+    }
+  }
   let msg = `Added ${delivered} recipient${delivered !== 1 ? 's' : ''}`;
   if (failed > 0) msg += ` (${failed} could not be reached)`;
   logger.info('/qurl add recipients', { sendId, delivered, failed });
-  // Return delivered/failed explicitly so callers don't have to regex-parse msg.
-  return { msg, newResourceIds, newQurlIds, delivered, failed, newRecipients: resolvedRecipients };
+  return { msg, newLinks, delivered, failed, newRecipients: resolvedRecipients };
 }
 
 // --- /qurl revoke handler ---

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1177,6 +1177,17 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
         }
       }
       trackingGeneration++;
+      // If the monitor had already settled (all initial recipients viewed
+      // → setInterval cleared), re-arm it so the new recipients' views
+      // get a chance to flip. Without this, /qurl add on an already-
+      // resolved send leaves the counter frozen at `N viewed / M pending`
+      // for the rest of the 1h monitor lifetime.
+      if (allDone && !stopped) {
+        allDone = false;
+        clearInterval(timer);
+        timer = setInterval(runTick, pollInterval);
+        if (timer && timer.unref) timer.unref();
+      }
     },
     setMessageId(id) { messageId = id; },
     stop() {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -32,7 +32,7 @@ const {
 } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
-const { deleteLink, getResourceStatus } = require('./qurl');
+const { deleteLink } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 const { deleteFlow, transitionFlow, supersedeOrCreate } = require('./flow-state');
 const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } = require('./flow-dispatch');
@@ -1107,7 +1107,15 @@ async function persistDispatchResult(sendId, recipientDiscordId, result) {
 // the original message).
 const activeMonitors = new Set();
 
-function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, expiresIn, baseMsg, buttonRowArg, delivered, apiKey) {
+// Interaction tokens (webhook tokens) expire 15 minutes after the
+// originating interaction. The monitor outlives that for any send with
+// expiry > 15 min (capped at 1h), so we capture the channel message ID
+// after the initial editReply and switch to bot-token PATCH edits once
+// we're inside the TTL danger zone. 14-minute cutover leaves slack for
+// clock drift between this process and Discord's edge.
+const INTERACTION_TOKEN_TTL_CUTOVER_MS = 14 * 60 * 1000;
+
+function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, expiresIn, baseMsg, buttonRowArg, delivered) {
   // Rebind params as closure-mutable so stop() can null them out for GC.
   // Long-running monitors (up to 1h × MAX_CONCURRENT_MONITORS=50) otherwise
   // pin interaction/recipients/buttonRow in the setInterval closure.
@@ -1115,33 +1123,48 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   let qurlLinks = qurlLinksArg;
   let recipients = recipientsArg;
   let buttonRow = buttonRowArg;
-  void buttonRow; // buttonRow is used transitively via setComponents inline; keep alias for symmetry
+  let messageId = null; // set via control.setMessageId after initial editReply
   // Returns a control object: call monitor.addRecipients(count) when new recipients are added
   let currentBaseMsg = baseMsg;
   let stopped = false;
   let timer = null; // assigned after control object
+
+  // Empty-qurl_id boundary guard. If ANY recipient's link lacks a
+  // qurl_id (upstream qurl-service / connector hasn't rolled past
+  // qurl-service #598 yet), degrade the WHOLE monitor to base-msg
+  // mode rather than partial counting — a "3 of 10 viewed" rendering
+  // built from a partial-attribution set would mislead the sender
+  // worse than no counter at all.
+  const viewCounterDegraded = qurlLinks.some(l => !l.qurlId);
+  if (viewCounterDegraded) {
+    logger.warn('Monitor view counter degraded — some links missing qurl_id (check upstream qurl-s3-connector version + qurl-service #598 rollout)', {
+      sendId, missing: qurlLinks.filter(l => !l.qurlId).length, total: qurlLinks.length,
+    });
+  }
+
   const control = {
-    addRecipients(count, newResourceIds) {
+    addRecipients(count, newQurlIds) {
       expectedCount += count;
-      if (newResourceIds) {
-        for (const rid of newResourceIds) {
-          if (!resourceIds.includes(rid)) resourceIds.push(rid);
+      if (Array.isArray(newQurlIds)) {
+        for (const qid of newQurlIds) {
+          if (qid && !trackedQurlIds.has(qid)) trackedQurlIds.add(qid);
         }
       }
-      trackedQurlIds = null;
+      // Bump the generation so an in-flight tick's snapshot knows to
+      // discard its result — the post-add tracked set is wider than
+      // the pre-add snapshot it was built against.
       trackingGeneration++;
+    },
+    setMessageId(id) {
+      messageId = id;
     },
     stop() {
       if (stopped) return;
       stopped = true;
       clearInterval(timer);
       activeMonitors.delete(control);
-      // Release references on the closures; over many sends these would
-      // otherwise accumulate. trackedQurlIds may already be null (see
-      // addRecipients — null forces a re-init next tick).
       linkStatus.clear();
-      if (trackedQurlIds) trackedQurlIds.clear();
-      trackedQurlIds = null;
+      trackedQurlIds.clear();
       // Drop the big closure-captured objects so GC can reclaim them — an
       // idle timer that was already cleared above holds the closure frame
       // alive until the control object itself is GC'd.
@@ -1164,170 +1187,103 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   const MAX_MONITOR_DURATION_MS = 60 * 60 * 1000;
   const maxMonitorMs = Math.min(expiryMs + 60000, MAX_MONITOR_DURATION_MS);
 
-  const resourceIds = [...new Set(qurlLinks.map(l => l.resourceId))];
   let expectedCount = delivered;
 
-  // Track status per qurl_id: { status, username }
+  // Seed tracked qurl_ids synchronously from the in-memory qurlLinks. No
+  // first-tick upstream discovery pass needed (the pre-PR-455 monitor
+  // walked GET /v1/qurls/:id; that endpoint strips the qurls array for
+  // type=transit, so the discovery never returned anything anyway).
+  // Each linkStatus entry seeds with the recipient's username so the
+  // first tick's webhook-fed access_count update can flip status →
+  // 'opened' without losing the label.
+  const trackedQurlIds = new Set(qurlLinks.map(l => l.qurlId).filter(Boolean));
   const linkStatus = new Map();
-  let trackedQurlIds = null;
-  // Monotonic counter bumped by addRecipients(). A tick that begins init
-  // while generation=N and finishes after generation advanced to N+1 must
-  // abort — its localSet was built against pre-add resourceIds/expectedCount.
+  for (let i = 0; i < qurlLinks.length; i++) {
+    const qid = qurlLinks[i].qurlId;
+    if (!qid) continue;
+    const username = recipients[i] ? recipients[i].username : `user-${i + 1}`;
+    linkStatus.set(qid, { status: 'pending', username });
+  }
+  // Monotonic counter bumped by addRecipients(). A tick that begins
+  // reading while generation=N and finishes after generation advanced
+  // to N+1 must skip its render — its accessCount map was built against
+  // the pre-add trackedQurlIds set and could under-report.
   let trackingGeneration = 0;
   let allDone = false;
 
   const pollInterval = Math.max(15000, Math.min(60000, expiryMs / 10));
   // First poll fires fast so the live view counter catches sub-second
   // self-destruct sends where the recipient opens + burns the link
-  // before the standard pollInterval tick would have fired. Fan-out
-  // per tick is `resourceIds.length` parallel GETs (not recipient
-  // count — qurls are batched per resource at TOKENS_PER_RESOURCE),
-  // so the t=3s vs. t=15s shift is a small load delta on qurl-service.
+  // before the standard pollInterval tick would have fired. Reader is
+  // a single DDB BatchGet (no upstream qurl-service round trip), so
+  // the t=3s vs. t=15s shift is a tiny RCU delta — much cheaper than
+  // the pre-PR-455 N-resource-fanout this replaced.
   const FIRST_POLL_DELAY_MS = 3000;
   const startTime = Date.now();
-  // Same termination check used at two sites (runTick early-exit +
-  // post-first-tick scheduling guard); centralized so a future
-  // condition (e.g., revoked) lands in one place.
   const isTerminated = () => stopped || allDone || Date.now() - startTime > maxMonitorMs;
 
+  // Bot-token PATCH bypasses the 15-min interaction-token TTL by
+  // editing the channel message directly. Returns silently on Discord
+  // errors so a stale interaction can't crash the setInterval — every
+  // edit attempt is best-effort, the link itself is the durable
+  // surface (recipients see status from their DM, not this message).
+  async function safeEdit(payload) {
+    if (!interaction) return;
+    const useChannelEdit = Date.now() - startTime >= INTERACTION_TOKEN_TTL_CUTOVER_MS;
+    if (useChannelEdit && messageId && interaction.channelId) {
+      await editDM(interaction.channelId, messageId, payload).catch(logIgnoredDiscordErr);
+      return;
+    }
+    await interaction.editReply(payload).catch(logIgnoredDiscordErr);
+  }
+
   function buildStatusMsg() {
-    // View-counter rendering temporarily removed. qurl-service strips
-    // the `qurls` field from `GET /v1/qurls/:id` responses for
-    // type=transit resources (every Discord bot send is transit, since
-    // the connector targets the fileviewer URL). With qurls always
-    // empty, the polling-based counter could only ever render
-    // `0 of N viewed` — actively misleading. Returning the bare
-    // currentBaseMsg until the webhook-based replacement lands
-    // (qurl-service publishes EventQurlAccessed → bot receives →
-    // updates the confirmation directly, no polling). Tracking
-    // issue + webhook plan: qurl-service #596.
-    //
-    // `linkStatus`/`expectedCount` machinery is intentionally kept as
-    // scaffolding the webhook handler can populate once the receiver
-    // lands; the monitor setInterval also stays (now a no-op render-
-    // wise, but the polls cost nothing operationally beyond the bot's
-    // existing qurl-service GETs).
-    return currentBaseMsg;
+    if (viewCounterDegraded) return currentBaseMsg;
+    const viewed = [...linkStatus.values()].filter(s => s.status === 'opened').length;
+    const pending = expectedCount - viewed;
+    // `👀 N viewed / M pending` matches the pre-PR-455 wire format the
+    // sender already knows; restoring the same string keeps muscle
+    // memory intact rather than introducing a new format alongside the
+    // webhook backend swap.
+    return `${currentBaseMsg}\n👀 ${viewed} viewed / ${Math.max(0, pending)} pending`;
   }
 
   let pollCount = 0;
-  // INVARIANT: `trackedQurlIds` starts null and is populated on the first tick
-  // (see line ~277). control.addRecipients() sets it back to null mid-tick so
-  // the NEXT tick re-initializes tracking against the new link set. Any read
-  // of `trackedQurlIds` inside this callback that happens AFTER an `await`
-  // must first re-check `if (!trackedQurlIds) return;` because addRecipients
-  // can null it during any awaited gap. If you add new awaits here, guard
-  // subsequent reads accordingly.
   const runTick = async () => {
     pollCount++;
     if (pollCount > 20 && pollCount % 4 !== 0) return;
     else if (pollCount > 5 && pollCount % 2 !== 0) return;
     if (isTerminated()) {
       clearInterval(timer);
-      // interaction may have been nulled by stop() if this callback was
-      // already mid-execution when stop fired — clearInterval only prevents
-      // FUTURE ticks, not the one currently running. Skip the final edit
-      // in that case; the closure refs are already being released.
       if (!interaction) return;
       const finalMsg = buildStatusMsg() + '\n(Use `/qurl revoke` to revoke later)';
-      await interaction.editReply({ content: finalMsg, components: [] }).catch(logIgnoredDiscordErr);
+      await safeEdit({ content: finalMsg, components: [] });
       return;
     }
+    if (viewCounterDegraded || trackedQurlIds.size === 0) return;
     try {
-      let changed = false;
-
-      // Initialize tracking on first poll. A single send may span multiple
-      // resources (both file sends >TOKENS_PER_RESOURCE, which re-upload in
-      // batches of 10, and location sends which mint one qurl per resource),
-      // so walk every resource and collect all its qurls, then pick the
-      // `expectedCount` most recent across the whole send.
-      if (!trackedQurlIds) {
-        // Snapshot the generation BEFORE the await. If addRecipients fires
-        // during Promise.all it will bump the counter and the post-await
-        // check will abort this init — the new tick must re-read
-        // resourceIds/expectedCount against the updated state.
-        const genAtStart = trackingGeneration;
-        const snapshotResourceIds = resourceIds.slice();
-        const snapshotExpectedCount = expectedCount;
-        const localSet = new Set();
-        const statuses = await Promise.all(
-          snapshotResourceIds.map(rid => getResourceStatus(rid, apiKey).catch(() => null))
-        );
-        if (trackingGeneration !== genAtStart) {
-          // addRecipients ran during the await; the snapshot is stale.
-          // Leave trackedQurlIds null so the next tick re-inits fresh.
-          return;
-        }
-        const allQurls = [];
-        for (const data of statuses) {
-          if (!data || !data.qurls) continue;
-          for (const q of data.qurls) allQurls.push(q);
-        }
-        // Secondary sort on qurl_id makes the order deterministic when two
-        // qurls land in the same created_at millisecond — otherwise the
-        // positional recipient→qurl mapping becomes non-deterministic.
-        allQurls.sort((a, b) => {
-          const d = new Date(a.created_at) - new Date(b.created_at);
-          if (d !== 0) return d;
-          return String(a.qurl_id).localeCompare(String(b.qurl_id));
-        });
-        const recentN = allQurls.slice(-snapshotExpectedCount);
-        if (recentN.length !== recipients.length) {
-          logger.warn('Monitor tracking count mismatch', {
-            sendId, qurls: recentN.length, recipients: recipients.length,
-          });
-        }
-        // Bound the zip to min(qurls, recipients) so we never index recipients
-        // past its end or leave a qurl without a label. Any excess on either
-        // side is logged above for oncall diagnosis.
-        const trackCount = Math.min(recentN.length, recipients.length);
-        for (let i = 0; i < trackCount; i++) {
-          const q = recentN[i];
-          localSet.add(q.qurl_id);
-          const username = recipients[i] ? recipients[i].username : `user-${i + 1}`;
-          // Preserve opened/expired status from a prior init pass —
-          // addRecipients() nulls trackedQurlIds and the next tick re-runs
-          // this init block. Blindly resetting to 'pending' would briefly
-          // render `0 of N+M viewed` until the same tick's poll loop
-          // re-flips. Only seed 'pending' for genuinely new qurl_ids;
-          // the subsequent poll pass will still upgrade any newly-opened.
-          const existing = linkStatus.get(q.qurl_id);
-          if (existing && existing.status !== 'pending') {
-            linkStatus.set(q.qurl_id, { ...existing, username });
-          } else {
-            linkStatus.set(q.qurl_id, { status: 'pending', username });
-          }
-        }
-        trackedQurlIds = localSet;
-        logger.info('Link monitor tracking', { sendId, tracked: trackedQurlIds.size, resources: resourceIds.length });
+      const genAtStart = trackingGeneration;
+      const views = await db.getQurlViews([...trackedQurlIds]);
+      if (trackingGeneration !== genAtStart) {
+        // addRecipients ran during the BatchGet — the views map was
+        // built against a stale tracked set. Next tick re-reads
+        // against the widened set.
+        return;
       }
+      if (!interaction) return; // stop() raced the await
 
-      // Poll all resources for status changes (parallel to avoid N sequential API calls per tick)
-      const pollResults = await Promise.all(
-        resourceIds.map(rid => getResourceStatus(rid, apiKey).catch(() => null))
-      );
-      // control.addRecipients() can null out trackedQurlIds during the await
-      // above — skip this tick and let the next one re-init the tracking set.
-      if (!trackedQurlIds) return;
-      for (const data of pollResults) {
-        if (!data || !data.qurls) continue;
-        for (const qurl of data.qurls) {
-          if (!trackedQurlIds.has(qurl.qurl_id)) continue;
-          const current = linkStatus.get(qurl.qurl_id);
-          if (!current) continue;
-          if (qurl.use_count > 0 && current.status !== 'opened') {
-            linkStatus.set(qurl.qurl_id, { ...current, status: 'opened' }); changed = true;
-          } else if (qurl.status === 'expired' && current.status === 'pending') {
-            linkStatus.set(qurl.qurl_id, { ...current, status: 'expired' }); changed = true;
-          }
+      let changed = false;
+      for (const [qurlId, current] of linkStatus.entries()) {
+        const v = views.get(qurlId);
+        if (!v) continue;
+        if (v.accessCount > 0 && current.status !== 'opened') {
+          linkStatus.set(qurlId, { ...current, status: 'opened' });
+          changed = true;
         }
       }
       if (changed) {
-        // Same race as above — stop() may have nulled interaction during the
-        // awaited Promise.all. Skip the edit; next tick's stopped-check exits.
-        if (!interaction) return;
         const pending = [...linkStatus.values()].filter(s => s.status === 'pending').length;
-        await interaction.editReply({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] }).catch(logIgnoredDiscordErr);
+        await safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] });
         if (pending === 0) { allDone = true; clearInterval(timer); }
       }
     } catch (err) {
@@ -1388,7 +1344,7 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
  * @param {string} opts.expiresAt — ISO string; forwarded to mintLinks.
  * @param {number} opts.recipientCount — number of tokens to mint in total.
  * @param {string} opts.apiKey — QURL API key.
- * @returns {Array<{qurl_link: string, resourceId: string}>}
+ * @returns {Array<{qurl_link: string, qurl_id: string, resourceId: string}>}
  */
 async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey }) {
   const allLinks = [];
@@ -1404,7 +1360,11 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
     const batchSize = Math.min(TOKENS_PER_RESOURCE, recipientCount - i);
     const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey);
     for (const link of minted) {
-      allLinks.push({ qurl_link: link.qurl_link, resourceId: currentResourceId });
+      // qurl_id is the per-link join key against the qurl.accessed webhook
+      // payload — empty string means the upstream connector was speaking
+      // the pre qurl-service #598 wire and the view counter will degrade
+      // to the bare base message (see monitorLinkStatus' empty-id guard).
+      allLinks.push({ qurl_link: link.qurl_link, qurl_id: link.qurl_id || '', resourceId: currentResourceId });
     }
     tokensUsed += batchSize;
   }
@@ -1710,6 +1670,7 @@ async function executeSendPipeline(interaction, {
       qurlLinks = recipients.map((r, i) => ({
         recipientId: r.id,
         qurlLink: allLinks[i].qurl_link,
+        qurlId: allLinks[i].qurl_id,
         resourceId: allLinks[i].resourceId,
       }));
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
@@ -1743,6 +1704,7 @@ async function executeSendPipeline(interaction, {
       qurlLinks = recipients.map((r, i) => ({
         recipientId: r.id,
         qurlLink: allLinks[i].qurl_link,
+        qurlId: allLinks[i].qurl_id,
         resourceId: allLinks[i].resourceId,
       }));
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
@@ -1976,7 +1938,7 @@ async function executeSendPipeline(interaction, {
   // one view.
   let monitor = null;
   if (delivered > 0) {
-    monitor = monitorLinkStatus(sendId, interaction, qurlLinks, recipients, expiresIn, confirmMsg, buttonRow, delivered, apiKey);
+    monitor = monitorLinkStatus(sendId, interaction, qurlLinks, recipients, expiresIn, confirmMsg, buttonRow, delivered);
   }
   const initialPayload = {
     content: monitor ? monitor.getFullMsg() : confirmMsg,
@@ -1996,6 +1958,11 @@ async function executeSendPipeline(interaction, {
     if (monitor) monitor.stop();
     throw err;
   }
+  // Feed the monitor the channel message ID so it can fall back to bot-
+  // token PATCH once the 15-min interaction token expires. response.id
+  // is populated by interaction.editReply's Message return — without
+  // this hand-off the past-14-min ticks land on a dead webhook token.
+  if (monitor && response && response.id) monitor.setMessageId(response.id);
 
   // Non-ephemeral channel notification when sending to @everyone or the
   // voice-channel population. Recipients on voice or scrolling on mobile
@@ -2221,8 +2188,11 @@ async function executeSendPipeline(interaction, {
 
             if (addResult.delivered > 0) {
               addRecipientsCount += addResult.delivered;
-              // Tell the monitor to track the new links (including new resource IDs for location sends)
-              monitor.addRecipients(addResult.delivered, addResult.newResourceIds);
+              // Tell the monitor to track the new links — feed the new
+              // per-recipient qurl_ids so the next webhook-fed tick can
+              // count their views (newResourceIds was the pre-PR-455
+              // shape; the monitor reads via DDB BatchGet on qurl_id now).
+              monitor.addRecipients(addResult.delivered, addResult.newQurlIds);
               const totalSent = delivered + addRecipientsCount;
               confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | ${formatSelfDestructSegment(selfDestructSeconds)}`;
               if (failed > 0) confirmMsg += `\n${failed} could not be reached`;
@@ -2287,7 +2257,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const senderDiscordId = originalInteraction.user.id;
   const sendConfig = await db.getSendConfig(sendId, senderDiscordId);
   if (!sendConfig) {
-    return { msg: 'Send configuration not found.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: [] };
+    return { msg: 'Send configuration not found.', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: [] };
   }
 
   // #352 entry gate. Shares the same `EXPIRY_LABELS` membership
@@ -2309,7 +2279,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     logger.warn('addRecipients refused invalid expires_in', { sendId, expiresIn: truncForLog(sendConfig.expires_in) });
     return {
       msg: `Cannot add recipients — this send's saved expiry is invalid (the original send's links still work; create a new send to reach additional recipients).`,
-      newResourceIds: [], delivered: 0, failed: 0, newRecipients: [],
+      newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: [],
     };
   }
 
@@ -2327,7 +2297,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const resolvedRecipients = newRecipients.map(u => ({ id: u.id, username: u.username }));
 
   if (newRecipients.length === 0) {
-    return { msg: 'No valid recipients selected (bots and yourself are excluded).', newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg: 'No valid recipients selected (bots and yourself are excluded).', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Create new QURL links for each resource type in the send config
@@ -2337,7 +2307,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const hasLocation = sendConfig.actual_url;
 
   if (!hasFile && !hasLocation) {
-    return { msg: 'Cannot add recipients — send configuration is incomplete.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg: 'Cannot add recipients — send configuration is incomplete.', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Tracks which prep paths actually completed so we can emit a single
@@ -2364,7 +2334,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       if (!sendConfig.attachment_url) {
         return {
           msg: 'Cannot add file recipients — original attachment is no longer available. Please create a new send.',
-          newResourceIds: [], newRecipients: resolvedRecipients,
+          newResourceIds: [], newQurlIds: [], newRecipients: resolvedRecipients,
           delivered: 0,
           failed: 0,
         };
@@ -2377,7 +2347,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         logger.error('addRecipients refused non-Discord attachment_url', { sendId });
         return {
           msg: 'Cannot add file recipients — original attachment URL is no longer valid. Please create a new send.',
-          newResourceIds: [], newRecipients: resolvedRecipients,
+          newResourceIds: [], newQurlIds: [], newRecipients: resolvedRecipients,
           delivered: 0,
           failed: 0,
         };
@@ -2410,13 +2380,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
-        return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+        return { msg, newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
 
       if (allLinks.length < newRecipients.length) {
         logger.error('mintLinks returned fewer links than expected in addRecipients', { expected: newRecipients.length, got: allLinks.length });
         const newResourceIds = [...new Set(allLinks.map(l => l.resourceId))];
-        return { msg: `Only ${allLinks.length} of ${newRecipients.length} links created. Try again.`, newResourceIds, delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+        const newQurlIds = allLinks.map(l => l.qurl_id).filter(Boolean);
+        return { msg: `Only ${allLinks.length} of ${newRecipients.length} links created. Try again.`, newResourceIds, newQurlIds, delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
       // Iterate by allLinks length so an off-by-one can never index out of bounds.
       // The guard above ensures allLinks.length >= newRecipients.length.
@@ -2426,6 +2397,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         if (!recipientLinks[r.id]) recipientLinks[r.id] = [];
         recipientLinks[r.id].push({
           qurlLink: allLinks[i].qurl_link,
+          qurlId: allLinks[i].qurl_id,
           resourceId: allLinks[i].resourceId,
           resType: RESOURCE_TYPES.FILE,
           label: `File (${sanitizeFilename(sendConfig.attachment_name || 'file')})`,
@@ -2447,12 +2419,13 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
       if (allLinks.length < newRecipients.length) {
         logger.error('mintLinks returned fewer links than expected in addRecipients (location)', { expected: newRecipients.length, got: allLinks.length });
-        return { msg: `Only ${allLinks.length} of ${newRecipients.length} location links created. Try again.`, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+        return { msg: `Only ${allLinks.length} of ${newRecipients.length} location links created. Try again.`, newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
       newRecipients.forEach((r, i) => {
         if (!recipientLinks[r.id]) recipientLinks[r.id] = [];
         recipientLinks[r.id].push({
           qurlLink: allLinks[i].qurl_link,
+          qurlId: allLinks[i].qurl_id,
           resourceId: allLinks[i].resourceId,
           resType: RESOURCE_TYPES.MAPS, label: sendConfig.location_name || 'Google Maps',
         });
@@ -2465,7 +2438,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
-    return { msg, newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg, newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Single emission per send. `kind` carries the composition so a future
@@ -2478,7 +2451,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
   const recipientIds = Object.keys(recipientLinks);
   if (recipientIds.length === 0) {
-    return { msg: 'Failed to create any links.', newResourceIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
+    return { msg: 'Failed to create any links.', newResourceIds: [], newQurlIds: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
   // Hoist payload-shared inputs to the top of the dispatch block so
@@ -2531,7 +2504,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     });
     return {
       msg: 'Failed to save link records. Recipients were not messaged. Please try again.',
-      newResourceIds: [], newRecipients: resolvedRecipients,
+      newResourceIds: [], newQurlIds: [], newRecipients: resolvedRecipients,
       delivered: 0,
       failed: 0,
     };
@@ -2609,11 +2582,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
 
   const allLinks = Object.values(recipientLinks).flat();
   const newResourceIds = [...new Set(allLinks.map(l => l.resourceId))];
+  const newQurlIds = allLinks.map(l => l.qurlId).filter(Boolean);
   let msg = `Added ${delivered} recipient${delivered !== 1 ? 's' : ''}`;
   if (failed > 0) msg += ` (${failed} could not be reached)`;
   logger.info('/qurl add recipients', { sendId, delivered, failed });
   // Return delivered/failed explicitly so callers don't have to regex-parse msg.
-  return { msg, newResourceIds, delivered, failed, newRecipients: resolvedRecipients };
+  return { msg, newResourceIds, newQurlIds, delivered, failed, newRecipients: resolvedRecipients };
 }
 
 // --- /qurl revoke handler ---

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -356,6 +356,13 @@ module.exports = {
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
   GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
 
+  // qURL webhook receiver HMAC. Peer setting lives in the qurl-service
+  // subscription record (`secret` field on POST /v1/webhooks) and must
+  // match exactly. Boot WARN + per-request 503 if unset, so a fresh
+  // deploy without the SSM param populated is visible immediately
+  // rather than silent-failing later.
+  QURL_WEBHOOK_SECRET: process.env.QURL_WEBHOOK_SECRET,
+
   // qURL OAuth (Auth0) — for /qurl setup admin consent flow.
   // When unset, /qurl setup falls back to the legacy modal-paste path so the
   // bot stays usable until Justin registers the Auth0 application + drops

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -356,11 +356,8 @@ module.exports = {
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
   GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
 
-  // qURL webhook receiver HMAC. Peer setting lives in the qurl-service
-  // subscription record (`secret` field on POST /v1/webhooks) and must
-  // match exactly. Boot WARN + per-request 503 if unset, so a fresh
-  // deploy without the SSM param populated is visible immediately
-  // rather than silent-failing later.
+  // qURL webhook receiver HMAC; peer is the qurl-service subscription's
+  // `secret` field on POST /v1/webhooks (must match exactly).
   QURL_WEBHOOK_SECRET: process.env.QURL_WEBHOOK_SECRET,
 
   // qURL OAuth (Auth0) — for /qurl setup admin consent flow.

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -415,6 +415,41 @@ const AUDIT_EVENTS = {
   // stays zero — but for an idle bot the rotation also doesn't
   // matter until someone tries to use it.
   DEPENDENCY_AUTH_FAILURE: 'dependency_auth_failure',
+
+  // ── qURL webhook receiver (POST /webhooks/qurl) ──
+  //
+  // The receiver writes view counts to the qurl_views DDB table; the
+  // monitor's setInterval reads them. These four events drive the
+  // CW metric filters + alarms in qurl-integrations-infra's
+  // monitoring.tf. Dimension shapes documented inline at each emit
+  // site (apps/discord/src/routes/qurl-webhook.js).
+  //
+  // Cardinality: all four are flat counters. Do NOT promote
+  // `qurl_id` or `resource_id` to dimensions — both are unbounded.
+
+  // Every accepted webhook, including dedup-on-replay. `result` field
+  // distinguishes `recorded` vs `dedup` for the dashboard. Absence
+  // for an extended window is the "subscription drift / qurl-service
+  // down" signal once a traffic floor is established.
+  QURL_WEBHOOK_RECEIVED: 'qurl_webhook_received',
+
+  // Signature verification failed. Pairs with the per-IP rate limit
+  // — a sustained rate is either (a) qurl-service ↔ SSM secret drift
+  // (operator fix: re-set both in lockstep) or (b) an attacker
+  // hammering the endpoint after discovering it.
+  QURL_WEBHOOK_SIGNATURE_INVALID: 'qurl_webhook_signature_invalid',
+
+  // Per-IP rate limit kicked in after BAD_SIG_MAX failed-sig attempts.
+  // Different signal than SIGNATURE_INVALID: that one fires per-bad-sig;
+  // this one fires per-429 response. Volume of this event is bounded
+  // by the rate-limit threshold, so a sustained rate means a sustained
+  // attacker (legit traffic NEVER triggers this).
+  QURL_WEBHOOK_RATE_LIMITED: 'qurl_webhook_rate_limited',
+
+  // Store write threw (typically a DDB throttle). Returned 5xx to
+  // qurl-service so the delivery is retried. Sustained rate means
+  // qurl_views table is hot — provision tweak needed.
+  QURL_WEBHOOK_STORE_ERROR: 'qurl_webhook_store_error',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -417,8 +417,9 @@ const AUDIT_EVENTS = {
   DEPENDENCY_AUTH_FAILURE: 'dependency_auth_failure',
 
   // qURL webhook receiver — feeds CloudWatch metric filters +
-  // alarms in qurl-integrations-infra monitoring.tf. Flat counters
-  // only: do NOT promote qurl_id/resource_id to dimensions (unbounded).
+  // alarms managed in the deploying organization's infrastructure
+  // (separate from this repo). Flat counters only: do NOT promote
+  // qurl_id/resource_id to dimensions (unbounded).
   QURL_WEBHOOK_RECEIVED: 'qurl_webhook_received',
   // Sustained rate = SSM secret drift OR attacker probing.
   QURL_WEBHOOK_SIGNATURE_INVALID: 'qurl_webhook_signature_invalid',

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -416,39 +416,15 @@ const AUDIT_EVENTS = {
   // matter until someone tries to use it.
   DEPENDENCY_AUTH_FAILURE: 'dependency_auth_failure',
 
-  // ── qURL webhook receiver (POST /webhooks/qurl) ──
-  //
-  // The receiver writes view counts to the qurl_views DDB table; the
-  // monitor's setInterval reads them. These four events drive the
-  // CW metric filters + alarms in qurl-integrations-infra's
-  // monitoring.tf. Dimension shapes documented inline at each emit
-  // site (apps/discord/src/routes/qurl-webhook.js).
-  //
-  // Cardinality: all four are flat counters. Do NOT promote
-  // `qurl_id` or `resource_id` to dimensions — both are unbounded.
-
-  // Every accepted webhook, including dedup-on-replay. `result` field
-  // distinguishes `recorded` vs `dedup` for the dashboard. Absence
-  // for an extended window is the "subscription drift / qurl-service
-  // down" signal once a traffic floor is established.
+  // qURL webhook receiver — feeds CloudWatch metric filters +
+  // alarms in qurl-integrations-infra monitoring.tf. Flat counters
+  // only: do NOT promote qurl_id/resource_id to dimensions (unbounded).
   QURL_WEBHOOK_RECEIVED: 'qurl_webhook_received',
-
-  // Signature verification failed. Pairs with the per-IP rate limit
-  // — a sustained rate is either (a) qurl-service ↔ SSM secret drift
-  // (operator fix: re-set both in lockstep) or (b) an attacker
-  // hammering the endpoint after discovering it.
+  // Sustained rate = SSM secret drift OR attacker probing.
   QURL_WEBHOOK_SIGNATURE_INVALID: 'qurl_webhook_signature_invalid',
-
-  // Per-IP rate limit kicked in after BAD_SIG_MAX failed-sig attempts.
-  // Different signal than SIGNATURE_INVALID: that one fires per-bad-sig;
-  // this one fires per-429 response. Volume of this event is bounded
-  // by the rate-limit threshold, so a sustained rate means a sustained
-  // attacker (legit traffic NEVER triggers this).
+  // Legit traffic NEVER triggers — sustained rate = sustained attacker.
   QURL_WEBHOOK_RATE_LIMITED: 'qurl_webhook_rate_limited',
-
-  // Store write threw (typically a DDB throttle). Returned 5xx to
-  // qurl-service so the delivery is retried. Sustained rate means
-  // qurl_views table is hot — provision tweak needed.
+  // Sustained rate = qurl_views table hot.
   QURL_WEBHOOK_STORE_ERROR: 'qurl_webhook_store_error',
 };
 
@@ -458,6 +434,14 @@ const AUDIT_EVENTS = {
 // constant objects in this file aren't frozen, but AUDIT_EVENTS is the
 // only one whose mutation is undetectable by tests.
 Object.freeze(AUDIT_EVENTS);
+
+// Wire-protocol event-type strings for qURL webhook payloads.
+// Pinned as constants so a typo in the receiver's type check (or in a
+// test asserting against the wire shape) fails to import rather than
+// silently matching nothing. Mirrors qurl-service WebhookEventType.
+const QURL_WEBHOOK_EVENTS = Object.freeze({
+  ACCESSED: 'qurl.accessed',
+});
 
 // Discord gateway dispatch event names (the `t` field on op=0 frames).
 // Today only INTERACTION_CREATE is published to the worker tier;
@@ -509,6 +493,7 @@ module.exports = {
   GITHUB_ACTIONS,
   GOOD_FIRST_ISSUE_PATTERNS,
   AUDIT_EVENTS,
+  QURL_WEBHOOK_EVENTS,
   TRUST,
   GATEWAY_DISPATCH_TYPES,
   LOG_KINDS,

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -102,10 +102,14 @@ router.post('/qurl', async (req, res) => {
     return res.status(200).json({ status: 'invalid-payload' });
   }
 
-  // Strict typeof — Number(null) === 0 would otherwise let `null` slip
-  // through as accessCount=0, costing a DDB write per such event.
-  if (typeof data.access_count !== 'number' || !Number.isFinite(data.access_count) || data.access_count < 0) {
-    logger.warn('qURL webhook access_count not a non-negative number', { qurl_id: data.qurl_id, access_count: data.access_count });
+  // Strict integer gate — qurl-service emits access_count as Go int64
+  // (`WebhookEvent.Data['access_count']`), so a non-integer or a value
+  // past 2^53 here would be a wire-shape regression. isSafeInteger
+  // (NOT just isFinite + >= 0) catches the float case + the unsafe-
+  // int case in one check. Also blocks Number(null)===0 from slipping
+  // through, which would otherwise cost a DDB write per such event.
+  if (!Number.isSafeInteger(data.access_count) || data.access_count < 0) {
+    logger.warn('qURL webhook access_count not a non-negative integer', { qurl_id: data.qurl_id, access_count: data.access_count });
     return res.status(200).json({ status: 'invalid-payload' });
   }
   const accessCount = data.access_count;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -21,6 +21,11 @@ const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hard
 const router = express.Router();
 
 const SIGNATURE_HEADER = 'qurl-signature';
+// Lowercase only by design: Node's crypto.digest('hex') and Go's
+// hex.EncodeToString both emit lowercase. A future cross-language
+// emitter defaulting to uppercase hex would silently 401 every
+// webhook — make the regex flag the regression instead of the /i flag
+// silently absorbing it.
 const SIGNATURE_PATTERN = /^[0-9a-f]{64}$/;
 
 const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
@@ -68,10 +73,21 @@ router.post('/qurl', async (req, res) => {
   const eventType = req.body?.type;
   const data = req.body?.data;
   const eventId = req.body?.id;
-  if (!eventId) {
-    logger.warn('qURL webhook missing body.id (per-event replay key)');
+  // typeof guard (not just falsy): a payload with `id: { weird: true }`
+  // would otherwise pass through DDB's UpdateExpression and persist a
+  // non-scalar replay key — silent corruption of dedup semantics.
+  if (typeof eventId !== 'string' || !eventId) {
+    logger.warn('qURL webhook missing or non-string body.id (per-event replay key)');
     return res.status(200).json({ status: 'invalid-payload' });
   }
+
+  // TODO(freshness): the signature pins payload integrity but not
+  // freshness. A captured event with a never-seen `id` and a
+  // sufficiently-advanced access_count would still be accepted long
+  // after capture. qurl-service includes a signed `timestamp` field;
+  // adding a `now() - body.timestamp > N` rejection would close the
+  // replay window. Out of scope for this PR (qurl-service is the only
+  // valid emitter today).
 
   if (eventType !== QURL_WEBHOOK_EVENTS.ACCESSED) {
     logger.debug('qURL webhook event ignored', { type: eventType });
@@ -79,24 +95,34 @@ router.post('/qurl', async (req, res) => {
   }
 
   if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
-    logger.warn('qURL webhook qurl.accessed missing qurl_id', { data });
+    // Limit logged fields — `data` is post-trust but unbounded in shape
+    // and may include attacker-influenced src_ip/user_agent for non-
+    // transit resources. Log only the keys the pipeline actually reads.
+    logger.warn('qURL webhook qurl.accessed missing qurl_id', { qurl_id: data?.qurl_id, resource_id: data?.resource_id });
     return res.status(200).json({ status: 'invalid-payload' });
   }
 
-  const accessCount = Number(data.access_count);
-  if (!Number.isFinite(accessCount) || accessCount < 0) {
+  // Strict typeof — Number(null) === 0 would otherwise let `null` slip
+  // through as accessCount=0, costing a DDB write per such event.
+  if (typeof data.access_count !== 'number' || !Number.isFinite(data.access_count) || data.access_count < 0) {
     logger.warn('qURL webhook access_count not a non-negative number', { qurl_id: data.qurl_id, access_count: data.access_count });
     return res.status(200).json({ status: 'invalid-payload' });
   }
+  const accessCount = data.access_count;
+
+  // Strict equality — Boolean(data.consumed) would coerce the string
+  // "false" to true. Pinning to the boolean catches a future emit-side
+  // regression that JSON-encodes the field as a string.
+  const consumed = data.consumed === true;
 
   try {
     const result = await db.recordQurlView({
       qurlId: data.qurl_id,
       accessCount,
-      consumed: Boolean(data.consumed),
+      consumed,
       eventId,
     });
-    logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed: Boolean(data.consumed), result });
+    logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result });
     return res.status(200).json({ status: result });
   } catch (err) {

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -7,12 +7,23 @@
 // can land on instance A while the originating monitor's setInterval
 // runs on instance B, so we never reach for an in-process EventEmitter.
 //
-// Wire contract pinned by qurl-service:
-//   header  `QURL-Signature`  bare hex HMAC-SHA256 over raw body (no
-//                             `sha256=` prefix — different shape from
-//                             GitHub's signature scheme; do not copy
-//                             routes/webhooks.js' prefix-check verbatim)
-//   body    `{event, data:{qurl_id, resource_id, access_count, consumed}}`
+// Wire contract pinned by qurl-service domain.WebhookEvent
+// (internal/domain/webhook.go) + domain.SignPayload:
+//   header  `QURL-Signature`   bare hex HMAC-SHA256 over raw body (no
+//                              `sha256=` prefix — different shape from
+//                              GitHub's signature scheme; do not copy
+//                              routes/webhooks.js' prefix-check verbatim)
+//   header  `QURL-Delivery`    per-delivery ID (`wd_…`). Different
+//                              across redeliveries of the same event,
+//                              so NOT a replay key — use body.id for that.
+//   body    `{id, type, data:{qurl_id, resource_id, access_count, consumed},
+//             owner_id, timestamp, api_version}`
+//
+// Field NAMES matter: qurl-service emits `type` (not `event`) and `id`
+// (not `event_id`). Receiver-side renames of either field silently
+// 200-ignore every inbound webhook because the type check fails first.
+// Pinning the qurl-service field names here so a future "let's normalize
+// to event_id" refactor in EITHER repo fails CI rather than going dark.
 //
 // `src_ip` and `user_agent` are stripped server-side for type=transit
 // resources (the connector-owned privacy boundary). Discord bot sends
@@ -28,6 +39,7 @@ const crypto = require('crypto');
 const config = require('../config');
 const db = require('../store');
 const logger = require('../logger');
+const { AUDIT_EVENTS } = require('../constants');
 
 const router = express.Router();
 
@@ -113,6 +125,7 @@ router.post('/qurl', async (req, res) => {
   const existing = (badSigAttempts.get(ip) || []).filter(t => t > Date.now() - BAD_SIG_WINDOW_MS);
   if (existing.length >= BAD_SIG_MAX) {
     logger.warn('qURL webhook rate limit exceeded (bad signatures)', { ip, recentFailures: existing.length });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RATE_LIMITED, { recent_failures: existing.length });
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
 
@@ -128,28 +141,35 @@ router.post('/qurl', async (req, res) => {
   if (!verifySignature(req)) {
     const n = recordBadSig(ip);
     logger.warn('Invalid qURL webhook signature', { ip, totalInWindow: n });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID, { total_in_window: n });
     return res.status(401).json({ error: 'Invalid signature' });
   }
 
-  const event = req.body?.event;
+  const eventType = req.body?.type;
   const data = req.body?.data;
-  // Replay protection key — peer is qurl-service's per-delivery event_id.
-  // We also fall back to message_id (older payload shape) so a
-  // qurl-service rev that hasn't standardized the field name yet still
-  // gets dedup. If BOTH are absent the payload predates webhook
-  // hardening; record under a synthesized key derived from the body so
-  // we still get SOME replay protection (won't dedup across distinct
-  // events, but a literal redelivery hashes to the same key).
-  const eventId = req.body?.event_id || req.body?.message_id ||
-    crypto.createHash('sha256').update(req.rawBody).digest('hex');
+  // Replay-protection key. Peer is qurl-service's WebhookEvent.ID
+  // (json `id`) — stable across redeliveries of the same event, so
+  // `last_event_id <> :eid` actually catches redeliveries. The peer
+  // does NOT use `event_id` / `message_id`; those names were a
+  // pre-merge guess on this side that 200-ignored every inbound
+  // webhook before #465 review caught it.
+  const eventId = req.body?.id;
+  if (!eventId) {
+    // Defensive: a future qurl-service refactor that drops `id` from
+    // the payload would silently disable replay protection — log the
+    // gap and reject so the regression surfaces immediately rather
+    // than via "duplicate view counts" downstream.
+    logger.warn('qURL webhook missing body.id (per-event replay key)');
+    return res.status(200).json({ status: 'invalid-payload' });
+  }
 
   // Only qurl.accessed drives the view counter today. Other event types
   // (e.g. qurl.created, qurl.revoked) may arrive if the subscription is
   // broader than necessary — silently 200 them so qurl-service doesn't
   // retry on the bot's account.
-  if (event !== 'qurl.accessed') {
-    logger.debug('qURL webhook event ignored', { event });
-    return res.status(200).json({ status: 'ignored', event });
+  if (eventType !== 'qurl.accessed') {
+    logger.debug('qURL webhook event ignored', { type: eventType });
+    return res.status(200).json({ status: 'ignored', type: eventType });
   }
 
   if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
@@ -174,11 +194,19 @@ router.post('/qurl', async (req, res) => {
       eventId,
     });
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed: Boolean(data.consumed), result });
+    // Audit ALL accepted webhooks — including dedup — so the
+    // QurlWebhookReceivedTotal metric reflects "qurl-service is
+    // reaching us" continuously. A drop to zero across an extended
+    // window is the load-bearing alarm signal (subscription drift /
+    // qurl-service down). Result dimension lets the dashboard split
+    // recorded vs dedup without a second filter.
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result });
     return res.status(200).json({ status: result });
   } catch (err) {
     // 5xx so qurl-service retries — transient DDB throttle should not
     // silently drop a view event.
     logger.error('Failed to record qURL view', { error: err.message, qurl_id: data.qurl_id });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_STORE_ERROR, { error_type: err.name || 'unknown' });
     return res.status(500).json({ error: 'Internal error' });
   }
 });

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -1,0 +1,191 @@
+// qURL webhook receiver
+//
+// Inbound endpoint for qurl-service's `qurl.accessed` event. Writes the
+// view count + consumed flag to the qurl_views DDB table; the live
+// monitor's setInterval reads from that table (see commands.js
+// monitorLinkStatus). DDB is the multi-instance bridge — a webhook
+// can land on instance A while the originating monitor's setInterval
+// runs on instance B, so we never reach for an in-process EventEmitter.
+//
+// Wire contract pinned by qurl-service:
+//   header  `QURL-Signature`  bare hex HMAC-SHA256 over raw body (no
+//                             `sha256=` prefix — different shape from
+//                             GitHub's signature scheme; do not copy
+//                             routes/webhooks.js' prefix-check verbatim)
+//   body    `{event, data:{qurl_id, resource_id, access_count, consumed}}`
+//
+// `src_ip` and `user_agent` are stripped server-side for type=transit
+// resources (the connector-owned privacy boundary). Discord bot sends
+// are always transit, so we don't even attempt to read those fields.
+//
+// Secret-unset behavior: route still mounts, but every request is
+// rejected with 503. A boot WARN surfaces the misconfig before traffic
+// arrives — operator sees "webhook receiver mounted in unconfigured
+// mode" in startup logs.
+
+const express = require('express');
+const crypto = require('crypto');
+const config = require('../config');
+const db = require('../store');
+const logger = require('../logger');
+
+const router = express.Router();
+
+// Bare hex digest (no `sha256=` prefix). qurl-service sends raw hex —
+// peer is `internal/domain/webhook.go::HeaderSignature` (qurl-service
+// repo). Length is fixed at 64 lowercase hex chars; reject anything
+// else before timingSafeEqual so a malformed header can't produce
+// unequal-length buffers inside the try/catch.
+function verifySignature(req) {
+  const signature = req.headers['qurl-signature'];
+
+  if (!config.QURL_WEBHOOK_SECRET) {
+    // Logged at error level so oncall catches the misconfig immediately.
+    // The boot-time WARN in server.js is the first signal; this is the
+    // per-request follow-up if traffic arrives before the secret is set.
+    logger.error('QURL_WEBHOOK_SECRET not configured — rejecting qURL webhook');
+    return false;
+  }
+
+  if (!signature) {
+    logger.warn('qURL webhook missing QURL-Signature header');
+    return false;
+  }
+  if (typeof signature !== 'string' || !/^[0-9a-f]{64}$/.test(signature)) {
+    logger.warn('qURL webhook signature has unexpected format', {
+      length: typeof signature === 'string' ? signature.length : 0,
+    });
+    return false;
+  }
+  if (!req.rawBody) {
+    logger.error('qURL webhook middleware did not populate rawBody — check server.js middleware ordering. Signature verification is BLOCKED until fixed.');
+    return false;
+  }
+
+  const hmac = crypto.createHmac('sha256', config.QURL_WEBHOOK_SECRET);
+  const digest = hmac.update(req.rawBody).digest('hex');
+
+  try {
+    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+  } catch {
+    return false;
+  }
+}
+
+// Per-IP failed-sig counter — mirrors routes/webhooks.js shape so the
+// two webhook surfaces have parallel hardening. SCALING: single-instance
+// only; move to Redis when the bot runs horizontally.
+const BAD_SIG_WINDOW_MS = 60_000;
+const BAD_SIG_MAX = 30;
+const BAD_SIG_PER_IP_CAP = BAD_SIG_MAX * 4;
+const badSigAttempts = new Map();
+
+const badSigSweep = setInterval(() => {
+  const cutoff = Date.now() - BAD_SIG_WINDOW_MS * 2;
+  for (const [ip, times] of badSigAttempts) {
+    const recent = times.filter(t => t > cutoff);
+    if (recent.length === 0) badSigAttempts.delete(ip);
+    else badSigAttempts.set(ip, recent);
+  }
+}, 5 * 60 * 1000);
+badSigSweep.unref();
+
+function recordBadSig(ip) {
+  const now = Date.now();
+  let list = (badSigAttempts.get(ip) || []).filter(t => t > now - BAD_SIG_WINDOW_MS);
+  list.push(now);
+  if (list.length > BAD_SIG_PER_IP_CAP) list = list.slice(-BAD_SIG_PER_IP_CAP);
+  if (badSigAttempts.size > 10_000) {
+    const dropCount = Math.max(1, Math.floor(badSigAttempts.size / 10));
+    const it = badSigAttempts.keys();
+    for (let i = 0; i < dropCount; i++) {
+      const k = it.next().value;
+      if (k === undefined) break;
+      badSigAttempts.delete(k);
+    }
+  }
+  badSigAttempts.set(ip, list);
+  return list.length;
+}
+
+router.post('/qurl', async (req, res) => {
+  const ip = req.ip || 'unknown';
+  const existing = (badSigAttempts.get(ip) || []).filter(t => t > Date.now() - BAD_SIG_WINDOW_MS);
+  if (existing.length >= BAD_SIG_MAX) {
+    logger.warn('qURL webhook rate limit exceeded (bad signatures)', { ip, recentFailures: existing.length });
+    return res.status(429).json({ error: 'Too many invalid webhook attempts' });
+  }
+
+  // Secret-unset path returns 503 (not 401) — the discriminator matters
+  // for oncall: 503 says "receiver is up but unconfigured"; 401 says
+  // "real signature mismatch." Without it, an operator forgetting to
+  // set the SSM param after first deploy would see the same status as
+  // a genuine wire-shape regression.
+  if (!config.QURL_WEBHOOK_SECRET) {
+    return res.status(503).json({ error: 'Webhook receiver not configured' });
+  }
+
+  if (!verifySignature(req)) {
+    const n = recordBadSig(ip);
+    logger.warn('Invalid qURL webhook signature', { ip, totalInWindow: n });
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  const event = req.body?.event;
+  const data = req.body?.data;
+  // Replay protection key — peer is qurl-service's per-delivery event_id.
+  // We also fall back to message_id (older payload shape) so a
+  // qurl-service rev that hasn't standardized the field name yet still
+  // gets dedup. If BOTH are absent the payload predates webhook
+  // hardening; record under a synthesized key derived from the body so
+  // we still get SOME replay protection (won't dedup across distinct
+  // events, but a literal redelivery hashes to the same key).
+  const eventId = req.body?.event_id || req.body?.message_id ||
+    crypto.createHash('sha256').update(req.rawBody).digest('hex');
+
+  // Only qurl.accessed drives the view counter today. Other event types
+  // (e.g. qurl.created, qurl.revoked) may arrive if the subscription is
+  // broader than necessary — silently 200 them so qurl-service doesn't
+  // retry on the bot's account.
+  if (event !== 'qurl.accessed') {
+    logger.debug('qURL webhook event ignored', { event });
+    return res.status(200).json({ status: 'ignored', event });
+  }
+
+  if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
+    logger.warn('qURL webhook qurl.accessed missing qurl_id', { data });
+    // 200 — the event was authentic, the payload was bad. Returning 4xx
+    // here would make qurl-service retry, but no amount of retry will
+    // fix a malformed payload. Log + drop.
+    return res.status(200).json({ status: 'invalid-payload' });
+  }
+
+  const accessCount = Number(data.access_count);
+  if (!Number.isFinite(accessCount) || accessCount < 0) {
+    logger.warn('qURL webhook access_count not a non-negative number', { qurl_id: data.qurl_id, access_count: data.access_count });
+    return res.status(200).json({ status: 'invalid-payload' });
+  }
+
+  try {
+    const result = await db.recordQurlView({
+      qurlId: data.qurl_id,
+      accessCount,
+      consumed: Boolean(data.consumed),
+      eventId,
+    });
+    logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed: Boolean(data.consumed), result });
+    return res.status(200).json({ status: result });
+  } catch (err) {
+    // 5xx so qurl-service retries — transient DDB throttle should not
+    // silently drop a view event.
+    logger.error('Failed to record qURL view', { error: err.message, qurl_id: data.qurl_id });
+    return res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// Export sweep handle so server.js stopIntervals() can clear it on
+// graceful shutdown — symmetric with the metricsSweepInterval pattern.
+module.exports = router;
+module.exports.stopIntervals = function stopIntervals() {
+  clearInterval(badSigSweep);
+};

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -1,69 +1,37 @@
-// qURL webhook receiver
+// qURL webhook receiver — POST /webhooks/qurl
 //
-// Inbound endpoint for qurl-service's `qurl.accessed` event. Writes the
-// view count + consumed flag to the qurl_views DDB table; the live
-// monitor's setInterval reads from that table (see commands.js
-// monitorLinkStatus). DDB is the multi-instance bridge — a webhook
-// can land on instance A while the originating monitor's setInterval
-// runs on instance B, so we never reach for an in-process EventEmitter.
-//
-// Wire contract pinned by qurl-service domain.WebhookEvent
-// (internal/domain/webhook.go) + domain.SignPayload:
-//   header  `QURL-Signature`   bare hex HMAC-SHA256 over raw body (no
-//                              `sha256=` prefix — different shape from
-//                              GitHub's signature scheme; do not copy
-//                              routes/webhooks.js' prefix-check verbatim)
-//   header  `QURL-Delivery`    per-delivery ID (`wd_…`). Different
-//                              across redeliveries of the same event,
-//                              so NOT a replay key — use body.id for that.
-//   body    `{id, type, data:{qurl_id, resource_id, access_count, consumed},
-//             owner_id, timestamp, api_version}`
-//
-// Field NAMES matter: qurl-service emits `type` (not `event`) and `id`
-// (not `event_id`). Receiver-side renames of either field silently
-// 200-ignore every inbound webhook because the type check fails first.
-// Pinning the qurl-service field names here so a future "let's normalize
-// to event_id" refactor in EITHER repo fails CI rather than going dark.
+// Wire contract (qurl-service/internal/domain/webhook.go::WebhookEvent +
+// SignPayload):
+//   header  `QURL-Signature`  bare hex HMAC-SHA256 (NO `sha256=` prefix —
+//                             that's GitHub's shape)
+//   body    {id, type, data:{qurl_id, resource_id, access_count, consumed},
+//            owner_id, timestamp, api_version}
 //
 // `src_ip` and `user_agent` are stripped server-side for type=transit
-// resources (the connector-owned privacy boundary). Discord bot sends
-// are always transit, so we don't even attempt to read those fields.
-//
-// Secret-unset behavior: route still mounts, but every request is
-// rejected with 503. A boot WARN surfaces the misconfig before traffic
-// arrives — operator sees "webhook receiver mounted in unconfigured
-// mode" in startup logs.
+// resources (connector-owned privacy boundary). Discord bot sends are
+// always transit.
 
 const express = require('express');
-const crypto = require('crypto');
 const config = require('../config');
 const db = require('../store');
 const logger = require('../logger');
-const { AUDIT_EVENTS } = require('../constants');
+const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS } = require('../constants');
+const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
 
 const router = express.Router();
 
-// Bare hex digest (no `sha256=` prefix). qurl-service sends raw hex —
-// peer is `internal/domain/webhook.go::HeaderSignature` (qurl-service
-// repo). Length is fixed at 64 lowercase hex chars; reject anything
-// else before timingSafeEqual so a malformed header can't produce
-// unequal-length buffers inside the try/catch.
+const SIGNATURE_HEADER = 'qurl-signature';
+const SIGNATURE_PATTERN = /^[0-9a-f]{64}$/;
+
+const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
+
 function verifySignature(req) {
-  const signature = req.headers['qurl-signature'];
-
-  if (!config.QURL_WEBHOOK_SECRET) {
-    // Logged at error level so oncall catches the misconfig immediately.
-    // The boot-time WARN in server.js is the first signal; this is the
-    // per-request follow-up if traffic arrives before the secret is set.
-    logger.error('QURL_WEBHOOK_SECRET not configured — rejecting qURL webhook');
-    return false;
-  }
-
+  const signature = req.headers[SIGNATURE_HEADER];
   if (!signature) {
     logger.warn('qURL webhook missing QURL-Signature header');
     return false;
   }
-  if (typeof signature !== 'string' || !/^[0-9a-f]{64}$/.test(signature)) {
+  if (typeof signature !== 'string' || !SIGNATURE_PATTERN.test(signature)) {
     logger.warn('qURL webhook signature has unexpected format', {
       length: typeof signature === 'string' ? signature.length : 0,
     });
@@ -73,73 +41,25 @@ function verifySignature(req) {
     logger.error('qURL webhook middleware did not populate rawBody — check server.js middleware ordering. Signature verification is BLOCKED until fixed.');
     return false;
   }
-
-  const hmac = crypto.createHmac('sha256', config.QURL_WEBHOOK_SECRET);
-  const digest = hmac.update(req.rawBody).digest('hex');
-
-  try {
-    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
-  } catch {
-    return false;
-  }
-}
-
-// Per-IP failed-sig counter — mirrors routes/webhooks.js shape so the
-// two webhook surfaces have parallel hardening. SCALING: single-instance
-// only; move to Redis when the bot runs horizontally.
-const BAD_SIG_WINDOW_MS = 60_000;
-const BAD_SIG_MAX = 30;
-const BAD_SIG_PER_IP_CAP = BAD_SIG_MAX * 4;
-const badSigAttempts = new Map();
-
-const badSigSweep = setInterval(() => {
-  const cutoff = Date.now() - BAD_SIG_WINDOW_MS * 2;
-  for (const [ip, times] of badSigAttempts) {
-    const recent = times.filter(t => t > cutoff);
-    if (recent.length === 0) badSigAttempts.delete(ip);
-    else badSigAttempts.set(ip, recent);
-  }
-}, 5 * 60 * 1000);
-badSigSweep.unref();
-
-function recordBadSig(ip) {
-  const now = Date.now();
-  let list = (badSigAttempts.get(ip) || []).filter(t => t > now - BAD_SIG_WINDOW_MS);
-  list.push(now);
-  if (list.length > BAD_SIG_PER_IP_CAP) list = list.slice(-BAD_SIG_PER_IP_CAP);
-  if (badSigAttempts.size > 10_000) {
-    const dropCount = Math.max(1, Math.floor(badSigAttempts.size / 10));
-    const it = badSigAttempts.keys();
-    for (let i = 0; i < dropCount; i++) {
-      const k = it.next().value;
-      if (k === undefined) break;
-      badSigAttempts.delete(k);
-    }
-  }
-  badSigAttempts.set(ip, list);
-  return list.length;
+  return verifyHmacSha256(req.rawBody, config.QURL_WEBHOOK_SECRET, signature);
 }
 
 router.post('/qurl', async (req, res) => {
   const ip = req.ip || 'unknown';
-  const existing = (badSigAttempts.get(ip) || []).filter(t => t > Date.now() - BAD_SIG_WINDOW_MS);
-  if (existing.length >= BAD_SIG_MAX) {
-    logger.warn('qURL webhook rate limit exceeded (bad signatures)', { ip, recentFailures: existing.length });
-    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RATE_LIMITED, { recent_failures: existing.length });
+  if (badSigLimiter.shouldThrottle(ip)) {
+    logger.warn('qURL webhook rate limit exceeded (bad signatures)', { ip });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RATE_LIMITED, {});
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
 
-  // Secret-unset path returns 503 (not 401) — the discriminator matters
-  // for oncall: 503 says "receiver is up but unconfigured"; 401 says
-  // "real signature mismatch." Without it, an operator forgetting to
-  // set the SSM param after first deploy would see the same status as
-  // a genuine wire-shape regression.
+  // 503 vs 401: 503 says "receiver is up but unconfigured" (set
+  // QURL_WEBHOOK_SECRET in SSM); 401 says "real signature mismatch."
   if (!config.QURL_WEBHOOK_SECRET) {
     return res.status(503).json({ error: 'Webhook receiver not configured' });
   }
 
   if (!verifySignature(req)) {
-    const n = recordBadSig(ip);
+    const n = badSigLimiter.recordBadSig(ip);
     logger.warn('Invalid qURL webhook signature', { ip, totalInWindow: n });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID, { total_in_window: n });
     return res.status(401).json({ error: 'Invalid signature' });
@@ -147,36 +67,19 @@ router.post('/qurl', async (req, res) => {
 
   const eventType = req.body?.type;
   const data = req.body?.data;
-  // Replay-protection key. Peer is qurl-service's WebhookEvent.ID
-  // (json `id`) — stable across redeliveries of the same event, so
-  // `last_event_id <> :eid` actually catches redeliveries. The peer
-  // does NOT use `event_id` / `message_id`; those names were a
-  // pre-merge guess on this side that 200-ignored every inbound
-  // webhook before #465 review caught it.
   const eventId = req.body?.id;
   if (!eventId) {
-    // Defensive: a future qurl-service refactor that drops `id` from
-    // the payload would silently disable replay protection — log the
-    // gap and reject so the regression surfaces immediately rather
-    // than via "duplicate view counts" downstream.
     logger.warn('qURL webhook missing body.id (per-event replay key)');
     return res.status(200).json({ status: 'invalid-payload' });
   }
 
-  // Only qurl.accessed drives the view counter today. Other event types
-  // (e.g. qurl.created, qurl.revoked) may arrive if the subscription is
-  // broader than necessary — silently 200 them so qurl-service doesn't
-  // retry on the bot's account.
-  if (eventType !== 'qurl.accessed') {
+  if (eventType !== QURL_WEBHOOK_EVENTS.ACCESSED) {
     logger.debug('qURL webhook event ignored', { type: eventType });
     return res.status(200).json({ status: 'ignored', type: eventType });
   }
 
   if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
     logger.warn('qURL webhook qurl.accessed missing qurl_id', { data });
-    // 200 — the event was authentic, the payload was bad. Returning 4xx
-    // here would make qurl-service retry, but no amount of retry will
-    // fix a malformed payload. Log + drop.
     return res.status(200).json({ status: 'invalid-payload' });
   }
 
@@ -194,12 +97,6 @@ router.post('/qurl', async (req, res) => {
       eventId,
     });
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed: Boolean(data.consumed), result });
-    // Audit ALL accepted webhooks — including dedup — so the
-    // QurlWebhookReceivedTotal metric reflects "qurl-service is
-    // reaching us" continuously. A drop to zero across an extended
-    // window is the load-bearing alarm signal (subscription drift /
-    // qurl-service down). Result dimension lets the dashboard split
-    // recorded vs dedup without a second filter.
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result });
     return res.status(200).json({ status: result });
   } catch (err) {
@@ -211,9 +108,7 @@ router.post('/qurl', async (req, res) => {
   }
 });
 
-// Export sweep handle so server.js stopIntervals() can clear it on
-// graceful shutdown — symmetric with the metricsSweepInterval pattern.
-module.exports = router;
-module.exports.stopIntervals = function stopIntervals() {
-  clearInterval(badSigSweep);
+router.stopIntervals = function stopIntervals() {
+  badSigLimiter.stopSweep();
 };
+module.exports = router;

--- a/apps/discord/src/routes/webhooks.js
+++ b/apps/discord/src/routes/webhooks.js
@@ -1,12 +1,12 @@
 // GitHub webhook routes
 const express = require('express');
-const crypto = require('crypto');
 const { EmbedBuilder } = require('discord.js');
 const config = require('../config');
 const db = require('../store');
 const logger = require('../logger');
 const { COLORS, GOOD_FIRST_ISSUE_PATTERNS } = require('../constants');
 const { escapeDiscordMarkdown } = require('../utils/sanitize');
+const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
 // Short alias — GitHub webhook payloads put user-controlled text everywhere
 // (PR title, issue title, commit message, branch name, label). We render
 // those inside Discord embeds, which render markdown including [text](url)
@@ -33,49 +33,35 @@ const {
 
 const router = express.Router();
 
-// Verify GitHub webhook signature
+// `sha256=<64 lowercase hex>` is GitHub's canonical signature shape. We
+// validate the shape before calling verifyHmacSha256 so a malformed
+// header (wrong length, non-hex) is rejected before timingSafeEqual.
+const GITHUB_SIGNATURE_PATTERN = /^sha256=[0-9a-f]{64}$/;
+
 function verifySignature(req) {
   const signature = req.headers['x-hub-signature-256'];
-
   if (!config.GITHUB_WEBHOOK_SECRET) {
     logger.error('GITHUB_WEBHOOK_SECRET not configured - rejecting webhook');
     return false;
   }
-
   if (!signature) {
     logger.warn('Webhook request missing signature');
     return false;
   }
-  // Validate the header is exactly `sha256=<64 lowercase hex>` before it
-  // reaches timingSafeEqual. An attacker can't pick the digest, but a
-  // malformed header (wrong length, non-hex) should be rejected early
-  // rather than producing unequal-length buffers inside the try/catch.
-  if (typeof signature !== 'string' || !/^sha256=[0-9a-f]{64}$/.test(signature)) {
-    // Don't log the (attacker-controlled) signature prefix — only shape data.
+  if (typeof signature !== 'string' || !GITHUB_SIGNATURE_PATTERN.test(signature)) {
     logger.warn('Webhook signature has unexpected format', {
       length: typeof signature === 'string' ? signature.length : 0,
       hasPrefix: typeof signature === 'string' && signature.startsWith('sha256='),
     });
     return false;
   }
-  // Defensive: if middleware ordering ever changes or a request arrives with
-  // a non-JSON content type, rawBody may be absent. hmac.update(undefined)
-  // throws TypeError, which is outside the try/catch below. Logged at error
-  // level so oncall catches a silent misconfiguration quickly — legit GitHub
-  // traffic always has a JSON body and hits the /webhook express.json parser.
   if (!req.rawBody) {
     logger.error('Webhook middleware did not populate rawBody — check server.js middleware ordering. Signature verification is BLOCKED until fixed.');
     return false;
   }
-
-  const hmac = crypto.createHmac('sha256', config.GITHUB_WEBHOOK_SECRET);
-  const digest = 'sha256=' + hmac.update(req.rawBody).digest('hex');
-
-  try {
-    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
-  } catch {
-    return false;
-  }
+  // Strip the `sha256=` prefix before the constant-time compare — the
+  // shared helper compares bare hex.
+  return verifyHmacSha256(req.rawBody, config.GITHUB_WEBHOOK_SECRET, signature.slice('sha256='.length));
 }
 
 // Check if repo belongs to allowed organization
@@ -92,59 +78,17 @@ function isAutomatedBot(prUser) {
   return prUser.type === 'Bot' || botNames.some(bot => username.includes(bot));
 }
 
-// Per-IP counter of failed-signature attempts so an attacker can't burn CPU
-// by firing unlimited invalid webhooks. Legitimate GitHub traffic (valid
-// HMAC) is never throttled. Swept every 5 minutes.
-// SCALING: single-instance only. Move to Redis if the bot runs horizontally.
-const BAD_SIG_WINDOW_MS = 60_000;
-const BAD_SIG_MAX = 30;
-const badSigAttempts = new Map(); // ip -> number[]  (timestamps)
-setInterval(() => {
-  const cutoff = Date.now() - BAD_SIG_WINDOW_MS * 2;
-  for (const [ip, times] of badSigAttempts) {
-    const recent = times.filter(t => t > cutoff);
-    if (recent.length === 0) badSigAttempts.delete(ip);
-    else badSigAttempts.set(ip, recent);
-  }
-}, 5 * 60 * 1000).unref();
+const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
 
-// Hard cap per-IP array to prevent a single abusive IP from growing its
-// timestamp list unboundedly between sweeps.
-const BAD_SIG_PER_IP_CAP = BAD_SIG_MAX * 4;
-
-function recordBadSig(ip) {
-  const now = Date.now();
-  let list = (badSigAttempts.get(ip) || []).filter(t => t > now - BAD_SIG_WINDOW_MS);
-  list.push(now);
-  if (list.length > BAD_SIG_PER_IP_CAP) {
-    list = list.slice(-BAD_SIG_PER_IP_CAP);
-  }
-  if (badSigAttempts.size > 10_000) {
-    // Same 10%-drop strategy as oauth.js rateLimitStore — single-entry
-    // eviction can't keep up with a distributed flood of unique IPs.
-    const dropCount = Math.max(1, Math.floor(badSigAttempts.size / 10));
-    const it = badSigAttempts.keys();
-    for (let i = 0; i < dropCount; i++) {
-      const k = it.next().value;
-      if (k === undefined) break;
-      badSigAttempts.delete(k);
-    }
-  }
-  badSigAttempts.set(ip, list);
-  return list.length;
-}
-
-// Main webhook handler
 router.post('/github', async (req, res) => {
   const ip = req.ip || 'unknown';
-  const existing = (badSigAttempts.get(ip) || []).filter(t => t > Date.now() - BAD_SIG_WINDOW_MS);
-  if (existing.length >= BAD_SIG_MAX) {
-    logger.warn('Webhook rate limit exceeded (bad signatures)', { ip, recentFailures: existing.length });
+  if (badSigLimiter.shouldThrottle(ip)) {
+    logger.warn('Webhook rate limit exceeded (bad signatures)', { ip });
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
 
   if (!verifySignature(req)) {
-    const n = recordBadSig(ip);
+    const n = badSigLimiter.recordBadSig(ip);
     logger.warn('Invalid webhook signature', { ip, totalInWindow: n });
     return res.status(401).json({ error: 'Invalid signature' });
   }
@@ -440,4 +384,7 @@ async function handleActivityFeed(event, payload) {
   }
 }
 
+router.stopIntervals = function stopIntervals() {
+  badSigLimiter.stopSweep();
+};
 module.exports = router;

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -64,38 +64,19 @@ app.use(helmet({
 
 // Parse JSON for webhooks with raw body for signature verification. MUST be
 // registered BEFORE the general app.use(express.json()) below so webhook
-// requests hit this parser first and get req.rawBody populated. Do not
-// reorder without also updating routes/webhooks.js + routes/qurl-webhook.js
-// verifySignature().
-//
-// Startup contract: each verifySignature() asserts req.rawBody exists at
-// request time and refuses the request with an error log if the middleware
-// chain drops it. See those files' guard comments for details.
-//
-// /webhook (GitHub): gated on isOpenNHPActive for symmetry with the router
-// mount below — when /webhook routes aren't mounted, Express would still
-// parse up to 1 MB of JSON per request before falling through to the 404
-// handler. Skipping the parser registration avoids that wasted work.
-if (config.isOpenNHPActive) {
-  app.use('/webhook', express.json({
-    limit: '1mb',
-    verify: (req, _res, buf) => {
-      req.rawBody = buf;
-    }
-  }));
-}
-
-// /webhooks (qURL): unconditional — the qurl-service-fed view counter
-// is part of the universal /qurl send + /qurl map surface, not gated on
-// GitHub-OpenNHP mode. The route itself refuses inbound traffic when
-// QURL_WEBHOOK_SECRET is unset (boot WARN + per-request 503), so the
-// parser running pre-config is a no-op cost on a tiny attack surface.
-app.use('/webhooks', express.json({
+// requests hit this parser first and get req.rawBody populated.
+const rawBodyJson = express.json({
   limit: '1mb',
-  verify: (req, _res, buf) => {
-    req.rawBody = buf;
-  }
-}));
+  verify: (req, _res, buf) => { req.rawBody = buf; },
+});
+
+// /webhook (GitHub) gated on isOpenNHPActive so we don't parse 1MB of
+// JSON for routes that aren't mounted. /webhooks (qURL) is unconditional
+// — the receiver itself returns 503 when QURL_WEBHOOK_SECRET is unset.
+if (config.isOpenNHPActive) {
+  app.use('/webhook', rawBodyJson);
+}
+app.use('/webhooks', rawBodyJson);
 
 app.use(express.json({ limit: '1mb' }));
 
@@ -209,12 +190,12 @@ if (config.isOpenNHPActive) {
   logger.info('Single-guild plain mode (ENABLE_OPENNHP_FEATURES=false): /auth and /webhook routes not mounted.');
 }
 
-// qURL webhook receiver — unconditional mount. Powers the post-PR-#455
-// view counter UI for /qurl send + /qurl map. Refuses traffic with 503
-// until QURL_WEBHOOK_SECRET is set (boot WARN below surfaces the gap).
+// Unconditional mount — the route returns 503 until QURL_WEBHOOK_SECRET
+// is set, so a fresh deploy never accepts traffic without the secret.
 app.use('/webhooks', qurlWebhookRouter);
 if (!config.QURL_WEBHOOK_SECRET) {
-  logger.warn('QURL_WEBHOOK_SECRET unset — qURL webhook receiver mounted but will reject all inbound traffic with 503. The view counter on /qurl send + /qurl map will stay at the bare base message until the secret is configured (SSM /<project>/QURL_WEBHOOK_SECRET, then restart).');
+  logger.warn('QURL_WEBHOOK_SECRET unset — qURL webhook receiver returns 503 on all inbound');
+  logger.warn('To enable: set SSM /<project>/QURL_WEBHOOK_SECRET, then restart the task');
 }
 
 // Cache-Control: no-store on every response from the OAuth surfaces —
@@ -284,11 +265,10 @@ function startServer() {
 
 function stopIntervals() {
   clearInterval(metricsSweepInterval);
-  // qurl-webhook owns its own per-IP bad-sig sweep; mirror the metrics
-  // pattern so graceful shutdown stops every router-owned interval.
-  if (typeof qurlWebhookRouter.stopIntervals === 'function') {
-    qurlWebhookRouter.stopIntervals();
-  }
+  // Each webhook router owns a per-IP bad-sig sweep; stop them all on
+  // graceful shutdown so the interval doesn't outlive the server.
+  if (typeof qurlWebhookRouter.stopIntervals === 'function') qurlWebhookRouter.stopIntervals();
+  if (typeof webhooksRouter.stopIntervals === 'function') webhooksRouter.stopIntervals();
 }
 
 module.exports = { app, startServer, stopIntervals };

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -10,6 +10,7 @@ const oauthRouter = require('./routes/oauth');
 const qurlOAuthRouter = require('./routes/qurl-oauth');
 const discordInstallRouter = require('./routes/discord-install');
 const webhooksRouter = require('./routes/webhooks');
+const qurlWebhookRouter = require('./routes/qurl-webhook');
 
 const app = express();
 
@@ -62,29 +63,39 @@ app.use(helmet({
 }));
 
 // Parse JSON for webhooks with raw body for signature verification. MUST be
-// registered BEFORE the general app.use(express.json()) below so /webhook
+// registered BEFORE the general app.use(express.json()) below so webhook
 // requests hit this parser first and get req.rawBody populated. Do not
-// reorder without also updating routes/webhooks.js verifySignature().
+// reorder without also updating routes/webhooks.js + routes/qurl-webhook.js
+// verifySignature().
 //
-// Startup contract: routes/webhooks.js verifySignature() asserts req.rawBody
-// exists at request time and refuses the request with an error log if the
-// middleware chain drops it. See that file's guard comment for details.
+// Startup contract: each verifySignature() asserts req.rawBody exists at
+// request time and refuses the request with an error log if the middleware
+// chain drops it. See those files' guard comments for details.
 //
-// Gated on isOpenNHPActive for symmetry with the router mount below —
-// when /webhook routes aren't mounted, Express would still parse up to
-// 1 MB of JSON per request before falling through to the 404 handler.
-// Skipping the parser registration avoids that wasted work (and the
-// small DoS surface of parsing unauthenticated request bodies).
+// /webhook (GitHub): gated on isOpenNHPActive for symmetry with the router
+// mount below — when /webhook routes aren't mounted, Express would still
+// parse up to 1 MB of JSON per request before falling through to the 404
+// handler. Skipping the parser registration avoids that wasted work.
 if (config.isOpenNHPActive) {
   app.use('/webhook', express.json({
-    // GitHub push-event payloads can exceed Express's 100KB default. Cap at
-    // 1MB so we accept legitimate payloads but still bound request memory.
     limit: '1mb',
     verify: (req, _res, buf) => {
       req.rawBody = buf;
     }
   }));
 }
+
+// /webhooks (qURL): unconditional — the qurl-service-fed view counter
+// is part of the universal /qurl send + /qurl map surface, not gated on
+// GitHub-OpenNHP mode. The route itself refuses inbound traffic when
+// QURL_WEBHOOK_SECRET is unset (boot WARN + per-request 503), so the
+// parser running pre-config is a no-op cost on a tiny attack surface.
+app.use('/webhooks', express.json({
+  limit: '1mb',
+  verify: (req, _res, buf) => {
+    req.rawBody = buf;
+  }
+}));
 
 app.use(express.json({ limit: '1mb' }));
 
@@ -198,6 +209,14 @@ if (config.isOpenNHPActive) {
   logger.info('Single-guild plain mode (ENABLE_OPENNHP_FEATURES=false): /auth and /webhook routes not mounted.');
 }
 
+// qURL webhook receiver — unconditional mount. Powers the post-PR-#455
+// view counter UI for /qurl send + /qurl map. Refuses traffic with 503
+// until QURL_WEBHOOK_SECRET is set (boot WARN below surfaces the gap).
+app.use('/webhooks', qurlWebhookRouter);
+if (!config.QURL_WEBHOOK_SECRET) {
+  logger.warn('QURL_WEBHOOK_SECRET unset — qURL webhook receiver mounted but will reject all inbound traffic with 503. The view counter on /qurl send + /qurl map will stay at the bare base message until the secret is configured (SSM /<project>/QURL_WEBHOOK_SECRET, then restart).');
+}
+
 // Cache-Control: no-store on every response from the OAuth surfaces —
 // success page surfaces guild + qURL email + key prefix; error pages
 // could leak detail in the future; not-configured page is also OAuth-
@@ -265,6 +284,11 @@ function startServer() {
 
 function stopIntervals() {
   clearInterval(metricsSweepInterval);
+  // qurl-webhook owns its own per-IP bad-sig sweep; mirror the metrics
+  // pattern so graceful shutdown stops every router-owned interval.
+  if (typeof qurlWebhookRouter.stopIntervals === 'function') {
+    qurlWebhookRouter.stopIntervals();
+  }
 }
 
 module.exports = { app, startServer, stopIntervals };

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -94,6 +94,10 @@ const STORE_METHODS = Object.freeze([
   'getSendResourceIds',
   'getSendItems',
 
+  // QURL views (webhook-fed view counter)
+  'recordQurlView',
+  'getQurlViews',
+
   // Guild (BYOK) API keys
   'getGuildApiKey',
   'setGuildApiKey',

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1025,9 +1025,10 @@ async function recordQURLSendBatch(sends) {
 
 // ── QURL views (webhook-fed view counter for /qurl send + /qurl map) ──
 
-// 30d TTL refreshed on every write. Safely past the longest monitor
-// lifetime (1h cap) + longest link expiry (7d) + DDB's ~48h TTL
-// precision — no monitor will ever read a row about to reap.
+// 30d TTL on `expires_at` (peer attribute name across every TTL table
+// in qurl-bot-ddb), refreshed on every write. Safely past the longest
+// monitor lifetime (1h cap) + longest link expiry (7d) + DDB's ~48h
+// TTL precision — no monitor will ever read a row about to reap.
 const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 // `consumed` is persisted + returned by getQurlViews but not yet
@@ -1058,14 +1059,15 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
         + 'last_event_id <> :eid AND ('
         + 'access_count < :n OR (access_count = :n AND consumed = :false AND :c = :true)'
         + '))',
-      UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now, #ttl = :ttl',
-      ExpressionAttributeNames: { '#ttl': 'ttl' },
+      UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now, expires_at = :exp',
       ExpressionAttributeValues: {
         ':n': accessCount,
         ':c': consumedBool,
         ':eid': eventId,
         ':now': new Date(nowMs).toISOString(),
-        ':ttl': Math.floor(nowMs / 1000) + QURL_VIEW_TTL_SECONDS,
+        // DDB silently refuses to expire rows whose TTL attribute isn't
+        // a Number — keep this as epoch seconds (integer), not a string.
+        ':exp': Math.floor(nowMs / 1000) + QURL_VIEW_TTL_SECONDS,
         ':false': false,
         ':true': true,
       },

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1042,6 +1042,12 @@ const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
 // false→true consumed clause covers a qurl-service emission shape
 // where a follow-on event records the burn without re-bumping the
 // counter; without it we'd silently drop that signal.
+//
+// Asymmetry note: a consumed: true → false flip at the same
+// access_count is silently dropped as "dedup" — intentional for
+// self-destruct semantics ("once consumed, always consumed"). If
+// qurl-service ever needs to un-consume a row, that's a separate
+// API contract change.
 async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
   if (!qurlId) throw new Error('recordQurlView: qurlId is required');
   if (typeof accessCount !== 'number' || accessCount < 0) {

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -58,6 +58,7 @@ const {
   UpdateCommand,
   QueryCommand,
   ScanCommand,
+  BatchGetCommand,
   BatchWriteCommand,
 } = require('@aws-sdk/lib-dynamodb');
 
@@ -122,6 +123,7 @@ const TABLES = Object.freeze({
   weekly_stats: `${TABLE_PREFIX}weekly-stats`,
   qurl_sends: `${TABLE_PREFIX}qurl-sends`,
   qurl_send_configs: `${TABLE_PREFIX}qurl-send-configs`,
+  qurl_views: `${TABLE_PREFIX}qurl-views`,
   orphaned_oauth_tokens: `${TABLE_PREFIX}orphaned-oauth-tokens`,
   guild_configs: `${TABLE_PREFIX}guild-configs`,
 });
@@ -1021,6 +1023,103 @@ async function recordQURLSendBatch(sends) {
   }
 }
 
+// ── QURL views (webhook-fed view counter for /qurl send + /qurl map) ──
+
+// recordQurlView is the qurl.accessed webhook's persistence sink. The
+// conditional update implements MAX-merge semantics: a redelivery, a
+// stale (lower-count) replay, or an out-of-order arrival is silently
+// dropped. The monitor's setInterval polls this table (live view
+// counter); a webhook can land on a different bot instance than the
+// one running the originating monitor's setInterval, so the join is
+// always through DDB — never in-process pub/sub.
+async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
+  if (!qurlId) throw new Error('recordQurlView: qurlId is required');
+  if (typeof accessCount !== 'number' || accessCount < 0) {
+    throw new Error(`recordQurlView: accessCount must be a non-negative number (got ${accessCount})`);
+  }
+  if (!eventId) throw new Error('recordQurlView: eventId is required for replay protection');
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: TABLES.qurl_views,
+      Key: { qurl_id: qurlId },
+      // Two-clause condition: first arrival ALWAYS wins; subsequent
+      // arrivals must be a distinct event AND advance the count. The
+      // event-id clause is the replay guard (qurl-service's delivery
+      // retries reuse the same event_id); the count clause guards the
+      // "out-of-order arrival" case (event N+1 races event N, and N
+      // arrives second — we never want to regress access_count).
+      ConditionExpression: 'attribute_not_exists(last_event_id) OR (last_event_id <> :eid AND access_count < :n)',
+      UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now',
+      ExpressionAttributeValues: {
+        ':n': accessCount,
+        ':c': Boolean(consumed),
+        ':eid': eventId,
+        ':now': nowIso(),
+      },
+    }));
+    return 'recorded';
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      // Either a redelivery (same event_id) or an out-of-order arrival
+      // (lower or equal count). Either way the row already reflects
+      // a >= state — silently drop. The caller can treat 'dedup' as
+      // success for the webhook's 200 response (drop ≠ failure).
+      return 'dedup';
+    }
+    throw err;
+  }
+}
+
+// getQurlViews BatchGets the view rows for an in-memory qurlLinks set.
+// DDB BatchGetItem caps at 100 keys per request; the monitor's tracked
+// set is bounded by QURL_SEND_MAX_RECIPIENTS (50 today), so a single
+// request handles every realistic call. Returns a Map keyed on qurl_id.
+async function getQurlViews(qurlIds) {
+  if (!Array.isArray(qurlIds) || qurlIds.length === 0) return new Map();
+  // De-dupe + drop empty strings defensively. An empty qurl_id reaching
+  // BatchGet would be a collision attractor (every empty-id row lands
+  // on the same key) — the boundary in commands.js' empty-id guard
+  // should already filter, but defense-in-depth at the store edge
+  // keeps the invariant local.
+  const keys = [...new Set(qurlIds.filter(Boolean))].map(id => ({ qurl_id: id }));
+  if (keys.length === 0) return new Map();
+  // BatchGet caps at 100 keys/request. Today max recipients is 50, so
+  // chunking is purely defensive — if QURL_SEND_MAX_RECIPIENTS ever
+  // rises past 100 we degrade gracefully instead of returning a
+  // partial map silently.
+  const CHUNK = 100;
+  const out = new Map();
+  for (let i = 0; i < keys.length; i += CHUNK) {
+    const slice = keys.slice(i, i + CHUNK);
+    const res = await ddb.send(new BatchGetCommand({
+      RequestItems: { [TABLES.qurl_views]: { Keys: slice } },
+    }));
+    const items = (res.Responses && res.Responses[TABLES.qurl_views]) || [];
+    for (const item of items) {
+      out.set(item.qurl_id, {
+        accessCount: item.access_count || 0,
+        consumed: Boolean(item.consumed),
+      });
+    }
+    // UnprocessedKeys is populated under throttle. A single retry covers
+    // the realistic case (small fan-out); persistent unprocessed keys
+    // would mean a hot table — that's an oncall signal, not a per-call
+    // retry loop. Match recordQURLSendBatch's bounded-retry pattern.
+    const unprocessed = res.UnprocessedKeys && res.UnprocessedKeys[TABLES.qurl_views];
+    if (unprocessed && unprocessed.Keys && unprocessed.Keys.length > 0) {
+      const retry = await ddb.send(new BatchGetCommand({ RequestItems: { [TABLES.qurl_views]: unprocessed } }));
+      const retryItems = (retry.Responses && retry.Responses[TABLES.qurl_views]) || [];
+      for (const item of retryItems) {
+        out.set(item.qurl_id, {
+          accessCount: item.access_count || 0,
+          consumed: Boolean(item.consumed),
+        });
+      }
+    }
+  }
+  return out;
+}
+
 async function updateSendDMStatus(sendId, recipientDiscordId, status) {
   await ddb.send(new UpdateCommand({
     TableName: TABLES.qurl_sends,
@@ -1548,6 +1647,8 @@ module.exports = {
   recordQURLSend, recordQURLSendBatch, updateSendDMStatus, markSendDMDelivered,
   getRecentSends, markSendRevoked,
   saveSendConfig, getSendConfig, getSendResourceIds, getSendItems,
+  // QURL views (webhook-fed)
+  recordQurlView, getQurlViews,
   // Guild configs
   getGuildApiKey, setGuildApiKey, removeGuildApiKey, getGuildConfig, getGuildConfigWithApiKey,
   // Orphaned tokens

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1025,110 +1025,90 @@ async function recordQURLSendBatch(sends) {
 
 // ── QURL views (webhook-fed view counter for /qurl send + /qurl map) ──
 
-// 30-day TTL window on qurl_views rows. Safely past the longest
-// monitor lifetime (1h cap) + the longest link expiry (7d), with
-// ~3 weeks of buffer for DDB's TTL precision (rows can survive
-// up to 48h past their stamp before the asynchronous reaper sweeps
-// them). A shorter window risks dropping a row a monitor is still
-// reading; a longer window leaves unbounded growth on the table.
+// 30d TTL refreshed on every write. Safely past the longest monitor
+// lifetime (1h cap) + longest link expiry (7d) + DDB's ~48h TTL
+// precision — no monitor will ever read a row about to reap.
 const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
 
-// recordQurlView is the qurl.accessed webhook's persistence sink. The
-// conditional update implements MAX-merge semantics: a redelivery, a
-// stale (lower-count) replay, or an out-of-order arrival is silently
-// dropped. The monitor's setInterval polls this table (live view
-// counter); a webhook can land on a different bot instance than the
-// one running the originating monitor's setInterval, so the join is
-// always through DDB — never in-process pub/sub.
-//
-// Every successful write refreshes the `ttl` attribute to (now + 30d).
-// A qURL that keeps receiving views (e.g. a multi-use link) keeps its
-// row alive; once views stop, the row reaps 30d later.
+// `consumed` is persisted + returned by getQurlViews but not yet
+// rendered by the monitor (runTick only checks accessCount > 0).
+// Reserved for a future "🔥 N consumed" state on self-destruct sends —
+// see commands.js buildStatusMsg for the render site.
+
+// MAX-merge conditional update — first arrival ALWAYS wins; subsequent
+// arrivals must be a distinct event AND either advance access_count OR
+// flip consumed false → true at the same access_count. The trailing
+// false→true consumed clause covers a qurl-service emission shape
+// where a follow-on event records the burn without re-bumping the
+// counter; without it we'd silently drop that signal.
 async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
   if (!qurlId) throw new Error('recordQurlView: qurlId is required');
   if (typeof accessCount !== 'number' || accessCount < 0) {
     throw new Error(`recordQurlView: accessCount must be a non-negative number (got ${accessCount})`);
   }
   if (!eventId) throw new Error('recordQurlView: eventId is required for replay protection');
+  const nowMs = Date.now();
+  const consumedBool = Boolean(consumed);
   try {
     await ddb.send(new UpdateCommand({
       TableName: TABLES.qurl_views,
       Key: { qurl_id: qurlId },
-      // Two-clause condition: first arrival ALWAYS wins; subsequent
-      // arrivals must be a distinct event AND advance the count. The
-      // event-id clause is the replay guard (qurl-service's delivery
-      // retries reuse the same event_id); the count clause guards the
-      // "out-of-order arrival" case (event N+1 races event N, and N
-      // arrives second — we never want to regress access_count).
-      ConditionExpression: 'attribute_not_exists(last_event_id) OR (last_event_id <> :eid AND access_count < :n)',
+      ConditionExpression:
+        'attribute_not_exists(last_event_id) OR ('
+        + 'last_event_id <> :eid AND ('
+        + 'access_count < :n OR (access_count = :n AND consumed = :false AND :c = :true)'
+        + '))',
       UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now, #ttl = :ttl',
       ExpressionAttributeNames: { '#ttl': 'ttl' },
       ExpressionAttributeValues: {
         ':n': accessCount,
-        ':c': Boolean(consumed),
+        ':c': consumedBool,
         ':eid': eventId,
-        ':now': nowIso(),
-        ':ttl': Math.floor(Date.now() / 1000) + QURL_VIEW_TTL_SECONDS,
+        ':now': new Date(nowMs).toISOString(),
+        ':ttl': Math.floor(nowMs / 1000) + QURL_VIEW_TTL_SECONDS,
+        ':false': false,
+        ':true': true,
       },
     }));
     return 'recorded';
   } catch (err) {
     if (err.name === 'ConditionalCheckFailedException') {
-      // Either a redelivery (same event_id) or an out-of-order arrival
-      // (lower or equal count). Either way the row already reflects
-      // a >= state — silently drop. The caller can treat 'dedup' as
-      // success for the webhook's 200 response (drop ≠ failure).
+      // Replay (same event_id) OR out-of-order (lower-or-equal count
+      // with no consumed flip). Row already reflects a >= state.
       return 'dedup';
     }
     throw err;
   }
 }
 
-// getQurlViews BatchGets the view rows for an in-memory qurlLinks set.
-// DDB BatchGetItem caps at 100 keys per request; the monitor's tracked
-// set is bounded by QURL_SEND_MAX_RECIPIENTS (50 today), so a single
-// request handles every realistic call. Returns a Map keyed on qurl_id.
+// Returns a Map<qurl_id, {accessCount, consumed}>. BatchGet caps at 100
+// keys per request; today max recipients is 50 so chunking is defensive.
 async function getQurlViews(qurlIds) {
   if (!Array.isArray(qurlIds) || qurlIds.length === 0) return new Map();
-  // De-dupe + drop empty strings defensively. An empty qurl_id reaching
-  // BatchGet would be a collision attractor (every empty-id row lands
-  // on the same key) — the boundary in commands.js' empty-id guard
-  // should already filter, but defense-in-depth at the store edge
-  // keeps the invariant local.
+  // Drop empties defensively — an empty qurl_id is a collision attractor.
   const keys = [...new Set(qurlIds.filter(Boolean))].map(id => ({ qurl_id: id }));
   if (keys.length === 0) return new Map();
-  // BatchGet caps at 100 keys/request. Today max recipients is 50, so
-  // chunking is purely defensive — if QURL_SEND_MAX_RECIPIENTS ever
-  // rises past 100 we degrade gracefully instead of returning a
-  // partial map silently.
   const CHUNK = 100;
   const out = new Map();
-  for (let i = 0; i < keys.length; i += CHUNK) {
-    const slice = keys.slice(i, i + CHUNK);
-    const res = await ddb.send(new BatchGetCommand({
-      RequestItems: { [TABLES.qurl_views]: { Keys: slice } },
-    }));
-    const items = (res.Responses && res.Responses[TABLES.qurl_views]) || [];
-    for (const item of items) {
+  const collect = (res) => {
+    for (const item of (res.Responses && res.Responses[TABLES.qurl_views]) || []) {
       out.set(item.qurl_id, {
         accessCount: item.access_count || 0,
         consumed: Boolean(item.consumed),
       });
     }
-    // UnprocessedKeys is populated under throttle. A single retry covers
-    // the realistic case (small fan-out); persistent unprocessed keys
-    // would mean a hot table — that's an oncall signal, not a per-call
-    // retry loop. Match recordQURLSendBatch's bounded-retry pattern.
+  };
+  for (let i = 0; i < keys.length; i += CHUNK) {
+    const slice = keys.slice(i, i + CHUNK);
+    const res = await ddb.send(new BatchGetCommand({
+      RequestItems: { [TABLES.qurl_views]: { Keys: slice } },
+    }));
+    collect(res);
+    // Single retry on UnprocessedKeys — persistent throttle is an oncall
+    // signal, not a per-call retry loop.
     const unprocessed = res.UnprocessedKeys && res.UnprocessedKeys[TABLES.qurl_views];
     if (unprocessed && unprocessed.Keys && unprocessed.Keys.length > 0) {
-      const retry = await ddb.send(new BatchGetCommand({ RequestItems: { [TABLES.qurl_views]: unprocessed } }));
-      const retryItems = (retry.Responses && retry.Responses[TABLES.qurl_views]) || [];
-      for (const item of retryItems) {
-        out.set(item.qurl_id, {
-          accessCount: item.access_count || 0,
-          consumed: Boolean(item.consumed),
-        });
-      }
+      collect(await ddb.send(new BatchGetCommand({ RequestItems: { [TABLES.qurl_views]: unprocessed } })));
     }
   }
   return out;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1025,6 +1025,14 @@ async function recordQURLSendBatch(sends) {
 
 // ── QURL views (webhook-fed view counter for /qurl send + /qurl map) ──
 
+// 30-day TTL window on qurl_views rows. Safely past the longest
+// monitor lifetime (1h cap) + the longest link expiry (7d), with
+// ~3 weeks of buffer for DDB's TTL precision (rows can survive
+// up to 48h past their stamp before the asynchronous reaper sweeps
+// them). A shorter window risks dropping a row a monitor is still
+// reading; a longer window leaves unbounded growth on the table.
+const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
+
 // recordQurlView is the qurl.accessed webhook's persistence sink. The
 // conditional update implements MAX-merge semantics: a redelivery, a
 // stale (lower-count) replay, or an out-of-order arrival is silently
@@ -1032,6 +1040,10 @@ async function recordQURLSendBatch(sends) {
 // counter); a webhook can land on a different bot instance than the
 // one running the originating monitor's setInterval, so the join is
 // always through DDB — never in-process pub/sub.
+//
+// Every successful write refreshes the `ttl` attribute to (now + 30d).
+// A qURL that keeps receiving views (e.g. a multi-use link) keeps its
+// row alive; once views stop, the row reaps 30d later.
 async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
   if (!qurlId) throw new Error('recordQurlView: qurlId is required');
   if (typeof accessCount !== 'number' || accessCount < 0) {
@@ -1049,12 +1061,14 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
       // "out-of-order arrival" case (event N+1 races event N, and N
       // arrives second — we never want to regress access_count).
       ConditionExpression: 'attribute_not_exists(last_event_id) OR (last_event_id <> :eid AND access_count < :n)',
-      UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now',
+      UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now, #ttl = :ttl',
+      ExpressionAttributeNames: { '#ttl': 'ttl' },
       ExpressionAttributeValues: {
         ':n': accessCount,
         ':c': Boolean(consumed),
         ':eid': eventId,
         ':now': nowIso(),
+        ':ttl': Math.floor(Date.now() / 1000) + QURL_VIEW_TTL_SECONDS,
       },
     }));
     return 'recorded';

--- a/apps/discord/src/utils/webhook-hardening.js
+++ b/apps/discord/src/utils/webhook-hardening.js
@@ -1,0 +1,77 @@
+// Shared hardening for HTTP webhook receivers (GitHub, qURL).
+//
+// Both routes need the same anti-abuse machinery (per-IP bad-signature
+// counter with sweep + cap) and the same constant-time HMAC compare.
+// Keeping the two implementations in lockstep by hand drifted at least
+// once (GitHub's sweep wasn't unref'd before this extraction); a shared
+// module makes that class of drift impossible.
+//
+// SCALING: single-instance only. Move to Redis if the bot runs
+// horizontally.
+
+const crypto = require('crypto');
+
+function createBadSigLimiter({
+  windowMs = 60_000,
+  max = 30,
+  perIpCap = 120,
+  sweepMs = 5 * 60 * 1000,
+  globalCap = 10_000,
+} = {}) {
+  const attempts = new Map();
+  const sweep = setInterval(() => {
+    const cutoff = Date.now() - windowMs * 2;
+    for (const [ip, times] of attempts) {
+      const recent = times.filter(t => t > cutoff);
+      if (recent.length === 0) attempts.delete(ip);
+      else attempts.set(ip, recent);
+    }
+  }, sweepMs);
+  sweep.unref();
+
+  return {
+    // Skip the .filter() allocation when there's no prior entry — the
+    // happy path of legit traffic never has a bad-sig history.
+    shouldThrottle(ip) {
+      const list = attempts.get(ip);
+      if (!list) return false;
+      return list.filter(t => t > Date.now() - windowMs).length >= max;
+    },
+    recordBadSig(ip) {
+      const now = Date.now();
+      let list = (attempts.get(ip) || []).filter(t => t > now - windowMs);
+      list.push(now);
+      if (list.length > perIpCap) list = list.slice(-perIpCap);
+      // 10%-drop on global cap: single-entry eviction can't keep up
+      // with a distributed flood of unique IPs.
+      if (attempts.size > globalCap) {
+        const drop = Math.max(1, Math.floor(attempts.size / 10));
+        const it = attempts.keys();
+        for (let i = 0; i < drop; i++) {
+          const k = it.next().value;
+          if (k === undefined) break;
+          attempts.delete(k);
+        }
+      }
+      attempts.set(ip, list);
+      return list.length;
+    },
+    stopSweep() { clearInterval(sweep); },
+  };
+}
+
+// `expectedHex` is the bare 64-char hex digest the caller pulled from
+// the request header (any vendor-specific prefix like `sha256=` must be
+// stripped first). Returns false on any error so callers can branch on
+// a single bool.
+function verifyHmacSha256(rawBody, secret, expectedHex) {
+  if (!rawBody || !secret || !expectedHex) return false;
+  const digest = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expectedHex), Buffer.from(digest));
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { createBadSigLimiter, verifyHmacSha256 };

--- a/apps/discord/src/utils/webhook-hardening.js
+++ b/apps/discord/src/utils/webhook-hardening.js
@@ -12,13 +12,20 @@
 
 const crypto = require('crypto');
 
+// 5min sweep deletes entries older than 2 windows — keeps an entry's
+// next-request landing inside the active 60s window from being
+// prematurely evicted. Do NOT "fix" the * 2 to * 1; the second window
+// is the load-bearing slack against sweep-vs-request race.
 function createBadSigLimiter({
   windowMs = 60_000,
   max = 30,
-  perIpCap = 120,
+  perIpCap,
   sweepMs = 5 * 60 * 1000,
   globalCap = 10_000,
 } = {}) {
+  // perIpCap defaults to max * 4 so a caller bumping max=60 doesn't
+  // leave the per-IP array sized for max=30.
+  if (perIpCap === undefined) perIpCap = max * 4;
   const attempts = new Map();
   const sweep = setInterval(() => {
     const cutoff = Date.now() - windowMs * 2;

--- a/apps/discord/src/utils/webhook-hardening.js
+++ b/apps/discord/src/utils/webhook-hardening.js
@@ -3,8 +3,9 @@
 // Both routes need the same anti-abuse machinery (per-IP bad-signature
 // counter with sweep + cap) and the same constant-time HMAC compare.
 // Keeping the two implementations in lockstep by hand drifted at least
-// once (GitHub's sweep wasn't unref'd before this extraction); a shared
-// module makes that class of drift impossible.
+// once (GitHub's sweep had no clearInterval handle so graceful shutdown
+// leaked the timer; the qURL copy added one); a shared module makes
+// that class of drift impossible.
 //
 // SCALING: single-instance only. Move to Redis if the bot runs
 // horizontally.

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1008,8 +1008,9 @@ describe('qurl sends', () => {
 // ── QURL views (webhook-fed view counter) ──
 
 describe('qurl views', () => {
-  test('recordQurlView: conditional UpdateItem with MAX-merge + replay-protection clause', async () => {
+  test('recordQurlView: conditional UpdateItem with MAX-merge + replay-protection clause + TTL refresh', async () => {
     ddbMock.on(UpdateCommand).resolves({});
+    const before = Math.floor(Date.now() / 1000);
     const result = await store.recordQurlView({
       qurlId: 'q_aaaaaaaaaa1', accessCount: 3, consumed: false, eventId: 'evt-1',
     });
@@ -1026,6 +1027,15 @@ describe('qurl views', () => {
     expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
       ':n': 3, ':c': false, ':eid': 'evt-1',
     }));
+    // TTL refresh on every write — 30 days from now. The window must
+    // be longer than the longest monitor lifetime (1h cap) + longest
+    // link expiry (7d) + DDB TTL's ~48h precision slop. 30d gives
+    // ~3 weeks of buffer.
+    expect(input.UpdateExpression).toMatch(/#ttl = :ttl/);
+    expect(input.ExpressionAttributeNames).toEqual(expect.objectContaining({ '#ttl': 'ttl' }));
+    const THIRTY_DAYS = 30 * 24 * 60 * 60;
+    expect(input.ExpressionAttributeValues[':ttl']).toBeGreaterThanOrEqual(before + THIRTY_DAYS);
+    expect(input.ExpressionAttributeValues[':ttl']).toBeLessThanOrEqual(before + THIRTY_DAYS + 5);
   });
 
   test('recordQurlView: ConditionalCheckFailedException → "dedup" (replay path, NOT a failure)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1018,14 +1018,18 @@ describe('qurl views', () => {
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(input.TableName).toBe('test-prefix-qurl-views');
     expect(input.Key).toEqual({ qurl_id: 'q_aaaaaaaaaa1' });
-    // The condition is the load-bearing safety net — pin it exactly so
-    // a refactor that drops either clause (replay OR out-of-order)
-    // fails CI rather than silently corrupting the view counter.
+    // Pin the condition exactly so a refactor that drops any clause
+    // (replay, out-of-order, OR the consumed false→true flip on equal
+    // access_count) fails CI rather than silently corrupting the
+    // counter.
     expect(input.ConditionExpression).toBe(
-      'attribute_not_exists(last_event_id) OR (last_event_id <> :eid AND access_count < :n)',
+      'attribute_not_exists(last_event_id) OR ('
+      + 'last_event_id <> :eid AND ('
+      + 'access_count < :n OR (access_count = :n AND consumed = :false AND :c = :true)'
+      + '))',
     );
     expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
-      ':n': 3, ':c': false, ':eid': 'evt-1',
+      ':n': 3, ':c': false, ':eid': 'evt-1', ':false': false, ':true': true,
     }));
     // TTL refresh on every write — 30 days from now. The window must
     // be longer than the longest monitor lifetime (1h cap) + longest

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -53,6 +53,7 @@ const {
   UpdateCommand,
   QueryCommand,
   ScanCommand,
+  BatchGetCommand,
   BatchWriteCommand,
 } = require('@aws-sdk/lib-dynamodb');
 
@@ -1001,6 +1002,115 @@ describe('qurl sends', () => {
     });
     const result = await store.getSendConfig('s1', 'attacker');
     expect(result).toBeUndefined();
+  });
+});
+
+// ── QURL views (webhook-fed view counter) ──
+
+describe('qurl views', () => {
+  test('recordQurlView: conditional UpdateItem with MAX-merge + replay-protection clause', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    const result = await store.recordQurlView({
+      qurlId: 'q_aaaaaaaaaa1', accessCount: 3, consumed: false, eventId: 'evt-1',
+    });
+    expect(result).toBe('recorded');
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.TableName).toBe('test-prefix-qurl-views');
+    expect(input.Key).toEqual({ qurl_id: 'q_aaaaaaaaaa1' });
+    // The condition is the load-bearing safety net — pin it exactly so
+    // a refactor that drops either clause (replay OR out-of-order)
+    // fails CI rather than silently corrupting the view counter.
+    expect(input.ConditionExpression).toBe(
+      'attribute_not_exists(last_event_id) OR (last_event_id <> :eid AND access_count < :n)',
+    );
+    expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
+      ':n': 3, ':c': false, ':eid': 'evt-1',
+    }));
+  });
+
+  test('recordQurlView: ConditionalCheckFailedException → "dedup" (replay path, NOT a failure)', async () => {
+    const err = new Error('cond fail');
+    err.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(err);
+    const result = await store.recordQurlView({
+      qurlId: 'q_x', accessCount: 1, consumed: false, eventId: 'evt-1',
+    });
+    expect(result).toBe('dedup');
+  });
+
+  test('recordQurlView: rejects qurlId="" so an empty-id collision attractor never lands in DDB', async () => {
+    await expect(
+      store.recordQurlView({ qurlId: '', accessCount: 1, consumed: false, eventId: 'e' }),
+    ).rejects.toThrow(/qurlId is required/);
+  });
+
+  test('recordQurlView: rejects negative or non-numeric accessCount', async () => {
+    await expect(
+      store.recordQurlView({ qurlId: 'q_x', accessCount: -1, consumed: false, eventId: 'e' }),
+    ).rejects.toThrow(/non-negative/);
+    await expect(
+      store.recordQurlView({ qurlId: 'q_x', accessCount: 'two', consumed: false, eventId: 'e' }),
+    ).rejects.toThrow(/non-negative/);
+  });
+
+  test('recordQurlView: rejects missing eventId (replay protection requires a key)', async () => {
+    await expect(
+      store.recordQurlView({ qurlId: 'q_x', accessCount: 1, consumed: false }),
+    ).rejects.toThrow(/eventId is required/);
+  });
+
+  test('getQurlViews: BatchGet for tracked ids, returns Map keyed on qurl_id', async () => {
+    ddbMock.on(BatchGetCommand).resolves({
+      Responses: {
+        'test-prefix-qurl-views': [
+          { qurl_id: 'q_a', access_count: 2, consumed: false },
+          { qurl_id: 'q_b', access_count: 1, consumed: true },
+        ],
+      },
+    });
+    const views = await store.getQurlViews(['q_a', 'q_b', 'q_c']);
+    expect(views.size).toBe(2);
+    expect(views.get('q_a')).toEqual({ accessCount: 2, consumed: false });
+    expect(views.get('q_b')).toEqual({ accessCount: 1, consumed: true });
+    expect(views.get('q_c')).toBeUndefined();
+    const keys = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input
+      .RequestItems['test-prefix-qurl-views'].Keys;
+    expect(keys).toEqual(expect.arrayContaining([
+      { qurl_id: 'q_a' }, { qurl_id: 'q_b' }, { qurl_id: 'q_c' },
+    ]));
+  });
+
+  test('getQurlViews: short-circuits to empty Map when called with empty or all-empty input', async () => {
+    expect((await store.getQurlViews([])).size).toBe(0);
+    expect((await store.getQurlViews(['', null, undefined])).size).toBe(0);
+    expect(ddbMock.commandCalls(BatchGetCommand)).toHaveLength(0);
+  });
+
+  test('getQurlViews: de-dupes input ids before BatchGet', async () => {
+    ddbMock.on(BatchGetCommand).resolves({ Responses: {} });
+    await store.getQurlViews(['q_a', 'q_a', 'q_b']);
+    const keys = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input
+      .RequestItems['test-prefix-qurl-views'].Keys;
+    expect(keys).toHaveLength(2);
+  });
+
+  test('getQurlViews: retries once on UnprocessedKeys', async () => {
+    let attempt = 0;
+    ddbMock.on(BatchGetCommand).callsFake(() => {
+      attempt++;
+      if (attempt === 1) {
+        return Promise.resolve({
+          Responses: { 'test-prefix-qurl-views': [{ qurl_id: 'q_a', access_count: 1, consumed: false }] },
+          UnprocessedKeys: { 'test-prefix-qurl-views': { Keys: [{ qurl_id: 'q_b' }] } },
+        });
+      }
+      return Promise.resolve({
+        Responses: { 'test-prefix-qurl-views': [{ qurl_id: 'q_b', access_count: 2, consumed: false }] },
+      });
+    });
+    const views = await store.getQurlViews(['q_a', 'q_b']);
+    expect(attempt).toBe(2);
+    expect(views.size).toBe(2);
   });
 });
 

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1031,15 +1031,14 @@ describe('qurl views', () => {
     expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
       ':n': 3, ':c': false, ':eid': 'evt-1', ':false': false, ':true': true,
     }));
-    // TTL refresh on every write — 30 days from now. The window must
-    // be longer than the longest monitor lifetime (1h cap) + longest
-    // link expiry (7d) + DDB TTL's ~48h precision slop. 30d gives
-    // ~3 weeks of buffer.
-    expect(input.UpdateExpression).toMatch(/#ttl = :ttl/);
-    expect(input.ExpressionAttributeNames).toEqual(expect.objectContaining({ '#ttl': 'ttl' }));
+    // TTL refresh on every write — 30 days from now, written to
+    // `expires_at` (the canonical TTL-attribute name across every
+    // table in this module). Numeric epoch seconds; DDB silently
+    // refuses to expire rows whose TTL attribute is the wrong type.
+    expect(input.UpdateExpression).toMatch(/expires_at = :exp/);
     const THIRTY_DAYS = 30 * 24 * 60 * 60;
-    expect(input.ExpressionAttributeValues[':ttl']).toBeGreaterThanOrEqual(before + THIRTY_DAYS);
-    expect(input.ExpressionAttributeValues[':ttl']).toBeLessThanOrEqual(before + THIRTY_DAYS + 5);
+    expect(input.ExpressionAttributeValues[':exp']).toBeGreaterThanOrEqual(before + THIRTY_DAYS);
+    expect(input.ExpressionAttributeValues[':exp']).toBeLessThanOrEqual(before + THIRTY_DAYS + 5);
   });
 
   test('recordQurlView: ConditionalCheckFailedException → "dedup" (replay path, NOT a failure)', async () => {

--- a/apps/discord/tests/qurl-webhook-flow.test.js
+++ b/apps/discord/tests/qurl-webhook-flow.test.js
@@ -1,21 +1,8 @@
-/**
- * Full webhook flow integration test
- *
- * Exercises every layer of the bot's qURL-webhook pipeline against the
- * actual Express app + actual monitor code, with the DDB store
- * replaced by an in-memory implementation that mirrors the conditional
- * MAX-merge + BatchGet semantics. The payload is signed with the same
- * algorithm qurl-service uses (HMAC-SHA256 bare hex over the raw body,
- * per qurl-service:internal/domain/webhook.go::SignPayload), and field
- * names match qurl-service's WebhookEvent JSON tags exactly.
- *
- * Why this test exists: my pre-merge unit tests in qurl-webhook.test.js
- * used the wrong field names (`event`/`event_id` instead of `type`/`id`)
- * — they passed because the same wrong names lived on both sides. This
- * flow test pins the contract by sending a payload that mirrors what
- * qurl-service actually emits and asserting downstream side effects
- * (monitor UI updates) through real bot code.
- */
+// End-to-end flow test: signed payload (qurl-service wire shape) → Express
+// route → store → monitor.getFullMsg(). Only the wire-shape + render flow
+// is covered here — dedup, out-of-order, and foreign-qurl isolation are
+// pinned at the store layer in ddb-store.test.js (they were duplicating
+// coverage when previously asserted against the in-memory mock).
 
 const crypto = require('crypto');
 
@@ -30,25 +17,13 @@ jest.mock('../src/discord', () => ({
   sendDM: jest.fn(),
 }));
 
-// In-memory store that mirrors the conditional MAX-merge semantics of
-// the real DDB-backed store. The flow test depends on these semantics
-// (replay protection, out-of-order rejection) being preserved end-to-
-// end — without them, the monitor would see regressed counts on
-// retry.
 function makeStore() {
-  const rows = new Map(); // qurl_id → {accessCount, consumed, lastEventId}
+  const rows = new Map();
   return {
     rows,
     async recordQurlView({ qurlId, accessCount, consumed, eventId }) {
       const existing = rows.get(qurlId);
-      if (!existing) {
-        rows.set(qurlId, { accessCount, consumed, lastEventId: eventId });
-        return 'recorded';
-      }
-      // Match the real DDB ConditionExpression:
-      //   attribute_not_exists(last_event_id) OR
-      //   (last_event_id <> :eid AND access_count < :n)
-      if (existing.lastEventId !== eventId && existing.accessCount < accessCount) {
+      if (!existing || (existing.lastEventId !== eventId && existing.accessCount < accessCount)) {
         rows.set(qurlId, { accessCount, consumed, lastEventId: eventId });
         return 'recorded';
       }
@@ -56,8 +31,7 @@ function makeStore() {
     },
     async getQurlViews(qurlIds) {
       const out = new Map();
-      const keys = [...new Set(qurlIds.filter(Boolean))];
-      for (const k of keys) {
+      for (const k of new Set(qurlIds.filter(Boolean))) {
         const r = rows.get(k);
         if (r) out.set(k, { accessCount: r.accessCount, consumed: r.consumed });
       }
@@ -81,30 +55,19 @@ const { app } = require('../src/server');
 const { _test } = require('../src/commands');
 const { monitorLinkStatus, activeMonitors } = _test;
 
-// Mirror qurl-service:internal/domain/webhook.go::SignPayload. Bare hex
-// HMAC-SHA256 over the raw body. Reproducing the algorithm verbatim
-// (rather than importing a shared lib) is intentional: this test is
-// the canonical place a wire-format regression in EITHER side would
-// surface, so the algorithm needs to live independently of whatever
-// shared crypto module the bot or qurl-service ship next.
+// Reproduced from qurl-service:internal/domain/webhook.go::SignPayload —
+// kept independent of any shared lib so a wire-format regression on
+// either side surfaces here, not via a coupled import.
 function qurlServiceSign(rawBody, secret) {
   return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
 }
 
-// Mirror qurl-service:internal/domain/webhook.go::WebhookEvent exactly.
-// Field names + types must match WebhookEvent's `json:` tags. This is
-// the test-side contract pin — a mismatch with qurl-service's emit
-// shape fails CI loudly rather than going silent in prod.
+// Field shape pinned to qurl-service WebhookEvent JSON tags.
 function buildQurlAccessedPayload({ id, qurlId, resourceId, accessCount, consumed }) {
   return {
     id,
     type: 'qurl.accessed',
-    data: {
-      qurl_id: qurlId,
-      resource_id: resourceId,
-      access_count: accessCount,
-      consumed,
-    },
+    data: { qurl_id: qurlId, resource_id: resourceId, access_count: accessCount, consumed },
     owner_id: 'usr_flow_test',
     timestamp: new Date().toISOString(),
     api_version: '2024-01-01',
@@ -136,17 +99,12 @@ beforeEach(() => {
 });
 
 // Construction order matters: the receiver runs under real timers
-// (supertest needs setImmediate to flush); the monitor's setInterval
-// must be set up under fake timers. We populate the store first
-// (real timers, via the receiver), then switch to fakes and
-// construct + tick the monitor. This avoids the toggle-mid-monitor
-// trap where a setInterval registered under one timer mode is
-// abandoned when the other mode takes over.
+// (supertest needs setImmediate); the monitor's setInterval is
+// installed under fake timers. We populate the store first, then
+// switch to fakes for the monitor — never toggle modes once a
+// setInterval is registered.
 describe('full webhook flow: qurl-service shape → bot receiver → store → monitor UI', () => {
-  it('a single qurl.accessed delivery flips one recipient from pending → viewed', async () => {
-    // Stage 1: receiver under real timers. Webhook signed with qurl-
-    // service's exact algorithm + field shape — the wire-format
-    // regression class that pre-merge unit tests missed.
+  it('a single delivery flips pending → viewed', async () => {
     const res = await deliverWebhook(buildQurlAccessedPayload({
       id: 'evt_alice_1', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
     }));
@@ -156,10 +114,6 @@ describe('full webhook flow: qurl-service shape → bot receiver → store → m
       accessCount: 1, consumed: false, lastEventId: 'evt_alice_1',
     });
 
-    // Stage 2: monitor under fake timers. Constructed AFTER the
-    // store is populated so a single 15s tick is enough to see the
-    // update; we never toggle timer modes once the setInterval is
-    // installed.
     jest.useFakeTimers();
     try {
       const interaction = makeInteraction();
@@ -174,7 +128,7 @@ describe('full webhook flow: qurl-service shape → bot receiver → store → m
       );
       expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 0 viewed / 2 pending');
 
-      await jest.advanceTimersByTimeAsync(15000); // 1m expiry → 15s pollInterval
+      await jest.advanceTimersByTimeAsync(15000);
 
       expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 1 viewed / 1 pending');
       expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -186,32 +140,7 @@ describe('full webhook flow: qurl-service shape → bot receiver → store → m
     }
   });
 
-  it('redelivery (same event_id) is deduped and the counter does not double-advance', async () => {
-    const p = buildQurlAccessedPayload({
-      id: 'evt_replay', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
-    });
-    const first = await deliverWebhook(p);
-    const second = await deliverWebhook(p); // exact same payload + signature
-    expect(first.body).toEqual({ status: 'recorded' });
-    expect(second.body).toEqual({ status: 'dedup' });
-    expect(mockStore.rows.get('q_aaaaaaaaaa1').accessCount).toBe(1);
-  });
-
-  it('out-of-order delivery (lower count after higher count) is silently rejected', async () => {
-    // qurl-service docs explicitly warn that access_count is best-effort
-    // under concurrent load. The conditional MAX-merge guarantees a
-    // late-arriving lower-count event never regresses the row.
-    await deliverWebhook(buildQurlAccessedPayload({
-      id: 'evt_high', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 3, consumed: false,
-    }));
-    const stale = await deliverWebhook(buildQurlAccessedPayload({
-      id: 'evt_low', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
-    }));
-    expect(stale.body).toEqual({ status: 'dedup' });
-    expect(mockStore.rows.get('q_aaaaaaaaaa1').accessCount).toBe(3);
-  });
-
-  it('multiple distinct qurls in the same send each advance independently', async () => {
+  it('multiple distinct qurls in one send advance independently', async () => {
     await deliverWebhook(buildQurlAccessedPayload({
       id: 'evt_a', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
     }));
@@ -237,36 +166,7 @@ describe('full webhook flow: qurl-service shape → bot receiver → store → m
         '1m', 'Sent to 3 users', { components: [] }, 3,
       );
       await jest.advanceTimersByTimeAsync(15000);
-      // Two of three flipped to opened — Bob's still pending.
       expect(monitor.getFullMsg()).toBe('Sent to 3 users\n👀 2 viewed / 1 pending');
-      monitor.stop();
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('non-tracked qurl_id (foreign send) writes to the store but does not affect this monitor', async () => {
-    // Webhook for a qurl_id that belongs to a different send. The
-    // store accepts it (the receiver isn't send-aware); the monitor's
-    // BatchGet against its own qurlLinks set ignores it.
-    await deliverWebhook(buildQurlAccessedPayload({
-      id: 'evt_foreign', qurlId: 'q_zzzzzzzzzzz', resourceId: 'res-99', accessCount: 1, consumed: false,
-    }));
-    expect(mockStore.rows.has('q_zzzzzzzzzzz')).toBe(true);
-
-    jest.useFakeTimers();
-    try {
-      const interaction = makeInteraction();
-      const qurlLinks = [
-        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://qurl.site/#a', recipientId: 'r1' },
-      ];
-      const monitor = monitorLinkStatus(
-        'flow-send-4', interaction, qurlLinks,
-        [{ id: 'r1', username: 'Alice' }],
-        '1m', 'Sent to 1 user', { components: [] }, 1,
-      );
-      await jest.advanceTimersByTimeAsync(15000);
-      expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 0 viewed / 1 pending');
       monitor.stop();
     } finally {
       jest.useRealTimers();

--- a/apps/discord/tests/qurl-webhook-flow.test.js
+++ b/apps/discord/tests/qurl-webhook-flow.test.js
@@ -1,0 +1,275 @@
+/**
+ * Full webhook flow integration test
+ *
+ * Exercises every layer of the bot's qURL-webhook pipeline against the
+ * actual Express app + actual monitor code, with the DDB store
+ * replaced by an in-memory implementation that mirrors the conditional
+ * MAX-merge + BatchGet semantics. The payload is signed with the same
+ * algorithm qurl-service uses (HMAC-SHA256 bare hex over the raw body,
+ * per qurl-service:internal/domain/webhook.go::SignPayload), and field
+ * names match qurl-service's WebhookEvent JSON tags exactly.
+ *
+ * Why this test exists: my pre-merge unit tests in qurl-webhook.test.js
+ * used the wrong field names (`event`/`event_id` instead of `type`/`id`)
+ * — they passed because the same wrong names lived on both sides. This
+ * flow test pins the contract by sending a payload that mirrors what
+ * qurl-service actually emits and asserting downstream side effects
+ * (monitor UI updates) through real bot code.
+ */
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+// In-memory store that mirrors the conditional MAX-merge semantics of
+// the real DDB-backed store. The flow test depends on these semantics
+// (replay protection, out-of-order rejection) being preserved end-to-
+// end — without them, the monitor would see regressed counts on
+// retry.
+function makeStore() {
+  const rows = new Map(); // qurl_id → {accessCount, consumed, lastEventId}
+  return {
+    rows,
+    async recordQurlView({ qurlId, accessCount, consumed, eventId }) {
+      const existing = rows.get(qurlId);
+      if (!existing) {
+        rows.set(qurlId, { accessCount, consumed, lastEventId: eventId });
+        return 'recorded';
+      }
+      // Match the real DDB ConditionExpression:
+      //   attribute_not_exists(last_event_id) OR
+      //   (last_event_id <> :eid AND access_count < :n)
+      if (existing.lastEventId !== eventId && existing.accessCount < accessCount) {
+        rows.set(qurlId, { accessCount, consumed, lastEventId: eventId });
+        return 'recorded';
+      }
+      return 'dedup';
+    },
+    async getQurlViews(qurlIds) {
+      const out = new Map();
+      const keys = [...new Set(qurlIds.filter(Boolean))];
+      for (const k of keys) {
+        const r = rows.get(k);
+        if (r) out.set(k, { accessCount: r.accessCount, consumed: r.consumed });
+      }
+      return out;
+    },
+    healthCheck: jest.fn(),
+    getStats: jest.fn(() => ({})),
+  };
+}
+
+const mockStore = makeStore();
+jest.mock('../src/store', () => mockStore);
+
+process.env.QURL_WEBHOOK_SECRET = 'flow-test-secret';
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const { _test } = require('../src/commands');
+const { monitorLinkStatus, activeMonitors } = _test;
+
+// Mirror qurl-service:internal/domain/webhook.go::SignPayload. Bare hex
+// HMAC-SHA256 over the raw body. Reproducing the algorithm verbatim
+// (rather than importing a shared lib) is intentional: this test is
+// the canonical place a wire-format regression in EITHER side would
+// surface, so the algorithm needs to live independently of whatever
+// shared crypto module the bot or qurl-service ship next.
+function qurlServiceSign(rawBody, secret) {
+  return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+// Mirror qurl-service:internal/domain/webhook.go::WebhookEvent exactly.
+// Field names + types must match WebhookEvent's `json:` tags. This is
+// the test-side contract pin — a mismatch with qurl-service's emit
+// shape fails CI loudly rather than going silent in prod.
+function buildQurlAccessedPayload({ id, qurlId, resourceId, accessCount, consumed }) {
+  return {
+    id,
+    type: 'qurl.accessed',
+    data: {
+      qurl_id: qurlId,
+      resource_id: resourceId,
+      access_count: accessCount,
+      consumed,
+    },
+    owner_id: 'usr_flow_test',
+    timestamp: new Date().toISOString(),
+    api_version: '2024-01-01',
+  };
+}
+
+async function deliverWebhook(payload) {
+  const raw = JSON.stringify(payload);
+  const sig = qurlServiceSign(raw, process.env.QURL_WEBHOOK_SECRET);
+  return request(app)
+    .post('/webhooks/qurl')
+    .set('Content-Type', 'application/json')
+    .set('QURL-Signature', sig)
+    .send(raw);
+}
+
+function makeInteraction() {
+  return {
+    user: { id: 'sender-1', username: 'Sender' },
+    channelId: 'ch-1',
+    editReply: jest.fn().mockResolvedValue(undefined),
+    member: { displayName: 'Sender' },
+  };
+}
+
+beforeEach(() => {
+  mockStore.rows.clear();
+  for (const m of Array.from(activeMonitors)) m.stop();
+});
+
+// Construction order matters: the receiver runs under real timers
+// (supertest needs setImmediate to flush); the monitor's setInterval
+// must be set up under fake timers. We populate the store first
+// (real timers, via the receiver), then switch to fakes and
+// construct + tick the monitor. This avoids the toggle-mid-monitor
+// trap where a setInterval registered under one timer mode is
+// abandoned when the other mode takes over.
+describe('full webhook flow: qurl-service shape → bot receiver → store → monitor UI', () => {
+  it('a single qurl.accessed delivery flips one recipient from pending → viewed', async () => {
+    // Stage 1: receiver under real timers. Webhook signed with qurl-
+    // service's exact algorithm + field shape — the wire-format
+    // regression class that pre-merge unit tests missed.
+    const res = await deliverWebhook(buildQurlAccessedPayload({
+      id: 'evt_alice_1', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
+    }));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+    expect(mockStore.rows.get('q_aaaaaaaaaa1')).toEqual({
+      accessCount: 1, consumed: false, lastEventId: 'evt_alice_1',
+    });
+
+    // Stage 2: monitor under fake timers. Constructed AFTER the
+    // store is populated so a single 15s tick is enough to see the
+    // update; we never toggle timer modes once the setInterval is
+    // installed.
+    jest.useFakeTimers();
+    try {
+      const interaction = makeInteraction();
+      const qurlLinks = [
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://qurl.site/#at_x', recipientId: 'r1' },
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa2', qurlLink: 'https://qurl.site/#at_y', recipientId: 'r2' },
+      ];
+      const monitor = monitorLinkStatus(
+        'flow-send-1', interaction, qurlLinks,
+        [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
+        '1m', 'Sent to 2 users', { components: [] }, 2,
+      );
+      expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 0 viewed / 2 pending');
+
+      await jest.advanceTimersByTimeAsync(15000); // 1m expiry → 15s pollInterval
+
+      expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 1 viewed / 1 pending');
+      expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringContaining('👀 1 viewed / 1 pending'),
+      }));
+      monitor.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('redelivery (same event_id) is deduped and the counter does not double-advance', async () => {
+    const p = buildQurlAccessedPayload({
+      id: 'evt_replay', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
+    });
+    const first = await deliverWebhook(p);
+    const second = await deliverWebhook(p); // exact same payload + signature
+    expect(first.body).toEqual({ status: 'recorded' });
+    expect(second.body).toEqual({ status: 'dedup' });
+    expect(mockStore.rows.get('q_aaaaaaaaaa1').accessCount).toBe(1);
+  });
+
+  it('out-of-order delivery (lower count after higher count) is silently rejected', async () => {
+    // qurl-service docs explicitly warn that access_count is best-effort
+    // under concurrent load. The conditional MAX-merge guarantees a
+    // late-arriving lower-count event never regresses the row.
+    await deliverWebhook(buildQurlAccessedPayload({
+      id: 'evt_high', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 3, consumed: false,
+    }));
+    const stale = await deliverWebhook(buildQurlAccessedPayload({
+      id: 'evt_low', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
+    }));
+    expect(stale.body).toEqual({ status: 'dedup' });
+    expect(mockStore.rows.get('q_aaaaaaaaaa1').accessCount).toBe(3);
+  });
+
+  it('multiple distinct qurls in the same send each advance independently', async () => {
+    await deliverWebhook(buildQurlAccessedPayload({
+      id: 'evt_a', qurlId: 'q_aaaaaaaaaa1', resourceId: 'res-1', accessCount: 1, consumed: false,
+    }));
+    await deliverWebhook(buildQurlAccessedPayload({
+      id: 'evt_c', qurlId: 'q_aaaaaaaaaa3', resourceId: 'res-1', accessCount: 1, consumed: false,
+    }));
+
+    jest.useFakeTimers();
+    try {
+      const interaction = makeInteraction();
+      const qurlLinks = [
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://qurl.site/#a', recipientId: 'r1' },
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa2', qurlLink: 'https://qurl.site/#b', recipientId: 'r2' },
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa3', qurlLink: 'https://qurl.site/#c', recipientId: 'r3' },
+      ];
+      const monitor = monitorLinkStatus(
+        'flow-send-3', interaction, qurlLinks,
+        [
+          { id: 'r1', username: 'Alice' },
+          { id: 'r2', username: 'Bob' },
+          { id: 'r3', username: 'Carol' },
+        ],
+        '1m', 'Sent to 3 users', { components: [] }, 3,
+      );
+      await jest.advanceTimersByTimeAsync(15000);
+      // Two of three flipped to opened — Bob's still pending.
+      expect(monitor.getFullMsg()).toBe('Sent to 3 users\n👀 2 viewed / 1 pending');
+      monitor.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('non-tracked qurl_id (foreign send) writes to the store but does not affect this monitor', async () => {
+    // Webhook for a qurl_id that belongs to a different send. The
+    // store accepts it (the receiver isn't send-aware); the monitor's
+    // BatchGet against its own qurlLinks set ignores it.
+    await deliverWebhook(buildQurlAccessedPayload({
+      id: 'evt_foreign', qurlId: 'q_zzzzzzzzzzz', resourceId: 'res-99', accessCount: 1, consumed: false,
+    }));
+    expect(mockStore.rows.has('q_zzzzzzzzzzz')).toBe(true);
+
+    jest.useFakeTimers();
+    try {
+      const interaction = makeInteraction();
+      const qurlLinks = [
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://qurl.site/#a', recipientId: 'r1' },
+      ];
+      const monitor = monitorLinkStatus(
+        'flow-send-4', interaction, qurlLinks,
+        [{ id: 'r1', username: 'Alice' }],
+        '1m', 'Sent to 1 user', { components: [] }, 1,
+      );
+      await jest.advanceTimersByTimeAsync(15000);
+      expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 0 viewed / 1 pending');
+      monitor.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/discord/tests/qurl-webhook-flow.test.js
+++ b/apps/discord/tests/qurl-webhook-flow.test.js
@@ -55,9 +55,10 @@ const { app } = require('../src/server');
 const { _test } = require('../src/commands');
 const { monitorLinkStatus, activeMonitors } = _test;
 
-// Reproduced from qurl-service:internal/domain/webhook.go::SignPayload —
-// kept independent of any shared lib so a wire-format regression on
-// either side surfaces here, not via a coupled import.
+// Reproduces qurl-service's webhook payload signing (HMAC-SHA256 bare
+// hex over the raw body), independent of any shared lib so a
+// wire-format regression on either side surfaces here, not via a
+// coupled import.
 function qurlServiceSign(rawBody, secret) {
   return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
 }

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -214,22 +214,75 @@ describe('POST /webhooks/qurl — payload handling', () => {
       eventId: 'evt-1',
     }));
   });
+
+  it('rejects body.id that is not a string (e.g., an object slipped through)', async () => {
+    // Regression guard for the receiver's typeof guard. Without it the
+    // non-scalar would persist as the DDB replay key — silent corruption
+    // of dedup semantics for downstream events with that id.
+    const payload = { ...VALID_PAYLOAD, id: { weird: true } };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('rejects access_count=null (Number(null)===0 must not slip through)', async () => {
+    const payload = { ...VALID_PAYLOAD, data: { ...VALID_PAYLOAD.data, access_count: null } };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('treats consumed as boolean-only — the string "false" does NOT coerce to true', async () => {
+    // Regression guard for strict === true vs Boolean() coercion.
+    // If qurl-service ever JSON-encodes consumed as a string, the
+    // receiver must NOT silently flip the wrong way.
+    const payload = { ...VALID_PAYLOAD, data: { ...VALID_PAYLOAD.data, consumed: 'false' } };
+    const raw = JSON.stringify(payload);
+    await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(mockRecordQurlView).toHaveBeenCalledWith(expect.objectContaining({ consumed: false }));
+  });
 });
 
+// Each describe re-loads the module so the per-instance rate-limit Map
+// doesn't accumulate bad-sig counts from earlier suites. jest.isolateModules
+// would also work; resetModules + reset of the audit-payload mock is the
+// minimal-surface choice.
 describe('POST /webhooks/qurl — bad-signature rate limit', () => {
+  let isolatedApp;
+  beforeAll(() => {
+    jest.resetModules();
+    // eslint-disable-next-line global-require
+    isolatedApp = require('../src/server').app;
+  });
   it('returns 429 once an IP crosses BAD_SIG_MAX failed-signature attempts', async () => {
     const raw = JSON.stringify(VALID_PAYLOAD);
     // 30 failed attempts crosses the BAD_SIG_MAX threshold.
     for (let i = 0; i < 30; i++) {
       // eslint-disable-next-line no-await-in-loop
-      await request(app)
+      await request(isolatedApp)
         .post('/webhooks/qurl')
         .set('Content-Type', 'application/json')
         .set('QURL-Signature', signBody(raw, 'wrong-secret'))
         .send(raw);
     }
     // 31st request hits the rate limit before signature check.
-    const res = await request(app)
+    const res = await request(isolatedApp)
       .post('/webhooks/qurl')
       .set('Content-Type', 'application/json')
       .set('QURL-Signature', signBody(raw))

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -1,8 +1,14 @@
 // qURL webhook receiver tests
 //
-// Pins the wire contract with qurl-service:
+// Pins the wire contract with qurl-service `domain.WebhookEvent`:
 //   header `QURL-Signature` = bare hex HMAC-SHA256 (no `sha256=` prefix)
-//   body   {event, event_id, data:{qurl_id, resource_id, access_count, consumed}}
+//   body   {id, type, data:{qurl_id, resource_id, access_count, consumed},
+//           owner_id, timestamp, api_version}
+//
+// Field names `type` and `id` (NOT `event` or `event_id`) match the
+// qurl-service emit-side. A rename on either side without the matching
+// rename on the other silently 200-ignores every webhook — these tests
+// pin the names so the regression fails CI loudly.
 //
 // Different from routes/webhooks.js (GitHub) — that one uses
 // `X-Hub-Signature-256: sha256=…`. Do not let the two routes drift.
@@ -43,9 +49,12 @@ function signBody(rawJson, secret = 'test-qurl-secret') {
 }
 
 const VALID_PAYLOAD = {
-  event: 'qurl.accessed',
-  event_id: 'evt-1',
+  id: 'evt-1',
+  type: 'qurl.accessed',
   data: { qurl_id: 'q_aaaaaaaaaa1', resource_id: 'r_111', access_count: 1, consumed: false },
+  owner_id: 'usr_test',
+  timestamp: '2026-05-19T12:00:00Z',
+  api_version: '2024-01-01',
 };
 
 beforeEach(() => {
@@ -117,7 +126,7 @@ describe('POST /webhooks/qurl — signature verification', () => {
 
 describe('POST /webhooks/qurl — payload handling', () => {
   it('ignores non-qurl.accessed events with 200 (so qurl-service does not retry)', async () => {
-    const payload = { ...VALID_PAYLOAD, event: 'qurl.created' };
+    const payload = { ...VALID_PAYLOAD, type: 'qurl.created' };
     const raw = JSON.stringify(payload);
     const res = await request(app)
       .post('/webhooks/qurl')
@@ -129,8 +138,39 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(mockRecordQurlView).not.toHaveBeenCalled();
   });
 
+  it('does NOT treat legacy `event` field as the event type — qurl-service emits `type`', async () => {
+    // Regression guard: if the receiver is ever "helpfully" patched to
+    // accept `event` as a synonym for `type`, this test fails. The
+    // qurl-service contract pins `type`; a synonym path silently
+    // accepts malformed payloads.
+    const payload = { id: 'evt-1', event: 'qurl.accessed', data: VALID_PAYLOAD.data };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    // type is undefined → falls into the "non-qurl.accessed" ignore path.
+    expect(res.body).toEqual(expect.objectContaining({ status: 'ignored' }));
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 invalid-payload when body.id missing (no replay-protection key)', async () => {
+    const { id, ...rest } = VALID_PAYLOAD; // eslint-disable-line no-unused-vars
+    const raw = JSON.stringify(rest);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
   it('returns 200 invalid-payload when qurl_id missing (no retry — payload is malformed, not transient)', async () => {
-    const payload = { event: 'qurl.accessed', event_id: 'e1', data: { access_count: 1 } };
+    const payload = { id: 'evt-1', type: 'qurl.accessed', data: { access_count: 1 } };
     const raw = JSON.stringify(payload);
     const res = await request(app)
       .post('/webhooks/qurl')
@@ -144,7 +184,7 @@ describe('POST /webhooks/qurl — payload handling', () => {
 
   it('returns 200 invalid-payload when access_count is negative', async () => {
     const payload = {
-      event: 'qurl.accessed', event_id: 'e1',
+      id: 'evt-1', type: 'qurl.accessed',
       data: { qurl_id: 'q_aaaaaaaaaa1', access_count: -3, consumed: false },
     };
     const raw = JSON.stringify(payload);
@@ -180,23 +220,16 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(res.status).toBe(500);
   });
 
-  it('falls back to a body-hash event_id when payload omits event_id and message_id', async () => {
-    // Older qurl-service revs may not include event_id. The body-hash
-    // fallback guarantees a literal redelivery still dedups (same body →
-    // same hash → conditional update rejects on last_event_id match).
-    const payload = {
-      event: 'qurl.accessed',
-      data: { qurl_id: 'q_aaaaaaaaaa1', access_count: 2, consumed: true },
-    };
-    const raw = JSON.stringify(payload);
-    const res = await request(app)
+  it('passes body.id through verbatim as the eventId replay key', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    await request(app)
       .post('/webhooks/qurl')
       .set('Content-Type', 'application/json')
       .set('QURL-Signature', signBody(raw))
       .send(raw);
-    expect(res.status).toBe(200);
-    const call = mockRecordQurlView.mock.calls[0][0];
-    expect(call.eventId).toMatch(/^[0-9a-f]{64}$/); // SHA-256 hex
+    expect(mockRecordQurlView).toHaveBeenCalledWith(expect.objectContaining({
+      eventId: 'evt-1',
+    }));
   });
 });
 

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -244,6 +244,19 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(mockRecordQurlView).not.toHaveBeenCalled();
   });
 
+  it('rejects fractional access_count (wire contract is Go int64; floats are a shape regression)', async () => {
+    const payload = { ...VALID_PAYLOAD, data: { ...VALID_PAYLOAD.data, access_count: 1.5 } };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
   it('treats consumed as boolean-only — the string "false" does NOT coerce to true', async () => {
     // Regression guard for strict === true vs Boolean() coercion.
     // If qurl-service ever JSON-encodes consumed as a string, the

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -138,27 +138,10 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(mockRecordQurlView).not.toHaveBeenCalled();
   });
 
-  it('does NOT treat legacy `event` field as the event type — qurl-service emits `type`', async () => {
-    // Regression guard: if the receiver is ever "helpfully" patched to
-    // accept `event` as a synonym for `type`, this test fails. The
-    // qurl-service contract pins `type`; a synonym path silently
-    // accepts malformed payloads.
-    const payload = { id: 'evt-1', event: 'qurl.accessed', data: VALID_PAYLOAD.data };
-    const raw = JSON.stringify(payload);
-    const res = await request(app)
-      .post('/webhooks/qurl')
-      .set('Content-Type', 'application/json')
-      .set('QURL-Signature', signBody(raw))
-      .send(raw);
-    expect(res.status).toBe(200);
-    // type is undefined → falls into the "non-qurl.accessed" ignore path.
-    expect(res.body).toEqual(expect.objectContaining({ status: 'ignored' }));
-    expect(mockRecordQurlView).not.toHaveBeenCalled();
-  });
-
   it('returns 200 invalid-payload when body.id missing (no replay-protection key)', async () => {
-    const { id, ...rest } = VALID_PAYLOAD; // eslint-disable-line no-unused-vars
-    const raw = JSON.stringify(rest);
+    const payload = { ...VALID_PAYLOAD };
+    delete payload.id;
+    const raw = JSON.stringify(payload);
     const res = await request(app)
       .post('/webhooks/qurl')
       .set('Content-Type', 'application/json')

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -1,0 +1,223 @@
+// qURL webhook receiver tests
+//
+// Pins the wire contract with qurl-service:
+//   header `QURL-Signature` = bare hex HMAC-SHA256 (no `sha256=` prefix)
+//   body   {event, event_id, data:{qurl_id, resource_id, access_count, consumed}}
+//
+// Different from routes/webhooks.js (GitHub) — that one uses
+// `X-Hub-Signature-256: sha256=…`. Do not let the two routes drift.
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+const mockRecordQurlView = jest.fn(async () => 'recorded');
+jest.mock('../src/store', () => ({
+  recordQurlView: mockRecordQurlView,
+  // No-op stubs for the other store methods server.js touches at boot
+  // (healthCheck via /health) so the request flow doesn't reach for
+  // real DDB credentials.
+  healthCheck: jest.fn(),
+  getStats: jest.fn(() => ({})),
+}));
+
+process.env.QURL_WEBHOOK_SECRET = 'test-qurl-secret';
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+
+function signBody(rawJson, secret = 'test-qurl-secret') {
+  return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
+}
+
+const VALID_PAYLOAD = {
+  event: 'qurl.accessed',
+  event_id: 'evt-1',
+  data: { qurl_id: 'q_aaaaaaaaaa1', resource_id: 'r_111', access_count: 1, consumed: false },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRecordQurlView.mockImplementation(async () => 'recorded');
+});
+
+describe('POST /webhooks/qurl — signature verification', () => {
+  it('accepts a request with a valid bare-hex HMAC over the raw body', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+    expect(mockRecordQurlView).toHaveBeenCalledWith(expect.objectContaining({
+      qurlId: 'q_aaaaaaaaaa1',
+      accessCount: 1,
+      consumed: false,
+      eventId: 'evt-1',
+    }));
+  });
+
+  it('rejects a request with a wrong signature (401)', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw, 'wrong-secret'))
+      .send(raw);
+    expect(res.status).toBe(401);
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with a missing signature header (401)', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .send(raw);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a malformed signature (wrong length / non-hex)', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', 'not-a-hex-digest')
+      .send(raw);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a sha256-prefixed signature (GitHub-style would be wrong wire shape)', async () => {
+    // Catches the most likely "copied from GitHub webhook" regression
+    // — qurl-service sends BARE hex; a 'sha256=' prefix never matches
+    // the strict 64-hex-char regex.
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', 'sha256=' + signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /webhooks/qurl — payload handling', () => {
+  it('ignores non-qurl.accessed events with 200 (so qurl-service does not retry)', async () => {
+    const payload = { ...VALID_PAYLOAD, event: 'qurl.created' };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ status: 'ignored' }));
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 invalid-payload when qurl_id missing (no retry — payload is malformed, not transient)', async () => {
+    const payload = { event: 'qurl.accessed', event_id: 'e1', data: { access_count: 1 } };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 invalid-payload when access_count is negative', async () => {
+    const payload = {
+      event: 'qurl.accessed', event_id: 'e1',
+      data: { qurl_id: 'q_aaaaaaaaaa1', access_count: -3, consumed: false },
+    };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+  });
+
+  it('surfaces store dedup result on replay', async () => {
+    mockRecordQurlView.mockResolvedValueOnce('dedup');
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'dedup' });
+  });
+
+  it('returns 500 (retriable) when the store throws — qurl-service redelivery is the recovery path', async () => {
+    mockRecordQurlView.mockRejectedValueOnce(new Error('DDB throttled'));
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(500);
+  });
+
+  it('falls back to a body-hash event_id when payload omits event_id and message_id', async () => {
+    // Older qurl-service revs may not include event_id. The body-hash
+    // fallback guarantees a literal redelivery still dedups (same body →
+    // same hash → conditional update rejects on last_event_id match).
+    const payload = {
+      event: 'qurl.accessed',
+      data: { qurl_id: 'q_aaaaaaaaaa1', access_count: 2, consumed: true },
+    };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    const call = mockRecordQurlView.mock.calls[0][0];
+    expect(call.eventId).toMatch(/^[0-9a-f]{64}$/); // SHA-256 hex
+  });
+});
+
+describe('POST /webhooks/qurl — bad-signature rate limit', () => {
+  it('returns 429 once an IP crosses BAD_SIG_MAX failed-signature attempts', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    // 30 failed attempts crosses the BAD_SIG_MAX threshold.
+    for (let i = 0; i < 30; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await request(app)
+        .post('/webhooks/qurl')
+        .set('Content-Type', 'application/json')
+        .set('QURL-Signature', signBody(raw, 'wrong-secret'))
+        .send(raw);
+    }
+    // 31st request hits the rate limit before signature check.
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -530,6 +530,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
 
     // /qurl add a new recipient AFTER the monitor settled.
     monitor.updateBaseMsg('Sent to 2 users');
+    const callsBeforeAdd = mockDb.getQurlViews.mock.calls.length;
     monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa9', username: 'Eve' }]);
 
     // The re-armed setInterval picks up Eve's view on the next tick.
@@ -539,6 +540,10 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
     ]));
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
+    // The post-allDone tick must actually have fired — a missing
+    // re-arm would leave callsBeforeAdd == calls.length and the
+    // counter frozen at 1/0 instead of advancing to 2/0.
+    expect(mockDb.getQurlViews.mock.calls.length).toBeGreaterThan(callsBeforeAdd);
     expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 2 viewed / 0 pending');
     monitor.stop();
   });

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -575,6 +575,28 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
     monitor.stop();
   });
 
+  it('addRecipients() with a missing qurl_id flips viewCounterDegraded AND warns once', async () => {
+    // Regression guard for the silent-degrade bug cr round 3 surfaced:
+    // construction-time degrade warns once at send-start, but a /qurl
+    // add link arriving without qurl_id has to leave a breadcrumb too.
+    const monitor = monitorLinkStatus(
+      'send-degrade-add', makeInteraction(),
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent to 1 user', { components: [] }, 1,
+    );
+    expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 0 viewed / 1 pending');
+
+    monitor.addRecipients(1, [{ qurlId: '', username: 'Eve' }]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('degraded mid-life'),
+      expect.objectContaining({ sendId: 'send-degrade-add' }),
+    );
+    // Counter degrades to bare base msg, NOT a partial-attribution render.
+    expect(monitor.getFullMsg()).toBe('Sent to 1 user');
+    monitor.stop();
+  });
+
   it('addRecipients() de-dupes a qurl_id already in the tracked set', async () => {
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -344,7 +344,7 @@ describe('monitorLinkStatus — view-counter render from qurl_views', () => {
       'send-1', makeInteraction(),
       TWO_LINK_SET,
       [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
-      '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
+      '1m', 'Sent to 2 users', { components: [] }, 2,
     );
     expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 0 viewed / 2 pending');
     monitor.stop();
@@ -356,7 +356,7 @@ describe('monitorLinkStatus — view-counter render from qurl_views', () => {
       'send-1', interaction,
       TWO_LINK_SET,
       [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
-      '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
+      '1m', 'Sent to 2 users', { components: [] }, 2,
     );
 
     // First tick: one of the two has been viewed (webhook landed via
@@ -377,7 +377,7 @@ describe('monitorLinkStatus — view-counter render from qurl_views', () => {
       'send-1', interaction,
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
 
     mockDb.getQurlViews.mockResolvedValueOnce(new Map([
@@ -399,7 +399,7 @@ describe('monitorLinkStatus — view-counter render from qurl_views', () => {
       'send-1', interaction,
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
@@ -427,7 +427,7 @@ describe('monitorLinkStatus — empty-qurl_id boundary guard', () => {
       'send-1', makeInteraction(),
       mixed,
       [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
-      '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
+      '1m', 'Sent to 2 users', { components: [] }, 2,
     );
     expect(monitor.getFullMsg()).toBe('Sent to 2 users');
     expect(monitor.getFullMsg()).not.toMatch(/viewed|pending|👀/);
@@ -453,7 +453,7 @@ describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream f
       'send-1', makeInteraction(),
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
     await jest.advanceTimersByTimeAsync(2500);
     expect(mockDb.getQurlViews).not.toHaveBeenCalled();
@@ -467,7 +467,7 @@ describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream f
       'send-1', makeInteraction(),
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
 
     await jest.advanceTimersByTimeAsync(3000);
@@ -492,7 +492,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
       'send-1', makeInteraction(),
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
 
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
@@ -518,7 +518,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
       'send-resolve-add', interaction,
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent to 1 user', { components: [] }, 1, 'apikey',
+      '1m', 'Sent to 1 user', { components: [] }, 1,
     );
 
     // Initial recipient views — triggers allDone + clearInterval.
@@ -533,12 +533,14 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
     const callsBeforeAdd = mockDb.getQurlViews.mock.calls.length;
     monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa9', username: 'Eve' }]);
 
-    // The re-armed setInterval picks up Eve's view on the next tick.
+    // Re-arm uses the FIRST_POLL_DELAY_MS (3s) fast-tick pattern,
+    // mirroring construction. Eve's view should land within a few
+    // seconds of /qurl add, not pollInterval later.
     mockDb.getQurlViews.mockResolvedValueOnce(new Map([
       ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
       ['q_aaaaaaaaaa9', { accessCount: 1, consumed: false }],
     ]));
-    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+    await jest.advanceTimersByTimeAsync(3500);
 
     // The post-allDone tick must actually have fired — a missing
     // re-arm would leave callsBeforeAdd == calls.length and the
@@ -558,7 +560,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
       'send-add-bug', interaction,
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent to 1 user', { components: [] }, 1, 'apikey',
+      '1m', 'Sent to 1 user', { components: [] }, 1,
     );
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
@@ -578,7 +580,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
       'send-1', makeInteraction(),
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
     // Same ID already tracked — should be a no-op insertion-wise.
     monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa1', username: 'Alice' }]);
@@ -599,7 +601,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
       'send-1', interaction,
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
     monitor.stop();
@@ -614,19 +616,26 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
   });
 });
 
-describe('monitorLinkStatus — interaction-token TTL channel-edit fallback', () => {
+describe('monitorLinkStatus — edits always go through interaction.editReply (ephemeral-safe)', () => {
   beforeEach(() => { jest.useFakeTimers(); });
   afterEach(() => { jest.useRealTimers(); });
 
-  it('edits via interaction.editReply before 14min cutover', async () => {
+  it('never falls back to editDM — the confirm message is ephemeral and ephemeral edits are interaction-token-only', async () => {
+    // Pre-refactor the monitor switched to editDM (bot-token PATCH)
+    // past the 14-min cutover to bypass the interaction-token TTL.
+    // That fallback is broken on ephemeral messages (executeSendPipeline
+    // deferReplies ephemeral, and ephemeral messages can only be edited
+    // via the interaction webhook token). The monitor cap was lowered
+    // to 14 min so we don't run setIntervals past the usable window.
+    // This test pins the contract: no editDM call from the monitor
+    // path, no matter what.
     const interaction = makeInteraction();
     const monitor = monitorLinkStatus(
       'send-1', interaction,
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1h', 'Sent', { components: [] }, 1, 'apikey',
+      '1h', 'Sent', { components: [] }, 1,
     );
-    monitor.setMessageId('msg-1');
 
     mockDb.getQurlViews.mockResolvedValueOnce(new Map([
       ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
@@ -636,59 +645,21 @@ describe('monitorLinkStatus — interaction-token TTL channel-edit fallback', ()
     expect(mockEditDM).not.toHaveBeenCalled();
     monitor.stop();
   });
-
-  it('edits via editDM (bot-token PATCH) once past the 14min cutover', async () => {
-    const interaction = makeInteraction();
-    const startedAt = Date.now();
-    const monitor = monitorLinkStatus(
-      'send-2', interaction,
-      ONE_LINK_SET,
-      [{ id: 'r1', username: 'Alice' }],
-      '1h', 'Sent', { components: [] }, 1, 'apikey',
-    );
-    monitor.setMessageId('msg-2');
-
-    // SCENARIO: fresh monitor whose first tick happens to land past
-    // the 14-min cutover (e.g. a long-tail Discord-edge stall before
-    // the initial editReply settles). NOT a model of a monitor that
-    // already ran 14 minutes of normal ticks — that path's pollCount
-    // would have crossed the % 2 throttle and skipped odd ticks, which
-    // setSystemTime sidesteps by bypassing intervening fires entirely.
-    // A future refactor that moves the throttle below an early-running
-    // tick should add a separate test for the "ran through the
-    // throttle then crossed cutover" scenario.
-    jest.setSystemTime(startedAt + 14 * 60 * 1000 + 5000);
-    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
-      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
-    ]));
-    // Fast-tick is FIRST_POLL_DELAY_MS = 3000 — by the time the
-    // intervening setSystemTime jump has happened, the setTimeout is
-    // still pending, so the very next advanceTimersByTimeAsync(3000)
-    // fires the first tick. The runTick reads Date.now() AFTER our
-    // setSystemTime above, so the cutover check sees >14min and
-    // routes through editDM.
-    await jest.advanceTimersByTimeAsync(3000);
-    expect(mockEditDM).toHaveBeenCalledWith(
-      'ch-1', 'msg-2',
-      expect.objectContaining({ content: expect.stringContaining('👀') }),
-    );
-    monitor.stop();
-  });
 });
 
 describe('monitorLinkStatus — duration cap + activeMonitors LRU', () => {
   beforeEach(() => { jest.useFakeTimers(); });
   afterEach(() => { jest.useRealTimers(); });
 
-  it('stops + posts final after MAX_MONITOR_DURATION_MS (1h cap on long expiries)', async () => {
+  it('stops + posts final after MAX_MONITOR_DURATION_MS (14min cap matches interaction-token TTL)', async () => {
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '7d', 'Sent', { components: [] }, 1, 'apikey',
+      '7d', 'Sent', { components: [] }, 1,
     );
-    // Skip ~1h+1min so the cap branch fires.
-    await jest.advanceTimersByTimeAsync(60 * 60 * 1000 + 60 * 1000);
+    // Skip ~14min+1min so the cap branch fires.
+    await jest.advanceTimersByTimeAsync(14 * 60 * 1000 + 60 * 1000);
     monitor.stop();
   });
 
@@ -700,25 +671,24 @@ describe('monitorLinkStatus — duration cap + activeMonitors LRU', () => {
         `send-${i}`, makeInteraction(),
         [{ resourceId: `res-${i}`, qurlId: `q_aaaaaaaaaa${i}`, qurlLink: `https://q.test/${i}`, recipientId: `r${i}` }],
         [{ id: `r${i}`, username: `User${i}` }],
-        '1m', 'Sent', { components: [] }, 1, 'apikey',
+        '1m', 'Sent', { components: [] }, 1,
       ));
     }
     expect(activeMonitors.size).toBe(before + 5);
     for (const m of monitors) m.stop();
   });
 
-  it('exposes control surface: addRecipients, stop, updateBaseMsg, getFullMsg, setMessageId', () => {
+  it('exposes control surface: addRecipients, stop, updateBaseMsg, getFullMsg', () => {
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
       ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      '1m', 'Sent', { components: [] }, 1,
     );
     expect(typeof monitor.addRecipients).toBe('function');
     expect(typeof monitor.stop).toBe('function');
     expect(typeof monitor.updateBaseMsg).toBe('function');
     expect(typeof monitor.getFullMsg).toBe('function');
-    expect(typeof monitor.setMessageId).toBe('function');
 
     monitor.updateBaseMsg('New base');
     expect(monitor.getFullMsg()).toContain('New base');

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -324,9 +324,10 @@ beforeEach(() => {
 // monitorLinkStatus
 // ===========================================================================
 
-// Canonical qurlLinks shape post-PR (post qurl-service #598 + connector
-// #747): every link carries a qurlId, which the monitor uses as the
-// BatchGet key against the qurl_views table.
+// Canonical qurlLinks shape: every link carries a qurlId, which the
+// monitor uses as the BatchGet key against the qurl_views table.
+// Pre-rollout, upstream connectors didn't surface qurl_id from
+// MintLink — the empty-id boundary guard handles that case.
 const TWO_LINK_SET = [
   { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://q.test/1', recipientId: 'r1' },
   { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa2', qurlLink: 'https://q.test/2', recipientId: 'r2' },

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -509,6 +509,40 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
     monitor.stop();
   });
 
+  it('addRecipients() re-arms the monitor after allDone so post-resolve adds still see views', async () => {
+    // cr-flagged repro: send to N → all view → setInterval clears
+    // (allDone) → /qurl add M more → without the re-arm, the counter
+    // stays frozen for the rest of the 1h cap.
+    const interaction = makeInteraction();
+    const monitor = monitorLinkStatus(
+      'send-resolve-add', interaction,
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent to 1 user', { components: [] }, 1, 'apikey',
+    );
+
+    // Initial recipient views — triggers allDone + clearInterval.
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+    expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 1 viewed / 0 pending');
+
+    // /qurl add a new recipient AFTER the monitor settled.
+    monitor.updateBaseMsg('Sent to 2 users');
+    monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa9', username: 'Eve' }]);
+
+    // The re-armed setInterval picks up Eve's view on the next tick.
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+      ['q_aaaaaaaaaa9', { accessCount: 1, consumed: false }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 2 viewed / 0 pending');
+    monitor.stop();
+  });
+
   it('addRecipients() seeds linkStatus so views on newly-added recipients flip pending → viewed', async () => {
     // Regression guard for the cr-flagged bug: extending trackedQurlIds
     // without also seeding linkStatus left the new recipients invisible

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -500,12 +500,37 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
 
     // Add a recipient with a new qurl_id. The monitor's next BatchGet
     // must include the new id in its key list.
-    monitor.addRecipients(1, ['q_aaaaaaaaaa3']);
+    monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa3', username: 'Charlie' }]);
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
     expect(mockDb.getQurlViews).toHaveBeenCalled();
     const lastCallKeys = mockDb.getQurlViews.mock.calls.at(-1)[0];
     expect(lastCallKeys).toContain('q_aaaaaaaaaa3');
+    monitor.stop();
+  });
+
+  it('addRecipients() seeds linkStatus so views on newly-added recipients flip pending → viewed', async () => {
+    // Regression guard for the cr-flagged bug: extending trackedQurlIds
+    // without also seeding linkStatus left the new recipients invisible
+    // to the status-flip loop. Webhook would land, BatchGet would
+    // return the row, but the counter never advanced.
+    const interaction = makeInteraction();
+    const monitor = monitorLinkStatus(
+      'send-add-bug', interaction,
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent to 1 user', { components: [] }, 1, 'apikey',
+    );
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa9', username: 'Eve' }]);
+
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa9', { accessCount: 1, consumed: false }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 1 viewed / 1 pending');
     monitor.stop();
   });
 
@@ -517,7 +542,7 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
     // Same ID already tracked — should be a no-op insertion-wise.
-    monitor.addRecipients(1, ['q_aaaaaaaaaa1']);
+    monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa1', username: 'Alice' }]);
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
     const lastCallKeys = mockDb.getQurlViews.mock.calls.at(-1)[0];
     // Set semantics — only one entry for q_aaaaaaaaaa1.
@@ -540,7 +565,13 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
     monitor.stop();
     await jest.advanceTimersByTimeAsync(10000);
-    expect(true).toBe(true);
+    // Contract: no uncaught throw, no "poll failed" log emission from
+    // the racing tick. logger.error firing here would mean stop() let
+    // a thrown error escape the setInterval callback.
+    expect(logger.error).not.toHaveBeenCalledWith(
+      'Link monitor poll failed',
+      expect.any(Object),
+    );
   });
 });
 
@@ -578,11 +609,15 @@ describe('monitorLinkStatus — interaction-token TTL channel-edit fallback', ()
     );
     monitor.setMessageId('msg-2');
 
-    // Jump system time past the 14-min cutover WITHOUT firing the
-    // intervening ticks — those would have advanced pollCount past
-    // the throttling boundary and skipped odd ticks. setSystemTime
-    // moves wall time only; the next advanceTimersByTimeAsync fires
-    // the next scheduled tick.
+    // SCENARIO: fresh monitor whose first tick happens to land past
+    // the 14-min cutover (e.g. a long-tail Discord-edge stall before
+    // the initial editReply settles). NOT a model of a monitor that
+    // already ran 14 minutes of normal ticks — that path's pollCount
+    // would have crossed the % 2 throttle and skipped odd ticks, which
+    // setSystemTime sidesteps by bypassing intervening fires entirely.
+    // A future refactor that moves the throttle below an early-running
+    // tick should add a separate test for the "ran through the
+    // throttle then crossed cutover" scenario.
     jest.setSystemTime(startedAt + 14 * 60 * 1000 + 5000);
     mockDb.getQurlViews.mockResolvedValueOnce(new Map([
       ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
@@ -1753,7 +1788,6 @@ describe('handleAddRecipients — happy path (location)', () => {
     expect(result.delivered).toBe(2);
     expect(result.failed).toBe(0);
     expect(result.msg).toMatch(/Added 2 recipients/);
-    expect(result.newResourceIds).toEqual(expect.arrayContaining(['res-loc-new']));
     // Happy-path delivery coalesces status='sent' + DM refs into a
     // single markSendDMDelivered write per recipient.
     expect(mockDb.markSendDMDelivered).toHaveBeenCalledTimes(2);

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -138,6 +138,11 @@ const mockDb = {
   markSendRevoked: jest.fn(),
   getSendConfig: jest.fn(),
   saveSendConfig: jest.fn(),
+  // qurl_views webhook-fed reader. Default is an empty Map so a test
+  // that doesn't override gets the "no views yet" path. Per-test
+  // mockResolvedValueOnce drives the status-transition assertions.
+  getQurlViews: jest.fn(async () => new Map()),
+  recordQurlView: jest.fn(),
 };
 jest.mock('../src/store', () => mockDb);
 
@@ -176,12 +181,10 @@ jest.mock('../src/connector', () => ({
   isAllowedSourceUrl: (url) => typeof url === 'string' && url.startsWith('https://cdn.discordapp.com'),
 }));
 
-const mockGetResourceStatus = jest.fn();
 const mockDeleteLink = jest.fn();
 jest.mock('../src/qurl', () => ({
   createOneTimeLink: jest.fn(),
   deleteLink: mockDeleteLink,
-  getResourceStatus: mockGetResourceStatus,
 }));
 
 jest.mock('../src/places', () => ({ searchPlaces: jest.fn().mockResolvedValue([]) }));
@@ -321,238 +324,161 @@ beforeEach(() => {
 // monitorLinkStatus
 // ===========================================================================
 
-describe('monitorLinkStatus — initial poll + tracking', () => {
+// Canonical qurlLinks shape post-PR (post qurl-service #598 + connector
+// #747): every link carries a qurlId, which the monitor uses as the
+// BatchGet key against the qurl_views table.
+const TWO_LINK_SET = [
+  { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://q.test/1', recipientId: 'r1' },
+  { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa2', qurlLink: 'https://q.test/2', recipientId: 'r2' },
+];
+const ONE_LINK_SET = [
+  { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://q.test/1', recipientId: 'r1' },
+];
+
+describe('monitorLinkStatus — view-counter render from qurl_views', () => {
   beforeEach(() => { jest.useFakeTimers(); });
-  afterEach(() => {
-    jest.useRealTimers();
+  afterEach(() => { jest.useRealTimers(); });
+
+  it('initial getFullMsg() shows 0 viewed / N pending before any webhook lands', () => {
+    const monitor = monitorLinkStatus(
+      'send-1', makeInteraction(),
+      TWO_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
+      '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
+    );
+    expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 0 viewed / 2 pending');
+    monitor.stop();
   });
 
-  it('initializes trackedQurlIds from getResourceStatus on first tick', async () => {
+  it('webhook-fed view advances `viewed` counter on next tick', async () => {
     const interaction = makeInteraction();
-    mockGetResourceStatus.mockResolvedValue({
-      qurls: [
-        { qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' },
-        { qurl_id: 'q2', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:01Z' },
-      ],
-    });
-
     const monitor = monitorLinkStatus(
       'send-1', interaction,
-      [{ resourceId: 'res-1', qurl_link: 'https://q.test/x' }],
+      TWO_LINK_SET,
       [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
       '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
     );
 
+    // First tick: one of the two has been viewed (webhook landed via
+    // the qurl-webhook receiver, which wrote to qurl_views).
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
-    expect(mockGetResourceStatus).toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalledWith(
-      'Link monitor tracking',
-      expect.objectContaining({ sendId: 'send-1', tracked: 2, resources: 1 }),
-    );
+    expect(interaction.editReply).toHaveBeenCalled();
+    expect(monitor.getFullMsg()).toBe('Sent to 2 users\n👀 1 viewed / 1 pending');
     monitor.stop();
   });
 
-  it('warns when getResourceStatus returns fewer qurls than recipients', async () => {
+  it('all viewed → final-message edit clears components', async () => {
     const interaction = makeInteraction();
-    // Only 1 qurl returned, but 2 recipients sent — count mismatch.
-    mockGetResourceStatus.mockResolvedValue({
-      qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' }],
-    });
-
     const monitor = monitorLinkStatus(
       'send-1', interaction,
-      [{ resourceId: 'res-1', qurl_link: 'https://q.test/x' }],
-      [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
-      '1m', 'Sent', { components: [] }, 2, 'apikey',
-    );
-
-    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Monitor tracking count mismatch',
-      expect.objectContaining({ sendId: 'send-1', qurls: 1, recipients: 2 }),
-    );
-    monitor.stop();
-  });
-
-  it('returns early on first tick if getResourceStatus rejects on every resource', async () => {
-    const interaction = makeInteraction();
-    // .catch(() => null) on the call site — rejected promises become null,
-    // which is filtered out before the localSet.add loop. trackedQurlIds
-    // ends up empty (Set, size 0) but is still set, so the next tick
-    // proceeds normally with an empty tracked set.
-    mockGetResourceStatus.mockRejectedValue(new Error('upstream 503'));
-
-    const monitor = monitorLinkStatus(
-      'send-1', interaction,
-      [{ resourceId: 'res-1' }],
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
 
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: true }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL); // termination tick
+
+    const lastCall = interaction.editReply.mock.calls.at(-1);
+    expect(lastCall?.[0]).toEqual(expect.objectContaining({ components: [] }));
+    monitor.stop();
+  });
+
+  it('BatchGet error logs but does not crash the setInterval', async () => {
+    const interaction = makeInteraction();
+    mockDb.getQurlViews.mockRejectedValueOnce(new Error('DDB throttled'));
+
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent', { components: [] }, 1, 'apikey',
+    );
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
-    // No throw; init logged; no editReply because no status changes.
+    expect(logger.error).toHaveBeenCalledWith('Link monitor poll failed', expect.any(Object));
+    // No editReply because the BatchGet failed before any status diff.
     expect(interaction.editReply).not.toHaveBeenCalled();
     monitor.stop();
   });
 });
 
-describe('monitorLinkStatus — status transitions', () => {
+describe('monitorLinkStatus — empty-qurl_id boundary guard', () => {
   beforeEach(() => { jest.useFakeTimers(); });
   afterEach(() => { jest.useRealTimers(); });
 
-  it('all-opened → posts final message and clears interval', async () => {
-    const interaction = makeInteraction();
-    mockGetResourceStatus
-      .mockResolvedValueOnce({
-        qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' }],
-      })
-      .mockResolvedValueOnce({
-        qurls: [{ qurl_id: 'q1', use_count: 1, status: 'active', created_at: '2026-01-01T00:00:00Z' }],
-      });
-
+  it('any missing qurlId degrades the whole monitor to bare base-msg', async () => {
+    // Mixed batch: one link has qurlId, one does not. Misattribution
+    // would render `1 of 2 viewed` from a partial-attribution set —
+    // worse UX than no counter. Boundary guard degrades the whole
+    // monitor.
+    const mixed = [
+      { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://q.test/1', recipientId: 'r1' },
+      { resourceId: 'res-1', qurlId: '', qurlLink: 'https://q.test/2', recipientId: 'r2' },
+    ];
     const monitor = monitorLinkStatus(
-      'send-1', interaction,
-      [{ resourceId: 'res-1' }],
-      [{ id: 'r1', username: 'Alice' }],
-      '1m', 'Sent', { components: [] }, 1, 'apikey',
+      'send-1', makeInteraction(),
+      mixed,
+      [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
+      '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
+    );
+    expect(monitor.getFullMsg()).toBe('Sent to 2 users');
+    expect(monitor.getFullMsg()).not.toMatch(/viewed|pending|👀/);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Monitor view counter degraded'),
+      expect.objectContaining({ sendId: 'send-1', missing: 1, total: 2 }),
     );
 
+    // No DDB read happens during degraded mode — the BatchGet is
+    // unconditionally skipped at the top of runTick when degraded.
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-
-    // After all-done, an additional tick should hit the stop branch;
-    // a final-message editReply with components: [] confirms the path.
-    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-
-    const lastCall = interaction.editReply.mock.calls.at(-1);
-    expect(lastCall?.[0]).toEqual(expect.objectContaining({ components: expect.any(Array) }));
-    // monitor.stop() in afterEach is a no-op since allDone already cleared
+    expect(mockDb.getQurlViews).not.toHaveBeenCalled();
     monitor.stop();
   });
 });
 
-// First-poll latency: pre-PR the first tick fired at pollInterval
-// View counter is temporarily disabled at the render layer.
-// qurl-service's transit-resource strip (PR #539/#568) removes the
-// `qurls` field from GET /v1/qurls/:id responses for connector
-// uploads (= every Discord bot send), so the polling-based counter
-// could only ever render `0 of N viewed`. Until the webhook-based
-// replacement lands (qurl-service #596 + bot receiver), buildStatusMsg
-// returns the bare currentBaseMsg. Pin the disable so a re-enable
-// without the upstream fix surfaces here.
-describe('monitorLinkStatus — view counter temporarily disabled (qurl-service transit-strip)', () => {
-  it('getFullMsg() returns bare currentBaseMsg regardless of linkStatus state', async () => {
-    jest.useFakeTimers();
-    try {
-      // Even with all qurls "viewed" in the mock response, the headline
-      // must NOT render (the data is unreliable on transit resources).
-      mockGetResourceStatus.mockResolvedValue({
-        qurls: [
-          { qurl_id: 'q1', use_count: 1, status: 'active', created_at: '2026-01-01T00:00:00Z' },
-          { qurl_id: 'q2', use_count: 1, status: 'active', created_at: '2026-01-01T00:00:01Z' },
-        ],
-      });
-      const monitor = monitorLinkStatus(
-        'send-1', makeInteraction(),
-        [{ resourceId: 'res-1' }],
-        [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
-        '1m', 'Sent to 2 users', { components: [] }, 2, 'apikey',
-      );
-
-      // Pre-poll baseline: bare currentBaseMsg.
-      expect(monitor.getFullMsg()).toBe('Sent to 2 users');
-
-      // After polls — linkStatus would have 2 'opened' entries if the
-      // renderer ran, but the bare message must persist.
-      await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-      await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-      expect(monitor.getFullMsg()).toBe('Sent to 2 users');
-      expect(monitor.getFullMsg()).not.toMatch(/viewed|expired|👀|✅|⏰/);
-
-      monitor.stop();
-
-      // Post-stop too — bare message remains (no frozen-render machinery
-      // needed when there's nothing to freeze).
-      expect(monitor.getFullMsg()).toBe('Sent to 2 users');
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-});
-
-// (15-60s). For short-TTL self-destruct sends the recipient could open
-// + burn the link before the first poll ran, meaning the sender's
-// view counter never reflected the view at all. New cadence: first
-// tick at 3s via setTimeout, then setInterval at pollInterval for
-// subsequent ticks. Pin the 3s number so a future refactor that
-// reintroduces the old setInterval-only shape fails CI.
-describe('monitorLinkStatus — first-poll cadence', () => {
+describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream fanout)', () => {
   beforeEach(() => { jest.useFakeTimers(); });
   afterEach(() => { jest.useRealTimers(); });
 
   it('first tick fires at ~3s, not at the 15s pollInterval', async () => {
-    mockGetResourceStatus.mockResolvedValue({
-      qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' }],
-    });
-
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
-      [{ resourceId: 'res-1' }],
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
-
-    // Advance to just before the new first-poll mark — should NOT
-    // have polled yet.
     await jest.advanceTimersByTimeAsync(2500);
-    expect(mockGetResourceStatus).not.toHaveBeenCalled();
-
-    // Cross the 3s mark — first poll must fire.
+    expect(mockDb.getQurlViews).not.toHaveBeenCalled();
     await jest.advanceTimersByTimeAsync(1000);
-    expect(mockGetResourceStatus).toHaveBeenCalled();
-
+    expect(mockDb.getQurlViews).toHaveBeenCalled();
     monitor.stop();
   });
 
-  it('subsequent ticks honor the standard pollInterval after the fast first tick', async () => {
-    // The setTimeout-then-setInterval pattern's failure mode is
-    // accidentally calling setInterval(runTick, FIRST_POLL_DELAY_MS)
-    // — every subsequent poll would then fire every 3s, hammering
-    // qurl-service. Pin that tick 2 lands at first-tick + pollInterval
-    // (~3s + 15s = 18s), not first-tick + 3s.
-    //
-    // Tick 1 calls getResourceStatus twice (init pass + poll pass —
-    // see the `if (!trackedQurlIds)` init block + the subsequent
-    // pollResults Promise.all). The test snapshots that count at
-    // t=3s and asserts it doesn't grow until the setInterval fires
-    // at t=18s.
-    mockGetResourceStatus.mockResolvedValue({
-      qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' }],
-    });
-
+  it('subsequent ticks honor standard pollInterval after the fast first tick', async () => {
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
-      [{ resourceId: 'res-1' }],
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
 
-    await jest.advanceTimersByTimeAsync(3000);   // first tick
-    const callsAfterFirstTick = mockGetResourceStatus.mock.calls.length;
+    await jest.advanceTimersByTimeAsync(3000);
+    const callsAfterFirstTick = mockDb.getQurlViews.mock.calls.length;
     expect(callsAfterFirstTick).toBeGreaterThanOrEqual(1);
 
-    // 3s later (now t=6s) — setInterval still waiting for its first
-    // fire at t=18s. No additional calls expected.
-    await jest.advanceTimersByTimeAsync(3000);
-    expect(mockGetResourceStatus.mock.calls.length).toBe(callsAfterFirstTick);
+    await jest.advanceTimersByTimeAsync(3000); // t=6s — no tick due
+    expect(mockDb.getQurlViews.mock.calls.length).toBe(callsAfterFirstTick);
 
-    // Cross t=18s — second tick fires from the setInterval.
-    await jest.advanceTimersByTimeAsync(12500);
-    expect(mockGetResourceStatus.mock.calls.length).toBeGreaterThan(callsAfterFirstTick);
-
+    await jest.advanceTimersByTimeAsync(12500); // cross t=18s
+    expect(mockDb.getQurlViews.mock.calls.length).toBeGreaterThan(callsAfterFirstTick);
     monitor.stop();
   });
 });
@@ -561,84 +487,118 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
   beforeEach(() => { jest.useFakeTimers(); });
   afterEach(() => { jest.useRealTimers(); });
 
-  it('addRecipients() bumps generation and forces re-init on next tick', async () => {
-    const interaction = makeInteraction();
-    mockGetResourceStatus.mockResolvedValue({
-      qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z' }],
-    });
-
+  it('addRecipients() extends trackedQurlIds and the next tick BatchGets the new IDs', async () => {
     const monitor = monitorLinkStatus(
-      'send-1', interaction,
-      [{ resourceId: 'res-1' }],
+      'send-1', makeInteraction(),
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
 
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+    mockDb.getQurlViews.mockClear();
 
-    // Add a recipient + new resource. Generation bumps; trackedQurlIds nulls.
-    monitor.addRecipients(1, ['res-2']);
-
-    // Next tick re-inits — getResourceStatus called again across both resources.
-    mockGetResourceStatus.mockClear();
+    // Add a recipient with a new qurl_id. The monitor's next BatchGet
+    // must include the new id in its key list.
+    monitor.addRecipients(1, ['q_aaaaaaaaaa3']);
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
 
-    expect(mockGetResourceStatus).toHaveBeenCalled();
+    expect(mockDb.getQurlViews).toHaveBeenCalled();
+    const lastCallKeys = mockDb.getQurlViews.mock.calls.at(-1)[0];
+    expect(lastCallKeys).toContain('q_aaaaaaaaaa3');
     monitor.stop();
   });
 
-  it('addRecipients() de-dupes new resource IDs already in the list', async () => {
-    const interaction = makeInteraction();
-    mockGetResourceStatus.mockResolvedValue({ qurls: [] });
-
+  it('addRecipients() de-dupes a qurl_id already in the tracked set', async () => {
     const monitor = monitorLinkStatus(
-      'send-1', interaction,
-      [{ resourceId: 'res-1' }],
+      'send-1', makeInteraction(),
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
-
-    // Calling addRecipients with an already-present resourceId should not
-    // dup it. The Set-of-resourceIds semantics live inside the function;
-    // this asserts no crash + the next tick still polls cleanly.
-    monitor.addRecipients(1, ['res-1']);
+    // Same ID already tracked — should be a no-op insertion-wise.
+    monitor.addRecipients(1, ['q_aaaaaaaaaa1']);
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+    const lastCallKeys = mockDb.getQurlViews.mock.calls.at(-1)[0];
+    // Set semantics — only one entry for q_aaaaaaaaaa1.
+    expect(lastCallKeys.filter(k => k === 'q_aaaaaaaaaa1')).toHaveLength(1);
     monitor.stop();
   });
 
-  it('stop() called concurrently with running tick — caught by outer try/catch, no crash', async () => {
+  it('stop() called concurrently with a running tick — no unhandled rejection', async () => {
     const interaction = makeInteraction();
-    mockGetResourceStatus.mockImplementation(() => {
-      // Simulate slow upstream — by the time this resolves, stop() has run.
-      return new Promise(resolve => setTimeout(() => resolve({ qurls: [{
-        qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01T00:00:00Z',
-      }] }), 5000));
-    });
+    mockDb.getQurlViews.mockImplementation(() => new Promise(resolve =>
+      setTimeout(() => resolve(new Map([['q_aaaaaaaaaa1', { accessCount: 0, consumed: false }]])), 5000),
+    ));
 
     const monitor = monitorLinkStatus(
       'send-1', interaction,
-      [{ resourceId: 'res-1' }],
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
-
-    // Kick the first tick + start the slow getResourceStatus.
     await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
-    // Stop NOW, mid-await, before getResourceStatus resolves. stop() nulls
-    // `interaction`, `qurlLinks`, `recipients`, `buttonRow`. The first-tick
-    // init block reads `recipients.length` AFTER the Promise.all resolves,
-    // so a stop() during that gap surfaces as an NPE — caught by the outer
-    // try/catch on line 609 and logged as 'Link monitor poll failed'.
-    // The contract is: no thrown error escapes the setInterval; the impact
-    // is one logged error line per affected tick, not a process crash.
-    // (Tightening the post-await guard is tracked separately.)
     monitor.stop();
     await jest.advanceTimersByTimeAsync(10000);
-
-    // No unhandled rejection; the outer try/catch contained the failure.
-    // The exact log shape (none vs one logged poll-failed) depends on the
-    // race window — we only assert the failure-mode contract: no crash.
     expect(true).toBe(true);
+  });
+});
+
+describe('monitorLinkStatus — interaction-token TTL channel-edit fallback', () => {
+  beforeEach(() => { jest.useFakeTimers(); });
+  afterEach(() => { jest.useRealTimers(); });
+
+  it('edits via interaction.editReply before 14min cutover', async () => {
+    const interaction = makeInteraction();
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1h', 'Sent', { components: [] }, 1, 'apikey',
+    );
+    monitor.setMessageId('msg-1');
+
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+    expect(interaction.editReply).toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it('edits via editDM (bot-token PATCH) once past the 14min cutover', async () => {
+    const interaction = makeInteraction();
+    const startedAt = Date.now();
+    const monitor = monitorLinkStatus(
+      'send-2', interaction,
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1h', 'Sent', { components: [] }, 1, 'apikey',
+    );
+    monitor.setMessageId('msg-2');
+
+    // Jump system time past the 14-min cutover WITHOUT firing the
+    // intervening ticks — those would have advanced pollCount past
+    // the throttling boundary and skipped odd ticks. setSystemTime
+    // moves wall time only; the next advanceTimersByTimeAsync fires
+    // the next scheduled tick.
+    jest.setSystemTime(startedAt + 14 * 60 * 1000 + 5000);
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    // Fast-tick is FIRST_POLL_DELAY_MS = 3000 — by the time the
+    // intervening setSystemTime jump has happened, the setTimeout is
+    // still pending, so the very next advanceTimersByTimeAsync(3000)
+    // fires the first tick. The runTick reads Date.now() AFTER our
+    // setSystemTime above, so the cutover check sees >14min and
+    // routes through editDM.
+    await jest.advanceTimersByTimeAsync(3000);
+    expect(mockEditDM).toHaveBeenCalledWith(
+      'ch-1', 'msg-2',
+      expect.objectContaining({ content: expect.stringContaining('👀') }),
+    );
+    monitor.stop();
   });
 });
 
@@ -647,60 +607,45 @@ describe('monitorLinkStatus — duration cap + activeMonitors LRU', () => {
   afterEach(() => { jest.useRealTimers(); });
 
   it('stops + posts final after MAX_MONITOR_DURATION_MS (1h cap on long expiries)', async () => {
-    const interaction = makeInteraction();
-    mockGetResourceStatus.mockResolvedValue({ qurls: [] });
-
-    // 7d expiry → MAX_MONITOR_DURATION_MS (1h) clamps the run.
     const monitor = monitorLinkStatus(
-      'send-1', interaction,
-      [{ resourceId: 'res-1' }],
+      'send-1', makeInteraction(),
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '7d', 'Sent', { components: [] }, 1, 'apikey',
     );
-
     // Skip ~1h+1min so the cap branch fires.
     await jest.advanceTimersByTimeAsync(60 * 60 * 1000 + 60 * 1000);
-
-    // The cap branch sets the final message + clears interval; monitor
-    // is removed from activeMonitors via stop(). Subsequent .stop() is
-    // idempotent.
     monitor.stop();
   });
 
-  it('LRU-evicts oldest monitor when activeMonitors hits MAX_CONCURRENT_MONITORS', () => {
-    // The cap is 50 in module-private state. We can't test the exact
-    // boundary without exposing the constant, but we can confirm the set
-    // behavior: starting many monitors keeps activeMonitors size bounded
-    // and oldest gets stop()'d.
+  it('LRU bookkeeping: activeMonitors grows by N when N monitors start under the cap', () => {
     const before = activeMonitors.size;
     const monitors = [];
     for (let i = 0; i < 5; i++) {
       monitors.push(monitorLinkStatus(
         `send-${i}`, makeInteraction(),
-        [{ resourceId: `res-${i}` }],
+        [{ resourceId: `res-${i}`, qurlId: `q_aaaaaaaaaa${i}`, qurlLink: `https://q.test/${i}`, recipientId: `r${i}` }],
         [{ id: `r${i}`, username: `User${i}` }],
         '1m', 'Sent', { components: [] }, 1, 'apikey',
       ));
     }
-    // Set should have grown by exactly 5 (no eviction at 5 < 50 cap).
     expect(activeMonitors.size).toBe(before + 5);
     for (const m of monitors) m.stop();
   });
 
-  it('exposes control methods: addRecipients, stop, updateBaseMsg, getFullMsg', () => {
+  it('exposes control surface: addRecipients, stop, updateBaseMsg, getFullMsg, setMessageId', () => {
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
-      [{ resourceId: 'res-1' }],
+      ONE_LINK_SET,
       [{ id: 'r1', username: 'Alice' }],
       '1m', 'Sent', { components: [] }, 1, 'apikey',
     );
-
     expect(typeof monitor.addRecipients).toBe('function');
     expect(typeof monitor.stop).toBe('function');
     expect(typeof monitor.updateBaseMsg).toBe('function');
     expect(typeof monitor.getFullMsg).toBe('function');
+    expect(typeof monitor.setMessageId).toBe('function');
 
-    // updateBaseMsg + getFullMsg round-trip with new base message.
     monitor.updateBaseMsg('New base');
     expect(monitor.getFullMsg()).toContain('New base');
     monitor.stop();


### PR DESCRIPTION
## Summary
Restores the `👀 N viewed / M pending` line on `/qurl send` + `/qurl map` confirmation messages that was removed in #455. The old upstream-polling implementation went silent when transit resources stopped surfacing their `qurls` array; this PR replaces the poll with a `qurl.accessed` webhook receiver.

- New `POST /webhooks/qurl` route with HMAC-SHA256 verify (shared with the GitHub webhook via the new `src/utils/webhook-hardening.js`), per-IP bad-sig rate limit, replay protection
- New `qurl_views` DDB store methods: `recordQurlView` (conditional MAX-merge update with 30-day TTL refresh) + `getQurlViews` (BatchGet)
- Live monitor reader swapped from `getResourceStatus` upstream poll → `db.getQurlViews` BatchGet on the in-memory `qurlLinks` set
- `qurl_id` threaded from `connector.mintLinks` → `mintLinksInBatches` → `qurlLinks` element shape
- Monitor capped at 14 min to match the interaction webhook token's TTL (ephemeral confirmation messages can only be edited via that token; past it, no edit path works)
- 2414 tests pass; new receiver + store + flow + monitor tests included

## Why
The view counter is a sender-facing signal that recipients are actually engaging with the share. It went dark in #455 when the polling source dried up. The webhook approach is also strictly more correct: the upstream poll only ever rendered "opened" on full minute-tick boundaries, while the webhook fires within seconds of the recipient clicking.

DDB is intentionally the multi-instance bridge — a webhook landing on instance A reaches a monitor running on instance B without any in-process pub/sub.

## Wire contract
- Header `QURL-Signature` = bare hex HMAC-SHA256 over the raw body (no `sha256=` prefix — different from GitHub's wire shape)
- Body `{id, type, data:{qurl_id, resource_id, access_count, consumed}, owner_id, timestamp, api_version}` (matches qurl-service's `WebhookEvent` payload contract)
- `src_ip` + `user_agent` are stripped server-side for transit resources (connector-owned privacy boundary; Discord bot sends are always transit)

## Operator setup
Full step-by-step in `apps/discord/docs/qurl-webhook-rollout.md`:
1. Provision the `qurl-views` DDB table (handled by the deploying organization's infrastructure)
2. Deploy the bot
3. Set `QURL_WEBHOOK_SECRET` in SSM
4. Register the qurl-service webhook subscription with the same secret

The receiver returns 503 with a boot WARN until step 3 is done. No webhooks arrive until step 4. Both failure modes are documented in the runbook with recovery paths.

## Test plan
- [x] `npx jest` — 2414 tests pass
- [x] `npx eslint` clean
- [ ] Sandbox: deploy, set SSM secret, register subscription, run `/qurl send` to a test recipient, confirm counter advances
- [ ] Prod: same sequence after sandbox validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)