### PR TITLE
feat(slack): show slug column in /qurl list resources (closes Phase 3)

### DIFF
--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -252,10 +252,11 @@ func resourceSortKey(r *client.Resource) string {
 //   - With alias bound:    `• \`$<alias>\` → <target_url>`
 //   - Without alias bound: `• \`$<resource_id>\` → <target_url> (no alias set)`
 //   - Tunnel (Type=tunnel): `• \`$<token>\` → (tunnel)`
+//   - Tunnel with slug:    `• \`$<token>\` → (tunnel) [slug:<slug>]`
 //   - Empty target (other): `• \`$<token>\` → <empty>`
 //
 // When `r.Description` is set, it appends ` — <description>` as a
-// trailing annotation (after the alias-set/tunnel hints). Legacy
+// trailing annotation (after the alias-set/tunnel/slug hints). Legacy
 // /qurl list rendered description on a separate visual axis; the
 // trailing-em-dash form keeps the one-line-per-row shape needed for
 // the copy-paste-ready `$<token>` workflow while preserving the
@@ -273,6 +274,16 @@ func resourceSortKey(r *client.Resource) string {
 // type), NOT on empty target_url — keying on the empty field would
 // silently re-label any non-tunnel row with a missing target as
 // "(tunnel)", which would mislead operators triaging a data glitch.
+//
+// Slug fragment ([slug:<slug>]) renders ONLY on tunnel rows that carry
+// a non-empty Slug. URL/transit resources never carry a slug on the
+// wire (qurl-service rejects slug on non-tunnel creates) so the
+// fragment is structurally tunnel-scoped. A tunnel row WITHOUT a slug
+// — legacy / pre-Phase-1A — renders the fragment-free shape so existing
+// fixtures (and operator muscle memory) keep working. The customer's
+// onboarding flow runs `/qurl list resources` to match what their
+// sidecar provisioned (via QURL_TUNNEL_SLUG) against a resource_id
+// before pairing it with an alias.
 func formatResourceListLine(r *client.Resource) string {
 	token := r.Alias
 	noAlias := false
@@ -289,7 +300,11 @@ func formatResourceListLine(r *client.Resource) string {
 		// is the effective destination). Render a placeholder so the
 		// row still reads cleanly. The "(no alias set)" annotation
 		// is suppressed here — see godoc.
-		return fmt.Sprintf("• `$%s` → (tunnel)%s", token, descSuffix)
+		slugFrag := ""
+		if r.Slug != "" {
+			slugFrag = " [slug:" + r.Slug + "]"
+		}
+		return fmt.Sprintf("• `$%s` → (tunnel)%s%s", token, slugFrag, descSuffix)
 	}
 	target := r.TargetURL
 	if target == "" {

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -331,6 +331,150 @@ func TestHandleList_TunnelResourceWithoutAlias(t *testing.T) {
 	}
 }
 
+// TestHandleList_TunnelResourceWithSlug fences the customer-onboarding
+// Phase 3 rendering: a tunnel resource with a non-empty `slug` (set
+// by the sidecar's QURL_TUNNEL_SLUG bootstrap) surfaces the slug as
+// a "[slug:<slug>]" fragment between the "(tunnel)" placeholder and
+// the optional description suffix. The customer's bot user reads this
+// to match what the sidecar provisioned against a resource_id before
+// pairing it with an alias via `/qurl set-alias`.
+func TestHandleList_TunnelResourceWithSlug(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_slg", fAttrAlias: "prod-dash", testKeyType: resourceTypeTunnel, testKeySlug: "prod-dashboard"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$prod-dash` → (tunnel) [slug:prod-dashboard]") {
+		t.Errorf("async reply missing tunnel-with-slug row: %q", async)
+	}
+}
+
+// TestHandleList_TunnelResourceWithSlugAndDescription fences the
+// composition of the slug fragment with the trailing-em-dash
+// description suffix. Slug fragment renders BEFORE the description,
+// so the line reads "(tunnel) [slug:<slug>] — <description>" — slug
+// is structural metadata about the resource identity, description is
+// operator-authored prose, and the visual axis preserves that order.
+func TestHandleList_TunnelResourceWithSlugAndDescription(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_sd", fAttrAlias: "ops", testKeyType: resourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "ops jump host"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$ops` → (tunnel) [slug:ops-bastion] — ops jump host") {
+		t.Errorf("async reply missing tunnel-with-slug + description row: %q", async)
+	}
+}
+
+// TestHandleList_TunnelResourceWithoutSlugOmitsFragment fences the
+// legacy / pre-Phase-1A path: a tunnel resource with an empty Slug
+// (qurl-service didn't surface slug until PR #743; pre-existing tunnels
+// may carry no slug for the lifetime of the row) renders the
+// fragment-free "(tunnel)" shape. Choosing "omit cleanly" over
+// "slug:none" parallels how URL/transit rows already work and keeps
+// the row identical to the pre-Phase-3 shape for legacy tunnels.
+func TestHandleList_TunnelResourceWithoutSlugOmitsFragment(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_nos", fAttrAlias: "legacy-tun", testKeyType: resourceTypeTunnel},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$legacy-tun` → (tunnel)") {
+		t.Errorf("async reply missing tunnel placeholder for legacy slug-less tunnel: %q", async)
+	}
+	if strings.Contains(async, "[slug:") {
+		t.Errorf("slug fragment leaked on tunnel row without a slug: %q", async)
+	}
+	if strings.Contains(async, "slug:none") {
+		t.Errorf("slug:none placeholder leaked — implementation chose to omit cleanly: %q", async)
+	}
+}
+
+// TestHandleList_URLResourceNeverShowsSlugFragment fences the
+// tunnel-scope of the slug fragment: a URL/transit resource MUST NOT
+// render a "[slug:...]" fragment even if a stray `slug` field shows
+// up on the wire (qurl-service rejects slug on non-tunnel creates,
+// but defense-in-depth: the renderer keys the fragment on Type=tunnel,
+// not on the slug field's presence).
+func TestHandleList_URLResourceNeverShowsSlugFragment(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			// Stray slug on a URL row — server shouldn't emit this,
+			// but the renderer must defend the type-scoped contract.
+			{testKeyResourceID: "r_url_xxxxxx", fAttrAlias: "prod-url", testKeyTargetURL: "https://url-row.example.com", testKeySlug: "should-not-render"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$prod-url` → https://url-row.example.com") {
+		t.Errorf("async reply missing URL row: %q", async)
+	}
+	if strings.Contains(async, "[slug:") {
+		t.Errorf("slug fragment leaked on a URL/transit row: %q", async)
+	}
+	if strings.Contains(async, "should-not-render") {
+		t.Errorf("stray wire-level slug bled through on a URL row: %q", async)
+	}
+}
+
+// TestHandleList_MixedTypesOnlyTunnelRowsShowSlug fences the
+// per-row scoping in a heterogeneous list: only tunnel rows surface
+// "[slug:...]" fragments; URL rows render plain.
+func TestHandleList_MixedTypesOnlyTunnelRowsShowSlug(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tun_slug_a", fAttrAlias: "atun", testKeyType: resourceTypeTunnel, testKeySlug: "alpha-tunnel"},
+			{testKeyResourceID: "r_url_btarg1", fAttrAlias: "burl", testKeyTargetURL: "https://b.example.com"},
+			{testKeyResourceID: "r_tun_noslug", fAttrAlias: "ctun", testKeyType: resourceTypeTunnel},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	// Tunnel with slug → fragment present.
+	if !strings.Contains(async, "`$atun` → (tunnel) [slug:alpha-tunnel]") {
+		t.Errorf("async reply missing slug-bearing tunnel row: %q", async)
+	}
+	// URL row → no fragment, plain target.
+	if !strings.Contains(async, "`$burl` → https://b.example.com") {
+		t.Errorf("async reply missing URL row: %q", async)
+	}
+	// Tunnel without slug → bare "(tunnel)" with no fragment.
+	if !strings.Contains(async, "`$ctun` → (tunnel)") {
+		t.Errorf("async reply missing slug-less tunnel row: %q", async)
+	}
+	// Exactly one slug fragment in the whole reply — the URL and
+	// slug-less tunnel rows MUST NOT carry one.
+	if got := strings.Count(async, "[slug:"); got != 1 {
+		t.Errorf("expected exactly one [slug:...] fragment across mixed list, got %d: %q", got, async)
+	}
+}
+
 // TestHandleList_ResourceWithDescription fences the trailing
 // "— <description>" annotation. Legacy /qurl list rendered description
 // on a separate line; the resource-pivoted version preserves the
@@ -341,9 +485,9 @@ func TestHandleList_ResourceWithDescription(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_desc_aaaaa", fAttrAlias: "prod", testKeyTargetURL: "https://prod", "description": "production gateway"},
+			{testKeyResourceID: "r_desc_aaaaa", fAttrAlias: "prod", testKeyTargetURL: "https://prod", testKeyDescription: "production gateway"},
 			{testKeyResourceID: "r_nodesc_bbbb", fAttrAlias: "stage", testKeyTargetURL: "https://stage"},
-			{testKeyResourceID: "r_tun_descrip", fAttrAlias: "tun", testKeyType: resourceTypeTunnel, "description": "ops bastion"},
+			{testKeyResourceID: "r_tun_descrip", fAttrAlias: "tun", testKeyType: resourceTypeTunnel, testKeyDescription: "ops bastion"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)

--- a/apps/slack/internal/handler_test_helpers_test.go
+++ b/apps/slack/internal/handler_test_helpers_test.go
@@ -12,15 +12,16 @@ import (
 // constants in tests because goconst would otherwise flag the 4+
 // duplications across fixture builders.
 const (
-	testKeyData       = "data"
-	testKeyError      = "error"
-	testKeyResourceID = "resource_id"
-	testKeySlug       = "slug"
-	testKeyStatus     = "status"
-	testKeyTitle      = "title"
-	testKeyType       = "type"
-	testKeyTargetURL  = "target_url"
-	testResourceIDFix = "r_prod_db" // canonical test resource_id
+	testKeyData        = "data"
+	testKeyError       = "error"
+	testKeyResourceID  = "resource_id"
+	testKeySlug        = "slug"
+	testKeyStatus      = "status"
+	testKeyTitle       = "title"
+	testKeyType        = "type"
+	testKeyTargetURL   = "target_url"
+	testKeyDescription = "description"
+	testResourceIDFix  = "r_prod_db" // canonical test resource_id
 	// mintByTestResourcePath is the resource-scoped mint endpoint
 	// that `client.Create` hits when given a ResourceID (alias-form
 	// /qurl get). Lifted so the alias-form tests register their


### PR DESCRIPTION
## Summary

Customer-onboarding **Phase 3** of the v1 plan: surface the tunnel `slug` in `/qurl list resources` so customers can match what their sidecar provisioned (via `QURL_TUNNEL_SLUG`) against a `resource_id` before pairing it with an alias via `/qurl set-alias`.

Tunnel-type resources now render as:

```
• `$prod-dash` → (tunnel) [slug:prod-dashboard]
• `$prod-dash` → (tunnel) [slug:prod-dashboard] — production dashboard
```

URL/transit rows and slug-less legacy tunnels render unchanged.

## Rendering format

Plain-text mrkdwn (no block-kit) — block-kit polish is **Phase 5** per the v1 plan's "Out of scope" section. The slug fragment slots between the existing `(tunnel)` placeholder and the optional ` — <description>` suffix: slug is structural metadata about the resource identity; description is operator-authored prose. The visual axis preserves that ordering.

## Design notes

- **Slug fragment is tunnel-scoped on Type, not on field presence.** The renderer keys `[slug:...]` rendering on `r.Type == "tunnel"`, NOT on a non-empty `Slug` field. A stray `slug` value on a URL/transit row (defense-in-depth — qurl-service rejects this on create) does NOT bleed through. Test `TestHandleList_URLResourceNeverShowsSlugFragment` pins this.
- **Legacy slug-less tunnels render fragment-free, not `slug:none`.** Pre-Phase-1A tunnel resources may have no `slug` for the lifetime of the row. Omitting cleanly parallels how URL/transit rows already work and keeps existing fixtures + operator muscle memory unchanged (existing `TestHandleList_TunnelResource` and `TestHandleList_TunnelResourceWithoutAlias` pass untouched).
- **No drift signal.** `shared/client/client.go` already had `Slug string \`json:"slug,omitempty"\`` on the `Resource` struct, and `testKeySlug = "slug"` was already in `handler_test_helpers_test.go`. The breadcrumb says this PR is the planned consumer.

## Cross-repo context

- Server-side `slug` field on `ResourceData`: layervai/qurl-service#743 (`feat(api): surface slug on QurlData/ResourceData for tunnel rows`).
- Client-side slug bootstrap: layervai/qurl-reverse-tunnel-client#192 (`feat(agent): tunnel-identity bootstrap via slug find-or-create`).
- Tunnel-resource policy defaults (server-side, `one_time_use` etc.): layervai/qurl-service#728.

This closes the loop on the v1 customer onboarding flow: sidecar provisions → `/qurl list resources` surfaces slug → `/qurl set-alias`.

## Out of scope (deferred)

- `/qurl create-tunnel $name` Slack command — v1.1 follow-up.
- Block-kit modals and action buttons — Phase 5 polish.
- Tunnel-type policy defaults — already done server-side in qurl-service #728.
- `handler_get.go` changes — bot's qURL minting path is unchanged.

## Test plan

- [x] `go test -count=1 ./apps/slack/internal/...` — all green (4 new tests + all existing pass)
- [x] `gofmt -w .` clean
- [x] `golangci-lint run --timeout=5m ./apps/slack/...` — same baseline lint counts as `main` (no new violations introduced; no `//nolint` directives added)
- [x] Full repo `go test -count=1 ./...` clean
- [x] New tests cover: tunnel-with-slug, tunnel-with-slug+description, tunnel-without-slug (fragment omitted), URL row never shows slug fragment, mixed-types list (exactly-one fragment count)