### PR TITLE
refactor(discord): mintLinks options-bag + shared isPositiveFinite predicate

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -27,6 +27,7 @@ const {
   expiryToMs,
   formatSelfDestructLabel,
   formatSelfDestructSegment,
+  isPositiveFinite,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
@@ -1490,7 +1491,12 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       tokensUsed = 0;
     }
     const batchSize = Math.min(TOKENS_PER_RESOURCE, recipientCount - i);
-    const minted = await mintLinks(currentResourceId, expiresAt, batchSize, apiKey, selfDestructSeconds);
+    const minted = await mintLinks(currentResourceId, {
+      expiresAt,
+      n: batchSize,
+      apiKey,
+      selfDestructSeconds,
+    });
     for (const link of minted) {
       // qurl_id is the join key against qurl.accessed webhooks; empty
       // string degrades the whole monitor to bare base-msg.
@@ -4058,7 +4064,7 @@ function renderConfirmCardContent({
     content += `\n**To:** ${validRecipients.length} user${validRecipients.length === 1 ? '' : 's'} (${previewNames}${more})\n`;
   }
   content += `**Expires:** ${EXPIRY_LABELS[expiresIn] || expiresIn}\n`;
-  if (Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0) {
+  if (isPositiveFinite(selfDestructSeconds)) {
     content += `**Self-destruct:** ${formatSelfDestructLabel(selfDestructSeconds)}\n`;
   }
   if (personalMessage) {
@@ -4256,7 +4262,7 @@ function renderConfirmCardRows({
   // corrupted DDB row carrying an off-preset finite value (which would
   // otherwise leave every option un-defaulted and force Discord to
   // render the first option's label — wrong UX).
-  const hasTimer = Number.isFinite(selfDestructSeconds) && selfDestructSeconds > 0;
+  const hasTimer = isPositiveFinite(selfDestructSeconds);
   const hasMatchingPreset = hasTimer && SELF_DESTRUCT_PRESETS.some((p) => p.seconds === selfDestructSeconds);
   if (hasTimer && !hasMatchingPreset) {
     // Symmetric with the expiry off-set warn below: a finite positive

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3505,7 +3505,7 @@ const SELF_DESTRUCT_PRESET_SECONDS = new Set(SELF_DESTRUCT_PRESETS.map((p) => p.
 function selfDestructOptionToSeconds(value) {
   if (!value || value === SELF_DESTRUCT_NO_TIMER_CHOICE) return null;
   const n = Number(value);
-  if (!Number.isFinite(n) || n <= 0) return null;
+  if (!isPositiveFinite(n)) return null;
   // Match the parsed Number directly — SELF_DESTRUCT_PRESETS contains
   // 0.5 (the "1/2 second" preset), so a Math.floor here would map 0.5
   // → 0 (not in the set) and silently downgrade to "no timer." The

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -170,9 +170,9 @@ function connectorAuthHeaders(apiKey) {
 // 1 * time.Second. A reader looking at one wire field should know the
 // other has the opposite handling for the 0.5s preset.
 function appendViewerTtl(form, viewerTtlSeconds) {
-  // isPositiveFinite already filters non-numbers (Number.isFinite('30')
-  // is false) and zero/negative — same invariant the modal-prefill
-  // setValue uses.
+  // Strict positive-finite: isPositiveFinite filters non-numbers
+  // (Number.isFinite('30') is false), zero, negatives, and ±Infinity
+  // — same invariant the modal-prefill setValue uses.
   if (isPositiveFinite(viewerTtlSeconds)) {
     form.append('viewer_ttl_seconds', String(viewerTtlSeconds));
   }
@@ -349,7 +349,7 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * @param {?number} [opts.selfDestructSeconds] — see formatSessionDurationSeconds for value mapping. Defaults to null.
  * @returns {Promise<Array<{qurl_id: string, qurl_link: string, expires_at: string}>>}
  */
-async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds = null }) {
+async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds = null } = {}) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -2,7 +2,7 @@ const config = require('./config');
 const logger = require('./logger');
 
 const { sanitizeFilename } = require('./utils/sanitize');
-const { formatSessionDurationSeconds } = require('./utils/time');
+const { formatSessionDurationSeconds, isPositiveFinite } = require('./utils/time');
 
 const { MAX_FILE_SIZE } = require('./constants');
 const MAX_CDN_REDIRECTS = 3;
@@ -170,10 +170,10 @@ function connectorAuthHeaders(apiKey) {
 // 1 * time.Second. A reader looking at one wire field should know the
 // other has the opposite handling for the 0.5s preset.
 function appendViewerTtl(form, viewerTtlSeconds) {
-  // Number.isFinite already filters non-numbers (Number.isFinite('30') is
-  // false), so the typeof guard would be redundant. Strict positive-finite
-  // is the same invariant the modal-prefill setValue uses.
-  if (Number.isFinite(viewerTtlSeconds) && viewerTtlSeconds > 0) {
+  // isPositiveFinite already filters non-numbers (Number.isFinite('30')
+  // is false) and zero/negative — same invariant the modal-prefill
+  // setValue uses.
+  if (isPositiveFinite(viewerTtlSeconds)) {
     form.append('viewer_ttl_seconds', String(viewerTtlSeconds));
   }
 }
@@ -340,13 +340,16 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * `SELF_DESTRUCT_PRESETS`).
  *
  * @param {string} resourceId — connector resource_id (alphanum + `_-`).
- * @param {string} expiresAt — ISO string forwarded as `expires_at`.
- * @param {number} n — integer 1..100, count of links to mint.
- * @param {?string} apiKey — caller API key; falls back to `config.QURL_API_KEY`.
- * @param {?number} [selfDestructSeconds] — see formatSessionDurationSeconds for value mapping. Defaults to null.
+ * @param {object} opts — minting options. Bag-shaped for sibling-consistency
+ *   with mintLinksInBatches, whose call-through used to position-align the
+ *   adjacent `expiresAt` and `apiKey` strings (cycle-1 footgun on PR #483).
+ * @param {string} opts.expiresAt — ISO string forwarded as `expires_at`.
+ * @param {number} opts.n — integer 1..100, count of links to mint.
+ * @param {?string} [opts.apiKey] — caller API key; falls back to `config.QURL_API_KEY`.
+ * @param {?number} [opts.selfDestructSeconds] — see formatSessionDurationSeconds for value mapping. Defaults to null.
  * @returns {Promise<Array<{qurl_id: string, qurl_link: string, expires_at: string}>>}
  */
-async function mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds = null) {
+async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds = null } = {}) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -349,7 +349,7 @@ async function downloadAndUpload(sourceUrl, filename, contentType, apiKey, viewe
  * @param {?number} [opts.selfDestructSeconds] — see formatSessionDurationSeconds for value mapping. Defaults to null.
  * @returns {Promise<Array<{qurl_id: string, qurl_link: string, expires_at: string}>>}
  */
-async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds = null } = {}) {
+async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds = null }) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1,5 +1,6 @@
 const config = require('./config');
 const logger = require('./logger');
+const { isPositiveFinite } = require('./utils/time');
 const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
 const { createGatewayWsShim } = require('./gateway-ws-shim');
@@ -250,11 +251,11 @@ if (isNaN(config.PENDING_LINK_EXPIRY_MINUTES) || config.PENDING_LINK_EXPIRY_MINU
   logger.error('PENDING_LINK_EXPIRY_MINUTES must be a positive integer');
   process.exit(1);
 }
-if (!Number.isFinite(config.RATE_LIMIT_WINDOW_MS) || config.RATE_LIMIT_WINDOW_MS <= 0) {
+if (!isPositiveFinite(config.RATE_LIMIT_WINDOW_MS)) {
   logger.error('RATE_LIMIT_WINDOW_MS must be a positive integer (set to 0 would disable rate limiting)');
   process.exit(1);
 }
-if (!Number.isFinite(config.RATE_LIMIT_MAX_REQUESTS) || config.RATE_LIMIT_MAX_REQUESTS <= 0) {
+if (!isPositiveFinite(config.RATE_LIMIT_MAX_REQUESTS)) {
   logger.error('RATE_LIMIT_MAX_REQUESTS must be a positive integer');
   process.exit(1);
 }

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -6,6 +6,7 @@ const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
 const { renderPage } = require('./templates/page');
+const { isPositiveFinite } = require('./utils/time');
 const oauthRouter = require('./routes/oauth');
 const qurlOAuthRouter = require('./routes/qurl-oauth');
 const discordInstallRouter = require('./routes/discord-install');
@@ -24,13 +25,13 @@ const app = express();
 // proxy', …)`. Express also accepts `true` (trust ALL hops) and `'true'`
 // (string), both of which let an attacker spoof X-Forwarded-For via any
 // upstream proxy to rotate their apparent IP and bypass the per-IP rate
-// limiter. The parseInt + Number.isFinite + > 0 chain below rejects all
-// of those: `'true'` / `'yes'` parse to NaN, negative values are
-// dropped, and a missing env falls through to the production-only
-// default of `1` (one hop = the ALB) rather than `true`.
+// limiter. The parseInt + isPositiveFinite chain below rejects all of
+// those: `'true'` / `'yes'` parse to NaN, negative values are dropped,
+// and a missing env falls through to the production-only default of `1`
+// (one hop = the ALB) rather than `true`.
 if (process.env.TRUST_PROXY) {
   const hops = parseInt(process.env.TRUST_PROXY, 10);
-  if (Number.isFinite(hops) && hops > 0) {
+  if (isPositiveFinite(hops)) {
     app.set('trust proxy', hops);
   } else {
     logger.warn(`Ignoring invalid TRUST_PROXY=${process.env.TRUST_PROXY} (must be a positive integer hop count, NOT 'true')`);

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -66,6 +66,7 @@ const { encrypt, encryptStrict, decrypt } = require('../utils/crypto');
 const config = require('../config');
 const logger = require('../logger');
 const { DM_STATUS } = require('../constants');
+const { isPositiveFinite } = require('../utils/time');
 
 // Badge taxonomy — stable string enum values so callers that
 // compare or persist them across boots stay consistent.
@@ -204,7 +205,7 @@ function getPreviousMonthString(date = new Date()) {
 // Same fail-fast philosophy as the DDB_TABLE_PREFIX / AWS_REGION
 // guards above.
 const PENDING_LINK_EXPIRY_MS = Math.trunc(Number(config.PENDING_LINK_EXPIRY_MINUTES)) * 60 * 1000;
-if (!Number.isFinite(PENDING_LINK_EXPIRY_MS) || PENDING_LINK_EXPIRY_MS <= 0) {
+if (!isPositiveFinite(PENDING_LINK_EXPIRY_MS)) {
   throw new Error(`config.PENDING_LINK_EXPIRY_MINUTES is required to be a positive number when STORE_TYPE=ddb (got '${config.PENDING_LINK_EXPIRY_MINUTES}'). Set it in the deployment template alongside DDB_TABLE_PREFIX / AWS_REGION.`);
 }
 

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -162,11 +162,22 @@ function formatSelfDestructSegment(seconds) {
 // changes, the other must too — fenced by qurl-integrations-infra
 // PR #764 + this PR landing as a coordinated pair.
 function formatSessionDurationSeconds(seconds) {
-  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  if (!isPositiveFinite(seconds)) return null;
   // Math.ceil of any value in (0, 1] is 1; of any positive finite
-  // number is ≥1. Combined with the > 0 guard above, this never
-  // emits "0s".
+  // number is ≥1. Combined with the isPositiveFinite guard above,
+  // this never emits "0s".
   return `${Math.ceil(seconds)}s`;
+}
+
+// isPositiveFinite — single predicate for "valid positive numeric
+// seconds/count/TTL" gate. Rejects null, undefined, NaN, ±Infinity,
+// 0, and negative numbers. Six call sites (connector.js, commands.js
+// (x2), server.js, time.js (x2)) all used the inline
+// `Number.isFinite(x) && x > 0` form — extracting here so the
+// predicate definition lives next to the formatter that already
+// owns the seconds/TTL semantics.
+function isPositiveFinite(n) {
+  return Number.isFinite(n) && n > 0;
 }
 
 module.exports = {
@@ -175,6 +186,7 @@ module.exports = {
   formatSelfDestructLabel,
   formatSelfDestructSegment,
   formatSessionDurationSeconds,
+  isPositiveFinite,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -11,7 +11,7 @@ function parseExpiryMs(expiresIn) {
   const match = String(expiresIn ?? '').match(/^(\d{1,6})([mhd])$/);
   if (!match) return null;
   const ms = Number(match[1]) * EXPIRY_UNITS[match[2]] * 1000;
-  if (!Number.isFinite(ms) || ms <= 0) return null;
+  if (!isPositiveFinite(ms)) return null;
   return Math.min(ms, MAX_EXPIRY_MS);
 }
 
@@ -124,7 +124,7 @@ function formatSelfDestructLabel(seconds) {
 // selected" sentinel — so the segment is always present and aligned
 // with the rest of the header.
 function formatSelfDestructSegment(seconds) {
-  if (Number.isFinite(seconds) && seconds > 0) {
+  if (isPositiveFinite(seconds)) {
     return `Self-destruct: ${formatSelfDestructLabel(seconds)}`;
   }
   return 'Self-destruct: off';
@@ -171,11 +171,11 @@ function formatSessionDurationSeconds(seconds) {
 
 // isPositiveFinite — single predicate for "valid positive numeric
 // seconds/count/TTL" gate. Rejects null, undefined, NaN, ±Infinity,
-// 0, and negative numbers. Six call sites (connector.js, commands.js
-// (x2), server.js, time.js (x2)) all used the inline
-// `Number.isFinite(x) && x > 0` form — extracting here so the
-// predicate definition lives next to the formatter that already
-// owns the seconds/TTL semantics.
+// 0, and negative numbers. Replaces 11 inline `Number.isFinite(x) &&
+// x > 0` / `!Number.isFinite(x) || x <= 0` sites across
+// connector.js, commands.js (×3), server.js, index.js (×2),
+// store/ddb-store.js, and time.js (×3). Co-located with the
+// formatters that own the seconds/TTL semantics.
 function isPositiveFinite(n) {
   return Number.isFinite(n) && n > 0;
 }

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -2,13 +2,12 @@ const logger = require('../logger');
 
 // isPositiveFinite — single predicate for "valid positive numeric
 // seconds/count/TTL" gate. Rejects null, undefined, NaN, ±Infinity,
-// 0, and negative numbers. Replaces 11 inline `Number.isFinite(x) &&
-// x > 0` / `!Number.isFinite(x) || x <= 0` sites across
-// connector.js, commands.js (×3), server.js, index.js (×2),
-// store/ddb-store.js, and time.js (×3). Hoisted to file top so
-// readers scanning top-to-bottom see the predicate before its
-// (lexically lower) call sites in parseExpiryMs /
-// formatSelfDestructSegment / formatSessionDurationSeconds.
+// 0, and negative numbers. Strict Number.isFinite (NOT global
+// isFinite) so non-numbers like '1', true, {} are also rejected
+// without coercion. Use whenever you need "definitely a positive
+// number" — TTL gates, count validators, threshold checks. Hoisted
+// to file top so readers see the definition before its (lexically
+// lower) callers in this file.
 function isPositiveFinite(n) {
   return Number.isFinite(n) && n > 0;
 }

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -1,5 +1,18 @@
 const logger = require('../logger');
 
+// isPositiveFinite — single predicate for "valid positive numeric
+// seconds/count/TTL" gate. Rejects null, undefined, NaN, ±Infinity,
+// 0, and negative numbers. Replaces 11 inline `Number.isFinite(x) &&
+// x > 0` / `!Number.isFinite(x) || x <= 0` sites across
+// connector.js, commands.js (×3), server.js, index.js (×2),
+// store/ddb-store.js, and time.js (×3). Hoisted to file top so
+// readers scanning top-to-bottom see the predicate before its
+// (lexically lower) call sites in parseExpiryMs /
+// formatSelfDestructSegment / formatSessionDurationSeconds.
+function isPositiveFinite(n) {
+  return Number.isFinite(n) && n > 0;
+}
+
 const EXPIRY_UNITS = { m: 60, h: 3600, d: 86400 };
 // Cap the expiry at 30 days in ms. An arbitrarily large numeric component in
 // the expiry string (e.g. "99999999999d") would otherwise overflow Number
@@ -167,17 +180,6 @@ function formatSessionDurationSeconds(seconds) {
   // number is ≥1. Combined with the isPositiveFinite guard above,
   // this never emits "0s".
   return `${Math.ceil(seconds)}s`;
-}
-
-// isPositiveFinite — single predicate for "valid positive numeric
-// seconds/count/TTL" gate. Rejects null, undefined, NaN, ±Infinity,
-// 0, and negative numbers. Replaces 11 inline `Number.isFinite(x) &&
-// x > 0` / `!Number.isFinite(x) || x <= 0` sites across
-// connector.js, commands.js (×3), server.js, index.js (×2),
-// store/ddb-store.js, and time.js (×3). Co-located with the
-// formatters that own the seconds/TTL semantics.
-function isPositiveFinite(n) {
-  return Number.isFinite(n) && n > 0;
 }
 
 module.exports = {

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -125,6 +125,13 @@ function isLegitimateSelfDestructSelectValue(value) {
 function formatSelfDestructLabel(seconds) {
   const match = findPresetBySeconds(seconds);
   if (match) return match.label;
+  // Intentionally NOT isPositiveFinite — this branch's purpose is
+  // to flag *non-finite* (NaN/Infinity) as "(invalid)" while still
+  // letting 0 / negative off-preset values render as "0s" / "-5s"
+  // for the next gate to handle (the form caller maps a finite-but-
+  // off-preset value to the underlying numeric formatting). Don't
+  // "finish the refactor" by switching to isPositiveFinite — that
+  // would silently re-route 0 / negatives to "(invalid)" too.
   if (!Number.isFinite(seconds)) return '(invalid)';
   return `${seconds}s`;
 }

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -211,31 +211,31 @@ describe('Connector client — coverage boost', () => {
 
       it('sends session_duration when selfDestructSeconds provided', async () => {
         const getBody = captureMintBody();
-        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, 30);
+        await connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 1, selfDestructSeconds: 30 });
         expect(getBody().session_duration).toBe('30s');
       });
 
       it('clamps 0.5 (fileviewer preset) to "1s" — qurl-service MinSessionDuration floor', async () => {
         const getBody = captureMintBody();
-        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, 0.5);
+        await connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 1, selfDestructSeconds: 0.5 });
         expect(getBody().session_duration).toBe('1s');
       });
 
       it('ceils fractional values >1 (defensive — presets are all integer ≥1)', async () => {
         const getBody = captureMintBody();
-        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, 2.3);
+        await connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 1, selfDestructSeconds: 2.3 });
         expect(getBody().session_duration).toBe('3s');
       });
 
       it('omits session_duration when null', async () => {
         const getBody = captureMintBody();
-        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, null);
+        await connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 1, selfDestructSeconds: null });
         expect(getBody().session_duration).toBeUndefined();
       });
 
-      it('omits session_duration when undefined (default param)', async () => {
+      it('omits session_duration when omitted (default param)', async () => {
         const getBody = captureMintBody();
-        await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined);
+        await connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 1 });
         expect(getBody().session_duration).toBeUndefined();
       });
 
@@ -253,7 +253,7 @@ describe('Connector client — coverage boost', () => {
         for (const v of cases) {
           const getBody = captureMintBody();
           // eslint-disable-next-line no-await-in-loop
-          await connector.mintLinks('r_xyz', '2099-01-01T00:00:00Z', 1, undefined, v);
+          await connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 1, selfDestructSeconds: v });
           expect(getBody().session_duration).toBeUndefined();
         }
       });
@@ -301,7 +301,7 @@ describe('Connector client — coverage boost', () => {
       });
 
       try {
-        await connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1);
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 });
         throw new Error('expected throw');
       } catch (e) {
         expect(e.message).toMatch(/Connector mint_link failed \(502\)/);
@@ -322,7 +322,7 @@ describe('Connector client — coverage boost', () => {
       });
 
       try {
-        await connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1);
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 });
         throw new Error('expected throw');
       } catch (e) {
         expect(e.apiCode).toBe('quota_exceeded');
@@ -340,7 +340,7 @@ describe('Connector client — coverage boost', () => {
       });
 
       try {
-        await connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1);
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 });
         throw new Error('expected throw');
       } catch (e) {
         expect(e.status).toBe(500);
@@ -356,7 +356,7 @@ describe('Connector client — coverage boost', () => {
       });
 
       try {
-        await connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1);
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 });
         throw new Error('expected throw');
       } catch (e) {
         expect(e.status).toBe(503);
@@ -372,7 +372,7 @@ describe('Connector client — coverage boost', () => {
       });
 
       try {
-        await connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1);
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 });
         throw new Error('expected throw');
       } catch (e) {
         expect(e.status).toBe(504);
@@ -388,7 +388,7 @@ describe('Connector client — coverage boost', () => {
         json: async () => ({ success: true, links: null }),
       });
 
-      await expect(connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1))
+      await expect(connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 }))
         .rejects.toThrow('Connector mint_link returned no links array');
     });
 
@@ -398,7 +398,7 @@ describe('Connector client — coverage boost', () => {
         json: async () => ({ success: true, links: 'not-array' }),
       });
 
-      await expect(connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1))
+      await expect(connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 }))
         .rejects.toThrow('Connector mint_link returned no links array');
     });
 
@@ -408,7 +408,7 @@ describe('Connector client — coverage boost', () => {
         json: async () => ({ success: true }),
       });
 
-      await expect(connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1))
+      await expect(connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 }))
         .rejects.toThrow('Connector mint_link returned no links array');
     });
   });
@@ -444,7 +444,7 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
   });
 
   it('throws when QURL_API_KEY is empty on mintLinks', async () => {
-    await expect(connector.mintLinks('res-1', '2026-01-01T00:00:00Z', 1))
+    await expect(connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 }))
       .rejects.toThrow('QURL_API_KEY is not configured');
   });
 });

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -777,7 +777,7 @@ describe('Connector client', () => {
         json: async () => ({ success: true, links: mockLinks }),
       });
 
-      const result = await connector.mintLinks('conn-res-1', '2026-01-16T00:00:00.000Z', 2);
+      const result = await connector.mintLinks('conn-res-1', { expiresAt: '2026-01-16T00:00:00.000Z', n: 2 });
 
       expect(globalThis.fetch).toHaveBeenCalledTimes(1);
       const [url, opts] = globalThis.fetch.mock.calls[0];
@@ -800,7 +800,7 @@ describe('Connector client', () => {
         text: async () => 'Bad Request',
       });
 
-      await expect(connector.mintLinks('bad', 'date', 1))
+      await expect(connector.mintLinks('bad', { expiresAt: 'date', n: 1 }))
         .rejects.toThrow(/Connector mint_link failed.*400/);
     });
 
@@ -810,7 +810,7 @@ describe('Connector client', () => {
         json: async () => ({ success: false }),
       });
 
-      await expect(connector.mintLinks('id', 'date', 1))
+      await expect(connector.mintLinks('id', { expiresAt: 'date', n: 1 }))
         .rejects.toThrow(/success: false/);
     });
   });
@@ -1277,7 +1277,7 @@ describe('handleAddRecipients', () => {
       null,
     );
     // mintLinks is called against the NEW resource (conn-res-43)
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', expect.any(String), 2, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
     // createOneTimeLink should NOT have been called
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     // DMs should have been sent
@@ -1332,10 +1332,7 @@ describe('handleAddRecipients', () => {
     // silently drop the value at the boundary.
     expect(mockMintLinks).toHaveBeenCalledWith(
       'conn-res-44',
-      expect.any(String),
-      1,
-      'test-api-key',
-      30,
+      { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: 30 },
     );
   });
 
@@ -1368,7 +1365,7 @@ describe('handleAddRecipients', () => {
       'location.json', 'test-api-key',
       null,
     );
-    expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', expect.any(String), 1, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('res-loc-1', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(mockSendDM).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(1);
     expect(mockDb.recordQURLSendBatch.mock.calls[0][0]).toHaveLength(1);
@@ -1411,10 +1408,7 @@ describe('handleAddRecipients', () => {
     // even if the upload side caught it.
     expect(mockMintLinks).toHaveBeenCalledWith(
       'res-loc-2',
-      expect.any(String),
-      1,
-      'test-api-key',
-      300,
+      { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: 300 },
     );
   });
 
@@ -1449,7 +1443,7 @@ describe('handleAddRecipients', () => {
       'location.json', 'test-api-key',
       null,
     );
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', expect.any(String), 1, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-maps', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     expect(result.msg).toMatch(/Added 1 recipient/);
   });
@@ -1541,7 +1535,7 @@ describe('handleAddRecipients', () => {
     // Only Alice and Bob should get DMs (bot and sender excluded)
     expect(mockSendDM).toHaveBeenCalledTimes(2);
     expect(mockUploadJsonToConnector).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', expect.any(String), 2, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(result.msg).toMatch(/Added 2 recipients/);
   });
 
@@ -1606,8 +1600,8 @@ describe('handleAddRecipients', () => {
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockReUploadBuffer).toHaveBeenCalledTimes(1);
     expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', expect.any(String), 10, 'test-api-key', null);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', expect.any(String), 2, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', { expiresAt: expect.any(String), n: 10, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(result.msg).toMatch(/Added 12 recipients/);
   });
 
@@ -1639,7 +1633,7 @@ describe('handleAddRecipients', () => {
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockMintLinks).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', expect.any(String), 8, 'test-api-key', null);
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', { expiresAt: expect.any(String), n: 8, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(mockSendDM).toHaveBeenCalledTimes(8);
     expect(result.msg).toMatch(/Added 8 recipients/);
   });

--- a/apps/discord/tests/time.test.js
+++ b/apps/discord/tests/time.test.js
@@ -18,6 +18,7 @@ const {
   formatSelfDestructLabel,
   formatSelfDestructSegment,
   formatSessionDurationSeconds,
+  isPositiveFinite,
   selfDestructSelectValueToSeconds,
   isLegitimateSelfDestructSelectValue,
   SELF_DESTRUCT_PRESETS,
@@ -228,6 +229,44 @@ describe('utils/time', () => {
       const cases = [null, undefined, NaN, Infinity, -Infinity, '30', '0.5', true, false, {}, [], 0, -1, -0.5];
       for (const v of cases) {
         expect(formatSessionDurationSeconds(v)).toBeNull();
+      }
+    });
+  });
+
+  // isPositiveFinite is the shared "valid positive numeric
+  // seconds/count/TTL" gate replacing 11 inline `Number.isFinite(x)
+  // && x > 0` sites. Tested here directly (in addition to integration
+  // coverage at each call site) so the contract lives co-located with
+  // the formatters that share the gate.
+  describe('isPositiveFinite', () => {
+    it('returns true for positive finite numbers', () => {
+      const cases = [0.5, 1, 5, 30, 1.0001, 1e308, Number.MAX_SAFE_INTEGER];
+      for (const v of cases) {
+        expect(isPositiveFinite(v)).toBe(true);
+      }
+    });
+
+    it('returns false for null / undefined / NaN / ±Infinity', () => {
+      const cases = [null, undefined, NaN, Infinity, -Infinity];
+      for (const v of cases) {
+        expect(isPositiveFinite(v)).toBe(false);
+      }
+    });
+
+    it('returns false for zero and negative finite numbers', () => {
+      const cases = [0, -0, -1, -0.5, -1e308, Number.MIN_SAFE_INTEGER];
+      for (const v of cases) {
+        expect(isPositiveFinite(v)).toBe(false);
+      }
+    });
+
+    it('returns false for non-number types (no Number coercion)', () => {
+      // Number.isFinite (strict variant, used internally) rejects
+      // string/boolean/object/array without coercion. This is
+      // load-bearing: the global isFinite() would coerce '0x1' → 1.
+      const cases = ['1', '0.5', '30s', true, false, {}, [], () => 1];
+      for (const v of cases) {
+        expect(isPositiveFinite(v)).toBe(false);
       }
     });
   });


### PR DESCRIPTION
## Summary

Two PR #483-derived follow-ups bundled into one focused refactor:

### 1. `mintLinks(resourceId, opts)` — options-bag for sibling-consistency

`mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey, selfDestructSeconds })` was already options-bag shaped, but its inner call to `mintLinks(resourceId, expiresAt, n, apiKey, selfDestructSeconds)` was 5 positional args — two adjacent strings (`resourceId` + `expiresAt`) and a 3rd (`apiKey`) all swappable at the call site without a compile error. PR #483 cycle-1 review flagged this as a footgun matching the qurl-s3-connector `MintLinkOptions` Go-side refactor (layervai/qurl-integrations-infra#767).

New shape: `mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds })`. `resourceId` stays positional (always required, the URL path component); everything else is in the bag.

### 2. `isPositiveFinite(n)` — shared predicate

The `Number.isFinite(x) && x > 0` (and its `!Number.isFinite(x) || x <= 0` negation) idiom was inlined at **11 sites**:

- `connector.js` (×1) — `appendViewerTtl` viewerTtlSeconds gate
- `commands.js` (×3) — self-destruct gates + `selfDestructOptionToSeconds`
- `server.js` (×1) — TRUST_PROXY parse
- `index.js` (×2) — `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX_REQUESTS`
- `store/ddb-store.js` (×1) — `PENDING_LINK_EXPIRY_MS`
- `utils/time.js` (×3) — `parseExpiryMs`, `formatSelfDestructSegment`, `formatSessionDurationSeconds`

Extracted into `utils/time.js`, hoisted to file top (so readers don't hit unresolved references before its definition), and fenced by a direct unit test alongside the integration coverage at every call site.

## Why

Both items were `please-fix` deferrals from PR #483's CR cycles 2/3/4. Landing as a focused refactor rather than re-opening #483 keeps the bug-fix commit history clean.

## Test plan

- [x] Full `npx jest`: **2584 / 2584 passed** (added 4 new `isPositiveFinite` tests; no regressions; 22 prior test call sites updated, including 9 `mockMintLinks.toHaveBeenCalledWith(...)` expectations rewritten to the bag shape)
- [x] `npx eslint src/ tests/`: clean
- [x] Behavior identical — pure refactor; no wire-format / runtime semantics changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)