### PR TITLE
fix(slack): drop phantom views:write scope from install flow

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -156,7 +156,7 @@ For customer Slack installs, configure the Slack app with:
   shapes defensively, but qURL does not request or persist Slack refresh tokens
   yet, so rotation-enabled apps need refresh support before production use.
 
-When moving to per-workspace token storage, existing customer workspaces must
+With per-workspace token storage in place, existing customer workspaces must
 reinstall or reauthorize the Slack app so Slack issues a per-workspace bot
 token. New installs through `/oauth/slack/install` store that token
 automatically, and guided `/qurl tunnel install` uses it for `views.open`

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -148,7 +148,7 @@ For customer Slack installs, configure the Slack app with:
 - Customer install link: `https://<SLACK_BASE_URL host>/oauth/slack/install`
 - Slash command request URL: `https://<SLACK_BASE_URL host>/slack/commands`
 - Interactivity request URL: `https://<SLACK_BASE_URL host>/slack/interactions`
-- Bot scopes: at least `commands` (`views.open` itself requires no scope)
+- Bot scopes: `commands` (the captured token is used only for `views.open`, which requires no scope of its own)
 - Installation mode: workspace-level installs or Enterprise Grid org-level
   installs. Org-level bot tokens are stored under Slack `enterprise_id`; qURL
   workspace setup and admin checks still use workspace `team_id`.

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -14,7 +14,7 @@ Customer onboarding is install-first:
 - `/qurl get <$slug|$alias>` — Mint a one-time qURL for a tunnel `$slug` or a channel `$alias` (raw URLs aren't supported)
 - `/qurl set-alias $<alias> $<slug>` — Point a channel shortcut at a tunnel slug (admin-only)
 - `/qurl unset-alias $<alias>` — Remove a channel shortcut binding (admin-only)
-- `/qurl tunnel install` — Guided tunnel sidecar setup with target-environment choices (admin-only; uses the workspace bot token stored during Slack app install with `views:write`)
+- `/qurl tunnel install` — Guided tunnel sidecar setup with target-environment choices (admin-only; uses the workspace bot token stored during Slack app install)
 - `/qurl tunnel install <slug|$slug> [port:<n>] [alias:$shortcut] [env:<target>] [container:<name>]` — Provision a tunnel from a typed command (admin-only; default local port is 8080)
 - `/qurl list` — List the protected tunnel resources available to you (with their bound channel shortcuts)
 - Link unfurling for `qurl.link` URLs (planned)
@@ -115,7 +115,7 @@ docker buildx build --platform linux/arm64 \
 | `SLACK_CLIENT_ID` | Slack install | Slack app client ID used by `/oauth/slack/install`. Required for customer installs that capture per-workspace bot tokens. |
 | `SLACK_CLIENT_SECRET` | Slack install | Slack app client secret used by `/oauth/slack/callback` to exchange Slack's OAuth code. |
 | `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. Use a distinct production secret from `OAUTH_STATE_SECRET`; the fallback is only for local/dev compatibility. |
-| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,views:write`; any override must still include both required scopes. |
+| `SLACK_BOT_SCOPES` | No | Comma/space-separated bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands` (the captured token is used only for `views.open`, which requires no scope); any override must still include `commands`. |
 | `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
 | `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.xyz`) |
 | `WORKSPACE_STATE_TABLE` | Yes | DynamoDB table holding per-workspace API keys (provisioned by `qurl-integrations-infra`) |
@@ -148,7 +148,7 @@ For customer Slack installs, configure the Slack app with:
 - Customer install link: `https://<SLACK_BASE_URL host>/oauth/slack/install`
 - Slash command request URL: `https://<SLACK_BASE_URL host>/slack/commands`
 - Interactivity request URL: `https://<SLACK_BASE_URL host>/slack/interactions`
-- Bot scopes: at least `commands` and `views:write`
+- Bot scopes: at least `commands` (`views.open` itself requires no scope)
 - Installation mode: workspace-level installs or Enterprise Grid org-level
   installs. Org-level bot tokens are stored under Slack `enterprise_id`; qURL
   workspace setup and admin checks still use workspace `team_id`.
@@ -156,10 +156,9 @@ For customer Slack installs, configure the Slack app with:
   shapes defensively, but qURL does not request or persist Slack refresh tokens
   yet, so rotation-enabled apps need refresh support before production use.
 
-After adding `views:write` or moving to per-workspace token storage, existing
-customer workspaces must reinstall or reauthorize the Slack app so Slack issues
-a bot token with the new scope. New installs through `/oauth/slack/install`
-store that token automatically, and guided `/qurl tunnel install` will use it
-for `views.open`. If Slack tells a customer guided tunnel setup needs the latest
-qURL Slack app install, send them through this reinstall link and confirm the app
-grants `views:write`.
+When moving to per-workspace token storage, existing customer workspaces must
+reinstall or reauthorize the Slack app so Slack issues a per-workspace bot
+token. New installs through `/oauth/slack/install` store that token
+automatically, and guided `/qurl tunnel install` uses it for `views.open`
+(which requires no scope). If Slack tells a customer guided tunnel setup needs
+the latest qURL Slack app install, send them through this reinstall link.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -764,16 +764,23 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	scopes := slackinstall.DefaultBotScopes()
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
 		scopes = slackinstall.NormalizeScopes([]string{raw})
+		// Strip a stale `views:write` (not a real Slack scope, see
+		// slackinstall.DefaultBotScopes) from operator overrides rather than
+		// forward or reject it: forwarding makes every customer install fail at
+		// Slack's authorize step with invalid_scope until the SLACK_BOT_SCOPES
+		// runbook is patched, while rejecting it in Validate() would abort bot
+		// startup. Stripping keeps installs working off the valid scopes and
+		// warns the operator. EqualFold because NormalizeScopes does not lowercase.
+		kept := make([]string, 0, len(scopes))
 		for _, s := range scopes {
-			if s == "views:write" {
-				// Warn rather than reject: a Validate() failure below aborts
-				// bot startup, so a stale `views:write` carried over in a
-				// SLACK_BOT_SCOPES runbook value shouldn't take the whole bot
-				// down. Slack rejects it at authorize with invalid_scope, which
-				// the callback already logs.
-				slog.Warn("SLACK_BOT_SCOPES includes views:write, which is not a real Slack scope; Slack rejects it at authorize with invalid_scope. Remove it — the install flow needs only commands.")
-				break
+			if strings.EqualFold(s, "views:write") {
+				continue
 			}
+			kept = append(kept, s)
+		}
+		if len(kept) != len(scopes) {
+			scopes = kept
+			slog.Warn("SLACK_BOT_SCOPES included views:write, which is not a real Slack scope; dropped it. The install flow needs only commands.")
 		}
 	}
 	cfg := slackinstall.Config{

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -764,23 +764,15 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	scopes := slackinstall.DefaultBotScopes()
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
 		scopes = slackinstall.NormalizeScopes([]string{raw})
-		// Strip a stale `views:write` (not a real Slack scope, see
-		// slackinstall.DefaultBotScopes) from operator overrides rather than
-		// forward or reject it: forwarding makes every customer install fail at
-		// Slack's authorize step with invalid_scope until the SLACK_BOT_SCOPES
-		// runbook is patched, while rejecting it in Validate() would abort bot
-		// startup. Stripping keeps installs working off the valid scopes and
-		// warns the operator. EqualFold because NormalizeScopes does not lowercase.
-		kept := make([]string, 0, len(scopes))
-		for _, s := range scopes {
-			if strings.EqualFold(s, "views:write") {
-				continue
-			}
-			kept = append(kept, s)
-		}
-		if len(kept) != len(scopes) {
+		// Strip a stale views:write from operator overrides (see
+		// slackinstall.DropUnsupportedScopes) rather than forward or reject it:
+		// forwarding makes every customer install fail at Slack's authorize step
+		// with invalid_scope until the SLACK_BOT_SCOPES runbook is patched, while
+		// rejecting it in Validate() would abort bot startup. Stripping keeps
+		// installs working off the valid scopes and warns the operator.
+		if kept, dropped := slackinstall.DropUnsupportedScopes(scopes); len(dropped) > 0 {
 			scopes = kept
-			slog.Warn("SLACK_BOT_SCOPES included views:write, which is not a real Slack scope; dropped it. The install flow needs only commands.")
+			slog.Warn("SLACK_BOT_SCOPES included views:write, which is not a real Slack scope; dropped it. SLACK_BOT_SCOPES must still include commands.", "stripped_scope", "views:write")
 		}
 	}
 	cfg := slackinstall.Config{

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -764,12 +764,9 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	scopes := slackinstall.DefaultBotScopes()
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
 		scopes = slackinstall.NormalizeScopes([]string{raw})
-		// Strip a stale views:write from operator overrides (see
-		// slackinstall.DropUnsupportedScopes) rather than forward or reject it:
-		// forwarding makes every customer install fail at Slack's authorize step
-		// with invalid_scope until the SLACK_BOT_SCOPES runbook is patched, while
-		// rejecting it in Validate() would abort bot startup. Stripping keeps
-		// installs working off the valid scopes and warns the operator.
+		// Strip unsupported scopes (see slackinstall.DropUnsupportedScopes) from
+		// operator overrides before Validate, so a stale SLACK_BOT_SCOPES value
+		// warns rather than aborting bot startup.
 		if kept, dropped := slackinstall.DropUnsupportedScopes(scopes); len(dropped) > 0 {
 			scopes = kept
 			slog.Warn("SLACK_BOT_SCOPES included views:write, which is not a real Slack scope; dropped it. SLACK_BOT_SCOPES must still include commands.", "stripped_scope", "views:write")

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -764,6 +764,17 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	scopes := slackinstall.DefaultBotScopes()
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
 		scopes = slackinstall.NormalizeScopes([]string{raw})
+		for _, s := range scopes {
+			if s == "views:write" {
+				// Warn rather than reject: a Validate() failure below aborts
+				// bot startup, so a stale `views:write` carried over in a
+				// SLACK_BOT_SCOPES runbook value shouldn't take the whole bot
+				// down. Slack rejects it at authorize with invalid_scope, which
+				// the callback already logs.
+				slog.Warn("SLACK_BOT_SCOPES includes views:write, which is not a real Slack scope; Slack rejects it at authorize with invalid_scope. Remove it — the install flow needs only commands.")
+				break
+			}
+		}
 	}
 	cfg := slackinstall.Config{
 		ClientID:     clientID,

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -765,11 +765,13 @@ func buildSlackInstallConfig(provider *auth.DDBProvider) (slackinstall.Config, b
 	if raw := strings.TrimSpace(os.Getenv(envSlackBotScopes)); raw != "" {
 		scopes = slackinstall.NormalizeScopes([]string{raw})
 		// Strip unsupported scopes (see slackinstall.DropUnsupportedScopes) from
-		// operator overrides before Validate, so a stale SLACK_BOT_SCOPES value
-		// warns rather than aborting bot startup.
+		// operator overrides before Validate: a stale SLACK_BOT_SCOPES with
+		// surviving valid scopes then warns instead of aborting startup. (An
+		// override of only unsupported scopes strips to empty and Validate still
+		// rejects it.)
 		if kept, dropped := slackinstall.DropUnsupportedScopes(scopes); len(dropped) > 0 {
 			scopes = kept
-			slog.Warn("SLACK_BOT_SCOPES included views:write, which is not a real Slack scope; dropped it. SLACK_BOT_SCOPES must still include commands.", "stripped_scope", "views:write")
+			slog.Warn("SLACK_BOT_SCOPES included views:write, which is not a real Slack scope; dropped it. SLACK_BOT_SCOPES must still include commands.")
 		}
 	}
 	cfg := slackinstall.Config{

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -556,6 +556,22 @@ func TestBuildSlackInstallConfigStripsViewsWriteOverride(t *testing.T) {
 	}
 }
 
+// If a SLACK_BOT_SCOPES override strips to nothing (only views:write), config
+// load surfaces the "at least one bot scope" error rather than silently falling
+// back to the defaults — so the operator must fix the override.
+func TestBuildSlackInstallConfigRejectsOverrideThatStripsToEmpty(t *testing.T) {
+	env := validSlackInstallEnv()
+	env[envSlackBotScopes] = "views:write"
+	applySlackInstallEnv(t, env)
+	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if ok || err == nil || !strings.Contains(err.Error(), "at least one bot scope") {
+		t.Fatalf("ok=%v err=%v, want config load to fail on empty scope set", ok, err)
+	}
+	if len(cfg.BotScopes) != 0 {
+		t.Fatalf("BotScopes = %v, want empty config on failure", cfg.BotScopes)
+	}
+}
+
 func TestSlackInstallConfigRejectsBadBaseURL(t *testing.T) {
 	env := validSlackInstallEnv()
 	env["SLACK_BASE_URL"] = "http://slack-bot.example"

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -539,18 +537,13 @@ func TestBuildSlackInstallConfigCustomScopes(t *testing.T) {
 	}
 }
 
-// A stale `views:write` in a SLACK_BOT_SCOPES override is dropped (not
-// forwarded, not rejected) so customer installs keep working off the valid
-// scopes while the operator is warned to patch their runbook: forwarding it
-// would fail every install at Slack with invalid_scope, and rejecting it in
-// Validate() would abort bot startup. Mixed case also exercises the
-// case-insensitive match.
-func TestBuildSlackInstallConfigStripsAndWarnsViewsWrite(t *testing.T) {
-	var logs bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
-
+// A stale `views:write` in a SLACK_BOT_SCOPES override is stripped at config
+// load (see slackinstall.DropUnsupportedScopes), so the install flow keeps
+// working off the valid scopes instead of breaking every install with
+// invalid_scope or aborting startup. Mixed case confirms the wiring uses the
+// case-insensitive helper; the drop decision itself is unit-tested in the
+// slackinstall package.
+func TestBuildSlackInstallConfigStripsViewsWriteOverride(t *testing.T) {
 	env := validSlackInstallEnv()
 	env[envSlackBotScopes] = "commands,Views:Write"
 	applySlackInstallEnv(t, env)
@@ -560,9 +553,6 @@ func TestBuildSlackInstallConfigStripsAndWarnsViewsWrite(t *testing.T) {
 	}
 	if strings.Join(cfg.BotScopes, ",") != "commands" {
 		t.Fatalf("scopes = %v, want views:write stripped", cfg.BotScopes)
-	}
-	if !strings.Contains(logs.String(), "views:write") {
-		t.Fatalf("expected a warning naming views:write, got %q", logs.String())
 	}
 }
 

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -482,7 +482,7 @@ func TestBuildSlackInstallConfigHappyPath(t *testing.T) {
 	if string(cfg.StateSecret) != validStateSecret {
 		t.Fatalf("StateSecret not threaded through")
 	}
-	if strings.Join(cfg.BotScopes, ",") != "commands,views:write" {
+	if strings.Join(cfg.BotScopes, ",") != "commands" {
 		t.Fatalf("default bot scopes = %v", cfg.BotScopes)
 	}
 	if cfg.TokenStore == nil {
@@ -526,13 +526,13 @@ func TestBuildSlackInstallConfigMissingVar(t *testing.T) {
 
 func TestBuildSlackInstallConfigCustomScopes(t *testing.T) {
 	env := validSlackInstallEnv()
-	env[envSlackBotScopes] = "commands views:write,chat:write"
+	env[envSlackBotScopes] = "commands chat:write,im:write"
 	applySlackInstallEnv(t, env)
 	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
 	if err != nil || !ok {
 		t.Fatalf("ok=%v err=%v", ok, err)
 	}
-	if strings.Join(cfg.BotScopes, ",") != "commands,views:write,chat:write" {
+	if strings.Join(cfg.BotScopes, ",") != "commands,chat:write,im:write" {
 		t.Fatalf("custom scopes = %v", cfg.BotScopes)
 	}
 }

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -537,20 +539,30 @@ func TestBuildSlackInstallConfigCustomScopes(t *testing.T) {
 	}
 }
 
-// A stale `views:write` in SLACK_BOT_SCOPES must not abort bot startup. Config
-// load forwards the override (warning about the phantom scope) rather than
-// failing Validate(), which would crash the whole bot — Slack rejects the
-// scope at authorize with invalid_scope, which the callback handles.
-func TestBuildSlackInstallConfigAcceptsStaleViewsWriteOverride(t *testing.T) {
+// A stale `views:write` in a SLACK_BOT_SCOPES override is dropped (not
+// forwarded, not rejected) so customer installs keep working off the valid
+// scopes while the operator is warned to patch their runbook: forwarding it
+// would fail every install at Slack with invalid_scope, and rejecting it in
+// Validate() would abort bot startup. Mixed case also exercises the
+// case-insensitive match.
+func TestBuildSlackInstallConfigStripsAndWarnsViewsWrite(t *testing.T) {
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	env := validSlackInstallEnv()
-	env[envSlackBotScopes] = "commands,views:write"
+	env[envSlackBotScopes] = "commands,Views:Write"
 	applySlackInstallEnv(t, env)
 	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
 	if err != nil || !ok {
-		t.Fatalf("ok=%v err=%v, want config load to succeed despite views:write", ok, err)
+		t.Fatalf("ok=%v err=%v, want config load to succeed", ok, err)
 	}
-	if strings.Join(cfg.BotScopes, ",") != "commands,views:write" {
-		t.Fatalf("scopes = %v, want override forwarded as-is", cfg.BotScopes)
+	if strings.Join(cfg.BotScopes, ",") != "commands" {
+		t.Fatalf("scopes = %v, want views:write stripped", cfg.BotScopes)
+	}
+	if !strings.Contains(logs.String(), "views:write") {
+		t.Fatalf("expected a warning naming views:write, got %q", logs.String())
 	}
 }
 

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -537,6 +537,23 @@ func TestBuildSlackInstallConfigCustomScopes(t *testing.T) {
 	}
 }
 
+// A stale `views:write` in SLACK_BOT_SCOPES must not abort bot startup. Config
+// load forwards the override (warning about the phantom scope) rather than
+// failing Validate(), which would crash the whole bot — Slack rejects the
+// scope at authorize with invalid_scope, which the callback handles.
+func TestBuildSlackInstallConfigAcceptsStaleViewsWriteOverride(t *testing.T) {
+	env := validSlackInstallEnv()
+	env[envSlackBotScopes] = "commands,views:write"
+	applySlackInstallEnv(t, env)
+	cfg, ok, err := buildSlackInstallConfig(newFakeProvider())
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v, want config load to succeed despite views:write", ok, err)
+	}
+	if strings.Join(cfg.BotScopes, ",") != "commands,views:write" {
+		t.Fatalf("scopes = %v, want override forwarded as-is", cfg.BotScopes)
+	}
+}
+
 func TestSlackInstallConfigRejectsBadBaseURL(t *testing.T) {
 	env := validSlackInstallEnv()
 	env["SLACK_BASE_URL"] = "http://slack-bot.example"

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -168,6 +168,13 @@ func (c *Config) Validate() error {
 	if len(scopes) == 0 {
 		return errors.New("at least one bot scope is required")
 	}
+	// Direct callers (and a regression in DefaultBotScopes) bypass the
+	// cmd-layer strip, so reject unsupported scopes here too. The env path
+	// strips them before Validate is reached, so operators still get the
+	// non-fatal strip-and-warn; only programmatic misuse reaches this error.
+	if _, dropped := DropUnsupportedScopes(scopes); len(dropped) > 0 {
+		return fmt.Errorf("bot scopes include scope(s) Slack rejects with invalid_scope: %s", strings.Join(dropped, ","))
+	}
 	if missing := missingRequiredScopes(scopes); len(missing) > 0 {
 		return fmt.Errorf("bot scopes missing required scope(s): %s", strings.Join(missing, ","))
 	}

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -102,8 +102,8 @@ type TokenStore interface {
 // used solely for views.open (see apps/slack/cmd/main.go), which requires no
 // scope (https://docs.slack.dev/reference/methods/views.open), and `commands`
 // is the minimal scope to install this slash-command app into a workspace.
-// An earlier revision also requested `views:write`, which is not a real Slack
-// scope — Slack rejects it at the authorize step with `invalid_scope`.
+// Do not add `views:write`: it is not a real Slack scope, so Slack rejects it
+// at the authorize step with `invalid_scope`.
 func DefaultBotScopes() []string {
 	return []string{botScopeCommands}
 }

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -45,7 +45,6 @@ const (
 	slackOAuthBodyLimit         = 16 << 10
 	slackInstallFlow            = "slack-install"
 	botScopeCommands            = "commands"
-	botScopeViewsWrite          = "views:write"
 	slackOAuthErrorBadRedirect  = "bad_redirect_uri"
 	slackOAuthErrorUnrecognized = "unrecognized"
 )
@@ -98,9 +97,15 @@ type TokenStore interface {
 	SetSlackBotToken(ctx context.Context, workspaceID string, install *auth.SlackBotTokenInstall) error
 }
 
-// DefaultBotScopes returns the minimum Slack bot scopes needed by qURL.
+// DefaultBotScopes returns the minimum Slack bot scopes the install flow
+// requests. Only `commands` is needed: the captured per-workspace token is
+// used solely for views.open (see apps/slack/cmd/main.go), which requires no
+// scope (https://docs.slack.dev/reference/methods/views.open), and `commands`
+// is the minimal scope to install this slash-command app into a workspace.
+// An earlier revision also requested `views:write`, which is not a real Slack
+// scope — Slack rejects it at the authorize step with `invalid_scope`.
 func DefaultBotScopes() []string {
-	return []string{botScopeCommands, botScopeViewsWrite}
+	return []string{botScopeCommands}
 }
 
 // RegisterRoutes wires the Slack install OAuth endpoints onto mux.

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -108,6 +108,24 @@ func DefaultBotScopes() []string {
 	return []string{botScopeCommands}
 }
 
+// DropUnsupportedScopes removes scope strings that are not real Slack OAuth
+// scopes (currently just views:write — see DefaultBotScopes) from an
+// operator-supplied scope set, returning the kept and dropped scopes. Slack
+// rejects such scopes at authorize with invalid_scope, so callers strip them
+// from SLACK_BOT_SCOPES overrides — keeping installs working off the valid
+// scopes — and surface the dropped scopes to the operator. Matching is
+// case-insensitive because NormalizeScopes does not lowercase.
+func DropUnsupportedScopes(scopes []string) (kept, dropped []string) {
+	for _, s := range scopes {
+		if strings.EqualFold(s, "views:write") {
+			dropped = append(dropped, s)
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept, dropped
+}
+
 // RegisterRoutes wires the Slack install OAuth endpoints onto mux.
 func RegisterRoutes(mux *http.ServeMux, cfg *Config) error {
 	if cfg == nil {

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -88,6 +88,31 @@ func TestConfigValidateRequiresCommandsScope(t *testing.T) {
 	}
 }
 
+func TestDropUnsupportedScopes(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          []string
+		wantKept    string
+		wantDropped string
+	}{
+		{"nothing unsupported", []string{"commands", "chat:write"}, "commands,chat:write", ""},
+		{"strips views:write", []string{"commands", "views:write"}, "commands", "views:write"},
+		{"case-insensitive", []string{"commands", "Views:Write"}, "commands", "Views:Write"},
+		{"only views:write leaves empty", []string{"views:write"}, "", "views:write"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kept, dropped := DropUnsupportedScopes(tt.in)
+			if strings.Join(kept, ",") != tt.wantKept {
+				t.Errorf("kept = %v, want %q", kept, tt.wantKept)
+			}
+			if strings.Join(dropped, ",") != tt.wantDropped {
+				t.Errorf("dropped = %v, want %q", dropped, tt.wantDropped)
+			}
+		})
+	}
+}
+
 func TestInstallRedirectsToSlackAuthorizeWithStateCookie(t *testing.T) {
 	store := &fakeTokenStore{}
 	w := httptest.NewRecorder()

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -21,7 +21,7 @@ const testStateSecret = "0123456789abcdef0123456789abcdef"
 const (
 	testClientID        = "111.222"
 	testClientSecret    = "secret"
-	testScopeCSV        = "commands,views:write"
+	testScopeCSV        = "commands"
 	testWorkspaceID     = "T_WORKSPACE"
 	testEnterpriseID    = "E_GRID"
 	testWorkspaceToken  = "xoxb-123456789012345678901234567890"
@@ -57,7 +57,7 @@ func testConfig(store *fakeTokenStore) Config {
 		ClientSecret: testClientSecret,
 		SlackBaseURL: "https://slack-bot.example",
 		StateSecret:  []byte(testStateSecret),
-		BotScopes:    []string{botScopeCommands, botScopeViewsWrite},
+		BotScopes:    []string{botScopeCommands},
 		TokenStore:   store,
 		Now:          func() time.Time { return time.Unix(1800000000, 0).UTC() },
 	}
@@ -74,13 +74,17 @@ func testStateHTTPCookie(value string) *http.Cookie {
 	}
 }
 
-func TestConfigValidateRequiresGuidedInstallScopes(t *testing.T) {
+func TestConfigValidateRequiresCommandsScope(t *testing.T) {
 	cfg := testConfig(&fakeTokenStore{})
+	// `commands` alone is sufficient: views.open (the only consumer of the
+	// captured token) requires no scope, so the install flow no longer
+	// requests the nonexistent views:write scope.
 	cfg.BotScopes = []string{botScopeCommands}
-	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), botScopeViewsWrite) {
-		t.Fatalf("Validate error = %v, want missing views:write", err)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate error = %v, want nil for commands-only scopes", err)
 	}
-	cfg.BotScopes = []string{botScopeViewsWrite}
+	// A scope set missing `commands` is still rejected.
+	cfg.BotScopes = []string{"chat:write"}
 	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), botScopeCommands) {
 		t.Fatalf("Validate error = %v, want missing commands", err)
 	}
@@ -550,10 +554,12 @@ func TestCallbackRejectsMissingRequiredSlackScopes(t *testing.T) {
 	}
 	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// Grant a scope set that omits the required `commands` scope, so
+		// missingRequiredScopes flags it and the callback rejects with 422.
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":                 true,
 			testAccessTokenKey:   testWorkspaceToken,
-			testResponseKeyScope: botScopeCommands,
+			testResponseKeyScope: "chat:write",
 			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -76,9 +76,7 @@ func testStateHTTPCookie(value string) *http.Cookie {
 
 func TestConfigValidateRequiresCommandsScope(t *testing.T) {
 	cfg := testConfig(&fakeTokenStore{})
-	// `commands` alone is sufficient: views.open (the only consumer of the
-	// captured token) requires no scope, so the install flow no longer
-	// requests the nonexistent views:write scope.
+	// `commands` alone is sufficient (see DefaultBotScopes for why).
 	cfg.BotScopes = []string{botScopeCommands}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate error = %v, want nil for commands-only scopes", err)

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -88,6 +88,16 @@ func TestConfigValidateRequiresCommandsScope(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsUnsupportedScope(t *testing.T) {
+	cfg := testConfig(&fakeTokenStore{})
+	// Direct construction bypasses the cmd-layer strip, so Validate must reject
+	// views:write itself rather than forward it to Slack (invalid_scope).
+	cfg.BotScopes = []string{botScopeCommands, "views:write"}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "views:write") {
+		t.Fatalf("Validate error = %v, want rejection naming views:write", err)
+	}
+}
+
 func TestDropUnsupportedScopes(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -91,7 +91,7 @@ func TestConfigValidateRequiresCommandsScope(t *testing.T) {
 func TestConfigValidateRejectsUnsupportedScope(t *testing.T) {
 	cfg := testConfig(&fakeTokenStore{})
 	// Direct construction bypasses the cmd-layer strip, so Validate must reject
-	// views:write itself rather than forward it to Slack (invalid_scope).
+	// views:write itself rather than forward it to Slack.
 	cfg.BotScopes = []string{botScopeCommands, "views:write"}
 	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "views:write") {
 		t.Fatalf("Validate error = %v, want rejection naming views:write", err)

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -422,7 +422,7 @@ func TestDDBProviderSetSlackBotToken(t *testing.T) {
 		BotUserID:    "U_BOT",
 		AppID:        "A_APP",
 		EnterpriseID: "E_GRID",
-		Scopes:       []string{"views:write", "commands", "views:write"},
+		Scopes:       []string{"chat:write", "commands", "chat:write"},
 	})
 	if err != nil {
 		t.Fatalf("SetSlackBotToken: %v", err)
@@ -437,7 +437,7 @@ func TestDDBProviderSetSlackBotToken(t *testing.T) {
 	if v, ok := values[":dk"].(*ddbtypes.AttributeValueMemberB); !ok || string(v.Value) != passthroughWrappedKey {
 		t.Errorf("slack token data key wrong: %v", values[":dk"])
 	}
-	if v, ok := values[":scopes"].(*ddbtypes.AttributeValueMemberSS); !ok || strings.Join(v.Value, ",") != "commands,views:write" {
+	if v, ok := values[":scopes"].(*ddbtypes.AttributeValueMemberSS); !ok || strings.Join(v.Value, ",") != "chat:write,commands" {
 		t.Errorf("scopes should be sorted/deduped: %v", values[":scopes"])
 	}
 	if got := *ddb.updateInput.UpdateExpression; !strings.Contains(got, "slack_bot_installed_at = if_not_exists(slack_bot_installed_at, :now)") {


### PR DESCRIPTION
## Problem

The Slack app-install flow requested bot scopes `commands` + `views:write` (`slackinstall.DefaultBotScopes()`), but **`views:write` is not a real Slack OAuth scope**:

- Slack's `views.open` — the call that renders the `/qurl tunnel install` modal — requires **no scope** ([docs](https://docs.slack.dev/reference/methods/views.open): *"Scopes: No scopes required"*).
- The "Add an OAuth Scope" picker on api.slack.com doesn't list `views:write`.

Because the install handler put `commands,views:write` in the Slack `oauth/v2/authorize` URL, Slack would reject the flow with **`invalid_scope`** (an error the callback already allowlists in `safeSlackOAuthErrorCode`), so the workspace app-install flow could never capture a bot token. There was also no env workaround: `Config.Validate()` hard-rejected any scope set missing `views:write`. This never surfaced live only because the flow was never activated (its env vars weren't wired — that wiring is `qurl-integrations-infra#800`).

## Fix

The captured per-workspace token is used **solely** for `views.open` (`apps/slack/cmd/main.go`: *"Slack views.open wired with per-workspace token lookup"*), which needs no scope. `commands` is the minimal scope required to install the slash-command app into a workspace. So `DefaultBotScopes()` now returns just `["commands"]`.

- `routes.go`: remove the `botScopeViewsWrite` const; `DefaultBotScopes()` → `["commands"]` (with a comment explaining why).
- `routes_test.go`: a `commands`-only config now validates; the missing-required-scope callback test grants a scope set **without** `commands` so it still exercises the 422 rejection path.
- `main_test.go`: default-scope and custom-scope assertions use real scopes.
- `README.md`: correct the `SLACK_BOT_SCOPES` default (`commands`) and the bot-scope setup guidance.

## Validation

`go build ./apps/slack/...`, `go test ./apps/slack/internal/slackinstall/... ./apps/slack/cmd/...`, `go vet`, and `pre-commit run` all pass.

## Context

This is the code-side companion to the infra activation of the Slack app install flow (`qurl-integrations-infra#800` wired `SLACK_CLIENT_ID/SECRET`). Without this fix, the install OAuth fails at the authorize step regardless of infra/manifest. Note: the Slack app manifest must **not** carry `views:write` either — `apps.manifest.update` would reject it.