### PR TITLE
feat(discord): auto-register qurl-service webhook on boot

### DIFF
--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -125,6 +125,23 @@ already exists and the SSM secret is populated. The durable upstream
 fix — making `POST /v1/webhooks` idempotent on `(owner_id, url)` —
 is tracked separately.
 
+**Dedupe-recovery boot also needs `desired_count=1`.** If the first
+deploy was accidentally run at `desired_count>1` and produced
+duplicate subscriptions, the *next* boot enters the dedupe-recovery
+path: it deletes the non-survivor duplicates AND force-rotates the
+survivor's secret (the survivor's pre-rotate secret belongs to a
+deleted replica's POST, so SSM almost certainly disagrees). That
+force-rotate runs on every replica concurrently, with the same
+last-write-wins SSM race that the steady-state reuse path was
+designed to avoid. To exit the duplicate state cleanly:
+
+1. Scale to `desired_count=1`.
+2. Confirm one boot completed cleanly (`Webhook subscription
+   reconciled (existing found, bootstrap rotate)` + the warn line
+   for `Webhook subscription duplicates detected — deleting
+   non-survivors`).
+3. Scale back to target desired_count.
+
 ### Persistence env var
 
 The registrar writes the active secret back to AWS Systems Manager

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -97,6 +97,50 @@ SSM-loaded secret is non-empty and non-`PLACEHOLDER`. Steady-state
 restarts reuse the SSM value; only the bootstrap path (no sub yet,
 or seeded `PLACEHOLDER`) rotates.
 
+### Cold-bootstrap of a fresh environment — DEPLOY AT desired_count=1 FIRST
+
+On the very first deploy to a fresh environment, no subscription
+exists yet AND no SSM secret exists yet. If N replicas boot
+concurrently in that state, each replica independently `POST`s
+`/v1/webhooks` and N duplicate subscriptions are created, each with
+a distinct server-generated secret. SSM is last-write-wins so only
+one replica's secret persists; the N-1 surviving duplicate
+subscriptions deliver events to dead secrets and 401 forever until
+manual cleanup.
+
+The registrar's dedupe path (next boot finds the duplicates and
+deletes all but the oldest survivor by `created_at`) is RECOVERY,
+not prevention. To avoid the race entirely on a fresh environment:
+
+1. Scale the bot HTTP service to `desired_count=1` before the first
+   deploy.
+2. Confirm one boot completed cleanly (`qURL webhook self-
+   registration complete` log line + `created` action).
+3. Scale back to the target desired_count.
+
+This procedure is only required on the first deploy of a brand-new
+environment. Every subsequent deploy (rolling, blue/green, redeploy)
+falls into the steady-state `reused` path because the subscription
+already exists and the SSM secret is populated. The durable upstream
+fix — making `POST /v1/webhooks` idempotent on `(owner_id, url)` —
+is tracked separately.
+
+### Persistence env var
+
+The registrar writes the active secret back to AWS Systems Manager
+Parameter Store when `QURL_WEBHOOK_SECRET_SSM_PARAM` is set in the
+bot's environment. The value is the full SSM parameter name (e.g.
+`/discord-bot/sandbox/QURL_WEBHOOK_SECRET`). When unset, the
+registrar runs in-memory-only — usable for local dev but every
+restart rotates the secret because there's no place to read the
+previous one from.
+
+The IAM role for the bot's task needs `ssm:PutParameter` on that
+specific parameter. The bot tolerates `AccessDeniedException`
+gracefully (logs `warn`, continues with in-memory secret) so a
+missing grant degrades to "the secret rotates each boot, but the
+bot still works" rather than a crashloop.
+
 ## What the bot does NOT need
 
 - The full `qurl.accessed` payload's `src_ip` / `user_agent` fields —

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -158,6 +158,23 @@ gracefully (logs `warn`, continues with in-memory secret) so a
 missing grant degrades to "the secret rotates each boot, but the
 bot still works" rather than a crashloop.
 
+**Latent risk if persistence stays broken**: every replica restart
+hits the bootstrap-rotate path (no real SSM secret available), which
+re-introduces the multi-replica rotate race on every redeploy. The
+warn log `Webhook secret persistence failed (auto-register continues
+with in-memory secret only)` is the early-warning signal — alarm on
+it if oncall hasn't built a CloudWatch rule yet.
+
+**Operational note — `description` field staleness**: the
+`description` shown in the qurl-service webhook UI is captured at
+create time (e.g. `Discord bot view counter (region=us-east-2,
+env=sandbox)`) and is NOT reconciled by subsequent boots. If the
+environment is renamed or migrated to a new region, the UI label
+stays stale until the subscription is deleted and recreated.
+Observability-only — the bot keeps working — but operators sweeping
+the qurl-service UI for "which sub belongs to which env" should not
+trust the description as authoritative.
+
 ## What the bot does NOT need
 
 - The full `qurl.accessed` payload's `src_ip` / `user_agent` fields —

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -11,46 +11,32 @@ This rollout replaces the poll with a `qurl.accessed` webhook receiver.
 
 ## Rollout order
 
-Each step blocks the next — do not skip ahead.
-
-1. **`qurl-views` DDB table.** Provisioned by the deploying organization's
-   infrastructure (separate from this repo). Without it, the bot's
-   monitor `BatchGet` returns the empty map and the counter silently
-   stays at `0 viewed / N pending` forever. Confirm with:
+1. **`qurl-views` DDB table.** Provisioned by the deploying
+   organization's infrastructure (separate from this repo). Without
+   it, the bot's monitor `BatchGet` returns the empty map and the
+   counter silently stays at `0 viewed / N pending` forever. Confirm
+   with:
    ```
    aws dynamodb describe-table \
      --table-name <DDB_TABLE_PREFIX>qurl-views \
      --region <env-region>
    ```
-2. **Deploy the bot.** Code mounts `/webhooks/qurl` unconditionally and
-   warns on boot if `QURL_WEBHOOK_SECRET` is unset — that's the operator
-   signal that step 3 hasn't happened yet.
-3. **Set the SSM secret.**
-   ```
-   aws ssm put-parameter \
-     --name "/<project>/QURL_WEBHOOK_SECRET" \
-     --type SecureString \
-     --value "$(openssl rand -hex 32)" \
-     --overwrite \
-     --region <env-region>
-   ```
-   Then restart the task so the secret is picked up:
-   ```
-   aws ecs update-service --service <svc> --force-new-deployment ...
-   ```
-4. **Register the subscription with qurl-service.** The subscription's
-   `secret` field MUST be the same hex string as step 3 — the bot's
-   verifySignature pins bare-hex HMAC-SHA256 over the raw body.
-   ```
-   curl -X POST https://<qurl-service-host>/v1/webhooks \
-     -H 'Authorization: Bearer <qurl-service-admin-token>' \
-     -H 'Content-Type: application/json' \
-     -d '{
-       "url": "https://<bot-host>/webhooks/qurl",
-       "event_types": ["qurl.accessed"],
-       "secret": "<same-hex-as-step-3>"
-     }'
-   ```
+2. **Deploy the bot.** On `isHttp` boot, the bot self-registers its
+   `qurl.accessed` webhook subscription with qurl-service using its
+   own `QURL_API_KEY` (the same key it uses to mint qURLs — so the
+   subscription's `owner_id` matches the qURLs the bot creates).
+   Steady-state reuses the secret already in SSM/env. Bootstrap (no
+   subscription yet, or SSM seeded with `PLACEHOLDER`) creates or
+   rotates the subscription and best-effort writes the secret back
+   to SSM via `ssm:PutParameter`.
+
+   No manual operator curl required. The bot's `qURL webhook self-
+   registration complete` log line confirms the registration on each
+   boot.
+
+   Recovery if auto-register fails: the registrar logs at error
+   level and the bot continues booting; manual fallback is the
+   `curl` step in the [appendix](#appendix-manual-recovery) below.
 
 ## Wire shape (pinned)
 
@@ -99,23 +85,61 @@ Each step blocks the next — do not skip ahead.
   bare base message (no `👀` line at all) and emits one WARN per
   affected send. Recover by deploying the connector forward.
 
-## Known operator-burden tradeoffs
+## Multi-replica safety
 
-- **Secret coupled in two places.** Step 3's SSM value and step 4's
-  subscription `secret` field must match by hand; rotation is a
-  coordinated edit, not a single command. Auto-register-at-boot
-  (bot POSTs the subscription on startup with the same value it
-  read from SSM) would collapse this to one source of truth —
-  deferred because giving the bot a qurl-service admin token
-  widens the bot's blast radius beyond the per-guild `QURL_API_KEY`
-  it has today. Revisit when the admin-token surface has tighter
-  scoping (per-subscription instead of org-wide).
+Multiple HTTP replicas booting concurrently used to race on
+`POST /v1/webhooks/{id}/secret` — server-side last-write-wins meant
+N-1 replicas held a stale secret in memory, and the ALB-routed
+traffic across them 401'd on roughly `(N-1)/N` of inbound webhooks
+until the next restart settled the fleet. The registrar now skips
+rotation when (a) an existing subscription is found AND (b) the
+SSM-loaded secret is non-empty and non-`PLACEHOLDER`. Steady-state
+restarts reuse the SSM value; only the bootstrap path (no sub yet,
+or seeded `PLACEHOLDER`) rotates.
 
 ## What the bot does NOT need
 
-- A webhook auto-registration handshake — subscriptions are managed
-  out-of-band (curl above). See "operator-burden tradeoffs" for
-  why this isn't automated today.
 - The full `qurl.accessed` payload's `src_ip` / `user_agent` fields —
   they're stripped for transit resources at the qurl-service boundary,
   per the connector-owned redaction policy.
+
+## Appendix — manual recovery
+
+Use this only if auto-register failed and the bot logs show
+`qURL webhook self-registration failed` repeatedly. Replace the
+placeholder values:
+
+```
+# 1. Create or rotate the subscription with the bot's own API key
+#    (NOT an admin token — owner_id must match the bot's qURL-mint
+#    owner_id, otherwise events get filtered out before delivery).
+curl -X POST https://<qurl-service-host>/v1/webhooks \
+  -H "Authorization: Bearer $(aws ssm get-parameter --name /<project>/QURL_API_KEY --with-decryption --query 'Parameter.Value' --output text)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://<bot-host>/webhooks/qurl",
+    "events": ["qurl.accessed"],
+    "description": "manual recovery"
+  }'
+# Capture the `secret` from the response.
+
+# 2. Put it in SSM so the next bot boot picks it up.
+aws ssm put-parameter \
+  --name "/<project>/QURL_WEBHOOK_SECRET" \
+  --type SecureString \
+  --value "<secret-from-step-1>" \
+  --overwrite \
+  --region <env-region>
+
+# 3. Force a redeploy.
+aws ecs update-service \
+  --cluster <cluster> \
+  --service <bot-http-service> \
+  --force-new-deployment \
+  --region <env-region>
+```
+
+After step 3, the bot will boot with the SSM secret in env,
+the auto-register will find the existing sub + the real
+SSM-loaded secret, take the reuse path, and the rotation race
+is gone for steady-state.

--- a/apps/discord/docs/qurl-webhook-rollout.md
+++ b/apps/discord/docs/qurl-webhook-rollout.md
@@ -161,9 +161,16 @@ bot still works" rather than a crashloop.
 **Latent risk if persistence stays broken**: every replica restart
 hits the bootstrap-rotate path (no real SSM secret available), which
 re-introduces the multi-replica rotate race on every redeploy. The
-warn log `Webhook secret persistence failed (auto-register continues
-with in-memory secret only)` is the early-warning signal — alarm on
-it if oncall hasn't built a CloudWatch rule yet.
+warn log `qURL webhook secret persistence failed (auto-register
+continues with in-memory secret only)` is the early-warning signal —
+alarm on it if oncall hasn't built a CloudWatch rule yet.
+
+**Higher-severity signal** — alarm on the outer error too:
+`qURL webhook self-registration failed`. This fires when GET/POST/
+PATCH/DELETE against qurl-service fails (transient 5xx, network
+abort, etc.) and the bot fell back to the manual-curl recovery path.
+Without an alarm, the failure is invisible until users notice
+"counter sat at 0" — exactly the gap this PR was built to close.
 
 **Operational note — `description` field staleness**: the
 `description` shown in the qurl-service webhook UI is captured at

--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1036.0",
         "@aws-sdk/client-sqs": "^3.1036.0",
+        "@aws-sdk/client-ssm": "^3.1036.0",
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "@discordjs/rest": "~2.6.0",
         "@discordjs/ws": "~1.2.3",
@@ -272,16 +273,20 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.974.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.10.tgz",
-      "integrity": "sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==",
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1050.0.tgz",
+      "integrity": "sha512-ZYo51WgVwAf2REtQv9M8U7E+j3oG7pmuxNkAQLFcieUVLnsDchCUyCnQ2N8GKWxZ5ckbSOHOm5fGds5Z13Lbjw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -289,15 +294,34 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.36.tgz",
-      "integrity": "sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -306,16 +330,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.38.tgz",
-      "integrity": "sha512-cHZo3bV6zN9joDQ2AYVctfzHTKStxWKwnGu0z7GwCUC+DAtB3qL/+26l+a63RbmFbVvb1JK+0vJKodN3hRMwyw==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -324,22 +348,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.40.tgz",
-      "integrity": "sha512-0NFGS9I3PD2yMveQqqpwpRdyZVStzgk0Yr2rZHh80kV/QNqQCK5lSrksvU3nBcRNSUF5Uk8rL3Xk0EVR+UVAnA==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/credential-provider-env": "^3.972.36",
-        "@aws-sdk/credential-provider-http": "^3.972.38",
-        "@aws-sdk/credential-provider-login": "^3.972.40",
-        "@aws-sdk/credential-provider-process": "^3.972.36",
-        "@aws-sdk/credential-provider-sso": "^3.972.40",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.40",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/credential-provider-imds": "^4.3.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -348,15 +372,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.40.tgz",
-      "integrity": "sha512-IEIl+UQnrEjZP53TSl91e8LBephi4i1Mt9WZrMgN8pOg6xPOLZdkN1GhsEzjkMD1TQy4Fp2dwWA/9ToTQFOlLA==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -365,20 +389,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.41.tgz",
-      "integrity": "sha512-h6BlclpsPGkx7Pv7ukr8oKVqN3jvxnH5n9ZIUQa8focr1ZkKd2MYiPJ2Nv9GI97dohJVJBfZAsTp/qoZL5R1pw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.36",
-        "@aws-sdk/credential-provider-http": "^3.972.38",
-        "@aws-sdk/credential-provider-ini": "^3.972.40",
-        "@aws-sdk/credential-provider-process": "^3.972.36",
-        "@aws-sdk/credential-provider-sso": "^3.972.40",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.40",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/credential-provider-imds": "^4.3.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -387,14 +411,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.36.tgz",
-      "integrity": "sha512-eDQ6X7clTAOxXegOx4rGT1hyfusGEYdJGCGo0Ym2+CKeMQBjk+SJSxSVev11NJew5xJHJ/c3hryl2awKaxuSEA==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -403,16 +427,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.40.tgz",
-      "integrity": "sha512-jaABbsoOkGlKg5kaHetYmUV6mWM57H89ia0Yksom1XxC847mfjmEVb4p7VijS1sjPbXjUii4cftJuwsl4MXkRg==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/token-providers": "3.1047.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -421,15 +445,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.40.tgz",
-      "integrity": "sha512-bfIrM8IIzbRtXRQWx/vNEUBLTImLZyX5uKk8uSdeSAZ4Mj3Yi4UnRJLK4FkQLWErbM3McpVLQ1DaM6XO66Ed5g==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -581,27 +605,19 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.8.tgz",
-      "integrity": "sha512-/Vw2M27w+0APfMDzDpvv8auA4WiJ4D22+lC61pMS2M8Wk+4IydeRqh5utbrh+A5gQRxgUYd/xz3tdv8nQlmiHg==",
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/middleware-host-header": "^3.972.11",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/region-config-resolver": "^3.972.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@aws-sdk/util-user-agent-browser": "^3.972.11",
-        "@aws-sdk/util-user-agent-node": "^3.973.26",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -625,14 +641,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz",
-      "integrity": "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==",
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -641,15 +657,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1047.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1047.0.tgz",
-      "integrity": "sha512-GwJUeMijpeO2SOGGLRg4q2Nj9foBUBd7hTALYVId+m8fQmA4P2hITp5dmrZFd4AjEkSVmt2eFqmk3TttF7HZeQ==",
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1036.0",
     "@aws-sdk/client-sqs": "^3.1036.0",
+    "@aws-sdk/client-ssm": "^3.1036.0",
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "@discordjs/rest": "~2.6.0",
     "@discordjs/ws": "~1.2.3",

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -664,4 +664,17 @@ module.exports = {
   // Exposed as a function, NOT a property — second call returns
   // undefined.
   takeGatewayHandoffHmac,
+
+  // Explicit setter for QURL_WEBHOOK_SECRET that the auto-register
+  // path (apps/discord/src/qurl-webhook-registrar.js) calls after
+  // it learns the canonical secret from qurl-service. The receiver
+  // (routes/qurl-webhook.js) reads `config.QURL_WEBHOOK_SECRET`
+  // straight from this object, so the assignment IS what makes the
+  // newly-registered secret visible. Surface as a setter rather
+  // than a bare property mutation so the wiring is greppable and
+  // the test surface (`config.setQurlWebhookSecret(...)` →
+  // receiver verifies new secret) is obvious.
+  setQurlWebhookSecret(secret) {
+    this.QURL_WEBHOOK_SECRET = secret;
+  },
 };

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -665,16 +665,11 @@ module.exports = {
   // undefined.
   takeGatewayHandoffHmac,
 
-  // Explicit setter for QURL_WEBHOOK_SECRET that the auto-register
-  // path (apps/discord/src/qurl-webhook-registrar.js) calls after
-  // it learns the canonical secret from qurl-service. The receiver
-  // (routes/qurl-webhook.js) reads `config.QURL_WEBHOOK_SECRET`
-  // straight from this object, so the assignment IS what makes the
-  // newly-registered secret visible. Surface as a setter rather
-  // than a bare property mutation so the wiring is greppable and
-  // the test surface (`config.setQurlWebhookSecret(...)` →
-  // receiver verifies new secret) is obvious.
-  setQurlWebhookSecret(secret) {
-    this.QURL_WEBHOOK_SECRET = secret;
-  },
+};
+
+// Closure-based (not a shorthand method) so destructure-and-call works:
+// `const { setQurlWebhookSecret } = require('./config')` invocations
+// would otherwise run with `this === undefined` in strict mode.
+module.exports.setQurlWebhookSecret = function setQurlWebhookSecret(secret) {
+  module.exports.QURL_WEBHOOK_SECRET = secret;
 };

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -358,6 +358,13 @@ module.exports = {
 
   // qURL webhook receiver HMAC; peer is the qurl-service subscription's
   // `secret` field on POST /v1/webhooks (must match exactly).
+  // CONSUMERS: ALWAYS read via `config.QURL_WEBHOOK_SECRET` (property
+  // access on the exports object). Do NOT destructure
+  // `const { QURL_WEBHOOK_SECRET } = require('./config')` — that
+  // captures the pre-rotation value and 401s every webhook after
+  // setQurlWebhookSecret runs, with no rebind on rotation. The
+  // receiver in routes/qurl-webhook.js reads `config.QURL_WEBHOOK_SECRET`
+  // on every request precisely so the rotated value takes effect.
   QURL_WEBHOOK_SECRET: process.env.QURL_WEBHOOK_SECRET,
   // SSM parameter name where the auto-register path persists the
   // rotated webhook secret. Unset = in-memory-only (every restart

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -359,6 +359,11 @@ module.exports = {
   // qURL webhook receiver HMAC; peer is the qurl-service subscription's
   // `secret` field on POST /v1/webhooks (must match exactly).
   QURL_WEBHOOK_SECRET: process.env.QURL_WEBHOOK_SECRET,
+  // SSM parameter name where the auto-register path persists the
+  // rotated webhook secret. Unset = in-memory-only (every restart
+  // rotates because there's no place to read the previous one from).
+  // Pulled through config.* (not direct process.env) for grep-uniformity.
+  QURL_WEBHOOK_SECRET_SSM_PARAM: process.env.QURL_WEBHOOK_SECRET_SSM_PARAM,
 
   // qURL OAuth (Auth0) — for /qurl setup admin consent flow.
   // When unset, /qurl setup falls back to the legacy modal-paste path so the

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1134,7 +1134,12 @@ async function start() {
       ensureWebhookSubscription({
         apiEndpoint: config.QURL_ENDPOINT,
         apiKey: config.QURL_API_KEY,
-        bridgeUrl: `${config.BASE_URL}/webhooks/qurl`,
+        // Strip a trailing slash so `BASE_URL=https://bot/` doesn't
+        // produce `https://bot//webhooks/qurl` — canonicalUrl can
+        // normalize trailing-slash drift between subs, but not an
+        // internal double slash, which would silently fail to match
+        // any hand-registered sub that lacks it.
+        bridgeUrl: `${config.BASE_URL.replace(/\/$/, '')}/webhooks/qurl`,
         description,
         // Pass the SSM-loaded secret so the registrar can skip rotation
         // when steady-state (existing sub + non-PLACEHOLDER secret) —

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -25,6 +25,8 @@ const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
 const { handleFlowInteraction } = require('./flow-dispatch');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const { ensureWebhookSubscription } = require('./qurl-webhook-registrar');
+// Eager require so a missing dep fails at boot, not at first persist.
+const ssmSdk = require('@aws-sdk/client-ssm');
 const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
 const db = require('./store');
@@ -1101,26 +1103,39 @@ async function start() {
     // route still works. config.QURL_API_KEY + BASE_URL must be set
     // (already required for /qurl send to function).
     if (config.QURL_API_KEY && config.QURL_ENDPOINT && config.BASE_URL) {
-      // persistSecret: lazy SSM PutParameter so the registrar stays
-      // SDK-agnostic. Lazy-required so a missing @aws-sdk/client-ssm
-      // dep doesn't break boot — it just degrades to in-memory-only.
+      // 5s timeout so a hung IMDS / network blackhole can't leave the
+      // registrar's `.then(setQurlWebhookSecret)` pending forever and
+      // strand the receiver on PLACEHOLDER. bestEffortPersist swallows
+      // the rejection and degrades to in-memory-only.
       const persistSecret = process.env.QURL_WEBHOOK_SECRET_SSM_PARAM
         ? async (secret) => {
-          const ssm = require('@aws-sdk/client-ssm');
-          const client = new ssm.SSMClient({ region: process.env.AWS_REGION });
-          await client.send(new ssm.PutParameterCommand({
+          const client = new ssmSdk.SSMClient({ region: process.env.AWS_REGION });
+          const put = client.send(new ssmSdk.PutParameterCommand({
             Name: process.env.QURL_WEBHOOK_SECRET_SSM_PARAM,
             Type: 'SecureString',
             Value: secret,
             Overwrite: true,
           }));
+          let timeoutHandle;
+          const timeout = new Promise((_, reject) => {
+            timeoutHandle = setTimeout(() => reject(new Error('SSM PutParameter timed out after 5s')), 5_000);
+          });
+          try {
+            await Promise.race([put, timeout]);
+          } finally {
+            clearTimeout(timeoutHandle);
+          }
         }
         : undefined;
+      // 200-char clip in case qurl-service ever applies a length cap
+      // server-side — otherwise the create would 4xx into an infinite
+      // retry-create loop.
+      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'}, env=${process.env.NODE_ENV || 'unset'})`.slice(0, 200);
       ensureWebhookSubscription({
         apiEndpoint: config.QURL_ENDPOINT,
         apiKey: config.QURL_API_KEY,
         bridgeUrl: `${config.BASE_URL}/webhooks/qurl`,
-        description: `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'}, env=${process.env.NODE_ENV || 'unset'})`,
+        description,
         // Pass the SSM-loaded secret so the registrar can skip rotation
         // when steady-state (existing sub + non-PLACEHOLDER secret) —
         // prevents multi-replica HTTP-fleet boots from rotating each

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1121,27 +1121,28 @@ async function start() {
       // the rejection and degrades to in-memory-only.
       const persistSecret = config.QURL_WEBHOOK_SECRET_SSM_PARAM
         ? async (secret) => {
-          const put = getSsmClient().send(new ssmSdk.PutParameterCommand({
+          // abortSignal on the SDK call so a 5s timeout actually
+          // cancels the underlying HTTP request, freeing the socket /
+          // credentials sooner. Without this, Promise.race would
+          // resolve after 5s but the SDK send would keep running in
+          // the background (idempotent because Overwrite=true, but
+          // wasteful).
+          await getSsmClient().send(new ssmSdk.PutParameterCommand({
             Name: config.QURL_WEBHOOK_SECRET_SSM_PARAM,
             Type: 'SecureString',
             Value: secret,
             Overwrite: true,
-          }));
-          let timeoutHandle;
-          const timeout = new Promise((_, reject) => {
-            timeoutHandle = setTimeout(() => reject(new Error('SSM PutParameter timed out after 5s')), 5_000);
-          });
-          try {
-            await Promise.race([put, timeout]);
-          } finally {
-            clearTimeout(timeoutHandle);
-          }
+          }, { abortSignal: AbortSignal.timeout(5_000) }));
         }
         : undefined;
       // Length cap lives at the wire boundary (createSubscription in
-      // qurl-webhook-registrar.js). This caller just builds the human-
-      // readable string.
-      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'}, env=${process.env.NODE_ENV || 'unset'})`;
+      // qurl-webhook-registrar.js). The env label uses region only —
+      // NODE_ENV is conventionally `production` for both sandbox and
+      // prod deploys, so it would render `env=production` everywhere
+      // and not actually disambiguate. Region is the meaningful
+      // breakdown; operators distinguishing sandbox/prod use the
+      // subscription's owner_id or URL host instead.
+      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'})`;
       ensureWebhookSubscription({
         apiEndpoint: config.QURL_ENDPOINT,
         apiKey: config.QURL_API_KEY,
@@ -1174,8 +1175,15 @@ async function start() {
         // Don't crash the boot path — manual curl is still a recovery
         // route. But log loudly so the failure is visible without
         // user-facing symptoms.
+        // Cap err.message — most failures are short (HTTP status +
+        // op), but a TypeError stack or a non-QurlServiceError raw
+        // throw could include a long message that survived redactSecret
+        // (which only walks parsed bodies, not free-form strings).
+        // 500 chars covers typical stack tops without unbounded log
+        // lines.
+        const errMsg = typeof err.message === 'string' ? err.message.slice(0, 500) : '';
         logger.error('qURL webhook self-registration failed', {
-          error: err.message,
+          error: errMsg,
           status: err.status,
           op: err.op,
         });

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -24,7 +24,7 @@ const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
 const { handleFlowInteraction } = require('./flow-dispatch');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
-const { ensureWebhookSubscription } = require('./qurl-webhook-registrar');
+const { ensureWebhookSubscription, buildSsmPersistSecret } = require('./qurl-webhook-registrar');
 // Eager require so a missing dep fails at boot, not at first persist.
 const ssmSdk = require('@aws-sdk/client-ssm');
 // Hoisted to module scope (matches the DynamoDBClient pattern above):
@@ -1120,20 +1120,11 @@ async function start() {
       // strand the receiver on PLACEHOLDER. bestEffortPersist swallows
       // the rejection and degrades to in-memory-only.
       const persistSecret = config.QURL_WEBHOOK_SECRET_SSM_PARAM
-        ? async (secret) => {
-          // abortSignal on the SDK call so a 5s timeout actually
-          // cancels the underlying HTTP request, freeing the socket /
-          // credentials sooner. Without this, Promise.race would
-          // resolve after 5s but the SDK send would keep running in
-          // the background (idempotent because Overwrite=true, but
-          // wasteful).
-          await getSsmClient().send(new ssmSdk.PutParameterCommand({
-            Name: config.QURL_WEBHOOK_SECRET_SSM_PARAM,
-            Type: 'SecureString',
-            Value: secret,
-            Overwrite: true,
-          }, { abortSignal: AbortSignal.timeout(5_000) }));
-        }
+        ? buildSsmPersistSecret({
+          ssmClient: getSsmClient(),
+          paramName: config.QURL_WEBHOOK_SECRET_SSM_PARAM,
+          PutParameterCommand: ssmSdk.PutParameterCommand,
+        })
         : undefined;
       // Length cap lives at the wire boundary (createSubscription in
       // qurl-webhook-registrar.js). The env label uses region only —

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -24,6 +24,7 @@ const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
 const { handleFlowInteraction } = require('./flow-dispatch');
 const { startServer, stopIntervals: stopServerIntervals } = require('./server');
+const { ensureWebhookSubscription } = require('./qurl-webhook-registrar');
 const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
 const db = require('./store');
@@ -1094,6 +1095,56 @@ async function start() {
   //     /qurl command surface dead until a human notices.
   if (isHttp) {
     httpServer = startServer();
+    // Self-register the qurl.accessed webhook subscription post-listen,
+    // pre-traffic. Fire-and-forget — failures log loudly but don't
+    // crash the boot path because the manual operator-curl recovery
+    // route still works. config.QURL_API_KEY + BASE_URL must be set
+    // (already required for /qurl send to function).
+    if (config.QURL_API_KEY && config.QURL_ENDPOINT && config.BASE_URL) {
+      // persistSecret: lazy SSM PutParameter so the registrar stays
+      // SDK-agnostic. Lazy-required so a missing @aws-sdk/client-ssm
+      // dep doesn't break boot — it just degrades to in-memory-only.
+      const persistSecret = process.env.QURL_WEBHOOK_SECRET_SSM_PARAM
+        ? async (secret) => {
+          const ssm = require('@aws-sdk/client-ssm');
+          const client = new ssm.SSMClient({ region: process.env.AWS_REGION });
+          await client.send(new ssm.PutParameterCommand({
+            Name: process.env.QURL_WEBHOOK_SECRET_SSM_PARAM,
+            Type: 'SecureString',
+            Value: secret,
+            Overwrite: true,
+          }));
+        }
+        : undefined;
+      ensureWebhookSubscription({
+        apiEndpoint: config.QURL_ENDPOINT,
+        apiKey: config.QURL_API_KEY,
+        bridgeUrl: `${config.BASE_URL}/webhooks/qurl`,
+        description: `Discord bot view counter (${process.env.AWS_REGION || 'unknown-region'}, ${process.env.NODE_ENV || 'unknown-env'})`,
+        persistSecret,
+      }).then(result => {
+        // Update the in-memory secret so the receiver uses what the
+        // registrar just got (especially important when persistSecret
+        // is denied or skipped — without this update the receiver
+        // would still verify against the OLD config.QURL_WEBHOOK_SECRET).
+        config.QURL_WEBHOOK_SECRET = result.secret;
+        logger.info('qURL webhook self-registration complete', {
+          webhook_id: result.webhookId,
+          action: result.action,
+        });
+      }).catch(err => {
+        // Don't crash the boot path — manual curl is still a recovery
+        // route. But log loudly so the failure is visible without
+        // user-facing symptoms.
+        logger.error('qURL webhook self-registration failed', {
+          error: err.message,
+          status: err.status,
+          op: err.op,
+        });
+      });
+    } else {
+      logger.warn('qURL webhook self-registration skipped — QURL_API_KEY / QURL_ENDPOINT / BASE_URL missing');
+    }
   } else if (isGateway) {
     // Returns 503 until isReady() flips true (after READY from the
     // Discord gateway). Dockerfile --start-period=30s covers this

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -27,6 +27,18 @@ const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const { ensureWebhookSubscription } = require('./qurl-webhook-registrar');
 // Eager require so a missing dep fails at boot, not at first persist.
 const ssmSdk = require('@aws-sdk/client-ssm');
+// Hoisted to module scope (matches the DynamoDBClient pattern above):
+// consistent client lifecycle, SDK connection-reuse logic gets a fair
+// shot if persistSecret is ever called more than once per boot.
+// Created lazily inside the closure so processes that don't persist
+// (no QURL_WEBHOOK_SECRET_SSM_PARAM) don't pay the construction cost.
+let ssmClientInstance = null;
+function getSsmClient() {
+  if (!ssmClientInstance) {
+    ssmClientInstance = new ssmSdk.SSMClient({ region: process.env.AWS_REGION });
+  }
+  return ssmClientInstance;
+}
 const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
 const db = require('./store');
@@ -1109,12 +1121,7 @@ async function start() {
       // the rejection and degrades to in-memory-only.
       const persistSecret = config.QURL_WEBHOOK_SECRET_SSM_PARAM
         ? async (secret) => {
-          // AWS_REGION stays a direct process.env read — matches the
-          // pattern in event-publisher.js, event-consumer.js, etc.
-          // Pulling it through config.js would be a separate cross-
-          // cutting cleanup.
-          const client = new ssmSdk.SSMClient({ region: process.env.AWS_REGION });
-          const put = client.send(new ssmSdk.PutParameterCommand({
+          const put = getSsmClient().send(new ssmSdk.PutParameterCommand({
             Name: config.QURL_WEBHOOK_SECRET_SSM_PARAM,
             Type: 'SecureString',
             Value: secret,
@@ -1131,10 +1138,10 @@ async function start() {
           }
         }
         : undefined;
-      // 200-char clip in case qurl-service ever applies a length cap
-      // server-side — otherwise the create would 4xx into an infinite
-      // retry-create loop.
-      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'}, env=${process.env.NODE_ENV || 'unset'})`.slice(0, 200);
+      // Length cap lives at the wire boundary (createSubscription in
+      // qurl-webhook-registrar.js). This caller just builds the human-
+      // readable string.
+      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'}, env=${process.env.NODE_ENV || 'unset'})`;
       ensureWebhookSubscription({
         apiEndpoint: config.QURL_ENDPOINT,
         apiKey: config.QURL_API_KEY,

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1128,11 +1128,13 @@ async function start() {
         initialSecret: config.QURL_WEBHOOK_SECRET,
         persistSecret,
       }).then(result => {
-        // Update the in-memory secret so the receiver uses what the
-        // registrar just got (especially important when persistSecret
-        // is denied or skipped — without this update the receiver
-        // would still verify against the OLD config.QURL_WEBHOOK_SECRET).
-        config.QURL_WEBHOOK_SECRET = result.secret;
+        // Wire the registrar's secret into the receiver via the
+        // config setter. The receiver reads config.QURL_WEBHOOK_SECRET
+        // every request; updating it here makes the new secret
+        // visible immediately. Setter (vs direct mutation) keeps
+        // the test surface for "receiver verifies the new secret"
+        // explicit + greppable.
+        config.setQurlWebhookSecret(result.secret);
         logger.info('qURL webhook self-registration complete', {
           webhook_id: result.webhookId,
           action: result.action,

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1107,11 +1107,15 @@ async function start() {
       // registrar's `.then(setQurlWebhookSecret)` pending forever and
       // strand the receiver on PLACEHOLDER. bestEffortPersist swallows
       // the rejection and degrades to in-memory-only.
-      const persistSecret = process.env.QURL_WEBHOOK_SECRET_SSM_PARAM
+      const persistSecret = config.QURL_WEBHOOK_SECRET_SSM_PARAM
         ? async (secret) => {
+          // AWS_REGION stays a direct process.env read — matches the
+          // pattern in event-publisher.js, event-consumer.js, etc.
+          // Pulling it through config.js would be a separate cross-
+          // cutting cleanup.
           const client = new ssmSdk.SSMClient({ region: process.env.AWS_REGION });
           const put = client.send(new ssmSdk.PutParameterCommand({
-            Name: process.env.QURL_WEBHOOK_SECRET_SSM_PARAM,
+            Name: config.QURL_WEBHOOK_SECRET_SSM_PARAM,
             Type: 'SecureString',
             Value: secret,
             Overwrite: true,

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1120,7 +1120,12 @@ async function start() {
         apiEndpoint: config.QURL_ENDPOINT,
         apiKey: config.QURL_API_KEY,
         bridgeUrl: `${config.BASE_URL}/webhooks/qurl`,
-        description: `Discord bot view counter (${process.env.AWS_REGION || 'unknown-region'}, ${process.env.NODE_ENV || 'unknown-env'})`,
+        description: `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'}, env=${process.env.NODE_ENV || 'unset'})`,
+        // Pass the SSM-loaded secret so the registrar can skip rotation
+        // when steady-state (existing sub + non-PLACEHOLDER secret) —
+        // prevents multi-replica HTTP-fleet boots from rotating each
+        // other's secrets into uselessness.
+        initialSecret: config.QURL_WEBHOOK_SECRET,
         persistSecret,
       }).then(result => {
         // Update the in-memory secret so the receiver uses what the

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -27,18 +27,10 @@ const { startServer, stopIntervals: stopServerIntervals } = require('./server');
 const { ensureWebhookSubscription, buildSsmPersistSecret } = require('./qurl-webhook-registrar');
 // Eager require so a missing dep fails at boot, not at first persist.
 const ssmSdk = require('@aws-sdk/client-ssm');
-// Hoisted to module scope (matches the DynamoDBClient pattern above):
-// consistent client lifecycle, SDK connection-reuse logic gets a fair
-// shot if persistSecret is ever called more than once per boot.
-// Created lazily inside the closure so processes that don't persist
-// (no QURL_WEBHOOK_SECRET_SSM_PARAM) don't pay the construction cost.
-let ssmClientInstance = null;
-function getSsmClient() {
-  if (!ssmClientInstance) {
-    ssmClientInstance = new ssmSdk.SSMClient({ region: process.env.AWS_REGION });
-  }
-  return ssmClientInstance;
-}
+// SSM client constructed inside the persistSecret factory below at
+// the single call-site. The lazy-init wrapper was over-engineered:
+// persistSecret runs at most once per boot, so there's nothing to
+// amortize across multiple calls.
 const { startGatewayHealthServer } = require('./gateway-health');
 const { startGatewayHeartbeat, startActiveGuildCount, noteGatewayActivity } = require('./gateway-metrics');
 const db = require('./store');
@@ -1121,7 +1113,7 @@ async function start() {
       // the rejection and degrades to in-memory-only.
       const persistSecret = config.QURL_WEBHOOK_SECRET_SSM_PARAM
         ? buildSsmPersistSecret({
-          ssmClient: getSsmClient(),
+          ssmClient: new ssmSdk.SSMClient({ region: process.env.AWS_REGION }),
           paramName: config.QURL_WEBHOOK_SECRET_SSM_PARAM,
           PutParameterCommand: ssmSdk.PutParameterCommand,
         })
@@ -1133,7 +1125,9 @@ async function start() {
       // and not actually disambiguate. Region is the meaningful
       // breakdown; operators distinguishing sandbox/prod use the
       // subscription's owner_id or URL host instead.
-      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unset'})`;
+      // `unknown` (not `unset`) so the qurl-service UI label reads as
+      // a missing-value diagnostic rather than a configured value.
+      const description = `Discord bot view counter (region=${process.env.AWS_REGION || 'unknown'})`;
       ensureWebhookSubscription({
         apiEndpoint: config.QURL_ENDPOINT,
         apiKey: config.QURL_API_KEY,

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -6,21 +6,25 @@
 // looked healthy but the counter never advanced. The sandbox rollout
 // of #465 burned ~20 minutes on this exact gap.
 //
-// Now: bot self-registers (or reconciles + rotates) on every boot.
-// The secret returned by qurl-service POST/regenerate lives in
-// process memory; we attempt a best-effort SSM put so an oncall
-// running `get-parameter` can see the current secret, but the SSM
-// write is NOT load-bearing for correctness — if PutParameter fails
-// (e.g. missing IAM grant), the in-memory secret is what the
-// receiver verifies against and the SSM value is stale until the
-// next boot succeeds.
+// Multi-replica safety: an HTTP fleet of N replicas all booting
+// together used to race on POST /v1/webhooks/{id}/secret —
+// server-side last-write-wins meant (N-1) replicas held a stale
+// secret in their in-memory config.QURL_WEBHOOK_SECRET, and the
+// ALB-routed traffic across all of them 401'd on ~(N-1)/N of
+// inbound webhooks until eventual restart. Fix in this rev: rotate
+// the secret ONLY if (a) no subscription exists yet, or (b) the
+// existing one matches our URL but the caller can't supply a
+// known-good secret to verify against (initialSecret unset / set
+// to the terraform-seeded PLACEHOLDER). Steady-state restarts find
+// (existing sub + real SSM secret) and skip the rotate — every
+// replica reads the same secret from SSM/env and stays in lock-step.
 //
-// Subscription lifecycle invariant: at any moment there is at most
-// one subscription per (owner_id, bot URL) pair. On boot the bot
-// finds the existing one (if any) and rotates its secret; otherwise
-// creates fresh. Duplicates from concurrent boots across an HTTP
-// fleet are possible but bounded — the cleanup is a manual
-// `gh issue` for now (rare; not load-bearing).
+// Boot ordering note: the HTTP listener opens BEFORE the registrar
+// resolves, so a webhook that arrives in the brief startup window
+// hits the receiver before config.QURL_WEBHOOK_SECRET is updated.
+// Result: 503 (if env didn't have a secret) or 401 (if env held a
+// stale value). qurl-service retries both. The fire-and-forget call
+// pattern in index.js owns this window; we don't mask it here.
 //
 // Owner-scope: subscriptions are tied to the owner_id of the API
 // key used to create them. The bot uses QURL_API_KEY (same key it
@@ -31,11 +35,32 @@ const logger = require('./logger');
 
 const QURL_ACCESSED = 'qurl.accessed';
 
+// `PLACEHOLDER` is the terraform-seeded sentinel value for the
+// QURL_WEBHOOK_SECRET SSM parameter — before any registrar run has
+// landed a real secret, the parameter holds this literal. Treat it
+// as "no real secret yet" so the bootstrap path can land a fresh
+// rotation without permanently re-rotating every restart afterward.
+const PLACEHOLDER_SECRET = 'PLACEHOLDER';
+
+// Strip the `secret` field from a parsed body before stringifying.
+// Error messages echo response bodies into CloudWatch; defense-in-
+// depth scrubbing avoids the secret leaking via a logger error.
+function redactSecret(body) {
+  if (!body || typeof body !== 'object') return body;
+  const clone = Array.isArray(body) ? [...body] : { ...body };
+  if (clone.data && typeof clone.data === 'object' && 'secret' in clone.data) {
+    clone.data = { ...clone.data, secret: '[REDACTED]' };
+  }
+  if ('secret' in clone) clone.secret = '[REDACTED]';
+  return clone;
+}
+
 class QurlServiceError extends Error {
   constructor(status, body, op) {
-    super(`qurl-service ${op} returned ${status}: ${typeof body === 'string' ? body : JSON.stringify(body).slice(0, 400)}`);
+    const safe = redactSecret(body);
+    super(`qurl-service ${op} returned ${status}: ${typeof safe === 'string' ? safe : JSON.stringify(safe).slice(0, 400)}`);
     this.status = status;
-    this.body = body;
+    this.body = safe;
     this.op = op;
   }
 }
@@ -58,16 +83,42 @@ async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeou
   return parsed;
 }
 
-// Returns the existing subscription for our URL, or null.
+// Canonicalize URL for comparison — strict equality (`s.url === bridgeUrl`)
+// misses trailing-slash / default-port / case-difference drift. Using
+// URL().href round-trip handles case + default-port. We also strip
+// any trailing slash from the pathname (URL().href preserves it),
+// since `/webhooks/qurl` and `/webhooks/qurl/` are equivalent
+// receivers for our routing. Fall back to the raw string on a parse
+// error so a future malformed URL doesn't crash boot.
+function canonicalUrl(u) {
+  try {
+    const url = new URL(u);
+    if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+      url.pathname = url.pathname.slice(0, -1);
+    }
+    return url.href;
+  } catch { return u; }
+}
+
+// Returns the existing subscription for our URL, or null. Paginates so a
+// caller with many subs doesn't lose the match on page 2. Page size of
+// 100 is the qurl-service default cap; loop bounded at 50 iterations
+// (5000 subs) so a misbehaving cursor can't spin forever.
 async function findExistingSubscription({ apiEndpoint, apiKey, bridgeUrl }) {
-  const resp = await callQurlService({
-    method: 'GET',
-    path: '/v1/webhooks',
-    apiEndpoint,
-    apiKey,
-  });
-  const subs = (resp && resp.data) || [];
-  return subs.find(s => s.url === bridgeUrl) || null;
+  const target = canonicalUrl(bridgeUrl);
+  let cursor = '';
+  for (let i = 0; i < 50; i++) {
+    const path = `/v1/webhooks${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''}`;
+    const resp = await callQurlService({ method: 'GET', path, apiEndpoint, apiKey });
+    const subs = (resp && resp.data) || [];
+    const match = subs.find(s => canonicalUrl(s.url) === target);
+    if (match) return match;
+    const next = resp && resp.meta && resp.meta.next_cursor;
+    if (!next) return null;
+    cursor = next;
+  }
+  logger.warn('findExistingSubscription: pagination cap hit (50 pages); possible stuck cursor');
+  return null;
 }
 
 async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description }) {
@@ -108,17 +159,13 @@ async function patchEvents({ apiEndpoint, apiKey, webhookId, events }) {
 // Best-effort: don't throw on failure. Secret persistence is
 // observability, not load-bearing. The caller decides the
 // persistence backend (SSM today, could be DDB / Secrets Manager
-// later) via the persistSecret callback. If it throws, we just
-// log + continue — the in-memory secret returned to the caller
-// is what the receiver verifies against.
+// later) via the persistSecret callback.
 async function bestEffortPersist({ persistSecret, value }) {
   if (typeof persistSecret !== 'function') return;
   try {
     await persistSecret(value);
     logger.info('qURL webhook secret persisted');
   } catch (err) {
-    // AccessDenied is the expected case before the IAM grant lands —
-    // log at warn rather than error so it's visible but not alarming.
     const level = err.name === 'AccessDeniedException' ? 'warn' : 'error';
     logger[level]('Webhook secret persistence failed (auto-register continues with in-memory secret only)', {
       error: err.message,
@@ -132,15 +179,16 @@ async function bestEffortPersist({ persistSecret, value }) {
  * Returns the secret to use for HMAC verification.
  *
  * @param {object} opts
- * @param {string} opts.apiEndpoint    - qurl-service base URL (config.QURL_ENDPOINT)
+ * @param {string} opts.apiEndpoint    - qurl-service base URL
  * @param {string} opts.apiKey         - bot's QURL_API_KEY
- * @param {string} opts.bridgeUrl      - bot's own /webhooks/qurl URL (BASE_URL + '/webhooks/qurl')
+ * @param {string} opts.bridgeUrl      - bot's own /webhooks/qurl URL
  * @param {string} opts.description    - human-readable; surfaces in qurl-service UI
- * @param {Function} [opts.persistSecret] - optional async(secret) → void callback for best-effort persistence (e.g. SSM PutParameter). Failures are caught and logged but do NOT propagate — the in-memory secret remains usable.
- * @returns {Promise<{secret: string, webhookId: string, action: 'created' | 'rotated'}>}
+ * @param {string} [opts.initialSecret] - the secret the caller already has in-memory (e.g. from SSM/env). When set to a non-placeholder value AND an existing subscription is found, the registrar SKIPS rotation — every replica reuses the same secret instead of rotating each other into uselessness.
+ * @param {Function} [opts.persistSecret] - optional async(secret) → void callback for best-effort persistence
+ * @returns {Promise<{secret: string, webhookId: string, action: 'created' | 'rotated' | 'reused'}>}
  */
 async function ensureWebhookSubscription(opts) {
-  const { apiEndpoint, apiKey, bridgeUrl, description, persistSecret } = opts;
+  const { apiEndpoint, apiKey, bridgeUrl, description, initialSecret, persistSecret } = opts;
   if (!apiEndpoint || !apiKey || !bridgeUrl) {
     throw new Error('ensureWebhookSubscription: apiEndpoint, apiKey, bridgeUrl all required');
   }
@@ -150,25 +198,46 @@ async function ensureWebhookSubscription(opts) {
   let secret;
   let action;
 
-  if (existing) {
+  // Skip-rotation guard: an existing subscription PLUS a known-good
+  // initial secret means we're in steady-state — any other replica
+  // already created the sub and put the secret in SSM/env, and we
+  // can trust both. Rotating here would split-brain the fleet.
+  const initialIsRealSecret = typeof initialSecret === 'string'
+    && initialSecret.length > 0
+    && initialSecret !== PLACEHOLDER_SECRET;
+
+  if (existing && initialIsRealSecret) {
     webhookId = existing.webhook_id;
-    // Reconcile events list if drifted.
+    secret = initialSecret;
+    action = 'reused';
+    // Reconcile events list if drifted — PATCH is idempotent so two
+    // replicas racing here is harmless.
     const eventsMatch = Array.isArray(existing.events) && existing.events.includes(QURL_ACCESSED);
     if (!eventsMatch) {
       logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId, current: existing.events });
       await patchEvents({ apiEndpoint, apiKey, webhookId, events: [QURL_ACCESSED] });
     }
-    // Rotate the secret on every boot. We can't recover the existing
-    // secret via GET (qurl-service returns it only on create/rotate),
-    // so a fresh boot has to rotate to get into a known state. The
-    // small in-flight window where qurl-service has the new secret
-    // but a delivery in flight signed with the old will fail
-    // signature check — qurl-service retries those, so the worst
-    // case is a single late retry per boot. Acceptable.
+    logger.info('Webhook subscription reused (existing found, SSM secret trusted, no rotate)', { webhookId, url: bridgeUrl });
+    return { secret, webhookId, action };
+  }
+
+  if (existing) {
+    // Bootstrap path: subscription exists but we don't have a usable
+    // secret in-memory (placeholder or empty). Rotate to recover.
+    // Multi-replica race here is bounded — qurl-service is last-
+    // write-wins, and the steady-state guard above means this branch
+    // only fires until SSM has a real secret. After the first
+    // successful persist, subsequent restarts hit the reuse path.
+    webhookId = existing.webhook_id;
+    const eventsMatch = Array.isArray(existing.events) && existing.events.includes(QURL_ACCESSED);
+    if (!eventsMatch) {
+      logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId, current: existing.events });
+      await patchEvents({ apiEndpoint, apiKey, webhookId, events: [QURL_ACCESSED] });
+    }
     const rotated = await rotateSecret({ apiEndpoint, apiKey, webhookId });
     secret = rotated.secret;
     action = 'rotated';
-    logger.info('Webhook subscription reconciled (existing found, secret rotated)', { webhookId, url: bridgeUrl });
+    logger.info('Webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
   } else {
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
     webhookId = created.webhook_id;
@@ -178,9 +247,6 @@ async function ensureWebhookSubscription(opts) {
   }
 
   if (!secret) {
-    // The server's response shape requires `secret` on create/rotate.
-    // If it's missing the contract has drifted — fail loudly rather
-    // than continue with an empty secret that would 401 every event.
     throw new Error(`Webhook subscription ${action} but no secret in response (qurl-service contract drift?)`);
   }
 
@@ -191,6 +257,7 @@ async function ensureWebhookSubscription(opts) {
 
 module.exports = {
   ensureWebhookSubscription,
+  PLACEHOLDER_SECRET,
   // Exported for tests:
   _internals: {
     findExistingSubscription,
@@ -198,6 +265,8 @@ module.exports = {
     rotateSecret,
     patchEvents,
     bestEffortPersist,
+    canonicalUrl,
+    redactSecret,
     QurlServiceError,
   },
 };

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -109,7 +109,9 @@ async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeou
 // round-trip handles HOST case (lowercased) + default ports (:80/:443
 // elided). PATHNAME case is intentionally NOT folded — Express and
 // qurl-service both route case-sensitively, so `/Webhooks/qurl` and
-// `/webhooks/qurl` are genuinely different routes. We do strip a
+// `/webhooks/qurl` are genuinely different routes. QUERY STRINGS are
+// preserved as-is (not normalized) — a sub registered with `?ver=1`
+// is a different route than the unparametrized one. We do strip a
 // trailing slash from the pathname (URL().href preserves it), since
 // `/webhooks/qurl` and `/webhooks/qurl/` hit the same Express handler.
 // Fall back to the raw string on a parse error so a future malformed
@@ -148,7 +150,10 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
     const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}&limit=100` : '?limit=100';
     const path = `/v1/webhooks${qs}`;
     const resp = await callQurlService({ method: 'GET', path, apiEndpoint, apiKey });
-    const subs = (resp && resp.data) || [];
+    // Array.isArray guard — a future contract drift returning
+    // `data: {...}` would otherwise iterate object property values in
+    // a confusing way and silently treat them as subscription objects.
+    const subs = Array.isArray(resp?.data) ? resp.data : [];
     for (const s of subs) {
       if (canonicalUrl(s.url) === target) matches.push(s);
     }
@@ -193,12 +198,21 @@ function pickSurvivor(matches) {
   return sorted[0];
 }
 
+// Max chars for the human-readable description in qurl-service. Sliced
+// at the wire boundary (here) rather than at the caller so future
+// callers don't have to remember the cap. The 200 is defense against
+// a hypothetical future server-side cap that would otherwise 4xx the
+// create into an infinite retry-create loop — qurl-service doesn't
+// document one today.
+const DESCRIPTION_MAX_LEN = 200;
+
 // Note: `description` is set only at create time and is not reconciled
 // on subsequent boots. Region / NODE_ENV captured in the description
 // string can go stale after env rename / region migration; that's
 // observability-only (qurl-service UI label) and not worth a PATCH
 // on every boot.
 async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description }) {
+  const safeDescription = typeof description === 'string' ? description.slice(0, DESCRIPTION_MAX_LEN) : '';
   const resp = await callQurlService({
     method: 'POST',
     path: '/v1/webhooks',
@@ -207,10 +221,18 @@ async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description 
     body: {
       url: bridgeUrl,
       events: [QURL_ACCESSED],
-      description,
+      description: safeDescription,
     },
   });
-  return resp && resp.data;
+  // Defensive: if a future contract drift returns {data: null} or
+  // omits the fields, accessing .webhook_id/.secret would throw a
+  // raw TypeError with no context. Surface the contract violation
+  // explicitly so the boot-log error is greppable.
+  const data = resp?.data;
+  if (!data || typeof data.webhook_id !== 'string' || typeof data.secret !== 'string') {
+    throw new Error('createSubscription: contract drift (response missing webhook_id or secret)');
+  }
+  return data;
 }
 
 async function rotateSecret({ apiEndpoint, apiKey, webhookId }) {
@@ -220,7 +242,11 @@ async function rotateSecret({ apiEndpoint, apiKey, webhookId }) {
     apiEndpoint,
     apiKey,
   });
-  return resp && resp.data;
+  const data = resp?.data;
+  if (!data || typeof data.secret !== 'string') {
+    throw new Error('rotateSecret: contract drift (response missing secret)');
+  }
+  return data;
 }
 
 async function patchEvents({ apiEndpoint, apiKey, webhookId, events }) {
@@ -331,7 +357,18 @@ async function ensureWebhookSubscription(opts) {
     webhookId = existing.webhook_id;
     secret = initialSecret;
     action = 'reused';
-    await reconcileEvents({ apiEndpoint, apiKey, existing });
+    // Wrap the PATCH in try/catch matching the rotate branch — a
+    // transient 5xx here shouldn't flip the boot log to "self-
+    // registration failed" when the in-memory secret is already
+    // correct (initialSecret). Events drift is recoverable on the
+    // next boot via the same code path.
+    try {
+      await reconcileEvents({ apiEndpoint, apiKey, existing });
+    } catch (err) {
+      logger.error('Webhook subscription events PATCH failed in reuse path (continuing — receiver still works with initialSecret)', {
+        webhookId, op: 'reconcileEvents', error: err.message, status: err.status,
+      });
+    }
     logger.info('Webhook subscription reused (existing found, SSM secret trusted, no rotate)', { webhookId, url: bridgeUrl });
     return { secret, webhookId, action };
   }

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -358,7 +358,11 @@ async function ensureWebhookSubscription(opts) {
     // Parallel — each DELETE is independent + the 404-on-concurrent-
     // delete path is already swallowed per-loser, so concurrency is
     // safe. N=2-5 in practice (replica count); sequential would add
-    // ~100-200ms per loser on the recovery boot.
+    // ~100-200ms per loser on the recovery boot. Note: Promise.all
+    // propagates the FIRST non-404 rejection; siblings keep running
+    // detached. That's acceptable here — we already lost the race for
+    // a clean delete state, and the boot path will fail loudly on the
+    // first error rather than logging N of them.
     await Promise.all(losers.map(loser =>
       deleteSubscription({ apiEndpoint, apiKey, webhookId: loser.webhook_id }),
     ));
@@ -432,17 +436,40 @@ async function ensureWebhookSubscription(opts) {
     logger.info('qURL webhook subscription created', { webhookId, url: bridgeUrl });
   }
 
-  if (!secret) {
-    throw new Error(`Webhook subscription ${action} but no secret in response (qurl-service contract drift?)`);
-  }
+  // Note: no `if (!secret)` guard here — `createSubscription` and
+  // `rotateSecret` both validate `typeof data.secret === 'string'`
+  // and throw their own contract-drift error before returning. A
+  // second check at this point would be unreachable.
 
   await bestEffortPersist({ persistSecret, value: secret });
 
   return { secret, webhookId, action };
 }
 
+// Build a persistSecret callback that writes the rotated secret to an
+// SSM SecureString parameter with a 5s timeout. Extracted from
+// index.js so the timeout-placement (abortSignal on send's second arg,
+// NOT on the Command constructor — the constructor silently drops
+// extra args and defeats the timeout) is greppable and pinnable in
+// tests. Callers inject the SDK module + client to keep this file
+// SDK-import-free (so unit tests don't have to mock SSM SDK eagerly).
+function buildSsmPersistSecret({ ssmClient, paramName, PutParameterCommand, timeoutMs = 5_000 }) {
+  return async (secret) => {
+    await ssmClient.send(
+      new PutParameterCommand({
+        Name: paramName,
+        Type: 'SecureString',
+        Value: secret,
+        Overwrite: true,
+      }),
+      { abortSignal: AbortSignal.timeout(timeoutMs) },
+    );
+  };
+}
+
 module.exports = {
   ensureWebhookSubscription,
+  buildSsmPersistSecret,
   PLACEHOLDER_SECRET,
   _internals: {
     canonicalUrl,

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -1,0 +1,203 @@
+// qURL webhook self-registration
+//
+// Pre-#469 the operator had to register the bot's webhook subscription
+// with qurl-service via curl. That step gated the entire view-counter
+// feature and silently failed-open: bot deploys with no subscription
+// looked healthy but the counter never advanced. The sandbox rollout
+// of #465 burned ~20 minutes on this exact gap.
+//
+// Now: bot self-registers (or reconciles + rotates) on every boot.
+// The secret returned by qurl-service POST/regenerate lives in
+// process memory; we attempt a best-effort SSM put so an oncall
+// running `get-parameter` can see the current secret, but the SSM
+// write is NOT load-bearing for correctness — if PutParameter fails
+// (e.g. missing IAM grant), the in-memory secret is what the
+// receiver verifies against and the SSM value is stale until the
+// next boot succeeds.
+//
+// Subscription lifecycle invariant: at any moment there is at most
+// one subscription per (owner_id, bot URL) pair. On boot the bot
+// finds the existing one (if any) and rotates its secret; otherwise
+// creates fresh. Duplicates from concurrent boots across an HTTP
+// fleet are possible but bounded — the cleanup is a manual
+// `gh issue` for now (rare; not load-bearing).
+//
+// Owner-scope: subscriptions are tied to the owner_id of the API
+// key used to create them. The bot uses QURL_API_KEY (same key it
+// uses to mint qURLs), so the subscription receives events for the
+// qURLs the bot creates — matching what /qurl send users care about.
+
+const logger = require('./logger');
+
+const QURL_ACCESSED = 'qurl.accessed';
+
+class QurlServiceError extends Error {
+  constructor(status, body, op) {
+    super(`qurl-service ${op} returned ${status}: ${typeof body === 'string' ? body : JSON.stringify(body).slice(0, 400)}`);
+    this.status = status;
+    this.body = body;
+    this.op = op;
+  }
+}
+
+async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeoutMs = 10_000 }) {
+  const opts = {
+    method,
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(timeoutMs),
+  };
+  if (body !== undefined) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(body);
+  }
+  const resp = await fetch(`${apiEndpoint}${path}`, opts);
+  const text = await resp.text();
+  let parsed = text;
+  try { parsed = text ? JSON.parse(text) : null; } catch { /* keep as text */ }
+  if (!resp.ok) throw new QurlServiceError(resp.status, parsed, `${method} ${path}`);
+  return parsed;
+}
+
+// Returns the existing subscription for our URL, or null.
+async function findExistingSubscription({ apiEndpoint, apiKey, bridgeUrl }) {
+  const resp = await callQurlService({
+    method: 'GET',
+    path: '/v1/webhooks',
+    apiEndpoint,
+    apiKey,
+  });
+  const subs = (resp && resp.data) || [];
+  return subs.find(s => s.url === bridgeUrl) || null;
+}
+
+async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description }) {
+  const resp = await callQurlService({
+    method: 'POST',
+    path: '/v1/webhooks',
+    apiEndpoint,
+    apiKey,
+    body: {
+      url: bridgeUrl,
+      events: [QURL_ACCESSED],
+      description,
+    },
+  });
+  return resp && resp.data;
+}
+
+async function rotateSecret({ apiEndpoint, apiKey, webhookId }) {
+  const resp = await callQurlService({
+    method: 'POST',
+    path: `/v1/webhooks/${webhookId}/secret`,
+    apiEndpoint,
+    apiKey,
+  });
+  return resp && resp.data;
+}
+
+async function patchEvents({ apiEndpoint, apiKey, webhookId, events }) {
+  await callQurlService({
+    method: 'PATCH',
+    path: `/v1/webhooks/${webhookId}`,
+    apiEndpoint,
+    apiKey,
+    body: { events },
+  });
+}
+
+// Best-effort: don't throw on failure. Secret persistence is
+// observability, not load-bearing. The caller decides the
+// persistence backend (SSM today, could be DDB / Secrets Manager
+// later) via the persistSecret callback. If it throws, we just
+// log + continue — the in-memory secret returned to the caller
+// is what the receiver verifies against.
+async function bestEffortPersist({ persistSecret, value }) {
+  if (typeof persistSecret !== 'function') return;
+  try {
+    await persistSecret(value);
+    logger.info('qURL webhook secret persisted');
+  } catch (err) {
+    // AccessDenied is the expected case before the IAM grant lands —
+    // log at warn rather than error so it's visible but not alarming.
+    const level = err.name === 'AccessDeniedException' ? 'warn' : 'error';
+    logger[level]('Webhook secret persistence failed (auto-register continues with in-memory secret only)', {
+      error: err.message,
+      code: err.name,
+    });
+  }
+}
+
+/**
+ * Ensure a qurl.accessed subscription exists for the bot's bridge URL.
+ * Returns the secret to use for HMAC verification.
+ *
+ * @param {object} opts
+ * @param {string} opts.apiEndpoint    - qurl-service base URL (config.QURL_ENDPOINT)
+ * @param {string} opts.apiKey         - bot's QURL_API_KEY
+ * @param {string} opts.bridgeUrl      - bot's own /webhooks/qurl URL (BASE_URL + '/webhooks/qurl')
+ * @param {string} opts.description    - human-readable; surfaces in qurl-service UI
+ * @param {Function} [opts.persistSecret] - optional async(secret) → void callback for best-effort persistence (e.g. SSM PutParameter). Failures are caught and logged but do NOT propagate — the in-memory secret remains usable.
+ * @returns {Promise<{secret: string, webhookId: string, action: 'created' | 'rotated'}>}
+ */
+async function ensureWebhookSubscription(opts) {
+  const { apiEndpoint, apiKey, bridgeUrl, description, persistSecret } = opts;
+  if (!apiEndpoint || !apiKey || !bridgeUrl) {
+    throw new Error('ensureWebhookSubscription: apiEndpoint, apiKey, bridgeUrl all required');
+  }
+
+  const existing = await findExistingSubscription({ apiEndpoint, apiKey, bridgeUrl });
+  let webhookId;
+  let secret;
+  let action;
+
+  if (existing) {
+    webhookId = existing.webhook_id;
+    // Reconcile events list if drifted.
+    const eventsMatch = Array.isArray(existing.events) && existing.events.includes(QURL_ACCESSED);
+    if (!eventsMatch) {
+      logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId, current: existing.events });
+      await patchEvents({ apiEndpoint, apiKey, webhookId, events: [QURL_ACCESSED] });
+    }
+    // Rotate the secret on every boot. We can't recover the existing
+    // secret via GET (qurl-service returns it only on create/rotate),
+    // so a fresh boot has to rotate to get into a known state. The
+    // small in-flight window where qurl-service has the new secret
+    // but a delivery in flight signed with the old will fail
+    // signature check — qurl-service retries those, so the worst
+    // case is a single late retry per boot. Acceptable.
+    const rotated = await rotateSecret({ apiEndpoint, apiKey, webhookId });
+    secret = rotated.secret;
+    action = 'rotated';
+    logger.info('Webhook subscription reconciled (existing found, secret rotated)', { webhookId, url: bridgeUrl });
+  } else {
+    const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
+    webhookId = created.webhook_id;
+    secret = created.secret;
+    action = 'created';
+    logger.info('Webhook subscription created', { webhookId, url: bridgeUrl });
+  }
+
+  if (!secret) {
+    // The server's response shape requires `secret` on create/rotate.
+    // If it's missing the contract has drifted — fail loudly rather
+    // than continue with an empty secret that would 401 every event.
+    throw new Error(`Webhook subscription ${action} but no secret in response (qurl-service contract drift?)`);
+  }
+
+  await bestEffortPersist({ persistSecret, value: secret });
+
+  return { secret, webhookId, action };
+}
+
+module.exports = {
+  ensureWebhookSubscription,
+  // Exported for tests:
+  _internals: {
+    findExistingSubscription,
+    createSubscription,
+    rotateSecret,
+    patchEvents,
+    bestEffortPersist,
+    QurlServiceError,
+  },
+};

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -235,8 +235,14 @@ async function bestEffortPersist({ persistSecret, value }) {
     logger.info('qURL webhook secret persisted');
   } catch (err) {
     const level = err.name === 'AccessDeniedException' ? 'warn' : 'error';
+    // Cap err.message length — if a future SDK ever echoes the
+    // attempted-write value into a validation error, an unbounded log
+    // line would leak the secret to CloudWatch. 200 chars is enough
+    // for typical SDK errors ("User is not authorized to perform: ...")
+    // and short enough that a multi-KB leak would be visibly truncated.
+    const safeMsg = typeof err.message === 'string' ? err.message.slice(0, 200) : '';
     logger[level]('Webhook secret persistence failed (auto-register continues with in-memory secret only)', {
-      error: err.message,
+      error: safeMsg,
       code: err.name,
     });
   }
@@ -279,7 +285,8 @@ async function ensureWebhookSubscription(opts) {
   // converges without coordination.
   const matches = await findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl });
   const existing = pickSurvivor(matches);
-  if (matches.length > 1 && existing) {
+  const wasDedupe = matches.length > 1 && existing != null;
+  if (wasDedupe) {
     const losers = matches.filter(s => s.webhook_id !== existing.webhook_id);
     logger.warn('Webhook subscription duplicates detected — deleting non-survivors', {
       total: matches.length,
@@ -300,11 +307,18 @@ async function ensureWebhookSubscription(opts) {
   // initial secret means we're in steady-state — any other replica
   // already created the sub and put the secret in SSM/env, and we
   // can trust both. Rotating here would split-brain the fleet.
+  //
+  // EXCEPT after dedupe: the SSM secret may belong to a replica's POST
+  // that we just DELETEd (cold-bootstrap created N subs each with a
+  // distinct server-generated secret; SSM is last-write-wins, so the
+  // surviving sub's secret is almost certainly NOT the one in SSM).
+  // Force a rotate so SSM gets a known-good value tied to the
+  // survivor. One-time cost on dedupe; subsequent restarts reuse.
   const initialIsRealSecret = typeof initialSecret === 'string'
     && initialSecret.length > 0
     && initialSecret !== PLACEHOLDER_SECRET;
 
-  if (existing && initialIsRealSecret) {
+  if (existing && initialIsRealSecret && !wasDedupe) {
     webhookId = existing.webhook_id;
     secret = initialSecret;
     action = 'reused';

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -57,21 +57,27 @@ const QURL_ACCESSED = QURL_WEBHOOK_EVENTS.ACCESSED;
 // rotation without permanently re-rotating every restart afterward.
 const PLACEHOLDER_SECRET = 'PLACEHOLDER';
 
-// Strip `secret` fields anywhere in a parsed body before stringifying.
-// Error messages echo response bodies into CloudWatch; defense-in-
-// depth scrubbing avoids the secret leaking via a logger error.
-// Walks objects + arrays recursively because qurl-service's error
-// envelope shape isn't pinned — `data.webhook.secret`,
+// Strip secret-shaped fields anywhere in a parsed body before
+// stringifying. Error messages echo response bodies into CloudWatch;
+// defense-in-depth scrubbing avoids the secret leaking via a logger
+// error. Walks objects + arrays recursively because qurl-service's
+// error envelope shape isn't pinned — `data.webhook.secret`,
 // `data[0].secret`, or `error.detail.secret` would all bypass a
 // top-level-only redactor.
+//
+// Match policy: any key containing "secret" (case-insensitive), so
+// `webhook_secret`, `signing_secret`, `secret_key`, `client_secret`
+// all redact too. Receiver wouldn't accept those field names anyway —
+// this is purely a log-leak guard.
 const REDACT_MAX_DEPTH = 8;
+const SECRET_KEY_RE = /secret/i;
 function redactSecret(body, depth = 0) {
   if (depth > REDACT_MAX_DEPTH) return body;
   if (!body || typeof body !== 'object') return body;
   if (Array.isArray(body)) return body.map(v => redactSecret(v, depth + 1));
   const out = {};
   for (const [k, v] of Object.entries(body)) {
-    out[k] = (k === 'secret') ? '[REDACTED]' : redactSecret(v, depth + 1);
+    out[k] = SECRET_KEY_RE.test(k) ? '[REDACTED]' : redactSecret(v, depth + 1);
   }
   return out;
 }
@@ -87,6 +93,7 @@ class QurlServiceError extends Error {
 }
 
 async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeoutMs = 10_000 }) {
+  const op = `${method} ${path}`;
   const opts = {
     method,
     headers: { Authorization: `Bearer ${apiKey}` },
@@ -96,11 +103,21 @@ async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeou
     opts.headers['Content-Type'] = 'application/json';
     opts.body = JSON.stringify(body);
   }
-  const resp = await fetch(`${apiEndpoint}${path}`, opts);
+  let resp;
+  try {
+    resp = await fetch(`${apiEndpoint}${path}`, opts);
+  } catch (err) {
+    // fetch can reject before we have a response (AbortError on
+    // timeout, DNS failure, TLS handshake error). Re-throw with `op`
+    // attached so oncall greps for `op=GET /v1/webhooks` catch
+    // network errors too, not just HTTP-status errors.
+    err.op = op;
+    throw err;
+  }
   const text = await resp.text();
   let parsed = text;
   try { parsed = text ? JSON.parse(text) : null; } catch { /* keep as text */ }
-  if (!resp.ok) throw new QurlServiceError(resp.status, parsed, `${method} ${path}`);
+  if (!resp.ok) throw new QurlServiceError(resp.status, parsed, op);
   return parsed;
 }
 

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -72,7 +72,11 @@ const PLACEHOLDER_SECRET = 'PLACEHOLDER';
 const REDACT_MAX_DEPTH = 8;
 const SECRET_KEY_RE = /secret/i;
 function redactSecret(body, depth = 0) {
-  if (depth > REDACT_MAX_DEPTH) return body;
+  // Fail-closed at the depth cap: return a marker instead of the raw
+  // subtree, so a deeply-wrapped secret can't survive the truncation.
+  // 8 levels is comfortably past any qurl-service error envelope shape
+  // observed; deeper than that is anomalous and warrants visibility.
+  if (depth > REDACT_MAX_DEPTH) return '[TRUNCATED]';
   if (!body || typeof body !== 'object') return body;
   if (Array.isArray(body)) return body.map(v => redactSecret(v, depth + 1));
   const out = {};
@@ -207,6 +211,11 @@ function pickSurvivor(matches) {
   if (matches.length === 0) return null;
   if (matches.length === 1) return matches[0];
   const sorted = [...matches].sort((a, b) => {
+    // Asymmetric timestamps: the row with a timestamp wins (it carries
+    // more information than the row without). Only fall through to lex
+    // when both lack or both share the same timestamp.
+    if (a.created_at && !b.created_at) return -1;
+    if (!a.created_at && b.created_at) return 1;
     if (a.created_at && b.created_at && a.created_at !== b.created_at) {
       return a.created_at < b.created_at ? -1 : 1;
     }
@@ -293,7 +302,7 @@ async function bestEffortPersist({ persistSecret, value }) {
     // for typical SDK errors ("User is not authorized to perform: ...")
     // and short enough that a multi-KB leak would be visibly truncated.
     const safeMsg = typeof err.message === 'string' ? err.message.slice(0, 200) : '';
-    logger[level]('Webhook secret persistence failed (auto-register continues with in-memory secret only)', {
+    logger[level]('qURL webhook secret persistence failed (auto-register continues with in-memory secret only)', {
       error: safeMsg,
       code: err.name,
     });
@@ -307,7 +316,7 @@ async function bestEffortPersist({ persistSecret, value }) {
 async function reconcileEvents({ apiEndpoint, apiKey, existing }) {
   const events = existing?.events ?? [];
   if (events.includes(QURL_ACCESSED)) return;
-  logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId: existing.webhook_id, current: events });
+  logger.info('qURL webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId: existing.webhook_id, current: events });
   await patchEvents({ apiEndpoint, apiKey, webhookId: existing.webhook_id, events: [QURL_ACCESSED] });
 }
 
@@ -340,15 +349,19 @@ async function ensureWebhookSubscription(opts) {
   const wasDedupe = matches.length > 1 && existing != null;
   if (wasDedupe) {
     const losers = matches.filter(s => s.webhook_id !== existing.webhook_id);
-    logger.warn('Webhook subscription duplicates detected — deleting non-survivors', {
+    logger.warn('qURL webhook subscription duplicates detected — deleting non-survivors', {
       total: matches.length,
       survivor: existing.webhook_id,
       losers: losers.map(s => s.webhook_id),
       url: bridgeUrl,
     });
-    for (const loser of losers) {
-      await deleteSubscription({ apiEndpoint, apiKey, webhookId: loser.webhook_id });
-    }
+    // Parallel — each DELETE is independent + the 404-on-concurrent-
+    // delete path is already swallowed per-loser, so concurrency is
+    // safe. N=2-5 in practice (replica count); sequential would add
+    // ~100-200ms per loser on the recovery boot.
+    await Promise.all(losers.map(loser =>
+      deleteSubscription({ apiEndpoint, apiKey, webhookId: loser.webhook_id }),
+    ));
   }
 
   let webhookId;
@@ -382,11 +395,11 @@ async function ensureWebhookSubscription(opts) {
     try {
       await reconcileEvents({ apiEndpoint, apiKey, existing });
     } catch (err) {
-      logger.error('Webhook subscription events PATCH failed in reuse path (continuing — receiver still works with initialSecret)', {
+      logger.error('qURL webhook subscription events PATCH failed in reuse path (continuing — receiver still works with initialSecret)', {
         webhookId, op: 'reconcileEvents', error: err.message, status: err.status,
       });
     }
-    logger.info('Webhook subscription reused (existing found, SSM secret trusted, no rotate)', { webhookId, url: bridgeUrl });
+    logger.info('qURL webhook subscription reused (existing found, SSM secret trusted, no rotate)', { webhookId, url: bridgeUrl });
     return { secret, webhookId, action };
   }
 
@@ -406,17 +419,17 @@ async function ensureWebhookSubscription(opts) {
       // Log + continue: rotation already landed, so the bot is
       // functionally healthy. Events drift can be reconciled on the
       // next boot or via a manual PATCH.
-      logger.error('Webhook subscription events PATCH failed after rotate (continuing — rotation succeeded)', {
+      logger.error('qURL webhook subscription events PATCH failed after rotate (continuing — rotation succeeded)', {
         webhookId, op: 'reconcileEvents', error: err.message, status: err.status,
       });
     }
-    logger.info('Webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
+    logger.info('qURL webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
   } else {
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
     webhookId = created.webhook_id;
     secret = created.secret;
     action = 'created';
-    logger.info('Webhook subscription created', { webhookId, url: bridgeUrl });
+    logger.info('qURL webhook subscription created', { webhookId, url: bridgeUrl });
   }
 
   if (!secret) {

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -127,9 +127,9 @@ function canonicalUrl(u) {
 // Returns ALL subscriptions matching our URL (typically 0 or 1; >1
 // only after a cold-bootstrap race created duplicates — see the
 // dedupe path in ensureWebhookSubscription). Paginates so a caller
-// with many subs doesn't lose the match on page 2. Page size 100 is
-// the qurl-service default cap; loop bounded at 50 iterations
-// (5000 subs) so a misbehaving cursor can't spin forever.
+// with many subs doesn't lose the match on page 2. Page size 100
+// requested explicitly; loop bounded at 50 iterations (5000 subs)
+// so a misbehaving cursor can't spin forever.
 //
 // Two terminal states to distinguish:
 //   - natural exhaustion (cursor walk ends, no more pages) → returns
@@ -142,7 +142,11 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
   const matches = [];
   let cursor = '';
   for (let i = 0; i < 50; i++) {
-    const path = `/v1/webhooks${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''}`;
+    // Explicit limit=100 (vs relying on a server default that could
+    // silently change). Combined with the 50-page cap, bounds the
+    // total walk at 5000 subs.
+    const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}&limit=100` : '?limit=100';
+    const path = `/v1/webhooks${qs}`;
     const resp = await callQurlService({ method: 'GET', path, apiEndpoint, apiKey });
     const subs = (resp && resp.data) || [];
     for (const s of subs) {
@@ -189,6 +193,11 @@ function pickSurvivor(matches) {
   return sorted[0];
 }
 
+// Note: `description` is set only at create time and is not reconciled
+// on subsequent boots. Region / NODE_ENV captured in the description
+// string can go stale after env rename / region migration; that's
+// observability-only (qurl-service UI label) and not worth a PATCH
+// on every boot.
 async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description }) {
   const resp = await callQurlService({
     method: 'POST',

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -120,8 +120,20 @@ async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeou
   }
   const text = await resp.text();
   let parsed = text;
-  try { parsed = text ? JSON.parse(text) : null; } catch { /* keep as text */ }
-  if (!resp.ok) throw new QurlServiceError(resp.status, parsed, op);
+  let parsedJson = true;
+  try { parsed = text ? JSON.parse(text) : null; } catch { parsedJson = false; }
+  if (!resp.ok) {
+    // Defense-in-depth scrub for the non-JSON branch — redactSecret
+    // is a no-op on strings (it only walks object keys), so a 5xx
+    // with the secret embedded in a plaintext stack trace or proxy-
+    // injected HTML would otherwise reach the log via the QurlServiceError
+    // message. Match any 32+ hex-character run (qurl-service emits
+    // 64-hex `whsec_...` per its API contract) before stringification.
+    if (!parsedJson && typeof parsed === 'string') {
+      parsed = parsed.replace(/[0-9a-f]{32,}/gi, '[REDACTED]');
+    }
+    throw new QurlServiceError(resp.status, parsed, op);
+  }
   return parsed;
 }
 
@@ -147,12 +159,17 @@ function canonicalUrl(u) {
   } catch { return u; }
 }
 
+// Page-walk bound — 50 × 100 = 5000 subscriptions. Combined with the
+// explicit `?limit=100` below, a misbehaving cursor can't spin forever.
+// Named constant for grep-parity with REDACT_MAX_DEPTH / DESCRIPTION_MAX_LEN.
+const MAX_PAGINATION_PAGES = 50;
+
 // Returns ALL subscriptions matching our URL (typically 0 or 1; >1
 // only after a cold-bootstrap race created duplicates — see the
 // dedupe path in ensureWebhookSubscription). Paginates so a caller
 // with many subs doesn't lose the match on page 2. Page size 100
-// requested explicitly; loop bounded at 50 iterations (5000 subs)
-// so a misbehaving cursor can't spin forever.
+// requested explicitly; loop bounded by MAX_PAGINATION_PAGES so a
+// misbehaving cursor can't spin forever.
 //
 // Two terminal states to distinguish:
 //   - natural exhaustion (cursor walk ends, no more pages) → returns
@@ -164,7 +181,7 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
   const target = canonicalUrl(bridgeUrl);
   const matches = [];
   let cursor = '';
-  for (let i = 0; i < 50; i++) {
+  for (let i = 0; i < MAX_PAGINATION_PAGES; i++) {
     // Explicit limit=100 (vs relying on a server default that could
     // silently change). Combined with the 50-page cap, bounds the
     // total walk at 5000 subs.
@@ -182,7 +199,7 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
     if (!next) return matches;
     cursor = next;
   }
-  throw new Error('findExistingSubscriptions: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor — refusing to fall through to create-fresh which would compound duplicates');
+  throw new Error(`findExistingSubscriptions: pagination cap hit (${MAX_PAGINATION_PAGES} pages, ~${MAX_PAGINATION_PAGES * 100} subs); possible stuck cursor — refusing to fall through to create-fresh which would compound duplicates`);
 }
 
 async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
@@ -313,6 +330,14 @@ async function bestEffortPersist({ persistSecret, value }) {
 // includes qurl.accessed. PATCH is idempotent so two replicas racing
 // here is harmless. Factored out because the reuse path and the
 // rotate path both need it.
+//
+// Inclusion-only policy: we only PATCH when qurl.accessed is MISSING
+// — we don't trim extra event types that an operator or future
+// server-side default may have added (qurl.created, qurl.revoked,
+// etc.). Additive drift is tolerated because the receiver
+// 200-ignores any non-qurl.accessed type, so the bot doesn't care
+// what else is subscribed. Trimming here would fight a legitimate
+// operator action without coordination.
 async function reconcileEvents({ apiEndpoint, apiKey, existing }) {
   const events = existing?.events ?? [];
   if (events.includes(QURL_ACCESSED)) return;

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -6,8 +6,8 @@
 // looked healthy but the counter never advanced. The sandbox rollout
 // of #465 burned ~20 minutes on this exact gap.
 //
-// Multi-replica safety: an HTTP fleet of N replicas all booting
-// together used to race on POST /v1/webhooks/{id}/secret —
+// Multi-replica safety (steady-state): an HTTP fleet of N replicas
+// all booting together used to race on POST /v1/webhooks/{id}/secret —
 // server-side last-write-wins meant (N-1) replicas held a stale
 // secret in their in-memory config.QURL_WEBHOOK_SECRET, and the
 // ALB-routed traffic across all of them 401'd on ~(N-1)/N of
@@ -18,6 +18,20 @@
 // to the terraform-seeded PLACEHOLDER). Steady-state restarts find
 // (existing sub + real SSM secret) and skip the rotate — every
 // replica reads the same secret from SSM/env and stays in lock-step.
+//
+// Cold-bootstrap race (open): on the very first deploy to a fresh
+// environment, no subscription exists yet AND no SSM secret exists
+// yet, so all N replicas independently call POST /v1/webhooks →
+// create N duplicate subscriptions, each with a distinct server-
+// generated secret. SSM's PutParameter is last-write-wins so SSM
+// converges to one replica's secret; the other N-1 replicas hold
+// dead-secret subscriptions that 401 inbound deliveries forever.
+// `dedupeSubscriptions` below is RECOVERY (next boot cleans up the
+// duplicates) — it does NOT prevent the create-race on the first
+// boot. The durable fix is upstream: qurl-service making POST
+// /v1/webhooks idempotent on (owner_id, url). Until then, runbook
+// pins the first deploy of a fresh environment to a single-replica
+// rollout — see docs/qurl-webhook-rollout.md.
 //
 // Boot ordering note: the HTTP listener opens BEFORE the registrar
 // resolves, so a webhook that arrives in the brief startup window
@@ -32,8 +46,9 @@
 // qURLs the bot creates — matching what /qurl send users care about.
 
 const logger = require('./logger');
+const { QURL_WEBHOOK_EVENTS } = require('./constants');
 
-const QURL_ACCESSED = 'qurl.accessed';
+const QURL_ACCESSED = QURL_WEBHOOK_EVENTS.ACCESSED;
 
 // `PLACEHOLDER` is the terraform-seeded sentinel value for the
 // QURL_WEBHOOK_SECRET SSM parameter — before any registrar run has
@@ -42,17 +57,23 @@ const QURL_ACCESSED = 'qurl.accessed';
 // rotation without permanently re-rotating every restart afterward.
 const PLACEHOLDER_SECRET = 'PLACEHOLDER';
 
-// Strip the `secret` field from a parsed body before stringifying.
+// Strip `secret` fields anywhere in a parsed body before stringifying.
 // Error messages echo response bodies into CloudWatch; defense-in-
 // depth scrubbing avoids the secret leaking via a logger error.
-function redactSecret(body) {
+// Walks objects + arrays recursively because qurl-service's error
+// envelope shape isn't pinned — `data.webhook.secret`,
+// `data[0].secret`, or `error.detail.secret` would all bypass a
+// top-level-only redactor.
+const REDACT_MAX_DEPTH = 8;
+function redactSecret(body, depth = 0) {
+  if (depth > REDACT_MAX_DEPTH) return body;
   if (!body || typeof body !== 'object') return body;
-  const clone = Array.isArray(body) ? [...body] : { ...body };
-  if (clone.data && typeof clone.data === 'object' && 'secret' in clone.data) {
-    clone.data = { ...clone.data, secret: '[REDACTED]' };
+  if (Array.isArray(body)) return body.map(v => redactSecret(v, depth + 1));
+  const out = {};
+  for (const [k, v] of Object.entries(body)) {
+    out[k] = (k === 'secret') ? '[REDACTED]' : redactSecret(v, depth + 1);
   }
-  if ('secret' in clone) clone.secret = '[REDACTED]';
-  return clone;
+  return out;
 }
 
 class QurlServiceError extends Error {
@@ -84,12 +105,15 @@ async function callQurlService({ method, path, apiEndpoint, apiKey, body, timeou
 }
 
 // Canonicalize URL for comparison — strict equality (`s.url === bridgeUrl`)
-// misses trailing-slash / default-port / case-difference drift. Using
-// URL().href round-trip handles case + default-port. We also strip
-// any trailing slash from the pathname (URL().href preserves it),
-// since `/webhooks/qurl` and `/webhooks/qurl/` are equivalent
-// receivers for our routing. Fall back to the raw string on a parse
-// error so a future malformed URL doesn't crash boot.
+// misses trailing-slash / default-port / host-case drift. URL().href
+// round-trip handles HOST case (lowercased) + default ports (:80/:443
+// elided). PATHNAME case is intentionally NOT folded — Express and
+// qurl-service both route case-sensitively, so `/Webhooks/qurl` and
+// `/webhooks/qurl` are genuinely different routes. We do strip a
+// trailing slash from the pathname (URL().href preserves it), since
+// `/webhooks/qurl` and `/webhooks/qurl/` hit the same Express handler.
+// Fall back to the raw string on a parse error so a future malformed
+// URL doesn't crash boot.
 function canonicalUrl(u) {
   try {
     const url = new URL(u);
@@ -100,25 +124,69 @@ function canonicalUrl(u) {
   } catch { return u; }
 }
 
-// Returns the existing subscription for our URL, or null. Paginates so a
-// caller with many subs doesn't lose the match on page 2. Page size of
-// 100 is the qurl-service default cap; loop bounded at 50 iterations
+// Returns ALL subscriptions matching our URL (typically 0 or 1; >1
+// only after a cold-bootstrap race created duplicates — see the
+// dedupe path in ensureWebhookSubscription). Paginates so a caller
+// with many subs doesn't lose the match on page 2. Page size 100 is
+// the qurl-service default cap; loop bounded at 50 iterations
 // (5000 subs) so a misbehaving cursor can't spin forever.
-async function findExistingSubscription({ apiEndpoint, apiKey, bridgeUrl }) {
+//
+// Two terminal states to distinguish:
+//   - natural exhaustion (cursor walk ends, no more pages) → returns
+//     [] (possibly with no matches), caller takes create-fresh path.
+//   - 50-page cap hit (cursor never ends) → THROWS, refuses to fall
+//     through to create-fresh which would silently compound
+//     duplicates on every restart.
+async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
   const target = canonicalUrl(bridgeUrl);
+  const matches = [];
   let cursor = '';
   for (let i = 0; i < 50; i++) {
     const path = `/v1/webhooks${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''}`;
     const resp = await callQurlService({ method: 'GET', path, apiEndpoint, apiKey });
     const subs = (resp && resp.data) || [];
-    const match = subs.find(s => canonicalUrl(s.url) === target);
-    if (match) return match;
+    for (const s of subs) {
+      if (canonicalUrl(s.url) === target) matches.push(s);
+    }
     const next = resp && resp.meta && resp.meta.next_cursor;
-    if (!next) return null;
+    if (!next) return matches;
     cursor = next;
   }
-  logger.warn('findExistingSubscription: pagination cap hit (50 pages); possible stuck cursor');
-  return null;
+  throw new Error('findExistingSubscriptions: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor — refusing to fall through to create-fresh which would compound duplicates');
+}
+
+async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
+  try {
+    await callQurlService({
+      method: 'DELETE',
+      path: `/v1/webhooks/${webhookId}`,
+      apiEndpoint,
+      apiKey,
+    });
+  } catch (err) {
+    // 404 = another replica deleted it concurrently. Treat as
+    // success — the goal state ("this duplicate is gone") is met.
+    if (err.status !== 404) throw err;
+  }
+}
+
+// Pick a deterministic survivor across replicas so two replicas racing
+// on dedupe converge on the same one without coordination. Oldest-by-
+// created_at is the natural choice (first-to-exist wins); fall back to
+// lexicographic webhook_id when qurl-service omits the timestamp. Both
+// keys are independent of replica identity, so both replicas pick the
+// same survivor and both call DELETE on the same set of duplicates
+// (404-on-second is handled in `deleteSubscription`).
+function pickSurvivor(matches) {
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0];
+  const sorted = [...matches].sort((a, b) => {
+    if (a.created_at && b.created_at && a.created_at !== b.created_at) {
+      return a.created_at < b.created_at ? -1 : 1;
+    }
+    return (a.webhook_id || '') < (b.webhook_id || '') ? -1 : 1;
+  });
+  return sorted[0];
 }
 
 async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description }) {
@@ -174,6 +242,17 @@ async function bestEffortPersist({ persistSecret, value }) {
   }
 }
 
+// Reconcile the events list on an existing subscription so it
+// includes qurl.accessed. PATCH is idempotent so two replicas racing
+// here is harmless. Factored out because the reuse path and the
+// rotate path both need it.
+async function reconcileEvents({ apiEndpoint, apiKey, existing }) {
+  const events = existing?.events ?? [];
+  if (events.includes(QURL_ACCESSED)) return;
+  logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId: existing.webhook_id, current: events });
+  await patchEvents({ apiEndpoint, apiKey, webhookId: existing.webhook_id, events: [QURL_ACCESSED] });
+}
+
 /**
  * Ensure a qurl.accessed subscription exists for the bot's bridge URL.
  * Returns the secret to use for HMAC verification.
@@ -193,7 +272,26 @@ async function ensureWebhookSubscription(opts) {
     throw new Error('ensureWebhookSubscription: apiEndpoint, apiKey, bridgeUrl all required');
   }
 
-  const existing = await findExistingSubscription({ apiEndpoint, apiKey, bridgeUrl });
+  // Find all subs matching our URL. Normally 0 or 1. >1 means a prior
+  // cold-bootstrap created duplicates — RECOVER by keeping the
+  // deterministic survivor + deleting the rest. Both replicas independently
+  // pick the same survivor (oldest by created_at) so concurrent dedupe
+  // converges without coordination.
+  const matches = await findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl });
+  const existing = pickSurvivor(matches);
+  if (matches.length > 1 && existing) {
+    const losers = matches.filter(s => s.webhook_id !== existing.webhook_id);
+    logger.warn('Webhook subscription duplicates detected — deleting non-survivors', {
+      total: matches.length,
+      survivor: existing.webhook_id,
+      losers: losers.map(s => s.webhook_id),
+      url: bridgeUrl,
+    });
+    for (const loser of losers) {
+      await deleteSubscription({ apiEndpoint, apiKey, webhookId: loser.webhook_id });
+    }
+  }
+
   let webhookId;
   let secret;
   let action;
@@ -210,33 +308,31 @@ async function ensureWebhookSubscription(opts) {
     webhookId = existing.webhook_id;
     secret = initialSecret;
     action = 'reused';
-    // Reconcile events list if drifted — PATCH is idempotent so two
-    // replicas racing here is harmless.
-    const eventsMatch = Array.isArray(existing.events) && existing.events.includes(QURL_ACCESSED);
-    if (!eventsMatch) {
-      logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId, current: existing.events });
-      await patchEvents({ apiEndpoint, apiKey, webhookId, events: [QURL_ACCESSED] });
-    }
+    await reconcileEvents({ apiEndpoint, apiKey, existing });
     logger.info('Webhook subscription reused (existing found, SSM secret trusted, no rotate)', { webhookId, url: bridgeUrl });
     return { secret, webhookId, action };
   }
 
   if (existing) {
     // Bootstrap path: subscription exists but we don't have a usable
-    // secret in-memory (placeholder or empty). Rotate to recover.
-    // Multi-replica race here is bounded — qurl-service is last-
-    // write-wins, and the steady-state guard above means this branch
-    // only fires until SSM has a real secret. After the first
-    // successful persist, subsequent restarts hit the reuse path.
+    // secret in-memory (placeholder or empty). Rotate FIRST so the
+    // boot can succeed even if the events PATCH fails — a stuck PATCH
+    // shouldn't block secret recovery, otherwise the receiver stays
+    // on PLACEHOLDER and 503s every webhook until manual intervention.
     webhookId = existing.webhook_id;
-    const eventsMatch = Array.isArray(existing.events) && existing.events.includes(QURL_ACCESSED);
-    if (!eventsMatch) {
-      logger.info('Webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId, current: existing.events });
-      await patchEvents({ apiEndpoint, apiKey, webhookId, events: [QURL_ACCESSED] });
-    }
     const rotated = await rotateSecret({ apiEndpoint, apiKey, webhookId });
     secret = rotated.secret;
     action = 'rotated';
+    try {
+      await reconcileEvents({ apiEndpoint, apiKey, existing });
+    } catch (err) {
+      // Log + continue: rotation already landed, so the bot is
+      // functionally healthy. Events drift can be reconciled on the
+      // next boot or via a manual PATCH.
+      logger.error('Webhook subscription events PATCH failed after rotate (continuing — rotation succeeded)', {
+        webhookId, op: 'reconcileEvents', error: err.message, status: err.status,
+      });
+    }
     logger.info('Webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
   } else {
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
@@ -258,14 +354,9 @@ async function ensureWebhookSubscription(opts) {
 module.exports = {
   ensureWebhookSubscription,
   PLACEHOLDER_SECRET,
-  // Exported for tests:
   _internals: {
-    findExistingSubscription,
-    createSubscription,
-    rotateSecret,
-    patchEvents,
-    bestEffortPersist,
     canonicalUrl,
+    pickSurvivor,
     redactSecret,
     QurlServiceError,
   },

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -57,9 +57,15 @@ router.post('/qurl', async (req, res) => {
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
 
-  // 503 vs 401: 503 says "receiver is up but unconfigured" (set
-  // QURL_WEBHOOK_SECRET in SSM); 401 says "real signature mismatch."
-  if (!config.QURL_WEBHOOK_SECRET) {
+  // 503 vs 401: 503 says "receiver is up but unconfigured"; 401 says
+  // "real signature mismatch." `PLACEHOLDER` is the terraform-seeded
+  // sentinel — treating it as "unconfigured" handles the boot race
+  // where a webhook arrives in the brief window AFTER the listener
+  // opens but BEFORE auto-register has updated config with the real
+  // secret. qurl-service retries 503 deliveries; what we'd return
+  // otherwise (401 against the placeholder) is non-retriable from
+  // qurl-service's perspective and would drop the event.
+  if (!config.QURL_WEBHOOK_SECRET || config.QURL_WEBHOOK_SECRET === 'PLACEHOLDER') {
     return res.status(503).json({ error: 'Webhook receiver not configured' });
   }
 

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -17,6 +17,7 @@ const db = require('../store');
 const logger = require('../logger');
 const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS } = require('../constants');
 const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
+const { PLACEHOLDER_SECRET } = require('../qurl-webhook-registrar');
 
 const router = express.Router();
 
@@ -65,7 +66,7 @@ router.post('/qurl', async (req, res) => {
   // secret. qurl-service retries 503 deliveries; what we'd return
   // otherwise (401 against the placeholder) is non-retriable from
   // qurl-service's perspective and would drop the event.
-  if (!config.QURL_WEBHOOK_SECRET || config.QURL_WEBHOOK_SECRET === 'PLACEHOLDER') {
+  if (!config.QURL_WEBHOOK_SECRET || config.QURL_WEBHOOK_SECRET === PLACEHOLDER_SECRET) {
     return res.status(503).json({ error: 'Webhook receiver not configured' });
   }
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1,0 +1,228 @@
+// Tests for the qurl-service webhook self-registration helper.
+//
+// Wire-contract pinned against qurl-service's public Webhooks API:
+//   POST /v1/webhooks                  → creates, returns secret
+//   POST /v1/webhooks/{id}/secret      → rotates, returns NEW secret
+//   GET  /v1/webhooks                  → lists for owner
+//   PATCH /v1/webhooks/{id}            → updates events list
+
+const { ensureWebhookSubscription, _internals } = require('../src/qurl-webhook-registrar');
+
+const ORIGINAL_FETCH = global.fetch;
+
+function mockFetchResponses(handlers) {
+  global.fetch = jest.fn(async (url, opts) => {
+    const path = url.replace(/^https?:\/\/[^/]+/, '');
+    const method = opts.method || 'GET';
+    const handler = handlers[`${method} ${path}`];
+    if (!handler) {
+      throw new Error(`Unmocked fetch: ${method} ${path}`);
+    }
+    const { status = 200, body, throwError } = handler(opts);
+    if (throwError) throw throwError;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    };
+  });
+}
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+const BASE_OPTS = {
+  apiEndpoint: 'https://api.test.example',
+  apiKey: 'lv_test_key',
+  bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+  description: 'test description',
+};
+
+describe('ensureWebhookSubscription — no existing subscription → creates fresh', () => {
+  it('POSTs /v1/webhooks with the right body and returns the server-generated secret', async () => {
+    let createBody = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [], meta: {} } }),
+      'POST /v1/webhooks': (opts) => {
+        createBody = JSON.parse(opts.body);
+        return { status: 201, body: { data: {
+          webhook_id: 'wh_test_new',
+          secret: 'whsec_fresh_secret',
+          url: BASE_OPTS.bridgeUrl,
+          events: ['qurl.accessed'],
+        } } };
+      },
+    });
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    expect(createBody).toEqual({
+      url: BASE_OPTS.bridgeUrl,
+      events: ['qurl.accessed'],
+      description: BASE_OPTS.description,
+    });
+    expect(result).toEqual({
+      secret: 'whsec_fresh_secret',
+      webhookId: 'wh_test_new',
+      action: 'created',
+    });
+  });
+});
+
+describe('ensureWebhookSubscription — existing subscription with matching URL → rotates secret', () => {
+  it('finds the sub, calls POST /v1/webhooks/{id}/secret, returns the rotated secret', async () => {
+    let rotatedFor = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing',
+        url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => {
+        rotatedFor = 'wh_existing';
+        return { body: { data: { webhook_id: 'wh_existing', secret: 'whsec_rotated' } } };
+      },
+    });
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    expect(rotatedFor).toBe('wh_existing');
+    expect(result).toEqual({
+      secret: 'whsec_rotated',
+      webhookId: 'wh_existing',
+      action: 'rotated',
+    });
+  });
+
+  it('patches events if the existing list does not include qurl.accessed', async () => {
+    let patchedEvents = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing',
+        url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.created'], // drift — missing qurl.accessed
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': (opts) => {
+        patchedEvents = JSON.parse(opts.body).events;
+        return { body: { data: { webhook_id: 'wh_existing' } } };
+      },
+      'POST /v1/webhooks/wh_existing/secret': () => ({
+        body: { data: { webhook_id: 'wh_existing', secret: 'whsec_post_patch' } },
+      }),
+    });
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    expect(patchedEvents).toEqual(['qurl.accessed']);
+    expect(result.secret).toBe('whsec_post_patch');
+  });
+});
+
+describe('ensureWebhookSubscription — error paths', () => {
+  it('throws when qurl-service returns 401 (bad API key)', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ status: 401, body: { error: 'Unauthorized' } }),
+    });
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/401/);
+  });
+
+  it('throws if create response has no secret (contract drift)', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_new',
+        // No secret field — contract drift
+      } } }),
+    });
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/no secret in response/);
+  });
+
+  it('throws on missing required option', async () => {
+    await expect(ensureWebhookSubscription({ apiEndpoint: 'x' })).rejects.toThrow(/required/);
+  });
+});
+
+describe('ensureWebhookSubscription — best-effort secret persistence', () => {
+  it('invokes persistSecret callback with the server-generated secret', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_persisted', secret: 'whsec_to_persist',
+      } } }),
+    });
+    const persistSecret = jest.fn(async () => {});
+    const result = await ensureWebhookSubscription({
+      ...BASE_OPTS,
+      persistSecret,
+    });
+    expect(persistSecret).toHaveBeenCalledWith('whsec_to_persist');
+    expect(result.secret).toBe('whsec_to_persist');
+  });
+
+  it('returns the secret EVEN IF persistSecret throws (best-effort)', async () => {
+    // Load-bearing safety property: persistence is observability, not
+    // correctness. If IAM denies PutParameter (or whatever backend the
+    // caller wired) we STILL return the secret so the receiver can
+    // verify against it in-process. Without this, an AccessDenied
+    // would crash the registrar and the bot would 503 on every webhook.
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_denied', secret: 'whsec_in_memory_only',
+      } } }),
+    });
+    const accessDenied = new Error('User is not authorized to perform: ssm:PutParameter');
+    accessDenied.name = 'AccessDeniedException';
+    const persistSecret = jest.fn(async () => { throw accessDenied; });
+    const result = await ensureWebhookSubscription({
+      ...BASE_OPTS,
+      persistSecret,
+    });
+    expect(result.secret).toBe('whsec_in_memory_only');
+    expect(persistSecret).toHaveBeenCalled();
+  });
+
+  it('skips persistence entirely when persistSecret is not provided', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_no_persist', secret: 'whsec_in_memory_only',
+      } } }),
+    });
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    expect(result.secret).toBe('whsec_in_memory_only');
+  });
+});
+
+describe('ensureWebhookSubscription — wire-contract pins', () => {
+  it('uses Bearer auth + JSON content-type', async () => {
+    let getOpts = null;
+    let postOpts = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': (opts) => {
+        getOpts = opts;
+        return { body: { data: [] } };
+      },
+      'POST /v1/webhooks': (opts) => {
+        postOpts = opts;
+        return { status: 201, body: { data: { webhook_id: 'wh', secret: 'whsec_' } } };
+      },
+    });
+    await ensureWebhookSubscription(BASE_OPTS);
+    expect(getOpts.headers.Authorization).toBe(`Bearer ${BASE_OPTS.apiKey}`);
+    expect(postOpts.headers.Authorization).toBe(`Bearer ${BASE_OPTS.apiKey}`);
+    expect(postOpts.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('events list is the exact ["qurl.accessed"] string (regression guard)', async () => {
+    // The qurl-service spec lists multiple event types; we ONLY want
+    // qurl.accessed. If a future change accidentally subscribes to
+    // qurl.created / .revoked etc., the receiver would ignore those
+    // with 200 — but the metric volume + log noise would grow.
+    let body = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': (opts) => {
+        body = JSON.parse(opts.body);
+        return { status: 201, body: { data: { webhook_id: 'wh', secret: 'whsec_' } } };
+      },
+    });
+    await ensureWebhookSubscription(BASE_OPTS);
+    expect(body.events).toEqual(['qurl.accessed']);
+  });
+});

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -172,6 +172,23 @@ describe('ensureWebhookSubscription — existing sub + real initialSecret → RE
     expect(patched).toBe(true);
   });
 
+  it('returns reused successfully even when the events PATCH fails (transient 5xx must not flip the boot log)', async () => {
+    // Receiver is already correct via initialSecret. A transient PATCH
+    // 5xx shouldn't make ensureWebhookSubscription reject — the boot
+    // log would then say "self-registration failed" while the bot is
+    // actually healthy. Catch + log + return reused.
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.created'], // drift
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': () => ({ status: 500, body: { error: 'transient' } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(result.secret).toBe('whsec_known');
+    expect(result.action).toBe('reused');
+    expect(result.webhookId).toBe('wh_existing');
+  });
+
   it('does NOT PATCH when events already include qurl.accessed (no-drift positive case)', async () => {
     let patched = false;
     mockFetchResponses({
@@ -283,7 +300,25 @@ describe('ensureWebhookSubscription — error paths', () => {
         // No secret field — contract drift
       } } }),
     });
-    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/no secret in response/);
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/contract drift/);
+  });
+
+  it('throws if create response has no data envelope (contract drift)', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { /* no data */ } }),
+    });
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/contract drift/);
+  });
+
+  it('throws if rotate response has no secret (contract drift)', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => ({ body: { data: { webhook_id: 'wh_existing' /* no secret */ } } }),
+    });
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/rotateSecret.*contract drift/);
   });
 
   it('throws on missing required option', async () => {
@@ -340,6 +375,40 @@ describe('ensureWebhookSubscription — best-effort secret persistence', () => {
     });
     const result = await ensureWebhookSubscription(BASE_OPTS);
     expect(result.secret).toBe('whsec_in_memory_only');
+  });
+});
+
+describe('ensureWebhookSubscription — description length defense', () => {
+  // Slice lives at the wire boundary (createSubscription) so future
+  // callers don't have to remember the 200-char cap. Defense against
+  // a hypothetical future qurl-service-side length-cap 4xx that
+  // would otherwise infinite-loop on retry-create.
+  it('clips description to 200 chars at the wire boundary regardless of caller input', async () => {
+    let sentDescription = null;
+    const longDescription = 'x'.repeat(500);
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': (opts) => {
+        sentDescription = JSON.parse(opts.body).description;
+        return { status: 201, body: { data: { webhook_id: 'wh_clipped', secret: 'whsec_' } } };
+      },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, description: longDescription });
+    expect(sentDescription).toHaveLength(200);
+    expect(sentDescription).toBe('x'.repeat(200));
+  });
+
+  it('treats non-string description as empty', async () => {
+    let sentDescription = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': (opts) => {
+        sentDescription = JSON.parse(opts.body).description;
+        return { status: 201, body: { data: { webhook_id: 'wh', secret: 'whsec_' } } };
+      },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, description: undefined });
+    expect(sentDescription).toBe('');
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -376,7 +376,7 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
   // Cold-bootstrap with N replicas + empty SSM creates N duplicate subs
   // (each replica POSTs concurrently). This path tests RECOVERY on the
   // next boot: pick deterministic survivor, DELETE others, continue.
-  it('deletes duplicates and keeps oldest-by-created_at survivor', async () => {
+  it('deletes duplicates and keeps oldest-by-created_at survivor (force-rotates the survivor)', async () => {
     const deletedIds = [];
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
@@ -386,10 +386,11 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => { deletedIds.push('wh_b'); return { status: 204, body: '' }; },
       'DELETE /v1/webhooks/wh_c': () => { deletedIds.push('wh_c'); return { status: 204, body: '' }; },
+      'POST /v1/webhooks/wh_a/secret': () => ({ body: { data: { webhook_id: 'wh_a', secret: 'whsec_rot' } } }),
     });
     const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
     expect(result.webhookId).toBe('wh_a');
-    expect(result.action).toBe('reused');
+    expect(result.action).toBe('rotated'); // dedupe always force-rotates
     expect(deletedIds.sort()).toEqual(['wh_b', 'wh_c']);
   });
 
@@ -401,6 +402,7 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
         { webhook_id: 'wh_aaa', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] }, // lex-first — survivor
       ] } }),
       'DELETE /v1/webhooks/wh_zzz': () => { deletedIds.push('wh_zzz'); return { status: 204, body: '' }; },
+      'POST /v1/webhooks/wh_aaa/secret': () => ({ body: { data: { webhook_id: 'wh_aaa', secret: 'whsec_rot' } } }),
     });
     const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
     expect(result.webhookId).toBe('wh_aaa');
@@ -417,10 +419,41 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
         { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => ({ status: 404, body: { error: 'not found' } }),
+      'POST /v1/webhooks/wh_a/secret': () => ({ body: { data: { webhook_id: 'wh_a', secret: 'whsec_rot' } } }),
     });
     const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
     expect(result.webhookId).toBe('wh_a');
-    expect(result.action).toBe('reused');
+    expect(result.action).toBe('rotated');
+  });
+
+  it('force-rotates the survivor even when initialSecret is real (closes SSM↔survivor mismatch)', async () => {
+    // Cold-bootstrap created N subs each with distinct server-generated
+    // secrets. The SSM-persisted secret (last-write-wins) almost
+    // certainly belongs to a replica whose sub we just DELETEd. If we
+    // took the REUSE path with initialSecret, the receiver would 401
+    // every inbound forever (survivor's secret is unknown). Force-
+    // rotate produces a known-good secret tied to the survivor.
+    let rotated = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T10:00:00Z' }, // survivor
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T11:00:00Z' },
+      ] } }),
+      'DELETE /v1/webhooks/wh_b': () => ({ status: 204, body: '' }),
+      'POST /v1/webhooks/wh_a/secret': () => {
+        rotated = true;
+        return { body: { data: { webhook_id: 'wh_a', secret: 'whsec_post_dedupe' } } };
+      },
+    });
+    const result = await ensureWebhookSubscription({
+      ...BASE_OPTS,
+      initialSecret: 'whsec_was_in_ssm_but_for_wh_b',
+    });
+    expect(rotated).toBe(true);
+    expect(result.webhookId).toBe('wh_a');
+    expect(result.action).toBe('rotated'); // NOT 'reused' — dedupe forces rotate
+    expect(result.secret).toBe('whsec_post_dedupe');
+    expect(result.secret).not.toBe('whsec_was_in_ssm_but_for_wh_b');
   });
 
   it('propagates non-404 DELETE errors so a real failure surfaces', async () => {
@@ -432,6 +465,38 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
       'DELETE /v1/webhooks/wh_b': () => ({ status: 500, body: { error: 'oops' } }),
     });
     await expect(ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' })).rejects.toThrow(/500/);
+  });
+});
+
+describe('ensureWebhookSubscription — real config integration (setQurlWebhookSecret)', () => {
+  // The fakeConfig-based mutation-seam test (above) keeps the unit
+  // hermetic but pins a synthesized shape. This test exercises the
+  // REAL `setQurlWebhookSecret` from src/config.js so a future rename
+  // or signature change is caught loudly here instead of at boot.
+  it('writing through the real config setter updates the canonical export', () => {
+    const config = require('../src/config');
+    const prev = config.QURL_WEBHOOK_SECRET;
+    try {
+      config.setQurlWebhookSecret('whsec_integration_test');
+      expect(config.QURL_WEBHOOK_SECRET).toBe('whsec_integration_test');
+    } finally {
+      config.setQurlWebhookSecret(prev);
+    }
+  });
+
+  it('works even when destructured-and-called (closure-captures module.exports, not `this`)', () => {
+    const { setQurlWebhookSecret } = require('../src/config');
+    const config = require('../src/config');
+    const prev = config.QURL_WEBHOOK_SECRET;
+    try {
+      // Pre-fix shorthand `setQurlWebhookSecret(secret) { this.X = secret }`
+      // would silently TypeError here because `this` is undefined in
+      // strict-mode standalone calls.
+      setQurlWebhookSecret('whsec_destructured');
+      expect(config.QURL_WEBHOOK_SECRET).toBe('whsec_destructured');
+    } finally {
+      setQurlWebhookSecret(prev);
+    }
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -44,6 +44,31 @@ const BASE_OPTS = {
   description: 'test description',
 };
 
+describe('ensureWebhookSubscription — cold bootstrap (no existing sub + no real initialSecret) → creates', () => {
+  // The first-deploy-of-a-fresh-environment path. `initialSecret` is
+  // either unset (env never had QURL_WEBHOOK_SECRET) or set to the
+  // terraform-seeded PLACEHOLDER. Either way, action='created'.
+  it.each([
+    ['initialSecret undefined', undefined],
+    ['initialSecret empty string', ''],
+    ['initialSecret PLACEHOLDER literal', 'PLACEHOLDER'],
+  ])('creates a fresh subscription when no existing matches the bridge URL — %s', async (_label, initialSecret) => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_cold_bootstrap',
+        secret: 'whsec_fresh',
+        url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.accessed'],
+      } } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret });
+    expect(result.action).toBe('created');
+    expect(result.webhookId).toBe('wh_cold_bootstrap');
+    expect(result.secret).toBe('whsec_fresh');
+  });
+});
+
 describe('ensureWebhookSubscription — no existing subscription → creates fresh', () => {
   it('POSTs /v1/webhooks with the right body and returns the server-generated secret', async () => {
     let createBody = null;
@@ -701,6 +726,17 @@ describe('redactSecret — recursive scrubbing', () => {
     const out = redactSecret({ a: 1, b: 'x', c: null, d: false });
     expect(out).toEqual({ a: 1, b: 'x', c: null, d: false });
   });
+  it('fail-closes at depth cap with [TRUNCATED] (deeply-wrapped secret cannot survive)', () => {
+    // Build a body with a `secret` field deeper than REDACT_MAX_DEPTH (8).
+    let nested = { secret: 'whsec_deeply_nested' };
+    for (let i = 0; i < 10; i++) nested = { wrap: nested };
+    const out = redactSecret(nested);
+    // Walk to the truncation point and check the subtree was replaced
+    // by '[TRUNCATED]' instead of the original {secret: ...} subtree.
+    const json = JSON.stringify(out);
+    expect(json).not.toContain('whsec_deeply_nested');
+    expect(json).toContain('[TRUNCATED]');
+  });
 });
 
 describe('pickSurvivor — deterministic across replicas', () => {
@@ -724,6 +760,20 @@ describe('pickSurvivor — deterministic across replicas', () => {
       { webhook_id: 'wh_aaa' },
     ]);
     expect(winner.webhook_id).toBe('wh_aaa');
+  });
+  it('prefers the row with a timestamp over the row without (mixed case)', () => {
+    // Asymmetric responses (one row has created_at, the other doesn't)
+    // should resolve to the timestamped row regardless of input order.
+    const winner1 = pickSurvivor([
+      { webhook_id: 'wh_zzz', created_at: '2026-05-19T10:00:00Z' },
+      { webhook_id: 'wh_aaa' /* no timestamp */ },
+    ]);
+    expect(winner1.webhook_id).toBe('wh_zzz');
+    const winner2 = pickSurvivor([
+      { webhook_id: 'wh_aaa' /* no timestamp */ },
+      { webhook_id: 'wh_zzz', created_at: '2026-05-19T10:00:00Z' },
+    ]);
+    expect(winner2.webhook_id).toBe('wh_zzz');
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -656,6 +656,21 @@ describe('ensureWebhookSubscription — fetch timeout', () => {
     global.fetch = jest.fn(async () => { throw abortErr; });
     await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/aborted/i);
   });
+  it('attaches `op` to pre-response fetch errors so oncall greps catch network failures too', async () => {
+    // callQurlService used to surface only resp-status errors with op;
+    // pre-response failures (AbortError, DNS, TLS) lacked the op field,
+    // so a "filter logs by op=GET /v1/webhooks" search silently missed
+    // network errors. Now op is attached at the catch site.
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    global.fetch = jest.fn(async () => { throw abortErr; });
+    let caught;
+    try {
+      await ensureWebhookSubscription(BASE_OPTS);
+    } catch (err) { caught = err; }
+    expect(caught).toBeDefined();
+    expect(caught.op).toBe('GET /v1/webhooks?limit=100');
+  });
 });
 
 describe('redactSecret — recursive scrubbing', () => {
@@ -664,6 +679,18 @@ describe('redactSecret — recursive scrubbing', () => {
     const out = redactSecret({ data: { webhook: { secret: 'whsec_leaked', other: 'fine' } } });
     expect(out.data.webhook.secret).toBe('[REDACTED]');
     expect(out.data.webhook.other).toBe('fine');
+  });
+  it('scrubs secret-shaped key variants (webhook_secret, signing_secret, client_secret)', () => {
+    const out = redactSecret({
+      webhook_secret: 'whsec_a',
+      signing_secret: 'whsec_b',
+      client_secret: 'whsec_c',
+      regular_field: 'fine',
+    });
+    expect(out.webhook_secret).toBe('[REDACTED]');
+    expect(out.signing_secret).toBe('[REDACTED]');
+    expect(out.client_secret).toBe('[REDACTED]');
+    expect(out.regular_field).toBe('fine');
   });
   it('scrubs secrets inside arrays of objects', () => {
     const out = redactSecret({ data: [{ secret: 'whsec_one' }, { secret: 'whsec_two' }] });

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -14,7 +14,12 @@ function mockFetchResponses(handlers) {
   global.fetch = jest.fn(async (url, opts) => {
     const path = url.replace(/^https?:\/\/[^/]+/, '');
     const method = opts.method || 'GET';
-    const handler = handlers[`${method} ${path}`];
+    // Try exact match first (so tests targeting a specific query string
+    // like `?cursor=page2` still work), then fall back to pathname-only
+    // so tests don't have to enumerate every `?limit=100` / `?limit=100&cursor=...`
+    // variation that the registrar adds for defensive reasons.
+    const pathnameOnly = path.split('?')[0];
+    const handler = handlers[`${method} ${path}`] || handlers[`${method} ${pathnameOnly}`];
     if (!handler) {
       throw new Error(`Unmocked fetch: ${method} ${path}`);
     }
@@ -207,12 +212,16 @@ describe('ensureWebhookSubscription — URL canonicalization', () => {
 
 describe('ensureWebhookSubscription — pagination', () => {
   it('walks cursor pages until the matching sub is found', async () => {
+    // Test keys spell the exact path the registrar produces so the
+    // exact-match path-with-query takes precedence over the
+    // pathname-only fallback (which would otherwise return the
+    // first-page handler for every call → cursor walk would loop).
     mockFetchResponses({
-      'GET /v1/webhooks': () => ({ body: {
+      'GET /v1/webhooks?limit=100': () => ({ body: {
         data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed'] }],
         meta: { next_cursor: 'page2', has_more: true },
       } }),
-      'GET /v1/webhooks?cursor=page2': () => ({ body: {
+      'GET /v1/webhooks?cursor=page2&limit=100': () => ({ body: {
         data: [{ webhook_id: 'wh_match', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] }],
         meta: { next_cursor: '', has_more: false },
       } }),
@@ -222,7 +231,7 @@ describe('ensureWebhookSubscription — pagination', () => {
     expect(result.action).toBe('reused');
   });
 
-  it('returns null (→ creates fresh) when cursor walk exhausts without a match', async () => {
+  it('returns [] (→ creates fresh) when cursor walk exhausts without any match', async () => {
     let createCalled = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: {

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -68,7 +68,7 @@ describe('ensureWebhookSubscription — no existing subscription → creates fre
   });
 });
 
-describe('ensureWebhookSubscription — existing subscription with matching URL → rotates secret', () => {
+describe('ensureWebhookSubscription — existing sub, bootstrap (no real initialSecret) → rotates', () => {
   it('finds the sub, calls POST /v1/webhooks/{id}/secret, returns the rotated secret', async () => {
     let rotatedFor = null;
     mockFetchResponses({
@@ -91,6 +91,20 @@ describe('ensureWebhookSubscription — existing subscription with matching URL 
     });
   });
 
+  it('also rotates when initialSecret is the terraform PLACEHOLDER sentinel', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => ({
+        body: { data: { webhook_id: 'wh_existing', secret: 'whsec_post_bootstrap' } },
+      }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'PLACEHOLDER' });
+    expect(result.action).toBe('rotated');
+    expect(result.secret).toBe('whsec_post_bootstrap');
+  });
+
   it('patches events if the existing list does not include qurl.accessed', async () => {
     let patchedEvents = null;
     mockFetchResponses({
@@ -110,6 +124,137 @@ describe('ensureWebhookSubscription — existing subscription with matching URL 
     const result = await ensureWebhookSubscription(BASE_OPTS);
     expect(patchedEvents).toEqual(['qurl.accessed']);
     expect(result.secret).toBe('whsec_post_patch');
+  });
+});
+
+describe('ensureWebhookSubscription — existing sub + real initialSecret → REUSE (multi-replica safety)', () => {
+  it('skips POST /secret entirely and returns the initialSecret unchanged', async () => {
+    // The load-bearing multi-replica safety property. Pre-fix, each
+    // HTTP replica rotated → server-side last-write-wins → (N-1)
+    // replicas held stale secrets → ALB-routed events 401'd on
+    // ~(N-1)/N of replicas until a follow-up restart.
+    let secretEndpointHit = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => {
+        secretEndpointHit = true;
+        return { body: { data: {} } };
+      },
+    });
+    const result = await ensureWebhookSubscription({
+      ...BASE_OPTS,
+      initialSecret: 'whsec_already_known',
+    });
+    expect(secretEndpointHit).toBe(false); // critical: no rotation
+    expect(result).toEqual({
+      secret: 'whsec_already_known',
+      webhookId: 'wh_existing',
+      action: 'reused',
+    });
+  });
+
+  it('still PATCHes events on drift even in the reuse path (PATCH is idempotent)', async () => {
+    let patched = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.created'],
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': () => { patched = true; return { body: { data: {} } }; },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patched).toBe(true);
+  });
+
+  it('does NOT PATCH when events already include qurl.accessed (no-drift positive case)', async () => {
+    let patched = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': () => { patched = true; return { body: { data: {} } }; },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patched).toBe(false);
+  });
+});
+
+describe('ensureWebhookSubscription — URL canonicalization', () => {
+  it('matches an existing sub even when URLs differ by trailing slash', async () => {
+    let rotated = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing',
+        url: 'https://bot.test.example/webhooks/qurl/', // trailing slash
+        events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => {
+        rotated = true;
+        return { body: { data: { webhook_id: 'wh_existing', secret: 'whsec_x' } } };
+      },
+    });
+    // bridgeUrl has NO trailing slash; strict equality would miss
+    // and create a duplicate. canonicalUrl matches both.
+    const result = await ensureWebhookSubscription({
+      ...BASE_OPTS,
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+    });
+    expect(rotated).toBe(true);
+    expect(result.action).toBe('rotated'); // matched the existing sub, not 'created'
+  });
+});
+
+describe('ensureWebhookSubscription — pagination', () => {
+  it('walks cursor pages until the matching sub is found', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: {
+        data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed'] }],
+        meta: { next_cursor: 'page2', has_more: true },
+      } }),
+      'GET /v1/webhooks?cursor=page2': () => ({ body: {
+        data: [{ webhook_id: 'wh_match', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] }],
+        meta: { next_cursor: '', has_more: false },
+      } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(result.webhookId).toBe('wh_match');
+    expect(result.action).toBe('reused');
+  });
+
+  it('returns null (→ creates fresh) when cursor walk exhausts without a match', async () => {
+    let createCalled = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: {
+        data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed'] }],
+        meta: { next_cursor: '', has_more: false },
+      } }),
+      'POST /v1/webhooks': () => {
+        createCalled = true;
+        return { status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } };
+      },
+    });
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    expect(createCalled).toBe(true);
+    expect(result.action).toBe('created');
+  });
+});
+
+describe('ensureWebhookSubscription — secret redaction in error messages', () => {
+  it('redacts secret from response body when surfacing an error', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({
+        status: 500,
+        body: { error: 'Internal Server Error', data: { secret: 'whsec_leaked', other: 'fine' } },
+      }),
+    });
+    let caught;
+    try {
+      await ensureWebhookSubscription(BASE_OPTS);
+    } catch (err) { caught = err; }
+    expect(caught).toBeDefined();
+    expect(caught.message).not.toContain('whsec_leaked');
+    expect(caught.message).toContain('[REDACTED]');
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -371,3 +371,28 @@ describe('ensureWebhookSubscription — wire-contract pins', () => {
     expect(body.events).toEqual(['qurl.accessed']);
   });
 });
+
+describe('ensureWebhookSubscription — config-mutation seam (receiver picks up new secret)', () => {
+  // The wire-up cr called out: receiver reads config.QURL_WEBHOOK_SECRET
+  // on every request; the registrar's `.then()` callback writes to
+  // config via setQurlWebhookSecret() — that mutation IS what makes
+  // the new secret active without restarting the process. Test pins
+  // both directions: registrar returns a secret, caller writes it to
+  // config, receiver-side verification (in-process simulation) uses it.
+  it('the secret the registrar returns is the one the receiver verifies against', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_seam', secret: 'whsec_new_active',
+      } } }),
+    });
+    const fakeConfig = { QURL_WEBHOOK_SECRET: 'PLACEHOLDER' };
+    const setQurlWebhookSecret = (s) => { fakeConfig.QURL_WEBHOOK_SECRET = s; };
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    // Caller's responsibility (mirrors apps/discord/src/index.js):
+    setQurlWebhookSecret(result.secret);
+    // After the .then() resolves, the receiver's view of the config:
+    expect(fakeConfig.QURL_WEBHOOK_SECRET).toBe('whsec_new_active');
+    expect(fakeConfig.QURL_WEBHOOK_SECRET).not.toBe('PLACEHOLDER');
+  });
+});

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -372,6 +372,191 @@ describe('ensureWebhookSubscription — wire-contract pins', () => {
   });
 });
 
+describe('ensureWebhookSubscription — duplicate-subscription recovery', () => {
+  // Cold-bootstrap with N replicas + empty SSM creates N duplicate subs
+  // (each replica POSTs concurrently). This path tests RECOVERY on the
+  // next boot: pick deterministic survivor, DELETE others, continue.
+  it('deletes duplicates and keeps oldest-by-created_at survivor', async () => {
+    const deletedIds = [];
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T12:00:00Z' },
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T10:00:00Z' }, // older — survivor
+        { webhook_id: 'wh_c', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T14:00:00Z' },
+      ] } }),
+      'DELETE /v1/webhooks/wh_b': () => { deletedIds.push('wh_b'); return { status: 204, body: '' }; },
+      'DELETE /v1/webhooks/wh_c': () => { deletedIds.push('wh_c'); return { status: 204, body: '' }; },
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(result.webhookId).toBe('wh_a');
+    expect(result.action).toBe('reused');
+    expect(deletedIds.sort()).toEqual(['wh_b', 'wh_c']);
+  });
+
+  it('falls back to lexicographic webhook_id when created_at is absent (no replica-identity coupling)', async () => {
+    const deletedIds = [];
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_zzz', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_aaa', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] }, // lex-first — survivor
+      ] } }),
+      'DELETE /v1/webhooks/wh_zzz': () => { deletedIds.push('wh_zzz'); return { status: 204, body: '' }; },
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(result.webhookId).toBe('wh_aaa');
+    expect(deletedIds).toEqual(['wh_zzz']);
+  });
+
+  it('treats DELETE 404 as success (concurrent dedupe race)', async () => {
+    // Two replicas independently picking the same survivor + DELETEing
+    // the same losers means the second DELETE on each loser hits 404.
+    // The dedupe path must NOT crash on this.
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+      ] } }),
+      'DELETE /v1/webhooks/wh_b': () => ({ status: 404, body: { error: 'not found' } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(result.webhookId).toBe('wh_a');
+    expect(result.action).toBe('reused');
+  });
+
+  it('propagates non-404 DELETE errors so a real failure surfaces', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+      ] } }),
+      'DELETE /v1/webhooks/wh_b': () => ({ status: 500, body: { error: 'oops' } }),
+    });
+    await expect(ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' })).rejects.toThrow(/500/);
+  });
+});
+
+describe('ensureWebhookSubscription — multi-subscription scan', () => {
+  it('matches the correct sub when several non-matching ones share the page', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_other_1', url: 'https://elsewhere.example/hook1', events: ['qurl.accessed'] },
+        { webhook_id: 'wh_match',   url: BASE_OPTS.bridgeUrl,              events: ['qurl.accessed'] },
+        { webhook_id: 'wh_other_2', url: 'https://elsewhere.example/hook2', events: ['qurl.accessed'] },
+      ] } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(result.webhookId).toBe('wh_match');
+    expect(result.action).toBe('reused');
+  });
+});
+
+describe('ensureWebhookSubscription — rotation survives PATCH failure', () => {
+  it('returns the rotated secret even when the events PATCH fails', async () => {
+    // Behavior pin: if PATCH ran before rotate and threw, the bot
+    // would never get a usable secret on this boot — receiver stays on
+    // PLACEHOLDER, 503s forever. Asserting the rotated secret made it
+    // out implicitly proves rotation ran (and succeeded) despite the
+    // PATCH 500. Doesn't pin call order, so a future refactor that
+    // makes rotation+PATCH independent still passes.
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.created'], // drift
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => ({
+        body: { data: { webhook_id: 'wh_existing', secret: 'whsec_rotated_ok' } },
+      }),
+      'PATCH /v1/webhooks/wh_existing': () => ({ status: 500, body: { error: 'transient' } }),
+    });
+    const result = await ensureWebhookSubscription(BASE_OPTS);
+    expect(result.secret).toBe('whsec_rotated_ok');
+    expect(result.action).toBe('rotated');
+  });
+});
+
+describe('ensureWebhookSubscription — events drift edge cases', () => {
+  it('triggers PATCH when existing.events is undefined (regression guard for Array.isArray(undefined))', async () => {
+    let patched = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, // no events field at all
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': () => { patched = true; return { body: { data: {} } }; },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patched).toBe(true);
+  });
+});
+
+describe('ensureWebhookSubscription — pagination cap', () => {
+  it('throws when the 50-page cap is hit (refuses to fall through to create-fresh)', async () => {
+    // Silently returning null + creating-fresh would compound duplicates
+    // on every restart with a stuck cursor.
+    global.fetch = jest.fn(async () => ({
+      ok: true, status: 200,
+      text: async () => JSON.stringify({
+        data: [{ webhook_id: 'wh_other', url: 'https://other.example', events: [] }],
+        meta: { next_cursor: 'never-ends', has_more: true },
+      }),
+    }));
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/pagination cap/i);
+  });
+});
+
+describe('ensureWebhookSubscription — fetch timeout', () => {
+  it('surfaces AbortError when qurl-service hangs past the 10s deadline', async () => {
+    // The registrar relies on AbortSignal.timeout(10_000) — verify the
+    // surface is an error, not a hung promise. Replaces the awaited
+    // fetch with one that throws an AbortError synchronously to avoid
+    // real-time waits in tests.
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    global.fetch = jest.fn(async () => { throw abortErr; });
+    await expect(ensureWebhookSubscription(BASE_OPTS)).rejects.toThrow(/aborted/i);
+  });
+});
+
+describe('redactSecret — recursive scrubbing', () => {
+  const { redactSecret } = _internals;
+  it('scrubs nested secret fields at any depth', () => {
+    const out = redactSecret({ data: { webhook: { secret: 'whsec_leaked', other: 'fine' } } });
+    expect(out.data.webhook.secret).toBe('[REDACTED]');
+    expect(out.data.webhook.other).toBe('fine');
+  });
+  it('scrubs secrets inside arrays of objects', () => {
+    const out = redactSecret({ data: [{ secret: 'whsec_one' }, { secret: 'whsec_two' }] });
+    expect(out.data[0].secret).toBe('[REDACTED]');
+    expect(out.data[1].secret).toBe('[REDACTED]');
+  });
+  it('leaves non-secret leaf values intact', () => {
+    const out = redactSecret({ a: 1, b: 'x', c: null, d: false });
+    expect(out).toEqual({ a: 1, b: 'x', c: null, d: false });
+  });
+});
+
+describe('pickSurvivor — deterministic across replicas', () => {
+  const { pickSurvivor } = _internals;
+  it('returns null on empty input', () => {
+    expect(pickSurvivor([])).toBeNull();
+  });
+  it('returns the single match when only one', () => {
+    expect(pickSurvivor([{ webhook_id: 'x' }])).toEqual({ webhook_id: 'x' });
+  });
+  it('picks oldest created_at when both present', () => {
+    const winner = pickSurvivor([
+      { webhook_id: 'wh_z', created_at: '2026-05-19T12:00:00Z' },
+      { webhook_id: 'wh_a', created_at: '2026-05-19T10:00:00Z' },
+    ]);
+    expect(winner.webhook_id).toBe('wh_a');
+  });
+  it('falls back to lex webhook_id when created_at is missing', () => {
+    const winner = pickSurvivor([
+      { webhook_id: 'wh_zzz' },
+      { webhook_id: 'wh_aaa' },
+    ]);
+    expect(winner.webhook_id).toBe('wh_aaa');
+  });
+});
+
 describe('ensureWebhookSubscription — config-mutation seam (receiver picks up new secret)', () => {
   // The wire-up cr called out: receiver reads config.QURL_WEBHOOK_SECRET
   // on every request; the registrar's `.then()` callback writes to

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -6,7 +6,7 @@
 //   GET  /v1/webhooks                  → lists for owner
 //   PATCH /v1/webhooks/{id}            → updates events list
 
-const { ensureWebhookSubscription, _internals } = require('../src/qurl-webhook-registrar');
+const { ensureWebhookSubscription, buildSsmPersistSecret, _internals } = require('../src/qurl-webhook-registrar');
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -736,6 +736,37 @@ describe('redactSecret — recursive scrubbing', () => {
     const json = JSON.stringify(out);
     expect(json).not.toContain('whsec_deeply_nested');
     expect(json).toContain('[TRUNCATED]');
+  });
+});
+
+describe('buildSsmPersistSecret — abortSignal placement (regression guard for cr round-8)', () => {
+  it('passes abortSignal on send\'s SECOND arg, not on the Command constructor (constructor would silently drop it)', async () => {
+    // The bug round-8 caught: putting {abortSignal: ...} as the second
+    // arg to `new PutParameterCommand({...}, ...)` is silently dropped
+    // because the Command takes only `input`. Has to land on
+    // `client.send(cmd, { abortSignal })`.
+    let sendCalls = [];
+    const fakeSsmClient = { send: jest.fn(async (cmd, opts) => { sendCalls.push({ cmd, opts }); }) };
+    class FakePutParameterCommand {
+      constructor(input) { this.input = input; }
+    }
+    const persist = buildSsmPersistSecret({
+      ssmClient: fakeSsmClient,
+      paramName: '/test/QURL_WEBHOOK_SECRET',
+      PutParameterCommand: FakePutParameterCommand,
+    });
+    await persist('whsec_new_value');
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0].cmd.input).toEqual({
+      Name: '/test/QURL_WEBHOOK_SECRET',
+      Type: 'SecureString',
+      Value: 'whsec_new_value',
+      Overwrite: true,
+    });
+    // Critical assertion — abortSignal lives on the send-call options,
+    // NOT swallowed by the Command constructor.
+    expect(sendCalls[0].opts).toEqual({ abortSignal: expect.any(AbortSignal) });
+    expect(sendCalls[0].opts.abortSignal.aborted).toBe(false);
   });
 });
 

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -62,6 +62,31 @@ beforeEach(() => {
   mockRecordQurlView.mockImplementation(async () => 'recorded');
 });
 
+describe('POST /webhooks/qurl — boot-race PLACEHOLDER handling', () => {
+  // During the brief window between server-listen and auto-register
+  // resolving, config.QURL_WEBHOOK_SECRET may still hold the
+  // terraform-seeded PLACEHOLDER. The receiver MUST 503 (qurl-service
+  // retriable) on this case rather than 401 (non-retriable) — a 401
+  // would drop in-flight events permanently.
+  it('returns 503 when secret is the literal PLACEHOLDER (boot race)', async () => {
+    // eslint-disable-next-line global-require
+    const config = require('../src/config');
+    const original = config.QURL_WEBHOOK_SECRET;
+    config.QURL_WEBHOOK_SECRET = 'PLACEHOLDER';
+    try {
+      const res = await request(app)
+        .post('/webhooks/qurl')
+        .set('Content-Type', 'application/json')
+        .set('QURL-Signature', '0'.repeat(64))
+        .send('{}');
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({ error: 'Webhook receiver not configured' });
+    } finally {
+      config.QURL_WEBHOOK_SECRET = original;
+    }
+  });
+});
+
 describe('POST /webhooks/qurl — signature verification', () => {
   it('accepts a request with a valid bare-hex HMAC over the raw body', async () => {
     const raw = JSON.stringify(VALID_PAYLOAD);

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -72,7 +72,10 @@ describe('POST /webhooks/qurl — boot-race PLACEHOLDER handling', () => {
     // eslint-disable-next-line global-require
     const config = require('../src/config');
     const original = config.QURL_WEBHOOK_SECRET;
-    config.QURL_WEBHOOK_SECRET = 'PLACEHOLDER';
+    // Use the setter (not direct mutation) — single canonical path
+    // means a future rename of QURL_WEBHOOK_SECRET → setSecret would
+    // fail this test loudly rather than silently mutate the wrong key.
+    config.setQurlWebhookSecret('PLACEHOLDER');
     try {
       const res = await request(app)
         .post('/webhooks/qurl')
@@ -82,7 +85,7 @@ describe('POST /webhooks/qurl — boot-race PLACEHOLDER handling', () => {
       expect(res.status).toBe(503);
       expect(res.body).toEqual({ error: 'Webhook receiver not configured' });
     } finally {
-      config.QURL_WEBHOOK_SECRET = original;
+      config.setQurlWebhookSecret(original);
     }
   });
 });

--- a/apps/discord/tests/templates.test.js
+++ b/apps/discord/tests/templates.test.js
@@ -9,6 +9,17 @@ jest.mock('../src/constants', () => ({
     WARNING: 0xF39C12,
     ERROR: 0xE74C3C,
   },
+  // Required by qurl-webhook-registrar (transitively loaded via
+  // qurl-webhook route → server.js). Keep the wire literal exact —
+  // qurl-service rejects any other event-type string.
+  QURL_WEBHOOK_EVENTS: { ACCESSED: 'qurl.accessed' },
+  // Required by qurl-webhook route — receiver-side audit-event keys.
+  AUDIT_EVENTS: {
+    QURL_WEBHOOK_RATE_LIMITED: 'qurl_webhook_rate_limited',
+    QURL_WEBHOOK_SIGNATURE_INVALID: 'qurl_webhook_signature_invalid',
+    QURL_WEBHOOK_RECEIVED: 'qurl_webhook_received',
+    QURL_WEBHOOK_STORE_ERROR: 'qurl_webhook_store_error',
+  },
 }));
 
 const { renderPage } = require('../src/templates/page');


### PR DESCRIPTION
## Summary
Closes #469. Bot self-registers its `qurl.accessed` subscription with qurl-service on every boot, eliminating the manual operator curl that gated the entire view-counter feature.

## Why
The sandbox rollout of #465 hit this exact gap: operator missed the manual curl step from `apps/discord/docs/qurl-webhook-rollout.md`, bot ran clean, counter sat at `0 viewed / N pending` forever. Real-time debugging revealed:
1. No subscription = no webhook deliveries = empty `qurl-views` table = counter never advances.
2. Worse, a registration done with the WRONG token (m2m smoke-test token vs the bot's own `QURL_API_KEY`) attached the subscription to the wrong `owner_id` — qurl-service's `PublishEvent(ownerID, ...)` filters by owner, so events from the bot's qURLs were silently dropped.

Self-register makes both gaps impossible: bot uses its own `QURL_API_KEY` (correct owner_id), runs on every boot (no human step to miss).

## Design
- **On boot**: GET subs via the bot's `QURL_API_KEY`. If matches exist, dedupe to a deterministic survivor (oldest by `created_at`, lex-id fallback) — recovery from prior cold-bootstrap duplicate creates. Then:
  - **Reuse path** (existing sub + real SSM secret): skip rotation entirely, return the SSM secret. This is the steady-state path on every restart after the first.
  - **Bootstrap rotate path** (existing sub + no SSM secret, e.g. PLACEHOLDER): rotate the secret first, then PATCH events if drifted. Rotate-first so a stuck PATCH doesn't strand the receiver on PLACEHOLDER.
  - **Create path** (no existing sub): POST `/v1/webhooks` to create.
- **Steady-state multi-replica safety**: every replica reads the same SSM secret on boot and takes the reuse path. The pre-fix rotate-every-boot pattern raced replicas into each other's secrets (last-write-wins ⇒ (N-1)/N replicas held stale).
- **Cold-bootstrap race (open)**: on the very first deploy to a fresh environment, no sub exists yet AND no SSM secret exists yet, so N replicas all POST create concurrently → N duplicates. The dedupe path is RECOVERY (next boot cleans up) — operator runbook pins the first deploy to `desired_count=1` to avoid this entirely. Durable fix is upstream-side idempotency on `(owner_id, url)`, tracked separately.
- **Fire-and-forget on the boot path** so a transient qurl-service hiccup doesn't crash the bot start sequence. Manual curl + ECS force-deploy remains the recovery route.
- **persistSecret callback** (best-effort SSM `PutParameter`, 5s timeout) for oncall visibility. NOT load-bearing — IAM denial / SSM timeout is caught + logged + the in-memory secret is what the receiver verifies against. SDK-agnostic interface (registrar takes a `persistSecret: async (secret) => void` callback; `index.js` wires it to SSM).

## Round-2 cr items (commits 6709d7b, ac3e3b4, 5dc87f3)
- **A** dedupe + survivor selection: oldest-by-created_at with lex-id fallback so concurrent dedupe converges across replicas without coordination
- **B** rotate-then-patch ordering: bootstrap-rotate now runs rotateSecret first; events PATCH wrapped in try/catch so a stuck PATCH doesn't strand the receiver
- **C** pagination cap throws (instead of returning null → silent fallthrough to create-fresh)
- **E** redactSecret recursive (was top-level-only): walks objects + arrays to depth 8
- **F** shared `PLACEHOLDER_SECRET` constant — receiver imports from registrar (was duplicated literal)
- **H** description sliced to 200 chars defense against future server-side length cap
- **I** persistSecret wrapped in 5s timeout
- **L** config setter hardened (closure-capture, not `this`-coupled)
- **M** `reconcileEvents` helper factored out, both branches call it
- **N** `@aws-sdk/client-ssm` require hoisted to top (was lazy)
- Runbook updated: cold-bootstrap single-replica discipline, `QURL_WEBHOOK_SECRET_SSM_PARAM` env-var documentation, IAM grant scope

## Tests
- 36 in `tests/qurl-webhook-registrar.test.js`: create-fresh / rotate-existing / PATCH-on-drift / persist-callback contract / wire-contract guards / dedupe (oldest+lex+concurrent-404+non-404-propagation) / multi-sub middle-match / rotation-survives-PATCH-failure / events-undefined / pagination-cap-throw / fetch-AbortError / recursive-redact / pickSurvivor unit tests / config-mutation seam.
- Full bot suite: 2451 pass.

## Test plan
- [x] `npx jest` — 2451 pass
- [x] Lint clean
- [x] Sandbox: deploy → bot boots, `qURL webhook self-registration complete` logged, subscription registered owner-scoped, counter advances on `/qurl send` end-to-end without manual curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)