### PR TITLE
fix(slack): support enterprise guided tunnel tokens

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -40,8 +40,10 @@ by the current bot deployment.
   encryption posture as qURL API keys. `SLACK_BOT_TOKEN` is only a legacy
   single-workspace fallback; customers do not manually provide bot tokens, and
   production guided setup should use the per-workspace token captured by Slack
-  install OAuth. Org-level Enterprise Grid installs are not supported in this
-  flow; install qURL to each workspace that should use guided tunnel setup.
+  install OAuth. Enterprise Grid org-level installs are also supported: the
+  enterprise-scoped bot token is stored under the Slack `enterprise_id`, while
+  qURL API keys and admin state remain scoped to each invoking workspace's
+  `team_id`.
 - **Tunnel onboarding:** `/qurl tunnel install` opens a Slack modal with the
   bot token for the invoking workspace, letting an admin choose the tunnel
   slug, optional channel shortcut, local port, and target environment
@@ -148,8 +150,9 @@ For customer Slack installs, configure the Slack app with:
 - Slash command request URL: `https://<SLACK_BASE_URL host>/slack/commands`
 - Interactivity request URL: `https://<SLACK_BASE_URL host>/slack/interactions`
 - Bot scopes: at least `commands` and `views:write`
-- Installation mode: workspace-level installs; org-level Enterprise Grid
-  installs are rejected until enterprise-scoped tokens are supported
+- Installation mode: workspace-level installs or Enterprise Grid org-level
+  installs. Org-level bot tokens are stored under Slack `enterprise_id`; qURL
+  workspace setup and admin checks still use workspace `team_id`.
 - Token posture: non-rotating bot tokens. The validator accepts `xoxe.xoxb-`
   shapes defensively, but qURL does not request or persist Slack refresh tokens
   yet, so rotation-enabled apps need refresh support before production use.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -222,6 +222,7 @@ func run() error {
 		return fmt.Errorf("slack install config: %w", err)
 	}
 	if ok {
+		handler.SetSlackInstallURL(strings.TrimRight(slackInstallCfg.SlackBaseURL, "/") + slackinstall.InstallPath)
 		slackInstallCfg.OnTokenStored = invalidateWorkspaceSlackToken
 		if err := slackinstall.RegisterRoutes(rootMux, &slackInstallCfg); err != nil {
 			return fmt.Errorf("slack install routes: %w", err)
@@ -336,7 +337,10 @@ type workspaceSlackTokenLookupStart struct {
 }
 
 type workspaceSlackTokenLookupCache struct {
-	mu             sync.Mutex
+	mu sync.Mutex
+	// Cache keys are Slack token owners: workspace team_id values for
+	// workspace installs, and enterprise_id values for Enterprise Grid org
+	// installs. The ID spaces are disjoint, so one cache can hold both.
 	positive       map[string]cachedSlackBotToken
 	negative       map[string]time.Time
 	inFlight       map[string]*workspaceSlackTokenLookupCall

--- a/apps/slack/internal/admin_handler_helpers_test.go
+++ b/apps/slack/internal/admin_handler_helpers_test.go
@@ -18,6 +18,7 @@ package internal
 //     response_url follow-up text is read off the captured POST.
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -130,7 +131,8 @@ type adminSlashInvoker struct {
 	responseU *httptest.Server
 	// channelID overrides the slash-command channel_id form field
 	// for the next invocation. Empty falls back to "C_test".
-	channelID string
+	channelID    string
+	enterpriseID string
 }
 
 // newAdminSlashInvoker spins up a response_url-capturing httptest
@@ -179,10 +181,14 @@ func (a *adminSlashInvoker) invokeAdmin(text, teamID, userID string) (status int
 		"channel_id":   {a.channelID},
 		"response_url": {a.responseU.URL},
 		"trigger_id":   {"trigger_test"},
-	}.Encode()
+	}
+	if a.enterpriseID != "" {
+		body.Set(fieldEnterpriseID, a.enterpriseID)
+	}
+	encoded := body.Encode()
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPost, "/slack/commands", strings.NewReader(body))
-	sig, ts := signSlackBody(a.t, body)
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/slack/commands", strings.NewReader(encoded))
+	sig, ts := signSlackBody(a.t, encoded)
 	r.Header.Set(headerSlackSignature, sig)
 	r.Header.Set(headerSlackTimestamp, ts)
 	a.h.ServeHTTP(w, r)

--- a/apps/slack/internal/fakeddb_test.go
+++ b/apps/slack/internal/fakeddb_test.go
@@ -52,6 +52,8 @@ type fakeDDB struct {
 	updateHook func(in *dynamodb.UpdateItemInput)
 	// putHook mirrors updateHook for PutItem (BindWorkspace).
 	putHook func(in *dynamodb.PutItemInput)
+	// getHook mirrors updateHook for GetItem read assertions.
+	getHook func(table string, key map[string]string)
 	// getItemErrs maps tableName → injected GetItem error.
 	getItemErrs map[string]error
 	// updateItemErrs maps tableName → injected UpdateItem error.
@@ -150,6 +152,13 @@ func (f *fakeDDB) SetPutItemHook(hook func(in interface{})) {
 		return
 	}
 	f.putHook = func(in *dynamodb.PutItemInput) { hook(in) }
+}
+
+// SetGetItemHook installs a callback invoked on every GetItem.
+func (f *fakeDDB) SetGetItemHook(hook func(table string, key map[string]string)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getHook = hook
 }
 
 // tableNames groups the table names used across the post-pivot
@@ -257,6 +266,9 @@ func (f *fakeDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...fun
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	name := aws.ToString(in.TableName)
+	if f.getHook != nil {
+		f.getHook(name, stringKey(in.Key))
+	}
 	if err, ok := f.getItemErrs[name]; ok {
 		return nil, err
 	}
@@ -285,6 +297,16 @@ func (f *fakeDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...fun
 		return &dynamodb.GetItemOutput{}, nil
 	}
 	return &dynamodb.GetItemOutput{Item: cloneItem(item)}, nil
+}
+
+func stringKey(in map[string]ddbtypes.AttributeValue) map[string]string {
+	out := make(map[string]string, len(in))
+	for name, value := range in {
+		if s, ok := value.(*ddbtypes.AttributeValueMemberS); ok {
+			out[name] = s.Value
+		}
+	}
+	return out
 }
 
 // PutItem implements [slackdata.DynamoDBClient]. Honors the

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -194,15 +194,20 @@ type Config struct {
 	AdminStore *slackdata.Store
 
 	// OpenView posts a `views.open` Slack web API call to display a
-	// modal in response to a slash command. The teamID parameter is
-	// present so production can route through per-workspace OAuth bot
-	// tokens; the current cmd/main.go fallback uses one SLACK_BOT_TOKEN.
-	// TODO(slack-oauth): switch production wiring to per-workspace bot token
-	// lookup once OAuth installs are the only supported Slack deployment path.
-	// Tests inject a stub that records the call. Tunnel install uses this
-	// for guided setup; setalias-rebind can use the same seam for
-	// confirmation modals.
+	// modal in response to a slash command. The token owner parameter is
+	// usually the workspace team_id; Enterprise Grid org installs can pass
+	// enterprise_id instead while the modal metadata remains workspace-scoped.
+	// Legacy single-workspace deploys can still fall back to one
+	// SLACK_BOT_TOKEN. Tests inject a stub that records the call. Tunnel
+	// install uses this for guided setup; setalias-rebind can use the same seam
+	// for confirmation modals.
 	OpenView OpenViewFunc
+
+	// SlackInstallURL starts the Slack app install/reauthorization flow that
+	// stores the per-workspace bot token used by OpenView. When set, guided
+	// setup can give sandbox admins a direct recovery link instead of an
+	// operator-only reinstall prompt.
+	SlackInstallURL string
 
 	// PostDM is the `chat.postMessage` web API for the `dm:true` flag
 	// on `/qurl get`. Production wires this in cmd/main.go; tests
@@ -322,6 +327,18 @@ func (h *Handler) SetOAuthSetup(cfg oauth.SetupConfig) {
 	// poison every subsequent MintState call.
 	cfg.StateSecret = append([]byte(nil), cfg.StateSecret...)
 	h.oauthSetup = &cfg
+}
+
+// SetSlackInstallURL wires the customer Slack install URL used to recover
+// guided tunnel setup when a workspace has no stored bot token yet. Must be
+// called before Serve. Empty is a no-op so deployments without Slack install
+// OAuth keep the operator-directed fallback copy.
+func (h *Handler) SetSlackInstallURL(installURL string) {
+	installURL = strings.TrimSpace(installURL)
+	if installURL == "" {
+		return
+	}
+	h.cfg.SlackInstallURL = installURL
 }
 
 // NewHandler creates a new Slack handler. Config is intentionally

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -273,6 +273,7 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 		return
 	}
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	enterpriseID := strings.TrimSpace(values.Get(fieldEnterpriseID))
 	userID := strings.TrimSpace(values.Get(fieldUserID))
 	channelID := strings.TrimSpace(values.Get(fieldChannelID))
 	if channelID == "" {
@@ -287,13 +288,14 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 	log := slog.With(
 		"command", "tunnel_install_wizard",
 		"team_id", teamID,
+		"enterprise_id", enterpriseID,
 		"channel_id", channelID,
 		"user_id", userID,
 		"trigger_id", triggerID,
 	)
 	triggerReceivedAt := h.now()
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.openTunnelInstallWizard(ctx, log, teamID, channelID, userID, triggerID, values.Get(fieldResponseURL), triggerReceivedAt)
+		h.openTunnelInstallWizard(ctx, log, teamID, enterpriseID, channelID, userID, triggerID, values.Get(fieldResponseURL), triggerReceivedAt)
 	}) {
 		respondSlack(w, ackBusy)
 		return
@@ -307,7 +309,7 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 	respondSlack(w, ackWorkingOnIt)
 }
 
-func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger, teamID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
+func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
 	triggerElapsed := h.now().Sub(triggerReceivedAt)
 	if triggerElapsed < 0 {
 		triggerElapsed = 0
@@ -368,7 +370,7 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 	}
 	openCtx, openCancel := context.WithTimeout(ctx, openBudget)
 	defer openCancel()
-	if err := h.cfg.OpenView(openCtx, teamID, triggerID, view); err != nil {
+	if err := h.openTunnelInstallView(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
 		log.Error("tunnel install wizard views.open failed",
 			"error", err,
 			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
@@ -384,13 +386,36 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 		case errors.Is(err, ErrSlackRateLimited):
 			_ = h.postErrorResponse(log, responseURL, tunnelInstallRateLimitMessage(err), true)
 		case errors.Is(err, auth.ErrSlackBotTokenNotConfigured):
-			_ = h.postErrorResponse(log, responseURL, "Guided tunnel setup needs the latest qURL Slack app install. Ask a workspace admin to open the qURL Slack install link your operator provided, then run `/qurl tunnel install` again.", true)
+			_ = h.postErrorResponse(log, responseURL, h.guidedTunnelSlackAppInstallMessage(), true)
 		default:
 			_ = h.postErrorResponse(log, responseURL, "Could not open guided tunnel setup. Please retry or contact support.", true)
 		}
 		return
 	}
 	_ = h.deleteOriginalResponse(log, responseURL)
+}
+
+func (h *Handler) openTunnelInstallView(ctx context.Context, log *slog.Logger, teamID, enterpriseID, triggerID string, view []byte) error {
+	err := h.cfg.OpenView(ctx, teamID, triggerID, view)
+	if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+		return err
+	}
+	if enterpriseID == "" || enterpriseID == teamID {
+		return err
+	}
+	log.Warn("workspace Slack bot token missing; retrying guided modal with Enterprise Grid install token",
+		"team_id", teamID,
+		"enterprise_id", enterpriseID,
+	)
+	return h.cfg.OpenView(ctx, enterpriseID, triggerID, view)
+}
+
+func (h *Handler) guidedTunnelSlackAppInstallMessage() string {
+	installURL := strings.TrimSpace(h.cfg.SlackInstallURL)
+	if installURL == "" || strings.ContainsAny(installURL, "<>|") {
+		return "Guided tunnel setup needs the latest qURL Slack app install. Ask a workspace admin to open the qURL Slack install link your operator provided, then run `/qurl tunnel install` again."
+	}
+	return "Guided tunnel setup needs the latest qURL Slack app install. Ask a workspace admin to open <" + installURL + "|the qURL Slack install link>, then run `/qurl tunnel install` again."
 }
 
 func slackTriggerOpenViewBudgetRemaining(triggerElapsed time.Duration) time.Duration {

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
@@ -37,6 +38,7 @@ const (
 	testTunnelComposeWeb   = "web_1"
 	testTunnelDockerWeb    = "web_1-2"
 	testSlackTriggerID     = "trigger_test"
+	testEnterpriseID       = "E_GRID"
 )
 
 const (
@@ -505,6 +507,146 @@ func TestTunnelInstallBareOpensGuidedModal(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallBareFallsBackToEnterpriseInstallToken(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	adminChecks := make(chan string, 4)
+	ts.ddb.SetGetItemHook(func(table string, key map[string]string) {
+		if table == ts.tableNames.workspace {
+			adminChecks <- key[fAttrSlackTeamID]
+		}
+	})
+	type openViewCall struct {
+		tokenOwnerID string
+		triggerID    string
+		view         []byte
+	}
+	calls := make(chan openViewCall, 2)
+	unexpectedTokenOwner := make(chan string, 1)
+	h.cfg.OpenView = func(_ context.Context, tokenOwnerID, triggerID string, viewJSON []byte) error {
+		calls <- openViewCall{
+			tokenOwnerID: tokenOwnerID,
+			triggerID:    triggerID,
+			view:         append([]byte(nil), viewJSON...),
+		}
+		if tokenOwnerID == testAdminTeamID {
+			return fmt.Errorf("token lookup: %w", auth.ErrSlackBotTokenNotConfigured)
+		}
+		if tokenOwnerID != testEnterpriseID {
+			unexpectedTokenOwner <- tokenOwnerID
+			return fmt.Errorf("unexpected token lookup id %q", tokenOwnerID)
+		}
+		return nil
+	}
+
+	inv := newAdminSlashInvoker(t, h)
+	inv.enterpriseID = testEnterpriseID
+	status, ack := inv.invokeAdmin("tunnel install", testAdminTeamID, testAdminUserID)
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if ack != ackWorkingOnIt {
+		t.Fatalf("ack = %q, want %q", ack, ackWorkingOnIt)
+	}
+	var first, second openViewCall
+	select {
+	case first = <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("workspace OpenView lookup was not called")
+	}
+	select {
+	case second = <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enterprise OpenView fallback was not called")
+	}
+	if first.tokenOwnerID != testAdminTeamID || second.tokenOwnerID != testEnterpriseID {
+		t.Fatalf("OpenView token lookup order = %q, %q; want team then enterprise", first.tokenOwnerID, second.tokenOwnerID)
+	}
+	select {
+	case tokenOwnerID := <-unexpectedTokenOwner:
+		t.Fatalf("unexpected token lookup id %q", tokenOwnerID)
+	default:
+	}
+	select {
+	case adminTeamID := <-adminChecks:
+		if adminTeamID != testAdminTeamID {
+			t.Fatalf("admin check teamID = %q, want workspace team %q", adminTeamID, testAdminTeamID)
+		}
+	default:
+		t.Fatal("admin check was not recorded")
+	}
+	var modal map[string]any
+	if err := json.Unmarshal(second.view, &modal); err != nil {
+		t.Fatalf("modal JSON: %v", err)
+	}
+	pm, ok := modal[blockKitFieldPrivateMetadata].(string)
+	if !ok || pm == "" {
+		t.Fatalf("private_metadata = %T %q, want non-empty string", modal[blockKitFieldPrivateMetadata], modal[blockKitFieldPrivateMetadata])
+	}
+	var meta TunnelInstallModalMetadata
+	if err := json.Unmarshal([]byte(pm), &meta); err != nil {
+		t.Fatalf("private_metadata JSON: %v", err)
+	}
+	if meta.TeamID != testAdminTeamID {
+		t.Fatalf("metadata TeamID = %q, want workspace team %q", meta.TeamID, testAdminTeamID)
+	}
+	deleteBody := inv.captured.waitForBody(t, 2*time.Second)
+	if got := parseSlackReplyBool(t, deleteBody, "delete_original"); !got {
+		t.Fatalf("delete_original = %v, want true after enterprise-token modal open", got)
+	}
+}
+
+func TestTunnelInstallBareReportsInstallLinkWhenWorkspaceAndEnterpriseTokensMissing(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.SetSlackInstallURL("https://slack-bot.example/oauth/slack/install")
+	calls := make(chan string, 2)
+	h.cfg.OpenView = func(_ context.Context, tokenOwnerID, _ string, _ []byte) error {
+		calls <- tokenOwnerID
+		return fmt.Errorf("token lookup: %w", auth.ErrSlackBotTokenNotConfigured)
+	}
+
+	inv := newAdminSlashInvoker(t, h)
+	inv.enterpriseID = testEnterpriseID
+	status, ack := inv.invokeAdmin("tunnel install", testAdminTeamID, testAdminUserID)
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(ack, "Working on it") {
+		t.Fatalf("ack = %q, want immediate guided setup copy", ack)
+	}
+	var gotCalls []string
+	for len(gotCalls) < 2 {
+		select {
+		case tokenOwnerID := <-calls:
+			gotCalls = append(gotCalls, tokenOwnerID)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("OpenView token lookups = %v, want workspace then enterprise", gotCalls)
+		}
+	}
+	if strings.Join(gotCalls, ",") != testAdminTeamID+","+testEnterpriseID {
+		t.Fatalf("OpenView token lookups = %v, want workspace then enterprise", gotCalls)
+	}
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	for _, want := range []string{
+		"latest qURL Slack app install",
+		"<https://slack-bot.example/oauth/slack/install|the qURL Slack install link>",
+		"/qurl tunnel install",
+	} {
+		if !strings.Contains(async, want) {
+			t.Fatalf("async reply = %q, missing %q", async, want)
+		}
+	}
+}
+
 func TestHelpListsGuidedAndTypedTunnelInstall(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -681,6 +823,81 @@ func TestTunnelInstallBareReportsRateLimitRetryAfter(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallBareReportsSlackInstallLinkWhenWorkspaceBotTokenMissing(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.SetSlackInstallURL("https://slack-bot.example/oauth/slack/install")
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error {
+		return fmt.Errorf("token lookup: %w", auth.ErrSlackBotTokenNotConfigured)
+	}
+
+	inv := newAdminSlashInvoker(t, h)
+	status, ack := inv.invokeAdmin("tunnel install", testAdminTeamID, testAdminUserID)
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(ack, "Working on it") {
+		t.Fatalf("ack = %q, want immediate guided setup copy", ack)
+	}
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	for _, want := range []string{
+		"latest qURL Slack app install",
+		"<https://slack-bot.example/oauth/slack/install|the qURL Slack install link>",
+		"/qurl tunnel install",
+	} {
+		if !strings.Contains(async, want) {
+			t.Fatalf("async reply = %q, missing %q", async, want)
+		}
+	}
+	if strings.Contains(async, "operator provided") {
+		t.Fatalf("async reply = %q, should include the configured install link", async)
+	}
+}
+
+func TestTunnelInstallBareReportsOperatorFallbackWhenSlackInstallURLUnset(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error {
+		return fmt.Errorf("token lookup: %w", auth.ErrSlackBotTokenNotConfigured)
+	}
+
+	inv := newAdminSlashInvoker(t, h)
+	status, ack := inv.invokeAdmin("tunnel install", testAdminTeamID, testAdminUserID)
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(ack, "Working on it") {
+		t.Fatalf("ack = %q, want immediate guided setup copy", ack)
+	}
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, "operator provided") {
+		t.Fatalf("async reply = %q, want operator-provided fallback copy", async)
+	}
+	if strings.Contains(async, "|the qURL Slack install link>") {
+		t.Fatalf("async reply = %q, should not render a Slack link without a configured install URL", async)
+	}
+}
+
+func TestGuidedTunnelSlackAppInstallMessageRejectsMrkdwnBreakout(t *testing.T) {
+	h := &Handler{cfg: Config{SlackInstallURL: "https://slack-bot.example/oauth/slack/install|bad"}}
+	got := h.guidedTunnelSlackAppInstallMessage()
+
+	if !strings.Contains(got, "operator provided") {
+		t.Fatalf("message = %q, want operator-provided fallback copy", got)
+	}
+	if strings.Contains(got, "|the qURL Slack install link>") {
+		t.Fatalf("message = %q, should not render a Slack link for malformed install URL", got)
+	}
+}
+
 func TestSlackTriggerBudgetsFitWithinTriggerWindow(t *testing.T) {
 	t.Parallel()
 
@@ -738,7 +955,7 @@ func TestTunnelInstallBareSkipsOpenViewWhenTriggerWindowAlreadySpent(t *testing.
 	}
 	inv := newAdminSlashInvoker(t, h)
 
-	h.openTunnelInstallWizard(context.Background(), slog.Default(), testAdminTeamID, testTunnelChannelID, testAdminUserID, testSlackTriggerID, inv.responseU.URL, fixedNow)
+	h.openTunnelInstallWizard(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, testSlackTriggerID, inv.responseU.URL, fixedNow)
 
 	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
 	if !strings.Contains(async, "setup window expired") || !strings.Contains(async, "/qurl tunnel install") {

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -26,13 +26,14 @@ import (
 // it would risk SSRF if the signature gate ever broke, so postResponse
 // validates the scheme and host before dialing.
 const (
-	fieldResponseURL = "response_url"
-	fieldTeamID      = "team_id"
-	fieldUserID      = "user_id"
-	fieldChannelID   = "channel_id"
-	fieldCommand     = "command"
-	fieldText        = "text"
-	fieldTriggerID   = "trigger_id"
+	fieldResponseURL  = "response_url"
+	fieldTeamID       = "team_id"
+	fieldUserID       = "user_id"
+	fieldChannelID    = "channel_id"
+	fieldCommand      = "command"
+	fieldText         = "text"
+	fieldTriggerID    = "trigger_id"
+	fieldEnterpriseID = "enterprise_id"
 )
 
 // slackResponseURLHost is Slack's webhook ingress for slash-command
@@ -66,6 +67,7 @@ func (h *Handler) runAsync(w http.ResponseWriter, command string, values url.Val
 	log := slog.With(
 		"command", command,
 		"team_id", values.Get(fieldTeamID),
+		"enterprise_id", values.Get(fieldEnterpriseID),
 		"channel_id", values.Get(fieldChannelID),
 		"trigger_id", values.Get(fieldTriggerID),
 	)

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -46,6 +46,7 @@ const (
 	slackInstallFlow            = "slack-install"
 	botScopeCommands            = "commands"
 	botScopeViewsWrite          = "views:write"
+	slackOAuthErrorBadRedirect  = "bad_redirect_uri"
 	slackOAuthErrorUnrecognized = "unrecognized"
 )
 
@@ -67,7 +68,7 @@ code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 <div class="card">
 <h1><span class="ok">&#10003;</span> qURL Slack app installed</h1>
 <p>Guided tunnel setup is enabled for this workspace. Return to Slack and run <code>/qurl tunnel install</code>.</p>
-<p>Workspace: <code>{{.TeamID}}</code></p>
+<p>Install target: <code>{{.InstallTarget}}</code></p>
 </div>
 </body>
 </html>`))
@@ -254,31 +255,29 @@ func Callback(cfg *Config) http.HandlerFunc {
 			return
 		}
 		enterpriseID := strings.TrimSpace(resp.Enterprise.ID)
-		if resp.IsEnterpriseInstall {
-			logSlackInstallEnterpriseInstallUnsupported(resp.IsEnterpriseInstall, enterpriseID != "")
-			fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusUnprocessableEntity)
-			return
-		}
 		teamID := strings.TrimSpace(resp.Team.ID)
-		if teamID == "" {
-			if enterpriseID != "" {
-				logSlackInstallEnterpriseInstallUnsupported(resp.IsEnterpriseInstall, enterpriseID != "")
-				fail("Slack Enterprise Grid org installs are not supported; install qURL to a workspace instead", http.StatusUnprocessableEntity)
+		tokenOwnerID := teamID
+		if resp.IsEnterpriseInstall {
+			tokenOwnerID = enterpriseID
+			if tokenOwnerID == "" {
+				logSlackInstallMissingEnterpriseID(strings.TrimSpace(resp.AppID) != "")
+				fail("Slack Enterprise Grid org install did not include an enterprise id", http.StatusUnprocessableEntity)
 				return
 			}
+		} else if tokenOwnerID == "" {
 			logSlackInstallMissingTeamID(strings.TrimSpace(resp.AppID) != "")
 			fail("Slack workspace install did not include a workspace id", http.StatusUnprocessableEntity)
 			return
 		}
 		installedBy := strings.TrimSpace(resp.AuthedUser.ID)
 		if installedBy == "" {
-			logSlackInstallMissingAuthedUser(teamID != "")
+			logSlackInstallMissingAuthedUser(tokenOwnerID != "")
 			fail("Slack workspace install did not include an installer id", http.StatusUnprocessableEntity)
 			return
 		}
 		grantedScopes := NormalizeScopes([]string{resp.Scope})
 		if missing := missingRequiredScopes(grantedScopes); len(missing) > 0 {
-			logSlackInstallMissingRequiredScopes(missing, teamID != "")
+			logSlackInstallMissingRequiredScopes(missing, tokenOwnerID != "")
 			fail("Slack install did not grant required bot scopes", http.StatusUnprocessableEntity)
 			return
 		}
@@ -287,7 +286,7 @@ func Callback(cfg *Config) http.HandlerFunc {
 		// keeps request-scoped values for tracing while detaching client cancel.
 		persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(r.Context()), persistTimeout)
 		defer persistCancel()
-		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, teamID, &auth.SlackBotTokenInstall{
+		if err := cfg.TokenStore.SetSlackBotToken(persistCtx, tokenOwnerID, &auth.SlackBotTokenInstall{
 			BotToken:     resp.AccessToken,
 			InstalledBy:  installedBy,
 			BotUserID:    resp.BotUserID,
@@ -295,19 +294,19 @@ func Callback(cfg *Config) http.HandlerFunc {
 			EnterpriseID: enterpriseID,
 			Scopes:       grantedScopes,
 		}); err != nil {
-			logSlackInstallPersistFailed(err, teamID != "", installedBy != "")
+			logSlackInstallPersistFailed(err, tokenOwnerID != "", installedBy != "")
 			fail("Slack install could not be stored", http.StatusInternalServerError)
 			return
 		}
 		clearStateCookie(w)
 		if cfg.OnTokenStored != nil {
-			cfg.OnTokenStored(teamID)
+			cfg.OnTokenStored(tokenOwnerID)
 		}
 		slog.Info("Slack app install stored workspace bot token", // #nosec G706 -- Slack IDs are structured slog attributes; JSON handlers escape control bytes.
-			"team_id", teamID, "installed_by", installedBy,
+			"token_owner_id", tokenOwnerID, "team_id", teamID, "installed_by", installedBy,
 			"bot_user_id", resp.BotUserID, "app_id", resp.AppID,
-			"enterprise_id", enterpriseID)
-		renderSuccess(w, teamID)
+			"enterprise_id", enterpriseID, "is_enterprise_install", resp.IsEnterpriseInstall)
+		renderSuccess(w, tokenOwnerID)
 	}
 }
 
@@ -533,7 +532,7 @@ func safeSlackOAuthErrorCode(raw string) string {
 	code := strings.TrimSpace(raw)
 	switch code {
 	case "access_denied",
-		"bad_redirect_uri",
+		slackOAuthErrorBadRedirect,
 		"invalid_client_id",
 		"invalid_redirect_uri",
 		"invalid_scope",
@@ -553,28 +552,27 @@ func logSlackInstallMissingTeamID(appIDPresent bool) {
 	slog.Error("Slack install token exchange missing team id", "app_id_present", appIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
 }
 
-func logSlackInstallEnterpriseInstallUnsupported(isEnterpriseInstall, enterpriseIDPresent bool) {
-	slog.Error("Slack install rejected unsupported Enterprise Grid org install", // #nosec G706 -- only booleans are logged; no Slack string reaches the attribute.
-		"is_enterprise_install", isEnterpriseInstall, "enterprise_id_present", enterpriseIDPresent)
+func logSlackInstallMissingEnterpriseID(appIDPresent bool) {
+	slog.Error("Slack install token exchange missing enterprise id for org install", "app_id_present", appIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
 }
 
 func logSlackInstallMissingAuthedUser(teamIDPresent bool) {
 	slog.Error("Slack install token exchange missing authed user id", "team_id_present", teamIDPresent) // #nosec G706 -- only a boolean is logged; no Slack string reaches the attribute.
 }
 
-func logSlackInstallPersistFailed(err error, teamIDPresent, installedByPresent bool) {
+func logSlackInstallPersistFailed(err error, tokenOwnerIDPresent, installedByPresent bool) {
 	slog.Error("Slack install token persist failed", // #nosec G706 -- only booleans plus the storage error are logged.
-		"error", err, "team_id_present", teamIDPresent, "installed_by_present", installedByPresent)
+		"error", err, "token_owner_id_present", tokenOwnerIDPresent, "installed_by_present", installedByPresent)
 }
 
-func logSlackInstallMissingRequiredScopes(missing []string, teamIDPresent bool) {
+func logSlackInstallMissingRequiredScopes(missing []string, tokenOwnerIDPresent bool) {
 	// missing follows DefaultBotScopes order for operator readability. Stored
 	// scopes are normalized separately as a sorted DDB String Set.
 	slog.Warn("Slack install token exchange missing required bot scope(s)", // #nosec G706 -- missing scopes come from DefaultBotScopes constants.
-		"missing_scopes", strings.Join(missing, ","), "team_id_present", teamIDPresent)
+		"missing_scopes", strings.Join(missing, ","), "token_owner_id_present", tokenOwnerIDPresent)
 }
 
-func renderSuccess(w http.ResponseWriter, teamID string) {
+func renderSuccess(w http.ResponseWriter, installTarget string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Frame-Options", "DENY")
@@ -583,7 +581,7 @@ func renderSuccess(w http.ResponseWriter, teamID string) {
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	if err := successTemplate.Execute(w, struct{ TeamID string }{TeamID: teamID}); err != nil {
+	if err := successTemplate.Execute(w, struct{ InstallTarget string }{InstallTarget: installTarget}); err != nil {
 		slog.Warn("Slack install success page write failed", "error", err)
 	}
 }

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -23,10 +23,18 @@ const (
 	testClientSecret    = "secret"
 	testScopeCSV        = "commands,views:write"
 	testWorkspaceID     = "T_WORKSPACE"
+	testEnterpriseID    = "E_GRID"
 	testWorkspaceToken  = "xoxb-123456789012345678901234567890"
 	testAuthCode        = "abc123"
 	testAccessTokenKey  = "access_token"
 	testSlackInstallURL = CallbackPath + "?code=" + testAuthCode + "&state="
+
+	testResponseKeyScope               = "scope"
+	testResponseKeyTeam                = "team"
+	testResponseKeyEnterprise          = "enterprise"
+	testResponseKeyAuthedUser          = "authed_user"
+	testResponseKeyIsEnterpriseInstall = "is_enterprise_install"
+	testInstallerUserID                = "U_INSTALLER"
 )
 
 type fakeTokenStore struct {
@@ -102,8 +110,8 @@ func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
 	if q.Get("client_id") != testClientID {
 		t.Errorf("client_id = %q", q.Get("client_id"))
 	}
-	if q.Get("scope") != testScopeCSV {
-		t.Errorf("scope = %q", q.Get("scope"))
+	if q.Get(testResponseKeyScope) != testScopeCSV {
+		t.Errorf("scope = %q", q.Get(testResponseKeyScope))
 	}
 	if q.Get("redirect_uri") != "https://slack-bot.example/oauth/slack/callback" {
 		t.Errorf("redirect_uri = %q", q.Get("redirect_uri"))
@@ -156,20 +164,20 @@ func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
 		gotForm = r.Form
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":               true,
-			testAccessTokenKey: testWorkspaceToken,
-			"scope":            testScopeCSV,
-			"bot_user_id":      "U_BOT",
-			"app_id":           "A_APP",
-			"team": map[string]string{
+			"ok":                 true,
+			testAccessTokenKey:   testWorkspaceToken,
+			testResponseKeyScope: testScopeCSV,
+			"bot_user_id":        "U_BOT",
+			"app_id":             "A_APP",
+			testResponseKeyTeam: map[string]string{
 				"id":   testWorkspaceID,
 				"name": "Customer",
 			},
-			"enterprise": map[string]string{
-				"id": "E_GRID",
+			testResponseKeyEnterprise: map[string]string{
+				"id": testEnterpriseID,
 			},
-			"authed_user": map[string]string{
-				"id": "U_INSTALLER",
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
 			},
 		})
 	}))
@@ -199,10 +207,10 @@ func TestCallbackStoresWorkspaceBotToken(t *testing.T) {
 		t.Fatalf("workspaceID = %q", store.workspaceID)
 	}
 	if store.install.BotToken != testWorkspaceToken ||
-		store.install.InstalledBy != "U_INSTALLER" ||
+		store.install.InstalledBy != testInstallerUserID ||
 		store.install.BotUserID != "U_BOT" ||
 		store.install.AppID != "A_APP" ||
-		store.install.EnterpriseID != "E_GRID" {
+		store.install.EnterpriseID != testEnterpriseID {
 		t.Fatalf("stored install mismatch: %+v", store.install)
 	}
 	if strings.Join(store.install.Scopes, ",") != testScopeCSV {
@@ -324,7 +332,7 @@ func TestCallbackSurfacesSlackOAuthError(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
-			"error": "bad_redirect_uri",
+			"error": slackOAuthErrorBadRedirect,
 		})
 	}))
 	defer slack.Close()
@@ -374,7 +382,7 @@ func TestCallbackRejectsSlackResponseMissingTeamID(t *testing.T) {
 	}
 }
 
-func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
+func TestCallbackStoresEnterpriseGridOrgInstallToken(t *testing.T) {
 	store := &fakeTokenStore{}
 	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
 	if err != nil {
@@ -383,18 +391,56 @@ func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
 	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":                    true,
-			testAccessTokenKey:      testWorkspaceToken,
-			"scope":                 testScopeCSV,
-			"is_enterprise_install": true,
-			"team": map[string]string{
+			"ok":                               true,
+			testAccessTokenKey:                 testWorkspaceToken,
+			testResponseKeyScope:               testScopeCSV,
+			testResponseKeyIsEnterpriseInstall: true,
+			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},
-			"enterprise": map[string]string{
-				"id": "E_GRID",
+			testResponseKeyEnterprise: map[string]string{
+				"id": testEnterpriseID,
 			},
-			"authed_user": map[string]string{
-				"id": "U_INSTALLER",
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
+			},
+		})
+	}))
+	defer slack.Close()
+
+	cfg := testConfig(store)
+	cfg.OAuthAccessURL = slack.URL
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, testSlackInstallURL+url.QueryEscape(state), http.NoBody)
+	req.AddCookie(testStateHTTPCookie(state))
+	Callback(&cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", w.Code, w.Body.String())
+	}
+	if store.workspaceID != testEnterpriseID {
+		t.Fatalf("workspaceID = %q, want enterprise id", store.workspaceID)
+	}
+	if store.install.EnterpriseID != testEnterpriseID {
+		t.Fatalf("EnterpriseID = %q, want %q", store.install.EnterpriseID, testEnterpriseID)
+	}
+}
+
+func TestCallbackRejectsEnterpriseGridOrgInstallWithoutEnterpriseID(t *testing.T) {
+	store := &fakeTokenStore{}
+	state, err := mintState([]byte(testStateSecret), time.Unix(1800000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("mintState: %v", err)
+	}
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":                               true,
+			testAccessTokenKey:                 testWorkspaceToken,
+			testResponseKeyScope:               testScopeCSV,
+			testResponseKeyIsEnterpriseInstall: true,
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
 			},
 		})
 	}))
@@ -411,10 +457,10 @@ func TestCallbackRejectsEnterpriseGridOrgInstall(t *testing.T) {
 		t.Fatalf("status = %d, want 422", w.Code)
 	}
 	if store.workspaceID != "" {
-		t.Fatalf("store should not be called for org-level Enterprise Grid install, got %q", store.workspaceID)
+		t.Fatalf("store should not be called without enterprise id, got %q", store.workspaceID)
 	}
-	if !strings.Contains(w.Body.String(), "Enterprise Grid") {
-		t.Fatalf("body = %q, want Enterprise Grid guidance", w.Body.String())
+	if !strings.Contains(w.Body.String(), "enterprise id") {
+		t.Fatalf("body = %q, want enterprise id guidance", w.Body.String())
 	}
 }
 
@@ -427,18 +473,18 @@ func TestCallbackAcceptsWorkspaceInstallWithinEnterpriseGrid(t *testing.T) {
 	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":                    true,
-			testAccessTokenKey:      testWorkspaceToken,
-			"scope":                 testScopeCSV,
-			"is_enterprise_install": false,
-			"team": map[string]string{
+			"ok":                               true,
+			testAccessTokenKey:                 testWorkspaceToken,
+			testResponseKeyScope:               testScopeCSV,
+			testResponseKeyIsEnterpriseInstall: false,
+			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},
-			"enterprise": map[string]string{
-				"id": "E_GRID",
+			testResponseKeyEnterprise: map[string]string{
+				"id": testEnterpriseID,
 			},
-			"authed_user": map[string]string{
-				"id": "U_INSTALLER",
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
 			},
 		})
 	}))
@@ -457,8 +503,8 @@ func TestCallbackAcceptsWorkspaceInstallWithinEnterpriseGrid(t *testing.T) {
 	if store.workspaceID != testWorkspaceID {
 		t.Fatalf("workspaceID = %q, want %q", store.workspaceID, testWorkspaceID)
 	}
-	if store.install.EnterpriseID != "E_GRID" {
-		t.Fatalf("EnterpriseID = %q, want E_GRID", store.install.EnterpriseID)
+	if store.install.EnterpriseID != testEnterpriseID {
+		t.Fatalf("EnterpriseID = %q, want %q", store.install.EnterpriseID, testEnterpriseID)
 	}
 }
 
@@ -471,10 +517,10 @@ func TestCallbackRejectsSlackResponseMissingAuthedUserID(t *testing.T) {
 	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":               true,
-			testAccessTokenKey: testWorkspaceToken,
-			"scope":            testScopeCSV,
-			"team": map[string]string{
+			"ok":                 true,
+			testAccessTokenKey:   testWorkspaceToken,
+			testResponseKeyScope: testScopeCSV,
+			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},
 		})
@@ -505,14 +551,14 @@ func TestCallbackRejectsMissingRequiredSlackScopes(t *testing.T) {
 	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":               true,
-			testAccessTokenKey: testWorkspaceToken,
-			"scope":            botScopeCommands,
-			"team": map[string]string{
+			"ok":                 true,
+			testAccessTokenKey:   testWorkspaceToken,
+			testResponseKeyScope: botScopeCommands,
+			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},
-			"authed_user": map[string]string{
-				"id": "U_INSTALLER",
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
 			},
 		})
 	}))
@@ -547,11 +593,11 @@ func TestCallbackRejectsMalformedSlackBotToken(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":               true,
 			testAccessTokenKey: "xoxa-123456789012345678901234567890",
-			"team": map[string]string{
+			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},
-			"authed_user": map[string]string{
-				"id": "U_INSTALLER",
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
 			},
 		})
 	}))
@@ -581,14 +627,14 @@ func TestCallbackSurfacesTokenStoreFailure(t *testing.T) {
 	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":               true,
-			testAccessTokenKey: testWorkspaceToken,
-			"scope":            testScopeCSV,
-			"team": map[string]string{
+			"ok":                 true,
+			testAccessTokenKey:   testWorkspaceToken,
+			testResponseKeyScope: testScopeCSV,
+			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},
-			"authed_user": map[string]string{
-				"id": "U_INSTALLER",
+			testResponseKeyAuthedUser: map[string]string{
+				"id": testInstallerUserID,
 			},
 		})
 	}))
@@ -665,7 +711,7 @@ func TestCallbackDoesNotLeakSlackHTTPErrorBody(t *testing.T) {
 func TestSafeSlackOAuthErrorCode(t *testing.T) {
 	for _, code := range []string{
 		"access_denied",
-		"bad_redirect_uri",
+		slackOAuthErrorBadRedirect,
 		"invalid_client_id",
 		"invalid_redirect_uri",
 		"invalid_scope",


### PR DESCRIPTION
## Summary
- stores Enterprise Grid org-level Slack install tokens under `enterprise_id` instead of rejecting those installs
- retries guided tunnel `views.open` with the enterprise install token when the workspace `team_id` has no stored bot token
- preserves workspace-scoped qURL/admin metadata in the tunnel modal while using the enterprise token only for Slack Web API auth
- keeps a last-resort install link for genuinely missing token state

## Business relevance
Sandbox Enterprise Grid installs can use `/qurl tunnel install` guided setup with the already-installed latest qURL Slack app, instead of being incorrectly told to reinstall because no workspace-scoped bot token exists.

## Tests
- `go test -count=1 ./apps/slack/... ./shared/...`
- `golangci-lint run ./apps/slack/... ./shared/... --timeout=5m --new-from-rev=origin/main`
- `golangci-lint run ./apps/slack/internal/slackinstall/... --timeout=5m`
- `git diff --check`