### PR TITLE
feat(slack): store workspace bot tokens for guided installs

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -148,4 +148,6 @@ After adding `views:write` or moving to per-workspace token storage, existing
 customer workspaces must reinstall or reauthorize the Slack app so Slack issues
 a bot token with the new scope. New installs through `/oauth/slack/install`
 store that token automatically, and guided `/qurl tunnel install` will use it
-for `views.open`.
+for `views.open`. If Slack tells a customer guided tunnel setup needs the latest
+qURL Slack app install, send them through this reinstall link and confirm the app
+grants `views:write`.

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -9,7 +9,7 @@ Slack bot for creating and managing qURLs via slash commands, with per-workspace
 - `/qurl get $shortcut` — Mint a qURL for a channel shortcut
 - `/qurl set-alias $shortcut <url|resource-id|$tunnel-slug>` — Bind a channel shortcut (admin-only)
 - `/qurl unset-alias $shortcut` — Remove a channel shortcut binding (admin-only)
-- `/qurl tunnel install` — Guided tunnel sidecar setup with target-environment choices (admin-only; requires `SLACK_BOT_TOKEN` with `views:write`)
+- `/qurl tunnel install` — Guided tunnel sidecar setup with target-environment choices (admin-only; requires Slack app install OAuth with `views:write`)
 - `/qurl tunnel install <slug|$slug> [port:<n>] [alias:$shortcut] [env:<target>] [container:<name>]` — Provision a tunnel from a typed command (admin-only; default local port is 8080)
 - `/qurl list` — List recent qURLs
 - Link unfurling for `qurl.link` URLs (planned)
@@ -21,17 +21,24 @@ by the current bot deployment.
 ## Architecture
 
 - **Runtime:** AWS Fargate (arm64, distroless container) behind an
-  ALB that terminates TLS and routes `/slack/*`, `/oauth/qurl/*`, and `/health`.
+  ALB that terminates TLS and routes `/slack/*`, `/oauth/slack/*`,
+  `/oauth/qurl/*`, and `/health`.
 - **Auth:** Per-workspace qURL API key, minted via `/qurl setup` →
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
-- **Tunnel onboarding:** `/qurl tunnel install` opens a Slack modal when
-  `SLACK_BOT_TOKEN` is configured, letting an admin choose the tunnel slug,
-  optional channel shortcut, local port, and target environment
+- **Slack app install:** Customer workspaces install qURL through
+  `/oauth/slack/install`, which redirects to Slack OAuth with the bot scopes
+  needed by the slash command and modal surfaces. The callback stores Slack's
+  workspace bot token in `workspace_state` using the same KMS envelope
+  encryption posture as qURL API keys. `SLACK_BOT_TOKEN` is only a legacy
+  single-workspace fallback; production guided setup should use the
+  per-workspace token captured by Slack install OAuth.
+- **Tunnel onboarding:** `/qurl tunnel install` opens a Slack modal with the
+  bot token for the invoking workspace, letting an admin choose the tunnel
+  slug, optional channel shortcut, local port, and target environment
   (Docker, Docker Compose, ECS/Fargate, or Kubernetes). `/qurl tunnel install <slug>` (or
-  `$slug`) remains available for CLI-style admins and sandbox deployments
-  without modal support. Both paths use the
+  `$slug`) remains available for CLI-style admins. Both paths use the
   workspace API key to find-or-create a tunnel resource scoped to the
   connected qURL account, bind `$<slug>` or the `alias:` shortcut override in
   the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API
@@ -58,6 +65,8 @@ by the current bot deployment.
   - `POST /slack/commands` — Slash command handler (ack-then-async)
   - `POST /slack/events` — Event subscriptions (link unfurling planned)
   - `POST /slack/interactions` — Interactive components and modals
+  - `GET /oauth/slack/install` — Begin Slack app install; redirects to Slack OAuth
+  - `GET /oauth/slack/callback` — Slack OAuth redirect target; encrypts + persists workspace bot token
   - `GET /oauth/qurl/start` — Begin OAuth flow (state token required)
   - `GET /oauth/qurl/callback` — Auth0 redirect target; mints + persists key
   - `GET /health` — ALB target-group health probe
@@ -73,7 +82,8 @@ go test -race -count=1 ./apps/slack/...
 WORKSPACE_STATE_TABLE=workspace-state-dev \
 WORKSPACE_STATE_KMS_KEY_ARN=arn:aws:kms:us-east-1:...:key/... \
 SLACK_SIGNING_SECRET=... \
-SLACK_BOT_TOKEN=xoxb-... \
+SLACK_CLIENT_ID=... \
+SLACK_CLIENT_SECRET=... \
 QURL_ENDPOINT=https://api.layerv.xyz \
 AUTH0_DOMAIN=layerv.us.auth0.com \
 AUTH0_CLIENT_ID=... \
@@ -93,15 +103,19 @@ docker buildx build --platform linux/arm64 \
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `SLACK_SIGNING_SECRET` | Yes | Slack app signing secret |
-| `SLACK_BOT_TOKEN` | No | Slack bot token used for `views.open` so `/qurl tunnel install` can show the guided installer. Requires the Slack app to grant `views:write`. Accepts `xoxb-` and `xoxe.xoxb-` bot-token shapes; without it, the typed `/qurl tunnel install <slug>` path still works. |
+| `SLACK_CLIENT_ID` | Slack install | Slack app client ID used by `/oauth/slack/install`. Required for customer installs that capture per-workspace bot tokens. |
+| `SLACK_CLIENT_SECRET` | Slack install | Slack app client secret used by `/oauth/slack/callback` to exchange Slack's OAuth code. |
+| `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. If unset, `OAUTH_STATE_SECRET` is accepted as a fallback. |
+| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`. Keep `views:write` for guided tunnel setup. |
+| `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
 | `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.xyz`) |
 | `WORKSPACE_STATE_TABLE` | Yes | DynamoDB table holding per-workspace API keys (provisioned by `qurl-integrations-infra`) |
-| `WORKSPACE_STATE_KMS_KEY_ARN` | Yes | KMS CMK ARN used to envelope-encrypt the workspace API key column |
+| `WORKSPACE_STATE_KMS_KEY_ARN` | Yes | KMS CMK ARN used to envelope-encrypt workspace API keys and Slack bot tokens |
 | `AUTH0_DOMAIN` | OAuth | Auth0 tenant FQDN, e.g. `layerv.us.auth0.com`. Scheme prefix and trailing slash are stripped at config-load. |
 | `AUTH0_CLIENT_ID` | OAuth | Auth0 application client_id for the bot |
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
-| `SLACK_BASE_URL` | OAuth | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose `redirect_uri` and the `/qurl setup` link. |
+| `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
 | `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl tunnel install`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-reverse-tunnel-client@sha256:<digest>`. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |
@@ -114,3 +128,17 @@ The `OAuth` group is required only when the bot needs to serve the
 `/oauth/qurl/{start,callback}` surface. Boots without these vars still
 serve `/slack/*` and `/health`; `/qurl setup` replies "OAuth is not
 configured" until the OAuth env vars are populated.
+
+For customer Slack installs, configure the Slack app with:
+
+- OAuth redirect URL: `https://<SLACK_BASE_URL host>/oauth/slack/callback`
+- Customer install link: `https://<SLACK_BASE_URL host>/oauth/slack/install`
+- Slash command request URL: `https://<SLACK_BASE_URL host>/slack/commands`
+- Interactivity request URL: `https://<SLACK_BASE_URL host>/slack/interactions`
+- Bot scopes: at least `commands` and `views:write`
+
+After adding `views:write` or moving to per-workspace token storage, existing
+customer workspaces must reinstall or reauthorize the Slack app so Slack issues
+a bot token with the new scope. New installs through `/oauth/slack/install`
+store that token automatically, and guided `/qurl tunnel install` will use it
+for `views.open`.

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -33,7 +33,9 @@ by the current bot deployment.
   workspace bot token in `workspace_state` using the same KMS envelope
   encryption posture as qURL API keys. `SLACK_BOT_TOKEN` is only a legacy
   single-workspace fallback; production guided setup should use the
-  per-workspace token captured by Slack install OAuth.
+  per-workspace token captured by Slack install OAuth. Org-level Enterprise
+  Grid installs are not supported in this flow; install qURL to each workspace
+  that should use guided tunnel setup.
 - **Tunnel onboarding:** `/qurl tunnel install` opens a Slack modal with the
   bot token for the invoking workspace, letting an admin choose the tunnel
   slug, optional channel shortcut, local port, and target environment
@@ -136,6 +138,8 @@ For customer Slack installs, configure the Slack app with:
 - Slash command request URL: `https://<SLACK_BASE_URL host>/slack/commands`
 - Interactivity request URL: `https://<SLACK_BASE_URL host>/slack/interactions`
 - Bot scopes: at least `commands` and `views:write`
+- Installation mode: workspace-level installs; org-level Enterprise Grid
+  installs are rejected until enterprise-scoped tokens are supported
 
 After adding `views:write` or moving to per-workspace token storage, existing
 customer workspaces must reinstall or reauthorize the Slack app so Slack issues

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -107,7 +107,7 @@ docker buildx build --platform linux/arm64 \
 | `SLACK_SIGNING_SECRET` | Yes | Slack app signing secret |
 | `SLACK_CLIENT_ID` | Slack install | Slack app client ID used by `/oauth/slack/install`. Required for customer installs that capture per-workspace bot tokens. |
 | `SLACK_CLIENT_SECRET` | Slack install | Slack app client secret used by `/oauth/slack/callback` to exchange Slack's OAuth code. |
-| `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. If unset, `OAUTH_STATE_SECRET` is accepted as a fallback. |
+| `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. Use a distinct production secret from `OAUTH_STATE_SECRET`; the fallback is only for local/dev compatibility. |
 | `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`. Keep `views:write` for guided tunnel setup. |
 | `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
 | `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.xyz`) |

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -108,7 +108,7 @@ docker buildx build --platform linux/arm64 \
 | `SLACK_CLIENT_ID` | Slack install | Slack app client ID used by `/oauth/slack/install`. Required for customer installs that capture per-workspace bot tokens. |
 | `SLACK_CLIENT_SECRET` | Slack install | Slack app client secret used by `/oauth/slack/callback` to exchange Slack's OAuth code. |
 | `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. Use a distinct production secret from `OAUTH_STATE_SECRET`; the fallback is only for local/dev compatibility. |
-| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`. Keep `views:write` for guided tunnel setup. |
+| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`. Both `commands` and `views:write` are required; startup rejects configs missing either. |
 | `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
 | `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.xyz`) |
 | `WORKSPACE_STATE_TABLE` | Yes | DynamoDB table holding per-workspace API keys (provisioned by `qurl-integrations-infra`) |
@@ -140,6 +140,9 @@ For customer Slack installs, configure the Slack app with:
 - Bot scopes: at least `commands` and `views:write`
 - Installation mode: workspace-level installs; org-level Enterprise Grid
   installs are rejected until enterprise-scoped tokens are supported
+- Token posture: non-rotating bot tokens. The validator accepts `xoxe.xoxb-`
+  shapes defensively, but qURL does not request or persist Slack refresh tokens
+  yet, so rotation-enabled apps need refresh support before production use.
 
 After adding `views:write` or moving to per-workspace token storage, existing
 customer workspaces must reinstall or reauthorize the Slack app so Slack issues

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -108,7 +108,7 @@ docker buildx build --platform linux/arm64 \
 | `SLACK_CLIENT_ID` | Slack install | Slack app client ID used by `/oauth/slack/install`. Required for customer installs that capture per-workspace bot tokens. |
 | `SLACK_CLIENT_SECRET` | Slack install | Slack app client secret used by `/oauth/slack/callback` to exchange Slack's OAuth code. |
 | `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. Use a distinct production secret from `OAUTH_STATE_SECRET`; the fallback is only for local/dev compatibility. |
-| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`. Both `commands` and `views:write` are required; startup rejects configs missing either. |
+| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`; any override must still include both required scopes. |
 | `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
 | `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.xyz`) |
 | `WORKSPACE_STATE_TABLE` | Yes | DynamoDB table holding per-workspace API keys (provisioned by `qurl-integrations-infra`) |

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -332,14 +332,17 @@ type workspaceSlackTokenLookupStart struct {
 	negativeHit bool
 	call        *workspaceSlackTokenLookupCall
 	owner       bool
+	generation  uint64
 }
 
 type workspaceSlackTokenLookupCache struct {
-	mu        sync.Mutex
-	positive  map[string]cachedSlackBotToken
-	negative  map[string]time.Time
-	inFlight  map[string]*workspaceSlackTokenLookupCall
-	lastSweep time.Time
+	mu             sync.Mutex
+	positive       map[string]cachedSlackBotToken
+	negative       map[string]time.Time
+	inFlight       map[string]*workspaceSlackTokenLookupCall
+	generation     map[string]uint64
+	fallbackWarned map[string]struct{}
+	lastSweep      time.Time
 }
 
 func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) slackOpenViewTokenLookup {
@@ -352,9 +355,11 @@ func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider
 		now = time.Now
 	}
 	cache := &workspaceSlackTokenLookupCache{
-		positive: map[string]cachedSlackBotToken{},
-		negative: map[string]time.Time{},
-		inFlight: map[string]*workspaceSlackTokenLookupCall{},
+		positive:       map[string]cachedSlackBotToken{},
+		negative:       map[string]time.Time{},
+		inFlight:       map[string]*workspaceSlackTokenLookupCall{},
+		generation:     map[string]uint64{},
+		fallbackWarned: map[string]struct{}{},
 	}
 	return func(ctx context.Context, teamID string) (string, error) {
 		teamID = strings.TrimSpace(teamID)
@@ -364,6 +369,7 @@ func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider
 			case start.positiveHit:
 				return start.token, nil
 			case start.negativeHit && fallbackToken != "":
+				cache.warnLegacySlackBotTokenFallback(teamID)
 				return fallbackToken, nil
 			case start.negativeHit:
 				return "", auth.ErrSlackBotTokenNotConfigured
@@ -375,7 +381,7 @@ func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider
 					return "", ctx.Err()
 				}
 			}
-			return fetchAndFinishWorkspaceSlackToken(ctx, provider, cache, start.call, teamID, fallbackToken, ttl, now)
+			return fetchAndFinishWorkspaceSlackToken(ctx, provider, cache, start.call, teamID, fallbackToken, ttl, now, start.generation)
 		}
 
 		token, _, _, err := fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
@@ -417,6 +423,7 @@ func fetchAndFinishWorkspaceSlackToken(
 	fallbackToken string,
 	ttl time.Duration,
 	now func() time.Time,
+	generation uint64,
 ) (token string, err error) {
 	var cachePositive bool
 	var cacheNegative bool
@@ -426,14 +433,17 @@ func fetchAndFinishWorkspaceSlackToken(
 		if rec := recover(); rec != nil {
 			if !finished {
 				result = workspaceSlackTokenLookupResult{err: errors.New("workspace Slack bot token lookup panicked")}
-				cache.finish(teamID, call, result, false, false, ttl, slackWorkspaceTokenNegativeCacheTTL, now())
+				cache.finish(teamID, call, result, false, false, ttl, 0, now(), generation)
 			}
 			panic(rec)
 		}
 	}()
 	token, cachePositive, cacheNegative, err = fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
 	result = workspaceSlackTokenLookupResult{token: token, err: err}
-	cache.finish(teamID, call, result, cachePositive, cacheNegative, ttl, slackWorkspaceTokenNegativeCacheTTL, now())
+	if cacheNegative && err == nil && fallbackToken != "" {
+		cache.warnLegacySlackBotTokenFallback(teamID)
+	}
+	cache.finish(teamID, call, result, cachePositive, cacheNegative, ttl, slackWorkspaceTokenNegativeCacheTTL, now(), generation)
 	finished = true
 	return token, err
 }
@@ -442,6 +452,7 @@ func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, ttl time.Dura
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.sweepExpiredLocked(at)
+	generation := c.generation[teamID]
 	if ttl > 0 {
 		cached, ok := c.positive[teamID]
 		if ok && at.Before(cached.expiresAt) {
@@ -465,7 +476,7 @@ func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, ttl time.Dura
 	}
 	call := &workspaceSlackTokenLookupCall{done: make(chan struct{})}
 	c.inFlight[teamID] = call
-	return workspaceSlackTokenLookupStart{call: call, owner: true}
+	return workspaceSlackTokenLookupStart{call: call, owner: true, generation: generation}
 }
 
 func (c *workspaceSlackTokenLookupCache) finish(
@@ -477,21 +488,25 @@ func (c *workspaceSlackTokenLookupCache) finish(
 	positiveTTL time.Duration,
 	negativeTTL time.Duration,
 	at time.Time,
+	generation uint64,
 ) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if cachePositive && positiveTTL > 0 {
+	canCache := generation == c.generation[teamID]
+	if cachePositive && positiveTTL > 0 && canCache {
 		c.positive[teamID] = cachedSlackBotToken{
 			token:     result.token,
 			expiresAt: at.Add(positiveTTL),
 		}
 		delete(c.negative, teamID)
 	}
-	if cacheNegative && negativeTTL > 0 {
+	if cacheNegative && negativeTTL > 0 && canCache {
 		c.negative[teamID] = at.Add(negativeTTL)
 	}
 	call.workspaceSlackTokenLookupResult = result
-	delete(c.inFlight, teamID)
+	if c.inFlight[teamID] == call {
+		delete(c.inFlight, teamID)
+	}
 	close(call.done)
 }
 
@@ -504,6 +519,33 @@ func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
 	defer c.mu.Unlock()
 	delete(c.positive, teamID)
 	delete(c.negative, teamID)
+	delete(c.inFlight, teamID)
+	delete(c.fallbackWarned, teamID)
+	if c.generation == nil {
+		c.generation = map[string]uint64{}
+	}
+	c.generation[teamID]++
+}
+
+func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID string) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" || !c.markLegacySlackBotTokenFallbackWarned(teamID) {
+		return
+	}
+	slog.Warn("legacy SLACK_BOT_TOKEN fallback is serving workspace without Slack install token", "team_id", teamID) // #nosec G706 -- Slack team IDs are structured slog attributes; JSON handlers escape control bytes.
+}
+
+func (c *workspaceSlackTokenLookupCache) markLegacySlackBotTokenFallbackWarned(teamID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fallbackWarned == nil {
+		c.fallbackWarned = map[string]struct{}{}
+	}
+	if _, ok := c.fallbackWarned[teamID]; ok {
+		return false
+	}
+	c.fallbackWarned[teamID] = struct{}{}
+	return true
 }
 
 func (c *workspaceSlackTokenLookupCache) sweepExpiredLocked(at time.Time) {
@@ -688,11 +730,11 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 }
 
 const (
-	envSlackClientID            = "SLACK_CLIENT_ID"
-	envSlackClientSecret        = "SLACK_CLIENT_SECRET"
-	envSlackInstallStateSecret  = "SLACK_INSTALL_STATE_SECRET"
-	envSlackBotScopes           = "SLACK_BOT_SCOPES"
-	slackInstallStateMissingKey = "SLACK_INSTALL_STATE"
+	envSlackClientID                    = "SLACK_CLIENT_ID"
+	envSlackClientSecret                = "SLACK_CLIENT_SECRET"
+	envSlackInstallStateSecret          = "SLACK_INSTALL_STATE_SECRET"
+	envSlackBotScopes                   = "SLACK_BOT_SCOPES"
+	displayKeySlackInstallStateFallback = "SLACK_INSTALL_STATE"
 )
 
 func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, bool, error) {
@@ -705,10 +747,10 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	}
 
 	missing := missingSlackInstallEnvVars(map[string]string{
-		envSlackClientID:            clientID,
-		envSlackClientSecret:        clientSecret,
-		"SLACK_BASE_URL":            baseURL,
-		slackInstallStateMissingKey: stateSecret,
+		envSlackClientID:                    clientID,
+		envSlackClientSecret:                clientSecret,
+		"SLACK_BASE_URL":                    baseURL,
+		displayKeySlackInstallStateFallback: stateSecret,
 	})
 	if len(missing) > 0 {
 		slog.Warn("Slack install routes NOT registered — required env vars unset", "missing", missing)
@@ -727,15 +769,18 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 		BotScopes:    scopes,
 		TokenStore:   provider,
 	}
+	if err := cfg.Validate(); err != nil {
+		return slackinstall.Config{}, false, err
+	}
 	return cfg, true, nil
 }
 
 func missingSlackInstallEnvVars(values map[string]string) []string {
-	keys := []string{envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL", slackInstallStateMissingKey}
+	keys := []string{envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL", displayKeySlackInstallStateFallback}
 	var missing []string
 	for _, k := range keys {
 		if values[k] == "" {
-			if k == slackInstallStateMissingKey {
+			if k == displayKeySlackInstallStateFallback {
 				missing = append(missing, envSlackInstallStateSecret+" (or OAUTH_STATE_SECRET)")
 				continue
 			}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -499,6 +499,7 @@ func (c *workspaceSlackTokenLookupCache) finish(
 			expiresAt: at.Add(positiveTTL),
 		}
 		delete(c.negative, teamID)
+		delete(c.fallbackWarned, teamID)
 	}
 	if cacheNegative && negativeTTL > 0 && canCache {
 		c.negative[teamID] = at.Add(negativeTTL)
@@ -560,6 +561,7 @@ func (c *workspaceSlackTokenLookupCache) sweepExpiredLocked(at time.Time) {
 	for teamID, expiresAt := range c.negative {
 		if !at.Before(expiresAt) {
 			delete(c.negative, teamID)
+			delete(c.fallbackWarned, teamID)
 		}
 	}
 	c.lastSweep = at

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -345,11 +345,6 @@ type workspaceSlackTokenLookupCache struct {
 	lastSweep      time.Time
 }
 
-func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) slackOpenViewTokenLookup {
-	lookup, _ := newWorkspaceSlackTokenLookupWithInvalidation(provider, fallbackToken, ttl, now)
-	return lookup
-}
-
 func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) (lookup slackOpenViewTokenLookup, purge func(string)) {
 	if now == nil {
 		now = time.Now
@@ -522,9 +517,6 @@ func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
 	delete(c.negative, teamID)
 	delete(c.inFlight, teamID)
 	delete(c.fallbackWarned, teamID)
-	if c.generation == nil {
-		c.generation = map[string]uint64{}
-	}
 	c.generation[teamID]++
 }
 
@@ -553,6 +545,9 @@ func (c *workspaceSlackTokenLookupCache) sweepExpiredLocked(at time.Time) {
 	if !c.lastSweep.IsZero() && at.Sub(c.lastSweep) < slackWorkspaceTokenCacheSweepEvery {
 		return
 	}
+	// The sweep is intentionally minute-gated: it is O(workspaces seen by this
+	// process), but the current customer cardinality keeps that below the Slack
+	// trigger budget while avoiding a background janitor goroutine.
 	for teamID, cached := range c.positive {
 		if !at.Before(cached.expiresAt) {
 			delete(c.positive, teamID)

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -543,9 +543,6 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 		slog.Warn("Slack install routes NOT registered — required env vars unset", "missing", missing)
 		return slackinstall.Config{}, false, nil
 	}
-	if err := validateSlackBaseOrigin(baseURL); err != nil {
-		return slackinstall.Config{}, false, err
-	}
 
 	scopes := slackinstall.DefaultBotScopes()
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
@@ -558,9 +555,6 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 		StateSecret:  []byte(stateSecret),
 		BotScopes:    scopes,
 		TokenStore:   provider,
-	}
-	if err := cfg.Validate(); err != nil {
-		return slackinstall.Config{}, false, err
 	}
 	return cfg, true, nil
 }
@@ -578,16 +572,6 @@ func missingSlackInstallEnvVars(values map[string]string) []string {
 		}
 	}
 	return missing
-}
-
-func validateSlackBaseOrigin(baseURL string) error {
-	if !strings.HasPrefix(baseURL, "https://") {
-		return fmt.Errorf("SLACK_BASE_URL must be https:// (got %q)", baseURL)
-	}
-	if u, err := url.Parse(baseURL); err != nil || u.Host == "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
-		return fmt.Errorf("SLACK_BASE_URL must be a bare https:// origin with no path/query/userinfo (got %q)", baseURL)
-	}
-	return nil
 }
 
 // adminStoreAdapter bridges *slackdata.Store to the oauth.AdminStore

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -75,6 +75,7 @@ const (
 	// legacy SLACK_BOT_TOKEN fallback window after a customer reinstalls.
 	slackWorkspaceTokenCacheTTL         = 30 * time.Second
 	slackWorkspaceTokenNegativeCacheTTL = 10 * time.Second
+	slackWorkspaceTokenCacheSweepEvery  = time.Minute
 )
 
 // version is set at build time via `-ldflags "-X main.version=<sha>"`.
@@ -332,10 +333,11 @@ type workspaceSlackTokenLookupStart struct {
 }
 
 type workspaceSlackTokenLookupCache struct {
-	mu       sync.Mutex
-	positive map[string]cachedSlackBotToken
-	negative map[string]time.Time
-	inFlight map[string]*workspaceSlackTokenLookupCall
+	mu        sync.Mutex
+	positive  map[string]cachedSlackBotToken
+	negative  map[string]time.Time
+	inFlight  map[string]*workspaceSlackTokenLookupCall
+	lastSweep time.Time
 }
 
 func slackOpenViewFuncWithWorkspaceTokens(provider slackBotTokenProvider, fallbackToken, userAgent string) internal.OpenViewFunc {
@@ -390,6 +392,8 @@ func fetchWorkspaceSlackToken(ctx context.Context, provider slackBotTokenProvide
 			return "", false, false, errors.New("workspace Slack bot token is empty")
 		}
 		if err := auth.ValidateSlackBotTokenShape(token); err != nil {
+			// Do not cache malformed-token errors; once the workspace row is
+			// repaired, the next lookup should observe the fix immediately.
 			return "", false, false, fmt.Errorf("workspace Slack bot token: %w", err)
 		}
 		return token, true, false, nil
@@ -408,6 +412,7 @@ func fetchWorkspaceSlackToken(ctx context.Context, provider slackBotTokenProvide
 func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, ttl time.Duration, at time.Time) workspaceSlackTokenLookupStart {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.sweepExpiredLocked(at)
 	if ttl > 0 {
 		cached, ok := c.positive[teamID]
 		if ok && at.Before(cached.expiresAt) {
@@ -459,6 +464,23 @@ func (c *workspaceSlackTokenLookupCache) finish(
 	call.workspaceSlackTokenLookupResult = result
 	delete(c.inFlight, teamID)
 	close(call.done)
+}
+
+func (c *workspaceSlackTokenLookupCache) sweepExpiredLocked(at time.Time) {
+	if !c.lastSweep.IsZero() && at.Sub(c.lastSweep) < slackWorkspaceTokenCacheSweepEvery {
+		return
+	}
+	for teamID, cached := range c.positive {
+		if !at.Before(cached.expiresAt) {
+			delete(c.positive, teamID)
+		}
+	}
+	for teamID, expiresAt := range c.negative {
+		if !at.Before(expiresAt) {
+			delete(c.negative, teamID)
+		}
+	}
+	c.lastSweep = at
 }
 
 // minStateSecretBytes is the operator floor for OAUTH_STATE_SECRET.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -71,8 +72,9 @@ const (
 	maxHeaderBytes = 8 << 10 // 8 KiB
 	// Slack remains the token-validity authority; these bounds are only a local
 	// boot-time typo guard for obviously truncated or pasted-wrong values.
-	slackBotTokenTypoGuardMin = 30
-	slackBotTokenTypoGuardMax = 1024
+	slackBotTokenTypoGuardMin   = 30
+	slackBotTokenTypoGuardMax   = 1024
+	slackWorkspaceTokenCacheTTL = 5 * time.Minute
 )
 
 // version is set at build time via `-ldflags "-X main.version=<sha>"`.
@@ -213,7 +215,7 @@ func run() error {
 		// workspace admins; without that gate, any user could
 		// initiate a flow that overwrites the workspace's qURL key
 		// against their own Auth0 account.
-		slog.Info("CONFIGURATION REMINDER: /qurl setup is workspace-admin-only by manifest, not by code - verify the Slack app manifest restricts the command")
+		slog.Info("CONFIGURATION REMINDER: /qurl setup is workspace-admin-only by manifest, not by code — verify the Slack app manifest restricts the command")
 	}
 	// Else: buildOAuthConfig already logged the specific missing-var
 	// list; nothing more to say here.
@@ -306,17 +308,61 @@ func run() error {
 	return nil
 }
 
-func slackOpenViewFuncWithWorkspaceTokens(provider *auth.DDBProvider, fallbackToken, userAgent string) internal.OpenViewFunc {
-	return newSlackOpenViewFuncWithTokenLookup(func(ctx context.Context, teamID string) (string, error) {
+type slackBotTokenProvider interface {
+	SlackBotToken(ctx context.Context, workspaceID string) (string, error)
+}
+
+type cachedSlackBotToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+func slackOpenViewFuncWithWorkspaceTokens(provider slackBotTokenProvider, fallbackToken, userAgent string) internal.OpenViewFunc {
+	lookup := newWorkspaceSlackTokenLookup(provider, fallbackToken, slackWorkspaceTokenCacheTTL, time.Now)
+	return newSlackOpenViewFuncWithTokenLookup(lookup, userAgent, slackViewsOpenURL, nil)
+}
+
+func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) slackOpenViewTokenLookup {
+	if now == nil {
+		now = time.Now
+	}
+	var mu sync.Mutex
+	cache := map[string]cachedSlackBotToken{}
+	return func(ctx context.Context, teamID string) (string, error) {
+		teamID = strings.TrimSpace(teamID)
+		if teamID != "" && ttl > 0 {
+			mu.Lock()
+			cached, ok := cache[teamID]
+			mu.Unlock()
+			if ok && now().Before(cached.expiresAt) {
+				return cached.token, nil
+			}
+		}
+
 		token, err := provider.SlackBotToken(ctx, teamID)
 		if err == nil {
+			token = strings.TrimSpace(token)
+			if token == "" {
+				return "", errors.New("workspace Slack bot token is empty")
+			}
+			if err := validateSlackBotTokenShape(token); err != nil {
+				return "", fmt.Errorf("workspace Slack bot token: %w", err)
+			}
+			if teamID != "" && ttl > 0 {
+				mu.Lock()
+				cache[teamID] = cachedSlackBotToken{
+					token:     token,
+					expiresAt: now().Add(ttl),
+				}
+				mu.Unlock()
+			}
 			return token, nil
 		}
 		if errors.Is(err, auth.ErrSlackBotTokenNotConfigured) && fallbackToken != "" {
 			return fallbackToken, nil
 		}
 		return "", err
-	}, userAgent, slackViewsOpenURL, nil)
+	}
 }
 
 // minStateSecretBytes is the operator floor for OAUTH_STATE_SECRET.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -213,16 +213,18 @@ func run() error {
 		// workspace admins; without that gate, any user could
 		// initiate a flow that overwrites the workspace's qURL key
 		// against their own Auth0 account.
-		slog.Info("CONFIGURATION REMINDER: /qurl setup is workspace-admin-only by manifest, not by code — verify the Slack app manifest restricts the command")
+		slog.Info("CONFIGURATION REMINDER: /qurl setup is workspace-admin-only by manifest, not by code - verify the Slack app manifest restricts the command")
 	}
 	// Else: buildOAuthConfig already logged the specific missing-var
 	// list; nothing more to say here.
 	slackInstallCfg, ok, err := buildSlackInstallConfig(ddbProvider)
 	if err != nil {
-		return fmt.Errorf("Slack install config: %w", err)
+		return fmt.Errorf("slack install config: %w", err)
 	}
 	if ok {
-		slackinstall.RegisterRoutes(rootMux, slackInstallCfg)
+		if err := slackinstall.RegisterRoutes(rootMux, &slackInstallCfg); err != nil {
+			return fmt.Errorf("slack install routes: %w", err)
+		}
 		slog.Info("registered /oauth/slack/{install,callback} routes")
 	}
 
@@ -515,10 +517,11 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 }
 
 const (
-	envSlackClientID           = "SLACK_CLIENT_ID"
-	envSlackClientSecret       = "SLACK_CLIENT_SECRET"
-	envSlackInstallStateSecret = "SLACK_INSTALL_STATE_SECRET"
-	envSlackBotScopes          = "SLACK_BOT_SCOPES"
+	envSlackClientID            = "SLACK_CLIENT_ID"
+	envSlackClientSecret        = "SLACK_CLIENT_SECRET"
+	envSlackInstallStateSecret  = "SLACK_INSTALL_STATE_SECRET"
+	envSlackBotScopes           = "SLACK_BOT_SCOPES"
+	slackInstallStateMissingKey = "SLACK_INSTALL_STATE"
 )
 
 func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, bool, error) {
@@ -531,10 +534,10 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	}
 
 	missing := missingSlackInstallEnvVars(map[string]string{
-		envSlackClientID:      clientID,
-		envSlackClientSecret:  clientSecret,
-		"SLACK_BASE_URL":      baseURL,
-		"SLACK_INSTALL_STATE": stateSecret,
+		envSlackClientID:            clientID,
+		envSlackClientSecret:        clientSecret,
+		"SLACK_BASE_URL":            baseURL,
+		slackInstallStateMissingKey: stateSecret,
 	})
 	if len(missing) > 0 {
 		slog.Warn("Slack install routes NOT registered — required env vars unset", "missing", missing)
@@ -546,7 +549,7 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 
 	scopes := slackinstall.DefaultBotScopes()
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
-		scopes = splitScopeEnv(raw)
+		scopes = slackinstall.NormalizeScopes([]string{raw})
 	}
 	cfg := slackinstall.Config{
 		ClientID:     clientID,
@@ -563,11 +566,11 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 }
 
 func missingSlackInstallEnvVars(values map[string]string) []string {
-	keys := []string{envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL", "SLACK_INSTALL_STATE"}
+	keys := []string{envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL", slackInstallStateMissingKey}
 	var missing []string
 	for _, k := range keys {
 		if values[k] == "" {
-			if k == "SLACK_INSTALL_STATE" {
+			if k == slackInstallStateMissingKey {
 				missing = append(missing, envSlackInstallStateSecret+" (or OAUTH_STATE_SECRET)")
 				continue
 			}
@@ -585,12 +588,6 @@ func validateSlackBaseOrigin(baseURL string) error {
 		return fmt.Errorf("SLACK_BASE_URL must be a bare https:// origin with no path/query/userinfo (got %q)", baseURL)
 	}
 	return nil
-}
-
-func splitScopeEnv(raw string) []string {
-	return strings.FieldsFunc(raw, func(r rune) bool {
-		return r == ',' || r == ' ' || r == '\n' || r == '\t'
-	})
 }
 
 // adminStoreAdapter bridges *slackdata.Store to the oauth.AdminStore

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -70,11 +70,11 @@ const (
 	// timestamp + standard headers fit comfortably in 2 KiB) but bounds
 	// the per-connection memory an attacker can force pre-handler.
 	maxHeaderBytes = 8 << 10 // 8 KiB
-	// Slack remains the token-validity authority; these bounds are only a local
-	// boot-time typo guard for obviously truncated or pasted-wrong values.
-	slackBotTokenTypoGuardMin   = 30
-	slackBotTokenTypoGuardMax   = 1024
-	slackWorkspaceTokenCacheTTL = 5 * time.Minute
+	// Keep reinstall propagation short while avoiding DDB/KMS on every modal
+	// open. Negative caching is deliberately shorter because it can extend the
+	// legacy SLACK_BOT_TOKEN fallback window after a customer reinstalls.
+	slackWorkspaceTokenCacheTTL         = 30 * time.Second
+	slackWorkspaceTokenNegativeCacheTTL = 10 * time.Second
 )
 
 // version is set at build time via `-ldflags "-X main.version=<sha>"`.
@@ -135,15 +135,11 @@ func run() error {
 		return fmt.Errorf("QURL_TUNNEL_IMAGE: %w", err)
 	}
 	slackBotToken := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN"))
-	if err := validateSlackBotTokenShape(slackBotToken); err != nil {
-		return err
+	if err := auth.ValidateSlackBotTokenShape(slackBotToken); err != nil {
+		return fmt.Errorf("invalid SLACK_BOT_TOKEN: %w", err)
 	}
 	openView := slackOpenViewFuncWithWorkspaceTokens(ddbProvider, slackBotToken, userAgent)
-	if slackBotToken != "" {
-		slog.Info("Slack views.open wired with per-workspace token lookup and legacy SLACK_BOT_TOKEN fallback")
-	} else {
-		slog.Info("Slack views.open wired with per-workspace token lookup")
-	}
+	slog.Info("Slack views.open wired with per-workspace token lookup", "legacy_fallback_enabled", slackBotToken != "") // #nosec G706 -- only a boolean derived from token presence is logged; the token value is never logged.
 
 	// signalCtx is hoisted above so the DDB-provider constructor can
 	// observe shutdown during AWS config load. It feeds two seams: the
@@ -317,6 +313,31 @@ type cachedSlackBotToken struct {
 	expiresAt time.Time
 }
 
+type workspaceSlackTokenLookupResult struct {
+	token string
+	err   error
+}
+
+type workspaceSlackTokenLookupCall struct {
+	done chan struct{}
+	workspaceSlackTokenLookupResult
+}
+
+type workspaceSlackTokenLookupStart struct {
+	token       string
+	positiveHit bool
+	negativeHit bool
+	call        *workspaceSlackTokenLookupCall
+	owner       bool
+}
+
+type workspaceSlackTokenLookupCache struct {
+	mu       sync.Mutex
+	positive map[string]cachedSlackBotToken
+	negative map[string]time.Time
+	inFlight map[string]*workspaceSlackTokenLookupCall
+}
+
 func slackOpenViewFuncWithWorkspaceTokens(provider slackBotTokenProvider, fallbackToken, userAgent string) internal.OpenViewFunc {
 	lookup := newWorkspaceSlackTokenLookup(provider, fallbackToken, slackWorkspaceTokenCacheTTL, time.Now)
 	return newSlackOpenViewFuncWithTokenLookup(lookup, userAgent, slackViewsOpenURL, nil)
@@ -326,43 +347,118 @@ func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken 
 	if now == nil {
 		now = time.Now
 	}
-	var mu sync.Mutex
-	cache := map[string]cachedSlackBotToken{}
+	cache := &workspaceSlackTokenLookupCache{
+		positive: map[string]cachedSlackBotToken{},
+		negative: map[string]time.Time{},
+		inFlight: map[string]*workspaceSlackTokenLookupCall{},
+	}
 	return func(ctx context.Context, teamID string) (string, error) {
 		teamID = strings.TrimSpace(teamID)
-		if teamID != "" && ttl > 0 {
-			mu.Lock()
-			cached, ok := cache[teamID]
-			mu.Unlock()
-			if ok && now().Before(cached.expiresAt) {
-				return cached.token, nil
+		if teamID != "" {
+			start := cache.getOrStart(teamID, ttl, now())
+			switch {
+			case start.positiveHit:
+				return start.token, nil
+			case start.negativeHit && fallbackToken != "":
+				return fallbackToken, nil
+			case start.negativeHit:
+				return "", auth.ErrSlackBotTokenNotConfigured
+			case !start.owner:
+				select {
+				case <-start.call.done:
+					return start.call.token, start.call.err
+				case <-ctx.Done():
+					return "", ctx.Err()
+				}
 			}
+			token, cachePositive, cacheNegative, err := fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
+			result := workspaceSlackTokenLookupResult{token: token, err: err}
+			cache.finish(teamID, start.call, result, cachePositive, cacheNegative, ttl, slackWorkspaceTokenNegativeCacheTTL, now())
+			return token, err
 		}
 
-		token, err := provider.SlackBotToken(ctx, teamID)
-		if err == nil {
-			token = strings.TrimSpace(token)
-			if token == "" {
-				return "", errors.New("workspace Slack bot token is empty")
-			}
-			if err := validateSlackBotTokenShape(token); err != nil {
-				return "", fmt.Errorf("workspace Slack bot token: %w", err)
-			}
-			if teamID != "" && ttl > 0 {
-				mu.Lock()
-				cache[teamID] = cachedSlackBotToken{
-					token:     token,
-					expiresAt: now().Add(ttl),
-				}
-				mu.Unlock()
-			}
-			return token, nil
-		}
-		if errors.Is(err, auth.ErrSlackBotTokenNotConfigured) && fallbackToken != "" {
-			return fallbackToken, nil
-		}
-		return "", err
+		token, _, _, err := fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
+		return token, err
 	}
+}
+
+func fetchWorkspaceSlackToken(ctx context.Context, provider slackBotTokenProvider, teamID, fallbackToken string) (token string, cachePositive, cacheNegative bool, err error) {
+	token, err = provider.SlackBotToken(ctx, teamID)
+	if err == nil {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return "", false, false, errors.New("workspace Slack bot token is empty")
+		}
+		if err := auth.ValidateSlackBotTokenShape(token); err != nil {
+			return "", false, false, fmt.Errorf("workspace Slack bot token: %w", err)
+		}
+		return token, true, false, nil
+	}
+	// The legacy fallback is only for workspaces that have not installed the
+	// Slack app yet. Other DDB/KMS failures should stay visible to operators.
+	if errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+		if fallbackToken != "" {
+			return fallbackToken, false, true, nil
+		}
+		return "", false, true, err
+	}
+	return "", false, false, err
+}
+
+func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, ttl time.Duration, at time.Time) workspaceSlackTokenLookupStart {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ttl > 0 {
+		cached, ok := c.positive[teamID]
+		if ok && at.Before(cached.expiresAt) {
+			return workspaceSlackTokenLookupStart{token: cached.token, positiveHit: true}
+		}
+		if ok {
+			delete(c.positive, teamID)
+		}
+	}
+
+	expiresAt, ok := c.negative[teamID]
+	if ok && at.Before(expiresAt) {
+		return workspaceSlackTokenLookupStart{negativeHit: true}
+	}
+	if ok {
+		delete(c.negative, teamID)
+	}
+
+	if call, ok := c.inFlight[teamID]; ok {
+		return workspaceSlackTokenLookupStart{call: call}
+	}
+	call := &workspaceSlackTokenLookupCall{done: make(chan struct{})}
+	c.inFlight[teamID] = call
+	return workspaceSlackTokenLookupStart{call: call, owner: true}
+}
+
+func (c *workspaceSlackTokenLookupCache) finish(
+	teamID string,
+	call *workspaceSlackTokenLookupCall,
+	result workspaceSlackTokenLookupResult,
+	cachePositive bool,
+	cacheNegative bool,
+	positiveTTL time.Duration,
+	negativeTTL time.Duration,
+	at time.Time,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cachePositive && positiveTTL > 0 {
+		c.positive[teamID] = cachedSlackBotToken{
+			token:     result.token,
+			expiresAt: at.Add(positiveTTL),
+		}
+		delete(c.negative, teamID)
+	}
+	if cacheNegative && negativeTTL > 0 {
+		c.negative[teamID] = at.Add(negativeTTL)
+	}
+	call.workspaceSlackTokenLookupResult = result
+	delete(c.inFlight, teamID)
+	close(call.done)
 }
 
 // minStateSecretBytes is the operator floor for OAUTH_STATE_SECRET.
@@ -376,39 +472,6 @@ const minStateSecretBytes = oauth.StateMinSecret
 // calls oauth.NewJWKSVerifier directly via this seam.
 var newJWKSVerifier = func(ctx context.Context, issuer, audience string) (oauth.IDTokenVerifier, error) {
 	return oauth.NewJWKSVerifier(ctx, issuer, audience)
-}
-
-func validateSlackBotTokenShape(token string) error {
-	if token == "" {
-		return nil
-	}
-	// Keep this as a light local shape check. Slack token formats have changed
-	// over time, and the Slack API remains the authority on token validity. The
-	// upper bound is intentionally generous; when set, this only catches obvious
-	// config mistakes such as truncated tokens or bytes outside visible ASCII.
-	// Keep the lower bound loose: this boot-time check is only a local typo
-	// guard, while Slack's auth response remains the validity oracle.
-	if len(token) < slackBotTokenTypoGuardMin {
-		return fmt.Errorf("SLACK_BOT_TOKEN is shorter than %d characters", slackBotTokenTypoGuardMin)
-	}
-	if len(token) > slackBotTokenTypoGuardMax {
-		return fmt.Errorf("SLACK_BOT_TOKEN is longer than %d characters", slackBotTokenTypoGuardMax)
-	}
-	if !validSlackBotTokenPrefix(token) {
-		return errors.New("SLACK_BOT_TOKEN must be a Slack bot token starting with xoxb- or xoxe.xoxb-")
-	}
-	for i, b := range []byte(token) {
-		if b >= '!' && b <= '~' {
-			continue
-		}
-		return fmt.Errorf("SLACK_BOT_TOKEN contains invalid characters near byte %d", i)
-	}
-	return nil
-}
-
-func validSlackBotTokenPrefix(token string) bool {
-	return strings.HasPrefix(token, "xoxb-") ||
-		strings.HasPrefix(token, "xoxe.xoxb-")
 }
 
 // missingOAuthEnvVars returns the env-var names with empty values, in

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -139,7 +139,8 @@ func run() error {
 	if err := auth.ValidateSlackBotTokenShape(slackBotToken); err != nil {
 		return fmt.Errorf("invalid SLACK_BOT_TOKEN: %w", err)
 	}
-	openView := slackOpenViewFuncWithWorkspaceTokens(ddbProvider, slackBotToken, userAgent)
+	workspaceTokenLookup, invalidateWorkspaceSlackToken := newWorkspaceSlackTokenLookupWithInvalidation(ddbProvider, slackBotToken, slackWorkspaceTokenCacheTTL, time.Now)
+	openView := newSlackOpenViewFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackViewsOpenURL, nil)
 	slog.Info("Slack views.open wired with per-workspace token lookup", "legacy_fallback_enabled", slackBotToken != "") // #nosec G706 -- only a boolean derived from token presence is logged; the token value is never logged.
 
 	// signalCtx is hoisted above so the DDB-provider constructor can
@@ -221,6 +222,7 @@ func run() error {
 		return fmt.Errorf("slack install config: %w", err)
 	}
 	if ok {
+		slackInstallCfg.OnTokenStored = invalidateWorkspaceSlackToken
 		if err := slackinstall.RegisterRoutes(rootMux, &slackInstallCfg); err != nil {
 			return fmt.Errorf("slack install routes: %w", err)
 		}
@@ -340,12 +342,12 @@ type workspaceSlackTokenLookupCache struct {
 	lastSweep time.Time
 }
 
-func slackOpenViewFuncWithWorkspaceTokens(provider slackBotTokenProvider, fallbackToken, userAgent string) internal.OpenViewFunc {
-	lookup := newWorkspaceSlackTokenLookup(provider, fallbackToken, slackWorkspaceTokenCacheTTL, time.Now)
-	return newSlackOpenViewFuncWithTokenLookup(lookup, userAgent, slackViewsOpenURL, nil)
+func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) slackOpenViewTokenLookup {
+	lookup, _ := newWorkspaceSlackTokenLookupWithInvalidation(provider, fallbackToken, ttl, now)
+	return lookup
 }
 
-func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) slackOpenViewTokenLookup {
+func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) (lookup slackOpenViewTokenLookup, purge func(string)) {
 	if now == nil {
 		now = time.Now
 	}
@@ -373,15 +375,12 @@ func newWorkspaceSlackTokenLookup(provider slackBotTokenProvider, fallbackToken 
 					return "", ctx.Err()
 				}
 			}
-			token, cachePositive, cacheNegative, err := fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
-			result := workspaceSlackTokenLookupResult{token: token, err: err}
-			cache.finish(teamID, start.call, result, cachePositive, cacheNegative, ttl, slackWorkspaceTokenNegativeCacheTTL, now())
-			return token, err
+			return fetchAndFinishWorkspaceSlackToken(ctx, provider, cache, start.call, teamID, fallbackToken, ttl, now)
 		}
 
 		token, _, _, err := fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
 		return token, err
-	}
+	}, cache.purge
 }
 
 func fetchWorkspaceSlackToken(ctx context.Context, provider slackBotTokenProvider, teamID, fallbackToken string) (token string, cachePositive, cacheNegative bool, err error) {
@@ -407,6 +406,36 @@ func fetchWorkspaceSlackToken(ctx context.Context, provider slackBotTokenProvide
 		return "", false, true, err
 	}
 	return "", false, false, err
+}
+
+func fetchAndFinishWorkspaceSlackToken(
+	ctx context.Context,
+	provider slackBotTokenProvider,
+	cache *workspaceSlackTokenLookupCache,
+	call *workspaceSlackTokenLookupCall,
+	teamID string,
+	fallbackToken string,
+	ttl time.Duration,
+	now func() time.Time,
+) (token string, err error) {
+	var cachePositive bool
+	var cacheNegative bool
+	result := workspaceSlackTokenLookupResult{}
+	finished := false
+	defer func() {
+		if rec := recover(); rec != nil {
+			if !finished {
+				result = workspaceSlackTokenLookupResult{err: errors.New("workspace Slack bot token lookup panicked")}
+				cache.finish(teamID, call, result, false, false, ttl, slackWorkspaceTokenNegativeCacheTTL, now())
+			}
+			panic(rec)
+		}
+	}()
+	token, cachePositive, cacheNegative, err = fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
+	result = workspaceSlackTokenLookupResult{token: token, err: err}
+	cache.finish(teamID, call, result, cachePositive, cacheNegative, ttl, slackWorkspaceTokenNegativeCacheTTL, now())
+	finished = true
+	return token, err
 }
 
 func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, ttl time.Duration, at time.Time) workspaceSlackTokenLookupStart {
@@ -464,6 +493,17 @@ func (c *workspaceSlackTokenLookupCache) finish(
 	call.workspaceSlackTokenLookupResult = result
 	delete(c.inFlight, teamID)
 	close(call.done)
+}
+
+func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.positive, teamID)
+	delete(c.negative, teamID)
 }
 
 func (c *workspaceSlackTokenLookupCache) sweepExpiredLocked(at time.Time) {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackinstall"
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
@@ -132,14 +133,14 @@ func run() error {
 		return fmt.Errorf("QURL_TUNNEL_IMAGE: %w", err)
 	}
 	slackBotToken := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN"))
-	var openView internal.OpenViewFunc
 	if err := validateSlackBotTokenShape(slackBotToken); err != nil {
 		return err
 	}
+	openView := slackOpenViewFuncWithWorkspaceTokens(ddbProvider, slackBotToken, userAgent)
 	if slackBotToken != "" {
-		openView = slackOpenViewFunc(slackBotToken, userAgent)
+		slog.Info("Slack views.open wired with per-workspace token lookup and legacy SLACK_BOT_TOKEN fallback")
 	} else {
-		slog.Info("Slack views.open disabled", "reason", "slack_bot_token_unset")
+		slog.Info("Slack views.open wired with per-workspace token lookup")
 	}
 
 	// signalCtx is hoisted above so the DDB-provider constructor can
@@ -216,6 +217,14 @@ func run() error {
 	}
 	// Else: buildOAuthConfig already logged the specific missing-var
 	// list; nothing more to say here.
+	slackInstallCfg, ok, err := buildSlackInstallConfig(ddbProvider)
+	if err != nil {
+		return fmt.Errorf("Slack install config: %w", err)
+	}
+	if ok {
+		slackinstall.RegisterRoutes(rootMux, slackInstallCfg)
+		slog.Info("registered /oauth/slack/{install,callback} routes")
+	}
 
 	srv := &http.Server{
 		// Addr intentionally omitted: srv.Serve(ln) ignores it, and we
@@ -293,6 +302,19 @@ func run() error {
 	}
 	slog.Info("server stopped cleanly")
 	return nil
+}
+
+func slackOpenViewFuncWithWorkspaceTokens(provider *auth.DDBProvider, fallbackToken, userAgent string) internal.OpenViewFunc {
+	return newSlackOpenViewFuncWithTokenLookup(func(ctx context.Context, teamID string) (string, error) {
+		token, err := provider.SlackBotToken(ctx, teamID)
+		if err == nil {
+			return token, nil
+		}
+		if errors.Is(err, auth.ErrSlackBotTokenNotConfigured) && fallbackToken != "" {
+			return fallbackToken, nil
+		}
+		return "", err
+	}, userAgent, slackViewsOpenURL, nil)
 }
 
 // minStateSecretBytes is the operator floor for OAUTH_STATE_SECRET.
@@ -490,6 +512,85 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 		// SlackClient left nil for now — DM-after-success Slack-API
 		// wiring is a follow-up; the success-page HTML still renders.
 	}, true, nil
+}
+
+const (
+	envSlackClientID           = "SLACK_CLIENT_ID"
+	envSlackClientSecret       = "SLACK_CLIENT_SECRET"
+	envSlackInstallStateSecret = "SLACK_INSTALL_STATE_SECRET"
+	envSlackBotScopes          = "SLACK_BOT_SCOPES"
+)
+
+func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, bool, error) {
+	clientID := strings.TrimSpace(os.Getenv(envSlackClientID))
+	clientSecret := strings.TrimSpace(os.Getenv(envSlackClientSecret))
+	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("SLACK_BASE_URL")), "/")
+	stateSecret := os.Getenv(envSlackInstallStateSecret)
+	if stateSecret == "" {
+		stateSecret = os.Getenv("OAUTH_STATE_SECRET")
+	}
+
+	missing := missingSlackInstallEnvVars(map[string]string{
+		envSlackClientID:      clientID,
+		envSlackClientSecret:  clientSecret,
+		"SLACK_BASE_URL":      baseURL,
+		"SLACK_INSTALL_STATE": stateSecret,
+	})
+	if len(missing) > 0 {
+		slog.Warn("Slack install routes NOT registered — required env vars unset", "missing", missing)
+		return slackinstall.Config{}, false, nil
+	}
+	if err := validateSlackBaseOrigin(baseURL); err != nil {
+		return slackinstall.Config{}, false, err
+	}
+
+	scopes := slackinstall.DefaultBotScopes()
+	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
+		scopes = splitScopeEnv(raw)
+	}
+	cfg := slackinstall.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		SlackBaseURL: baseURL,
+		StateSecret:  []byte(stateSecret),
+		BotScopes:    scopes,
+		TokenStore:   provider,
+	}
+	if err := cfg.Validate(); err != nil {
+		return slackinstall.Config{}, false, err
+	}
+	return cfg, true, nil
+}
+
+func missingSlackInstallEnvVars(values map[string]string) []string {
+	keys := []string{envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL", "SLACK_INSTALL_STATE"}
+	var missing []string
+	for _, k := range keys {
+		if values[k] == "" {
+			if k == "SLACK_INSTALL_STATE" {
+				missing = append(missing, envSlackInstallStateSecret+" (or OAUTH_STATE_SECRET)")
+				continue
+			}
+			missing = append(missing, k)
+		}
+	}
+	return missing
+}
+
+func validateSlackBaseOrigin(baseURL string) error {
+	if !strings.HasPrefix(baseURL, "https://") {
+		return fmt.Errorf("SLACK_BASE_URL must be https:// (got %q)", baseURL)
+	}
+	if u, err := url.Parse(baseURL); err != nil || u.Host == "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
+		return fmt.Errorf("SLACK_BASE_URL must be a bare https:// origin with no path/query/userinfo (got %q)", baseURL)
+	}
+	return nil
+}
+
+func splitScopeEnv(raw string) []string {
+	return strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\n' || r == '\t'
+	})
 }
 
 // adminStoreAdapter bridges *slackdata.Store to the oauth.AdminStore

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -76,29 +76,29 @@ func TestValidateSlackBotToken(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "unset"},
-		{name: "bot token", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxb-")+10)},
-		{name: "rotating bot token", token: "xoxe.xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxe.xoxb-"))},
-		{name: "rotating refresh token", token: "xoxe-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxe-")), wantErr: true},
+		{name: "bot token", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxb-")+10)},
+		{name: "rotating bot token", token: "xoxe.xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxe.xoxb-"))},
+		{name: "rotating refresh token", token: "xoxe-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxe-")), wantErr: true},
 		{name: "user token", token: "xoxp-test-token", wantErr: true},
 		{name: "app token", token: "xapp-test-token", wantErr: true},
 		{name: "placeholder bot token", token: "xoxb-", wantErr: true},
-		{name: "minimum typo-guard length bot token", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxb-"))},
-		{name: "one below typo-guard length", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxb-")-1), wantErr: true},
+		{name: "minimum typo-guard length bot token", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxb-"))},
+		{name: "one below typo-guard length", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxb-")-1), wantErr: true},
 		{name: "token with whitespace", token: "xoxb-test-token\r", wantErr: true},
 		{name: "token with non-ascii", token: "xoxb-test-tokené", wantErr: true},
-		{name: "token with underscore", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxb-")) + "_ok"},
-		{name: "token with dot", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMin-len("xoxb-")) + ".ok"},
+		{name: "token with underscore", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxb-")) + "_ok"},
+		{name: "token with dot", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMin-len("xoxb-")) + ".ok"},
 		{name: "long bot token", token: "xoxb-" + strings.Repeat("a", 250)},
-		{name: "maximum typo-guard length bot token", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMax-len("xoxb-"))},
-		{name: "one above typo-guard length", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMax-len("xoxb-")+1), wantErr: true},
-		{name: "token too long", token: "xoxb-" + strings.Repeat("a", slackBotTokenTypoGuardMax-len("xoxb-")+100), wantErr: true},
+		{name: "maximum typo-guard length bot token", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMax-len("xoxb-"))},
+		{name: "one above typo-guard length", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMax-len("xoxb-")+1), wantErr: true},
+		{name: "token too long", token: "xoxb-" + strings.Repeat("a", auth.SlackBotTokenTypoGuardMax-len("xoxb-")+100), wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateSlackBotTokenShape(tc.token)
+			err := auth.ValidateSlackBotTokenShape(tc.token)
 			if (err != nil) != tc.wantErr {
-				t.Fatalf("validateSlackBotTokenShape(%q) err=%v, wantErr=%v", tc.token, err, tc.wantErr)
+				t.Fatalf("ValidateSlackBotTokenShape(%q) err=%v, wantErr=%v", tc.token, err, tc.wantErr)
 			}
 		})
 	}

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -541,11 +541,11 @@ func TestSlackInstallConfigRejectsBadBaseURL(t *testing.T) {
 	env := validSlackInstallEnv()
 	env["SLACK_BASE_URL"] = "http://slack-bot.example"
 	applySlackInstallEnv(t, env)
-	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
-	if err != nil || !ok {
-		t.Fatalf("ok=%v err=%v, want config to defer validation to route registration", ok, err)
+	_, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if ok {
+		t.Fatal("ok=true, want bad Slack install base URL to fail at config build")
 	}
-	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "https://") {
-		t.Fatalf("Validate err=%v, want https error", err)
+	if err == nil || !strings.Contains(err.Error(), "https://") {
+		t.Fatalf("err=%v, want https error", err)
 	}
 }

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -537,12 +537,15 @@ func TestBuildSlackInstallConfigCustomScopes(t *testing.T) {
 	}
 }
 
-func TestBuildSlackInstallConfigRejectsBadBaseURL(t *testing.T) {
+func TestSlackInstallConfigRejectsBadBaseURL(t *testing.T) {
 	env := validSlackInstallEnv()
 	env["SLACK_BASE_URL"] = "http://slack-bot.example"
 	applySlackInstallEnv(t, env)
-	_, ok, err := buildSlackInstallConfig(newFakeProvider())
-	if ok || err == nil || !strings.Contains(err.Error(), "https://") {
-		t.Fatalf("ok=%v err=%v, want https error", ok, err)
+	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v, want config to defer validation to route registration", ok, err)
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "https://") {
+		t.Fatalf("Validate err=%v, want https error", err)
 	}
 }

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -40,6 +40,11 @@ var oauthEnvKeys = []string{
 	"SLACK_BASE_URL", "OAUTH_STATE_SECRET", "QURL_ENDPOINT",
 }
 
+var slackInstallEnvKeys = []string{
+	envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL",
+	envSlackInstallStateSecret, "OAUTH_STATE_SECRET", envSlackBotScopes,
+}
+
 func validEnv() map[string]string {
 	return map[string]string{
 		"AUTH0_DOMAIN":        "example.auth0.com",
@@ -49,6 +54,17 @@ func validEnv() map[string]string {
 		"SLACK_BASE_URL":      "https://slack-bot.example",
 		"OAUTH_STATE_SECRET":  validStateSecret,
 		"QURL_ENDPOINT":       "https://api.qurl.invalid",
+	}
+}
+
+func validSlackInstallEnv() map[string]string {
+	return map[string]string{
+		envSlackClientID:           "111.222",
+		envSlackClientSecret:       "slack-secret",
+		"SLACK_BASE_URL":           "https://slack-bot.example",
+		envSlackInstallStateSecret: validStateSecret,
+		"OAUTH_STATE_SECRET":       "",
+		envSlackBotScopes:          "",
 	}
 }
 
@@ -94,6 +110,13 @@ func TestValidateSlackBotToken(t *testing.T) {
 func applyEnv(t *testing.T, kvs map[string]string) {
 	t.Helper()
 	for _, k := range oauthEnvKeys {
+		t.Setenv(k, kvs[k])
+	}
+}
+
+func applySlackInstallEnv(t *testing.T, kvs map[string]string) {
+	t.Helper()
+	for _, k := range slackInstallEnvKeys {
 		t.Setenv(k, kvs[k])
 	}
 }
@@ -437,5 +460,89 @@ func TestBuildOAuthConfigNormalizesURLEnvVars(t *testing.T) {
 	}
 	if cfg.Auth0Domain != "example.auth0.com" {
 		t.Errorf("Auth0Domain not normalized (expect scheme + trailing slash stripped): got %q", cfg.Auth0Domain)
+	}
+}
+
+func TestBuildSlackInstallConfigHappyPath(t *testing.T) {
+	env := validSlackInstallEnv()
+	applySlackInstallEnv(t, env)
+	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true with Slack install env set")
+	}
+	if cfg.ClientID != "111.222" || cfg.ClientSecret != "slack-secret" {
+		t.Fatalf("Slack client config not threaded through: %+v", cfg)
+	}
+	if cfg.SlackBaseURL != "https://slack-bot.example" {
+		t.Fatalf("SlackBaseURL = %q", cfg.SlackBaseURL)
+	}
+	if string(cfg.StateSecret) != validStateSecret {
+		t.Fatalf("StateSecret not threaded through")
+	}
+	if strings.Join(cfg.BotScopes, ",") != "commands,views:write" {
+		t.Fatalf("default bot scopes = %v", cfg.BotScopes)
+	}
+	if cfg.TokenStore == nil {
+		t.Fatal("TokenStore should be wired")
+	}
+}
+
+func TestBuildSlackInstallConfigFallsBackToOAuthStateSecret(t *testing.T) {
+	env := validSlackInstallEnv()
+	env[envSlackInstallStateSecret] = ""
+	env["OAUTH_STATE_SECRET"] = validStateSecret
+	applySlackInstallEnv(t, env)
+	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v, want fallback to OAUTH_STATE_SECRET", ok, err)
+	}
+	if string(cfg.StateSecret) != validStateSecret {
+		t.Fatalf("StateSecret not sourced from OAUTH_STATE_SECRET")
+	}
+}
+
+func TestBuildSlackInstallConfigMissingVar(t *testing.T) {
+	for _, missing := range []string{envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL", envSlackInstallStateSecret} {
+		t.Run("missing="+missing, func(t *testing.T) {
+			env := validSlackInstallEnv()
+			delete(env, missing)
+			if missing == envSlackInstallStateSecret {
+				env["OAUTH_STATE_SECRET"] = ""
+			}
+			applySlackInstallEnv(t, env)
+			_, ok, err := buildSlackInstallConfig(newFakeProvider())
+			if err != nil {
+				t.Fatalf("expected nil error on missing var, got %v", err)
+			}
+			if ok {
+				t.Fatalf("expected ok=false when %s is missing", missing)
+			}
+		})
+	}
+}
+
+func TestBuildSlackInstallConfigCustomScopes(t *testing.T) {
+	env := validSlackInstallEnv()
+	env[envSlackBotScopes] = "commands views:write,chat:write"
+	applySlackInstallEnv(t, env)
+	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	if strings.Join(cfg.BotScopes, ",") != "commands,views:write,chat:write" {
+		t.Fatalf("custom scopes = %v", cfg.BotScopes)
+	}
+}
+
+func TestBuildSlackInstallConfigRejectsBadBaseURL(t *testing.T) {
+	env := validSlackInstallEnv()
+	env["SLACK_BASE_URL"] = "http://slack-bot.example"
+	applySlackInstallEnv(t, env)
+	_, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if ok || err == nil || !strings.Contains(err.Error(), "https://") {
+		t.Fatalf("ok=%v err=%v, want https error", ok, err)
 	}
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -31,10 +31,6 @@ const slackViewsOpenResponseBodyLimit = 64 * 1024
 const slackOpenViewMaxErrorSnippetBytes = 200
 const slackOpenViewTruncationSuffix = "..."
 
-func slackOpenViewFunc(token, userAgent string) func(context.Context, string, string, []byte) error {
-	return newSlackOpenViewFunc(token, userAgent, slackViewsOpenURL)
-}
-
 func newSlackOpenViewFunc(token, userAgent, viewsOpenURL string) func(context.Context, string, string, []byte) error {
 	return newSlackOpenViewFuncWithClient(token, userAgent, viewsOpenURL, nil)
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -40,6 +40,14 @@ func newSlackOpenViewFunc(token, userAgent, viewsOpenURL string) func(context.Co
 }
 
 func newSlackOpenViewFuncWithClient(token, userAgent, viewsOpenURL string, httpClient *http.Client) func(context.Context, string, string, []byte) error {
+	return newSlackOpenViewFuncWithTokenLookup(func(context.Context, string) (string, error) {
+		return token, nil
+	}, userAgent, viewsOpenURL, httpClient)
+}
+
+type slackOpenViewTokenLookup func(ctx context.Context, teamID string) (string, error)
+
+func newSlackOpenViewFuncWithTokenLookup(lookup slackOpenViewTokenLookup, userAgent, viewsOpenURL string, httpClient *http.Client) func(context.Context, string, string, []byte) error {
 	if httpClient == nil {
 		httpClient = defaultSlackViewsOpenClient()
 	}
@@ -47,14 +55,18 @@ func newSlackOpenViewFuncWithClient(token, userAgent, viewsOpenURL string, httpC
 	if userAgent == "" {
 		userAgent = defaultSlackOpenViewUserAgent
 	}
-	// The teamID parameter is intentionally part of the Config.OpenView seam
-	// so production wiring can move from this single-token deployment shape to
-	// per-team OAuth token lookup without changing the handler contract. The
-	// workspace install row written by internal/oauth is the future lookup
-	// authority for this token.
-	// TODO(slack-oauth): look up the workspace bot token by teamID once the
-	// per-workspace OAuth token store is the only production path.
-	return func(ctx context.Context, _ string, triggerID string, viewJSON []byte) error {
+	// The teamID parameter lets production select the bot token Slack issued
+	// for the workspace that invoked the slash command. Tests and single-
+	// workspace development still use the static-token wrapper above.
+	return func(ctx context.Context, teamID string, triggerID string, viewJSON []byte) error {
+		token, err := lookup(ctx, teamID)
+		if err != nil {
+			return fmt.Errorf("views.open token lookup: %w", err)
+		}
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return errors.New("views.open token lookup: empty token")
+		}
 		viewJSON = bytes.TrimSpace(viewJSON)
 		// json.Valid accepts arrays and scalars; views.open requires a view
 		// object, so reject non-object roots before sending the request.

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -146,7 +146,7 @@ func TestSlackOpenViewFuncUsesWorkspaceTokenLookup(t *testing.T) {
 func TestWorkspaceSlackTokenLookupCachesDDBToken(t *testing.T) {
 	provider := &fakeSlackBotTokenProvider{token: testWorkspaceSlackBotToken}
 	now := time.Unix(1800000000, 0)
-	lookup := newWorkspaceSlackTokenLookup(provider, "", time.Minute, func() time.Time {
+	lookup, _ := newWorkspaceSlackTokenLookupWithInvalidation(provider, "", time.Minute, func() time.Time {
 		return now
 	})
 
@@ -175,7 +175,7 @@ func TestWorkspaceSlackTokenLookupCachesDDBToken(t *testing.T) {
 func TestWorkspaceSlackTokenLookupFallsBackWhenUnset(t *testing.T) {
 	provider := &fakeSlackBotTokenProvider{err: auth.ErrSlackBotTokenNotConfigured}
 	now := time.Unix(1800000000, 0)
-	lookup := newWorkspaceSlackTokenLookup(provider, "xoxb-fallback", time.Minute, func() time.Time {
+	lookup, _ := newWorkspaceSlackTokenLookupWithInvalidation(provider, "xoxb-fallback", time.Minute, func() time.Time {
 		return now
 	})
 
@@ -297,7 +297,7 @@ func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
 	t.Cleanup(func() {
 		unblockOnce.Do(func() { close(provider.unblock) })
 	})
-	lookup := newWorkspaceSlackTokenLookup(provider, "", time.Minute, nil)
+	lookup, _ := newWorkspaceSlackTokenLookupWithInvalidation(provider, "", time.Minute, nil)
 
 	const callers = 8
 	errs := make(chan error, callers)
@@ -338,7 +338,7 @@ func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
 
 func TestWorkspaceSlackTokenLookupReleasesInFlightOnPanic(t *testing.T) {
 	provider := &panicOnceSlackBotTokenProvider{}
-	lookup := newWorkspaceSlackTokenLookup(provider, "", time.Minute, nil)
+	lookup, _ := newWorkspaceSlackTokenLookupWithInvalidation(provider, "", time.Minute, nil)
 
 	func() {
 		defer func() {

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -57,6 +57,51 @@ func TestSlackOpenViewFuncPostsViewsOpenPayload(t *testing.T) {
 	}
 }
 
+func TestSlackOpenViewFuncUsesWorkspaceTokenLookup(t *testing.T) {
+	t.Parallel()
+	var gotTeam string
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	openView := newSlackOpenViewFuncWithTokenLookup(func(_ context.Context, teamID string) (string, error) {
+		gotTeam = teamID
+		return "xoxb-workspace-token", nil
+	}, "qurl-slack/test", srv.URL, nil)
+	if err := openView(context.Background(), "T_lookup", "trigger_test", []byte(`{"type":"modal"}`)); err != nil {
+		t.Fatalf("views.open: %v", err)
+	}
+	if gotTeam != "T_lookup" {
+		t.Fatalf("lookup teamID = %q, want T_lookup", gotTeam)
+	}
+	if gotAuth != "Bearer xoxb-workspace-token" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestSlackOpenViewFuncLookupErrorSkipsRequest(t *testing.T) {
+	t.Parallel()
+	var called atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called.Store(true)
+	}))
+	t.Cleanup(srv.Close)
+
+	openView := newSlackOpenViewFuncWithTokenLookup(func(context.Context, string) (string, error) {
+		return "", errors.New("missing workspace token")
+	}, "qurl-slack/test", srv.URL, nil)
+	err := openView(context.Background(), "T_missing", "trigger_test", []byte(`{"type":"modal"}`))
+	if err == nil || !strings.Contains(err.Error(), "token lookup") {
+		t.Fatalf("error = %v, want token lookup error", err)
+	}
+	if called.Load() {
+		t.Fatal("views.open request should not be sent when token lookup fails")
+	}
+}
+
 func TestSlackOpenViewFuncDefaultsUserAgent(t *testing.T) {
 	t.Parallel()
 	var gotUA string

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -373,6 +373,10 @@ func TestWorkspaceSlackTokenLookupCacheSweepsExpiredEntries(t *testing.T) {
 			"T_negative_fresh":   at.Add(time.Minute),
 		},
 		inFlight: map[string]*workspaceSlackTokenLookupCall{},
+		fallbackWarned: map[string]struct{}{
+			"T_negative_expired": {},
+			"T_negative_fresh":   {},
+		},
 	}
 
 	start := cache.getOrStart("T_new", time.Minute, at)
@@ -390,6 +394,12 @@ func TestWorkspaceSlackTokenLookupCacheSweepsExpiredEntries(t *testing.T) {
 	}
 	if _, ok := cache.negative["T_negative_fresh"]; !ok {
 		t.Fatal("fresh negative cache entry should remain")
+	}
+	if _, ok := cache.fallbackWarned["T_negative_expired"]; ok {
+		t.Fatal("expired negative cache entry should clear fallback warning state")
+	}
+	if _, ok := cache.fallbackWarned["T_negative_fresh"]; !ok {
+		t.Fatal("fresh negative cache entry should keep fallback warning state")
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -19,7 +19,10 @@ import (
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
-const testWorkspaceSlackBotToken = "xoxb-123456789012345678901234567890"
+const (
+	testWorkspaceSlackBotToken        = "xoxb-123456789012345678901234567890"
+	testRotatedWorkspaceSlackBotToken = "xoxb-223456789012345678901234567890"
+)
 
 type fakeSlackBotTokenProvider struct {
 	token string
@@ -45,6 +48,17 @@ func (f *blockingSlackBotTokenProvider) SlackBotToken(context.Context, string) (
 	f.once.Do(func() { close(f.started) })
 	<-f.unblock
 	return f.token, nil
+}
+
+type panicOnceSlackBotTokenProvider struct {
+	calls atomic.Int64
+}
+
+func (f *panicOnceSlackBotTokenProvider) SlackBotToken(context.Context, string) (string, error) {
+	if f.calls.Add(1) == 1 {
+		panic("simulated token lookup panic")
+	}
+	return testWorkspaceSlackBotToken, nil
 }
 
 func TestSlackOpenViewFuncPostsViewsOpenPayload(t *testing.T) {
@@ -171,6 +185,39 @@ func TestWorkspaceSlackTokenLookupFallsBackWhenUnset(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSlackTokenLookupInvalidationPurgesCache(t *testing.T) {
+	provider := &fakeSlackBotTokenProvider{token: testWorkspaceSlackBotToken}
+	lookup, purge := newWorkspaceSlackTokenLookupWithInvalidation(provider, "", time.Minute, nil)
+
+	token, err := lookup(context.Background(), "T_rotate")
+	if err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	if token != testWorkspaceSlackBotToken {
+		t.Fatalf("token = %q, want initial token", token)
+	}
+	provider.token = testRotatedWorkspaceSlackBotToken
+	token, err = lookup(context.Background(), "T_rotate")
+	if err != nil {
+		t.Fatalf("cached lookup: %v", err)
+	}
+	if token != testWorkspaceSlackBotToken {
+		t.Fatalf("token = %q, want cached initial token", token)
+	}
+
+	purge("T_rotate")
+	token, err = lookup(context.Background(), "T_rotate")
+	if err != nil {
+		t.Fatalf("lookup after purge: %v", err)
+	}
+	if token != testRotatedWorkspaceSlackBotToken {
+		t.Fatalf("token = %q, want rotated token", token)
+	}
+	if calls := provider.calls.Load(); calls != 2 {
+		t.Fatalf("provider calls = %d, want 2", calls)
+	}
+}
+
 func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
 	provider := &blockingSlackBotTokenProvider{
 		token:   testWorkspaceSlackBotToken,
@@ -203,7 +250,7 @@ func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
 
 	select {
 	case <-provider.started:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("provider lookup did not start")
 	}
 	unblockOnce.Do(func() { close(provider.unblock) })
@@ -217,6 +264,31 @@ func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
 	}
 	if calls := provider.calls.Load(); calls != 1 {
 		t.Fatalf("provider calls = %d, want 1", calls)
+	}
+}
+
+func TestWorkspaceSlackTokenLookupReleasesInFlightOnPanic(t *testing.T) {
+	provider := &panicOnceSlackBotTokenProvider{}
+	lookup := newWorkspaceSlackTokenLookup(provider, "", time.Minute, nil)
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("first lookup should panic")
+			}
+		}()
+		_, _ = lookup(context.Background(), "T_panic")
+	}()
+
+	token, err := lookup(context.Background(), "T_panic")
+	if err != nil {
+		t.Fatalf("second lookup should start after panic cleanup: %v", err)
+	}
+	if token != testWorkspaceSlackBotToken {
+		t.Fatalf("token = %q, want workspace token", token)
+	}
+	if calls := provider.calls.Load(); calls != 2 {
+		t.Fatalf("provider calls = %d, want 2", calls)
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -50,6 +50,22 @@ func (f *blockingSlackBotTokenProvider) SlackBotToken(context.Context, string) (
 	return f.token, nil
 }
 
+type capturingBlockingSlackBotTokenProvider struct {
+	token   string
+	started chan struct{}
+	unblock chan struct{}
+	once    sync.Once
+	calls   atomic.Int64
+}
+
+func (f *capturingBlockingSlackBotTokenProvider) SlackBotToken(context.Context, string) (string, error) {
+	f.calls.Add(1)
+	token := f.token
+	f.once.Do(func() { close(f.started) })
+	<-f.unblock
+	return token, nil
+}
+
 type panicOnceSlackBotTokenProvider struct {
 	calls atomic.Int64
 }
@@ -212,6 +228,59 @@ func TestWorkspaceSlackTokenLookupInvalidationPurgesCache(t *testing.T) {
 	}
 	if token != testRotatedWorkspaceSlackBotToken {
 		t.Fatalf("token = %q, want rotated token", token)
+	}
+	if calls := provider.calls.Load(); calls != 2 {
+		t.Fatalf("provider calls = %d, want 2", calls)
+	}
+}
+
+func TestWorkspaceSlackTokenLookupPurgeDetachesStaleInFlight(t *testing.T) {
+	provider := &capturingBlockingSlackBotTokenProvider{
+		token:   testWorkspaceSlackBotToken,
+		started: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+	var unblockOnce sync.Once
+	t.Cleanup(func() {
+		unblockOnce.Do(func() { close(provider.unblock) })
+	})
+	lookup, purge := newWorkspaceSlackTokenLookupWithInvalidation(provider, "", time.Minute, nil)
+	first := make(chan struct {
+		token string
+		err   error
+	}, 1)
+
+	go func() {
+		token, err := lookup(context.Background(), "T_race")
+		first <- struct {
+			token string
+			err   error
+		}{token: token, err: err}
+	}()
+
+	select {
+	case <-provider.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider lookup did not start")
+	}
+	provider.token = testRotatedWorkspaceSlackBotToken
+	purge("T_race")
+	unblockOnce.Do(func() { close(provider.unblock) })
+
+	got := <-first
+	if got.err != nil {
+		t.Fatalf("first lookup: %v", got.err)
+	}
+	if got.token != testWorkspaceSlackBotToken {
+		t.Fatalf("first token = %q, want stale in-flight token", got.token)
+	}
+
+	token, err := lookup(context.Background(), "T_race")
+	if err != nil {
+		t.Fatalf("lookup after stale in-flight finishes: %v", err)
+	}
+	if token != testRotatedWorkspaceSlackBotToken {
+		t.Fatalf("token after purge = %q, want rotated token", token)
 	}
 	if calls := provider.calls.Load(); calls != 2 {
 		t.Fatalf("provider calls = %d, want 2", calls)

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -29,6 +30,21 @@ type fakeSlackBotTokenProvider struct {
 func (f *fakeSlackBotTokenProvider) SlackBotToken(context.Context, string) (string, error) {
 	f.calls.Add(1)
 	return f.token, f.err
+}
+
+type blockingSlackBotTokenProvider struct {
+	token   string
+	started chan struct{}
+	unblock chan struct{}
+	once    sync.Once
+	calls   atomic.Int64
+}
+
+func (f *blockingSlackBotTokenProvider) SlackBotToken(context.Context, string) (string, error) {
+	f.calls.Add(1)
+	f.once.Do(func() { close(f.started) })
+	<-f.unblock
+	return f.token, nil
 }
 
 func TestSlackOpenViewFuncPostsViewsOpenPayload(t *testing.T) {
@@ -128,14 +144,79 @@ func TestWorkspaceSlackTokenLookupCachesDDBToken(t *testing.T) {
 
 func TestWorkspaceSlackTokenLookupFallsBackWhenUnset(t *testing.T) {
 	provider := &fakeSlackBotTokenProvider{err: auth.ErrSlackBotTokenNotConfigured}
-	lookup := newWorkspaceSlackTokenLookup(provider, "xoxb-fallback", time.Minute, nil)
+	now := time.Unix(1800000000, 0)
+	lookup := newWorkspaceSlackTokenLookup(provider, "xoxb-fallback", time.Minute, func() time.Time {
+		return now
+	})
 
-	token, err := lookup(context.Background(), "T_legacy")
-	if err != nil {
-		t.Fatalf("lookup fallback: %v", err)
+	for i := 0; i < 2; i++ {
+		token, err := lookup(context.Background(), "T_legacy")
+		if err != nil {
+			t.Fatalf("lookup fallback %d: %v", i, err)
+		}
+		if token != "xoxb-fallback" {
+			t.Fatalf("token = %q, want fallback", token)
+		}
 	}
-	if token != "xoxb-fallback" {
-		t.Fatalf("token = %q, want fallback", token)
+	if calls := provider.calls.Load(); calls != 1 {
+		t.Fatalf("provider calls before negative TTL = %d, want 1", calls)
+	}
+
+	now = now.Add(slackWorkspaceTokenNegativeCacheTTL + time.Second)
+	if _, err := lookup(context.Background(), "T_legacy"); err != nil {
+		t.Fatalf("lookup fallback after negative TTL: %v", err)
+	}
+	if calls := provider.calls.Load(); calls != 2 {
+		t.Fatalf("provider calls after negative TTL = %d, want 2", calls)
+	}
+}
+
+func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
+	provider := &blockingSlackBotTokenProvider{
+		token:   testWorkspaceSlackBotToken,
+		started: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+	var unblockOnce sync.Once
+	t.Cleanup(func() {
+		unblockOnce.Do(func() { close(provider.unblock) })
+	})
+	lookup := newWorkspaceSlackTokenLookup(provider, "", time.Minute, nil)
+
+	const callers = 8
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			token, err := lookup(context.Background(), "T_singleflight")
+			if err != nil {
+				errs <- err
+				return
+			}
+			if token != testWorkspaceSlackBotToken {
+				errs <- errors.New("unexpected token")
+			}
+		}()
+	}
+
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("provider lookup did not start")
+	}
+	unblockOnce.Do(func() { close(provider.unblock) })
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("lookup error: %v", err)
+		}
+	}
+	if calls := provider.calls.Load(); calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", calls)
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -11,10 +11,25 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
+
+const testWorkspaceSlackBotToken = "xoxb-123456789012345678901234567890"
+
+type fakeSlackBotTokenProvider struct {
+	token string
+	err   error
+	calls atomic.Int64
+}
+
+func (f *fakeSlackBotTokenProvider) SlackBotToken(context.Context, string) (string, error) {
+	f.calls.Add(1)
+	return f.token, f.err
+}
 
 func TestSlackOpenViewFuncPostsViewsOpenPayload(t *testing.T) {
 	t.Parallel()
@@ -79,6 +94,48 @@ func TestSlackOpenViewFuncUsesWorkspaceTokenLookup(t *testing.T) {
 	}
 	if gotAuth != "Bearer xoxb-workspace-token" {
 		t.Fatalf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestWorkspaceSlackTokenLookupCachesDDBToken(t *testing.T) {
+	provider := &fakeSlackBotTokenProvider{token: testWorkspaceSlackBotToken}
+	now := time.Unix(1800000000, 0)
+	lookup := newWorkspaceSlackTokenLookup(provider, "", time.Minute, func() time.Time {
+		return now
+	})
+
+	for i := 0; i < 2; i++ {
+		token, err := lookup(context.Background(), "T_cache")
+		if err != nil {
+			t.Fatalf("lookup %d: %v", i, err)
+		}
+		if token != testWorkspaceSlackBotToken {
+			t.Fatalf("token = %q, want cached workspace token", token)
+		}
+	}
+	if calls := provider.calls.Load(); calls != 1 {
+		t.Fatalf("provider calls before TTL = %d, want 1", calls)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	if _, err := lookup(context.Background(), "T_cache"); err != nil {
+		t.Fatalf("lookup after TTL: %v", err)
+	}
+	if calls := provider.calls.Load(); calls != 2 {
+		t.Fatalf("provider calls after TTL = %d, want 2", calls)
+	}
+}
+
+func TestWorkspaceSlackTokenLookupFallsBackWhenUnset(t *testing.T) {
+	provider := &fakeSlackBotTokenProvider{err: auth.ErrSlackBotTokenNotConfigured}
+	lookup := newWorkspaceSlackTokenLookup(provider, "xoxb-fallback", time.Minute, nil)
+
+	token, err := lookup(context.Background(), "T_legacy")
+	if err != nil {
+		t.Fatalf("lookup fallback: %v", err)
+	}
+	if token != "xoxb-fallback" {
+		t.Fatalf("token = %q, want fallback", token)
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -220,6 +220,38 @@ func TestWorkspaceSlackTokenLookupCollapsesConcurrentMisses(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSlackTokenLookupCacheSweepsExpiredEntries(t *testing.T) {
+	at := time.Unix(1800000000, 0)
+	cache := &workspaceSlackTokenLookupCache{
+		positive: map[string]cachedSlackBotToken{
+			"T_expired": {token: testWorkspaceSlackBotToken, expiresAt: at.Add(-time.Second)},
+			"T_fresh":   {token: testWorkspaceSlackBotToken, expiresAt: at.Add(time.Minute)},
+		},
+		negative: map[string]time.Time{
+			"T_negative_expired": at.Add(-time.Second),
+			"T_negative_fresh":   at.Add(time.Minute),
+		},
+		inFlight: map[string]*workspaceSlackTokenLookupCall{},
+	}
+
+	start := cache.getOrStart("T_new", time.Minute, at)
+	if !start.owner {
+		t.Fatal("new team should start a provider lookup")
+	}
+	if _, ok := cache.positive["T_expired"]; ok {
+		t.Fatal("expired positive cache entry was not swept")
+	}
+	if _, ok := cache.negative["T_negative_expired"]; ok {
+		t.Fatal("expired negative cache entry was not swept")
+	}
+	if _, ok := cache.positive["T_fresh"]; !ok {
+		t.Fatal("fresh positive cache entry should remain")
+	}
+	if _, ok := cache.negative["T_negative_fresh"]; !ok {
+		t.Fatal("fresh negative cache entry should remain")
+	}
+}
+
 func TestSlackOpenViewFuncLookupErrorSkipsRequest(t *testing.T) {
 	t.Parallel()
 	var called atomic.Bool

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -384,7 +384,7 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 		case errors.Is(err, ErrSlackRateLimited):
 			_ = h.postErrorResponse(log, responseURL, tunnelInstallRateLimitMessage(err), true)
 		case errors.Is(err, auth.ErrSlackBotTokenNotConfigured):
-			_ = h.postErrorResponse(log, responseURL, "Guided tunnel setup needs the latest qURL Slack app install. Ask a workspace admin to reinstall qURL for Slack, then run `/qurl tunnel install` again.", true)
+			_ = h.postErrorResponse(log, responseURL, "Guided tunnel setup needs the latest qURL Slack app install. Ask a workspace admin to open the qURL Slack install link your operator provided, then run `/qurl tunnel install` again.", true)
 		default:
 			_ = h.postErrorResponse(log, responseURL, "Could not open guided tunnel setup. Please retry or contact support.", true)
 		}

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
@@ -373,6 +374,7 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 			"slack_views_open_deadline_exceeded", errors.Is(err, context.DeadlineExceeded),
 			"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
+			"slack_bot_token_not_configured", errors.Is(err, auth.ErrSlackBotTokenNotConfigured),
 		)
 		switch {
 		case errors.Is(err, ErrSlackTriggerExpired):
@@ -381,6 +383,8 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 			_ = h.postErrorResponse(log, responseURL, "Slack did not respond before the setup window expired. Run `/qurl tunnel install` again.", true)
 		case errors.Is(err, ErrSlackRateLimited):
 			_ = h.postErrorResponse(log, responseURL, tunnelInstallRateLimitMessage(err), true)
+		case errors.Is(err, auth.ErrSlackBotTokenNotConfigured):
+			_ = h.postErrorResponse(log, responseURL, "Guided tunnel setup needs the latest qURL Slack app install. Ask a workspace admin to reinstall qURL for Slack, then run `/qurl tunnel install` again.", true)
 		default:
 			_ = h.postErrorResponse(log, responseURL, "Could not open guided tunnel setup. Please retry or contact support.", true)
 		}

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -110,6 +110,7 @@ func RegisterRoutes(mux *http.ServeMux, cfg *Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
+	cfg.BotScopes = NormalizeScopes(cfg.BotScopes)
 	cfg.ensureHTTPClient()
 	mux.HandleFunc(InstallPath, Install(cfg))
 	mux.HandleFunc(CallbackPath, Callback(cfg))
@@ -146,7 +147,6 @@ func (c *Config) Validate() error {
 	if missing := missingRequiredScopes(scopes); len(missing) > 0 {
 		return fmt.Errorf("bot scopes missing required scope(s): %s", strings.Join(missing, ","))
 	}
-	c.BotScopes = scopes
 	return nil
 }
 
@@ -208,6 +208,7 @@ func Install(cfg *Config) http.HandlerFunc {
 			http.Error(w, "could not start Slack install", http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Cache-Control", "no-store")
 		setStateCookie(w, state, cfg.now())
 		http.Redirect(w, r, authorizeURL(cfg, state), http.StatusFound)
 	}
@@ -253,9 +254,14 @@ func Callback(cfg *Config) http.HandlerFunc {
 			return
 		}
 		enterpriseID := strings.TrimSpace(resp.Enterprise.ID)
+		if resp.IsEnterpriseInstall {
+			logSlackInstallEnterpriseInstallUnsupported(resp.IsEnterpriseInstall, enterpriseID != "")
+			fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusUnprocessableEntity)
+			return
+		}
 		teamID := strings.TrimSpace(resp.Team.ID)
 		if teamID == "" {
-			if resp.IsEnterpriseInstall || enterpriseID != "" {
+			if enterpriseID != "" {
 				logSlackInstallEnterpriseInstallUnsupported(resp.IsEnterpriseInstall, enterpriseID != "")
 				fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusUnprocessableEntity)
 				return
@@ -572,6 +578,8 @@ func renderSuccess(w http.ResponseWriter, teamID string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Frame-Options", "DENY")
+	// The success page is a self-contained static HTML document. It relaxes
+	// style-src only for the inline style block above; no script is allowed.
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	slackoauth "github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
@@ -37,7 +38,8 @@ const (
 	slackAuthorizeURL          = "https://slack.com/oauth/v2/authorize"
 	stateCookieName            = "__Host-qurl-slack-install-state"
 	stateTTL                   = 10 * time.Minute
-	stateMinSecretBytes        = 32
+	stateMinSecretBytes        = slackoauth.StateMinSecret
+	stateFutureSkew            = 30 * time.Second
 	slackOAuthTimeout          = 10 * time.Second
 	persistTimeout             = 15 * time.Second
 	slackOAuthBodyLimit        = 8 << 10
@@ -216,56 +218,60 @@ func Callback(cfg *Config) http.HandlerFunc {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		fail := func(message string, code int) {
+			clearStateCookie(w)
+			http.Error(w, message, code)
+		}
 		if errParam := r.URL.Query().Get("error"); errParam != "" {
 			logSlackInstallCallbackError(safeSlackOAuthErrorCode(errParam), len(errParam))
-			clearStateCookie(w)
-			http.Error(w, "Slack install was not completed", http.StatusBadRequest)
+			fail("Slack install was not completed", http.StatusBadRequest)
 			return
 		}
 		code := strings.TrimSpace(r.URL.Query().Get("code"))
 		state := strings.TrimSpace(r.URL.Query().Get("state"))
 		if code == "" || state == "" {
-			clearStateCookie(w)
-			http.Error(w, "missing Slack install code or state", http.StatusBadRequest)
+			fail("missing Slack install code or state", http.StatusBadRequest)
 			return
 		}
 		if !verifyCookieState(r, state) {
-			clearStateCookie(w)
-			http.Error(w, "Slack install must be completed in the same browser", http.StatusBadRequest)
+			fail("Slack install must be completed in the same browser", http.StatusBadRequest)
 			return
 		}
 		if err := verifyState(cfg.StateSecret, state, cfg.now()); err != nil {
 			slog.Warn("Slack install rejected invalid state", "error", err)
-			clearStateCookie(w)
-			http.Error(w, "invalid or expired Slack install link", http.StatusBadRequest)
+			fail("invalid or expired Slack install link", http.StatusBadRequest)
 			return
 		}
 
 		resp, err := exchangeCode(r.Context(), cfg, code)
 		if err != nil {
 			slog.Error("Slack install token exchange failed", "error", err)
-			clearStateCookie(w)
-			http.Error(w, "Slack install token exchange failed", http.StatusBadGateway)
-			return
-		}
-		teamID := strings.TrimSpace(resp.Team.ID)
-		if teamID == "" {
-			logSlackInstallMissingTeamID(strings.TrimSpace(resp.AppID) != "")
-			clearStateCookie(w)
-			http.Error(w, "Slack workspace install did not include a workspace id", http.StatusBadGateway)
+			fail("Slack install token exchange failed", http.StatusBadGateway)
 			return
 		}
 		enterpriseID := strings.TrimSpace(resp.Enterprise.ID)
+		teamID := strings.TrimSpace(resp.Team.ID)
+		if teamID == "" {
+			if resp.IsEnterpriseInstall || enterpriseID != "" {
+				logSlackInstallEnterpriseInstallUnsupported(resp.IsEnterpriseInstall, enterpriseID != "")
+				fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusBadGateway)
+				return
+			}
+			logSlackInstallMissingTeamID(strings.TrimSpace(resp.AppID) != "")
+			fail("Slack workspace install did not include a workspace id", http.StatusBadGateway)
+			return
+		}
 		installedBy := strings.TrimSpace(resp.AuthedUser.ID)
 		if installedBy == "" {
 			logSlackInstallMissingAuthedUser(teamID != "")
-			clearStateCookie(w)
-			http.Error(w, "Slack workspace install did not include an installer id", http.StatusBadGateway)
+			fail("Slack workspace install did not include an installer id", http.StatusBadGateway)
 			return
 		}
 		grantedScopes := NormalizeScopes([]string{resp.Scope})
 		if missing := missingRequiredScopes(grantedScopes); len(missing) > 0 {
 			logSlackInstallMissingRequiredScopes(missing, teamID != "")
+			fail("Slack install did not grant required bot scopes", http.StatusBadGateway)
+			return
 		}
 		// Slack OAuth codes are single-use, so persist should finish even if the
 		// browser disconnects after Slack redirects back to us.
@@ -280,8 +286,7 @@ func Callback(cfg *Config) http.HandlerFunc {
 			Scopes:       grantedScopes,
 		}); err != nil {
 			logSlackInstallPersistFailed(err, teamID != "", installedBy != "")
-			clearStateCookie(w)
-			http.Error(w, "Slack install could not be stored", http.StatusInternalServerError)
+			fail("Slack install could not be stored", http.StatusInternalServerError)
 			return
 		}
 
@@ -367,7 +372,7 @@ func verifyState(secret []byte, token string, now time.Time) error {
 		return fmt.Errorf("state payload JSON: %w", err)
 	}
 	createdAt := time.Unix(payload.CreatedAtUnix, 0)
-	if now.Before(createdAt.Add(-1 * time.Minute)) {
+	if now.Before(createdAt.Add(-1 * stateFutureSkew)) {
 		return errors.New("state timestamp is in the future")
 	}
 	if now.Sub(createdAt) > stateTTL {
@@ -423,19 +428,18 @@ func verifyCookieState(r *http.Request, state string) bool {
 }
 
 type oauthAccessResponse struct {
-	OK          bool   `json:"ok"`
-	Error       string `json:"error"`
-	AccessToken string `json:"access_token"`
-	Scope       string `json:"scope"`
-	BotUserID   string `json:"bot_user_id"`
-	AppID       string `json:"app_id"`
-	Team        struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
+	OK                  bool   `json:"ok"`
+	Error               string `json:"error"`
+	AccessToken         string `json:"access_token"`
+	Scope               string `json:"scope"`
+	BotUserID           string `json:"bot_user_id"`
+	AppID               string `json:"app_id"`
+	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
+	Team                struct {
+		ID string `json:"id"`
 	} `json:"team"`
 	Enterprise struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
+		ID string `json:"id"`
 	} `json:"enterprise"`
 	AuthedUser struct {
 		ID string `json:"id"`
@@ -536,6 +540,11 @@ func logSlackInstallCallbackError(errorCode string, errorLen int) {
 
 func logSlackInstallMissingTeamID(appIDPresent bool) {
 	slog.Error("Slack install token exchange missing team id", "app_id_present", appIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
+}
+
+func logSlackInstallEnterpriseInstallUnsupported(isEnterpriseInstall, enterpriseIDPresent bool) {
+	slog.Error("Slack install rejected unsupported Enterprise Grid org install", // #nosec G706 -- only booleans are logged; no Slack string reaches the attribute.
+		"is_enterprise_install", isEnterpriseInstall, "enterprise_id_present", enterpriseIDPresent)
 }
 
 func logSlackInstallMissingAuthedUser(teamIDPresent bool) {

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -42,7 +42,7 @@ const (
 	stateFutureSkew            = 30 * time.Second
 	slackOAuthTimeout          = 10 * time.Second
 	persistTimeout             = 15 * time.Second
-	slackOAuthBodyLimit        = 8 << 10
+	slackOAuthBodyLimit        = 16 << 10
 	slackInstallFlow           = "slack-install"
 	botScopeCommands           = "commands"
 	botScopeViewsWrite         = "views:write"
@@ -87,7 +87,8 @@ type Config struct {
 	Now            func() time.Time
 	OAuthAccessURL string
 	// OnTokenStored is called after a workspace bot token is persisted. The
-	// main package uses it to evict any same-process views.open token cache.
+	// main package uses it to evict the same-process views.open token cache;
+	// sibling pods rely on the short workspace-token TTL to observe reinstalls.
 	OnTokenStored func(teamID string)
 }
 
@@ -145,6 +146,7 @@ func (c *Config) Validate() error {
 	if missing := missingRequiredScopes(scopes); len(missing) > 0 {
 		return fmt.Errorf("bot scopes missing required scope(s): %s", strings.Join(missing, ","))
 	}
+	c.BotScopes = scopes
 	return nil
 }
 
@@ -308,7 +310,7 @@ func authorizeURL(cfg *Config, state string) string {
 	u := *slackAuthorizeBaseURL
 	q := u.Query()
 	q.Set("client_id", strings.TrimSpace(cfg.ClientID))
-	q.Set("scope", strings.Join(NormalizeScopes(cfg.BotScopes), ","))
+	q.Set("scope", strings.Join(cfg.BotScopes, ","))
 	q.Set("redirect_uri", callbackURL(cfg.SlackBaseURL))
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
@@ -324,11 +326,7 @@ func mustParseSlackAuthorizeURL() *url.URL {
 }
 
 func callbackURL(baseURL string) string {
-	u, err := url.JoinPath(strings.TrimRight(baseURL, "/"), CallbackPath)
-	if err != nil {
-		return strings.TrimRight(baseURL, "/") + CallbackPath
-	}
-	return u
+	return strings.TrimRight(baseURL, "/") + CallbackPath
 }
 
 type statePayload struct {
@@ -399,6 +397,8 @@ func signState(secret []byte, body string) string {
 }
 
 func setStateCookie(w http.ResponseWriter, state string, now time.Time) {
+	// A second install tab intentionally clobbers the first tab's cookie; the
+	// first callback then fails CSRF instead of completing an older state.
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
 		Value:    state,

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -44,6 +44,7 @@ const (
 	slackInstallFlow           = "slack-install"
 	botScopeCommands           = "commands"
 	botScopeViewsWrite         = "views:write"
+	slackOAuthErrorUnknown     = "unrecognized"
 )
 
 var successTemplate = template.Must(template.New("slack-install-success").Parse(`<!DOCTYPE html>
@@ -68,6 +69,8 @@ code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 </div>
 </body>
 </html>`))
+
+var slackAuthorizeBaseURL = mustParseSlackAuthorizeURL()
 
 // Config holds the Slack app OAuth installation settings.
 type Config struct {
@@ -118,8 +121,11 @@ func (c *Config) Validate() error {
 	if strings.TrimSpace(c.SlackBaseURL) == "" {
 		return errors.New("slack base URL is required")
 	}
-	if !strings.HasPrefix(c.SlackBaseURL, "https://") {
-		return fmt.Errorf("slack base URL must be https:// (got %q)", c.SlackBaseURL)
+	baseURL, err := url.Parse(strings.TrimSpace(c.SlackBaseURL))
+	if err != nil || baseURL.Scheme != "https" || baseURL.Host == "" ||
+		strings.TrimRight(baseURL.Path, "/") != "" || baseURL.RawQuery != "" ||
+		baseURL.Fragment != "" || baseURL.User != nil {
+		return fmt.Errorf("slack base URL must be a bare https:// origin with no path/query/userinfo (got %q)", c.SlackBaseURL)
 	}
 	if len(c.StateSecret) < stateMinSecretBytes {
 		return fmt.Errorf("state secret must be at least %d bytes", stateMinSecretBytes)
@@ -211,7 +217,7 @@ func Callback(cfg *Config) http.HandlerFunc {
 			return
 		}
 		if errParam := r.URL.Query().Get("error"); errParam != "" {
-			logSlackInstallCallbackError(len(errParam))
+			logSlackInstallCallbackError(safeSlackOAuthErrorCode(errParam), len(errParam))
 			clearStateCookie(w)
 			http.Error(w, "Slack install was not completed", http.StatusBadRequest)
 			return
@@ -251,6 +257,12 @@ func Callback(cfg *Config) http.HandlerFunc {
 		}
 		enterpriseID := strings.TrimSpace(resp.Enterprise.ID)
 		installedBy := strings.TrimSpace(resp.AuthedUser.ID)
+		if installedBy == "" {
+			logSlackInstallMissingAuthedUser(teamID != "")
+			clearStateCookie(w)
+			http.Error(w, "Slack workspace install did not include an installer id", http.StatusBadGateway)
+			return
+		}
 		persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
 		defer persistCancel()
 		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, &auth.SlackBotTokenInstall{
@@ -277,7 +289,7 @@ func Callback(cfg *Config) http.HandlerFunc {
 }
 
 func authorizeURL(cfg *Config, state string) string {
-	u, _ := url.Parse(slackAuthorizeURL)
+	u := *slackAuthorizeBaseURL
 	q := u.Query()
 	q.Set("client_id", strings.TrimSpace(cfg.ClientID))
 	q.Set("scope", strings.Join(NormalizeScopes(cfg.BotScopes), ","))
@@ -285,6 +297,14 @@ func authorizeURL(cfg *Config, state string) string {
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	return u.String()
+}
+
+func mustParseSlackAuthorizeURL() *url.URL {
+	u, err := url.Parse(slackAuthorizeURL)
+	if err != nil {
+		panic("slackinstall: invalid Slack authorize URL constant: " + err.Error())
+	}
+	return u
 }
 
 func callbackURL(baseURL string) string {
@@ -484,12 +504,32 @@ func NormalizeScopes(scopes []string) []string {
 	return out
 }
 
-func logSlackInstallCallbackError(errorLen int) {
-	slog.Warn("Slack install callback returned error", "error_len", errorLen) // #nosec G706 -- only a length is logged; no request string reaches the attribute.
+func safeSlackOAuthErrorCode(raw string) string {
+	code := strings.TrimSpace(raw)
+	switch code {
+	case "access_denied",
+		"bad_redirect_uri",
+		"invalid_client_id",
+		"invalid_redirect_uri",
+		"invalid_scope",
+		"invalid_state",
+		"invalid_team_for_non_distributed_app":
+		return code
+	default:
+		return slackOAuthErrorUnknown
+	}
+}
+
+func logSlackInstallCallbackError(errorCode string, errorLen int) {
+	slog.Warn("Slack install callback returned error", "error", errorCode, "error_len", errorLen) // #nosec G706 -- error is allowlisted by safeSlackOAuthErrorCode before logging.
 }
 
 func logSlackInstallMissingTeamID(appIDPresent bool) {
 	slog.Error("Slack install token exchange missing team id", "app_id_present", appIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
+}
+
+func logSlackInstallMissingAuthedUser(teamIDPresent bool) {
+	slog.Error("Slack install token exchange missing authed user id", "team_id_present", teamIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
 }
 
 func logSlackInstallPersistFailed(err error, teamIDPresent, installedByPresent bool) {

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -34,19 +34,19 @@ const (
 	// CallbackPath receives Slack's OAuth redirect after app installation.
 	CallbackPath = "/oauth/slack/callback"
 
-	defaultSlackOAuthAccessURL = "https://slack.com/api/oauth.v2.access"
-	slackAuthorizeURL          = "https://slack.com/oauth/v2/authorize"
-	stateCookieName            = "__Host-qurl-slack-install-state"
-	stateTTL                   = 10 * time.Minute
-	stateMinSecretBytes        = slackoauth.StateMinSecret
-	stateFutureSkew            = 30 * time.Second
-	slackOAuthTimeout          = 10 * time.Second
-	persistTimeout             = 15 * time.Second
-	slackOAuthBodyLimit        = 16 << 10
-	slackInstallFlow           = "slack-install"
-	botScopeCommands           = "commands"
-	botScopeViewsWrite         = "views:write"
-	slackOAuthErrorUnknown     = "unrecognized"
+	defaultSlackOAuthAccessURL  = "https://slack.com/api/oauth.v2.access"
+	slackAuthorizeURL           = "https://slack.com/oauth/v2/authorize"
+	stateCookieName             = "__Host-qurl-slack-install-state"
+	stateTTL                    = 10 * time.Minute
+	stateMinSecretBytes         = slackoauth.StateMinSecret
+	stateFutureSkew             = 30 * time.Second
+	slackOAuthTimeout           = 10 * time.Second
+	persistTimeout              = 15 * time.Second
+	slackOAuthBodyLimit         = 16 << 10
+	slackInstallFlow            = "slack-install"
+	botScopeCommands            = "commands"
+	botScopeViewsWrite          = "views:write"
+	slackOAuthErrorUnrecognized = "unrecognized"
 )
 
 var successTemplate = template.Must(template.New("slack-install-success").Parse(`<!DOCTYPE html>
@@ -299,11 +299,10 @@ func Callback(cfg *Config) http.HandlerFunc {
 			fail("Slack install could not be stored", http.StatusInternalServerError)
 			return
 		}
+		clearStateCookie(w)
 		if cfg.OnTokenStored != nil {
 			cfg.OnTokenStored(teamID)
 		}
-
-		clearStateCookie(w)
 		slog.Info("Slack app install stored workspace bot token", // #nosec G706 -- Slack IDs are structured slog attributes; JSON handlers escape control bytes.
 			"team_id", teamID, "installed_by", installedBy,
 			"bot_user_id", resp.BotUserID, "app_id", resp.AppID,
@@ -482,6 +481,7 @@ func exchangeCode(ctx context.Context, cfg *Config, code string) (*oauthAccessRe
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if len(raw) > slackOAuthBodyLimit {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, fmt.Errorf("response exceeded %d bytes", slackOAuthBodyLimit)
 	}
 	if resp.StatusCode >= 300 {
@@ -541,7 +541,7 @@ func safeSlackOAuthErrorCode(raw string) string {
 		"invalid_team_for_non_distributed_app":
 		return code
 	default:
-		return slackOAuthErrorUnknown
+		return slackOAuthErrorUnrecognized
 	}
 }
 

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -44,6 +44,8 @@ const (
 	slackInstallFlow           = "slack-install"
 	botScopeCommands           = "commands"
 	botScopeViewsWrite         = "views:write"
+	slackBotTokenMinBytes      = 30
+	slackBotTokenMaxBytes      = 1024
 	slackOAuthErrorUnknown     = "unrecognized"
 )
 
@@ -263,6 +265,8 @@ func Callback(cfg *Config) http.HandlerFunc {
 			http.Error(w, "Slack workspace install did not include an installer id", http.StatusBadGateway)
 			return
 		}
+		// Slack OAuth codes are single-use, so persist should finish even if the
+		// browser disconnects after Slack redirects back to us.
 		persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
 		defer persistCancel()
 		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, &auth.SlackBotTokenInstall{
@@ -479,6 +483,9 @@ func exchangeCode(ctx context.Context, cfg *Config, code string) (*oauthAccessRe
 	if strings.TrimSpace(out.AccessToken) == "" {
 		return nil, errors.New("slack oauth.v2.access returned empty access_token")
 	}
+	if err := validateSlackOAuthBotTokenShape(out.AccessToken); err != nil {
+		return nil, fmt.Errorf("slack oauth.v2.access returned invalid access_token: %w", err)
+	}
 	return &out, nil
 }
 
@@ -518,6 +525,25 @@ func safeSlackOAuthErrorCode(raw string) string {
 	default:
 		return slackOAuthErrorUnknown
 	}
+}
+
+func validateSlackOAuthBotTokenShape(token string) error {
+	if len(token) < slackBotTokenMinBytes {
+		return fmt.Errorf("token shorter than %d bytes", slackBotTokenMinBytes)
+	}
+	if len(token) > slackBotTokenMaxBytes {
+		return fmt.Errorf("token longer than %d bytes", slackBotTokenMaxBytes)
+	}
+	if !strings.HasPrefix(token, "xoxb-") && !strings.HasPrefix(token, "xoxe.xoxb-") {
+		return errors.New("token must start with xoxb- or xoxe.xoxb-")
+	}
+	for i, b := range []byte(token) {
+		if b >= '!' && b <= '~' {
+			continue
+		}
+		return fmt.Errorf("token contains invalid characters near byte %d", i)
+	}
+	return nil
 }
 
 func logSlackInstallCallbackError(errorCode string, errorLen int) {

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -86,6 +86,9 @@ type Config struct {
 	// Now is injected for test-time clock pinning. Nil uses time.Now.
 	Now            func() time.Time
 	OAuthAccessURL string
+	// OnTokenStored is called after a workspace bot token is persisted. The
+	// main package uses it to evict any same-process views.open token cache.
+	OnTokenStored func(teamID string)
 }
 
 // TokenStore persists the Slack-issued workspace bot token.
@@ -191,7 +194,6 @@ func (c *Config) oauthAccessURL() string {
 
 // Install starts the Slack app OAuth installation flow.
 func Install(cfg *Config) http.HandlerFunc {
-	cfg.ensureHTTPClient()
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
@@ -211,7 +213,6 @@ func Install(cfg *Config) http.HandlerFunc {
 
 // Callback exchanges Slack's OAuth code and stores the workspace bot token.
 func Callback(cfg *Config) http.HandlerFunc {
-	cfg.ensureHTTPClient()
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
@@ -254,28 +255,29 @@ func Callback(cfg *Config) http.HandlerFunc {
 		if teamID == "" {
 			if resp.IsEnterpriseInstall || enterpriseID != "" {
 				logSlackInstallEnterpriseInstallUnsupported(resp.IsEnterpriseInstall, enterpriseID != "")
-				fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusBadGateway)
+				fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusUnprocessableEntity)
 				return
 			}
 			logSlackInstallMissingTeamID(strings.TrimSpace(resp.AppID) != "")
-			fail("Slack workspace install did not include a workspace id", http.StatusBadGateway)
+			fail("Slack workspace install did not include a workspace id", http.StatusUnprocessableEntity)
 			return
 		}
 		installedBy := strings.TrimSpace(resp.AuthedUser.ID)
 		if installedBy == "" {
 			logSlackInstallMissingAuthedUser(teamID != "")
-			fail("Slack workspace install did not include an installer id", http.StatusBadGateway)
+			fail("Slack workspace install did not include an installer id", http.StatusUnprocessableEntity)
 			return
 		}
 		grantedScopes := NormalizeScopes([]string{resp.Scope})
 		if missing := missingRequiredScopes(grantedScopes); len(missing) > 0 {
 			logSlackInstallMissingRequiredScopes(missing, teamID != "")
-			fail("Slack install did not grant required bot scopes", http.StatusBadGateway)
+			fail("Slack install did not grant required bot scopes", http.StatusUnprocessableEntity)
 			return
 		}
 		// Slack OAuth codes are single-use, so persist should finish even if the
-		// browser disconnects after Slack redirects back to us.
-		persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
+		// browser disconnects after Slack redirects back to us. WithoutCancel
+		// keeps request-scoped values for tracing while detaching client cancel.
+		persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(r.Context()), persistTimeout)
 		defer persistCancel()
 		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, &auth.SlackBotTokenInstall{
 			BotToken:     resp.AccessToken,
@@ -288,6 +290,9 @@ func Callback(cfg *Config) http.HandlerFunc {
 			logSlackInstallPersistFailed(err, teamID != "", installedBy != "")
 			fail("Slack install could not be stored", http.StatusInternalServerError)
 			return
+		}
+		if cfg.OnTokenStored != nil {
+			cfg.OnTokenStored(teamID)
 		}
 
 		clearStateCookie(w)

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -1,0 +1,477 @@
+// Package slackinstall implements the Slack app OAuth installation flow.
+//
+// This is distinct from apps/slack/internal/oauth, which connects an already
+// installed Slack workspace to a qURL account through Auth0. This package
+// captures the Slack-issued bot token for each customer workspace so Web API
+// calls such as views.open can be made with the token that belongs to the
+// workspace that invoked the slash command.
+package slackinstall
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+const (
+	InstallPath  = "/oauth/slack/install"
+	CallbackPath = "/oauth/slack/callback"
+
+	defaultSlackOAuthAccessURL = "https://slack.com/api/oauth.v2.access"
+	slackAuthorizeURL          = "https://slack.com/oauth/v2/authorize"
+	stateCookieName            = "__Host-qurl-slack-install-state"
+	stateTTL                   = 10 * time.Minute
+	stateMinSecretBytes        = 32
+	slackOAuthTimeout          = 10 * time.Second
+	persistTimeout             = 15 * time.Second
+	slackOAuthBodyLimit        = 8 << 10
+)
+
+var successTemplate = template.Must(template.New("slack-install-success").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>qURL Slack Installed</title>
+<meta name="robots" content="noindex">
+<style>
+body{font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;color:#111}
+.card{border:1px solid #d1d5db;border-radius:12px;padding:2rem;background:#f9fafb}
+h1{margin:0 0 .5rem;font-size:1.5rem}
+code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
+.ok{color:#059669;font-weight:600}
+</style>
+</head>
+<body>
+<div class="card">
+<h1><span class="ok">&#10003;</span> qURL Slack app installed</h1>
+<p>Guided tunnel setup is enabled for this workspace. Return to Slack and run <code>/qurl tunnel install</code>.</p>
+<p>Workspace: <code>{{.TeamID}}</code></p>
+</div>
+</body>
+</html>`))
+
+type Config struct {
+	ClientID       string
+	ClientSecret   string
+	SlackBaseURL   string
+	StateSecret    []byte
+	BotScopes      []string
+	TokenStore     TokenStore
+	HTTPClient     *http.Client
+	Now            func() time.Time
+	OAuthAccessURL string
+}
+
+type TokenStore interface {
+	SetSlackBotToken(ctx context.Context, workspaceID string, install auth.SlackBotTokenInstall) error
+}
+
+func DefaultBotScopes() []string {
+	return []string{"commands", "views:write"}
+}
+
+func RegisterRoutes(mux *http.ServeMux, cfg Config) {
+	if err := cfg.Validate(); err != nil {
+		panic("slackinstall.RegisterRoutes: " + err.Error())
+	}
+	mux.HandleFunc(InstallPath, Install(cfg))
+	mux.HandleFunc(CallbackPath, Callback(cfg))
+}
+
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.ClientID) == "" {
+		return errors.New("ClientID is required")
+	}
+	if strings.TrimSpace(c.ClientSecret) == "" {
+		return errors.New("ClientSecret is required")
+	}
+	if strings.TrimSpace(c.SlackBaseURL) == "" {
+		return errors.New("SlackBaseURL is required")
+	}
+	if !strings.HasPrefix(c.SlackBaseURL, "https://") {
+		return fmt.Errorf("SlackBaseURL must be https:// (got %q)", c.SlackBaseURL)
+	}
+	if len(c.StateSecret) < stateMinSecretBytes {
+		return fmt.Errorf("StateSecret must be at least %d bytes", stateMinSecretBytes)
+	}
+	if c.TokenStore == nil {
+		return errors.New("TokenStore is required")
+	}
+	scopes := normalizeScopes(c.BotScopes)
+	if len(scopes) == 0 {
+		return errors.New("at least one bot scope is required")
+	}
+	if missing := missingRequiredScopes(scopes); len(missing) > 0 {
+		return fmt.Errorf("bot scopes missing required scope(s): %s", strings.Join(missing, ","))
+	}
+	return nil
+}
+
+func missingRequiredScopes(scopes []string) []string {
+	have := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		have[scope] = struct{}{}
+	}
+	var missing []string
+	for _, scope := range DefaultBotScopes() {
+		if _, ok := have[scope]; !ok {
+			missing = append(missing, scope)
+		}
+	}
+	return missing
+}
+
+func (c Config) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func (c Config) client() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{
+		Timeout: slackOAuthTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (c Config) oauthAccessURL() string {
+	if strings.TrimSpace(c.OAuthAccessURL) != "" {
+		return strings.TrimSpace(c.OAuthAccessURL)
+	}
+	return defaultSlackOAuthAccessURL
+}
+
+func Install(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		state, err := mintState(cfg.StateSecret, cfg.now())
+		if err != nil {
+			slog.Error("slack install state mint failed", "error", err)
+			http.Error(w, "could not start Slack install", http.StatusInternalServerError)
+			return
+		}
+		setStateCookie(w, state, cfg.now())
+		http.Redirect(w, r, authorizeURL(cfg, state), http.StatusFound)
+	}
+}
+
+func Callback(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if errParam := r.URL.Query().Get("error"); errParam != "" {
+			slog.Warn("Slack install callback returned error", "error", errParam)
+			clearStateCookie(w)
+			http.Error(w, "Slack install was not completed", http.StatusBadRequest)
+			return
+		}
+		code := strings.TrimSpace(r.URL.Query().Get("code"))
+		state := strings.TrimSpace(r.URL.Query().Get("state"))
+		if code == "" || state == "" {
+			clearStateCookie(w)
+			http.Error(w, "missing Slack install code or state", http.StatusBadRequest)
+			return
+		}
+		if !verifyCookieState(r, state) {
+			clearStateCookie(w)
+			http.Error(w, "Slack install must be completed in the same browser", http.StatusBadRequest)
+			return
+		}
+		if err := verifyState(cfg.StateSecret, state, cfg.now()); err != nil {
+			slog.Warn("Slack install rejected invalid state", "error", err)
+			clearStateCookie(w)
+			http.Error(w, "invalid or expired Slack install link", http.StatusBadRequest)
+			return
+		}
+
+		resp, err := exchangeCode(r.Context(), cfg, code)
+		if err != nil {
+			slog.Error("Slack install token exchange failed", "error", err)
+			clearStateCookie(w)
+			http.Error(w, "Slack install token exchange failed", http.StatusBadGateway)
+			return
+		}
+		teamID := strings.TrimSpace(resp.Team.ID)
+		if teamID == "" {
+			slog.Error("Slack install token exchange missing team id", "app_id", resp.AppID)
+			clearStateCookie(w)
+			http.Error(w, "Slack workspace install did not include a workspace id", http.StatusBadGateway)
+			return
+		}
+		enterpriseID := strings.TrimSpace(resp.Enterprise.ID)
+		installedBy := strings.TrimSpace(resp.AuthedUser.ID)
+		persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
+		defer persistCancel()
+		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, auth.SlackBotTokenInstall{
+			BotToken:     resp.AccessToken,
+			InstalledBy:  installedBy,
+			BotUserID:    resp.BotUserID,
+			AppID:        resp.AppID,
+			EnterpriseID: enterpriseID,
+			Scopes:       splitSlackScopes(resp.Scope),
+		}); err != nil {
+			slog.Error("Slack install token persist failed",
+				"error", err, "team_id", teamID, "installed_by", installedBy)
+			clearStateCookie(w)
+			http.Error(w, "Slack install could not be stored", http.StatusInternalServerError)
+			return
+		}
+
+		clearStateCookie(w)
+		slog.Info("Slack app install stored workspace bot token",
+			"team_id", teamID, "installed_by", installedBy,
+			"bot_user_id", resp.BotUserID, "app_id", resp.AppID,
+			"enterprise_id", enterpriseID)
+		renderSuccess(w, teamID)
+	}
+}
+
+func authorizeURL(cfg Config, state string) string {
+	u, _ := url.Parse(slackAuthorizeURL)
+	q := u.Query()
+	q.Set("client_id", strings.TrimSpace(cfg.ClientID))
+	q.Set("scope", strings.Join(normalizeScopes(cfg.BotScopes), ","))
+	q.Set("redirect_uri", callbackURL(cfg.SlackBaseURL))
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func callbackURL(baseURL string) string {
+	u, err := url.JoinPath(strings.TrimRight(baseURL, "/"), CallbackPath)
+	if err != nil {
+		return strings.TrimRight(baseURL, "/") + CallbackPath
+	}
+	return u
+}
+
+type statePayload struct {
+	Nonce         string `json:"nonce"`
+	CreatedAtUnix int64  `json:"created_at_unix"`
+}
+
+func mintState(secret []byte, now time.Time) (string, error) {
+	nonce := make([]byte, 24)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(statePayload{
+		Nonce:         base64.RawURLEncoding.EncodeToString(nonce),
+		CreatedAtUnix: now.UTC().Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	sig := signState(secret, body)
+	return body + "." + sig, nil
+}
+
+func verifyState(secret []byte, token string, now time.Time) error {
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return errors.New("malformed state")
+	}
+	wantSig := signState(secret, parts[0])
+	if !hmac.Equal([]byte(parts[1]), []byte(wantSig)) {
+		return errors.New("state signature mismatch")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return fmt.Errorf("state payload decode: %w", err)
+	}
+	var payload statePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return fmt.Errorf("state payload JSON: %w", err)
+	}
+	createdAt := time.Unix(payload.CreatedAtUnix, 0)
+	if now.Before(createdAt.Add(-1 * time.Minute)) {
+		return errors.New("state timestamp is in the future")
+	}
+	if now.Sub(createdAt) > stateTTL {
+		return errors.New("state expired")
+	}
+	if payload.Nonce == "" {
+		return errors.New("state nonce is empty")
+	}
+	return nil
+}
+
+func signState(secret []byte, body string) string {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(body))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func setStateCookie(w http.ResponseWriter, state string, now time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    state,
+		Path:     "/",
+		Expires:  now.Add(stateTTL),
+		MaxAge:   int(stateTTL.Seconds()),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func clearStateCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func verifyCookieState(r *http.Request, state string) bool {
+	cookie, err := r.Cookie(stateCookieName)
+	if err != nil {
+		return false
+	}
+	return hmac.Equal([]byte(cookie.Value), []byte(state))
+}
+
+type oauthAccessResponse struct {
+	OK          bool   `json:"ok"`
+	Error       string `json:"error"`
+	AccessToken string `json:"access_token"`
+	Scope       string `json:"scope"`
+	BotUserID   string `json:"bot_user_id"`
+	AppID       string `json:"app_id"`
+	Team        struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"team"`
+	Enterprise struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"enterprise"`
+	AuthedUser struct {
+		ID string `json:"id"`
+	} `json:"authed_user"`
+}
+
+func exchangeCode(ctx context.Context, cfg Config, code string) (*oauthAccessResponse, error) {
+	form := url.Values{}
+	form.Set("client_id", strings.TrimSpace(cfg.ClientID))
+	form.Set("client_secret", strings.TrimSpace(cfg.ClientSecret))
+	form.Set("code", code)
+	form.Set("redirect_uri", callbackURL(cfg.SlackBaseURL))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.oauthAccessURL(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := cfg.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackOAuthBodyLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if len(raw) > slackOAuthBodyLimit {
+		return nil, fmt.Errorf("response exceeded %d bytes", slackOAuthBodyLimit)
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, responseSnippet(raw))
+	}
+	var out oauthAccessResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if !out.OK {
+		code := strings.TrimSpace(out.Error)
+		if code == "" {
+			code = "not_ok"
+		}
+		return nil, fmt.Errorf("Slack oauth.v2.access: %s", code)
+	}
+	if strings.TrimSpace(out.AccessToken) == "" {
+		return nil, errors.New("Slack oauth.v2.access returned empty access_token")
+	}
+	return &out, nil
+}
+
+func responseSnippet(raw []byte) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) > 200 {
+		raw = append(raw[:197], '.', '.', '.')
+	}
+	return strings.ToValidUTF8(string(raw), "\uFFFD")
+}
+
+func normalizeScopes(scopes []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		for _, part := range strings.Split(scope, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if _, ok := seen[part]; ok {
+				continue
+			}
+			seen[part] = struct{}{}
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func splitSlackScopes(scope string) []string {
+	return normalizeScopes(strings.FieldsFunc(scope, func(r rune) bool {
+		return r == ',' || r == ' '
+	}))
+}
+
+func renderSuccess(w http.ResponseWriter, teamID string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if err := successTemplate.Execute(w, struct{ TeamID string }{TeamID: teamID}); err != nil {
+		slog.Warn("Slack install success page write failed", "error", err)
+	}
+}

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -44,8 +44,6 @@ const (
 	slackInstallFlow           = "slack-install"
 	botScopeCommands           = "commands"
 	botScopeViewsWrite         = "views:write"
-	slackBotTokenMinBytes      = 30
-	slackBotTokenMaxBytes      = 1024
 	slackOAuthErrorUnknown     = "unrecognized"
 )
 
@@ -265,6 +263,10 @@ func Callback(cfg *Config) http.HandlerFunc {
 			http.Error(w, "Slack workspace install did not include an installer id", http.StatusBadGateway)
 			return
 		}
+		grantedScopes := NormalizeScopes([]string{resp.Scope})
+		if missing := missingRequiredScopes(grantedScopes); len(missing) > 0 {
+			logSlackInstallMissingRequiredScopes(missing, teamID != "")
+		}
 		// Slack OAuth codes are single-use, so persist should finish even if the
 		// browser disconnects after Slack redirects back to us.
 		persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
@@ -275,7 +277,7 @@ func Callback(cfg *Config) http.HandlerFunc {
 			BotUserID:    resp.BotUserID,
 			AppID:        resp.AppID,
 			EnterpriseID: enterpriseID,
-			Scopes:       NormalizeScopes([]string{resp.Scope}),
+			Scopes:       grantedScopes,
 		}); err != nil {
 			logSlackInstallPersistFailed(err, teamID != "", installedBy != "")
 			clearStateCookie(w)
@@ -404,6 +406,7 @@ func clearStateCookie(w http.ResponseWriter) {
 		Name:     stateCookieName,
 		Value:    "",
 		Path:     "/",
+		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
 		Secure:   true,
 		HttpOnly: true,
@@ -483,7 +486,7 @@ func exchangeCode(ctx context.Context, cfg *Config, code string) (*oauthAccessRe
 	if strings.TrimSpace(out.AccessToken) == "" {
 		return nil, errors.New("slack oauth.v2.access returned empty access_token")
 	}
-	if err := validateSlackOAuthBotTokenShape(out.AccessToken); err != nil {
+	if err := auth.ValidateSlackBotTokenShape(out.AccessToken); err != nil {
 		return nil, fmt.Errorf("slack oauth.v2.access returned invalid access_token: %w", err)
 	}
 	return &out, nil
@@ -527,25 +530,6 @@ func safeSlackOAuthErrorCode(raw string) string {
 	}
 }
 
-func validateSlackOAuthBotTokenShape(token string) error {
-	if len(token) < slackBotTokenMinBytes {
-		return fmt.Errorf("token shorter than %d bytes", slackBotTokenMinBytes)
-	}
-	if len(token) > slackBotTokenMaxBytes {
-		return fmt.Errorf("token longer than %d bytes", slackBotTokenMaxBytes)
-	}
-	if !strings.HasPrefix(token, "xoxb-") && !strings.HasPrefix(token, "xoxe.xoxb-") {
-		return errors.New("token must start with xoxb- or xoxe.xoxb-")
-	}
-	for i, b := range []byte(token) {
-		if b >= '!' && b <= '~' {
-			continue
-		}
-		return fmt.Errorf("token contains invalid characters near byte %d", i)
-	}
-	return nil
-}
-
 func logSlackInstallCallbackError(errorCode string, errorLen int) {
 	slog.Warn("Slack install callback returned error", "error", errorCode, "error_len", errorLen) // #nosec G706 -- error is allowlisted by safeSlackOAuthErrorCode before logging.
 }
@@ -561,6 +545,11 @@ func logSlackInstallMissingAuthedUser(teamIDPresent bool) {
 func logSlackInstallPersistFailed(err error, teamIDPresent, installedByPresent bool) {
 	slog.Error("Slack install token persist failed", // #nosec G706 -- only booleans plus the storage error are logged.
 		"error", err, "team_id_present", teamIDPresent, "installed_by_present", installedByPresent)
+}
+
+func logSlackInstallMissingRequiredScopes(missing []string, teamIDPresent bool) {
+	slog.Warn("Slack install token exchange missing required bot scope(s)", // #nosec G706 -- missing scopes come from DefaultBotScopes constants.
+		"missing_scopes", strings.Join(missing, ","), "team_id_present", teamIDPresent)
 }
 
 func renderSuccess(w http.ResponseWriter, teamID string) {

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -8,7 +8,6 @@
 package slackinstall
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/rand"
@@ -29,7 +28,9 @@ import (
 )
 
 const (
-	InstallPath  = "/oauth/slack/install"
+	// InstallPath starts Slack app installation for customer workspaces.
+	InstallPath = "/oauth/slack/install"
+	// CallbackPath receives Slack's OAuth redirect after app installation.
 	CallbackPath = "/oauth/slack/callback"
 
 	defaultSlackOAuthAccessURL = "https://slack.com/api/oauth.v2.access"
@@ -40,6 +41,9 @@ const (
 	slackOAuthTimeout          = 10 * time.Second
 	persistTimeout             = 15 * time.Second
 	slackOAuthBodyLimit        = 8 << 10
+	slackInstallFlow           = "slack-install"
+	botScopeCommands           = "commands"
+	botScopeViewsWrite         = "views:write"
 )
 
 var successTemplate = template.Must(template.New("slack-install-success").Parse(`<!DOCTYPE html>
@@ -65,54 +69,65 @@ code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 </body>
 </html>`))
 
+// Config holds the Slack app OAuth installation settings.
 type Config struct {
-	ClientID       string
-	ClientSecret   string
-	SlackBaseURL   string
-	StateSecret    []byte
-	BotScopes      []string
-	TokenStore     TokenStore
-	HTTPClient     *http.Client
+	ClientID     string
+	ClientSecret string
+	SlackBaseURL string
+	StateSecret  []byte
+	BotScopes    []string
+	TokenStore   TokenStore
+	HTTPClient   *http.Client
+	// Now is injected for test-time clock pinning. Nil uses time.Now.
 	Now            func() time.Time
 	OAuthAccessURL string
 }
 
+// TokenStore persists the Slack-issued workspace bot token.
 type TokenStore interface {
-	SetSlackBotToken(ctx context.Context, workspaceID string, install auth.SlackBotTokenInstall) error
+	SetSlackBotToken(ctx context.Context, workspaceID string, install *auth.SlackBotTokenInstall) error
 }
 
+// DefaultBotScopes returns the minimum Slack bot scopes needed by qURL.
 func DefaultBotScopes() []string {
-	return []string{"commands", "views:write"}
+	return []string{botScopeCommands, botScopeViewsWrite}
 }
 
-func RegisterRoutes(mux *http.ServeMux, cfg Config) {
-	if err := cfg.Validate(); err != nil {
-		panic("slackinstall.RegisterRoutes: " + err.Error())
+// RegisterRoutes wires the Slack install OAuth endpoints onto mux.
+func RegisterRoutes(mux *http.ServeMux, cfg *Config) error {
+	if cfg == nil {
+		return errors.New("config is required")
 	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	cfg.ensureHTTPClient()
 	mux.HandleFunc(InstallPath, Install(cfg))
 	mux.HandleFunc(CallbackPath, Callback(cfg))
+	return nil
 }
 
-func (c Config) Validate() error {
+// Validate checks that cfg can safely serve the Slack install flow.
+func (c *Config) Validate() error {
 	if strings.TrimSpace(c.ClientID) == "" {
-		return errors.New("ClientID is required")
+		return errors.New("client ID is required")
 	}
 	if strings.TrimSpace(c.ClientSecret) == "" {
-		return errors.New("ClientSecret is required")
+		return errors.New("client secret is required")
 	}
 	if strings.TrimSpace(c.SlackBaseURL) == "" {
-		return errors.New("SlackBaseURL is required")
+		return errors.New("slack base URL is required")
 	}
 	if !strings.HasPrefix(c.SlackBaseURL, "https://") {
-		return fmt.Errorf("SlackBaseURL must be https:// (got %q)", c.SlackBaseURL)
+		return fmt.Errorf("slack base URL must be https:// (got %q)", c.SlackBaseURL)
 	}
 	if len(c.StateSecret) < stateMinSecretBytes {
-		return fmt.Errorf("StateSecret must be at least %d bytes", stateMinSecretBytes)
+		return fmt.Errorf("state secret must be at least %d bytes", stateMinSecretBytes)
 	}
 	if c.TokenStore == nil {
-		return errors.New("TokenStore is required")
+		return errors.New("token store is required")
 	}
-	scopes := normalizeScopes(c.BotScopes)
+	scopes := NormalizeScopes(c.BotScopes)
 	if len(scopes) == 0 {
 		return errors.New("at least one bot scope is required")
 	}
@@ -136,33 +151,39 @@ func missingRequiredScopes(scopes []string) []string {
 	return missing
 }
 
-func (c Config) now() time.Time {
+func (c *Config) now() time.Time {
 	if c.Now != nil {
 		return c.Now()
 	}
 	return time.Now()
 }
 
-func (c Config) client() *http.Client {
-	if c.HTTPClient != nil {
-		return c.HTTPClient
-	}
-	return &http.Client{
-		Timeout: slackOAuthTimeout,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+func (c *Config) ensureHTTPClient() {
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{
+			Timeout: slackOAuthTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
 	}
 }
 
-func (c Config) oauthAccessURL() string {
+func (c *Config) client() *http.Client {
+	c.ensureHTTPClient()
+	return c.HTTPClient
+}
+
+func (c *Config) oauthAccessURL() string {
 	if strings.TrimSpace(c.OAuthAccessURL) != "" {
 		return strings.TrimSpace(c.OAuthAccessURL)
 	}
 	return defaultSlackOAuthAccessURL
 }
 
-func Install(cfg Config) http.HandlerFunc {
+// Install starts the Slack app OAuth installation flow.
+func Install(cfg *Config) http.HandlerFunc {
+	cfg.ensureHTTPClient()
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
@@ -180,7 +201,9 @@ func Install(cfg Config) http.HandlerFunc {
 	}
 }
 
-func Callback(cfg Config) http.HandlerFunc {
+// Callback exchanges Slack's OAuth code and stores the workspace bot token.
+func Callback(cfg *Config) http.HandlerFunc {
+	cfg.ensureHTTPClient()
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
@@ -188,7 +211,7 @@ func Callback(cfg Config) http.HandlerFunc {
 			return
 		}
 		if errParam := r.URL.Query().Get("error"); errParam != "" {
-			slog.Warn("Slack install callback returned error", "error", errParam)
+			logSlackInstallCallbackError(len(errParam))
 			clearStateCookie(w)
 			http.Error(w, "Slack install was not completed", http.StatusBadRequest)
 			return
@@ -221,7 +244,7 @@ func Callback(cfg Config) http.HandlerFunc {
 		}
 		teamID := strings.TrimSpace(resp.Team.ID)
 		if teamID == "" {
-			slog.Error("Slack install token exchange missing team id", "app_id", resp.AppID)
+			logSlackInstallMissingTeamID(strings.TrimSpace(resp.AppID) != "")
 			clearStateCookie(w)
 			http.Error(w, "Slack workspace install did not include a workspace id", http.StatusBadGateway)
 			return
@@ -230,23 +253,22 @@ func Callback(cfg Config) http.HandlerFunc {
 		installedBy := strings.TrimSpace(resp.AuthedUser.ID)
 		persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
 		defer persistCancel()
-		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, auth.SlackBotTokenInstall{
+		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, &auth.SlackBotTokenInstall{
 			BotToken:     resp.AccessToken,
 			InstalledBy:  installedBy,
 			BotUserID:    resp.BotUserID,
 			AppID:        resp.AppID,
 			EnterpriseID: enterpriseID,
-			Scopes:       splitSlackScopes(resp.Scope),
+			Scopes:       NormalizeScopes([]string{resp.Scope}),
 		}); err != nil {
-			slog.Error("Slack install token persist failed",
-				"error", err, "team_id", teamID, "installed_by", installedBy)
+			logSlackInstallPersistFailed(err, teamID != "", installedBy != "")
 			clearStateCookie(w)
 			http.Error(w, "Slack install could not be stored", http.StatusInternalServerError)
 			return
 		}
 
 		clearStateCookie(w)
-		slog.Info("Slack app install stored workspace bot token",
+		slog.Info("Slack app install stored workspace bot token", // #nosec G706 -- Slack IDs are structured slog attributes; JSON handlers escape control bytes.
 			"team_id", teamID, "installed_by", installedBy,
 			"bot_user_id", resp.BotUserID, "app_id", resp.AppID,
 			"enterprise_id", enterpriseID)
@@ -254,11 +276,11 @@ func Callback(cfg Config) http.HandlerFunc {
 	}
 }
 
-func authorizeURL(cfg Config, state string) string {
+func authorizeURL(cfg *Config, state string) string {
 	u, _ := url.Parse(slackAuthorizeURL)
 	q := u.Query()
 	q.Set("client_id", strings.TrimSpace(cfg.ClientID))
-	q.Set("scope", strings.Join(normalizeScopes(cfg.BotScopes), ","))
+	q.Set("scope", strings.Join(NormalizeScopes(cfg.BotScopes), ","))
 	q.Set("redirect_uri", callbackURL(cfg.SlackBaseURL))
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
@@ -274,16 +296,22 @@ func callbackURL(baseURL string) string {
 }
 
 type statePayload struct {
+	Flow          string `json:"flow"`
 	Nonce         string `json:"nonce"`
 	CreatedAtUnix int64  `json:"created_at_unix"`
 }
 
+// Slack install state is signed and browser-bound, but not one-time-use: a
+// same-browser replay inside stateTTL can repeat the Slack code-exchange path.
+// That is acceptable for this install-only flow because Slack OAuth codes are
+// single-use and the persisted token update is idempotent by workspace.
 func mintState(secret []byte, now time.Time) (string, error) {
 	nonce := make([]byte, 24)
 	if _, err := rand.Read(nonce); err != nil {
 		return "", err
 	}
 	payload, err := json.Marshal(statePayload{
+		Flow:          slackInstallFlow,
 		Nonce:         base64.RawURLEncoding.EncodeToString(nonce),
 		CreatedAtUnix: now.UTC().Unix(),
 	})
@@ -321,6 +349,9 @@ func verifyState(secret []byte, token string, now time.Time) error {
 	}
 	if payload.Nonce == "" {
 		return errors.New("state nonce is empty")
+	}
+	if payload.Flow != slackInstallFlow {
+		return errors.New("state flow mismatch")
 	}
 	return nil
 }
@@ -384,7 +415,7 @@ type oauthAccessResponse struct {
 	} `json:"authed_user"`
 }
 
-func exchangeCode(ctx context.Context, cfg Config, code string) (*oauthAccessResponse, error) {
+func exchangeCode(ctx context.Context, cfg *Config, code string) (*oauthAccessResponse, error) {
 	form := url.Values{}
 	form.Set("client_id", strings.TrimSpace(cfg.ClientID))
 	form.Set("client_secret", strings.TrimSpace(cfg.ClientSecret))
@@ -412,7 +443,7 @@ func exchangeCode(ctx context.Context, cfg Config, code string) (*oauthAccessRes
 		return nil, fmt.Errorf("response exceeded %d bytes", slackOAuthBodyLimit)
 	}
 	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, responseSnippet(raw))
+		return nil, fmt.Errorf("http %d", resp.StatusCode)
 	}
 	var out oauthAccessResponse
 	if err := json.Unmarshal(raw, &out); err != nil {
@@ -423,27 +454,22 @@ func exchangeCode(ctx context.Context, cfg Config, code string) (*oauthAccessRes
 		if code == "" {
 			code = "not_ok"
 		}
-		return nil, fmt.Errorf("Slack oauth.v2.access: %s", code)
+		return nil, fmt.Errorf("slack oauth.v2.access: %s", code)
 	}
 	if strings.TrimSpace(out.AccessToken) == "" {
-		return nil, errors.New("Slack oauth.v2.access returned empty access_token")
+		return nil, errors.New("slack oauth.v2.access returned empty access_token")
 	}
 	return &out, nil
 }
 
-func responseSnippet(raw []byte) string {
-	raw = bytes.TrimSpace(raw)
-	if len(raw) > 200 {
-		raw = append(raw[:197], '.', '.', '.')
-	}
-	return strings.ToValidUTF8(string(raw), "\uFFFD")
-}
-
-func normalizeScopes(scopes []string) []string {
+// NormalizeScopes trims, splits, deduplicates, and preserves Slack scope order.
+func NormalizeScopes(scopes []string) []string {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(scopes))
 	for _, scope := range scopes {
-		for _, part := range strings.Split(scope, ",") {
+		for _, part := range strings.FieldsFunc(scope, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\n' || r == '\t'
+		}) {
 			part = strings.TrimSpace(part)
 			if part == "" {
 				continue
@@ -458,10 +484,17 @@ func normalizeScopes(scopes []string) []string {
 	return out
 }
 
-func splitSlackScopes(scope string) []string {
-	return normalizeScopes(strings.FieldsFunc(scope, func(r rune) bool {
-		return r == ',' || r == ' '
-	}))
+func logSlackInstallCallbackError(errorLen int) {
+	slog.Warn("Slack install callback returned error", "error_len", errorLen) // #nosec G706 -- only a length is logged; no request string reaches the attribute.
+}
+
+func logSlackInstallMissingTeamID(appIDPresent bool) {
+	slog.Error("Slack install token exchange missing team id", "app_id_present", appIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
+}
+
+func logSlackInstallPersistFailed(err error, teamIDPresent, installedByPresent bool) {
+	slog.Error("Slack install token persist failed", // #nosec G706 -- only booleans plus the storage error are logged.
+		"error", err, "team_id_present", teamIDPresent, "installed_by_present", installedByPresent)
 }
 
 func renderSuccess(w http.ResponseWriter, teamID string) {

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -562,6 +562,8 @@ func logSlackInstallPersistFailed(err error, teamIDPresent, installedByPresent b
 }
 
 func logSlackInstallMissingRequiredScopes(missing []string, teamIDPresent bool) {
+	// missing follows DefaultBotScopes order for operator readability. Stored
+	// scopes are normalized separately as a sorted DDB String Set.
 	slog.Warn("Slack install token exchange missing required bot scope(s)", // #nosec G706 -- missing scopes come from DefaultBotScopes constants.
 		"missing_scopes", strings.Join(missing, ","), "team_id_present", teamIDPresent)
 }

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -676,10 +676,10 @@ func TestSafeSlackOAuthErrorCode(t *testing.T) {
 			t.Fatalf("allowlisted error = %q, want %q", got, code)
 		}
 	}
-	if got := safeSlackOAuthErrorCode("bad\nvalue"); got != slackOAuthErrorUnknown {
-		t.Fatalf("unexpected error = %q, want %s", got, slackOAuthErrorUnknown)
+	if got := safeSlackOAuthErrorCode("bad\nvalue"); got != slackOAuthErrorUnrecognized {
+		t.Fatalf("unexpected error = %q, want %s", got, slackOAuthErrorUnrecognized)
 	}
-	if got := safeSlackOAuthErrorCode("not_authed"); got != slackOAuthErrorUnknown {
-		t.Fatalf("unexpected Slack API error = %q, want %s", got, slackOAuthErrorUnknown)
+	if got := safeSlackOAuthErrorCode("not_authed"); got != slackOAuthErrorUnrecognized {
+		t.Fatalf("unexpected Slack API error = %q, want %s", got, slackOAuthErrorUnrecognized)
 	}
 }

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -23,7 +23,7 @@ const (
 	testClientSecret    = "secret"
 	testScopeCSV        = "commands,views:write"
 	testWorkspaceID     = "T_WORKSPACE"
-	testWorkspaceToken  = "xoxb-workspace-token"
+	testWorkspaceToken  = "xoxb-123456789012345678901234567890"
 	testAuthCode        = "abc123"
 	testAccessTokenKey  = "access_token"
 	testSlackInstallURL = CallbackPath + "?code=" + testAuthCode + "&state="
@@ -118,6 +118,20 @@ func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
 	}
 	if !cookies[0].Secure || !cookies[0].HttpOnly || cookies[0].SameSite != http.SameSiteLaxMode {
 		t.Fatalf("state cookie flags not hardened: %#v", cookies[0])
+	}
+}
+
+func TestInstallRejectsNonGET(t *testing.T) {
+	cfg := testConfig(&fakeTokenStore{})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, InstallPath, http.NoBody)
+	Install(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+	if w.Header().Get("Allow") != "GET" {
+		t.Fatalf("Allow = %q, want GET", w.Header().Get("Allow"))
 	}
 }
 
@@ -383,6 +397,42 @@ func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
 	}
 }
 
+func TestCallbackRejectsMalformedSlackBotToken(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":               true,
+			testAccessTokenKey: "xoxa-123456789012345678901234567890",
+			"team": map[string]string{
+				"id": testWorkspaceID,
+			},
+			"authed_user": map[string]string{
+				"id": "U_INSTALLER",
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called with malformed token, got %q", store.workspaceID)
+	}
+}
+
 func TestCallbackSurfacesTokenStoreFailure(t *testing.T) {
 	store := &fakeTokenStore{err: errors.New("ddb down")}
 	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
@@ -473,10 +523,23 @@ func TestCallbackDoesNotLeakSlackHTTPErrorBody(t *testing.T) {
 }
 
 func TestSafeSlackOAuthErrorCode(t *testing.T) {
-	if got := safeSlackOAuthErrorCode(" invalid_scope "); got != "invalid_scope" {
-		t.Fatalf("allowlisted error = %q, want invalid_scope", got)
+	for _, code := range []string{
+		"access_denied",
+		"bad_redirect_uri",
+		"invalid_client_id",
+		"invalid_redirect_uri",
+		"invalid_scope",
+		"invalid_state",
+		"invalid_team_for_non_distributed_app",
+	} {
+		if got := safeSlackOAuthErrorCode(" " + code + " "); got != code {
+			t.Fatalf("allowlisted error = %q, want %q", got, code)
+		}
 	}
 	if got := safeSlackOAuthErrorCode("bad\nvalue"); got != slackOAuthErrorUnknown {
 		t.Fatalf("unexpected error = %q, want %s", got, slackOAuthErrorUnknown)
+	}
+	if got := safeSlackOAuthErrorCode("not_authed"); got != slackOAuthErrorUnknown {
+		t.Fatalf("unexpected Slack API error = %q, want %s", got, slackOAuthErrorUnknown)
 	}
 }

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -2,7 +2,10 @@ package slackinstall
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,38 +18,62 @@ import (
 
 const testStateSecret = "0123456789abcdef0123456789abcdef"
 
+const (
+	testClientID        = "111.222"
+	testClientSecret    = "secret"
+	testScopeCSV        = "commands,views:write"
+	testWorkspaceID     = "T_WORKSPACE"
+	testWorkspaceToken  = "xoxb-workspace-token"
+	testAuthCode        = "abc123"
+	testAccessTokenKey  = "access_token"
+	testSlackInstallURL = CallbackPath + "?code=" + testAuthCode + "&state="
+)
+
 type fakeTokenStore struct {
 	workspaceID string
 	install     auth.SlackBotTokenInstall
 	err         error
 }
 
-func (f *fakeTokenStore) SetSlackBotToken(_ context.Context, workspaceID string, install auth.SlackBotTokenInstall) error {
+func (f *fakeTokenStore) SetSlackBotToken(_ context.Context, workspaceID string, install *auth.SlackBotTokenInstall) error {
 	f.workspaceID = workspaceID
-	f.install = install
+	if install != nil {
+		f.install = *install
+	}
 	return f.err
 }
 
 func testConfig(store *fakeTokenStore) Config {
 	return Config{
-		ClientID:     "111.222",
-		ClientSecret: "secret",
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
 		SlackBaseURL: "https://slack-bot.example",
 		StateSecret:  []byte(testStateSecret),
-		BotScopes:    []string{"commands", "views:write"},
+		BotScopes:    []string{botScopeCommands, botScopeViewsWrite},
 		TokenStore:   store,
 		Now:          func() time.Time { return time.Unix(1800000000, 0).UTC() },
 	}
 }
 
+func testStateHTTPCookie(value string) *http.Cookie {
+	return &http.Cookie{
+		Name:     stateCookieName,
+		Value:    value,
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
 func TestConfigValidateRequiresGuidedInstallScopes(t *testing.T) {
 	cfg := testConfig(&fakeTokenStore{})
-	cfg.BotScopes = []string{"commands"}
-	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "views:write") {
+	cfg.BotScopes = []string{botScopeCommands}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), botScopeViewsWrite) {
 		t.Fatalf("Validate error = %v, want missing views:write", err)
 	}
-	cfg.BotScopes = []string{"views:write"}
-	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "commands") {
+	cfg.BotScopes = []string{botScopeViewsWrite}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), botScopeCommands) {
 		t.Fatalf("Validate error = %v, want missing commands", err)
 	}
 }
@@ -54,8 +81,9 @@ func TestConfigValidateRequiresGuidedInstallScopes(t *testing.T) {
 func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
 	store := &fakeTokenStore{}
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, InstallPath, http.NoBody)
-	Install(testConfig(store)).ServeHTTP(w, req)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, InstallPath, http.NoBody)
+	cfg := testConfig(store)
+	Install(&cfg).ServeHTTP(w, req)
 
 	if w.Code != http.StatusFound {
 		t.Fatalf("status = %d, want 302", w.Code)
@@ -68,10 +96,10 @@ func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
 		t.Fatalf("Location = %s, want Slack authorize URL", loc.String())
 	}
 	q := loc.Query()
-	if q.Get("client_id") != "111.222" {
+	if q.Get("client_id") != testClientID {
 		t.Errorf("client_id = %q", q.Get("client_id"))
 	}
-	if q.Get("scope") != "commands,views:write" {
+	if q.Get("scope") != testScopeCSV {
 		t.Errorf("scope = %q", q.Get("scope"))
 	}
 	if q.Get("redirect_uri") != "https://slack-bot.example/oauth/slack/callback" {
@@ -111,13 +139,13 @@ func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
 		gotForm = r.Form
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":           true,
-			"access_token": "xoxb-workspace-token",
-			"scope":        "commands,views:write",
-			"bot_user_id":  "U_BOT",
-			"app_id":       "A_APP",
+			"ok":               true,
+			testAccessTokenKey: testWorkspaceToken,
+			"scope":            testScopeCSV,
+			"bot_user_id":      "U_BOT",
+			"app_id":           "A_APP",
 			"team": map[string]string{
-				"id":   "T_WORKSPACE",
+				"id":   testWorkspaceID,
 				"name": "Customer",
 			},
 			"enterprise": map[string]string{
@@ -133,33 +161,33 @@ func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
 	cfg := testConfig(store)
 	cfg.OAuthAccessURL = slack.URL
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, CallbackPath+"?code=abc123&state="+url.QueryEscape(state), http.NoBody)
-	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
-	Callback(cfg).ServeHTTP(w, req)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%q", w.Code, w.Body.String())
 	}
-	if gotForm.Get("client_id") != "111.222" || gotForm.Get("client_secret") != "secret" || gotForm.Get("code") != "abc123" {
+	if gotForm.Get("client_id") != testClientID || gotForm.Get("client_secret") != testClientSecret || gotForm.Get("code") != testAuthCode {
 		t.Fatalf("unexpected Slack exchange form: %v", gotForm)
 	}
 	if gotForm.Get("redirect_uri") != "https://slack-bot.example/oauth/slack/callback" {
 		t.Fatalf("redirect_uri = %q", gotForm.Get("redirect_uri"))
 	}
-	if store.workspaceID != "T_WORKSPACE" {
+	if store.workspaceID != testWorkspaceID {
 		t.Fatalf("workspaceID = %q", store.workspaceID)
 	}
-	if store.install.BotToken != "xoxb-workspace-token" ||
+	if store.install.BotToken != testWorkspaceToken ||
 		store.install.InstalledBy != "U_INSTALLER" ||
 		store.install.BotUserID != "U_BOT" ||
 		store.install.AppID != "A_APP" ||
 		store.install.EnterpriseID != "E_GRID" {
 		t.Fatalf("stored install mismatch: %+v", store.install)
 	}
-	if strings.Join(store.install.Scopes, ",") != "commands,views:write" {
+	if strings.Join(store.install.Scopes, ",") != testScopeCSV {
 		t.Fatalf("scopes = %v", store.install.Scopes)
 	}
-	if strings.Contains(w.Body.String(), "xoxb-workspace-token") {
+	if strings.Contains(w.Body.String(), testWorkspaceToken) {
 		t.Fatal("success page leaked bot token")
 	}
 }
@@ -171,15 +199,94 @@ func TestCallbackRejectsStateCookieMismatch(t *testing.T) {
 		t.Fatalf("mintState: %v", err)
 	}
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, CallbackPath+"?code=abc123&state="+url.QueryEscape(state), http.NoBody)
-	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: "different"})
-	Callback(testConfig(store)).ServeHTTP(w, req)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie("different"))
+	cfg := testConfig(store)
+	Callback(&cfg).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called on CSRF mismatch, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackRejectsExpiredState(t *testing.T) {
+	store := &fakeTokenStore{}
+	createdAt := time.Unix(1800000000, 0).UTC().Add(-stateTTL - time.Second)
+	state, err := mintState([]byte(testStateSecret), createdAt)
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	cfg := testConfig(store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called on expired state, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackRejectsWrongStateFlow(t *testing.T) {
+	store := &fakeTokenStore{}
+	payload, err := json.Marshal(statePayload{
+		Flow:          "qurl-oauth",
+		Nonce:         "nonce",
+		CreatedAtUnix: time.Unix(1800000000, 0).UTC().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	state := body + "." + signState([]byte(testStateSecret), body)
+	cfg := testConfig(store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called on wrong state flow, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackRejectsMissingQueryParams(t *testing.T) {
+	for _, rawQuery := range []string{"code=" + testAuthCode, "state=" + testAuthCode, ""} {
+		t.Run(rawQuery, func(t *testing.T) {
+			store := &fakeTokenStore{}
+			cfg := testConfig(store)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, CallbackPath+"?"+rawQuery, http.NoBody)
+			Callback(&cfg).ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", w.Code)
+			}
+			if store.workspaceID != "" {
+				t.Fatalf("store should not be called on missing params, got %q", store.workspaceID)
+			}
+		})
+	}
+}
+
+func TestCallbackRejectsNonGET(t *testing.T) {
+	cfg := testConfig(&fakeTokenStore{})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, CallbackPath, http.NoBody)
+	Callback(&cfg).ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+	if w.Header().Get("Allow") != "GET" {
+		t.Fatalf("Allow = %q, want GET", w.Header().Get("Allow"))
 	}
 }
 
@@ -201,14 +308,130 @@ func TestCallbackSurfacesSlackOAuthError(t *testing.T) {
 	cfg := testConfig(store)
 	cfg.OAuthAccessURL = slack.URL
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, CallbackPath+"?code=abc123&state="+url.QueryEscape(state), http.NoBody)
-	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
-	Callback(cfg).ServeHTTP(w, req)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", w.Code)
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called after Slack OAuth error, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackRejectsSlackResponseMissingTeamID(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":               true,
+			testAccessTokenKey: testWorkspaceToken,
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called without team id, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackSurfacesTokenStoreFailure(t *testing.T) {
+	store := &fakeTokenStore{err: errors.New("ddb down")}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":               true,
+			testAccessTokenKey: testWorkspaceToken,
+			"team": map[string]string{
+				"id": testWorkspaceID,
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	if store.workspaceID != testWorkspaceID {
+		t.Fatalf("store should be called before surfacing persist failure, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackRejectsOversizedSlackOAuthResponse(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, strings.Repeat("x", slackOAuthBodyLimit+1))
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called on oversized Slack response, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackDoesNotLeakSlackHTTPErrorBody(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"access_token":"xoxb-should-not-leak"}`))
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "xoxb-should-not-leak") {
+		t.Fatal("callback response leaked Slack OAuth error body")
 	}
 }

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -364,6 +364,47 @@ func TestCallbackRejectsSlackResponseMissingTeamID(t *testing.T) {
 	}
 }
 
+func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":                    true,
+			testAccessTokenKey:      testWorkspaceToken,
+			"scope":                 testScopeCSV,
+			"is_enterprise_install": true,
+			"enterprise": map[string]string{
+				"id": "E_GRID",
+			},
+			"authed_user": map[string]string{
+				"id": "U_INSTALLER",
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called for org-level Enterprise Grid install, got %q", store.workspaceID)
+	}
+	if !strings.Contains(w.Body.String(), "Enterprise Grid") {
+		t.Fatalf("body = %q, want Enterprise Grid guidance", w.Body.String())
+	}
+}
+
 func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
 	store := &fakeTokenStore{}
 	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
@@ -375,6 +416,7 @@ func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":               true,
 			testAccessTokenKey: testWorkspaceToken,
+			"scope":            testScopeCSV,
 			"team": map[string]string{
 				"id": testWorkspaceID,
 			},
@@ -394,6 +436,46 @@ func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called without authed user id, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackRejectsMissingRequiredSlackScopes(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":               true,
+			testAccessTokenKey: testWorkspaceToken,
+			"scope":            botScopeCommands,
+			"team": map[string]string{
+				"id": testWorkspaceID,
+			},
+			"authed_user": map[string]string{
+				"id": "U_INSTALLER",
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called without required scopes, got %q", store.workspaceID)
+	}
+	if !strings.Contains(w.Body.String(), "required bot scopes") {
+		t.Fatalf("body = %q, want required-scope guidance", w.Body.String())
 	}
 }
 
@@ -444,6 +526,7 @@ func TestCallbackSurfacesTokenStoreFailure(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":               true,
 			testAccessTokenKey: testWorkspaceToken,
+			"scope":            testScopeCSV,
 			"team": map[string]string{
 				"id": testWorkspaceID,
 			},

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -1,0 +1,214 @@
+package slackinstall
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+const testStateSecret = "0123456789abcdef0123456789abcdef"
+
+type fakeTokenStore struct {
+	workspaceID string
+	install     auth.SlackBotTokenInstall
+	err         error
+}
+
+func (f *fakeTokenStore) SetSlackBotToken(_ context.Context, workspaceID string, install auth.SlackBotTokenInstall) error {
+	f.workspaceID = workspaceID
+	f.install = install
+	return f.err
+}
+
+func testConfig(store *fakeTokenStore) Config {
+	return Config{
+		ClientID:     "111.222",
+		ClientSecret: "secret",
+		SlackBaseURL: "https://slack-bot.example",
+		StateSecret:  []byte(testStateSecret),
+		BotScopes:    []string{"commands", "views:write"},
+		TokenStore:   store,
+		Now:          func() time.Time { return time.Unix(1800000000, 0).UTC() },
+	}
+}
+
+func TestConfigValidateRequiresGuidedInstallScopes(t *testing.T) {
+	cfg := testConfig(&fakeTokenStore{})
+	cfg.BotScopes = []string{"commands"}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "views:write") {
+		t.Fatalf("Validate error = %v, want missing views:write", err)
+	}
+	cfg.BotScopes = []string{"views:write"}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "commands") {
+		t.Fatalf("Validate error = %v, want missing commands", err)
+	}
+}
+
+func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
+	store := &fakeTokenStore{}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, InstallPath, http.NoBody)
+	Install(testConfig(store)).ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", w.Code)
+	}
+	loc, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	if loc.Scheme != "https" || loc.Host != "slack.com" || loc.Path != "/oauth/v2/authorize" {
+		t.Fatalf("Location = %s, want Slack authorize URL", loc.String())
+	}
+	q := loc.Query()
+	if q.Get("client_id") != "111.222" {
+		t.Errorf("client_id = %q", q.Get("client_id"))
+	}
+	if q.Get("scope") != "commands,views:write" {
+		t.Errorf("scope = %q", q.Get("scope"))
+	}
+	if q.Get("redirect_uri") != "https://slack-bot.example/oauth/slack/callback" {
+		t.Errorf("redirect_uri = %q", q.Get("redirect_uri"))
+	}
+	state := q.Get("state")
+	if state == "" {
+		t.Fatal("state missing from redirect")
+	}
+	if err := verifyState([]byte(testStateSecret), state, time.Unix(1800000000, 0).UTC()); err != nil {
+		t.Fatalf("redirect state did not verify: %v", err)
+	}
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != stateCookieName || cookies[0].Value != state {
+		t.Fatalf("state cookie mismatch: %#v", cookies)
+	}
+	if !cookies[0].Secure || !cookies[0].HttpOnly || cookies[0].SameSite != http.SameSiteLaxMode {
+		t.Fatalf("state cookie flags not hardened: %#v", cookies[0])
+	}
+}
+
+func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+
+	var gotForm url.Values
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("Slack exchange method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		gotForm = r.Form
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":           true,
+			"access_token": "xoxb-workspace-token",
+			"scope":        "commands,views:write",
+			"bot_user_id":  "U_BOT",
+			"app_id":       "A_APP",
+			"team": map[string]string{
+				"id":   "T_WORKSPACE",
+				"name": "Customer",
+			},
+			"enterprise": map[string]string{
+				"id": "E_GRID",
+			},
+			"authed_user": map[string]string{
+				"id": "U_INSTALLER",
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, CallbackPath+"?code=abc123&state="+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	Callback(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", w.Code, w.Body.String())
+	}
+	if gotForm.Get("client_id") != "111.222" || gotForm.Get("client_secret") != "secret" || gotForm.Get("code") != "abc123" {
+		t.Fatalf("unexpected Slack exchange form: %v", gotForm)
+	}
+	if gotForm.Get("redirect_uri") != "https://slack-bot.example/oauth/slack/callback" {
+		t.Fatalf("redirect_uri = %q", gotForm.Get("redirect_uri"))
+	}
+	if store.workspaceID != "T_WORKSPACE" {
+		t.Fatalf("workspaceID = %q", store.workspaceID)
+	}
+	if store.install.BotToken != "xoxb-workspace-token" ||
+		store.install.InstalledBy != "U_INSTALLER" ||
+		store.install.BotUserID != "U_BOT" ||
+		store.install.AppID != "A_APP" ||
+		store.install.EnterpriseID != "E_GRID" {
+		t.Fatalf("stored install mismatch: %+v", store.install)
+	}
+	if strings.Join(store.install.Scopes, ",") != "commands,views:write" {
+		t.Fatalf("scopes = %v", store.install.Scopes)
+	}
+	if strings.Contains(w.Body.String(), "xoxb-workspace-token") {
+		t.Fatal("success page leaked bot token")
+	}
+}
+
+func TestCallbackRejectsStateCookieMismatch(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, CallbackPath+"?code=abc123&state="+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: "different"})
+	Callback(testConfig(store)).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called on CSRF mismatch, got %q", store.workspaceID)
+	}
+}
+
+func TestCallbackSurfacesSlackOAuthError(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "bad_redirect_uri",
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, CallbackPath+"?code=abc123&state="+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	Callback(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called after Slack OAuth error, got %q", store.workspaceID)
+	}
+}

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -174,6 +174,10 @@ func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
 
 	cfg := testConfig(store)
 	cfg.OAuthAccessURL = slack.URL
+	var invalidatedTeamID string
+	cfg.OnTokenStored = func(teamID string) {
+		invalidatedTeamID = teamID
+	}
 	w := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
 	req.AddCookie(testStateHTTPCookie(state))
@@ -200,6 +204,9 @@ func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
 	}
 	if strings.Join(store.install.Scopes, ",") != testScopeCSV {
 		t.Fatalf("scopes = %v", store.install.Scopes)
+	}
+	if invalidatedTeamID != testWorkspaceID {
+		t.Fatalf("OnTokenStored teamID = %q, want %q", invalidatedTeamID, testWorkspaceID)
 	}
 	if strings.Contains(w.Body.String(), testWorkspaceToken) {
 		t.Fatal("success page leaked bot token")
@@ -356,8 +363,8 @@ func TestCallbackRejectsSlackResponseMissingTeamID(t *testing.T) {
 	req.AddCookie(testStateHTTPCookie(state))
 	Callback(&cfg).ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", w.Code)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called without team id, got %q", store.workspaceID)
@@ -394,8 +401,8 @@ func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
 	req.AddCookie(testStateHTTPCookie(state))
 	Callback(&cfg).ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", w.Code)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called for org-level Enterprise Grid install, got %q", store.workspaceID)
@@ -431,8 +438,8 @@ func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
 	req.AddCookie(testStateHTTPCookie(state))
 	Callback(&cfg).ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", w.Code)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called without authed user id, got %q", store.workspaceID)
@@ -468,8 +475,8 @@ func TestCallbackRejectsMissingRequiredSlackScopes(t *testing.T) {
 	req.AddCookie(testStateHTTPCookie(state))
 	Callback(&cfg).ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", w.Code)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
 	}
 	if store.workspaceID != "" {
 		t.Fatalf("store should not be called without required scopes, got %q", store.workspaceID)

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -88,6 +88,9 @@ func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
 	if w.Code != http.StatusFound {
 		t.Fatalf("status = %d, want 302", w.Code)
 	}
+	if w.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", w.Header().Get("Cache-Control"))
+	}
 	loc, err := url.Parse(w.Header().Get("Location"))
 	if err != nil {
 		t.Fatalf("parse Location: %v", err)
@@ -384,6 +387,9 @@ func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
 			testAccessTokenKey:      testWorkspaceToken,
 			"scope":                 testScopeCSV,
 			"is_enterprise_install": true,
+			"team": map[string]string{
+				"id": testWorkspaceID,
+			},
 			"enterprise": map[string]string{
 				"id": "E_GRID",
 			},
@@ -409,6 +415,50 @@ func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Enterprise Grid") {
 		t.Fatalf("body = %q, want Enterprise Grid guidance", w.Body.String())
+	}
+}
+
+func TestCallbackAcceptsWorkspaceInstallWithinEnterpriseGrid(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":                    true,
+			testAccessTokenKey:      testWorkspaceToken,
+			"scope":                 testScopeCSV,
+			"is_enterprise_install": false,
+			"team": map[string]string{
+				"id": testWorkspaceID,
+			},
+			"enterprise": map[string]string{
+				"id": "E_GRID",
+			},
+			"authed_user": map[string]string{
+				"id": "U_INSTALLER",
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", w.Code, w.Body.String())
+	}
+	if store.workspaceID != testWorkspaceID {
+		t.Fatalf("workspaceID = %q, want %q", store.workspaceID, testWorkspaceID)
+	}
+	if store.install.EnterpriseID != "E_GRID" {
+		t.Fatalf("EnterpriseID = %q, want E_GRID", store.install.EnterpriseID)
 	}
 }
 

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -350,6 +350,39 @@ func TestCallbackRejectsSlackResponseMissingTeamID(t *testing.T) {
 	}
 }
 
+func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":               true,
+			testAccessTokenKey: testWorkspaceToken,
+			"team": map[string]string{
+				"id": testWorkspaceID,
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if store.workspaceID != "" {
+		t.Fatalf("store should not be called without authed user id, got %q", store.workspaceID)
+	}
+}
+
 func TestCallbackSurfacesTokenStoreFailure(t *testing.T) {
 	store := &fakeTokenStore{err: errors.New("ddb down")}
 	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
@@ -363,6 +396,9 @@ func TestCallbackSurfacesTokenStoreFailure(t *testing.T) {
 			testAccessTokenKey: testWorkspaceToken,
 			"team": map[string]string{
 				"id": testWorkspaceID,
+			},
+			"authed_user": map[string]string{
+				"id": "U_INSTALLER",
 			},
 		})
 	}))
@@ -433,5 +469,14 @@ func TestCallbackDoesNotLeakSlackHTTPErrorBody(t *testing.T) {
 	}
 	if strings.Contains(w.Body.String(), "xoxb-should-not-leak") {
 		t.Fatal("callback response leaked Slack OAuth error body")
+	}
+}
+
+func TestSafeSlackOAuthErrorCode(t *testing.T) {
+	if got := safeSlackOAuthErrorCode(" invalid_scope "); got != "invalid_scope" {
+		t.Fatalf("allowlisted error = %q, want invalid_scope", got)
+	}
+	if got := safeSlackOAuthErrorCode("bad\nvalue"); got != slackOAuthErrorUnknown {
+		t.Fatalf("unexpected error = %q, want %s", got, slackOAuthErrorUnknown)
 	}
 }

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -424,7 +424,7 @@ func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, 
 		":dk":    &ddbtypes.AttributeValueMemberB{Value: wrapped},
 		":now":   &ddbtypes.AttributeValueMemberS{Value: now},
 	}
-	removeParts := []string{}
+	var removeParts []string
 	setStringAttr := func(attr, token, value string) {
 		value = strings.TrimSpace(value)
 		if value == "" {

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -316,6 +316,8 @@ func (p *DDBProvider) SlackBotToken(ctx context.Context, workspaceID string) (st
 		return "", fmt.Errorf("DDBProvider.SlackBotToken: workspace %q: %w", workspaceID, ErrSlackBotTokenNotConfigured)
 	}
 
+	// Rows can exist before a Slack app install because /qurl setup writes the
+	// qURL API key first. Missing Slack columns are expected in that state.
 	ctBlob, ok := out.Item[attrSlackBotToken].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(ctBlob.Value) == 0 {
 		return "", fmt.Errorf("DDBProvider.SlackBotToken: workspace %q: %w", workspaceID, ErrSlackBotTokenNotConfigured)

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -355,6 +355,8 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 	now := p.nowOrDefault().UTC().Format(time.RFC3339)
 	updateExpr := fmt.Sprintf("SET %s = :key, %s = :dk, %s = :by, %s = :now, %s = if_not_exists(%s, :now)",
 		attrQURLAPIKey, attrDataKeyCT, attrConfiguredBy, attrUpdatedAt, attrConfiguredAt, attrConfiguredAt)
+	// TODO(#265): UpdateItem closes the DDB row clobber race, but a losing
+	// concurrent qurl-service mint can still leave an orphaned upstream key.
 	out, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -355,8 +355,11 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 	now := p.nowOrDefault().UTC().Format(time.RFC3339)
 	updateExpr := fmt.Sprintf("SET %s = :key, %s = :dk, %s = :by, %s = :now, %s = if_not_exists(%s, :now)",
 		attrQURLAPIKey, attrDataKeyCT, attrConfiguredBy, attrUpdatedAt, attrConfiguredAt, attrConfiguredAt)
-	// TODO(#265): UpdateItem closes the DDB row clobber race, but a losing
-	// concurrent qurl-service mint can still leave an orphaned upstream key.
+	// TODO(#265): this UpdateItem closes the old GetItem+PutItem row-clobber
+	// window and preserves Slack install metadata, but the upstream qurl-service
+	// mint still happens before this write. If concurrent admins mint different
+	// keys, the earlier key can still be overwritten here and left orphaned
+	// upstream because there is no losing-write signal to trigger a revoke.
 	out, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -462,7 +462,7 @@ func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, 
 	}); err != nil {
 		return fmt.Errorf("DDBProvider.SetSlackBotToken: UpdateItem: %w", err)
 	}
-	slog.Info("DDBProvider.SetSlackBotToken stored Slack app bot token metadata",
+	slog.Info("DDBProvider.SetSlackBotToken stored Slack app bot token metadata", // #nosec G706 -- Slack IDs are structured slog attributes; JSON handlers escape control bytes.
 		"workspace_id", workspaceID,
 		"installed_by", install.InstalledBy,
 		"bot_user_id", install.BotUserID,

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -353,20 +353,31 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 	}
 
 	now := p.nowOrDefault().UTC().Format(time.RFC3339)
-	if _, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+	updateExpr := fmt.Sprintf("SET %s = :key, %s = :dk, %s = :by, %s = :now, %s = if_not_exists(%s, :now)",
+		attrQURLAPIKey, attrDataKeyCT, attrConfiguredBy, attrUpdatedAt, attrConfiguredAt, attrConfiguredAt)
+	out, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-		UpdateExpression: aws.String("SET qurl_api_key = :key, qurl_api_key_dk = :dk, configured_by = :by, updated_at = :now, configured_at = if_not_exists(configured_at, :now)"),
+		UpdateExpression: aws.String(updateExpr),
 		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 			":key": &ddbtypes.AttributeValueMemberB{Value: ct},
 			":dk":  &ddbtypes.AttributeValueMemberB{Value: wrapped},
 			":by":  &ddbtypes.AttributeValueMemberS{Value: configuredBy},
 			":now": &ddbtypes.AttributeValueMemberS{Value: now},
 		},
-	}); err != nil {
+		ReturnValues: ddbtypes.ReturnValueUpdatedOld,
+	})
+	if err != nil {
 		return fmt.Errorf("DDBProvider.SetAPIKey: UpdateItem: %w", err)
+	}
+	if out != nil {
+		if _, rotated := out.Attributes[attrQURLAPIKey]; rotated {
+			slog.Warn("DDBProvider.SetAPIKey overwrote existing workspace API key",
+				"workspace_id", workspaceID,
+				"configured_by", configuredBy)
+		}
 	}
 	return nil
 }
@@ -374,9 +385,12 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 // SetSlackBotToken upserts the encrypted Slack bot token captured during Slack
 // app install or reinstall. It intentionally updates only Slack-specific
 // attributes so the qURL API key columns survive app reauthorization.
-func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, install SlackBotTokenInstall) error {
+func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, install *SlackBotTokenInstall) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.SetSlackBotToken: workspaceID is empty")
+	}
+	if install == nil {
+		return errors.New("DDBProvider.SetSlackBotToken: install is nil")
 	}
 	if install.BotToken == "" {
 		return errors.New("DDBProvider.SetSlackBotToken: bot token is empty")
@@ -389,10 +403,10 @@ func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, 
 	now := p.nowOrDefault().UTC().Format(time.RFC3339)
 
 	setParts := []string{
-		"slack_bot_token = :token",
-		"slack_bot_token_dk = :dk",
-		"slack_bot_updated_at = :now",
-		"slack_bot_installed_at = if_not_exists(slack_bot_installed_at, :now)",
+		attrSlackBotToken + " = :token",
+		attrSlackBotTokenDK + " = :dk",
+		attrSlackBotUpdatedAt + " = :now",
+		attrSlackBotInstalledAt + " = if_not_exists(" + attrSlackBotInstalledAt + ", :now)",
 	}
 	values := map[string]ddbtypes.AttributeValue{
 		":token": &ddbtypes.AttributeValueMemberB{Value: ct},

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -399,11 +399,15 @@ func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, 
 	if install == nil {
 		return errors.New("DDBProvider.SetSlackBotToken: install is nil")
 	}
-	if install.BotToken == "" {
+	botToken := strings.TrimSpace(install.BotToken)
+	if botToken == "" {
 		return errors.New("DDBProvider.SetSlackBotToken: bot token is empty")
 	}
+	if err := ValidateSlackBotTokenShape(botToken); err != nil {
+		return fmt.Errorf("DDBProvider.SetSlackBotToken: invalid bot token: %w", err)
+	}
 
-	ct, wrapped, err := p.Encryptor.Seal(ctx, []byte(install.BotToken), []byte(workspaceID))
+	ct, wrapped, err := p.Encryptor.Seal(ctx, []byte(botToken), []byte(workspaceID))
 	if err != nil {
 		return fmt.Errorf("DDBProvider.SetSlackBotToken: encrypt: %w", err)
 	}

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -36,6 +36,8 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -63,6 +65,16 @@ const (
 	attrConfiguredBy = "configured_by"
 	attrConfiguredAt = "configured_at"
 	attrUpdatedAt    = "updated_at"
+
+	attrSlackBotToken       = "slack_bot_token"
+	attrSlackBotTokenDK     = "slack_bot_token_dk"
+	attrSlackBotInstalledBy = "slack_bot_installed_by"
+	attrSlackBotInstalledAt = "slack_bot_installed_at"
+	attrSlackBotUpdatedAt   = "slack_bot_updated_at"
+	attrSlackBotUserID      = "slack_bot_user_id"
+	attrSlackAppID          = "slack_app_id"
+	attrSlackEnterpriseID   = "slack_enterprise_id"
+	attrSlackBotScopes      = "slack_bot_scopes"
 )
 
 // Env var names — operator-set via the Fargate task definition (the
@@ -84,12 +96,19 @@ const (
 // /oauth/qurl/start rather than rendering a generic "auth failed" error.
 var ErrWorkspaceNotConfigured = errors.New("workspace not configured — admin must complete /oauth/qurl/start")
 
+// ErrSlackBotTokenNotConfigured is returned when a workspace has not completed
+// the Slack app OAuth install/reinstall path that grants a per-workspace bot
+// token. The Slack handler catches this distinctly from decrypt/transport
+// failures so old installs can be pointed at the reinstall path.
+var ErrSlackBotTokenNotConfigured = errors.New("workspace Slack bot token not configured — admin must reinstall the Slack app")
+
 // DynamoDBClient is the slice of *dynamodb.Client the provider actually
 // uses. Exposed as an interface so tests can inject a fake without
 // spinning up localstack.
 type DynamoDBClient interface {
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
 	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
 }
 
@@ -118,6 +137,19 @@ type DDBProvider struct {
 	// updated_at assertions without poking package-global state. Defaults
 	// to time.Now.
 	Now func() time.Time
+}
+
+// SlackBotTokenInstall is the workspace-scoped Slack OAuth material persisted
+// after a customer installs or reauthorizes the Slack app. BotToken is stored
+// encrypted; the remaining fields are operational metadata for audits and
+// support triage.
+type SlackBotTokenInstall struct {
+	BotToken     string
+	InstalledBy  string
+	BotUserID    string
+	AppID        string
+	EnterpriseID string
+	Scopes       []string
 }
 
 // nowOrDefault is the safe clock accessor — NewDDBProvider always sets
@@ -242,7 +274,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 
 	ctBlob, ok := out.Item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(ctBlob.Value) == 0 {
-		return "", errors.New("DDBProvider.APIKey: stored item missing or has wrong type for qurl_api_key")
+		return "", fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
 	}
 	wrappedKey, ok := out.Item[attrDataKeyCT].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(wrappedKey.Value) == 0 {
@@ -263,9 +295,50 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	return string(pt), nil
 }
 
-// SetAPIKey upserts the per-workspace API key. The configuredBy field
+// SlackBotToken looks up the per-workspace Slack bot token captured during
+// Slack app OAuth installation. Missing token attributes are treated as a
+// reinstall-needed state instead of row corruption because older workspace rows
+// legitimately predate Slack bot-token persistence.
+func (p *DDBProvider) SlackBotToken(ctx context.Context, workspaceID string) (string, error) {
+	if workspaceID == "" {
+		return "", errors.New("DDBProvider.SlackBotToken: workspaceID is empty")
+	}
+	out, err := p.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(p.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("DDBProvider.SlackBotToken: GetItem: %w", err)
+	}
+	if len(out.Item) == 0 {
+		return "", fmt.Errorf("DDBProvider.SlackBotToken: workspace %q: %w", workspaceID, ErrSlackBotTokenNotConfigured)
+	}
+
+	ctBlob, ok := out.Item[attrSlackBotToken].(*ddbtypes.AttributeValueMemberB)
+	if !ok || len(ctBlob.Value) == 0 {
+		return "", fmt.Errorf("DDBProvider.SlackBotToken: workspace %q: %w", workspaceID, ErrSlackBotTokenNotConfigured)
+	}
+	wrappedKey, ok := out.Item[attrSlackBotTokenDK].(*ddbtypes.AttributeValueMemberB)
+	if !ok || len(wrappedKey.Value) == 0 {
+		return "", fmt.Errorf("DDBProvider.SlackBotToken: workspace %q: %w", workspaceID, ErrSlackBotTokenNotConfigured)
+	}
+
+	pt, err := p.Encryptor.Open(ctx, ctBlob.Value, wrappedKey.Value, []byte(workspaceID))
+	if err != nil {
+		return "", fmt.Errorf("DDBProvider.SlackBotToken: decrypt: %w", err)
+	}
+	if len(pt) == 0 {
+		return "", errors.New("DDBProvider.SlackBotToken: decrypted plaintext is empty")
+	}
+	return string(pt), nil
+}
+
+// SetAPIKey upserts the per-workspace qURL API key. The configuredBy field
 // is informational (the Slack user_id of the admin who completed
-// /oauth/qurl/callback) and is persisted plaintext.
+// /oauth/qurl/callback) and is persisted plaintext. UpdateItem is used instead
+// of PutItem so Slack app install metadata in the same row is preserved.
 func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, configuredBy string) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.SetAPIKey: workspaceID is empty")
@@ -279,73 +352,117 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 		return fmt.Errorf("DDBProvider.SetAPIKey: encrypt: %w", err)
 	}
 
-	// Pre-flight GetItem serves two purposes on this rare path:
-	//   1. Preserve the original configured_at on key rotation — otherwise
-	//      every rotation would overwrite the first-install timestamp and
-	//      the audit trail loses the install date.
-	//   2. Emit a warn line on overwrite so operator dashboards can
-	//      distinguish first-installs from rotation churn.
-	// The install path is invoked once per workspace, so doubling the RTT
-	// here is a non-issue. A transient transport error here is fail-fast:
-	// without the pre-flight read we'd silently destroy configured_at on
-	// rotation, which is the exact failure mode this branch exists to
-	// prevent. The caller retries via /qurl setup.
-	//
-	// Race acknowledged: read-modify-write is TOCTOU under concurrent
-	// /qurl setup completions for the same workspace. Two simultaneous
-	// installers can both see "no row," both encrypt fresh keys, and
-	// race on PutItem. The losing PutItem clobbers the winner: loser's
-	// configured_at overwrites winner's, AND the winner's qurl-service
-	// key is now orphaned in qurl-service (the existing fire-and-forget
-	// revoke covers only the persist-failure case, not the "lost the
-	// PutItem race" case — the winner's persist returned success even
-	// though the row was immediately overwritten). Collision requires
-	// two parallel admins clicking the /qurl setup link within ~the
-	// DDB write latency, on the *same* workspace — extremely rare by
-	// construction. Tracked at #265: switch to PutItem +
-	// ReturnValues=ALL_OLD (or UpdateItem with
-	// `if_not_exists(configured_at, :now)`) for an atomic close. When
-	// that lands, mintAndPersist should also revoke on conflict so the
-	// orphan window closes end-to-end.
-	existing, err := p.Client.GetItem(ctx, &dynamodb.GetItemInput{
+	now := p.nowOrDefault().UTC().Format(time.RFC3339)
+	if _, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-	})
-	if err != nil {
-		return fmt.Errorf("DDBProvider.SetAPIKey: pre-flight GetItem: %w", err)
-	}
-	overwriting := existing != nil && len(existing.Item) > 0
-
-	now := p.nowOrDefault().UTC().Format(time.RFC3339)
-	configuredAt := now
-	if overwriting {
-		if prev, ok := existing.Item[attrConfiguredAt].(*ddbtypes.AttributeValueMemberS); ok && prev.Value != "" {
-			configuredAt = prev.Value
-		}
-	}
-	item := map[string]ddbtypes.AttributeValue{
-		attrTeamID:       &ddbtypes.AttributeValueMemberS{Value: workspaceID},
-		attrQURLAPIKey:   &ddbtypes.AttributeValueMemberB{Value: ct},
-		attrDataKeyCT:    &ddbtypes.AttributeValueMemberB{Value: wrapped},
-		attrConfiguredBy: &ddbtypes.AttributeValueMemberS{Value: configuredBy},
-		attrUpdatedAt:    &ddbtypes.AttributeValueMemberS{Value: now},
-		attrConfiguredAt: &ddbtypes.AttributeValueMemberS{Value: configuredAt},
-	}
-
-	if _, err := p.Client.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName: aws.String(p.TableName),
-		Item:      item,
+		UpdateExpression: aws.String("SET qurl_api_key = :key, qurl_api_key_dk = :dk, configured_by = :by, updated_at = :now, configured_at = if_not_exists(configured_at, :now)"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":key": &ddbtypes.AttributeValueMemberB{Value: ct},
+			":dk":  &ddbtypes.AttributeValueMemberB{Value: wrapped},
+			":by":  &ddbtypes.AttributeValueMemberS{Value: configuredBy},
+			":now": &ddbtypes.AttributeValueMemberS{Value: now},
+		},
 	}); err != nil {
-		return fmt.Errorf("DDBProvider.SetAPIKey: PutItem: %w", err)
-	}
-	if overwriting {
-		slog.Warn("DDBProvider.SetAPIKey overwrote existing workspace row",
-			"workspace_id", workspaceID,
-			"configured_by", configuredBy)
+		return fmt.Errorf("DDBProvider.SetAPIKey: UpdateItem: %w", err)
 	}
 	return nil
+}
+
+// SetSlackBotToken upserts the encrypted Slack bot token captured during Slack
+// app install or reinstall. It intentionally updates only Slack-specific
+// attributes so the qURL API key columns survive app reauthorization.
+func (p *DDBProvider) SetSlackBotToken(ctx context.Context, workspaceID string, install SlackBotTokenInstall) error {
+	if workspaceID == "" {
+		return errors.New("DDBProvider.SetSlackBotToken: workspaceID is empty")
+	}
+	if install.BotToken == "" {
+		return errors.New("DDBProvider.SetSlackBotToken: bot token is empty")
+	}
+
+	ct, wrapped, err := p.Encryptor.Seal(ctx, []byte(install.BotToken), []byte(workspaceID))
+	if err != nil {
+		return fmt.Errorf("DDBProvider.SetSlackBotToken: encrypt: %w", err)
+	}
+	now := p.nowOrDefault().UTC().Format(time.RFC3339)
+
+	setParts := []string{
+		"slack_bot_token = :token",
+		"slack_bot_token_dk = :dk",
+		"slack_bot_updated_at = :now",
+		"slack_bot_installed_at = if_not_exists(slack_bot_installed_at, :now)",
+	}
+	values := map[string]ddbtypes.AttributeValue{
+		":token": &ddbtypes.AttributeValueMemberB{Value: ct},
+		":dk":    &ddbtypes.AttributeValueMemberB{Value: wrapped},
+		":now":   &ddbtypes.AttributeValueMemberS{Value: now},
+	}
+	removeParts := []string{}
+	setStringAttr := func(attr, token, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			removeParts = append(removeParts, attr)
+			return
+		}
+		setParts = append(setParts, attr+" = "+token)
+		values[token] = &ddbtypes.AttributeValueMemberS{Value: value}
+	}
+	setStringAttr(attrSlackBotInstalledBy, ":installed_by", install.InstalledBy)
+	setStringAttr(attrSlackBotUserID, ":bot_user_id", install.BotUserID)
+	setStringAttr(attrSlackAppID, ":app_id", install.AppID)
+	setStringAttr(attrSlackEnterpriseID, ":enterprise_id", install.EnterpriseID)
+
+	scopes := normalizedStringSet(install.Scopes)
+	if len(scopes) > 0 {
+		setParts = append(setParts, attrSlackBotScopes+" = :scopes")
+		values[":scopes"] = &ddbtypes.AttributeValueMemberSS{Value: scopes}
+	} else {
+		removeParts = append(removeParts, attrSlackBotScopes)
+	}
+
+	expr := "SET " + strings.Join(setParts, ", ")
+	if len(removeParts) > 0 {
+		expr += " REMOVE " + strings.Join(removeParts, ", ")
+	}
+
+	if _, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(p.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
+		},
+		UpdateExpression:          aws.String(expr),
+		ExpressionAttributeValues: values,
+	}); err != nil {
+		return fmt.Errorf("DDBProvider.SetSlackBotToken: UpdateItem: %w", err)
+	}
+	slog.Info("DDBProvider.SetSlackBotToken stored Slack app bot token metadata",
+		"workspace_id", workspaceID,
+		"installed_by", install.InstalledBy,
+		"bot_user_id", install.BotUserID,
+		"app_id", install.AppID,
+		"enterprise_id", install.EnterpriseID,
+		"scope_count", len(scopes))
+	return nil
+}
+
+func normalizedStringSet(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // DeleteAPIKey removes the per-workspace row. Used by the uninstall /

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	testTeamID        = "T123ABCDEF"
-	testSlackBotToken = "xoxb-secret"
+	testSlackBotToken = "xoxb-123456789012345678901234567890"
 )
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
@@ -449,6 +449,20 @@ func TestDDBProviderSetSlackBotTokenRemovesEmptyOptionalMetadata(t *testing.T) {
 	}
 	if _, ok := ddb.updateInput.ExpressionAttributeValues[":scopes"]; ok {
 		t.Fatal("empty scopes should not write :scopes")
+	}
+}
+
+func TestDDBProviderSetSlackBotTokenRejectsMalformedToken(t *testing.T) {
+	ddb := &fakeDDBClient{}
+	p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+	err := p.SetSlackBotToken(context.Background(), testTeamID, &SlackBotTokenInstall{
+		BotToken: "xoxa-123456789012345678901234567890",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid bot token") {
+		t.Fatalf("err=%v, want invalid bot token", err)
+	}
+	if ddb.updateInput != nil {
+		t.Fatal("malformed token should not write DDB")
 	}
 }
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -11,19 +11,23 @@ import (
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-const testTeamID = "T123ABCDEF"
+const (
+	testTeamID        = "T123ABCDEF"
+	testSlackBotToken = "xoxb-secret"
+)
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
 // predetermined results. Captures Put/Delete inputs for assertion.
 type fakeDDBClient struct {
-	getOutput   *dynamodb.GetItemOutput
-	getErr      error
-	putInput    *dynamodb.PutItemInput
-	putErr      error
-	updateInput *dynamodb.UpdateItemInput
-	updateErr   error
-	delInput    *dynamodb.DeleteItemInput
-	delErr      error
+	getOutput    *dynamodb.GetItemOutput
+	getErr       error
+	putInput     *dynamodb.PutItemInput
+	putErr       error
+	updateInput  *dynamodb.UpdateItemInput
+	updateOutput *dynamodb.UpdateItemOutput
+	updateErr    error
+	delInput     *dynamodb.DeleteItemInput
+	delErr       error
 }
 
 func (f *fakeDDBClient) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
@@ -35,6 +39,9 @@ func (f *fakeDDBClient) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ 
 }
 func (f *fakeDDBClient) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
 	f.updateInput = in
+	if f.updateOutput != nil {
+		return f.updateOutput, f.updateErr
+	}
 	return &dynamodb.UpdateItemOutput{}, f.updateErr
 }
 func (f *fakeDDBClient) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
@@ -253,6 +260,9 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "configured_at = if_not_exists(configured_at, :now)") {
 		t.Errorf("UpdateExpression should preserve configured_at with if_not_exists, got %q", got)
 	}
+	if ddb.updateInput.ReturnValues != ddbtypes.ReturnValueUpdatedOld {
+		t.Errorf("ReturnValues = %v, want UPDATED_OLD for rotation observability", ddb.updateInput.ReturnValues)
+	}
 }
 
 func TestDDBProviderSetAPIKeySurfacesUpdateError(t *testing.T) {
@@ -325,7 +335,7 @@ func TestDDBProviderSlackBotToken(t *testing.T) {
 			getOutput: &dynamodb.GetItemOutput{
 				Item: map[string]ddbtypes.AttributeValue{
 					attrTeamID:          &ddbtypes.AttributeValueMemberS{Value: testTeamID},
-					attrSlackBotToken:   &ddbtypes.AttributeValueMemberB{Value: []byte("xoxb-secret")},
+					attrSlackBotToken:   &ddbtypes.AttributeValueMemberB{Value: []byte(testSlackBotToken)},
 					attrSlackBotTokenDK: &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
 				},
 			},
@@ -335,8 +345,8 @@ func TestDDBProviderSlackBotToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("SlackBotToken: %v", err)
 		}
-		if got != "xoxb-secret" {
-			t.Fatalf("got %q want %q", got, "xoxb-secret")
+		if got != testSlackBotToken {
+			t.Fatalf("got %q want %q", got, testSlackBotToken)
 		}
 	})
 
@@ -372,8 +382,8 @@ func TestDDBProviderSetSlackBotToken(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		Now:       func() time.Time { return fixedNow },
 	}
-	err := p.SetSlackBotToken(context.Background(), testTeamID, SlackBotTokenInstall{
-		BotToken:     "xoxb-secret",
+	err := p.SetSlackBotToken(context.Background(), testTeamID, &SlackBotTokenInstall{
+		BotToken:     testSlackBotToken,
 		InstalledBy:  "U_INSTALLER",
 		BotUserID:    "U_BOT",
 		AppID:        "A_APP",
@@ -387,7 +397,7 @@ func TestDDBProviderSetSlackBotToken(t *testing.T) {
 		t.Fatal("expected UpdateItem called")
 	}
 	values := ddb.updateInput.ExpressionAttributeValues
-	if v, ok := values[":token"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != "xoxb-secret" {
+	if v, ok := values[":token"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != testSlackBotToken {
 		t.Errorf("slack token wrong: %v", values[":token"])
 	}
 	if v, ok := values[":dk"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != passthroughWrappedKey {
@@ -398,6 +408,31 @@ func TestDDBProviderSetSlackBotToken(t *testing.T) {
 	}
 	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "slack_bot_installed_at = if_not_exists(slack_bot_installed_at, :now)") {
 		t.Errorf("UpdateExpression should preserve original Slack installed_at, got %q", got)
+	}
+}
+
+func TestDDBProviderSetSlackBotTokenRemovesEmptyOptionalMetadata(t *testing.T) {
+	ddb := &fakeDDBClient{}
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+		Now:       func() time.Time { return time.Unix(1700000000, 0).UTC() },
+	}
+	err := p.SetSlackBotToken(context.Background(), testTeamID, &SlackBotTokenInstall{
+		BotToken: testSlackBotToken,
+	})
+	if err != nil {
+		t.Fatalf("SetSlackBotToken: %v", err)
+	}
+	got := *ddb.updateInput.UpdateExpression
+	for _, attr := range []string{attrSlackBotInstalledBy, attrSlackBotUserID, attrSlackAppID, attrSlackEnterpriseID, attrSlackBotScopes} {
+		if !strings.Contains(got, attr) {
+			t.Fatalf("UpdateExpression should mention %s in REMOVE branch, got %q", attr, got)
+		}
+	}
+	if _, ok := ddb.updateInput.ExpressionAttributeValues[":scopes"]; ok {
+		t.Fatal("empty scopes should not write :scopes")
 	}
 }
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,12 +16,14 @@ const testTeamID = "T123ABCDEF"
 // fakeDDBClient is a hand-rolled stub the table tests configure with
 // predetermined results. Captures Put/Delete inputs for assertion.
 type fakeDDBClient struct {
-	getOutput *dynamodb.GetItemOutput
-	getErr    error
-	putInput  *dynamodb.PutItemInput
-	putErr    error
-	delInput  *dynamodb.DeleteItemInput
-	delErr    error
+	getOutput   *dynamodb.GetItemOutput
+	getErr      error
+	putInput    *dynamodb.PutItemInput
+	putErr      error
+	updateInput *dynamodb.UpdateItemInput
+	updateErr   error
+	delInput    *dynamodb.DeleteItemInput
+	delErr      error
 }
 
 func (f *fakeDDBClient) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
@@ -29,6 +32,10 @@ func (f *fakeDDBClient) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ .
 func (f *fakeDDBClient) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
 	f.putInput = in
 	return &dynamodb.PutItemOutput{}, f.putErr
+}
+func (f *fakeDDBClient) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.updateInput = in
+	return &dynamodb.UpdateItemOutput{}, f.updateErr
 }
 func (f *fakeDDBClient) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
 	f.delInput = in
@@ -204,8 +211,8 @@ func TestDDBProviderAPIKey(t *testing.T) {
 		}
 		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
 		_, err := p.APIKey(context.Background(), testTeamID)
-		if err == nil {
-			t.Fatal("want error, got nil")
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured for Slack-installed but qURL-unconfigured row, got %v", err)
 		}
 	})
 }
@@ -223,38 +230,33 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetAPIKey: %v", err)
 	}
-	if ddb.putInput == nil {
-		t.Fatal("expected PutItem called")
+	if ddb.updateInput == nil {
+		t.Fatal("expected UpdateItem called")
 	}
-	item := ddb.putInput.Item
-	if v, ok := item[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
-		t.Errorf("team_id wrong: %v", item[attrTeamID])
+	if v, ok := ddb.updateInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
+		t.Errorf("team_id wrong: %v", ddb.updateInput.Key[attrTeamID])
 	}
-	if v, ok := item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != "lv_live_xxx" {
-		t.Errorf("qurl_api_key wrong: %v", item[attrQURLAPIKey])
+	values := ddb.updateInput.ExpressionAttributeValues
+	if v, ok := values[":key"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != "lv_live_xxx" {
+		t.Errorf("qurl_api_key wrong: %v", values[":key"])
 	}
-	if v, ok := item[attrDataKeyCT].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != passthroughWrappedKey {
-		t.Errorf("dk wrong: %v", item[attrDataKeyCT])
+	if v, ok := values[":dk"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != passthroughWrappedKey {
+		t.Errorf("dk wrong: %v", values[":dk"])
 	}
-	if v, ok := item[attrConfiguredBy].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "U_ADMIN" {
-		t.Errorf("configured_by wrong: %v", item[attrConfiguredBy])
+	if v, ok := values[":by"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "U_ADMIN" {
+		t.Errorf("configured_by wrong: %v", values[":by"])
 	}
 	wantTS := fixedNow.Format(time.RFC3339)
-	if v, ok := item[attrUpdatedAt].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantTS {
-		t.Errorf("updated_at wrong: got %v want %q", item[attrUpdatedAt], wantTS)
+	if v, ok := values[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantTS {
+		t.Errorf("timestamp wrong: got %v want %q", values[":now"], wantTS)
 	}
-	if v, ok := item[attrConfiguredAt].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantTS {
-		t.Errorf("configured_at wrong: got %v want %q", item[attrConfiguredAt], wantTS)
+	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "configured_at = if_not_exists(configured_at, :now)") {
+		t.Errorf("UpdateExpression should preserve configured_at with if_not_exists, got %q", got)
 	}
 }
 
-// TestDDBProviderSetAPIKeyFailsFastOnGetItemError locks the contract
-// that a transient pre-flight GetItem failure aborts the write rather
-// than degrading to "destroy configured_at on rotation". Without the
-// fail-fast, a transport blip would silently wipe the original install
-// timestamp.
-func TestDDBProviderSetAPIKeyFailsFastOnGetItemError(t *testing.T) {
-	ddb := &fakeDDBClient{getErr: errors.New("ddb transient")}
+func TestDDBProviderSetAPIKeySurfacesUpdateError(t *testing.T) {
+	ddb := &fakeDDBClient{updateErr: errors.New("ddb transient")}
 	p := &DDBProvider{
 		Client:    ddb,
 		TableName: "ws",
@@ -262,11 +264,11 @@ func TestDDBProviderSetAPIKeyFailsFastOnGetItemError(t *testing.T) {
 		Now:       func() time.Time { return time.Unix(1700000000, 0).UTC() },
 	}
 	err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_xxx", "U_ADMIN")
-	if err == nil {
-		t.Fatal("expected error when pre-flight GetItem fails")
+	if err == nil || !strings.Contains(err.Error(), "UpdateItem") {
+		t.Fatalf("expected UpdateItem error, got %v", err)
 	}
 	if ddb.putInput != nil {
-		t.Error("PutItem must NOT run when pre-flight GetItem errored")
+		t.Error("PutItem must NOT run on the SetAPIKey path")
 	}
 }
 
@@ -276,17 +278,7 @@ func TestDDBProviderSetAPIKeyFailsFastOnGetItemError(t *testing.T) {
 // "now". A rotation that wiped configured_at would silently destroy
 // audit trail.
 func TestDDBProviderSetAPIKeyPreservesConfiguredAt(t *testing.T) {
-	original := "2026-01-01T00:00:00Z"
-	ddb := &fakeDDBClient{
-		getOutput: &dynamodb.GetItemOutput{
-			Item: map[string]ddbtypes.AttributeValue{
-				attrTeamID:       &ddbtypes.AttributeValueMemberS{Value: testTeamID},
-				attrQURLAPIKey:   &ddbtypes.AttributeValueMemberB{Value: []byte("old-ct")},
-				attrDataKeyCT:    &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
-				attrConfiguredAt: &ddbtypes.AttributeValueMemberS{Value: original},
-			},
-		},
-	}
+	ddb := &fakeDDBClient{}
 	rotatedAt := time.Unix(1800000000, 0).UTC()
 	p := &DDBProvider{
 		Client:    ddb,
@@ -297,13 +289,15 @@ func TestDDBProviderSetAPIKeyPreservesConfiguredAt(t *testing.T) {
 	if err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_new", "U_ADMIN2"); err != nil {
 		t.Fatalf("SetAPIKey: %v", err)
 	}
-	item := ddb.putInput.Item
-	if v, ok := item[attrConfiguredAt].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != original {
-		t.Errorf("configured_at must preserve original on rotation: got %v want %q", item[attrConfiguredAt], original)
+	if ddb.updateInput == nil {
+		t.Fatal("expected UpdateItem called")
+	}
+	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "configured_at = if_not_exists(configured_at, :now)") {
+		t.Errorf("configured_at must preserve original on rotation via if_not_exists, got %q", got)
 	}
 	wantUpdated := rotatedAt.Format(time.RFC3339)
-	if v, ok := item[attrUpdatedAt].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantUpdated {
-		t.Errorf("updated_at must move to rotation time: got %v want %q", item[attrUpdatedAt], wantUpdated)
+	if v, ok := ddb.updateInput.ExpressionAttributeValues[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantUpdated {
+		t.Errorf("updated_at must move to rotation time: got %v want %q", ddb.updateInput.ExpressionAttributeValues[":now"], wantUpdated)
 	}
 }
 
@@ -322,6 +316,88 @@ func TestDDBProviderSetAPIKeyNilNowDoesNotPanic(t *testing.T) {
 	}
 	if err := p.SetAPIKey(context.Background(), testTeamID, "lv_live", "U_x"); err != nil {
 		t.Fatalf("SetAPIKey with nil Now should fall through to time.Now, got err: %v", err)
+	}
+}
+
+func TestDDBProviderSlackBotToken(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{
+				Item: map[string]ddbtypes.AttributeValue{
+					attrTeamID:          &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+					attrSlackBotToken:   &ddbtypes.AttributeValueMemberB{Value: []byte("xoxb-secret")},
+					attrSlackBotTokenDK: &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+				},
+			},
+		}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		got, err := p.SlackBotToken(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("SlackBotToken: %v", err)
+		}
+		if got != "xoxb-secret" {
+			t.Fatalf("got %q want %q", got, "xoxb-secret")
+		}
+	})
+
+	t.Run("missing row", func(t *testing.T) {
+		ddb := &fakeDDBClient{getOutput: &dynamodb.GetItemOutput{}}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		_, err := p.SlackBotToken(context.Background(), testTeamID)
+		if !errors.Is(err, ErrSlackBotTokenNotConfigured) {
+			t.Fatalf("want ErrSlackBotTokenNotConfigured, got %v", err)
+		}
+	})
+
+	t.Run("old row without Slack token", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+				attrTeamID: &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+			}},
+		}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		_, err := p.SlackBotToken(context.Background(), testTeamID)
+		if !errors.Is(err, ErrSlackBotTokenNotConfigured) {
+			t.Fatalf("want ErrSlackBotTokenNotConfigured, got %v", err)
+		}
+	})
+}
+
+func TestDDBProviderSetSlackBotToken(t *testing.T) {
+	ddb := &fakeDDBClient{}
+	fixedNow := time.Unix(1700000000, 0).UTC()
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+		Now:       func() time.Time { return fixedNow },
+	}
+	err := p.SetSlackBotToken(context.Background(), testTeamID, SlackBotTokenInstall{
+		BotToken:     "xoxb-secret",
+		InstalledBy:  "U_INSTALLER",
+		BotUserID:    "U_BOT",
+		AppID:        "A_APP",
+		EnterpriseID: "E_GRID",
+		Scopes:       []string{"views:write", "commands", "views:write"},
+	})
+	if err != nil {
+		t.Fatalf("SetSlackBotToken: %v", err)
+	}
+	if ddb.updateInput == nil {
+		t.Fatal("expected UpdateItem called")
+	}
+	values := ddb.updateInput.ExpressionAttributeValues
+	if v, ok := values[":token"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != "xoxb-secret" {
+		t.Errorf("slack token wrong: %v", values[":token"])
+	}
+	if v, ok := values[":dk"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != passthroughWrappedKey {
+		t.Errorf("slack token data key wrong: %v", values[":dk"])
+	}
+	if v, ok := values[":scopes"].(*ddbtypes.AttributeValueMemberSS); !ok || strings.Join(v.Value, ",") != "commands,views:write" {
+		t.Errorf("scopes should be sorted/deduped: %v", values[":scopes"])
+	}
+	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "slack_bot_installed_at = if_not_exists(slack_bot_installed_at, :now)") {
+		t.Errorf("UpdateExpression should preserve original Slack installed_at, got %q", got)
 	}
 }
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -257,8 +257,24 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 	if v, ok := values[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantTS {
 		t.Errorf("timestamp wrong: got %v want %q", values[":now"], wantTS)
 	}
-	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "configured_at = if_not_exists(configured_at, :now)") {
+	got := *ddb.updateInput.UpdateExpression
+	if !strings.Contains(got, "configured_at = if_not_exists(configured_at, :now)") {
 		t.Errorf("UpdateExpression should preserve configured_at with if_not_exists, got %q", got)
+	}
+	for _, attr := range []string{
+		attrSlackBotToken,
+		attrSlackBotTokenDK,
+		attrSlackBotInstalledBy,
+		attrSlackBotInstalledAt,
+		attrSlackBotUpdatedAt,
+		attrSlackBotUserID,
+		attrSlackAppID,
+		attrSlackEnterpriseID,
+		attrSlackBotScopes,
+	} {
+		if strings.Contains(got, attr) {
+			t.Errorf("SetAPIKey UpdateExpression should not touch Slack attr %s, got %q", attr, got)
+		}
 	}
 	if ddb.updateInput.ReturnValues != ddbtypes.ReturnValueUpdatedOld {
 		t.Errorf("ReturnValues = %v, want UPDATED_OLD for rotation observability", ddb.updateInput.ReturnValues)

--- a/shared/auth/slack_token.go
+++ b/shared/auth/slack_token.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SlackBotTokenTypoGuardMin is a loose local lower bound for Slack bot tokens.
+const SlackBotTokenTypoGuardMin = 30
+
+// SlackBotTokenTypoGuardMax is a generous local upper bound for Slack bot tokens.
+const SlackBotTokenTypoGuardMax = 1024
+
+// ValidateSlackBotTokenShape catches obvious Slack bot-token typos before a
+// malformed token is used for Slack Web API calls or persisted after OAuth.
+func ValidateSlackBotTokenShape(token string) error {
+	if token == "" {
+		return nil
+	}
+	if len(token) < SlackBotTokenTypoGuardMin {
+		return fmt.Errorf("slack bot token is shorter than %d characters", SlackBotTokenTypoGuardMin)
+	}
+	if len(token) > SlackBotTokenTypoGuardMax {
+		return fmt.Errorf("slack bot token is longer than %d characters", SlackBotTokenTypoGuardMax)
+	}
+	if !validSlackBotTokenPrefix(token) {
+		return errors.New("slack bot token must start with xoxb- or xoxe.xoxb-")
+	}
+	for i, b := range []byte(token) {
+		if b >= '!' && b <= '~' {
+			continue
+		}
+		return fmt.Errorf("slack bot token contains invalid characters near byte %d", i)
+	}
+	return nil
+}
+
+func validSlackBotTokenPrefix(token string) bool {
+	return strings.HasPrefix(token, "xoxb-") ||
+		strings.HasPrefix(token, "xoxe.xoxb-")
+}

--- a/shared/auth/slack_token_test.go
+++ b/shared/auth/slack_token_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSlackBotTokenShape(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{name: "empty allowed"},
+		{name: "bot token", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")+10)},
+		{name: "rotating bot token", token: "xoxe.xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxe.xoxb-"))},
+		{name: "rotating refresh token", token: "xoxe-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxe-")), wantErr: true},
+		{name: "wrong prefix", token: "abc-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("abc-")), wantErr: true},
+		{name: "minimum length", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-"))},
+		{name: "too short", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")-1), wantErr: true},
+		{name: "space rejected", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")) + " bad", wantErr: true},
+		{name: "underscore allowed", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")) + "_ok"},
+		{name: "dot allowed", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")) + ".ok"},
+		{name: "delete control rejected", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")) + string(rune(0x7f)), wantErr: true},
+		{name: "non ascii rejected", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMin-len("xoxb-")) + "é", wantErr: true},
+		{name: "maximum length", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMax-len("xoxb-"))},
+		{name: "too long", token: "xoxb-" + strings.Repeat("a", SlackBotTokenTypoGuardMax-len("xoxb-")+1), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSlackBotTokenShape(tc.token)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateSlackBotTokenShape(%q) err=%v, wantErr=%v", tc.token, err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add Slack app install OAuth routes that capture each workspace bot token
- store Slack bot tokens encrypted in workspace_state and use them for views.open by team_id, with token-shape validation at both OAuth exchange and storage boundaries
- keep SLACK_BOT_TOKEN as a legacy fallback, warn once per workspace/negative-cache window when it is actively serving, improve reinstall guidance, and document rollout settings
- harden the guided install flow with flow-bound state, safer OAuth error logging, shared token validation, singleflight workspace token lookup, short positive/negative cache TTLs, generation-guarded same-process cache purge on reinstall, missing-scope rejection, Enterprise Grid org-install rejection, and focused callback/storage/cache tests

## Business relevance
This makes guided tunnel setup available to every customer workspace instead of depending on a single deployment-level Slack bot token. It reduces onboarding friction for tunnel installs and gives support a deterministic reinstall path when customers need the new views:write scope.

## Validation
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m ./...
- go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/... (total coverage 78.7%)

## Rollout notes
- configure SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_BASE_URL, and SLACK_INSTALL_STATE_SECRET
- use a distinct production SLACK_INSTALL_STATE_SECRET instead of relying on the OAUTH_STATE_SECRET fallback
- route /oauth/slack/* to the Slack bot service and confirm the ALB/proxy preserves Set-Cookie on the install redirect
- configure Slack OAuth redirect URL to /oauth/slack/callback and install URL to /oauth/slack/install
- keep both commands and views:write bot scopes enabled; any SLACK_BOT_SCOPES override must include both
- use non-rotating Slack bot tokens until refresh-token persistence is implemented
- ensure IAM allows dynamodb:UpdateItem on WORKSPACE_STATE_TABLE
- have existing customer workspaces reinstall or reauthorize so Slack issues a bot token with views:write
- use workspace-level Slack installs; org-level Enterprise Grid installs are intentionally rejected until enterprise-scoped tokens are supported

## Follow-ups
- #265 is partially closed here for the DDB row clobber race via UpdateItem; an orphaned qurl-service key from a losing concurrent mint remains tracked as follow-up.
