### PR TITLE
fix(discord): forward selfDestructSeconds as session_duration on mintLinks

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1471,9 +1471,14 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
  * @param {string} opts.expiresAt — ISO string; forwarded to mintLinks.
  * @param {number} opts.recipientCount — number of tokens to mint in total.
  * @param {string} opts.apiKey — QURL API key.
+ * @param {?number} [opts.selfDestructSeconds] — when set, forwarded to mintLinks
+ *   as `session_duration`. Each minted token gets an L7 session window matching
+ *   the fileviewer's client-side self-destruct timer. null/undefined inherits
+ *   qurl-service's QURL_SESSION_TTL default. See mintLinks for value mapping
+ *   (0.5 → "1s", N>=1 → ceil to whole seconds).
  * @returns {Array<{qurl_link: string, qurl_id: string, resourceId: string}>}
  */
-async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey }) {
+async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey, selfDestructSeconds = null }) {
   const allLinks = [];
   let currentResourceId = initialResourceId;
   let tokensUsed = 0;
@@ -1485,7 +1490,7 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       tokensUsed = 0;
     }
     const batchSize = Math.min(TOKENS_PER_RESOURCE, recipientCount - i);
-    const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey);
+    const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey, selfDestructSeconds);
     for (const link of minted) {
       // qurl_id is the join key against qurl.accessed webhooks; empty
       // string degrades the whole monitor to bare base-msg.
@@ -1781,6 +1786,7 @@ async function executeSendPipeline(interaction, {
           expiresAt,
           recipientCount: recipients.length,
           apiKey,
+          selfDestructSeconds,
         });
       } finally {
         bufHolder.buf = null;
@@ -1818,6 +1824,7 @@ async function executeSendPipeline(interaction, {
         expiresAt,
         recipientCount: recipients.length,
         apiKey,
+        selfDestructSeconds,
       });
 
       if (allLinks.length < recipients.length) {
@@ -2485,6 +2492,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           expiresAt,
           recipientCount: newRecipients.length,
           apiKey,
+          selfDestructSeconds: inheritedDestruct,
         });
       } catch (err) {
         // Discord CDN URLs are signed and expire (~24h). If re-download fails,
@@ -2529,6 +2537,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
         expiresAt,
         recipientCount: newRecipients.length,
         apiKey,
+        selfDestructSeconds: inheritedDestruct,
       });
 
       if (allLinks.length < newRecipients.length) {

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -323,7 +323,24 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * one-time tokens, so one recipient opening their link doesn't
  * invalidate anyone else's.
  */
-async function mintLinks(resourceId, expiresAt, n, apiKey) {
+// mintLinks mints `n` access tokens on the connector's `/api/mint_link`
+// endpoint. selfDestructSeconds, when set, is forwarded as
+// `session_duration` so every minted token gets an L7 session window
+// matching the fileviewer's client-side self-destruct timer.
+//
+// Without this, the upload-time auto-created token correctly inherits
+// session_duration via the connector's CreateQURL path
+// (qurl-integrations-infra#540), but every additional token minted on
+// the same resource defaults back to qurl-service's QURL_SESSION_TTL
+// (3600s sandbox). A recipient of the self-destruct send could then
+// refresh `*.qurl.site/...` past the fileviewer blank and see the
+// content again for up to an hour. Tracked: qurl-integrations-infra#764.
+//
+// Value mapping (matches SELF_DESTRUCT_PRESETS in src/utils/time.js):
+//   selfDestructSeconds null     → omit session_duration → server default
+//   selfDestructSeconds 0.5      → "1s" (qurl-service MinSessionDuration)
+//   selfDestructSeconds N >= 1   → "Ns" (whole-seconds rounded up)
+async function mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds = null) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);
@@ -335,10 +352,20 @@ async function mintLinks(resourceId, expiresAt, n, apiKey) {
   if (!Number.isInteger(n) || n < 1 || n > 100) {
     throw new Error(`Invalid link count (n must be integer 1..100): ${n}`);
   }
+  const body = { expires_at: expiresAt, n, one_time_use: true };
+  if (selfDestructSeconds !== null && selfDestructSeconds !== undefined) {
+    // Math.ceil clamps fractional presets (the only one today is 0.5)
+    // up to 1s — qurl-service rejects sub-second session_duration via
+    // its MinSessionDuration = 1 * time.Second validator. The 0.5s
+    // preset's fileviewer-side 500ms canvas blank still fires; only
+    // the L7 session window floors at 1s.
+    const seconds = Math.max(1, Math.ceil(selfDestructSeconds));
+    body.session_duration = `${seconds}s`;
+  }
   const response = await fetch(`${config.CONNECTOR_URL}/api/mint_link/${resourceId}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...connectorAuthHeaders(apiKey) },
-    body: JSON.stringify({ expires_at: expiresAt, n, one_time_use: true }),
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(30000),
   });
 

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -2,6 +2,7 @@ const config = require('./config');
 const logger = require('./logger');
 
 const { sanitizeFilename } = require('./utils/sanitize');
+const { formatSessionDurationSeconds } = require('./utils/time');
 
 const { MAX_FILE_SIZE } = require('./constants');
 const MAX_CDN_REDIRECTS = 3;
@@ -323,31 +324,19 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * one-time tokens, so one recipient opening their link doesn't
  * invalidate anyone else's.
  *
- * `selfDestructSeconds`, when a finite positive number, is forwarded
- * as `session_duration` so every minted token gets an L7 session
- * window matching the fileviewer's client-side self-destruct timer.
- * Without this, the upload-time auto-created token correctly inherits
- * `session_duration` via the connector's CreateQURL path
- * (qurl-integrations-infra#540), but every additional token minted on
- * the same resource defaults back to qurl-service's `QURL_SESSION_TTL`
- * (3600s sandbox). A recipient of the self-destruct send could then
- * refresh `*.qurl.site/...` past the fileviewer blank and see the
- * content again for up to an hour. Tracked:
- * qurl-integrations-infra#764.
- *
- * Value mapping (matches SELF_DESTRUCT_PRESETS in src/utils/time.js):
- * - `null` / `undefined` / non-finite / non-numeric → omit
- *   `session_duration` → qurl-service uses its server default.
- * - `0.5` (the only fractional preset) → `"1s"` (qurl-service
- *   `MinSessionDuration = 1 * time.Second` floor; fileviewer's
- *   500ms client-side blank still fires).
- * - `N >= 1` → `"Ns"` (whole-seconds, ceil'd defensively).
+ * `selfDestructSeconds` is forwarded as `session_duration` so every
+ * minted token's L7 session window matches the fileviewer's client-
+ * side self-destruct timer (closes the mint-side gap left by
+ * qurl-integrations-infra#540, tracked in qurl-integrations-infra#764).
+ * The seconds→duration-string mapping lives in
+ * `utils/time.js::formatSessionDurationSeconds` (co-located with
+ * `SELF_DESTRUCT_PRESETS`).
  *
  * @param {string} resourceId — connector resource_id (alphanum + `_-`).
  * @param {string} expiresAt — ISO string forwarded as `expires_at`.
  * @param {number} n — integer 1..100, count of links to mint.
  * @param {?string} apiKey — caller API key; falls back to `config.QURL_API_KEY`.
- * @param {?number} [selfDestructSeconds] — see Value mapping above. Defaults to null.
+ * @param {?number} [selfDestructSeconds] — see formatSessionDurationSeconds for value mapping. Defaults to null.
  * @returns {Promise<Array<{qurl_id: string, qurl_link: string, expires_at: string}>>}
  */
 async function mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds = null) {
@@ -363,22 +352,9 @@ async function mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds =
     throw new Error(`Invalid link count (n must be integer 1..100): ${n}`);
   }
   const body = { expires_at: expiresAt, n, one_time_use: true };
-  // Mirror `appendViewerTtl`'s defensive contract (connector.js:164):
-  // gate on Number.isFinite(x) && x > 0 to reject NaN, ±Infinity, the
-  // string "30", booleans, objects, null, and undefined. The confirm-
-  // card dropdown is the contract today (only the 7 SELF_DESTRUCT_
-  // PRESETS values reach this layer), but mintLinks is exported, so
-  // a future caller passing garbage shouldn't put "NaNs" / "Infinitys"
-  // on the wire and turn a recoverable upstream input mistake into a
-  // confusing 400 from qurl-service::validateSessionDuration.
-  if (Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0) {
-    // Math.ceil clamps fractional presets (the only one today is 0.5)
-    // up to 1s — qurl-service rejects sub-second session_duration via
-    // its MinSessionDuration = 1 * time.Second validator. The 0.5s
-    // preset's fileviewer-side 500ms canvas blank still fires; only
-    // the L7 session window floors at 1s.
-    const seconds = Math.max(1, Math.ceil(selfDestructSeconds));
-    body.session_duration = `${seconds}s`;
+  const sessionDuration = formatSessionDurationSeconds(selfDestructSeconds);
+  if (sessionDuration !== null) {
+    body.session_duration = sessionDuration;
   }
   const response = await fetch(`${config.CONNECTOR_URL}/api/mint_link/${resourceId}`, {
     method: 'POST',

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -322,24 +322,34 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * field applies PER minted link: `n` recipients get `n` independent
  * one-time tokens, so one recipient opening their link doesn't
  * invalidate anyone else's.
+ *
+ * `selfDestructSeconds`, when a finite positive number, is forwarded
+ * as `session_duration` so every minted token gets an L7 session
+ * window matching the fileviewer's client-side self-destruct timer.
+ * Without this, the upload-time auto-created token correctly inherits
+ * `session_duration` via the connector's CreateQURL path
+ * (qurl-integrations-infra#540), but every additional token minted on
+ * the same resource defaults back to qurl-service's `QURL_SESSION_TTL`
+ * (3600s sandbox). A recipient of the self-destruct send could then
+ * refresh `*.qurl.site/...` past the fileviewer blank and see the
+ * content again for up to an hour. Tracked:
+ * qurl-integrations-infra#764.
+ *
+ * Value mapping (matches SELF_DESTRUCT_PRESETS in src/utils/time.js):
+ * - `null` / `undefined` / non-finite / non-numeric → omit
+ *   `session_duration` → qurl-service uses its server default.
+ * - `0.5` (the only fractional preset) → `"1s"` (qurl-service
+ *   `MinSessionDuration = 1 * time.Second` floor; fileviewer's
+ *   500ms client-side blank still fires).
+ * - `N >= 1` → `"Ns"` (whole-seconds, ceil'd defensively).
+ *
+ * @param {string} resourceId — connector resource_id (alphanum + `_-`).
+ * @param {string} expiresAt — ISO string forwarded as `expires_at`.
+ * @param {number} n — integer 1..100, count of links to mint.
+ * @param {?string} apiKey — caller API key; falls back to `config.QURL_API_KEY`.
+ * @param {?number} [selfDestructSeconds] — see Value mapping above. Defaults to null.
+ * @returns {Promise<Array<{qurl_id: string, qurl_link: string, expires_at: string}>>}
  */
-// mintLinks mints `n` access tokens on the connector's `/api/mint_link`
-// endpoint. selfDestructSeconds, when set, is forwarded as
-// `session_duration` so every minted token gets an L7 session window
-// matching the fileviewer's client-side self-destruct timer.
-//
-// Without this, the upload-time auto-created token correctly inherits
-// session_duration via the connector's CreateQURL path
-// (qurl-integrations-infra#540), but every additional token minted on
-// the same resource defaults back to qurl-service's QURL_SESSION_TTL
-// (3600s sandbox). A recipient of the self-destruct send could then
-// refresh `*.qurl.site/...` past the fileviewer blank and see the
-// content again for up to an hour. Tracked: qurl-integrations-infra#764.
-//
-// Value mapping (matches SELF_DESTRUCT_PRESETS in src/utils/time.js):
-//   selfDestructSeconds null     → omit session_duration → server default
-//   selfDestructSeconds 0.5      → "1s" (qurl-service MinSessionDuration)
-//   selfDestructSeconds N >= 1   → "Ns" (whole-seconds rounded up)
 async function mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds = null) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
@@ -353,7 +363,15 @@ async function mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds =
     throw new Error(`Invalid link count (n must be integer 1..100): ${n}`);
   }
   const body = { expires_at: expiresAt, n, one_time_use: true };
-  if (selfDestructSeconds !== null && selfDestructSeconds !== undefined) {
+  // Mirror `appendViewerTtl`'s defensive contract (connector.js:164):
+  // gate on Number.isFinite(x) && x > 0 to reject NaN, ±Infinity, the
+  // string "30", booleans, objects, null, and undefined. The confirm-
+  // card dropdown is the contract today (only the 7 SELF_DESTRUCT_
+  // PRESETS values reach this layer), but mintLinks is exported, so
+  // a future caller passing garbage shouldn't put "NaNs" / "Infinitys"
+  // on the wire and turn a recoverable upstream input mistake into a
+  // confusing 400 from qurl-service::validateSessionDuration.
+  if (Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0) {
     // Math.ceil clamps fractional presets (the only one today is 0.5)
     // up to 1s — qurl-service rejects sub-second session_duration via
     // its MinSessionDuration = 1 * time.Second validator. The 0.5s

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -162,6 +162,13 @@ function connectorAuthHeaders(apiKey) {
 // re-upload, file via Discord CDN download, JSON) thread the same wire
 // field name. The connector validates the value (PR #477); we forward
 // it as a string and let the connector own the contract.
+//
+// Asymmetry note: viewer_ttl_seconds is forwarded VERBATIM (so 0.5 →
+// "0.5"; the fileviewer's client-side blank reads the value directly).
+// The sibling formatSessionDurationSeconds() helper in utils/time.js
+// FLOORS 0.5 to "1s" because qurl-service's MinSessionDuration is
+// 1 * time.Second. A reader looking at one wire field should know the
+// other has the opposite handling for the 0.5s preset.
 function appendViewerTtl(form, viewerTtlSeconds) {
   // Number.isFinite already filters non-numbers (Number.isFinite('30') is
   // false), so the typeof guard would be redundant. Strict positive-finite

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -123,11 +123,48 @@ function formatSelfDestructSegment(seconds) {
   return 'Self-destruct: off';
 }
 
+// formatSessionDurationSeconds maps a SELF_DESTRUCT_PRESETS-shaped
+// number to the qurl-service-format duration string the connector's
+// `mint_link` body and the upload-time `CreateQURL` body both expect.
+//
+// Co-located with SELF_DESTRUCT_PRESETS because the preset values are
+// the ONLY legitimate input source — keeping the formatter here
+// prevents the bot's wire-format mapping from drifting if the preset
+// set ever changes (e.g., adding a 100ms preset would force a decision
+// here about how to floor it).
+//
+// Returns the duration string (e.g. "1s", "30s") when the input is a
+// finite positive number; returns null otherwise. Callers should omit
+// the wire field entirely when the result is null (qurl-service then
+// uses QURL_SESSION_TTL as the default).
+//
+// Value mapping:
+//   null / undefined / non-finite / non-numeric / ≤0  → null (omit)
+//   0.5 (the only fractional preset)                  → "1s" (qurl-service
+//                                                       MinSessionDuration
+//                                                       floor — fileviewer's
+//                                                       500ms client-side
+//                                                       blank still fires)
+//   N >= 1                                            → "Ns" (Math.ceil
+//                                                       defensively floors
+//                                                       any non-preset
+//                                                       fractional input)
+//
+// Mirrors qurl-s3-connector's `sessionDurationFor()` (Go) so the
+// upload-time and mint-time wire mappings stay in lockstep. If one
+// changes, the other must too — fenced by qurl-integrations-infra
+// PR #764 + this PR landing as a coordinated pair.
+function formatSessionDurationSeconds(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return `${Math.max(1, Math.ceil(seconds))}s`;
+}
+
 module.exports = {
   expiryToISO,
   expiryToMs,
   formatSelfDestructLabel,
   formatSelfDestructSegment,
+  formatSessionDurationSeconds,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -39,6 +39,13 @@ function expiryToMs(expiresIn) {
 // (qurl-s3-connector PR #477). Connector contract is 0.5–3600 inclusive,
 // so every preset here is in range; clamping is unreachable.
 const SELF_DESTRUCT_PRESETS = Object.freeze([
+  // 0.5s residual: fileviewer blanks at 500ms (client-side), but the
+  // L7 session_duration floors at 1s per qurl-service's
+  // MinSessionDuration. A recipient refreshing between t=500ms and
+  // t=1000ms still re-renders. The preset is intentionally retained
+  // because the client-side blank is the perceived "self destruct"
+  // and the 500ms residual closes on retry past 1s. If qurl-service
+  // ever lowers MinSessionDuration to sub-second, this gap closes.
   Object.freeze({ seconds: 0.5, label: '1/2 second' }),
   Object.freeze({ seconds: 1, label: '1 second' }),
   Object.freeze({ seconds: 5, label: '5 seconds' }),
@@ -156,9 +163,9 @@ function formatSelfDestructSegment(seconds) {
 // PR #764 + this PR landing as a coordinated pair.
 function formatSessionDurationSeconds(seconds) {
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
-  // Math.ceil of any value in (0, 1] is already 1; Math.ceil of any
-  // positive finite number is ≥1. The earlier `Math.max(1, ...)`
-  // floor was redundant given the `seconds <= 0` guard above.
+  // Math.ceil of any value in (0, 1] is 1; of any positive finite
+  // number is ≥1. Combined with the > 0 guard above, this never
+  // emits "0s".
   return `${Math.ceil(seconds)}s`;
 }
 

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -156,7 +156,10 @@ function formatSelfDestructSegment(seconds) {
 // PR #764 + this PR landing as a coordinated pair.
 function formatSessionDurationSeconds(seconds) {
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
-  return `${Math.max(1, Math.ceil(seconds))}s`;
+  // Math.ceil of any value in (0, 1] is already 1; Math.ceil of any
+  // positive finite number is ≥1. The earlier `Math.max(1, ...)`
+  // floor was redundant given the `seconds <= 0` guard above.
+  return `${Math.ceil(seconds)}s`;
 }
 
 module.exports = {

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -191,6 +191,55 @@ describe('Connector client — coverage boost', () => {
       expect(ttlField.value).toBe('60');
     });
 
+    // mintLinks forwards selfDestructSeconds as session_duration so
+    // every minted token on a self-destruct send gets an L7 session
+    // window matching the fileviewer's client-side blank. Sibling of
+    // the viewer_ttl_seconds tests above — same value, different
+    // wire-field (mint_link request JSON, not upload form).
+    describe('mintLinks — session_duration forwarding', () => {
+      function captureMintBody() {
+        let bodyJSON = null;
+        globalThis.fetch = jest.fn(async (_url, opts) => {
+          bodyJSON = JSON.parse(opts.body);
+          return {
+            ok: true,
+            json: async () => ({ success: true, links: [{ qurl_id: 'q_1', qurl_link: 'https://q.test/l' }] }),
+          };
+        });
+        return () => bodyJSON;
+      }
+
+      it('sends session_duration when selfDestructSeconds provided', async () => {
+        const getBody = captureMintBody();
+        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, 30);
+        expect(getBody().session_duration).toBe('30s');
+      });
+
+      it('clamps 0.5 (fileviewer preset) to "1s" — qurl-service MinSessionDuration floor', async () => {
+        const getBody = captureMintBody();
+        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, 0.5);
+        expect(getBody().session_duration).toBe('1s');
+      });
+
+      it('ceils fractional values >1 (defensive — presets are all integer ≥1)', async () => {
+        const getBody = captureMintBody();
+        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, 2.3);
+        expect(getBody().session_duration).toBe('3s');
+      });
+
+      it('omits session_duration when null', async () => {
+        const getBody = captureMintBody();
+        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, null);
+        expect(getBody().session_duration).toBeUndefined();
+      });
+
+      it('omits session_duration when undefined (default param)', async () => {
+        const getBody = captureMintBody();
+        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined);
+        expect(getBody().session_duration).toBeUndefined();
+      });
+    });
+
     it('omits viewer_ttl_seconds for non-positive / non-finite / wrong-type input', async () => {
       // Defensive: an upstream caller passing 0, NaN, or a string by
       // mistake shouldn't cause the field to land on the form. The

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -238,6 +238,26 @@ describe('Connector client — coverage boost', () => {
         await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined);
         expect(getBody().session_duration).toBeUndefined();
       });
+
+      // Defensive: a future caller passing NaN, ±Infinity, a numeric
+      // string, a boolean, or an object shouldn't put garbage on the
+      // wire ("NaNs", "Infinitys", etc.) and turn a recoverable input
+      // mistake into a confusing 400 from qurl-service's
+      // validateSessionDuration. Math.max(1, ...) already handles
+      // negatives but Number.isFinite is what catches the non-numeric
+      // / non-finite inputs. Mirrors the sibling viewer_ttl_seconds
+      // defensive-input test at this file's :243 (same idiom, same
+      // belt-and-suspenders justification: the confirm-card dropdown
+      // is the contract, but mintLinks is exported).
+      it('omits session_duration for non-finite / wrong-type / non-positive inputs', async () => {
+        const cases = [NaN, Infinity, -Infinity, '30', '0.5', true, false, {}, [], 0, -1, -0.5];
+        for (const v of cases) {
+          const getBody = captureMintBody();
+          // eslint-disable-next-line no-await-in-loop
+          await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, v);
+          expect(getBody().session_duration).toBeUndefined();
+        }
+      });
     });
 
     it('omits viewer_ttl_seconds for non-positive / non-finite / wrong-type input', async () => {

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -243,12 +243,11 @@ describe('Connector client — coverage boost', () => {
       // string, a boolean, or an object shouldn't put garbage on the
       // wire ("NaNs", "Infinitys", etc.) and turn a recoverable input
       // mistake into a confusing 400 from qurl-service's
-      // validateSessionDuration. Math.max(1, ...) already handles
-      // negatives but Number.isFinite is what catches the non-numeric
-      // / non-finite inputs. Mirrors the sibling viewer_ttl_seconds
-      // defensive-input test at this file's :243 (same idiom, same
-      // belt-and-suspenders justification: the confirm-card dropdown
-      // is the contract, but mintLinks is exported).
+      // validateSessionDuration. `Number.isFinite(x) && x > 0` is the
+      // load-bearing predicate. Mirrors the sibling viewer_ttl_seconds
+      // defensive-input test below (same idiom, same belt-and-
+      // suspenders justification: the confirm-card dropdown is the
+      // contract, but mintLinks is exported).
       it('omits session_duration for non-finite / wrong-type / non-positive inputs', async () => {
         const cases = [NaN, Infinity, -Infinity, '30', '0.5', true, false, {}, [], 0, -1, -0.5];
         for (const v of cases) {

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -1277,7 +1277,7 @@ describe('handleAddRecipients', () => {
       null,
     );
     // mintLinks is called against the NEW resource (conn-res-43)
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key', null);
     // createOneTimeLink should NOT have been called
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     // DMs should have been sent
@@ -1354,7 +1354,7 @@ describe('handleAddRecipients', () => {
       'location.json', 'test-api-key',
       null,
     );
-    expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', expect.any(String), 1, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', expect.any(String), 1, 'test-api-key', null);
     expect(mockSendDM).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch.mock.calls[0][0]).toHaveLength(1);
@@ -1423,7 +1423,7 @@ describe('handleAddRecipients', () => {
       'location.json', 'test-api-key',
       null,
     );
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', expect.any(String), 1, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', expect.any(String), 1, 'test-api-key', null);
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     expect(result.msg).toMatch(/Added 1 recipient/);
   });
@@ -1515,7 +1515,7 @@ describe('handleAddRecipients', () => {
     // Only Alice and Bob should get DMs (bot and sender excluded)
     expect(mockSendDM).toHaveBeenCalledTimes(2);
     expect(mockUploadJsonToConnector).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', expect.any(String), 2, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', expect.any(String), 2, 'test-api-key', null);
     expect(result.msg).toMatch(/Added 2 recipients/);
   });
 
@@ -1580,8 +1580,8 @@ describe('handleAddRecipients', () => {
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockReUploadBuffer).toHaveBeenCalledTimes(1);
     expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', expect.any(String), 10, 'test-api-key');
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', expect.any(String), 2, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', expect.any(String), 10, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', expect.any(String), 2, 'test-api-key', null);
     expect(result.msg).toMatch(/Added 12 recipients/);
   });
 
@@ -1613,7 +1613,7 @@ describe('handleAddRecipients', () => {
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockMintLinks).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', expect.any(String), 8, 'test-api-key');
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', expect.any(String), 8, 'test-api-key', null);
     expect(mockSendDM).toHaveBeenCalledTimes(8);
     expect(result.msg).toMatch(/Added 8 recipients/);
   });

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -1323,6 +1323,20 @@ describe('handleAddRecipients', () => {
       'test-api-key',
       30,
     );
+    // End-to-end fence (CR cycle 2 ask): selfDestructSeconds must
+    // also reach mintLinks. The 7 sibling assertions in this file
+    // pin the call signature with null; this one pins that a
+    // non-null value flows through mintLinksInBatches → mintLinks
+    // unchanged. Without this, a future rename of the
+    // mintLinksInBatches opt key (selfDestructSeconds → ...) would
+    // silently drop the value at the boundary.
+    expect(mockMintLinks).toHaveBeenCalledWith(
+      'conn-res-44',
+      expect.any(String),
+      1,
+      'test-api-key',
+      30,
+    );
   });
 
   it('URL send: uploads location JSON and mints links', async () => {
@@ -1387,6 +1401,18 @@ describe('handleAddRecipients', () => {
     expect(mockUploadJsonToConnector).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'google-map', url: 'https://example.com/doc' }),
       'location.json',
+      'test-api-key',
+      300,
+    );
+    // Symmetric with the file-path end-to-end fence above:
+    // selfDestructSeconds must also reach mintLinks on the URL/maps
+    // re-upload path. Without this, a future rename of the
+    // mintLinksInBatches opt key would silently drop the value here
+    // even if the upload side caught it.
+    expect(mockMintLinks).toHaveBeenCalledWith(
+      'res-loc-2',
+      expect.any(String),
+      1,
       'test-api-key',
       300,
     );

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -17,6 +17,7 @@ const {
   expiryToMs,
   formatSelfDestructLabel,
   formatSelfDestructSegment,
+  formatSessionDurationSeconds,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
@@ -178,6 +179,56 @@ describe('utils/time', () => {
       expect(formatSelfDestructSegment(Infinity)).toBe('Self-destruct: off');
       expect(formatSelfDestructSegment(0)).toBe('Self-destruct: off');
       expect(formatSelfDestructSegment(-5)).toBe('Self-destruct: off');
+    });
+  });
+
+  // formatSessionDurationSeconds is the connector→qurl-service ABI
+  // formatter for the bot's `session_duration` wire field. Tested here
+  // alongside its only legitimate input source (SELF_DESTRUCT_PRESETS)
+  // so a future preset change forces a co-located test update.
+  describe('formatSessionDurationSeconds', () => {
+    it('every preset maps to "Ns" with whole-seconds floor', () => {
+      // Round-trip the full preset set so adding a new preset forces a
+      // decision about how this formatter handles it (and updates the
+      // test if behavior changes).
+      const expected = {
+        0.5: '1s', // qurl-service MinSessionDuration floor
+        1: '1s',
+        5: '5s',
+        30: '30s',
+        300: '300s',
+        1800: '1800s',
+        3600: '3600s',
+      };
+      for (const preset of SELF_DESTRUCT_PRESETS) {
+        expect(formatSessionDurationSeconds(preset.seconds))
+          .toBe(expected[preset.seconds]);
+      }
+    });
+
+    it('clamps the 0.5s preset to "1s" (MinSessionDuration floor)', () => {
+      // qurl-service rejects sub-second session_duration via
+      // MinSessionDuration = 1 * time.Second. The 0.5s preset's
+      // fileviewer-side 500ms canvas blank still fires; only the L7
+      // session window floors at 1s.
+      expect(formatSessionDurationSeconds(0.5)).toBe('1s');
+    });
+
+    it('ceils fractional values > 1 (defensive — presets are integer ≥1)', () => {
+      expect(formatSessionDurationSeconds(2.3)).toBe('3s');
+      expect(formatSessionDurationSeconds(1.0001)).toBe('2s');
+    });
+
+    it('returns null for null / undefined / non-finite / non-numeric / ≤0', () => {
+      // Mirrors the appendViewerTtl defensive contract on the sibling
+      // upload wire field (connector.js:appendViewerTtl) so the bot
+      // can never put "NaNs" / "Infinitys" on the wire and turn a
+      // recoverable upstream-input mistake into a confusing 400 from
+      // qurl-service::validateSessionDuration.
+      const cases = [null, undefined, NaN, Infinity, -Infinity, '30', '0.5', true, false, {}, [], 0, -1, -0.5];
+      for (const v of cases) {
+        expect(formatSessionDurationSeconds(v)).toBeNull();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Plumbs the user's chosen self-destruct timer through to the qURL token's `session_duration`, so every minted link's L7 session window matches the fileviewer's client-side blank.

## Why

Surfaced by a user-reported bug on sandbox resource `r_9mii4njollm` (`expire_after=0.5` on the fileviewer URL): **refresh the `*.qurl.site/...` page past the 500ms canvas blank → fileviewer re-renders the full content**.

Root cause is in this repo + [`qurl-integrations-infra`](https://github.com/layervai/qurl-integrations-infra/pull/764):

| Token | `one_time_use` | DDB `session_duration_seconds` | Why null |
|---|---|---|---|
| Upload-time auto-created | false | null (should have been 1) | Connector deploy lag (#540) |
| Bot-minted (one per recipient) | true | null | `mintLinks()` doesn't forward selfDestructSeconds |

So every minted token defaults to `QURL_SESSION_TTL` (sandbox: **3600s**). Recipients can refresh for up to an hour after the fileviewer's 500ms blank — defeating the entire self-destruct UX. The L7 gate from [`traefik-plugins#173`](https://github.com/layervai/traefik-plugins/pull/173) is correctly authorizing because qurl-service correctly says the session is still valid.

## Changes

| File | Change |
|---|---|
| `src/connector.js::mintLinks` | New 5th param `selfDestructSeconds = null`. Formats as `"Ns"`, clamps `0.5 → "1s"` (qurl-service `MinSessionDuration` floor), ceils fractional values >1 (defensive — only the 0.5s preset is fractional today), includes in request body as `session_duration`. Null/undefined → field omitted → server default. |
| `src/commands.js::mintLinksInBatches` | New `selfDestructSeconds` opt, forwarded to every `mintLinks` call inside the batching loop. |
| `src/commands.js` (4 call sites) | Pass `selfDestructSeconds` (send-pipeline file + location) / `inheritedDestruct` (addRecipients file + location). All 4 call sites already had the value in scope. |
| `tests/send-pipeline-helpers.test.js` | 7 existing `mockMintLinks` call-signature assertions updated for the new 5th arg (null in these tests since none set self-destruct). |
| `tests/connector-coverage.test.js` | 5 new tests under "mintLinks — session_duration forwarding" fencing the value mapping. |

## Value mapping (matches `SELF_DESTRUCT_PRESETS`)

| User preset | `selfDestructSeconds` | Sent to connector |
|---|---|---|
| "No timer" | null | (field omitted → server default) |
| "1/2 second" | 0.5 | `"1s"` (clamped to qurl-service floor) |
| "1 second" | 1 | `"1s"` |
| "5 seconds" | 5 | `"5s"` |
| "30 seconds" | 30 | `"30s"` |
| "5 minutes" | 300 | `"300s"` |
| "30 minutes" | 1800 | `"1800s"` |
| "1 hour" | 3600 | `"3600s"` |

The 0.5s preset's fileviewer-side 500ms canvas blank still fires; only the L7 session window floors at 1s. For all other presets, exact match.

## Test plan

- [x] `npm test` — 2548 passed (+5 new), 0 failed (1 unrelated Lambda test-suite fails to load due to missing `@aws-sdk/client-ssm` — pre-existing)
- [x] `npm run lint` clean
- [ ] Deploy after [`qurl-integrations-infra#764`](https://github.com/layervai/qurl-integrations-infra/pull/764) merges + the connector deploys. Reverse order would silently drop `session_duration` at the connector handler (unknown JSON fields default to ignored).
- [ ] Manual sandbox verification: send a file via `/qurl file` with self-destruct=30s, capture the recipient's DDB `qurl-access-tokens` row, confirm `session_duration_seconds=30`. Verify refresh past 30s gets silentDropped.

## Coordinates with

- [`qurl-integrations-infra#764`](https://github.com/layervai/qurl-integrations-infra/pull/764) — connector forwards `session_duration` on mint_link path. **Must land + deploy first**, or the bot's new field is dropped silently.
- [`qurl-integrations-infra#540`](https://github.com/layervai/qurl-integrations-infra/pull/540) — upload-side counterpart (sessionDurationFor → CreateQURL). Already merged.
- [`layervai/traefik-plugins#173`](https://github.com/layervai/traefik-plugins/pull/173) — the L7 gate this fix relies on. Already merged + deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)