### PR TITLE
fix(slack): accept dollar-prefixed tunnel install slugs

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -9,7 +9,7 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 - `/qurl get $alias` — Mint a qURL for a channel alias
 - `/qurl set-alias $alias <url|resource-id|$tunnel-slug>` — Bind a channel alias (admin-only)
 - `/qurl unset-alias $alias` — Remove a channel alias binding (admin-only)
-- `/qurl tunnel install <slug> [port:<n>] [alias:$alias]` — Provision a Docker sidecar tunnel (admin-only; default local port is 8080)
+- `/qurl tunnel install <slug|$slug> [port:<n>] [alias:$alias]` — Provision a Docker sidecar tunnel (admin-only; default local port is 8080)
 - `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
 - Channel notifications on qURL events (planned)
@@ -25,7 +25,7 @@ by the current bot deployment.
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
-- **Tunnel onboarding:** `/qurl tunnel install <slug>` uses the
+- **Tunnel onboarding:** `/qurl tunnel install <slug>` (or `$slug`) uses the
   workspace API key to find-or-create a tunnel resource scoped to the
   connected qURL account, bind `$<slug>` or the `alias:` override in
   the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -40,9 +40,10 @@ func parseTunnelInstall(text string) (args *tunnelInstallArgs, userMsg string) {
 	if len(fields) < 2 || fields[0] != "install" {
 		return nil, tunnelInstallUsage()
 	}
+	slug := strings.TrimPrefix(fields[1], "$")
 	args = &tunnelInstallArgs{
-		Slug:      fields[1],
-		Alias:     fields[1],
+		Slug:      slug,
+		Alias:     slug,
 		LocalPort: defaultTunnelLocalPort,
 	}
 	if !tunnelSlugPattern.MatchString(args.Slug) {
@@ -74,7 +75,7 @@ func parseTunnelInstall(text string) (args *tunnelInstallArgs, userMsg string) {
 }
 
 func tunnelInstallUsage() string {
-	return "Usage: `/qurl tunnel install <slug> [port:8080] [alias:$alias]`\nExample: `/qurl tunnel install prod-dashboard port:8080`"
+	return "Usage: `/qurl tunnel install <slug|$slug> [port:8080] [alias:$alias]`\nExample: `/qurl tunnel install prod-dashboard port:8080`"
 }
 
 // handleTunnel routes `/qurl tunnel install <slug>`.

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -35,9 +35,12 @@ func TestParseTunnelInstall(t *testing.T) {
 		wantPort  int
 	}{
 		{name: "minimal", text: testTunnelInstallCmd, wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort},
+		{name: "slug with alias sigil", text: "tunnel install $" + testTunnelSlug, wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort},
 		{name: "port and alias", text: testTunnelInstallCmd + " port:9090 alias:$dash", wantSlug: testTunnelSlug, wantAlias: "dash", wantPort: 9090},
 		{name: "alias without sigil", text: testTunnelInstallCmd + " alias:dash", wantSlug: testTunnelSlug, wantAlias: "dash", wantPort: defaultTunnelLocalPort},
 		{name: "bad slug uppercase", text: "tunnel install Prod", wantErr: true},
+		{name: "empty slug after sigil", text: "tunnel install $", wantErr: true},
+		{name: "double sigil slug", text: "tunnel install $$prod", wantErr: true},
 		{name: "bad port", text: testTunnelInstallCmd + " port:70000", wantErr: true},
 		{name: "unknown option", text: testTunnelInstallCmd + " mode:fast", wantErr: true},
 	}


### PR DESCRIPTION
## Summary
- accept `/qurl tunnel install $slug` by canonicalizing the install slug before validation
- keep resource creation, alias binding, bootstrap keys, and rendered Docker env using the bare slug
- document the optional `$` form in the Slack README

## Tests
- `go test ./apps/slack/internal`