### PR TITLE
fix(discord): strip Terraform-seeded PLACEHOLDER in Lambda handler

### DIFF
--- a/apps/discord/lambda/webhook-registrar/index.js
+++ b/apps/discord/lambda/webhook-registrar/index.js
@@ -101,6 +101,17 @@ const {
 // Lambda is the sole place that knows about this literal. Stripping
 // to null here lets the registrar library's initialIsRealSecret
 // guard correctly treat it as "no real secret yet, bootstrap-rotate."
+//
+// TODO(infra-sentinel-sync): the literal "PLACEHOLDER" is also the
+// seed value for `aws_ssm_parameter.bot["QURL_WEBHOOK_SECRET"]` in
+// qurl-integrations-infra/qurl-bot-discord/terraform/main.tf. If
+// infra ever renames the sentinel (e.g., "REPLACE_ME"), update here
+// in lockstep — otherwise the strip silently no-ops and the original
+// failure mode (bot reads literal as real secret → 401s every
+// webhook) returns. `git grep TODO(infra-sentinel-sync)` across both
+// repos finds every site that needs the lockstep edit. The same
+// marker appears in apps/discord/src/boot-requirements.js for the
+// GOOGLE_MAPS_API_KEY sentinel parallel case.
 const TERRAFORM_SEEDED_PLACEHOLDER = 'PLACEHOLDER';
 
 // SSM client at module scope — Lambda reuses the same execution

--- a/apps/discord/lambda/webhook-registrar/index.js
+++ b/apps/discord/lambda/webhook-registrar/index.js
@@ -94,6 +94,15 @@ const {
   buildSsmPersistSecret,
 } = require('../../src/qurl-webhook-registrar');
 
+// Terraform-seeded sentinel value for the QURL_WEBHOOK_SECRET SSM
+// parameter — see qurl-integrations-infra:qurl-bot-discord/terraform/
+// main.tf's `aws_ssm_parameter.bot`. The bot's receiver dropped its
+// own PLACEHOLDER-sentinel check in qurl-integrations#472, so the
+// Lambda is the sole place that knows about this literal. Stripping
+// to null here lets the registrar library's initialIsRealSecret
+// guard correctly treat it as "no real secret yet, bootstrap-rotate."
+const TERRAFORM_SEEDED_PLACEHOLDER = 'PLACEHOLDER';
+
 // SSM client at module scope — Lambda reuses the same execution
 // context across consecutive invocations within the same container
 // lifetime, so reusing the client is a meaningful perf win for
@@ -214,7 +223,21 @@ exports.handler = async (event, context) => {
   // (manual rotation, scheduled rotation) the SSM value is the
   // previously-persisted secret — ensureWebhookSubscription's
   // initialIsRealSecret guard reuses it if the sub still matches.
-  const initialSecret = await readSsmSecureString({ ssmClient, name: input.ssmParamName });
+  //
+  // Strip the Terraform-seeded sentinel: qurl-integrations-infra
+  // creates aws_ssm_parameter.bot["QURL_WEBHOOK_SECRET"] with
+  // value="PLACEHOLDER" (lifecycle ignore_changes preserves the real
+  // value once written, but a fresh env carries the literal until
+  // the first Lambda run rotates it). The registrar library's
+  // initialIsRealSecret guard checks length>0 only — without this
+  // strip, the literal "PLACEHOLDER" would pass as a "real" secret,
+  // and if an existing subscription was created out-of-band
+  // (operator curl, manual setup), the reuse path would return
+  // "PLACEHOLDER" to the bot → 401 every webhook. Stripping here
+  // is belt-and-suspenders to the Terraform `depends_on` chain that
+  // already serializes Lambda-before-ECS on the common path.
+  const rawSsmSecret = await readSsmSecureString({ ssmClient, name: input.ssmParamName });
+  const initialSecret = rawSsmSecret === TERRAFORM_SEEDED_PLACEHOLDER ? null : rawSsmSecret;
 
   // Lambda STRICT-persist path: do NOT pass `persistSecret` into
   // `ensureWebhookSubscription` (its `bestEffortPersist` swallows

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -203,6 +203,70 @@ describe('webhook-registrar Lambda — secret never echoes in handler response (
   });
 });
 
+describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel handling', () => {
+  // qurl-integrations-infra creates aws_ssm_parameter.bot["QURL_WEBHOOK_SECRET"]
+  // with value="PLACEHOLDER" on first apply. The bot's receiver dropped
+  // its PLACEHOLDER sentinel check in PR #472, so the Lambda is the
+  // sole place that strips this literal. Without the strip, an
+  // operator-pre-created subscription + PLACEHOLDER SSM value would
+  // make the Lambda's reuse path return "PLACEHOLDER" as the secret →
+  // bot would 401 every webhook.
+  it('strips PLACEHOLDER and rotates when an existing sub is found (cold-bootstrap recovery)', async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
+      .resolves({ Parameter: { Value: 'lv_test_key' } })
+      .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
+      .resolves({ Parameter: { Value: 'PLACEHOLDER' } })
+      .on(PutParameterCommand)
+      .resolves({});
+    mockQurlService({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_op_created',
+        url: BASE_EVENT.bridgeUrl,
+        events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_op_created/secret': () => ({
+        body: { data: { webhook_id: 'wh_op_created', secret: 'whsec_rotated_strip' } },
+      }),
+    });
+    const result = await handler(BASE_EVENT, CONTEXT);
+    // Critical: rotated, NOT reused — the strip turned PLACEHOLDER
+    // into null, which makes initialIsRealSecret false, which forces
+    // the bootstrap-rotate branch.
+    expect(result.action).toBe('rotated');
+    expect(result.webhookId).toBe('wh_op_created');
+    // Stronger: the SSM-persisted value is the FRESH rotated secret,
+    // not the literal "PLACEHOLDER" we read.
+    const putCalls = ssmMock.commandCalls(PutParameterCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input.Value).toBe('whsec_rotated_strip');
+    expect(putCalls[0].args[0].input.Value).not.toBe('PLACEHOLDER');
+    // Defensive: the response body to Terraform doesn't echo the
+    // sentinel either (just in case).
+    expect(JSON.stringify(result)).not.toContain('PLACEHOLDER');
+  });
+
+  it('strips PLACEHOLDER and creates fresh when no existing sub (fresh-env first apply)', async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
+      .resolves({ Parameter: { Value: 'lv_test_key' } })
+      .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
+      .resolves({ Parameter: { Value: 'PLACEHOLDER' } })
+      .on(PutParameterCommand)
+      .resolves({});
+    mockQurlService({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_fresh', secret: 'whsec_created_strip',
+      } } }),
+    });
+    const result = await handler(BASE_EVENT, CONTEXT);
+    expect(result.action).toBe('created');
+    const putCalls = ssmMock.commandCalls(PutParameterCommand);
+    expect(putCalls[0].args[0].input.Value).toBe('whsec_created_strip');
+  });
+});
+
 describe('webhook-registrar Lambda — bootstrap rotate (existing sub, SSM empty)', () => {
   // Path that fires when an operator-or-prior-deploy created the
   // subscription out-of-band but the Lambda hasn't populated the

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -211,7 +211,7 @@ describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel han
   // operator-pre-created subscription + PLACEHOLDER SSM value would
   // make the Lambda's reuse path return "PLACEHOLDER" as the secret →
   // bot would 401 every webhook.
-  it('strips PLACEHOLDER and rotates when an existing sub is found (cold-bootstrap recovery)', async () => {
+  it('strips PLACEHOLDER and rotates when an existing sub is found (post-seed first-apply recovery)', async () => {
     ssmMock
       .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
       .resolves({ Parameter: { Value: 'lv_test_key' } })
@@ -244,6 +244,37 @@ describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel han
     // Defensive: the response body to Terraform doesn't echo the
     // sentinel either (just in case).
     expect(JSON.stringify(result)).not.toContain('PLACEHOLDER');
+  });
+
+  it.each([
+    ['lowercase', 'placeholder'],
+    ['trailing space', 'PLACEHOLDER '],
+    ['leading space', ' PLACEHOLDER'],
+    ['mixed case', 'Placeholder'],
+  ])('does NOT strip case/whitespace variants — %s "%s" is treated as a real secret', async (_label, ssmValue) => {
+    // The strip is an exact-string compare against the
+    // Terraform-emitted literal. Case/whitespace variants are NOT
+    // the Terraform sentinel — they'd indicate operator-set values
+    // and should pass through unchanged (taking the reuse path if
+    // an existing sub matches). This pins the exact-match semantic
+    // so a future "be helpful" refactor (e.g., `.trim().toUpperCase()`)
+    // doesn't broaden the strip to legitimate values.
+    ssmMock
+      .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
+      .resolves({ Parameter: { Value: 'lv_test_key' } })
+      .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
+      .resolves({ Parameter: { Value: ssmValue } });
+    let rotateHit = false;
+    mockQurlService({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_EVENT.bridgeUrl, events: ['qurl.accessed'],
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => { rotateHit = true; return { body: { data: {} } }; },
+    });
+    const result = await handler(BASE_EVENT, CONTEXT);
+    // Reuse path — the variant value passed through as the secret.
+    expect(result.action).toBe('reused');
+    expect(rotateHit).toBe(false);
   });
 
   it('strips PLACEHOLDER and creates fresh when no existing sub (fresh-env first apply)', async () => {

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -263,7 +263,9 @@ describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel han
       .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
       .resolves({ Parameter: { Value: 'lv_test_key' } })
       .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
-      .resolves({ Parameter: { Value: ssmValue } });
+      .resolves({ Parameter: { Value: ssmValue } })
+      .on(PutParameterCommand)
+      .resolves({});
     let rotateHit = false;
     mockQurlService({
       'GET /v1/webhooks': () => ({ body: { data: [{
@@ -275,6 +277,10 @@ describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel han
     // Reuse path — the variant value passed through as the secret.
     expect(result.action).toBe('reused');
     expect(rotateHit).toBe(false);
+    // Explicit no-PutParameter pin: reuse path skips SSM write (the
+    // "skip persist on reused" optimization in the handler). A future
+    // refactor that re-introduces noisy steady-state writes lands here.
+    expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(0);
   });
 
   it('strips PLACEHOLDER and creates fresh when no existing sub (fresh-env first apply)', async () => {

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -251,6 +251,9 @@ describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel han
     ['trailing space', 'PLACEHOLDER '],
     ['leading space', ' PLACEHOLDER'],
     ['mixed case', 'Placeholder'],
+    // Trailing newline — most plausible accidental variant if SSM is
+    // ever populated via shell pipe (`echo PLACEHOLDER | aws ssm ...`).
+    ['trailing newline', 'PLACEHOLDER\n'],
   ])('does NOT strip case/whitespace variants — %s "%s" is treated as a real secret', async (_label, ssmValue) => {
     // The strip is an exact-string compare against the
     // Terraform-emitted literal. Case/whitespace variants are NOT
@@ -263,20 +266,17 @@ describe('webhook-registrar Lambda — Terraform-seeded PLACEHOLDER sentinel han
       .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
       .resolves({ Parameter: { Value: 'lv_test_key' } })
       .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
-      .resolves({ Parameter: { Value: ssmValue } })
-      .on(PutParameterCommand)
-      .resolves({});
-    let rotateHit = false;
+      .resolves({ Parameter: { Value: ssmValue } });
+    // No POST /secret mock — reuse path skips the rotate call entirely.
+    // If a future regression DID hit rotate, the unmocked-fetch error
+    // would catch it loudly.
     mockQurlService({
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing', url: BASE_EVENT.bridgeUrl, events: ['qurl.accessed'],
       }] } }),
-      'POST /v1/webhooks/wh_existing/secret': () => { rotateHit = true; return { body: { data: {} } }; },
     });
     const result = await handler(BASE_EVENT, CONTEXT);
-    // Reuse path — the variant value passed through as the secret.
     expect(result.action).toBe('reused');
-    expect(rotateHit).toBe(false);
     // Explicit no-PutParameter pin: reuse path skips SSM write (the
     // "skip persist on reused" optimization in the handler). A future
     // refactor that re-introduces noisy steady-state writes lands here.


### PR DESCRIPTION
## Summary

Defensive strip of the Terraform-seeded `"PLACEHOLDER"` SSM sentinel in the webhook-registrar Lambda handler, before passing `initialSecret` to the shared registrar library.

## Why

PR #472 dropped the `"PLACEHOLDER"` sentinel check from the bot's receiver (per ops direction "no placeholders"). The companion infra PR ([qurl-integrations-infra#752](https://github.com/layervai/qurl-integrations-infra/pull/752)) still has to seed `aws_ssm_parameter.bot["QURL_WEBHOOK_SECRET"]` with a literal value (`"PLACEHOLDER"`) — SSM `SecureString` doesn't allow empty values, and the ARN must exist before the bot's task-def `secrets[].valueFrom` reference is created.

The Terraform `depends_on = [aws_lambda_invocation.webhook_registrar]` chain on `aws_ecs_service.bot_http` covers the common case: Lambda runs → SSM populated → ECS launches with the real secret. But an edge case lurks:

- Operator manually creates a qurl-service webhook subscription out-of-band (during a manual-recovery → automated-takeover transition)
- SSM still holds `"PLACEHOLDER"` (Lambda hasn't run yet)
- Lambda fires, reads `"PLACEHOLDER"`, `ensureWebhookSubscription` sees `initialIsRealSecret = true` (length > 0), takes the REUSE path, returns `"PLACEHOLDER"` as the secret
- Lambda persists `"PLACEHOLDER"` back to SSM via strict-persist
- Bot tasks read `"PLACEHOLDER"` from env and verify webhooks against it — every inbound 401s

## Fix

One-line strip at the Lambda's SSM-read site:

```js
const rawSsmSecret = await readSsmSecureString({ ... });
const initialSecret = rawSsmSecret === TERRAFORM_SEEDED_PLACEHOLDER ? null : rawSsmSecret;
```

Sentinel value defined as a top-level `TERRAFORM_SEEDED_PLACEHOLDER` constant for greppability. The shared library stays untouched — `null` makes `initialIsRealSecret` false, forcing the bootstrap-rotate path.

## Tests

2 new Lambda tests (29 → 31):
- `strips PLACEHOLDER and rotates when an existing sub is found (cold-bootstrap recovery)` — explicit assertion that the persisted SSM value is a fresh rotated secret, NOT the literal `"PLACEHOLDER"`.
- `strips PLACEHOLDER and creates fresh when no existing sub (fresh-env first apply)` — confirms strip + create-path interaction.

Full bot suite: 2504 pass. Lint clean.

## Test plan
- [x] `npx jest` — 2504 pass
- [x] Lint clean
- [ ] Sandbox: after qurl-integrations-infra#752 applies, the Lambda strip is exercised on `terraform apply` (sandbox SSM already has a real `whsec_*` value from earlier setup, so the strip is a no-op there; the rotation-recovery test path is what matters for prod first-apply)
- [ ] Companion infra PR linked: layervai/qurl-integrations-infra#752

🤖 Generated with [Claude Code](https://claude.com/claude-code)