### PR TITLE
fix(slack): unwrap <url|display> in setalias target

### DIFF
--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -178,12 +178,32 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 		out.Target = "$" + slug
 		return out, ""
 	}
+	// Slack's `should_escape: true` (set on /qurl-admin so `admin add
+	// <@U…>` resolves) wraps user-typed URLs as `<url|display>`. Strip
+	// the wrapping so url.Parse below sees a bare URL and the stored
+	// target stays clean.
+	tgt = unwrapSlackAutolink(tgt)
 	u, err := url.Parse(tgt)
 	if err != nil || (u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS) || u.Host == "" {
 		return nil, msgAliasTargetInvalid
 	}
 	out.Target = tgt
 	return out, ""
+}
+
+// unwrapSlackAutolink strips the `<url|display>` (or `<url>`) wrapping
+// Slack applies to typed URLs when the slash command has
+// `should_escape: true`. Returns the inner URL when wrapping is
+// present, else returns the input unchanged.
+func unwrapSlackAutolink(tgt string) string {
+	if len(tgt) < 2 || tgt[0] != '<' || tgt[len(tgt)-1] != '>' {
+		return tgt
+	}
+	inner := tgt[1 : len(tgt)-1]
+	if i := strings.IndexByte(inner, '|'); i >= 0 {
+		return inner[:i]
+	}
+	return inner
 }
 
 // requireAlias checks that `tok` is `$<alias>` and returns the alias

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -198,7 +198,9 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 // substitutions Slack applies under the same flag. The entity decode
 // only runs when the wrap is present — that's the signal `should_escape`
 // fired — so a user who literally typed `&amp;` outside an escaped
-// command keeps it intact.
+// command keeps it intact. Splits on the *first* `|` to match Slack's
+// `<url|display>` grammar; a URL containing a raw `|` would be ambiguous
+// here, and Slack autodetect percent-encodes `|` to `%7C` anyway.
 func unwrapSlackAutolink(tgt string) string {
 	if len(tgt) < 2 || tgt[0] != '<' || tgt[len(tgt)-1] != '>' {
 		return tgt

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -198,8 +198,11 @@ var slackEscapeUndo = strings.NewReplacer("&amp;", "&", "&lt;", "<", "&gt;", ">"
 // unwrapSlackAutolink strips the `<url|display>` (or `<url>`) wrapping
 // Slack applies to typed URLs when the slash command has
 // `should_escape: true`, and undoes the entity substitutions Slack
-// applies under the same flag. Splits on the *first* `|` to match
-// Slack's `<url|display>` grammar; a URL containing a raw `|` would be
+// applies under the same flag. The entity decode is intentionally
+// gated on wrap presence — Slack applies both transformations together,
+// so an unwrapped input is treated as literal user text and a stray
+// `&amp;` is left alone. Splits on the *first* `|` to match Slack's
+// `<url|display>` grammar; a URL containing a raw `|` would be
 // ambiguous here, and Slack autodetect percent-encodes `|` to `%7C`
 // anyway.
 func unwrapSlackAutolink(tgt string) string {

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -178,10 +178,6 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 		out.Target = "$" + slug
 		return out, ""
 	}
-	// Slack's `should_escape: true` (set on /qurl-admin so `admin add
-	// <@U…>` resolves) wraps user-typed URLs as `<url|display>`. Strip
-	// the wrapping so url.Parse below sees a bare URL and the stored
-	// target stays clean.
 	tgt = unwrapSlackAutolink(tgt)
 	u, err := url.Parse(tgt)
 	if err != nil || (u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS) || u.Host == "" {

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -193,17 +194,20 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 
 // unwrapSlackAutolink strips the `<url|display>` (or `<url>`) wrapping
 // Slack applies to typed URLs when the slash command has
-// `should_escape: true`. Returns the inner URL when wrapping is
-// present, else returns the input unchanged.
+// `should_escape: true`, and decodes the `&amp;` / `&lt;` / `&gt;`
+// substitutions Slack applies under the same flag. The entity decode
+// only runs when the wrap is present — that's the signal `should_escape`
+// fired — so a user who literally typed `&amp;` outside an escaped
+// command keeps it intact.
 func unwrapSlackAutolink(tgt string) string {
 	if len(tgt) < 2 || tgt[0] != '<' || tgt[len(tgt)-1] != '>' {
 		return tgt
 	}
 	inner := tgt[1 : len(tgt)-1]
 	if i := strings.IndexByte(inner, '|'); i >= 0 {
-		return inner[:i]
+		inner = inner[:i]
 	}
-	return inner
+	return html.UnescapeString(inner)
 }
 
 // requireAlias checks that `tok` is `$<alias>` and returns the alias

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"html"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -192,15 +191,21 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 	return out, ""
 }
 
+// slackEscapeUndo reverses exactly the three substitutions Slack applies
+// under `should_escape: true` (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`).
+// Deliberately not `html.UnescapeString`: that decodes the full HTML5
+// entity set, including numeric refs like `&#96;` → "`" and `&#1;` →
+// "\x01", which would slip past the backtick/non-printable fence that
+// runs on the raw byte stream upstream of this function.
+var slackEscapeUndo = strings.NewReplacer("&amp;", "&", "&lt;", "<", "&gt;", ">")
+
 // unwrapSlackAutolink strips the `<url|display>` (or `<url>`) wrapping
 // Slack applies to typed URLs when the slash command has
-// `should_escape: true`, and decodes the `&amp;` / `&lt;` / `&gt;`
-// substitutions Slack applies under the same flag. The entity decode
-// only runs when the wrap is present — that's the signal `should_escape`
-// fired — so a user who literally typed `&amp;` outside an escaped
-// command keeps it intact. Splits on the *first* `|` to match Slack's
-// `<url|display>` grammar; a URL containing a raw `|` would be ambiguous
-// here, and Slack autodetect percent-encodes `|` to `%7C` anyway.
+// `should_escape: true`, and undoes the entity substitutions Slack
+// applies under the same flag. Splits on the *first* `|` to match
+// Slack's `<url|display>` grammar; a URL containing a raw `|` would be
+// ambiguous here, and Slack autodetect percent-encodes `|` to `%7C`
+// anyway.
 func unwrapSlackAutolink(tgt string) string {
 	if len(tgt) < 2 || tgt[0] != '<' || tgt[len(tgt)-1] != '>' {
 		return tgt
@@ -209,7 +214,7 @@ func unwrapSlackAutolink(tgt string) string {
 	if i := strings.IndexByte(inner, '|'); i >= 0 {
 		inner = inner[:i]
 	}
-	return html.UnescapeString(inner)
+	return slackEscapeUndo.Replace(inner)
 }
 
 // requireAlias checks that `tok` is `$<alias>` and returns the alias

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -199,6 +199,12 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 		// green-lit by the unwrap — the inner has no scheme, so the
 		// existing http(s) gate rejects with the generic copy.
 		{name: "user mention rejected (no scheme after unwrap)", input: "$staging <@U12345>", wantErr: true},
+		// The byte-level backtick/non-printable fence at the top of
+		// parseAliasArgs runs *before* unwrap. Restricting the entity
+		// decode to Slack's documented set (&amp;/&lt;/&gt;) keeps
+		// numeric refs like `&#96;` (backtick) from sneaking past
+		// that fence and breaking the success-copy code fence.
+		{name: "numeric entity ref not decoded through wrap", input: "$staging <https://example.com/&#96;x>", wantAlias: testAliasName, wantTgt: "https://example.com/&#96;x"},
 		{name: "happy resource id", input: "$staging r_abc123", wantAlias: testAliasName, wantTgt: "r_abc123"},
 		{name: "single-char alias allowed", input: "$a https://x.example", wantAlias: "a", wantTgt: "https://x.example"},
 		{name: "internal dashes allowed", input: "$demo-grafana https://x.example", wantAlias: "demo-grafana", wantTgt: "https://x.example"},

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -185,6 +185,12 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 		wantTgt   string
 	}{
 		{name: "happy URL", input: "$staging https://example.com", wantAlias: testAliasName, wantTgt: testAliasURL},
+		// Slack wraps user-typed URLs as <url|display> when the slash
+		// command has should_escape:true (set on /qurl-admin so
+		// `admin add <@U…>` mentions resolve). Unwrap before url.Parse
+		// and store the bare URL.
+		{name: "happy URL slack-autolinked", input: "$staging <https://example.com|https://example.com>", wantAlias: testAliasName, wantTgt: testAliasURL},
+		{name: "happy URL slack-autolinked no display", input: "$staging <https://example.com>", wantAlias: testAliasName, wantTgt: testAliasURL},
 		{name: "happy resource id", input: "$staging r_abc123", wantAlias: testAliasName, wantTgt: "r_abc123"},
 		{name: "single-char alias allowed", input: "$a https://x.example", wantAlias: "a", wantTgt: "https://x.example"},
 		{name: "internal dashes allowed", input: "$demo-grafana https://x.example", wantAlias: "demo-grafana", wantTgt: "https://x.example"},

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -191,6 +191,14 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 		// and store the bare URL.
 		{name: "happy URL slack-autolinked", input: "$staging <https://example.com|https://example.com>", wantAlias: testAliasName, wantTgt: testAliasURL},
 		{name: "happy URL slack-autolinked no display", input: "$staging <https://example.com>", wantAlias: testAliasName, wantTgt: testAliasURL},
+		// should_escape:true also HTML-encodes &/</> inside the
+		// autolink. Round-trip the entity decode so the stored target
+		// is a bare URL the SDK will accept verbatim.
+		{name: "happy URL slack-autolinked with entity-encoded query", input: "$staging <https://example.com?a=1&amp;b=2|https://example.com?a=1&amp;b=2>", wantAlias: testAliasName, wantTgt: "https://example.com?a=1&b=2"},
+		// Regression guard: a bare `<@U…>` mention shouldn't get
+		// green-lit by the unwrap — the inner has no scheme, so the
+		// existing http(s) gate rejects with the generic copy.
+		{name: "user mention rejected (no scheme after unwrap)", input: "$staging <@U12345>", wantErr: true},
 		{name: "happy resource id", input: "$staging r_abc123", wantAlias: testAliasName, wantTgt: "r_abc123"},
 		{name: "single-char alias allowed", input: "$a https://x.example", wantAlias: "a", wantTgt: "https://x.example"},
 		{name: "internal dashes allowed", input: "$demo-grafana https://x.example", wantAlias: "demo-grafana", wantTgt: "https://x.example"},


### PR DESCRIPTION
## Summary

- Strip Slack's `<url|display>` autolink wrapping from the `setalias <target>` token before `url.Parse`, so the admin command keeps accepting URLs after `/qurl-admin` switches to `should_escape: true` (layervai/qurl-integrations-infra#798).
- Adds 2 unit-test rows in `TestParseAliasArgs_SetAlias` covering the `<url|display>` and `<url>` forms.

## Why now

`/qurl-admin` is being flipped to `should_escape: true` in qurl-integrations-infra#798 so that the new `admin add <@U…>` / `admin remove <@U…>` verbs at `parser.go:243` actually receive wrapped user mentions (the regex requires the `<@U…>` form; raw `@username` text would silently reject). The same flag wraps user-typed URLs as `<url|display>`, which the existing `parseAliasArgs` path at `handler_alias.go:181` rejected via `url.Parse → empty Scheme`. This patch closes that gap.

Resource-id (`r_…`) and tunnel-slug (`$slug`) targets aren't auto-linked by Slack, so they pass through unchanged.

## Test plan

- [x] `go test -race -count=1 ./apps/slack/...` (full slack suite, all green)
- [x] `golangci-lint run --timeout=5m --new-from-rev=origin/main ./apps/slack/...` (0 new issues)
- [ ] After merge, with infra#798 also merged: `/qurl-sandbox-admin setalias $foo https://example.com` round-trips and the stored target is `https://example.com` (not the wrapped form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)