### PR TITLE
docs(slack): document tunnel install flow

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -15,7 +15,8 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 - Channel notifications on qURL events (planned)
 
 Run `/qurl help` in Slack for command modifiers such as `once:true`,
-`dm:true`, and `reason:"..."`.
+`dm:true`, and `reason:"..."`; `dm:true` appears only when DM posting
+is configured.
 
 ## Architecture
 
@@ -30,8 +31,9 @@ Run `/qurl help` in Slack for command modifiers such as `once:true`,
   connected qURL account, bind `$<slug>` or the `alias:` override in
   the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API
   key. The Slack response renders a Docker sidecar command that mounts
-  the bootstrap key from a file and passes `QURL_TUNNEL_SLUG=<slug>` to
-  the client. Delete the Slack response and remove the mounted key file
+  the bootstrap key from a file, passes that file path via
+  `QURL_API_KEY_FILE`, and passes `QURL_TUNNEL_SLUG=<slug>` to the
+  client. Delete the Slack response and remove the mounted key file
   after the first successful sidecar start.
 - **Endpoints:**
   - `POST /slack/commands` — Slash command handler (ack-then-async)

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -6,7 +6,7 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 
 - `/qurl setup` — Connect qURL to the workspace (admin-only; one-shot OAuth flow against Auth0)
 - `/qurl get <url>` — Mint a qURL for a URL
-- `/qurl get $alias` — Mint a qURL for a channel-bound resource alias
+- `/qurl get $alias` — Mint a qURL for a channel alias
 - `/qurl set-alias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias
 - `/qurl unset-alias $alias` — Remove a channel alias binding
 - `/qurl tunnel install <slug> [port:<n>] [alias:$alias]` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only; default local port is 8080)
@@ -24,10 +24,11 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
   KMS envelope encryption with `workspace_id` bound as AAD.
 - **Tunnel onboarding:** `/qurl tunnel install <slug>` uses the
   workspace API key to find-or-create a tunnel resource scoped to the
-  connected qURL account, bind `$<slug>` in the current Slack channel,
-  and mint a 1-hour `tunnel_bootstrap` API key. The Slack response
-  renders a Docker sidecar command that mounts the bootstrap key from
-  a file and passes `QURL_TUNNEL_SLUG=<slug>` to the client.
+  connected qURL account, bind `$<slug>` or the `alias:` override in
+  the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API
+  key. The Slack response renders a Docker sidecar command that mounts
+  the bootstrap key from a file and passes `QURL_TUNNEL_SLUG=<slug>` to
+  the client.
 - **Endpoints:**
   - `POST /slack/commands` — Slash command handler (ack-then-async)
   - `POST /slack/events` — Event subscriptions (link unfurling planned)
@@ -80,7 +81,7 @@ docker buildx build --platform linux/arm64 \
 
 `WORKSPACE_STATE_TABLE` + `WORKSPACE_STATE_KMS_KEY_ARN` are
 unconditionally required at startup — the bot needs DDB+KMS for
-per-workspace key lookups even on `/qurl create`/`/qurl list`.
+per-workspace key lookups even on `/qurl get`/`/qurl list`.
 
 The `OAuth` group is required only when the bot needs to serve the
 `/oauth/qurl/{start,callback}` surface. Boots without these vars still

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -6,6 +6,9 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 
 - `/qurl setup` — Connect qURL to the workspace (admin-only; one-shot OAuth flow against Auth0)
 - `/qurl create <url>` — Create a qURL
+- `/qurl get $alias` — Mint a qURL for a channel-bound resource alias
+- `/qurl setalias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias
+- `/qurl tunnel install <slug>` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only)
 - `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
 - Channel notifications on qURL events (planned)
@@ -18,6 +21,12 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
+- **Tunnel onboarding:** `/qurl tunnel install <slug>` uses the
+  workspace API key to find-or-create an owner-scoped tunnel resource,
+  bind `$<slug>` in the current Slack channel, and mint a 1-hour
+  `tunnel_bootstrap` API key. The Slack response renders a Docker
+  sidecar command that mounts the bootstrap key from a file and passes
+  `QURL_TUNNEL_SLUG=<slug>` to the client.
 - **Endpoints:**
   - `POST /slack/commands` — Slash command handler (ack-then-async)
   - `POST /slack/events` — Event subscriptions (link unfurling planned)
@@ -65,6 +74,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
 | `SLACK_BASE_URL` | OAuth | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose `redirect_uri` and the `/qurl setup` link. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
+| `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl tunnel install`. Set this to an immutable release tag or digest for production rollout. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |
 
 `WORKSPACE_STATE_TABLE` + `WORKSPACE_STATE_KMS_KEY_ARN` are

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -7,8 +7,8 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 - `/qurl setup` — Connect qURL to the workspace (admin-only; one-shot OAuth flow against Auth0)
 - `/qurl create <url>` — Create a qURL
 - `/qurl get $alias` — Mint a qURL for a channel-bound resource alias
-- `/qurl setalias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias
-- `/qurl tunnel install <slug>` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only)
+- `/qurl set-alias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias
+- `/qurl tunnel install <slug> [port:8080] [alias:$alias]` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only)
 - `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
 - Channel notifications on qURL events (planned)
@@ -22,11 +22,11 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
 - **Tunnel onboarding:** `/qurl tunnel install <slug>` uses the
-  workspace API key to find-or-create an owner-scoped tunnel resource,
-  bind `$<slug>` in the current Slack channel, and mint a 1-hour
-  `tunnel_bootstrap` API key. The Slack response renders a Docker
-  sidecar command that mounts the bootstrap key from a file and passes
-  `QURL_TUNNEL_SLUG=<slug>` to the client.
+  workspace API key to find-or-create a tunnel resource scoped to the
+  connected qURL account, bind `$<slug>` in the current Slack channel,
+  and mint a 1-hour `tunnel_bootstrap` API key. The Slack response
+  renders a Docker sidecar command that mounts the bootstrap key from
+  a file and passes `QURL_TUNNEL_SLUG=<slug>` to the client.
 - **Endpoints:**
   - `POST /slack/commands` — Slash command handler (ack-then-async)
   - `POST /slack/events` — Event subscriptions (link unfurling planned)

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -7,12 +7,15 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 - `/qurl setup` — Connect qURL to the workspace (admin-only; one-shot OAuth flow against Auth0)
 - `/qurl get <url>` — Mint a qURL for a URL
 - `/qurl get $alias` — Mint a qURL for a channel alias
-- `/qurl set-alias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias
-- `/qurl unset-alias $alias` — Remove a channel alias binding
-- `/qurl tunnel install <slug> [port:<n>] [alias:$alias]` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only; default local port is 8080)
+- `/qurl set-alias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias (admin-only)
+- `/qurl unset-alias $alias` — Remove a channel alias binding (admin-only)
+- `/qurl tunnel install <slug> [port:<n>] [alias:$alias]` — Provision a Docker sidecar tunnel (admin-only; default local port is 8080)
 - `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
 - Channel notifications on qURL events (planned)
+
+Run `/qurl help` in Slack for command modifiers such as `once:true`,
+`dm:true`, and `reason:"..."`.
 
 ## Architecture
 
@@ -28,7 +31,8 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
   the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API
   key. The Slack response renders a Docker sidecar command that mounts
   the bootstrap key from a file and passes `QURL_TUNNEL_SLUG=<slug>` to
-  the client.
+  the client. Delete the Slack response and remove the mounted key file
+  after the first successful sidecar start.
 - **Endpoints:**
   - `POST /slack/commands` — Slash command handler (ack-then-async)
   - `POST /slack/events` — Event subscriptions (link unfurling planned)

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -5,10 +5,11 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 ## Features
 
 - `/qurl setup` — Connect qURL to the workspace (admin-only; one-shot OAuth flow against Auth0)
-- `/qurl create <url>` — Create a qURL
+- `/qurl get <url>` — Mint a qURL for a URL
 - `/qurl get $alias` — Mint a qURL for a channel-bound resource alias
 - `/qurl set-alias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias
-- `/qurl tunnel install <slug> [port:8080] [alias:$alias]` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only)
+- `/qurl unset-alias $alias` — Remove a channel alias binding
+- `/qurl tunnel install <slug> [port:<n>] [alias:$alias]` — Create a tunnel resource, bind a channel alias, and mint a short-lived Docker sidecar bootstrap key (admin-only; default local port is 8080)
 - `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
 - Channel notifications on qURL events (planned)

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -14,9 +14,8 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 - Link unfurling for `qurl.link` URLs (planned)
 - Channel notifications on qURL events (planned)
 
-Run `/qurl help` in Slack for command modifiers such as `once:true`,
-`dm:true`, and `reason:"..."`; `dm:true` appears only when DM posting
-is configured.
+Run `/qurl help` in Slack for the canonical command modifiers enabled
+by the current bot deployment.
 
 ## Architecture
 
@@ -30,11 +29,12 @@ is configured.
   workspace API key to find-or-create a tunnel resource scoped to the
   connected qURL account, bind `$<slug>` or the `alias:` override in
   the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API
-  key. The Slack response renders a Docker sidecar command that mounts
-  the bootstrap key from a file, passes that file path via
+  key. When `alias:` is omitted, the slug doubles as the channel alias.
+  The Slack response renders a Docker sidecar command that mounts the
+  bootstrap key from a file, passes that file path via
   `QURL_API_KEY_FILE`, and passes `QURL_TUNNEL_SLUG=<slug>` to the
-  client. Delete the Slack response and remove the mounted key file
-  after the first successful sidecar start.
+  client. Delete the Slack response once the sidecar is running, and
+  remove the mounted key file after the first successful sidecar start.
 - **Endpoints:**
   - `POST /slack/commands` — Slash command handler (ack-then-async)
   - `POST /slack/events` — Event subscriptions (link unfurling planned)
@@ -82,7 +82,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
 | `SLACK_BASE_URL` | OAuth | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose `redirect_uri` and the `/qurl setup` link. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
-| `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl tunnel install`. Set this to an immutable release tag or digest for production rollout. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. |
+| `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl tunnel install`. Set this to an immutable release tag or digest for production rollout. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |
 
 `WORKSPACE_STATE_TABLE` + `WORKSPACE_STATE_KMS_KEY_ARN` are


### PR DESCRIPTION
## Summary
- document the Slack tunnel install command in the Slack integration README
- note the connected-account tunnel resource + short-lived tunnel_bootstrap key flow
- document QURL_TUNNEL_IMAGE for production image pinning

## Test
- git diff --check
- go test ./apps/slack/...
