### PR TITLE
ci(slack): run build when golangci config changes

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -8,6 +8,7 @@ on:
       - 'shared/**'
       - 'go.mod'
       - 'go.sum'
+      - '.golangci.yml'
       - '.github/workflows/slack.yml'
   pull_request:
     branches: [main]
@@ -16,6 +17,7 @@ on:
       - 'shared/**'
       - 'go.mod'
       - 'go.sum'
+      - '.golangci.yml'
       - '.github/workflows/slack.yml'
 
 permissions:


### PR DESCRIPTION
## Summary
- add `.golangci.yml` to the Slack workflow path filters for push and PR events
- ensure lint-config fixes rerun Slack CI and can dispatch the Slack sandbox deploy

## Context
- The guided tunnel installer landed in #513, but the `slack: Build and Test` workflow failed in lint, so `trigger-deploy` was skipped.
- #521 fixed the lint config, but `.golangci.yml` was not included in the Slack workflow path filters, so that merge did not trigger Slack CI or a Slack deploy.
- This workflow-only change makes future lint-config changes exercise the Slack pipeline. Because `.github/workflows/slack.yml` is already watched, this PR will also run Slack CI on merge.

## Validation
- `git diff --check`
- `actionlint .github/workflows/slack.yml`