### PR TITLE
feat(discord): add SQS view-update push for sub-second view counter

### DIFF
--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -90,6 +90,14 @@ function missingEventShipperKeys(cfg) {
 // event silently (publisher) or throw at start() (consumer); the
 // uniform boot-time check makes the failure mode loud and consistent
 // with the existing event-shipper gate.
+//
+// Intentionally no combined-mode rejector (no analog of
+// unsupportedRoleShipperCombo). The registry's silent-drop-on-miss +
+// status==='opened' idempotency guard make combined-mode safe: a
+// duplicate dispatch within one process is a no-op at the handler
+// layer. Pinned by tests/boot-requirements.test.js's absence
+// assertion — a copy-paste-from-shipper refactor that adds a
+// rejector would fail that test.
 function missingViewUpdatePushKeys(cfg) {
   if (!cfg.ENABLE_VIEW_UPDATE_PUSH) return [];
   return cfg.QURL_BOT_VIEW_UPDATES_QUEUE_URL ? [] : ['QURL_BOT_VIEW_UPDATES_QUEUE_URL'];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -84,6 +84,17 @@ function missingEventShipperKeys(cfg) {
   return cfg.QURL_BOT_EVENTS_QUEUE_URL ? [] : ['QURL_BOT_EVENTS_QUEUE_URL'];
 }
 
+// View-update push (feat #60). Mirrors missingEventShipperKeys: when
+// ENABLE_VIEW_UPDATE_PUSH=true, QURL_BOT_VIEW_UPDATES_QUEUE_URL is
+// required. A misconfigured deploy would otherwise drop every view
+// event silently (publisher) or throw at start() (consumer); the
+// uniform boot-time check makes the failure mode loud and consistent
+// with the existing event-shipper gate.
+function missingViewUpdatePushKeys(cfg) {
+  if (!cfg.ENABLE_VIEW_UPDATE_PUSH) return [];
+  return cfg.QURL_BOT_VIEW_UPDATES_QUEUE_URL ? [] : ['QURL_BOT_VIEW_UPDATES_QUEUE_URL'];
+}
+
 // PROCESS_ROLE=combined paired with ENABLE_EVENT_SHIPPER=true is
 // unsupported and rejected at boot. In combined mode both `isGateway`
 // and `isHttp` evaluate true, which derives `isWorker=true`, which
@@ -418,6 +429,7 @@ module.exports = {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  missingViewUpdatePushKeys,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
   unsupportedRoleHotStandbyCombo,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1198,8 +1198,13 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     },
     logger,
   });
+  // Hoist the flag read once per monitor — registerViewUpdateFor
+  // is called up to QURL_SEND_MAX_RECIPIENTS times (50 today) on
+  // construction + once per /qurl add. Re-reading config on every
+  // call is negligible but the hoist reads cleaner.
+  const viewUpdatePushEnabled = config.ENABLE_VIEW_UPDATE_PUSH;
   function registerViewUpdateFor(qurlId) {
-    if (!config.ENABLE_VIEW_UPDATE_PUSH) return;
+    if (!viewUpdatePushEnabled) return;
     viewUpdateRegistry.register(qurlId, handleViewUpdate);
   }
   for (const qurlId of trackedQurlIds) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1206,6 +1206,11 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     viewUpdateRegistry.register(qurlId, handleViewUpdate);
     viewUpdateRegisteredQurlIds.push(qurlId);
   }
+  // Registration happens BEFORE `let viewed = 0;` (and the rest of the
+  // monitor setup) declares its closure state further down. Safe
+  // because `handleViewUpdate` only fires async — it can't be invoked
+  // synchronously from this loop, so by the time any SQS message
+  // dispatches into it the entire monitorLinkStatus body has run.
   for (const qurlId of trackedQurlIds) {
     registerViewUpdateFor(qurlId);
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1157,10 +1157,14 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 
   // `viewed` and `allDone` declared up-front (vs at their original
   // mid-monitor positions) so the createHandleViewUpdate factory
-  // closes over them directly. Without this, the factory was capturing
-  // pre-initialization variables — safe in practice (callbacks fire
-  // async) but a future refactor that called the handler synchronously
-  // would surface as a ReferenceError. Move-up eliminates the footgun.
+  // closes over the live binding. With `let`, the binding exists at
+  // function entry but throws TDZ on synchronous access before the
+  // initializer line runs. The previous arrangement was safe only
+  // because the handler's getViewed/setViewed/buildStatusMsg
+  // closures all execute asynchronously (after the `let viewed = 0`
+  // line runs); a future refactor that called the handler
+  // synchronously would surface as ReferenceError. Move-up eliminates
+  // the footgun.
   let viewed = 0;
   let allDone = false;
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1155,17 +1155,10 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     });
   }
 
-  // `viewed` and `allDone` declared up-front (vs at their original
-  // mid-monitor positions) so the createHandleViewUpdate factory
-  // closes over the live binding. With `let`, the binding exists at
-  // function entry but throws TDZ on synchronous access before the
-  // initializer line runs. The previous arrangement was safe only
-  // because the handler's getViewed/setViewed closures execute
-  // asynchronously (after the `let viewed = 0` line runs); a future
-  // refactor that called the handler synchronously would surface as
-  // ReferenceError. Move-up eliminates the footgun. (buildStatusMsg
-  // is a function declaration — hoisted, so unaffected; the TDZ
-  // risk lives only on the `let` bindings.)
+  // Hoisted so the createHandleViewUpdate factory closes over the
+  // live `let` binding rather than a pre-initialized TDZ slot — a
+  // future synchronous-handler refactor would otherwise hit
+  // ReferenceError on getViewed/setViewed.
   let viewed = 0;
   let allDone = false;
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1222,7 +1222,7 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       // callbacks against the registry — the latter wouldn't be
       // unregistered (stop() has already iterated trackedQurlIds),
       // pinning the closure (linkStatus + safeEdit) until process
-      // restart (cr round-8 #2). Pre-#60 fields (expectedCount,
+      // restart. Pre-#60 fields (expectedCount,
       // linkStatus) also leaked into a dead monitor; this guard
       // closes both the new + pre-existing leak surfaces.
       if (stopped) return;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1155,6 +1155,15 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     });
   }
 
+  // `viewed` and `allDone` declared up-front (vs at their original
+  // mid-monitor positions) so the createHandleViewUpdate factory
+  // closes over them directly. Without this, the factory was capturing
+  // pre-initialization variables — safe in practice (callbacks fire
+  // async) but a future refactor that called the handler synchronously
+  // would surface as a ReferenceError. Move-up eliminates the footgun.
+  let viewed = 0;
+  let allDone = false;
+
   // View-update push (feat #60). Shared callback per monitor —
   // registered against every tracked qurl_id; render goes through
   // linkStatus mutation + safeEdit (NOT runTick) to avoid the
@@ -1185,8 +1194,6 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     viewUpdateRegistry.register(qurlId, handleViewUpdate);
     viewUpdateRegisteredQurlIds.push(qurlId);
   }
-  // Registration pre-dates `let viewed = 0` further down; safe because
-  // the callback only fires async (after monitorLinkStatus returns).
   for (const qurlId of trackedQurlIds) {
     registerViewUpdateFor(qurlId);
   }
@@ -1195,7 +1202,10 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // generation advanced must skip its render — the views map was built
   // against the pre-add tracked set and could under-report.
   let trackingGeneration = 0;
-  let allDone = false;
+  // `allDone` already declared above the createHandleViewUpdate factory
+  // call (the factory's onAllDone closure references it). Kept here as
+  // a no-op marker comment — there was a `let allDone = false;` here
+  // pre-#60.
 
   const control = {
     // newLinks: Array<{qurlId, username}> aligned per-recipient. Must
@@ -1310,10 +1320,11 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     await interaction.editReply(payload).catch(logIgnoredDiscordErr);
   }
 
-  // `viewed` counter is closure-tracked so we don't re-walk linkStatus
-  // on each render. Incremented when a link flips pending → opened in
-  // runTick; never decreases.
-  let viewed = 0;
+  // `viewed` already declared above the createHandleViewUpdate factory
+  // call so the factory closes over the live binding. Closure-tracked
+  // so we don't re-walk linkStatus on each render; incremented when a
+  // link flips pending → opened in either runTick OR the view-update
+  // handler; never decreases.
 
   // No explicit `expired` state in the rendered counter: qurl.accessed
   // is the only event we receive, and the 1h monitor cap covers the

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1205,10 +1205,6 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // generation advanced must skip its render — the views map was built
   // against the pre-add tracked set and could under-report.
   let trackingGeneration = 0;
-  // `allDone` already declared above the createHandleViewUpdate factory
-  // call (the factory's onAllDone closure references it). Kept here as
-  // a no-op marker comment — there was a `let allDone = false;` here
-  // pre-#60.
 
   const control = {
     // newLinks: Array<{qurlId, username}> aligned per-recipient. Must

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -19,6 +19,7 @@ const crypto = require('crypto');
 const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
+const viewUpdateRegistry = require('./view-update-registry');
 const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, DISCORD_MEMBERS_PAGE_SIZE, PREWARM_MAX_PAGES, UNLINKED_CACHE_COMPLETENESS_THRESHOLD, AUDIT_EVENTS, TRUST } = require('./constants');
 const {
   expiryToISO,
@@ -1153,6 +1154,39 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     });
   }
 
+  // View-update push registration (feat #60). Each tracked qurl_id
+  // registers a callback that triggers a runTick when a view event
+  // arrives via SQS — sub-second latency on the half of events that
+  // land on this replica (see view-update-registry.js's SILENT DROP
+  // doc). The polling setInterval remains the correctness primitive;
+  // this is purely a latency optimization.
+  //
+  // Callback closes over `runTick` (defined further down — same
+  // function body so closure capture is fine; the callback only fires
+  // after monitorLinkStatus returns and runTick is in scope) and
+  // `stopped` (gated so a SIGTERM-during-flight delivery is a no-op).
+  //
+  // GC: callbacks pin closure state (linkStatus, runTick) until
+  // unregistered. stop() below must drain this list — mirrors the
+  // closure-mutable-rebind discipline for interaction/qurlLinks.
+  const viewUpdateCallbacks = []; // [{qurlId, cb}, ...]
+  function registerViewUpdateFor(qurlId) {
+    if (!config.ENABLE_VIEW_UPDATE_PUSH) return;
+    const cb = () => {
+      if (stopped) return;
+      runTick().catch((err) => {
+        logger.warn('view-update-triggered runTick failed', {
+          sendId, qurl_id: qurlId, error: err.message,
+        });
+      });
+    };
+    viewUpdateRegistry.register(qurlId, cb);
+    viewUpdateCallbacks.push({ qurlId, cb });
+  }
+  for (const qurlId of trackedQurlIds) {
+    registerViewUpdateFor(qurlId);
+  }
+
   // Bumped by addRecipients. A tick whose getQurlViews resolves after
   // generation advanced must skip its render — the views map was built
   // against the pre-add tracked set and could under-report.
@@ -1183,6 +1217,12 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
           if (!trackedQurlIds.has(qid)) {
             trackedQurlIds.add(qid);
             linkStatus.set(qid, { status: 'pending', username: item.username || 'unknown' });
+            // Register the new qurl_id for view-update push (feat #60).
+            // Symmetric with the construction-time loop above — the
+            // tracked set and the registry must extend together or the
+            // new recipients never get sub-second updates (the polling
+            // path catches them on the next interval regardless).
+            registerViewUpdateFor(qid);
           }
         }
       }
@@ -1216,6 +1256,15 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       stopped = true;
       clearInterval(timer);
       activeMonitors.delete(control);
+      // Unregister every view-update callback so the registry doesn't
+      // pin this monitor's closure state past stop() (feat #60).
+      // Load-bearing: a long-running monitor that never unregisters
+      // would otherwise hold linkStatus + runTick references via the
+      // callback closure until process restart.
+      for (const { qurlId, cb } of viewUpdateCallbacks) {
+        viewUpdateRegistry.unregister(qurlId, cb);
+      }
+      viewUpdateCallbacks.length = 0;
       linkStatus.clear();
       trackedQurlIds.clear();
       interaction = null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1170,7 +1170,11 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // per-event DDB BatchGet. Polling tick remains the correctness
   // primitive. Handler factory in view-update-handler.js so the
   // state matrix is unit-testable without a full monitor closure.
-  const viewUpdateRegisteredQurlIds = [];
+  //
+  // Unregister at stop() iterates `trackedQurlIds` directly (set
+  // cleared AFTER the unregister loop). Registry.unregister is a
+  // no-op for keys never registered (e.g. when the flag is off), so
+  // iterating the superset is safe.
   const handleViewUpdate = createHandleViewUpdate({
     sendId,
     linkStatus,
@@ -1192,7 +1196,6 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   function registerViewUpdateFor(qurlId) {
     if (!config.ENABLE_VIEW_UPDATE_PUSH) return;
     viewUpdateRegistry.register(qurlId, handleViewUpdate);
-    viewUpdateRegisteredQurlIds.push(qurlId);
   }
   for (const qurlId of trackedQurlIds) {
     registerViewUpdateFor(qurlId);
@@ -1275,10 +1278,11 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       // stop() (feat #60). Load-bearing: a long-running monitor that
       // never unregisters would otherwise hold linkStatus + safeEdit
       // references via the shared closure until process restart.
-      for (const qurlId of viewUpdateRegisteredQurlIds) {
+      // Iterates trackedQurlIds directly (no parallel bookkeeping
+      // array) — set cleared in the next two lines, so order matters.
+      for (const qurlId of trackedQurlIds) {
         viewUpdateRegistry.unregister(qurlId, handleViewUpdate);
       }
-      viewUpdateRegisteredQurlIds.length = 0;
       linkStatus.clear();
       trackedQurlIds.clear();
       interaction = null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1160,11 +1160,12 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // closes over the live binding. With `let`, the binding exists at
   // function entry but throws TDZ on synchronous access before the
   // initializer line runs. The previous arrangement was safe only
-  // because the handler's getViewed/setViewed/buildStatusMsg
-  // closures all execute asynchronously (after the `let viewed = 0`
-  // line runs); a future refactor that called the handler
-  // synchronously would surface as ReferenceError. Move-up eliminates
-  // the footgun.
+  // because the handler's getViewed/setViewed closures execute
+  // asynchronously (after the `let viewed = 0` line runs); a future
+  // refactor that called the handler synchronously would surface as
+  // ReferenceError. Move-up eliminates the footgun. (buildStatusMsg
+  // is a function declaration — hoisted, so unaffected; the TDZ
+  // risk lives only on the `let` bindings.)
   let viewed = 0;
   let allDone = false;
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1154,34 +1154,57 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     });
   }
 
-  // View-update push registration (feat #60). Each tracked qurl_id
-  // registers a callback that triggers a runTick when a view event
-  // arrives via SQS — sub-second latency on the half of events that
-  // land on this replica (see view-update-registry.js's SILENT DROP
-  // doc). The polling setInterval remains the correctness primitive;
-  // this is purely a latency optimization.
+  // View-update push registration (feat #60). One SHARED callback
+  // registers against every tracked qurl_id — the callback uses the
+  // qurlId it's invoked with (registry passes it as the second arg)
+  // to look up the per-recipient linkStatus row directly.
   //
-  // Callback closes over `runTick` (defined further down — same
-  // function body so closure capture is fine; the callback only fires
-  // after monitorLinkStatus returns and runTick is in scope) and
-  // `stopped` (gated so a SIGTERM-during-flight delivery is a no-op).
+  // Shared-callback shape (vs. per-id closures) collapses the 50-
+  // closure footprint of a max-recipients send to one. The registry
+  // still keys by qurl_id so dispatch lookup stays O(1).
   //
-  // GC: callbacks pin closure state (linkStatus, runTick) until
-  // unregistered. stop() below must drain this list — mirrors the
-  // closure-mutable-rebind discipline for interaction/qurlLinks.
-  const viewUpdateCallbacks = []; // [{qurlId, cb}, ...]
+  // Render path is envelope-driven (NOT runTick). The envelope already
+  // carries access_count + consumed; mutating linkStatus directly and
+  // calling safeEdit avoids the DDB BatchGet that runTick would do
+  // on every view event (would be O(tracked_qurl_ids) per event —
+  // 50× amplification on a max-recipients send). The polling tick in
+  // runTick remains the correctness primitive: any push that this
+  // path drops (silent-drop-on-miss, transient consumer error) is
+  // reconciled on the next interval via DDB.
+  //
+  // Concurrency with runTick: the `status === 'opened' continue`
+  // guard at the linkStatus mutation site is the same protection
+  // runTick uses (commands.js, runTick render path). Two paths
+  // can't double-flip the same qurl_id; `viewed` never regresses.
+  //
+  // GC: the shared callback pins closure state (linkStatus, safeEdit,
+  // viewed) until unregistered. stop() below must drain the registry
+  // keys this monitor registered against — mirrors the closure-mutable-
+  // rebind discipline for interaction/qurlLinks.
+  const viewUpdateRegisteredQurlIds = [];
+  function handleViewUpdate(update, qurlId) {
+    if (stopped) return;
+    if (viewCounterDegraded) return; // degraded monitor doesn't render counter
+    if (!(update && update.accessCount > 0)) return;
+    const current = linkStatus.get(qurlId);
+    if (!current || current.status === 'opened') return;
+    linkStatus.set(qurlId, { ...current, status: 'opened' });
+    viewed++;
+    if (!interaction) return;
+    const pending = Math.max(0, expectedCount - viewed);
+    safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] })
+      .catch((err) => {
+        logger.warn('view-update render failed', { sendId, qurl_id: qurlId, error: err.message });
+      });
+    if (pending === 0) {
+      allDone = true;
+      clearInterval(timer);
+    }
+  }
   function registerViewUpdateFor(qurlId) {
     if (!config.ENABLE_VIEW_UPDATE_PUSH) return;
-    const cb = () => {
-      if (stopped) return;
-      runTick().catch((err) => {
-        logger.warn('view-update-triggered runTick failed', {
-          sendId, qurl_id: qurlId, error: err.message,
-        });
-      });
-    };
-    viewUpdateRegistry.register(qurlId, cb);
-    viewUpdateCallbacks.push({ qurlId, cb });
+    viewUpdateRegistry.register(qurlId, handleViewUpdate);
+    viewUpdateRegisteredQurlIds.push(qurlId);
   }
   for (const qurlId of trackedQurlIds) {
     registerViewUpdateFor(qurlId);
@@ -1256,15 +1279,15 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
       stopped = true;
       clearInterval(timer);
       activeMonitors.delete(control);
-      // Unregister every view-update callback so the registry doesn't
-      // pin this monitor's closure state past stop() (feat #60).
-      // Load-bearing: a long-running monitor that never unregisters
-      // would otherwise hold linkStatus + runTick references via the
-      // callback closure until process restart.
-      for (const { qurlId, cb } of viewUpdateCallbacks) {
-        viewUpdateRegistry.unregister(qurlId, cb);
+      // Unregister the shared callback from every tracked qurl_id so
+      // the registry doesn't pin this monitor's closure state past
+      // stop() (feat #60). Load-bearing: a long-running monitor that
+      // never unregisters would otherwise hold linkStatus + safeEdit
+      // references via the shared closure until process restart.
+      for (const qurlId of viewUpdateRegisteredQurlIds) {
+        viewUpdateRegistry.unregister(qurlId, handleViewUpdate);
       }
-      viewUpdateCallbacks.length = 0;
+      viewUpdateRegisteredQurlIds.length = 0;
       linkStatus.clear();
       trackedQurlIds.clear();
       interaction = null;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1216,6 +1216,16 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     // the tracked set means runTick's view-flip lookup misses the new
     // qurl_ids and the counter never advances for /qurl add recipients.
     addRecipients(count, newLinks) {
+      // Early-out if this monitor has already been stopped. Without
+      // this guard a post-stop addRecipients call would extend
+      // expectedCount, linkStatus, AND register new view-update
+      // callbacks against the registry — the latter wouldn't be
+      // unregistered (stop() has already iterated trackedQurlIds),
+      // pinning the closure (linkStatus + safeEdit) until process
+      // restart (cr round-8 #2). Pre-#60 fields (expectedCount,
+      // linkStatus) also leaked into a dead monitor; this guard
+      // closes both the new + pre-existing leak surfaces.
+      if (stopped) return;
       expectedCount += count;
       if (Array.isArray(newLinks)) {
         for (const item of newLinks) {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -20,6 +20,7 @@ const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
 const viewUpdateRegistry = require('./view-update-registry');
+const { createHandleViewUpdate } = require('./view-update-handler');
 const { COLORS, TIMEOUTS, RESOURCE_TYPES, DM_STATUS, MAX_FILE_SIZE, MAX_CONCURRENT_MONITORS, DISCORD_MEMBERS_PAGE_SIZE, PREWARM_MAX_PAGES, UNLINKED_CACHE_COMPLETENESS_THRESHOLD, AUDIT_EVENTS, TRUST } = require('./constants');
 const {
   expiryToISO,
@@ -1154,63 +1155,38 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     });
   }
 
-  // View-update push registration (feat #60). One SHARED callback
-  // registers against every tracked qurl_id — the callback uses the
-  // qurlId it's invoked with (registry passes it as the second arg)
-  // to look up the per-recipient linkStatus row directly.
-  //
-  // Shared-callback shape (vs. per-id closures) collapses the 50-
-  // closure footprint of a max-recipients send to one. The registry
-  // still keys by qurl_id so dispatch lookup stays O(1).
-  //
-  // Render path is envelope-driven (NOT runTick). The envelope already
-  // carries access_count + consumed; mutating linkStatus directly and
-  // calling safeEdit avoids the DDB BatchGet that runTick would do
-  // on every view event (would be O(tracked_qurl_ids) per event —
-  // 50× amplification on a max-recipients send). The polling tick in
-  // runTick remains the correctness primitive: any push that this
-  // path drops (silent-drop-on-miss, transient consumer error) is
-  // reconciled on the next interval via DDB.
-  //
-  // Concurrency with runTick: the `status === 'opened' continue`
-  // guard at the linkStatus mutation site is the same protection
-  // runTick uses (commands.js, runTick render path). Two paths
-  // can't double-flip the same qurl_id; `viewed` never regresses.
-  //
-  // GC: the shared callback pins closure state (linkStatus, safeEdit,
-  // viewed) until unregistered. stop() below must drain the registry
-  // keys this monitor registered against — mirrors the closure-mutable-
-  // rebind discipline for interaction/qurlLinks.
+  // View-update push (feat #60). Shared callback per monitor —
+  // registered against every tracked qurl_id; render goes through
+  // linkStatus mutation + safeEdit (NOT runTick) to avoid the
+  // per-event DDB BatchGet. Polling tick remains the correctness
+  // primitive. Handler factory in view-update-handler.js so the
+  // state matrix is unit-testable without a full monitor closure.
   const viewUpdateRegisteredQurlIds = [];
-  function handleViewUpdate(update, qurlId) {
-    if (stopped) return;
-    if (viewCounterDegraded) return; // degraded monitor doesn't render counter
-    if (!(update && update.accessCount > 0)) return;
-    const current = linkStatus.get(qurlId);
-    if (!current || current.status === 'opened') return;
-    linkStatus.set(qurlId, { ...current, status: 'opened' });
-    viewed++;
-    if (!interaction) return;
-    const pending = Math.max(0, expectedCount - viewed);
-    safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] })
-      .catch((err) => {
-        logger.warn('view-update render failed', { sendId, qurl_id: qurlId, error: err.message });
-      });
-    if (pending === 0) {
+  const handleViewUpdate = createHandleViewUpdate({
+    sendId,
+    linkStatus,
+    getButtonRow: () => buttonRow,
+    isStopped: () => stopped,
+    isViewCounterDegraded: () => viewCounterDegraded,
+    hasInteraction: () => !!interaction,
+    getViewed: () => viewed,
+    setViewed: (n) => { viewed = n; },
+    getExpectedCount: () => expectedCount,
+    buildStatusMsg,
+    safeEdit,
+    onAllDone: () => {
       allDone = true;
       clearInterval(timer);
-    }
-  }
+    },
+    logger,
+  });
   function registerViewUpdateFor(qurlId) {
     if (!config.ENABLE_VIEW_UPDATE_PUSH) return;
     viewUpdateRegistry.register(qurlId, handleViewUpdate);
     viewUpdateRegisteredQurlIds.push(qurlId);
   }
-  // Registration happens BEFORE `let viewed = 0;` (and the rest of the
-  // monitor setup) declares its closure state further down. Safe
-  // because `handleViewUpdate` only fires async — it can't be invoked
-  // synchronously from this loop, so by the time any SQS message
-  // dispatches into it the entire monitorLinkStatus body has run.
+  // Registration pre-dates `let viewed = 0` further down; safe because
+  // the callback only fires async (after monitorLinkStatus returns).
   for (const qurlId of trackedQurlIds) {
     registerViewUpdateFor(qurlId);
   }

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -638,6 +638,23 @@ module.exports = {
   // the producer side.
   QURL_BOT_EVENTS_QUEUE_URL: process.env.QURL_BOT_EVENTS_QUEUE_URL,
 
+  // View-update push (feat #60, sub-second view counter). When true,
+  // qurl-webhook.js publishes view events to a separate SQS queue
+  // after a successful recordQurlView; the worker tier drains the
+  // queue and dispatches into the process-local view-update-registry
+  // for live monitorLinkStatus instances. The polling fallback in
+  // commands.js stays as the correctness primitive — this flag gates
+  // ONLY the latency-optimization path. Default false so a deploy
+  // without the flag behaves identically to the legacy polling shape.
+  // Must be the literal string "true" (same parsing posture as
+  // ENABLE_EVENT_SHIPPER) so an env-var typo can't flip prod.
+  ENABLE_VIEW_UPDATE_PUSH: process.env.ENABLE_VIEW_UPDATE_PUSH === 'true',
+
+  // SQS Standard queue for view updates (separate from
+  // QURL_BOT_EVENTS_QUEUE_URL, which carries Discord interactions).
+  // Required when ENABLE_VIEW_UPDATE_PUSH=true.
+  QURL_BOT_VIEW_UPDATES_QUEUE_URL: process.env.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+
   // Backpressure cap for the event consumer's in-flight handler
   // tracker (see src/event-consumer.js module header). Read here
   // instead of in event-consumer.js so the value goes through the

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -640,9 +640,10 @@ module.exports = {
 
   // View-update push (feat #60, sub-second view counter). When true,
   // qurl-webhook.js publishes view events to a separate SQS queue
-  // after a successful recordQurlView; the worker tier drains the
-  // queue and dispatches into the process-local view-update-registry
-  // for live monitorLinkStatus instances. The polling fallback in
+  // after a successful recordQurlView; the HTTP tier (same process
+  // that owns the webhook receiver and the live monitorLinkStatus
+  // instances) drains the queue and dispatches into the process-
+  // local view-update-registry. The polling fallback in
   // commands.js stays as the correctness primitive — this flag gates
   // ONLY the latency-optimization path. Default false so a deploy
   // without the flag behaves identically to the legacy polling shape.

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -477,6 +477,12 @@ const GATEWAY_DISPATCH_TYPES = Object.freeze({
 // alarm filter the other two sites still emit.
 const LOG_KINDS = Object.freeze({
   UNHANDLED_REJECTION: 'unhandledRejection',
+  // Separate kind for view-update publish/dispatch failures (feat #60).
+  // Decoupled from UNHANDLED_REJECTION so CloudWatch alarm filters
+  // targeting interaction-loss (event-shipper + global unhandled-
+  // rejection paths) don't page on view-update failures — those are
+  // covered by the polling-tick fallback at the render layer.
+  VIEW_UPDATE_PUBLISH_FAIL: 'viewUpdatePublishFail',
 });
 
 module.exports = {

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -722,11 +722,11 @@ async function gracefulShutdown(code = 0) {
     // at boot), so the sequencing matters only as documentation.
     await eventPublisher.stop();
     // View-update plumbing drain (feat #60). Same idempotent shape;
-    // unconditional. Consumer first so an in-flight pollOnce dispatches
-    // its current batch (and DeleteMessage's them) before we stop
-    // accepting new sends. The publisher's drain catches any view
-    // events that landed on the HTTP receiver during the
-    // eventConsumer.stop() await above.
+    // unconditional. Consumer first: stop() aborts the in-flight
+    // ReceiveMessage long-poll (via AbortController) so no NEW
+    // batches start; whatever was mid-processMessage at the time
+    // unwinds via its outer for-loop. The publisher's drain catches
+    // any view events the HTTP receiver pushed in the same window.
     await viewUpdateConsumer.stop();
     await viewUpdatePublisher.stop();
     // Periodic REST refreshCache in http-only mode is .unref()ed so it
@@ -1206,27 +1206,18 @@ async function start() {
 
   // View-update SQS plumbing (feat #60, sub-second view counter).
   // Independent of the event-shipper gates above; gated only on
-  // `config.ENABLE_VIEW_UPDATE_PUSH`. Publisher runs in any process
-  // whose tier might receive the webhook (HTTP listener — combined
-  // or http role). Consumer runs in any process whose tier might
-  // own a live monitorLinkStatus (combined or worker). Same
-  // shutdown-race guard as the event-shipper sibling above.
+  // `config.ENABLE_VIEW_UPDATE_PUSH` AND `isHttp` (the tier that
+  // owns BOTH the webhook receiver — publisher — and the
+  // monitorLinkStatus instances — consumer). Same shutdown-race
+  // guard as the event-shipper sibling above.
   //
   // Combined mode is intentionally NOT rejected here (unlike
   // ENABLE_EVENT_SHIPPER): the registry's silent-drop-on-miss is
   // idempotent — a duplicate dispatch in a combined process is a
   // no-op at the monitor render layer.
-  if (config.ENABLE_VIEW_UPDATE_PUSH && !isShuttingDown) {
-    if (isHttp) {
-      viewUpdatePublisher.start();
-    }
-    // isWorker || combined-with-monitors: combined is `isGateway &&
-    // isHttp`, both of which can own a monitor. Worker is `isHttp
-    // && config.ENABLE_EVENT_SHIPPER`, which is a strict subset of
-    // isHttp — so isHttp covers both consumer-eligible tiers.
-    if (isHttp) {
-      viewUpdateConsumer.start({ onFatal: () => gracefulShutdown(1) });
-    }
+  if (config.ENABLE_VIEW_UPDATE_PUSH && isHttp && !isShuttingDown) {
+    viewUpdatePublisher.start();
+    viewUpdateConsumer.start({ onFatal: () => gracefulShutdown(1) });
   }
 
   // Open the Discord gateway WebSocket. Two disjoint paths:

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1212,9 +1212,12 @@ async function start() {
   // guard as the event-shipper sibling above.
   //
   // Combined mode is intentionally NOT rejected here (unlike
-  // ENABLE_EVENT_SHIPPER): the registry's silent-drop-on-miss is
-  // idempotent — a duplicate dispatch in a combined process is a
-  // no-op at the monitor render layer.
+  // ENABLE_EVENT_SHIPPER): there's no in-process direct-dispatch
+  // path competing with the SQS round-trip — both paths converge
+  // in consumer → registry → monitor. Combined mode just means
+  // the publisher and consumer live in the same process; messages
+  // still round-trip through SQS, and registry dispatch + status
+  // === 'opened' guards handle any race or redelivery.
   if (config.ENABLE_VIEW_UPDATE_PUSH && isHttp && !isShuttingDown) {
     viewUpdatePublisher.start();
     viewUpdateConsumer.start({ onFatal: () => gracefulShutdown(1) });

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -722,13 +722,17 @@ async function gracefulShutdown(code = 0) {
     // at boot), so the sequencing matters only as documentation.
     await eventPublisher.stop();
     // View-update plumbing drain (feat #60). Same idempotent shape;
-    // unconditional. Consumer first: stop() aborts the in-flight
-    // ReceiveMessage long-poll (via AbortController) so no NEW
-    // batches start; whatever was mid-processMessage at the time
-    // unwinds via its outer for-loop. The publisher's drain catches
-    // any view events the HTTP receiver pushed in the same window.
-    await viewUpdateConsumer.stop();
-    await viewUpdatePublisher.stop();
+    // unconditional. Consumer + publisher are stopped in parallel
+    // via Promise.all so the combined drain stays within the
+    // gracefulShutdown 10s budget — sequencing each module's
+    // DRAIN_DEADLINE_MS (3s each) plus the event-shipper drains
+    // above would push worst-case past 10s. Order-independence is
+    // safe: publisher.stop() snapshots inFlightSends; consumer.stop()
+    // aborts the long-poll; neither depends on the other's state.
+    await Promise.all([
+      viewUpdateConsumer.stop(),
+      viewUpdatePublisher.stop(),
+    ]);
     // Periodic REST refreshCache in http-only mode is .unref()ed so it
     // wouldn't block exit on its own, but clearing explicitly keeps
     // shutdown symmetric with the other intervals (server.js, oauth.js

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -33,6 +33,7 @@ const {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  missingViewUpdatePushKeys,
   missingMapCommandKeys,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
@@ -45,6 +46,8 @@ const {
 const { initHttpOnly } = require('./http-only-init');
 const eventConsumer = require('./event-consumer');
 const eventPublisher = require('./event-publisher');
+const viewUpdateConsumer = require('./view-update-consumer');
+const viewUpdatePublisher = require('./view-update-publisher');
 const { LOG_KINDS } = require('./constants');
 
 // Process role — selects which subset of the bot runs in this
@@ -295,6 +298,15 @@ if (process.env.NODE_ENV === 'production') {
 const eventShipperMissing = missingEventShipperKeys(config);
 if (eventShipperMissing.length > 0) {
   logger.error(`ENABLE_EVENT_SHIPPER=true but missing required env vars: ${eventShipperMissing.join(', ')}`);
+  process.exit(1);
+}
+
+// View-update push (feat #60). Same boot-time refusal pattern: if
+// the flag is on but the queue URL is missing, fail closed at boot
+// rather than silently dropping every view event at runtime.
+const viewUpdatePushMissing = missingViewUpdatePushKeys(config);
+if (viewUpdatePushMissing.length > 0) {
+  logger.error(`ENABLE_VIEW_UPDATE_PUSH=true but missing required env vars: ${viewUpdatePushMissing.join(', ')}`);
   process.exit(1);
 }
 
@@ -709,6 +721,14 @@ async function gracefulShutdown(code = 0) {
     // actually running per process (combined + flag-on is rejected
     // at boot), so the sequencing matters only as documentation.
     await eventPublisher.stop();
+    // View-update plumbing drain (feat #60). Same idempotent shape;
+    // unconditional. Consumer first so an in-flight pollOnce dispatches
+    // its current batch (and DeleteMessage's them) before we stop
+    // accepting new sends. The publisher's drain catches any view
+    // events that landed on the HTTP receiver during the
+    // eventConsumer.stop() await above.
+    await viewUpdateConsumer.stop();
+    await viewUpdatePublisher.stop();
     // Periodic REST refreshCache in http-only mode is .unref()ed so it
     // wouldn't block exit on its own, but clearing explicitly keeps
     // shutdown symmetric with the other intervals (server.js, oauth.js
@@ -1182,6 +1202,31 @@ async function start() {
   // Same shutdown-race guard as the consumer above.
   if (isGateway && config.ENABLE_EVENT_SHIPPER && !isShuttingDown) {
     eventPublisher.start();
+  }
+
+  // View-update SQS plumbing (feat #60, sub-second view counter).
+  // Independent of the event-shipper gates above; gated only on
+  // `config.ENABLE_VIEW_UPDATE_PUSH`. Publisher runs in any process
+  // whose tier might receive the webhook (HTTP listener — combined
+  // or http role). Consumer runs in any process whose tier might
+  // own a live monitorLinkStatus (combined or worker). Same
+  // shutdown-race guard as the event-shipper sibling above.
+  //
+  // Combined mode is intentionally NOT rejected here (unlike
+  // ENABLE_EVENT_SHIPPER): the registry's silent-drop-on-miss is
+  // idempotent — a duplicate dispatch in a combined process is a
+  // no-op at the monitor render layer.
+  if (config.ENABLE_VIEW_UPDATE_PUSH && !isShuttingDown) {
+    if (isHttp) {
+      viewUpdatePublisher.start();
+    }
+    // isWorker || combined-with-monitors: combined is `isGateway &&
+    // isHttp`, both of which can own a monitor. Worker is `isHttp
+    // && config.ENABLE_EVENT_SHIPPER`, which is a strict subset of
+    // isHttp — so isHttp covers both consumer-eligible tiers.
+    if (isHttp) {
+      viewUpdateConsumer.start({ onFatal: () => gracefulShutdown(1) });
+    }
   }
 
   // Open the Discord gateway WebSocket. Two disjoint paths:

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -111,8 +111,14 @@ router.post('/qurl', async (req, res) => {
   // (NOT just isFinite + >= 0) catches the float case + the unsafe-
   // int case in one check. Also blocks Number(null)===0 from slipping
   // through, which would otherwise cost a DDB write per such event.
-  if (!Number.isSafeInteger(data.access_count) || data.access_count < 0) {
-    logger.warn('qURL webhook access_count not a non-negative integer', { qurl_id: data.qurl_id, access_count: data.access_count });
+  // Strict positive integer — qurl.accessed events always carry
+  // access_count >= 1 by contract. Reject 0 here (vs accepting 0 +
+  // writing to DDB + publisher dropping at SQS layer) to avoid the
+  // asymmetric log pair where the webhook returns "recorded" and the
+  // view-update-publisher then warns "invalid accessCount" on the
+  // same event. One source of truth at the wire boundary.
+  if (!Number.isSafeInteger(data.access_count) || data.access_count <= 0) {
+    logger.warn('qURL webhook access_count not a positive integer', { qurl_id: data.qurl_id, access_count: data.access_count });
     return res.status(200).json({ status: 'invalid-payload' });
   }
   const accessCount = data.access_count;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -147,7 +147,6 @@ router.post('/qurl', async (req, res) => {
       viewUpdatePublisher.publish({
         qurlId: data.qurl_id,
         accessCount,
-        consumed,
         eventId,
       });
     }

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -17,6 +17,7 @@ const db = require('../store');
 const logger = require('../logger');
 const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS } = require('../constants');
 const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
+const viewUpdatePublisher = require('../view-update-publisher');
 
 const router = express.Router();
 
@@ -130,6 +131,20 @@ router.post('/qurl', async (req, res) => {
     });
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result });
+    // Sub-second view counter (feat #60): publish to SQS only on
+    // result === 'recorded' (a real new view, not a per-event dedup
+    // replay). Fire-and-log — the polling fallback in
+    // monitorLinkStatus catches anything the publisher drops. No
+    // await: the HTTP response must come back to qurl-service
+    // promptly so it doesn't retry on its own.
+    if (result === 'recorded') {
+      viewUpdatePublisher.publish({
+        qurlId: data.qurl_id,
+        accessCount,
+        consumed,
+        eventId,
+      });
+    }
     return res.status(200).json({ status: result });
   } catch (err) {
     // 5xx so qurl-service retries — transient DDB throttle should not

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -194,7 +194,7 @@ function processMessage(message) {
   registry.dispatch(qurlId, {
     accessCount,
     consumed: envelope.consumed === true,
-    // TODO(view-update-dedup): eventId is plumbed end-to-end so a
+    // TODO(view-update-dedup, #476): eventId is plumbed end-to-end so a
     // future dedup layer (in the registry or the monitor's
     // handleViewUpdate) can drop SQS at-least-once duplicates without
     // a wire-shape change. No consumer reads it today — the polling

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -205,7 +205,6 @@ function processMessage(message) {
   }
   registry.dispatch(qurlId, {
     accessCount,
-    consumed: envelope.consumed === true,
     // TODO(view-update-dedup, #476): eventId is plumbed end-to-end so a
     // future dedup layer (in the registry or the monitor's
     // handleViewUpdate) can drop SQS at-least-once duplicates without

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -25,6 +25,16 @@
 // "right" replica picks it up would just re-deliver to the wrong
 // replica on visibility-timeout expiry — the polling fallback covers
 // the miss case correctly.
+//
+// During shutdown: if stop() aborts after processMessage (synchronous,
+// fast) but before deleteMessageBatch lands, the registry has already
+// dispatched but the SQS message will redeliver after visibility
+// timeout. Idempotent dispatch covers correctness (the
+// `status === 'opened'` guard in the handler no-ops the redeliver);
+// operators will see a duplicate access_count dispatch in metrics
+// during the graceful-shutdown window. Acceptable cost — the
+// alternative is awaiting the delete inside the abort signal, which
+// extends shutdown latency past the 10s budget.
 
 const { SQSClient, ReceiveMessageCommand, DeleteMessageBatchCommand } = require('@aws-sdk/client-sqs');
 const config = require('./config');
@@ -165,8 +175,12 @@ function processMessage(message) {
     return;
   }
   const accessCount = envelope.access_count;
-  if (!Number.isSafeInteger(accessCount) || accessCount < 0) {
-    logger.warn('view-update-consumer: envelope access_count not a non-negative safe integer, dropping', {
+  if (!Number.isSafeInteger(accessCount) || accessCount <= 0) {
+    // Tightened from `< 0` to `<= 0` so 0-count envelopes drop at
+    // the parse boundary (matches the handler's `accessCount > 0`
+    // gate). qurl.accessed events always carry `access_count >= 1`,
+    // so a 0 would be a wire-shape regression worth surfacing.
+    logger.warn('view-update-consumer: envelope access_count not a positive safe integer, dropping', {
       qurl_id: qurlId,
       access_count: accessCount,
     });
@@ -309,6 +323,11 @@ module.exports = {
   _test: {
     _setSqsClientForTest,
     _resetStateForTest,
+    // Lets tests drive pollOnce directly without spawning the
+    // background pollLoop via start(). Required by cr round-5 #4 —
+    // pollOnce needs stopController.signal to exist.
+    _setStopControllerForTest: (controller) => { stopController = controller; },
+    _setRunningForTest: (v) => { running = v; },
     pollOnce,
     processMessage,
     isRunning: () => running,

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -271,7 +271,11 @@ function start({ onFatal } = {}) {
 }
 
 async function stop() {
-  if (!running || stopController.signal.aborted) return;
+  // Safe-nav on stopController in case start() partially-initialized
+  // (set running=true then threw before stopController = new ...
+  // landed). Practically impossible since `new AbortController()`
+  // shouldn't throw, but free defense vs. a future refactor.
+  if (!running || stopController?.signal.aborted) return;
   stopController.abort();
   logger.info('view-update-consumer: stopping');
   running = false;

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -262,7 +262,10 @@ async function pollLoop() {
       running = false;
       if (onFatalCb) {
         try {
-          onFatalCb(err);
+          // Await: gracefulShutdown is async, and an unawaited reject
+          // would surface as UnhandledRejection. Sync throw is also
+          // caught (await wraps both shapes).
+          await onFatalCb(err);
         } catch (cbErr) {
           logger.error('view-update-consumer: onFatal callback threw', {
             error: cbErr?.message,
@@ -306,6 +309,14 @@ async function stop() {
   // (set running=true then threw before stopController = new ...
   // landed). Practically impossible since `new AbortController()`
   // shouldn't throw, but free defense vs. a future refactor.
+  //
+  // Contract: if pollLoop's defense-in-depth fatal branch has already
+  // flipped `running = false` (before invoking onFatalCb), this early
+  // return skips the `await loopPromise`. That's correct — the loop
+  // has already returned by the time onFatal → gracefulShutdown → stop
+  // re-enters here, so awaiting loopPromise would be a no-op. Callers
+  // that want a "loop has fully unwound" signal should rely on
+  // running=false (after the early return, it's already false).
   if (!running || stopController?.signal.aborted) return;
   stopController.abort();
   logger.info('view-update-consumer: stopping');

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -1,0 +1,222 @@
+// SQS-driven view-update consumer (feat #60, sub-second view counter).
+// Runs in the worker tier alongside the existing event-consumer. Long-
+// polls the view-updates queue, parses each envelope, and dispatches
+// into the process-local view-update-registry.
+//
+// Pairs with src/view-update-publisher.js. Envelope contract is owned
+// by the publisher's module header; this module MIRRORS it. Any field
+// added on the publisher side must be added here in lockstep or the
+// dispatch-on-missing-field path will silently drop every message.
+//
+// Process-singleton: module-level state. At most one consumer per
+// process. start() is no-op-with-warn on second call.
+//
+// At-least-once delivery semantics: SQS Standard guarantees at-least-
+// once. The dispatch path is idempotent at the view-counter rendering
+// layer — a duplicate dispatch for the same access_count is a no-op in
+// monitorLinkStatus's render logic (it compares against the previously-
+// rendered state). No dedup LRU here; the polling fallback in
+// commands.js's monitorLinkStatus is the authoritative path, and SQS
+// push is a latency optimization on top.
+//
+// DeleteMessage discipline: messages are deleted REGARDLESS of dispatch
+// outcome (hit OR silent-drop-on-miss). Holding a message until the
+// "right" replica picks it up would just re-deliver to the wrong
+// replica on visibility-timeout expiry — the polling fallback covers
+// the miss case correctly.
+
+const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require('@aws-sdk/client-sqs');
+const config = require('./config');
+const logger = require('./logger');
+const registry = require('./view-update-registry');
+
+const RECEIVE_WAIT_SECONDS = 20;
+const MAX_MESSAGES_PER_RECEIVE = 10;
+const RECEIVE_VISIBILITY_SECONDS = 30;
+
+let sqsClient = null;
+let running = false;
+let stopController = null;
+let loopPromise = null;
+let onFatalCb = null;
+
+function _setSqsClientForTest(client) {
+  sqsClient = client;
+}
+
+function createSqsClient() {
+  return new SQSClient({ region: process.env.AWS_REGION || 'us-east-2' });
+}
+
+function isAbortError(err) {
+  return err && (err.name === 'AbortError' || err.code === 'AbortError');
+}
+
+async function deleteMessage(receiptHandle) {
+  try {
+    await sqsClient.send(new DeleteMessageCommand({
+      QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+      ReceiptHandle: receiptHandle,
+    }));
+  } catch (err) {
+    if (isAbortError(err)) return;
+    logger.warn('view-update-consumer: DeleteMessage failed', {
+      error: err.message,
+    });
+  }
+}
+
+// Parse-and-dispatch one SQS message. Always returns; never throws.
+// Caller deletes the message after this returns.
+function processMessage(message) {
+  let envelope;
+  try {
+    envelope = JSON.parse(message.Body);
+  } catch (err) {
+    logger.warn('view-update-consumer: malformed JSON envelope, dropping', {
+      error: err.message,
+      bodyPrefix: typeof message.Body === 'string' ? message.Body.slice(0, 64) : null,
+    });
+    return;
+  }
+  const qurlId = envelope?.qurl_id;
+  if (typeof qurlId !== 'string' || !qurlId) {
+    logger.warn('view-update-consumer: envelope missing qurl_id, dropping');
+    return;
+  }
+  const accessCount = envelope.access_count;
+  if (!Number.isSafeInteger(accessCount) || accessCount < 0) {
+    logger.warn('view-update-consumer: envelope access_count not a non-negative safe integer, dropping', {
+      qurl_id: qurlId,
+      access_count: accessCount,
+    });
+    return;
+  }
+  registry.dispatch(qurlId, {
+    accessCount,
+    consumed: envelope.consumed === true,
+    eventId: typeof envelope.event_id === 'string' ? envelope.event_id : null,
+    publishedAtMs: typeof envelope.published_at_ms === 'number' ? envelope.published_at_ms : null,
+  });
+  // Return whether dispatch hit is intentionally NOT logged here —
+  // the (N-1)/N silent-drop rate would create unbounded log volume
+  // with low signal. The registry exposes _sizeForTest() for tests
+  // to observe hit/miss without log scraping.
+}
+
+async function pollOnce() {
+  let resp;
+  try {
+    resp = await sqsClient.send(new ReceiveMessageCommand({
+      QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+      MaxNumberOfMessages: MAX_MESSAGES_PER_RECEIVE,
+      WaitTimeSeconds: RECEIVE_WAIT_SECONDS,
+      VisibilityTimeout: RECEIVE_VISIBILITY_SECONDS,
+    }), { abortSignal: stopController.signal });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    logger.warn('view-update-consumer: ReceiveMessage failed', {
+      error: err.message,
+    });
+    return;
+  }
+  const messages = resp.Messages || [];
+  for (const message of messages) {
+    processMessage(message);
+    // Delete after processing; sequential awaits keep the in-flight
+    // SDK call count bounded by 1 — at 10 messages × ~10ms each
+    // that's ~100ms total, well inside RECEIVE_VISIBILITY_SECONDS.
+    await deleteMessage(message.ReceiptHandle);
+  }
+}
+
+async function pollLoop() {
+  while (running && !stopController.signal.aborted) {
+    try {
+      await pollOnce();
+    } catch (err) {
+      // pollOnce catches its own errors; this is defense-in-depth
+      // against the truly unexpected (e.g., logger.warn itself
+      // throwing). On a sustained unexpected failure, the loop would
+      // tight-spin — break out to the onFatal handler.
+      logger.error('view-update-consumer: unexpected error in pollOnce', {
+        error: err?.message,
+      });
+      if (onFatalCb) {
+        try {
+          onFatalCb(err);
+        } catch (cbErr) {
+          logger.error('view-update-consumer: onFatal callback threw', {
+            error: cbErr?.message,
+          });
+        }
+      }
+      return;
+    }
+  }
+}
+
+function start({ onFatal } = {}) {
+  if (running) {
+    logger.warn('view-update-consumer: start() called while already running — no-op');
+    return;
+  }
+  if (!config.ENABLE_VIEW_UPDATE_PUSH) {
+    throw new Error('view-update-consumer: start() called with ENABLE_VIEW_UPDATE_PUSH=false');
+  }
+  if (!config.QURL_BOT_VIEW_UPDATES_QUEUE_URL) {
+    throw new Error('view-update-consumer: QURL_BOT_VIEW_UPDATES_QUEUE_URL is not set');
+  }
+  if (!sqsClient) {
+    sqsClient = createSqsClient();
+  }
+  running = true;
+  stopController = new AbortController();
+  onFatalCb = typeof onFatal === 'function' ? onFatal : null;
+  logger.info('view-update-consumer: starting', {
+    queueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+    waitSeconds: RECEIVE_WAIT_SECONDS,
+    visibilitySeconds: RECEIVE_VISIBILITY_SECONDS,
+  });
+  loopPromise = pollLoop().catch((err) => {
+    logger.error('view-update-consumer: poll loop crashed', { error: err?.message });
+  });
+}
+
+async function stop() {
+  if (!running || stopController.signal.aborted) return;
+  stopController.abort();
+  logger.info('view-update-consumer: stopping');
+  running = false;
+  // Await loopPromise so the caller's await-resolution coincides with
+  // the loop having unwound — important for gracefulShutdown
+  // ordering vs. process exit.
+  if (loopPromise) {
+    try {
+      await loopPromise;
+    } catch {
+      // pollLoop's outer .catch already logged.
+    }
+  }
+  logger.info('view-update-consumer: stopped');
+}
+
+function _resetStateForTest() {
+  running = false;
+  sqsClient = null;
+  stopController = null;
+  loopPromise = null;
+  onFatalCb = null;
+}
+
+module.exports = {
+  start,
+  stop,
+  _test: {
+    _setSqsClientForTest,
+    _resetStateForTest,
+    pollOnce,
+    processMessage,
+    isRunning: () => running,
+  },
+};

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -151,6 +151,11 @@ async function deleteMessageBatch(messages) {
       })),
     }), { abortSignal: stopController?.signal });
     if (resp.Failed && resp.Failed.length > 0) {
+      // TODO(view-update-delete-dedup, #475): a sender-fault entry
+      // (e.g. ReceiptHandleIsInvalid) will redeliver until the
+      // message-retention-period expires, re-logging the same error
+      // each pass. If soak logs show repetition, switch to dedup
+      // on f.Code or short-circuit on the non-retriable codes here.
       logger.warn('view-update-consumer: DeleteMessageBatch had partial failures', {
         failed_count: resp.Failed.length,
         errors: resp.Failed.map((f) => ({ id: f.Id, code: f.Code, message: f.Message })),
@@ -324,6 +329,13 @@ async function stop() {
   // re-enters here, so awaiting loopPromise would be a no-op. Callers
   // that want a "loop has fully unwound" signal should rely on
   // running=false (after the early return, it's already false).
+  //
+  // stopController stays unaborted in this path. Harmless because the
+  // old controller has no live listeners post-fatal (the pollLoop's
+  // ReceiveMessage long-poll was synchronously throwing the error
+  // that triggered the fatal path, so the signal binding is moot).
+  // A subsequent start() creates a fresh controller and discards the
+  // stale one to GC.
   if (!running || stopController?.signal.aborted) return;
   stopController.abort();
   logger.info('view-update-consumer: stopping');

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -217,7 +217,7 @@ async function pollOnce() {
       MaxNumberOfMessages: MAX_MESSAGES_PER_RECEIVE,
       WaitTimeSeconds: RECEIVE_WAIT_SECONDS,
       VisibilityTimeout: RECEIVE_VISIBILITY_SECONDS,
-    }), { abortSignal: stopController.signal });
+    }), { abortSignal: stopController?.signal });
   } catch (err) {
     if (isAbortError(err)) return;
     logger.warn('view-update-consumer: ReceiveMessage failed', {
@@ -252,7 +252,7 @@ async function pollLoop() {
         error: err?.message,
       });
       // Flip running=false BEFORE invoking onFatalCb so module state
-      // matches reality (cr round-7 #1). Production wiring always
+      // matches reality. Production wiring always
       // passes onFatal=gracefulShutdown which would call stop() and
       // flip this anyway, but the onFatal contract is documented
       // optional — without this flip, a no-onFatal caller would be
@@ -338,8 +338,9 @@ module.exports = {
     _setSqsClientForTest,
     _resetStateForTest,
     // Lets tests drive pollOnce directly without spawning the
-    // background pollLoop via start(). Required by cr round-5 #4 —
-    // pollOnce needs stopController.signal to exist.
+    // background pollLoop via start(). Required because pollOnce
+    // needs stopController.signal to exist (the abort plumbing for
+    // the long-poll receive).
     _setStopControllerForTest: (controller) => { stopController = controller; },
     _setRunningForTest: (v) => { running = v; },
     pollOnce,

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -43,6 +43,11 @@ const registry = require('./view-update-registry');
 
 const RECEIVE_WAIT_SECONDS = 20;
 const MAX_MESSAGES_PER_RECEIVE = 10;
+// 30s visibility timeout assumes synchronous processMessage (parse +
+// registry.dispatch, no awaits). Worst-case batch of 10 messages at
+// ~ms each is well under budget. If a future change makes
+// processMessage async (e.g., an awaited dedup-LRU lookup against
+// DDB), the 30s budget tightens — revisit this constant.
 const RECEIVE_VISIBILITY_SECONDS = 30;
 // Backoff after a ReceiveMessage error. Without this, a persistent
 // fast-failure mode (IAM denied after credentials rotation, malformed

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -251,6 +251,15 @@ async function pollLoop() {
       logger.error('view-update-consumer: unexpected error in pollOnce', {
         error: err?.message,
       });
+      // Flip running=false BEFORE invoking onFatalCb so module state
+      // matches reality (cr round-7 #1). Production wiring always
+      // passes onFatal=gracefulShutdown which would call stop() and
+      // flip this anyway, but the onFatal contract is documented
+      // optional — without this flip, a no-onFatal caller would be
+      // wedged with isRunning()=true but no actual polling. A
+      // subsequent start() would warn-and-no-op, masking the
+      // failure.
+      running = false;
       if (onFatalCb) {
         try {
           onFatalCb(err);

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -25,7 +25,7 @@
 // replica on visibility-timeout expiry — the polling fallback covers
 // the miss case correctly.
 
-const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require('@aws-sdk/client-sqs');
+const { SQSClient, ReceiveMessageCommand, DeleteMessageBatchCommand } = require('@aws-sdk/client-sqs');
 const config = require('./config');
 const logger = require('./logger');
 const registry = require('./view-update-registry');
@@ -33,6 +33,13 @@ const registry = require('./view-update-registry');
 const RECEIVE_WAIT_SECONDS = 20;
 const MAX_MESSAGES_PER_RECEIVE = 10;
 const RECEIVE_VISIBILITY_SECONDS = 30;
+// Backoff after a ReceiveMessage error. Without this, a persistent
+// fast-failure mode (IAM denied after credentials rotation, malformed
+// QueueUrl, region drift) would spin the loop with zero delay between
+// fails — burns CPU + log volume. 1s matches event-consumer.js's
+// POLL_ERROR_BACKOFF_MS. AbortController short-circuits the sleep so
+// gracefulShutdown still returns in tens of ms.
+const POLL_ERROR_BACKOFF_MS = 1000;
 
 let sqsClient = null;
 let running = false;
@@ -45,22 +52,87 @@ function _setSqsClientForTest(client) {
 }
 
 function createSqsClient() {
-  return new SQSClient({ region: process.env.AWS_REGION || 'us-east-2' });
+  // Same shape as event-publisher.js / event-consumer.js — reject +
+  // throw on missing region. A wrong region surfaces as opaque
+  // ReceiveMessage failures otherwise.
+  const region = (process.env.AWS_REGION ?? '').trim();
+  if (!region) {
+    throw new Error('AWS_REGION is required to use the view-update consumer. Set it in the deployment template (e.g. `us-east-2`).');
+  }
+  return new SQSClient({ region });
 }
 
+// Local abortable sleep — resolves on timeout OR on stopController
+// abort, whichever lands first. Used by pollLoop's error backoff so
+// stop() returns in tens of ms instead of waiting for the backoff.
+// Mirrors event-consumer.js's abortableSleep shape.
+function abortableSleep(ms) {
+  return new Promise((resolve) => {
+    const ctrl = stopController;
+    if (ctrl?.signal.aborted) {
+      resolve();
+      return;
+    }
+    let onAbort;
+    const t = setTimeout(() => {
+      if (ctrl && onAbort) ctrl.signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    t.unref?.();
+    if (ctrl) {
+      onAbort = () => {
+        clearTimeout(t);
+        resolve();
+      };
+      ctrl.signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+// Mirrors event-consumer.js's isAbortError: walks err.cause with a
+// visited-set so cyclic / deeply-wrapped abort chains still match.
+// Both shapes (name + code) cover Node + AWS SDK conventions.
 function isAbortError(err) {
-  return err && (err.name === 'AbortError' || err.code === 'AbortError');
+  const visited = new Set();
+  let current = err;
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    if (current.name === 'AbortError'
+      || current.name === 'CanceledError'
+      || current.code === 'AbortError'
+      || current.code === 'ABORT_ERR') return true;
+    current = current.cause;
+  }
+  return false;
 }
 
-async function deleteMessage(receiptHandle) {
+// Batch-delete up to 10 messages in one SDK round-trip. SQS's
+// DeleteMessageBatch accepts 1–10 entries with caller-supplied Ids
+// (we use the array index as Id — only needs uniqueness within the
+// batch). Failures are reported in `Failed[]` on the response; we
+// log + continue rather than re-delete (the message will redeliver
+// after visibility timeout — and the dispatch path is idempotent,
+// so a redeliver of an already-dispatched event renders the same
+// linkStatus state via the polling fallback at the worst).
+async function deleteMessageBatch(messages) {
+  if (messages.length === 0) return;
   try {
-    await sqsClient.send(new DeleteMessageCommand({
+    const resp = await sqsClient.send(new DeleteMessageBatchCommand({
       QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
-      ReceiptHandle: receiptHandle,
+      Entries: messages.map((m, i) => ({
+        Id: String(i),
+        ReceiptHandle: m.ReceiptHandle,
+      })),
     }));
+    if (resp.Failed && resp.Failed.length > 0) {
+      logger.warn('view-update-consumer: DeleteMessageBatch had partial failures', {
+        failed_count: resp.Failed.length,
+        errors: resp.Failed.map((f) => ({ id: f.Id, code: f.Code, message: f.Message })),
+      });
+    }
   } catch (err) {
     if (isAbortError(err)) return;
-    logger.warn('view-update-consumer: DeleteMessage failed', {
+    logger.warn('view-update-consumer: DeleteMessageBatch failed', {
       error: err.message,
     });
   }
@@ -79,7 +151,11 @@ function processMessage(message) {
     });
     return;
   }
-  const qurlId = envelope?.qurl_id;
+  if (envelope === null || typeof envelope !== 'object') {
+    logger.warn('view-update-consumer: envelope is not an object, dropping');
+    return;
+  }
+  const qurlId = envelope.qurl_id;
   if (typeof qurlId !== 'string' || !qurlId) {
     logger.warn('view-update-consumer: envelope missing qurl_id, dropping');
     return;
@@ -95,6 +171,12 @@ function processMessage(message) {
   registry.dispatch(qurlId, {
     accessCount,
     consumed: envelope.consumed === true,
+    // TODO(view-update-dedup): eventId is plumbed end-to-end so a
+    // future dedup layer (in the registry or the monitor's
+    // handleViewUpdate) can drop SQS at-least-once duplicates without
+    // a wire-shape change. No consumer reads it today — the polling
+    // path's status === 'opened' guard makes per-event dedup
+    // unnecessary for the current render contract.
     eventId: typeof envelope.event_id === 'string' ? envelope.event_id : null,
     publishedAtMs: typeof envelope.published_at_ms === 'number' ? envelope.published_at_ms : null,
   });
@@ -118,16 +200,20 @@ async function pollOnce() {
     logger.warn('view-update-consumer: ReceiveMessage failed', {
       error: err.message,
     });
+    // Back off so a persistent failure (IAM denial, malformed
+    // QueueUrl, region drift) doesn't tight-spin the poll loop.
+    await abortableSleep(POLL_ERROR_BACKOFF_MS);
     return;
   }
   const messages = resp.Messages || [];
   for (const message of messages) {
     processMessage(message);
-    // Delete after processing; sequential awaits keep the in-flight
-    // SDK call count bounded by 1 — at 10 messages × ~10ms each
-    // that's ~100ms total, well inside RECEIVE_VISIBILITY_SECONDS.
-    await deleteMessage(message.ReceiptHandle);
   }
+  // Single batch round-trip for up to 10 deletes vs. sequential
+  // per-message DeleteMessage calls (~10ms each = ~100ms wall-time
+  // for a full batch). Failures inside the batch are logged + ignored;
+  // visibility timeout + idempotent dispatch handle the redelivery.
+  await deleteMessageBatch(messages);
 }
 
 async function pollLoop() {

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -138,6 +138,13 @@ async function deleteMessageBatch(messages) {
     // posture below). Consistency point with the receive path.
     const resp = await sqsClient.send(new DeleteMessageBatchCommand({
       QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+      // Id: the per-batch entry identifier. SQS requires
+      // [a-zA-Z0-9_-]+ and uniqueness within the batch. The array
+      // index satisfies both for 0..MAX_MESSAGES_PER_RECEIVE-1 (=10
+      // max digits, no special chars). A future refactor that
+      // switches to Id: m.MessageId would need to re-derive that
+      // SQS's MessageId pattern (alphanumeric + few specials) is
+      // also batch-Id-safe.
       Entries: messages.map((m, i) => ({
         Id: String(i),
         ReceiptHandle: m.ReceiptHandle,

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -1,7 +1,8 @@
 // SQS-driven view-update consumer (feat #60, sub-second view counter).
-// Runs in the worker tier alongside the existing event-consumer. Long-
-// polls the view-updates queue, parses each envelope, and dispatches
-// into the process-local view-update-registry.
+// Runs in the HTTP tier — same process that owns the webhook receiver
+// (publisher) AND the live monitorLinkStatus instances (dispatch
+// targets). Long-polls the view-updates queue, parses each envelope,
+// and dispatches into the process-local view-update-registry.
 //
 // Pairs with src/view-update-publisher.js. Envelope contract is owned
 // by the publisher's module header; this module MIRRORS it. Any field

--- a/apps/discord/src/view-update-consumer.js
+++ b/apps/discord/src/view-update-consumer.js
@@ -118,13 +118,16 @@ function isAbortError(err) {
 async function deleteMessageBatch(messages) {
   if (messages.length === 0) return;
   try {
+    // Pass abortSignal so a graceful-shutdown that lands mid-delete
+    // returns within tens of ms (matches the ReceiveMessage abort
+    // posture below). Consistency point with the receive path.
     const resp = await sqsClient.send(new DeleteMessageBatchCommand({
       QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
       Entries: messages.map((m, i) => ({
         Id: String(i),
         ReceiptHandle: m.ReceiptHandle,
       })),
-    }));
+    }), { abortSignal: stopController?.signal });
     if (resp.Failed && resp.Failed.length > 0) {
       logger.warn('view-update-consumer: DeleteMessageBatch had partial failures', {
         failed_count: resp.Failed.length,

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -57,18 +57,24 @@ function createHandleViewUpdate({
     linkStatus.set(qurlId, { ...current, status: 'opened' });
     setViewed(getViewed() + 1);
     // Asymmetry vs runTick (commands.js): the poll path's
-    // `if (!interaction) return` GATES before its views loop, so it
+    // `if (!interaction) return` gates before its views loop, so it
     // never bumps `viewed` on a nulled-interaction tick. The push
     // path here bumps first so the in-memory counter stays consistent
     // with the eventual DDB state. Unreachable in practice today —
     // `interaction` is only nulled by stop(), after which isStopped()
     // gates above — but the order matters if a future refactor adds
     // a token-expiry path that nulls interaction without going
-    // through stop(). Either-shape behavior is documented; do not
-    // "fix" the asymmetry without verifying the polling-path branch
-    // too. Same applies to onAllDone below.
-    if (!hasInteraction()) return;
+    // through stop().
     const pending = Math.max(0, getExpectedCount() - getViewed());
+    // Hoisted ABOVE the hasInteraction() gate so a push event that
+    // takes pending to 0 tears down the interval even when the
+    // interaction token is null (cr round-5 #3). onAllDone()'s side
+    // effects (allDone=true + clearInterval(timer)) are safe with a
+    // nulled interaction; without this hoist, a polling-path
+    // refactor that nulled interaction outside stop() would leave
+    // the interval spinning until the 14-min maxMonitorMs cap.
+    if (pending === 0) onAllDone();
+    if (!hasInteraction()) return;
     // getButtonRow() is a getter (vs. capturing the value) because
     // the monitor reassigns buttonRow to null in stop(); a snapshot
     // at factory-call time would pin a stale reference past stop().
@@ -82,7 +88,6 @@ function createHandleViewUpdate({
         error: err.message,
       });
     });
-    if (pending === 0) onAllDone();
   };
 }
 

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -1,0 +1,80 @@
+// Render path for view-update push (feat #60). Extracted from
+// `monitorLinkStatus` in commands.js so the state matrix can be unit-
+// tested without spinning up a full monitor closure (discord.js
+// interaction, db, setInterval, etc.).
+//
+// The factory takes accessor/mutator closures because the monitor's
+// state (stopped, viewed, allDone, interaction) is closure-mutable
+// inside `monitorLinkStatus`. A flat state-object snapshot would race
+// the polling tick's mutations. Same accessor shape as the existing
+// `monitorLinkStatus` runTick path.
+//
+// Contract — the returned handler:
+//   1. No-ops when `isStopped()`, `isViewCounterDegraded()`, or
+//      `update.accessCount <= 0`.
+//   2. No-ops when the qurl_id has already flipped to `status: 'opened'`
+//      (same idempotency guard runTick uses; protects against double-
+//      increment when push + poll race).
+//   3. On a genuine pending → opened transition: mutates `linkStatus`,
+//      bumps `viewed` via setViewed, and fires safeEdit with the new
+//      status message + buttonRow (or empty components when all viewed).
+//   4. Calls `onAllDone()` when viewed === expectedCount so the
+//      caller can flip `allDone = true` + clearInterval(timer).
+//
+// Tests against this factory pin the load-bearing state-matrix paths:
+//   - stopped early return
+//   - viewCounterDegraded early return
+//   - accessCount <= 0 early return
+//   - idempotency on status === 'opened'
+//   - viewed mutation + safeEdit call shape
+//   - onAllDone fires on the transition that takes pending to 0
+//
+// Render failures are caught + logged (NOT thrown). safeEdit is the
+// only async surface here; the consumer's pollLoop has no way to
+// recover from a render throw anyway, so swallow + log.
+
+function createHandleViewUpdate({
+  sendId,
+  linkStatus,
+  getButtonRow,
+  isStopped,
+  isViewCounterDegraded,
+  hasInteraction,
+  getViewed,
+  setViewed,
+  getExpectedCount,
+  buildStatusMsg,
+  safeEdit,
+  onAllDone,
+  logger,
+}) {
+  return function handleViewUpdate(update, qurlId) {
+    if (isStopped()) return;
+    if (isViewCounterDegraded()) return;
+    if (!(update && update.accessCount > 0)) return;
+    const current = linkStatus.get(qurlId);
+    if (!current || current.status === 'opened') return;
+    linkStatus.set(qurlId, { ...current, status: 'opened' });
+    setViewed(getViewed() + 1);
+    if (!hasInteraction()) return;
+    const pending = Math.max(0, getExpectedCount() - getViewed());
+    // getButtonRow() is a getter (vs. capturing the value) because
+    // the monitor reassigns buttonRow to null in stop(); a snapshot
+    // at factory-call time would pin a stale reference past stop().
+    safeEdit({
+      content: buildStatusMsg(),
+      components: pending > 0 ? [getButtonRow()] : [],
+    }).catch((err) => {
+      logger.warn('view-update render failed', {
+        sendId,
+        qurl_id: qurlId,
+        error: err.message,
+      });
+    });
+    if (pending === 0) onAllDone();
+  };
+}
+
+module.exports = {
+  createHandleViewUpdate,
+};

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -88,6 +88,12 @@ function createHandleViewUpdate({
     // throws (effectively never). Kept so a future refactor that
     // removes safeEdit's internal swallow can't surface as an
     // UnhandledRejection from this fire-and-forget dispatch.
+    //
+    // Relies on safeEdit being `async` (returns a Promise). A future
+    // refactor that switches safeEdit to a sync-return shape would
+    // make this `.catch` throw at runtime — pin the async return
+    // shape if that refactor is contemplated, or wrap with
+    // `Promise.resolve(safeEdit(...))` for paranoid safety.
     safeEdit({
       content: buildStatusMsg(),
       components: pending > 0 ? [getButtonRow()] : [],

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -56,6 +56,17 @@ function createHandleViewUpdate({
     if (!current || current.status === 'opened') return;
     linkStatus.set(qurlId, { ...current, status: 'opened' });
     setViewed(getViewed() + 1);
+    // Asymmetry vs runTick (commands.js): the poll path's
+    // `if (!interaction) return` GATES before its views loop, so it
+    // never bumps `viewed` on a nulled-interaction tick. The push
+    // path here bumps first so the in-memory counter stays consistent
+    // with the eventual DDB state. Unreachable in practice today —
+    // `interaction` is only nulled by stop(), after which isStopped()
+    // gates above — but the order matters if a future refactor adds
+    // a token-expiry path that nulls interaction without going
+    // through stop(). Either-shape behavior is documented; do not
+    // "fix" the asymmetry without verifying the polling-path branch
+    // too. Same applies to onAllDone below.
     if (!hasInteraction()) return;
     const pending = Math.max(0, getExpectedCount() - getViewed());
     // getButtonRow() is a getter (vs. capturing the value) because

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -51,7 +51,11 @@ function createHandleViewUpdate({
   return function handleViewUpdate(update, qurlId) {
     if (isStopped()) return;
     if (isViewCounterDegraded()) return;
-    if (!(update && update.accessCount > 0)) return;
+    // Number.isSafeInteger guard mirrors the consumer's parse-time
+    // gate. `"3" > 0` would coerce truthy; tightening to strict
+    // integer keeps the handler boundary symmetric with the wire
+    // boundary so a stringly-typed regression can't slip through.
+    if (!(update && Number.isSafeInteger(update.accessCount) && update.accessCount > 0)) return;
     const current = linkStatus.get(qurlId);
     if (!current || current.status === 'opened') return;
     linkStatus.set(qurlId, { ...current, status: 'opened' });
@@ -78,6 +82,12 @@ function createHandleViewUpdate({
     // getButtonRow() is a getter (vs. capturing the value) because
     // the monitor reassigns buttonRow to null in stop(); a snapshot
     // at factory-call time would pin a stale reference past stop().
+    // .catch is defense-in-depth — `safeEdit` in commands.js already
+    // swallows the Discord-side rejection via `logIgnoredDiscordErr`,
+    // so this catch only fires if `logIgnoredDiscordErr` itself
+    // throws (effectively never). Kept so a future refactor that
+    // removes safeEdit's internal swallow can't surface as an
+    // UnhandledRejection from this fire-and-forget dispatch.
     safeEdit({
       content: buildStatusMsg(),
       components: pending > 0 ? [getButtonRow()] : [],

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -60,23 +60,13 @@ function createHandleViewUpdate({
     if (!current || current.status === 'opened') return;
     linkStatus.set(qurlId, { ...current, status: 'opened' });
     setViewed(getViewed() + 1);
-    // Asymmetry vs runTick (commands.js): the poll path's
-    // `if (!interaction) return` gates before its views loop, so it
-    // never bumps `viewed` on a nulled-interaction tick. The push
-    // path here bumps first so the in-memory counter stays consistent
-    // with the eventual DDB state. Unreachable in practice today —
-    // `interaction` is only nulled by stop(), after which isStopped()
-    // gates above — but the order matters if a future refactor adds
-    // a token-expiry path that nulls interaction without going
-    // through stop().
+    // Invariant: push path mutates linkStatus + viewed BEFORE the
+    // hasInteraction gate (vs runTick's gate-before-loop in
+    // commands.js). Keeps the in-memory counter consistent with the
+    // eventual DDB state regardless of render reachability.
     const pending = Math.max(0, getExpectedCount() - getViewed());
-    // Hoisted ABOVE the hasInteraction() gate so a push event that
-    // takes pending to 0 tears down the interval even when the
-    // interaction token is null. onAllDone()'s side
-    // effects (allDone=true + clearInterval(timer)) are safe with a
-    // nulled interaction; without this hoist, a polling-path
-    // refactor that nulled interaction outside stop() would leave
-    // the interval spinning until the 14-min maxMonitorMs cap.
+    // onAllDone is interaction-independent (clearInterval +
+    // allDone=true), so fire it before the hasInteraction gate.
     if (pending === 0) onAllDone();
     if (!hasInteraction()) return;
     // getButtonRow() is a getter (vs. capturing the value) because
@@ -85,19 +75,14 @@ function createHandleViewUpdate({
     // .catch is defense-in-depth — `safeEdit` in commands.js already
     // swallows the Discord-side rejection via `logIgnoredDiscordErr`,
     // so this catch only fires if `logIgnoredDiscordErr` itself
-    // throws (effectively never). Kept so a future refactor that
-    // removes safeEdit's internal swallow can't surface as an
-    // UnhandledRejection from this fire-and-forget dispatch.
-    //
-    // Relies on safeEdit being `async` (returns a Promise). A future
-    // refactor that switches safeEdit to a sync-return shape would
-    // make this `.catch` throw at runtime — pin the async return
-    // shape if that refactor is contemplated, or wrap with
-    // `Promise.resolve(safeEdit(...))` for paranoid safety.
-    safeEdit({
+    // throws (effectively never). Promise.resolve wrap hardens
+    // against a future refactor that switches safeEdit to a sync-
+    // return shape — without it, a sync-return safeEdit would make
+    // `.catch` throw at runtime.
+    Promise.resolve(safeEdit({
       content: buildStatusMsg(),
       components: pending > 0 ? [getButtonRow()] : [],
-    }).catch((err) => {
+    })).catch((err) => {
       logger.warn('view-update render failed', {
         sendId,
         qurl_id: qurlId,

--- a/apps/discord/src/view-update-handler.js
+++ b/apps/discord/src/view-update-handler.js
@@ -68,7 +68,7 @@ function createHandleViewUpdate({
     const pending = Math.max(0, getExpectedCount() - getViewed());
     // Hoisted ABOVE the hasInteraction() gate so a push event that
     // takes pending to 0 tears down the interval even when the
-    // interaction token is null (cr round-5 #3). onAllDone()'s side
+    // interaction token is null. onAllDone()'s side
     // effects (allDone=true + clearInterval(timer)) are safe with a
     // nulled interaction; without this hoist, a polling-path
     // refactor that nulled interaction outside stop() would leave

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -143,6 +143,15 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
       .finally(() => {
         inFlightSends.delete(sendPromise);
       });
+    // Track the .catch().finally() chain (post-cleanup promise) rather
+    // than the raw sqsClient.send(...) promise. Diverges from
+    // event-publisher.js's shape — there the raw send is tracked so
+    // Promise.allSettled in stop() sees the rejection shape. Here the
+    // chain always resolves (the .catch swallows + logs), so allSettled
+    // never sees a rejected entry — and the .finally has already
+    // cleaned up the Set entry by the time allSettled resolves the
+    // tracking promise. Both shapes drain correctly; this one trades
+    // sibling-symmetry for slightly tidier post-allSettled state.
     inFlightSends.add(sendPromise);
   } catch (err) {
     // Sync throw — SDK input validation, JSON.stringify cycle, etc.
@@ -181,14 +190,13 @@ function start() {
 // Drain in-flight SendMessage promises up to DRAIN_DEADLINE_MS.
 // Mirrors event-publisher.stop()'s discipline.
 //
-// publish() → drain race: a publish() that observed running=true
-// synchronously can land on inFlightSends.add(...) AFTER stop()
-// snapshotted the set via [...inFlightSends] below. The post-snapshot
-// send completes detached without drain coverage. Same posture as
-// event-publisher.js. Acceptable in this module because the polling
-// fallback at the render layer catches the resulting view-counter
-// miss; flagged for parity with the sibling so a future drain-
-// hardening pass touches both files together.
+// stop()-vs-publish() ordering: single-threaded JS means there's no
+// actual race here — publish()'s synchronous path (running check
+// through inFlightSends.add) cannot interleave with stop()'s
+// synchronous path (running=false through [...inFlightSends]
+// snapshot). Kept this comment block (and the shape of stop()) for
+// parity with event-publisher.js so a future drain-hardening pass
+// reads both modules identically.
 async function stop() {
   if (!running) return;
   running = false;

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -10,7 +10,9 @@
 //   {
 //     "qurl_id":         "qrl_xxxx",
 //     "access_count":    42,           // int from qurl-service WebhookEvent.Data
-//     "consumed":        false,        // bool
+//     // `consumed` deliberately omitted (cr round-14 #3) — handler
+//     // doesn't read it; re-add in the envelope-contract module
+//     // when a render path needs it.
 //     "event_id":        "evt_xxxx",   // qurl-service-emitted dedup key
 //     "published_at_ms": 1739462812345 // Date.now() at envelope build
 //   }
@@ -34,14 +36,13 @@
 // `kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL` (NOT UNHANDLED_REJECTION)
 // keeps the paging pivot separate from event-shipper alerts.
 //
-// `consumed` rendered-state asymmetry: the field is plumbed end-to-end
-// but discarded at the handler today (view-update-handler.js does not
-// read `update.consumed`; only `accessCount`). The strict-coerce-to-
-// false on non-boolean is
-// loud (warn-logged with consumed_type) but the rendered state will
-// be wrong if an upstream regression sends `"true"` string — academic
-// today; surface in CloudWatch via the LOG_KINDS pivot before any
-// future render path starts using `consumed`.
+// `consumed` from the webhook is intentionally NOT plumbed through
+// the envelope today — the handler doesn't read it, and carrying an
+// unused field would create a contract-regression surface (silent
+// coerce-to-false if upstream emits a string) for code that nothing
+// consumes. Re-introduce as one struct field when a future render
+// path needs the boolean (see #476 envelope-contract module
+// follow-up).
 //
 // Process-singleton: module-level state. At most one publisher per
 // process. start() is no-op-with-warn on second call.
@@ -50,6 +51,13 @@ const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
 const config = require('./config');
 const logger = require('./logger');
 const { LOG_KINDS } = require('./constants');
+
+// Backpressure cap on in-flight SendMessage promises. Drops with
+// log when reached — fire-and-log + polling fallback bound the
+// correctness cost. Cap is high enough that a steady-state webhook
+// rate won't trip it; a sustained SQS throttle (region partition,
+// IAM rotation) is the failure mode this protects against.
+const MAX_INFLIGHT_SENDS = 1000;
 
 // Mutable so tests can shrink the deadline. INITIAL_DRAIN_DEADLINE_MS
 // captures the module-load value so `_resetStateForTest` restores
@@ -86,7 +94,7 @@ function createSqsClient() {
 // (SDK input validation, JSON.stringify pathological cases) so the
 // route's catch block doesn't flip a successful 200 into a retried
 // 500. Same posture as event-publisher.js's publish().
-function publish({ qurlId, accessCount, consumed, eventId }) {
+function publish({ qurlId, accessCount, eventId }) {
   if (!running) return; // safe no-op when disabled
   if (typeof qurlId !== 'string' || !qurlId) {
     // Defensive — the caller already validates the shape. A regression
@@ -107,24 +115,23 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
     });
     return;
   }
-  // The webhook handler (qurl-webhook.js) already strict-coerces
-  // `data.consumed` to a literal boolean before calling here, so
-  // anything other than `true` / `false` arriving at this point is a
-  // caller-side regression worth surfacing. Log + coerce-to-false
-  // rather than silently flipping a string into a false-boolean.
-  let consumedBool = consumed;
-  if (typeof consumedBool !== 'boolean') {
-    logger.warn('view-update-publisher: consumed is not a boolean (contract regression)', {
+  // Backpressure cap: drop-with-log when inFlightSends would exceed
+  // the cap. Sustained SQS throttle (region partition, IAM rotation)
+  // would otherwise let the set grow with webhook arrival rate.
+  // Polling fallback covers any view that's dropped here.
+  if (inFlightSends.size >= MAX_INFLIGHT_SENDS) {
+    logger.warn('view-update-publisher: in-flight cap reached, dropping send', {
       qurl_id: qurlId,
-      consumed_type: typeof consumed,
+      in_flight: inFlightSends.size,
+      cap: MAX_INFLIGHT_SENDS,
+      kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL,
     });
-    consumedBool = false;
+    return;
   }
   try {
     const envelope = {
       qurl_id: qurlId,
       access_count: accessCount,
-      consumed: consumedBool,
       event_id: eventId,
       published_at_ms: Date.now(),
     };

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -105,7 +105,7 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
   // `data.consumed` to a literal boolean before calling here, so
   // anything other than `true` / `false` arriving at this point is a
   // caller-side regression worth surfacing. Log + coerce-to-false
-  // rather than silently flipping (cr round-3 #8).
+  // rather than silently flipping a string into a false-boolean.
   let consumedBool = consumed;
   if (typeof consumedBool !== 'boolean') {
     logger.warn('view-update-publisher: consumed is not a boolean (contract regression)', {
@@ -130,7 +130,7 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
         logger.warn('view-update-publisher: SendMessage failed (fire-and-log)', {
           qurl_id: qurlId,
           error: err.message,
-          stack: err.stack,
+          stack: err?.stack,
           kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL,
         });
       })

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -2,7 +2,7 @@
 // Wired into qurl-webhook.js after a successful recordQurlView returns
 // `result === 'recorded'` — i.e., a real new view event (not a
 // per-event dedup hit). The consumer (view-update-consumer.js) drains
-// the queue on worker replicas and dispatches into the process-local
+// the queue on HTTP-tier replicas and dispatches into the process-local
 // view-update-registry.
 //
 // Pairs with src/view-update-consumer.js. Envelope contract:
@@ -174,6 +174,15 @@ function start() {
 
 // Drain in-flight SendMessage promises up to DRAIN_DEADLINE_MS.
 // Mirrors event-publisher.stop()'s discipline.
+//
+// publish() → drain race: a publish() that observed running=true
+// synchronously can land on inFlightSends.add(...) AFTER stop()
+// snapshotted the set via [...inFlightSends] below. The post-snapshot
+// send completes detached without drain coverage. Same posture as
+// event-publisher.js. Acceptable in this module because the polling
+// fallback at the render layer catches the resulting view-counter
+// miss; flagged for parity with the sibling so a future drain-
+// hardening pass touches both files together.
 async function stop() {
   if (!running) return;
   running = false;

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -35,8 +35,9 @@
 // keeps the paging pivot separate from event-shipper alerts.
 //
 // `consumed` rendered-state asymmetry: the field is plumbed end-to-end
-// but does NOT drive any user-visible Discord render today (only the
-// in-memory linkStatus). The strict-coerce-to-false on non-boolean is
+// but discarded at the handler today (view-update-handler.js does not
+// read `update.consumed`; only `accessCount`). The strict-coerce-to-
+// false on non-boolean is
 // loud (warn-logged with consumed_type) but the rendered state will
 // be wrong if an upstream regression sends `"true"` string — academic
 // today; surface in CloudWatch via the LOG_KINDS pivot before any
@@ -50,10 +51,15 @@ const config = require('./config');
 const logger = require('./logger');
 const { LOG_KINDS } = require('./constants');
 
-// Mutable so tests can shrink the deadline. Mirrors event-publisher.js's
-// getter-export shape — see that file's _setDrainDeadlineForTest
-// comment block for the snapshot-at-module-load footgun this dodges.
-let DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
+// Mutable so tests can shrink the deadline. INITIAL_DRAIN_DEADLINE_MS
+// captures the module-load value so `_resetStateForTest` restores
+// what was in scope at construction — mirrors event-publisher.js's
+// snapshot shape and dodges the test-config-mock-drift footgun (re-
+// reading `config.QURL_BOT_DRAIN_DEADLINE_MS` in reset would pick up
+// whatever the mock currently exposes, not what the module loaded
+// with).
+const INITIAL_DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
+let DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 
 let sqsClient = null;
 let running = false;
@@ -222,7 +228,7 @@ function _resetStateForTest() {
   running = false;
   sqsClient = null;
   inFlightSends.clear();
-  DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
+  DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
 }
 
 module.exports = {

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -27,6 +27,21 @@
 // posture — the in-process fallback (here: polling) makes a queue
 // outage observable without action.
 //
+// Log severity (warn vs error): event-publisher.js uses logger.error
+// because interaction loss is user-visible (3s ACK deadline). This
+// module uses logger.warn because the polling tick covers
+// correctness — sustained warns merit attention but not paging.
+// `kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL` (NOT UNHANDLED_REJECTION)
+// keeps the paging pivot separate from event-shipper alerts.
+//
+// `consumed` rendered-state asymmetry: the field is plumbed end-to-end
+// but does NOT drive any user-visible Discord render today (only the
+// in-memory linkStatus). The strict-coerce-to-false on non-boolean is
+// loud (warn-logged with consumed_type) but the rendered state will
+// be wrong if an upstream regression sends `"true"` string — academic
+// today; surface in CloudWatch via the LOG_KINDS pivot before any
+// future render path starts using `consumed`.
+//
 // Process-singleton: module-level state. At most one publisher per
 // process. start() is no-op-with-warn on second call.
 
@@ -74,6 +89,18 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
     logger.warn('view-update-publisher: publish() called with invalid qurlId', { qurlId });
     return;
   }
+  // Mirror the consumer's `accessCount <= 0` gate at the parse boundary
+  // so a caller regression doesn't burn a SendMessage on a payload the
+  // consumer would drop anyway. qurl.accessed webhooks always carry
+  // access_count >= 1; a 0 / NaN / non-integer is a wire-shape
+  // regression worth catching producer-side too.
+  if (!Number.isSafeInteger(accessCount) || accessCount <= 0) {
+    logger.warn('view-update-publisher: publish() called with invalid accessCount', {
+      qurlId,
+      accessCount,
+    });
+    return;
+  }
   // The webhook handler (qurl-webhook.js) already strict-coerces
   // `data.consumed` to a literal boolean before calling here, so
   // anything other than `true` / `false` arriving at this point is a
@@ -103,7 +130,8 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
         logger.warn('view-update-publisher: SendMessage failed (fire-and-log)', {
           qurl_id: qurlId,
           error: err.message,
-          kind: LOG_KINDS.UNHANDLED_REJECTION,
+          stack: err.stack,
+          kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL,
         });
       })
       .finally(() => {
@@ -118,7 +146,8 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
     logger.warn('view-update-publisher: publish() sync threw (fire-and-log)', {
       qurl_id: qurlId,
       error: err.message,
-      kind: LOG_KINDS.UNHANDLED_REJECTION,
+      stack: err.stack,
+      kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL,
     });
   }
 }

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -33,9 +33,12 @@
 const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
 const config = require('./config');
 const logger = require('./logger');
+const { LOG_KINDS } = require('./constants');
 
-const INITIAL_DRAIN_DEADLINE_MS = 5_000;
-let DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
+// Mutable so tests can shrink the deadline. Mirrors event-publisher.js's
+// getter-export shape — see that file's _setDrainDeadlineForTest
+// comment block for the snapshot-at-module-load footgun this dodges.
+let DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
 
 let sqsClient = null;
 let running = false;
@@ -46,11 +49,22 @@ function _setSqsClientForTest(client) {
 }
 
 function createSqsClient() {
-  return new SQSClient({ region: process.env.AWS_REGION || 'us-east-2' });
+  // Lazy AWS_REGION read mirrors event-publisher.js / event-consumer.js
+  // — reject + throw on missing region rather than silently falling
+  // back. A wrong region surfaces as opaque SendMessage failures inside
+  // pollLoop / publish error logs otherwise.
+  const region = (process.env.AWS_REGION ?? '').trim();
+  if (!region) {
+    throw new Error('AWS_REGION is required to use the view-update publisher. Set it in the deployment template (e.g. `us-east-2`).');
+  }
+  return new SQSClient({ region });
 }
 
 // Fire-and-log. No await. Safe to call from the hot path
-// (qurl-webhook handler).
+// (qurl-webhook handler) — the inner try/catch contains sync throws
+// (SDK input validation, JSON.stringify pathological cases) so the
+// route's catch block doesn't flip a successful 200 into a retried
+// 500. Same posture as event-publisher.js's publish().
 function publish({ qurlId, accessCount, consumed, eventId }) {
   if (!running) return; // safe no-op when disabled
   if (typeof qurlId !== 'string' || !qurlId) {
@@ -60,29 +74,40 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
     logger.warn('view-update-publisher: publish() called with invalid qurlId', { qurlId });
     return;
   }
-  const envelope = {
-    qurl_id: qurlId,
-    access_count: accessCount,
-    consumed: consumed === true,
-    event_id: eventId,
-    published_at_ms: Date.now(),
-  };
-  let sendPromise;
-  sendPromise = sqsClient.send(new SendMessageCommand({
-    QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
-    MessageBody: JSON.stringify(envelope),
-  }))
-    .catch((err) => {
-      logger.warn('view-update-publisher: SendMessage failed (fire-and-log)', {
-        qurl_id: qurlId,
-        error: err.message,
-        kind: 'unhandledRejection',
+  try {
+    const envelope = {
+      qurl_id: qurlId,
+      access_count: accessCount,
+      consumed: consumed === true,
+      event_id: eventId,
+      published_at_ms: Date.now(),
+    };
+    const sendPromise = sqsClient.send(new SendMessageCommand({
+      QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+      MessageBody: JSON.stringify(envelope),
+    }))
+      .catch((err) => {
+        logger.warn('view-update-publisher: SendMessage failed (fire-and-log)', {
+          qurl_id: qurlId,
+          error: err.message,
+          kind: LOG_KINDS.UNHANDLED_REJECTION,
+        });
+      })
+      .finally(() => {
+        inFlightSends.delete(sendPromise);
       });
-    })
-    .finally(() => {
-      inFlightSends.delete(sendPromise);
+    inFlightSends.add(sendPromise);
+  } catch (err) {
+    // Sync throw — SDK input validation, JSON.stringify cycle, etc.
+    // Swallow + log so the webhook receiver's route handler stays
+    // 200. The DDB write that preceded this call is already committed;
+    // the polling fallback catches the view counter render regardless.
+    logger.warn('view-update-publisher: publish() sync threw (fire-and-log)', {
+      qurl_id: qurlId,
+      error: err.message,
+      kind: LOG_KINDS.UNHANDLED_REJECTION,
     });
-  inFlightSends.add(sendPromise);
+  }
 }
 
 function start() {
@@ -146,7 +171,7 @@ function _resetStateForTest() {
   running = false;
   sqsClient = null;
   inFlightSends.clear();
-  DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
+  DRAIN_DEADLINE_MS = config.QURL_BOT_DRAIN_DEADLINE_MS;
 }
 
 module.exports = {

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -74,11 +74,24 @@ function publish({ qurlId, accessCount, consumed, eventId }) {
     logger.warn('view-update-publisher: publish() called with invalid qurlId', { qurlId });
     return;
   }
+  // The webhook handler (qurl-webhook.js) already strict-coerces
+  // `data.consumed` to a literal boolean before calling here, so
+  // anything other than `true` / `false` arriving at this point is a
+  // caller-side regression worth surfacing. Log + coerce-to-false
+  // rather than silently flipping (cr round-3 #8).
+  let consumedBool = consumed;
+  if (typeof consumedBool !== 'boolean') {
+    logger.warn('view-update-publisher: consumed is not a boolean (contract regression)', {
+      qurl_id: qurlId,
+      consumed_type: typeof consumed,
+    });
+    consumedBool = false;
+  }
   try {
     const envelope = {
       qurl_id: qurlId,
       access_count: accessCount,
-      consumed: consumed === true,
+      consumed: consumedBool,
       event_id: eventId,
       published_at_ms: Date.now(),
     };

--- a/apps/discord/src/view-update-publisher.js
+++ b/apps/discord/src/view-update-publisher.js
@@ -1,0 +1,164 @@
+// SQS-driven view-update publisher (feat #60, sub-second view counter).
+// Wired into qurl-webhook.js after a successful recordQurlView returns
+// `result === 'recorded'` — i.e., a real new view event (not a
+// per-event dedup hit). The consumer (view-update-consumer.js) drains
+// the queue on worker replicas and dispatches into the process-local
+// view-update-registry.
+//
+// Pairs with src/view-update-consumer.js. Envelope contract:
+//
+//   {
+//     "qurl_id":         "qrl_xxxx",
+//     "access_count":    42,           // int from qurl-service WebhookEvent.Data
+//     "consumed":        false,        // bool
+//     "event_id":        "evt_xxxx",   // qurl-service-emitted dedup key
+//     "published_at_ms": 1739462812345 // Date.now() at envelope build
+//   }
+//
+// Latency optimization, NOT correctness primitive. The
+// monitorLinkStatus polling path in commands.js (unchanged by this PR)
+// is the authoritative view-counter mechanism. SQS push only shaves
+// latency on the half-of-events that land on the replica running the
+// monitor (see view-update-registry.js's SILENT DROP doc).
+//
+// Send-failure semantics: fire-and-log. A transient SQS error means
+// the view event is LOST from the SQS-push perspective; the polling
+// path catches it on the next interval. Mirrors event-publisher.js's
+// posture — the in-process fallback (here: polling) makes a queue
+// outage observable without action.
+//
+// Process-singleton: module-level state. At most one publisher per
+// process. start() is no-op-with-warn on second call.
+
+const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
+const config = require('./config');
+const logger = require('./logger');
+
+const INITIAL_DRAIN_DEADLINE_MS = 5_000;
+let DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
+
+let sqsClient = null;
+let running = false;
+const inFlightSends = new Set();
+
+function _setSqsClientForTest(client) {
+  sqsClient = client;
+}
+
+function createSqsClient() {
+  return new SQSClient({ region: process.env.AWS_REGION || 'us-east-2' });
+}
+
+// Fire-and-log. No await. Safe to call from the hot path
+// (qurl-webhook handler).
+function publish({ qurlId, accessCount, consumed, eventId }) {
+  if (!running) return; // safe no-op when disabled
+  if (typeof qurlId !== 'string' || !qurlId) {
+    // Defensive — the caller already validates the shape. A regression
+    // that called publish() with junk would otherwise build a bad
+    // envelope and burn a SendMessage on it.
+    logger.warn('view-update-publisher: publish() called with invalid qurlId', { qurlId });
+    return;
+  }
+  const envelope = {
+    qurl_id: qurlId,
+    access_count: accessCount,
+    consumed: consumed === true,
+    event_id: eventId,
+    published_at_ms: Date.now(),
+  };
+  let sendPromise;
+  sendPromise = sqsClient.send(new SendMessageCommand({
+    QueueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+    MessageBody: JSON.stringify(envelope),
+  }))
+    .catch((err) => {
+      logger.warn('view-update-publisher: SendMessage failed (fire-and-log)', {
+        qurl_id: qurlId,
+        error: err.message,
+        kind: 'unhandledRejection',
+      });
+    })
+    .finally(() => {
+      inFlightSends.delete(sendPromise);
+    });
+  inFlightSends.add(sendPromise);
+}
+
+function start() {
+  if (running) {
+    logger.warn('view-update-publisher: start() called while already running — no-op');
+    return;
+  }
+  if (!config.ENABLE_VIEW_UPDATE_PUSH) {
+    throw new Error('view-update-publisher: start() called with ENABLE_VIEW_UPDATE_PUSH=false');
+  }
+  if (!config.QURL_BOT_VIEW_UPDATES_QUEUE_URL) {
+    throw new Error('view-update-publisher: QURL_BOT_VIEW_UPDATES_QUEUE_URL is not set');
+  }
+  if (!sqsClient) {
+    sqsClient = createSqsClient();
+  }
+  running = true;
+  logger.info('view-update-publisher: starting', {
+    queueUrl: config.QURL_BOT_VIEW_UPDATES_QUEUE_URL,
+  });
+}
+
+// Drain in-flight SendMessage promises up to DRAIN_DEADLINE_MS.
+// Mirrors event-publisher.stop()'s discipline.
+async function stop() {
+  if (!running) return;
+  running = false;
+  if (inFlightSends.size === 0) {
+    logger.info('view-update-publisher: stop complete (no in-flight sends to drain)');
+    return;
+  }
+  const drainCount = inFlightSends.size;
+  const drainStartNs = process.hrtime.bigint();
+  let drainTimer;
+  try {
+    await Promise.race([
+      Promise.allSettled([...inFlightSends]),
+      new Promise((resolve) => {
+        drainTimer = setTimeout(resolve, DRAIN_DEADLINE_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(drainTimer);
+  }
+  const elapsedMs = Number((process.hrtime.bigint() - drainStartNs) / 1_000_000n);
+  if (inFlightSends.size > 0) {
+    logger.warn('view-update-publisher: drain deadline elapsed, proceeding with sends still in-flight', {
+      unsettled: inFlightSends.size,
+      settled: drainCount - inFlightSends.size,
+      elapsedMs,
+    });
+  } else {
+    logger.info('view-update-publisher: drain complete', {
+      count: drainCount,
+      elapsedMs,
+    });
+  }
+}
+
+function _resetStateForTest() {
+  running = false;
+  sqsClient = null;
+  inFlightSends.clear();
+  DRAIN_DEADLINE_MS = INITIAL_DRAIN_DEADLINE_MS;
+}
+
+module.exports = {
+  start,
+  stop,
+  publish,
+  _test: {
+    _setSqsClientForTest,
+    _resetStateForTest,
+    getInFlightCount: () => inFlightSends.size,
+    isRunning: () => running,
+    getDrainDeadlineMs: () => DRAIN_DEADLINE_MS,
+    _setDrainDeadlineForTest: (ms) => { DRAIN_DEADLINE_MS = ms; },
+  },
+};

--- a/apps/discord/src/view-update-registry.js
+++ b/apps/discord/src/view-update-registry.js
@@ -49,6 +49,12 @@ function unregister(qurlId, callback) {
 // Returns true if at least one callback was invoked; false on silent
 // drop (no monitor on this replica). Caller (consumer) deletes the
 // message regardless — see SILENT DROP IS LOAD-BEARING above.
+//
+// Callback signature: (update, qurlId). qurlId is passed in so a
+// single shared closure can register against all of a monitor's
+// tracked qurl_ids without paying per-id closure-creation cost — a
+// 50-recipient send registers the SAME callback against 50 keys,
+// each Set holds one element, callback distinguishes inside.
 function dispatch(qurlId, update) {
   const set = registry.get(qurlId);
   if (!set || set.size === 0) return false;
@@ -57,7 +63,7 @@ function dispatch(qurlId, update) {
   const snapshot = Array.from(set);
   for (const cb of snapshot) {
     try {
-      cb(update);
+      cb(update, qurlId);
     } catch (err) {
       logger.error('view-update-registry: callback threw', {
         qurl_id: qurlId,

--- a/apps/discord/src/view-update-registry.js
+++ b/apps/discord/src/view-update-registry.js
@@ -1,0 +1,92 @@
+// Process-local view-update registry for the sub-second view counter
+// (feat #60). The webhook receiver (qurl-webhook.js) publishes view
+// events to SQS; the consumer (view-update-consumer.js) drains the
+// queue and calls `dispatch(qurl_id, update)` on this registry. Live
+// monitorLinkStatus instances register a callback per qurl_id when
+// they start and unregister when they stop.
+//
+// SILENT DROP IS LOAD-BEARING: with N worker replicas, the SQS-Standard
+// fan-out gives any one replica a (1/N) probability of receiving the
+// message for a given monitor. The dispatch path returns false on
+// lookup miss; the consumer deletes the message regardless. The polling
+// path in monitorLinkStatus (unchanged by this PR) is the correctness
+// primitive — SQS push only shaves latency on the hit half.
+//
+// GC discipline: the registry holds callbacks that close over monitor
+// state (linkStatus Map, baseMsg, etc.). A long-running monitor that
+// never unregisters would pin all that closure state until process
+// restart. `unregister(qurlId, cb)` MUST be called from
+// monitorLinkStatus.stop() and addRecipients(). Mirrors the
+// closure-mutable-rebind discipline already in commands.js's
+// monitorLinkStatus stop() path.
+
+const logger = require('./logger');
+
+const registry = new Map(); // qurl_id → Set<callback>
+
+function register(qurlId, callback) {
+  if (typeof qurlId !== 'string' || !qurlId) {
+    throw new Error('view-update-registry.register: qurlId must be a non-empty string');
+  }
+  if (typeof callback !== 'function') {
+    throw new Error('view-update-registry.register: callback must be a function');
+  }
+  let set = registry.get(qurlId);
+  if (!set) {
+    set = new Set();
+    registry.set(qurlId, set);
+  }
+  set.add(callback);
+}
+
+function unregister(qurlId, callback) {
+  const set = registry.get(qurlId);
+  if (!set) return;
+  set.delete(callback);
+  if (set.size === 0) registry.delete(qurlId);
+}
+
+// Returns true if at least one callback was invoked; false on silent
+// drop (no monitor on this replica). Caller (consumer) deletes the
+// message regardless — see SILENT DROP IS LOAD-BEARING above.
+function dispatch(qurlId, update) {
+  const set = registry.get(qurlId);
+  if (!set || set.size === 0) return false;
+  // Snapshot to defensively allow callbacks to unregister themselves
+  // mid-iteration without mutating the live set we're iterating.
+  const snapshot = Array.from(set);
+  for (const cb of snapshot) {
+    try {
+      cb(update);
+    } catch (err) {
+      logger.error('view-update-registry: callback threw', {
+        qurl_id: qurlId,
+        error: err.message,
+      });
+    }
+  }
+  return true;
+}
+
+function _sizeForTest() {
+  return registry.size;
+}
+
+function _entryCountForTest(qurlId) {
+  return (registry.get(qurlId) || new Set()).size;
+}
+
+function _resetForTest() {
+  registry.clear();
+}
+
+module.exports = {
+  register,
+  unregister,
+  dispatch,
+  _test: {
+    _sizeForTest,
+    _entryCountForTest,
+    _resetForTest,
+  },
+};

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -175,6 +175,36 @@ describe('missingEventShipperKeys', () => {
   });
 });
 
+describe('missingViewUpdatePushKeys', () => {
+  const { missingViewUpdatePushKeys } = require('../src/boot-requirements');
+
+  it('returns empty when the flag is unset (view-update-push path inactive)', () => {
+    expect(missingViewUpdatePushKeys({})).toEqual([]);
+    expect(missingViewUpdatePushKeys({ ENABLE_VIEW_UPDATE_PUSH: false })).toEqual([]);
+    expect(
+      missingViewUpdatePushKeys({ ENABLE_VIEW_UPDATE_PUSH: false, QURL_BOT_VIEW_UPDATES_QUEUE_URL: undefined })
+    ).toEqual([]);
+  });
+
+  it('flags QURL_BOT_VIEW_UPDATES_QUEUE_URL when flag is on without a URL', () => {
+    expect(
+      missingViewUpdatePushKeys({ ENABLE_VIEW_UPDATE_PUSH: true })
+    ).toEqual(['QURL_BOT_VIEW_UPDATES_QUEUE_URL']);
+    expect(
+      missingViewUpdatePushKeys({ ENABLE_VIEW_UPDATE_PUSH: true, QURL_BOT_VIEW_UPDATES_QUEUE_URL: '' })
+    ).toEqual(['QURL_BOT_VIEW_UPDATES_QUEUE_URL']);
+  });
+
+  it('returns empty when both are set', () => {
+    expect(
+      missingViewUpdatePushKeys({
+        ENABLE_VIEW_UPDATE_PUSH: true,
+        QURL_BOT_VIEW_UPDATES_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-view-updates',
+      }),
+    ).toEqual([]);
+  });
+});
+
 describe('unsupportedRoleShipperCombo', () => {
   it('rejects combined + flag-on with operator-facing remediation', () => {
     const msg = unsupportedRoleShipperCombo('combined', true);

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -203,6 +203,35 @@ describe('missingViewUpdatePushKeys', () => {
       }),
     ).toEqual([]);
   });
+
+  // cr round-5 #7: pin the asymmetric "URL set without the flag"
+  // case. During the flag-flip rollout, infra changes may land the
+  // URL on the task def BEFORE the flag flips — the boot check
+  // must treat that as a harmlessly-ignored config.
+  it('returns empty when URL is set but flag is off (mid-rollout shape)', () => {
+    expect(
+      missingViewUpdatePushKeys({
+        ENABLE_VIEW_UPDATE_PUSH: false,
+        QURL_BOT_VIEW_UPDATES_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-view-updates',
+      }),
+    ).toEqual([]);
+  });
+});
+
+// cr round-5 #5: pin the contract that combined-mode + view-update-push
+// is intentionally accepted (no analog of `unsupportedRoleShipperCombo`).
+// Locks the design so a copy-paste-from-shipper refactor doesn't silently
+// add a rejection.
+describe('combined-mode + view-update-push (no equivalent of unsupportedRoleShipperCombo)', () => {
+  it('boot-requirements exports no view-update combined-mode rejector', () => {
+    // The shipper has unsupportedRoleShipperCombo for combined-mode
+    // rejection. The view-update-push intentionally has no such
+    // helper — the registry's silent-drop-on-miss + status==='opened'
+    // idempotency guard make combined-mode safe.
+    const bootReq = require('../src/boot-requirements');
+    expect(bootReq.unsupportedRoleShipperCombo).toBeDefined();
+    expect(bootReq.unsupportedRoleViewUpdatePushCombo).toBeUndefined();
+  });
 });
 
 describe('unsupportedRoleShipperCombo', () => {

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -204,10 +204,10 @@ describe('missingViewUpdatePushKeys', () => {
     ).toEqual([]);
   });
 
-  // cr round-5 #7: pin the asymmetric "URL set without the flag"
-  // case. During the flag-flip rollout, infra changes may land the
-  // URL on the task def BEFORE the flag flips — the boot check
-  // must treat that as a harmlessly-ignored config.
+  // Pin the asymmetric "URL set without the flag" case. During the
+  // flag-flip rollout, infra changes may land the URL on the task
+  // def BEFORE the flag flips — the boot check must treat that as
+  // a harmlessly-ignored config.
   it('returns empty when URL is set but flag is off (mid-rollout shape)', () => {
     expect(
       missingViewUpdatePushKeys({
@@ -218,7 +218,7 @@ describe('missingViewUpdatePushKeys', () => {
   });
 });
 
-// cr round-5 #5: pin the contract that combined-mode + view-update-push
+// Pin the contract that combined-mode + view-update-push
 // is intentionally accepted (no analog of `unsupportedRoleShipperCombo`).
 // Locks the design so a copy-paste-from-shipper refactor doesn't silently
 // add a rejection.

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -36,6 +36,17 @@ jest.mock('../src/store', () => ({
   getStats: jest.fn(() => ({})),
 }));
 
+// Mock the view-update publisher (feat #60) so the route's
+// `if (result === 'recorded') publish(...)` gate is observable.
+// Without this mock, publish() would no-op against an unstarted
+// publisher and the gate would be untestable.
+const mockViewUpdatePublish = jest.fn();
+jest.mock('../src/view-update-publisher', () => ({
+  publish: mockViewUpdatePublish,
+  start: jest.fn(),
+  stop: jest.fn(),
+}));
+
 process.env.QURL_WEBHOOK_SECRET = 'test-qurl-secret';
 process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
 process.env.AWS_REGION = 'us-east-2';
@@ -60,6 +71,56 @@ const VALID_PAYLOAD = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockRecordQurlView.mockImplementation(async () => 'recorded');
+  mockViewUpdatePublish.mockReset();
+});
+
+describe('POST /webhooks/qurl — view-update push gate (feat #60)', () => {
+  // The route calls viewUpdatePublisher.publish() ONLY when
+  // recordQurlView returns the literal 'recorded' (real new view) —
+  // NOT on dedup hits or any other status. A regression that flipped
+  // to truthy-check (`if (result)`) would send SQS messages for every
+  // dedup replay too, exhausting the queue + amplifying CloudWatch
+  // costs on a high-replay-rate qurl.
+  const signedRequest = (payload) => {
+    const raw = JSON.stringify(payload);
+    return request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+  };
+
+  it('publishes on result === "recorded"', async () => {
+    mockRecordQurlView.mockImplementation(async () => 'recorded');
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(mockViewUpdatePublish).toHaveBeenCalledTimes(1);
+    expect(mockViewUpdatePublish).toHaveBeenCalledWith({
+      qurlId: VALID_PAYLOAD.data.qurl_id,
+      accessCount: VALID_PAYLOAD.data.access_count,
+      consumed: VALID_PAYLOAD.data.consumed,
+      eventId: VALID_PAYLOAD.id,
+    });
+  });
+
+  it('does NOT publish on dedup result (e.g. "deduped")', async () => {
+    mockRecordQurlView.mockImplementation(async () => 'deduped');
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(mockViewUpdatePublish).not.toHaveBeenCalled();
+  });
+
+  it('does NOT publish on any non-"recorded" result', async () => {
+    // Strict-equality guard catches a future store regression that
+    // returned 'updated' or other truthy strings — those should NOT
+    // trigger a push.
+    for (const result of ['updated', 'noop', 'replayed', '', null, undefined]) {
+      jest.clearAllMocks();
+      mockRecordQurlView.mockImplementation(async () => result);
+      await signedRequest(VALID_PAYLOAD);
+      expect(mockViewUpdatePublish).not.toHaveBeenCalled();
+    }
+  });
 });
 
 describe('POST /webhooks/qurl — unconfigured secret returns 503 (retriable)', () => {

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -265,6 +265,28 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(res.body).toEqual({ status: 'invalid-payload' });
   });
 
+  it('returns 200 invalid-payload when access_count is 0 (parity with publisher gate)', async () => {
+    // qurl.accessed events always carry access_count >= 1 by
+    // contract. Rejecting 0 here keeps the wire boundary as the
+    // single source of truth — without this gate, a 0-count event
+    // would record in DDB and then trip the publisher's
+    // "invalid accessCount" warn, producing an asymmetric log pair.
+    const payload = {
+      id: 'evt-zero', type: 'qurl.accessed',
+      data: { qurl_id: 'q_aaaaaaaaaa1', access_count: 0, consumed: false },
+    };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+    expect(mockViewUpdatePublish).not.toHaveBeenCalled();
+  });
+
   it('surfaces store dedup result on replay', async () => {
     mockRecordQurlView.mockResolvedValueOnce('dedup');
     const raw = JSON.stringify(VALID_PAYLOAD);

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -98,7 +98,6 @@ describe('POST /webhooks/qurl — view-update push gate (feat #60)', () => {
     expect(mockViewUpdatePublish).toHaveBeenCalledWith({
       qurlId: VALID_PAYLOAD.data.qurl_id,
       accessCount: VALID_PAYLOAD.data.access_count,
-      consumed: VALID_PAYLOAD.data.consumed,
       eventId: VALID_PAYLOAD.id,
     });
   });

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -614,6 +614,38 @@ describe('monitorLinkStatus — addRecipients() + stop() races', () => {
     monitor.stop();
   });
 
+  it('addRecipients() called AFTER stop() is a strict no-op', async () => {
+    // Defends the GC leak surface: a post-stop addRecipients would
+    // otherwise extend expectedCount + linkStatus + register new
+    // view-update callbacks against the registry that the unregister
+    // loop (already iterated) won't pick up — pinning closure state
+    // to process restart. The early-out at the top of addRecipients
+    // closes both the pre-#60 (expectedCount/linkStatus) and post-#60
+    // (registry register) leak shapes.
+    const monitor = monitorLinkStatus(
+      'send-after-stop', makeInteraction(),
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent to 1 user', { components: [] }, 1,
+    );
+
+    // Snapshot the monitor's pre-stop render state so we can assert
+    // it doesn't change after the post-stop addRecipients call.
+    const preStopMsg = monitor.getFullMsg();
+    monitor.stop();
+
+    // Post-stop addRecipients call. Without the guard this would
+    // bump expectedCount from 1 to 2 and visibly change the render
+    // (pending count would increment).
+    monitor.addRecipients(1, [{ qurlId: 'q_aaaaaaaaaa9', username: 'Eve' }]);
+
+    // expectedCount unchanged → buildStatusMsg returns the same
+    // string. (getFullMsg() also returns the post-stop sentinel
+    // depending on internal state — equality with the pre-stop
+    // snapshot is the assertion that matters.)
+    expect(monitor.getFullMsg()).toBe(preStopMsg);
+  });
+
   it('stop() called concurrently with a running tick — no unhandled rejection', async () => {
     const interaction = makeInteraction();
     mockDb.getQurlViews.mockImplementation(() => new Promise(resolve =>

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -29,7 +29,7 @@ jest.mock('../src/logger', () => ({
 }));
 
 const { mockClient } = require('aws-sdk-client-mock');
-const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require('@aws-sdk/client-sqs');
+const { SQSClient, ReceiveMessageCommand, DeleteMessageBatchCommand } = require('@aws-sdk/client-sqs');
 
 const sqsMock = mockClient(SQSClient);
 
@@ -105,12 +105,25 @@ describe('view-update-consumer', () => {
         }),
         ReceiptHandle: 'rh-1',
       });
-      expect(cb).toHaveBeenCalledWith(expect.objectContaining({
-        accessCount: 7,
-        consumed: false,
-        eventId: 'evt_x',
-        publishedAtMs: 1739462812345,
-      }));
+      expect(cb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessCount: 7,
+          consumed: false,
+          eventId: 'evt_x',
+          publishedAtMs: 1739462812345,
+        }),
+        'qrl_x',
+      );
+    });
+
+    test('non-object envelope (e.g. JSON number) is dropped', () => {
+      consumer._test.processMessage({
+        Body: JSON.stringify(42),
+        ReceiptHandle: 'rh-1',
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('not an object'),
+      );
     });
 
     test('malformed JSON is dropped without throwing', () => {
@@ -191,15 +204,17 @@ describe('view-update-consumer', () => {
           ],
         })
         .resolves({ Messages: [] });
-      sqsMock.on(DeleteMessageCommand).resolves({});
+      sqsMock.on(DeleteMessageBatchCommand).resolves({});
 
       consumer.start();
       await consumer._test.pollOnce();
 
       expect(cb).toHaveBeenCalled();
-      const delCalls = sqsMock.commandCalls(DeleteMessageCommand);
+      const delCalls = sqsMock.commandCalls(DeleteMessageBatchCommand);
       expect(delCalls).toHaveLength(1);
-      expect(delCalls[0].args[0].input.ReceiptHandle).toBe('rh-1');
+      const entries = delCalls[0].args[0].input.Entries;
+      expect(entries).toHaveLength(1);
+      expect(entries[0].ReceiptHandle).toBe('rh-1');
 
       await consumer.stop();
     });
@@ -218,12 +233,14 @@ describe('view-update-consumer', () => {
           ],
         })
         .resolves({ Messages: [] });
-      sqsMock.on(DeleteMessageCommand).resolves({});
+      sqsMock.on(DeleteMessageBatchCommand).resolves({});
 
       consumer.start();
       await consumer._test.pollOnce();
 
-      expect(sqsMock.commandCalls(DeleteMessageCommand)).toHaveLength(1);
+      const delCalls = sqsMock.commandCalls(DeleteMessageBatchCommand);
+      expect(delCalls).toHaveLength(1);
+      expect(delCalls[0].args[0].input.Entries[0].ReceiptHandle).toBe('rh-1');
 
       await consumer.stop();
     });
@@ -238,6 +255,22 @@ describe('view-update-consumer', () => {
 
       // AbortError is the expected shape during stop() — must not
       // be logged as a real failure.
+      const errLogs = logger.warn.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('ReceiveMessage failed'),
+      );
+      expect(errLogs).toHaveLength(0);
+
+      await consumer.stop();
+    });
+
+    test('AbortError via err.code (older SDK shape) is also handled cleanly', async () => {
+      const abortErr = new Error('aborted');
+      abortErr.code = 'AbortError';
+      sqsMock.on(ReceiveMessageCommand).rejects(abortErr);
+
+      consumer.start();
+      await consumer._test.pollOnce();
+
       const errLogs = logger.warn.mock.calls.filter(
         ([msg]) => typeof msg === 'string' && msg.includes('ReceiveMessage failed'),
       );

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -339,5 +339,27 @@ describe('view-update-consumer', () => {
       // would catch it, but explicit stop here keeps the test honest.
       await consumer.stop();
     });
+
+    test('pollLoop defense-in-depth path flips running=false before invoking onFatalCb (cr round-7 #1)', () => {
+      // Direct test of the defense-in-depth fatal-path order: the
+      // module-state flip (running=false) must precede onFatalCb so a
+      // caller without an onFatal handler doesn't end up wedged with
+      // isRunning()=true but no actual polling. Verified by stubbing
+      // onFatal as a sync function that observes the state at the
+      // moment of invocation. Direct exercise via the start({onFatal})
+      // contract would require mocking pollOnce to throw across an
+      // await — heavier than testing the order via inspection here.
+      const observedRunningInOnFatal = [];
+      consumer._test._setRunningForTest(true);
+      // Simulate the fatal-path code's sequence directly by setting
+      // running=false before invoking the callback, then asserting
+      // the callback observed the flipped state. The actual production
+      // path is in pollLoop's catch block — this test pins the order.
+      const onFatal = () => observedRunningInOnFatal.push(consumer._test.isRunning());
+      // Mirror the pollLoop sequence: flip first, then invoke.
+      consumer._test._setRunningForTest(false);
+      onFatal();
+      expect(observedRunningInOnFatal).toEqual([false]);
+    });
   });
 });

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -99,7 +99,6 @@ describe('view-update-consumer', () => {
         Body: JSON.stringify({
           qurl_id: 'qrl_x',
           access_count: 7,
-          consumed: false,
           event_id: 'evt_x',
           published_at_ms: 1739462812345,
         }),
@@ -108,7 +107,6 @@ describe('view-update-consumer', () => {
       expect(cb).toHaveBeenCalledWith(
         expect.objectContaining({
           accessCount: 7,
-          consumed: false,
           eventId: 'evt_x',
           publishedAtMs: 1739462812345,
         }),
@@ -195,7 +193,7 @@ describe('view-update-consumer', () => {
       // called — the (N-1)/N miss rate would otherwise create
       // unbounded log volume with low signal.
       consumer._test.processMessage({
-        Body: JSON.stringify({ qurl_id: 'qrl_nope', access_count: 1, consumed: false }),
+        Body: JSON.stringify({ qurl_id: 'qrl_nope', access_count: 1 }),
         ReceiptHandle: 'rh-1',
       });
       expect(logger.warn).not.toHaveBeenCalled();
@@ -217,7 +215,7 @@ describe('view-update-consumer', () => {
           {
             MessageId: 'm1',
             ReceiptHandle: 'rh-1',
-            Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 3, consumed: false }),
+            Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 3 }),
           },
         ],
       });
@@ -242,7 +240,7 @@ describe('view-update-consumer', () => {
           {
             MessageId: 'm1',
             ReceiptHandle: 'rh-1',
-            Body: JSON.stringify({ qurl_id: 'qrl_nobody_home', access_count: 1, consumed: false }),
+            Body: JSON.stringify({ qurl_id: 'qrl_nobody_home', access_count: 1 }),
           },
         ],
       });

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -340,26 +340,13 @@ describe('view-update-consumer', () => {
       await consumer.stop();
     });
 
-    test('pollLoop defense-in-depth path flips running=false before invoking onFatalCb', () => {
-      // Direct test of the defense-in-depth fatal-path order: the
-      // module-state flip (running=false) must precede onFatalCb so a
-      // caller without an onFatal handler doesn't end up wedged with
-      // isRunning()=true but no actual polling. Verified by stubbing
-      // onFatal as a sync function that observes the state at the
-      // moment of invocation. Direct exercise via the start({onFatal})
-      // contract would require mocking pollOnce to throw across an
-      // await — heavier than testing the order via inspection here.
-      const observedRunningInOnFatal = [];
-      consumer._test._setRunningForTest(true);
-      // Simulate the fatal-path code's sequence directly by setting
-      // running=false before invoking the callback, then asserting
-      // the callback observed the flipped state. The actual production
-      // path is in pollLoop's catch block — this test pins the order.
-      const onFatal = () => observedRunningInOnFatal.push(consumer._test.isRunning());
-      // Mirror the pollLoop sequence: flip first, then invoke.
-      consumer._test._setRunningForTest(false);
-      onFatal();
-      expect(observedRunningInOnFatal).toEqual([false]);
-    });
+    // pollLoop's defense-in-depth fatal-path order (running = false
+    // BEFORE onFatalCb invocation) is one-line production code that's
+    // verifiable by inspection — the prior simulation test added
+    // coverage without exercising the path, and driving the real
+    // path requires mocking the SDK + logger to throw across awaits
+    // in a brittle setup that races microtask scheduling (cr round-12
+    // #3). Deleted per cr's option (a). The contract is documented
+    // inline at view-update-consumer.js's pollLoop catch block.
   });
 });

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for src/view-update-consumer.js — the SQS consumer for
+ * view-update push (feat #60).
+ *
+ * Covers:
+ *   - start/stop lifecycle: idempotency, flag/queue-url guards
+ *   - processMessage: valid envelope dispatches to registry
+ *   - processMessage: malformed JSON dropped (no throw)
+ *   - processMessage: envelope missing qurl_id dropped
+ *   - processMessage: invalid access_count dropped
+ *   - pollOnce: receives + deletes each message
+ *   - pollOnce: silent-drop-on-miss still deletes the message
+ *     (LOAD-BEARING: holding the message would just re-deliver to
+ *     the same replica on visibility-timeout expiry)
+ *   - AbortError on ReceiveMessage handled cleanly
+ */
+
+jest.mock('../src/config', () => ({
+  ENABLE_VIEW_UPDATE_PUSH: true,
+  QURL_BOT_VIEW_UPDATES_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-view-updates',
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+const { mockClient } = require('aws-sdk-client-mock');
+const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require('@aws-sdk/client-sqs');
+
+const sqsMock = mockClient(SQSClient);
+
+const consumer = require('../src/view-update-consumer');
+const registry = require('../src/view-update-registry');
+const logger = require('../src/logger');
+
+beforeAll(() => {
+  if (!process.env.AWS_REGION) process.env.AWS_REGION = 'us-east-2';
+});
+
+beforeEach(async () => {
+  if (consumer._test.isRunning()) await consumer.stop();
+  consumer._test._resetStateForTest();
+  registry._test._resetForTest();
+  sqsMock.reset();
+  jest.clearAllMocks();
+  const realClient = new SQSClient({ region: 'us-east-2' });
+  consumer._test._setSqsClientForTest(realClient);
+});
+
+describe('view-update-consumer', () => {
+  describe('start / stop lifecycle', () => {
+    test('start() requires the flag', () => {
+      const config = require('../src/config');
+      const original = config.ENABLE_VIEW_UPDATE_PUSH;
+      config.ENABLE_VIEW_UPDATE_PUSH = false;
+      try {
+        expect(() => consumer.start()).toThrow(/ENABLE_VIEW_UPDATE_PUSH=false/);
+      } finally {
+        config.ENABLE_VIEW_UPDATE_PUSH = original;
+      }
+    });
+
+    test('start() requires queue URL', () => {
+      const config = require('../src/config');
+      const original = config.QURL_BOT_VIEW_UPDATES_QUEUE_URL;
+      config.QURL_BOT_VIEW_UPDATES_QUEUE_URL = undefined;
+      try {
+        expect(() => consumer.start()).toThrow(/QURL_BOT_VIEW_UPDATES_QUEUE_URL is not set/);
+      } finally {
+        config.QURL_BOT_VIEW_UPDATES_QUEUE_URL = original;
+      }
+    });
+
+    test('start() is idempotent on second call', async () => {
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      consumer.start();
+      expect(consumer._test.isRunning()).toBe(true);
+      consumer.start();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/start.*already running/),
+      );
+      await consumer.stop();
+    });
+
+    test('stop() is a no-op when not running', async () => {
+      await expect(consumer.stop()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('processMessage', () => {
+    test('valid envelope dispatches to registry', () => {
+      const cb = jest.fn();
+      registry.register('qrl_x', cb);
+      consumer._test.processMessage({
+        Body: JSON.stringify({
+          qurl_id: 'qrl_x',
+          access_count: 7,
+          consumed: false,
+          event_id: 'evt_x',
+          published_at_ms: 1739462812345,
+        }),
+        ReceiptHandle: 'rh-1',
+      });
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({
+        accessCount: 7,
+        consumed: false,
+        eventId: 'evt_x',
+        publishedAtMs: 1739462812345,
+      }));
+    });
+
+    test('malformed JSON is dropped without throwing', () => {
+      expect(() => consumer._test.processMessage({
+        Body: '{not valid json',
+        ReceiptHandle: 'rh-1',
+      })).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('malformed JSON envelope'),
+        expect.any(Object),
+      );
+    });
+
+    test('envelope missing qurl_id is dropped', () => {
+      consumer._test.processMessage({
+        Body: JSON.stringify({ access_count: 1 }),
+        ReceiptHandle: 'rh-1',
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing qurl_id'),
+      );
+    });
+
+    test('envelope with invalid access_count is dropped', () => {
+      const cb = jest.fn();
+      registry.register('qrl_x', cb);
+
+      consumer._test.processMessage({
+        Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: -1 }),
+        ReceiptHandle: 'rh-1',
+      });
+      consumer._test.processMessage({
+        Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 1.5 }),
+        ReceiptHandle: 'rh-2',
+      });
+      consumer._test.processMessage({
+        Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 'seven' }),
+        ReceiptHandle: 'rh-3',
+      });
+
+      expect(cb).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('access_count not a non-negative safe integer'),
+        expect.any(Object),
+      );
+    });
+
+    test('silent-drop on registry miss is not logged', () => {
+      // No callback registered for qrl_nope. Logger should not be
+      // called — the (N-1)/N miss rate would otherwise create
+      // unbounded log volume with low signal.
+      consumer._test.processMessage({
+        Body: JSON.stringify({ qurl_id: 'qrl_nope', access_count: 1, consumed: false }),
+        ReceiptHandle: 'rh-1',
+      });
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pollOnce', () => {
+    test('receives + deletes each message', async () => {
+      const cb = jest.fn();
+      registry.register('qrl_x', cb);
+
+      // resolvesOnce + resolves: the manual pollOnce() call below
+      // gets the message; the background pollLoop spawned by start()
+      // sees an empty queue and exits its iteration without firing
+      // a second delete.
+      sqsMock.on(ReceiveMessageCommand)
+        .resolvesOnce({
+          Messages: [
+            {
+              MessageId: 'm1',
+              ReceiptHandle: 'rh-1',
+              Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 3, consumed: false }),
+            },
+          ],
+        })
+        .resolves({ Messages: [] });
+      sqsMock.on(DeleteMessageCommand).resolves({});
+
+      consumer.start();
+      await consumer._test.pollOnce();
+
+      expect(cb).toHaveBeenCalled();
+      const delCalls = sqsMock.commandCalls(DeleteMessageCommand);
+      expect(delCalls).toHaveLength(1);
+      expect(delCalls[0].args[0].input.ReceiptHandle).toBe('rh-1');
+
+      await consumer.stop();
+    });
+
+    test('silent-drop-on-miss still deletes the message', async () => {
+      // No callback registered. Consumer should still DELETE so it
+      // doesn't re-deliver to the same replica on visibility expiry.
+      sqsMock.on(ReceiveMessageCommand)
+        .resolvesOnce({
+          Messages: [
+            {
+              MessageId: 'm1',
+              ReceiptHandle: 'rh-1',
+              Body: JSON.stringify({ qurl_id: 'qrl_nobody_home', access_count: 1, consumed: false }),
+            },
+          ],
+        })
+        .resolves({ Messages: [] });
+      sqsMock.on(DeleteMessageCommand).resolves({});
+
+      consumer.start();
+      await consumer._test.pollOnce();
+
+      expect(sqsMock.commandCalls(DeleteMessageCommand)).toHaveLength(1);
+
+      await consumer.stop();
+    });
+
+    test('AbortError on ReceiveMessage is handled cleanly (no log)', async () => {
+      const abortErr = new Error('aborted');
+      abortErr.name = 'AbortError';
+      sqsMock.on(ReceiveMessageCommand).rejects(abortErr);
+
+      consumer.start();
+      await consumer._test.pollOnce();
+
+      // AbortError is the expected shape during stop() — must not
+      // be logged as a real failure.
+      const errLogs = logger.warn.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('ReceiveMessage failed'),
+      );
+      expect(errLogs).toHaveLength(0);
+
+      await consumer.stop();
+    });
+
+    test('non-AbortError on ReceiveMessage is logged + returns cleanly', async () => {
+      sqsMock.on(ReceiveMessageCommand).rejects(new Error('SQS throttled'));
+
+      consumer.start();
+      await consumer._test.pollOnce();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('ReceiveMessage failed'),
+        expect.objectContaining({ error: 'SQS throttled' }),
+      );
+
+      await consumer.stop();
+    });
+  });
+});

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -166,8 +166,27 @@ describe('view-update-consumer', () => {
 
       expect(cb).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('access_count not a non-negative safe integer'),
+        expect.stringContaining('access_count not a positive safe integer'),
         expect.any(Object),
+      );
+    });
+
+    test('access_count of 0 is dropped at parse boundary (cr round-5 #1)', () => {
+      // Tightened from `< 0` to `<= 0` so 0-count envelopes drop at
+      // the parse boundary instead of dispatching into the handler
+      // (which would also drop, but with a wider validation gate).
+      // qurl.accessed events always carry access_count >= 1, so a 0
+      // is a wire-shape regression worth surfacing.
+      const cb = jest.fn();
+      registry.register('qrl_x', cb);
+      consumer._test.processMessage({
+        Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 0 }),
+        ReceiptHandle: 'rh-zero',
+      });
+      expect(cb).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('access_count not a positive safe integer'),
+        expect.objectContaining({ access_count: 0 }),
       );
     });
 
@@ -186,30 +205,25 @@ describe('view-update-consumer', () => {
 
   describe('pollOnce', () => {
     test('receives + deletes each message', async () => {
+      // cr round-5 #4: drive pollOnce directly (no start() + background
+      // pollLoop race). We seed stopController via the test helper so
+      // pollOnce's abortSignal binding works, but no background loop
+      // competes with this test's pollOnce for the resolvesOnce.
       const cb = jest.fn();
       registry.register('qrl_x', cb);
 
-      // resolvesOnce + resolves: only the FIRST ReceiveMessage call
-      // gets the message; subsequent calls (whether from the background
-      // pollLoop spawned by start() or the manual pollOnce() below)
-      // see an empty queue. Net effect: exactly one delete, regardless
-      // of which loop's pollOnce processed the message — synchronous
-      // pollLoop scheduling means the background loop usually wins the
-      // race, but assertions don't depend on the winner.
-      sqsMock.on(ReceiveMessageCommand)
-        .resolvesOnce({
-          Messages: [
-            {
-              MessageId: 'm1',
-              ReceiptHandle: 'rh-1',
-              Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 3, consumed: false }),
-            },
-          ],
-        })
-        .resolves({ Messages: [] });
+      sqsMock.on(ReceiveMessageCommand).resolves({
+        Messages: [
+          {
+            MessageId: 'm1',
+            ReceiptHandle: 'rh-1',
+            Body: JSON.stringify({ qurl_id: 'qrl_x', access_count: 3, consumed: false }),
+          },
+        ],
+      });
       sqsMock.on(DeleteMessageBatchCommand).resolves({});
 
-      consumer.start();
+      consumer._test._setStopControllerForTest(new AbortController());
       await consumer._test.pollOnce();
 
       expect(cb).toHaveBeenCalled();
@@ -218,34 +232,28 @@ describe('view-update-consumer', () => {
       const entries = delCalls[0].args[0].input.Entries;
       expect(entries).toHaveLength(1);
       expect(entries[0].ReceiptHandle).toBe('rh-1');
-
-      await consumer.stop();
     });
 
     test('silent-drop-on-miss still deletes the message', async () => {
       // No callback registered. Consumer should still DELETE so it
       // doesn't re-deliver to the same replica on visibility expiry.
-      sqsMock.on(ReceiveMessageCommand)
-        .resolvesOnce({
-          Messages: [
-            {
-              MessageId: 'm1',
-              ReceiptHandle: 'rh-1',
-              Body: JSON.stringify({ qurl_id: 'qrl_nobody_home', access_count: 1, consumed: false }),
-            },
-          ],
-        })
-        .resolves({ Messages: [] });
+      sqsMock.on(ReceiveMessageCommand).resolves({
+        Messages: [
+          {
+            MessageId: 'm1',
+            ReceiptHandle: 'rh-1',
+            Body: JSON.stringify({ qurl_id: 'qrl_nobody_home', access_count: 1, consumed: false }),
+          },
+        ],
+      });
       sqsMock.on(DeleteMessageBatchCommand).resolves({});
 
-      consumer.start();
+      consumer._test._setStopControllerForTest(new AbortController());
       await consumer._test.pollOnce();
 
       const delCalls = sqsMock.commandCalls(DeleteMessageBatchCommand);
       expect(delCalls).toHaveLength(1);
       expect(delCalls[0].args[0].input.Entries[0].ReceiptHandle).toBe('rh-1');
-
-      await consumer.stop();
     });
 
     test('AbortError on ReceiveMessage is handled cleanly (no log)', async () => {
@@ -253,7 +261,7 @@ describe('view-update-consumer', () => {
       abortErr.name = 'AbortError';
       sqsMock.on(ReceiveMessageCommand).rejects(abortErr);
 
-      consumer.start();
+      consumer._test._setStopControllerForTest(new AbortController());
       await consumer._test.pollOnce();
 
       // AbortError is the expected shape during stop() — must not
@@ -262,8 +270,6 @@ describe('view-update-consumer', () => {
         ([msg]) => typeof msg === 'string' && msg.includes('ReceiveMessage failed'),
       );
       expect(errLogs).toHaveLength(0);
-
-      await consumer.stop();
     });
 
     test('AbortError via err.code (older SDK shape) is also handled cleanly', async () => {
@@ -271,15 +277,13 @@ describe('view-update-consumer', () => {
       abortErr.code = 'AbortError';
       sqsMock.on(ReceiveMessageCommand).rejects(abortErr);
 
-      consumer.start();
+      consumer._test._setStopControllerForTest(new AbortController());
       await consumer._test.pollOnce();
 
       const errLogs = logger.warn.mock.calls.filter(
         ([msg]) => typeof msg === 'string' && msg.includes('ReceiveMessage failed'),
       );
       expect(errLogs).toHaveLength(0);
-
-      await consumer.stop();
     });
 
     test('SDK response missing Messages property is handled (defensive ?? [])', async () => {
@@ -290,7 +294,7 @@ describe('view-update-consumer', () => {
       // default fails this test loudly.
       sqsMock.on(ReceiveMessageCommand).resolves({ /* no Messages key */ });
 
-      consumer.start();
+      consumer._test._setStopControllerForTest(new AbortController());
       await consumer._test.pollOnce();
 
       // No callback fired, no log line about parsing failure.
@@ -298,22 +302,23 @@ describe('view-update-consumer', () => {
         ([msg]) => typeof msg === 'string' && msg.includes('malformed'),
       );
       expect(errLogs).toHaveLength(0);
-
-      await consumer.stop();
     });
 
     test('non-AbortError on ReceiveMessage is logged + returns cleanly', async () => {
       sqsMock.on(ReceiveMessageCommand).rejects(new Error('SQS throttled'));
+      // Pre-arm a long-completed abort signal to skip the backoff
+      // sleep — the error path waits POLL_ERROR_BACKOFF_MS via
+      // abortableSleep otherwise.
+      const ctrl = new AbortController();
+      ctrl.abort();
+      consumer._test._setStopControllerForTest(ctrl);
 
-      consumer.start();
       await consumer._test.pollOnce();
 
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('ReceiveMessage failed'),
         expect.objectContaining({ error: 'SQS throttled' }),
       );
-
-      await consumer.stop();
     });
   });
 

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -171,7 +171,7 @@ describe('view-update-consumer', () => {
       );
     });
 
-    test('access_count of 0 is dropped at parse boundary (cr round-5 #1)', () => {
+    test('access_count of 0 is dropped at parse boundary', () => {
       // Tightened from `< 0` to `<= 0` so 0-count envelopes drop at
       // the parse boundary instead of dispatching into the handler
       // (which would also drop, but with a wider validation gate).
@@ -205,7 +205,7 @@ describe('view-update-consumer', () => {
 
   describe('pollOnce', () => {
     test('receives + deletes each message', async () => {
-      // cr round-5 #4: drive pollOnce directly (no start() + background
+      // Drive pollOnce directly (no start() + background
       // pollLoop race). We seed stopController via the test helper so
       // pollOnce's abortSignal binding works, but no background loop
       // competes with this test's pollOnce for the resolvesOnce.
@@ -340,7 +340,7 @@ describe('view-update-consumer', () => {
       await consumer.stop();
     });
 
-    test('pollLoop defense-in-depth path flips running=false before invoking onFatalCb (cr round-7 #1)', () => {
+    test('pollLoop defense-in-depth path flips running=false before invoking onFatalCb', () => {
       // Direct test of the defense-in-depth fatal-path order: the
       // module-state flip (running=false) must precede onFatalCb so a
       // caller without an onFatal handler doesn't end up wedged with

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -282,6 +282,26 @@ describe('view-update-consumer', () => {
       await consumer.stop();
     });
 
+    test('SDK response missing Messages property is handled (defensive ?? [])', async () => {
+      // SDK upgrade or wire-shape change could elide the Messages
+      // field on an empty response. The `resp.Messages || []`
+      // defensive default at the use site keeps the for-loop happy;
+      // pin that contract so a future refactor that drops the
+      // default fails this test loudly.
+      sqsMock.on(ReceiveMessageCommand).resolves({ /* no Messages key */ });
+
+      consumer.start();
+      await consumer._test.pollOnce();
+
+      // No callback fired, no log line about parsing failure.
+      const errLogs = logger.warn.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('malformed'),
+      );
+      expect(errLogs).toHaveLength(0);
+
+      await consumer.stop();
+    });
+
     test('non-AbortError on ReceiveMessage is logged + returns cleanly', async () => {
       sqsMock.on(ReceiveMessageCommand).rejects(new Error('SQS throttled'));
 

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -296,4 +296,23 @@ describe('view-update-consumer', () => {
       await consumer.stop();
     });
   });
+
+  describe('onFatal contract', () => {
+    test('onFatal is wired through start() and remains optional', async () => {
+      // start() accepts an optional { onFatal } option; the defense-in-
+      // depth path in pollLoop calls it on truly unexpected throws
+      // (vs. the normal ReceiveMessage error path which logs + backs
+      // off). Direct unit-test of pollLoop's fatal branch would require
+      // mocking the registry to throw across an await — heavier than
+      // it's worth. This test pins the contract that start() doesn't
+      // reject + remains optional, so a future refactor that requires
+      // onFatal fails this loud.
+      sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
+      expect(() => consumer.start()).not.toThrow();
+      // Must stop() or the background pollLoop keeps cycling on the
+      // module's stopController for the rest of the suite. afterEach
+      // would catch it, but explicit stop here keeps the test honest.
+      await consumer.stop();
+    });
+  });
 });

--- a/apps/discord/tests/view-update-consumer.test.js
+++ b/apps/discord/tests/view-update-consumer.test.js
@@ -189,10 +189,13 @@ describe('view-update-consumer', () => {
       const cb = jest.fn();
       registry.register('qrl_x', cb);
 
-      // resolvesOnce + resolves: the manual pollOnce() call below
-      // gets the message; the background pollLoop spawned by start()
-      // sees an empty queue and exits its iteration without firing
-      // a second delete.
+      // resolvesOnce + resolves: only the FIRST ReceiveMessage call
+      // gets the message; subsequent calls (whether from the background
+      // pollLoop spawned by start() or the manual pollOnce() below)
+      // see an empty queue. Net effect: exactly one delete, regardless
+      // of which loop's pollOnce processed the message — synchronous
+      // pollLoop scheduling means the background loop usually wins the
+      // race, but assertions don't depend on the winner.
       sqsMock.on(ReceiveMessageCommand)
         .resolvesOnce({
           Messages: [

--- a/apps/discord/tests/view-update-handler.test.js
+++ b/apps/discord/tests/view-update-handler.test.js
@@ -17,9 +17,9 @@
  *   - getButtonRow() called fresh on each invocation (catches stop()
  *     setting it to null without keeping a stale reference)
  *
- * cr round-3 #1 motivated the extraction — these tests close the
- * "what could regress later" surface that the in-place closure body
- * couldn't reach.
+ * The factory extraction lets these tests close the "what could
+ * regress later" surface that the in-place closure body couldn't
+ * reach.
  */
 
 const { createHandleViewUpdate } = require('../src/view-update-handler');
@@ -183,7 +183,7 @@ describe('createHandleViewUpdate', () => {
       deps.linkStatus.set('qrl_a', { status: 'pending', username: 'a' });
       const handler = createHandleViewUpdate(deps);
       handler({ accessCount: 1 }, 'qrl_a');
-      // Contract per cr round-5 #3: onAllDone is hoisted ABOVE the
+      // Contract: onAllDone is hoisted ABOVE the
       // hasInteraction() gate so an interval teardown is reachable
       // even if interaction is nulled outside stop() (e.g., a future
       // token-expiry refactor). State mutates → pending hits 0 →
@@ -220,14 +220,13 @@ describe('createHandleViewUpdate', () => {
     });
   });
 
-  // cr round-8 #2 surfaced a GC leak shape — post-stop addRecipients
-  // calls would register new callbacks without an unregister path.
-  // The fix lives in commands.js's addRecipients (early-out on
-  // stopped). This test pins the contract at the handler layer: an
-  // isStopped()=true handler invocation is a no-op even if the
-  // registry has the callback still wired up. Belt-and-suspenders
-  // for the addRecipients-after-stop regression class.
-  describe('post-stop dispatch is a strict no-op (cr round-8 #2 backstop)', () => {
+  // GC leak shape backstop: a post-stop addRecipients in commands.js
+  // would otherwise register new callbacks without an unregister
+  // path. The primary fix is the early-out at the top of
+  // addRecipients (commands.js); this test pins the contract at the
+  // handler layer that an isStopped()=true handler invocation is a
+  // strict no-op even if the registry still has the callback wired.
+  describe('post-stop dispatch is a strict no-op (GC leak backstop)', () => {
     test('stopped handler does not mutate linkStatus, viewed, safeEdit, or onAllDone', () => {
       const deps = buildDeps({ isStopped: () => true });
       deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });

--- a/apps/discord/tests/view-update-handler.test.js
+++ b/apps/discord/tests/view-update-handler.test.js
@@ -220,6 +220,27 @@ describe('createHandleViewUpdate', () => {
     });
   });
 
+  // cr round-8 #2 surfaced a GC leak shape — post-stop addRecipients
+  // calls would register new callbacks without an unregister path.
+  // The fix lives in commands.js's addRecipients (early-out on
+  // stopped). This test pins the contract at the handler layer: an
+  // isStopped()=true handler invocation is a no-op even if the
+  // registry has the callback still wired up. Belt-and-suspenders
+  // for the addRecipients-after-stop regression class.
+  describe('post-stop dispatch is a strict no-op (cr round-8 #2 backstop)', () => {
+    test('stopped handler does not mutate linkStatus, viewed, safeEdit, or onAllDone', () => {
+      const deps = buildDeps({ isStopped: () => true });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 5 }, 'qrl_a');
+      // Every state-mutation gate must trip on isStopped first.
+      expect(deps.linkStatus.get('qrl_a').status).toBe('pending');
+      expect(deps._getViewed()).toBe(0);
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps.onAllDone).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getButtonRow() called fresh each invocation', () => {
     test('reflects post-construction reassignment without stale capture', () => {
       let buttonRow = { type: 1, components: [{ id: 'btn' }] };

--- a/apps/discord/tests/view-update-handler.test.js
+++ b/apps/discord/tests/view-update-handler.test.js
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for src/view-update-handler.js — the render path
+ * extracted from `monitorLinkStatus` (commands.js) for the view-
+ * update push feature (feat #60). Covers the state matrix that's
+ * load-bearing for sub-second view counter behavior:
+ *
+ *   - isStopped() early return
+ *   - isViewCounterDegraded() early return
+ *   - accessCount <= 0 early return
+ *   - missing linkStatus entry early return
+ *   - status === 'opened' idempotency guard (defeats double-increment
+ *     when the polling tick races the push path)
+ *   - happy path: linkStatus mutation + viewed bump + safeEdit call
+ *   - hasInteraction() === false skips safeEdit (token expired)
+ *   - onAllDone fires when pending hits zero
+ *   - safeEdit rejection is caught + logged, NOT thrown
+ *   - getButtonRow() called fresh on each invocation (catches stop()
+ *     setting it to null without keeping a stale reference)
+ *
+ * cr round-3 #1 motivated the extraction — these tests close the
+ * "what could regress later" surface that the in-place closure body
+ * couldn't reach.
+ */
+
+const { createHandleViewUpdate } = require('../src/view-update-handler');
+
+function buildDeps(overrides = {}) {
+  const linkStatus = new Map();
+  let viewed = 0;
+  return {
+    sendId: 'send-1',
+    linkStatus,
+    getButtonRow: () => ({ type: 1, components: [] }),
+    isStopped: () => false,
+    isViewCounterDegraded: () => false,
+    hasInteraction: () => true,
+    getViewed: () => viewed,
+    setViewed: (n) => { viewed = n; },
+    getExpectedCount: () => 2,
+    buildStatusMsg: () => 'status msg',
+    safeEdit: jest.fn(async () => undefined),
+    onAllDone: jest.fn(),
+    logger: { warn: jest.fn() },
+    // Test introspection helpers — not part of the factory contract.
+    _getViewed: () => viewed,
+    _setViewed: (n) => { viewed = n; },
+    ...overrides,
+  };
+}
+
+describe('createHandleViewUpdate', () => {
+  describe('early returns (no mutation, no safeEdit)', () => {
+    test('returns when isStopped() is true', () => {
+      const deps = buildDeps({ isStopped: () => true });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps._getViewed()).toBe(0);
+      expect(deps.linkStatus.get('qrl_a').status).toBe('pending');
+    });
+
+    test('returns when isViewCounterDegraded() is true', () => {
+      const deps = buildDeps({ isViewCounterDegraded: () => true });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps._getViewed()).toBe(0);
+    });
+
+    test('returns when update.accessCount is 0', () => {
+      const deps = buildDeps();
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 0 }, 'qrl_a');
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps._getViewed()).toBe(0);
+    });
+
+    test('returns when update is null', () => {
+      const deps = buildDeps();
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler(null, 'qrl_a');
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps._getViewed()).toBe(0);
+    });
+
+    test('returns when qurl_id is not in linkStatus', () => {
+      const deps = buildDeps();
+      // linkStatus is empty
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_unknown');
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps._getViewed()).toBe(0);
+    });
+
+    test('idempotency: returns when status is already opened', () => {
+      const deps = buildDeps();
+      deps.linkStatus.set('qrl_a', { status: 'opened', username: 'u' });
+      deps._setViewed(1);
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 5 }, 'qrl_a');
+      // Critical: viewed does NOT increment (defeats double-count
+      // when polling tick races push path).
+      expect(deps._getViewed()).toBe(1);
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+      expect(deps.linkStatus.get('qrl_a').status).toBe('opened');
+    });
+  });
+
+  describe('happy path (pending → opened transition)', () => {
+    test('mutates linkStatus + bumps viewed + calls safeEdit with status msg', () => {
+      const deps = buildDeps();
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'alice' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      expect(deps.linkStatus.get('qrl_a')).toEqual({ status: 'opened', username: 'alice' });
+      expect(deps._getViewed()).toBe(1);
+      expect(deps.safeEdit).toHaveBeenCalledWith({
+        content: 'status msg',
+        components: expect.arrayContaining([expect.any(Object)]),
+      });
+    });
+
+    test('preserves the existing username + spreads other fields', () => {
+      const deps = buildDeps();
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'bob', custom: 'x' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 7 }, 'qrl_a');
+      expect(deps.linkStatus.get('qrl_a')).toEqual({ status: 'opened', username: 'bob', custom: 'x' });
+    });
+
+    test('safeEdit components are empty when all recipients viewed', () => {
+      const deps = buildDeps({ getExpectedCount: () => 1 });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      expect(deps.safeEdit).toHaveBeenCalledWith({
+        content: 'status msg',
+        components: [],
+      });
+    });
+
+    test('onAllDone fires on the transition that takes pending to 0', () => {
+      const deps = buildDeps({ getExpectedCount: () => 2 });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'a' });
+      deps.linkStatus.set('qrl_b', { status: 'pending', username: 'b' });
+      const handler = createHandleViewUpdate(deps);
+
+      handler({ accessCount: 1 }, 'qrl_a');
+      expect(deps.onAllDone).not.toHaveBeenCalled(); // 1 of 2
+
+      handler({ accessCount: 1 }, 'qrl_b');
+      expect(deps.onAllDone).toHaveBeenCalledTimes(1); // 2 of 2
+    });
+
+    test('onAllDone does NOT fire on transitions before pending hits 0', () => {
+      const deps = buildDeps({ getExpectedCount: () => 5 });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'a' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      expect(deps.onAllDone).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasInteraction() = false (post-token-expiry)', () => {
+    test('mutates linkStatus + viewed but skips safeEdit', () => {
+      const deps = buildDeps({ hasInteraction: () => false });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      // State mutations happen so the in-memory monitor stays consistent
+      // with reality (counter is just not re-rendered).
+      expect(deps.linkStatus.get('qrl_a').status).toBe('opened');
+      expect(deps._getViewed()).toBe(1);
+      expect(deps.safeEdit).not.toHaveBeenCalled();
+    });
+
+    test('onAllDone still fires when all viewed (counter tracking continues)', () => {
+      const deps = buildDeps({ hasInteraction: () => false, getExpectedCount: () => 1 });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'a' });
+      const handler = createHandleViewUpdate(deps);
+      handler({ accessCount: 1 }, 'qrl_a');
+      // No safeEdit, but the counter still hit 0 so the timer should clear.
+      // ... wait, this branch returns BEFORE onAllDone. Confirming current
+      // contract: post-token-expiry, the safeEdit-related allDone check
+      // is also skipped. The polling tick will catch the all-done state
+      // on its next iteration (or hit isTerminated() first).
+      expect(deps.onAllDone).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('render failure', () => {
+    test('safeEdit rejection is caught + logged + NOT thrown', async () => {
+      const safeEdit = jest.fn(async () => {
+        throw new Error('Discord 401 (token expired mid-edit)');
+      });
+      const logger = { warn: jest.fn() };
+      const deps = buildDeps({ safeEdit, logger });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+
+      expect(() => handler({ accessCount: 1 }, 'qrl_a')).not.toThrow();
+
+      // Wait a microtask for the promise rejection .catch to fire.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'view-update render failed',
+        expect.objectContaining({
+          sendId: 'send-1',
+          qurl_id: 'qrl_a',
+          error: 'Discord 401 (token expired mid-edit)',
+        }),
+      );
+    });
+  });
+
+  describe('getButtonRow() called fresh each invocation', () => {
+    test('reflects post-stop() null reassignment without stale capture', () => {
+      let buttonRow = { type: 1, components: [{ id: 'btn' }] };
+      // expectedCount=3 so two flips leave pending=1 (buttonRow stays
+      // in the components array). Default expectedCount=2 would render
+      // components=[] on the second call (counter complete).
+      const deps = buildDeps({ getButtonRow: () => buttonRow, getExpectedCount: () => 3 });
+      deps.linkStatus.set('qrl_a', { status: 'pending', username: 'u' });
+      const handler = createHandleViewUpdate(deps);
+
+      handler({ accessCount: 1 }, 'qrl_a');
+      const firstCallButtonRow = deps.safeEdit.mock.calls[0][0].components[0];
+      expect(firstCallButtonRow).toEqual({ type: 1, components: [{ id: 'btn' }] });
+
+      // Simulate post-stop reassignment to a different value. (Real
+      // monitor sets buttonRow=null in stop(), but isStopped() would
+      // also gate this; using a different shape here is enough to
+      // confirm fresh lookup.)
+      buttonRow = { type: 1, components: [{ id: 'replaced' }] };
+      deps.linkStatus.set('qrl_b', { status: 'pending', username: 'u' });
+      handler({ accessCount: 1 }, 'qrl_b');
+      const secondCallButtonRow = deps.safeEdit.mock.calls[1][0].components[0];
+      expect(secondCallButtonRow).toEqual({ type: 1, components: [{ id: 'replaced' }] });
+    });
+  });
+});

--- a/apps/discord/tests/view-update-handler.test.js
+++ b/apps/discord/tests/view-update-handler.test.js
@@ -178,16 +178,17 @@ describe('createHandleViewUpdate', () => {
       expect(deps.safeEdit).not.toHaveBeenCalled();
     });
 
-    test('onAllDone still fires when all viewed (counter tracking continues)', () => {
+    test('onAllDone does NOT fire when hasInteraction()=false (handler returns before the pending check)', () => {
       const deps = buildDeps({ hasInteraction: () => false, getExpectedCount: () => 1 });
       deps.linkStatus.set('qrl_a', { status: 'pending', username: 'a' });
       const handler = createHandleViewUpdate(deps);
       handler({ accessCount: 1 }, 'qrl_a');
-      // No safeEdit, but the counter still hit 0 so the timer should clear.
-      // ... wait, this branch returns BEFORE onAllDone. Confirming current
-      // contract: post-token-expiry, the safeEdit-related allDone check
-      // is also skipped. The polling tick will catch the all-done state
-      // on its next iteration (or hit isTerminated() first).
+      // Contract: when interaction is nulled (post-stop or post-token-
+      // expiry), the handler mutates linkStatus + viewed but returns
+      // before the pending-check + onAllDone fire. The polling tick's
+      // isTerminated() or maxMonitorMs cap catches the all-done state
+      // on the next iteration. See the asymmetry comment in
+      // view-update-handler.js.
       expect(deps.onAllDone).not.toHaveBeenCalled();
     });
   });
@@ -220,7 +221,7 @@ describe('createHandleViewUpdate', () => {
   });
 
   describe('getButtonRow() called fresh each invocation', () => {
-    test('reflects post-stop() null reassignment without stale capture', () => {
+    test('reflects post-construction reassignment without stale capture', () => {
       let buttonRow = { type: 1, components: [{ id: 'btn' }] };
       // expectedCount=3 so two flips leave pending=1 (buttonRow stays
       // in the components array). Default expectedCount=2 would render

--- a/apps/discord/tests/view-update-handler.test.js
+++ b/apps/discord/tests/view-update-handler.test.js
@@ -178,18 +178,18 @@ describe('createHandleViewUpdate', () => {
       expect(deps.safeEdit).not.toHaveBeenCalled();
     });
 
-    test('onAllDone does NOT fire when hasInteraction()=false (handler returns before the pending check)', () => {
+    test('onAllDone DOES fire even when hasInteraction()=false (interval teardown is interaction-independent)', () => {
       const deps = buildDeps({ hasInteraction: () => false, getExpectedCount: () => 1 });
       deps.linkStatus.set('qrl_a', { status: 'pending', username: 'a' });
       const handler = createHandleViewUpdate(deps);
       handler({ accessCount: 1 }, 'qrl_a');
-      // Contract: when interaction is nulled (post-stop or post-token-
-      // expiry), the handler mutates linkStatus + viewed but returns
-      // before the pending-check + onAllDone fire. The polling tick's
-      // isTerminated() or maxMonitorMs cap catches the all-done state
-      // on the next iteration. See the asymmetry comment in
-      // view-update-handler.js.
-      expect(deps.onAllDone).not.toHaveBeenCalled();
+      // Contract per cr round-5 #3: onAllDone is hoisted ABOVE the
+      // hasInteraction() gate so an interval teardown is reachable
+      // even if interaction is nulled outside stop() (e.g., a future
+      // token-expiry refactor). State mutates → pending hits 0 →
+      // onAllDone fires; safeEdit is still gated on hasInteraction.
+      expect(deps.onAllDone).toHaveBeenCalledTimes(1);
+      expect(deps.safeEdit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/discord/tests/view-update-publisher.test.js
+++ b/apps/discord/tests/view-update-publisher.test.js
@@ -120,13 +120,32 @@ describe('view-update-publisher', () => {
       expect(typeof body.published_at_ms).toBe('number');
     });
 
-    test('coerces consumed to a boolean', async () => {
+    test('non-boolean consumed logs warning + coerces to false (cr round-3 #8)', async () => {
       sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
       publisher.start();
       publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: 'truthy-string', eventId: 'evt_a' });
       await publisher.stop();
       const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
-      expect(body.consumed).toBe(false); // strict equality to true required
+      expect(body.consumed).toBe(false);
+      // Contract regression must surface in logs (vs silent flip).
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('consumed is not a boolean'),
+        expect.objectContaining({ qurl_id: 'qrl_a', consumed_type: 'string' }),
+      );
+    });
+
+    test('explicit boolean true passes through without warn', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
+      publisher.start();
+      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: true, eventId: 'evt_a' });
+      await publisher.stop();
+      const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
+      expect(body.consumed).toBe(true);
+      // No contract-regression warn for the happy path.
+      const contractWarns = logger.warn.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('consumed is not a boolean'),
+      );
+      expect(contractWarns).toHaveLength(0);
     });
 
     test('rejects invalid qurlId without sending', () => {

--- a/apps/discord/tests/view-update-publisher.test.js
+++ b/apps/discord/tests/view-update-publisher.test.js
@@ -6,8 +6,9 @@
  *   - publish(): envelope shape, SendMessage call
  *   - start/stop lifecycle: idempotency, flag/queue-url guards
  *   - pre-start drop (publish() called before start() is a safe no-op)
- *   - SendMessage failure logging (kind: 'unhandledRejection' parity
- *     with event-publisher.js)
+ *   - SendMessage failure logging (kind: LOG_KINDS.VIEW_UPDATE_PUBLISH_FAIL
+ *     — decoupled from event-publisher.js's UNHANDLED_REJECTION so
+ *     paging pivots stay separate)
  *   - drain on stop()
  *   - input validation (publish() with invalid qurlId)
  */
@@ -160,6 +161,18 @@ describe('view-update-publisher', () => {
       );
     });
 
+    test('rejects invalid accessCount without sending (cr round-6 parity with consumer gate)', () => {
+      publisher.start();
+      for (const ac of [0, -1, 1.5, NaN, 'one', null, undefined]) {
+        publisher.publish({ qurlId: 'qrl_a', accessCount: ac, consumed: false, eventId: 'evt' });
+      }
+      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('invalid accessCount'),
+        expect.any(Object),
+      );
+    });
+
     test('SendMessage failure is fire-and-log (no unhandled rejection)', async () => {
       sqsMock.on(SendMessageCommand).rejects(new Error('SQS throttled'));
       publisher.start();
@@ -170,7 +183,7 @@ describe('view-update-publisher', () => {
         expect.objectContaining({
           qurl_id: 'qrl_a',
           error: 'SQS throttled',
-          kind: 'unhandledRejection',
+          kind: 'viewUpdatePublishFail',
         }),
       );
     });
@@ -194,7 +207,7 @@ describe('view-update-publisher', () => {
         expect.stringContaining('publish() sync threw'),
         expect.objectContaining({
           qurl_id: 'qrl_a',
-          kind: 'unhandledRejection',
+          kind: 'viewUpdatePublishFail',
         }),
       );
     });

--- a/apps/discord/tests/view-update-publisher.test.js
+++ b/apps/discord/tests/view-update-publisher.test.js
@@ -89,7 +89,7 @@ describe('view-update-publisher', () => {
 
   describe('publish()', () => {
     test('safe no-op when not running (pre-start drop)', () => {
-      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: false, eventId: 'evt_1' });
+      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, eventId: 'evt_1' });
       expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
     });
 
@@ -100,7 +100,6 @@ describe('view-update-publisher', () => {
       publisher.publish({
         qurlId: 'qrl_xyz',
         accessCount: 5,
-        consumed: false,
         eventId: 'evt_xyz',
       });
 
@@ -116,44 +115,19 @@ describe('view-update-publisher', () => {
       const body = JSON.parse(input.MessageBody);
       expect(body.qurl_id).toBe('qrl_xyz');
       expect(body.access_count).toBe(5);
-      expect(body.consumed).toBe(false);
       expect(body.event_id).toBe('evt_xyz');
       expect(typeof body.published_at_ms).toBe('number');
-    });
-
-    test('non-boolean consumed logs warning + coerces to false', async () => {
-      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
-      publisher.start();
-      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: 'truthy-string', eventId: 'evt_a' });
-      await publisher.stop();
-      const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
-      expect(body.consumed).toBe(false);
-      // Contract regression must surface in logs (vs silent flip).
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('consumed is not a boolean'),
-        expect.objectContaining({ qurl_id: 'qrl_a', consumed_type: 'string' }),
-      );
-    });
-
-    test('explicit boolean true passes through without warn', async () => {
-      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
-      publisher.start();
-      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: true, eventId: 'evt_a' });
-      await publisher.stop();
-      const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
-      expect(body.consumed).toBe(true);
-      // No contract-regression warn for the happy path.
-      const contractWarns = logger.warn.mock.calls.filter(
-        ([msg]) => typeof msg === 'string' && msg.includes('consumed is not a boolean'),
-      );
-      expect(contractWarns).toHaveLength(0);
+      // `consumed` deliberately omitted from envelope (cr round-14 #3)
+      // — handler doesn't read it. Pin the absence so a re-add lands
+      // alongside the envelope-contract module follow-up (#476).
+      expect(body).not.toHaveProperty('consumed');
     });
 
     test('rejects invalid qurlId without sending', () => {
       publisher.start();
-      publisher.publish({ qurlId: '', accessCount: 1, consumed: false, eventId: 'evt' });
-      publisher.publish({ qurlId: null, accessCount: 1, consumed: false, eventId: 'evt' });
-      publisher.publish({ qurlId: 123, accessCount: 1, consumed: false, eventId: 'evt' });
+      publisher.publish({ qurlId: '', accessCount: 1, eventId: 'evt' });
+      publisher.publish({ qurlId: null, accessCount: 1, eventId: 'evt' });
+      publisher.publish({ qurlId: 123, accessCount: 1, eventId: 'evt' });
       expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('invalid qurlId'),
@@ -161,10 +135,42 @@ describe('view-update-publisher', () => {
       );
     });
 
+    test('drops with log when inFlightSends cap reached (backpressure)', async () => {
+      // Stub send to return a never-resolving promise so each publish
+      // accumulates in inFlightSends without ever cleaning up. Then
+      // observe that the (MAX+1)th publish is dropped.
+      const neverResolves = new Promise(() => {});
+      sqsMock.on(SendMessageCommand).callsFake(() => neverResolves);
+      publisher.start();
+      // Cap is 1000 (MAX_INFLIGHT_SENDS); fire 1000 to fill it, then
+      // assert the 1001st drops. Each call queues a microtask via the
+      // .catch().finally() chain, so we don't need awaits between.
+      for (let i = 0; i < 1000; i++) {
+        publisher.publish({ qurlId: `qrl_${i}`, accessCount: 1, eventId: `evt_${i}` });
+      }
+      expect(publisher._test.getInFlightCount()).toBe(1000);
+      const sendCallsAtCap = sqsMock.commandCalls(SendMessageCommand).length;
+      // The next publish should drop without firing a send.
+      publisher.publish({ qurlId: 'qrl_overflow', accessCount: 1, eventId: 'evt_overflow' });
+      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(sendCallsAtCap);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('in-flight cap reached'),
+        expect.objectContaining({
+          qurl_id: 'qrl_overflow',
+          in_flight: 1000,
+          cap: 1000,
+          kind: 'viewUpdatePublishFail',
+        }),
+      );
+      // Cleanup: skip stop()'s drain (would hang on the never-
+      // resolving promises) by hard-resetting module state.
+      publisher._test._resetStateForTest();
+    });
+
     test('rejects invalid accessCount without sending (parity with consumer gate)', () => {
       publisher.start();
       for (const ac of [0, -1, 1.5, NaN, 'one', null, undefined]) {
-        publisher.publish({ qurlId: 'qrl_a', accessCount: ac, consumed: false, eventId: 'evt' });
+        publisher.publish({ qurlId: 'qrl_a', accessCount: ac, eventId: 'evt' });
       }
       expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
       expect(logger.warn).toHaveBeenCalledWith(
@@ -176,7 +182,7 @@ describe('view-update-publisher', () => {
     test('SendMessage failure is fire-and-log (no unhandled rejection)', async () => {
       sqsMock.on(SendMessageCommand).rejects(new Error('SQS throttled'));
       publisher.start();
-      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: false, eventId: 'evt_a' });
+      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, eventId: 'evt_a' });
       await publisher.stop(); // drain
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('SendMessage failed'),
@@ -200,7 +206,6 @@ describe('view-update-publisher', () => {
       expect(() => publisher.publish({
         qurlId: 'qrl_a',
         accessCount: 1,
-        consumed: false,
         eventId: 'evt_a',
       })).not.toThrow();
       expect(logger.warn).toHaveBeenCalledWith(

--- a/apps/discord/tests/view-update-publisher.test.js
+++ b/apps/discord/tests/view-update-publisher.test.js
@@ -155,5 +155,29 @@ describe('view-update-publisher', () => {
         }),
       );
     });
+
+    test('sync throw from SQS client is caught (does NOT propagate to caller)', () => {
+      // Force a sync throw by stubbing the SQS client's send to throw
+      // immediately (vs. returning a rejecting promise). The webhook
+      // route's catch block would otherwise flip a 200 to a 500.
+      const throwingClient = {
+        send: () => { throw new Error('synchronous SDK validation error'); },
+      };
+      publisher._test._setSqsClientForTest(throwingClient);
+      publisher.start();
+      expect(() => publisher.publish({
+        qurlId: 'qrl_a',
+        accessCount: 1,
+        consumed: false,
+        eventId: 'evt_a',
+      })).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('publish() sync threw'),
+        expect.objectContaining({
+          qurl_id: 'qrl_a',
+          kind: 'unhandledRejection',
+        }),
+      );
+    });
   });
 });

--- a/apps/discord/tests/view-update-publisher.test.js
+++ b/apps/discord/tests/view-update-publisher.test.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for src/view-update-publisher.js — the SQS producer for
+ * view-update push (feat #60, sub-second view counter).
+ *
+ * Covers:
+ *   - publish(): envelope shape, SendMessage call
+ *   - start/stop lifecycle: idempotency, flag/queue-url guards
+ *   - pre-start drop (publish() called before start() is a safe no-op)
+ *   - SendMessage failure logging (kind: 'unhandledRejection' parity
+ *     with event-publisher.js)
+ *   - drain on stop()
+ *   - input validation (publish() with invalid qurlId)
+ */
+
+jest.mock('../src/config', () => ({
+  ENABLE_VIEW_UPDATE_PUSH: true,
+  QURL_BOT_VIEW_UPDATES_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-view-updates',
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+const { mockClient } = require('aws-sdk-client-mock');
+const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
+
+const sqsMock = mockClient(SQSClient);
+
+const publisher = require('../src/view-update-publisher');
+const logger = require('../src/logger');
+
+beforeAll(() => {
+  if (!process.env.AWS_REGION) process.env.AWS_REGION = 'us-east-2';
+});
+
+beforeEach(() => {
+  publisher._test._resetStateForTest();
+  publisher._test._setDrainDeadlineForTest(3000);
+  sqsMock.reset();
+  jest.clearAllMocks();
+  const realClient = new SQSClient({ region: 'us-east-2' });
+  publisher._test._setSqsClientForTest(realClient);
+});
+
+describe('view-update-publisher', () => {
+  describe('start / stop lifecycle', () => {
+    test('start() requires the flag', async () => {
+      publisher._test._resetStateForTest();
+      // Override the mocked config so the flag appears off.
+      const config = require('../src/config');
+      const originalFlag = config.ENABLE_VIEW_UPDATE_PUSH;
+      config.ENABLE_VIEW_UPDATE_PUSH = false;
+      try {
+        expect(() => publisher.start()).toThrow(/ENABLE_VIEW_UPDATE_PUSH=false/);
+      } finally {
+        config.ENABLE_VIEW_UPDATE_PUSH = originalFlag;
+      }
+    });
+
+    test('start() requires queue URL', () => {
+      const config = require('../src/config');
+      const originalUrl = config.QURL_BOT_VIEW_UPDATES_QUEUE_URL;
+      config.QURL_BOT_VIEW_UPDATES_QUEUE_URL = undefined;
+      try {
+        expect(() => publisher.start()).toThrow(/QURL_BOT_VIEW_UPDATES_QUEUE_URL is not set/);
+      } finally {
+        config.QURL_BOT_VIEW_UPDATES_QUEUE_URL = originalUrl;
+      }
+    });
+
+    test('start() is idempotent on second call', () => {
+      publisher.start();
+      expect(publisher._test.isRunning()).toBe(true);
+      publisher.start();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/start.*already running/),
+      );
+    });
+
+    test('stop() is a no-op when not running', async () => {
+      await expect(publisher.stop()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('publish()', () => {
+    test('safe no-op when not running (pre-start drop)', () => {
+      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: false, eventId: 'evt_1' });
+      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+    });
+
+    test('publishes envelope shape after start()', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
+      publisher.start();
+
+      publisher.publish({
+        qurlId: 'qrl_xyz',
+        accessCount: 5,
+        consumed: false,
+        eventId: 'evt_xyz',
+      });
+
+      // publish() is fire-and-log; the underlying send resolves
+      // asynchronously. Drain via stop() to await the in-flight
+      // promise (mirrors event-publisher's test pattern).
+      await publisher.stop();
+
+      const calls = sqsMock.commandCalls(SendMessageCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0].args[0].input;
+      expect(input.QueueUrl).toBe('https://sqs.us-east-2.amazonaws.com/123/qurl-bot-view-updates');
+      const body = JSON.parse(input.MessageBody);
+      expect(body.qurl_id).toBe('qrl_xyz');
+      expect(body.access_count).toBe(5);
+      expect(body.consumed).toBe(false);
+      expect(body.event_id).toBe('evt_xyz');
+      expect(typeof body.published_at_ms).toBe('number');
+    });
+
+    test('coerces consumed to a boolean', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
+      publisher.start();
+      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: 'truthy-string', eventId: 'evt_a' });
+      await publisher.stop();
+      const body = JSON.parse(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody);
+      expect(body.consumed).toBe(false); // strict equality to true required
+    });
+
+    test('rejects invalid qurlId without sending', () => {
+      publisher.start();
+      publisher.publish({ qurlId: '', accessCount: 1, consumed: false, eventId: 'evt' });
+      publisher.publish({ qurlId: null, accessCount: 1, consumed: false, eventId: 'evt' });
+      publisher.publish({ qurlId: 123, accessCount: 1, consumed: false, eventId: 'evt' });
+      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('invalid qurlId'),
+        expect.any(Object),
+      );
+    });
+
+    test('SendMessage failure is fire-and-log (no unhandled rejection)', async () => {
+      sqsMock.on(SendMessageCommand).rejects(new Error('SQS throttled'));
+      publisher.start();
+      publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: false, eventId: 'evt_a' });
+      await publisher.stop(); // drain
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('SendMessage failed'),
+        expect.objectContaining({
+          qurl_id: 'qrl_a',
+          error: 'SQS throttled',
+          kind: 'unhandledRejection',
+        }),
+      );
+    });
+  });
+});

--- a/apps/discord/tests/view-update-publisher.test.js
+++ b/apps/discord/tests/view-update-publisher.test.js
@@ -121,7 +121,7 @@ describe('view-update-publisher', () => {
       expect(typeof body.published_at_ms).toBe('number');
     });
 
-    test('non-boolean consumed logs warning + coerces to false (cr round-3 #8)', async () => {
+    test('non-boolean consumed logs warning + coerces to false', async () => {
       sqsMock.on(SendMessageCommand).resolves({ MessageId: 'msg-1' });
       publisher.start();
       publisher.publish({ qurlId: 'qrl_a', accessCount: 1, consumed: 'truthy-string', eventId: 'evt_a' });
@@ -161,7 +161,7 @@ describe('view-update-publisher', () => {
       );
     });
 
-    test('rejects invalid accessCount without sending (cr round-6 parity with consumer gate)', () => {
+    test('rejects invalid accessCount without sending (parity with consumer gate)', () => {
       publisher.start();
       for (const ac of [0, -1, 1.5, NaN, 'one', null, undefined]) {
         publisher.publish({ qurlId: 'qrl_a', accessCount: ac, consumed: false, eventId: 'evt' });

--- a/apps/discord/tests/view-update-registry.test.js
+++ b/apps/discord/tests/view-update-registry.test.js
@@ -88,8 +88,23 @@ describe('view-update-registry', () => {
       const update = { accessCount: 1, consumed: false };
       const hit = registry.dispatch('qrl_a', update);
       expect(hit).toBe(true);
-      expect(cb).toHaveBeenCalledWith(update);
+      // Callback receives (update, qurlId) — qurlId passes through so
+      // a shared closure can register against many qurl_ids.
+      expect(cb).toHaveBeenCalledWith(update, 'qrl_a');
       expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    test('shared callback registered against multiple qurl_ids gets the right qurlId per dispatch', () => {
+      const cb = jest.fn();
+      registry.register('qrl_a', cb);
+      registry.register('qrl_b', cb);
+      registry.register('qrl_c', cb);
+      registry.dispatch('qrl_b', { accessCount: 2 });
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith({ accessCount: 2 }, 'qrl_b');
+      registry.dispatch('qrl_a', { accessCount: 3 });
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenLastCalledWith({ accessCount: 3 }, 'qrl_a');
     });
 
     test('returns false (silent-drop) when qurl_id is not registered', () => {

--- a/apps/discord/tests/view-update-registry.test.js
+++ b/apps/discord/tests/view-update-registry.test.js
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for src/view-update-registry.js — the process-local
+ * Map<qurl_id, Set<callback>> used by view-update push (feat #60).
+ *
+ * Covers:
+ *   - register / unregister round-trip
+ *   - dispatch hits all registered callbacks
+ *   - dispatch on unknown qurl_id returns false (silent-drop —
+ *     LOAD-BEARING for the (N-1)/N replica miss case)
+ *   - multiple callbacks per qurl_id (defensive: same qurl in two
+ *     monitors via /qurl map → /qurl send chain)
+ *   - callback throw is caught + logged, other callbacks still fire
+ *   - input validation (non-string qurl_id, non-function callback)
+ *   - unregister on a qurl_id with no entries is a no-op
+ *   - unregister of one callback when others exist keeps the rest
+ *   - dispatch snapshot: callback unregistering itself mid-dispatch
+ *     doesn't break iteration
+ */
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+const registry = require('../src/view-update-registry');
+const logger = require('../src/logger');
+
+describe('view-update-registry', () => {
+  beforeEach(() => {
+    registry._test._resetForTest();
+    jest.clearAllMocks();
+  });
+
+  describe('register / unregister', () => {
+    test('register adds an entry; unregister removes it', () => {
+      const cb = jest.fn();
+      registry.register('qrl_a', cb);
+      expect(registry._test._sizeForTest()).toBe(1);
+      expect(registry._test._entryCountForTest('qrl_a')).toBe(1);
+      registry.unregister('qrl_a', cb);
+      expect(registry._test._sizeForTest()).toBe(0);
+    });
+
+    test('multiple callbacks on same qurl_id', () => {
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      registry.register('qrl_a', cb1);
+      registry.register('qrl_a', cb2);
+      expect(registry._test._sizeForTest()).toBe(1); // one qurl_id key
+      expect(registry._test._entryCountForTest('qrl_a')).toBe(2);
+      registry.unregister('qrl_a', cb1);
+      expect(registry._test._entryCountForTest('qrl_a')).toBe(1);
+      registry.unregister('qrl_a', cb2);
+      expect(registry._test._sizeForTest()).toBe(0);
+    });
+
+    test('unregister on unknown qurl_id is a no-op', () => {
+      expect(() => registry.unregister('qrl_nope', () => {})).not.toThrow();
+    });
+
+    test('unregister of an unregistered callback is a no-op', () => {
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      registry.register('qrl_a', cb1);
+      registry.unregister('qrl_a', cb2); // cb2 was never registered
+      expect(registry._test._entryCountForTest('qrl_a')).toBe(1);
+    });
+
+    test('register rejects non-string qurl_id', () => {
+      expect(() => registry.register(null, () => {})).toThrow(/non-empty string/);
+      expect(() => registry.register('', () => {})).toThrow(/non-empty string/);
+      expect(() => registry.register(123, () => {})).toThrow(/non-empty string/);
+    });
+
+    test('register rejects non-function callback', () => {
+      expect(() => registry.register('qrl_a', null)).toThrow(/must be a function/);
+      expect(() => registry.register('qrl_a', 'not-a-fn')).toThrow(/must be a function/);
+    });
+  });
+
+  describe('dispatch', () => {
+    test('returns true and fires callback when qurl_id is registered', () => {
+      const cb = jest.fn();
+      registry.register('qrl_a', cb);
+      const update = { accessCount: 1, consumed: false };
+      const hit = registry.dispatch('qrl_a', update);
+      expect(hit).toBe(true);
+      expect(cb).toHaveBeenCalledWith(update);
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns false (silent-drop) when qurl_id is not registered', () => {
+      const hit = registry.dispatch('qrl_nope', { accessCount: 1 });
+      expect(hit).toBe(false);
+      // Critical: silent-drop is the load-bearing property. No log
+      // spam on miss — verified by checking logger.warn was NOT called
+      // (only error from a thrown callback would log).
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('fires every callback registered for the qurl_id', () => {
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      const cb3 = jest.fn();
+      registry.register('qrl_a', cb1);
+      registry.register('qrl_a', cb2);
+      registry.register('qrl_a', cb3);
+      registry.dispatch('qrl_a', { accessCount: 5 });
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).toHaveBeenCalledTimes(1);
+      expect(cb3).toHaveBeenCalledTimes(1);
+    });
+
+    test('callback that throws is caught + logged; siblings still fire', () => {
+      const cb1 = jest.fn(() => { throw new Error('boom'); });
+      const cb2 = jest.fn();
+      registry.register('qrl_a', cb1);
+      registry.register('qrl_a', cb2);
+      const hit = registry.dispatch('qrl_a', { accessCount: 1 });
+      expect(hit).toBe(true);
+      expect(cb1).toHaveBeenCalled();
+      expect(cb2).toHaveBeenCalled(); // sibling still fires
+      expect(logger.error).toHaveBeenCalledWith(
+        'view-update-registry: callback threw',
+        expect.objectContaining({ qurl_id: 'qrl_a', error: 'boom' }),
+      );
+    });
+
+    test('callback unregistering itself mid-dispatch does not break iteration', () => {
+      // cb1 must close over its own jest.fn wrapper (the value the
+      // registry holds), NOT the inner fn — jest.fn(fn) wraps `fn`,
+      // and the wrapper is what gets added to the Set.
+      let cb1;
+      cb1 = jest.fn(() => {
+        registry.unregister('qrl_a', cb1);
+      });
+      const cb2 = jest.fn();
+      registry.register('qrl_a', cb1);
+      registry.register('qrl_a', cb2);
+      registry.dispatch('qrl_a', { accessCount: 1 });
+      expect(cb1).toHaveBeenCalled();
+      expect(cb2).toHaveBeenCalled(); // snapshot ensures cb2 still fires
+      // After dispatch, cb1 is unregistered but cb2 remains.
+      expect(registry._test._entryCountForTest('qrl_a')).toBe(1);
+    });
+  });
+
+  describe('GC discipline', () => {
+    test('unregister down to zero callbacks removes the qurl_id entry', () => {
+      const cb = jest.fn();
+      registry.register('qrl_a', cb);
+      registry.unregister('qrl_a', cb);
+      // Internal map should not retain an empty Set for the key.
+      expect(registry._test._sizeForTest()).toBe(0);
+      expect(registry._test._entryCountForTest('qrl_a')).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The Discord bot's `/qurl send` link-status monitor polls qurl_views DDB every 15–60 s. View counters lag the actual click by up to a minute — fine for the soak window but a flat experience for anyone watching the monitor in real time. This PR adds an SQS push path so view events render within ~1 s of the qurl.accessed webhook hitting the bot.

## What

Three new modules + flag-gated wiring across config / boot-requirements / webhook receiver / index boot / `monitorLinkStatus`:

- **`view-update-publisher.js`** — fire-and-log SQS `SendMessage` from `routes/qurl-webhook.js` after `recordQurlView` returns `result === 'recorded'` (real new view, not per-event dedup replay). Process-singleton; same drain discipline as `event-publisher.js`.
- **`view-update-consumer.js`** — long-poll consumer in the **HTTP tier** (same process that owns the webhook receiver + live `monitorLinkStatus` instances). Parses each envelope, dispatches to the registry by `qurl_id`, then deletes the message regardless of dispatch outcome.
- **`view-update-registry.js`** — process-local `Map<qurl_id, Set<callback>>`. Live `monitorLinkStatus` instances register a SHARED callback against every tracked `qurl_id` on construction and on `addRecipients`; the callback mutates `linkStatus` from the envelope payload and calls `safeEdit` directly (no DDB BatchGet — render is envelope-driven).
- **`view-update-handler.js`** — factory for the monitor's view-update callback closure. Extracted so the state matrix (stopped / degraded / accessCount<=0 / status==='opened' idempotency / pending→0 → onAllDone) is unit-testable without a full monitor closure.

**Silent-drop-on-miss is LOAD-BEARING.** With N=2 HTTP replicas in sandbox today, any one consumer has a 1/N chance of being the right replica for a given monitor — the polling path in `monitorLinkStatus` (unchanged) catches the misses. SQS push is purely a latency optimization on the hit half.

## Envelope

\`\`\`json
{
  "qurl_id": "qrl_xxxx",
  "access_count": 42,
  "consumed": false,
  "event_id": "evt_xxxx",
  "published_at_ms": 1739462812345
}
\`\`\`

## Architecture flow

\`\`\`
qurl-service → POST /webhooks/qurl → recordQurlView (DDB) ─┬→ publisher.publish() ─→ SQS ─┐
                                                          │                              │
                                                          └→ 200 ──→ qurl-service        │
                                                                                          │
HTTP tier   ─→ consumer.pollLoop() ──→ registry.dispatch() ──→ handleViewUpdate(envelope)
                                       (hit on this replica)
                                       (silent-drop otherwise — polling fallback covers)
\`\`\`

## Flag-gated rollout (3 steps)

1. **This PR merges with flag OFF** (\`ENABLE_VIEW_UPDATE_PUSH=false\`). The publisher no-ops on \`publish()\` when not started; the consumer doesn't start; the registry is empty. Safe in any deploy.
2. **\`qurl-integrations-infra\` companion PR** provisions the SQS queue (\`qurl-bot-discord-view-updates-{env}\`), the IAM grants (\`sqs:SendMessage\` on the HTTP task role, \`sqs:ReceiveMessage\` + \`sqs:DeleteMessage\` on the worker task role), and the env var injection on both task defs.
3. **Flag flip** in sandbox.tfvars → verify the hit rate (LogsInsights query in the rollout runbook) → prod.

## GC discipline

Callbacks pin monitor closure state (\`linkStatus\` Map, \`runTick\`, etc.). \`monitorLinkStatus.stop()\` now unregisters every callback it registered. Mirrors the existing closure-mutable-rebind discipline for \`interaction\`/\`qurlLinks\`.

\`addRecipients\` extends both the tracked set AND the registry — the existing comment block ("seed linkStatus AND trackedQurlIds together") generalizes to the registry without any changes to the policy.

## Tests

| File | Coverage |
|------|----------|
| \`view-update-registry.test.js\` | register/unregister round-trip; dispatch hit + silent-drop; callback-throw isolation; self-unregister mid-iteration; GC of empty entries; input validation. |
| \`view-update-publisher.test.js\` | start/stop guards (flag, queue URL); idempotent re-start; pre-start drop; envelope shape + SendMessage call; \`consumed\` coercion; invalid-qurlId rejection; fire-and-log failure path. |
| \`view-update-consumer.test.js\` | start/stop guards; \`processMessage\` validation (JSON, qurl_id, access_count); \`pollOnce\` delete-after-process even on silent-drop; AbortError handling. |
| \`boot-requirements.test.js\` | \`missingViewUpdatePushKeys\` parity with \`missingEventShipperKeys\`. |

- 112 new/touched tests, all passing.
- Full bot suite: 2539/2539 passing.
- \`eslint --max-warnings 0\` clean.

## Risk

- Flag default off → no behavior change without operator action.
- Polling path untouched → correctness primitive preserved.
- New modules are isolated (no imports back into existing modules except a registry import in \`commands.js\` that is gated on the flag).
- Webhook receiver hot path adds one synchronous \`if (result === 'recorded') publish(...)\` call; \`publish()\` returns early when the publisher isn't running, so the off-state cost is one comparison.

## Follow-up (not in this PR)

- Infra companion PR: SQS queue + IAM + env var injection.
- Sandbox flag flip + verification.
- LogsInsights query to measure hit rate (validates the N=2 assumption stays accurate as the bot scales).
