### PR TITLE
feat(slack): owner-only /setup gate + workspace owner = Slack user, not Auth0 sub

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -205,14 +205,17 @@ func run() error {
 			StateSecret:  oauthCfg.OAuthStateSecret,
 			SlackBaseURL: oauthCfg.SlackBaseURL,
 		})
-		// Operator reminder: /qurl setup runs whichever Slack user
-		// invokes it. Workspace identity comes from the signature-
-		// verified payload, but ROLE is not enforced in this binary.
-		// The Slack app manifest must restrict /qurl setup to
-		// workspace admins; without that gate, any user could
-		// initiate a flow that overwrites the workspace's qURL key
-		// against their own Auth0 account.
-		slog.Info("CONFIGURATION REMINDER: /qurl setup is workspace-admin-only by manifest, not by code — verify the Slack app manifest restricts the command")
+		// Operator note: /qurl setup re-runs are now gated in code —
+		// the first user to complete setup on an unbound workspace
+		// becomes its owner, and only that owner can re-run setup
+		// afterward (enforced in handleSetup via AdminStore, with
+		// BindWorkspace as the structural backstop). The remaining
+		// exposure is the first-install claim: any workspace member
+		// can be the first to run /qurl setup and thereby claim
+		// ownership. Restrict who can reach the command at install
+		// time (Slack app manifest / onboarding) if first-claim
+		// ownership matters for this deployment.
+		slog.Info("CONFIGURATION NOTE: /qurl setup re-runs are owner-only (enforced in code); first install is first-user-wins — restrict command availability at install time if first-claim ownership matters")
 	}
 	// Else: buildOAuthConfig already logged the specific missing-var
 	// list; nothing more to say here.

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -735,8 +735,22 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 		// otherwise → non-owner rebind attempt, refuse here so we
 		// don't even mint the state token / setup URL.
 		if ownerID != "" && ownerID != userID {
-			slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
-			respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is <@%s>. Ask them to re-run setup, or use `/qurl admin` for non-owner admin actions.", ownerID))
+			// Shape-guard the stored owner_id before interpolating it
+			// into a `<@%s>` mention. BindWorkspace writes owner_id
+			// from the OAuth callback (a different code path than the
+			// parser), and a pre-pivot row holds an Auth0 sub, not a
+			// Slack ID — exactly the case the migration runbook calls
+			// out. Mirrors the looksLikeSlackUserID guard in
+			// handleAdminList so a malformed value can't break out of
+			// the mention surface or render visibly broken.
+			ownerMention := "the existing workspace owner"
+			if looksLikeSlackUserID(ownerID) {
+				ownerMention = fmt.Sprintf("<@%s>", ownerID)
+				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID) //nolint:gosec // G706: slog escapes control bytes in attribute values; owner_user_id is shape-validated by looksLikeSlackUserID above.
+			} else {
+				slog.Error("/qurl setup: rebind refused; stored owner_id is shape-bad — likely a pre-pivot Auth0 sub. Operator must delete the workspace_mappings row to recover.", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID and owner_id_len is an int.
+			}
+			respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is %s. Ask them to re-run setup, or use `/qurl admin` for non-owner admin actions.", ownerMention))
 			return
 		}
 	}
@@ -801,7 +815,8 @@ func (h *Handler) helpMessage() string {
 		"• `/qurl get <url|$name> once:true` — Get a single-use qURL; the link burns on first redemption",
 		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
 		"• `/qurl list` — Show your 5 most recent qURLs",
-		"• `/qurl setup` — Connect qURL to your Slack workspace and become its owner. After the first setup only the workspace owner can re-run this — other admins (added via `/qurl admin add`) can use the rest of the admin verbs but cannot rotate the qURL credential.",
+		"• `/qurl setup` — Connect qURL to your Slack workspace (one-time setup; the runner becomes the workspace owner)",
+		"• Re-running `/qurl setup` is owner-only — added admins (via `/qurl admin add`) can use the other admin verbs but cannot rotate the qURL credential",
 	)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
 		if h.cfg.OpenView != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -760,6 +760,12 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 		// get a setup URL, but BindWorkspace's consistent owner check is
 		// the structural backstop — that caller just lands on the
 		// generic rebind-refused page instead of the friendly copy here.
+		// The eventual read is deliberate, not an oversight: CheckAdmin
+		// is the shared admin-gate read (same call the admin verbs make),
+		// so the race only ever costs the loser a less-friendly error
+		// page — never security, since the consistent backstop is
+		// authoritative. Upgrading just this caller to a consistent read
+		// would spend 2x RCU on every /setup to improve one racer's copy.
 		if ownerID != "" && ownerID != userID {
 			// Shape-guard the stored owner_id before interpolating it
 			// into a `<@%s>` mention. BindWorkspace writes owner_id

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -794,7 +794,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			// owner is the existing workspace owner".
 			if looksLikeSlackUserID(ownerID) {
 				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID) //nolint:gosec // G706: slog escapes control bytes in attribute values; owner_user_id is shape-validated by looksLikeSlackUserID above.
-				respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is <@%s>. Ask them to re-run setup, or use `/qurl admin` for non-owner admin actions.", ownerID))
+				respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is <@%s>. Ask them to re-run setup. For admin actions that don't need workspace ownership, use the other `/qurl admin` commands.", ownerID))
 			} else {
 				slog.Error("/qurl setup: rebind refused; stored owner_id is shape-bad — likely a pre-pivot Auth0 sub. Operator must delete the workspace_mappings row to recover.", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID and owner_id_len is an int.
 				respondSlack(w, "Only the workspace owner can re-run `/qurl setup`, but this workspace's stored owner record is malformed and can't be displayed (likely a legacy record). Please contact support to recover access.")

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -742,15 +742,16 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			// Slack ID — exactly the case the migration runbook calls
 			// out. Mirrors the looksLikeSlackUserID guard in
 			// handleAdminList so a malformed value can't break out of
-			// the mention surface or render visibly broken.
-			ownerMention := "the existing workspace owner"
+			// the mention surface. Branch the whole reply so the
+			// shape-bad copy reads cleanly rather than "the current
+			// owner is the existing workspace owner".
 			if looksLikeSlackUserID(ownerID) {
-				ownerMention = fmt.Sprintf("<@%s>", ownerID)
 				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID) //nolint:gosec // G706: slog escapes control bytes in attribute values; owner_user_id is shape-validated by looksLikeSlackUserID above.
+				respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is <@%s>. Ask them to re-run setup, or use `/qurl admin` for non-owner admin actions.", ownerID))
 			} else {
 				slog.Error("/qurl setup: rebind refused; stored owner_id is shape-bad — likely a pre-pivot Auth0 sub. Operator must delete the workspace_mappings row to recover.", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID and owner_id_len is an int.
+				respondSlack(w, "Only the workspace owner can re-run `/qurl setup`, but this workspace's stored owner record is malformed and can't be displayed (likely a legacy record). Please contact support to recover access.")
 			}
-			respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is %s. Ask them to re-run setup, or use `/qurl admin` for non-owner admin actions.", ownerMention))
 			return
 		}
 	}
@@ -816,8 +817,16 @@ func (h *Handler) helpMessage() string {
 		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
 		"• `/qurl list` — Show your 5 most recent qURLs",
 		"• `/qurl setup` — Connect qURL to your Slack workspace (one-time setup; the runner becomes the workspace owner)",
-		"• Re-running `/qurl setup` is owner-only — added admins (via `/qurl admin add`) can use the other admin verbs but cannot rotate the qURL credential",
 	)
+	if h.cfg.AdminStore != nil {
+		// The owner-only re-run gate only exists when AdminStore is
+		// wired (it's skipped on the sandbox/no-DDB path), so only
+		// advertise it there — matches how the admin verbs below
+		// render conditionally.
+		lines = append(lines,
+			"• Re-running `/qurl setup` is owner-only — added admins (via `/qurl admin add`) can use the other admin verbs but cannot rotate the qURL credential",
+		)
+	}
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
 		if h.cfg.OpenView != nil {
 			lines = append(lines,

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -730,10 +730,19 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			return
 		}
 		// ownerID=="" → workspace not yet bound → fresh install, allow.
+		// (CheckAdmin reads eventually-consistent, and BindWorkspace
+		// validates OwnerID != "" before PutItem, so an empty ownerID
+		// reliably means "no row yet" rather than a half-written one.)
 		// ownerID==userID → idempotent rerun by owner (rotates the
 		// API key on OAuth-callback success), allow.
 		// otherwise → non-owner rebind attempt, refuse here so we
 		// don't even mint the state token / setup URL.
+		//
+		// This gate is best-effort: in the brief eventual-read window
+		// after a fresh bind a fast second-mover could still see "" and
+		// get a setup URL, but BindWorkspace's consistent owner check is
+		// the structural backstop — that caller just lands on the
+		// generic rebind-refused page instead of the friendly copy here.
 		if ownerID != "" && ownerID != userID {
 			// Shape-guard the stored owner_id before interpolating it
 			// into a `<@%s>` mention. BindWorkspace writes owner_id

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -689,15 +689,20 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 // (the alternative, taking team_id from an unsigned query param at
 // /start, was the workspace-rebind primitive flagged in PR review).
 //
-// Admin restriction: this handler does NOT verify the invoking user is
-// a workspace admin. That gate lives in the Slack app manifest — the
-// `/qurl setup` command must be declared admin-only (or restricted via
-// channel/role permissions in the install config). Without that gate,
-// any workspace user could initiate setup and overwrite the workspace's
-// qURL key with one minted against their own Auth0 account. Confirm
-// the manifest before shipping; an in-bot check would require an extra
-// Slack API round-trip per setup attempt that the manifest already
-// covers.
+// Owner-only rebind gate: on fresh install (no workspace_mappings
+// row), any workspace user may run /setup — that user becomes the
+// workspace owner. On subsequent runs only the owner is permitted;
+// other workspace members (including admins added via /qurl admin
+// add) get a "owner-only" reply. Without this gate, any added admin
+// could complete OAuth against their own Auth0 account and silently
+// rotate the workspace's qURL credential — the OAuth callback's
+// BindWorkspace also rejects that case as a defense in depth, but
+// gating here means non-owners don't get a setup URL minted in their
+// name at all (cleaner audit, no half-completed OAuth flows).
+//
+// AdminStore=nil (sandbox / no-DDB) skips the gate — same posture as
+// every other admin verb. The reply on missing AdminStore stays the
+// pre-existing "qURL OAuth is not configured" branch.
 func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 	if h.oauthSetup == nil {
 		respondSlack(w, "qURL OAuth is not configured on this Slack bot deployment. Contact the operator.")
@@ -708,6 +713,32 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 	if teamID == "" || userID == "" {
 		respondSlack(w, "Could not read your Slack workspace or user ID from the command payload.")
 		return
+	}
+	// Owner gate. AdminStore==nil skips entirely (sandbox/no-DDB);
+	// otherwise check whether the workspace has an owner and whether
+	// it's the invoking user. CheckAdmin returns (isAdmin, ownerID,
+	// err); we only consume ownerID here — the admin-set membership
+	// is irrelevant for /setup specifically (added admins can't rerun
+	// /setup, only the owner can).
+	if h.cfg.AdminStore != nil {
+		gateCtx, gateCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+		_, ownerID, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
+		gateCancel()
+		if err != nil {
+			slog.Error("/qurl setup: owner check failed", "error", err, "team_id", teamID, "user_id", userID)
+			respondSlack(w, ":warning: could not verify workspace ownership (upstream error; see logs). Try again in a moment.")
+			return
+		}
+		// ownerID=="" → workspace not yet bound → fresh install, allow.
+		// ownerID==userID → idempotent rerun by owner (rotates the
+		// API key on OAuth-callback success), allow.
+		// otherwise → non-owner rebind attempt, refuse here so we
+		// don't even mint the state token / setup URL.
+		if ownerID != "" && ownerID != userID {
+			slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
+			respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is <@%s>. Ask them to re-run setup, or use `/qurl admin` for non-owner admin actions.", ownerID))
+			return
+		}
 	}
 	state, err := oauth.MintState(h.oauthSetup.StateSecret, teamID, userID, h.now())
 	if err != nil {
@@ -770,7 +801,7 @@ func (h *Handler) helpMessage() string {
 		"• `/qurl get <url|$name> once:true` — Get a single-use qURL; the link burns on first redemption",
 		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
 		"• `/qurl list` — Show your 5 most recent qURLs",
-		"• `/qurl setup` — Connect qURL to your Slack workspace and become its qURL admin (workspace admin only)",
+		"• `/qurl setup` — Connect qURL to your Slack workspace and become its owner. After the first setup only the workspace owner can re-run this — other admins (added via `/qurl admin add`) can use the rest of the admin verbs but cannot rotate the qURL credential.",
 	)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
 		if h.cfg.OpenView != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -744,7 +744,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 		defer gateCancel()
 		_, ownerID, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
 		if err != nil {
-			slog.Error("/qurl setup: owner check failed", "error", err, "team_id", teamID, "user_id", userID)
+			slog.Error("/qurl setup: owner check failed", "error", err, "team_id", teamID, "caller_user_id", userID)
 			respondSlack(w, ":warning: could not verify workspace ownership (upstream error; see logs). Try again in a moment.")
 			return
 		}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -833,7 +833,7 @@ func (h *Handler) helpMessage() string {
 		// advertise it there — matches how the admin verbs below
 		// render conditionally.
 		lines = append(lines,
-			"• Re-running `/qurl setup` is owner-only — added admins (via `/qurl admin add`) can use the other admin verbs but cannot rotate the qURL credential",
+			"• Re-running `/qurl setup` is owner-only — added admins (via `/qurl admin add`) can use the other admin verbs but cannot reconnect this workspace's qURL account",
 		)
 	}
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -757,7 +757,14 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 		// ownerID=="" → workspace not yet bound → fresh install, allow.
 		// (CheckAdmin reads eventually-consistent, and BindWorkspace
 		// validates OwnerID != "" before PutItem, so an empty ownerID
-		// reliably means "no row yet" rather than a half-written one.)
+		// almost always means "no row yet" rather than a half-written
+		// one.) The one exception is a manually-edited row left with a
+		// blank owner_id: it also reads as "" here and slips past this
+		// gate, but BindWorkspace's consistent check refuses it (the
+		// caller lands on the rebind-refused page after the OAuth round-
+		// trip, and the empty-owner Warn there flags the bad row). That
+		// requires DDB tampering, so it isn't worth a second read to
+		// distinguish at the gate.
 		// ownerID==userID → idempotent rerun by owner (rotates the
 		// API key on OAuth-callback success), allow.
 		// otherwise → non-owner rebind attempt, refuse here so we
@@ -854,17 +861,16 @@ func (h *Handler) helpMessage() string {
 	lines = append(lines,
 		"• `/qurl get <url|$slug> reason:\"…\"` — Mint a one-time qURL, recording a reason in the audit log",
 		"• `/qurl list` — List the tunnels available to you",
-		"• `/qurl setup` — Connect qURL to your Slack workspace (one-time setup; the runner becomes the workspace owner)",
 	)
+	// The ownership semantics only exist when AdminStore is wired; on the
+	// sandbox/no-DDB path the owner gate is skipped, so re-running /setup
+	// just mints again. Append the owner parenthetical only there so the
+	// help text matches the actual behavior of the deployment.
+	setupLine := "• `/qurl setup` — Connect qURL to your Slack workspace"
 	if h.cfg.AdminStore != nil {
-		// The owner-only re-run gate only exists when AdminStore is
-		// wired (it's skipped on the sandbox/no-DDB path), so only
-		// advertise it there — matches how the admin verbs below
-		// render conditionally.
-		lines = append(lines,
-			"• Re-running `/qurl setup` is owner-only — only the workspace owner (whoever first connected qURL) can reconnect the account",
-		)
+		setupLine += " (one-time setup; the first runner becomes the workspace owner — only they can re-run it)"
 	}
+	lines = append(lines, setupLine)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
 		if h.cfg.OpenView != nil {
 			lines = append(lines,

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -717,9 +717,11 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 // gating here means non-owners don't get a setup URL minted in their
 // name at all (cleaner audit, no half-completed OAuth flows).
 //
-// AdminStore=nil (sandbox / no-DDB) skips the gate — same posture as
-// every other admin verb. The reply on missing AdminStore stays the
-// pre-existing "qURL OAuth is not configured" branch.
+// AdminStore=nil (sandbox / no-DDB) skips the owner gate — same posture
+// as every other admin verb; the caller falls through to mint as on a
+// fresh install. That is a separate short-circuit from the oauthSetup==nil
+// check below, which is the branch that returns "qURL OAuth is not
+// configured" (and which fires first, before AdminStore is consulted).
 func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 	if h.oauthSetup == nil {
 		respondSlack(w, "qURL OAuth is not configured on this Slack bot deployment. Contact the operator.")
@@ -854,7 +856,7 @@ func (h *Handler) helpMessage() string {
 		// advertise it there — matches how the admin verbs below
 		// render conditionally.
 		lines = append(lines,
-			"• Only the workspace owner can re-run `/qurl setup`; added admins use the other `/qurl admin` verbs but can't reconnect the qURL account",
+			"• Re-running `/qurl setup` is owner-only — only the workspace owner (whoever first connected qURL) can reconnect the account",
 		)
 	}
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -739,8 +739,8 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 	// /setup, only the owner can).
 	if h.cfg.AdminStore != nil {
 		gateCtx, gateCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+		defer gateCancel()
 		_, ownerID, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
-		gateCancel()
 		if err != nil {
 			slog.Error("/qurl setup: owner check failed", "error", err, "team_id", teamID, "user_id", userID)
 			respondSlack(w, ":warning: could not verify workspace ownership (upstream error; see logs). Try again in a moment.")
@@ -848,7 +848,7 @@ func (h *Handler) helpMessage() string {
 		// advertise it there — matches how the admin verbs below
 		// render conditionally.
 		lines = append(lines,
-			"• Re-running `/qurl setup` is owner-only — added admins (via `/qurl admin add`) can use the other admin verbs but cannot reconnect this workspace's qURL account",
+			"• Only the workspace owner can re-run `/qurl setup`; added admins use the other `/qurl admin` verbs but can't reconnect the qURL account",
 		)
 	}
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -708,7 +708,10 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 //
 // Owner-only rebind gate: on fresh install (no workspace_mappings
 // row), any workspace user may run /setup — that user becomes the
-// workspace owner. On subsequent runs only the owner is permitted;
+// workspace owner. First install is first-user-wins: if two members
+// race an unbound workspace, BindWorkspace's consistent read picks the
+// single winner (the loser gets the rebind-refused page). On
+// subsequent runs only the owner is permitted;
 // other workspace members (including admins added via /qurl admin
 // add) get a "owner-only" reply. Without this gate, any added admin
 // could complete OAuth against their own Auth0 account and silently
@@ -738,7 +741,10 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 	// it's the invoking user. CheckAdmin returns (isAdmin, ownerID,
 	// err); we only consume ownerID here — the admin-set membership
 	// is irrelevant for /setup specifically (added admins can't rerun
-	// /setup, only the owner can).
+	// /setup, only the owner can). Times the read off h.baseCtx (not the
+	// request ctx) so a Slack-side connection-close can't truncate the
+	// gate read mid-flight; adminGateBudget is the only bound — same
+	// posture as requireAdminSync.
 	if h.cfg.AdminStore != nil {
 		gateCtx, gateCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
 		defer gateCancel()

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -868,7 +868,7 @@ func (h *Handler) helpMessage() string {
 	// help text matches the actual behavior of the deployment.
 	setupLine := "• `/qurl setup` — Connect qURL to your Slack workspace"
 	if h.cfg.AdminStore != nil {
-		setupLine += " (one-time setup; the first runner becomes the workspace owner — only they can re-run it)"
+		setupLine += " (the first runner becomes the workspace owner; only they can re-run it)"
 	}
 	lines = append(lines, setupLine)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -101,9 +101,11 @@ const workspaceUnboundReply = "Workspace isn't bound — run `/qurl setup` first
 
 // adminGateBudget bounds the sync admin-gate CheckAdmin call so a
 // hung DDB can't out-block Slack's 3s slash-command ack window. The
-// gate is the FIRST upstream call on every sync admin verb; using
-// `context.Background()` here would let a misbehaving upstream
-// silently consume the entire user-visible budget.
+// gate is the FIRST upstream call on every sync admin verb (and is
+// reused by the owner gate in handleSetup, which makes the same
+// CheckAdmin call); using `context.Background()` here would let a
+// misbehaving upstream silently consume the entire user-visible
+// budget.
 //
 // 800ms covers a healthy DDB GetItem with ample tail-latency margin
 // (warm-path p99 is well under 100ms; 800ms is ~10x that). The

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1074,6 +1074,35 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
+	t.Run("shape-bad owner_id (pre-pivot Auth0 sub): refused without broken mention", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// Migration-day state: a pre-pivot row whose owner_id holds the
+		// Auth0 id_token sub, not a Slack ID. A non-owner rerun must be
+		// refused WITHOUT interpolating the sub into a `<@…>` mention
+		// (which Slack would render visibly broken). Seed the row
+		// directly since BindWorkspace now only ever writes Slack IDs.
+		const auth0Sub = "auth0|653fpre-pivot-subxyz"
+		ts.ddb.seedItem(t, ts.tableNames.workspace, map[string]ddbtypes.AttributeValue{
+			fAttrSlackTeamID:       stringMember(team),
+			fAttrOwnerID:           stringMember(auth0Sub),
+			fAttrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{testAdminUserID}},
+			fAttrCreatedAt:         stringMember(testWorkspaceConfiguredAt.UTC().Format(time.RFC3339)),
+		})
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, stranger)
+		if strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Fatalf("shape-bad owner: setup URL was minted (should be refused): %q", got)
+		}
+		if strings.Contains(got, auth0Sub) {
+			t.Errorf("shape-bad owner: reply leaked the raw Auth0 sub (anywhere, incl. the mention surface): %q", got)
+		}
+		if !strings.Contains(got, "the existing workspace owner") {
+			t.Errorf("shape-bad owner: reply missing the shape-bad fallback copy, got: %q", got)
+		}
+	})
+
 	t.Run("added admin (not owner) reruns setup: refused", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		// seedAdmin binds owner=UOWNER001 and seeds UADMIN001 on the

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1106,6 +1106,30 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
+	t.Run("owner not on admin set: setup URL still minted (gate keys off owner_id, not admin membership)", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// Regression guard: the owner gate must consult owner_id ALONE,
+		// never admin_slack_user_ids membership. Seed a row whose owner_id
+		// is the caller (UOWNER001) but whose admin set does NOT include
+		// them (only UADMIN001) — the state after an owner is dropped from
+		// the admin set via /qurl admin remove. /setup must still mint for
+		// the owner. If a future change re-coupled the gate to admin-set
+		// membership (the pre-PR BindWorkspace behavior), this fails.
+		ts.ddb.seedItem(t, ts.tableNames.workspace, map[string]ddbtypes.AttributeValue{
+			fAttrSlackTeamID:       stringMember(team),
+			fAttrOwnerID:           stringMember(owner),
+			fAttrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{testAdminUserID}},
+			fAttrCreatedAt:         stringMember(testWorkspaceConfiguredAt.UTC().Format(time.RFC3339)),
+		})
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, owner)
+		if !strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Errorf("owner-not-on-admin-set: expected setup URL (gate must key off owner_id alone), got: %q", got)
+		}
+	})
+
 	t.Run("CheckAdmin error: fail-closed, no setup URL minted", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		// Workspace is bound, but the owner-gate's CheckAdmin read

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1052,12 +1052,15 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
-	t.Run("owner reruns setup: setup URL minted", func(t *testing.T) {
+	t.Run("owner reruns setup (owner on the admin set): setup URL minted", func(t *testing.T) {
 		ts := newAdminTestServers(t)
-		// seedAdmin binds the workspace with owner=UOWNER001 and the
-		// same user on the admin set. The gate compares the invoker
-		// (UOWNER001) to ownerID and short-circuits to mint.
-		ts.seedAdmin(t)
+		// Realistic post-bind state: owner_id IS the sole admin —
+		// BindWorkspace seeds the owner onto admin_slack_user_ids at first
+		// bind. Seed it explicitly (not via seedAdmin, which puts a
+		// *different* user on the admin set) so this case genuinely diverges
+		// from the "owner not on admin set" subtest below: together they
+		// prove the gate keys off owner_id regardless of admin-set membership.
+		ts.seedWorkspace(t, team, owner, owner, testWorkspaceConfiguredAt)
 		h := newAdminTestHandler(t, ts)
 		wireSetup(t, h)
 

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1106,6 +1106,27 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
+	t.Run("CheckAdmin error: fail-closed, no setup URL minted", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// Workspace is bound, but the owner-gate's CheckAdmin read
+		// fails (transient DDB). The gate is security-relevant, so it
+		// must fail CLOSED: surface the upstream-error reply and do NOT
+		// fall through to mint a setup URL. Mirrors
+		// TestHandleAdminRevoke_CheckAdminError for the admin verbs.
+		ts.seedAdmin(t)
+		ts.ddb.SetGetItemErr(ts.tableNames.workspace, errString("injected DDB transient"))
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, owner)
+		if strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Fatalf("CheckAdmin error: setup URL was minted (must fail closed): %q", got)
+		}
+		if !strings.Contains(got, "could not verify workspace ownership") {
+			t.Errorf("CheckAdmin error: reply missing the upstream-error surface, got: %q", got)
+		}
+	})
+
 	t.Run("added admin (not owner) reruns setup: refused", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		// seedAdmin binds owner=UOWNER001 and seeds UADMIN001 on the

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1035,6 +1035,23 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
+	t.Run("AdminStore nil (sandbox/no-DDB): owner gate skipped, setup URL minted", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+		// Sandbox / no-DDB posture: with AdminStore unset the owner gate
+		// is skipped entirely and /setup mints unconditionally, same as a
+		// fresh install. Null the store after construction to exercise that
+		// short-circuit (mirrors the sandbox cmd/main.go wiring). Even a
+		// non-owner (stranger) must get a URL since the gate never runs.
+		h.cfg.AdminStore = nil
+
+		got := invokeSetup(t, h, stranger)
+		if !strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Errorf("AdminStore nil: expected setup URL (owner gate must be skipped), got: %q", got)
+		}
+	})
+
 	t.Run("owner reruns setup: setup URL minted", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		// seedAdmin binds the workspace with owner=UOWNER001 and the

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1098,8 +1098,11 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		if strings.Contains(got, auth0Sub) {
 			t.Errorf("shape-bad owner: reply leaked the raw Auth0 sub (anywhere, incl. the mention surface): %q", got)
 		}
-		if !strings.Contains(got, "the existing workspace owner") {
-			t.Errorf("shape-bad owner: reply missing the shape-bad fallback copy, got: %q", got)
+		if strings.Contains(got, "<@") {
+			t.Errorf("shape-bad owner: reply rendered a mention surface instead of the malformed-record fallback: %q", got)
+		}
+		if !strings.Contains(got, "malformed") {
+			t.Errorf("shape-bad owner: reply missing the malformed-record fallback copy, got: %q", got)
 		}
 	})
 

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -12,6 +14,7 @@ import (
 
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
 
@@ -972,4 +975,122 @@ func TestLooksLikeSlackUserID_MatchesUserMentionPattern(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHandleSetup_OwnerGate exercises the slash-command-level owner
+// gate on `/qurl setup`. Three branches: fresh install (no workspace
+// row → anyone allowed), owner reruns setup (idempotent → URL minted),
+// non-owner attempts setup (refuse with friendly copy mentioning the
+// owner).
+//
+// AdminStore-backed: the gate calls AdminStore.CheckAdmin to read the
+// stored owner_id. Uses newAdminTestServers + newAdminTestHandler so
+// the underlying DDB row reflects what the handler reads.
+func TestHandleSetup_OwnerGate(t *testing.T) {
+	const (
+		// Use the test-suite constants from admin_test_helpers_test.go.
+		owner    = testAdminOwnerID // UOWNER001 (matches looksLikeSlackUserID).
+		stranger = "USTRANGER000"   // Different Slack user — non-owner caller.
+		team     = testAdminTeamID  // T_team
+	)
+	const slackBaseURL = "https://slack-bot.example"
+	stateSecret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes.
+
+	wireSetup := func(t *testing.T, h *Handler) {
+		t.Helper()
+		h.SetOAuthSetup(oauth.SetupConfig{
+			StateSecret:  stateSecret,
+			SlackBaseURL: slackBaseURL,
+		})
+	}
+
+	const setupText = "setup"
+	invokeSetup := func(t *testing.T, h *Handler, userID string) string {
+		t.Helper()
+		body := url.Values{
+			fieldCommand: {testSlashCmd},
+			fieldText:    {setupText},
+			fieldTeamID:  {team},
+			fieldUserID:  {userID},
+		}.Encode()
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+		if w.Code != http.StatusOK {
+			t.Fatalf("/qurl setup status: %d body=%s", w.Code, w.Body.String())
+		}
+		return parseSlackText(t, w.Body.Bytes())
+	}
+
+	t.Run("fresh install: no workspace row → anyone allowed", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// No seedAdmin / seedWorkspace — workspace_mappings table is
+		// empty. CheckAdmin returns ("", "", nil); the gate falls
+		// through to mint.
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, stranger)
+		if !strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Errorf("fresh install: expected setup URL, got: %q", got)
+		}
+	})
+
+	t.Run("owner reruns setup: setup URL minted", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// seedAdmin binds the workspace with owner=UOWNER001 and the
+		// same user on the admin set. The gate compares the invoker
+		// (UOWNER001) to ownerID and short-circuits to mint.
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, owner)
+		if !strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Errorf("owner rerun: expected setup URL, got: %q", got)
+		}
+	})
+
+	t.Run("non-owner reruns setup: refused with owner mention", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// Workspace is bound to UOWNER001. The caller is USTRANGER000
+		// — not on the admin set, definitely not the owner. Gate
+		// rejects upfront with a copy that mentions the existing owner.
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, stranger)
+		if strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Fatalf("non-owner: setup URL was minted (should be refused): %q", got)
+		}
+		// The reply must mention the existing owner so the requester
+		// knows whom to ask. The mention syntax `<@U…>` is what Slack
+		// renders into a clickable user reference.
+		if !strings.Contains(got, "<@"+owner+">") {
+			t.Errorf("non-owner: reply missing owner mention <@%s>, got: %q", owner, got)
+		}
+		if !strings.Contains(got, "owner") {
+			t.Errorf("non-owner: reply missing 'owner' word for clarity, got: %q", got)
+		}
+	})
+
+	t.Run("added admin (not owner) reruns setup: refused", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		// seedAdmin binds owner=UOWNER001 and seeds UADMIN001 on the
+		// admin set. UADMIN001 is an "admin" (can run /qurl admin
+		// list/add/remove/revoke + tunnel etc.) but is NOT the owner.
+		// /setup must refuse them — this is the load-bearing
+		// safeguard against admins rotating the workspace credential.
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		got := invokeSetup(t, h, testAdminUserID)
+		if strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Fatalf("added admin: setup URL was minted (should be refused — owner-only): %q", got)
+		}
+		if !strings.Contains(got, "<@"+owner+">") {
+			t.Errorf("added admin: reply missing owner mention <@%s>, got: %q", owner, got)
+		}
+	})
 }

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -276,13 +276,14 @@ func (h *Handler) aliasPreamble(w http.ResponseWriter, values url.Values, verb s
 //
 // **Admin restriction:** This handler is admin-gated at the Slack app
 // manifest level — the `/qurl setalias` command must be declared
-// admin-only in the install config. The same posture is used for
-// `/qurl setup` (see handleSetup) — gating in the manifest avoids an
-// extra Slack API round-trip per invocation. The CR feedback on the
-// old #230 (claude-bot review id 2026-05-10) flagged "admin gate
-// before alias resolution" as an info-disclosure surface. Moving the
-// gate to the manifest closes that gap structurally: a non-admin's
-// command never reaches this handler.
+// admin-only in the install config; gating in the manifest avoids an
+// extra Slack API round-trip per invocation. (Note: `/qurl setup`
+// does NOT share this posture — it enforces an owner-only gate in
+// code, see handleSetup.) The CR feedback on the old #230 (claude-bot
+// review id 2026-05-10) flagged "admin gate before alias resolution"
+// as an info-disclosure surface. Moving the gate to the manifest
+// closes that gap structurally: a non-admin's command never reaches
+// this handler.
 //
 // **Reply contract:** URL/resource_id targets reply synchronously and
 // ephemerally per the

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -419,19 +419,22 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 	}
 	switch code {
 	case BindConflictAlreadyBoundToCaller:
-		// Same Slack user re-running /qurl setup — they were already
-		// admin. We continue to mint, which rotates their API key.
-		// Operator-visible effect: "key rotated, admin set unchanged."
-		slog.Info("oauth/callback rebind idempotent (caller already on admin set)", //nolint:gosec // G706: slog escapes control bytes in attribute values.
+		// The workspace owner is re-running /qurl setup — the stored
+		// owner_id matches the verified caller (owner-only short-circuit;
+		// added admins do NOT land here, they get AlreadyBound). We
+		// continue to mint, which rotates their API key. Operator-visible
+		// effect: "key rotated, owner + admin set unchanged."
+		slog.Info("oauth/callback rebind idempotent (caller is the workspace owner)", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID)
 		return true
 	case BindConflictAlreadyBound, BindConflictUnverified:
-		// A different admin holds the workspace (or we can't tell —
-		// treat unverified the same way; the safer default is to
-		// refuse the rebind than to potentially overwrite). No mint
-		// has happened yet, so nothing to revoke — the existing
-		// admin's key row is untouched.
-		slog.Warn("oauth/callback rebind refused — workspace held by different admin", //nolint:gosec // G706: slog escapes control bytes in attribute values.
+		// A different Slack user owns the workspace — the caller isn't
+		// the stored owner_id (this fires for added admins too, not just
+		// strangers), or we can't tell (treat unverified the same way;
+		// the safer default is to refuse the rebind than to potentially
+		// overwrite). No mint has happened yet, so nothing to revoke —
+		// the existing owner's key row is untouched.
+		slog.Warn("oauth/callback rebind refused — workspace owned by a different Slack user", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID, "conflict", string(code), "error", bindErr)
 		renderRebindRefused(w, teamID)
 		return false

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -359,9 +359,22 @@ func verifyIDTokenClaims(ctx context.Context, cfg Config, idToken string) (email
 // key and never overwrites an existing admin's stored credential.
 //
 // AdminStore=nil is the sandbox / no-DDB path — log and skip.
-// qurlSub=="" means the verifier failed; we can't bind without the
-// OwnerID. Render a 500 — half-installing (API key minted, admin
-// verbs broken) is the worst-of-both-worlds state.
+// qurlSub=="" means the verifier failed; we still refuse the bind
+// (the Auth0 identity check is a security gate at OAuth time even
+// though qurlSub is no longer persisted in workspace_mappings —
+// without it, anyone with workspace OAuth-flow access could complete
+// /setup without proving qURL service identity). Render a 500 —
+// half-installing (API key minted, admin verbs broken) is the
+// worst-of-both-worlds state.
+//
+// `verified.UserID` is the Slack user ID of the /setup invoker
+// (HMAC-verified through the OAuth state token). That value becomes
+// BOTH the workspace_mappings.owner_id (the long-lived "only this
+// Slack user can re-run /setup" anchor) AND the initial entry in
+// admin_slack_user_ids. The two are the same value at first bind
+// by construction; /qurl admin add later grows the admin set but
+// leaves owner_id immutable. See WorkspaceMapping doc in slackdata
+// for the model rationale.
 //
 //nolint:gocritic // hugeParam: Config value-pass posture matches the rest of the package.
 func checkBindAllowed(w http.ResponseWriter, cfg Config, verified VerifiedState, qurlSub string) bool {
@@ -379,7 +392,7 @@ func checkBindAllowed(w http.ResponseWriter, cfg Config, verified VerifiedState,
 	bindCtx, bindCancel := context.WithTimeout(context.Background(), bindTimeout)
 	defer bindCancel()
 	bindErr := cfg.AdminStore.BindWorkspace(bindCtx,
-		&WorkspaceMapping{TeamID: verified.TeamID, OwnerID: qurlSub},
+		&WorkspaceMapping{TeamID: verified.TeamID, OwnerID: verified.UserID},
 		verified.UserID)
 	if bindErr == nil {
 		return true

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -359,13 +359,17 @@ func verifyIDTokenClaims(ctx context.Context, cfg Config, idToken string) (email
 // key and never overwrites an existing admin's stored credential.
 //
 // AdminStore=nil is the sandbox / no-DDB path — log and skip.
-// qurlSub=="" means the verifier failed; we still refuse the bind
-// (the Auth0 identity check is a security gate at OAuth time even
-// though qurlSub is no longer persisted in workspace_mappings —
-// without it, anyone with workspace OAuth-flow access could complete
-// /setup without proving qURL service identity). Render a 500 —
-// half-installing (API key minted, admin verbs broken) is the
-// worst-of-both-worlds state.
+// qurlSub is the output of the upstream id_token verifier (VerifySub,
+// logged on failure earlier in the callback), not the gate itself.
+// qurlSub=="" therefore means that verification silently failed — we
+// have no proof the OAuth flow originated from a legit Auth0 session,
+// so we refuse the bind here rather than half-install. The Auth0
+// identity check stays a security gate at OAuth time even though
+// qurlSub is no longer persisted in workspace_mappings; without it,
+// anyone with workspace OAuth-flow access could complete /setup
+// without proving qURL service identity. Render a 500 — half-
+// installing (API key minted, admin verbs broken) is the worst-of-
+// both-worlds state.
 //
 // `verified.UserID` is the Slack user ID of the /setup invoker
 // (HMAC-verified through the OAuth state token). That value becomes

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -702,8 +702,15 @@ func TestCallbackSeedsAdminOnBind(t *testing.T) {
 	if admin.gotTeamID != testTeamID {
 		t.Errorf("BindWorkspace TeamID: got %q want %q", admin.gotTeamID, testTeamID)
 	}
-	if admin.gotOwner != testAdminSub {
-		t.Errorf("BindWorkspace OwnerID: got %q want %q (must come from id_token sub claim)", admin.gotOwner, testAdminSub)
+	// OwnerID is the Slack user ID of the /setup invoker (workspace
+	// owner in the LayerV admin model). It must equal verified.UserID
+	// — the same value as seedAdmin — by construction at first bind.
+	// The id_token sub claim is still required at OAuth-callback time
+	// (verifier runs upstream of this) but no longer persisted; the
+	// security gate it provides is still in place via the
+	// `qurlSub == ""` check in checkBindAllowed.
+	if admin.gotOwner != testUserID {
+		t.Errorf("BindWorkspace OwnerID: got %q want %q (must equal verified.UserID — the Slack user who ran /setup)", admin.gotOwner, testUserID)
 	}
 	if admin.gotSeed != testUserID {
 		t.Errorf("BindWorkspace seedAdmin: got %q want %q (must come from verified state's userID)", admin.gotSeed, testUserID)

--- a/apps/slack/internal/slackdata/store.go
+++ b/apps/slack/internal/slackdata/store.go
@@ -216,8 +216,26 @@ type PolicyEntry struct {
 
 // WorkspaceMapping describes the 1:1 workspace → owner row stored on
 // the workspace_mappings table. Passed to `BindWorkspace` from the
-// OAuth callback to seed the row (TeamID from the HMAC'd state,
-// OwnerID from the JWKS-verified id_token sub).
+// OAuth callback to seed the row.
+//
+// OwnerID is the Slack user ID of the Slack user who completed the
+// first `/qurl setup` flow for this workspace — the "workspace
+// owner" in the LayerV admin model. Only the owner can re-run
+// `/qurl setup` after the first bind; other admins (added via
+// `/qurl admin add`) can run the rest of the admin commands but
+// cannot rotate the workspace's qURL credential. The OAuth
+// callback gates this distinction: BindWorkspace classifies a
+// rebind attempt as AlreadyBoundToCaller iff the OwnerID stored
+// here matches the new caller's verified Slack user ID.
+//
+// Historical note: prior versions stored the JWKS-verified Auth0
+// id_token sub here. That diverged from /qurl admin list's
+// Slack-mention rendering (it expects a Slack user ID shape) and
+// from /qurl setup's owner-only gate (which compares to the
+// invoking Slack user). Switched to Slack user ID end-to-end —
+// the Auth0 sub stays a runtime-only gate at OAuth callback time
+// (id_token verification still refuses installs without a valid
+// sub) but isn't persisted here.
 type WorkspaceMapping struct {
 	TeamID    string    `json:"team_id"`
 	OwnerID   string    `json:"owner_id"`

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -20,6 +20,19 @@ import (
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+// Slack-shaped test user IDs — kept Slack-shape (U-prefix uppercase
+// alphanumeric) so the handler-layer renderers' `looksLikeSlackUserID`
+// guard accepts them in /qurl admin list output. The dual-shape
+// fixtures below (testCallerSlackID for the BindWorkspace caller,
+// testOtherSlackID for a different Slack user holding the workspace)
+// are paired so a same-caller rebind asserts AlreadyBoundToCaller
+// while a different-caller rebind asserts AlreadyBound.
+const (
+	testCallerSlackID = "U_caller"
+	testOtherSlackID  = "U_other"
+	testOwnerSlackID  = "U_owner"
+)
+
 // stubDDB is a minimal in-package DynamoDBClient that returns
 // pre-canned responses keyed by op. Just enough for the package-
 // boundary tests below — the cross-handler integration tests have a
@@ -170,15 +183,16 @@ func TestBindWorkspace_ValidationGuards(t *testing.T) {
 // the two-branch 409 mapping that the handler's `surfaceBindError`
 // branches on via `ae.Code`:
 //
-//   - row exists, admin_slack_user_ids contains the caller →
-//     ErrCodeWorkspaceAlreadyBoundToCaller
-//   - row exists, admin_slack_user_ids does not contain the caller →
-//     ErrCodeWorkspaceAlreadyBound
+//   - row exists, owner_id matches the caller's seedAdmin →
+//     ErrCodeWorkspaceAlreadyBoundToCaller (idempotent rerun by owner)
+//   - row exists, owner_id is a different Slack user (including added
+//     admins) → ErrCodeWorkspaceAlreadyBound (refuse — owner-only
+//     rebind, the rest of the admin verbs gate via admin_set instead)
 //
 // Drift either constant or invert the branch and the handler's
 // user-copy will desynchronize from the actual workspace state.
 func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
-	t.Run("same caller already bound", func(t *testing.T) {
+	t.Run("owner reruns setup → idempotent", func(t *testing.T) {
 		store := newStore(&stubDDB{
 			putItemFn: func(_ *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
 				return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
@@ -186,13 +200,14 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
 				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
 					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:     &ddbtypes.AttributeValueMemberS{Value: testCallerSlackID},
 					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
-						Value: []string{"U_caller", "U_other"},
+						Value: []string{testCallerSlackID, testOtherSlackID},
 					},
 				}}, nil
 			},
 		})
-		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, "U_caller")
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: testCallerSlackID}, testCallerSlackID)
 		var ae *Error
 		if !errors.As(err, &ae) {
 			t.Fatalf("got %v, want *Error", err)
@@ -205,6 +220,36 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 		}
 	})
 
+	t.Run("added admin reruns setup → refuse (owner-only rebind)", func(t *testing.T) {
+		// Admin set contains the caller (they were /qurl admin add'd
+		// after first bind), but they're NOT the owner. Pre-owner-gate
+		// this returned AlreadyBoundToCaller (idempotent); post-gate
+		// it must return AlreadyBound (refuse) so the added admin
+		// can't rotate the workspace credential to their own Auth0.
+		store := newStore(&stubDDB{
+			putItemFn: func(_ *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+				return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
+			},
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:     &ddbtypes.AttributeValueMemberS{Value: testOwnerSlackID},
+					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
+						Value: []string{testOwnerSlackID, testCallerSlackID},
+					},
+				}}, nil
+			},
+		})
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: testCallerSlackID}, testCallerSlackID)
+		var ae *Error
+		if !errors.As(err, &ae) {
+			t.Fatalf("got %v, want *Error", err)
+		}
+		if ae.Code != ErrCodeWorkspaceAlreadyBound {
+			t.Errorf("Code = %q, want %q", ae.Code, ErrCodeWorkspaceAlreadyBound)
+		}
+	})
+
 	t.Run("different admin holds workspace", func(t *testing.T) {
 		store := newStore(&stubDDB{
 			putItemFn: func(_ *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
@@ -213,13 +258,14 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
 				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
 					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:     &ddbtypes.AttributeValueMemberS{Value: testOtherSlackID},
 					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
-						Value: []string{"U_other"},
+						Value: []string{testOtherSlackID},
 					},
 				}}, nil
 			},
 		})
-		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, "U_caller")
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: testCallerSlackID}, testCallerSlackID)
 		var ae *Error
 		if !errors.As(err, &ae) {
 			t.Fatalf("got %v, want *Error", err)
@@ -245,11 +291,11 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 				disambigConsistent = aws.ToBool(in.ConsistentRead)
 				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
 					attrSlackTeamID:       &ddbtypes.AttributeValueMemberS{Value: "T"},
-					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{"U_other"}},
+					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{testOtherSlackID}},
 				}}, nil
 			},
 		})
-		_ = store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, "U_caller")
+		_ = store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, testCallerSlackID)
 		if !disambigConsistent {
 			t.Errorf("disambig GetItem ConsistentRead = false, want true (regression would replay the eventual-consistency race)")
 		}
@@ -271,7 +317,7 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 				return nil, errors.New("transport blip")
 			},
 		})
-		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, "U_caller")
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, testCallerSlackID)
 		var ae *Error
 		if !errors.As(err, &ae) {
 			t.Fatalf("got %v, want *Error", err)
@@ -334,7 +380,7 @@ func TestBindWorkspace_TransportErrorMapsTo503(t *testing.T) {
 			return nil, errors.New("dial tcp: timeout")
 		},
 	})
-	err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, "U_caller")
+	err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: "u_owner"}, testCallerSlackID)
 	var ae *Error
 	if !errors.As(err, &ae) {
 		t.Fatalf("got %v, want *Error", err)

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -278,6 +278,37 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 		}
 	})
 
+	t.Run("row exists with empty owner_id → refuse (no hijack to AlreadyBoundToCaller)", func(t *testing.T) {
+		// Operational-corruption guard: a manually edited / truncated row
+		// can exist with no owner_id. The owner comparison must NOT treat
+		// "" == "" as a same-owner match (which would hand the workspace to
+		// any caller via AlreadyBoundToCaller). It must refuse with the
+		// safe default, AlreadyBound. seedAdmin is always non-empty here,
+		// so the empty existingOwner can never equal it.
+		store := newStore(&stubDDB{
+			putItemFn: func(_ *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+				return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
+			},
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
+					// owner_id intentionally absent (corrupt row).
+					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
+						Value: []string{testCallerSlackID},
+					},
+				}}, nil
+			},
+		})
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: testCallerSlackID}, testCallerSlackID)
+		var ae *Error
+		if !errors.As(err, &ae) {
+			t.Fatalf("got %v, want *Error", err)
+		}
+		if ae.Code != ErrCodeWorkspaceAlreadyBound {
+			t.Errorf("Code = %q, want %q (empty owner_id must not short-circuit to AlreadyBoundToCaller)", ae.Code, ErrCodeWorkspaceAlreadyBound)
+		}
+	})
+
 	// Fence round-19 cr #1: the post-CCFE disambiguation GetItem
 	// MUST use ConsistentRead=true. The CCFE confirms a row exists,
 	// but an eventually-consistent read on a stale replica could

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -20,17 +20,20 @@ import (
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// Slack-shaped test user IDs — kept Slack-shape (U-prefix uppercase
-// alphanumeric) so the handler-layer renderers' `looksLikeSlackUserID`
-// guard accepts them in /qurl admin list output. The dual-shape
-// fixtures below (testCallerSlackID for the BindWorkspace caller,
+// Slack-shaped test user IDs — kept in real Slack-ID shape (U-prefix
+// + uppercase-alphanumeric, matching `looksLikeSlackUserID`) so these
+// fixtures mirror production owner_id/admin values rather than ad-hoc
+// strings. These tests assert at the store boundary (BindWorkspace
+// classification), not the handler renderer, but matching the
+// production shape keeps the fixtures honest and copy-safe. The paired
+// fixtures (testCallerSlackID for the BindWorkspace caller,
 // testOtherSlackID for a different Slack user holding the workspace)
-// are paired so a same-caller rebind asserts AlreadyBoundToCaller
-// while a different-caller rebind asserts AlreadyBound.
+// let a same-caller rebind assert AlreadyBoundToCaller while a
+// different-caller rebind asserts AlreadyBound.
 const (
-	testCallerSlackID = "U_caller"
-	testOtherSlackID  = "U_other"
-	testOwnerSlackID  = "U_owner"
+	testCallerSlackID = "UCALLER01"
+	testOtherSlackID  = "UOTHER001"
+	testOwnerSlackID  = "UOWNER001"
 )
 
 // stubDDB is a minimal in-package DynamoDBClient that returns

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -156,13 +156,22 @@ func (s *Store) CheckAdmin(ctx context.Context, teamID, slackUserID string) (isA
 // seedAdmin becomes the only entry in admin_slack_user_ids;
 // additional admins are added later via /qurl admin add.
 //
+// OwnerID is the Slack user ID of the first /setup invoker — written
+// once at first bind, never mutated by /qurl admin add. Only the
+// owner can re-run /setup; other admins can run the rest of the
+// admin verbs but cannot rotate the workspace's qURL credential.
+//
 // Returns 409 (via *Error) if the row already exists. Two sub-cases:
-//   - caller is already on the admin set → ErrCodeWorkspaceAlreadyBoundToCaller.
-//     The callback treats this as idempotent success and continues
-//     to mint, rotating the API key without mutating the admin set.
-//   - a different admin holds the workspace → ErrCodeWorkspaceAlreadyBound.
+//   - the existing row's owner_id matches the caller's seedAdmin →
+//     ErrCodeWorkspaceAlreadyBoundToCaller. The callback treats this
+//     as idempotent success and continues to mint, rotating the API
+//     key without mutating the admin set. Only the OWNER short-
+//     circuits this way — admins added via /qurl admin add cannot
+//     re-run /setup, by design (prevents them from rotating the
+//     workspace credential to a different Auth0 account).
+//   - any other caller (admin or non-admin) → ErrCodeWorkspaceAlreadyBound.
 //     The callback renders a rebind-refused page; no key is minted
-//     so there's nothing to revoke and the existing admin's
+//     so there's nothing to revoke and the existing owner's
 //     workspace_keys row stays intact.
 //
 // Surfacing same-owner as 409 (instead of silently overwriting) is
@@ -261,31 +270,36 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 		}
 	}
 	if len(check.Item) > 0 {
-		for _, u := range readStringSet(check.Item, attrAdminSlackUserIDs) {
-			if u == seedAdmin {
-				return &Error{
-					StatusCode: http.StatusConflict,
-					Code:       ErrCodeWorkspaceAlreadyBoundToCaller,
-					Title:      "BindWorkspace: caller is already on this workspace's admin set",
-				}
+		// Compare against the row's owner_id directly. Owner-only
+		// rebind: any caller whose Slack ID isn't the owner gets the
+		// "different admin" branch, including admins added via
+		// /qurl admin add. This is the load-bearing safeguard — a
+		// non-owner admin re-running /setup would otherwise rotate
+		// the workspace's qURL credential to their own Auth0 account,
+		// silently locking the original owner out at the qurl-service
+		// layer (workspace_keys reassigned to a different auth0_subject).
+		existingOwner := readString(check.Item, attrOwnerID)
+		if existingOwner == seedAdmin {
+			return &Error{
+				StatusCode: http.StatusConflict,
+				Code:       ErrCodeWorkspaceAlreadyBoundToCaller,
+				Title:      "BindWorkspace: caller is the existing workspace owner",
 			}
 		}
 	}
-	// ErrCodeWorkspaceAlreadyBound covers two structurally distinct
-	// conflicts: (a) the existing row's owner_id matches m.OwnerID
-	// (same qURL account holder reinstalling) but the OAuth state
-	// names a Slack user who isn't on the admin set, and (b) the
-	// existing row's owner_id is a DIFFERENT qURL account entirely
-	// (a fresh /qurl setup from a different Auth0 identity). Both
-	// produce the same "different admin claims this workspace" user
-	// copy because the user signal is the same — they cannot become
-	// admin via the OAuth path regardless of which mismatch fired.
-	// Operators who need the distinction read the workspace_mappings
-	// row directly.
+	// ErrCodeWorkspaceAlreadyBound fires for every non-owner rebind
+	// attempt — added admins, random workspace members, anyone whose
+	// Slack ID doesn't equal the stored OwnerID. The callback renders
+	// a rebind-refused page with the existing owner's mention so the
+	// caller knows whom to ask if they need to re-OAuth. Operators
+	// debugging persistent rebind-refused on a fresh install should
+	// check whether the workspace_mappings row carries a stale OwnerID
+	// from a deleted Slack user; manual row delete + re-run /setup is
+	// the recovery.
 	return &Error{
 		StatusCode: http.StatusConflict,
 		Code:       ErrCodeWorkspaceAlreadyBound,
-		Title:      "BindWorkspace: workspace is already claimed by a different admin",
+		Title:      "BindWorkspace: workspace is owned by a different Slack user",
 	}
 }
 

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -207,6 +207,12 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 	// would clobber later-added admins. Both deserve the 409 signal;
 	// the post-CCFE disambiguation read below distinguishes the two
 	// cases so the callback can branch idempotent vs. rebind-refused.
+	// owner_id and seed_admin_slack_user_id are equal by construction at
+	// first bind (the callback passes verified.UserID for both), not by
+	// coincidence. They're kept distinct because their long-term roles
+	// diverge: owner_id is the mutable-someday gate anchor (the #539
+	// transfer verb would rewrite it), while seed_admin_slack_user_id is
+	// the write-once forensic record of who originally claimed the workspace.
 	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(s.WorkspaceMappingsName),
 		Item: map[string]ddbtypes.AttributeValue{

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -299,7 +299,7 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 			// through to AlreadyBound, the safe default), but log so the
 			// malformed row is grep-able rather than silently routing to the
 			// generic rebind-refused page.
-			slog.Warn("BindWorkspace: row exists but owner_id is empty — likely a manually edited row; refusing rebind (AlreadyBound)", "team_id", m.TeamID)
+			slog.Warn("BindWorkspace: row exists but owner_id is empty — likely a manually edited row; refusing rebind (AlreadyBound)", "team_id", m.TeamID, "admin_count", len(readStringSet(check.Item, attrAdminSlackUserIDs)))
 		}
 	}
 	// ErrCodeWorkspaceAlreadyBound fires for every non-owner rebind

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -286,6 +286,15 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 				Title:      "BindWorkspace: caller is the existing workspace owner",
 			}
 		}
+		if existingOwner == "" {
+			// A row exists but carries no owner_id. This shouldn't happen —
+			// every BindWorkspace PutItem writes a non-empty OwnerID — so it
+			// means a manually edited / truncated row. We still refuse (fall
+			// through to AlreadyBound, the safe default), but log so the
+			// malformed row is grep-able rather than silently routing to the
+			// generic rebind-refused page.
+			slog.Warn("BindWorkspace: row exists but owner_id is empty — likely a manually edited row; refusing rebind (AlreadyBound)", "team_id", m.TeamID)
+		}
 	}
 	// ErrCodeWorkspaceAlreadyBound fires for every non-owner rebind
 	// attempt — added admins, random workspace members, anyone whose


### PR DESCRIPTION
## Summary

Two coupled changes that move the slack-bot admin model to the **LayerV-admin** intent (workspace owner is the Slack identity that ran first /setup) and fix the long-standing `/qurl admin list` owner-display bug.

### 1. `workspace_mappings.owner_id` = Slack user ID

Was: the JWKS-verified Auth0 id_token sub. The handler-side renderer for `/qurl admin list` already expected a Slack user ID (`looksLikeSlackUserID` guard on the `<@%s>` mention render), so the owner line was rendering "(unknown — workspace owner record is missing; contact support)" for every properly-bound workspace — that's the bug. The Auth0 sub stays a runtime gate at OAuth-callback time (id_token must still verify before bind) but is no longer persisted.

### 2. `/setup` owner-only gate at the slash-command surface

- **Fresh install** (no workspace_mappings row): anyone can run `/setup` — that user becomes the owner.
- **Subsequent runs**: only the owner is allowed; any other workspace user — including admins added via `/qurl admin add` — gets a refusal naming the existing owner.

Without this gate, an added admin could complete OAuth against their own Auth0 account and silently rotate the workspace's qURL credential, locking the original owner out at the qurl-service layer. The OAuth callback's `BindWorkspace` classifier also enforces this as defense in depth (now compares seedAdmin to the row's `owner_id` rather than scanning the admin set), but slash-level rejection means non-owners never get a setup URL minted in their name.

The rest of the admin verbs (`admin add/remove/list/revoke`, `tunnel`, `setalias`, `unsetalias`) continue to use the broader admin_set membership gate, unchanged. Only `/setup` is owner-only.

## Migration (sandbox)

Existing sandbox `workspace_mappings` rows have `owner_id` = Auth0 sub. After this deploys, every `/setup` attempt against an existing row will be classified as a different-owner rebind and refused (the stored Auth0 sub won't equal any caller's Slack ID).

**Prod scope:** the Slack bot is sandbox-only today — the prod Slack-OAuth + infra chain hasn't shipped, so there are no prod `workspace_mappings` rows to migrate. Prod will deploy this (post-pivot) binary from the start and write `owner_id` = Slack ID on the first `/setup`, so a prod row will never carry an Auth0-sub `owner_id`. This migration is sandbox-scoped.

**Operator recovery:**

```bash
aws dynamodb delete-item \
  --table-name <workspace-mappings-table-name> \
  --key '{"slack_team_id":{"S":"<TEAM_ID>"}}' \
  --region us-east-2
# then re-run /qurl-sandbox setup in Slack — fresh row written with owner_id = Slack ID
```

The qurl-service-side `workspace_keys` row stays put through this — the bot re-mints the key on the next /setup against the same workspace, and the existing API key is rotated as usual.

The same `delete-item` recovery applies if the workspace owner later leaves or is deactivated in Slack: `owner_id` is immutable once set, so until an in-band ownership-transfer verb exists (tracked in #539) the operator deletes the row and the new intended owner re-runs `/qurl-sandbox setup`.

## Test plan

- [x] `TestHandleSetup_OwnerGate` (new) — seven subtests: fresh install (anyone allowed) / owner rerun (idempotent) / non-owner refuse (with owner mention) / added admin refuse (load-bearing safeguard) / shape-bad legacy owner_id (refused without a broken mention) / owner not on admin set (gate keys off owner_id alone) / CheckAdmin error (fail-closed)
- [x] `TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin` (updated) — owner rerun → AlreadyBoundToCaller; added admin → AlreadyBound; different Slack user → AlreadyBound
- [x] `TestCallbackSeedsAdminOnBind` (updated) — asserts OwnerID equals verified.UserID (Slack ID) rather than the id_token sub
- [x] `go test -race ./apps/slack/...` clean
- [x] `golangci-lint run --new-from-rev=origin/main ./apps/slack/...` — 0 new issues
- [ ] Post-merge: deploy slack-bot to sandbox, delete existing workspace_mappings row, re-run `/qurl-sandbox setup`, confirm owner shows in `/qurl-sandbox admin list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Fresh-install ownership claim (race / wrong-user):** on an unbound workspace, `/setup` is first-user-wins — any workspace member who runs it first becomes the owner (the slash gate reads eventually-consistent; `BindWorkspace` consistent-read picks the single winner). If the wrong user claims ownership (e.g. a member beats the intended admin to it), recovery is the same `delete-item` above followed by the intended owner re-running `/qurl-sandbox setup`. Restrict who can reach the command at install time if first-claim ownership matters.
