### PR TITLE
fix(discord): alias `consumed` reserved keyword in qurl_views UpdateExpression

### DIFF
--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1060,12 +1060,17 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
     await ddb.send(new UpdateCommand({
       TableName: TABLES.qurl_views,
       Key: { qurl_id: qurlId },
+      // `consumed` is a DDB reserved keyword (see the AWS reserved-words
+      // list); referencing it as a bare attribute name in Update/
+      // ConditionExpression returns ValidationException at write time.
+      // Aliased via ExpressionAttributeNames to dodge that.
       ConditionExpression:
         'attribute_not_exists(last_event_id) OR ('
         + 'last_event_id <> :eid AND ('
-        + 'access_count < :n OR (access_count = :n AND consumed = :false AND :c = :true)'
+        + 'access_count < :n OR (access_count = :n AND #consumed = :false AND :c = :true)'
         + '))',
-      UpdateExpression: 'SET access_count = :n, consumed = :c, last_event_id = :eid, last_updated = :now, expires_at = :exp',
+      UpdateExpression: 'SET access_count = :n, #consumed = :c, last_event_id = :eid, last_updated = :now, expires_at = :exp',
+      ExpressionAttributeNames: { '#consumed': 'consumed' },
       ExpressionAttributeValues: {
         ':n': accessCount,
         ':c': consumedBool,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1060,10 +1060,8 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
     await ddb.send(new UpdateCommand({
       TableName: TABLES.qurl_views,
       Key: { qurl_id: qurlId },
-      // `consumed` is a DDB reserved keyword (see the AWS reserved-words
-      // list); referencing it as a bare attribute name in Update/
-      // ConditionExpression returns ValidationException at write time.
-      // Aliased via ExpressionAttributeNames to dodge that.
+      // `consumed` is a DDB reserved keyword — must be aliased via
+      // ExpressionAttributeNames or DDB returns ValidationException.
       ConditionExpression:
         'attribute_not_exists(last_event_id) OR ('
         + 'last_event_id <> :eid AND ('

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1021,13 +1021,17 @@ describe('qurl views', () => {
     // Pin the condition exactly so a refactor that drops any clause
     // (replay, out-of-order, OR the consumed false→true flip on equal
     // access_count) fails CI rather than silently corrupting the
-    // counter.
+    // counter. `#consumed` is the DDB-reserved-keyword alias.
     expect(input.ConditionExpression).toBe(
       'attribute_not_exists(last_event_id) OR ('
       + 'last_event_id <> :eid AND ('
-      + 'access_count < :n OR (access_count = :n AND consumed = :false AND :c = :true)'
+      + 'access_count < :n OR (access_count = :n AND #consumed = :false AND :c = :true)'
       + '))',
     );
+    expect(input.UpdateExpression).toBe(
+      'SET access_count = :n, #consumed = :c, last_event_id = :eid, last_updated = :now, expires_at = :exp',
+    );
+    expect(input.ExpressionAttributeNames).toEqual({ '#consumed': 'consumed' });
     expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
       ':n': 3, ':c': false, ':eid': 'evt-1', ':false': false, ':true': true,
     }));


### PR DESCRIPTION
## Summary
Discovered during sandbox smoke test of #465. A signed POST to `/webhooks/qurl` returned **HTTP 500** because DDB rejected the `recordQurlView` ConditionExpression + UpdateExpression with:

```
Invalid UpdateExpression: Attribute name is a reserved keyword; reserved keyword: consumed
```

The merged code referenced `consumed` as a bare attribute name. DDB's reserved-words list (which includes `consumed`) requires aliasing via `ExpressionAttributeNames`.

## Fix
- `ExpressionAttributeNames: { '#consumed': 'consumed' }` + replace bare `consumed` with `#consumed` in both expressions.
- Update the ConditionExpression-literal pin in `ddb-store.test.js` so the test still catches a future regression that drops any clause.

## Why unit tests + flow test missed this
Both use `aws-sdk-client-mock` (unit) + an in-memory mock (flow). Neither validates DDB-side reserved-keyword rules — only a real DDB call exercises that path. The sandbox smoke test is the canonical place this class of bug surfaces. No new test class added in this hotfix; a real-DDB test suite is out of scope.

## Test plan
- [x] `npx jest` — 2414 tests pass
- [x] Lint clean
- [ ] Sandbox: re-run signed smoke POST after deploy → expect HTTP 200 `{"status":"recorded"}` + new row in `qurl-views`

🤖 Generated with [Claude Code](https://claude.com/claude-code)