### PR TITLE
feat(discord): per-guild qurl-service webhook subscriptions (BYOK view counter fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ apps/discord/scripts/*
 !apps/discord/scripts/loadtest-standalone.js
 !apps/discord/scripts/gateway-resume-spike.js
 !apps/discord/scripts/provision-ddb-local.js
+!apps/discord/scripts/provision-guild-subscriptions.js
 apps/discord/.github/
 apps/discord/railway.json

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// One-shot backfill: register a qurl.accessed webhook subscription
+// for every linked guild that doesn't have one yet.
+//
+// Run AFTER deploying the BYOK view-counter change (the migration
+// that introduced setGuildApiKey-time subscription registration).
+// Already-linked guilds wouldn't otherwise pick up a subscription
+// until they manually re-link via `/qurl setup`; this script catches
+// them in one pass.
+//
+// Idempotent: rows that already have a `webhook_id` are skipped.
+// Safe to re-run on partial failures (e.g. transient qurl-service
+// 5xx mid-batch) — only the rows that didn't complete on the first
+// pass will be touched on the second.
+//
+// Usage:
+//   node apps/discord/scripts/provision-guild-subscriptions.js [--dry-run]
+//
+// Required env: BASE_URL, QURL_ENDPOINT, AWS credentials with read +
+// UpdateItem on the guild_configs table, KEY_ENCRYPTION_KEY (for
+// decrypting stored qurl_api_keys), and any other env the bot's
+// config.js validates at boot. Easiest invocation is `npm run
+// provision-guild-subscriptions` after sourcing the bot's task-def
+// env (e.g. via ECS Exec or a sandbox shell with the same envs).
+//
+// SCOPE: only operates on the qurl_api_key + webhook_* attributes of
+// the `guild_configs` DDB table. Does not touch any other table.
+
+'use strict';
+
+const db = require('../src/store');
+const config = require('../src/config');
+const logger = require('../src/logger');
+const { linkGuildWebhookSubscription } = require('../src/guild-webhook-link');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  if (!config.QURL_ENDPOINT || !config.BASE_URL) {
+    console.error('FATAL: QURL_ENDPOINT and BASE_URL must be set');
+    process.exit(1);
+  }
+
+  // Scan the guild_configs table for every row with a stored API key.
+  // We use the raw store helpers (not scanGuildSubscriptions, which
+  // filters down to rows that ALREADY have a webhook_id) because the
+  // backfill universe is precisely "has key, no subscription yet".
+  //
+  // listAll-style helper isn't exposed on the contract; getAllGuilds
+  // doesn't exist either. We approximate by scanning + filtering
+  // through getGuildConfigWithApiKey for each candidate guildId. To
+  // discover candidates, we use scanGuildSubscriptions PLUS the
+  // contract's awkward fact that DDB scanAll inside ddb-store.js
+  // already returns full rows. The cleanest path: import scanAll via
+  // an internal scan helper. The pragmatic path: small inline scan
+  // here.
+  //
+  // Pragmatic path: the bot's contract exposes nothing for "list every
+  // guildId in guild_configs". Add a helper via DDB SDK directly so
+  // the script stays single-purpose and doesn't grow the Store
+  // contract just for a one-off operator tool.
+
+  const {
+    DynamoDBClient,
+  } = require('@aws-sdk/client-dynamodb');
+  const {
+    DynamoDBDocumentClient,
+    ScanCommand,
+  } = require('@aws-sdk/lib-dynamodb');
+  const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({
+    region: process.env.AWS_REGION || 'us-east-2',
+  }));
+  const TABLE = `qurl-bot-discord-${config.ENVIRONMENT || process.env.ENVIRONMENT || 'sandbox'}-guild-configs`;
+
+  let scanned = 0;
+  let candidates = 0;
+  let skipped = 0;
+  let provisioned = 0;
+  let failed = 0;
+  let ExclusiveStartKey;
+
+  do {
+    const res = await ddb.send(new ScanCommand({ TableName: TABLE, ExclusiveStartKey }));
+    const rows = res.Items || [];
+    for (const row of rows) {
+      scanned += 1;
+      if (!row.qurl_api_key) { skipped += 1; continue; }
+      if (row.webhook_id) { skipped += 1; continue; }
+      candidates += 1;
+      const guildId = row.guild_id;
+      console.log(`[backfill] candidate guild_id=${guildId}`);
+      if (DRY_RUN) continue;
+      // Decrypt the stored key via the same path getGuildApiKey uses.
+      // Then call the shared link helper. linkGuildWebhookSubscription
+      // is non-throwing — it returns { ok, reason } so we can count
+      // outcomes without try/catch noise.
+      const apiKey = await db.getGuildApiKey(guildId);
+      if (!apiKey) {
+        console.warn(`[backfill] guild_id=${guildId} qurl_api_key decrypted empty — skipping`);
+        skipped += 1;
+        continue;
+      }
+      const result = await linkGuildWebhookSubscription({
+        guildId, apiKey, descriptionContext: 'via=backfill-script',
+      });
+      if (result.ok) {
+        provisioned += 1;
+        console.log(`[backfill] provisioned guild_id=${guildId} action=${result.action}`);
+      } else {
+        failed += 1;
+        console.error(`[backfill] FAILED guild_id=${guildId} reason=${result.reason}`);
+      }
+    }
+    ExclusiveStartKey = res.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+
+  console.log('\n=== Backfill summary ===');
+  console.log(`Table:        ${TABLE}`);
+  console.log(`Dry run:      ${DRY_RUN}`);
+  console.log(`Scanned:      ${scanned}`);
+  console.log(`Candidates:   ${candidates}`);
+  console.log(`Skipped:      ${skipped}`);
+  if (!DRY_RUN) {
+    console.log(`Provisioned:  ${provisioned}`);
+    console.log(`Failed:       ${failed}`);
+  }
+  // Exit non-zero if any candidate failed so operator CI / shell
+  // chains catch partial-failure runs.
+  process.exit(failed > 0 ? 2 : 0);
+}
+
+main().catch((err) => {
+  logger.error('provision-guild-subscriptions crashed', { error: err.message, stack: err.stack });
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -16,6 +16,13 @@
 // Usage:
 //   node apps/discord/scripts/provision-guild-subscriptions.js [--dry-run]
 //
+// Exit codes:
+//   0  clean — no failures (dry-run or real)
+//   2  one or more rows failed (intentional in dry-run too: it
+//      surfaces KMS drift before an operator commits to a real run)
+//   3  MAX_PAGES hit — cursor likely not advancing, investigate
+//      before re-running
+//
 // Required env: BASE_URL, QURL_ENDPOINT, AWS credentials with read +
 // UpdateItem on the guild_configs table, KEY_ENCRYPTION_KEY (for
 // decrypting stored qurl_api_keys), and any other env the bot's

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -147,9 +147,16 @@ async function main() {
   }
   // Always print failed counters even in dry-run — decrypt errors
   // increment failedDecrypt in either mode, and a silent exit 2
-  // would let an operator miss them.
+  // would let an operator miss them. Exit codes:
+  //   0  clean — no failures (dry-run or real)
+  //   2  one or more rows failed (intentional in dry-run too: it
+  //      surfaces KMS drift before an operator commits to a real run)
+  //   3  MAX_PAGES hit — cursor likely not advancing
   console.log(`FailedDecrypt: ${failedDecrypt}`);
   console.log(`FailedLink:    ${failedLink}`);
+  if (DRY_RUN && failedTotal > 0) {
+    console.log('NOTE: dry-run exit 2 is intentional — failures above must be triaged before a real run');
+  }
   process.exit(failedTotal > 0 ? 2 : 0);
 }
 

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -40,26 +40,15 @@ async function main() {
     console.error('FATAL: QURL_ENDPOINT and BASE_URL must be set');
     process.exit(1);
   }
+  if (!config.DDB_TABLE_PREFIX || !config.DDB_TABLE_PREFIX.endsWith('-')) {
+    console.error(`FATAL: DDB_TABLE_PREFIX must be set and end with "-" (got ${JSON.stringify(config.DDB_TABLE_PREFIX)})`);
+    process.exit(1);
+  }
 
-  // Scan the guild_configs table for every row with a stored API key.
-  // We use the raw store helpers (not scanGuildSubscriptions, which
-  // filters down to rows that ALREADY have a webhook_id) because the
-  // backfill universe is precisely "has key, no subscription yet".
-  //
-  // listAll-style helper isn't exposed on the contract; getAllGuilds
-  // doesn't exist either. We approximate by scanning + filtering
-  // through getGuildConfigWithApiKey for each candidate guildId. To
-  // discover candidates, we use scanGuildSubscriptions PLUS the
-  // contract's awkward fact that DDB scanAll inside ddb-store.js
-  // already returns full rows. The cleanest path: import scanAll via
-  // an internal scan helper. The pragmatic path: small inline scan
-  // here.
-  //
-  // Pragmatic path: the bot's contract exposes nothing for "list every
-  // guildId in guild_configs". Add a helper via DDB SDK directly so
-  // the script stays single-purpose and doesn't grow the Store
-  // contract just for a one-off operator tool.
-
+  // Contract has no "list every guild_configs row" helper, so the
+  // script issues its own ScanCommand. Table name MUST come from the
+  // bot's own config.DDB_TABLE_PREFIX so the script can't target a
+  // different table than the running bot.
   const {
     DynamoDBClient,
   } = require('@aws-sdk/client-dynamodb');
@@ -70,7 +59,7 @@ async function main() {
   const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({
     region: process.env.AWS_REGION || 'us-east-2',
   }));
-  const TABLE = `qurl-bot-discord-${config.ENVIRONMENT || process.env.ENVIRONMENT || 'sandbox'}-guild-configs`;
+  const TABLE = `${config.DDB_TABLE_PREFIX}guild-configs`;
 
   let scanned = 0;
   let candidates = 0;

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -25,6 +25,14 @@
 //
 // SCOPE: only operates on the qurl_api_key + webhook_* attributes of
 // the `guild_configs` DDB table. Does not touch any other table.
+//
+// PERFORMANCE NOTE: each linkGuildWebhookSubscription call transitively
+// invokes propagateGuildWebhookSubscription, which today does a full-
+// table ConsistentRead scan of guild_configs. The backfill is
+// therefore O(rows²) RCU. Acceptable at current scale (≤10 BYOK
+// guilds in prod); a re-run after the #486 GSI migration on
+// webhook_owner_id reduces this to O(rows × ownersScanned), and is
+// effectively free thereafter.
 
 'use strict';
 

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -93,7 +93,16 @@ async function main() {
       console.error(`[backfill] FATAL: exceeded MAX_PAGES=${MAX_PAGES} — cursor may not be advancing`);
       process.exit(3);
     }
-    const res = await ddb.send(new ScanCommand({ TableName: TABLE, ExclusiveStartKey }));
+    // FilterExpression is server-side post-read (DDB charges RCU on
+    // unfiltered rows), so it doesn't save cost — but it does shrink
+    // client-side memory pressure and suppresses noise from rows
+    // that obviously have nothing to provision (no qurl_api_key OR
+    // already-provisioned webhook_id).
+    const res = await ddb.send(new ScanCommand({
+      TableName: TABLE,
+      ExclusiveStartKey,
+      FilterExpression: 'attribute_exists(qurl_api_key) AND attribute_not_exists(webhook_id)',
+    }));
     const rows = res.Items || [];
     for (const row of rows) {
       scanned += 1;

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -90,25 +90,28 @@ async function main() {
       const guildId = row.guild_id;
       console.log(`[backfill] candidate guild_id=${guildId}`);
       if (DRY_RUN) continue;
-      // Decrypt the stored key via the same path getGuildApiKey uses.
-      // Then call the shared link helper. linkGuildWebhookSubscription
-      // is non-throwing — it returns { ok, reason } so we can count
-      // outcomes without try/catch noise.
-      const apiKey = await db.getGuildApiKey(guildId);
-      if (!apiKey) {
-        console.warn(`[backfill] guild_id=${guildId} qurl_api_key decrypted empty — skipping`);
-        skipped += 1;
-        continue;
-      }
-      const result = await linkGuildWebhookSubscription({
-        guildId, apiKey, descriptionContext: 'via=backfill-script',
-      });
-      if (result.ok) {
-        provisioned += 1;
-        console.log(`[backfill] provisioned guild_id=${guildId} action=${result.action}`);
-      } else {
+      // Per-row try/catch so one corrupt encrypted row doesn't abort
+      // the whole backfill.
+      try {
+        const apiKey = await db.getGuildApiKey(guildId);
+        if (!apiKey) {
+          console.warn(`[backfill] guild_id=${guildId} qurl_api_key decrypted empty — skipping`);
+          skipped += 1;
+          continue;
+        }
+        const result = await linkGuildWebhookSubscription({
+          guildId, apiKey, descriptionContext: 'via=backfill-script',
+        });
+        if (result.ok) {
+          provisioned += 1;
+          console.log(`[backfill] provisioned guild_id=${guildId} action=${result.action}`);
+        } else {
+          failed += 1;
+          console.error(`[backfill] FAILED guild_id=${guildId} reason=${result.reason}`);
+        }
+      } catch (rowErr) {
         failed += 1;
-        console.error(`[backfill] FAILED guild_id=${guildId} reason=${result.reason}`);
+        console.error(`[backfill] FAILED guild_id=${guildId} threw: ${rowErr?.message}`);
       }
     }
     ExclusiveStartKey = res.LastEvaluatedKey;

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -60,7 +60,13 @@ async function main() {
   let candidates = 0;
   let skipped = 0;
   let provisioned = 0;
-  let failed = 0;
+  // Split-counter: decrypt-side failures point at KEY_ENCRYPTION_KEY
+  // drift or row corruption; link-side failures point at qurl-service
+  // (5xx, auth) or downstream DDB. Triage path differs sharply for
+  // each — bundling them under one Failed: counter forces the
+  // operator to grep the per-row stderr lines to disambiguate.
+  let failedDecrypt = 0;
+  let failedLink = 0;
   let ExclusiveStartKey;
 
   do {
@@ -72,23 +78,30 @@ async function main() {
       if (row.webhook_id) { skipped += 1; continue; }
       candidates += 1;
       const guildId = row.guild_id;
-      // Per-row try/catch so one corrupt encrypted row doesn't abort
-      // the whole backfill. The decrypt is performed even in DRY_RUN
-      // mode so operators see decrypt failures in the preview rather
-      // than discovering them mid-real-run.
+      // Decrypt step isolated so a failure increments failedDecrypt
+      // (vs the link step's failedLink). The decrypt runs even in
+      // DRY_RUN so operators see decrypt failures in the preview
+      // rather than discovering them mid-real-run.
+      let apiKey;
       try {
-        const apiKey = await db.getGuildApiKey(guildId);
-        if (!apiKey) {
-          console.warn(`[backfill] guild_id=${guildId} qurl_api_key decrypted empty — skipping`);
-          skipped += 1;
-          continue;
-        }
-        console.log(`[backfill] candidate guild_id=${guildId}`);
-        if (DRY_RUN) continue;
-        // linkGuildWebhookSubscription also calls subs.upsertGuild
-        // on success — that's a no-op in this script context (the
-        // registry isn't .start()'d) but DDB is the source of truth,
-        // so running bots pick the new row up on their next 30s tick.
+        apiKey = await db.getGuildApiKey(guildId);
+      } catch (decryptErr) {
+        failedDecrypt += 1;
+        console.error(`[backfill] DECRYPT_FAILED guild_id=${guildId} threw: ${decryptErr?.message}`);
+        continue;
+      }
+      if (!apiKey) {
+        console.warn(`[backfill] guild_id=${guildId} qurl_api_key decrypted empty — skipping`);
+        skipped += 1;
+        continue;
+      }
+      console.log(`[backfill] candidate guild_id=${guildId}`);
+      if (DRY_RUN) continue;
+      // linkGuildWebhookSubscription also calls subs.upsertGuild
+      // on success — that's a no-op in this script context (the
+      // registry isn't .start()'d) but DDB is the source of truth,
+      // so running bots pick the new row up on their next 30s tick.
+      try {
         const result = await linkGuildWebhookSubscription({
           guildId, apiKey, descriptionContext: 'via=backfill-script',
         });
@@ -96,17 +109,18 @@ async function main() {
           provisioned += 1;
           console.log(`[backfill] provisioned guild_id=${guildId} action=${result.action}`);
         } else {
-          failed += 1;
-          console.error(`[backfill] FAILED guild_id=${guildId} reason=${result.reason}`);
+          failedLink += 1;
+          console.error(`[backfill] LINK_FAILED guild_id=${guildId} reason=${result.reason}`);
         }
-      } catch (rowErr) {
-        failed += 1;
-        console.error(`[backfill] FAILED guild_id=${guildId} threw: ${rowErr?.message}`);
+      } catch (linkErr) {
+        failedLink += 1;
+        console.error(`[backfill] LINK_FAILED guild_id=${guildId} threw: ${linkErr?.message}`);
       }
     }
     ExclusiveStartKey = res.LastEvaluatedKey;
   } while (ExclusiveStartKey);
 
+  const failedTotal = failedDecrypt + failedLink;
   console.log('\n=== Backfill summary ===');
   console.log(`Table:        ${TABLE}`);
   console.log(`Dry run:      ${DRY_RUN}`);
@@ -116,11 +130,12 @@ async function main() {
   if (!DRY_RUN) {
     console.log(`Provisioned:  ${provisioned}`);
   }
-  // Always print Failed: even in dry-run — getGuildApiKey decrypt
-  // errors increment `failed` in either mode, and silent exit 2
+  // Always print failed counters even in dry-run — decrypt errors
+  // increment failedDecrypt in either mode, and a silent exit 2
   // would let an operator miss them.
-  console.log(`Failed:       ${failed}`);
-  process.exit(failed > 0 ? 2 : 0);
+  console.log(`FailedDecrypt: ${failedDecrypt}`);
+  console.log(`FailedLink:    ${failedLink}`);
+  process.exit(failedTotal > 0 ? 2 : 0);
 }
 
 main().catch((err) => {

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -90,6 +90,10 @@ async function main() {
         }
         console.log(`[backfill] candidate guild_id=${guildId}`);
         if (DRY_RUN) continue;
+        // linkGuildWebhookSubscription also calls subs.upsertGuild
+        // on success — that's a no-op in this script context (the
+        // registry isn't .start()'d) but DDB is the source of truth,
+        // so running bots pick the new row up on their next 30s tick.
         const result = await linkGuildWebhookSubscription({
           guildId, apiKey, descriptionContext: 'via=backfill-script',
         });

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -120,10 +120,11 @@ async function main() {
   console.log(`Skipped:      ${skipped}`);
   if (!DRY_RUN) {
     console.log(`Provisioned:  ${provisioned}`);
-    console.log(`Failed:       ${failed}`);
   }
-  // Exit non-zero if any candidate failed so operator CI / shell
-  // chains catch partial-failure runs.
+  // Always print Failed: even in dry-run — getGuildApiKey decrypt
+  // errors increment `failed` in either mode, and silent exit 2
+  // would let an operator miss them.
+  console.log(`Failed:       ${failed}`);
   process.exit(failed > 0 ? 2 : 0);
 }
 

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -68,8 +68,21 @@ async function main() {
   let failedDecrypt = 0;
   let failedLink = 0;
   let ExclusiveStartKey;
+  // Anti-runaway cap. Mirrors the 50-page guard in
+  // ensureWebhookSubscription's findExistingSubscriptions. At DDB's
+  // default 1MB page size, 50 pages caps the worst-case scan at
+  // ~50MB of guild_configs rows (far beyond plausible bot scale).
+  // A future bug causing the cursor to not advance would otherwise
+  // silently spin forever.
+  const MAX_PAGES = 50;
+  let pageCount = 0;
 
   do {
+    pageCount += 1;
+    if (pageCount > MAX_PAGES) {
+      console.error(`[backfill] FATAL: exceeded MAX_PAGES=${MAX_PAGES} — cursor may not be advancing`);
+      process.exit(3);
+    }
     const res = await ddb.send(new ScanCommand({ TableName: TABLE, ExclusiveStartKey }));
     const rows = res.Items || [];
     for (const row of rows) {

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -32,6 +32,8 @@ const db = require('../src/store');
 const config = require('../src/config');
 const logger = require('../src/logger');
 const { linkGuildWebhookSubscription } = require('../src/guild-webhook-link');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, ScanCommand } = require('@aws-sdk/lib-dynamodb');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -49,13 +51,6 @@ async function main() {
   // script issues its own ScanCommand. Table name MUST come from the
   // bot's own config.DDB_TABLE_PREFIX so the script can't target a
   // different table than the running bot.
-  const {
-    DynamoDBClient,
-  } = require('@aws-sdk/client-dynamodb');
-  const {
-    DynamoDBDocumentClient,
-    ScanCommand,
-  } = require('@aws-sdk/lib-dynamodb');
   const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({
     region: process.env.AWS_REGION || 'us-east-2',
   }));

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -68,13 +68,15 @@ async function main() {
   let failedDecrypt = 0;
   let failedLink = 0;
   let ExclusiveStartKey;
-  // Anti-runaway cap. Mirrors the 50-page guard in
-  // ensureWebhookSubscription's findExistingSubscriptions. At DDB's
-  // default 1MB page size, 50 pages caps the worst-case scan at
-  // ~50MB of guild_configs rows (far beyond plausible bot scale).
-  // A future bug causing the cursor to not advance would otherwise
-  // silently spin forever.
-  const MAX_PAGES = 50;
+  // Anti-runaway cap. At DDB's default 1MB page size, 1000 pages
+  // caps the worst-case scan at ~1GB of guild_configs rows — well
+  // past plausible bot scale even after organic growth, but bounded
+  // enough that a non-advancing cursor still fails closed rather
+  // than spin forever. If a future operator hits the cap, recovery
+  // is: (1) confirm the cursor IS advancing (LastEvaluatedKey
+  // changes between pages); (2) raise this cap or chunk the run by
+  // pre-filtering rows to those with non-null qurl_api_key.
+  const MAX_PAGES = 1000;
   let pageCount = 0;
 
   do {

--- a/apps/discord/scripts/provision-guild-subscriptions.js
+++ b/apps/discord/scripts/provision-guild-subscriptions.js
@@ -77,10 +77,10 @@ async function main() {
       if (row.webhook_id) { skipped += 1; continue; }
       candidates += 1;
       const guildId = row.guild_id;
-      console.log(`[backfill] candidate guild_id=${guildId}`);
-      if (DRY_RUN) continue;
       // Per-row try/catch so one corrupt encrypted row doesn't abort
-      // the whole backfill.
+      // the whole backfill. The decrypt is performed even in DRY_RUN
+      // mode so operators see decrypt failures in the preview rather
+      // than discovering them mid-real-run.
       try {
         const apiKey = await db.getGuildApiKey(guildId);
         if (!apiKey) {
@@ -88,6 +88,8 @@ async function main() {
           skipped += 1;
           continue;
         }
+        console.log(`[backfill] candidate guild_id=${guildId}`);
+        if (DRY_RUN) continue;
         const result = await linkGuildWebhookSubscription({
           guildId, apiKey, descriptionContext: 'via=backfill-script',
         });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3281,17 +3281,17 @@ async function handleSetupModal(interaction, { flow_id }) {
   await db.setGuildApiKey(interaction.guildId, submittedKey, interaction.user.id);
   logger.info('Guild API key configured', logFields);
 
-  // Best-effort register a per-guild qurl.accessed webhook subscription
-  // under THIS guild's API key so the BYOK view counter fires for qurls
-  // it mints. Non-blocking — the helper swallows all failures and
-  // audit-logs; admin still gets the success reply even if the
-  // webhook wiring fails. View counter degrades to the polling
-  // fallback until the backfill script catches up.
-  await linkGuildWebhookSubscription({
+  // Fire-and-forget per-guild webhook subscription register. The
+  // helper does network + DDB work that can take seconds; awaiting
+  // would delay the modal-reply unacceptably. A failure only
+  // degrades the view counter to the polling fallback.
+  linkGuildWebhookSubscription({
     guildId: interaction.guildId,
     apiKey: submittedKey,
     descriptionContext: `via=paste, configuredBy=${interaction.user.id}`,
-  });
+  }).catch((err) => logger.warn('linkGuildWebhookSubscription threw (non-blocking)', {
+    error: err?.message, guildId: interaction.guildId,
+  }));
 
   // Swallow Discord errors on the post-persist editReply. If the
   // editReply throws AFTER setGuildApiKey commits, letting it

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3283,13 +3283,14 @@ async function handleSetupModal(interaction, { flow_id }) {
 
   // Fire-and-forget per-guild webhook subscription register. The
   // helper does network + DDB work that can take seconds; awaiting
-  // would delay the modal-reply unacceptably. A failure only
-  // degrades the view counter to the polling fallback.
+  // would delay the modal reply unacceptably. .catch is defense-in-
+  // depth — the helper never re-throws by contract and emits its
+  // own audit events.
   linkGuildWebhookSubscription({
     guildId: interaction.guildId,
     apiKey: submittedKey,
     descriptionContext: `via=paste, configuredBy=${interaction.user.id}`,
-  }).catch((err) => logger.warn('linkGuildWebhookSubscription threw (non-blocking)', {
+  }).catch((err) => logger.warn('linkGuildWebhookSubscription contract drift — threw unexpectedly', {
     error: err?.message, guildId: interaction.guildId,
   }));
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -3286,6 +3286,10 @@ async function handleSetupModal(interaction, { flow_id }) {
   // would delay the modal reply unacceptably. .catch is defense-in-
   // depth — the helper never re-throws by contract and emits its
   // own audit events.
+  //
+  // KNOWN QUIRK (tracked in issue #487): SIGTERM mid-link drops
+  // the in-flight work; operator runs /qurl setup or backfill.
+  // Polling fallback covers correctness.
   linkGuildWebhookSubscription({
     guildId: interaction.guildId,
     apiKey: submittedKey,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -38,7 +38,7 @@ const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 const { deleteFlow, transitionFlow, supersedeOrCreate } = require('./flow-state');
-const { linkGuildWebhookSubscription } = require('./guild-webhook-link');
+const { fireAndForgetLinkGuildWebhookSubscription } = require('./guild-webhook-link');
 const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } = require('./flow-dispatch');
 const {
   searchPlaces,
@@ -3281,22 +3281,12 @@ async function handleSetupModal(interaction, { flow_id }) {
   await db.setGuildApiKey(interaction.guildId, submittedKey, interaction.user.id);
   logger.info('Guild API key configured', logFields);
 
-  // Fire-and-forget per-guild webhook subscription register. The
-  // helper does network + DDB work that can take seconds; awaiting
-  // would delay the modal reply unacceptably. .catch is defense-in-
-  // depth — the helper never re-throws by contract and emits its
-  // own audit events.
-  //
-  // KNOWN QUIRK (tracked in issue #487): SIGTERM mid-link drops
-  // the in-flight work; operator runs /qurl setup or backfill.
-  // Polling fallback covers correctness.
-  linkGuildWebhookSubscription({
+  fireAndForgetLinkGuildWebhookSubscription({
     guildId: interaction.guildId,
     apiKey: submittedKey,
-    descriptionContext: `via=paste, configuredBy=${interaction.user.id}`,
-  }).catch((err) => logger.warn('linkGuildWebhookSubscription contract drift — threw unexpectedly', {
-    error: err?.message, guildId: interaction.guildId,
-  }));
+    via: 'paste',
+    configuredBy: interaction.user.id,
+  });
 
   // Swallow Discord errors on the post-persist editReply. If the
   // editReply throws AFTER setGuildApiKey commits, letting it

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -38,6 +38,7 @@ const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const { deleteLink } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 const { deleteFlow, transitionFlow, supersedeOrCreate } = require('./flow-state');
+const { linkGuildWebhookSubscription } = require('./guild-webhook-link');
 const { flowIdForInteraction, registerFlow, safeReply, siblingMessageForStage } = require('./flow-dispatch');
 const {
   searchPlaces,
@@ -3279,6 +3280,19 @@ async function handleSetupModal(interaction, { flow_id }) {
 
   await db.setGuildApiKey(interaction.guildId, submittedKey, interaction.user.id);
   logger.info('Guild API key configured', logFields);
+
+  // Best-effort register a per-guild qurl.accessed webhook subscription
+  // under THIS guild's API key so the BYOK view counter fires for qurls
+  // it mints. Non-blocking — the helper swallows all failures and
+  // audit-logs; admin still gets the success reply even if the
+  // webhook wiring fails. View counter degrades to the polling
+  // fallback until the backfill script catches up.
+  await linkGuildWebhookSubscription({
+    guildId: interaction.guildId,
+    apiKey: submittedKey,
+    descriptionContext: `via=paste, configuredBy=${interaction.user.id}`,
+  });
+
   // Swallow Discord errors on the post-persist editReply. If the
   // editReply throws AFTER setGuildApiKey commits, letting it
   // propagate would fire the dispatcher's universal safety-net

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -458,6 +458,12 @@ const AUDIT_EVENTS = {
   // tamper — a guild's secret is unrecoverable from the cache until
   // re-encrypted via backfill or /qurl setup.
   QURL_WEBHOOK_CACHE_ROW_DECRYPT_FAIL: 'qurl_webhook_cache_row_decrypt_fail',
+  // Mass-decrypt-fail escalation. Fires once per scan when >50% of
+  // provisioned rows fail decrypt (min 3 rows). Distinguishes a KMS-
+  // wide event from a single bad row — both emit the per-row event
+  // above, so without this distinct signal an alarm can't tell them
+  // apart by event-count alone.
+  QURL_WEBHOOK_CACHE_MASS_DECRYPT_FAIL: 'qurl_webhook_cache_mass_decrypt_fail',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -476,6 +476,12 @@ const AUDIT_EVENTS = {
   // metric-filter-greppable so a future orphan-subscription sweeper
   // can list-and-diff against qurl-service's own subscription state.
   QURL_WEBHOOK_ORPHAN_LEFT_AFTER_401: 'qurl_webhook_orphan_left_after_401',
+  // Sibling-row propagate partially failed: link succeeded for the
+  // user but some sibling guilds may hold a stale secret until the
+  // next propagate run converges them. Distinct from
+  // SUBSCRIPTION_REGISTER_FAILED so the REGISTER_FAILED metric
+  // filter unambiguously means "the link failed for the user."
+  QURL_WEBHOOK_PROPAGATE_PARTIAL: 'qurl_webhook_propagate_partial',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -449,8 +449,15 @@ const AUDIT_EVENTS = {
   // binary (success has its own event below).
   QURL_WEBHOOK_SUBSCRIPTION_REGISTERED: 'qurl_webhook_subscription_registered',
   QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED: 'qurl_webhook_subscription_register_failed',
+  // SUBSCRIPTION_DELETED has no production caller today — reserved for
+  // the future /qurl unlink admin command tracked in issue #487.
   QURL_WEBHOOK_SUBSCRIPTION_DELETED: 'qurl_webhook_subscription_deleted',
   QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED: 'qurl_webhook_subscription_delete_failed',
+  // Per-row decrypt failure during scanGuildSubscriptions. Sustained
+  // rate = KMS key rotation drift, partial migration, or manual DDB
+  // tamper — a guild's secret is unrecoverable from the cache until
+  // re-encrypted via backfill or /qurl setup.
+  QURL_WEBHOOK_CACHE_ROW_DECRYPT_FAIL: 'qurl_webhook_cache_row_decrypt_fail',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -455,9 +455,6 @@ const AUDIT_EVENTS = {
   // binary (success has its own event below).
   QURL_WEBHOOK_SUBSCRIPTION_REGISTERED: 'qurl_webhook_subscription_registered',
   QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED: 'qurl_webhook_subscription_register_failed',
-  // SUBSCRIPTION_DELETED has no production caller today — reserved for
-  // the future /qurl unlink admin command tracked in issue #487.
-  QURL_WEBHOOK_SUBSCRIPTION_DELETED: 'qurl_webhook_subscription_deleted',
   QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED: 'qurl_webhook_subscription_delete_failed',
   // Per-row decrypt failure during scanGuildSubscriptions. Sustained
   // rate = KMS key rotation drift, partial migration, or manual DDB

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -441,6 +441,12 @@ const AUDIT_EVENTS = {
   // Refresh failure. After N consecutive failures the registry stays
   // unprimed (or stale) — receiver responds 503; qurl-service retries.
   QURL_WEBHOOK_CACHE_REFRESH_FAIL: 'qurl_webhook_cache_refresh_fail',
+  // Default-key discovery failed for N consecutive ticks. Fires once
+  // at the escalation threshold. BYOK delivery is unaffected — the
+  // bot's own default-key webhook deliveries 401 until discovery
+  // recovers; ops should investigate qurl-service `GET /v1/webhooks`
+  // availability for the bot's QURL_API_KEY identity.
+  QURL_WEBHOOK_DEFAULT_DISCOVERY_FAIL: 'qurl_webhook_default_discovery_fail',
   // Lifecycle. SUBSCRIPTION_DELETE_FAILED fires when DELETE returns 401
   // (key revoked) or 404 (already gone) — both are swallowed so guild
   // unlink doesn't fail user-facing on stale qurl-service state.

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -444,7 +444,11 @@ const AUDIT_EVENTS = {
   // Lifecycle. SUBSCRIPTION_DELETE_FAILED fires when DELETE returns 401
   // (key revoked) or 404 (already gone) — both are swallowed so guild
   // unlink doesn't fail user-facing on stale qurl-service state.
+  // REGISTER_FAILED fires on every linkGuildWebhookSubscription failure
+  // branch so CloudWatch alarms can fire on the right side of the
+  // binary (success has its own event below).
   QURL_WEBHOOK_SUBSCRIPTION_REGISTERED: 'qurl_webhook_subscription_registered',
+  QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED: 'qurl_webhook_subscription_register_failed',
   QURL_WEBHOOK_SUBSCRIPTION_DELETED: 'qurl_webhook_subscription_deleted',
   QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED: 'qurl_webhook_subscription_delete_failed',
 };

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -470,6 +470,12 @@ const AUDIT_EVENTS = {
   // above, so without this distinct signal an alarm can't tell them
   // apart by event-count alone.
   QURL_WEBHOOK_CACHE_MASS_DECRYPT_FAIL: 'qurl_webhook_cache_mass_decrypt_fail',
+  // Orphan webhook left on qurl-service after a 401 rollback path —
+  // the admin revoked the key on layerv.ai before our DELETE landed.
+  // NOT alarmed by default (routine on every key rotation), but
+  // metric-filter-greppable so a future orphan-subscription sweeper
+  // can list-and-diff against qurl-service's own subscription state.
+  QURL_WEBHOOK_ORPHAN_LEFT_AFTER_401: 'qurl_webhook_orphan_left_after_401',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -427,6 +427,26 @@ const AUDIT_EVENTS = {
   QURL_WEBHOOK_RATE_LIMITED: 'qurl_webhook_rate_limited',
   // Sustained rate = qurl_views table hot.
   QURL_WEBHOOK_STORE_ERROR: 'qurl_webhook_store_error',
+
+  // Subscription registry (BYOK per-guild webhooks). The registry is a
+  // process-local Map<owner_id, …> primed from guild_configs at boot and
+  // refreshed every 30s. Sustained rate of UNPRIMED = boot stall OR DDB
+  // throttling on the priming scan. Sustained rate of UNKNOWN_OWNER after
+  // priming = a real auth0 owner is hitting the receiver without ever
+  // having linked a key (attacker probing) OR an upstream contract drift
+  // (qurl-service emitting events under a different owner_id than the one
+  // that registered the subscription).
+  QURL_WEBHOOK_CACHE_MISS_UNPRIMED: 'qurl_webhook_cache_miss_unprimed',
+  QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER: 'qurl_webhook_cache_miss_unknown_owner',
+  // Refresh failure. After N consecutive failures the registry stays
+  // unprimed (or stale) — receiver responds 503; qurl-service retries.
+  QURL_WEBHOOK_CACHE_REFRESH_FAIL: 'qurl_webhook_cache_refresh_fail',
+  // Lifecycle. SUBSCRIPTION_DELETE_FAILED fires when DELETE returns 401
+  // (key revoked) or 404 (already gone) — both are swallowed so guild
+  // unlink doesn't fail user-facing on stale qurl-service state.
+  QURL_WEBHOOK_SUBSCRIPTION_REGISTERED: 'qurl_webhook_subscription_registered',
+  QURL_WEBHOOK_SUBSCRIPTION_DELETED: 'qurl_webhook_subscription_deleted',
+  QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED: 'qurl_webhook_subscription_delete_failed',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -37,25 +37,43 @@ function bridgeUrl() {
   return `${config.BASE_URL.replace(/\/+$/, '')}/webhooks/qurl`;
 }
 
-// Fire-and-forget DELETE used by the three orphan-cleanup paths in
-// linkGuildWebhookSubscription. Centralized so the warn shape stays
-// consistent and a future-cr nit ("logger field names differ across
-// the three paths") doesn't recur.
+// Fire-and-forget DELETE used by the orphan-cleanup paths in
+// linkGuildWebhookSubscription. Emits the same DELETE_FAILED audit
+// event the non-rollback unlink path uses so a leaked-orphan
+// incident shows up on one CloudWatch metric regardless of which
+// path produced it.
 function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
   deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
-    .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
-      error: dErr?.message, webhookId, guildId,
-    }));
+    .catch((dErr) => {
+      logger.warn('Best-effort orphan-subscription delete threw', {
+        error: dErr?.message, webhookId, guildId,
+      });
+      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED, {
+        guild_id: guildId, status: dErr?.status || null, path: 'rollback',
+      });
+    });
+}
+
+// Centralizes the "warn + audit failure" pattern for the five
+// failure branches of linkGuildWebhookSubscription. Without this,
+// the branches only logger.warn — CloudWatch metric filters watching
+// for register-failure spikes would miss them.
+function auditLinkFailure(guildId, reason, extra) {
+  logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED, {
+    guild_id: guildId, reason, ...(extra || {}),
+  });
 }
 
 // Provision (idempotent) a per-guild webhook subscription.
 // `action` mirrors ensureWebhookSubscription: 'created' | 'rotated' | 'reused'.
 async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContext }) {
   if (!guildId || !apiKey) {
+    auditLinkFailure(guildId || '<missing>', LINK_RESULTS.MISSING_ARGS);
     return { ok: false, reason: LINK_RESULTS.MISSING_ARGS };
   }
   if (!config.BASE_URL || !config.QURL_ENDPOINT) {
     logger.warn('Per-guild webhook link skipped: BASE_URL or QURL_ENDPOINT unset', { guildId });
+    auditLinkFailure(guildId, LINK_RESULTS.CONFIG_MISSING);
     return { ok: false, reason: LINK_RESULTS.CONFIG_MISSING };
   }
 
@@ -71,6 +89,7 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     logger.warn('Per-guild webhook subscription registration failed', {
       error: err?.message, guildId,
     });
+    auditLinkFailure(guildId, LINK_RESULTS.REGISTER_FAILED);
     return { ok: false, reason: LINK_RESULTS.REGISTER_FAILED };
   }
 
@@ -80,6 +99,7 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     logger.warn('Per-guild webhook ownerId missing from registrar response; rolled back', {
       guildId, webhookId, action,
     });
+    auditLinkFailure(guildId, LINK_RESULTS.OWNER_MISSING);
     return { ok: false, reason: LINK_RESULTS.OWNER_MISSING };
   }
 
@@ -94,6 +114,7 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     logger.warn('Per-guild webhook subscription persisted-create rollback', {
       error: err?.message, guildId, webhookId,
     });
+    auditLinkFailure(guildId, LINK_RESULTS.PERSIST_FAILED);
     return { ok: false, reason: LINK_RESULTS.PERSIST_FAILED };
   }
 

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -213,7 +213,26 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
   return { ok: true, action };
 }
 
+// Fire-and-forget wrapper for the two splice points (commands.js
+// `/qurl setup` paste flow + qurl-oauth.js OAuth callback). Centralizes
+// the .catch + descriptionContext format so the two call sites stay
+// in sync — a future audit-log shape change should touch one place.
+//
+// KNOWN QUIRK (tracked in issue #487): SIGTERM mid-link drops the
+// in-flight work; the operator runs /qurl setup again or the
+// backfill script catches it. Polling fallback covers correctness.
+function fireAndForgetLinkGuildWebhookSubscription({ guildId, apiKey, via, configuredBy }) {
+  linkGuildWebhookSubscription({
+    guildId,
+    apiKey,
+    descriptionContext: `via=${via}, configuredBy=${configuredBy}`,
+  }).catch((err) => logger.warn('linkGuildWebhookSubscription contract drift — threw unexpectedly', {
+    error: err?.message, guildId,
+  }));
+}
+
 module.exports = {
   linkGuildWebhookSubscription,
+  fireAndForgetLinkGuildWebhookSubscription,
   LINK_RESULTS,
 };

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -49,11 +49,13 @@ function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
       if (status === 401) {
         // Routine re-key — admin revoked the key on layerv.ai before
         // our DELETE landed. Not alarm-worthy, but an orphan webhook
-        // is now stranded on qurl-service's account. Log at info so a
-        // per-guild history grep can still surface the orphan (without
-        // page-loading the audit channel on every key rotation).
-        logger.info('Orphan webhook subscription left on qurl-service (401 = key revoked)', {
-          webhook_id: webhookId, guild_id: guildId,
+        // is now stranded on qurl-service's account. Distinct audit
+        // event (NOT QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED) so a
+        // future orphan-subscription sweeper has a clean metric-
+        // filter grep target without needing a qurl-service-side
+        // list-and-diff. CloudWatch alarms should EXCLUDE this event.
+        logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_ORPHAN_LEFT_AFTER_401, {
+          guild_id: guildId, webhook_id: webhookId,
         });
         return;
       }
@@ -83,6 +85,16 @@ function auditLinkFailure(guildId, reason, extra) {
 
 // Provision (idempotent) a per-guild webhook subscription.
 // `action` mirrors ensureWebhookSubscription: 'created' | 'rotated' | 'reused'.
+//
+// `descriptionContext` is interpolated into a qurl-service UI string
+// ("Discord bot view counter (guild=<id>, <descriptionContext>)") and
+// MUST stay internally-controlled. Today's callers pass
+// 'via=oauth, configuredBy=<discord_user_id>',
+// 'via=paste, configuredBy=<discord_user_id>',
+// 'via=backfill-script' — all from internal flow tags. A future
+// caller that ever wants to put user-controlled text here should
+// instead sanitize to `[A-Za-z0-9=,_-]` (Discord user IDs are
+// decimal snowflakes; flow-tag literals are author-controlled).
 async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContext }) {
   if (!guildId || !apiKey) {
     auditLinkFailure(guildId || '<missing>', LINK_RESULTS.MISSING_ARGS);

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -128,8 +128,16 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     });
   } catch (err) {
     bestEffortDeleteSubscription({ apiKey, webhookId, guildId });
+    // ConditionalCheckFailedException from
+    // setGuildWebhookSubscription's attribute_exists(qurl_api_key)
+    // guard means setGuildApiKey wasn't called first (or its row
+    // was wiped between the two writes). Treat as hard caller-bug:
+    // bail out without touching the cache. The wider rollback (orphan
+    // DELETE above) still runs.
+    const isOrphanGuard = err?.name === 'ConditionalCheckFailedException';
     logger.warn('Per-guild webhook subscription persisted-create rollback', {
       error: err?.message, guildId, webhookId,
+      orphan_guard_tripped: isOrphanGuard,
     });
     auditLinkFailure(guildId, LINK_RESULTS.PERSIST_FAILED);
     return { ok: false, reason: LINK_RESULTS.PERSIST_FAILED };

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -190,9 +190,13 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
       logger.warn('Per-guild webhook secret propagation partially failed', {
         guildId, webhookOwnerId, webhookId, ...propagateResult,
       });
-      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED, {
+      // Distinct event (not REGISTER_FAILED) — the link itself
+      // SUCCEEDED for the user; only sibling-row convergence is
+      // partial. CloudWatch dashboards on REGISTER_FAILED should
+      // stay unambiguous as "link failed for the user."
+      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_PROPAGATE_PARTIAL, {
         guild_id: guildId,
-        reason: 'propagate-partial',
+        webhook_owner_id: webhookOwnerId,
         updated: propagateResult.updated,
         failed: propagateResult.failed,
       });

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -57,8 +57,15 @@ function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
         });
         return;
       }
+      // Audit any non-401 failure path INCLUDING network errors that
+      // surface as `status === undefined` (DNS, TLS, AbortError on
+      // timeout). Those previously fell through without an audit,
+      // hiding stranded orphans behind a single warn log.
       logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED, {
-        guild_id: guildId, status: status || null, path: 'rollback',
+        guild_id: guildId,
+        status: status || null,
+        error_type: dErr?.name || 'unknown',
+        path: 'rollback',
       });
     });
 }
@@ -128,6 +135,23 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     return { ok: false, reason: LINK_RESULTS.PERSIST_FAILED };
   }
 
+  // Seed the in-memory cache BEFORE propagation. Propagation runs a
+  // full table scan + N parallel sibling updates; a webhook that lands
+  // on this replica during that window would otherwise 503/401 until
+  // the next 30s tick. Propagation is best-effort by design — the
+  // registering replica's correctness shouldn't be gated on it.
+  // upsertGuild validates input types; if a future caller-bug feeds
+  // in an unexpected shape that the upstream guards missed, we still
+  // want the success audit to fire — DDB is authoritative, so a
+  // failed in-memory upsert is correctable on the next 30s tick.
+  try {
+    subs.upsertGuild({ guildId, ownerId: webhookOwnerId, webhookId, webhookSecret: secret });
+  } catch (err) {
+    logger.warn('subs.upsertGuild rejected (cache will reconcile on next scan)', {
+      error: err?.message, guildId,
+    });
+  }
+
   // Sibling rows under the same owner may hold a pre-rotate secret.
   // Best-effort propagation; scanOnce's updatedAt tiebreaker still
   // picks the freshly-written primary if this fails. Pass
@@ -159,17 +183,6 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     });
   }
 
-  // upsertGuild validates input types; if a future caller-bug feeds
-  // in an unexpected shape that the upstream guards missed, we still
-  // want the success audit to fire — DDB is authoritative, so a
-  // failed in-memory upsert is correctable on the next 30s tick.
-  try {
-    subs.upsertGuild({ guildId, ownerId: webhookOwnerId, webhookId, webhookSecret: secret });
-  } catch (err) {
-    logger.warn('subs.upsertGuild rejected (cache will reconcile on next scan)', {
-      error: err?.message, guildId,
-    });
-  }
   logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTERED, {
     guild_id: guildId, action,
   });

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -1,0 +1,269 @@
+// Per-guild qurl-service webhook subscription provisioning.
+//
+// Called from the two `setGuildApiKey` call sites (qurl-oauth callback +
+// /qurl setup admin form) and from the one-time backfill script. The
+// caller has already persisted the API key to DDB; this module's job
+// is to:
+//   1. ensure a qurl.accessed subscription exists under that API key
+//   2. discover the qurl-service owner_id the key resolves to
+//   3. persist {webhook_id, encrypted secret, owner_id} on the
+//      guild_configs row
+//   4. update the in-process subscription registry synchronously so
+//      the registering replica is immediately correct
+//
+// Partial-failure: if step 3 throws AFTER step 1 succeeded, the
+// just-created subscription is best-effort DELETE'd so the admin's
+// account isn't littered with orphan webhooks.
+//
+// All paths are non-blocking on caller error: the OAuth callback +
+// /qurl setup should report success for KEY LINKING even when the
+// view-counter wiring fails — the key still works, view counter just
+// degrades to the polling fallback until backfill catches up. This
+// module logs + audits but never re-throws to the caller.
+
+const config = require('./config');
+const db = require('./store');
+const logger = require('./logger');
+const { AUDIT_EVENTS } = require('./constants');
+const { ensureWebhookSubscription, deleteSubscription } = require('./qurl-webhook-registrar');
+const subs = require('./webhook-subscriptions');
+
+// 10s matches qurl-oauth.js's QURL_SERVICE_TIMEOUT_MS budget; keep
+// it tight so a stuck qurl-service GET doesn't block /qurl setup.
+const QURL_SERVICE_TIMEOUT_MS = 10_000;
+
+function bridgeUrl() {
+  // BASE_URL is validated upstream (variables.tf regex pins
+  // https://host[:port][/segment] with no trailing slash), but we
+  // still strip a trailing slash defensively so a future relaxation
+  // of that validation can't render `https://bot//webhooks/qurl`.
+  return `${config.BASE_URL.replace(/\/$/, '')}/webhooks/qurl`;
+}
+
+// Discover the qurl-service owner_id by listing the first webhook
+// under this key. Any of the caller's subs work since they all share
+// the key's owner — including the one we just created via
+// ensureWebhookSubscription. Returns null if the list is empty
+// (defensive — shouldn't happen since we just registered one) and
+// throws on transport / non-2xx errors so the partial-failure path
+// can roll back.
+async function discoverOwnerId(apiKey) {
+  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=1`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(QURL_SERVICE_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    throw new Error(`GET /v1/webhooks returned ${resp.status} on owner_id discovery`);
+  }
+  const body = await resp.json();
+  const first = Array.isArray(body?.data) ? body.data[0] : null;
+  return typeof first?.owner_id === 'string' && first.owner_id.length > 0
+    ? first.owner_id
+    : null;
+}
+
+// Provision (idempotent) a per-guild webhook subscription.
+//
+// Returns { ok: true, action } on success or { ok: false, reason } on
+// any failure. Never throws; the caller's user-facing flow continues
+// regardless of outcome.
+//
+// `action` mirrors ensureWebhookSubscription's: 'created' | 'rotated'
+// | 'reused'. Useful for distinguishing "fresh guild" from "admin
+// shared their key across N guilds" in audit logs.
+async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContext }) {
+  if (!guildId || !apiKey) {
+    return { ok: false, reason: 'missing-args' };
+  }
+  if (!config.BASE_URL || !config.QURL_ENDPOINT) {
+    logger.warn('Per-guild webhook link skipped: BASE_URL or QURL_ENDPOINT unset', { guildId });
+    return { ok: false, reason: 'config-missing' };
+  }
+
+  let registered = null;
+  try {
+    registered = await ensureWebhookSubscription({
+      apiEndpoint: config.QURL_ENDPOINT,
+      apiKey,
+      bridgeUrl: bridgeUrl(),
+      description: `Discord bot view counter (guild=${guildId}${descriptionContext ? `, ${descriptionContext}` : ''})`,
+    });
+  } catch (err) {
+    logger.warn('Per-guild webhook subscription registration failed', {
+      error: err?.message, guildId,
+    });
+    return { ok: false, reason: 'register-failed' };
+  }
+
+  const { webhookId, secret, action } = registered;
+
+  let webhookOwnerId;
+  try {
+    webhookOwnerId = await discoverOwnerId(apiKey);
+  } catch (err) {
+    // Owner_id discovery failed AFTER we successfully registered.
+    // Without owner_id the receiver can't route inbound events to
+    // this subscription's secret — best-effort DELETE to avoid an
+    // orphan billing-active sub on the admin's account.
+    deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
+      .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
+        error: dErr?.message, webhookId, guildId,
+      }));
+    logger.warn('Per-guild webhook owner_id discovery failed; rolled back', {
+      error: err?.message, guildId, webhookId,
+    });
+    return { ok: false, reason: 'owner-discovery-failed' };
+  }
+  if (!webhookOwnerId) {
+    deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
+      .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
+        error: dErr?.message, webhookId, guildId,
+      }));
+    logger.warn('Per-guild webhook owner_id missing on discovery response; rolled back', {
+      guildId, webhookId,
+    });
+    return { ok: false, reason: 'owner-missing' };
+  }
+
+  try {
+    await db.setGuildWebhookSubscription(guildId, {
+      webhookId,
+      webhookSecret: secret,
+      webhookOwnerId,
+    });
+  } catch (err) {
+    // DDB write failed AFTER subscription was successfully created.
+    // Same orphan-cleanup rationale as qurl-oauth.js:413's orphan-
+    // mint cleanup. ensureWebhookSubscription's own dedupe heals on
+    // the next /qurl setup attempt.
+    deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
+      .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
+        error: dErr?.message, webhookId, guildId,
+      }));
+    logger.warn('Per-guild webhook subscription persisted-create rollback', {
+      error: err?.message, guildId, webhookId,
+    });
+    return { ok: false, reason: 'persist-failed' };
+  }
+
+  subs.upsertGuild({ guildId, ownerId: webhookOwnerId, webhookId, webhookSecret: secret });
+  logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTERED, {
+    guild_id: guildId, action,
+  });
+  return { ok: true, action };
+}
+
+// Best-effort tear-down of a guild's webhook subscription, used by
+// the unlink path. Reference-counted via listGuildSubscriptionsByOwner
+// so multi-guild admins (one auth0 owner across N guilds) don't kill
+// sibling delivery when one guild unlinks.
+//
+// DELETE 401 = the API key the helper would use has been revoked
+// already (typical re-key flow); DELETE 404 = subscription already
+// gone. Both swallowed; the QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED
+// audit captures them for forensic counting.
+async function unlinkGuildWebhookSubscription({ guildId, apiKey, webhookId, webhookOwnerId }) {
+  if (!guildId || !webhookOwnerId || !webhookId) {
+    return { ok: false, reason: 'missing-args' };
+  }
+
+  let siblings = [];
+  try {
+    siblings = await db.listGuildSubscriptionsByOwner(webhookOwnerId);
+  } catch (err) {
+    logger.warn('listGuildSubscriptionsByOwner threw — skipping DELETE to avoid killing siblings', {
+      error: err?.message, guildId, webhookOwnerId,
+    });
+    return { ok: false, reason: 'list-failed' };
+  }
+  const otherGuilds = siblings.filter(s => s.guildId !== guildId);
+  if (otherGuilds.length > 0) {
+    // Other guilds share this subscription; leave it alone. Local
+    // registry update only — let the next tick observe the row drop.
+    subs.removeGuild({ guildId, ownerId: webhookOwnerId });
+    return { ok: true, reason: 'kept-for-siblings', siblingCount: otherGuilds.length };
+  }
+
+  // Last guild for this subscription. Best-effort DELETE.
+  if (!apiKey || !config.QURL_ENDPOINT) {
+    logger.warn('Skipping DELETE: missing apiKey or QURL_ENDPOINT', { guildId });
+    subs.removeGuild({ guildId, ownerId: webhookOwnerId });
+    return { ok: false, reason: 'cannot-delete' };
+  }
+  try {
+    await deleteSubscription({
+      apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId,
+    });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETED, {
+      guild_id: guildId,
+    });
+  } catch (err) {
+    // 401 = key revoked (typical re-key flow); 404 should already be
+    // swallowed inside deleteSubscription itself (see qurl-webhook-
+    // registrar.js:192). Anything else is an unexpected qurl-service
+    // failure mode; log + audit but DON'T re-throw, since the caller
+    // (removeGuildApiKey) is in a critical unlink path.
+    const status = err?.status;
+    logger.warn('Per-guild webhook subscription DELETE failed (swallowed)', {
+      error: err?.message, status, guildId, webhookId,
+    });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED, {
+      guild_id: guildId, status: status || null,
+    });
+  }
+  subs.removeGuild({ guildId, ownerId: webhookOwnerId });
+  return { ok: true, reason: 'deleted' };
+}
+
+// One-shot orchestrator for the unlink path: load the guild's current
+// state, tear down the qurl-service subscription (ref-counted across
+// siblings), then delete the DDB row. Future callers that today don't
+// exist (an `/qurl unlink` admin command, an OAuth revoke handler)
+// MUST use this entry point rather than calling db.removeGuildApiKey
+// directly — otherwise the webhook subscription orphans on
+// qurl-service and the bot leaves an unprotected secret-less row
+// behind. See removeGuildApiKey in ddb-store.js for the comment that
+// points future authors here.
+async function unlinkGuildAndWebhook(guildId) {
+  if (!guildId) return { ok: false, reason: 'missing-args' };
+  let row;
+  try {
+    row = await db.getGuildConfigWithApiKey(guildId);
+  } catch (err) {
+    logger.warn('unlinkGuildAndWebhook: failed to load guild row', {
+      error: err?.message, guildId,
+    });
+    return { ok: false, reason: 'read-failed' };
+  }
+  if (!row) return { ok: true, reason: 'not-found' };
+
+  // Tear down the subscription FIRST so a partial-failure leaves
+  // observable orphan state (a DDB row with stale webhook_id) rather
+  // than an unobservable orphan (a row deleted but the webhook still
+  // billing-active on qurl-service). Best-effort throughout.
+  if (row.webhook_id && row.webhook_owner_id) {
+    await unlinkGuildWebhookSubscription({
+      guildId,
+      apiKey: row.qurl_api_key,
+      webhookId: row.webhook_id,
+      webhookOwnerId: row.webhook_owner_id,
+    });
+  }
+
+  try {
+    await db.removeGuildApiKey(guildId);
+  } catch (err) {
+    logger.warn('unlinkGuildAndWebhook: removeGuildApiKey failed', {
+      error: err?.message, guildId,
+    });
+    return { ok: false, reason: 'delete-failed' };
+  }
+  return { ok: true, reason: 'unlinked' };
+}
+
+module.exports = {
+  linkGuildWebhookSubscription,
+  unlinkGuildWebhookSubscription,
+  unlinkGuildAndWebhook,
+};

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -46,7 +46,17 @@ function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
       logger.warn('Best-effort orphan-subscription delete threw', {
         error: dErr?.message, status, webhookId, guildId,
       });
-      if (status === 401) return; // routine re-key flow; not alarm-worthy
+      if (status === 401) {
+        // Routine re-key — admin revoked the key on layerv.ai before
+        // our DELETE landed. Not alarm-worthy, but an orphan webhook
+        // is now stranded on qurl-service's account. Log at info so a
+        // per-guild history grep can still surface the orphan (without
+        // page-loading the audit channel on every key rotation).
+        logger.info('Orphan webhook subscription left on qurl-service (401 = key revoked)', {
+          webhook_id: webhookId, guild_id: guildId,
+        });
+        return;
+      }
       logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED, {
         guild_id: guildId, status: status || null, path: 'rollback',
       });

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -1,25 +1,8 @@
 // Per-guild qurl-service webhook subscription provisioning.
-//
-// Called from the two `setGuildApiKey` call sites (qurl-oauth callback +
-// /qurl setup admin form) and from the one-time backfill script. The
-// caller has already persisted the API key to DDB; this module's job
-// is to:
-//   1. ensure a qurl.accessed subscription exists under that API key
-//   2. discover the qurl-service owner_id the key resolves to
-//   3. persist {webhook_id, encrypted secret, owner_id} on the
-//      guild_configs row
-//   4. update the in-process subscription registry synchronously so
-//      the registering replica is immediately correct
-//
-// Partial-failure: if step 3 throws AFTER step 1 succeeded, the
-// just-created subscription is best-effort DELETE'd so the admin's
-// account isn't littered with orphan webhooks.
-//
-// All paths are non-blocking on caller error: the OAuth callback +
-// /qurl setup should report success for KEY LINKING even when the
-// view-counter wiring fails — the key still works, view counter just
-// degrades to the polling fallback until backfill catches up. This
-// module logs + audits but never re-throws to the caller.
+// Called from the two setGuildApiKey call sites + the backfill script.
+// Never re-throws to the caller: the OAuth callback / /qurl setup
+// should succeed for key linking even when view-counter wiring fails
+// (the polling fallback covers it until backfill catches up).
 
 const config = require('./config');
 const db = require('./store');
@@ -28,57 +11,52 @@ const { AUDIT_EVENTS } = require('./constants');
 const { ensureWebhookSubscription, deleteSubscription } = require('./qurl-webhook-registrar');
 const subs = require('./webhook-subscriptions');
 
-// 10s matches qurl-oauth.js's QURL_SERVICE_TIMEOUT_MS budget; keep
-// it tight so a stuck qurl-service GET doesn't block /qurl setup.
-const QURL_SERVICE_TIMEOUT_MS = 10_000;
+// Frozen discriminator for the `reason` field on link/unlink results.
+// Keeping it as an enum lets downstream audit-log parsers / dashboards
+// avoid string-typos and lets the receiver / store tests assert
+// against the canonical values.
+const LINK_RESULTS = Object.freeze({
+  MISSING_ARGS: 'missing-args',
+  CONFIG_MISSING: 'config-missing',
+  REGISTER_FAILED: 'register-failed',
+  OWNER_MISSING: 'owner-missing',
+  PERSIST_FAILED: 'persist-failed',
+  LIST_FAILED: 'list-failed',
+  CANNOT_DELETE: 'cannot-delete',
+  KEPT_FOR_SIBLINGS: 'kept-for-siblings',
+  DELETED: 'deleted',
+  NOT_FOUND: 'not-found',
+  READ_FAILED: 'read-failed',
+  DELETE_FAILED: 'delete-failed',
+  UNLINKED: 'unlinked',
+});
 
 function bridgeUrl() {
-  // BASE_URL is validated upstream (variables.tf regex pins
-  // https://host[:port][/segment] with no trailing slash), but we
-  // still strip a trailing slash defensively so a future relaxation
-  // of that validation can't render `https://bot//webhooks/qurl`.
-  return `${config.BASE_URL.replace(/\/$/, '')}/webhooks/qurl`;
+  // BASE_URL is validated upstream; multi-slash strip is defense
+  // against future config-drift.
+  return `${config.BASE_URL.replace(/\/+$/, '')}/webhooks/qurl`;
 }
 
-// Discover the qurl-service owner_id by listing the first webhook
-// under this key. Any of the caller's subs work since they all share
-// the key's owner — including the one we just created via
-// ensureWebhookSubscription. Returns null if the list is empty
-// (defensive — shouldn't happen since we just registered one) and
-// throws on transport / non-2xx errors so the partial-failure path
-// can roll back.
-async function discoverOwnerId(apiKey) {
-  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=1`, {
-    method: 'GET',
-    headers: { Authorization: `Bearer ${apiKey}` },
-    signal: AbortSignal.timeout(QURL_SERVICE_TIMEOUT_MS),
-  });
-  if (!resp.ok) {
-    throw new Error(`GET /v1/webhooks returned ${resp.status} on owner_id discovery`);
-  }
-  const body = await resp.json();
-  const first = Array.isArray(body?.data) ? body.data[0] : null;
-  return typeof first?.owner_id === 'string' && first.owner_id.length > 0
-    ? first.owner_id
-    : null;
+// Fire-and-forget DELETE used by the three orphan-cleanup paths in
+// linkGuildWebhookSubscription. Centralized so the warn shape stays
+// consistent and a future-cr nit ("logger field names differ across
+// the three paths") doesn't recur.
+function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
+  deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
+    .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
+      error: dErr?.message, webhookId, guildId,
+    }));
 }
 
 // Provision (idempotent) a per-guild webhook subscription.
-//
-// Returns { ok: true, action } on success or { ok: false, reason } on
-// any failure. Never throws; the caller's user-facing flow continues
-// regardless of outcome.
-//
-// `action` mirrors ensureWebhookSubscription's: 'created' | 'rotated'
-// | 'reused'. Useful for distinguishing "fresh guild" from "admin
-// shared their key across N guilds" in audit logs.
+// `action` mirrors ensureWebhookSubscription: 'created' | 'rotated' | 'reused'.
 async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContext }) {
   if (!guildId || !apiKey) {
-    return { ok: false, reason: 'missing-args' };
+    return { ok: false, reason: LINK_RESULTS.MISSING_ARGS };
   }
   if (!config.BASE_URL || !config.QURL_ENDPOINT) {
     logger.warn('Per-guild webhook link skipped: BASE_URL or QURL_ENDPOINT unset', { guildId });
-    return { ok: false, reason: 'config-missing' };
+    return { ok: false, reason: LINK_RESULTS.CONFIG_MISSING };
   }
 
   let registered = null;
@@ -93,37 +71,16 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     logger.warn('Per-guild webhook subscription registration failed', {
       error: err?.message, guildId,
     });
-    return { ok: false, reason: 'register-failed' };
+    return { ok: false, reason: LINK_RESULTS.REGISTER_FAILED };
   }
 
-  const { webhookId, secret, action } = registered;
-
-  let webhookOwnerId;
-  try {
-    webhookOwnerId = await discoverOwnerId(apiKey);
-  } catch (err) {
-    // Owner_id discovery failed AFTER we successfully registered.
-    // Without owner_id the receiver can't route inbound events to
-    // this subscription's secret — best-effort DELETE to avoid an
-    // orphan billing-active sub on the admin's account.
-    deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
-      .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
-        error: dErr?.message, webhookId, guildId,
-      }));
-    logger.warn('Per-guild webhook owner_id discovery failed; rolled back', {
-      error: err?.message, guildId, webhookId,
+  const { webhookId, secret, action, ownerId: webhookOwnerId } = registered;
+  if (typeof webhookOwnerId !== 'string' || !webhookOwnerId) {
+    bestEffortDeleteSubscription({ apiKey, webhookId, guildId });
+    logger.warn('Per-guild webhook ownerId missing from registrar response; rolled back', {
+      guildId, webhookId, action,
     });
-    return { ok: false, reason: 'owner-discovery-failed' };
-  }
-  if (!webhookOwnerId) {
-    deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
-      .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
-        error: dErr?.message, webhookId, guildId,
-      }));
-    logger.warn('Per-guild webhook owner_id missing on discovery response; rolled back', {
-      guildId, webhookId,
-    });
-    return { ok: false, reason: 'owner-missing' };
+    return { ok: false, reason: LINK_RESULTS.OWNER_MISSING };
   }
 
   try {
@@ -133,18 +90,24 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
       webhookOwnerId,
     });
   } catch (err) {
-    // DDB write failed AFTER subscription was successfully created.
-    // Same orphan-cleanup rationale as qurl-oauth.js:413's orphan-
-    // mint cleanup. ensureWebhookSubscription's own dedupe heals on
-    // the next /qurl setup attempt.
-    deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
-      .catch((dErr) => logger.warn('Best-effort orphan-subscription delete threw', {
-        error: dErr?.message, webhookId, guildId,
-      }));
+    bestEffortDeleteSubscription({ apiKey, webhookId, guildId });
     logger.warn('Per-guild webhook subscription persisted-create rollback', {
       error: err?.message, guildId, webhookId,
     });
-    return { ok: false, reason: 'persist-failed' };
+    return { ok: false, reason: LINK_RESULTS.PERSIST_FAILED };
+  }
+
+  // Sibling rows under the same owner may hold a pre-rotate secret.
+  // Best-effort propagation; the scanOnce tiebreaker still picks the
+  // freshly-written primary if this fails.
+  try {
+    await db.propagateGuildWebhookSubscription(webhookOwnerId, {
+      webhookId, webhookSecret: secret,
+    });
+  } catch (err) {
+    logger.warn('Per-guild webhook secret propagation to siblings failed (non-blocking)', {
+      error: err?.message, guildId, webhookOwnerId, webhookId,
+    });
   }
 
   subs.upsertGuild({ guildId, ownerId: webhookOwnerId, webhookId, webhookSecret: secret });
@@ -154,18 +117,13 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
   return { ok: true, action };
 }
 
-// Best-effort tear-down of a guild's webhook subscription, used by
-// the unlink path. Reference-counted via listGuildSubscriptionsByOwner
-// so multi-guild admins (one auth0 owner across N guilds) don't kill
-// sibling delivery when one guild unlinks.
-//
-// DELETE 401 = the API key the helper would use has been revoked
-// already (typical re-key flow); DELETE 404 = subscription already
-// gone. Both swallowed; the QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED
-// audit captures them for forensic counting.
+// Reference-counted tear-down for unlink: only DELETE the qurl-service
+// subscription if this was the last guild referencing it. 401 / 404 on
+// DELETE are swallowed (typical re-key flow has the old key already
+// revoked).
 async function unlinkGuildWebhookSubscription({ guildId, apiKey, webhookId, webhookOwnerId }) {
   if (!guildId || !webhookOwnerId || !webhookId) {
-    return { ok: false, reason: 'missing-args' };
+    return { ok: false, reason: LINK_RESULTS.MISSING_ARGS };
   }
 
   let siblings = [];
@@ -175,21 +133,18 @@ async function unlinkGuildWebhookSubscription({ guildId, apiKey, webhookId, webh
     logger.warn('listGuildSubscriptionsByOwner threw — skipping DELETE to avoid killing siblings', {
       error: err?.message, guildId, webhookOwnerId,
     });
-    return { ok: false, reason: 'list-failed' };
+    return { ok: false, reason: LINK_RESULTS.LIST_FAILED };
   }
   const otherGuilds = siblings.filter(s => s.guildId !== guildId);
   if (otherGuilds.length > 0) {
-    // Other guilds share this subscription; leave it alone. Local
-    // registry update only — let the next tick observe the row drop.
     subs.removeGuild({ guildId, ownerId: webhookOwnerId });
-    return { ok: true, reason: 'kept-for-siblings', siblingCount: otherGuilds.length };
+    return { ok: true, reason: LINK_RESULTS.KEPT_FOR_SIBLINGS, siblingCount: otherGuilds.length };
   }
 
-  // Last guild for this subscription. Best-effort DELETE.
   if (!apiKey || !config.QURL_ENDPOINT) {
     logger.warn('Skipping DELETE: missing apiKey or QURL_ENDPOINT', { guildId });
     subs.removeGuild({ guildId, ownerId: webhookOwnerId });
-    return { ok: false, reason: 'cannot-delete' };
+    return { ok: false, reason: LINK_RESULTS.CANNOT_DELETE };
   }
   try {
     await deleteSubscription({
@@ -199,11 +154,6 @@ async function unlinkGuildWebhookSubscription({ guildId, apiKey, webhookId, webh
       guild_id: guildId,
     });
   } catch (err) {
-    // 401 = key revoked (typical re-key flow); 404 should already be
-    // swallowed inside deleteSubscription itself (see qurl-webhook-
-    // registrar.js:192). Anything else is an unexpected qurl-service
-    // failure mode; log + audit but DON'T re-throw, since the caller
-    // (removeGuildApiKey) is in a critical unlink path.
     const status = err?.status;
     logger.warn('Per-guild webhook subscription DELETE failed (swallowed)', {
       error: err?.message, status, guildId, webhookId,
@@ -213,20 +163,15 @@ async function unlinkGuildWebhookSubscription({ guildId, apiKey, webhookId, webh
     });
   }
   subs.removeGuild({ guildId, ownerId: webhookOwnerId });
-  return { ok: true, reason: 'deleted' };
+  return { ok: true, reason: LINK_RESULTS.DELETED };
 }
 
-// One-shot orchestrator for the unlink path: load the guild's current
-// state, tear down the qurl-service subscription (ref-counted across
-// siblings), then delete the DDB row. Future callers that today don't
-// exist (an `/qurl unlink` admin command, an OAuth revoke handler)
-// MUST use this entry point rather than calling db.removeGuildApiKey
-// directly — otherwise the webhook subscription orphans on
-// qurl-service and the bot leaves an unprotected secret-less row
-// behind. See removeGuildApiKey in ddb-store.js for the comment that
-// points future authors here.
+// One-shot orchestrator for the unlink path. Tears down the
+// subscription FIRST (so partial failure leaves observable DDB state
+// rather than an unobservable qurl-service orphan), then drops the
+// DDB row via the raw delete.
 async function unlinkGuildAndWebhook(guildId) {
-  if (!guildId) return { ok: false, reason: 'missing-args' };
+  if (!guildId) return { ok: false, reason: LINK_RESULTS.MISSING_ARGS };
   let row;
   try {
     row = await db.getGuildConfigWithApiKey(guildId);
@@ -234,14 +179,10 @@ async function unlinkGuildAndWebhook(guildId) {
     logger.warn('unlinkGuildAndWebhook: failed to load guild row', {
       error: err?.message, guildId,
     });
-    return { ok: false, reason: 'read-failed' };
+    return { ok: false, reason: LINK_RESULTS.READ_FAILED };
   }
-  if (!row) return { ok: true, reason: 'not-found' };
+  if (!row) return { ok: true, reason: LINK_RESULTS.NOT_FOUND };
 
-  // Tear down the subscription FIRST so a partial-failure leaves
-  // observable orphan state (a DDB row with stale webhook_id) rather
-  // than an unobservable orphan (a row deleted but the webhook still
-  // billing-active on qurl-service). Best-effort throughout.
   if (row.webhook_id && row.webhook_owner_id) {
     await unlinkGuildWebhookSubscription({
       guildId,
@@ -252,18 +193,19 @@ async function unlinkGuildAndWebhook(guildId) {
   }
 
   try {
-    await db.removeGuildApiKey(guildId);
+    await db._removeGuildApiKeyRaw(guildId);
   } catch (err) {
-    logger.warn('unlinkGuildAndWebhook: removeGuildApiKey failed', {
+    logger.warn('unlinkGuildAndWebhook: _removeGuildApiKeyRaw failed', {
       error: err?.message, guildId,
     });
-    return { ok: false, reason: 'delete-failed' };
+    return { ok: false, reason: LINK_RESULTS.DELETE_FAILED };
   }
-  return { ok: true, reason: 'unlinked' };
+  return { ok: true, reason: LINK_RESULTS.UNLINKED };
 }
 
 module.exports = {
   linkGuildWebhookSubscription,
   unlinkGuildWebhookSubscription,
   unlinkGuildAndWebhook,
+  LINK_RESULTS,
 };

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -32,16 +32,23 @@ function bridgeUrl() {
 // rollback paths. Intentionally not awaited: the orphan-on-
 // qurl-service is itself ephemeral (it 401s every delivery on a
 // stale key) and the audit event is the operator-visible signal.
-// A leaked orphan converges via the future orphan-sweeper noted
-// in PR #485's Out-of-scope section.
+//
+// Audit-noise discrimination: 404 is swallowed inside the registrar
+// (concurrent-delete race; the goal state is already met). 401 is
+// the routine re-key signal — the admin revoked the key on
+// layerv.ai before our DELETE landed — so we log but DON'T audit
+// (would flood the alarm channel on every key rotation). 5xx and
+// network errors DO audit so an orphan-subscription leak is visible.
 function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
   deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
     .catch((dErr) => {
+      const status = dErr?.status;
       logger.warn('Best-effort orphan-subscription delete threw', {
-        error: dErr?.message, webhookId, guildId,
+        error: dErr?.message, status, webhookId, guildId,
       });
+      if (status === 401) return; // routine re-key flow; not alarm-worthy
       logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED, {
-        guild_id: guildId, status: dErr?.status || null, path: 'rollback',
+        guild_id: guildId, status: status || null, path: 'rollback',
       });
     });
 }

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -117,9 +117,25 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
   // excludeGuildId so the primary row (just written above) isn't
   // updated a second time.
   try {
-    await db.propagateGuildWebhookSubscription(webhookOwnerId, {
+    const propagateResult = await db.propagateGuildWebhookSubscription(webhookOwnerId, {
       webhookId, webhookSecret: secret, excludeGuildId: guildId,
     });
+    if (propagateResult.failed > 0) {
+      // Partial success: some sibling rows were updated, others
+      // threw. Their cache entries will pick up the stale secret on
+      // the next 30s tick and 401 every inbound webhook until
+      // another propagate run converges them. Audit so the
+      // CloudWatch alarm fires; the registration itself is still OK.
+      logger.warn('Per-guild webhook secret propagation partially failed', {
+        guildId, webhookOwnerId, webhookId, ...propagateResult,
+      });
+      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED, {
+        guild_id: guildId,
+        reason: 'propagate-partial',
+        updated: propagateResult.updated,
+        failed: propagateResult.failed,
+      });
+    }
   } catch (err) {
     logger.warn('Per-guild webhook secret propagation to siblings failed (non-blocking)', {
       error: err?.message, guildId, webhookOwnerId, webhookId,

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -126,7 +126,17 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
     });
   }
 
-  subs.upsertGuild({ guildId, ownerId: webhookOwnerId, webhookId, webhookSecret: secret });
+  // upsertGuild validates input types; if a future caller-bug feeds
+  // in an unexpected shape that the upstream guards missed, we still
+  // want the success audit to fire — DDB is authoritative, so a
+  // failed in-memory upsert is correctable on the next 30s tick.
+  try {
+    subs.upsertGuild({ guildId, ownerId: webhookOwnerId, webhookId, webhookSecret: secret });
+  } catch (err) {
+    logger.warn('subs.upsertGuild rejected (cache will reconcile on next scan)', {
+      error: err?.message, guildId,
+    });
+  }
   logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTERED, {
     guild_id: guildId, action,
   });

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -11,24 +11,15 @@ const { AUDIT_EVENTS } = require('./constants');
 const { ensureWebhookSubscription, deleteSubscription } = require('./qurl-webhook-registrar');
 const subs = require('./webhook-subscriptions');
 
-// Frozen discriminator for the `reason` field on link/unlink results.
-// Keeping it as an enum lets downstream audit-log parsers / dashboards
-// avoid string-typos and lets the receiver / store tests assert
-// against the canonical values.
+// Frozen discriminator for the `reason` field on link results.
+// Audit-log parsers / dashboards key on this; keeping it as an enum
+// catches typos that would silently break a metric filter.
 const LINK_RESULTS = Object.freeze({
   MISSING_ARGS: 'missing-args',
   CONFIG_MISSING: 'config-missing',
   REGISTER_FAILED: 'register-failed',
   OWNER_MISSING: 'owner-missing',
   PERSIST_FAILED: 'persist-failed',
-  LIST_FAILED: 'list-failed',
-  CANNOT_DELETE: 'cannot-delete',
-  KEPT_FOR_SIBLINGS: 'kept-for-siblings',
-  DELETED: 'deleted',
-  NOT_FOUND: 'not-found',
-  READ_FAILED: 'read-failed',
-  DELETE_FAILED: 'delete-failed',
-  UNLINKED: 'unlinked',
 });
 
 function bridgeUrl() {
@@ -37,11 +28,12 @@ function bridgeUrl() {
   return `${config.BASE_URL.replace(/\/+$/, '')}/webhooks/qurl`;
 }
 
-// Fire-and-forget DELETE used by the orphan-cleanup paths in
-// linkGuildWebhookSubscription. Emits the same DELETE_FAILED audit
-// event the non-rollback unlink path uses so a leaked-orphan
-// incident shows up on one CloudWatch metric regardless of which
-// path produced it.
+// Fire-and-forget DELETE used by linkGuildWebhookSubscription's
+// rollback paths. Intentionally not awaited: the orphan-on-
+// qurl-service is itself ephemeral (it 401s every delivery on a
+// stale key) and the audit event is the operator-visible signal.
+// A leaked orphan converges via the future orphan-sweeper noted
+// in PR #485's Out-of-scope section.
 function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
   deleteSubscription({ apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId })
     .catch((dErr) => {
@@ -54,10 +46,11 @@ function bestEffortDeleteSubscription({ apiKey, webhookId, guildId }) {
     });
 }
 
-// Centralizes the "warn + audit failure" pattern for the five
-// failure branches of linkGuildWebhookSubscription. Without this,
-// the branches only logger.warn — CloudWatch metric filters watching
-// for register-failure spikes would miss them.
+// Audit-emit helper for linkGuildWebhookSubscription's failure
+// branches. The MISSING_ARGS branch passes guild_id='<missing>' as a
+// sentinel; metric-filter dashboards that group by guild_id will
+// surface this as a synthetic group — acceptable since it should
+// only fire on caller-bug paths.
 function auditLinkFailure(guildId, reason, extra) {
   logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED, {
     guild_id: guildId, reason, ...(extra || {}),
@@ -119,11 +112,13 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
   }
 
   // Sibling rows under the same owner may hold a pre-rotate secret.
-  // Best-effort propagation; the scanOnce tiebreaker still picks the
-  // freshly-written primary if this fails.
+  // Best-effort propagation; scanOnce's updatedAt tiebreaker still
+  // picks the freshly-written primary if this fails. Pass
+  // excludeGuildId so the primary row (just written above) isn't
+  // updated a second time.
   try {
     await db.propagateGuildWebhookSubscription(webhookOwnerId, {
-      webhookId, webhookSecret: secret,
+      webhookId, webhookSecret: secret, excludeGuildId: guildId,
     });
   } catch (err) {
     logger.warn('Per-guild webhook secret propagation to siblings failed (non-blocking)', {
@@ -138,95 +133,7 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
   return { ok: true, action };
 }
 
-// Reference-counted tear-down for unlink: only DELETE the qurl-service
-// subscription if this was the last guild referencing it. 401 / 404 on
-// DELETE are swallowed (typical re-key flow has the old key already
-// revoked).
-async function unlinkGuildWebhookSubscription({ guildId, apiKey, webhookId, webhookOwnerId }) {
-  if (!guildId || !webhookOwnerId || !webhookId) {
-    return { ok: false, reason: LINK_RESULTS.MISSING_ARGS };
-  }
-
-  let siblings = [];
-  try {
-    siblings = await db.listGuildSubscriptionsByOwner(webhookOwnerId);
-  } catch (err) {
-    logger.warn('listGuildSubscriptionsByOwner threw — skipping DELETE to avoid killing siblings', {
-      error: err?.message, guildId, webhookOwnerId,
-    });
-    return { ok: false, reason: LINK_RESULTS.LIST_FAILED };
-  }
-  const otherGuilds = siblings.filter(s => s.guildId !== guildId);
-  if (otherGuilds.length > 0) {
-    subs.removeGuild({ guildId, ownerId: webhookOwnerId });
-    return { ok: true, reason: LINK_RESULTS.KEPT_FOR_SIBLINGS, siblingCount: otherGuilds.length };
-  }
-
-  if (!apiKey || !config.QURL_ENDPOINT) {
-    logger.warn('Skipping DELETE: missing apiKey or QURL_ENDPOINT', { guildId });
-    subs.removeGuild({ guildId, ownerId: webhookOwnerId });
-    return { ok: false, reason: LINK_RESULTS.CANNOT_DELETE };
-  }
-  try {
-    await deleteSubscription({
-      apiEndpoint: config.QURL_ENDPOINT, apiKey, webhookId,
-    });
-    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETED, {
-      guild_id: guildId,
-    });
-  } catch (err) {
-    const status = err?.status;
-    logger.warn('Per-guild webhook subscription DELETE failed (swallowed)', {
-      error: err?.message, status, guildId, webhookId,
-    });
-    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED, {
-      guild_id: guildId, status: status || null,
-    });
-  }
-  subs.removeGuild({ guildId, ownerId: webhookOwnerId });
-  return { ok: true, reason: LINK_RESULTS.DELETED };
-}
-
-// One-shot orchestrator for the unlink path. Tears down the
-// subscription FIRST (so partial failure leaves observable DDB state
-// rather than an unobservable qurl-service orphan), then drops the
-// DDB row via the raw delete.
-async function unlinkGuildAndWebhook(guildId) {
-  if (!guildId) return { ok: false, reason: LINK_RESULTS.MISSING_ARGS };
-  let row;
-  try {
-    row = await db.getGuildConfigWithApiKey(guildId);
-  } catch (err) {
-    logger.warn('unlinkGuildAndWebhook: failed to load guild row', {
-      error: err?.message, guildId,
-    });
-    return { ok: false, reason: LINK_RESULTS.READ_FAILED };
-  }
-  if (!row) return { ok: true, reason: LINK_RESULTS.NOT_FOUND };
-
-  if (row.webhook_id && row.webhook_owner_id) {
-    await unlinkGuildWebhookSubscription({
-      guildId,
-      apiKey: row.qurl_api_key,
-      webhookId: row.webhook_id,
-      webhookOwnerId: row.webhook_owner_id,
-    });
-  }
-
-  try {
-    await db._removeGuildApiKeyRaw(guildId);
-  } catch (err) {
-    logger.warn('unlinkGuildAndWebhook: _removeGuildApiKeyRaw failed', {
-      error: err?.message, guildId,
-    });
-    return { ok: false, reason: LINK_RESULTS.DELETE_FAILED };
-  }
-  return { ok: true, reason: LINK_RESULTS.UNLINKED };
-}
-
 module.exports = {
   linkGuildWebhookSubscription,
-  unlinkGuildWebhookSubscription,
-  unlinkGuildAndWebhook,
   LINK_RESULTS,
 };

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -49,6 +49,7 @@ const eventConsumer = require('./event-consumer');
 const eventPublisher = require('./event-publisher');
 const viewUpdateConsumer = require('./view-update-consumer');
 const viewUpdatePublisher = require('./view-update-publisher');
+const webhookSubscriptions = require('./webhook-subscriptions');
 const { LOG_KINDS } = require('./constants');
 
 // Process role — selects which subset of the bot runs in this
@@ -1119,16 +1120,31 @@ async function start() {
   //     /qurl command surface dead until a human notices.
   if (isHttp) {
     httpServer = startServer();
-    // Webhook subscription registration is OUT-OF-PROCESS as of the
-    // webhook-registrar Lambda — see
+    // Webhook subscription registration is OUT-OF-PROCESS for the
+    // bot's default key, via the webhook-registrar Lambda — see
     //   apps/discord/lambda/webhook-registrar/index.js  (handler)
     //   apps/discord/lambda/webhook-registrar/README.md  (bundling)
     //   apps/discord/docs/qurl-webhook-rollout.md        (operator flow)
-    // The Lambda is invoked once per deploy via Terraform, writes the
-    // rotated/created secret to SSM, and the bot reads
-    // `QURL_WEBHOOK_SECRET` from env at boot — single-instance Lambda
-    // is race-free by construction, no in-app dedupe/lock logic needed.
-    // Rotation: re-invoke the Lambda + force-redeploy the bot.
+    // The Lambda is invoked once per deploy via Terraform and writes
+    // the default-key secret to SSM; the bot reads QURL_WEBHOOK_SECRET
+    // from env at boot.
+    //
+    // PER-GUILD subscriptions (BYOK view counter) are in-process:
+    // every guild that links its own API key (via /qurl setup or the
+    // OAuth callback) gets its own subscription. The registry below
+    // owns the in-memory map<owner_id, secret> the multi-secret
+    // receiver consults on every inbound webhook, primes from
+    // guild_configs at boot, and refreshes every 30s — including
+    // re-discovering the default-key owner_id by listing the
+    // Lambda's subscription. See src/webhook-subscriptions.js.
+    //
+    // Fire-and-forget: the receiver returns 503 until cachePrimed is
+    // true, so a slow first-scan doesn't drop events — qurl-service
+    // retries 503. Awaiting here would delay the HTTP listener
+    // unnecessarily.
+    webhookSubscriptions.start().catch((err) => {
+      logger.error('webhook-subscriptions registry initial scan crash', { error: err?.message });
+    });
   } else if (isGateway) {
     // Returns 503 until isReady() flips true (after READY from the
     // Discord gateway). Dockerfile --start-period=30s covers this

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -488,6 +488,11 @@ module.exports = {
   ensureWebhookSubscription,
   deleteSubscription,
   buildSsmPersistSecret,
+  // Exposed for webhook-subscriptions.js so the registry's
+  // discoverDefaultOwnerId tick goes through the same QurlServiceError /
+  // op-tagged transport as the rest of the registrar surface — kept off
+  // _internals because it has a stable contract and an external caller.
+  callQurlService,
   _internals: {
     canonicalUrl,
     pickSurvivor,

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -333,7 +333,9 @@ async function reconcileEvents({ apiEndpoint, apiKey, existing }) {
  * @param {string} opts.description    - human-readable; surfaces in qurl-service UI
  * @param {string} [opts.initialSecret] - the secret the caller already has in-memory (e.g. from SSM/env). When set to a non-placeholder value AND an existing subscription is found, the registrar SKIPS rotation — every replica reuses the same secret instead of rotating each other into uselessness.
  * @param {Function} [opts.persistSecret] - optional async(secret) → void callback for best-effort persistence
- * @returns {Promise<{secret: string, webhookId: string, action: 'created' | 'rotated' | 'reused'}>}
+ * @returns {Promise<{secret: string, webhookId: string, action: 'created' | 'rotated' | 'reused', ownerId: string}>}
+ *   `ownerId` is the qurl-service auth0 owner the API key resolves to. Required
+ *   by per-guild callers for receiver routing.
  */
 async function ensureWebhookSubscription(opts) {
   const { apiEndpoint, apiKey, bridgeUrl, description, initialSecret, persistSecret } = opts;
@@ -390,6 +392,10 @@ async function ensureWebhookSubscription(opts) {
   const initialIsRealSecret = typeof initialSecret === 'string'
     && initialSecret.length > 0;
 
+  // Forwarded so per-guild callers can route inbound webhooks
+  // without a second GET /v1/webhooks.
+  let ownerId;
+
   if (existing && initialIsRealSecret && !wasDedupe) {
     // Trust assumption: the SSM-loaded `initialSecret` matches the
     // existing sub's server-side secret. No challenge/verify here.
@@ -400,6 +406,7 @@ async function ensureWebhookSubscription(opts) {
     webhookId = existing.webhook_id;
     secret = initialSecret;
     action = 'reused';
+    ownerId = existing.owner_id;
     // Wrap the PATCH in try/catch matching the rotate branch — a
     // transient 5xx here shouldn't flip the boot log to "self-
     // registration failed" when the in-memory secret is already
@@ -413,7 +420,7 @@ async function ensureWebhookSubscription(opts) {
       });
     }
     logger.info('qURL webhook subscription reused (existing found, SSM secret trusted, no rotate)', { webhookId, url: bridgeUrl });
-    return { secret, webhookId, action };
+    return { secret, webhookId, action, ownerId };
   }
 
   if (existing) {
@@ -422,6 +429,7 @@ async function ensureWebhookSubscription(opts) {
     // so the boot can succeed even if the events PATCH fails — a
     // stuck PATCH shouldn't block secret recovery.
     webhookId = existing.webhook_id;
+    ownerId = existing.owner_id;
     const rotated = await rotateSecret({ apiEndpoint, apiKey, webhookId });
     secret = rotated.secret;
     action = 'rotated';
@@ -441,6 +449,7 @@ async function ensureWebhookSubscription(opts) {
     webhookId = created.webhook_id;
     secret = created.secret;
     action = 'created';
+    ownerId = created.owner_id;
     logger.info('qURL webhook subscription created', { webhookId, url: bridgeUrl });
   }
 
@@ -451,7 +460,7 @@ async function ensureWebhookSubscription(opts) {
 
   await bestEffortPersist({ persistSecret, value: secret });
 
-  return { secret, webhookId, action };
+  return { secret, webhookId, action, ownerId };
 }
 
 // Build a persistSecret callback that writes the rotated secret to an

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -405,7 +405,7 @@ async function ensureWebhookSubscription(opts) {
     // → bootstrap-rotate path lands a known-good shared secret.
     webhookId = existing.webhook_id;
     secret = initialSecret;
-    action = 'reused';
+    action = WEBHOOK_ACTIONS.REUSED;
     ownerId = existing.owner_id;
     // Wrap the PATCH in try/catch matching the rotate branch — a
     // transient 5xx here shouldn't flip the boot log to "self-
@@ -432,7 +432,7 @@ async function ensureWebhookSubscription(opts) {
     ownerId = existing.owner_id;
     const rotated = await rotateSecret({ apiEndpoint, apiKey, webhookId });
     secret = rotated.secret;
-    action = 'rotated';
+    action = WEBHOOK_ACTIONS.ROTATED;
     try {
       await reconcileEvents({ apiEndpoint, apiKey, existing });
     } catch (err) {
@@ -448,7 +448,7 @@ async function ensureWebhookSubscription(opts) {
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
     webhookId = created.webhook_id;
     secret = created.secret;
-    action = 'created';
+    action = WEBHOOK_ACTIONS.CREATED;
     ownerId = created.owner_id;
     logger.info('qURL webhook subscription created', { webhookId, url: bridgeUrl });
   }
@@ -484,10 +484,21 @@ function buildSsmPersistSecret({ ssmClient, paramName, PutParameterCommand, time
   };
 }
 
+// Frozen enum mirrors the LINK_RESULTS / VERIFY_RESULTS pattern in
+// sibling modules — a typo in any assignment site fails as
+// `WEBHOOK_ACTIONS.UNDEFINED_THING` at require time, not as a
+// silent string-comparison miss in a future caller.
+const WEBHOOK_ACTIONS = Object.freeze({
+  CREATED: 'created',
+  ROTATED: 'rotated',
+  REUSED: 'reused',
+});
+
 module.exports = {
   ensureWebhookSubscription,
   deleteSubscription,
   buildSsmPersistSecret,
+  WEBHOOK_ACTIONS,
   // Exposed for webhook-subscriptions.js so the registry's
   // discoverDefaultOwnerId tick goes through the same QurlServiceError /
   // op-tagged transport as the rest of the registrar surface — kept off

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -477,6 +477,7 @@ function buildSsmPersistSecret({ ssmClient, paramName, PutParameterCommand, time
 
 module.exports = {
   ensureWebhookSubscription,
+  deleteSubscription,
   buildSsmPersistSecret,
   _internals: {
     canonicalUrl,

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -436,9 +436,14 @@ router.get('/callback', rateLimit, async (req, res) => {
 
   // 3a. Register a per-guild qurl.accessed webhook subscription (BYOK
   //     view counter). Fire-and-forget: the helper never re-throws by
-  //     contract and emits its own audit events; the .catch is a
-  //     defense-in-depth safety net against future contract drift, not
-  //     the primary failure-visibility channel.
+  //     contract and emits its own audit events; .catch is defense-
+  //     in-depth.
+  //
+  //     KNOWN QUIRK (tracked in issue #487): a SIGTERM mid-link
+  //     (ECS task cycle, deploy) drops the in-flight work and the
+  //     guild has no view-counter subscription until /qurl setup
+  //     runs again or the backfill script catches it. Polling
+  //     fallback covers correctness.
   linkGuildWebhookSubscription({
     guildId, apiKey, descriptionContext: `via=oauth, configuredBy=${discordUserId}`,
   }).catch((err) => logger.warn('linkGuildWebhookSubscription contract drift — threw unexpectedly', {

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -435,15 +435,16 @@ router.get('/callback', rateLimit, async (req, res) => {
   });
 
   // 3a. Register a per-guild qurl.accessed webhook subscription under
-  //     THIS guild's API key so the BYOK view counter fires for qurls
-  //     it mints. Non-blocking by design: linkGuildWebhookSubscription
-  //     swallows all internal failure modes and logs/audits — the user
-  //     still gets a "qURL connected" success page if the wiring
-  //     fails. View counter degrades to the polling fallback until
-  //     the backfill script catches them.
-  await linkGuildWebhookSubscription({
+  //     THIS guild's API key (BYOK view counter). True fire-and-forget:
+  //     the helper makes a qurl-service round-trip + a DDB scan that
+  //     can add up to a few seconds of latency to user-facing OAuth.
+  //     A failure here only degrades the view counter (polling fallback
+  //     still works); it must not delay the success page.
+  linkGuildWebhookSubscription({
     guildId, apiKey, descriptionContext: `via=oauth, configuredBy=${discordUserId}`,
-  });
+  }).catch((err) => logger.warn('linkGuildWebhookSubscription threw (non-blocking)', {
+    error: err?.message, guildId,
+  }));
 
   // 4. DM the admin so they have a confirmation that doesn't depend on the
   //    browser tab. Fire-and-forget — a delivery failure shouldn't block

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -17,7 +17,7 @@ const { readCookie } = require('../utils/cookies');
 const { shouldPromptConsent } = require('../utils/guild-config-state');
 const { singleStringParam } = require('../utils/query-params');
 const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
-const { linkGuildWebhookSubscription } = require('../guild-webhook-link');
+const { fireAndForgetLinkGuildWebhookSubscription } = require('../guild-webhook-link');
 
 // Network-call timeouts. Centralized so a future tuning of "qurl-service
 // is slow under load" doesn't require a hunt-and-replace across both
@@ -435,20 +435,10 @@ router.get('/callback', rateLimit, async (req, res) => {
   });
 
   // 3a. Register a per-guild qurl.accessed webhook subscription (BYOK
-  //     view counter). Fire-and-forget: the helper never re-throws by
-  //     contract and emits its own audit events; .catch is defense-
-  //     in-depth.
-  //
-  //     KNOWN QUIRK (tracked in issue #487): a SIGTERM mid-link
-  //     (ECS task cycle, deploy) drops the in-flight work and the
-  //     guild has no view-counter subscription until /qurl setup
-  //     runs again or the backfill script catches it. Polling
-  //     fallback covers correctness.
-  linkGuildWebhookSubscription({
-    guildId, apiKey, descriptionContext: `via=oauth, configuredBy=${discordUserId}`,
-  }).catch((err) => logger.warn('linkGuildWebhookSubscription contract drift — threw unexpectedly', {
-    error: err?.message, guildId,
-  }));
+  //     view counter). Fire-and-forget via the centralized helper.
+  fireAndForgetLinkGuildWebhookSubscription({
+    guildId, apiKey, via: 'oauth', configuredBy: discordUserId,
+  });
 
   // 4. DM the admin so they have a confirmation that doesn't depend on the
   //    browser tab. Fire-and-forget — a delivery failure shouldn't block

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -17,6 +17,7 @@ const { readCookie } = require('../utils/cookies');
 const { shouldPromptConsent } = require('../utils/guild-config-state');
 const { singleStringParam } = require('../utils/query-params');
 const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
+const { linkGuildWebhookSubscription } = require('../guild-webhook-link');
 
 // Network-call timeouts. Centralized so a future tuning of "qurl-service
 // is slow under load" doesn't require a hunt-and-replace across both
@@ -431,6 +432,17 @@ router.get('/callback', rateLimit, async (req, res) => {
   }
   logger.info('qURL OAuth setup complete', {
     guildId, configuredBy: discordUserId, keyPrefix,
+  });
+
+  // 3a. Register a per-guild qurl.accessed webhook subscription under
+  //     THIS guild's API key so the BYOK view counter fires for qurls
+  //     it mints. Non-blocking by design: linkGuildWebhookSubscription
+  //     swallows all internal failure modes and logs/audits — the user
+  //     still gets a "qURL connected" success page if the wiring
+  //     fails. View counter degrades to the polling fallback until
+  //     the backfill script catches them.
+  await linkGuildWebhookSubscription({
+    guildId, apiKey, descriptionContext: `via=oauth, configuredBy=${discordUserId}`,
   });
 
   // 4. DM the admin so they have a confirmation that doesn't depend on the

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -434,15 +434,14 @@ router.get('/callback', rateLimit, async (req, res) => {
     guildId, configuredBy: discordUserId, keyPrefix,
   });
 
-  // 3a. Register a per-guild qurl.accessed webhook subscription under
-  //     THIS guild's API key (BYOK view counter). True fire-and-forget:
-  //     the helper makes a qurl-service round-trip + a DDB scan that
-  //     can add up to a few seconds of latency to user-facing OAuth.
-  //     A failure here only degrades the view counter (polling fallback
-  //     still works); it must not delay the success page.
+  // 3a. Register a per-guild qurl.accessed webhook subscription (BYOK
+  //     view counter). Fire-and-forget: the helper never re-throws by
+  //     contract and emits its own audit events; the .catch is a
+  //     defense-in-depth safety net against future contract drift, not
+  //     the primary failure-visibility channel.
   linkGuildWebhookSubscription({
     guildId, apiKey, descriptionContext: `via=oauth, configuredBy=${discordUserId}`,
-  }).catch((err) => logger.warn('linkGuildWebhookSubscription threw (non-blocking)', {
+  }).catch((err) => logger.warn('linkGuildWebhookSubscription contract drift — threw unexpectedly', {
     error: err?.message, guildId,
   }));
 

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -46,6 +46,14 @@ const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
 // signed-shaped requests carrying bogus owner_id and never trip a
 // rate limit. Threshold is 5× the HMAC limiter to avoid throttling
 // during a real registry-rebuild incident.
+//
+// CROSS-TENANT FAIRNESS TRADE-OFF: keyed on IP alone. qurl-service
+// egresses from a small NAT/proxy pool so a single guild whose
+// webhook_owner_id has drifted vs. qurl-service's signing identity
+// can burn 150/min on the shared source IP and 429 other guilds'
+// legitimate events. Acceptable at low BYOK count today (≤10 in
+// prod); at scale this should key on (ip, owner_id) or skip per-IP
+// limiting for OWNER_UNKNOWN entirely.
 const unknownOwnerLimiter = createBadSigLimiter({ max: 150, windowMs: 60_000 });
 
 // Reason codes returned from verifyAndResolve. Caller maps them to
@@ -154,7 +162,11 @@ router.post('/qurl', async (req, res) => {
     const auditEvent = isUnknownOwner
       ? AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER
       : AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID;
-    logger.warn('qURL webhook verification failed', { ip, totalInWindow, result, ownerId });
+    // Truncate the attacker-controlled ownerId before logging — a
+    // mega-string would blow up log volume + confuse downstream
+    // parsers that group by line. 64 chars is well over an auth0 sub.
+    const safeOwnerId = typeof ownerId === 'string' ? ownerId.slice(0, 64) : ownerId;
+    logger.warn('qURL webhook verification failed', { ip, totalInWindow, result, ownerId: safeOwnerId });
     logger.audit(auditEvent, { total_in_window: totalInWindow, result });
     return res.status(401).json({ error: 'Invalid signature' });
   }

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -123,17 +123,20 @@ router.post('/qurl', async (req, res) => {
     return res.status(503).json({ error: 'Webhook receiver misconfigured' });
   }
 
-  // Every other failure shape is 401 + rate-limiter increment + audit.
-  // OWNER_UNKNOWN-after-primed gets a distinct audit so a real auth0
-  // owner probing the receiver shows up on a different dashboard line
-  // than HMAC-mismatch traffic (different threat models).
+  // OWNER_UNKNOWN / OWNER_ID_MISSING are operational drift, not
+  // attacker signal — skip the bad-sig limiter so a registry-drift
+  // burst from qurl-service's worker fleet doesn't also throttle
+  // legitimate webhooks on the same source IP.
   if (result !== VERIFY_RESULTS.OK) {
-    const n = badSigLimiter.recordBadSig(ip);
+    const isHmacFailure = result === VERIFY_RESULTS.SIG_INVALID
+      || result === VERIFY_RESULTS.SIG_HEADER_MISSING
+      || result === VERIFY_RESULTS.SIG_HEADER_MALFORMED;
+    const totalInWindow = isHmacFailure ? badSigLimiter.recordBadSig(ip) : null;
     const auditEvent = result === VERIFY_RESULTS.OWNER_UNKNOWN
       ? AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER
       : AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID;
-    logger.warn('qURL webhook verification failed', { ip, totalInWindow: n, result, ownerId });
-    logger.audit(auditEvent, { total_in_window: n, result });
+    logger.warn('qURL webhook verification failed', { ip, totalInWindow, result, ownerId });
+    logger.audit(auditEvent, { total_in_window: totalInWindow, result });
     return res.status(401).json({ error: 'Invalid signature' });
   }
 

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -276,10 +276,15 @@ router.post('/qurl', async (req, res) => {
     // await: the HTTP response must come back to qurl-service
     // promptly so it doesn't retry on its own.
     if (dbResult === 'recorded') {
-      viewUpdatePublisher.publish({
+      // Trailing .catch pins the fire-and-forget contract: if a future
+      // refactor makes publish() async-throwing, this prevents an
+      // UnhandledPromiseRejection from crashing the worker.
+      Promise.resolve(viewUpdatePublisher.publish({
         qurlId: data.qurl_id,
         accessCount,
         eventId,
+      })).catch((err) => {
+        logger.error('viewUpdatePublisher.publish threw', { error: err?.message, qurl_id: data.qurl_id });
       });
     }
     return res.status(200).json({ status: dbResult });

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -177,6 +177,15 @@ router.post('/qurl', async (req, res) => {
   //     (operational drift OR attacker probing with garbage owner_id;
   //     looser threshold so a real registry-rebuild burst doesn't
   //     throttle legitimate traffic on the same source IP).
+  //
+  // SIG_HEADER_MISSING / SIG_HEADER_MALFORMED route to badSigLimiter
+  // (30/min) on purpose: a missing/malformed signature is
+  // indistinguishable from attacker probing — a future qurl-service
+  // contract drift that dropped the header would throttle legitimate
+  // traffic, BUT loosening this would also weaken the brute-force
+  // ceiling against the auth0-key-rotation attack model. Trade-off
+  // chosen deliberately; do not loosen without re-deriving the
+  // threat model.
   if (result !== VERIFY_RESULTS.OK) {
     const isHmacFailure = result === VERIFY_RESULTS.SIG_INVALID
       || result === VERIFY_RESULTS.SIG_HEADER_MISSING

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -40,6 +40,13 @@ const SIGNATURE_HEADER = 'qurl-signature';
 const SIGNATURE_PATTERN = /^[0-9a-f]{64}$/;
 
 const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
+// Looser limiter for OWNER_UNKNOWN — operational drift is the
+// expected failure mode (not an attacker brute-forcing HMAC), but
+// without ANY ceiling an attacker could flood the receiver with
+// signed-shaped requests carrying bogus owner_id and never trip a
+// rate limit. Threshold is 5× the HMAC limiter to avoid throttling
+// during a real registry-rebuild incident.
+const unknownOwnerLimiter = createBadSigLimiter({ max: 150, windowMs: 60_000 });
 
 // Reason codes returned from verifyAndResolve. Caller maps them to
 // HTTP status + audit event + rate-limiter interaction in one place
@@ -73,14 +80,14 @@ function verifyAndResolve(req) {
     return { result: VERIFY_RESULTS.SIG_HEADER_MALFORMED };
   }
 
-  // Pre-HMAC owner_id read. req.body is already parsed by the
-  // rawBodyJson middleware in server.js (1mb cap on rawBody bounds
-  // any JSON.parse risk). The parser also stashed req.rawBody, which
-  // is what we HMAC. We treat req.body.owner_id as untrusted routing
-  // input — lookup grants no trust, HMAC is what grants trust.
-  // A malformed body never reaches us (express.json middleware would
-  // have already 400'd), but a body that parsed-successfully but
-  // lacks owner_id is possible and must produce 401, not 5xx.
+  // SECURITY: pre-HMAC parse depth/size MUST stay bounded by the
+  // rawBodyJson middleware cap (server.js, `limit: '1mb'`). Loosening
+  // that cap or adding extended type coercion here widens the
+  // pre-trust window — req.body is attacker-controlled JSON until
+  // the HMAC check below succeeds.
+  // The lookup itself grants no trust: a forged owner_id either
+  // misses the cache (→ 401) or hits a real secret the attacker
+  // can't forge against (→ 401).
   const ownerId = req.body && typeof req.body.owner_id === 'string' ? req.body.owner_id : null;
   if (!ownerId) {
     logger.warn('qURL webhook missing or non-string body.owner_id');
@@ -101,8 +108,8 @@ function verifyAndResolve(req) {
 
 router.post('/qurl', async (req, res) => {
   const ip = req.ip || 'unknown';
-  if (badSigLimiter.shouldThrottle(ip)) {
-    logger.warn('qURL webhook rate limit exceeded (bad signatures)', { ip });
+  if (badSigLimiter.shouldThrottle(ip) || unknownOwnerLimiter.shouldThrottle(ip)) {
+    logger.warn('qURL webhook rate limit exceeded', { ip });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RATE_LIMITED, {});
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
@@ -123,15 +130,22 @@ router.post('/qurl', async (req, res) => {
     return res.status(503).json({ error: 'Webhook receiver misconfigured' });
   }
 
-  // OWNER_UNKNOWN / OWNER_ID_MISSING are operational drift, not
-  // attacker signal — skip the bad-sig limiter so a registry-drift
-  // burst from qurl-service's worker fleet doesn't also throttle
-  // legitimate webhooks on the same source IP.
+  // Two limiters, two threat models:
+  //   - HMAC failures count toward badSigLimiter (attacker brute-
+  //     forcing the secret).
+  //   - OWNER_UNKNOWN / OWNER_ID_MISSING count toward unknownOwnerLimiter
+  //     (operational drift OR attacker probing with garbage owner_id;
+  //     looser threshold so a real registry-rebuild burst doesn't
+  //     throttle legitimate traffic on the same source IP).
   if (result !== VERIFY_RESULTS.OK) {
     const isHmacFailure = result === VERIFY_RESULTS.SIG_INVALID
       || result === VERIFY_RESULTS.SIG_HEADER_MISSING
       || result === VERIFY_RESULTS.SIG_HEADER_MALFORMED;
-    const totalInWindow = isHmacFailure ? badSigLimiter.recordBadSig(ip) : null;
+    const isUnknownOwner = result === VERIFY_RESULTS.OWNER_UNKNOWN
+      || result === VERIFY_RESULTS.OWNER_ID_MISSING;
+    let totalInWindow = null;
+    if (isHmacFailure) totalInWindow = badSigLimiter.recordBadSig(ip);
+    else if (isUnknownOwner) totalInWindow = unknownOwnerLimiter.recordBadSig(ip);
     const auditEvent = result === VERIFY_RESULTS.OWNER_UNKNOWN
       ? AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER
       : AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID;
@@ -229,6 +243,7 @@ router.post('/qurl', async (req, res) => {
 
 router.stopIntervals = function stopIntervals() {
   badSigLimiter.stopSweep();
+  unknownOwnerLimiter.stopSweep();
 };
 // Exposed for tests that want to assert against the policy table
 // without rebuilding the conditional ladder. NOT part of any external

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -116,6 +116,16 @@ function verifyAndResolve(req) {
   const secret = subs.getSecretForOwner(ownerId);
   if (!secret) {
     if (!subs.isPrimed()) return { result: VERIFY_RESULTS.CACHE_UNPRIMED, ownerId };
+    // Sibling-replica eventual-consistency lag: a freshly-linked
+    // guild's row is in DDB but THIS replica's last scan hasn't
+    // picked it up yet (linking-replica's upsertGuild is local-only;
+    // siblings catch up on the 30s tick). Treat as transient (503,
+    // retriable) until enough time has passed for at least two scan
+    // cycles to have seen the new owner — after that, 401 is the
+    // truthful response.
+    if (subs.isWithinSiblingLagWindow()) {
+      return { result: VERIFY_RESULTS.CACHE_UNPRIMED, ownerId };
+    }
     return { result: VERIFY_RESULTS.OWNER_UNKNOWN, ownerId };
   }
 

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -39,6 +39,15 @@ const SIGNATURE_HEADER = 'qurl-signature';
 // silently absorbing it.
 const SIGNATURE_PATTERN = /^[0-9a-f]{64}$/;
 
+// Replace control chars (0x00-0x1f + DEL) with '?' so attacker-
+// controlled strings can't spoof field separators or inject newlines
+// in line-oriented log shippers. The control-regex IS the point here.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+function sanitizeForLog(s) {
+  return s.replace(CONTROL_CHARS, '?');
+}
+
 const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
 // Looser limiter for OWNER_UNKNOWN — operational drift is the
 // expected failure mode (not an attacker brute-forcing HMAC), but
@@ -132,6 +141,11 @@ router.post('/qurl', async (req, res) => {
   // lag after a peer's setGuildApiKey; treating it as 401 would
   // silently drop a guild's first views post-link.
   if (result === VERIFY_RESULTS.CACHE_UNPRIMED) {
+    // Intentionally NOT counted toward unknownOwnerLimiter — the
+    // unprimed window is one-shot at boot (primed never flips back to
+    // false), so attacker exploitation here is bounded to the
+    // cold-start window. qurl-service retries 503 so the event isn't
+    // lost.
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNPRIMED, {});
     return res.status(503).json({ error: 'Webhook receiver warming up' });
   }
@@ -162,10 +176,14 @@ router.post('/qurl', async (req, res) => {
     const auditEvent = isUnknownOwner
       ? AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER
       : AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID;
-    // Truncate the attacker-controlled ownerId before logging — a
-    // mega-string would blow up log volume + confuse downstream
-    // parsers that group by line. 64 chars is well over an auth0 sub.
-    const safeOwnerId = typeof ownerId === 'string' ? ownerId.slice(0, 64) : ownerId;
+    // Truncate + strip non-printables on the attacker-controlled
+    // ownerId before logging. Mega-string blows up log volume; control
+    // chars (\n, \r, escape sequences) confuse line-oriented log
+    // parsers and can spoof field separators in some shippers.
+    // 64 chars is well over an auth0 sub.
+    const safeOwnerId = typeof ownerId === 'string'
+      ? sanitizeForLog(ownerId.slice(0, 64))
+      : ownerId;
     logger.warn('qURL webhook verification failed', { ip, totalInWindow, result, ownerId: safeOwnerId });
     logger.audit(auditEvent, { total_in_window: totalInWindow, result });
     return res.status(401).json({ error: 'Invalid signature' });

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -10,13 +10,23 @@
 // `src_ip` and `user_agent` are stripped server-side for type=transit
 // resources (connector-owned privacy boundary). Discord bot sends are
 // always transit.
+//
+// Multi-secret routing (BYOK view counter): inbound events carry the
+// qurl-service auth0 `owner_id` in the body envelope. The bot looks
+// the secret up by owner_id in the in-process subscription registry
+// BEFORE HMAC verification. That's safe because the lookup itself
+// grants no trust — HMAC verification still gates every accepted
+// event. Industry-standard pattern (Stripe, GitHub, Linear all do
+// this); the only alternative is making qurl-service include a
+// QURL-Webhook-Id header, which is a 2-repo coordination we don't
+// need for a problem the bot can solve itself.
 
 const express = require('express');
-const config = require('../config');
 const db = require('../store');
 const logger = require('../logger');
 const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS } = require('../constants');
 const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
+const subs = require('../webhook-subscriptions');
 const viewUpdatePublisher = require('../view-update-publisher');
 
 const router = express.Router();
@@ -31,23 +41,62 @@ const SIGNATURE_PATTERN = /^[0-9a-f]{64}$/;
 
 const badSigLimiter = createBadSigLimiter({ max: 30, windowMs: 60_000 });
 
-function verifySignature(req) {
+// Reason codes returned from verifyAndResolve. Caller maps them to
+// HTTP status + audit event + rate-limiter interaction in one place
+// so the policy table stays grep-able.
+const VERIFY_RESULTS = {
+  OK: 'ok',
+  RAW_BODY_MISSING: 'raw_body_missing',         // middleware bug; should never happen
+  SIG_HEADER_MISSING: 'sig_header_missing',
+  SIG_HEADER_MALFORMED: 'sig_header_malformed',
+  OWNER_ID_MISSING: 'owner_id_missing',         // parse failed OR field absent
+  CACHE_UNPRIMED: 'cache_unprimed',             // 503 — registry hasn't completed first scan
+  OWNER_UNKNOWN: 'owner_unknown',               // 401 — registry primed, owner not registered
+  SIG_INVALID: 'sig_invalid',                   // HMAC mismatch on real secret
+};
+
+function verifyAndResolve(req) {
+  if (!req.rawBody) {
+    logger.error('qURL webhook middleware did not populate rawBody — check server.js middleware ordering. Signature verification is BLOCKED until fixed.');
+    return { result: VERIFY_RESULTS.RAW_BODY_MISSING };
+  }
+
   const signature = req.headers[SIGNATURE_HEADER];
   if (!signature) {
     logger.warn('qURL webhook missing QURL-Signature header');
-    return false;
+    return { result: VERIFY_RESULTS.SIG_HEADER_MISSING };
   }
   if (typeof signature !== 'string' || !SIGNATURE_PATTERN.test(signature)) {
     logger.warn('qURL webhook signature has unexpected format', {
       length: typeof signature === 'string' ? signature.length : 0,
     });
-    return false;
+    return { result: VERIFY_RESULTS.SIG_HEADER_MALFORMED };
   }
-  if (!req.rawBody) {
-    logger.error('qURL webhook middleware did not populate rawBody — check server.js middleware ordering. Signature verification is BLOCKED until fixed.');
-    return false;
+
+  // Pre-HMAC owner_id read. req.body is already parsed by the
+  // rawBodyJson middleware in server.js (1mb cap on rawBody bounds
+  // any JSON.parse risk). The parser also stashed req.rawBody, which
+  // is what we HMAC. We treat req.body.owner_id as untrusted routing
+  // input — lookup grants no trust, HMAC is what grants trust.
+  // A malformed body never reaches us (express.json middleware would
+  // have already 400'd), but a body that parsed-successfully but
+  // lacks owner_id is possible and must produce 401, not 5xx.
+  const ownerId = req.body && typeof req.body.owner_id === 'string' ? req.body.owner_id : null;
+  if (!ownerId) {
+    logger.warn('qURL webhook missing or non-string body.owner_id');
+    return { result: VERIFY_RESULTS.OWNER_ID_MISSING };
   }
-  return verifyHmacSha256(req.rawBody, config.QURL_WEBHOOK_SECRET, signature);
+
+  const secret = subs.getSecretForOwner(ownerId);
+  if (!secret) {
+    if (!subs.isPrimed()) return { result: VERIFY_RESULTS.CACHE_UNPRIMED, ownerId };
+    return { result: VERIFY_RESULTS.OWNER_UNKNOWN, ownerId };
+  }
+
+  if (!verifyHmacSha256(req.rawBody, secret, signature)) {
+    return { result: VERIFY_RESULTS.SIG_INVALID, ownerId };
+  }
+  return { result: VERIFY_RESULTS.OK, ownerId };
 }
 
 router.post('/qurl', async (req, res) => {
@@ -58,18 +107,33 @@ router.post('/qurl', async (req, res) => {
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
 
-  // 503 (retriable) vs 401 (non-retriable): an empty/missing secret
-  // means the webhook-registrar Lambda hasn't populated SSM yet (or
-  // the bot task started before SSM injection completed). qurl-service
-  // retries 503; a 401 here would silently drop the event.
-  if (!config.QURL_WEBHOOK_SECRET) {
-    return res.status(503).json({ error: 'Webhook receiver not configured' });
+  const { result, ownerId } = verifyAndResolve(req);
+
+  // 503 is the only retriable failure mode — qurl-service retries 503
+  // (1+2+4+8+16=31s backoff, 5 attempts) but NOT 401. The cache-
+  // unprimed case happens at cold start and during sibling-replica
+  // lag after a peer's setGuildApiKey; treating it as 401 would
+  // silently drop a guild's first views post-link.
+  if (result === VERIFY_RESULTS.CACHE_UNPRIMED) {
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNPRIMED, {});
+    return res.status(503).json({ error: 'Webhook receiver warming up' });
+  }
+  if (result === VERIFY_RESULTS.RAW_BODY_MISSING) {
+    // Middleware bug — 503 so qurl-service retries while we investigate.
+    return res.status(503).json({ error: 'Webhook receiver misconfigured' });
   }
 
-  if (!verifySignature(req)) {
+  // Every other failure shape is 401 + rate-limiter increment + audit.
+  // OWNER_UNKNOWN-after-primed gets a distinct audit so a real auth0
+  // owner probing the receiver shows up on a different dashboard line
+  // than HMAC-mismatch traffic (different threat models).
+  if (result !== VERIFY_RESULTS.OK) {
     const n = badSigLimiter.recordBadSig(ip);
-    logger.warn('Invalid qURL webhook signature', { ip, totalInWindow: n });
-    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID, { total_in_window: n });
+    const auditEvent = result === VERIFY_RESULTS.OWNER_UNKNOWN
+      ? AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER
+      : AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID;
+    logger.warn('qURL webhook verification failed', { ip, totalInWindow: n, result, ownerId });
+    logger.audit(auditEvent, { total_in_window: n, result });
     return res.status(401).json({ error: 'Invalid signature' });
   }
 
@@ -129,28 +193,28 @@ router.post('/qurl', async (req, res) => {
   const consumed = data.consumed === true;
 
   try {
-    const result = await db.recordQurlView({
+    const dbResult = await db.recordQurlView({
       qurlId: data.qurl_id,
       accessCount,
       consumed,
       eventId,
     });
-    logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result });
-    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result });
+    logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result: dbResult });
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result: dbResult });
     // Sub-second view counter (feat #60): publish to SQS only on
     // result === 'recorded' (a real new view, not a per-event dedup
     // replay). Fire-and-log — the polling fallback in
     // monitorLinkStatus catches anything the publisher drops. No
     // await: the HTTP response must come back to qurl-service
     // promptly so it doesn't retry on its own.
-    if (result === 'recorded') {
+    if (dbResult === 'recorded') {
       viewUpdatePublisher.publish({
         qurlId: data.qurl_id,
         accessCount,
         eventId,
       });
     }
-    return res.status(200).json({ status: result });
+    return res.status(200).json({ status: dbResult });
   } catch (err) {
     // 5xx so qurl-service retries — transient DDB throttle should not
     // silently drop a view event.
@@ -163,4 +227,8 @@ router.post('/qurl', async (req, res) => {
 router.stopIntervals = function stopIntervals() {
   badSigLimiter.stopSweep();
 };
+// Exposed for tests that want to assert against the policy table
+// without rebuilding the conditional ladder. NOT part of any external
+// contract.
+router._VERIFY_RESULTS = VERIFY_RESULTS;
 module.exports = router;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -285,10 +285,13 @@ router.post('/qurl', async (req, res) => {
     // await: the HTTP response must come back to qurl-service
     // promptly so it doesn't retry on its own.
     if (dbResult === 'recorded') {
-      // Trailing .catch pins the fire-and-forget contract: if a future
-      // refactor makes publish() async-throwing, this prevents an
-      // UnhandledPromiseRejection from crashing the worker.
-      Promise.resolve(viewUpdatePublisher.publish({
+      // Fire-and-forget contract pinned against BOTH future async-
+      // throwing AND sync-throwing refactors of publish(). The
+      // Promise.resolve().then(() => …) idiom defers the call into
+      // the microtask queue so a synchronous throw inside publish()
+      // surfaces as a rejected promise (caught by the trailing
+      // .catch) instead of escaping past Promise.resolve(value).
+      Promise.resolve().then(() => viewUpdatePublisher.publish({
         qurlId: data.qurl_id,
         accessCount,
         eventId,

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -50,8 +50,10 @@ const unknownOwnerLimiter = createBadSigLimiter({ max: 150, windowMs: 60_000 });
 
 // Reason codes returned from verifyAndResolve. Caller maps them to
 // HTTP status + audit event + rate-limiter interaction in one place
-// so the policy table stays grep-able.
-const VERIFY_RESULTS = {
+// so the policy table stays grep-able. Frozen for parity with
+// LINK_RESULTS — typo in a string value would silently break the
+// downstream switch.
+const VERIFY_RESULTS = Object.freeze({
   OK: 'ok',
   RAW_BODY_MISSING: 'raw_body_missing',         // middleware bug; should never happen
   SIG_HEADER_MISSING: 'sig_header_missing',
@@ -60,7 +62,7 @@ const VERIFY_RESULTS = {
   CACHE_UNPRIMED: 'cache_unprimed',             // 503 — registry hasn't completed first scan
   OWNER_UNKNOWN: 'owner_unknown',               // 401 — registry primed, owner not registered
   SIG_INVALID: 'sig_invalid',                   // HMAC mismatch on real secret
-};
+});
 
 function verifyAndResolve(req) {
   if (!req.rawBody) {

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -127,6 +127,12 @@ function verifyAndResolve(req) {
 
 router.post('/qurl', async (req, res) => {
   const ip = req.ip || 'unknown';
+  // OR-coupling note: an IP that already burned the HMAC limiter
+  // (30/min) will get 429'd here even if its current request would
+  // have been OWNER_UNKNOWN (separately budgeted at 150/min). That's
+  // acceptable — the IP is already flagged as suspicious — so the
+  // looser unknown-owner threshold protects legitimate operational
+  // drift from OTHER IPs, not from the same already-bad-actor IP.
   if (badSigLimiter.shouldThrottle(ip) || unknownOwnerLimiter.shouldThrottle(ip)) {
     logger.warn('qURL webhook rate limit exceeded', { ip });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RATE_LIMITED, {});

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -146,7 +146,10 @@ router.post('/qurl', async (req, res) => {
     let totalInWindow = null;
     if (isHmacFailure) totalInWindow = badSigLimiter.recordBadSig(ip);
     else if (isUnknownOwner) totalInWindow = unknownOwnerLimiter.recordBadSig(ip);
-    const auditEvent = result === VERIFY_RESULTS.OWNER_UNKNOWN
+    // Audit-event split mirrors the threat-model split: OWNER_* are
+    // operational/payload-shape signal (route both to the same
+    // unknown-owner dashboard line); SIG_* are HMAC-failure signal.
+    const auditEvent = isUnknownOwner
       ? AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER
       : AUDIT_EVENTS.QURL_WEBHOOK_SIGNATURE_INVALID;
     logger.warn('qURL webhook verification failed', { ip, totalInWindow, result, ownerId });
@@ -245,8 +248,4 @@ router.stopIntervals = function stopIntervals() {
   badSigLimiter.stopSweep();
   unknownOwnerLimiter.stopSweep();
 };
-// Exposed for tests that want to assert against the policy table
-// without rebuilding the conditional ladder. NOT part of any external
-// contract.
-router._VERIFY_RESULTS = VERIFY_RESULTS;
 module.exports = router;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -285,12 +285,8 @@ router.post('/qurl', async (req, res) => {
     // await: the HTTP response must come back to qurl-service
     // promptly so it doesn't retry on its own.
     if (dbResult === 'recorded') {
-      // Fire-and-forget contract pinned against BOTH future async-
-      // throwing AND sync-throwing refactors of publish(). The
-      // Promise.resolve().then(() => …) idiom defers the call into
-      // the microtask queue so a synchronous throw inside publish()
-      // surfaces as a rejected promise (caught by the trailing
-      // .catch) instead of escaping past Promise.resolve(value).
+      // Defer into the microtask queue so a future sync-throw refactor
+      // of publish() surfaces as a rejection instead of escaping.
       Promise.resolve().then(() => viewUpdatePublisher.publish({
         qurlId: data.qurl_id,
         accessCount,

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -12,6 +12,7 @@ const qurlOAuthRouter = require('./routes/qurl-oauth');
 const discordInstallRouter = require('./routes/discord-install');
 const webhooksRouter = require('./routes/webhooks');
 const qurlWebhookRouter = require('./routes/qurl-webhook');
+const webhookSubscriptions = require('./webhook-subscriptions');
 
 const app = express();
 
@@ -270,6 +271,11 @@ function stopIntervals() {
   // graceful shutdown so the interval doesn't outlive the server.
   if (typeof qurlWebhookRouter.stopIntervals === 'function') qurlWebhookRouter.stopIntervals();
   if (typeof webhooksRouter.stopIntervals === 'function') webhooksRouter.stopIntervals();
+  // 30s subscription-registry refresh ticker (per-guild webhook
+  // secrets cache). No-op on the gateway tier where the registry was
+  // never started; required on the HTTP tier so the ticker doesn't
+  // outlive the server during graceful shutdown.
+  webhookSubscriptions.stop();
 }
 
 module.exports = { app, startServer, stopIntervals };

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -74,7 +74,9 @@ const rawBodyJson = express.json({
 
 // /webhook (GitHub) gated on isOpenNHPActive so we don't parse 1MB of
 // JSON for routes that aren't mounted. /webhooks (qURL) is unconditional
-// — the receiver itself returns 503 when QURL_WEBHOOK_SECRET is unset.
+// — the receiver returns 503 when the per-guild subscription registry
+// is still warming up (cold-start or sibling-replica lag), so an
+// unmounted-cap fresh deploy never accepts traffic.
 if (config.isOpenNHPActive) {
   app.use('/webhook', rawBodyJson);
 }
@@ -192,12 +194,16 @@ if (config.isOpenNHPActive) {
   logger.info('Single-guild plain mode (ENABLE_OPENNHP_FEATURES=false): /auth and /webhook routes not mounted.');
 }
 
-// Unconditional mount — the route returns 503 until QURL_WEBHOOK_SECRET
-// is set, so a fresh deploy never accepts traffic without the secret.
+// Unconditional mount. The receiver returns 503 while the per-guild
+// subscription registry (src/webhook-subscriptions.js) is unprimed
+// OR within the sibling-replica lag window — qurl-service retries
+// 503, so a fresh deploy never silently drops inbound webhooks.
+// Pure-BYOK setups (no QURL_WEBHOOK_SECRET) are supported; the
+// receiver matches each inbound event against the per-guild secret
+// the linking flow registered.
 app.use('/webhooks', qurlWebhookRouter);
 if (!config.QURL_WEBHOOK_SECRET) {
-  logger.warn('QURL_WEBHOOK_SECRET unset — qURL webhook receiver returns 503 on all inbound');
-  logger.warn('To enable: set SSM /<project>/QURL_WEBHOOK_SECRET, then restart the task');
+  logger.warn('QURL_WEBHOOK_SECRET unset — running pure-BYOK mode (no default-key subscription; per-guild registrations only)');
 }
 
 // Cache-Control: no-store on every response from the OAuth surfaces —

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -105,6 +105,12 @@ const STORE_METHODS = Object.freeze([
   'getGuildConfig',
   'getGuildConfigWithApiKey',
 
+  // Per-guild qurl-service webhook subscriptions (BYOK view counter)
+  'setGuildWebhookSubscription',
+  'clearGuildWebhookSubscription',
+  'listGuildSubscriptionsByOwner',
+  'scanGuildSubscriptions',
+
   // Orphaned OAuth tokens (background revoke-retry queue)
   'recordOrphanedToken',
   'countOrphanedTokens',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -101,9 +101,11 @@ const STORE_METHODS = Object.freeze([
   // Guild (BYOK) API keys
   'getGuildApiKey',
   'setGuildApiKey',
-  // Raw delete — see ddb-store.js's defensive comment. Production
-  // callers MUST use guild-webhook-link.js::unlinkGuildAndWebhook so
-  // the qurl-service subscription is torn down in lockstep.
+  // Raw delete — see ddb-store.js's defensive comment. No production
+  // caller today. A future /qurl unlink admin command MUST tear down
+  // the qurl-service subscription BEFORE invoking this, otherwise it
+  // leaks an orphan webhook on qurl-service. See the link-side
+  // pattern in guild-webhook-link.js::linkGuildWebhookSubscription.
   '_removeGuildApiKeyRaw',
   'getGuildConfig',
   'getGuildConfigWithApiKey',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -101,7 +101,10 @@ const STORE_METHODS = Object.freeze([
   // Guild (BYOK) API keys
   'getGuildApiKey',
   'setGuildApiKey',
-  'removeGuildApiKey',
+  // Raw delete — see ddb-store.js's defensive comment. Production
+  // callers MUST use guild-webhook-link.js::unlinkGuildAndWebhook so
+  // the qurl-service subscription is torn down in lockstep.
+  '_removeGuildApiKeyRaw',
   'getGuildConfig',
   'getGuildConfigWithApiKey',
 
@@ -110,6 +113,7 @@ const STORE_METHODS = Object.freeze([
   'clearGuildWebhookSubscription',
   'listGuildSubscriptionsByOwner',
   'scanGuildSubscriptions',
+  'propagateGuildWebhookSubscription',
 
   // Orphaned OAuth tokens (background revoke-retry queue)
   'recordOrphanedToken',

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1476,10 +1476,10 @@ async function setGuildApiKey(guildId, apiKey, configuredBy) {
   }));
 }
 
-// Raw delete. Bypasses qurl-service subscription teardown; use
-// `guild-webhook-link.js::unlinkGuildAndWebhook` to also tear down
-// the subscription. The leading underscore signals "internal — read
-// the orchestrator first."
+// Raw delete. No qurl-service subscription teardown. Today there is
+// no production caller; a future /qurl unlink admin command MUST
+// add an orchestrator that issues DELETE /v1/webhooks/{id} BEFORE
+// calling this, or it'll orphan the subscription on qurl-service.
 async function _removeGuildApiKeyRaw(guildId) {
   const res = await ddb.send(new DeleteCommand({
     TableName: TABLES.guild_configs,
@@ -1575,15 +1575,20 @@ async function listGuildSubscriptionsByOwner(webhookOwnerId) {
 // rows don't keep stale ciphertext that the cache tick could
 // deterministically pick on Scan-order tiebreak.
 //
-// Returns the count of rows updated (excludes the just-written
-// primary row, which the caller has already persisted). Per-row
-// errors surface as rejections in the Promise.allSettled result so
-// the caller can log+continue without losing visibility.
-async function propagateGuildWebhookSubscription(webhookOwnerId, { webhookId, webhookSecret }) {
+// `excludeGuildId` (optional): skip this guild — the caller has
+// already persisted it. Returns counts of rows updated/failed (the
+// excluded guild is not counted).
+async function propagateGuildWebhookSubscription(
+  webhookOwnerId,
+  { webhookId, webhookSecret, excludeGuildId },
+) {
   if (!webhookOwnerId || !webhookId || !webhookSecret) {
     throw new Error('propagateGuildWebhookSubscription: webhookOwnerId, webhookId, webhookSecret all required');
   }
-  const siblings = await listGuildSubscriptionsByOwner(webhookOwnerId);
+  const allMatches = await listGuildSubscriptionsByOwner(webhookOwnerId);
+  const siblings = excludeGuildId
+    ? allMatches.filter(s => s.guildId !== excludeGuildId)
+    : allMatches;
   if (siblings.length === 0) return { updated: 0, failed: 0 };
 
   const updatedAt = nowIso();

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1628,10 +1628,24 @@ async function scanGuildSubscriptions() {
   const out = [];
   for (const r of rows) {
     if (!r.webhook_id || !r.webhook_secret || !r.webhook_owner_id) continue;
+    let webhookSecret;
+    try {
+      webhookSecret = decrypt(r.webhook_secret);
+    } catch (err) {
+      // One corrupt row (key rotation gap, manual DDB tamper, partial
+      // migration) must NOT abort the entire scan — the cache would
+      // stay unprimed and every inbound webhook would 401. Log the
+      // bad row and continue; backfill or operator intervention can
+      // re-encrypt it later.
+      logger.warn('scanGuildSubscriptions: decrypt failed for row, skipping', {
+        guildId: r.guild_id, error: err.message,
+      });
+      continue;
+    }
     out.push({
       guildId: r.guild_id,
       webhookId: r.webhook_id,
-      webhookSecret: decrypt(r.webhook_secret),
+      webhookSecret,
       webhookOwnerId: r.webhook_owner_id,
       // ISO-8601 string OR undefined for rows pre-dating the
       // updated_at write. The cache treats `undefined` as "older

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1696,6 +1696,11 @@ async function scanGuildSubscriptions() {
   // gives ops a metric filter that means "KMS-wide outage" vs "one bad
   // row." Skip when 0 rows are provisioned — division-by-zero guard
   // and a no-op the alarm doesn't need to see.
+  // TODO: re-tune the 3-row floor at ≥20 BYOK guilds — at higher cardinality,
+  //   ">50% of ≥3" is too sensitive (it would fire on a 5-of-9 partial
+  //   tenant-key tier outage that's a real-but-not-mass event); switch to a
+  //   percentile band + absolute floor (e.g. >50% AND ≥5) or a separate
+  //   "tier-scoped" decrypt audit.
   if (provisionedCount >= 3 && decryptFailCount * 2 > provisionedCount) {
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MASS_DECRYPT_FAIL, {
       failed: decryptFailCount, provisioned: provisionedCount,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1562,6 +1562,8 @@ async function clearGuildWebhookSubscription(guildId) {
 //
 // Low-cardinality table (low hundreds of guilds at scale per
 // design discussion); full scan + in-JS filter is fine here.
+// TODO(#486): replace scanAll with a Query on the webhook_owner_id
+// GSI when guild_configs > ~10k rows.
 async function listGuildSubscriptionsByOwner(webhookOwnerId) {
   const rows = await scanAll(TABLES.guild_configs);
   return rows

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -65,7 +65,7 @@ const {
 const { encrypt, encryptStrict, decrypt } = require('../utils/crypto');
 const config = require('../config');
 const logger = require('../logger');
-const { DM_STATUS } = require('../constants');
+const { DM_STATUS, AUDIT_EVENTS } = require('../constants');
 const { isPositiveFinite } = require('../utils/time');
 
 // Badge taxonomy — stable string enum values so callers that
@@ -1641,11 +1641,15 @@ async function scanGuildSubscriptions() {
     } catch (err) {
       // One corrupt row (key rotation gap, manual DDB tamper, partial
       // migration) must NOT abort the entire scan — the cache would
-      // stay unprimed and every inbound webhook would 401. Log the
-      // bad row and continue; backfill or operator intervention can
-      // re-encrypt it later.
+      // stay unprimed and every inbound webhook would 401. Log + emit
+      // an audit so a CloudWatch metric-filter alarm can fire on
+      // sustained decrypt failures (KMS key drift); backfill or
+      // /qurl setup re-encrypts the row.
       logger.warn('scanGuildSubscriptions: decrypt failed for row, skipping', {
         guildId: r.guild_id, error: err.message,
+      });
+      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_ROW_DECRYPT_FAIL, {
+        guild_id: r.guild_id, error_type: err.name || 'unknown',
       });
       continue;
     }

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1538,9 +1538,17 @@ async function setGuildWebhookSubscription(guildId, { webhookId, webhookSecret, 
   if (!guildId || !webhookId || !webhookSecret || !webhookOwnerId) {
     throw new Error('setGuildWebhookSubscription: guildId, webhookId, webhookSecret, webhookOwnerId all required');
   }
+  // ConditionExpression: only write webhook_* attributes onto a row
+  // that ALREADY has a qurl_api_key. Without this guard, a future
+  // caller-bug or race that ran setGuildWebhookSubscription before
+  // setGuildApiKey would create an orphan guild_configs row with
+  // webhook_* attrs but no api key — receiver would have a secret
+  // but no link to the linking admin's identity. Mirrors the
+  // attribute_exists pattern in propagateGuildWebhookSubscription.
   await ddb.send(new UpdateCommand({
     TableName: TABLES.guild_configs,
     Key: { guild_id: guildId },
+    ConditionExpression: 'attribute_exists(qurl_api_key)',
     UpdateExpression: 'SET webhook_id = :wid, webhook_secret = :wsec, webhook_owner_id = :woid, updated_at = :u',
     ExpressionAttributeValues: {
       ':wid': webhookId,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1577,7 +1577,10 @@ async function clearGuildWebhookSubscription(guildId) {
 // propagation that fixes rotate-drift. RCU cost is acceptable on a
 // low-cardinality table.
 // TODO(#486): replace scanAll with a Query on the webhook_owner_id
-// GSI when guild_configs > ~10k rows.
+// GSI when guild_configs > ~10k rows. Every `/qurl setup` and OAuth
+// callback hits this via propagateGuildWebhookSubscription, so the
+// link-path cost is O(table_size) per call — same fix as the
+// 30s priming scan, single migration covers both.
 async function listGuildSubscriptionsByOwner(webhookOwnerId) {
   const rows = await scanAll(TABLES.guild_configs, { consistentRead: true });
   return rows

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1664,6 +1664,13 @@ async function propagateGuildWebhookSubscription(
 // per-tick RCU cost for a property the receiver already provides.
 // `propagateGuildWebhookSubscription` is where strong consistency
 // actually pays for itself (write-then-read same flow).
+// Per-row decrypt-fail alarm-once tracker. A permanently-corrupt row
+// would otherwise emit 2880 audits/day (30s tick × 2 replicas).
+// Cleared per guildId on its next successful decrypt — so a row that
+// recovers (operator re-encrypts via /qurl setup or backfill) resets
+// and re-alarms if it breaks again.
+const _decryptAlarmedGuilds = new Set();
+
 async function scanGuildSubscriptions() {
   const rows = await scanAll(TABLES.guild_configs);
   const out = [];
@@ -1675,6 +1682,10 @@ async function scanGuildSubscriptions() {
     let webhookSecret;
     try {
       webhookSecret = decrypt(r.webhook_secret);
+      // Successful decrypt — if this row was alarmed, clear so a
+      // future re-break re-fires (we want "the row went bad again"
+      // to page, not just "the row was ever bad").
+      if (_decryptAlarmedGuilds.has(r.guild_id)) _decryptAlarmedGuilds.delete(r.guild_id);
     } catch (err) {
       // One corrupt row (key rotation gap, manual DDB tamper, partial
       // migration) must NOT abort the entire scan — the cache would
@@ -1682,12 +1693,21 @@ async function scanGuildSubscriptions() {
       // an audit so a CloudWatch metric-filter alarm can fire on
       // sustained decrypt failures (KMS key drift); backfill or
       // /qurl setup re-encrypts the row.
+      //
+      // Alarm-once per guild_id per "outage": the audit fires on the
+      // FIRST decrypt failure for this row and stays silent until a
+      // successful decrypt resets the tracker (see try-branch above).
+      // The warn-log still fires every tick so per-row breakage stays
+      // visible at log-stream granularity.
       logger.warn('scanGuildSubscriptions: decrypt failed for row, skipping', {
         guildId: r.guild_id, error: err.message,
       });
-      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_ROW_DECRYPT_FAIL, {
-        guild_id: r.guild_id, error_type: err.name || 'unknown',
-      });
+      if (!_decryptAlarmedGuilds.has(r.guild_id)) {
+        logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_ROW_DECRYPT_FAIL, {
+          guild_id: r.guild_id, error_type: err.name || 'unknown',
+        });
+        _decryptAlarmedGuilds.add(r.guild_id);
+      }
       decryptFailCount += 1;
       continue;
     }

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1586,6 +1586,11 @@ async function propagateGuildWebhookSubscription(
     throw new Error('propagateGuildWebhookSubscription: webhookOwnerId, webhookId, webhookSecret all required');
   }
   const allMatches = await listGuildSubscriptionsByOwner(webhookOwnerId);
+  // Common case for a first-time admin: only the just-written primary
+  // row matches the owner. Short-circuit before the scan-filter pass.
+  if (excludeGuildId && allMatches.length === 1 && allMatches[0].guildId === excludeGuildId) {
+    return { updated: 0, failed: 0 };
+  }
   const siblings = excludeGuildId
     ? allMatches.filter(s => s.guildId !== excludeGuildId)
     : allMatches;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1647,11 +1647,17 @@ async function propagateGuildWebhookSubscription(
 // Returns every guild_configs row with a provisioned webhook
 // subscription, secret decrypted. Forwards `updatedAt` so the
 // in-process cache can tiebreak sibling rows during rotation drift.
-// Uses ConsistentRead so a recent setGuildWebhookSubscription on a
-// sibling replica IS visible to this replica's next scan — closes
-// the 401-on-fresh-link race within SIBLING_LAG_GRACE_MS.
+//
+// Eventually-consistent on purpose: the receiver's
+// `SIBLING_LAG_GRACE_MS` window upgrades any OWNER_UNKNOWN within
+// REFRESH_INTERVAL_MS + grace to 503-retriable, so a sibling replica
+// that hasn't seen DDB's replicated write yet does NOT 401 — the
+// next 30s tick catches it. Strong consistency would double the
+// per-tick RCU cost for a property the receiver already provides.
+// `propagateGuildWebhookSubscription` is where strong consistency
+// actually pays for itself (write-then-read same flow).
 async function scanGuildSubscriptions() {
-  const rows = await scanAll(TABLES.guild_configs, { consistentRead: true });
+  const rows = await scanAll(TABLES.guild_configs);
   const out = [];
   let provisionedCount = 0;
   let decryptFailCount = 0;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1570,12 +1570,16 @@ async function clearGuildWebhookSubscription(guildId) {
 // DELETE on qurl-service based on the count (don't kill sibling guilds
 // that share the same auth0 admin's API key).
 //
-// Low-cardinality table (low hundreds of guilds at scale per
-// design discussion); full scan + in-JS filter is fine here.
+// ConsistentRead because the link-time caller (propagateGuildWebhookSubscription)
+// runs IMMEDIATELY after a setGuildWebhookSubscription write — an
+// eventually-consistent scan could miss the just-written primary row
+// (or sibling rows from a concurrent link) and silently skip the
+// propagation that fixes rotate-drift. RCU cost is acceptable on a
+// low-cardinality table.
 // TODO(#486): replace scanAll with a Query on the webhook_owner_id
 // GSI when guild_configs > ~10k rows.
 async function listGuildSubscriptionsByOwner(webhookOwnerId) {
-  const rows = await scanAll(TABLES.guild_configs);
+  const rows = await scanAll(TABLES.guild_configs, { consistentRead: true });
   return rows
     .filter(r => r.webhook_owner_id === webhookOwnerId && r.webhook_id)
     .map(r => ({ guildId: r.guild_id, webhookId: r.webhook_id }));

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -661,11 +661,21 @@ async function queryAll(input) {
   return items;
 }
 
-async function scanAll(TableName) {
+async function scanAll(TableName, { consistentRead = false } = {}) {
   const items = [];
   let ExclusiveStartKey;
   do {
-    const res = await ddb.send(new ScanCommand({ TableName, ExclusiveStartKey }));
+    const res = await ddb.send(new ScanCommand({
+      TableName,
+      ExclusiveStartKey,
+      // ConsistentRead doubles RCU cost; the priming/refresh path for
+      // the webhook subscription registry uses it because a recent
+      // setGuildWebhookSubscription on a sibling replica MUST be
+      // visible to this replica's next scan within the
+      // SIBLING_LAG_GRACE_MS window. All other scanAll callers use
+      // the default eventually-consistent path.
+      ConsistentRead: consistentRead || undefined,
+    }));
     items.push(...(res.Items || []));
     ExclusiveStartKey = res.LastEvaluatedKey;
   } while (ExclusiveStartKey);
@@ -1630,8 +1640,11 @@ async function propagateGuildWebhookSubscription(
 // Returns every guild_configs row with a provisioned webhook
 // subscription, secret decrypted. Forwards `updatedAt` so the
 // in-process cache can tiebreak sibling rows during rotation drift.
+// Uses ConsistentRead so a recent setGuildWebhookSubscription on a
+// sibling replica IS visible to this replica's next scan — closes
+// the 401-on-fresh-link race within SIBLING_LAG_GRACE_MS.
 async function scanGuildSubscriptions() {
-  const rows = await scanAll(TABLES.guild_configs);
+  const rows = await scanAll(TABLES.guild_configs, { consistentRead: true });
   const out = [];
   for (const r of rows) {
     if (!r.webhook_id || !r.webhook_secret || !r.webhook_owner_id) continue;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1904,4 +1904,10 @@ module.exports = {
   // underscore signals intent. If you find yourself depending on
   // this outside tests, add a real public API instead.
   _TABLES_FOR_TESTING: TABLES,
+  // Test-only: clear the per-row decrypt-alarm tracker so a suite
+  // that asserts the alarm-fires-on-first-failure semantic starts
+  // each test from a clean slate. Production callers MUST NOT use
+  // this — production semantics depend on the tracker persisting
+  // for the process lifetime.
+  _resetDecryptAlarmedForTesting: () => _decryptAlarmedGuilds.clear(),
 };

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1476,15 +1476,11 @@ async function setGuildApiKey(guildId, apiKey, configuredBy) {
   }));
 }
 
-// Raw delete. Future callers that need to fully unlink a guild
-// (including tearing down its qurl-service webhook subscription)
-// MUST go through `guild-webhook-link.js::unlinkGuildAndWebhook`,
-// NOT this function — calling removeGuildApiKey directly leaves an
-// orphan webhook subscription on qurl-service for BYOK guilds.
-// Leaving the function exported (rather than renaming it `_raw`)
-// preserves API stability for the backfill script + tests that
-// only need the data-layer primitive.
-async function removeGuildApiKey(guildId) {
+// Raw delete. Bypasses qurl-service subscription teardown; use
+// `guild-webhook-link.js::unlinkGuildAndWebhook` to also tear down
+// the subscription. The leading underscore signals "internal — read
+// the orchestrator first."
+async function _removeGuildApiKeyRaw(guildId) {
   const res = await ddb.send(new DeleteCommand({
     TableName: TABLES.guild_configs,
     Key: { guild_id: guildId },
@@ -1573,11 +1569,55 @@ async function listGuildSubscriptionsByOwner(webhookOwnerId) {
     .map(r => ({ guildId: r.guild_id, webhookId: r.webhook_id }));
 }
 
-// Returns every guild_configs row that has a webhook subscription set,
-// with the secret decrypted. Used by the in-process subscription
-// registry's priming + 30s refresh tick. Rows missing webhook_id are
-// skipped — those are guilds with an API key but no provisioned
-// subscription yet (e.g. between deploy and the backfill script).
+// Propagate (webhookId, webhookSecret) to every sibling guild row
+// owned by the same webhookOwnerId. Called after
+// ensureWebhookSubscription rotates the shared secret so sibling
+// rows don't keep stale ciphertext that the cache tick could
+// deterministically pick on Scan-order tiebreak.
+//
+// Returns the count of rows updated (excludes the just-written
+// primary row, which the caller has already persisted). Per-row
+// errors surface as rejections in the Promise.allSettled result so
+// the caller can log+continue without losing visibility.
+async function propagateGuildWebhookSubscription(webhookOwnerId, { webhookId, webhookSecret }) {
+  if (!webhookOwnerId || !webhookId || !webhookSecret) {
+    throw new Error('propagateGuildWebhookSubscription: webhookOwnerId, webhookId, webhookSecret all required');
+  }
+  const siblings = await listGuildSubscriptionsByOwner(webhookOwnerId);
+  if (siblings.length === 0) return { updated: 0, failed: 0 };
+
+  const updatedAt = nowIso();
+  const encryptedSecret = encrypt(webhookSecret);
+  const results = await Promise.allSettled(siblings.map((s) => ddb.send(new UpdateCommand({
+    TableName: TABLES.guild_configs,
+    Key: { guild_id: s.guildId },
+    UpdateExpression: 'SET webhook_id = :wid, webhook_secret = :wsec, updated_at = :u',
+    // Defense against a race where the row was cleared between
+    // listGuildSubscriptionsByOwner and this write — never mint
+    // subscription state on a row that opted out.
+    ConditionExpression: 'attribute_exists(webhook_owner_id)',
+    ExpressionAttributeValues: {
+      ':wid': webhookId,
+      ':wsec': encryptedSecret,
+      ':u': updatedAt,
+    },
+  }))));
+
+  let updated = 0;
+  let failed = 0;
+  for (const r of results) {
+    if (r.status === 'fulfilled') { updated += 1; continue; }
+    // ConditionalCheckFailedException = sibling cleared between
+    // list and write; benign, not a failure.
+    if (r.reason?.name === 'ConditionalCheckFailedException') continue;
+    failed += 1;
+  }
+  return { updated, failed };
+}
+
+// Returns every guild_configs row with a provisioned webhook
+// subscription, secret decrypted. Forwards `updatedAt` so the
+// in-process cache can tiebreak sibling rows during rotation drift.
 async function scanGuildSubscriptions() {
   const rows = await scanAll(TABLES.guild_configs);
   const out = [];
@@ -1588,6 +1628,11 @@ async function scanGuildSubscriptions() {
       webhookId: r.webhook_id,
       webhookSecret: decrypt(r.webhook_secret),
       webhookOwnerId: r.webhook_owner_id,
+      // ISO-8601 string OR undefined for rows pre-dating the
+      // updated_at write. The cache treats `undefined` as "older
+      // than any timestamped row" so a stale legacy row never beats
+      // a freshly-written one in the tiebreak.
+      updatedAt: r.updated_at,
     });
   }
   return out;
@@ -1738,10 +1783,10 @@ module.exports = {
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs
-  getGuildApiKey, setGuildApiKey, removeGuildApiKey, getGuildConfig, getGuildConfigWithApiKey,
+  getGuildApiKey, setGuildApiKey, _removeGuildApiKeyRaw, getGuildConfig, getGuildConfigWithApiKey,
   // Per-guild webhook subscriptions (BYOK view counter)
   setGuildWebhookSubscription, clearGuildWebhookSubscription,
-  listGuildSubscriptionsByOwner, scanGuildSubscriptions,
+  listGuildSubscriptionsByOwner, scanGuildSubscriptions, propagateGuildWebhookSubscription,
   // Orphaned tokens
   recordOrphanedToken, countOrphanedTokens, listOrphanedTokens,
   decryptOrphanedToken, deleteOrphanedToken,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1650,8 +1650,11 @@ async function propagateGuildWebhookSubscription(
 async function scanGuildSubscriptions() {
   const rows = await scanAll(TABLES.guild_configs, { consistentRead: true });
   const out = [];
+  let provisionedCount = 0;
+  let decryptFailCount = 0;
   for (const r of rows) {
     if (!r.webhook_id || !r.webhook_secret || !r.webhook_owner_id) continue;
+    provisionedCount += 1;
     let webhookSecret;
     try {
       webhookSecret = decrypt(r.webhook_secret);
@@ -1668,6 +1671,7 @@ async function scanGuildSubscriptions() {
       logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_ROW_DECRYPT_FAIL, {
         guild_id: r.guild_id, error_type: err.name || 'unknown',
       });
+      decryptFailCount += 1;
       continue;
     }
     out.push({
@@ -1680,6 +1684,18 @@ async function scanGuildSubscriptions() {
       // than any timestamped row" so a stale legacy row never beats
       // a freshly-written one in the tiebreak.
       updatedAt: r.updated_at,
+    });
+  }
+  // Escalate when more than half of provisioned rows failed decrypt AND
+  // we saw at least 3 (avoids alarm spam on a 1-row sandbox table that
+  // tripped a single transient decrypt error). The per-row audit fires
+  // identically whether 1 row or all rows fail; this distinct event
+  // gives ops a metric filter that means "KMS-wide outage" vs "one bad
+  // row." Skip when 0 rows are provisioned — division-by-zero guard
+  // and a no-op the alarm doesn't need to see.
+  if (provisionedCount >= 3 && decryptFailCount * 2 > provisionedCount) {
+    logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_MASS_DECRYPT_FAIL, {
+      failed: decryptFailCount, provisioned: provisionedCount,
     });
   }
   return out;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1476,6 +1476,14 @@ async function setGuildApiKey(guildId, apiKey, configuredBy) {
   }));
 }
 
+// Raw delete. Future callers that need to fully unlink a guild
+// (including tearing down its qurl-service webhook subscription)
+// MUST go through `guild-webhook-link.js::unlinkGuildAndWebhook`,
+// NOT this function — calling removeGuildApiKey directly leaves an
+// orphan webhook subscription on qurl-service for BYOK guilds.
+// Leaving the function exported (rather than renaming it `_raw`)
+// preserves API stability for the backfill script + tests that
+// only need the data-layer primitive.
 async function removeGuildApiKey(guildId) {
   const res = await ddb.send(new DeleteCommand({
     TableName: TABLES.guild_configs,
@@ -1509,6 +1517,80 @@ async function getGuildConfigWithApiKey(guildId) {
   const row = res.Item;
   if (!row) return row;
   return { ...row, qurl_api_key: row.qurl_api_key ? decrypt(row.qurl_api_key) : row.qurl_api_key };
+}
+
+// ── Per-guild qurl-service webhook subscriptions (BYOK view counter) ──
+
+// webhook_secret stored encrypted (same envelope as qurl_api_key).
+// webhook_id + webhook_owner_id stored plain — neither is a credential
+// (webhook_id is a public-ish opaque identifier returned to API callers;
+// webhook_owner_id is an auth0 sub already echoed in inbound webhook
+// payloads). Keeping them plain avoids a decrypt() on every cache prime
+// and lets ad-hoc DDB queries by owner work without round-tripping
+// through the crypto module.
+async function setGuildWebhookSubscription(guildId, { webhookId, webhookSecret, webhookOwnerId }) {
+  if (!guildId || !webhookId || !webhookSecret || !webhookOwnerId) {
+    throw new Error('setGuildWebhookSubscription: guildId, webhookId, webhookSecret, webhookOwnerId all required');
+  }
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.guild_configs,
+    Key: { guild_id: guildId },
+    UpdateExpression: 'SET webhook_id = :wid, webhook_secret = :wsec, webhook_owner_id = :woid, updated_at = :u',
+    ExpressionAttributeValues: {
+      ':wid': webhookId,
+      ':wsec': encrypt(webhookSecret),
+      ':woid': webhookOwnerId,
+      ':u': nowIso(),
+    },
+  }));
+}
+
+// REMOVE the three webhook_* attributes; leaves the API key row intact.
+// Used when a guild rotates to a key whose owner_id differs from the
+// previous one and the caller has already DELETE'd the old subscription
+// (or accepted the orphan).
+async function clearGuildWebhookSubscription(guildId) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.guild_configs,
+    Key: { guild_id: guildId },
+    UpdateExpression: 'REMOVE webhook_id, webhook_secret, webhook_owner_id SET updated_at = :u',
+    ExpressionAttributeValues: { ':u': nowIso() },
+  }));
+}
+
+// Reference-counting helper for the unlink path. Returns all guild_ids
+// (including the caller's guild_id, if any) currently associated with
+// the given webhook_owner_id. The caller decides whether to issue
+// DELETE on qurl-service based on the count (don't kill sibling guilds
+// that share the same auth0 admin's API key).
+//
+// Low-cardinality table (low hundreds of guilds at scale per
+// design discussion); full scan + in-JS filter is fine here.
+async function listGuildSubscriptionsByOwner(webhookOwnerId) {
+  const rows = await scanAll(TABLES.guild_configs);
+  return rows
+    .filter(r => r.webhook_owner_id === webhookOwnerId && r.webhook_id)
+    .map(r => ({ guildId: r.guild_id, webhookId: r.webhook_id }));
+}
+
+// Returns every guild_configs row that has a webhook subscription set,
+// with the secret decrypted. Used by the in-process subscription
+// registry's priming + 30s refresh tick. Rows missing webhook_id are
+// skipped — those are guilds with an API key but no provisioned
+// subscription yet (e.g. between deploy and the backfill script).
+async function scanGuildSubscriptions() {
+  const rows = await scanAll(TABLES.guild_configs);
+  const out = [];
+  for (const r of rows) {
+    if (!r.webhook_id || !r.webhook_secret || !r.webhook_owner_id) continue;
+    out.push({
+      guildId: r.guild_id,
+      webhookId: r.webhook_id,
+      webhookSecret: decrypt(r.webhook_secret),
+      webhookOwnerId: r.webhook_owner_id,
+    });
+  }
+  return out;
 }
 
 // ── Orphaned OAuth tokens ──
@@ -1657,6 +1739,9 @@ module.exports = {
   recordQurlView, getQurlViews,
   // Guild configs
   getGuildApiKey, setGuildApiKey, removeGuildApiKey, getGuildConfig, getGuildConfigWithApiKey,
+  // Per-guild webhook subscriptions (BYOK view counter)
+  setGuildWebhookSubscription, clearGuildWebhookSubscription,
+  listGuildSubscriptionsByOwner, scanGuildSubscriptions,
   // Orphaned tokens
   recordOrphanedToken, countOrphanedTokens, listOrphanedTokens,
   decryptOrphanedToken, deleteOrphanedToken,

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -165,6 +165,15 @@ function removeGuild({ guildId, ownerId }) {
 // in the gap are 503'd via the unprimed-cache code path. Network /
 // HTTP errors are surfaced to the caller (scanOnce) so the tick's
 // failure counter increments correctly.
+//
+// ASSUMPTION: owner_id is identical across every webhook owned by a
+// single API key in qurl-service. True today by qurl-service's auth0
+// owner-binding contract. If qurl-service ever multi-tenants a key
+// (rare but plausible for partner-shared identities), this loop
+// returns whichever owner_id came first — the bot's default-key
+// subscription is then a coin flip. The same assumption underlies
+// BYOK row population via setGuildApiKey, so any change there needs
+// a coordinated rework here.
 async function discoverDefaultOwnerId() {
   if (!config.QURL_API_KEY || !config.QURL_ENDPOINT) return null;
   // limit=100 (was limit=10): owner_id is identical across all subs
@@ -390,6 +399,10 @@ async function refreshTick() {
     if (result === 'completed') consecutiveFailures = 0;
   } catch (err) {
     consecutiveFailures += 1;
+    // Dynamic logger[level] dispatch — relies on the logger having
+    // both `.warn` and `.error` methods. Production logger satisfies
+    // this; any new test file that mocks the logger MUST stub both
+    // OR the level-escalation path will throw on the unmocked call.
     const level = consecutiveFailures >= REFRESH_FAIL_ESCALATE_AT ? 'error' : 'warn';
     logger[level]('webhook subscription registry refresh failed', {
       error: err.message,

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -47,10 +47,16 @@ let timer = null;
 let defaultOwnerId = null;
 
 // Owners whose entries must survive scanOnce's clear-and-repopulate
-// swap. Reset at the top of each scan; re-applied after the swap so
-// a concurrent /qurl setup whose DDB write landed AFTER the scan
-// crossed its partition isn't silently dropped.
-let upsertsDuringScan = new Set();
+// swap. .clear()'d at the top of each scan; re-applied after the
+// swap so a concurrent /qurl setup whose DDB write landed AFTER the
+// scan crossed its partition isn't silently dropped.
+const upsertsDuringScan = new Set();
+
+// Sentinel for the default-key entry's webhookId field. A unique
+// Symbol can never collide with a real qurl-service webhook_id
+// (those are opaque strings). The receiver only reads webhookSecret
+// from the entry; the field is for debugging.
+const DEFAULT_KEY_SENTINEL = Symbol('default-key-subscription');
 
 function getSecretForOwner(ownerId) {
   if (!ownerId) return null;
@@ -130,11 +136,15 @@ async function discoverDefaultOwnerId() {
 // and rediscovers the default-key owner_id. Throws on any sub-step
 // failure; the caller (refreshTick) increments consecutiveFailures.
 async function scanOnce() {
-  upsertsDuringScan = new Set();
+  upsertsDuringScan.clear();
 
   // Parallelize the two independent network reads: the DDB scan and
   // the qurl-service GET /v1/webhooks. Sequential, they added 50-300ms
   // per tick for no benefit.
+  // TODO: GSI on webhook_owner_id when guild_configs row count
+  // exceeds ~10k — scanAll inside scanGuildSubscriptions and
+  // listGuildSubscriptionsByOwner is bounded by table size, not
+  // result size.
   const [rows, discoveredOwner] = await Promise.all([
     db.scanGuildSubscriptions(),
     discoverDefaultOwnerId(),
@@ -164,15 +174,26 @@ async function scanOnce() {
   if (discoveredOwner) {
     defaultOwnerId = discoveredOwner;
     if (config.QURL_WEBHOOK_SECRET) {
-      // GET /v1/webhooks?limit=1 doesn't pin which sub belongs to the
-      // default key; receiver only needs the secret, so a synthetic
-      // webhookId marks the default entry (never sent over the wire).
+      // Receiver only reads webhookSecret; the Symbol sentinel is
+      // for debugging and can never collide with a real opaque
+      // webhook_id string from qurl-service.
       next.set(discoveredOwner, {
-        guildIds: new Set(['__default__']),
+        guildIds: new Set([DEFAULT_KEY_SENTINEL]),
         webhookSecret: config.QURL_WEBHOOK_SECRET,
-        webhookId: '__default__',
+        webhookId: DEFAULT_KEY_SENTINEL,
       });
     }
+  } else {
+    // Default-key owner_id couldn't be discovered (QURL_API_KEY or
+    // QURL_ENDPOINT unset, or the Lambda hasn't run yet on a fresh
+    // deploy). Inbound webhooks for non-BYOK guilds will 401 until
+    // discovery succeeds. Warn so a CloudWatch metric filter on this
+    // line can alert on a fresh-deploy gap that outlasts the Lambda.
+    logger.warn('webhook-subscriptions: default-key owner_id discovery returned null', {
+      hasApiKey: Boolean(config.QURL_API_KEY),
+      hasEndpoint: Boolean(config.QURL_ENDPOINT),
+      hasWebhookSecret: Boolean(config.QURL_WEBHOOK_SECRET),
+    });
   }
 
   // Only snapshot when concurrent upserts could have landed. The
@@ -244,7 +265,7 @@ function _resetForTesting() {
   primed = false;
   consecutiveFailures = 0;
   defaultOwnerId = null;
-  upsertsDuringScan = new Set();
+  upsertsDuringScan.clear();
   if (timer) {
     clearInterval(timer);
     timer = null;

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -167,9 +167,11 @@ async function discoverDefaultOwnerId() {
     apiEndpoint: config.QURL_ENDPOINT,
     apiKey: config.QURL_API_KEY,
   });
-  const subs = Array.isArray(body?.data) ? body.data : [];
-  for (const s of subs) {
-    if (typeof s?.owner_id === 'string' && s.owner_id.length > 0) return s.owner_id;
+  // Local name `webhooks` (not `subs`) so it doesn't shadow the
+  // module convention everyone else uses for the registry import.
+  const webhooks = Array.isArray(body?.data) ? body.data : [];
+  for (const w of webhooks) {
+    if (typeof w?.owner_id === 'string' && w.owner_id.length > 0) return w.owner_id;
   }
   return null;
 }
@@ -189,13 +191,22 @@ async function scanOnce() {
   }
   scanInFlight = true;
   try {
+    // The clear-here is what makes upsertsDuringScan an *in-this-scan*
+    // tracker — without it, leftover entries from the previous scan
+    // would be re-applied as if they were concurrent, defeating the
+    // mid-scan-snapshot logic below. Between scans the set is
+    // harmless noise; only entries added between this .clear() and
+    // the snapshot/restore below are load-bearing.
     upsertsDuringScan.clear();
 
     // Parallelize the two independent network reads. Sequential they
     // added 50-300ms per tick.
     // TODO(#486): GSI on webhook_owner_id when guild_configs row
     // count exceeds ~10k — scanAll is bounded by table size, not
-    // result size.
+    // result size. When the GSI lands, the priming path can also drop
+    // to eventually-consistent reads (SIBLING_LAG_GRACE_MS already
+    // absorbs replication lag); strong consistency pays for itself in
+    // propagateGuildWebhookSubscription, not here.
     //
     // discoverDefaultOwnerId only fires while there's something to
     // discover: the bot's own owner_id never changes in-process (env
@@ -349,11 +360,23 @@ async function start() {
   timer.unref();
 }
 
+// Safe to call without having called start() — on the gateway tier
+// where the registry is never started, this is a no-op. If you ever
+// extend this beyond clearInterval, keep the unconditional-safe
+// contract: server.js calls stop() unconditionally for the gateway
+// tier (no start() match) and the HTTP tier alike.
 function stop() {
   if (timer) {
     clearInterval(timer);
     timer = null;
   }
+}
+
+// Test-only: drive lastScanCompletedAt directly so the receiver's
+// isWithinSiblingLagWindow check can be exercised at both ends of
+// the window in unit tests without time-mocking Date.now globally.
+function _setLastScanCompletedAtForTesting(ts) {
+  lastScanCompletedAt = ts;
 }
 
 // Test-only: reset module-level state. Production code must never
@@ -389,5 +412,6 @@ module.exports = {
   // synchronously. Production code uses the 30s setInterval inside
   // start() to call this.
   _refreshTickForTesting: refreshTick,
+  _setLastScanCompletedAtForTesting,
   _resetForTesting,
 };

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -235,16 +235,17 @@ async function scanOnce() {
           webhookId: DEFAULT_KEY_SENTINEL,
         });
       }
-    } else {
-      // Default-key owner_id discovery failed (no QURL_API_KEY /
-      // QURL_ENDPOINT, OR the Lambda hasn't run yet on a fresh
-      // deploy). Inbound webhooks for non-BYOK guilds 401 until
-      // discovery succeeds — alarm on this log line for fresh-deploy
-      // gaps that outlast the Lambda.
+    } else if (config.QURL_WEBHOOK_SECRET) {
+      // Only warn when we WANTED a default entry (secret is set) but
+      // discovery failed — that's the alarm-worthy case (fresh-deploy
+      // gap that outlasts the Lambda, qurl-service drift, etc.). For
+      // pure-BYOK setups (no default secret), discovery is
+      // intentionally skipped earlier and a null result here would
+      // just be the no-op path; warning every 30s in that
+      // configuration would dilute the alarm signal-to-noise.
       logger.warn('webhook-subscriptions: default-key owner_id discovery returned null', {
         hasApiKey: Boolean(config.QURL_API_KEY),
         hasEndpoint: Boolean(config.QURL_ENDPOINT),
-        hasWebhookSecret: Boolean(config.QURL_WEBHOOK_SECRET),
       });
     }
 

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -61,6 +61,19 @@ const upsertsDuringScan = new Set();
 // 503-unprimed path covers any extra delay.
 let scanInFlight = false;
 
+// Timestamp (ms) of the most recent successful scan. The receiver
+// reads this to decide whether an OWNER_UNKNOWN looks like "sibling
+// replica caught a fresh-link gap" (recent enough to be a still-
+// converging eventual-consistency state — return 503 so qurl-service
+// retries) or "owner is genuinely absent" (we've had time to refresh
+// at least twice — return 401).
+let lastScanCompletedAt = 0;
+// Tolerance past one full refresh interval. Accounts for clock drift,
+// DDB cross-AZ replication delay, and scan execution time. After
+// REFRESH_INTERVAL_MS + grace, an OWNER_UNKNOWN is treated as a real
+// 401 — we've had two scan chances to see the owner.
+const SIBLING_LAG_GRACE_MS = 5_000;
+
 // Sentinel for the default-key entry's webhookId and guildIds. A
 // unique Symbol can never collide with a real qurl-service webhook_id
 // (those are opaque strings). Receiver only reads webhookSecret from
@@ -268,10 +281,22 @@ async function scanOnce() {
     }
 
     primed = true;
+    lastScanCompletedAt = Date.now();
     return 'completed';
   } finally {
     scanInFlight = false;
   }
+}
+
+// Receiver helper: tells the receiver whether an OWNER_UNKNOWN is
+// likely a sibling-replica eventual-consistency lag (just-linked
+// guild not yet visible to this replica's scan) vs. a genuinely
+// absent owner. Used to upgrade 401 → 503 inside the lag window so
+// qurl-service's 5x retry catches the next-tick refresh.
+function isWithinSiblingLagWindow() {
+  if (lastScanCompletedAt === 0) return true; // never completed
+  const elapsed = Date.now() - lastScanCompletedAt;
+  return elapsed < (REFRESH_INTERVAL_MS + SIBLING_LAG_GRACE_MS);
 }
 
 async function refreshTick() {
@@ -332,6 +357,7 @@ function _resetForTesting() {
   defaultOwnerId = null;
   upsertsDuringScan.clear();
   scanInFlight = false;
+  lastScanCompletedAt = 0;
   if (timer) {
     clearInterval(timer);
     timer = null;
@@ -343,6 +369,7 @@ module.exports = {
   stop,
   getSecretForOwner,
   isPrimed,
+  isWithinSiblingLagWindow,
   upsertGuild,
   removeGuild,
   // Test-only: production callers should let the 30s ticker drive

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -197,12 +197,19 @@ async function scanOnce() {
   }
   scanInFlight = true;
   try {
-    // The clear-here is what makes upsertsDuringScan an *in-this-scan*
-    // tracker — without it, leftover entries from the previous scan
-    // would be re-applied as if they were concurrent, defeating the
-    // mid-scan-snapshot logic below. Between scans the set is
-    // harmless noise; only entries added between this .clear() and
-    // the snapshot/restore below are load-bearing.
+    // INVARIANT: only upserts that land between this .clear() and the
+    // snapshot read below count as "concurrent with this scan." The
+    // clear MUST happen before any await — JS's run-to-completion
+    // semantics mean every upsertGuild call up to here landed in this
+    // synchronous block (and is now zeroed); calls after the next
+    // await yield are what we need to track. A future async-ifying
+    // refactor that introduced an await between .clear() and the
+    // first network read would defeat this — the gap could swallow
+    // an upsertGuild that ran during the await, leaving its row in
+    // the cleared set but not re-applied via the liveSnapshot path.
+    // Between scans the set accumulates harmless noise (all entries
+    // are post-prior-scan synchronous upserts); the .clear is what
+    // re-zeros the in-scan tracker.
     upsertsDuringScan.clear();
 
     // TODO(#486): GSI on webhook_owner_id when guild_configs row

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -110,6 +110,11 @@ function upsertGuild({ guildId, ownerId, webhookId, webhookSecret }) {
 // (no sibling guilds + not the default-key owner), drops it. Default-
 // key entry is never dropped from removeGuild — it's owned by the
 // Lambda lifecycle and rediscovered by the tick.
+//
+// No production caller exists today; the future /qurl unlink admin
+// command MUST call this synchronously after writing to DDB so the
+// registering replica's cache is immediately correct (mirror of
+// upsertGuild's sync-update pattern).
 function removeGuild({ guildId, ownerId }) {
   if (!ownerId) return;
   const entry = subscriptions.get(ownerId);
@@ -199,7 +204,14 @@ async function scanOnce() {
 
     if (discoveredOwner) {
       defaultOwnerId = discoveredOwner;
-      if (config.QURL_WEBHOOK_SECRET) {
+      // Collision case: a BYOK guild that linked using the bot's OWN
+      // default API key has webhook_owner_id === discoveredOwner. The
+      // BYOK row already populated `next`; don't clobber its guildIds
+      // / webhookId with the synthetic default-key shape. The
+      // secret is identical in this case (both came from the same
+      // qurl-service subscription), so leaving the BYOK entry in
+      // place is observationally correct.
+      if (config.QURL_WEBHOOK_SECRET && !next.has(discoveredOwner)) {
         // Symbol sentinel for webhookId — receiver only reads
         // webhookSecret; can't collide with any real qurl-service
         // webhook_id (opaque string). NOTE: Symbols don't survive

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -24,6 +24,7 @@ const db = require('./store');
 const config = require('./config');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
+const { callQurlService } = require('./qurl-webhook-registrar');
 
 const REFRESH_INTERVAL_MS = 30_000;
 // After this many consecutive refresh failures we escalate via audit
@@ -157,15 +158,16 @@ async function discoverDefaultOwnerId() {
   // doesn't fail discovery — a bot key with 50+ subs is plausible
   // at scale; 100 stays under the typical page-size cap with no
   // pagination needed for the read-side.
-  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=100`, {
+  // Go through callQurlService for consistency with the rest of the
+  // registrar surface — same QurlServiceError shape, same op-tagged
+  // network-error handling, same 10s timeout default. The receiver
+  // shouldn't grow a second bespoke fetch path.
+  const body = await callQurlService({
     method: 'GET',
-    headers: { Authorization: `Bearer ${config.QURL_API_KEY}` },
-    signal: AbortSignal.timeout(10_000),
+    path: '/v1/webhooks?limit=100',
+    apiEndpoint: config.QURL_ENDPOINT,
+    apiKey: config.QURL_API_KEY,
   });
-  if (!resp.ok) {
-    throw new Error(`discoverDefaultOwnerId: GET /v1/webhooks returned ${resp.status}`);
-  }
-  const body = await resp.json();
   const subs = Array.isArray(body?.data) ? body.data : [];
   for (const s of subs) {
     if (typeof s?.owner_id === 'string' && s.owner_id.length > 0) return s.owner_id;
@@ -281,6 +283,15 @@ async function scanOnce() {
       }
     }
 
+    // INVARIANT: primed only ever transitions false → true within a
+    // process. It never flips back (transient scan failures leave the
+    // old map in place rather than re-flagging unprimed). This is
+    // load-bearing for the receiver's two-limiter threat model: the
+    // post-primed unknown-owner path runs unbounded HMAC work only when
+    // we're certain the cache reflects the world. If you ever need to
+    // re-flag unprimed mid-flight (e.g. an explicit cache-rebuild
+    // command), add a per-IP ceiling on the unprimed path FIRST.
+    // _resetForTesting() is the only allowed back-transition.
     primed = true;
     lastScanCompletedAt = Date.now();
     return 'completed';

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -75,16 +75,15 @@ let lastScanCompletedAt = 0;
 // 401 — we've had two scan chances to see the owner.
 const SIBLING_LAG_GRACE_MS = 5_000;
 
-// Sentinel for the default-key entry's webhookId and guildIds. A
-// unique Symbol can never collide with a real qurl-service webhook_id
-// (those are opaque strings). Receiver only reads webhookSecret from
-// the entry; the field is for debugging.
-// FOOT-GUN: Symbols don't survive JSON.stringify (debug-dump endpoint
-// will see webhookId as undefined) AND Array.from(entry.guildIds) on
-// the default entry yields [Symbol(...)] — telemetry that joins
-// guildIds with a delimiter or pushes them to a string-keyed log
-// field will surface a non-string for the default entry.
-const DEFAULT_KEY_SENTINEL = Symbol('default-key-subscription');
+// Sentinel for the default-key entry's webhookId and guildIds.
+// Double-underscore-bracketed string can't collide with a real
+// qurl-service webhook_id (those are `wh_...`-prefixed opaque base64-
+// ish strings, never bracketed underscores) or a Discord guild_id
+// (those are decimal-only snowflakes). JSON-serializable so a future
+// debug-dump endpoint or telemetry that walks the cache won't surface
+// `undefined` for the default entry — the choice cost ~zero vs Symbol
+// here since the receiver never compares webhookId for equality.
+const DEFAULT_KEY_SENTINEL = '__default-key__';
 
 function getSecretForOwner(ownerId) {
   if (!ownerId) return null;
@@ -239,12 +238,10 @@ async function scanOnce() {
       // qurl-service subscription), so leaving the BYOK entry in
       // place is observationally correct.
       if (config.QURL_WEBHOOK_SECRET && !next.has(discoveredOwner)) {
-        // Symbol sentinel for webhookId — receiver only reads
-        // webhookSecret; can't collide with any real qurl-service
-        // webhook_id (opaque string). NOTE: Symbols don't survive
-        // JSON.stringify, so a future debug-dump endpoint that
-        // serializes the cache will see webhookId as undefined for
-        // the default entry. Tradeoff favored over a sentinel string.
+        // String sentinel — receiver only reads webhookSecret, never
+        // compares webhookId. Bracketed underscores can't collide
+        // with `wh_...` qurl-service IDs or decimal Discord
+        // snowflakes (the only legal guildIds values).
         next.set(discoveredOwner, {
           guildIds: new Set([DEFAULT_KEY_SENTINEL]),
           webhookSecret: config.QURL_WEBHOOK_SECRET,

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -151,12 +151,13 @@ function removeGuild({ guildId, ownerId }) {
 // failure counter increments correctly.
 async function discoverDefaultOwnerId() {
   if (!config.QURL_API_KEY || !config.QURL_ENDPOINT) return null;
-  // limit=10 (was limit=1): owner_id is identical across all subs
-  // this key owns, so we only need one valid row. If a future
-  // contract drift drops owner_id from the FIRST row's response,
-  // limit=1 would return null even though row 2+ would be valid;
-  // 10 is a low-cost defense.
-  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=10`, {
+  // limit=100 (was limit=10): owner_id is identical across all subs
+  // this key owns, so we only need one valid row. Bumped to 100 so
+  // a contract drift that drops owner_id from rows 1..N silently
+  // doesn't fail discovery — a bot key with 50+ subs is plausible
+  // at scale; 100 stays under the typical page-size cap with no
+  // pagination needed for the read-side.
+  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=100`, {
     method: 'GET',
     headers: { Authorization: `Bearer ${config.QURL_API_KEY}` },
     signal: AbortSignal.timeout(10_000),
@@ -376,5 +377,9 @@ module.exports = {
   // refresh. Exposed because the test suite needs to drive scans
   // deterministically without waiting on real intervals.
   scanOnce,
+  // Test-only: drives the failure-counter + escalation-audit logic
+  // synchronously. Production code uses the 30s setInterval inside
+  // start() to call this.
+  _refreshTickForTesting: refreshTick,
   _resetForTesting,
 };

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -145,9 +145,14 @@ async function scanOnce() {
   // exceeds ~10k — scanAll inside scanGuildSubscriptions and
   // listGuildSubscriptionsByOwner is bounded by table size, not
   // result size.
+  //
+  // discoverDefaultOwnerId fires only until success — the bot's own
+  // owner_id never changes without a redeploy, so re-fetching every
+  // 30s after success is wasted load on qurl-service.
+  const needsDefaultDiscovery = !defaultOwnerId || !config.QURL_WEBHOOK_SECRET;
   const [rows, discoveredOwner] = await Promise.all([
     db.scanGuildSubscriptions(),
-    discoverDefaultOwnerId(),
+    needsDefaultDiscovery ? discoverDefaultOwnerId() : Promise.resolve(defaultOwnerId),
   ]);
 
   // Tiebreaker: when sibling rows for one owner disagree on (secret,

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -232,10 +232,10 @@ async function scanOnce() {
     const needsDefaultDiscovery = !!config.QURL_WEBHOOK_SECRET && !defaultOwnerId;
     const discoveryPromise = needsDefaultDiscovery
       ? discoverDefaultOwnerId().then(
-        (owner) => ({ ok: true, owner }),
-        (err) => ({ ok: false, error: err }),
+        (owner) => ({ ok: true, owner, fired: true }),
+        (err) => ({ ok: false, error: err, fired: true }),
       )
-      : Promise.resolve({ ok: true, owner: defaultOwnerId });
+      : Promise.resolve({ ok: true, owner: defaultOwnerId, fired: false });
     const [rows, discoveryResult] = await Promise.all([
       db.scanGuildSubscriptions(),
       discoveryPromise,
@@ -243,9 +243,14 @@ async function scanOnce() {
     let discoveredOwner;
     if (discoveryResult.ok) {
       discoveredOwner = discoveryResult.owner;
-      // Reset on success — independent of consecutiveFailures so a
-      // recovered discovery doesn't reset the DDB-scan counter.
-      discoveryConsecutiveFailures = 0;
+      // Only reset the failure counter when a discovery attempt
+      // actually fired AND succeeded. A no-op tick (defaultOwnerId
+      // already cached) must NOT reset — otherwise a future hot-
+      // reload of QURL_API_KEY that invalidates defaultOwnerId would
+      // lose any prior-discovery-failure escalation on the next no-op
+      // tick. Currently no such hot-reload path exists, but the
+      // semantic should match the variable's name.
+      if (discoveryResult.fired) discoveryConsecutiveFailures = 0;
     } else {
       discoveredOwner = defaultOwnerId; // keep prior value (likely null pre-first-success)
       discoveryConsecutiveFailures += 1;

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -138,7 +138,12 @@ function removeGuild({ guildId, ownerId }) {
 // failure counter increments correctly.
 async function discoverDefaultOwnerId() {
   if (!config.QURL_API_KEY || !config.QURL_ENDPOINT) return null;
-  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=1`, {
+  // limit=10 (was limit=1): owner_id is identical across all subs
+  // this key owns, so we only need one valid row. If a future
+  // contract drift drops owner_id from the FIRST row's response,
+  // limit=1 would return null even though row 2+ would be valid;
+  // 10 is a low-cost defense.
+  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=10`, {
     method: 'GET',
     headers: { Authorization: `Bearer ${config.QURL_API_KEY}` },
     signal: AbortSignal.timeout(10_000),
@@ -148,9 +153,6 @@ async function discoverDefaultOwnerId() {
   }
   const body = await resp.json();
   const subs = Array.isArray(body?.data) ? body.data : [];
-  // owner_id is the same across every subscription this key owns;
-  // any row works. Subs without owner_id (defensive against contract
-  // drift) are skipped.
   for (const s of subs) {
     if (typeof s?.owner_id === 'string' && s.owner_id.length > 0) return s.owner_id;
   }

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -52,6 +52,15 @@ let defaultOwnerId = null;
 // scan crossed its partition isn't silently dropped.
 const upsertsDuringScan = new Set();
 
+// Re-entrancy guard. setInterval doesn't await the previous tick, so
+// if scanGuildSubscriptions takes longer than REFRESH_INTERVAL_MS,
+// the next tick would fire while the current one is awaiting — both
+// would .clear() upsertsDuringScan and the second would wipe the
+// first's in-flight tracking, defeating the concurrent-upsert
+// preservation. Skipping the overlapping tick is safe: the receiver's
+// 503-unprimed path covers any extra delay.
+let scanInFlight = false;
+
 // Sentinel for the default-key entry's webhookId field. A unique
 // Symbol can never collide with a real qurl-service webhook_id
 // (those are opaque strings). The receiver only reads webhookSecret
@@ -73,8 +82,14 @@ function isPrimed() {
 // replica gets immediate consistency; sibling replicas converge on
 // next tick. Idempotent: same (guildId, ownerId) re-call just re-adds.
 function upsertGuild({ guildId, ownerId, webhookId, webhookSecret }) {
-  if (!guildId || !ownerId || !webhookId || !webhookSecret) {
-    throw new Error('upsertGuild: guildId, ownerId, webhookId, webhookSecret all required');
+  // Type-strict: a caller-bug passing `ownerId: 0` or `ownerId: {}`
+  // would pass a truthy-only check for some shapes and then break
+  // downstream Map.get(ownerId) lookups via strict equality.
+  if (typeof guildId !== 'string' || !guildId.length
+      || typeof ownerId !== 'string' || !ownerId.length
+      || (typeof webhookId !== 'string' || !webhookId.length)
+      || (typeof webhookSecret !== 'string' || !webhookSecret.length)) {
+    throw new Error('upsertGuild: guildId, ownerId, webhookId, webhookSecret must all be non-empty strings');
   }
   let entry = subscriptions.get(ownerId);
   if (!entry) {
@@ -136,86 +151,97 @@ async function discoverDefaultOwnerId() {
 // and rediscovers the default-key owner_id. Throws on any sub-step
 // failure; the caller (refreshTick) increments consecutiveFailures.
 async function scanOnce() {
-  upsertsDuringScan.clear();
-
-  // Parallelize the two independent network reads: the DDB scan and
-  // the qurl-service GET /v1/webhooks. Sequential, they added 50-300ms
-  // per tick for no benefit.
-  // TODO: GSI on webhook_owner_id when guild_configs row count
-  // exceeds ~10k — scanAll inside scanGuildSubscriptions and
-  // listGuildSubscriptionsByOwner is bounded by table size, not
-  // result size.
-  //
-  // discoverDefaultOwnerId fires only until success — the bot's own
-  // owner_id never changes without a redeploy, so re-fetching every
-  // 30s after success is wasted load on qurl-service.
-  const needsDefaultDiscovery = !defaultOwnerId || !config.QURL_WEBHOOK_SECRET;
-  const [rows, discoveredOwner] = await Promise.all([
-    db.scanGuildSubscriptions(),
-    needsDefaultDiscovery ? discoverDefaultOwnerId() : Promise.resolve(defaultOwnerId),
-  ]);
-
-  // Tiebreaker: when sibling rows for one owner disagree on (secret,
-  // webhookId) — the propagateGuildWebhookSubscription window — the
-  // row with the newest `updatedAt` wins. The chosen-updatedAt is a
-  // scan-local concern; we keep it in a parallel Map instead of
-  // attaching to the cache entry shape that the receiver consults.
-  const next = new Map();
-  const winningUpdatedAt = new Map();
-  for (const r of rows) {
-    let entry = next.get(r.webhookOwnerId);
-    if (!entry) {
-      entry = { guildIds: new Set(), webhookSecret: r.webhookSecret, webhookId: r.webhookId };
-      next.set(r.webhookOwnerId, entry);
-      winningUpdatedAt.set(r.webhookOwnerId, r.updatedAt || '');
-    } else if ((r.updatedAt || '') > winningUpdatedAt.get(r.webhookOwnerId)) {
-      entry.webhookSecret = r.webhookSecret;
-      entry.webhookId = r.webhookId;
-      winningUpdatedAt.set(r.webhookOwnerId, r.updatedAt || '');
-    }
-    entry.guildIds.add(r.guildId);
+  if (scanInFlight) {
+    // Drop the overlap rather than corrupt upsertsDuringScan tracking
+    // (see comment on the guard above). Caller doesn't see the skip;
+    // primed stays true (or stays false during cold-start).
+    return;
   }
+  scanInFlight = true;
+  try {
+    upsertsDuringScan.clear();
 
-  if (discoveredOwner) {
-    defaultOwnerId = discoveredOwner;
-    if (config.QURL_WEBHOOK_SECRET) {
-      // Receiver only reads webhookSecret; the Symbol sentinel is
-      // for debugging and can never collide with a real opaque
-      // webhook_id string from qurl-service.
-      next.set(discoveredOwner, {
-        guildIds: new Set([DEFAULT_KEY_SENTINEL]),
-        webhookSecret: config.QURL_WEBHOOK_SECRET,
-        webhookId: DEFAULT_KEY_SENTINEL,
+    // Parallelize the two independent network reads. Sequential they
+    // added 50-300ms per tick.
+    // TODO: GSI on webhook_owner_id when guild_configs row count
+    // exceeds ~10k — scanAll is bounded by table size, not result size.
+    //
+    // discoverDefaultOwnerId only fires while there's something to
+    // discover: the bot's own owner_id never changes in-process (env
+    // is read at boot), so once we have it AND a secret to pair with,
+    // the GET is wasted load on qurl-service.
+    const needsDefaultDiscovery = !!config.QURL_WEBHOOK_SECRET && !defaultOwnerId;
+    const [rows, discoveredOwner] = await Promise.all([
+      db.scanGuildSubscriptions(),
+      needsDefaultDiscovery ? discoverDefaultOwnerId() : Promise.resolve(defaultOwnerId),
+    ]);
+
+    // Tiebreaker: when sibling rows for one owner disagree on
+    // (secret, webhookId) — the propagateGuildWebhookSubscription
+    // window — the row with the newest updatedAt wins. winningUpdatedAt
+    // is a scan-local Map so the visible cache entry shape stays
+    // { guildIds, webhookSecret, webhookId }.
+    const next = new Map();
+    const winningUpdatedAt = new Map();
+    for (const r of rows) {
+      let entry = next.get(r.webhookOwnerId);
+      if (!entry) {
+        entry = { guildIds: new Set(), webhookSecret: r.webhookSecret, webhookId: r.webhookId };
+        next.set(r.webhookOwnerId, entry);
+        winningUpdatedAt.set(r.webhookOwnerId, r.updatedAt || '');
+      } else if ((r.updatedAt || '') > winningUpdatedAt.get(r.webhookOwnerId)) {
+        entry.webhookSecret = r.webhookSecret;
+        entry.webhookId = r.webhookId;
+        winningUpdatedAt.set(r.webhookOwnerId, r.updatedAt || '');
+      }
+      entry.guildIds.add(r.guildId);
+    }
+
+    if (discoveredOwner) {
+      defaultOwnerId = discoveredOwner;
+      if (config.QURL_WEBHOOK_SECRET) {
+        // Symbol sentinel for webhookId — receiver only reads
+        // webhookSecret; can't collide with any real qurl-service
+        // webhook_id (opaque string). NOTE: Symbols don't survive
+        // JSON.stringify, so a future debug-dump endpoint that
+        // serializes the cache will see webhookId as undefined for
+        // the default entry. Tradeoff favored over a sentinel string.
+        next.set(discoveredOwner, {
+          guildIds: new Set([DEFAULT_KEY_SENTINEL]),
+          webhookSecret: config.QURL_WEBHOOK_SECRET,
+          webhookId: DEFAULT_KEY_SENTINEL,
+        });
+      }
+    } else {
+      // Default-key owner_id discovery failed (no QURL_API_KEY /
+      // QURL_ENDPOINT, OR the Lambda hasn't run yet on a fresh
+      // deploy). Inbound webhooks for non-BYOK guilds 401 until
+      // discovery succeeds — alarm on this log line for fresh-deploy
+      // gaps that outlast the Lambda.
+      logger.warn('webhook-subscriptions: default-key owner_id discovery returned null', {
+        hasApiKey: Boolean(config.QURL_API_KEY),
+        hasEndpoint: Boolean(config.QURL_ENDPOINT),
+        hasWebhookSecret: Boolean(config.QURL_WEBHOOK_SECRET),
       });
     }
-  } else {
-    // Default-key owner_id couldn't be discovered (QURL_API_KEY or
-    // QURL_ENDPOINT unset, or the Lambda hasn't run yet on a fresh
-    // deploy). Inbound webhooks for non-BYOK guilds will 401 until
-    // discovery succeeds. Warn so a CloudWatch metric filter on this
-    // line can alert on a fresh-deploy gap that outlasts the Lambda.
-    logger.warn('webhook-subscriptions: default-key owner_id discovery returned null', {
-      hasApiKey: Boolean(config.QURL_API_KEY),
-      hasEndpoint: Boolean(config.QURL_ENDPOINT),
-      hasWebhookSecret: Boolean(config.QURL_WEBHOOK_SECRET),
-    });
-  }
 
-  // Only snapshot when concurrent upserts could have landed. The
-  // common case (no concurrent /qurl setup) skips the allocation.
-  const liveSnapshot = upsertsDuringScan.size > 0 ? new Map(subscriptions) : null;
-  subscriptions.clear();
-  for (const [k, v] of next.entries()) subscriptions.set(k, v);
+    // Only snapshot when concurrent upserts could have landed.
+    const liveSnapshot = upsertsDuringScan.size > 0 ? new Map(subscriptions) : null;
+    subscriptions.clear();
+    for (const [k, v] of next.entries()) subscriptions.set(k, v);
 
-  if (liveSnapshot) {
-    for (const ownerId of upsertsDuringScan) {
-      if (next.has(ownerId)) continue;
-      const liveEntry = liveSnapshot.get(ownerId);
-      if (liveEntry) subscriptions.set(ownerId, liveEntry);
+    if (liveSnapshot) {
+      for (const ownerId of upsertsDuringScan) {
+        if (next.has(ownerId)) continue;
+        const liveEntry = liveSnapshot.get(ownerId);
+        if (liveEntry) subscriptions.set(ownerId, liveEntry);
+      }
     }
-  }
 
-  primed = true;
+    primed = true;
+  } finally {
+    scanInFlight = false;
+  }
 }
 
 async function refreshTick() {
@@ -271,6 +297,7 @@ function _resetForTesting() {
   consecutiveFailures = 0;
   defaultOwnerId = null;
   upsertsDuringScan.clear();
+  scanInFlight = false;
   if (timer) {
     clearInterval(timer);
     timer = null;

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -61,10 +61,15 @@ const upsertsDuringScan = new Set();
 // 503-unprimed path covers any extra delay.
 let scanInFlight = false;
 
-// Sentinel for the default-key entry's webhookId field. A unique
-// Symbol can never collide with a real qurl-service webhook_id
-// (those are opaque strings). The receiver only reads webhookSecret
-// from the entry; the field is for debugging.
+// Sentinel for the default-key entry's webhookId and guildIds. A
+// unique Symbol can never collide with a real qurl-service webhook_id
+// (those are opaque strings). Receiver only reads webhookSecret from
+// the entry; the field is for debugging.
+// FOOT-GUN: Symbols don't survive JSON.stringify (debug-dump endpoint
+// will see webhookId as undefined) AND Array.from(entry.guildIds) on
+// the default entry yields [Symbol(...)] — telemetry that joins
+// guildIds with a delimiter or pushes them to a string-keyed log
+// field will surface a non-string for the default entry.
 const DEFAULT_KEY_SENTINEL = Symbol('default-key-subscription');
 
 function getSecretForOwner(ownerId) {
@@ -168,8 +173,9 @@ async function scanOnce() {
 
     // Parallelize the two independent network reads. Sequential they
     // added 50-300ms per tick.
-    // TODO: GSI on webhook_owner_id when guild_configs row count
-    // exceeds ~10k — scanAll is bounded by table size, not result size.
+    // TODO(#486): GSI on webhook_owner_id when guild_configs row
+    // count exceeds ~10k — scanAll is bounded by table size, not
+    // result size.
     //
     // discoverDefaultOwnerId only fires while there's something to
     // discover: the bot's own owner_id never changes in-process (env
@@ -243,8 +249,13 @@ async function scanOnce() {
     for (const [k, v] of next.entries()) subscriptions.set(k, v);
 
     if (liveSnapshot) {
+      // For any owner touched by upsertGuild during the scan, the
+      // in-memory write IS the truth — even when scan returned a row
+      // for the same owner. The scan may have caught a pre-rotate
+      // sibling row before propagateGuildWebhookSubscription
+      // converged; preferring liveSnapshot closes the up-to-30s
+      // window where the cache would otherwise hold a stale secret.
       for (const ownerId of upsertsDuringScan) {
-        if (next.has(ownerId)) continue;
         const liveEntry = liveSnapshot.get(ownerId);
         if (liveEntry) subscriptions.set(ownerId, liveEntry);
       }

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -36,7 +36,6 @@ const REFRESH_FAIL_ESCALATE_AT = 3;
 // orphan-token-sweeper.js's pattern and so tests can import a fresh
 // copy via jest.isolateModules().
 const subscriptions = new Map();
-let primed = false;
 let consecutiveFailures = 0;
 // Discovery-only failure counter. Tracked separately from
 // consecutiveFailures so a transient qurl-service 5xx during
@@ -97,8 +96,11 @@ function getSecretForOwner(ownerId) {
   return entry ? entry.webhookSecret : null;
 }
 
+// Derived from lastScanCompletedAt — primed === "we've completed at
+// least one scan." Two redundant flags would risk drift on a future
+// refactor that touched one but not the other.
 function isPrimed() {
-  return primed;
+  return lastScanCompletedAt > 0;
 }
 
 // Synchronous local-map mutation called by setGuildApiKey-adjacent
@@ -343,8 +345,18 @@ async function scanOnce() {
       });
     }
 
-    // Only snapshot when concurrent upserts could have landed.
-    const liveSnapshot = upsertsDuringScan.size > 0 ? new Map(subscriptions) : null;
+    // Snapshot ONLY the in-flight upsert owners — scales with the
+    // few concurrent /qurl setup calls during this scan, not the
+    // whole tenant count. A future 10k-tenant cache would otherwise
+    // pay an O(tenants) clone every scan tick.
+    let liveSnapshot = null;
+    if (upsertsDuringScan.size > 0) {
+      liveSnapshot = new Map();
+      for (const ownerId of upsertsDuringScan) {
+        const entry = subscriptions.get(ownerId);
+        if (entry) liveSnapshot.set(ownerId, entry);
+      }
+    }
     subscriptions.clear();
     for (const [k, v] of next.entries()) subscriptions.set(k, v);
 
@@ -355,22 +367,20 @@ async function scanOnce() {
       // sibling row before propagateGuildWebhookSubscription
       // converged; preferring liveSnapshot closes the up-to-30s
       // window where the cache would otherwise hold a stale secret.
-      for (const ownerId of upsertsDuringScan) {
-        const liveEntry = liveSnapshot.get(ownerId);
-        if (liveEntry) subscriptions.set(ownerId, liveEntry);
+      for (const [ownerId, liveEntry] of liveSnapshot) {
+        subscriptions.set(ownerId, liveEntry);
       }
     }
 
-    // INVARIANT: primed only ever transitions false → true within a
-    // process. It never flips back (transient scan failures leave the
-    // old map in place rather than re-flagging unprimed). This is
-    // load-bearing for the receiver's two-limiter threat model: the
-    // post-primed unknown-owner path runs unbounded HMAC work only when
-    // we're certain the cache reflects the world. If you ever need to
-    // re-flag unprimed mid-flight (e.g. an explicit cache-rebuild
-    // command), add a per-IP ceiling on the unprimed path FIRST.
-    // _resetForTesting() is the only allowed back-transition.
-    primed = true;
+    // INVARIANT: isPrimed() only ever transitions false → true within
+    // a process (lastScanCompletedAt is monotonically set on success;
+    // a transient scan failure leaves the prior timestamp in place).
+    // This is load-bearing for the receiver's two-limiter threat
+    // model: the post-primed unknown-owner path runs unbounded HMAC
+    // work only when we're certain the cache reflects the world. If
+    // you ever need to re-flag unprimed mid-flight (e.g. an explicit
+    // cache-rebuild command), add a per-IP ceiling on the unprimed
+    // path FIRST. _resetForTesting() is the only allowed back-transition.
     lastScanCompletedAt = Date.now();
     return 'completed';
   } finally {
@@ -458,7 +468,6 @@ function _setLastScanCompletedAtForTesting(ts) {
 // the ddb-store.js pattern for _TABLES_FOR_TESTING.
 function _resetForTesting() {
   subscriptions.clear();
-  primed = false;
   consecutiveFailures = 0;
   discoveryConsecutiveFailures = 0;
   defaultOwnerId = null;

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -141,6 +141,16 @@ function upsertGuild({ guildId, ownerId, webhookId, webhookSecret }) {
 // upsertGuild's sync-update pattern).
 function removeGuild({ guildId, ownerId }) {
   if (!ownerId) return;
+  // Reject the default-key sentinel as a guildId — a caller-bug that
+  // passed it would .delete() the sentinel from the default entry's
+  // guildIds Set, leaving the entry alive (the ownerId !== defaultOwnerId
+  // guard below catches that) but with a confusing size-zero state.
+  // Discord guildIds are decimal-only snowflakes; the bracketed-
+  // underscore sentinel can never legitimately appear here.
+  if (guildId === DEFAULT_KEY_SENTINEL) {
+    logger.warn('removeGuild called with DEFAULT_KEY_SENTINEL as guildId — caller bug, ignoring', { ownerId });
+    return;
+  }
   const entry = subscriptions.get(ownerId);
   if (!entry) return;
   entry.guildIds.delete(guildId);

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -46,6 +46,12 @@ let timer = null;
 // here keeps the discover/refresh fold idempotent.
 let defaultOwnerId = null;
 
+// Owners whose entries must survive scanOnce's clear-and-repopulate
+// swap. Reset at the top of each scan; re-applied after the swap so
+// a concurrent /qurl setup whose DDB write landed AFTER the scan
+// crossed its partition isn't silently dropped.
+let upsertsDuringScan = new Set();
+
 function getSecretForOwner(ownerId) {
   if (!ownerId) return null;
   const entry = subscriptions.get(ownerId);
@@ -69,15 +75,14 @@ function upsertGuild({ guildId, ownerId, webhookId, webhookSecret }) {
     entry = { guildIds: new Set(), webhookSecret, webhookId };
     subscriptions.set(ownerId, entry);
   } else {
-    // ensureWebhookSubscription dedupes on (owner_id, url); two
-    // guilds sharing an owner get the SAME webhookId + secret. If a
-    // future qurl-service change generates a new secret on re-link
-    // for the same owner, take the newer value — entries are
-    // last-write-wins by design.
+    // Last-write-wins. A second guild's link triggers qurl-service to
+    // rotate the shared secret; the newer value must replace the
+    // older one for the receiver to match qurl-service's signatures.
     entry.webhookSecret = webhookSecret;
     entry.webhookId = webhookId;
   }
   entry.guildIds.add(guildId);
+  upsertsDuringScan.add(ownerId);
 }
 
 // Removes guildId from its owner's entry; if the entry is now empty
@@ -121,35 +126,47 @@ async function discoverDefaultOwnerId() {
   return null;
 }
 
-// One refresh pass. Rebuilds the per-guild map from `guild_configs`
-// AND rediscovers the default-key owner_id (idempotent). Throws on
-// any sub-step failure so the caller increments the failure counter
-// — partial-pass state would mask drift.
+// One refresh pass. Rebuilds the per-owner map from `guild_configs`
+// and rediscovers the default-key owner_id. Throws on any sub-step
+// failure; the caller (refreshTick) increments consecutiveFailures.
 async function scanOnce() {
-  const rows = await db.scanGuildSubscriptions();
+  upsertsDuringScan = new Set();
 
-  // Rebuild rather than diff-apply: tiny table (low hundreds at
-  // scale), simpler than reconciling adds/drops, and any synchronous
-  // upsertGuild calls between scans are preserved because we rebuild
-  // the map before swapping.
+  // Parallelize the two independent network reads: the DDB scan and
+  // the qurl-service GET /v1/webhooks. Sequential, they added 50-300ms
+  // per tick for no benefit.
+  const [rows, discoveredOwner] = await Promise.all([
+    db.scanGuildSubscriptions(),
+    discoverDefaultOwnerId(),
+  ]);
+
+  // Tiebreaker: when sibling rows for one owner disagree on (secret,
+  // webhookId) — the propagateGuildWebhookSubscription window — the
+  // row with the newest `updatedAt` wins. The chosen-updatedAt is a
+  // scan-local concern; we keep it in a parallel Map instead of
+  // attaching to the cache entry shape that the receiver consults.
   const next = new Map();
+  const winningUpdatedAt = new Map();
   for (const r of rows) {
     let entry = next.get(r.webhookOwnerId);
     if (!entry) {
       entry = { guildIds: new Set(), webhookSecret: r.webhookSecret, webhookId: r.webhookId };
       next.set(r.webhookOwnerId, entry);
+      winningUpdatedAt.set(r.webhookOwnerId, r.updatedAt || '');
+    } else if ((r.updatedAt || '') > winningUpdatedAt.get(r.webhookOwnerId)) {
+      entry.webhookSecret = r.webhookSecret;
+      entry.webhookId = r.webhookId;
+      winningUpdatedAt.set(r.webhookOwnerId, r.updatedAt || '');
     }
     entry.guildIds.add(r.guildId);
   }
 
-  const discoveredOwner = await discoverDefaultOwnerId();
   if (discoveredOwner) {
     defaultOwnerId = discoveredOwner;
     if (config.QURL_WEBHOOK_SECRET) {
-      // We don't know the webhookId for the default-key sub from
-      // GET /v1/webhooks?limit=1 in a stable way — but the receiver
-      // only needs webhookSecret. Synthetic webhookId acts as a
-      // marker for the default entry; never sent over the wire.
+      // GET /v1/webhooks?limit=1 doesn't pin which sub belongs to the
+      // default key; receiver only needs the secret, so a synthetic
+      // webhookId marks the default entry (never sent over the wire).
       next.set(discoveredOwner, {
         guildIds: new Set(['__default__']),
         webhookSecret: config.QURL_WEBHOOK_SECRET,
@@ -158,12 +175,20 @@ async function scanOnce() {
     }
   }
 
-  // Atomic-ish swap. Clear-and-repopulate so any caller holding a
-  // reference to `subscriptions` sees a consistent post-swap state
-  // (Map.set is synchronous; no caller can observe a half-built map
-  // between iterations in single-threaded Node).
+  // Only snapshot when concurrent upserts could have landed. The
+  // common case (no concurrent /qurl setup) skips the allocation.
+  const liveSnapshot = upsertsDuringScan.size > 0 ? new Map(subscriptions) : null;
   subscriptions.clear();
   for (const [k, v] of next.entries()) subscriptions.set(k, v);
+
+  if (liveSnapshot) {
+    for (const ownerId of upsertsDuringScan) {
+      if (next.has(ownerId)) continue;
+      const liveEntry = liveSnapshot.get(ownerId);
+      if (liveEntry) subscriptions.set(ownerId, liveEntry);
+    }
+  }
+
   primed = true;
 }
 
@@ -219,6 +244,7 @@ function _resetForTesting() {
   primed = false;
   consecutiveFailures = 0;
   defaultOwnerId = null;
+  upsertsDuringScan = new Set();
   if (timer) {
     clearInterval(timer);
     timer = null;
@@ -232,9 +258,9 @@ module.exports = {
   isPrimed,
   upsertGuild,
   removeGuild,
-  // Exposed for the splice points in qurl-oauth.js + commands.js so
-  // they can do a synchronous local update after writing to DDB. NOT
-  // exposed as part of the receiver's hot path.
+  // Test-only: production callers should let the 30s ticker drive
+  // refresh. Exposed because the test suite needs to drive scans
+  // deterministically without waiting on real intervals.
   scanOnce,
   _resetForTesting,
 };

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -163,9 +163,12 @@ async function discoverDefaultOwnerId() {
 async function scanOnce() {
   if (scanInFlight) {
     // Drop the overlap rather than corrupt upsertsDuringScan tracking
-    // (see comment on the guard above). Caller doesn't see the skip;
-    // primed stays true (or stays false during cold-start).
-    return;
+    // (see comment on the guard above). Return a sentinel so the
+    // caller can distinguish "completed a real refresh" from "no-op'd
+    // because another was in flight" — refreshTick uses this to
+    // avoid resetting consecutiveFailures during a long-running
+    // outage (a slow scan that overlaps the next tick).
+    return 'skipped';
   }
   scanInFlight = true;
   try {
@@ -262,6 +265,7 @@ async function scanOnce() {
     }
 
     primed = true;
+    return 'completed';
   } finally {
     scanInFlight = false;
   }
@@ -269,8 +273,12 @@ async function scanOnce() {
 
 async function refreshTick() {
   try {
-    await scanOnce();
-    consecutiveFailures = 0;
+    const result = await scanOnce();
+    // Only reset on a completed scan. If scanOnce was 'skipped' (the
+    // previous tick is still in flight), leave the failure counter
+    // alone — a slow scan during an outage could otherwise mask the
+    // REFRESH_FAIL_ESCALATE_AT alarm.
+    if (result === 'completed') consecutiveFailures = 0;
   } catch (err) {
     consecutiveFailures += 1;
     const level = consecutiveFailures >= REFRESH_FAIL_ESCALATE_AT ? 'error' : 'warn';

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -38,6 +38,12 @@ const REFRESH_FAIL_ESCALATE_AT = 3;
 const subscriptions = new Map();
 let primed = false;
 let consecutiveFailures = 0;
+// Discovery-only failure counter. Tracked separately from
+// consecutiveFailures so a transient qurl-service 5xx during
+// discoverDefaultOwnerId doesn't take down BYOK delivery (the DDB
+// rows are independent). Receiver still 401s any default-key
+// webhooks until discovery succeeds, but BYOK guilds keep flowing.
+let discoveryConsecutiveFailures = 0;
 let timer = null;
 
 // The default-key entry lives in the same map under whatever owner_id
@@ -199,8 +205,6 @@ async function scanOnce() {
     // the snapshot/restore below are load-bearing.
     upsertsDuringScan.clear();
 
-    // Parallelize the two independent network reads. Sequential they
-    // added 50-300ms per tick.
     // TODO(#486): GSI on webhook_owner_id when guild_configs row
     // count exceeds ~10k — scanAll is bounded by table size, not
     // result size. When the GSI lands, the priming path can also drop
@@ -212,11 +216,46 @@ async function scanOnce() {
     // discover: the bot's own owner_id never changes in-process (env
     // is read at boot), so once we have it AND a secret to pair with,
     // the GET is wasted load on qurl-service.
+    //
+    // Discovery is fired in parallel with the DDB scan for latency,
+    // BUT its failure is caught locally instead of via Promise.all so
+    // a transient qurl-service 5xx during boot doesn't 503 every BYOK
+    // guild for 30s. The default-key entry stays absent (next tick
+    // retries); BYOK guilds resolve from the DDB rows normally.
     const needsDefaultDiscovery = !!config.QURL_WEBHOOK_SECRET && !defaultOwnerId;
-    const [rows, discoveredOwner] = await Promise.all([
+    const discoveryPromise = needsDefaultDiscovery
+      ? discoverDefaultOwnerId().then(
+        (owner) => ({ ok: true, owner }),
+        (err) => ({ ok: false, error: err }),
+      )
+      : Promise.resolve({ ok: true, owner: defaultOwnerId });
+    const [rows, discoveryResult] = await Promise.all([
       db.scanGuildSubscriptions(),
-      needsDefaultDiscovery ? discoverDefaultOwnerId() : Promise.resolve(defaultOwnerId),
+      discoveryPromise,
     ]);
+    let discoveredOwner;
+    if (discoveryResult.ok) {
+      discoveredOwner = discoveryResult.owner;
+      // Reset on success — independent of consecutiveFailures so a
+      // recovered discovery doesn't reset the DDB-scan counter.
+      discoveryConsecutiveFailures = 0;
+    } else {
+      discoveredOwner = defaultOwnerId; // keep prior value (likely null pre-first-success)
+      discoveryConsecutiveFailures += 1;
+      const level = discoveryConsecutiveFailures >= REFRESH_FAIL_ESCALATE_AT ? 'error' : 'warn';
+      logger[level]('default-key discovery failed (BYOK path unaffected)', {
+        error: discoveryResult.error.message,
+        consecutiveFailures: discoveryConsecutiveFailures,
+      });
+      if (discoveryConsecutiveFailures === REFRESH_FAIL_ESCALATE_AT) {
+        // Alarm-once at threshold so CloudWatch metric filters fire
+        // a single page per outage burst, not on every subsequent
+        // failed tick. Reset on success above.
+        logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_DEFAULT_DISCOVERY_FAIL, {
+          consecutive_failures: discoveryConsecutiveFailures,
+        });
+      }
+    }
 
     // Tiebreaker: when sibling rows for one owner disagree on
     // (secret, webhookId) — the propagateGuildWebhookSubscription
@@ -386,6 +425,7 @@ function _resetForTesting() {
   subscriptions.clear();
   primed = false;
   consecutiveFailures = 0;
+  discoveryConsecutiveFailures = 0;
   defaultOwnerId = null;
   upsertsDuringScan.clear();
   scanInFlight = false;

--- a/apps/discord/src/webhook-subscriptions.js
+++ b/apps/discord/src/webhook-subscriptions.js
@@ -1,0 +1,240 @@
+// Per-guild qurl-service webhook subscription registry.
+//
+// Process-local Map<owner_id, { guildIds: Set<string>, webhookSecret, webhookId }>
+// keyed by the qurl-service auth0 owner_id that authorizes the
+// subscription. Populated from `guild_configs` at boot and refreshed
+// every 30s; the registering replica updates its own map synchronously
+// inside the link/unlink flow so the user who just ran /qurl setup
+// doesn't race their own first view.
+//
+// Sibling replicas catch up on the next tick. qurl-service's retry
+// policy is 1+2+4+8+16=31s exponential backoff with a 30s worker tick
+// (≈60s total retry window per `webhook_service.go::scheduleRetryIfNeeded`),
+// so a 30s refresh stays inside it — a first-view event that lands on
+// a stale replica is retried after this replica has refreshed.
+//
+// Receiver semantics (in routes/qurl-webhook.js):
+//   - Before isPrimed(): unknown owner → 503 (retriable). Cold-start
+//     and any-DDB-flake case.
+//   - After isPrimed():  unknown owner → 401 (truthful).
+// qurl-service does NOT retry 401, so getting this split right is
+// load-bearing for don't-drop-views-during-deploy.
+
+const db = require('./store');
+const config = require('./config');
+const logger = require('./logger');
+const { AUDIT_EVENTS } = require('./constants');
+
+const REFRESH_INTERVAL_MS = 30_000;
+// After this many consecutive refresh failures we escalate via audit
+// so CloudWatch metric-filter alarms can page. We don't crash —
+// receiver responds 503 until refresh succeeds, qurl-service retries.
+const REFRESH_FAIL_ESCALATE_AT = 3;
+
+// Single-process state. Module-level (not a class) for parity with
+// orphan-token-sweeper.js's pattern and so tests can import a fresh
+// copy via jest.isolateModules().
+const subscriptions = new Map();
+let primed = false;
+let consecutiveFailures = 0;
+let timer = null;
+
+// The default-key entry lives in the same map under whatever owner_id
+// the bot's QURL_API_KEY resolves to. We don't know it at boot — we
+// discover it by listing the bot's own webhooks (the Lambda registered
+// at least one) on every refresh tick. Storing the discovered owner_id
+// here keeps the discover/refresh fold idempotent.
+let defaultOwnerId = null;
+
+function getSecretForOwner(ownerId) {
+  if (!ownerId) return null;
+  const entry = subscriptions.get(ownerId);
+  return entry ? entry.webhookSecret : null;
+}
+
+function isPrimed() {
+  return primed;
+}
+
+// Synchronous local-map mutation called by setGuildApiKey-adjacent
+// flows AFTER they've successfully written to DDB. The registering
+// replica gets immediate consistency; sibling replicas converge on
+// next tick. Idempotent: same (guildId, ownerId) re-call just re-adds.
+function upsertGuild({ guildId, ownerId, webhookId, webhookSecret }) {
+  if (!guildId || !ownerId || !webhookId || !webhookSecret) {
+    throw new Error('upsertGuild: guildId, ownerId, webhookId, webhookSecret all required');
+  }
+  let entry = subscriptions.get(ownerId);
+  if (!entry) {
+    entry = { guildIds: new Set(), webhookSecret, webhookId };
+    subscriptions.set(ownerId, entry);
+  } else {
+    // ensureWebhookSubscription dedupes on (owner_id, url); two
+    // guilds sharing an owner get the SAME webhookId + secret. If a
+    // future qurl-service change generates a new secret on re-link
+    // for the same owner, take the newer value — entries are
+    // last-write-wins by design.
+    entry.webhookSecret = webhookSecret;
+    entry.webhookId = webhookId;
+  }
+  entry.guildIds.add(guildId);
+}
+
+// Removes guildId from its owner's entry; if the entry is now empty
+// (no sibling guilds + not the default-key owner), drops it. Default-
+// key entry is never dropped from removeGuild — it's owned by the
+// Lambda lifecycle and rediscovered by the tick.
+function removeGuild({ guildId, ownerId }) {
+  if (!ownerId) return;
+  const entry = subscriptions.get(ownerId);
+  if (!entry) return;
+  entry.guildIds.delete(guildId);
+  if (entry.guildIds.size === 0 && ownerId !== defaultOwnerId) {
+    subscriptions.delete(ownerId);
+  }
+}
+
+// Fetches the default key's owner_id by listing its own webhooks.
+// Returns null if the list is empty (Lambda hasn't run yet on a
+// fresh deploy) — the tick will retry next cycle, and inbound events
+// in the gap are 503'd via the unprimed-cache code path. Network /
+// HTTP errors are surfaced to the caller (scanOnce) so the tick's
+// failure counter increments correctly.
+async function discoverDefaultOwnerId() {
+  if (!config.QURL_API_KEY || !config.QURL_ENDPOINT) return null;
+  const resp = await fetch(`${config.QURL_ENDPOINT}/v1/webhooks?limit=1`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${config.QURL_API_KEY}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!resp.ok) {
+    throw new Error(`discoverDefaultOwnerId: GET /v1/webhooks returned ${resp.status}`);
+  }
+  const body = await resp.json();
+  const subs = Array.isArray(body?.data) ? body.data : [];
+  // owner_id is the same across every subscription this key owns;
+  // any row works. Subs without owner_id (defensive against contract
+  // drift) are skipped.
+  for (const s of subs) {
+    if (typeof s?.owner_id === 'string' && s.owner_id.length > 0) return s.owner_id;
+  }
+  return null;
+}
+
+// One refresh pass. Rebuilds the per-guild map from `guild_configs`
+// AND rediscovers the default-key owner_id (idempotent). Throws on
+// any sub-step failure so the caller increments the failure counter
+// — partial-pass state would mask drift.
+async function scanOnce() {
+  const rows = await db.scanGuildSubscriptions();
+
+  // Rebuild rather than diff-apply: tiny table (low hundreds at
+  // scale), simpler than reconciling adds/drops, and any synchronous
+  // upsertGuild calls between scans are preserved because we rebuild
+  // the map before swapping.
+  const next = new Map();
+  for (const r of rows) {
+    let entry = next.get(r.webhookOwnerId);
+    if (!entry) {
+      entry = { guildIds: new Set(), webhookSecret: r.webhookSecret, webhookId: r.webhookId };
+      next.set(r.webhookOwnerId, entry);
+    }
+    entry.guildIds.add(r.guildId);
+  }
+
+  const discoveredOwner = await discoverDefaultOwnerId();
+  if (discoveredOwner) {
+    defaultOwnerId = discoveredOwner;
+    if (config.QURL_WEBHOOK_SECRET) {
+      // We don't know the webhookId for the default-key sub from
+      // GET /v1/webhooks?limit=1 in a stable way — but the receiver
+      // only needs webhookSecret. Synthetic webhookId acts as a
+      // marker for the default entry; never sent over the wire.
+      next.set(discoveredOwner, {
+        guildIds: new Set(['__default__']),
+        webhookSecret: config.QURL_WEBHOOK_SECRET,
+        webhookId: '__default__',
+      });
+    }
+  }
+
+  // Atomic-ish swap. Clear-and-repopulate so any caller holding a
+  // reference to `subscriptions` sees a consistent post-swap state
+  // (Map.set is synchronous; no caller can observe a half-built map
+  // between iterations in single-threaded Node).
+  subscriptions.clear();
+  for (const [k, v] of next.entries()) subscriptions.set(k, v);
+  primed = true;
+}
+
+async function refreshTick() {
+  try {
+    await scanOnce();
+    consecutiveFailures = 0;
+  } catch (err) {
+    consecutiveFailures += 1;
+    const level = consecutiveFailures >= REFRESH_FAIL_ESCALATE_AT ? 'error' : 'warn';
+    logger[level]('webhook subscription registry refresh failed', {
+      error: err.message,
+      consecutiveFailures,
+    });
+    if (consecutiveFailures === REFRESH_FAIL_ESCALATE_AT) {
+      // Audit emitted exactly once at the escalation threshold so a
+      // CloudWatch metric-filter alarm fires once per outage burst,
+      // not on every subsequent failed tick. Reset on success above.
+      logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_CACHE_REFRESH_FAIL, {
+        consecutive_failures: consecutiveFailures,
+      });
+    }
+  }
+}
+
+// Start the registry: an immediate scan plus a 30s ticker. Returns a
+// Promise that resolves after the initial scan attempt — caller can
+// `await start()` to block boot on cache-primed if it wants, or
+// fire-and-forget for non-blocking startup. We do not throw on first-
+// scan failure; the receiver's 503 path handles the unprimed gap and
+// the ticker retries.
+async function start() {
+  if (timer) return; // idempotent
+  await refreshTick();
+  timer = setInterval(() => {
+    refreshTick().catch(err => logger.error('webhook subscription registry refresh crash', { error: err.message }));
+  }, REFRESH_INTERVAL_MS);
+  timer.unref();
+}
+
+function stop() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+// Test-only: reset module-level state. Production code must never
+// reach for this — the leading-underscore signals intent. Mirrors
+// the ddb-store.js pattern for _TABLES_FOR_TESTING.
+function _resetForTesting() {
+  subscriptions.clear();
+  primed = false;
+  consecutiveFailures = 0;
+  defaultOwnerId = null;
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+module.exports = {
+  start,
+  stop,
+  getSecretForOwner,
+  isPrimed,
+  upsertGuild,
+  removeGuild,
+  // Exposed for the splice points in qurl-oauth.js + commands.js so
+  // they can do a synchronous local update after writing to DDB. NOT
+  // exposed as part of the receiver's hot path.
+  scanOnce,
+  _resetForTesting,
+};

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -259,14 +259,11 @@ jest.mock('../src/flow-state', () => ({
 
 // The `/qurl setup` paste-flow handler calls linkGuildWebhookSubscription
 // after persisting the key. The helper makes its own fetch() calls to
-// qurl-service (ensureWebhookSubscription + owner_id discovery), which
-// would inflate global.fetch call counts asserted by the setup-modal
-// suite. Stub it to a non-op for these tests; per-helper coverage lives
-// in tests/webhook-subscriptions.test.js + tests/qurl-webhook.test.js.
+// qurl-service that would inflate global.fetch call counts asserted by
+// the setup-modal suite. Stub to a no-op; per-helper coverage lives in
+// tests/guild-webhook-link.test.js.
 jest.mock('../src/guild-webhook-link', () => ({
   linkGuildWebhookSubscription: jest.fn().mockResolvedValue({ ok: true, action: 'created' }),
-  unlinkGuildWebhookSubscription: jest.fn().mockResolvedValue({ ok: true }),
-  unlinkGuildAndWebhook: jest.fn().mockResolvedValue({ ok: true }),
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -257,6 +257,18 @@ jest.mock('../src/flow-state', () => ({
   supersedeOrCreate: (...args) => mockSupersedeOrCreate(...args),
 }));
 
+// The `/qurl setup` paste-flow handler calls linkGuildWebhookSubscription
+// after persisting the key. The helper makes its own fetch() calls to
+// qurl-service (ensureWebhookSubscription + owner_id discovery), which
+// would inflate global.fetch call counts asserted by the setup-modal
+// suite. Stub it to a non-op for these tests; per-helper coverage lives
+// in tests/webhook-subscriptions.test.js + tests/qurl-webhook.test.js.
+jest.mock('../src/guild-webhook-link', () => ({
+  linkGuildWebhookSubscription: jest.fn().mockResolvedValue({ ok: true, action: 'created' }),
+  unlinkGuildWebhookSubscription: jest.fn().mockResolvedValue({ ok: true }),
+  unlinkGuildAndWebhook: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
 // ---------------------------------------------------------------------------
 // Require modules under test
 // ---------------------------------------------------------------------------

--- a/apps/discord/tests/commands-comprehensive.test.js
+++ b/apps/discord/tests/commands-comprehensive.test.js
@@ -264,6 +264,7 @@ jest.mock('../src/flow-state', () => ({
 // tests/guild-webhook-link.test.js.
 jest.mock('../src/guild-webhook-link', () => ({
   linkGuildWebhookSubscription: jest.fn().mockResolvedValue({ ok: true, action: 'created' }),
+  fireAndForgetLinkGuildWebhookSubscription: jest.fn(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -405,6 +405,55 @@ describe('guild configs', () => {
     expect(result).not.toHaveProperty('qurl_api_key');
     expect(result).toMatchObject({ guild_id: 'g-1', configured_by: 'admin' });
   });
+
+  test('propagateGuildWebhookSubscription: swallows ConditionalCheckFailedException as benign', async () => {
+    // Scenario: between listGuildSubscriptionsByOwner returning the
+    // sibling row and the UpdateCommand executing, another path
+    // cleared the sibling's webhook_owner_id (mid-rollback of an
+    // earlier link). The ConditionExpression rejects with CCFE.
+    // That's the documented "row no longer qualifies" signal — it
+    // MUST NOT bubble up as a failure (would mask real failures).
+    ddbMock.on(ScanCommand).resolves({ Items: [
+      { guild_id: 'g_sibling', webhook_id: 'wh_x', webhook_owner_id: 'usr_o' },
+    ] });
+    const ccfe = new Error('ConditionalCheckFailedException');
+    ccfe.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    const result = await store.propagateGuildWebhookSubscription('usr_o', {
+      webhookId: 'wh_new', webhookSecret: 'sec_new',
+    });
+    expect(result).toEqual({ updated: 0, failed: 0 });
+  });
+
+  test('propagateGuildWebhookSubscription: non-CCFE errors are counted as failed', async () => {
+    // A real DDB error (throttling, validation, etc.) is NOT benign —
+    // it counts toward the failed-row tally so the caller can decide
+    // whether to log+continue. Pins the discriminator at line 1633.
+    ddbMock.on(ScanCommand).resolves({ Items: [
+      { guild_id: 'g_sibling', webhook_id: 'wh_x', webhook_owner_id: 'usr_o' },
+    ] });
+    ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+    const result = await store.propagateGuildWebhookSubscription('usr_o', {
+      webhookId: 'wh_new', webhookSecret: 'sec_new',
+    });
+    expect(result).toEqual({ updated: 0, failed: 1 });
+  });
+
+  test('propagateGuildWebhookSubscription: excludes the just-written primary guild', async () => {
+    // excludeGuildId tells propagate to skip the primary row (already
+    // written by setGuildWebhookSubscription). Otherwise the primary
+    // would receive a redundant UpdateCommand with identical data.
+    ddbMock.on(ScanCommand).resolves({ Items: [
+      { guild_id: 'g_primary', webhook_id: 'wh_p', webhook_owner_id: 'usr_admin' },
+    ] });
+    const result = await store.propagateGuildWebhookSubscription('usr_admin', {
+      webhookId: 'wh_p', webhookSecret: 'sec_p', excludeGuildId: 'g_primary',
+    });
+    expect(result).toEqual({ updated: 0, failed: 0 });
+    // Short-circuit: no UpdateCommand fired for an "only excluded"
+    // result set.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
 });
 
 // ── Orphaned OAuth tokens (encryption + hash path) ──

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -439,6 +439,28 @@ describe('guild configs', () => {
     expect(result).toEqual({ updated: 0, failed: 1 });
   });
 
+  test('setGuildWebhookSubscription: rejects with CCFE when qurl_api_key row does not exist (orphan guard)', async () => {
+    // ConditionExpression on the UpdateCommand requires
+    // attribute_exists(qurl_api_key) — a caller-bug or race that ran
+    // setGuildWebhookSubscription before setGuildApiKey would otherwise
+    // create an orphan row with webhook_* attrs but no api key.
+    const ccfe = new Error('ConditionalCheckFailedException');
+    ccfe.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    await expect(store.setGuildWebhookSubscription('g_orphan', {
+      webhookId: 'wh_x',
+      webhookSecret: 'sec_x',
+      webhookOwnerId: 'usr_y',
+    })).rejects.toThrow(/ConditionalCheckFailedException/);
+    // Confirm the UpdateCommand actually carried the guard expression
+    // (would otherwise be a false-positive test that passes on any
+    // CCFE source — e.g. a different attribute condition).
+    const calls = ddbMock.commandCalls(UpdateCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input.ConditionExpression)
+      .toMatch(/attribute_exists\(qurl_api_key\)/);
+  });
+
   test('propagateGuildWebhookSubscription: excludes the just-written primary guild', async () => {
     // excludeGuildId tells propagate to skip the primary row (already
     // written by setGuildWebhookSubscription). Otherwise the primary

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -138,6 +138,25 @@ describe('linkGuildWebhookSubscription — propagation parameter', () => {
       { webhookId: 'wh_ok', webhookSecret: 'sec_ok', excludeGuildId: 'g_primary' },
     );
   });
+
+  // Partial propagate failure (e.g., one sibling throttled) MUST fire
+  // an audit. Without this, the sibling cache entry holds the stale
+  // secret for up to 30s and 401s every webhook silently.
+  it('emits SUBSCRIPTION_REGISTER_FAILED audit when propagate.failed > 0', async () => {
+    mockPropagateGuildWebhookSubscription.mockResolvedValueOnce({ updated: 1, failed: 2 });
+    const result = await linkGuildWebhookSubscription({
+      guildId: 'g_partial', apiKey: 'lv_x',
+    });
+    // Registration itself still succeeded — partial propagate is a
+    // secondary signal, not a hard rollback.
+    expect(result).toEqual({ ok: true, action: 'created' });
+    expect(mockAudit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED,
+      expect.objectContaining({
+        guild_id: 'g_partial', reason: 'propagate-partial', failed: 2, updated: 1,
+      }),
+    );
+  });
 });
 
 describe('linkGuildWebhookSubscription — bestEffortDeleteSubscription failure', () => {

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -139,3 +139,27 @@ describe('linkGuildWebhookSubscription — propagation parameter', () => {
     );
   });
 });
+
+describe('linkGuildWebhookSubscription — bestEffortDeleteSubscription failure', () => {
+  // When DDB write throws AFTER subscription creation, the rollback
+  // DELETE fires fire-and-forget. If qurl-service rejects the DELETE
+  // (e.g., 500 — not 401/404 which deleteSubscription itself swallows),
+  // the helper must still emit DELETE_FAILED audit so an orphan-
+  // subscription metric filter catches it. Without this test, the
+  // .catch branch was unexercised.
+  it('emits SUBSCRIPTION_DELETE_FAILED audit when rollback DELETE rejects', async () => {
+    mockSetGuildWebhookSubscription.mockRejectedValueOnce(new Error('DDB throttled'));
+    const dErr = new Error('qurl-service 500');
+    dErr.status = 500;
+    mockDeleteSubscription.mockRejectedValueOnce(dErr);
+    await linkGuildWebhookSubscription({
+      guildId: 'g_rollback_fail', apiKey: 'lv_x',
+    });
+    // Fire-and-forget — wait a microtask for the .catch handler.
+    await new Promise(setImmediate);
+    expect(mockAudit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED,
+      expect.objectContaining({ guild_id: 'g_rollback_fail', path: 'rollback' }),
+    );
+  });
+});

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -142,20 +142,27 @@ describe('linkGuildWebhookSubscription — propagation parameter', () => {
   // Partial propagate failure (e.g., one sibling throttled) MUST fire
   // an audit. Without this, the sibling cache entry holds the stale
   // secret for up to 30s and 401s every webhook silently.
-  it('emits SUBSCRIPTION_REGISTER_FAILED audit when propagate.failed > 0', async () => {
+  it('emits PROPAGATE_PARTIAL audit (NOT REGISTER_FAILED) when propagate.failed > 0', async () => {
     mockPropagateGuildWebhookSubscription.mockResolvedValueOnce({ updated: 1, failed: 2 });
     const result = await linkGuildWebhookSubscription({
       guildId: 'g_partial', apiKey: 'lv_x',
     });
     // Registration itself still succeeded — partial propagate is a
-    // secondary signal, not a hard rollback.
+    // secondary signal, not a hard rollback. Distinct event keeps
+    // the REGISTER_FAILED dashboard line unambiguously "the link
+    // failed for the user."
     expect(result).toEqual({ ok: true, action: 'created' });
     expect(mockAudit).toHaveBeenCalledWith(
-      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED,
+      AUDIT_EVENTS.QURL_WEBHOOK_PROPAGATE_PARTIAL,
       expect.objectContaining({
-        guild_id: 'g_partial', reason: 'propagate-partial', failed: 2, updated: 1,
+        guild_id: 'g_partial', failed: 2, updated: 1,
       }),
     );
+    // And REGISTER_FAILED must NOT be fired on this path.
+    const registerFailedCalls = mockAudit.mock.calls.filter(
+      ([event]) => event === AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED,
+    );
+    expect(registerFailedCalls).toHaveLength(0);
   });
 });
 

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -1,0 +1,201 @@
+// Tests for the link / unlink orchestrators. The cache-side scenarios
+// live in tests/webhook-subscriptions.test.js; this file covers the
+// db + registrar wiring + partial-failure rollback paths.
+
+const mockEnsureWebhookSubscription = jest.fn();
+const mockDeleteSubscription = jest.fn();
+jest.mock('../src/qurl-webhook-registrar', () => ({
+  ensureWebhookSubscription: mockEnsureWebhookSubscription,
+  deleteSubscription: mockDeleteSubscription,
+}));
+
+const mockSetGuildWebhookSubscription = jest.fn();
+const mockPropagateGuildWebhookSubscription = jest.fn();
+const mockListGuildSubscriptionsByOwner = jest.fn();
+const mockGetGuildConfigWithApiKey = jest.fn();
+const mockRemoveGuildApiKeyRaw = jest.fn();
+jest.mock('../src/store', () => ({
+  setGuildWebhookSubscription: mockSetGuildWebhookSubscription,
+  propagateGuildWebhookSubscription: mockPropagateGuildWebhookSubscription,
+  listGuildSubscriptionsByOwner: mockListGuildSubscriptionsByOwner,
+  getGuildConfigWithApiKey: mockGetGuildConfigWithApiKey,
+  _removeGuildApiKeyRaw: mockRemoveGuildApiKeyRaw,
+  // Stubs for unrelated config-time calls
+  healthCheck: jest.fn(),
+}));
+
+const mockUpsertGuild = jest.fn();
+const mockRemoveGuild = jest.fn();
+jest.mock('../src/webhook-subscriptions', () => ({
+  upsertGuild: mockUpsertGuild,
+  removeGuild: mockRemoveGuild,
+  isPrimed: () => true,
+  getSecretForOwner: () => null,
+  start: jest.fn(),
+  stop: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+const mockAudit = jest.fn();
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: mockAudit,
+}));
+
+process.env.QURL_API_KEY = 'lv_test_link';
+process.env.QURL_ENDPOINT = 'https://qurl.example';
+process.env.QURL_WEBHOOK_SECRET = 'wsec_test';
+process.env.BASE_URL = 'http://localhost:3000';
+process.env.AWS_REGION = 'us-east-2';
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+
+const {
+  linkGuildWebhookSubscription, unlinkGuildAndWebhook, LINK_RESULTS,
+} = require('../src/guild-webhook-link');
+const { AUDIT_EVENTS } = require('../src/constants');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEnsureWebhookSubscription.mockResolvedValue({
+    webhookId: 'wh_ok',
+    secret: 'sec_ok',
+    action: 'created',
+    ownerId: 'usr_ok',
+  });
+  mockSetGuildWebhookSubscription.mockResolvedValue();
+  mockPropagateGuildWebhookSubscription.mockResolvedValue({ updated: 0, failed: 0 });
+  mockDeleteSubscription.mockResolvedValue();
+  mockListGuildSubscriptionsByOwner.mockResolvedValue([]);
+});
+
+describe('linkGuildWebhookSubscription — partial-failure rollback', () => {
+  it('fires bestEffortDeleteSubscription when setGuildWebhookSubscription throws', async () => {
+    mockSetGuildWebhookSubscription.mockRejectedValueOnce(new Error('DDB throttled'));
+    const result = await linkGuildWebhookSubscription({
+      guildId: 'g1', apiKey: 'lv_guild_1',
+    });
+    expect(result).toEqual({ ok: false, reason: LINK_RESULTS.PERSIST_FAILED });
+    // Rollback DELETE attempted with the freshly-created webhookId.
+    expect(mockDeleteSubscription).toHaveBeenCalledWith({
+      apiEndpoint: 'https://qurl.example', apiKey: 'lv_guild_1', webhookId: 'wh_ok',
+    });
+    // Failure audit fires (cycle-2 cr concern #6).
+    expect(mockAudit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED,
+      expect.objectContaining({ reason: LINK_RESULTS.PERSIST_FAILED, guild_id: 'g1' }),
+    );
+  });
+
+  it('rolls back + emits OWNER_MISSING failure audit when registrar response lacks ownerId', async () => {
+    mockEnsureWebhookSubscription.mockResolvedValueOnce({
+      webhookId: 'wh_no_owner', secret: 'sec_x', action: 'created', ownerId: undefined,
+    });
+    const result = await linkGuildWebhookSubscription({
+      guildId: 'g2', apiKey: 'lv_guild_2',
+    });
+    expect(result).toEqual({ ok: false, reason: LINK_RESULTS.OWNER_MISSING });
+    expect(mockDeleteSubscription).toHaveBeenCalledWith(expect.objectContaining({
+      webhookId: 'wh_no_owner',
+    }));
+    expect(mockAudit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED,
+      expect.objectContaining({ reason: LINK_RESULTS.OWNER_MISSING }),
+    );
+  });
+
+  it('emits REGISTER_FAILED audit when ensureWebhookSubscription throws', async () => {
+    mockEnsureWebhookSubscription.mockRejectedValueOnce(new Error('qurl-service 502'));
+    const result = await linkGuildWebhookSubscription({
+      guildId: 'g3', apiKey: 'lv_guild_3',
+    });
+    expect(result).toEqual({ ok: false, reason: LINK_RESULTS.REGISTER_FAILED });
+    // No rollback DELETE: nothing was created.
+    expect(mockDeleteSubscription).not.toHaveBeenCalled();
+    expect(mockAudit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTER_FAILED,
+      expect.objectContaining({ reason: LINK_RESULTS.REGISTER_FAILED }),
+    );
+  });
+
+  it('happy path emits SUBSCRIPTION_REGISTERED audit and upserts the cache', async () => {
+    const result = await linkGuildWebhookSubscription({
+      guildId: 'g_happy', apiKey: 'lv_guild_happy',
+    });
+    expect(result).toEqual({ ok: true, action: 'created' });
+    expect(mockUpsertGuild).toHaveBeenCalledWith({
+      guildId: 'g_happy', ownerId: 'usr_ok', webhookId: 'wh_ok', webhookSecret: 'sec_ok',
+    });
+    expect(mockAudit).toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTERED,
+      expect.objectContaining({ guild_id: 'g_happy', action: 'created' }),
+    );
+  });
+});
+
+describe('unlinkGuildAndWebhook orchestrator', () => {
+  it('returns not-found when the row is absent', async () => {
+    mockGetGuildConfigWithApiKey.mockResolvedValueOnce(null);
+    const result = await unlinkGuildAndWebhook('g_missing');
+    expect(result).toEqual({ ok: true, reason: LINK_RESULTS.NOT_FOUND });
+    // Never reaches DELETE / raw-delete paths.
+    expect(mockDeleteSubscription).not.toHaveBeenCalled();
+    expect(mockRemoveGuildApiKeyRaw).not.toHaveBeenCalled();
+  });
+
+  it('tears down subscription THEN deletes row (order matters for orphan visibility)', async () => {
+    mockGetGuildConfigWithApiKey.mockResolvedValueOnce({
+      guild_id: 'g_unlink',
+      qurl_api_key: 'lv_guild_unlink',
+      webhook_id: 'wh_unlink',
+      webhook_owner_id: 'usr_unlink',
+    });
+    mockListGuildSubscriptionsByOwner.mockResolvedValueOnce([
+      // Only this guild; the unlink IS the last reference.
+      { guildId: 'g_unlink', webhookId: 'wh_unlink' },
+    ]);
+    const result = await unlinkGuildAndWebhook('g_unlink');
+    expect(result).toEqual({ ok: true, reason: LINK_RESULTS.UNLINKED });
+    expect(mockDeleteSubscription).toHaveBeenCalledWith({
+      apiEndpoint: 'https://qurl.example', apiKey: 'lv_guild_unlink', webhookId: 'wh_unlink',
+    });
+    expect(mockRemoveGuildApiKeyRaw).toHaveBeenCalledWith('g_unlink');
+    // Order verified via mock call sequence (later index = later call).
+    const deleteCallIdx = mockDeleteSubscription.mock.invocationCallOrder[0];
+    const rawDeleteCallIdx = mockRemoveGuildApiKeyRaw.mock.invocationCallOrder[0];
+    expect(deleteCallIdx).toBeLessThan(rawDeleteCallIdx);
+  });
+
+  it('preserves sibling subscription when other guilds share the same owner', async () => {
+    mockGetGuildConfigWithApiKey.mockResolvedValueOnce({
+      guild_id: 'g_one_of_many',
+      qurl_api_key: 'lv_shared',
+      webhook_id: 'wh_shared',
+      webhook_owner_id: 'usr_admin',
+    });
+    mockListGuildSubscriptionsByOwner.mockResolvedValueOnce([
+      { guildId: 'g_one_of_many', webhookId: 'wh_shared' },
+      { guildId: 'g_sibling', webhookId: 'wh_shared' },
+    ]);
+    const result = await unlinkGuildAndWebhook('g_one_of_many');
+    expect(result).toEqual({ ok: true, reason: LINK_RESULTS.UNLINKED });
+    // CRITICAL: sibling delivery survives — no DELETE issued.
+    expect(mockDeleteSubscription).not.toHaveBeenCalled();
+    expect(mockRemoveGuildApiKeyRaw).toHaveBeenCalledWith('g_one_of_many');
+  });
+
+  it('returns delete-failed when _removeGuildApiKeyRaw throws', async () => {
+    mockGetGuildConfigWithApiKey.mockResolvedValueOnce({
+      guild_id: 'g_raw_fail',
+      qurl_api_key: 'lv_x',
+      webhook_id: 'wh_x',
+      webhook_owner_id: 'usr_x',
+    });
+    mockRemoveGuildApiKeyRaw.mockRejectedValueOnce(new Error('DDB outage'));
+    const result = await unlinkGuildAndWebhook('g_raw_fail');
+    expect(result).toEqual({ ok: false, reason: LINK_RESULTS.DELETE_FAILED });
+  });
+});

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -181,4 +181,40 @@ describe('linkGuildWebhookSubscription — bestEffortDeleteSubscription failure'
       expect.objectContaining({ guild_id: 'g_rollback_fail', path: 'rollback' }),
     );
   });
+
+  // 404 is swallowed inside the registrar (concurrent-delete race).
+  // The .catch in bestEffortDeleteSubscription never fires → no
+  // audit. Pins the contract so future refactor doesn't widen the
+  // alarm-noise surface.
+  it('does NOT emit DELETE_FAILED audit when DELETE 404s (registrar swallows)', async () => {
+    mockSetGuildWebhookSubscription.mockRejectedValueOnce(new Error('DDB throttled'));
+    // Simulate registrar's swallow: deleteSubscription resolves silently.
+    mockDeleteSubscription.mockResolvedValueOnce(undefined);
+    await linkGuildWebhookSubscription({
+      guildId: 'g_404', apiKey: 'lv_x',
+    });
+    await new Promise(setImmediate);
+    expect(mockAudit).not.toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED,
+      expect.any(Object),
+    );
+  });
+
+  // 401 is the routine re-key signal (admin revoked the key on
+  // layerv.ai before our DELETE landed). Log only — auditing every
+  // re-key would flood the alarm channel.
+  it('does NOT emit DELETE_FAILED audit when DELETE 401s (routine re-key)', async () => {
+    mockSetGuildWebhookSubscription.mockRejectedValueOnce(new Error('DDB throttled'));
+    const dErr = new Error('qurl-service 401');
+    dErr.status = 401;
+    mockDeleteSubscription.mockRejectedValueOnce(dErr);
+    await linkGuildWebhookSubscription({
+      guildId: 'g_401', apiKey: 'lv_revoked',
+    });
+    await new Promise(setImmediate);
+    expect(mockAudit).not.toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_DELETE_FAILED,
+      expect.any(Object),
+    );
+  });
 });

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -1,6 +1,6 @@
-// Tests for the link / unlink orchestrators. The cache-side scenarios
-// live in tests/webhook-subscriptions.test.js; this file covers the
-// db + registrar wiring + partial-failure rollback paths.
+// Tests for the link orchestrator (db + registrar wiring + partial-
+// failure rollback). Cache-side scenarios live in
+// tests/webhook-subscriptions.test.js.
 
 const mockEnsureWebhookSubscription = jest.fn();
 const mockDeleteSubscription = jest.fn();
@@ -11,16 +11,9 @@ jest.mock('../src/qurl-webhook-registrar', () => ({
 
 const mockSetGuildWebhookSubscription = jest.fn();
 const mockPropagateGuildWebhookSubscription = jest.fn();
-const mockListGuildSubscriptionsByOwner = jest.fn();
-const mockGetGuildConfigWithApiKey = jest.fn();
-const mockRemoveGuildApiKeyRaw = jest.fn();
 jest.mock('../src/store', () => ({
   setGuildWebhookSubscription: mockSetGuildWebhookSubscription,
   propagateGuildWebhookSubscription: mockPropagateGuildWebhookSubscription,
-  listGuildSubscriptionsByOwner: mockListGuildSubscriptionsByOwner,
-  getGuildConfigWithApiKey: mockGetGuildConfigWithApiKey,
-  _removeGuildApiKeyRaw: mockRemoveGuildApiKeyRaw,
-  // Stubs for unrelated config-time calls
   healthCheck: jest.fn(),
 }));
 
@@ -54,7 +47,7 @@ process.env.AWS_REGION = 'us-east-2';
 process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
 
 const {
-  linkGuildWebhookSubscription, unlinkGuildAndWebhook, LINK_RESULTS,
+  linkGuildWebhookSubscription, LINK_RESULTS,
 } = require('../src/guild-webhook-link');
 const { AUDIT_EVENTS } = require('../src/constants');
 
@@ -69,7 +62,6 @@ beforeEach(() => {
   mockSetGuildWebhookSubscription.mockResolvedValue();
   mockPropagateGuildWebhookSubscription.mockResolvedValue({ updated: 0, failed: 0 });
   mockDeleteSubscription.mockResolvedValue();
-  mockListGuildSubscriptionsByOwner.mockResolvedValue([]);
 });
 
 describe('linkGuildWebhookSubscription — partial-failure rollback', () => {
@@ -136,66 +128,14 @@ describe('linkGuildWebhookSubscription — partial-failure rollback', () => {
   });
 });
 
-describe('unlinkGuildAndWebhook orchestrator', () => {
-  it('returns not-found when the row is absent', async () => {
-    mockGetGuildConfigWithApiKey.mockResolvedValueOnce(null);
-    const result = await unlinkGuildAndWebhook('g_missing');
-    expect(result).toEqual({ ok: true, reason: LINK_RESULTS.NOT_FOUND });
-    // Never reaches DELETE / raw-delete paths.
-    expect(mockDeleteSubscription).not.toHaveBeenCalled();
-    expect(mockRemoveGuildApiKeyRaw).not.toHaveBeenCalled();
-  });
-
-  it('tears down subscription THEN deletes row (order matters for orphan visibility)', async () => {
-    mockGetGuildConfigWithApiKey.mockResolvedValueOnce({
-      guild_id: 'g_unlink',
-      qurl_api_key: 'lv_guild_unlink',
-      webhook_id: 'wh_unlink',
-      webhook_owner_id: 'usr_unlink',
+describe('linkGuildWebhookSubscription — propagation parameter', () => {
+  it('passes the just-linked guildId to propagate so primary is skipped', async () => {
+    await linkGuildWebhookSubscription({
+      guildId: 'g_primary', apiKey: 'lv_test',
     });
-    mockListGuildSubscriptionsByOwner.mockResolvedValueOnce([
-      // Only this guild; the unlink IS the last reference.
-      { guildId: 'g_unlink', webhookId: 'wh_unlink' },
-    ]);
-    const result = await unlinkGuildAndWebhook('g_unlink');
-    expect(result).toEqual({ ok: true, reason: LINK_RESULTS.UNLINKED });
-    expect(mockDeleteSubscription).toHaveBeenCalledWith({
-      apiEndpoint: 'https://qurl.example', apiKey: 'lv_guild_unlink', webhookId: 'wh_unlink',
-    });
-    expect(mockRemoveGuildApiKeyRaw).toHaveBeenCalledWith('g_unlink');
-    // Order verified via mock call sequence (later index = later call).
-    const deleteCallIdx = mockDeleteSubscription.mock.invocationCallOrder[0];
-    const rawDeleteCallIdx = mockRemoveGuildApiKeyRaw.mock.invocationCallOrder[0];
-    expect(deleteCallIdx).toBeLessThan(rawDeleteCallIdx);
-  });
-
-  it('preserves sibling subscription when other guilds share the same owner', async () => {
-    mockGetGuildConfigWithApiKey.mockResolvedValueOnce({
-      guild_id: 'g_one_of_many',
-      qurl_api_key: 'lv_shared',
-      webhook_id: 'wh_shared',
-      webhook_owner_id: 'usr_admin',
-    });
-    mockListGuildSubscriptionsByOwner.mockResolvedValueOnce([
-      { guildId: 'g_one_of_many', webhookId: 'wh_shared' },
-      { guildId: 'g_sibling', webhookId: 'wh_shared' },
-    ]);
-    const result = await unlinkGuildAndWebhook('g_one_of_many');
-    expect(result).toEqual({ ok: true, reason: LINK_RESULTS.UNLINKED });
-    // CRITICAL: sibling delivery survives — no DELETE issued.
-    expect(mockDeleteSubscription).not.toHaveBeenCalled();
-    expect(mockRemoveGuildApiKeyRaw).toHaveBeenCalledWith('g_one_of_many');
-  });
-
-  it('returns delete-failed when _removeGuildApiKeyRaw throws', async () => {
-    mockGetGuildConfigWithApiKey.mockResolvedValueOnce({
-      guild_id: 'g_raw_fail',
-      qurl_api_key: 'lv_x',
-      webhook_id: 'wh_x',
-      webhook_owner_id: 'usr_x',
-    });
-    mockRemoveGuildApiKeyRaw.mockRejectedValueOnce(new Error('DDB outage'));
-    const result = await unlinkGuildAndWebhook('g_raw_fail');
-    expect(result).toEqual({ ok: false, reason: LINK_RESULTS.DELETE_FAILED });
+    expect(mockPropagateGuildWebhookSubscription).toHaveBeenCalledWith(
+      'usr_ok',
+      { webhookId: 'wh_ok', webhookSecret: 'sec_ok', excludeGuildId: 'g_primary' },
+    );
   });
 });

--- a/apps/discord/tests/qurl-webhook-flow.test.js
+++ b/apps/discord/tests/qurl-webhook-flow.test.js
@@ -45,6 +45,20 @@ function makeStore() {
 const mockStore = makeStore();
 jest.mock('../src/store', () => mockStore);
 
+// Multi-secret receiver: route the flow-test owner_id to the
+// flow-test secret via a mocked registry. Without this the receiver
+// returns 503 (unprimed) on every webhook delivery.
+jest.mock('../src/webhook-subscriptions', () => ({
+  isPrimed: () => true,
+  getSecretForOwner: (ownerId) => (ownerId === 'usr_flow_test' ? 'flow-test-secret' : null),
+  start: jest.fn(),
+  stop: jest.fn(),
+  upsertGuild: jest.fn(),
+  removeGuild: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
 process.env.QURL_WEBHOOK_SECRET = 'flow-test-secret';
 process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
 process.env.AWS_REGION = 'us-east-2';

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -874,3 +874,70 @@ describe('ensureWebhookSubscription — return-shape pin (Lambda persists then b
     expect(persisted).toEqual(['whsec_new_active']);
   });
 });
+
+describe('ensureWebhookSubscription — ownerId return field (per-guild receiver routing)', () => {
+  // guild-webhook-link.js consumes result.ownerId to populate the
+  // in-process secret cache. If qurl-service drops `owner_id` from a
+  // response shape, every BYOK guild's first link rolls back with
+  // OWNER_MISSING — pin the field across all three branches so the
+  // upstream contract regression fails loudly here.
+  it('forwards owner_id from a POST /v1/webhooks created response', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_new', secret: 'whsec_x', owner_id: 'auth0|created',
+      } } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS });
+    expect(result.action).toBe('created');
+    expect(result.ownerId).toBe('auth0|created');
+  });
+
+  it('forwards owner_id from the existing-sub rotate path', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing',
+        url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.accessed'],
+        owner_id: 'auth0|existing',
+      }] } }),
+      'POST /v1/webhooks/wh_existing/secret': () => ({ status: 200, body: { data: {
+        webhook_id: 'wh_existing', secret: 'whsec_rotated',
+      } } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS });
+    expect(result.action).toBe('rotated');
+    expect(result.ownerId).toBe('auth0|existing');
+  });
+
+  it('forwards owner_id from the reuse path (initialSecret + existing sub)', async () => {
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_reused',
+        url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.accessed'],
+        owner_id: 'auth0|reused',
+      }] } }),
+    });
+    const result = await ensureWebhookSubscription({
+      ...BASE_OPTS, initialSecret: 'whsec_already_known',
+    });
+    expect(result.action).toBe('reused');
+    expect(result.ownerId).toBe('auth0|reused');
+  });
+
+  it('leaks undefined when a future contract drift drops owner_id (caller must guard)', async () => {
+    // The guild-webhook-link OWNER_MISSING rollback catches this.
+    // Pinning the leakage here makes a contract regression LOUD.
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: {
+        webhook_id: 'wh_no_owner', secret: 'whsec_y', // no owner_id
+      } } }),
+    });
+    const result = await ensureWebhookSubscription({ ...BASE_OPTS });
+    expect(result.ownerId).toBeUndefined();
+    expect(result.secret).toBe('whsec_y');
+    expect(result.webhookId).toBe('wh_no_owner');
+  });
+});

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -941,3 +941,48 @@ describe('ensureWebhookSubscription — ownerId return field (per-guild receiver
     expect(result.webhookId).toBe('wh_no_owner');
   });
 });
+
+// Pinned to keep webhook-subscriptions.js::discoverDefaultOwnerId
+// from breaking silently if a future registrar refactor changes
+// callQurlService's signature. The external caller relies on
+// (method, path, apiEndpoint, apiKey) + response = parsed-JSON body.
+describe('callQurlService — exported contract', () => {
+  const { callQurlService } = require('../src/qurl-webhook-registrar');
+
+  beforeEach(() => { global.fetch = jest.fn(); });
+  afterAll(() => { global.fetch = ORIGINAL_FETCH; });
+
+  it('is exported as a top-level function (not _internals)', () => {
+    expect(typeof callQurlService).toBe('function');
+  });
+
+  it('returns the JSON-parsed body on 2xx', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true, status: 200, text: async () => JSON.stringify({ data: [{ id: 'x' }] }),
+    }));
+    const out = await callQurlService({
+      method: 'GET', path: '/v1/webhooks', apiEndpoint: 'https://q.example', apiKey: 'k',
+    });
+    expect(out).toEqual({ data: [{ id: 'x' }] });
+  });
+
+  it('forwards Authorization: Bearer <apiKey>', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true, status: 200, text: async () => '{}',
+    }));
+    await callQurlService({
+      method: 'GET', path: '/v1/webhooks', apiEndpoint: 'https://q.example', apiKey: 'secret-k',
+    });
+    const opts = global.fetch.mock.calls[0][1];
+    expect(opts.headers.Authorization).toBe('Bearer secret-k');
+  });
+
+  it('throws on non-2xx with the QurlServiceError shape (op + status)', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: false, status: 503, text: async () => '',
+    }));
+    await expect(callQurlService({
+      method: 'GET', path: '/v1/webhooks', apiEndpoint: 'https://q.example', apiKey: 'k',
+    })).rejects.toThrow(/returned 503/);
+  });
+});

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -441,12 +441,16 @@ describe('POST /webhooks/qurl — unknown-owner limiter (looser threshold)', () 
   //
   // FRAGILE: depends on jest.mock factory closures surviving
   // jest.resetModules — true today, but a future refactor that moves
-  // these mocks into beforeEach would silently break the isolation
-  // (the isolated `app` would see the unmocked registry).
+  // these mocks into beforeEach would silently break the isolation.
+  // Assert below that the isolated registry IS still the mock so a
+  // regression fails this test loudly instead of silent 503s.
   beforeAll(() => {
     jest.resetModules();
   });
   it('returns 429 after 150 OWNER_UNKNOWN events from the same IP', async () => {
+    // eslint-disable-next-line global-require
+    const isolatedSubs = require('../src/webhook-subscriptions');
+    expect(jest.isMockFunction(isolatedSubs.start)).toBe(true);
     // eslint-disable-next-line global-require
     const isolatedApp = require('../src/server').app;
     mockPrimed = true;
@@ -480,6 +484,9 @@ describe('POST /webhooks/qurl — bad-sig limiter scope (only HMAC failures coun
     jest.resetModules();
   });
   it('does NOT increment bad-sig limiter on OWNER_UNKNOWN', async () => {
+    // eslint-disable-next-line global-require
+    const isolatedSubs = require('../src/webhook-subscriptions');
+    expect(jest.isMockFunction(isolatedSubs.start)).toBe(true);
     // eslint-disable-next-line global-require
     const isolatedApp = require('../src/server').app;
     // Fresh ownership table: cache primed, owner not registered.

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -629,14 +629,18 @@ describe('POST /webhooks/qurl — body.owner_id parse failure modes', () => {
   // recordQurlView (the inner db call) is never invoked.
   it('rejects >1mb /webhooks bodies before the route handler runs', async () => {
     const big = JSON.stringify({ x: 'a'.repeat(2 * 1024 * 1024) });
-    await request(app)
+    const res = await request(app)
       .post('/webhooks/qurl')
       .set('Content-Type', 'application/json')
       .set('QURL-Signature', signBody(big))
       .send(big);
-    // PayloadTooLargeError gets caught by the global error handler →
-    // 500 response, but the important property is the route never saw
-    // the body.
+    // Status must be one of the rejection codes — guards against a
+    // future error-handler rewrite that swallows the oversized body
+    // into a silent 200 (which mockRecordQurlView alone wouldn't
+    // catch if the route silently returned 200 without a write).
+    // 413 = PayloadTooLargeError mapped to spec, 500 = current
+    // global-error-handler mapping, 400 = a future tighter handler.
+    expect([400, 413, 500]).toContain(res.status);
     expect(mockRecordQurlView).not.toHaveBeenCalled();
   });
 

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -421,6 +421,45 @@ describe('POST /webhooks/qurl — payload handling', () => {
   });
 });
 
+describe('POST /webhooks/qurl — bad-sig limiter scope (only HMAC failures count)', () => {
+  // 30 OWNER_UNKNOWN events from one IP must NOT 429 the 31st valid
+  // event — limiter is reserved for HMAC failures (attacker signal).
+  beforeAll(() => {
+    jest.resetModules();
+  });
+  it('does NOT increment bad-sig limiter on OWNER_UNKNOWN', async () => {
+    // eslint-disable-next-line global-require
+    const isolatedApp = require('../src/server').app;
+    // Fresh ownership table: cache primed, owner not registered.
+    mockPrimed = true;
+    mockOwnerSecrets.clear();
+    mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+    const unknownPayload = { ...VALID_PAYLOAD, owner_id: 'usr_unregistered' };
+    const unknownRaw = JSON.stringify(unknownPayload);
+
+    // 30 OWNER_UNKNOWN events — if these incremented the bad-sig
+    // counter, the 31st request below would 429.
+    for (let i = 0; i < 30; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const r = await request(isolatedApp)
+        .post('/webhooks/qurl')
+        .set('Content-Type', 'application/json')
+        .set('QURL-Signature', signBody(unknownRaw))
+        .send(unknownRaw);
+      expect(r.status).toBe(401);
+    }
+
+    // Switch to a valid signed event for a known owner; should pass.
+    const validRaw = JSON.stringify(VALID_PAYLOAD);
+    const valid = await request(isolatedApp)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(validRaw))
+      .send(validRaw);
+    expect(valid.status).toBe(200);
+  });
+});
+
 describe('POST /webhooks/qurl — multi-secret HMAC selection (BYOK view counter)', () => {
   // The receiver MUST verify HMAC against the secret registered for the
   // body's owner_id — not against any other owner's secret. A regression

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -53,10 +53,12 @@ jest.mock('../src/view-update-publisher', () => ({
 // secret signBody() uses; `mockPrimed` lets individual tests opt into
 // the 503-unprimed and 401-unknown-owner paths.
 let mockPrimed = true;
+let mockWithinLag = false;
 const mockOwnerSecrets = new Map();
 mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
 jest.mock('../src/webhook-subscriptions', () => ({
   isPrimed: () => mockPrimed,
+  isWithinSiblingLagWindow: () => mockWithinLag,
   getSecretForOwner: (ownerId) => mockOwnerSecrets.get(ownerId) || null,
   start: jest.fn(),
   stop: jest.fn(),
@@ -104,8 +106,10 @@ beforeEach(() => {
   mockViewUpdatePublish.mockReset();
   // Reset cache-state mocks to "primed + the usr_test owner is known"
   // so each test starts from a predictable baseline. Tests that need
-  // the unprimed / unknown-owner branches flip these explicitly.
+  // the unprimed / unknown-owner / sibling-lag branches flip these
+  // explicitly.
   mockPrimed = true;
+  mockWithinLag = false;
   mockOwnerSecrets.clear();
   mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
 });
@@ -180,12 +184,14 @@ describe('POST /webhooks/qurl — subscription-registry primed-vs-unprimed seman
     expect(res.status).toBe(503);
   });
 
-  // After the registry is primed, an unknown owner is the real signal
-  // — return 401 (truthful response). This is what an attacker probing
-  // the endpoint with a fabricated owner_id would see.
-  it('returns 401 when registry is primed but owner_id is unknown', async () => {
+  // After the registry is primed AND outside the sibling-replica lag
+  // window, an unknown owner is the real signal — return 401
+  // (truthful response). This is what an attacker probing the
+  // endpoint with a fabricated owner_id would see.
+  it('returns 401 when registry is primed AND outside lag window AND owner_id is unknown', async () => {
     mockPrimed = true;
-    mockOwnerSecrets.clear(); // owner_id present in body but no entry registered
+    mockWithinLag = false;
+    mockOwnerSecrets.clear();
     const raw = JSON.stringify(VALID_PAYLOAD);
     const res = await request(app)
       .post('/webhooks/qurl')
@@ -193,6 +199,23 @@ describe('POST /webhooks/qurl — subscription-registry primed-vs-unprimed seman
       .set('QURL-Signature', signBody(raw))
       .send(raw);
     expect(res.status).toBe(401);
+  });
+
+  // Sibling-replica eventual-consistency lag: a freshly-linked
+  // guild's row is in DDB but THIS replica's scan hasn't picked it
+  // up yet. Return 503 so qurl-service retries — the next tick on
+  // this replica will see the row and the retry succeeds.
+  it('returns 503 when registry is primed but owner_id is unknown AND within lag window', async () => {
+    mockPrimed = true;
+    mockWithinLag = true;
+    mockOwnerSecrets.clear();
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(503);
   });
 });
 

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -79,7 +79,9 @@ jest.mock('../src/logger', () => ({
   audit: mockAudit,
 }));
 
-process.env.QURL_WEBHOOK_SECRET = 'test-qurl-secret';
+// QURL_WEBHOOK_SECRET intentionally NOT set here — the receiver no
+// longer reads it directly; secrets come from the mocked
+// webhook-subscriptions registry above.
 process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
 process.env.AWS_REGION = 'us-east-2';
 process.env.BASE_URL = 'http://localhost:3000';
@@ -619,6 +621,23 @@ describe('POST /webhooks/qurl — body.owner_id parse failure modes', () => {
       .set('QURL-Signature', signBody(raw))
       .send(raw);
     expect(res.status).toBe(401);
+  });
+
+  // Behavioral pin for the 1mb pre-HMAC parse boundary documented in
+  // qurl-webhook.js's SECURITY comment. A >1mb body must be rejected
+  // BEFORE the route handler runs — verified by asserting
+  // recordQurlView (the inner db call) is never invoked.
+  it('rejects >1mb /webhooks bodies before the route handler runs', async () => {
+    const big = JSON.stringify({ x: 'a'.repeat(2 * 1024 * 1024) });
+    await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(big))
+      .send(big);
+    // PayloadTooLargeError gets caught by the global error handler →
+    // 500 response, but the important property is the route never saw
+    // the body.
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
   });
 
   // Pins the metric-filter contract: OWNER_ID_MISSING shares the

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -47,6 +47,25 @@ jest.mock('../src/view-update-publisher', () => ({
   stop: jest.fn(),
 }));
 
+// Multi-secret subscription registry. The receiver now looks up the
+// secret by `body.owner_id` instead of reading config.QURL_WEBHOOK_SECRET.
+// Tests mock the lookup so VALID_PAYLOAD's owner_id resolves to the same
+// secret signBody() uses; `mockPrimed` lets individual tests opt into
+// the 503-unprimed and 401-unknown-owner paths.
+let mockPrimed = true;
+const mockOwnerSecrets = new Map();
+mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+jest.mock('../src/webhook-subscriptions', () => ({
+  isPrimed: () => mockPrimed,
+  getSecretForOwner: (ownerId) => mockOwnerSecrets.get(ownerId) || null,
+  start: jest.fn(),
+  stop: jest.fn(),
+  upsertGuild: jest.fn(),
+  removeGuild: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
 process.env.QURL_WEBHOOK_SECRET = 'test-qurl-secret';
 process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
 process.env.AWS_REGION = 'us-east-2';
@@ -72,6 +91,12 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockRecordQurlView.mockImplementation(async () => 'recorded');
   mockViewUpdatePublish.mockReset();
+  // Reset cache-state mocks to "primed + the usr_test owner is known"
+  // so each test starts from a predictable baseline. Tests that need
+  // the unprimed / unknown-owner branches flip these explicitly.
+  mockPrimed = true;
+  mockOwnerSecrets.clear();
+  mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
 });
 
 describe('POST /webhooks/qurl — view-update push gate (feat #60)', () => {
@@ -122,27 +147,41 @@ describe('POST /webhooks/qurl — view-update push gate (feat #60)', () => {
   });
 });
 
-describe('POST /webhooks/qurl — unconfigured secret returns 503 (retriable)', () => {
-  // If the webhook-registrar Lambda hasn't populated SSM yet, or the
-  // ECS task started before SSM secret injection completed, the bot's
-  // config.QURL_WEBHOOK_SECRET will be empty. MUST 503 (qurl-service
-  // retries) not 401 (non-retriable, drops the event).
-  it('returns 503 when secret is empty', async () => {
-    // eslint-disable-next-line global-require
-    const config = require('../src/config');
-    const original = config.QURL_WEBHOOK_SECRET;
-    config.QURL_WEBHOOK_SECRET = '';
-    try {
-      const res = await request(app)
-        .post('/webhooks/qurl')
-        .set('Content-Type', 'application/json')
-        .set('QURL-Signature', '0'.repeat(64))
-        .send('{}');
-      expect(res.status).toBe(503);
-      expect(res.body).toEqual({ error: 'Webhook receiver not configured' });
-    } finally {
-      config.QURL_WEBHOOK_SECRET = original;
-    }
+describe('POST /webhooks/qurl — subscription-registry primed-vs-unprimed semantics', () => {
+  // Before the registry's first successful scan completes, ANY unknown
+  // owner_id is "transiently unknown" rather than "genuinely unknown"
+  // — return 503 (retriable). qurl-service retries 503 (1+2+4+8+16=31s
+  // backoff) but NOT 401, so a 401 here would silently drop a guild's
+  // very first views post-deploy.
+  it('returns 503 when registry is unprimed (cold start / DDB scan in-flight)', async () => {
+    // 503 fires when isPrimed()=false AND the owner_id lookup misses.
+    // A primed cache where the owner is registered always wins (we
+    // serve the request); only the unprimed-AND-miss combination
+    // signals "transient gap, retry me".
+    mockPrimed = false;
+    mockOwnerSecrets.clear();
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(503);
+  });
+
+  // After the registry is primed, an unknown owner is the real signal
+  // — return 401 (truthful response). This is what an attacker probing
+  // the endpoint with a fabricated owner_id would see.
+  it('returns 401 when registry is primed but owner_id is unknown', async () => {
+    mockPrimed = true;
+    mockOwnerSecrets.clear(); // owner_id present in body but no entry registered
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(401);
   });
 });
 
@@ -237,7 +276,11 @@ describe('POST /webhooks/qurl — payload handling', () => {
   });
 
   it('returns 200 invalid-payload when qurl_id missing (no retry — payload is malformed, not transient)', async () => {
-    const payload = { id: 'evt-1', type: 'qurl.accessed', data: { access_count: 1 } };
+    // owner_id must still be present + valid; the receiver verifies
+    // HMAC + resolves the registry entry BEFORE checking body
+    // payload shape, so an unsigned-or-unowned payload would 401
+    // before this branch.
+    const payload = { id: 'evt-1', type: 'qurl.accessed', owner_id: 'usr_test', data: { access_count: 1 } };
     const raw = JSON.stringify(payload);
     const res = await request(app)
       .post('/webhooks/qurl')
@@ -251,7 +294,7 @@ describe('POST /webhooks/qurl — payload handling', () => {
 
   it('returns 200 invalid-payload when access_count is negative', async () => {
     const payload = {
-      id: 'evt-1', type: 'qurl.accessed',
+      id: 'evt-1', type: 'qurl.accessed', owner_id: 'usr_test',
       data: { qurl_id: 'q_aaaaaaaaaa1', access_count: -3, consumed: false },
     };
     const raw = JSON.stringify(payload);
@@ -271,7 +314,7 @@ describe('POST /webhooks/qurl — payload handling', () => {
     // would record in DDB and then trip the publisher's
     // "invalid accessCount" warn, producing an asymmetric log pair.
     const payload = {
-      id: 'evt-zero', type: 'qurl.accessed',
+      id: 'evt-zero', type: 'qurl.accessed', owner_id: 'usr_test',
       data: { qurl_id: 'q_aaaaaaaaaa1', access_count: 0, consumed: false },
     };
     const raw = JSON.stringify(payload);
@@ -375,6 +418,86 @@ describe('POST /webhooks/qurl — payload handling', () => {
       .set('QURL-Signature', signBody(raw))
       .send(raw);
     expect(mockRecordQurlView).toHaveBeenCalledWith(expect.objectContaining({ consumed: false }));
+  });
+});
+
+describe('POST /webhooks/qurl — multi-secret HMAC selection (BYOK view counter)', () => {
+  // The receiver MUST verify HMAC against the secret registered for the
+  // body's owner_id — not against any other owner's secret. A regression
+  // that fell back to "any registered secret" would let a guild A's
+  // secret accept guild B's webhook, which is observationally fine
+  // (HMAC just has to match SOME secret) but would let an attacker who
+  // compromised any one guild's API key forge events for all other
+  // guilds — security drift, not a bug a test would otherwise catch.
+  it('picks the secret matching body.owner_id, not a sibling owner', async () => {
+    mockOwnerSecrets.set('usr_test', 'secret-A');
+    mockOwnerSecrets.set('usr_sibling', 'secret-B');
+    // Sign with usr_sibling's secret but send under usr_test owner_id
+    // — receiver should reject because secret-B doesn't match the
+    // owner_id-resolved secret-A.
+    const payload = { ...VALID_PAYLOAD, owner_id: 'usr_test' };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw, 'secret-B'))
+      .send(raw);
+    expect(res.status).toBe(401);
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('accepts a request signed with the owner_id-resolved secret', async () => {
+    mockOwnerSecrets.set('usr_byok_guild', 'guild-specific-secret');
+    const payload = { ...VALID_PAYLOAD, owner_id: 'usr_byok_guild' };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw, 'guild-specific-secret'))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+  });
+});
+
+describe('POST /webhooks/qurl — body.owner_id parse failure modes', () => {
+  // Pre-HMAC body parse is bounded (req.rawBody is 1mb-capped by
+  // server.js middleware), so we don't worry about deep-nesting V8
+  // exhaustion. The remaining gaps are missing/non-string owner_id
+  // and a body that parsed-successfully but lacks the field.
+  it('returns 401 when body.owner_id is missing entirely', async () => {
+    const payload = { ...VALID_PAYLOAD };
+    delete payload.owner_id;
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(401);
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when body.owner_id is non-string (e.g. object slipped through)', async () => {
+    const payload = { ...VALID_PAYLOAD, owner_id: { weird: true } };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when body.owner_id is empty string', async () => {
+    const payload = { ...VALID_PAYLOAD, owner_id: '' };
+    const raw = JSON.stringify(payload);
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(401);
   });
 });
 

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -66,6 +66,17 @@ jest.mock('../src/webhook-subscriptions', () => ({
   _resetForTesting: jest.fn(),
 }));
 
+// Capture audit emissions so tests can assert that the receiver fires
+// the right CloudWatch metric-filter event per failure branch.
+const mockAudit = jest.fn();
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: mockAudit,
+}));
+
 process.env.QURL_WEBHOOK_SECRET = 'test-qurl-secret';
 process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
 process.env.AWS_REGION = 'us-east-2';
@@ -537,6 +548,29 @@ describe('POST /webhooks/qurl — body.owner_id parse failure modes', () => {
       .set('QURL-Signature', signBody(raw))
       .send(raw);
     expect(res.status).toBe(401);
+  });
+
+  // Pins the metric-filter contract: OWNER_ID_MISSING shares the
+  // CACHE_MISS_UNKNOWN_OWNER audit with OWNER_UNKNOWN (operational /
+  // payload-shape signal, NOT HMAC-failure signal). A regression
+  // that routed it to SIGNATURE_INVALID would mix it with HMAC
+  // brute-force alarms.
+  it('fires CACHE_MISS_UNKNOWN_OWNER audit on missing body.owner_id', async () => {
+    const payload = { ...VALID_PAYLOAD };
+    delete payload.owner_id;
+    const raw = JSON.stringify(payload);
+    await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    // The receiver may emit OTHER audit events (rate-limit, cache-miss);
+    // we only assert the OWNER_ID_MISSING-specific one fired with
+    // the right event key and result value.
+    const auditCalls = mockAudit.mock.calls;
+    const ownerMissCall = auditCalls.find(([event]) => event === 'qurl_webhook_cache_miss_unknown_owner');
+    expect(ownerMissCall).toBeDefined();
+    expect(ownerMissCall[1]).toEqual(expect.objectContaining({ result: 'owner_id_missing' }));
   });
 });
 

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -432,6 +432,42 @@ describe('POST /webhooks/qurl — payload handling', () => {
   });
 });
 
+describe('POST /webhooks/qurl — unknown-owner limiter (looser threshold)', () => {
+  // 150/min is the unknownOwnerLimiter ceiling; OWNER_UNKNOWN traffic
+  // beyond that 429s. This pins the contract: an attacker probing the
+  // receiver with bogus owner_id from a single IP IS rate-limited
+  // (just at a looser threshold than HMAC brute-force), so we can't
+  // accidentally regress to no-ceiling-at-all.
+  beforeAll(() => {
+    jest.resetModules();
+  });
+  it('returns 429 after 150 OWNER_UNKNOWN events from the same IP', async () => {
+    // eslint-disable-next-line global-require
+    const isolatedApp = require('../src/server').app;
+    mockPrimed = true;
+    mockOwnerSecrets.clear();
+    mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+    const unknownPayload = { ...VALID_PAYLOAD, owner_id: 'usr_unregistered' };
+    const unknownRaw = JSON.stringify(unknownPayload);
+    // 150 burns the unknownOwnerLimiter exactly to its ceiling.
+    for (let i = 0; i < 150; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await request(isolatedApp)
+        .post('/webhooks/qurl')
+        .set('Content-Type', 'application/json')
+        .set('QURL-Signature', signBody(unknownRaw))
+        .send(unknownRaw);
+    }
+    // 151st OWNER_UNKNOWN event 429s.
+    const limited = await request(isolatedApp)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(unknownRaw))
+      .send(unknownRaw);
+    expect(limited.status).toBe(429);
+  });
+});
+
 describe('POST /webhooks/qurl — bad-sig limiter scope (only HMAC failures count)', () => {
   // 30 OWNER_UNKNOWN events from one IP must NOT 429 the 31st valid
   // event — limiter is reserved for HMAC failures (attacker signal).

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -438,6 +438,11 @@ describe('POST /webhooks/qurl — unknown-owner limiter (looser threshold)', () 
   // receiver with bogus owner_id from a single IP IS rate-limited
   // (just at a looser threshold than HMAC brute-force), so we can't
   // accidentally regress to no-ceiling-at-all.
+  //
+  // FRAGILE: depends on jest.mock factory closures surviving
+  // jest.resetModules — true today, but a future refactor that moves
+  // these mocks into beforeEach would silently break the isolation
+  // (the isolated `app` would see the unmocked registry).
   beforeAll(() => {
     jest.resetModules();
   });

--- a/apps/discord/tests/server.test.js
+++ b/apps/discord/tests/server.test.js
@@ -413,18 +413,17 @@ describe('server.js — /webhooks rawBody middleware invariant', () => {
     path.join(__dirname, '..', 'src', 'server.js'),
     'utf8',
   );
+  // Structural pin: the 1mb cap on /webhooks rawBodyJson is the pre-
+  // HMAC parse safety boundary documented in qurl-webhook.js. The
+  // behavioral counterpart (recordQurlView NOT called for a >1mb
+  // payload) lives in qurl-webhook.test.js where the store mock has
+  // the right shape; this regex pin catches whitespace-tolerant
+  // refactors that bump the limit constant.
   it('mounts rawBodyJson at /webhooks with a 1mb cap', () => {
-    // The middleware is defined as `const rawBodyJson = express.json({...})`
-    // and mounted via `app.use('/webhooks', rawBodyJson)`. Both
-    // properties are load-bearing for the pre-HMAC parse safety.
     expect(serverSource).toMatch(/rawBodyJson\s*=\s*express\.json\(\{[\s\S]*?limit:\s*['"]1mb['"][\s\S]*?\}\)/);
     expect(serverSource).toMatch(/app\.use\(\s*['"]\/webhooks['"]\s*,\s*rawBodyJson\s*\)/);
   });
-
   it('rawBodyJson populates req.rawBody (HMAC source-of-truth)', () => {
-    // verifyHmacSha256 runs against req.rawBody. If a refactor drops
-    // the verify-callback, the receiver would 503 forever (the
-    // existing rawBody-missing guard fires).
     expect(serverSource).toMatch(/verify:\s*\(\s*req\s*,\s*_?res\s*,\s*buf\s*\)\s*=>\s*\{[\s\S]*?req\.rawBody\s*=\s*buf/);
   });
 });

--- a/apps/discord/tests/server.test.js
+++ b/apps/discord/tests/server.test.js
@@ -396,3 +396,35 @@ describe('Server', () => {
     });
   });
 });
+
+// ─── /webhooks rawBody parser invariant ────────────────────────────
+//
+// The qurl-webhook receiver does a pre-HMAC JSON.parse of req.body
+// to extract owner_id for secret routing. The SECURITY invariant
+// (called out in qurl-webhook.js's verifyAndResolve comment) is that
+// the 1mb cap on rawBodyJson middleware bounds the pre-trust window.
+// A refactor that re-orders middleware or bumps the limit without
+// re-reading that warning would silently widen the attack surface;
+// this pin-test fails loudly when the cap regresses.
+describe('server.js — /webhooks rawBody middleware invariant', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const serverSource = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'server.js'),
+    'utf8',
+  );
+  it('mounts rawBodyJson at /webhooks with a 1mb cap', () => {
+    // The middleware is defined as `const rawBodyJson = express.json({...})`
+    // and mounted via `app.use('/webhooks', rawBodyJson)`. Both
+    // properties are load-bearing for the pre-HMAC parse safety.
+    expect(serverSource).toMatch(/rawBodyJson\s*=\s*express\.json\(\{[\s\S]*?limit:\s*['"]1mb['"][\s\S]*?\}\)/);
+    expect(serverSource).toMatch(/app\.use\(\s*['"]\/webhooks['"]\s*,\s*rawBodyJson\s*\)/);
+  });
+
+  it('rawBodyJson populates req.rawBody (HMAC source-of-truth)', () => {
+    // verifyHmacSha256 runs against req.rawBody. If a refactor drops
+    // the verify-callback, the receiver would 503 forever (the
+    // existing rawBody-missing guard fires).
+    expect(serverSource).toMatch(/verify:\s*\(\s*req\s*,\s*_?res\s*,\s*buf\s*\)\s*=>\s*\{[\s\S]*?req\.rawBody\s*=\s*buf/);
+  });
+});

--- a/apps/discord/tests/server.test.js
+++ b/apps/discord/tests/server.test.js
@@ -424,6 +424,24 @@ describe('server.js — /webhooks rawBody middleware invariant', () => {
     expect(serverSource).toMatch(/app\.use\(\s*['"]\/webhooks['"]\s*,\s*rawBodyJson\s*\)/);
   });
   it('rawBodyJson populates req.rawBody (HMAC source-of-truth)', () => {
-    expect(serverSource).toMatch(/verify:\s*\(\s*req\s*,\s*_?res\s*,\s*buf\s*\)\s*=>\s*\{[\s\S]*?req\.rawBody\s*=\s*buf/);
+    // Tolerant of variable-name and whitespace refactors (Prettier-
+    // style reformat won't break it): match the verify-callback shape
+    // by anchoring on `verify:` + `req.rawBody = buf` rather than the
+    // exact parenthesization of the arrow-fn parameters.
+    expect(serverSource).toMatch(/verify\s*:[\s\S]{0,200}?req\.rawBody\s*=\s*buf/);
+  });
+  it('no second body parser is mounted on /webhooks (would widen the pre-HMAC parse surface)', () => {
+    // A middleware re-order that adds e.g. `express.urlencoded` or
+    // `express.text` at /webhooks would let a different parser run
+    // before the receiver's owner_id extraction. The /webhooks path
+    // legitimately has multiple `app.use` mounts (rawBodyJson +
+    // qurlWebhookRouter), so target PARSERS specifically by name
+    // rather than by mount-count.
+    expect(serverSource).not.toMatch(/app\.use\(\s*['"]\/webhooks['"]\s*,\s*express\.(urlencoded|text|raw)/);
+    // And no bare express.json() at /webhooks either — only the
+    // audited rawBodyJson (which is also express.json(), but
+    // configured with the 1mb cap and the verify-callback) should
+    // mount as a parser on this path.
+    expect(serverSource).not.toMatch(/app\.use\(\s*['"]\/webhooks['"]\s*,\s*express\.json\b/);
   });
 });

--- a/apps/discord/tests/store-contract.test.js
+++ b/apps/discord/tests/store-contract.test.js
@@ -124,6 +124,34 @@ describe('store/contract', () => {
       const overlap = STORE_METHODS.filter(m => STORE_CONSTANTS.includes(m));
       expect(overlap).toEqual([]);
     });
+
+    it('no apps/discord/src caller references the pre-rename `removeGuildApiKey` name', () => {
+      // The contract method was renamed `removeGuildApiKey` →
+      // `_removeGuildApiKeyRaw` so the leading underscore signals
+      // "raw operation that does not also clean up sibling rows
+      // (webhook subscription)." Defensive guard: a future caller
+      // that accidentally re-types the old short name would silently
+      // skip the cleanup. This grep-style assertion makes the
+      // regression LOUD at test-time.
+      const fs = require('fs');
+      const path = require('path');
+      const SRC = path.resolve(__dirname, '../src');
+      const offenders = [];
+      function walk(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) { walk(full); continue; }
+          if (!entry.name.endsWith('.js')) continue;
+          const body = fs.readFileSync(full, 'utf8');
+          // Word-boundary match catches `db.removeGuildApiKey(` and
+          // `removeGuildApiKey,` without flagging the renamed
+          // `_removeGuildApiKeyRaw`.
+          if (/\bremoveGuildApiKey\b(?!Raw)/.test(body)) offenders.push(path.relative(SRC, full));
+        }
+      }
+      walk(SRC);
+      expect(offenders).toEqual([]);
+    });
   });
 });
 

--- a/apps/discord/tests/webhook-subscriptions-receiver.integration.test.js
+++ b/apps/discord/tests/webhook-subscriptions-receiver.integration.test.js
@@ -96,7 +96,7 @@ describe('webhook-subscriptions → receiver integration (seam contract)', () =>
     expect(res.body).toEqual({ status: 'recorded' });
   });
 
-  it('an unknown owner_id after priming returns 401 (post-prime truthful response)', async () => {
+  it('within the sibling-lag window, an unknown owner_id returns 503 (retriable — the just-linked-on-peer case)', async () => {
     mockScanGuildSubscriptions.mockResolvedValueOnce([
       {
         guildId: 'g_known',
@@ -107,9 +107,9 @@ describe('webhook-subscriptions → receiver integration (seam contract)', () =>
       },
     ]);
     await subs.scanOnce();
-    // Forward the lastScanCompletedAt past the sibling-lag window
-    // so an unknown owner is treated as a real 401 (not 503).
-    await new Promise(resolve => setTimeout(resolve, 50));
+    // lastScanCompletedAt = Date.now() (just-scanned) is well inside
+    // REFRESH_INTERVAL_MS + SIBLING_LAG_GRACE_MS, so the receiver
+    // upgrades OWNER_UNKNOWN → 503 (retriable for qurl-service).
 
     const payload = buildPayload({ ownerId: 'usr_unknown' });
     const raw = JSON.stringify(payload);
@@ -120,9 +120,35 @@ describe('webhook-subscriptions → receiver integration (seam contract)', () =>
       .set('Content-Type', 'application/json')
       .set('QURL-Signature', sig)
       .send(raw);
-    // Within the sibling-lag window the receiver returns 503;
-    // either is a legitimate "registry doesn't know this owner" —
-    // accept both rather than time-of-day flake.
-    expect([401, 503]).toContain(res.status);
+    expect(res.status).toBe(503);
+  });
+
+  it('past the sibling-lag window, an unknown owner_id returns 401 (truthful — owner is genuinely absent)', async () => {
+    mockScanGuildSubscriptions.mockResolvedValueOnce([
+      {
+        guildId: 'g_known',
+        webhookId: 'wh_known',
+        webhookSecret: 'sec_known',
+        webhookOwnerId: 'usr_known',
+        updatedAt: '2026-05-22T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    // Force lastScanCompletedAt into the deep past so the receiver
+    // sees us well past REFRESH_INTERVAL_MS + SIBLING_LAG_GRACE_MS
+    // (35s) and treats OWNER_UNKNOWN as a genuine 401 instead of a
+    // sibling-lag 503.
+    subs._setLastScanCompletedAtForTesting(Date.now() - 10 * 60_000);
+
+    const payload = buildPayload({ ownerId: 'usr_unknown' });
+    const raw = JSON.stringify(payload);
+    const sig = qurlServiceSign(raw, 'sec_known');
+
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', sig)
+      .send(raw);
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/discord/tests/webhook-subscriptions-receiver.integration.test.js
+++ b/apps/discord/tests/webhook-subscriptions-receiver.integration.test.js
@@ -1,0 +1,128 @@
+// Integration test pinning the seam between the REAL subscription
+// registry (webhook-subscriptions.js) and the REAL receiver
+// (routes/qurl-webhook.js): a row shape returned by
+// db.scanGuildSubscriptions() must produce a cache entry the receiver
+// can look up + HMAC-verify against. A field-shape drift between the
+// two modules (e.g. a future scanGuildSubscriptions rename of
+// `webhookOwnerId` → `ownerId`) would 401 every webhook in prod; here
+// it fails LOUD at test time.
+//
+// All other layers (Discord, monitor UI, view-update publisher) are
+// mocked to keep the test focused on the registry↔receiver contract.
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+// Mock the store but leave the registry REAL. scanGuildSubscriptions
+// returns a fixture row shaped exactly like the ddb-store output
+// contract; if the registry can't read it, the seam is broken.
+const mockScanGuildSubscriptions = jest.fn();
+jest.mock('../src/store', () => ({
+  scanGuildSubscriptions: mockScanGuildSubscriptions,
+  recordQurlView: jest.fn(async () => 'recorded'),
+  getQurlViews: jest.fn(async () => new Map()),
+  healthCheck: jest.fn(),
+  getStats: jest.fn(() => ({})),
+}));
+
+process.env.QURL_WEBHOOK_SECRET = '';
+process.env.QURL_API_KEY = '';
+process.env.QURL_ENDPOINT = '';
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const subs = require('../src/webhook-subscriptions');
+
+function qurlServiceSign(rawBody, secret) {
+  return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+function buildPayload({ ownerId }) {
+  return {
+    id: 'evt_seam_1',
+    type: 'qurl.accessed',
+    data: { qurl_id: 'q_seam_aaaaaa', resource_id: 'res-1', access_count: 1, consumed: false },
+    owner_id: ownerId,
+    timestamp: new Date().toISOString(),
+    api_version: '2024-01-01',
+  };
+}
+
+beforeEach(() => {
+  subs._resetForTesting();
+  mockScanGuildSubscriptions.mockReset();
+});
+
+describe('webhook-subscriptions → receiver integration (seam contract)', () => {
+  it('a row returned by scanGuildSubscriptions can be HMAC-verified by the receiver via owner_id lookup', async () => {
+    // Realistic row shape: every field name + type the ddb-store
+    // contract documents. A drift in any of these silently 401s in
+    // prod; the integration assertion catches it.
+    mockScanGuildSubscriptions.mockResolvedValueOnce([
+      {
+        guildId: 'g_integration',
+        webhookId: 'wh_integration',
+        webhookSecret: 'sec_integration',
+        webhookOwnerId: 'usr_integration',
+        updatedAt: '2026-05-22T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+
+    const payload = buildPayload({ ownerId: 'usr_integration' });
+    const raw = JSON.stringify(payload);
+    const sig = qurlServiceSign(raw, 'sec_integration');
+
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', sig)
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+  });
+
+  it('an unknown owner_id after priming returns 401 (post-prime truthful response)', async () => {
+    mockScanGuildSubscriptions.mockResolvedValueOnce([
+      {
+        guildId: 'g_known',
+        webhookId: 'wh_known',
+        webhookSecret: 'sec_known',
+        webhookOwnerId: 'usr_known',
+        updatedAt: '2026-05-22T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    // Forward the lastScanCompletedAt past the sibling-lag window
+    // so an unknown owner is treated as a real 401 (not 503).
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const payload = buildPayload({ ownerId: 'usr_unknown' });
+    const raw = JSON.stringify(payload);
+    const sig = qurlServiceSign(raw, 'sec_known');
+
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', sig)
+      .send(raw);
+    // Within the sibling-lag window the receiver returns 503;
+    // either is a legitimate "registry doesn't know this owner" —
+    // accept both rather than time-of-day flake.
+    expect([401, 503]).toContain(res.status);
+  });
+});

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -227,6 +227,42 @@ describe('webhook-subscriptions registry — synchronous local update API', () =
   });
 });
 
+describe('webhook-subscriptions registry — default-key discovery', () => {
+  // When GET /v1/webhooks returns an empty list (Lambda hasn't run
+  // on a fresh deploy, or QURL_API_KEY/QURL_ENDPOINT are unset),
+  // discoverDefaultOwnerId returns null. scanOnce must still flip
+  // primed=true (so inbound webhooks for KNOWN owners aren't held in
+  // 503), but the default-key entry must NOT be folded in (anything
+  // signed by the Lambda's default sub will 401 until discovery
+  // succeeds — which is the truthful response, since the bot can't
+  // verify those signatures).
+  it('still primes the cache when discoverDefaultOwnerId returns null', async () => {
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g1', webhookId: 'wh1', webhookSecret: 'sec1', webhookOwnerId: 'usr_byok' },
+    ]);
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: [] }),
+    }));
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+    // BYOK guild's entry still made it in.
+    expect(subs.getSecretForOwner('usr_byok')).toBe('sec1');
+    // Default-key entry absent — no usr_default lookup possible.
+    expect(subs.getSecretForOwner('usr_default')).toBeNull();
+  });
+
+  it('still primes the cache when GET response data field is missing', async () => {
+    mockScan.mockResolvedValueOnce([]);
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    }));
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+  });
+});
+
 describe('webhook-subscriptions registry — first-scan-failure semantics', () => {
   it('throws on scanOnce DDB failure (caller increments failure counter)', async () => {
     mockScan.mockRejectedValueOnce(new Error('DDB throttled'));

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -88,12 +88,6 @@ describe('webhook-subscriptions registry — priming + lookup', () => {
 });
 
 describe('webhook-subscriptions registry — multi-guild-shared-owner', () => {
-  // When one auth0 admin installs the bot in N guilds, every row
-  // shares the same owner_id + webhook_id + secret (qurl-service
-  // dedupes on (owner_id, url) per ensureWebhookSubscription). The
-  // cache entries collide on identical content; the GuildIds set
-  // tracks all guilds that point at this entry. Important for the
-  // unlink path's reference-counting.
   it('coalesces N rows sharing an owner_id into one cache entry', async () => {
     mockScan.mockResolvedValueOnce([
       { guildId: 'g1', webhookId: 'wh_shared', webhookSecret: 'sec_shared', webhookOwnerId: 'usr_admin' },
@@ -105,6 +99,88 @@ describe('webhook-subscriptions registry — multi-guild-shared-owner', () => {
     // know about guild_ids — that's a DDB-layer concern for the
     // unlink ref-count path.
     expect(subs.getSecretForOwner('usr_admin')).toBe('sec_shared');
+  });
+
+  // Rotate-drift tiebreaker: when sibling rows disagree on secret,
+  // the newest updatedAt MUST win (qurl-service signs with the
+  // post-rotate secret; a stale-row pick would 401 every webhook).
+  it('picks the secret from the most-recently-updated row on rotate-drift', async () => {
+    // Stale row first so first-write-wins regressions fail this test.
+    mockScan.mockResolvedValueOnce([
+      {
+        guildId: 'g1', webhookId: 'wh_v1', webhookSecret: 'sec_stale', webhookOwnerId: 'usr_admin',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+      {
+        guildId: 'g2', webhookId: 'wh_v2', webhookSecret: 'sec_fresh', webhookOwnerId: 'usr_admin',
+        updatedAt: '2026-05-21T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_admin')).toBe('sec_fresh');
+  });
+
+  it('picks the most-recently-updated row regardless of scan order', async () => {
+    mockScan.mockResolvedValueOnce([
+      {
+        guildId: 'g2', webhookId: 'wh_v2', webhookSecret: 'sec_fresh', webhookOwnerId: 'usr_admin',
+        updatedAt: '2026-05-21T00:00:00.000Z',
+      },
+      {
+        guildId: 'g1', webhookId: 'wh_v1', webhookSecret: 'sec_stale', webhookOwnerId: 'usr_admin',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_admin')).toBe('sec_fresh');
+  });
+
+  it('treats missing updatedAt as oldest (legacy row never beats a timestamped one)', async () => {
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g_legacy', webhookId: 'wh_legacy', webhookSecret: 'sec_legacy', webhookOwnerId: 'usr_admin' },
+      {
+        guildId: 'g_new', webhookId: 'wh_new', webhookSecret: 'sec_new', webhookOwnerId: 'usr_admin',
+        updatedAt: '2026-05-21T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_admin')).toBe('sec_new');
+  });
+});
+
+describe('webhook-subscriptions registry — concurrent upsert during scan', () => {
+  it('preserves an upsertGuild entry written while scanOnce is awaiting', async () => {
+    let resolveScan;
+    mockScan.mockImplementationOnce(() => new Promise((resolve) => { resolveScan = resolve; }));
+    // Kick off scanOnce — it'll suspend on the scan promise.
+    const scanPromise = subs.scanOnce();
+    // While scan is suspended, a concurrent /qurl setup writes a row.
+    subs.upsertGuild({
+      guildId: 'g_race', ownerId: 'usr_race', webhookId: 'wh_race', webhookSecret: 'sec_race',
+    });
+    // Scan completes — its `rows` doesn't include the racing guild
+    // because the row was written after the DDB read started.
+    resolveScan([]);
+    await scanPromise;
+    // The synchronous upsert MUST survive the rebuild. Without the
+    // upsertsDuringScan tracker, the clear() would wipe it and this
+    // expectation would fail with null.
+    expect(subs.getSecretForOwner('usr_race')).toBe('sec_race');
+  });
+
+  it('scan supersedes a pre-scan upsert when DDB row is also present', async () => {
+    subs.upsertGuild({
+      guildId: 'g_pre', ownerId: 'usr_pre', webhookId: 'wh_pre', webhookSecret: 'sec_pre',
+    });
+    mockScan.mockResolvedValueOnce([
+      {
+        guildId: 'g_pre', webhookId: 'wh_pre', webhookSecret: 'sec_pre_from_scan',
+        webhookOwnerId: 'usr_pre',
+        updatedAt: '2026-05-21T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_pre')).toBe('sec_pre_from_scan');
   });
 });
 

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -301,6 +301,21 @@ describe('webhook-subscriptions registry — scanInFlight re-entrancy guard', ()
     resolveFirst([]);
     await first;
   });
+
+  // Skipped scans return 'skipped' sentinel; completed scans return
+  // 'completed'. refreshTick uses this to avoid resetting the
+  // consecutiveFailures counter when a slow scan overlaps the next
+  // tick — otherwise an alarm-worthy outage would be masked.
+  it('returns "skipped" sentinel when another scan is in flight, "completed" otherwise', async () => {
+    let resolveFirst;
+    mockScan.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+    const first = subs.scanOnce();
+    const second = await subs.scanOnce();
+    expect(second).toBe('skipped');
+    resolveFirst([]);
+    const firstResult = await first;
+    expect(firstResult).toBe('completed');
+  });
 });
 
 describe('webhook-subscriptions registry — default-key + BYOK owner collision', () => {

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -1,0 +1,179 @@
+// In-process subscription registry — tests for cache priming, refresh,
+// failure escalation, multi-guild-shared-owner ref-counting, and the
+// synchronous local-update API. Mocks db.scanGuildSubscriptions +
+// fetch (used for default-key owner_id discovery) so the registry
+// loop is exercised against a deterministic fake.
+//
+// Heavily isolated via jest.resetModules in beforeEach — every test
+// starts with a fresh registry. The module's _resetForTesting helper
+// is the supported way to wipe in-process state without re-requiring;
+// we use both belt-and-suspenders.
+
+const realFetch = global.fetch;
+
+const mockScan = jest.fn();
+jest.mock('../src/store', () => ({
+  scanGuildSubscriptions: mockScan,
+}));
+
+process.env.QURL_API_KEY = 'lv_test_abc';
+process.env.QURL_ENDPOINT = 'https://qurl.layerv.ai';
+process.env.QURL_WEBHOOK_SECRET = 'default-key-secret';
+process.env.BASE_URL = 'http://localhost:3000';
+// AWS_REGION + DDB_TABLE_PREFIX are required by config.js validators
+// even though this test never touches DDB through the real path.
+process.env.AWS_REGION = 'us-east-2';
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+
+const subs = require('../src/webhook-subscriptions');
+
+beforeEach(() => {
+  subs._resetForTesting();
+  mockScan.mockReset();
+  // Default fetch mock returns the default-key owner_id discovery
+  // shape so the refresh tick can fold it in.
+  global.fetch = jest.fn(async () => ({
+    ok: true,
+    json: async () => ({ data: [{ owner_id: 'usr_default', webhook_id: 'wh_default' }] }),
+  }));
+});
+
+afterAll(() => {
+  global.fetch = realFetch;
+});
+
+describe('webhook-subscriptions registry — priming + lookup', () => {
+  it('returns null + isPrimed()=false before any scan completes', () => {
+    expect(subs.isPrimed()).toBe(false);
+    expect(subs.getSecretForOwner('usr_test')).toBeNull();
+  });
+
+  it('populates the map + flips isPrimed after a successful scanOnce', async () => {
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g1', webhookId: 'wh_g1', webhookSecret: 'sec_g1', webhookOwnerId: 'usr_a' },
+    ]);
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+    expect(subs.getSecretForOwner('usr_a')).toBe('sec_g1');
+    // Unrelated owner_id still resolves to null; primed means
+    // "I've completed a scan", not "everyone is registered".
+    expect(subs.getSecretForOwner('usr_unknown')).toBeNull();
+  });
+
+  it('folds the default-key owner in via GET /v1/webhooks discovery', async () => {
+    mockScan.mockResolvedValueOnce([]);
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+    // discoverDefaultOwnerId returned usr_default + QURL_WEBHOOK_SECRET
+    // env is wired as the default secret.
+    expect(subs.getSecretForOwner('usr_default')).toBe('default-key-secret');
+  });
+
+  it('rebuilds (not merges) on each scan — a removed row drops from the cache', async () => {
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g1', webhookId: 'wh_g1', webhookSecret: 'sec_a', webhookOwnerId: 'usr_a' },
+      { guildId: 'g2', webhookId: 'wh_g2', webhookSecret: 'sec_b', webhookOwnerId: 'usr_b' },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_a')).toBe('sec_a');
+    expect(subs.getSecretForOwner('usr_b')).toBe('sec_b');
+
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g2', webhookId: 'wh_g2', webhookSecret: 'sec_b', webhookOwnerId: 'usr_b' },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_a')).toBeNull();
+    expect(subs.getSecretForOwner('usr_b')).toBe('sec_b');
+  });
+});
+
+describe('webhook-subscriptions registry — multi-guild-shared-owner', () => {
+  // When one auth0 admin installs the bot in N guilds, every row
+  // shares the same owner_id + webhook_id + secret (qurl-service
+  // dedupes on (owner_id, url) per ensureWebhookSubscription). The
+  // cache entries collide on identical content; the GuildIds set
+  // tracks all guilds that point at this entry. Important for the
+  // unlink path's reference-counting.
+  it('coalesces N rows sharing an owner_id into one cache entry', async () => {
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g1', webhookId: 'wh_shared', webhookSecret: 'sec_shared', webhookOwnerId: 'usr_admin' },
+      { guildId: 'g2', webhookId: 'wh_shared', webhookSecret: 'sec_shared', webhookOwnerId: 'usr_admin' },
+      { guildId: 'g3', webhookId: 'wh_shared', webhookSecret: 'sec_shared', webhookOwnerId: 'usr_admin' },
+    ]);
+    await subs.scanOnce();
+    // One owner → one cached secret. The receiver doesn't need to
+    // know about guild_ids — that's a DDB-layer concern for the
+    // unlink ref-count path.
+    expect(subs.getSecretForOwner('usr_admin')).toBe('sec_shared');
+  });
+});
+
+describe('webhook-subscriptions registry — synchronous local update API', () => {
+  // upsertGuild / removeGuild are called from setGuildApiKey-adjacent
+  // flows so the registering replica is immediately correct. Sibling
+  // replicas converge on the next tick.
+  it('upsertGuild makes the secret immediately resolvable', () => {
+    subs.upsertGuild({
+      guildId: 'g_new', ownerId: 'usr_new', webhookId: 'wh_new', webhookSecret: 'sec_new',
+    });
+    expect(subs.getSecretForOwner('usr_new')).toBe('sec_new');
+  });
+
+  it('upsertGuild on an existing owner updates the secret (last-write-wins)', () => {
+    subs.upsertGuild({
+      guildId: 'g1', ownerId: 'usr_a', webhookId: 'wh_a', webhookSecret: 'sec_v1',
+    });
+    subs.upsertGuild({
+      guildId: 'g1', ownerId: 'usr_a', webhookId: 'wh_a', webhookSecret: 'sec_v2',
+    });
+    expect(subs.getSecretForOwner('usr_a')).toBe('sec_v2');
+  });
+
+  it('removeGuild drops the last guild + clears the cache entry', () => {
+    subs.upsertGuild({
+      guildId: 'g1', ownerId: 'usr_solo', webhookId: 'wh1', webhookSecret: 'sec1',
+    });
+    subs.removeGuild({ guildId: 'g1', ownerId: 'usr_solo' });
+    expect(subs.getSecretForOwner('usr_solo')).toBeNull();
+  });
+
+  it('removeGuild keeps the entry when sibling guilds remain', () => {
+    // Multi-guild-shared-owner: removing g1 doesn't kill g2's
+    // delivery. The receiver's secret lookup stays valid for usr_admin.
+    subs.upsertGuild({
+      guildId: 'g1', ownerId: 'usr_admin', webhookId: 'wh_shared', webhookSecret: 'sec_shared',
+    });
+    subs.upsertGuild({
+      guildId: 'g2', ownerId: 'usr_admin', webhookId: 'wh_shared', webhookSecret: 'sec_shared',
+    });
+    subs.removeGuild({ guildId: 'g1', ownerId: 'usr_admin' });
+    expect(subs.getSecretForOwner('usr_admin')).toBe('sec_shared');
+  });
+});
+
+describe('webhook-subscriptions registry — first-scan-failure semantics', () => {
+  it('throws on scanOnce DDB failure (caller increments failure counter)', async () => {
+    mockScan.mockRejectedValueOnce(new Error('DDB throttled'));
+    await expect(subs.scanOnce()).rejects.toThrow(/DDB throttled/);
+    expect(subs.isPrimed()).toBe(false);
+  });
+
+  it('throws on owner-discovery fetch failure (caller increments failure counter)', async () => {
+    mockScan.mockResolvedValueOnce([]);
+    global.fetch = jest.fn(async () => ({ ok: false, status: 503, json: async () => ({}) }));
+    await expect(subs.scanOnce()).rejects.toThrow(/GET \/v1\/webhooks returned 503/);
+    expect(subs.isPrimed()).toBe(false);
+  });
+
+  it('after recovery, a successful scan flips primed back to true', async () => {
+    mockScan.mockRejectedValueOnce(new Error('DDB throttled'));
+    await expect(subs.scanOnce()).rejects.toThrow();
+    expect(subs.isPrimed()).toBe(false);
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g1', webhookId: 'wh1', webhookSecret: 'sec1', webhookOwnerId: 'usr_x' },
+    ]);
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+    expect(subs.getSecretForOwner('usr_x')).toBe('sec1');
+  });
+});

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -16,6 +16,14 @@ jest.mock('../src/store', () => ({
   scanGuildSubscriptions: mockScan,
 }));
 
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
 process.env.QURL_API_KEY = 'lv_test_abc';
 process.env.QURL_ENDPOINT = 'https://qurl.layerv.ai';
 process.env.QURL_WEBHOOK_SECRET = 'default-key-secret';
@@ -392,38 +400,50 @@ describe('webhook-subscriptions registry — first-scan-failure semantics', () =
     expect(subs.isPrimed()).toBe(false);
   });
 
-  // Pin the alarm-once contract: the audit fires exactly once when
-  // consecutiveFailures crosses the escalation threshold, NOT on
-  // every subsequent failed tick. Without this guard, a sustained
-  // outage would flood the alarm channel.
-  it('emits QURL_WEBHOOK_CACHE_REFRESH_FAIL audit exactly once at the escalation threshold', async () => {
-    // The audit fires INSIDE refreshTick (which wraps scanOnce in a
-    // try/catch and tracks consecutiveFailures). We exercise
-    // refreshTick directly via start() — but start() also kicks the
-    // ticker. Easier: drive refreshTick semantics by calling scanOnce
-    // 3+ times under failure, then verify the logger.audit mock fired
-    // exactly once with the escalate-threshold event.
-    //
-    // Drive via start() which runs refreshTick immediately + sets
-    // interval. We then advance with extra start()s? No — easier to
-    // hit refreshTick directly. But it's not exported. Use the
-    // public API: scanOnce throws, count failures via N synchronous
-    // attempts.
-    //
-    // Workaround: temporarily expose by importing the module path and
-    // calling start() N times via .unref()'d intervals. Simpler still:
-    // just verify the AUDIT_EVENTS string is correct + the threshold
-    // constant, since refreshTick has trivial logic.
-    //
-    // Pin the constants by introspection so a future bump to
-    // REFRESH_FAIL_ESCALATE_AT doesn't accidentally silence the alarm.
-    const src = require('fs').readFileSync(
-      require('path').join(__dirname, '..', 'src', 'webhook-subscriptions.js'),
-      'utf8',
+  // Alarm-once contract: behavioral test via the test-only
+  // _refreshTickForTesting hook. Five consecutive failures must fire
+  // the QURL_WEBHOOK_CACHE_REFRESH_FAIL audit EXACTLY ONCE at the
+  // escalation threshold, not on every subsequent failed tick.
+  it('emits QURL_WEBHOOK_CACHE_REFRESH_FAIL audit exactly once across N consecutive failures', async () => {
+    const mockLogger = require('../src/logger');
+    mockLogger.audit.mockClear();
+    // 5 consecutive scan failures.
+    for (let i = 0; i < 5; i++) {
+      mockScan.mockRejectedValueOnce(new Error('DDB throttled'));
+      // eslint-disable-next-line no-await-in-loop
+      await subs._refreshTickForTesting();
+    }
+    const refreshFailCalls = mockLogger.audit.mock.calls.filter(
+      ([event]) => event === 'qurl_webhook_cache_refresh_fail',
     );
-    expect(src).toMatch(/REFRESH_FAIL_ESCALATE_AT\s*=\s*3/);
-    expect(src).toMatch(/consecutiveFailures\s*===\s*REFRESH_FAIL_ESCALATE_AT/);
-    expect(src).toMatch(/QURL_WEBHOOK_CACHE_REFRESH_FAIL/);
+    expect(refreshFailCalls).toHaveLength(1);
+    expect(refreshFailCalls[0][1]).toEqual(
+      expect.objectContaining({ consecutive_failures: 3 }),
+    );
+  });
+
+  it('resets failure counter + lets the next outage alarm fresh', async () => {
+    const mockLogger = require('../src/logger');
+    mockLogger.audit.mockClear();
+    // 3 fails → audit fires once.
+    for (let i = 0; i < 3; i++) {
+      mockScan.mockRejectedValueOnce(new Error('fail'));
+      // eslint-disable-next-line no-await-in-loop
+      await subs._refreshTickForTesting();
+    }
+    // Recovery: a successful scan resets consecutiveFailures.
+    mockScan.mockResolvedValueOnce([]);
+    await subs._refreshTickForTesting();
+    // 3 MORE fails → the NEXT outage alarms again.
+    for (let i = 0; i < 3; i++) {
+      mockScan.mockRejectedValueOnce(new Error('fail'));
+      // eslint-disable-next-line no-await-in-loop
+      await subs._refreshTickForTesting();
+    }
+    const refreshFailCalls = mockLogger.audit.mock.calls.filter(
+      ([event]) => event === 'qurl_webhook_cache_refresh_fail',
+    );
+    expect(refreshFailCalls).toHaveLength(2);
   });
 
   it('after recovery, a successful scan flips primed back to true', async () => {

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -227,6 +227,54 @@ describe('webhook-subscriptions registry — synchronous local update API', () =
   });
 });
 
+describe('webhook-subscriptions registry — scanInFlight re-entrancy guard', () => {
+  // If a tick takes longer than the 30s interval, the next interval
+  // fires while the first is still awaiting. Both calls would
+  // .clear() upsertsDuringScan and the second wipes the first's in-
+  // flight tracking. The guard drops the overlap. Pin the behavior
+  // so a refactor doesn't accidentally re-introduce the race.
+  it('drops an overlapping scanOnce while another is in flight', async () => {
+    let resolveFirst;
+    mockScan.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g_second', webhookId: 'wh_2', webhookSecret: 'sec_2', webhookOwnerId: 'usr_2' },
+    ]);
+    const first = subs.scanOnce();
+    // The second call returns IMMEDIATELY because scanInFlight is true;
+    // mockScan is NOT invoked a second time.
+    const second = subs.scanOnce();
+    await second;
+    expect(mockScan).toHaveBeenCalledTimes(1);
+    // Now finish the first scan so subsequent tests aren't tainted.
+    resolveFirst([]);
+    await first;
+  });
+});
+
+describe('webhook-subscriptions registry — default-key + BYOK owner collision', () => {
+  // Edge case: an admin links a BYOK guild using the SAME auth0 owner
+  // as the bot's default key (e.g., bot operator running /qurl setup
+  // in their own server). The BYOK row's webhook_owner_id ===
+  // discoveredOwner. Without the guard, the default-key fold would
+  // overwrite the BYOK entry's guildIds — observationally benign
+  // (the secret is the same) but a silent overwrite is dishonest.
+  it('does NOT clobber a BYOK entry that shares the default-key owner_id', async () => {
+    mockScan.mockResolvedValueOnce([
+      {
+        guildId: 'g_admin_byok', webhookId: 'wh_byok',
+        webhookSecret: 'sec_shared', webhookOwnerId: 'usr_default',
+        updatedAt: '2026-05-21T00:00:00.000Z',
+      },
+    ]);
+    // discoverDefaultOwnerId returns 'usr_default' — same as BYOK row.
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+    // Secret resolves; BYOK entry is preserved (webhookId stays the
+    // string 'wh_byok', NOT the DEFAULT_KEY_SENTINEL Symbol).
+    expect(subs.getSecretForOwner('usr_default')).toBe('sec_shared');
+  });
+});
+
 describe('webhook-subscriptions registry — default-key discovery', () => {
   // When GET /v1/webhooks returns an empty list (Lambda hasn't run
   // on a fresh deploy, or QURL_API_KEY/QURL_ENDPOINT are unset),

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -347,7 +347,7 @@ describe('webhook-subscriptions registry — default-key + BYOK owner collision'
     await subs.scanOnce();
     expect(subs.isPrimed()).toBe(true);
     // Secret resolves; BYOK entry is preserved (webhookId stays the
-    // string 'wh_byok', NOT the DEFAULT_KEY_SENTINEL Symbol).
+    // string 'wh_byok', NOT the DEFAULT_KEY_SENTINEL).
     expect(subs.getSecretForOwner('usr_default')).toBe('sec_shared');
   });
 });

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -350,6 +350,31 @@ describe('webhook-subscriptions registry — default-key + BYOK owner collision'
     // string 'wh_byok', NOT the DEFAULT_KEY_SENTINEL).
     expect(subs.getSecretForOwner('usr_default')).toBe('sec_shared');
   });
+
+  it('BYOK row wins over default-key when secrets DIFFER for the same owner (chosen behavior)', async () => {
+    // Future-bug scenario: qurl-service rotates the default-key secret
+    // but the BYOK row's secret stays stale (or vice versa). Today this
+    // can't happen because the BYOK row + default-key share the same
+    // qurl-service subscription on shared owner_id — but if the
+    // identity assumption is ever violated, the BYOK row is what
+    // wins, NOT the env-derived default secret. Pinning the chosen
+    // behavior here forces the next bug that breaks the identity
+    // assumption to surface as a LOUD test failure (the assumption
+    // shifted), not a silent prod 401 storm.
+    mockScan.mockResolvedValueOnce([
+      {
+        guildId: 'g_admin_byok', webhookId: 'wh_byok',
+        // Diverged secret — different from QURL_WEBHOOK_SECRET.
+        webhookSecret: 'sec_byok_only',
+        webhookOwnerId: 'usr_default',
+        updatedAt: '2026-05-21T00:00:00.000Z',
+      },
+    ]);
+    await subs.scanOnce();
+    expect(subs.isPrimed()).toBe(true);
+    // BYOK row wins, NOT the env QURL_WEBHOOK_SECRET ('default-key-secret').
+    expect(subs.getSecretForOwner('usr_default')).toBe('sec_byok_only');
+  });
 });
 
 describe('webhook-subscriptions registry — default-key discovery', () => {

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -393,17 +393,42 @@ describe('webhook-subscriptions registry — first-scan-failure semantics', () =
     expect(subs.isPrimed()).toBe(false);
   });
 
-  it('throws on owner-discovery fetch failure (caller increments failure counter)', async () => {
-    mockScan.mockResolvedValueOnce([]);
+  it('does NOT throw on owner-discovery fetch failure (BYOK delivery survives a transient qurl-service blip)', async () => {
+    // Decoupled from Promise.all rejection: discovery failure is
+    // caught locally, scan completes with the BYOK row, primed flips
+    // true, and BYOK lookups resolve. The default-key entry stays
+    // absent until discovery recovers.
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g_byok', webhookId: 'wh_byok', webhookSecret: 'sec_byok', webhookOwnerId: 'usr_byok' },
+    ]);
     global.fetch = jest.fn(async () => ({
       ok: false, status: 503, text: async () => '',
     }));
-    // callQurlService wraps the failure in a QurlServiceError that
-    // includes the op name in the message — assert on the 503 status
-    // appearing, not the exact text, so a future error-message
-    // rewording doesn't break the test.
-    await expect(subs.scanOnce()).rejects.toThrow(/returned 503/);
-    expect(subs.isPrimed()).toBe(false);
+    await expect(subs.scanOnce()).resolves.toBe('completed');
+    expect(subs.isPrimed()).toBe(true);
+    expect(subs.getSecretForOwner('usr_byok')).toBe('sec_byok');
+    expect(subs.getSecretForOwner('usr_default')).toBeNull();
+  });
+
+  it('emits QURL_WEBHOOK_DEFAULT_DISCOVERY_FAIL audit exactly once at the escalation threshold', async () => {
+    const mockLogger = require('../src/logger');
+    mockLogger.audit.mockClear();
+    // 5 consecutive discovery failures (DDB scan succeeds throughout).
+    for (let i = 0; i < 5; i++) {
+      mockScan.mockResolvedValueOnce([]);
+      global.fetch = jest.fn(async () => ({
+        ok: false, status: 503, text: async () => '',
+      }));
+      // eslint-disable-next-line no-await-in-loop
+      await subs._refreshTickForTesting();
+    }
+    const discoveryFailCalls = mockLogger.audit.mock.calls.filter(
+      ([event]) => event === 'qurl_webhook_default_discovery_fail',
+    );
+    expect(discoveryFailCalls).toHaveLength(1);
+    expect(discoveryFailCalls[0][1]).toEqual(
+      expect.objectContaining({ consecutive_failures: 3 }),
+    );
   });
 
   // Alarm-once contract: behavioral test via the test-only

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -410,6 +410,43 @@ describe('webhook-subscriptions registry — first-scan-failure semantics', () =
     expect(subs.getSecretForOwner('usr_default')).toBeNull();
   });
 
+  it('consecutiveFailures survives a "skipped" scan (long-running outage must still escalate)', async () => {
+    const mockLogger = require('../src/logger');
+    mockLogger.audit.mockClear();
+    // 2 fails — under threshold, no audit yet.
+    for (let i = 0; i < 2; i++) {
+      mockScan.mockRejectedValueOnce(new Error('fail'));
+      // eslint-disable-next-line no-await-in-loop
+      await subs._refreshTickForTesting();
+    }
+    // Force a 'skipped' tick by leaving scanInFlight true. Easiest
+    // path: kick a never-resolving scan and call refreshTick on top
+    // of it (the second one returns 'skipped' without throwing).
+    let resolveLong;
+    mockScan.mockReturnValueOnce(new Promise(r => { resolveLong = r; }));
+    const inflight = subs._refreshTickForTesting();
+    await subs._refreshTickForTesting(); // skipped — must NOT reset counter
+    resolveLong([]); // complete the long scan so the next assertion is meaningful
+    await inflight;
+    // The long-running scan that JUST completed was a SUCCESS (no
+    // throw), which resets the counter — this is correct behavior:
+    // a real recovery is real recovery. The point of this test is
+    // that the *skipped* tick alone didn't artificially reset.
+    // To pin the skip-doesn't-reset semantic, restart the failure
+    // streak and observe the audit fires at exactly 3 fails again
+    // (not 1 — would happen if skipped had been counted as success).
+    mockLogger.audit.mockClear();
+    for (let i = 0; i < 3; i++) {
+      mockScan.mockRejectedValueOnce(new Error('fail'));
+      // eslint-disable-next-line no-await-in-loop
+      await subs._refreshTickForTesting();
+    }
+    const calls = mockLogger.audit.mock.calls.filter(
+      ([event]) => event === 'qurl_webhook_cache_refresh_fail',
+    );
+    expect(calls).toHaveLength(1);
+  });
+
   it('emits QURL_WEBHOOK_DEFAULT_DISCOVERY_FAIL audit exactly once at the escalation threshold', async () => {
     const mockLogger = require('../src/logger');
     mockLogger.audit.mockClear();

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -182,6 +182,38 @@ describe('webhook-subscriptions registry — concurrent upsert during scan', () 
     await subs.scanOnce();
     expect(subs.getSecretForOwner('usr_pre')).toBe('sec_pre_from_scan');
   });
+
+  // Cycle-6 cr regression: scan caught a pre-rotate sibling row for
+  // owner X while a concurrent linkGuildWebhookSubscription wrote
+  // the post-rotate secret via upsertGuild. Without the cycle-6 fix
+  // (upsertsDuringScan overrides scan-result entries), the cache
+  // would hold the stale secret until the next 30s tick.
+  it('upsert mid-scan overrides scan result for the same owner (rotate-drift race)', async () => {
+    let resolveScan;
+    mockScan.mockImplementationOnce(() => new Promise((resolve) => { resolveScan = resolve; }));
+    const scanPromise = subs.scanOnce();
+    // Mid-scan: a concurrent link wrote the POST-rotate secret in
+    // memory via upsertGuild. DDB write may or may not be visible
+    // to the in-flight scan; assume it is and the scan caught a
+    // stale sibling row.
+    subs.upsertGuild({
+      guildId: 'g_primary', ownerId: 'usr_rot',
+      webhookId: 'wh_rot', webhookSecret: 'sec_post_rotate',
+    });
+    // Scan resolves with the PRE-rotate sibling row (rotate drift).
+    resolveScan([
+      {
+        guildId: 'g_sibling', webhookId: 'wh_rot', webhookSecret: 'sec_pre_rotate',
+        webhookOwnerId: 'usr_rot',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+    ]);
+    await scanPromise;
+    // The in-memory upsert MUST win — qurl-service signs with the
+    // post-rotate secret, so any cached pre-rotate secret would
+    // 401 every inbound webhook for this owner.
+    expect(subs.getSecretForOwner('usr_rot')).toBe('sec_post_rotate');
+  });
 });
 
 describe('webhook-subscriptions registry — synchronous local update API', () => {
@@ -224,6 +256,26 @@ describe('webhook-subscriptions registry — synchronous local update API', () =
     });
     subs.removeGuild({ guildId: 'g1', ownerId: 'usr_admin' });
     expect(subs.getSecretForOwner('usr_admin')).toBe('sec_shared');
+  });
+
+  // Defensive: pre-discovery (defaultOwnerId is null), removeGuild on
+  // a BYOK guild whose owner happens to equal what would BECOME the
+  // default owner could otherwise drop the entry. Doesn't matter
+  // today (no production caller), but pins the future-/qurl-unlink
+  // contract before that caller lands.
+  it('removeGuild on a sole-guild owner drops the entry pre-discovery (next scan rediscovers)', async () => {
+    subs.upsertGuild({
+      guildId: 'g1', ownerId: 'usr_byok', webhookId: 'wh_byok', webhookSecret: 'sec_byok',
+    });
+    subs.removeGuild({ guildId: 'g1', ownerId: 'usr_byok' });
+    expect(subs.getSecretForOwner('usr_byok')).toBeNull();
+    // The DDB row is still authoritative — the next 30s tick will
+    // restore the entry if the caller didn't also DDB-delete it.
+    mockScan.mockResolvedValueOnce([
+      { guildId: 'g1', webhookId: 'wh_byok', webhookSecret: 'sec_byok', webhookOwnerId: 'usr_byok' },
+    ]);
+    await subs.scanOnce();
+    expect(subs.getSecretForOwner('usr_byok')).toBe('sec_byok');
   });
 });
 

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -39,11 +39,13 @@ beforeEach(() => {
   subs._resetForTesting();
   mockScan.mockReset();
   // Default fetch mock returns the default-key owner_id discovery
-  // shape so the refresh tick can fold it in.
-  global.fetch = jest.fn(async () => ({
-    ok: true,
-    json: async () => ({ data: [{ owner_id: 'usr_default', webhook_id: 'wh_default' }] }),
-  }));
+  // shape so the refresh tick can fold it in. text() is required
+  // because discoverDefaultOwnerId goes through callQurlService,
+  // which reads body via text() then JSON.parses.
+  global.fetch = jest.fn(async () => {
+    const body = { data: [{ owner_id: 'usr_default', webhook_id: 'wh_default' }] };
+    return { ok: true, status: 200, text: async () => JSON.stringify(body) };
+  });
 });
 
 afterAll(() => {
@@ -364,8 +366,7 @@ describe('webhook-subscriptions registry — default-key discovery', () => {
       { guildId: 'g1', webhookId: 'wh1', webhookSecret: 'sec1', webhookOwnerId: 'usr_byok' },
     ]);
     global.fetch = jest.fn(async () => ({
-      ok: true,
-      json: async () => ({ data: [] }),
+      ok: true, status: 200, text: async () => JSON.stringify({ data: [] }),
     }));
     await subs.scanOnce();
     expect(subs.isPrimed()).toBe(true);
@@ -378,8 +379,7 @@ describe('webhook-subscriptions registry — default-key discovery', () => {
   it('still primes the cache when GET response data field is missing', async () => {
     mockScan.mockResolvedValueOnce([]);
     global.fetch = jest.fn(async () => ({
-      ok: true,
-      json: async () => ({}),
+      ok: true, status: 200, text: async () => JSON.stringify({}),
     }));
     await subs.scanOnce();
     expect(subs.isPrimed()).toBe(true);
@@ -395,8 +395,14 @@ describe('webhook-subscriptions registry — first-scan-failure semantics', () =
 
   it('throws on owner-discovery fetch failure (caller increments failure counter)', async () => {
     mockScan.mockResolvedValueOnce([]);
-    global.fetch = jest.fn(async () => ({ ok: false, status: 503, json: async () => ({}) }));
-    await expect(subs.scanOnce()).rejects.toThrow(/GET \/v1\/webhooks returned 503/);
+    global.fetch = jest.fn(async () => ({
+      ok: false, status: 503, text: async () => '',
+    }));
+    // callQurlService wraps the failure in a QurlServiceError that
+    // includes the op name in the message — assert on the 503 status
+    // appearing, not the exact text, so a future error-message
+    // rewording doesn't break the test.
+    await expect(subs.scanOnce()).rejects.toThrow(/returned 503/);
     expect(subs.isPrimed()).toBe(false);
   });
 

--- a/apps/discord/tests/webhook-subscriptions.test.js
+++ b/apps/discord/tests/webhook-subscriptions.test.js
@@ -392,6 +392,40 @@ describe('webhook-subscriptions registry — first-scan-failure semantics', () =
     expect(subs.isPrimed()).toBe(false);
   });
 
+  // Pin the alarm-once contract: the audit fires exactly once when
+  // consecutiveFailures crosses the escalation threshold, NOT on
+  // every subsequent failed tick. Without this guard, a sustained
+  // outage would flood the alarm channel.
+  it('emits QURL_WEBHOOK_CACHE_REFRESH_FAIL audit exactly once at the escalation threshold', async () => {
+    // The audit fires INSIDE refreshTick (which wraps scanOnce in a
+    // try/catch and tracks consecutiveFailures). We exercise
+    // refreshTick directly via start() — but start() also kicks the
+    // ticker. Easier: drive refreshTick semantics by calling scanOnce
+    // 3+ times under failure, then verify the logger.audit mock fired
+    // exactly once with the escalate-threshold event.
+    //
+    // Drive via start() which runs refreshTick immediately + sets
+    // interval. We then advance with extra start()s? No — easier to
+    // hit refreshTick directly. But it's not exported. Use the
+    // public API: scanOnce throws, count failures via N synchronous
+    // attempts.
+    //
+    // Workaround: temporarily expose by importing the module path and
+    // calling start() N times via .unref()'d intervals. Simpler still:
+    // just verify the AUDIT_EVENTS string is correct + the threshold
+    // constant, since refreshTick has trivial logic.
+    //
+    // Pin the constants by introspection so a future bump to
+    // REFRESH_FAIL_ESCALATE_AT doesn't accidentally silence the alarm.
+    const src = require('fs').readFileSync(
+      require('path').join(__dirname, '..', 'src', 'webhook-subscriptions.js'),
+      'utf8',
+    );
+    expect(src).toMatch(/REFRESH_FAIL_ESCALATE_AT\s*=\s*3/);
+    expect(src).toMatch(/consecutiveFailures\s*===\s*REFRESH_FAIL_ESCALATE_AT/);
+    expect(src).toMatch(/QURL_WEBHOOK_CACHE_REFRESH_FAIL/);
+  });
+
   it('after recovery, a successful scan flips primed back to true', async () => {
     mockScan.mockRejectedValueOnce(new Error('DDB throttled'));
     await expect(subs.scanOnce()).rejects.toThrow();


### PR DESCRIPTION
## Summary

Fixes the sub-second view counter for guilds that link their own qURL API key (BYOK). The bot mints qURLs under each guild's auth0 owner_id, but the existing default-key webhook subscription (created by the one-shot Lambda) only fires for the bot's own owner. qurl-service filters subscriptions by `owner_id`, so BYOK qURLs never produce a webhook — the bot falls back to polling.

**Verified in prod 2026-05-21**: two user views landed in qurl-service at 19:03 / 19:12 UTC but produced **zero** webhook deliveries. The accessed resources (`r_xu0v_wmftuk`, `r_aetctnovra8`) were owned by `auth0|69af78d7…`; the subscription `wh_ZT-PV5ms03uZ2V6Y` is owned by `auth0|69adc6ed…`.

This PR adds in-process per-guild subscription registration, a multi-secret receiver, and a one-time backfill script for already-linked guilds. The existing default-key subscription + Lambda are untouched (non-BYOK guilds keep working).

## Design

- **`src/webhook-subscriptions.js`** (NEW) — in-process `Map<owner_id, secret>` registry primed from `guild_configs` at boot + refreshed every 30s. Folds `GET /v1/webhooks` (default key) into the same tick to discover the Lambda's subscription owner_id automatically.
- **`src/guild-webhook-link.js`** (NEW) — link / unlink orchestration. Called from the OAuth callback and `/qurl setup` paste flow after `setGuildApiKey`. Partial-failure rollback via `deleteSubscription` if DDB persist throws. Reference-counted unlink — when one auth0 admin's API key covers N guilds, unlinking one preserves sibling delivery.
- **`src/routes/qurl-webhook.js`** — multi-secret receiver. Extracts `body.owner_id` pre-HMAC (`rawBody` is already 1mb-capped by middleware so the parse is bounded), looks up the secret in the registry, then HMACs. Returns **503** when the cache is unprimed (cold start / sibling-replica lag — qurl-service retries 503 with 1+2+4+8+16=31s backoff), **401** after priming for unknown owners (truthful response). Industry-standard pattern (Stripe / GitHub / Linear).
- **`src/store/ddb-store.js`** — new `webhook_id` (plain), `webhook_secret` (encrypted via existing `utils/crypto.js`), `webhook_owner_id` (plain) attributes on `guild_configs` rows. Helpers: `setGuildWebhookSubscription`, `clearGuildWebhookSubscription`, `listGuildSubscriptionsByOwner` (ref-counting), `scanGuildSubscriptions` (cache priming).
- **`scripts/provision-guild-subscriptions.js`** (NEW) — one-time backfill for already-linked guilds (3 in prod today). Idempotent + supports `--dry-run`.

## Observability

New audit events emit via the existing `logger.audit(AUDIT_EVENTS.X, {…})` pattern. CloudWatch metric filters in `qurl-integrations-infra` will pick them up automatically:

- `QURL_WEBHOOK_CACHE_MISS_UNPRIMED` (503 path)
- `QURL_WEBHOOK_CACHE_MISS_UNKNOWN_OWNER` (401 path, post-priming)
- `QURL_WEBHOOK_CACHE_REFRESH_FAIL` (escalates at 3 consecutive failures)
- `QURL_WEBHOOK_SUBSCRIPTION_REGISTERED` / `_DELETED` / `_DELETE_FAILED`

## Out of scope

- Secret rotation per subscription — qurl-service has no rotate endpoint; DELETE+create is the operational play if a secret leaks.
- Orphan-subscription sweeper — DELETE 401/404 swallowed at the call site; the orphan only consumes one row on qurl-service and 401s on every delivery. Periodic reconciliation is a future enhancement.

## Test plan

- [x] `npm test` — 2575 passing (1 pre-existing failure in `tests/lambda/webhook-registrar/index.test.js` due to missing `@aws-sdk/client-ssm` in the bot's package.json; confirmed unchanged on `main`).
- [x] `npm run lint` — clean.
- [x] `tests/store-contract.test.js` — passes with new methods registered in `STORE_METHODS`.
- [x] New `tests/webhook-subscriptions.test.js` covers: priming, refresh, multi-guild-shared-owner, first-scan-failure escalation, sync local-update API.
- [x] Extended `tests/qurl-webhook.test.js`: multi-secret HMAC selection (sibling-owner secret rejected), 503-when-unprimed, 401-when-primed-but-unknown, malformed/missing owner_id rejection.
- [ ] **Sandbox deploy**: link an API key via `/qurl setup`, mint a qURL via `/qurl send`, click the link, watch the counter increment sub-second in Discord. Confirm a `qurl.accessed` row appears in the sandbox `qurl-webhook-deliveries` DDB table.
- [ ] **Prod backfill**: after sandbox is verified, deploy to prod, then run `node apps/discord/scripts/provision-guild-subscriptions.js --dry-run` to confirm the 3 already-linked guilds are identified, then run without `--dry-run` to provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)