### PR TITLE
feat(slack): add once:true flag on /qurl get for one-time-use links

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -752,7 +752,7 @@ func (h *Handler) helpMessage() string {
 		lines = append(lines, "• `/qurl get <url|$name> dm:true` — DM the link to you instead of posting it in-channel")
 	}
 	lines = append(lines,
-		"• `/qurl get <url|$name> once:true` — Mint a single-use link; the first redemption burns it",
+		"• `/qurl get <url|$name> once:true` — Get a single-use qURL; the link burns on first redemption",
 		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
 		"• `/qurl list` — Show your 5 most recent qURLs",
 		"• `/qurl setup` — Connect qURL to your Slack workspace (workspace admin only)",

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -752,7 +752,7 @@ func (h *Handler) helpMessage() string {
 		lines = append(lines, "• `/qurl get <url|$name> dm:true` — DM the link to you instead of posting it in-channel")
 	}
 	lines = append(lines,
-		"• `/qurl get <url|$name> once:true` — The link works exactly once; redemption burns it",
+		"• `/qurl get <url|$name> once:true` — Mint a single-use link; the first redemption burns it",
 		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
 		"• `/qurl list` — Show your 5 most recent qURLs",
 		"• `/qurl setup` — Connect qURL to your Slack workspace (workspace admin only)",

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -752,6 +752,7 @@ func (h *Handler) helpMessage() string {
 		lines = append(lines, "• `/qurl get <url|$name> dm:true` — DM the link to you instead of posting it in-channel")
 	}
 	lines = append(lines,
+		"• `/qurl get <url|$name> once:true` — The link works exactly once; redemption burns it",
 		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
 		"• `/qurl list` — Show your 5 most recent qURLs",
 		"• `/qurl setup` — Connect qURL to your Slack workspace (workspace admin only)",

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -246,6 +246,7 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 
 	input := client.CreateInput{
 		Reason:         args.cmd.Reason(),
+		OneTimeUse:     args.cmd.Once(),
 		IdempotencyKey: IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
 	}
 
@@ -302,6 +303,12 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	}
 
 	message := ":link: *qURL ready:* " + out.QURLLink
+	if args.cmd.Once() {
+		// Make the single-use posture visible to the requester so they
+		// see what they shipped — a link that burns on first redemption
+		// behaves materially differently from the default.
+		message += " (one-time use)"
+	}
 	if args.cmd.DM() {
 		return h.deliverGetDM(ctx, log, args.userID, message), nil
 	}

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -304,9 +304,6 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 
 	message := ":link: *qURL ready:* " + out.QURLLink
 	if args.cmd.Once() {
-		// Make the single-use posture visible to the requester so they
-		// see what they shipped — a link that burns on first redemption
-		// behaves materially differently from the default.
 		message += " (one-time use)"
 	}
 	if args.cmd.DM() {

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -411,6 +411,70 @@ func TestCreateInputJSON_Reason(t *testing.T) {
 	}
 }
 
+// TestCreateInputJSON_OnceTrue fences the wire shape for the
+// once:true flag: the JSON body carries `one_time_use: true` so the
+// minted qURL burns on first redemption. Alias-form mint, matching
+// the [TestCreateInputJSON_Reason] sibling — the body shape is
+// `createForResourceBody`, which carries `OneTimeUse` directly.
+func TestCreateInputJSON_OnceTrue(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var capturedBody []byte
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = b
+		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db once:true", testAdminTeamID, testAdminUserID)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
+		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
+	}
+	if got, _ := parsed["one_time_use"].(bool); !got {
+		t.Errorf("one_time_use = %v, want true", parsed["one_time_use"])
+	}
+	if !strings.Contains(async, "(one-time use)") {
+		t.Errorf("async reply missing one-time-use suffix: %q", async)
+	}
+}
+
+// TestCreateInputJSON_OnceAbsent fences the absence half of the
+// once: contract: when the flag is omitted, the JSON body must NOT
+// carry `one_time_use` (the SDK's `omitempty` tag drops the false
+// zero value). Mirrors [TestCreateInputJSON_OnceTrue] so a regression
+// that flipped the default to true at the handler layer surfaces
+// here. Also pins that the reply copy does NOT carry the suffix on
+// the default path.
+func TestCreateInputJSON_OnceAbsent(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var capturedBody []byte
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = b
+		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
+		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
+	}
+	if _, ok := parsed["one_time_use"]; ok {
+		t.Errorf("one_time_use present on default mint body (omitempty must drop the false zero): %v", parsed)
+	}
+	if strings.Contains(async, "(one-time use)") {
+		t.Errorf("async reply carries one-time-use suffix without the flag: %q", async)
+	}
+}
+
 // TestCreateInputJSON_IdempotencyKeyHeader fences that the
 // Idempotency-Key header lands on the wire (not in the JSON body)
 // and is the sha256(team\x00channel\x00user\x00trigger). Alias-form,

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -322,6 +322,41 @@ func TestHandleGet_DMVariantPostDMSuccess(t *testing.T) {
 	}
 }
 
+// TestHandleGet_OnceTrueDMTrue fences that the (one-time use) suffix
+// rides into the DM payload (not the channel reply) when once: and
+// dm: stack. Guards against a future refactor that reorders the
+// suffix-append and DM-dispatch branches in getWork.
+func TestHandleGet_OnceTrueDMTrue(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeCreateFixture(t, w, "https://qurl.link/dm-once", testResourceIDFix)
+	})
+
+	var dmText string
+	h := newAdminTestHandler(t, ts)
+	h.cfg.PostDM = func(_ context.Context, _, text string) error {
+		dmText = text
+		return nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db once:true dm:true", testAdminTeamID, testAdminUserID)
+
+	if !strings.HasSuffix(strings.TrimSpace(dmText), "(one-time use)") {
+		t.Errorf("DM payload missing one-time-use suffix: %q", dmText)
+	}
+	if !strings.Contains(dmText, "https://qurl.link/dm-once") {
+		t.Errorf("DM payload missing link: %q", dmText)
+	}
+	if strings.Contains(async, "(one-time use)") {
+		t.Errorf("one-time-use suffix leaked to channel ephemeral on dm:true: %q", async)
+	}
+	if strings.Contains(async, "https://qurl.link/dm-once") {
+		t.Errorf("link leaked to channel ephemeral on dm:true: %q", async)
+	}
+}
+
 // TestHumanizeRetry fences the rate-limit retry-after rendering.
 // Sub-second collapses to "a moment" (so 0.4s doesn't print as "0s"
 // from int(0.4+0.5) rounding); minute-or-more rounds to integer.
@@ -465,6 +500,37 @@ func TestCreateInputJSON_OnceAbsent(t *testing.T) {
 	}
 	if strings.Contains(async, "(one-time use)") {
 		t.Errorf("async reply carries one-time-use suffix without the flag: %q", async)
+	}
+}
+
+// TestCreateInputJSON_OnceFalse fences the explicit-false branch:
+// `once:false` is accepted by the parser (Flags["once"]="false"),
+// `Once()` returns false via EqualFold, and `omitempty` drops the
+// zero from the body. Distinct from [TestCreateInputJSON_OnceAbsent]
+// because that test never populates the flag at all.
+func TestCreateInputJSON_OnceFalse(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var capturedBody []byte
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = b
+		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db once:false", testAdminTeamID, testAdminUserID)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
+		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
+	}
+	if _, ok := parsed["one_time_use"]; ok {
+		t.Errorf("one_time_use present on once:false mint body (omitempty must drop the false zero): %v", parsed)
+	}
+	if strings.Contains(async, "(one-time use)") {
+		t.Errorf("async reply carries one-time-use suffix on once:false: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -411,11 +411,8 @@ func TestCreateInputJSON_Reason(t *testing.T) {
 	}
 }
 
-// TestCreateInputJSON_OnceTrue fences the wire shape for the
-// once:true flag: the JSON body carries `one_time_use: true` so the
-// minted qURL burns on first redemption. Alias-form mint, matching
-// the [TestCreateInputJSON_Reason] sibling — the body shape is
-// `createForResourceBody`, which carries `OneTimeUse` directly.
+// TestCreateInputJSON_OnceTrue fences `one_time_use: true` on the
+// wire body and the `(one-time use)` suffix on the async reply.
 func TestCreateInputJSON_OnceTrue(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
@@ -442,13 +439,9 @@ func TestCreateInputJSON_OnceTrue(t *testing.T) {
 	}
 }
 
-// TestCreateInputJSON_OnceAbsent fences the absence half of the
-// once: contract: when the flag is omitted, the JSON body must NOT
-// carry `one_time_use` (the SDK's `omitempty` tag drops the false
-// zero value). Mirrors [TestCreateInputJSON_OnceTrue] so a regression
-// that flipped the default to true at the handler layer surfaces
-// here. Also pins that the reply copy does NOT carry the suffix on
-// the default path.
+// TestCreateInputJSON_OnceAbsent fences `omitempty` — without the
+// flag, `one_time_use` is absent from the body and the suffix is
+// absent from the reply.
 func TestCreateInputJSON_OnceAbsent(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -434,7 +434,7 @@ func TestCreateInputJSON_OnceTrue(t *testing.T) {
 	if got, _ := parsed["one_time_use"].(bool); !got {
 		t.Errorf("one_time_use = %v, want true", parsed["one_time_use"])
 	}
-	if !strings.Contains(async, "(one-time use)") {
+	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use)") {
 		t.Errorf("async reply missing one-time-use suffix: %q", async)
 	}
 }

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -143,11 +143,7 @@ func (c *Command) DM() bool {
 	return strings.EqualFold(v, "true")
 }
 
-// Once returns the parsed value of the `once:true` flag on `get`. When
-// set, the resulting qURL is single-use — the first redemption burns
-// the link. Mirrors [Command.DM]'s shape so `once:false` (and absence)
-// both return false; the applyFlag arm gates the value half so only
-// the literal `true` / `false` strings reach this accessor.
+// Once returns the parsed value of the `once:true` flag on `get`.
 func (c *Command) Once() bool {
 	if c == nil {
 		return false
@@ -221,13 +217,9 @@ var ErrInvalidQURLID = errors.New("invalid qurl_id")
 // Catches user-facing typos earlier than the handler dispatch.
 var ErrUnexpectedArgument = errors.New("unexpected argument")
 
-// flagKeyOnce is the canonical flag-key string for the strict-boolean
-// `once:` flag. Lifted to a constant so the accessor lookup, the
-// applyFlag case label, and the rejection error message share one
-// source — a future rename here propagates without a grep audit. The
-// sibling `dm` key is still inlined at its three call sites for
-// historical reasons; not pre-emptively refactored per
-// surgical-changes guidance.
+// flagKeyOnce is the canonical key for the `once:` strict-boolean
+// flag. Constant rather than literal because goconst flags `"once"`
+// at its 3-occurrence threshold on `--new-from-rev`.
 const flagKeyOnce = "once"
 
 // ErrInvalidFlag is the sentinel wrapped by every [applyFlag] error
@@ -877,11 +869,7 @@ func applyFlag(cmd *Command, tok string) error {
 		cmd.Flags[key] = val
 		return nil
 	case flagKeyOnce:
-		// Strict-posture boolean — same shape as `dm` above. Only
-		// `true` / `false` (case-folded) survive; `once:yes` /
-		// `once:1` / `once:please` reject so the user sees a friendly
-		// error instead of [Command.Once] silently returning false on
-		// a non-"true" value.
+		// Strict-boolean gate — same shape as `dm` above.
 		if !strings.EqualFold(val, "true") && !strings.EqualFold(val, "false") {
 			return fmt.Errorf("%w: once:%q (use once:true or omit the flag)", ErrInvalidFlag, val)
 		}

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -124,8 +124,8 @@ type Command struct {
 	// *caller* — the user who typed the command); this field holds the
 	// *target* of the verb (the user being added or removed).
 	UserID string
-	// Flags holds optional `key:value` flags. Only `dm` and `reason` are
-	// recognized today (on `get`).
+	// Flags holds optional `key:value` flags. Only `dm`, `once`, and
+	// `reason` are recognized today (on `get`).
 	Flags map[string]string
 	// Raw is the original trimmed text, kept for diagnostics.
 	Raw string
@@ -137,6 +137,22 @@ func (c *Command) DM() bool {
 		return false
 	}
 	v, ok := c.Flags["dm"]
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(v, "true")
+}
+
+// Once returns the parsed value of the `once:true` flag on `get`. When
+// set, the resulting qURL is single-use — the first redemption burns
+// the link. Mirrors [Command.DM]'s shape so `once:false` (and absence)
+// both return false; the applyFlag arm gates the value half so only
+// the literal `true` / `false` strings reach this accessor.
+func (c *Command) Once() bool {
+	if c == nil {
+		return false
+	}
+	v, ok := c.Flags[flagKeyOnce]
 	if !ok {
 		return false
 	}
@@ -204,6 +220,15 @@ var ErrInvalidQURLID = errors.New("invalid qurl_id")
 // positional arguments receives one (e.g. `admin policies extra`).
 // Catches user-facing typos earlier than the handler dispatch.
 var ErrUnexpectedArgument = errors.New("unexpected argument")
+
+// flagKeyOnce is the canonical flag-key string for the strict-boolean
+// `once:` flag. Lifted to a constant so the accessor lookup, the
+// applyFlag case label, and the rejection error message share one
+// source — a future rename here propagates without a grep audit. The
+// sibling `dm` key is still inlined at its three call sites for
+// historical reasons; not pre-emptively refactored per
+// surgical-changes guidance.
+const flagKeyOnce = "once"
 
 // ErrInvalidFlag is the sentinel wrapped by every [applyFlag] error
 // path (unknown key, missing-key-before-colon, empty value,
@@ -786,8 +811,8 @@ func hasASCIIPrefixFold(s, prefix string) bool {
 }
 
 // applyFlag parses a single `key:value` token into [Command.Flags]. Only
-// the recognized keys (`dm`, `reason`) survive — unknown keys are an
-// error so a typo doesn't silently no-op. The key half is
+// the recognized keys (`dm`, `once`, `reason`) survive — unknown keys
+// are an error so a typo doesn't silently no-op. The key half is
 // case-folded so `DM:true` and `Reason:foo` work the way users on
 // mobile clients (with auto-capitalize) expect; the value half is
 // preserved verbatim because reasons are user-facing prose. An
@@ -795,15 +820,15 @@ func hasASCIIPrefixFold(s, prefix string) bool {
 // in PR-3c.3+ should be able to distinguish "flag unset" from "flag
 // set to empty" by absence in [Command.Flags] alone.
 //
-// Per-key validation is strict-posture: `dm` accepts only the
-// boolean strings `true` / `false` (case-folded), so a user typing
-// `dm:yes` or `dm:1` sees a friendly error rather than the
+// Per-key validation is strict-posture: `dm` and `once` accept only
+// the boolean strings `true` / `false` (case-folded), so a user
+// typing `dm:yes` or `once:1` sees a friendly error rather than the
 // silent-falsey behavior the unvalidated form would have produced
-// ([Command.DM] case-equals against "true", so any non-"true" value
-// silently returns false — exactly the typo class the rest of the
-// parser rejects). `reason` accepts any non-empty prose because the
-// handler in PR-3c.3+ uses it for audit text where the user's exact
-// wording is the point.
+// ([Command.DM] / [Command.Once] case-equal against "true", so any
+// non-"true" value silently returns false — exactly the typo class
+// the rest of the parser rejects). `reason` accepts any non-empty
+// prose because the handler in PR-3c.3+ uses it for audit text where
+// the user's exact wording is the point.
 func applyFlag(cmd *Command, tok string) error {
 	colonIdx := strings.IndexByte(tok, ':')
 	if colonIdx < 0 {
@@ -848,6 +873,17 @@ func applyFlag(cmd *Command, tok string) error {
 		// values too.
 		if !strings.EqualFold(val, "true") && !strings.EqualFold(val, "false") {
 			return fmt.Errorf("%w: dm:%q (use dm:true or omit the flag)", ErrInvalidFlag, val)
+		}
+		cmd.Flags[key] = val
+		return nil
+	case flagKeyOnce:
+		// Strict-posture boolean — same shape as `dm` above. Only
+		// `true` / `false` (case-folded) survive; `once:yes` /
+		// `once:1` / `once:please` reject so the user sees a friendly
+		// error instead of [Command.Once] silently returning false on
+		// a non-"true" value.
+		if !strings.EqualFold(val, "true") && !strings.EqualFold(val, "false") {
+			return fmt.Errorf("%w: once:%q (use once:true or omit the flag)", ErrInvalidFlag, val)
 		}
 		cmd.Flags[key] = val
 		return nil

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -12,10 +12,7 @@ import (
 // facing wording changes, this is the single edit point.
 const dmRejectSubstr = "use dm:true"
 
-// onceRejectSubstr is the counterpart to [dmRejectSubstr] for the
-// once: strict-boolean gate. Mirrors the dm: rejection shape so a
-// loosening of either gate's value grammar surfaces here, not in
-// production via a silent-falsey [Command.Once].
+// onceRejectSubstr is the [dmRejectSubstr] counterpart for `once:`.
 const onceRejectSubstr = "use once:true"
 
 // TestParse_HappyPaths fences the recognized grammar of every subcommand.
@@ -40,9 +37,6 @@ func TestParse_HappyPaths(t *testing.T) {
 		{name: "get with once flag", text: "get $prod-db once:true", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "true"}},
 		{name: "get with reason flag", text: `get $prod-db reason:"on call"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"reason": "on call"}},
 		{name: "get with both flags", text: `get $prod-db dm:true reason:"audit"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "true", "reason": "audit"}},
-		// once: composes with the other two flags. Pinned as a single
-		// row so a future regression in flag-loop ordering surfaces
-		// without needing three separate composition probes.
 		{name: "get with once, dm, and reason flags", text: `get $prod-db once:true dm:true reason:"audit"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "true", "dm": "true", "reason": "audit"}},
 		{name: "setalias url", text: "setalias $prod-db https://internal.example.com", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "https://internal.example.com", wantFlags: map[string]string{}},
 		{name: "setalias resource_id", text: "setalias $prod-db r_abc123", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "r_abc123", wantFlags: map[string]string{}},
@@ -74,11 +68,7 @@ func TestParse_HappyPaths(t *testing.T) {
 		// "unknown flag" error.
 		{name: "dm:false accepted", text: "get $prod-db dm:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "false"}},
 		{name: "dm:FALSE case-folded", text: "get $prod-db dm:FALSE", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "FALSE"}},
-		// once:false mirrors dm:false — accepted because the strict-
-		// boolean gate allows both `true` and `false`, but [Command.Once]
-		// case-equals against "true" so it has the same runtime effect
-		// as omitting the flag. Accepting it explicitly lets users opt
-		// out without seeing an "unknown flag" error.
+		// once:false: same accepted-but-no-op posture as dm:false above.
 		{name: "once:false accepted", text: "get $prod-db once:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "false"}},
 		// Admin verb is lowercased before the AdminAction switch. Pinned
 		// so a future refactor that drops `strings.ToLower(verb)` can't
@@ -293,16 +283,12 @@ func TestParse_GetFlagErrors(t *testing.T) {
 		{name: "dm:1 rejected (not true/false)", text: "get $prod-db dm:1", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:yes rejected (not true/false)", text: "get $prod-db dm:yes", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:please rejected (not true/false)", text: "get $prod-db dm:please", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
-		// once: mirrors dm:'s strict-boolean gate. Without these
-		// rejections, `once:1` / `once:yes` would parse fine and then
-		// silently return false on [Command.Once] — exactly the
-		// silent-no-op failure mode the dm: rows above pin against.
-		// Empty `once:` and `once:""` cases are pinned by the shared
+		// once: mirrors dm:'s strict-boolean gate above. Empty-value
+		// cases for once: are covered by the shared `reason:`-keyed
 		// "empty bare value" / "empty quoted value" rows higher up.
 		{name: "once:1 rejected (not true/false)", text: "get $prod-db once:1", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
 		{name: "once:yes rejected (not true/false)", text: "get $prod-db once:yes", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
 		{name: "once:please rejected (not true/false)", text: "get $prod-db once:please", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
-		{name: "once: empty bare value rejected", text: "get $prod-db once:", wantSentnl: ErrInvalidFlag, wantSubstr: "empty value"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -600,9 +586,7 @@ func TestCommand_DM(t *testing.T) {
 	}
 }
 
-// TestCommand_Once mirrors [TestCommand_DM] for the once accessor —
-// nil receiver, absence, true (canonical + case-folded), and false
-// all pin the same contract the dm: accessor does.
+// TestCommand_Once is the [TestCommand_DM] counterpart for `Once()`.
 func TestCommand_Once(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -283,12 +283,14 @@ func TestParse_GetFlagErrors(t *testing.T) {
 		{name: "dm:1 rejected (not true/false)", text: "get $prod-db dm:1", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:yes rejected (not true/false)", text: "get $prod-db dm:yes", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:please rejected (not true/false)", text: "get $prod-db dm:please", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
-		// once: mirrors dm:'s strict-boolean gate above. Empty-value
-		// cases for once: are covered by the shared `reason:`-keyed
-		// "empty bare value" / "empty quoted value" rows higher up.
+		// once: mirrors dm:'s strict-boolean gate above. Explicit
+		// once:-keyed empty rows survive a refactor that moves per-
+		// key validation in front of the shared empty-value gate.
 		{name: "once:1 rejected (not true/false)", text: "get $prod-db once:1", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
 		{name: "once:yes rejected (not true/false)", text: "get $prod-db once:yes", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
 		{name: "once:please rejected (not true/false)", text: "get $prod-db once:please", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
+		{name: "once: bare empty rejected", text: "get $prod-db once:", wantSentnl: ErrInvalidFlag, wantSubstr: "empty value"},
+		{name: `once:"" quoted empty rejected`, text: `get $prod-db once:""`, wantSentnl: ErrInvalidFlag, wantSubstr: "empty value"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -12,6 +12,12 @@ import (
 // facing wording changes, this is the single edit point.
 const dmRejectSubstr = "use dm:true"
 
+// onceRejectSubstr is the counterpart to [dmRejectSubstr] for the
+// once: strict-boolean gate. Mirrors the dm: rejection shape so a
+// loosening of either gate's value grammar surfaces here, not in
+// production via a silent-falsey [Command.Once].
+const onceRejectSubstr = "use once:true"
+
 // TestParse_HappyPaths fences the recognized grammar of every subcommand.
 // One row per verb so a regression that drops or relabels a verb is the
 // failure that reaches review, not a behavioral diff in PR-3c.3+.
@@ -31,8 +37,13 @@ func TestParse_HappyPaths(t *testing.T) {
 		{name: "help literal", text: "help", wantSub: SubcmdHelp, wantFlags: map[string]string{}},
 		{name: "get alias", text: "get $prod-db", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{}},
 		{name: "get with dm flag", text: "get $prod-db dm:true", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "true"}},
+		{name: "get with once flag", text: "get $prod-db once:true", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "true"}},
 		{name: "get with reason flag", text: `get $prod-db reason:"on call"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"reason": "on call"}},
 		{name: "get with both flags", text: `get $prod-db dm:true reason:"audit"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "true", "reason": "audit"}},
+		// once: composes with the other two flags. Pinned as a single
+		// row so a future regression in flag-loop ordering surfaces
+		// without needing three separate composition probes.
+		{name: "get with once, dm, and reason flags", text: `get $prod-db once:true dm:true reason:"audit"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "true", "dm": "true", "reason": "audit"}},
 		{name: "setalias url", text: "setalias $prod-db https://internal.example.com", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "https://internal.example.com", wantFlags: map[string]string{}},
 		{name: "setalias resource_id", text: "setalias $prod-db r_abc123", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "r_abc123", wantFlags: map[string]string{}},
 		{name: "unsetalias", text: "unsetalias $prod-db", wantSub: SubcmdUnsetAlias, wantAlias: "prod-db", wantFlags: map[string]string{}},
@@ -63,6 +74,12 @@ func TestParse_HappyPaths(t *testing.T) {
 		// "unknown flag" error.
 		{name: "dm:false accepted", text: "get $prod-db dm:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "false"}},
 		{name: "dm:FALSE case-folded", text: "get $prod-db dm:FALSE", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "FALSE"}},
+		// once:false mirrors dm:false — accepted because the strict-
+		// boolean gate allows both `true` and `false`, but [Command.Once]
+		// case-equals against "true" so it has the same runtime effect
+		// as omitting the flag. Accepting it explicitly lets users opt
+		// out without seeing an "unknown flag" error.
+		{name: "once:false accepted", text: "get $prod-db once:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "false"}},
 		// Admin verb is lowercased before the AdminAction switch. Pinned
 		// so a future refactor that drops `strings.ToLower(verb)` can't
 		// silently regress mobile-client / auto-capitalize inputs.
@@ -276,6 +293,16 @@ func TestParse_GetFlagErrors(t *testing.T) {
 		{name: "dm:1 rejected (not true/false)", text: "get $prod-db dm:1", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:yes rejected (not true/false)", text: "get $prod-db dm:yes", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:please rejected (not true/false)", text: "get $prod-db dm:please", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
+		// once: mirrors dm:'s strict-boolean gate. Without these
+		// rejections, `once:1` / `once:yes` would parse fine and then
+		// silently return false on [Command.Once] — exactly the
+		// silent-no-op failure mode the dm: rows above pin against.
+		// Empty `once:` and `once:""` cases are pinned by the shared
+		// "empty bare value" / "empty quoted value" rows higher up.
+		{name: "once:1 rejected (not true/false)", text: "get $prod-db once:1", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
+		{name: "once:yes rejected (not true/false)", text: "get $prod-db once:yes", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
+		{name: "once:please rejected (not true/false)", text: "get $prod-db once:please", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
+		{name: "once: empty bare value rejected", text: "get $prod-db once:", wantSentnl: ErrInvalidFlag, wantSubstr: "empty value"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -568,6 +595,32 @@ func TestCommand_DM(t *testing.T) {
 			t.Parallel()
 			if got := tc.cmd.DM(); got != tc.want {
 				t.Errorf("DM() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCommand_Once mirrors [TestCommand_DM] for the once accessor —
+// nil receiver, absence, true (canonical + case-folded), and false
+// all pin the same contract the dm: accessor does.
+func TestCommand_Once(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cmd  *Command
+		want bool
+	}{
+		{name: "nil receiver", cmd: nil, want: false},
+		{name: "no flags", cmd: &Command{Flags: map[string]string{}}, want: false},
+		{name: "once:true", cmd: &Command{Flags: map[string]string{flagKeyOnce: "true"}}, want: true},
+		{name: "once:TRUE (case-insensitive)", cmd: &Command{Flags: map[string]string{flagKeyOnce: "TRUE"}}, want: true},
+		{name: "once:false", cmd: &Command{Flags: map[string]string{flagKeyOnce: "false"}}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.cmd.Once(); got != tc.want {
+				t.Errorf("Once() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds a `once:true` flag to the Slack bot's `/qurl get` command that mints a one-time-use qURL — the link burns on first redemption.

The qurl-service API has long supported `one_time_use: bool`, and the Go SDK already plumbs it (`shared/client/client.go` — `CreateInput.OneTimeUse` with `omitempty`). The Slack bot was the only surface still missing the entry point; this wires the flag through the parser, the mint request, and the reply copy.

### Behavior

- `/qurl get <url|$name> once:true` — mints a single-use qURL; success reply ends with ` (one-time use)` so the requester sees what they shipped.
- `/qurl get <url|$name> once:false` — accepted (same runtime effect as omitting the flag), no copy change.
- `/qurl get <url|$name>` (default) — unchanged; the SDK's `omitempty` keeps `one_time_use` off the wire.

### Strict-value parsing (mirrors `dm:`)

- `once:yes` / `once:1` / `once:please` / `once:` (empty) → reject with `ErrInvalidFlag` and a friendly "use once:true or omit the flag" message.
- Without this gate, a typo'd value would silently no-op (the accessor case-equals against `"true"`), which is exactly the failure mode the parser carefully rejects for typo'd flag keys.

### Composability

Stacks with `dm:` and `reason:` in any order. `/qurl get $name once:true dm:true reason:"incident #123"` is valid.

### Out of scope

Channel-policy default (`once_default`), custom max-uses (`uses:<n>`), and any `qurl-integrations-infra` side changes.

## Test plan

- [x] `go test ./apps/slack/... ./shared/...` — passes
- [x] `go test ./apps/slack/internal/ -race` — passes
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./apps/slack/...` — 0 issues
- [x] `pre-commit run --files <every changed file>` — passes
- Added 8 new parser-side test rows (happy-path + rejects + composition + `Once()` accessor) and 2 new handler-side test fns (`one_time_use` JSON wire shape + reply-copy suffix presence/absence).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>