### PR TITLE
feat(slack,shared): render tunnel-type qURLs via qurl_site instead of failing

### DIFF
--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -295,14 +295,20 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	if err != nil {
 		return "", mapMintError(log, err)
 	}
-	// Defensive: a 200 with an empty qurl_link is a server contract
-	// surprise — log loud and surface the generic retry message.
-	if out.QURLLink == "" {
-		log.Error("get: mint returned empty qurl_link — server contract surprise", "alias_form", isAliasForm, "resource_id_form", isResourceIDForm, "resource_id", input.ResourceID)
+	// Pick the user-facing URL by qURL kind. URL-redirect qURLs ship a
+	// token-bearing `qurl_link`; tunnel qURLs ship an empty `qurl_link`
+	// by server contract and the access surface lives on `qurl_site`
+	// (see CreateOutput's type-level doc + AccessURL helper). A truly
+	// missing URL (both fields empty) IS a server contract surprise —
+	// we keep the loud-error branch for that case so the alarm doesn't
+	// regress on a future server-side rename.
+	accessURL := out.AccessURL()
+	if accessURL == "" {
+		log.Error("get: mint returned no usable URL — server contract surprise", "alias_form", isAliasForm, "resource_id_form", isResourceIDForm, "resource_id", input.ResourceID, "type", out.Type)
 		return "", &userError{msg: commonGetMintFailedMessage}
 	}
 
-	message := ":link: *qURL ready:* " + out.QURLLink
+	message := ":link: *qURL ready:* " + accessURL
 	if args.cmd.Once() {
 		message += " (one-time use)"
 	}

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -18,11 +18,34 @@ func writeCreateFixture(t *testing.T, w http.ResponseWriter, link, resourceID st
 	body := map[string]any{
 		testKeyData: map[string]any{
 			testKeyResourceID: resourceID,
-			"qurl_link":       link,
+			testKeyQURLLink:   link,
 		},
 	}
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		t.Fatalf("encode: %v", err)
+	}
+}
+
+// writeTunnelCreateFixture writes the response shape `qurl-service`
+// emits for tunnel-type qURLs: `type:"tunnel"`, empty `qurl_link`,
+// populated `qurl_site`. Mirrors the contract pinned in
+// `qurl-service/internal/service/qurl_service.go::CreateQurl` and
+// the SDK doc on `client.CreateOutput`. Distinct fixture (rather
+// than a writeCreateFixture variant) so a future test reader sees
+// the empty-link shape as deliberate, not a typo.
+func writeTunnelCreateFixture(t *testing.T, w http.ResponseWriter, qurlSite, resourceID string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	body := map[string]any{
+		testKeyData: map[string]any{
+			testKeyResourceID: resourceID,
+			testKeyQURLLink:   "",
+			testKeyQURLSite:   qurlSite,
+			testKeyType:       "tunnel",
+		},
+	}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode tunnel fixture: %v", err)
 	}
 }
 
@@ -65,6 +88,76 @@ func TestHandleGet_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(async, "https://qurl.link/abc") {
 		t.Errorf("async reply missing link: %q", async)
+	}
+}
+
+// TestHandleGet_HappyPath_Tunnel fences the tunnel-qURL branch:
+// `qurl-service` emits `type:"tunnel"` + empty `qurl_link` +
+// populated `qurl_site`, and the handler must render `qurl_site` as
+// the user-facing URL instead of treating the empty link as a
+// contract surprise. Pre-fix, this test fails with the
+// "Failed to mint qURL" copy because handler_get.go's
+// `out.QURLLink == ""` short-circuit fired ahead of the kind
+// detector.
+func TestHandleGet_HappyPath_Tunnel(t *testing.T) {
+	const tunnelSite = "https://r_cnaip_fprni.qurl.site.layerv.xyz"
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "tunnel-demo", []string{testResourceIDFix})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeTunnelCreateFixture(t, w, tunnelSite, testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	status, ack, async := inv.invokeAdminAsync("get $tunnel-demo", testAdminTeamID, testAdminUserID)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if ack != ackWorkingOnIt {
+		t.Errorf("ack = %q, want %q", ack, ackWorkingOnIt)
+	}
+	if !strings.Contains(async, tunnelSite) {
+		t.Errorf("async reply missing tunnel qurl_site URL: %q (expected to contain %q)", async, tunnelSite)
+	}
+	// Defensive: a regression that ALSO surfaces the empty-link
+	// contract-surprise message alongside the URL would mask the fix —
+	// the user would see both a "qURL ready" line and a "Failed to
+	// mint" line. Explicit negative-assert so the loud-error branch
+	// stays exclusive to the truly-no-URL case.
+	if strings.Contains(async, "Failed to mint qURL") {
+		t.Errorf("async reply incorrectly surfaced contract-surprise copy on tunnel mint: %q", async)
+	}
+}
+
+// TestHandleGet_NoURLContractSurprise fences the truly-broken case:
+// neither `qurl_link` nor `qurl_site` populated. Server contract
+// surprise of the original "post-mint there must be SOME URL"
+// shape — caller surfaces the generic retry copy. This is the
+// branch the pre-fix `out.QURLLink == ""` check was guarding; we
+// kept it (now keyed on `AccessURL()==""`) so the loud-error path
+// doesn't regress when the server gets actually broken.
+func TestHandleGet_NoURLContractSurprise(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "broken-resource", []string{testResourceIDFix})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := map[string]any{
+			testKeyData: map[string]any{
+				testKeyResourceID: testResourceIDFix,
+				testKeyQURLLink:   "",
+				testKeyQURLSite:   "",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $broken-resource", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "Failed to mint qURL") {
+		t.Errorf("async reply missing contract-surprise copy on no-URL response: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_test_helpers_test.go
+++ b/apps/slack/internal/handler_test_helpers_test.go
@@ -18,6 +18,8 @@ const (
 	testKeyTitle      = "title"
 	testKeyType       = "type"
 	testKeyTargetURL  = "target_url"
+	testKeyQURLLink   = "qurl_link"
+	testKeyQURLSite   = "qurl_site"
 	testResourceIDFix = "r_prod_db" // canonical test resource_id
 	// mintByTestResourcePath is the resource-scoped mint endpoint
 	// that `client.Create` hits when given a ResourceID (alias-form

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -292,11 +292,69 @@ type CreateInput struct {
 }
 
 // CreateOutput is the response from creating a qURL.
+//
+// `QURLLink` vs `QURLSite` carry different shapes by resource kind, and
+// the kind is signaled on the wire via `type`:
+//
+//   - `type == ""` or `type == "url"` (URL-redirect qURLs): `QURLLink`
+//     is the user-facing access URL (`https://<qurl-link-domain>/#<token>`).
+//     `QURLSite` is set but secondary — it's the eventual redirect target
+//     once the token resolves.
+//   - `type == "tunnel"` (reverse-tunnel qURLs): `QURLLink` is EMPTY
+//     **by server contract** — `qurl-service` deliberately elides it
+//     (`internal/service/qurl_service.go::CreateQurl` only populates
+//     QurlLink when `!isTunnel`). `QURLSite` is the access surface.
+//
+// Callers MUST check `Type` (or the equivalent "non-empty QURLSite +
+// empty QURLLink") to pick the right user-facing URL — treating an
+// empty QURLLink as a server bug silently breaks the tunnel path.
 type CreateOutput struct {
 	ResourceID string     `json:"resource_id"`
 	QURLLink   string     `json:"qurl_link"`
 	QURLSite   string     `json:"qurl_site"`
 	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	// Type is the qURL kind. Either empty/"url" or "tunnel"; see the
+	// type-level doc for the per-kind URL contract.
+	Type string `json:"type,omitempty"`
+}
+
+// IsTunnel reports whether the qURL is a reverse-tunnel resource. The
+// check is wire-format-stable: server-side `qurl-service` sets `type`
+// to `"tunnel"` for tunnel qURLs (see `gen.CreateQurlData.Type` in
+// `qurl-service/internal/api/handlers/server.go`). The empty-QURLLink
+// shape (the secondary signal) is kept as a fallback because a future
+// `type` rename without a corresponding bot bump still has to keep
+// rendering for the existing user base.
+func (o *CreateOutput) IsTunnel() bool {
+	if o == nil {
+		return false
+	}
+	if o.Type == "tunnel" {
+		return true
+	}
+	// Defensive fallback: an empty QURLLink with a non-empty QURLSite
+	// is the wire shape qurl-service emits for tunnel qURLs even if
+	// the `type` field is unset (older minted rows, replays, etc.).
+	// A URL-redirect qURL with both empty would be a true server
+	// contract surprise — the caller's empty-QURLLink branch should
+	// keep its existing alarm.
+	return o.QURLLink == "" && o.QURLSite != ""
+}
+
+// AccessURL returns the user-facing URL to show in chat/UI. For URL
+// qURLs that's the `QURLLink` (token-bearing fragment URL); for
+// tunnel qURLs the human-clickable surface is `QURLSite` because
+// `QURLLink` is empty by contract. Returns empty when neither field
+// is populated — caller should treat that as a real server contract
+// surprise and surface a retry/diagnostic, not an empty link.
+func (o *CreateOutput) AccessURL() string {
+	if o == nil {
+		return ""
+	}
+	if o.IsTunnel() {
+		return o.QURLSite
+	}
+	return o.QURLLink
 }
 
 // isHeaderSafeASCIIByte reports whether b is safe to ship in a header

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -2141,3 +2141,86 @@ func TestUpdateResourceEmptyAliasPlusClearAliasReportsExclusivityFirst(t *testin
 		t.Fatalf("expected ErrUpdateResourceAliasClearExclusive (exclusivity beats empty-pointer), got %v", err)
 	}
 }
+
+// testTunnelQURLSite is the canonical fixture for tunnel-qURL
+// `qurl_site` values across the CreateOutput helper tests. The host
+// doesn't escape the wire — the helpers route by `type` / link-shape
+// only — so any well-formed HTTPS URL works; this value mirrors the
+// `<resource_id>.qurl.site.layerv.xyz` shape `qurl-service` emits.
+const testTunnelQURLSite = "https://example.qurl.site"
+
+// TestCreateOutput_IsTunnel_TypeFieldDominant pins the primary
+// detector: the wire `type` field. A `type:"tunnel"` response IS a
+// tunnel qURL regardless of what QURLLink/QURLSite happen to carry —
+// the kind is what `qurl-service` already declared. Future fields on
+// the response that affect URL shape should NOT short-circuit Type.
+func TestCreateOutput_IsTunnel_TypeFieldDominant(t *testing.T) {
+	out := &CreateOutput{Type: "tunnel", QURLLink: "", QURLSite: testTunnelQURLSite}
+	if !out.IsTunnel() {
+		t.Errorf("IsTunnel()=false on Type=\"tunnel\"; want true")
+	}
+	if got, want := out.AccessURL(), testTunnelQURLSite; got != want {
+		t.Errorf("AccessURL()=%q want=%q on tunnel with QURLSite set", got, want)
+	}
+}
+
+// TestCreateOutput_IsTunnel_FallbackEmptyLinkAndSite pins the
+// belt-and-suspenders fallback for the legacy / type-elided shape:
+// empty QURLLink + non-empty QURLSite is still treated as tunnel even
+// when `type` is absent. A future qurl-service version that stops
+// emitting Type (or renames it) must keep tunnel-rendering working
+// without a bot bump — the agent-bootstrap fleet ships ahead of bot
+// updates and the older-rendered tunnel rows live for 24h post-mint.
+func TestCreateOutput_IsTunnel_FallbackEmptyLinkAndSite(t *testing.T) {
+	out := &CreateOutput{Type: "", QURLLink: "", QURLSite: testTunnelQURLSite}
+	if !out.IsTunnel() {
+		t.Errorf("IsTunnel()=false on type-elided tunnel shape; want true")
+	}
+	if got, want := out.AccessURL(), testTunnelQURLSite; got != want {
+		t.Errorf("AccessURL()=%q want=%q on fallback tunnel", got, want)
+	}
+}
+
+// TestCreateOutput_IsTunnel_URLRedirectFalse pins that URL-redirect
+// qURLs do NOT report IsTunnel — they ship a populated QURLLink and
+// the caller renders that, even if Type happens to be unset (legacy
+// rows pre-Type-field).
+func TestCreateOutput_IsTunnel_URLRedirectFalse(t *testing.T) {
+	out := &CreateOutput{Type: "", QURLLink: "https://qurl.link/#abc", QURLSite: "https://target.example"}
+	if out.IsTunnel() {
+		t.Errorf("IsTunnel()=true on URL-redirect (populated QURLLink); want false")
+	}
+	if got, want := out.AccessURL(), "https://qurl.link/#abc"; got != want {
+		t.Errorf("AccessURL()=%q want=%q on URL-redirect", got, want)
+	}
+}
+
+// TestCreateOutput_AccessURL_EmptyBothFields fences the real
+// contract-surprise case: type may be absent and BOTH URL fields
+// empty. The caller still needs a non-nil signal to surface the
+// "server returned no usable URL" diagnostic — empty AccessURL is
+// the routing trigger. Don't optimize this to return a placeholder.
+func TestCreateOutput_AccessURL_EmptyBothFields(t *testing.T) {
+	out := &CreateOutput{}
+	if got := out.AccessURL(); got != "" {
+		t.Errorf("AccessURL()=%q on fully-empty output; want \"\" (real contract surprise)", got)
+	}
+	if out.IsTunnel() {
+		t.Errorf("IsTunnel()=true on fully-empty output; want false — type-less + URL-less is NOT a tunnel signal")
+	}
+}
+
+// TestCreateOutput_NilSafe covers the helper's nil receiver — any
+// future caller pattern that does `var out *CreateOutput; out.IsTunnel()`
+// (e.g. a deserialization-failed path) must not panic. The helpers
+// return their zero-equivalent so the caller's empty-URL branch
+// still trips cleanly.
+func TestCreateOutput_NilSafe(t *testing.T) {
+	var out *CreateOutput
+	if out.IsTunnel() {
+		t.Errorf("IsTunnel() on nil receiver returned true; want false")
+	}
+	if got := out.AccessURL(); got != "" {
+		t.Errorf("AccessURL() on nil receiver returned %q; want \"\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

`/qurl get $<tunnel-alias>` from `#qurl-bot-slack` returned `:warning: Failed to mint qURL. Please try again.` to the user even though `qurl-service` returned 201 on the mint. Reproduced today minting against `r_cnaip_fprni` in sandbox:

```
[21:27:10] qurl-api: POST /v1/resources/r_cnaip_fprni/qurls 201
[21:27:10] bot:      ":warning: Failed to mint qURL. Please try again."
```

The mint response body:

```json
{
  "data": {
    "qurl_id":     "q_c223125bf30",
    "qurl_link":   "",
    "qurl_site":   "https://r_cnaip_fprni.qurl.site.layerv.xyz",
    "resource_id": "r_cnaip_fprni",
    "type":        "tunnel"
  }
}
```

The empty `qurl_link` is intentional `qurl-service` behavior for tunnel-type qURLs:
- `internal/service/qurl_service.go::CreateQurl` only populates `output.QurlLink` when `!isTunnel`
- `internal/api/handlers/server.go:892` doc: `"tunnel → qurl_link='' rather than the field elided"`

`apps/slack/internal/handler_get.go` was treating empty `qurl_link` as a server-contract surprise (loud-error log + generic retry copy), masking the success and giving the user no signal. This PR makes the bot honor the tunnel contract.

## Changes

- **shared/client/client.go** — add `Type` field to `CreateOutput`, plus `IsTunnel()` + `AccessURL()` helpers. Primary detector is `type:"tunnel"` (wire-format-stable); defensive fallback on `QURLLink==""` + `QURLSite!=""` keeps the bot working against an older qurl-service that elides `type` (or a future field rename without a coordinated bump). `AccessURL()` returns the right URL per kind.
- **apps/slack/internal/handler_get.go** — switch the mint-output branch from `out.QURLLink == ""` to `out.AccessURL() == ""`. Loud-error retained for the truly-no-URL case (both fields empty) so the contract-surprise alarm doesn't regress.

## What this PR does NOT settle (worth a chat with Justin)

The qurl-service-side answer for "how does a user authenticate to a tunnel qURL via its `qurl_site` URL" — token in fragment? cookie set by an earlier resolve hop? — is the next blocker for end-to-end. From a fresh client today, `nc 443` to the AC NLB edge IPs (`3.148.116.249`, `16.58.63.221`, `3.17.248.131`) times out, so the `*.qurl.site.layerv.xyz` user-facing path isn't yet wired in sandbox. This PR is the minimum change to stop the bot from lying about successful mints — the access flow is a separate piece.

Once the access flow lands, this PR may need a follow-up to add token-bearing logic to `AccessURL()` (or to point at a token-injecting URL builder), depending on which token-carrying shape qurl-service settles on for tunnels.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./shared/client/... ./apps/slack/...` — full suite passes, including new tests
- [x] `golangci-lint run --new-from-rev=origin/main ./shared/client/... ./apps/slack/...` — 0 issues from this PR
- [x] New unit tests:
  - `TestCreateOutput_IsTunnel_TypeFieldDominant` — primary detector on `type:"tunnel"`
  - `TestCreateOutput_IsTunnel_FallbackEmptyLinkAndSite` — fallback for type-elided shape
  - `TestCreateOutput_IsTunnel_URLRedirectFalse` — URL-redirect doesn't false-positive
  - `TestCreateOutput_AccessURL_EmptyBothFields` — fully-empty stays the contract-surprise trigger
  - `TestCreateOutput_NilSafe` — nil receiver doesn't panic
- [x] New handler tests:
  - `TestHandleGet_HappyPath_Tunnel` — tunnel rendering end-to-end + negative-assert that "Failed to mint qURL" doesn't co-emit
  - `TestHandleGet_NoURLContractSurprise` — loud-error retention on truly-broken responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)