### PR TITLE
fix(slack): actionable error when /qurl setup hits the API-key limit

### DIFF
--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -508,9 +508,10 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	apiKey, keyID, keyPrefix, err := cfg.Minter.MintAPIKey(mintCtx, accessToken,
 		keyName, apiKeyScopes())
 	if err != nil {
+		limitReached := errors.Is(err, ErrAPIKeyLimitReached)
 		//nolint:gosec // G706: slog escapes control bytes in attribute values.
-		slog.Error("oauth/callback qurl-service mint failed", "error", err, "team_id", teamID, "api_key_limit", errors.Is(err, ErrAPIKeyLimitReached))
-		if errors.Is(err, ErrAPIKeyLimitReached) {
+		slog.Error("oauth/callback qurl-service mint failed", "error", err, "team_id", teamID, "api_key_limit_reached", limitReached)
+		if limitReached {
 			// Quota is a precondition the admin must clear themselves —
 			// retrying does nothing (the old "run setup again" advice was
 			// actively wrong here). 409 so an automated retry surfaces the
@@ -585,17 +586,27 @@ func dmAdminAsync(client SlackClient, userID, teamID, keyPrefix string) {
 	}
 }
 
-// renderRebindRefused writes the rebind-refused page. Same defense-in-
-// depth headers as the success page — the only differences are the body
-// template and a 409 status code (so an automated retry surfaces the
-// conflict rather than silently looping).
-func renderRebindRefused(w http.ResponseWriter, teamID string) {
+// setOAuthPageSecurityHeaders writes the defense-in-depth header set shared
+// by every OAuth-callback HTML response (success, rebind-refused, error).
+// These pages render post-redirect, so they shouldn't be framable
+// (clickjacking), shouldn't leak the callback URL via Referer to anything
+// they link to, and shouldn't load any off-origin resources beyond the
+// inline style.
+func setOAuthPageSecurityHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+}
+
+// renderRebindRefused writes the rebind-refused page. Same defense-in-
+// depth headers as the success page — the only differences are the body
+// template and a 409 status code (so an automated retry surfaces the
+// conflict rather than silently looping).
+func renderRebindRefused(w http.ResponseWriter, teamID string) {
+	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(http.StatusConflict)
 	if err := rebindRefusedPageTemplate.Execute(w, rebindRefusedPageData{TeamID: teamID}); err != nil {
 		slog.Warn("oauth/callback rebind-refused page write failed", "error", err)
@@ -607,12 +618,7 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 // renders human-readable, actionable guidance instead of a blank page with
 // raw text. Same defense-in-depth headers as renderRebindRefused.
 func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("X-Frame-Options", "DENY")
-	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
-	w.Header().Set("Referrer-Policy", "no-referrer")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(status)
 	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Message: message}); err != nil {
 		slog.Warn("oauth/callback error-page write failed", "error", err)
@@ -624,16 +630,7 @@ func renderSuccess(w http.ResponseWriter, teamID, keyPrefix, email string) {
 	// keyPrefix comes from qurl-service's JSON response; email is JWKS-
 	// verified — but the template's context-aware auto-escape is the
 	// load-bearing XSS defense here.
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store")
-	// Defense-in-depth headers: success page is rendered post-auth so it
-	// shouldn't be framable (clickjacking), shouldn't leak the URL via
-	// Referer to anything the page links to, and shouldn't load any
-	// off-origin resources beyond the inline style.
-	w.Header().Set("X-Frame-Options", "DENY")
-	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
-	w.Header().Set("Referrer-Policy", "no-referrer")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(http.StatusOK)
 	if err := successPageTemplate.Execute(w, successPageData{
 		TeamID:    teamID,

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -159,7 +159,6 @@ body{font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:4rem 
 h1{margin:0 0 .5rem;font-size:1.5rem}
 p{color:#374151;font-size:.95rem;line-height:1.5}
 .warn{color:#b91c1c;font-weight:600}
-code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 </style>
 </head>
 <body>

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -140,6 +140,43 @@ type rebindRefusedPageData struct {
 	TeamID string
 }
 
+// oauthErrorPageTemplate renders a styled, human-readable error page for
+// OAuth-callback failures that previously fell through to bare http.Error
+// (a blank white page with raw text — the experience operators flagged).
+// Same no-asset / strict-CSP posture as the success and rebind-refused
+// pages. Heading and Message are the only interpolations; html/template
+// auto-escapes both (they're operator-authored today, but the escape keeps
+// the page safe if a future caller passes an upstream string through).
+var oauthErrorPageTemplate = template.Must(template.New("oauth-error").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>qURL setup</title>
+<meta name="robots" content="noindex">
+<style>
+body{font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;color:#111}
+.card{border:1px solid #d1d5db;border-radius:12px;padding:2rem;background:#fef2f2}
+h1{margin:0 0 .5rem;font-size:1.5rem}
+p{color:#374151;font-size:.95rem;line-height:1.5}
+.warn{color:#b91c1c;font-weight:600}
+code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
+</style>
+</head>
+<body>
+<div class="card">
+<h1><span class="warn">&#9888;</span> {{.Heading}}</h1>
+<p>{{.Message}}</p>
+<p style="margin-top:1.5rem;font-size:.875rem;color:#6b7280">You can close this tab and return to Slack.</p>
+</div>
+</body>
+</html>`))
+
+// oauthErrorPageData is the model passed to oauthErrorPageTemplate.
+type oauthErrorPageData struct {
+	Heading string
+	Message string
+}
+
 // auth0TokenResponse is the slice of Auth0's /oauth/token response we read.
 type auth0TokenResponse struct {
 	AccessToken string `json:"access_token"`
@@ -471,8 +508,21 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	apiKey, keyID, keyPrefix, err := cfg.Minter.MintAPIKey(mintCtx, accessToken,
 		keyName, apiKeyScopes())
 	if err != nil {
-		slog.Error("oauth/callback qurl-service mint failed", "error", err, "team_id", teamID) //nolint:gosec // G706: slog escapes control bytes in attribute values.
-		http.Error(w, "could not provision qURL key — run /qurl setup again to retry", http.StatusBadGateway)
+		//nolint:gosec // G706: slog escapes control bytes in attribute values.
+		slog.Error("oauth/callback qurl-service mint failed", "error", err, "team_id", teamID, "api_key_limit", errors.Is(err, ErrAPIKeyLimitReached))
+		if errors.Is(err, ErrAPIKeyLimitReached) {
+			// Quota is a precondition the admin must clear themselves —
+			// retrying does nothing (the old "run setup again" advice was
+			// actively wrong here). 409 so an automated retry surfaces the
+			// conflict rather than looping. Don't state a key count: the cap
+			// is plan-dependent (free 3 / growth 50 / unlimited) and is
+			// qurl-service's to own.
+			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
+				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Each run of /qurl setup creates a new key — revoke one you no longer use, then run /qurl setup again.")
+			return "", false
+		}
+		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
+			"Something went wrong while creating your qURL API key. Run /qurl setup again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
 
@@ -549,6 +599,23 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 	w.WriteHeader(http.StatusConflict)
 	if err := rebindRefusedPageTemplate.Execute(w, rebindRefusedPageData{TeamID: teamID}); err != nil {
 		slog.Warn("oauth/callback rebind-refused page write failed", "error", err)
+	}
+}
+
+// renderOAuthErrorPage writes a styled error page with the given status.
+// Replaces bare http.Error on the mint-failure path so a callback failure
+// renders human-readable, actionable guidance instead of a blank page with
+// raw text. Same defense-in-depth headers as renderRebindRefused.
+func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Message: message}); err != nil {
+		slog.Warn("oauth/callback error-page write failed", "error", err)
 	}
 }
 

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -312,6 +312,28 @@ func TestSuccessPageHTMLEscapesInterpolations(t *testing.T) {
 	}
 }
 
+// TestOAuthErrorPageHTMLEscapesInterpolations is the symmetric lock for
+// renderOAuthErrorPage. Heading/Message are operator-authored today, but the
+// template doc comment notes a future caller could pass an upstream string
+// through — so the html/template auto-escape is the load-bearing defense if
+// that happens. A swap to text/template (or string concat) would let a
+// payload render raw; this fails first.
+func TestOAuthErrorPageHTMLEscapesInterpolations(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderOAuthErrorPage(rec, http.StatusBadGateway,
+		"<script>alert('h')</script>", "<img src=x onerror=alert('m')>")
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>") || strings.Contains(body, "<img src=x") {
+		t.Errorf("raw HTML rendered — auto-escape regressed:\n%s", body)
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Errorf("expected escaped <script> from Heading in body:\n%s", body)
+	}
+	if !strings.Contains(body, "&lt;img") {
+		t.Errorf("expected escaped <img> from Message in body:\n%s", body)
+	}
+}
+
 func TestCallbackIgnoresAdminUserQueryParam(t *testing.T) {
 	// Regression: configuredBy used to be read from ?admin_user=…
 	// which let an attacker pick the DM target. Now the value is
@@ -415,11 +437,11 @@ func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 		t.Fatalf("got %d want 502 (mint failure → 502)", rec.Code)
 	}
 	// The non-limit failure now renders a styled HTML page, not bare
-	// http.Error — lock the heading + headers so a regression back to plain
-	// text is caught. ("connect qURL" avoids the apostrophe in "Couldn't",
-	// which html/template escapes to &#39;.)
-	if body := rec.Body.String(); !strings.Contains(body, "connect qURL") {
-		t.Errorf("502 body should render the styled error page; got: %q", body)
+	// http.Error — pin the exact heading so a regression back to plain text
+	// (or a reworded heading) is caught. The apostrophe in "Couldn't" is
+	// html/template-escaped to &#39;, hence the entity form here.
+	if body := rec.Body.String(); !strings.Contains(body, "Couldn&#39;t connect qURL") {
+		t.Errorf("502 body should render the styled error page heading; got: %q", body)
 	}
 	assertSecurityHeaders(t, rec)
 	// Give any spurious revoke goroutine a window to fire.

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -410,6 +410,34 @@ func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 	}
 }
 
+// TestCallbackMintAPIKeyLimitRendersGuidance locks the actionable-error
+// contract: when the mint fails because the account is at its API-key cap,
+// the callback renders a 409 page that names the limit and tells the admin
+// to revoke a key — NOT the generic "run setup again to retry" (which never
+// clears a quota). No key is minted, so nothing is persisted.
+func TestCallbackMintAPIKeyLimitRendersGuidance(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	minter.mintErr = ErrAPIKeyLimitReached
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("got %d want 409 (api-key limit → 409)", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "limit") || !strings.Contains(strings.ToLower(body), "revoke") {
+		t.Errorf("body should name the key limit and how to clear it (revoke); got: %q", body)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKey must NOT run when the mint hit the API-key limit")
+	}
+}
+
 func TestCallbackRevokesOnPersistFailure(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
 	store.setErr = errors.New("ddb down")

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -199,6 +199,30 @@ func callbackRequest(state string) *http.Request {
 	return req
 }
 
+// assertSecurityHeaders checks the defense-in-depth header set every OAuth-
+// callback HTML response must carry. renderSuccess, renderRebindRefused, and
+// renderOAuthErrorPage all set the same six; centralizing the assertion means
+// a render path that silently drops one fails here instead of slipping past a
+// status-and-body-only test.
+func assertSecurityHeaders(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	want := map[string]string{
+		"Content-Type":           "text/html; charset=utf-8",
+		"Cache-Control":          "no-store",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "no-referrer",
+		"X-Content-Type-Options": "nosniff",
+	}
+	for h, v := range want {
+		if got := rec.Header().Get(h); got != v {
+			t.Errorf("%s: got %q want %q", h, got, v)
+		}
+	}
+	if csp := rec.Header().Get("Content-Security-Policy"); !strings.Contains(csp, "default-src 'none'") {
+		t.Errorf("CSP missing default-src 'none': %q", csp)
+	}
+}
+
 func TestCallbackHappyPath(t *testing.T) {
 	cfg, _, store, minter := newCallbackCfg(t)
 
@@ -224,18 +248,7 @@ func TestCallbackHappyPath(t *testing.T) {
 		t.Errorf("success body missing email: %s", body)
 	}
 	// Defense-in-depth headers are required on the success page.
-	if rec.Header().Get("X-Frame-Options") != "DENY" {
-		t.Errorf("X-Frame-Options: got %q want DENY", rec.Header().Get("X-Frame-Options"))
-	}
-	if !strings.Contains(rec.Header().Get("Content-Security-Policy"), "default-src 'none'") {
-		t.Errorf("CSP missing default-src 'none': %q", rec.Header().Get("Content-Security-Policy"))
-	}
-	if rec.Header().Get("Referrer-Policy") != "no-referrer" {
-		t.Errorf("Referrer-Policy: got %q want no-referrer", rec.Header().Get("Referrer-Policy"))
-	}
-	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
-		t.Errorf("X-Content-Type-Options: got %q want nosniff", rec.Header().Get("X-Content-Type-Options"))
-	}
+	assertSecurityHeaders(t, rec)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -401,6 +414,14 @@ func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("got %d want 502 (mint failure → 502)", rec.Code)
 	}
+	// The non-limit failure now renders a styled HTML page, not bare
+	// http.Error — lock the heading + headers so a regression back to plain
+	// text is caught. ("connect qURL" avoids the apostrophe in "Couldn't",
+	// which html/template escapes to &#39;.)
+	if body := rec.Body.String(); !strings.Contains(body, "connect qURL") {
+		t.Errorf("502 body should render the styled error page; got: %q", body)
+	}
+	assertSecurityHeaders(t, rec)
 	// Give any spurious revoke goroutine a window to fire.
 	time.Sleep(50 * time.Millisecond)
 	minter.revokeMu.Lock()
@@ -427,10 +448,11 @@ func TestCallbackMintAPIKeyLimitRendersGuidance(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("got %d want 409 (api-key limit → 409)", rec.Code)
 	}
-	body := rec.Body.String()
-	if !strings.Contains(body, "limit") || !strings.Contains(strings.ToLower(body), "revoke") {
-		t.Errorf("body should name the key limit and how to clear it (revoke); got: %q", body)
+	body := strings.ToLower(rec.Body.String())
+	if !strings.Contains(body, "limit") || !strings.Contains(body, "revoke") {
+		t.Errorf("body should name the key limit and how to clear it (revoke); got: %q", rec.Body.String())
 	}
+	assertSecurityHeaders(t, rec)
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -19,7 +19,22 @@ const (
 	// The real response is ~few hundred bytes; 8 KiB is generous head-
 	// room without leaving an unbounded read on a misbehaving upstream.
 	minterBodyLimit = 8 << 10
+
+	// errCodeAPIKeyLimit is the qurl-service error-envelope `code` returned
+	// when POST /v1/api-keys is refused because the owner is already at
+	// their plan's API-key cap (free tier = 3). Mirrors qurl-service's
+	// validation.ErrorCodeAPIKeyLimit. Both that endpoint's qurl:write
+	// scope gate AND this quota check surface as HTTP 403, so the status
+	// code alone can't disambiguate — the body `code` is the only signal.
+	errCodeAPIKeyLimit = "api_key_limit"
 )
+
+// ErrAPIKeyLimitReached is returned by MintAPIKey when qurl-service refuses
+// the mint because the account holds the maximum number of API keys for its
+// plan. The OAuth callback maps this to an actionable "revoke a key" page
+// rather than the generic "try again" message — retrying never clears a
+// quota, so the old advice was actively misleading.
+var ErrAPIKeyLimitReached = errors.New("qurl-service API key limit reached")
 
 // HTTPAPIKeyMinter is the production QURLAPIKeyMinter, calling
 // qurl-service /v1/api-keys with the Auth0 access_token as Bearer.
@@ -112,6 +127,9 @@ func (m *HTTPAPIKeyMinter) MintAPIKey(ctx context.Context, accessToken, name str
 		return "", "", "", fmt.Errorf("qurl-service /v1/api-keys response exceeded %d bytes", minterBodyLimit)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		if apiKeyLimitError(rb) {
+			return "", "", "", fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
+		}
 		return "", "", "", fmt.Errorf("qurl-service /v1/api-keys returned %d", resp.StatusCode)
 	}
 	var mr mintResponse
@@ -152,4 +170,21 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 		return fmt.Errorf("qurl-service DELETE /v1/api-keys returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// apiKeyLimitError reports whether body is a qurl-service error envelope
+// carrying the api-key-limit code. The envelope shape is
+// {"error":{"code":"...", ...}}; a body that doesn't parse to that shape
+// (e.g. a bare {"error":"forbidden"} string, or non-JSON) returns false so
+// the caller falls back to the generic status-code error.
+func apiKeyLimitError(body []byte) bool {
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return false
+	}
+	return env.Error.Code == errCodeAPIKeyLimit
 }

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -174,9 +174,12 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 
 // apiKeyLimitError reports whether body is a qurl-service error envelope
 // carrying the api-key-limit code. The envelope shape is
-// {"error":{"code":"...", ...}}; a body that doesn't parse to that shape
-// (e.g. a bare {"error":"forbidden"} string, or non-JSON) returns false so
-// the caller falls back to the generic status-code error.
+// {"error":{"code":"...", ...}} — qurl-service's own nested form, NOT RFC
+// 7807 problem+json (where code/title/detail are top-level, not nested under
+// "error"), so the match is driven by the parsed JSON shape, not the
+// response Content-Type. A body that doesn't parse to that shape (e.g. a
+// bare {"error":"forbidden"} string, or non-JSON) returns false so the
+// caller falls back to the generic status-code error.
 func apiKeyLimitError(body []byte) bool {
 	var env struct {
 		Error struct {

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -105,8 +105,36 @@ func TestHTTPAPIKeyMinterMintAPIKeyLimit(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	if err := mintAPIKeyOnlyErr(m); !errors.Is(err, ErrAPIKeyLimitReached) {
+	err := mintAPIKeyOnlyErr(m)
+	if !errors.Is(err, ErrAPIKeyLimitReached) {
 		t.Fatalf("expected ErrAPIKeyLimitReached, got %v", err)
+	}
+	// The %w wrap also keeps the status in the message operator logs grep —
+	// lock it so a refactor that drops the "(status %d)" suffix is caught.
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected wrapped status code in error, got %q", err.Error())
+	}
+}
+
+// TestHTTPAPIKeyMinterMintForbiddenEnvelopeStaysGeneric is the negative case
+// for apiKeyLimitError's code match: a well-formed error envelope carrying a
+// NON-limit code (here insufficient_scope) must stay a generic status error,
+// not the ErrAPIKeyLimitReached sentinel. Pins that the match is on the exact
+// code, so a future "any code containing limit" loosening breaks loudly.
+func TestHTTPAPIKeyMinterMintForbiddenEnvelopeStaysGeneric(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":{"code":"insufficient_scope","title":"Forbidden","detail":"token missing qurl:write"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintAPIKeyOnlyErr(m)
+	if errors.Is(err, ErrAPIKeyLimitReached) {
+		t.Fatalf("non-limit envelope code must NOT map to ErrAPIKeyLimitReached, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected generic status error, got %q", err)
 	}
 }
 

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -93,6 +93,23 @@ func TestHTTPAPIKeyMinterMintNon2xx(t *testing.T) {
 	}
 }
 
+// TestHTTPAPIKeyMinterMintAPIKeyLimit locks the contract that a 403 carrying
+// qurl-service's api_key_limit envelope maps to the ErrAPIKeyLimitReached
+// sentinel (so the callback can render the "revoke a key" guidance) — while
+// the plain {"error":"forbidden"} 403 above stays a generic status error.
+func TestHTTPAPIKeyMinterMintAPIKeyLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":{"code":"api_key_limit","title":"API Key Limit Exceeded","detail":"api key limit exceeded: plan limit reached"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	if err := mintAPIKeyOnlyErr(m); !errors.Is(err, ErrAPIKeyLimitReached) {
+		t.Fatalf("expected ErrAPIKeyLimitReached, got %v", err)
+	}
+}
+
 // TestHTTPAPIKeyMinterMintMissingAPIKey is the symmetric case to
 // MissingKeyID — qurl-service returns 200 with key_id but the api_key
 // field empty. The mint must reject so the bot doesn't hand the caller


### PR DESCRIPTION
## Problem

Running `/qurl setup` returned a bare white page reading:

> could not provision qURL key — run /qurl setup again to retry

That advice is **wrong** for the actual cause. `/qurl setup` mints a **new** qURL API key on every run (it overwrites the stored DDB row but doesn't revoke the prior key on qurl-service). Once an account reaches its plan's key cap (**free tier = 3**), qurl-service refuses the next mint with **HTTP 403** and error code `api_key_limit`. Retrying never clears a quota — the user has to revoke a key. (Confirmed in sandbox: at 3 keys it 403'd; revoking one let setup succeed.)

The callback couldn't tell the user that because (a) the minter collapsed every non-2xx into `returned <code>`, and (b) the `api_key_limit` 403 is indistinguishable on status alone from a genuine missing-scope 403 — the body `code` is the only signal.

## Change

- **`minter.go`**: parse qurl-service's error envelope (`{"error":{"code":...}}`) and return a typed `ErrAPIKeyLimitReached` when the code is `api_key_limit`. A body that isn't that shape (e.g. the existing `{"error":"forbidden"}` test case) falls back to the generic status error.
- **`callback.go`**: replace the bare `http.Error` on the mint-failure path with a styled HTML page (same strict-CSP/no-asset posture as the existing success and rebind-refused pages — no more blank white page). Two cases:
  - **key limit → 409**, names the cause + tells the admin to revoke a key.
  - **other mint failure → 502**, keeps the (correct, for transient errors) retry guidance.

The number of allowed keys is deliberately **not** stated — it's plan-dependent (free 3 / growth 50 / enterprise unlimited) and is qurl-service's to own.

### Before → After (the page text the user sees)

Before (both cases, blank page): `could not provision qURL key — run /qurl setup again to retry`

After, key-limit case:
> **⚠ qURL key limit reached**
> Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Each run of /qurl setup creates a new key — revoke one you no longer use, then run /qurl setup again.

After, other failure:
> **⚠ Couldn't connect qURL**
> Something went wrong while creating your qURL API key. Run /qurl setup again in a few minutes. If it keeps failing, please contact your qURL administrator.

(Wording is easy to tweak — say the word.)

## Tests

- `TestHTTPAPIKeyMinterMintAPIKeyLimit`: the `api_key_limit` envelope maps to `ErrAPIKeyLimitReached`; the plain `{"error":"forbidden"}` 403 stays generic.
- `TestCallbackMintAPIKeyLimitRendersGuidance`: the limit case renders a 409 page naming the limit + "revoke", and persists nothing.
- `go build`, `go test ./internal/oauth/...`, and `pre-commit` (incl. pinned golangci-lint v2.10.1) all pass.

## Note / possible follow-up

This fixes the *message*. The reason accounts hit the cap is that `/qurl setup` leaks a key per run (mints without revoking the prior — the orphan-key path, qurl-integrations#265-adjacent). Making setup revoke/reuse the previous workspace key would stop the accumulation at the source; out of scope here.