### PR TITLE
feat(slack): list tunnels only with slug tokens; /qurl get one-time by default

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -760,14 +760,14 @@ func (h *Handler) helpMessage() string {
 		"*/qurl* — Create and manage qURLs from Slack",
 		"",
 		"*Commands:*",
-		"• `/qurl get <url|$slug>` — Mint a one-time qURL for a URL or a `$slug` your Slack admin has configured in this channel",
+		"• `/qurl get <url|$slug>` — Mint a one-time qURL for a URL, or a `$slug` (tunnel or shortcut) configured in this channel",
 	}
 	if h.cfg.PostDM != nil {
 		lines = append(lines, "• `/qurl get <url|$slug> dm:true` — DM the link to you instead of posting it in-channel")
 	}
 	lines = append(lines,
 		"• `/qurl get <url|$slug> reason:\"…\"` — Same, annotating the audit log with a reason",
-		"• `/qurl list` — List the tunnels available in this workspace",
+		"• `/qurl list` — List the tunnels available to you",
 		"• `/qurl setup` — Connect qURL to your Slack workspace and become its qURL admin (workspace admin only)",
 	)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -760,16 +760,14 @@ func (h *Handler) helpMessage() string {
 		"*/qurl* — Create and manage qURLs from Slack",
 		"",
 		"*Commands:*",
-		"• `/qurl get <url>` — Get a qURL for a URL",
-		"• `/qurl get $name` — Get a qURL for a name your Slack admin has configured in this channel",
+		"• `/qurl get <url|$slug>` — Mint a one-time qURL for a URL or a `$slug` your Slack admin has configured in this channel",
 	}
 	if h.cfg.PostDM != nil {
-		lines = append(lines, "• `/qurl get <url|$name> dm:true` — DM the link to you instead of posting it in-channel")
+		lines = append(lines, "• `/qurl get <url|$slug> dm:true` — DM the link to you instead of posting it in-channel")
 	}
 	lines = append(lines,
-		"• `/qurl get <url|$name> once:true` — Get a single-use qURL; the link burns on first redemption",
-		"• `/qurl get <url|$name> reason:\"…\"` — Annotate the audit log with a reason",
-		"• `/qurl list` — Show your 5 most recent qURLs",
+		"• `/qurl get <url|$slug> reason:\"…\"` — Same, annotating the audit log with a reason",
+		"• `/qurl list` — List the tunnels available in this workspace",
 		"• `/qurl setup` — Connect qURL to your Slack workspace and become its qURL admin (workspace admin only)",
 	)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
@@ -795,7 +793,7 @@ func (h *Handler) helpMessage() string {
 		// on "shortcut" even though the admin verbs retain their
 		// historical set-alias/unset-alias names.
 		lines = append(lines,
-			"• `/qurl set-alias $<shortcut> <url-or-resource-id-or-$slug>` — Configure a qURL shortcut in this channel (admin only)",
+			"• `/qurl set-alias $<shortcut> <url-or-$slug>` — Configure a qURL shortcut in this channel (admin only)",
 			"• `/qurl unset-alias $<shortcut>` — Remove a qURL shortcut in this channel (admin only)",
 			"• `/qurl aliases` — List the qURL shortcuts configured in this channel",
 		)

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -766,7 +766,7 @@ func (h *Handler) helpMessage() string {
 		lines = append(lines, "• `/qurl get <url|$slug> dm:true` — DM the link to you instead of posting it in-channel")
 	}
 	lines = append(lines,
-		"• `/qurl get <url|$slug> reason:\"…\"` — Same, annotating the audit log with a reason",
+		"• `/qurl get <url|$slug> reason:\"…\"` — Mint a one-time qURL, recording a reason in the audit log",
 		"• `/qurl list` — List the tunnels available to you",
 		"• `/qurl setup` — Connect qURL to your Slack workspace and become its qURL admin (workspace admin only)",
 	)

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -389,6 +389,11 @@ func (h *Handler) resolveTunnelSlugAliasTarget(ctx context.Context, teamID, slug
 	}
 	for i := range page.Resources {
 		resource := &page.Resources[i]
+		// Defense-in-depth: the server's `?slug=` filter is single-
+		// purpose, but re-assert type/slug/active here so an upstream
+		// regression can't leak a non-tunnel, wrong-slug, or revoked
+		// resource into mintable state (this resolves the resource_id
+		// that both /qurl set-alias and /qurl get then mint against).
 		if resource.Type == client.ResourceTypeTunnel && resource.Slug == slug && resource.Status == client.StatusActive {
 			return resource.ResourceID, nil
 		}

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -86,7 +86,7 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 		return
 	}
 	if len(entries) == 0 {
-		_ = h.postResponse(log, responseURL, ":mag: No aliases are configured for this channel yet. Run `/qurl set-alias $<alias> <url-or-resource-id-or-$slug>` to add one.")
+		_ = h.postResponse(log, responseURL, ":mag: No aliases are configured for this channel yet. Run `/qurl set-alias $<alias> <url-or-$slug>` to add one.")
 		return
 	}
 
@@ -126,7 +126,7 @@ loop:
 			// Fill un-dispatched tail with id-only fallbacks.
 			for j := i; j < len(entries); j++ {
 				e := &entries[j]
-				lines[j] = formatAliasLine(e.Alias, "", e.ResourceID)
+				lines[j] = formatAliasLine(e.Alias, "", "", e.ResourceID)
 			}
 			break loop
 		}
@@ -137,16 +137,21 @@ loop:
 			e := &entries[idx]
 			alias := e.Alias
 			target := ""
+			slug := ""
 			if e.ResourceID != "" && e.Alias != "" {
 				// GetResourceByAlias is the customer-facing path that
-				// returns Alias + TargetURL. The Store row may carry
-				// alias=="" (legacy shape) — fall back to id-only in
-				// that case rather than swallowing a 404.
+				// returns the full Resource (Alias, TargetURL, Slug, …).
+				// The Store row may carry alias=="" (legacy shape) — fall
+				// back to id-only in that case rather than swallowing a
+				// 404. Tunnel resources have no TargetURL but carry a
+				// Slug, which [formatAliasLine] surfaces in place of the
+				// resource_id.
 				if r, rerr := c.GetResourceByAlias(ctx, e.Alias); rerr == nil {
 					if r.Alias != "" {
 						alias = r.Alias
 					}
 					target = r.TargetURL
+					slug = r.Slug
 				} else if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
 					// Distinct log from the 404/5xx branch so operators
 					// can tell "request was cut short by SIGTERM /
@@ -157,22 +162,35 @@ loop:
 					log.Debug("aliases: resource fetch failed in fanout", "error", rerr, "resource_id", e.ResourceID)
 				}
 			}
-			lines[idx] = formatAliasLine(alias, target, e.ResourceID)
+			lines[idx] = formatAliasLine(alias, target, slug, e.ResourceID)
 		}(i)
 	}
 	wg.Wait()
 	return lines
 }
 
-// formatAliasLine renders one row of the /qurl aliases listing. The
-// target is optional — when the per-row resource fetch fails we fall
-// back to "id only" rather than dropping the entry.
-func formatAliasLine(alias, target, resourceID string) string {
+// formatAliasLine renders one row of the /qurl aliases listing.
+// Right-hand side precedence, most to least specific:
+//
+//   - target_url (URL/transit resource):   • `$<alias>` → <url>
+//   - slug (tunnel resource, no target):   • `$<alias>` → `$<slug>`
+//   - resource_id (fetch failed / legacy): • `$<alias>` → `<r_id>`
+//   - bare alias (nothing resolved):       • `$<alias>`
+//
+// Tunnel-backed aliases have no target_url, so the slug is shown
+// instead of the opaque resource_id — it's the same `$<slug>` token
+// `/qurl list` renders and `/qurl get` accepts. resource_id remains the
+// last-resort fallback (a failed per-row fetch leaves slug empty), so
+// the user still sees one line per entry.
+func formatAliasLine(alias, target, slug, resourceID string) string {
 	if alias == "" {
 		alias = "(no alias)"
 	}
 	if target != "" {
 		return fmt.Sprintf("• `$%s` → %s", alias, target)
+	}
+	if slug != "" {
+		return fmt.Sprintf("• `$%s` → `$%s`", alias, slug)
 	}
 	if resourceID != "" {
 		return fmt.Sprintf("• `$%s` → `%s`", alias, resourceID)

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -195,5 +195,11 @@ func formatAliasLine(alias, target, slug, resourceID string) string {
 	if resourceID != "" {
 		return fmt.Sprintf("• `$%s` → `%s`", alias, resourceID)
 	}
+	// Bare token, nothing resolved. Only reachable with an empty
+	// resourceID — and fanoutAliasRows only fetches (and thus only
+	// reaches this formatter at all) when ResourceID != "", so a real
+	// PolicyEntry row never lands here. This is the defensive escape
+	// hatch for a synthetic/empty entry, kept so the listing still
+	// renders one line per entry rather than dropping it.
 	return fmt.Sprintf("• `$%s`", alias)
 }

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -33,6 +33,30 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 	}
 }
 
+// TestHandleAliases_TunnelAliasShowsSlug fences the alias→slug rendering
+// for tunnel-backed aliases: a tunnel resource has no target_url, so the
+// row shows the tunnel's `$<slug>` (the same token /qurl list renders
+// and /qurl get accepts) instead of the opaque resource_id.
+func TestHandleAliases_TunnelAliasShowsSlug(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		"bastion": "r_bastion01",
+	})
+	ts.addCustomer("GET", "/v1/resources/by-alias/bastion", func(w http.ResponseWriter, _ *http.Request) {
+		writeTunnelResourceFixture(t, w, "r_bastion01", "bastion", "ops-bastion")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$bastion` → `$ops-bastion`") {
+		t.Errorf("aliases reply missing alias→slug mapping: %q", async)
+	}
+	if strings.Contains(async, "r_bastion01") {
+		t.Errorf("aliases reply leaked opaque resource_id instead of slug: %q", async)
+	}
+}
+
 // TestHandleAliases_MultiAliasChannelDisplaysAllBindings fences the
 // post-pivot multi-binding behavior: a channel with three
 // alias_bindings emits a PolicyEntry per binding, and `/qurl

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -254,7 +254,7 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 
 	switch {
 	case isAliasForm:
-		boundResourceID, err := h.resolveAliasForGet(ctx, log, args.teamID, args.channelID, alias)
+		boundResourceID, err := h.resolveTokenForGet(ctx, log, args.teamID, args.channelID, args.userID, alias)
 		if err != nil {
 			return "", err
 		}
@@ -313,69 +313,114 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	return message, nil
 }
 
-// resolveAliasForGet resolves a `$<alias>` token to a resource_id via
-// the channel's `channel_policies.alias_bindings` map. The presence of
-// the binding in THIS channel is itself the authorization signal —
-// `/qurl setalias` is the admin act that authorizes a resource for use
-// in the channel.
+// resolveTokenForGet resolves a `$<token>` (channel alias or tunnel
+// slug) to a mintable resource_id for /qurl get, enforcing channel
+// authorization. Resolution order:
 //
-// NOTE: setalias is the only authorization signal today. If the
-// orthogonal `admin allow` / `allowed_resource_ids` surface gets
-// re-wired (currently dropped from this path), the channel-policy
-// gate goes between the binding lookup and the return.
+//  1. Channel alias binding (`channel_policies.alias_bindings`). The
+//     presence of the binding in THIS channel is itself the
+//     authorization signal — `/qurl set-alias` is the admin act that
+//     authorizes a resource for use here.
+//  2. Tunnel-slug fallback. When no binding matches, the token may
+//     still be a tunnel slug: `/qurl list` renders `$<slug>` for tunnels
+//     surfaced via admin-sees-all or `allowed_resource_ids` that have no
+//     `alias_bindings` row in this channel (e.g. a tunnel installed in
+//     another channel, or granted via cross-channel allow). Resolve the
+//     slug to its resource_id and gate it through the SAME channel
+//     allow-set as the `$r_<id>` form ([Handler.resourceAllowedForUser])
+//     so the list→get round-trip the list footer advertises stays
+//     honest without re-exposing the opaque r_<id> in the list.
 //
-// Returns a [*userError] (no logging at call site needed) on the
-// AdminStore-nil, lookup-failed, and binding-not-found branches.
-func (h *Handler) resolveAliasForGet(ctx context.Context, log *slog.Logger, teamID, channelID, alias string) (string, error) {
-	// Refuse early on a no-DDB sandbox deploy. Alias-form requires
-	// the channel-scoped binding store; URL form does not, so this
-	// gate only fires here.
+// Returns a [*userError] on AdminStore-nil, lookup failure,
+// not-a-known-token, or not-allowed-here.
+func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, teamID, channelID, userID, token string) (string, error) {
+	// Refuse early on a no-DDB sandbox deploy. Token-form requires the
+	// channel-scoped binding store; URL form does not, so this gate
+	// only fires here.
 	if h.cfg.AdminStore == nil {
-		log.Warn("get: AdminStore is nil; alias-form lookup unavailable", "team_id", teamID)
+		log.Warn("get: AdminStore is nil; token-form lookup unavailable", "team_id", teamID)
 		return "", errAdminStoreNotConfigured
 	}
-	resourceID, found, err := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, alias)
+	resourceID, found, err := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, token)
 	if err != nil {
-		log.Warn("get: alias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias)
+		log.Warn("get: alias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", token)
 		return "", &userError{msg: serviceUnreachableMessage}
 	}
-	if !found {
-		return "", &userError{msg: noResourceForAliasMessage(alias)}
+	if found {
+		return resourceID, nil
 	}
-	return resourceID, nil
+
+	// No binding — try the token as a tunnel slug, then authorize.
+	slugResourceID, slugErr := h.resolveTunnelSlugAliasTarget(ctx, teamID, token)
+	if slugErr != nil {
+		if errors.Is(slugErr, errTunnelSlugNotFound) {
+			// Neither a channel alias nor a live tunnel slug — genuinely
+			// unknown in this channel.
+			return "", &userError{msg: noResourceForAliasMessage(token)}
+		}
+		log.Warn("get: tunnel-slug fallback lookup failed", "error", slugErr, "team_id", teamID, "slug", token)
+		return "", &userError{msg: serviceUnreachableMessage}
+	}
+	allowed, authErr := h.resourceAllowedForUser(ctx, log, teamID, channelID, userID, slugResourceID)
+	if authErr != nil {
+		return "", authErr
+	}
+	if !allowed {
+		// Word the rejection with the slug the user typed, not the
+		// resolved r_<id> (which they never saw).
+		return "", &userError{msg: notAllowedInChannelMessage(token)}
+	}
+	return slugResourceID, nil
 }
 
-// authorizeResourceIDForGet enforces the channel-scoped allow on a
-// `$r_<id>` token. Workspace admins bypass the allow-set so the
-// list-and-get round-trip works in the admin's unfiltered list view;
-// non-admins must have the ID in `AllowedResourceIDsForChannel` (the
+// resourceAllowedForUser reports whether userID may mint against
+// resourceID in channelID. Workspace admins may always (so the
+// list-and-get round-trip works in the admin's unfiltered list view);
+// non-admins only when the ID is in `AllowedResourceIDsForChannel` (the
 // union of `alias_bindings.values()` and `allowed_resource_ids`),
 // keeping list visibility and mintability aligned for them.
 //
-// Returns nil on allow, [*userError] on AdminStore-nil, allow-set
-// fetch failure, or membership miss.
-func (h *Handler) authorizeResourceIDForGet(ctx context.Context, log *slog.Logger, teamID, channelID, userID, resourceID string) error {
-	// Resource-ID form needs an AdminStore for the admin probe + the
-	// channel allow-set. Same fail-closed posture as alias-form on a
-	// no-DDB sandbox.
+// Returns (false, [*userError]) on AdminStore-nil or allow-set fetch
+// failure so callers fail closed. The decision is split from the
+// user-facing "not allowed" message so both the `$r_<id>` form and the
+// tunnel-slug fallback can reuse it while wording the rejection in terms
+// of the token the user actually typed.
+func (h *Handler) resourceAllowedForUser(ctx context.Context, log *slog.Logger, teamID, channelID, userID, resourceID string) (bool, error) {
+	// Needs an AdminStore for the admin probe + the channel allow-set.
+	// Same fail-closed posture as alias-form on a no-DDB sandbox.
 	if h.cfg.AdminStore == nil {
-		log.Warn("get: AdminStore is nil; resource-id-form lookup unavailable", "team_id", teamID)
-		return errAdminStoreNotConfigured
+		log.Warn("get: AdminStore is nil; authorization unavailable", "team_id", teamID)
+		return false, errAdminStoreNotConfigured
 	}
 	isAdmin, _, adminErr := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
 	if adminErr != nil {
-		log.Warn("get: admin probe failed for resource-id form — treating as non-admin", "error", adminErr, "team_id", teamID, "user_id", userID)
+		log.Warn("get: admin probe failed — treating as non-admin", "error", adminErr, "team_id", teamID, "user_id", userID)
 		isAdmin = false
 	}
 	if isAdmin {
-		return nil
+		return true, nil
 	}
 	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(ctx, teamID, channelID)
 	if err != nil {
 		log.Warn("get: allowed-resource fetch failed", "error", err, "team_id", teamID, "channel_id", channelID)
-		return &userError{msg: serviceUnreachableMessage}
+		return false, &userError{msg: serviceUnreachableMessage}
 	}
-	if _, ok := allowed[resourceID]; !ok {
+	_, ok := allowed[resourceID]
+	return ok, nil
+}
+
+// authorizeResourceIDForGet enforces the channel-scoped allow on a
+// `$r_<id>` token via [Handler.resourceAllowedForUser], wording the
+// rejection with the resource_id the user pasted.
+//
+// Returns nil on allow, [*userError] on AdminStore-nil, allow-set
+// fetch failure, or membership miss.
+func (h *Handler) authorizeResourceIDForGet(ctx context.Context, log *slog.Logger, teamID, channelID, userID, resourceID string) error {
+	allowed, err := h.resourceAllowedForUser(ctx, log, teamID, channelID, userID, resourceID)
+	if err != nil {
+		return err
+	}
+	if !allowed {
 		return &userError{msg: notAllowedInChannelMessage(resourceID)}
 	}
 	return nil

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -343,7 +343,7 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 	}
 	resourceID, found, err := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, token)
 	if err != nil {
-		log.Warn("get: alias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", token)
+		log.Warn("get: alias lookup failed", "error", err, "team_id", teamID, "channel_id", channelID, "token", token)
 		return "", &userError{msg: serviceUnreachableMessage}
 	}
 	if found {
@@ -366,9 +366,16 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 		return "", authErr
 	}
 	if !allowed {
-		// Word the rejection with the slug the user typed, not the
-		// resolved r_<id> (which they never saw).
-		return "", &userError{msg: notAllowedInChannelMessage(token)}
+		// Collapse to the SAME "not configured" copy as the
+		// slug-not-found branch above. A non-admin must not be able to
+		// distinguish "this slug exists in the workspace but isn't
+		// allowed in this channel" from "no such slug" — that gap is a
+		// tunnel-slug enumeration oracle. This preserves the mirrored-
+		// copy posture the `$r_<id>` form documents
+		// ([notAllowedInChannelMessage]) on the slug-fallback path. Logs
+		// the real reason for operators; the wire text stays uniform.
+		log.Debug("get: tunnel slug resolved but not allowed in channel — surfacing not-configured copy", "team_id", teamID, "channel_id", channelID, "user_id", userID, "slug", token)
+		return "", &userError{msg: noResourceForAliasMessage(token)}
 	}
 	return slugResourceID, nil
 }

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -160,7 +160,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	if cmd.Alias == "" && cmd.Target == "" && cmd.Resource.Kind != ResourceTokenResourceID {
-		respondSlack(w, ":warning: Usage: `/qurl get <url>` to mint for a URL, or `/qurl get $name` to mint for a name your Slack admin has configured here.")
+		respondSlack(w, ":warning: Usage: `/qurl get <url>` to mint for a URL, or `/qurl get $slug` to mint for a tunnel or shortcut your Slack admin has configured here.")
 		return
 	}
 
@@ -245,8 +245,11 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	}
 
 	input := client.CreateInput{
-		Reason:         args.cmd.Reason(),
-		OneTimeUse:     args.cmd.Once(),
+		Reason: args.cmd.Reason(),
+		// One-time use is the default and only mode for `/qurl get` —
+		// every minted link burns on first redemption. There is no
+		// `once` flag; the behavior is unconditional.
+		OneTimeUse:     true,
 		IdempotencyKey: IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
 	}
 
@@ -302,10 +305,10 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		return "", &userError{msg: commonGetMintFailedMessage}
 	}
 
-	message := ":link: *qURL ready:* " + out.QURLLink
-	if args.cmd.Once() {
-		message += " (one-time use)"
-	}
+	// Every `/qurl get` link is one-time use (see OneTimeUse above), so
+	// the suffix is unconditional — it sets the expectation that the
+	// link burns on first redemption.
+	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use)"
 	if args.cmd.DM() {
 		return h.deliverGetDM(ctx, log, args.userID, message), nil
 	}

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -221,10 +221,10 @@ type getWorkArgs struct {
 }
 
 // getWork runs the inner resolve→rate-limit→mint pipeline for the
-// URL form (`/qurl get <url>`), the alias form (`/qurl get $name`),
-// and the resource-ID form (`/qurl get $r_<id>`). Returns the
-// rendered reply text (without leading `:warning:`) on success, or a
-// [*userError] whose msg routes to the user.
+// URL form (`/qurl get <url>`), the token form (`/qurl get $alias` or
+// `/qurl get $slug`), and the resource-ID form (`/qurl get $r_<id>`).
+// Returns the rendered reply text (without leading `:warning:`) on
+// success, or a [*userError] whose msg routes to the user.
 func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArgs) (string, error) {
 	alias := args.cmd.Alias
 	target := args.cmd.Target

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -246,9 +246,8 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 
 	input := client.CreateInput{
 		Reason: args.cmd.Reason(),
-		// One-time use is the default and only mode for `/qurl get` —
-		// every minted link burns on first redemption. There is no
-		// `once` flag; the behavior is unconditional.
+		// One-time use is the only mode for `/qurl get` — there is no
+		// `once` flag; every minted link burns on first redemption.
 		OneTimeUse:     true,
 		IdempotencyKey: IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
 	}
@@ -305,9 +304,8 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		return "", &userError{msg: commonGetMintFailedMessage}
 	}
 
-	// Every `/qurl get` link is one-time use (see OneTimeUse above), so
-	// the suffix is unconditional — it sets the expectation that the
-	// link burns on first redemption.
+	// Unconditional suffix — every `/qurl get` link is one-time use
+	// (see OneTimeUse above).
 	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use)"
 	if args.cmd.DM() {
 		return h.deliverGetDM(ctx, log, args.userID, message), nil

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -331,6 +331,11 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 //     so the list→get round-trip the list footer advertises stays
 //     honest without re-exposing the opaque r_<id> in the list.
 //
+// Cost note: every binding MISS now incurs one extra upstream hop
+// (GET /v1/resources?slug=…), including for plain typos. That's the
+// deliberate price of the round-trip honesty above — don't "optimize"
+// it away by short-circuiting the fallback on a binding miss.
+//
 // Returns a [*userError] on AdminStore-nil, lookup failure,
 // not-a-known-token, or not-allowed-here.
 func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, teamID, channelID, userID, token string) (string, error) {

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -322,11 +322,12 @@ func TestHandleGet_DMVariantPostDMSuccess(t *testing.T) {
 	}
 }
 
-// TestHandleGet_OnceTrueDMTrue fences that the (one-time use) suffix
-// rides into the DM payload (not the channel reply) when once: and
-// dm: stack. Guards against a future refactor that reorders the
-// suffix-append and DM-dispatch branches in getWork.
-func TestHandleGet_OnceTrueDMTrue(t *testing.T) {
+// TestHandleGet_DMRidesOneTimeSuffix fences that the (one-time use)
+// suffix rides into the DM payload (not the channel reply) on dm:true.
+// One-time use is the unconditional default for `/qurl get`, so the
+// suffix is always present; this guards against a future refactor that
+// reorders the suffix-append and DM-dispatch branches in getWork.
+func TestHandleGet_DMRidesOneTimeSuffix(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
 	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
@@ -341,7 +342,7 @@ func TestHandleGet_OnceTrueDMTrue(t *testing.T) {
 	}
 	inv := newAdminSlashInvoker(t, h)
 
-	_, _, async := inv.invokeAdminAsync("get $prod-db once:true dm:true", testAdminTeamID, testAdminUserID)
+	_, _, async := inv.invokeAdminAsync("get $prod-db dm:true", testAdminTeamID, testAdminUserID)
 
 	if !strings.HasSuffix(strings.TrimSpace(dmText), "(one-time use)") {
 		t.Errorf("DM payload missing one-time-use suffix: %q", dmText)
@@ -446,38 +447,12 @@ func TestCreateInputJSON_Reason(t *testing.T) {
 	}
 }
 
-// TestCreateInputJSON_OnceTrue fences `one_time_use: true` on the
-// wire body and the `(one-time use)` suffix on the async reply.
-func TestCreateInputJSON_OnceTrue(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	var capturedBody []byte
-	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
-		b, _ := io.ReadAll(r.Body)
-		capturedBody = b
-		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("get $prod-db once:true", testAdminTeamID, testAdminUserID)
-
-	var parsed map[string]any
-	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
-		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
-	}
-	if got, _ := parsed["one_time_use"].(bool); !got {
-		t.Errorf("one_time_use = %v, want true", parsed["one_time_use"])
-	}
-	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use)") {
-		t.Errorf("async reply missing one-time-use suffix: %q", async)
-	}
-}
-
-// TestCreateInputJSON_OnceAbsent fences `omitempty` — without the
-// flag, `one_time_use` is absent from the body and the suffix is
-// absent from the reply.
-func TestCreateInputJSON_OnceAbsent(t *testing.T) {
+// TestCreateInputJSON_OneTimeDefault fences that one-time use is the
+// unconditional default for `/qurl get`: with no flag at all, the wire
+// body carries `one_time_use: true` and the async reply carries the
+// `(one-time use)` suffix. There is no `once` flag — every `/qurl get`
+// link burns on first redemption.
+func TestCreateInputJSON_OneTimeDefault(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
 	var capturedBody []byte
@@ -495,42 +470,11 @@ func TestCreateInputJSON_OnceAbsent(t *testing.T) {
 	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
 		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
 	}
-	if _, ok := parsed["one_time_use"]; ok {
-		t.Errorf("one_time_use present on default mint body (omitempty must drop the false zero): %v", parsed)
+	if got, _ := parsed["one_time_use"].(bool); !got {
+		t.Errorf("one_time_use = %v, want true (one-time use is the unconditional default)", parsed["one_time_use"])
 	}
-	if strings.Contains(async, "(one-time use)") {
-		t.Errorf("async reply carries one-time-use suffix without the flag: %q", async)
-	}
-}
-
-// TestCreateInputJSON_OnceFalse fences the explicit-false branch:
-// `once:false` is accepted by the parser (Flags["once"]="false"),
-// `Once()` returns false via EqualFold, and `omitempty` drops the
-// zero from the body. Distinct from [TestCreateInputJSON_OnceAbsent]
-// because that test never populates the flag at all.
-func TestCreateInputJSON_OnceFalse(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	var capturedBody []byte
-	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
-		b, _ := io.ReadAll(r.Body)
-		capturedBody = b
-		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("get $prod-db once:false", testAdminTeamID, testAdminUserID)
-
-	var parsed map[string]any
-	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
-		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
-	}
-	if _, ok := parsed["one_time_use"]; ok {
-		t.Errorf("one_time_use present on once:false mint body (omitempty must drop the false zero): %v", parsed)
-	}
-	if strings.Contains(async, "(one-time use)") {
-		t.Errorf("async reply carries one-time-use suffix on once:false: %q", async)
+	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use)") {
+		t.Errorf("async reply missing one-time-use suffix: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // writeCreateFixture writes a POST /v1/qurls success envelope.
@@ -80,6 +82,13 @@ func TestHandleGet_AliasNotFound(t *testing.T) {
 	ts.addCustomer("POST", "/v1/qurls", func(w http.ResponseWriter, _ *http.Request) {
 		mintHits.Add(1)
 		w.WriteHeader(http.StatusOK)
+	})
+	// On an alias-binding miss, getWork falls back to a tunnel-slug
+	// lookup (GET /v1/resources?slug=…). `$missing` is neither a binding
+	// nor a live tunnel slug, so the resources listing returns empty and
+	// the user sees the "not configured for this channel" copy.
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
@@ -611,6 +620,95 @@ func TestHandleGet_DollarResourceIDNotInAllowedSetNonAdmin(t *testing.T) {
 	}
 	if mintHits.Load() != 0 {
 		t.Errorf("mint reached despite resource-id not-in-allow-set (hits = %d)", mintHits.Load())
+	}
+}
+
+// addTunnelSlugResource registers a GET /v1/resources handler that
+// resolves testTunnelSlug → testResourceIDFix as an active tunnel — the
+// upstream half of the `/qurl get $<slug>` slug-fallback path.
+func addTunnelSlugResource(t *testing.T, ts *adminTestServers) {
+	t.Helper()
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{{
+			testKeyResourceID: testResourceIDFix,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		}}, "", false)
+	})
+}
+
+// TestHandleGet_DollarSlugAllowedSetNonAdmin fences the list→get
+// round-trip for a tunnel that reaches a non-admin's /qurl list via
+// allowed_resource_ids only — no alias_binding in this channel (e.g. a
+// tunnel installed in another channel, then granted here). /qurl list
+// renders `$<slug>`; pasting it into /qurl get must mint. The token
+// misses the alias-binding lookup, falls back to slug resolution, and
+// the resolved resource_id passes the channel allow-set gate.
+func TestHandleGet_DollarSlugAllowedSetNonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{testResourceIDFix})
+	addTunnelSlugResource(t, ts)
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeCreateFixture(t, w, "https://qurl.link/by-slug", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "https://qurl.link/by-slug") {
+		t.Errorf("slug round-trip failed — async reply missing link: %q", async)
+	}
+}
+
+// TestHandleGet_DollarSlugNotAllowedNonAdmin fences the slug-fallback
+// authorization gate: a non-admin pasting a tunnel slug whose resource
+// isn't in the channel allow-set sees the slug-worded "not allowed"
+// copy (NOT the resolved r_<id>, which they never saw) and never
+// reaches the mint.
+func TestHandleGet_DollarSlugNotAllowedNonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_other_alloc"})
+	addTunnelSlugResource(t, ts)
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		writeCreateFixture(t, w, "https://qurl.link/should-not", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$"+testTunnelSlug+"` is not allowed in this channel") {
+		t.Errorf("async reply missing slug-worded not-allowed copy: %q", async)
+	}
+	if strings.Contains(async, testResourceIDFix) {
+		t.Errorf("resolved resource_id leaked in not-allowed message: %q", async)
+	}
+	if mintHits.Load() != 0 {
+		t.Errorf("mint reached despite slug not in allow-set (hits = %d)", mintHits.Load())
+	}
+}
+
+// TestHandleGet_DollarSlugAdminBypassesAllowedSet fences the admin
+// round-trip: a workspace admin sees every tunnel in /qurl list
+// (unfiltered) and can mint its `$<slug>` even with no alias_binding
+// and no allow-set entry in the current channel.
+func TestHandleGet_DollarSlugAdminBypassesAllowedSet(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	addTunnelSlugResource(t, ts)
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeCreateFixture(t, w, "https://qurl.link/admin-slug", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "https://qurl.link/admin-slug") {
+		t.Errorf("admin slug round-trip failed: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -716,8 +716,8 @@ func TestHandleGet_DollarSlugAdminBypassesAllowedSet(t *testing.T) {
 // admin asymmetry resolution: a workspace admin can mint `$r_<id>`
 // without the resource being in the current channel's allow-set,
 // matching `/qurl list`'s unfiltered admin view. Without this
-// bypass, the list footer's copy-paste promise ("Copy any `$token`
-// and run `/qurl get $token`") breaks for admins on cross-channel
+// bypass, the list footer's copy-paste promise ("Copy any `$slug`
+// and run `/qurl get $slug`") breaks for admins on cross-channel
 // resources.
 func TestHandleGet_DollarResourceIDAdminBypassesAllowedSet(t *testing.T) {
 	ts := newAdminTestServers(t)

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -663,10 +663,12 @@ func TestHandleGet_DollarSlugAllowedSetNonAdmin(t *testing.T) {
 }
 
 // TestHandleGet_DollarSlugNotAllowedNonAdmin fences the slug-fallback
-// authorization gate: a non-admin pasting a tunnel slug whose resource
-// isn't in the channel allow-set sees the slug-worded "not allowed"
-// copy (NOT the resolved r_<id>, which they never saw) and never
-// reaches the mint.
+// authorization gate AND its anti-enumeration posture: a non-admin
+// pasting a tunnel slug whose resource isn't in the channel allow-set
+// sees the SAME "not configured for this channel" copy as a
+// non-existent slug — not a distinct "not allowed" — so the wire text
+// can't be used to enumerate tunnel slugs that exist elsewhere in the
+// workspace. The resolved r_<id> never leaks and the mint never runs.
 func TestHandleGet_DollarSlugNotAllowedNonAdmin(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
@@ -681,14 +683,62 @@ func TestHandleGet_DollarSlugNotAllowedNonAdmin(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$"+testTunnelSlug+"` is not allowed in this channel") {
-		t.Errorf("async reply missing slug-worded not-allowed copy: %q", async)
+	// Collapsed to the not-found copy — see resolveTokenForGet.
+	if !strings.Contains(async, "`$"+testTunnelSlug+"` is not configured for this channel") {
+		t.Errorf("async reply missing anti-enumeration not-configured copy: %q", async)
+	}
+	if strings.Contains(async, "is not allowed in this channel") {
+		t.Errorf("not-allowed copy leaked the slug-exists-elsewhere distinction: %q", async)
 	}
 	if strings.Contains(async, testResourceIDFix) {
-		t.Errorf("resolved resource_id leaked in not-allowed message: %q", async)
+		t.Errorf("resolved resource_id leaked in rejection message: %q", async)
 	}
 	if mintHits.Load() != 0 {
 		t.Errorf("mint reached despite slug not in allow-set (hits = %d)", mintHits.Load())
+	}
+}
+
+// TestHandleGet_DollarTokenBindingWinsOverSlug fences the resolution
+// precedence in resolveTokenForGet: when a channel alias_binding exists
+// for the token, it is authoritative and the tunnel-slug fallback is
+// NOT consulted — even if a different tunnel happens to carry the same
+// name as its slug. Pins the ordering against a future refactor that
+// might flip it (which would let a same-named slug shadow an admin's
+// explicit binding).
+func TestHandleGet_DollarTokenBindingWinsOverSlug(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	// Bind the token to testResourceIDFix in this channel.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		testTunnelSlug: testResourceIDFix,
+	})
+	// A slug lookup, if (wrongly) consulted, would resolve to a DIFFERENT
+	// resource — its mint must never be hit.
+	var slugMintHits atomic.Int32
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{{
+			testKeyResourceID: "r_shadow_tun",
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		}}, "", false)
+	})
+	ts.addCustomer("POST", "/v1/resources/r_shadow_tun/qurls", func(w http.ResponseWriter, _ *http.Request) {
+		slugMintHits.Add(1)
+		writeCreateFixture(t, w, "https://qurl.link/SHADOW", "r_shadow_tun")
+	})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeCreateFixture(t, w, "https://qurl.link/from-binding", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "https://qurl.link/from-binding") {
+		t.Errorf("binding did not win — async reply missing binding link: %q", async)
+	}
+	if slugMintHits.Load() != 0 {
+		t.Errorf("slug fallback was consulted despite a live binding (shadow mint hits = %d)", slugMintHits.Load())
 	}
 }
 

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -49,13 +49,6 @@ const listTunnelsEmptyMessage = ":mag: No tunnels found in this workspace. Set o
 // nudges toward an admin escalation path.
 const listTunnelsNonAdminPaginationGapMessage = ":mag: No allowed tunnels on the first page of this workspace's listing. Tunnels allowed in this channel may exist past the first page — ask an admin to allow specific tunnels in this channel, or check `/qurl aliases` to see if a specific alias is set."
 
-// resourceTypeTunnel is the wire-level discriminator for tunnel
-// resources. Lifted to a constant so the list renderer keys on the
-// upstream type rather than guessing from empty `target_url` — a
-// non-tunnel resource with a transient empty target (data glitch,
-// partially-populated row) must NOT be silently re-labeled "(tunnel)".
-const resourceTypeTunnel = "tunnel"
-
 // handleListResources implements `/qurl list`. It lists the workspace's
 // tunnel resources (type=tunnel only — URL/transit resources are
 // filtered out) so each line is a copy-paste-ready `$<slug>` token the
@@ -171,13 +164,13 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 
 // filterTunnelResources returns only the tunnel-type resources from the
 // fetched page. `/qurl list` is tunnel-scoped; URL/transit resources are
-// dropped. Keys on r.Type == [resourceTypeTunnel] (the upstream
+// dropped. Keys on r.Type == [client.ResourceTypeTunnel] (the upstream
 // discriminator), NOT on an empty target_url, so a non-tunnel row with a
 // transient empty target isn't mis-included.
 func filterTunnelResources(resources []client.Resource) []client.Resource {
 	out := make([]client.Resource, 0, len(resources))
 	for i := range resources {
-		if resources[i].Type == resourceTypeTunnel {
+		if resources[i].Type == client.ResourceTypeTunnel {
 			out = append(out, resources[i])
 		}
 	}

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -13,38 +13,36 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-// listResourcesPageLimit is the default page size for `/qurl list`.
-// Pivoted from the legacy 5-qURLs render to 10-resources because:
-//
-//  1. Resources are coarser than qURLs (one Resource per target URL,
-//     many qURLs per Resource), so 10 of them carry more information
-//     than 5 qURLs.
-//  2. Listing surfaces the `$<alias>` / `$<resource_id>` shape so
-//     users can copy-paste straight into `/qurl get $<token>` — more
-//     rows in one slash-command response means fewer round-trips for
-//     the common "show me what's available" workflow.
-//  3. Slack's ephemeral message budget comfortably fits 10 rows (each
-//     at ~80-120 chars) without scrolling.
-const listResourcesPageLimit = 10
+// listResourcesScanLimit is the page size for the single
+// `/v1/resources` fetch backing `/qurl list`. `/qurl list` shows only
+// tunnel resources, but the API has no server-side type filter, so the
+// tunnel filter runs client-side on the fetched page. We over-fetch
+// (the server's max) rather than page to a small display target: a
+// 10-row page could surface zero tunnels in a URL-heavy workspace even
+// when tunnels exist, hiding the very thing the command is for. One
+// generous page keeps the command single-request while making the
+// client-side tunnel filter reliable; tunnel resources are created
+// deliberately (via `/qurl tunnel install`) so a real workspace has few
+// of them, well within Slack's ephemeral-message budget.
+const listResourcesScanLimit = 100
 
-// listResourcesEmptyMessage is the friendly empty-state copy. Points
-// the user at `/qurl create <url>` so a brand-new workspace knows
-// what to do next.
-const listResourcesEmptyMessage = ":mag: No qURL resources found in this workspace. Create one with `/qurl create <url>` first."
+// listTunnelsEmptyMessage is the friendly empty-state copy. Points the
+// user at `/qurl tunnel install <slug>` — the way tunnels are created —
+// so a workspace with no tunnels yet knows what to do next.
+const listTunnelsEmptyMessage = ":mag: No tunnels found in this workspace. Set one up with `/qurl tunnel install <slug>` first."
 
-// listResourcesNonAdminPaginationGapMessage is the user-facing copy
+// listTunnelsNonAdminPaginationGapMessage is the user-facing copy
 // for the case where a non-admin's filtered set is empty AND the
 // master list reports has_more=true. Without this distinct copy a
-// non-admin in a heavy workspace whose allow-listed resources sit
-// past the first page would see "Create one with /qurl create"
-// (wrong advice — the issue is pagination scope, not absence).
+// non-admin in a heavy workspace whose allow-listed tunnels sit
+// past the first page would see the plain empty-state (wrong advice —
+// the issue is pagination scope, not absence).
 //
-// "Allow specific resources" is the right verb for the common
-// case: an empty filtered set most often means no allow-list rows
-// for this channel yet, not an over-broad one that needs narrowing.
-// The hint nudges toward an admin escalation path rather than a
-// duplicate-resource workflow.
-const listResourcesNonAdminPaginationGapMessage = ":mag: No allowed resources on the first page of this workspace's listing. Resources allowed in this channel may exist past the first page — ask an admin to allow specific resources in this channel, or check `/qurl aliases` to see if a specific alias is set."
+// "Allow specific tunnels" is the right verb for the common case: an
+// empty filtered set most often means no allow-list rows for this
+// channel yet, not an over-broad one that needs narrowing. The hint
+// nudges toward an admin escalation path.
+const listTunnelsNonAdminPaginationGapMessage = ":mag: No allowed tunnels on the first page of this workspace's listing. Tunnels allowed in this channel may exist past the first page — ask an admin to allow specific tunnels in this channel, or check `/qurl aliases` to see if a specific alias is set."
 
 // resourceTypeTunnel is the wire-level discriminator for tunnel
 // resources. Lifted to a constant so the list renderer keys on the
@@ -53,15 +51,16 @@ const listResourcesNonAdminPaginationGapMessage = ":mag: No allowed resources on
 // partially-populated row) must NOT be silently re-labeled "(tunnel)".
 const resourceTypeTunnel = "tunnel"
 
-// handleListResources implements the refactored `/qurl list`. Pivots
-// the legacy "5 most recent qURLs" output to "10 most recent
-// Resources" so each line is a copy-paste-ready `$<alias>` (when
-// bound) or `$<resource_id>` token the user can pipe into
-// `/qurl get $<token>` without a manual alias-resolution step.
+// handleListResources implements `/qurl list`. It lists the workspace's
+// tunnel resources (type=tunnel only — URL/transit resources are
+// filtered out) so each line is a copy-paste-ready `$<slug>` token the
+// user can pipe into `/qurl get $<slug>` without a manual lookup. The
+// slug is the same stable handle `/qurl tunnel install <slug>` binds as
+// a channel alias, so the listed token resolves directly in `/qurl get`.
 //
 // Channel scoping:
-//   - workspace admins see every resource in the master listing.
-//   - non-admins see only resources allowed in the current channel
+//   - workspace admins see every tunnel in the master listing.
+//   - non-admins see only tunnels allowed in the current channel
 //     via channel_policies → resource_id set membership.
 //   - non-admin + empty channel_id is fail-closed (returns empty).
 //   - non-admin + policy-fetch failure is fail-closed (returns
@@ -91,13 +90,19 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		return
 	}
 
-	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesPageLimit})
+	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {
 		_ = h.postResponse(log, responseURL, ":warning: "+mapListResourcesError(log, teamID, err))
 		return
 	}
 
-	resources, isAdmin := h.scopeResourcesForUser(ctx, log, teamID, channelID, userID, page.Resources)
+	// `/qurl list` shows tunnels only. The API has no server-side type
+	// filter, so drop URL/transit resources here — BEFORE channel
+	// scoping — so every downstream branch (empty-state, scoping,
+	// footer) operates on the tunnel set.
+	tunnels := filterTunnelResources(page.Resources)
+
+	resources, isAdmin := h.scopeResourcesForUser(ctx, log, teamID, channelID, userID, tunnels)
 
 	if len(resources) == 0 {
 		// Pagination-gap copy only fires when (a) the user is a
@@ -108,48 +113,63 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// page" from "we never had a channel" (fail-closed branch
 		// in scopeResourcesForUser). Without it, the empty-channel
 		// fail-closed path would surface "ask an admin to allow
-		// specific resources in *this channel*" — misleading,
+		// specific tunnels in *this channel*" — misleading,
 		// because by construction there's no channel.
 		if !isAdmin && channelID != "" && page.HasMore {
-			log.Warn("list: non-admin filtered set is empty but master list has_more — allow-listed resources may sit past first page",
-				"team_id", teamID, "channel_id", channelID, "user_id", userID, "page_limit", listResourcesPageLimit)
-			_ = h.postResponse(log, responseURL, listResourcesNonAdminPaginationGapMessage)
+			log.Warn("list: non-admin filtered set is empty but master list has_more — allow-listed tunnels may sit past first page",
+				"team_id", teamID, "channel_id", channelID, "user_id", userID, "scan_limit", listResourcesScanLimit)
+			_ = h.postResponse(log, responseURL, listTunnelsNonAdminPaginationGapMessage)
 			return
 		}
-		_ = h.postResponse(log, responseURL, listResourcesEmptyMessage)
+		_ = h.postResponse(log, responseURL, listTunnelsEmptyMessage)
 		return
 	}
 
 	// Stable order for two-call idempotency at the Slack ephemeral
 	// surface — the server's pagination cursor implies an order but
-	// not a stable one across re-queries. Sort by the underlying
-	// token (alias if bound, else resource_id) BEFORE formatting.
+	// not a stable one across re-queries. Sort by the displayed token
+	// (the same slug→alias→resource_id precedence the rows render)
+	// BEFORE formatting.
 	sort.SliceStable(resources, func(i, j int) bool {
-		return resourceSortKey(&resources[i]) < resourceSortKey(&resources[j])
+		return tunnelToken(&resources[i]) < tunnelToken(&resources[j])
 	})
 	lines := make([]string, 0, len(resources))
 	for i := range resources {
-		lines = append(lines, formatResourceListLine(&resources[i]))
+		lines = append(lines, formatTunnelListLine(&resources[i]))
 	}
 
-	body := "*qURL Resources:*\n" + strings.Join(lines, "\n") +
-		"\n\n_Copy any `$token` and run `/qurl get $token` to mint a qURL link._"
+	body := "*qURL Tunnels:*\n" + strings.Join(lines, "\n") +
+		"\n\n_Copy any `$slug` and run `/qurl get $slug` to mint a one-time qURL link._"
 	if page.HasMore {
-		// Footer copy depends on whether the user's view is filtered.
-		// Admins see the master list directly, so "more past first N"
-		// matches what they'd expect. Non-admins see the filtered
-		// subset — additional allow-listed resources may sit past the
-		// first master-page-N scan, which the admin-copy footer
-		// understates ("more past first N" reads as "more of the same
-		// kind"). Distinct non-admin copy makes the gap explicit so
-		// users don't assume the rendered rows are exhaustive.
+		// has_more here means the workspace has more resources than the
+		// single scan page — there may be additional tunnels we didn't
+		// see. Footer copy depends on whether the user's view is
+		// filtered. Admins see the master list directly; non-admins see
+		// the channel-allowed subset, where allow-listed tunnels may sit
+		// past the first scan invisibly — distinct copy makes that gap
+		// explicit so users don't assume the rendered rows are exhaustive.
 		if isAdmin {
-			body += fmt.Sprintf("\n_…more results past the first %d-row scan — narrow with `/qurl get $alias` or ask an admin._", listResourcesPageLimit)
+			body += fmt.Sprintf("\n_…more resources past the first %d-row scan — some tunnels may not be shown._", listResourcesScanLimit)
 		} else {
-			body += fmt.Sprintf("\n_Showing allow-listed resources from the first %d-row scan; others may sit past it. Ask an admin to allow more in this channel, or narrow with `/qurl get $alias`._", listResourcesPageLimit)
+			body += fmt.Sprintf("\n_Showing allow-listed tunnels from the first %d-row scan; others may sit past it. Ask an admin to allow more in this channel._", listResourcesScanLimit)
 		}
 	}
 	_ = h.postResponse(log, responseURL, body)
+}
+
+// filterTunnelResources returns only the tunnel-type resources from the
+// fetched page. `/qurl list` is tunnel-scoped; URL/transit resources are
+// dropped. Keys on r.Type == [resourceTypeTunnel] (the upstream
+// discriminator), NOT on an empty target_url, so a non-tunnel row with a
+// transient empty target isn't mis-included.
+func filterTunnelResources(resources []client.Resource) []client.Resource {
+	out := make([]client.Resource, 0, len(resources))
+	for i := range resources {
+		if resources[i].Type == resourceTypeTunnel {
+			out = append(out, resources[i])
+		}
+	}
+	return out
 }
 
 // scopeResourcesForUser narrows the master resource list to what the
@@ -235,89 +255,49 @@ func filterResourcesByAllowedSet(resources []client.Resource, allowed map[string
 	return out
 }
 
-// resourceSortKey returns the token used to order rows in the
-// /qurl list output. Aliased rows sort by alias, un-aliased rows
-// sort by resource_id — the same token that ends up in the rendered
-// `$<token>` prefix.
-func resourceSortKey(r *client.Resource) string {
+// tunnelToken returns the `$<token>` identifier shown for a tunnel in
+// /qurl list — and the key rows sort by. Precedence:
+//
+//  1. Slug — the stable, owner-scoped tunnel handle. `/qurl tunnel
+//     install <slug>` binds `$<slug>` as a channel alias, so the slug
+//     pastes straight into `/qurl get $<slug>`. This is the common case
+//     and the identifier we want to surface (never the opaque r_<id>).
+//  2. Resource-level alias — fallback when a tunnel somehow carries no
+//     slug but does have an alias.
+//  3. resource_id — last resort for a legacy slug-less, alias-less
+//     tunnel. Vanishingly rare (tunnels are created with a slug), but
+//     better than an empty `$` token, and `/qurl get $r_<id>` still
+//     resolves it via the channel allow-set.
+func tunnelToken(r *client.Resource) string {
+	if r.Slug != "" {
+		return r.Slug
+	}
 	if r.Alias != "" {
 		return r.Alias
 	}
 	return r.ResourceID
 }
 
-// formatResourceListLine renders one resource as a single text line
-// in /qurl list output. Per-line shape:
+// formatTunnelListLine renders one tunnel resource as a single text
+// line in /qurl list output:
 //
-//   - With alias bound:    `• \`$<alias>\` → <target_url>`
-//   - Without alias bound: `• \`$<resource_id>\` → <target_url> (no alias set)`
-//   - Tunnel (Type=tunnel): `• \`$<token>\` → (tunnel)`
-//   - Tunnel with slug:    `• \`$<token>\` → (tunnel) [slug:<slug>]`
-//   - Empty target (other): `• \`$<token>\` → <empty>`
+//   - No description:   `• \`$<slug>\“
+//   - With description: `• \`$<slug>\` → <description>`
 //
-// When `r.Description` is set, it appends ` — <description>` as a
-// trailing annotation (after the alias-set/tunnel/slug hints). Legacy
-// /qurl list rendered description on a separate visual axis; the
-// trailing-em-dash form keeps the one-line-per-row shape needed for
-// the copy-paste-ready `$<token>` workflow while preserving the
-// operator-authored context.
-//
-// The token-in-backticks shape lets Slack render it as inline code
-// (easy click-to-copy) while keeping the line plaintext-greppable
-// for operator workflows. The "(no alias set)" annotation flags
-// non-tunnel rows that would benefit from a future `/qurl setalias`
-// call — it's suppressed on the tunnel branch because the "(tunnel)"
-// placeholder is already a strong visual signal and the doubled-up
-// "(tunnel) (no alias set)" reads as redundant noise.
-//
-// Tunnel detection keys on r.Type == "tunnel" (the upstream resource
-// type), NOT on empty target_url — keying on the empty field would
-// silently re-label any non-tunnel row with a missing target as
-// "(tunnel)", which would mislead operators triaging a data glitch.
-//
-// Slug fragment ([slug:<slug>]) renders ONLY on tunnel rows that carry
-// a non-empty Slug. URL/transit resources never carry a slug on the
-// wire (qurl-service rejects slug on non-tunnel creates) so the
-// fragment is structurally tunnel-scoped. A tunnel row WITHOUT a slug
-// — legacy / pre-Phase-1A — renders the fragment-free shape so existing
-// fixtures (and operator muscle memory) keep working. The customer's
-// onboarding flow runs `/qurl list resources` to match what their
-// sidecar provisioned (via QURL_TUNNEL_SLUG) against a resource_id
-// before pairing it with an alias.
-func formatResourceListLine(r *client.Resource) string {
-	token := r.Alias
-	noAlias := false
-	if token == "" {
-		token = r.ResourceID
-		noAlias = true
-	}
-	descSuffix := ""
+// The token is [tunnelToken] (slug-first; never the opaque r_<id> in
+// the common case). The token-in-backticks shape lets Slack render it
+// as inline code (easy click-to-copy) while keeping the line
+// plaintext-greppable. There is no `(tunnel)` label or `[slug:...]`
+// fragment — the whole list is tunnels and the token IS the slug, so
+// both would be redundant noise. The arrow joins the slug to its
+// human-readable description when one is set; an undescribed tunnel
+// renders just the token.
+func formatTunnelListLine(r *client.Resource) string {
+	line := "• `$" + tunnelToken(r) + "`"
 	if r.Description != "" {
-		descSuffix = " — " + r.Description
+		line += " → " + r.Description
 	}
-	if r.Type == resourceTypeTunnel {
-		// Tunnel-type resources have no target_url (the FRP server
-		// is the effective destination). Render a placeholder so the
-		// row still reads cleanly. The "(no alias set)" annotation
-		// is suppressed here — see godoc.
-		slugFrag := ""
-		if r.Slug != "" {
-			slugFrag = " [slug:" + r.Slug + "]"
-		}
-		return fmt.Sprintf("• `$%s` → (tunnel)%s%s", token, slugFrag, descSuffix)
-	}
-	target := r.TargetURL
-	if target == "" {
-		// Non-tunnel row with an empty target_url — render "<empty>"
-		// rather than silently labeling as a tunnel. Surfaces the
-		// data anomaly to user + ops without misleading either.
-		target = "<empty>"
-	}
-	suffix := ""
-	if noAlias {
-		suffix = " (no alias set)"
-	}
-	return fmt.Sprintf("• `$%s` → %s%s%s", token, target, suffix, descSuffix)
+	return line
 }
 
 // mapListResourcesError surfaces a friendly user-facing error for

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -114,15 +114,22 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// specific tunnels in *this channel*" — misleading,
 		// because by construction there's no channel.
 		//
-		// TODO(#531): page.HasMore is a master-list signal ("more
-		// resources of any type"), not "more tunnels". In a URL-heavy
-		// workspace with zero tunnels but >scan-limit resources, this
-		// branch fires and over-claims that allowed tunnels may sit
-		// past the page. The server-side type=tunnel filter in #531
-		// makes has_more tunnel-specific and removes the over-claim.
-		if !isAdmin && channelID != "" && page.HasMore {
-			log.Warn("list: non-admin filtered set is empty but master list has_more — allow-listed tunnels may sit past first page",
-				"team_id", teamID, "channel_id", channelID, "user_id", userID, "scan_limit", listResourcesScanLimit)
+		// The len(tunnels) > 0 guard keeps the gap-copy honest: it
+		// fires only when the scanned page DID contain tunnels that
+		// channel scoping filtered out for this non-admin. A URL-heavy
+		// workspace with zero tunnels on the page falls through to the
+		// plain empty-state instead of wrongly claiming "allowed tunnels
+		// may sit past the first page" when there are no tunnels at all.
+		//
+		// TODO(#531): page.HasMore is still a master-list signal ("more
+		// resources of any type"), so the residual ambiguity is a
+		// workspace with >scan-limit resources whose tunnels all sit
+		// past the first page — there the gap-copy is suppressed even
+		// though tunnels exist. The server-side type=tunnel filter in
+		// #531 makes has_more tunnel-accurate and removes the ambiguity.
+		if !isAdmin && channelID != "" && page.HasMore && len(tunnels) > 0 {
+			log.Warn("list: non-admin filtered set is empty but master list has_more with tunnels on the page — allow-listed tunnels may sit past first page",
+				"team_id", teamID, "channel_id", channelID, "user_id", userID, "scan_limit", listResourcesScanLimit, "page_tunnel_count", len(tunnels))
 			_ = h.postResponse(log, responseURL, listTunnelsNonAdminPaginationGapMessage)
 			return
 		}

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -24,6 +24,11 @@ import (
 // client-side tunnel filter reliable; tunnel resources are created
 // deliberately (via `/qurl tunnel install`) so a real workspace has few
 // of them, well within Slack's ephemeral-message budget.
+//
+// A server-side `type=tunnel` filter (tracked in #531) would let this
+// drop to a normal page size and make `page.HasMore` mean "more
+// tunnels" rather than "more resources of any type" — see the footer
+// caveat in [Handler.processListResources].
 const listResourcesScanLimit = 100
 
 // listTunnelsEmptyMessage is the friendly empty-state copy. Points the
@@ -281,8 +286,8 @@ func tunnelToken(r *client.Resource) string {
 // formatTunnelListLine renders one tunnel resource as a single text
 // line in /qurl list output:
 //
-//   - No description:   `• \`$<slug>\“
-//   - With description: `• \`$<slug>\` → <description>`
+//   - No description:   • `$<slug>`
+//   - With description: • `$<slug>` → <description>
 //
 // The token is [tunnelToken] (slug-first; never the opaque r_<id> in
 // the common case). The token-in-backticks shape lets Slack render it

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -31,10 +31,13 @@ import (
 // caveat in [Handler.processListResources].
 const listResourcesScanLimit = 100
 
-// listTunnelsEmptyMessage is the friendly empty-state copy. Points the
-// user at `/qurl tunnel install <slug>` — the way tunnels are created —
-// so a workspace with no tunnels yet knows what to do next.
+// listTunnelsEmptyMessage / listTunnelsEmptyMessageNonAdmin are the
+// friendly empty-state copy, branched on admin status. `/qurl tunnel
+// install` is admin-only, so admins are told to run it directly while
+// non-admins are routed to ask an admin — telling a non-admin to run a
+// command they can't would dead-end them.
 const listTunnelsEmptyMessage = ":mag: No tunnels found in this workspace. Set one up with `/qurl tunnel install <slug>` first."
+const listTunnelsEmptyMessageNonAdmin = ":mag: No tunnels found in this workspace. Ask a Slack admin to set one up with `/qurl tunnel install <slug>`."
 
 // listTunnelsNonAdminPaginationGapMessage is the user-facing copy
 // for the case where a non-admin's filtered set is empty AND the
@@ -133,17 +136,31 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 			_ = h.postResponse(log, responseURL, listTunnelsNonAdminPaginationGapMessage)
 			return
 		}
-		_ = h.postResponse(log, responseURL, listTunnelsEmptyMessage)
+		// `/qurl tunnel install` is admin-only, so route non-admins to
+		// ask an admin rather than dead-ending them on a command they
+		// can't run.
+		emptyMsg := listTunnelsEmptyMessage
+		if !isAdmin {
+			emptyMsg = listTunnelsEmptyMessageNonAdmin
+		}
+		_ = h.postResponse(log, responseURL, emptyMsg)
 		return
 	}
 
 	// Stable order for two-call idempotency at the Slack ephemeral
 	// surface — the server's pagination cursor implies an order but
 	// not a stable one across re-queries. Sort by the displayed token
-	// (the same slug→alias→resource_id precedence the rows render)
-	// BEFORE formatting.
+	// (the same slug→alias→resource_id precedence the rows render),
+	// with resource_id as a tiebreaker so two rows sharing a token
+	// (e.g. a slug == another row's alias) order deterministically
+	// rather than inheriting the unstable upstream order. BEFORE
+	// formatting.
 	sort.SliceStable(resources, func(i, j int) bool {
-		return tunnelToken(&resources[i]) < tunnelToken(&resources[j])
+		ti, tj := tunnelToken(&resources[i]), tunnelToken(&resources[j])
+		if ti != tj {
+			return ti < tj
+		}
+		return resources[i].ResourceID < resources[j].ResourceID
 	})
 	lines := make([]string, 0, len(resources))
 	for i := range resources {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -120,6 +120,13 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// fail-closed path would surface "ask an admin to allow
 		// specific tunnels in *this channel*" — misleading,
 		// because by construction there's no channel.
+		//
+		// TODO(#531): page.HasMore is a master-list signal ("more
+		// resources of any type"), not "more tunnels". In a URL-heavy
+		// workspace with zero tunnels but >scan-limit resources, this
+		// branch fires and over-claims that allowed tunnels may sit
+		// past the page. The server-side type=tunnel filter in #531
+		// makes has_more tunnel-specific and removes the over-claim.
 		if !isAdmin && channelID != "" && page.HasMore {
 			log.Warn("list: non-admin filtered set is empty but master list has_more — allow-listed tunnels may sit past first page",
 				"team_id", teamID, "channel_id", channelID, "user_id", userID, "scan_limit", listResourcesScanLimit)
@@ -156,7 +163,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		if isAdmin {
 			body += fmt.Sprintf("\n_…more resources past the first %d-row scan — some tunnels may not be shown._", listResourcesScanLimit)
 		} else {
-			body += fmt.Sprintf("\n_Showing allow-listed tunnels from the first %d-row scan; others may sit past it. Ask an admin to allow more in this channel._", listResourcesScanLimit)
+			body += fmt.Sprintf("\n_Showing allow-listed tunnels from the first %d-row scan; additional allow-listed tunnels may sit past it. Ask an admin to allow more in this channel._", listResourcesScanLimit)
 		}
 	}
 	_ = h.postResponse(log, responseURL, body)

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -98,14 +98,16 @@ func TestHandleList_NonAdminFiltersToChannelPolicy(t *testing.T) {
 	}
 }
 
-// TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias fences the
-// `allowed_resource_ids`-only branch of the union: a tunnel whose
+// TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAliasBinding fences
+// the `allowed_resource_ids`-only branch of the union: a tunnel whose
 // channel_policies has only `allowed_resource_ids` populated (no
 // `alias_bindings`) MUST surface in non-admin `/qurl list`. Pre-fix the
 // list handler walked alias-bindings only, so a pure-allowed-set
 // resource was `/qurl get`-mintable but invisible in `/qurl list` —
-// the two surfaces diverged. The row still renders its slug token.
-func TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias(t *testing.T) {
+// the two surfaces diverged. The row still renders its slug token
+// (the slug is a resource attribute, independent of the channel
+// alias_binding this test deliberately omits).
+func TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAliasBinding(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
 	// alias="" → seedPolicySet skips the auto-attached alias_bindings

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -537,6 +537,38 @@ func TestHandleList_StableSortByToken(t *testing.T) {
 	}
 }
 
+// TestHandleList_SortTiebreakerOnTokenCollision exercises the
+// resource_id tiebreaker directly: two tunnels yield the SAME
+// tunnelToken (`$dup`) — one via its slug, one via a resource-level
+// alias with no slug — so the comparator falls through to comparing
+// resource_id. The row with the lexicographically-smaller resource_id
+// must sort first, deterministically, rather than inheriting unstable
+// upstream order. Descriptions disambiguate the two identical tokens.
+func TestHandleList_SortTiebreakerOnTokenCollision(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		// Returned in reverse resource_id order; both render `$dup`.
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_bbb_dup", fAttrAlias: "dup", testKeyType: client.ResourceTypeTunnel, testKeyDescription: "beta-desc"},
+			{testKeyResourceID: "r_aaa_dup", testKeyType: client.ResourceTypeTunnel, testKeySlug: "dup", testKeyDescription: "alpha-desc"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	// Tiebreaker: r_aaa_dup < r_bbb_dup, so alpha-desc renders first.
+	alphaPos := strings.Index(async, "alpha-desc")
+	betaPos := strings.Index(async, "beta-desc")
+	if alphaPos < 0 || betaPos < 0 {
+		t.Fatalf("missing colliding-token rows: %q", async)
+	}
+	if alphaPos >= betaPos {
+		t.Errorf("tiebreaker not applied: expected alpha-desc (r_aaa) before beta-desc (r_bbb): %q", async)
+	}
+}
+
 // TestTunnelToken pins the slug → alias → resource_id precedence of the
 // `$<token>` shown for a tunnel row, directly (not just via the rendered
 // list output), so a future refactor that reorders the fallback chain

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -9,11 +9,14 @@ import (
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// Shared alias-name fixtures used across the /qurl list test cases.
-// Lifted to constants to satisfy goconst (min-occurrences=3) and to
-// keep the resource-row builder lines visually aligned. Assertion
-// sites read these names too, so a rename surfaces every site at
-// once.
+// Shared fixtures used across the /qurl list test cases. Lifted to
+// constants to satisfy goconst (min-occurrences=3) and to keep the
+// resource-row builder lines visually aligned. Assertion sites read
+// these names too, so a rename surfaces every site at once.
+//
+// `/qurl list` is tunnel-only and renders the slug as the `$<token>`,
+// so the fixtures below are tunnel resources (testKeyType:
+// resourceTypeTunnel) carrying a slug.
 const (
 	testListAliasProdDB = "prod-db"
 	testListAliasSecret = "secret"
@@ -40,46 +43,47 @@ func writeResourceListFixture(t *testing.T, w http.ResponseWriter, resources []m
 	}
 }
 
-// TestHandleList_AdminSeesAllResources fences the admin happy path:
-// a workspace admin sees every resource the master listing returns,
-// without channel-policy filtering.
-func TestHandleList_AdminSeesAllResources(t *testing.T) {
+// TestHandleList_AdminSeesAllTunnels fences the admin happy path: a
+// workspace admin sees every tunnel the master listing returns, without
+// channel-policy filtering. Each row renders the slug as the
+// copy-paste-ready `$<slug>` token.
+func TestHandleList_AdminSeesAllTunnels(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: testListResIDProdDB, fAttrAlias: testListAliasProdDB, testKeyTargetURL: "https://prod.example.com"},
-			{testKeyResourceID: "r_stage_db_bb", fAttrAlias: "stage-db", testKeyTargetURL: "https://stage.example.com"},
+			{testKeyResourceID: testListResIDProdDB, testKeyType: resourceTypeTunnel, testKeySlug: testListAliasProdDB},
+			{testKeyResourceID: "r_stage_db_bb", testKeyType: resourceTypeTunnel, testKeySlug: "stage-db"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "qURL Resources") {
+	if !strings.Contains(async, "qURL Tunnels") {
 		t.Errorf("async reply missing header: %q", async)
 	}
-	if !strings.Contains(async, "`$prod-db` → https://prod.example.com") {
+	if !strings.Contains(async, "`$prod-db`") {
 		t.Errorf("async reply missing prod-db row: %q", async)
 	}
-	if !strings.Contains(async, "`$stage-db` → https://stage.example.com") {
+	if !strings.Contains(async, "`$stage-db`") {
 		t.Errorf("async reply missing stage-db row: %q", async)
 	}
-	if !strings.Contains(async, "/qurl get $token") {
+	if !strings.Contains(async, "/qurl get $slug") {
 		t.Errorf("async reply missing copy-paste hint: %q", async)
 	}
 }
 
 // TestHandleList_NonAdminFiltersToChannelPolicy fences the non-admin
-// path: only resources allowed in the current channel are visible.
+// path: only tunnels allowed in the current channel are visible.
 func TestHandleList_NonAdminFiltersToChannelPolicy(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
-	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{"r_prod_db_aa"})
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testListResIDProdDB})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: testListResIDProdDB, fAttrAlias: testListAliasProdDB, testKeyTargetURL: "https://prod.example.com"},
-			{testKeyResourceID: "r_secret_xx", fAttrAlias: testListAliasSecret, testKeyTargetURL: "https://secret.example.com"},
+			{testKeyResourceID: testListResIDProdDB, testKeyType: resourceTypeTunnel, testKeySlug: testListAliasProdDB},
+			{testKeyResourceID: "r_secret_xx", testKeyType: resourceTypeTunnel, testKeySlug: testListAliasSecret},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -90,18 +94,17 @@ func TestHandleList_NonAdminFiltersToChannelPolicy(t *testing.T) {
 		t.Errorf("async reply missing allowed prod-db: %q", async)
 	}
 	if strings.Contains(async, "secret") {
-		t.Errorf("async reply leaked non-allowed resource: %q", async)
+		t.Errorf("async reply leaked non-allowed tunnel: %q", async)
 	}
 }
 
 // TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias fences the
-// `allowed_resource_ids`-only branch of the union: a row whose
+// `allowed_resource_ids`-only branch of the union: a tunnel whose
 // channel_policies has only `allowed_resource_ids` populated (no
-// `alias_bindings`) — a hand-seeded legacy shape from before the
-// alias-bindings pivot — MUST surface the resource in non-admin
-// `/qurl list`. Pre-fix the list handler walked alias-bindings
-// only, so a pure-allowed-set resource was `/qurl get`-mintable
-// but invisible in `/qurl list` — the two surfaces diverged.
+// `alias_bindings`) MUST surface in non-admin `/qurl list`. Pre-fix the
+// list handler walked alias-bindings only, so a pure-allowed-set
+// resource was `/qurl get`-mintable but invisible in `/qurl list` —
+// the two surfaces diverged. The row still renders its slug token.
 func TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
@@ -110,26 +113,26 @@ func TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAlias(t *testing.T) {
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_allow_only1"})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_allow_only1", testKeyTargetURL: "https://allowed.example.com"},
-			{testKeyResourceID: "r_secret_xx", fAttrAlias: testListAliasSecret, testKeyTargetURL: "https://secret.example.com"},
+			{testKeyResourceID: "r_allow_only1", testKeyType: resourceTypeTunnel, testKeySlug: "allow-only-tun"},
+			{testKeyResourceID: "r_secret_xx", testKeyType: resourceTypeTunnel, testKeySlug: testListAliasSecret},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$r_allow_only1`") {
-		t.Errorf("non-admin list dropped a resource that's in allowed_resource_ids but has no alias_binding: %q", async)
+	if !strings.Contains(async, "`$allow-only-tun`") {
+		t.Errorf("non-admin list dropped a tunnel in allowed_resource_ids but with no alias_binding: %q", async)
 	}
 	if strings.Contains(async, "secret") {
-		t.Errorf("async reply leaked non-allowed resource: %q", async)
+		t.Errorf("async reply leaked non-allowed tunnel: %q", async)
 	}
 }
 
 // TestHandleList_NonAdminUnionsAllowedSetAndAliasBindings fences the
 // union behavior across both surfaces on the same row: an
-// alias-bindings-only resource AND an allowed-set-only resource must
-// both surface (an alias-only resource that lives outside the
+// alias-bindings-only tunnel AND an allowed-set-only tunnel must both
+// surface (an alias-only resource that lives outside the
 // allowed_resource_ids gate is still mintable via the alias path's
 // channel-scoped binding, so it belongs in the listing).
 func TestHandleList_NonAdminUnionsAllowedSetAndAliasBindings(t *testing.T) {
@@ -152,23 +155,23 @@ func TestHandleList_NonAdminUnionsAllowedSetAndAliasBindings(t *testing.T) {
 	})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_allow_set_a", testKeyTargetURL: "https://allowset.example.com"},
-			{testKeyResourceID: "r_alias_only_b", fAttrAlias: "alias-b", testKeyTargetURL: "https://aliasonly.example.com"},
-			{testKeyResourceID: "r_neither_xx", fAttrAlias: "neither", testKeyTargetURL: "https://neither.example.com"},
+			{testKeyResourceID: "r_allow_set_a", testKeyType: resourceTypeTunnel, testKeySlug: "allowset-tun"},
+			{testKeyResourceID: "r_alias_only_b", testKeyType: resourceTypeTunnel, testKeySlug: "aliasonly-tun"},
+			{testKeyResourceID: "r_neither_xx", testKeyType: resourceTypeTunnel, testKeySlug: "neither-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$r_allow_set_a`") {
+	if !strings.Contains(async, "`$allowset-tun`") {
 		t.Errorf("union missed the allowed-set entry: %q", async)
 	}
-	if !strings.Contains(async, "`$alias-b`") {
+	if !strings.Contains(async, "`$aliasonly-tun`") {
 		t.Errorf("union missed the alias-binding entry: %q", async)
 	}
 	if strings.Contains(async, "neither") {
-		t.Errorf("union leaked a resource present in neither surface: %q", async)
+		t.Errorf("union leaked a tunnel present in neither surface: %q", async)
 	}
 }
 
@@ -181,7 +184,7 @@ func TestHandleList_NonAdminEmptyChannelFailsClose(t *testing.T) {
 	ts.seedNonAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_leaked_xx", fAttrAlias: "leaked", testKeyTargetURL: "https://leaked.example.com"},
+			{testKeyResourceID: "r_leaked_xx", testKeyType: resourceTypeTunnel, testKeySlug: "leaked-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -195,8 +198,8 @@ func TestHandleList_NonAdminEmptyChannelFailsClose(t *testing.T) {
 
 // TestHandleList_NonAdminPaginationGap fences the distinct empty-state
 // copy when a non-admin's filter is empty AND the master list has
-// more pages. Default empty-state ("Create one with /qurl create")
-// would mislead the user — the issue is pagination, not absence.
+// more pages. The plain empty-state would mislead the user — the issue
+// is pagination, not absence.
 func TestHandleList_NonAdminPaginationGap(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
@@ -205,7 +208,7 @@ func TestHandleList_NonAdminPaginationGap(t *testing.T) {
 	// fires.
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_unallowed_x", fAttrAlias: "unallowed", testKeyTargetURL: "https://x"},
+			{testKeyResourceID: "r_unallowed_x", testKeyType: resourceTypeTunnel, testKeySlug: "unallowed-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -221,14 +224,12 @@ func TestHandleList_NonAdminPaginationGap(t *testing.T) {
 // the empty-channel + has_more=true branch: the pagination-gap copy
 // must NOT fire when channel_id is empty (the message references
 // "this channel" — misleading when by construction there is none).
-// Regression-pin on the channelID != "" guard added in the round-7
-// CR pass.
 func TestHandleList_NonAdminEmptyChannelWithHasMoreShowsDefault(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_leaked_xx", fAttrAlias: "leaked", testKeyTargetURL: "https://leaked.example.com"},
+			{testKeyResourceID: "r_leaked_xx", testKeyType: resourceTypeTunnel, testKeySlug: "leaked-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -244,8 +245,8 @@ func TestHandleList_NonAdminEmptyChannelWithHasMoreShowsDefault(t *testing.T) {
 }
 
 // TestHandleList_EmptyWorkspace fences the friendly empty-state copy
-// for a brand-new workspace with zero resources. The hint nudges the
-// user toward `/qurl create`.
+// for a workspace with zero tunnels. The hint nudges the user toward
+// `/qurl tunnel install`.
 func TestHandleList_EmptyWorkspace(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -256,40 +257,86 @@ func TestHandleList_EmptyWorkspace(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "Create one with") {
-		t.Errorf("async reply missing empty-state hint: %q", async)
+	if !strings.Contains(async, "No tunnels found") {
+		t.Errorf("async reply missing empty-state copy: %q", async)
+	}
+	if !strings.Contains(async, "/qurl tunnel install") {
+		t.Errorf("async reply missing tunnel-install hint: %q", async)
 	}
 }
 
-// TestHandleList_UnaliasedResource fences the `$r_<id>` rendering for
-// resources without a bound alias. The row should be copy-paste-ready
-// into `/qurl get $r_<id>`.
-func TestHandleList_UnaliasedResource(t *testing.T) {
+// TestHandleList_URLResourcesFiltered fences the tunnel-only scope:
+// URL/transit resources MUST NOT appear in `/qurl list` at all — only
+// type=tunnel rows survive. A stray `slug` on a URL row doesn't rescue
+// it either; the filter keys on Type, not the slug field.
+func TestHandleList_URLResourcesFiltered(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_unaliased1", testKeyTargetURL: "https://noalias.example.com"},
+			{testKeyResourceID: "r_tun_aaaaaa", testKeyType: resourceTypeTunnel, testKeySlug: "alpha-tunnel"},
+			{testKeyResourceID: "r_url_btarg1", fAttrAlias: "burl", testKeyTargetURL: "https://b.example.com"},
+			{testKeyResourceID: "r_url_stray1", testKeyTargetURL: "https://c.example.com", testKeySlug: "stray-slug"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$r_unaliased1`") {
-		t.Errorf("async reply missing unaliased token shape: %q", async)
+	if !strings.Contains(async, "`$alpha-tunnel`") {
+		t.Errorf("async reply missing the tunnel row: %q", async)
 	}
-	if !strings.Contains(async, "(no alias set)") {
-		t.Errorf("async reply missing 'no alias set' suffix: %q", async)
+	if strings.Contains(async, "burl") || strings.Contains(async, "b.example.com") {
+		t.Errorf("URL resource leaked into tunnel-only list: %q", async)
+	}
+	if strings.Contains(async, "c.example.com") || strings.Contains(async, "stray-slug") {
+		t.Errorf("URL resource with stray slug leaked into tunnel-only list: %q", async)
 	}
 }
 
-// TestHandleList_TunnelResource fences the tunnel-resource rendering:
-// type=tunnel renders "(tunnel)" target placeholder regardless of
-// target_url. Keys on r.Type, NOT on empty target_url, so a non-tunnel
-// row with a data glitch (transient empty target) doesn't get
-// mislabeled.
-func TestHandleList_TunnelResource(t *testing.T) {
+// TestHandleList_TunnelSlugIsToken fences the core display contract:
+// a tunnel renders its slug as the `$<token>` — NOT the opaque
+// resource_id, NOT a resource-level alias, and with no `(tunnel)`
+// label or `[slug:...]` fragment (both redundant now that the whole
+// list is tunnels and the token IS the slug). The customer's
+// onboarding flow reads this slug to match what the sidecar
+// provisioned (via QURL_TUNNEL_SLUG) and pastes it into `/qurl get`.
+func TestHandleList_TunnelSlugIsToken(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_slg", fAttrAlias: "dash-alias", testKeyType: resourceTypeTunnel, testKeySlug: "prod-dashboard"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$prod-dashboard`") {
+		t.Errorf("async reply missing slug token: %q", async)
+	}
+	// Slug wins over the resource-level alias and never falls back to r_<id>.
+	if strings.Contains(async, "dash-alias") {
+		t.Errorf("resource-level alias shown instead of slug: %q", async)
+	}
+	if strings.Contains(async, "r_tunnel_slg") {
+		t.Errorf("opaque resource_id leaked when a slug was available: %q", async)
+	}
+	// No legacy decorations.
+	if strings.Contains(async, "(tunnel)") {
+		t.Errorf("redundant (tunnel) label leaked: %q", async)
+	}
+	if strings.Contains(async, "[slug:") {
+		t.Errorf("redundant [slug:...] fragment leaked: %q", async)
+	}
+}
+
+// TestHandleList_TunnelAliasFallbackWhenNoSlug fences the fallback
+// when a tunnel carries no slug but does carry a resource-level alias:
+// the alias is used as the token (never the r_<id>), still with no
+// `(tunnel)` label.
+func TestHandleList_TunnelAliasFallbackWhenNoSlug(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -301,17 +348,19 @@ func TestHandleList_TunnelResource(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$tun` → (tunnel)") {
-		t.Errorf("async reply missing tunnel placeholder: %q", async)
+	if !strings.Contains(async, "`$tun`") {
+		t.Errorf("async reply missing alias-fallback token: %q", async)
+	}
+	if strings.Contains(async, "(tunnel)") {
+		t.Errorf("redundant (tunnel) label leaked: %q", async)
 	}
 }
 
-// TestHandleList_TunnelResourceWithoutAlias fences the "(no alias set)"
-// suffix being suppressed on the tunnel branch: rendering
-// "$r_<id> → (tunnel) (no alias set)" doubles up two distinct
-// visual signals. Tunnel without an alias renders as just
-// "$r_<id> → (tunnel)" — the placeholder is signal enough.
-func TestHandleList_TunnelResourceWithoutAlias(t *testing.T) {
+// TestHandleList_TunnelResourceIDFallback fences the last-resort
+// fallback: a legacy tunnel with neither a slug nor an alias renders
+// the raw resource_id as the token (better than an empty `$`), with no
+// `(tunnel)` label and no "(no alias set)" suffix.
+func TestHandleList_TunnelResourceIDFallback(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -323,191 +372,41 @@ func TestHandleList_TunnelResourceWithoutAlias(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$r_tunnel_noa` → (tunnel)") {
-		t.Errorf("async reply missing tunnel placeholder for un-aliased tunnel: %q", async)
+	if !strings.Contains(async, "`$r_tunnel_noa`") {
+		t.Errorf("async reply missing resource_id fallback token: %q", async)
+	}
+	if strings.Contains(async, "(tunnel)") {
+		t.Errorf("redundant (tunnel) label leaked: %q", async)
 	}
 	if strings.Contains(async, "(no alias set)") {
-		t.Errorf("(no alias set) leaked on tunnel branch — doubled-up signal: %q", async)
+		t.Errorf("legacy (no alias set) suffix leaked: %q", async)
 	}
 }
 
-// TestHandleList_TunnelResourceWithSlug fences the customer-onboarding
-// Phase 3 rendering: a tunnel resource with a non-empty `slug` (set
-// by the sidecar's QURL_TUNNEL_SLUG bootstrap) surfaces the slug as
-// a "[slug:<slug>]" fragment between the "(tunnel)" placeholder and
-// the optional description suffix. The customer's bot user reads this
-// to match what the sidecar provisioned against a resource_id before
-// pairing it with an alias via `/qurl set-alias`.
-func TestHandleList_TunnelResourceWithSlug(t *testing.T) {
+// TestHandleList_TunnelWithDescription fences the trailing
+// "→ <description>" annotation, and that an undescribed tunnel renders
+// just the bare token (no dangling arrow).
+func TestHandleList_TunnelWithDescription(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tunnel_slg", fAttrAlias: "prod-dash", testKeyType: resourceTypeTunnel, testKeySlug: "prod-dashboard"},
+			{testKeyResourceID: "r_tun_desc1", testKeyType: resourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "ops jump host"},
+			{testKeyResourceID: "r_tun_nodes", testKeyType: resourceTypeTunnel, testKeySlug: "no-desc-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$prod-dash` → (tunnel) [slug:prod-dashboard]") {
-		t.Errorf("async reply missing tunnel-with-slug row: %q", async)
+	if !strings.Contains(async, "`$ops-bastion` → ops jump host") {
+		t.Errorf("async reply missing slug + description row: %q", async)
 	}
-}
-
-// TestHandleList_TunnelResourceWithSlugAndDescription fences the
-// composition of the slug fragment with the trailing-em-dash
-// description suffix. Slug fragment renders BEFORE the description,
-// so the line reads "(tunnel) [slug:<slug>] — <description>" — slug
-// is structural metadata about the resource identity, description is
-// operator-authored prose, and the visual axis preserves that order.
-func TestHandleList_TunnelResourceWithSlugAndDescription(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tunnel_sd", fAttrAlias: "ops", testKeyType: resourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "ops jump host"},
-		}, "", false)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$ops` → (tunnel) [slug:ops-bastion] — ops jump host") {
-		t.Errorf("async reply missing tunnel-with-slug + description row: %q", async)
+	if !strings.Contains(async, "`$no-desc-tun`") {
+		t.Errorf("async reply missing undescribed tunnel row: %q", async)
 	}
-}
-
-// TestHandleList_TunnelResourceWithoutSlugOmitsFragment fences the
-// legacy / pre-Phase-1A path: a tunnel resource with an empty Slug
-// (qurl-service didn't surface slug until PR #743; pre-existing tunnels
-// may carry no slug for the lifetime of the row) renders the
-// fragment-free "(tunnel)" shape. Choosing "omit cleanly" over
-// "slug:none" parallels how URL/transit rows already work and keeps
-// the row identical to the pre-Phase-3 shape for legacy tunnels.
-func TestHandleList_TunnelResourceWithoutSlugOmitsFragment(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tunnel_nos", fAttrAlias: "legacy-tun", testKeyType: resourceTypeTunnel},
-		}, "", false)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$legacy-tun` → (tunnel)") {
-		t.Errorf("async reply missing tunnel placeholder for legacy slug-less tunnel: %q", async)
-	}
-	if strings.Contains(async, "[slug:") {
-		t.Errorf("slug fragment leaked on tunnel row without a slug: %q", async)
-	}
-	if strings.Contains(async, "slug:none") {
-		t.Errorf("slug:none placeholder leaked — implementation chose to omit cleanly: %q", async)
-	}
-}
-
-// TestHandleList_URLResourceNeverShowsSlugFragment fences the
-// tunnel-scope of the slug fragment: a URL/transit resource MUST NOT
-// render a "[slug:...]" fragment even if a stray `slug` field shows
-// up on the wire (qurl-service rejects slug on non-tunnel creates,
-// but defense-in-depth: the renderer keys the fragment on Type=tunnel,
-// not on the slug field's presence).
-func TestHandleList_URLResourceNeverShowsSlugFragment(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, []map[string]any{
-			// Stray slug on a URL row — server shouldn't emit this,
-			// but the renderer must defend the type-scoped contract.
-			{testKeyResourceID: "r_url_xxxxxx", fAttrAlias: "prod-url", testKeyTargetURL: "https://url-row.example.com", testKeySlug: "should-not-render"},
-		}, "", false)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$prod-url` → https://url-row.example.com") {
-		t.Errorf("async reply missing URL row: %q", async)
-	}
-	if strings.Contains(async, "[slug:") {
-		t.Errorf("slug fragment leaked on a URL/transit row: %q", async)
-	}
-	if strings.Contains(async, "should-not-render") {
-		t.Errorf("stray wire-level slug bled through on a URL row: %q", async)
-	}
-}
-
-// TestHandleList_MixedTypesOnlyTunnelRowsShowSlug fences the
-// per-row scoping in a heterogeneous list: only tunnel rows surface
-// "[slug:...]" fragments; URL rows render plain.
-func TestHandleList_MixedTypesOnlyTunnelRowsShowSlug(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tun_slug_a", fAttrAlias: "atun", testKeyType: resourceTypeTunnel, testKeySlug: "alpha-tunnel"},
-			{testKeyResourceID: "r_url_btarg1", fAttrAlias: "burl", testKeyTargetURL: "https://b.example.com"},
-			{testKeyResourceID: "r_tun_noslug", fAttrAlias: "ctun", testKeyType: resourceTypeTunnel},
-		}, "", false)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	// Tunnel with slug → fragment present.
-	if !strings.Contains(async, "`$atun` → (tunnel) [slug:alpha-tunnel]") {
-		t.Errorf("async reply missing slug-bearing tunnel row: %q", async)
-	}
-	// URL row → no fragment, plain target.
-	if !strings.Contains(async, "`$burl` → https://b.example.com") {
-		t.Errorf("async reply missing URL row: %q", async)
-	}
-	// Tunnel without slug → bare "(tunnel)" with no fragment.
-	if !strings.Contains(async, "`$ctun` → (tunnel)") {
-		t.Errorf("async reply missing slug-less tunnel row: %q", async)
-	}
-	// Exactly one slug fragment in the whole reply — the URL and
-	// slug-less tunnel rows MUST NOT carry one.
-	if got := strings.Count(async, "[slug:"); got != 1 {
-		t.Errorf("expected exactly one [slug:...] fragment across mixed list, got %d: %q", got, async)
-	}
-}
-
-// TestHandleList_ResourceWithDescription fences the trailing
-// "— <description>" annotation. Legacy /qurl list rendered description
-// on a separate line; the resource-pivoted version preserves the
-// operator-authored context as a one-line suffix so each row stays
-// copy-paste-greppable.
-func TestHandleList_ResourceWithDescription(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_desc_aaaaa", fAttrAlias: "prod", testKeyTargetURL: "https://prod", testKeyDescription: "production gateway"},
-			{testKeyResourceID: "r_nodesc_bbbb", fAttrAlias: "stage", testKeyTargetURL: "https://stage"},
-			{testKeyResourceID: "r_tun_descrip", fAttrAlias: "tun", testKeyType: resourceTypeTunnel, testKeyDescription: "ops bastion"},
-		}, "", false)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	// Description-bearing row renders trailing em-dash + description.
-	if !strings.Contains(async, "`$prod` → https://prod — production gateway") {
-		t.Errorf("async reply missing description suffix on aliased row: %q", async)
-	}
-	// No-description row stays clean (no trailing em-dash).
-	if !strings.Contains(async, "`$stage` → https://stage") {
-		t.Errorf("async reply missing un-described row: %q", async)
-	}
-	if strings.Contains(async, "`$stage` → https://stage —") {
-		t.Errorf("un-described row should not render a trailing em-dash: %q", async)
-	}
-	// Tunnel rows also carry description.
-	if !strings.Contains(async, "`$tun` → (tunnel) — ops bastion") {
-		t.Errorf("async reply missing description suffix on tunnel row: %q", async)
+	if strings.Contains(async, "`$no-desc-tun` →") {
+		t.Errorf("undescribed tunnel should not render a trailing arrow: %q", async)
 	}
 }
 
@@ -518,44 +417,44 @@ func TestHandleList_HasMoreFooter(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_one_aa", fAttrAlias: "one", testKeyTargetURL: "https://one"},
+			{testKeyResourceID: "r_one_aa", testKeyType: resourceTypeTunnel, testKeySlug: "one-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "more results past") {
+	if !strings.Contains(async, "more resources past") {
 		t.Errorf("async reply missing has_more footer: %q", async)
 	}
 }
 
 // TestHandleList_NonAdminPartialPageHasMoreFooter fences the distinct
 // non-admin footer when the filtered set is NON-empty and master
-// has_more=true. The admin footer ("more results past first N") under-
-// states the gap because allow-listed resources may sit past the first
-// scan invisibly; the non-admin copy makes that explicit.
+// has_more=true. The admin footer understates the gap because
+// allow-listed tunnels may sit past the first scan invisibly; the
+// non-admin copy makes that explicit.
 func TestHandleList_NonAdminPartialPageHasMoreFooter(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
-	// One allowed resource in the channel, plus has_more=true so the
+	// One allowed tunnel in the channel, plus has_more=true so the
 	// non-admin pagination-aware footer branch fires.
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "one", []string{"r_one_xxxxxx"})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_one_xxxxxx", fAttrAlias: "one", testKeyTargetURL: "https://one"},
+			{testKeyResourceID: "r_one_xxxxxx", testKeyType: resourceTypeTunnel, testKeySlug: "one-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "Showing allow-listed resources") {
+	if !strings.Contains(async, "Showing allow-listed tunnels") {
 		t.Errorf("async reply missing non-admin partial-page footer: %q", async)
 	}
-	// Admin-only "more results past" copy must NOT fire on the non-admin
+	// Admin-only "more resources past" copy must NOT fire on the non-admin
 	// path — these two branches are deliberately disjoint.
-	if strings.Contains(async, "more results past") {
+	if strings.Contains(async, "more resources past") {
 		t.Errorf("async reply leaked admin-only footer copy on non-admin path: %q", async)
 	}
 }
@@ -567,7 +466,7 @@ func TestHandleList_AdminStoreNilTreatedAsNonAdmin(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_master_xx", fAttrAlias: "master", testKeyTargetURL: "https://x"},
+			{testKeyResourceID: "r_master_xx", testKeyType: resourceTypeTunnel, testKeySlug: "master-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -601,28 +500,28 @@ func TestHandleList_UpstreamError(t *testing.T) {
 	}
 }
 
-// TestHandleList_StableSortBetweenAliasAndResourceID fences the sort
-// order: rows are sorted by the underlying token (alias if bound,
-// resource_id otherwise) so two consecutive `/qurl list` calls render
+// TestHandleList_StableSortByToken fences the sort order: tunnel rows
+// are sorted by the displayed token (slug, else alias, else
+// resource_id) so two consecutive `/qurl list` calls render
 // identically.
-func TestHandleList_StableSortBetweenAliasAndResourceID(t *testing.T) {
+func TestHandleList_StableSortByToken(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		// Server returns in non-alphabetical order; the handler must
-		// sort.
+		// sort. The slug-less row sorts by its resource_id.
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_zzz_aaaaa", testKeyTargetURL: "https://zzz"},
-			{testKeyResourceID: "r_aaa_xxxxx", fAttrAlias: testListAliasAlpha, testKeyTargetURL: "https://alpha"},
-			{testKeyResourceID: "r_mmm_yyyyy", fAttrAlias: "middle", testKeyTargetURL: "https://mid"},
+			{testKeyResourceID: "r_zzz_aaaaa", testKeyType: resourceTypeTunnel},
+			{testKeyResourceID: "r_aaa_xxxxx", testKeyType: resourceTypeTunnel, testKeySlug: testListAliasAlpha},
+			{testKeyResourceID: "r_mmm_yyyyy", testKeyType: resourceTypeTunnel, testKeySlug: "middle"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	// "alpha" < "middle" < "r_zzz" (alphabetical, alias values
-	// sorted naturally; un-aliased rows sort by resource_id).
+	// "alpha" < "middle" < "r_zzz_aaaaa" (alphabetical; the slug-less
+	// row sorts by resource_id).
 	alphaPos := strings.Index(async, "`$alpha`")
 	middlePos := strings.Index(async, "`$middle`")
 	zzzPos := strings.Index(async, "`$r_zzz_aaaaa`")

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -564,20 +564,18 @@ func TestTunnelToken(t *testing.T) {
 	}
 }
 
-// TestHandleList_NonAdminPaginationGapZeroTunnels pins the current
-// behavior of the non-admin pagination-gap branch when the scanned page
-// holds only URL/transit resources (zero tunnels) and reports has_more.
-// page.HasMore is a master-list signal, so the gap copy fires even
-// though no tunnels exist — see the TODO(#531) at the branch. This test
-// documents that bounded-but-imperfect behavior; the server-side
-// type=tunnel filter (#531) will flip the expectation to the plain
-// empty-state, at which point this test should be updated in lockstep.
+// TestHandleList_NonAdminPaginationGapZeroTunnels fences the len(tunnels)
+// > 0 guard on the non-admin pagination-gap branch: when the scanned
+// page holds only URL/transit resources (zero tunnels) and reports
+// has_more, the gap-copy is SUPPRESSED — claiming "allowed tunnels may
+// sit past the first page" would be misleading when there are no tunnels
+// at all. The user sees the plain empty-state instead.
 func TestHandleList_NonAdminPaginationGapZeroTunnels(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		// Page is all URL resources — filterTunnelResources drops them
-		// all, so the non-admin filtered set is empty with has_more=true.
+		// all, so len(tunnels)==0 even though has_more=true.
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: "r_url_aaaaaa", fAttrAlias: "u1", testKeyTargetURL: "https://a.example.com"},
 			{testKeyResourceID: "r_url_bbbbbb", fAttrAlias: "u2", testKeyTargetURL: "https://b.example.com"},
@@ -587,11 +585,14 @@ func TestHandleList_NonAdminPaginationGapZeroTunnels(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	// Current (pre-#531) behavior: pagination-gap copy fires.
-	if !strings.Contains(async, "past the first page") {
-		t.Errorf("async reply missing pagination-gap copy (current pre-#531 behavior): %q", async)
+	// Gap-copy suppressed (zero tunnels on the page) → plain empty-state.
+	if !strings.Contains(async, "No tunnels found") {
+		t.Errorf("async reply missing plain empty-state (gap-copy should be suppressed with zero tunnels): %q", async)
 	}
-	// Regardless, no URL resource leaks into the (empty) tunnel listing.
+	if strings.Contains(async, "past the first page") {
+		t.Errorf("gap-copy fired despite zero tunnels on the page: %q", async)
+	}
+	// No URL resource leaks into the (empty) tunnel listing.
 	if strings.Contains(async, "a.example.com") || strings.Contains(async, "b.example.com") {
 		t.Errorf("URL resource leaked into tunnel list: %q", async)
 	}

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -18,7 +18,7 @@ import (
 //
 // `/qurl list` is tunnel-only and renders the slug as the `$<token>`,
 // so the fixtures below are tunnel resources (testKeyType:
-// resourceTypeTunnel) carrying a slug.
+// client.ResourceTypeTunnel) carrying a slug.
 const (
 	testListAliasProdDB = "prod-db"
 	testListAliasSecret = "secret"
@@ -54,8 +54,8 @@ func TestHandleList_AdminSeesAllTunnels(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: testListResIDProdDB, testKeyType: resourceTypeTunnel, testKeySlug: testListAliasProdDB},
-			{testKeyResourceID: "r_stage_db_bb", testKeyType: resourceTypeTunnel, testKeySlug: "stage-db"},
+			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB},
+			{testKeyResourceID: "r_stage_db_bb", testKeyType: client.ResourceTypeTunnel, testKeySlug: "stage-db"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -84,8 +84,8 @@ func TestHandleList_NonAdminFiltersToChannelPolicy(t *testing.T) {
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testListResIDProdDB})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: testListResIDProdDB, testKeyType: resourceTypeTunnel, testKeySlug: testListAliasProdDB},
-			{testKeyResourceID: "r_secret_xx", testKeyType: resourceTypeTunnel, testKeySlug: testListAliasSecret},
+			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB},
+			{testKeyResourceID: "r_secret_xx", testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasSecret},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -117,8 +117,8 @@ func TestHandleList_NonAdminSeesAllowedResourceIDsWithoutAliasBinding(t *testing
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_allow_only1"})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_allow_only1", testKeyType: resourceTypeTunnel, testKeySlug: "allow-only-tun"},
-			{testKeyResourceID: "r_secret_xx", testKeyType: resourceTypeTunnel, testKeySlug: testListAliasSecret},
+			{testKeyResourceID: "r_allow_only1", testKeyType: client.ResourceTypeTunnel, testKeySlug: "allow-only-tun"},
+			{testKeyResourceID: "r_secret_xx", testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasSecret},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -159,9 +159,9 @@ func TestHandleList_NonAdminUnionsAllowedSetAndAliasBindings(t *testing.T) {
 	})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_allow_set_a", testKeyType: resourceTypeTunnel, testKeySlug: "allowset-tun"},
-			{testKeyResourceID: "r_alias_only_b", testKeyType: resourceTypeTunnel, testKeySlug: "aliasonly-tun"},
-			{testKeyResourceID: "r_neither_xx", testKeyType: resourceTypeTunnel, testKeySlug: "neither-tun"},
+			{testKeyResourceID: "r_allow_set_a", testKeyType: client.ResourceTypeTunnel, testKeySlug: "allowset-tun"},
+			{testKeyResourceID: "r_alias_only_b", testKeyType: client.ResourceTypeTunnel, testKeySlug: "aliasonly-tun"},
+			{testKeyResourceID: "r_neither_xx", testKeyType: client.ResourceTypeTunnel, testKeySlug: "neither-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -188,7 +188,7 @@ func TestHandleList_NonAdminEmptyChannelFailsClose(t *testing.T) {
 	ts.seedNonAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_leaked_xx", testKeyType: resourceTypeTunnel, testKeySlug: "leaked-tun"},
+			{testKeyResourceID: "r_leaked_xx", testKeyType: client.ResourceTypeTunnel, testKeySlug: "leaked-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -212,7 +212,7 @@ func TestHandleList_NonAdminPaginationGap(t *testing.T) {
 	// fires.
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_unallowed_x", testKeyType: resourceTypeTunnel, testKeySlug: "unallowed-tun"},
+			{testKeyResourceID: "r_unallowed_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "unallowed-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -233,7 +233,7 @@ func TestHandleList_NonAdminEmptyChannelWithHasMoreShowsDefault(t *testing.T) {
 	ts.seedNonAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_leaked_xx", testKeyType: resourceTypeTunnel, testKeySlug: "leaked-tun"},
+			{testKeyResourceID: "r_leaked_xx", testKeyType: client.ResourceTypeTunnel, testKeySlug: "leaked-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -278,7 +278,7 @@ func TestHandleList_URLResourcesFiltered(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tun_aaaaaa", testKeyType: resourceTypeTunnel, testKeySlug: "alpha-tunnel"},
+			{testKeyResourceID: "r_tun_aaaaaa", testKeyType: client.ResourceTypeTunnel, testKeySlug: "alpha-tunnel"},
 			{testKeyResourceID: "r_url_btarg1", fAttrAlias: "burl", testKeyTargetURL: "https://b.example.com"},
 			{testKeyResourceID: "r_url_stray1", testKeyTargetURL: "https://c.example.com", testKeySlug: "stray-slug"},
 		}, "", false)
@@ -310,7 +310,7 @@ func TestHandleList_TunnelSlugIsToken(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tunnel_slg", fAttrAlias: "dash-alias", testKeyType: resourceTypeTunnel, testKeySlug: "prod-dashboard"},
+			{testKeyResourceID: "r_tunnel_slg", fAttrAlias: "dash-alias", testKeyType: client.ResourceTypeTunnel, testKeySlug: "prod-dashboard"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -345,7 +345,7 @@ func TestHandleList_TunnelAliasFallbackWhenNoSlug(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tunnel_aaa", fAttrAlias: "tun", testKeyType: resourceTypeTunnel},
+			{testKeyResourceID: "r_tunnel_aaa", fAttrAlias: "tun", testKeyType: client.ResourceTypeTunnel},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -369,7 +369,7 @@ func TestHandleList_TunnelResourceIDFallback(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tunnel_noa", testKeyType: resourceTypeTunnel},
+			{testKeyResourceID: "r_tunnel_noa", testKeyType: client.ResourceTypeTunnel},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -395,8 +395,8 @@ func TestHandleList_TunnelWithDescription(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_tun_desc1", testKeyType: resourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "ops jump host"},
-			{testKeyResourceID: "r_tun_nodes", testKeyType: resourceTypeTunnel, testKeySlug: "no-desc-tun"},
+			{testKeyResourceID: "r_tun_desc1", testKeyType: client.ResourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "ops jump host"},
+			{testKeyResourceID: "r_tun_nodes", testKeyType: client.ResourceTypeTunnel, testKeySlug: "no-desc-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -421,7 +421,7 @@ func TestHandleList_HasMoreFooter(t *testing.T) {
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_one_aa", testKeyType: resourceTypeTunnel, testKeySlug: "one-tun"},
+			{testKeyResourceID: "r_one_aa", testKeyType: client.ResourceTypeTunnel, testKeySlug: "one-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -446,7 +446,7 @@ func TestHandleList_NonAdminPartialPageHasMoreFooter(t *testing.T) {
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "one", []string{"r_one_xxxxxx"})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_one_xxxxxx", testKeyType: resourceTypeTunnel, testKeySlug: "one-tun"},
+			{testKeyResourceID: "r_one_xxxxxx", testKeyType: client.ResourceTypeTunnel, testKeySlug: "one-tun"},
 		}, "cursor_xyz", true)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -470,7 +470,7 @@ func TestHandleList_AdminStoreNilTreatedAsNonAdmin(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_master_xx", testKeyType: resourceTypeTunnel, testKeySlug: "master-tun"},
+			{testKeyResourceID: "r_master_xx", testKeyType: client.ResourceTypeTunnel, testKeySlug: "master-tun"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -515,9 +515,9 @@ func TestHandleList_StableSortByToken(t *testing.T) {
 		// Server returns in non-alphabetical order; the handler must
 		// sort. The slug-less row sorts by its resource_id.
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: "r_zzz_aaaaa", testKeyType: resourceTypeTunnel},
-			{testKeyResourceID: "r_aaa_xxxxx", testKeyType: resourceTypeTunnel, testKeySlug: testListAliasAlpha},
-			{testKeyResourceID: "r_mmm_yyyyy", testKeyType: resourceTypeTunnel, testKeySlug: "middle"},
+			{testKeyResourceID: "r_zzz_aaaaa", testKeyType: client.ResourceTypeTunnel},
+			{testKeyResourceID: "r_aaa_xxxxx", testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasAlpha},
+			{testKeyResourceID: "r_mmm_yyyyy", testKeyType: client.ResourceTypeTunnel, testKeySlug: "middle"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // Shared fixtures used across the /qurl list test cases. Lifted to
@@ -532,5 +534,65 @@ func TestHandleList_StableSortByToken(t *testing.T) {
 	}
 	if alphaPos >= middlePos || middlePos >= zzzPos {
 		t.Errorf("rows not sorted by token: alpha=%d middle=%d zzz=%d in %q", alphaPos, middlePos, zzzPos, async)
+	}
+}
+
+// TestTunnelToken pins the slug → alias → resource_id precedence of the
+// `$<token>` shown for a tunnel row, directly (not just via the rendered
+// list output), so a future refactor that reorders the fallback chain
+// fails loudly. Intended posture: the slug wins even when a
+// resource-level alias is also set, because the slug is the stable
+// handle `/qurl tunnel install <slug>` binds for `/qurl get $<slug>`.
+func TestTunnelToken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		r    client.Resource
+		want string
+	}{
+		{name: "slug wins over alias and resource_id", r: client.Resource{ResourceID: "r_one", Alias: "alias-one", Slug: "slug-one"}, want: "slug-one"},
+		{name: "alias used when no slug", r: client.Resource{ResourceID: "r_two", Alias: "alias-two"}, want: "alias-two"},
+		{name: "resource_id last resort when no slug or alias", r: client.Resource{ResourceID: "r_three"}, want: "r_three"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tunnelToken(&tc.r); got != tc.want {
+				t.Errorf("tunnelToken() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleList_NonAdminPaginationGapZeroTunnels pins the current
+// behavior of the non-admin pagination-gap branch when the scanned page
+// holds only URL/transit resources (zero tunnels) and reports has_more.
+// page.HasMore is a master-list signal, so the gap copy fires even
+// though no tunnels exist — see the TODO(#531) at the branch. This test
+// documents that bounded-but-imperfect behavior; the server-side
+// type=tunnel filter (#531) will flip the expectation to the plain
+// empty-state, at which point this test should be updated in lockstep.
+func TestHandleList_NonAdminPaginationGapZeroTunnels(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		// Page is all URL resources — filterTunnelResources drops them
+		// all, so the non-admin filtered set is empty with has_more=true.
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_url_aaaaaa", fAttrAlias: "u1", testKeyTargetURL: "https://a.example.com"},
+			{testKeyResourceID: "r_url_bbbbbb", fAttrAlias: "u2", testKeyTargetURL: "https://b.example.com"},
+		}, "cursor_xyz", true)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	// Current (pre-#531) behavior: pagination-gap copy fires.
+	if !strings.Contains(async, "past the first page") {
+		t.Errorf("async reply missing pagination-gap copy (current pre-#531 behavior): %q", async)
+	}
+	// Regardless, no URL resource leaks into the (empty) tunnel listing.
+	if strings.Contains(async, "a.example.com") || strings.Contains(async, "b.example.com") {
+		t.Errorf("URL resource leaked into tunnel list: %q", async)
 	}
 }

--- a/apps/slack/internal/handler_test_helpers_test.go
+++ b/apps/slack/internal/handler_test_helpers_test.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 	"testing"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // Common keys for the qurl-service response envelope. Lifted to
@@ -47,6 +49,27 @@ func writeResourceFixtureWithTarget(t *testing.T, w http.ResponseWriter, resourc
 			testKeyResourceID: resourceID,
 			"alias":           alias,
 			"target_url":      target,
+		},
+	}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+}
+
+// writeTunnelResourceFixture writes the by-alias resource envelope for
+// a TUNNEL resource: no target_url, carries a slug + active status.
+// Used by the aliases tests to exercise the alias→slug rendering branch
+// (formatAliasLine prefers the slug over the opaque resource_id).
+func writeTunnelResourceFixture(t *testing.T, w http.ResponseWriter, resourceID, alias, slug string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	body := map[string]any{
+		testKeyData: map[string]any{
+			testKeyResourceID: resourceID,
+			"alias":           alias,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       slug,
+			testKeyStatus:     client.StatusActive,
 		},
 	}
 	if err := json.NewEncoder(w).Encode(body); err != nil {

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -117,8 +117,10 @@ type Command struct {
 	// *caller* — the user who typed the command); this field holds the
 	// *target* of the verb (the user being added or removed).
 	UserID string
-	// Flags holds optional `key:value` flags. Only `dm`, `once`, and
-	// `reason` are recognized today (on `get`).
+	// Flags holds optional `key:value` flags. Only `dm` and `reason`
+	// are recognized today (on `get`). One-time use is unconditional
+	// for `get` — there is no `once` flag (the link always burns on
+	// first redemption), so it isn't a flag here.
 	Flags map[string]string
 	// Raw is the original trimmed text, kept for diagnostics.
 	Raw string
@@ -130,18 +132,6 @@ func (c *Command) DM() bool {
 		return false
 	}
 	v, ok := c.Flags["dm"]
-	if !ok {
-		return false
-	}
-	return strings.EqualFold(v, "true")
-}
-
-// Once returns the parsed value of the `once:true` flag on `get`.
-func (c *Command) Once() bool {
-	if c == nil {
-		return false
-	}
-	v, ok := c.Flags[flagKeyOnce]
 	if !ok {
 		return false
 	}
@@ -209,11 +199,6 @@ var ErrInvalidQURLID = errors.New("invalid qurl_id")
 // positional arguments receives one (e.g. `admin policies extra`).
 // Catches user-facing typos earlier than the handler dispatch.
 var ErrUnexpectedArgument = errors.New("unexpected argument")
-
-// flagKeyOnce is the canonical key for the `once:` strict-boolean
-// flag. Constant rather than literal because goconst flags `"once"`
-// at its 3-occurrence threshold on `--new-from-rev`.
-const flagKeyOnce = "once"
 
 // ErrInvalidFlag is the sentinel wrapped by every [applyFlag] error
 // path (unknown key, missing-key-before-colon, empty value,
@@ -784,7 +769,7 @@ func hasASCIIPrefixFold(s, prefix string) bool {
 }
 
 // applyFlag parses a single `key:value` token into [Command.Flags]. Only
-// the recognized keys (`dm`, `once`, `reason`) survive — unknown keys
+// the recognized keys (`dm`, `reason`) survive — unknown keys
 // are an error so a typo doesn't silently no-op. The key half is
 // case-folded so `DM:true` and `Reason:foo` work the way users on
 // mobile clients (with auto-capitalize) expect; the value half is
@@ -793,15 +778,14 @@ func hasASCIIPrefixFold(s, prefix string) bool {
 // in PR-3c.3+ should be able to distinguish "flag unset" from "flag
 // set to empty" by absence in [Command.Flags] alone.
 //
-// Per-key validation is strict-posture: `dm` and `once` accept only
-// the boolean strings `true` / `false` (case-folded), so a user
-// typing `dm:yes` or `once:1` sees a friendly error rather than the
-// silent-falsey behavior the unvalidated form would have produced
-// ([Command.DM] / [Command.Once] case-equal against "true", so any
-// non-"true" value silently returns false — exactly the typo class
-// the rest of the parser rejects). `reason` accepts any non-empty
-// prose because the handler in PR-3c.3+ uses it for audit text where
-// the user's exact wording is the point.
+// Per-key validation is strict-posture: `dm` accepts only the boolean
+// strings `true` / `false` (case-folded), so a user typing `dm:yes`
+// sees a friendly error rather than the silent-falsey behavior the
+// unvalidated form would have produced ([Command.DM] case-equals
+// against "true", so any non-"true" value silently returns false —
+// exactly the typo class the rest of the parser rejects). `reason`
+// accepts any non-empty prose because the handler in PR-3c.3+ uses it
+// for audit text where the user's exact wording is the point.
 func applyFlag(cmd *Command, tok string) error {
 	colonIdx := strings.IndexByte(tok, ':')
 	if colonIdx < 0 {
@@ -846,13 +830,6 @@ func applyFlag(cmd *Command, tok string) error {
 		// values too.
 		if !strings.EqualFold(val, "true") && !strings.EqualFold(val, "false") {
 			return fmt.Errorf("%w: dm:%q (use dm:true or omit the flag)", ErrInvalidFlag, val)
-		}
-		cmd.Flags[key] = val
-		return nil
-	case flagKeyOnce:
-		// Strict-boolean gate — same shape as `dm` above.
-		if !strings.EqualFold(val, "true") && !strings.EqualFold(val, "false") {
-			return fmt.Errorf("%w: once:%q (use once:true or omit the flag)", ErrInvalidFlag, val)
 		}
 		cmd.Flags[key] = val
 		return nil

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -836,6 +836,13 @@ func applyFlag(cmd *Command, tok string) error {
 	case "reason":
 		cmd.Flags[key] = val
 		return nil
+	case "once":
+		// `once` was removed — one-time use is now the unconditional
+		// default for `/qurl get`. Still reject (strict-flag posture),
+		// but with a transitional hint instead of the generic
+		// "unknown flag", since some users have `once:true` in saved
+		// slash-command recipes and deserve to know it's now redundant.
+		return fmt.Errorf("%w: `once` is no longer needed — every `/qurl get` link is one-time use by default", ErrInvalidFlag)
 	default:
 		return fmt.Errorf("%w: unknown flag %q", ErrInvalidFlag, key)
 	}

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -12,9 +12,6 @@ import (
 // facing wording changes, this is the single edit point.
 const dmRejectSubstr = "use dm:true"
 
-// onceRejectSubstr is the [dmRejectSubstr] counterpart for `once:`.
-const onceRejectSubstr = "use once:true"
-
 // TestParse_HappyPaths fences the recognized grammar of every subcommand.
 // One row per verb so a regression that drops or relabels a verb is the
 // failure that reaches review, not a behavioral diff in PR-3c.3+.
@@ -34,10 +31,8 @@ func TestParse_HappyPaths(t *testing.T) {
 		{name: "help literal", text: "help", wantSub: SubcmdHelp, wantFlags: map[string]string{}},
 		{name: "get alias", text: "get $prod-db", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{}},
 		{name: "get with dm flag", text: "get $prod-db dm:true", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "true"}},
-		{name: "get with once flag", text: "get $prod-db once:true", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "true"}},
 		{name: "get with reason flag", text: `get $prod-db reason:"on call"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"reason": "on call"}},
 		{name: "get with both flags", text: `get $prod-db dm:true reason:"audit"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "true", "reason": "audit"}},
-		{name: "get with once, dm, and reason flags", text: `get $prod-db once:true dm:true reason:"audit"`, wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "true", "dm": "true", "reason": "audit"}},
 		{name: "setalias url", text: "setalias $prod-db https://internal.example.com", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "https://internal.example.com", wantFlags: map[string]string{}},
 		{name: "setalias resource_id", text: "setalias $prod-db r_abc123", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "r_abc123", wantFlags: map[string]string{}},
 		{name: "setalias tunnel slug", text: "setalias $prod-db $prod-dashboard", wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "$prod-dashboard", wantFlags: map[string]string{}},
@@ -68,8 +63,6 @@ func TestParse_HappyPaths(t *testing.T) {
 		// "unknown flag" error.
 		{name: "dm:false accepted", text: "get $prod-db dm:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "false"}},
 		{name: "dm:FALSE case-folded", text: "get $prod-db dm:FALSE", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "FALSE"}},
-		// once:false: same accepted-but-no-op posture as dm:false above.
-		{name: "once:false accepted", text: "get $prod-db once:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{flagKeyOnce: "false"}},
 		// Admin verb is lowercased before the AdminAction switch. Pinned
 		// so a future refactor that drops `strings.ToLower(verb)` can't
 		// silently regress mobile-client / auto-capitalize inputs.
@@ -281,14 +274,12 @@ func TestParse_GetFlagErrors(t *testing.T) {
 		{name: "dm:1 rejected (not true/false)", text: "get $prod-db dm:1", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:yes rejected (not true/false)", text: "get $prod-db dm:yes", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		{name: "dm:please rejected (not true/false)", text: "get $prod-db dm:please", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
-		// once: mirrors dm:'s strict-boolean gate above. Explicit
-		// once:-keyed empty rows survive a refactor that moves per-
-		// key validation in front of the shared empty-value gate.
-		{name: "once:1 rejected (not true/false)", text: "get $prod-db once:1", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
-		{name: "once:yes rejected (not true/false)", text: "get $prod-db once:yes", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
-		{name: "once:please rejected (not true/false)", text: "get $prod-db once:please", wantSentnl: ErrInvalidFlag, wantSubstr: onceRejectSubstr},
-		{name: "once: bare empty rejected", text: "get $prod-db once:", wantSentnl: ErrInvalidFlag, wantSubstr: "empty value"},
-		{name: `once:"" quoted empty rejected`, text: `get $prod-db once:""`, wantSentnl: ErrInvalidFlag, wantSubstr: "empty value"},
+		// `once` is no longer a recognized flag — one-time use is the
+		// unconditional default for `/qurl get`, so the flag was removed.
+		// A stray `once:true` now reports the same "unknown flag" error
+		// as any other unrecognized key. Pins the removal so the flag
+		// can't be silently reintroduced.
+		{name: "once:true rejected as unknown flag", text: "get $prod-db once:true", wantSentnl: ErrInvalidFlag, wantSubstr: "unknown flag"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -553,30 +544,6 @@ func TestCommand_DM(t *testing.T) {
 			t.Parallel()
 			if got := tc.cmd.DM(); got != tc.want {
 				t.Errorf("DM() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-// TestCommand_Once is the [TestCommand_DM] counterpart for `Once()`.
-func TestCommand_Once(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		cmd  *Command
-		want bool
-	}{
-		{name: "nil receiver", cmd: nil, want: false},
-		{name: "no flags", cmd: &Command{Flags: map[string]string{}}, want: false},
-		{name: "once:true", cmd: &Command{Flags: map[string]string{flagKeyOnce: "true"}}, want: true},
-		{name: "once:TRUE (case-insensitive)", cmd: &Command{Flags: map[string]string{flagKeyOnce: "TRUE"}}, want: true},
-		{name: "once:false", cmd: &Command{Flags: map[string]string{flagKeyOnce: "false"}}, want: false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := tc.cmd.Once(); got != tc.want {
-				t.Errorf("Once() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -276,10 +276,12 @@ func TestParse_GetFlagErrors(t *testing.T) {
 		{name: "dm:please rejected (not true/false)", text: "get $prod-db dm:please", wantSentnl: ErrInvalidFlag, wantSubstr: dmRejectSubstr},
 		// `once` is no longer a recognized flag — one-time use is the
 		// unconditional default for `/qurl get`, so the flag was removed.
-		// A stray `once:true` now reports the same "unknown flag" error
-		// as any other unrecognized key. Pins the removal so the flag
-		// can't be silently reintroduced.
-		{name: "once:true rejected as unknown flag", text: "get $prod-db once:true", wantSentnl: ErrInvalidFlag, wantSubstr: "unknown flag"},
+		// A stray `once:true` is rejected (strict-flag posture) but with
+		// a transitional hint rather than the generic "unknown flag", so
+		// users with saved `once:true` recipes learn it's now redundant.
+		// Pins both the removal and the friendly message.
+		{name: "once:true rejected with transitional hint", text: "get $prod-db once:true", wantSentnl: ErrInvalidFlag, wantSubstr: "no longer needed"},
+		{name: "once:false also rejected with hint", text: "get $prod-db once:false", wantSentnl: ErrInvalidFlag, wantSubstr: "no longer needed"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Tightens the Slack bot's `/qurl list` and `/qurl get` surfaces so they speak in tunnel slugs instead of opaque internal identifiers, and makes one-time use the default for `/qurl get`.

## What changed

### `/qurl list` — tunnels only, slug as the token
- Lists **only tunnel resources** (`type=tunnel`). URL/transit resources are filtered out.
- Each row renders the tunnel **slug** as the copy-paste-ready `$<slug>` token, with a `slug → alias → resource_id` fallback chain. The opaque `r_<id>` only appears for a legacy tunnel that has neither a slug nor an alias (vanishingly rare).
- Dropped the now-redundant `(tunnel)` label and `[slug:…]` fragment — the whole list is tunnels and the token **is** the slug.

**Before → After:**
```
• `$r_0pxn89qcm9i` → (tunnel) [slug:kktest] — Slack tunnel install for kktest
• `$kktest` → Slack tunnel install for kktest
```

The slug is the same handle `/qurl tunnel install <slug>` already binds as a channel alias, so a listed `$<slug>` pastes straight into `/qurl get $<slug>` and resolves.

The list fetches one page at the server's max (100 resources) before filtering client-side — the resources API has no `type` filter, and a small page could otherwise surface zero tunnels in a URL-heavy workspace. Channel scoping, fail-closed posture, and the has-more footer are unchanged (footer copy now refers to tunnels).

### `/qurl get` — one-time use is the default
- Every `/qurl get` link is now one-time use, unconditionally. The `(one-time use)` suffix always appears so the expectation is set.
- The `once` flag is **removed**. A stray `once:true`/`once:false` is rejected with a transitional hint ("`once` is no longer needed — every `/qurl get` link is one-time use by default") rather than a generic "unknown flag", for users with saved recipes.
- `/qurl get $<slug>` now resolves **tunnel slugs**, not just channel `set-alias` bindings: when the alias lookup misses, it falls back to a slug→resource_id lookup gated by the same channel allow-set as the `$r_<id>` form (admin bypass / `allowed_resource_ids`). This keeps the `/qurl list` → `/qurl get` round-trip honest for tunnels surfaced via admin-sees-all or cross-channel allow (which have no binding in the current channel) — without re-exposing `r_<id>` in the list.

### Help / usage copy
- Get usage collapses to two forms: `/qurl get <url|$slug>` and `/qurl get <url|$slug> reason:"…"`. The `once:true` line is gone; the conditional `dm:true` line is unchanged.
- No more mentions of resource IDs: the list empty-state now points at `/qurl tunnel install <slug>` (the old copy referenced the deprecated `/qurl create`), and `set-alias` usage reads `<url-or-$slug>`.

## Notes
- **`/qurl list` no longer shows URL shortcuts.** A `set-alias`-bound URL/transit resource used to appear in `/qurl list`; it is now filtered out (tunnels only, per this PR's intent). Such shortcuts stay discoverable via `/qurl aliases` and usable via `/qurl get $<shortcut>`.
- The `$r_<id>` form still works in `/qurl get` (admins / channel allow-set) and `set-alias` still accepts a resource_id target — these are just no longer advertised in user-facing copy.
- `dm:true` is left intact (out of scope; it's a separately-wired, gated feature).
- The deprecated `/qurl create` continues to point users at `/qurl get`.

## Test plan
- Rewrote `handler_list_test.go` for the tunnel-only + slug-token behavior: slug-is-token, slug-wins-over-alias, alias/resource_id fallbacks, no `(tunnel)`/`[slug:]` decorations, URL resources filtered out, description rendering, channel scoping + fail-closed + pagination/footer, stable sort.
- Updated parser/get tests: removed the `once` happy-path/rejection cases and `Command.Once()` test, added regression pins that `once:true`/`once:false` are rejected with the transitional hint, and replaced the once-flag JSON tests with a single "one-time is the default" test. Added `TestTunnelToken`, the slug-fallback round-trip tests (allowed-set, admin-bypass, not-allowed), and a list pagination-gap-with-zero-tunnels pin.
- `go build ./...`, full `go test ./apps/slack/...`, `gofmt`, and `golangci-lint` (0 new issues vs `main`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



