### PR TITLE
fix(slack): aliases (not "shortcuts"), clearer slug/alias in list & aliases, self-heal legacy /qurl setup owner rows

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -791,7 +791,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			// the mention surface.
 			if looksLikeSlackUserID(ownerID) {
 				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID) //nolint:gosec // G706: slog escapes control bytes in attribute values; owner_user_id is shape-validated by looksLikeSlackUserID above.
-				respondSlack(w, fmt.Sprintf("`/qurl setup` can only be re-run by the person who first connected qURL to this workspace (<@%s>) — this stops anyone else from re-pointing it at a different qURL account. Ask them to re-run it. For admin tasks that don't need re-connecting, use the other `/qurl admin` commands.", ownerID))
+				respondSlack(w, fmt.Sprintf("`/qurl setup` can only be re-run by the person who first connected qURL to this workspace (<@%s>). This stops anyone else from re-pointing it at a different qURL account, so ask them to re-run it. For admin tasks that don't need re-connecting, use the other `/qurl admin` commands.", ownerID))
 				return
 			}
 			// Shape-bad owner_id → a pre-pivot Auth0 sub left behind by
@@ -802,7 +802,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			// callback by reclaiming the orphaned row for this caller
 			// (first-come-claims, the same posture as an unbound
 			// workspace). Log loudly so the legacy reclaim is grep-able.
-			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID and owner_id_len is an int.
+			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID, legacy_owner_prefix is the bounded provider prefix, owner_id_len is an int.
 		}
 	}
 	state, err := oauth.MintState(h.oauthSetup.StateSecret, teamID, userID, h.now())

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -751,7 +751,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 		_, ownerID, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
 		if err != nil {
 			slog.Error("/qurl setup: owner check failed", "error", err, "team_id", teamID, "caller_user_id", userID)
-			respondSlack(w, ":warning: could not verify workspace ownership (upstream error; see logs). Try again in a moment.")
+			respondSlack(w, ":warning: could not verify who connected qURL to this workspace (upstream error; see logs). Try again in a moment.")
 			return
 		}
 		// ownerID=="" → workspace not yet bound → fresh install, allow.
@@ -786,20 +786,23 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			// into a `<@%s>` mention. BindWorkspace writes owner_id
 			// from the OAuth callback (a different code path than the
 			// parser), and a pre-pivot row holds an Auth0 sub, not a
-			// Slack ID — exactly the case the migration runbook calls
-			// out. Mirrors the looksLikeSlackUserID guard in
+			// Slack ID. Mirrors the looksLikeSlackUserID guard in
 			// handleAdminList so a malformed value can't break out of
-			// the mention surface. Branch the whole reply so the
-			// shape-bad copy reads cleanly rather than "the current
-			// owner is the existing workspace owner".
+			// the mention surface.
 			if looksLikeSlackUserID(ownerID) {
 				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID) //nolint:gosec // G706: slog escapes control bytes in attribute values; owner_user_id is shape-validated by looksLikeSlackUserID above.
-				respondSlack(w, fmt.Sprintf("Only the workspace owner can re-run `/qurl setup`. The current owner is <@%s>. Ask them to re-run setup. For admin actions that don't need workspace ownership, use the other `/qurl admin` commands.", ownerID))
-			} else {
-				slog.Error("/qurl setup: rebind refused; stored owner_id is shape-bad — likely a pre-pivot Auth0 sub. Operator must delete the workspace_mappings row to recover.", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID and owner_id_len is an int.
-				respondSlack(w, "Only the workspace owner can re-run `/qurl setup`, but this workspace's stored owner record is malformed and can't be displayed (likely a legacy record). Please contact support to recover access.")
+				respondSlack(w, fmt.Sprintf("`/qurl setup` can only be re-run by the person who first connected qURL to this workspace (<@%s>) — this stops anyone else from re-pointing it at a different qURL account. Ask them to re-run it. For admin tasks that don't need re-connecting, use the other `/qurl admin` commands.", ownerID))
+				return
 			}
-			return
+			// Shape-bad owner_id → a pre-pivot Auth0 sub left behind by
+			// the #510 owner-model migration. No Slack user can ever
+			// match it, so this workspace is locked for everyone unless
+			// we let setup recover it. DON'T dead-end here — fall through
+			// to mint the setup URL; BindWorkspace self-heals on the
+			// callback by reclaiming the orphaned row for this caller
+			// (first-come-claims, the same posture as an unbound
+			// workspace). Log loudly so the legacy reclaim is grep-able.
+			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID)) //nolint:gosec // G706: slog escapes control bytes in attribute values; caller_user_id is the Slack-payload user ID and owner_id_len is an int.
 		}
 	}
 	state, err := oauth.MintState(h.oauthSetup.StateSecret, teamID, userID, h.now())
@@ -862,6 +865,10 @@ func (h *Handler) helpMessage() string {
 		"*Commands:*",
 	}
 	if h.cfg.AdminStore != nil {
+		// Glossary so the `$slug` / `$alias` tokens in the verbs and in
+		// `/qurl list` aren't unexplained. Only shown when AdminStore is
+		// wired — that's the only deploy where aliases exist.
+		//
 		// get resolves its $slug/$alias token through resolveTokenForGet,
 		// which fails closed (":warning: not configured") when AdminStore is
 		// nil — the URL form that once let get work without DDB is gone
@@ -869,6 +876,8 @@ func (h *Handler) helpMessage() string {
 		// advertises a verb whose only reply would be the not-configured
 		// error (same rule as `/qurl aliases` below).
 		lines = append(lines,
+			"_A tunnel's `$slug` is its name. A `$alias` is an alternate name for a tunnel in a channel — several aliases can point to one slug. Use either with `/qurl get`._",
+			"",
 			"• `/qurl get <$slug|$alias>` — Mint a one-time qURL for a tunnel `$slug` or a `$alias` configured in this channel",
 		)
 		if h.cfg.PostDM != nil {
@@ -888,7 +897,7 @@ func (h *Handler) helpMessage() string {
 		// otherwise help could advertise `/qurl aliases` on a deploy where
 		// it replies ":warning: not configured".
 		lines = append(lines,
-			"• `/qurl aliases` — List the qURL shortcuts configured in this channel",
+			"• `/qurl aliases` — List this channel's aliases and the tunnel each one points to",
 		)
 	}
 	lines = append(lines,
@@ -902,7 +911,7 @@ func (h *Handler) helpMessage() string {
 	// help text matches the actual behavior of the deployment.
 	setupLine := "• `/qurl setup` — Connect qURL to your Slack workspace"
 	if h.cfg.AdminStore != nil {
-		setupLine += " (the first runner becomes the workspace owner; only they can re-run it)"
+		setupLine += " (whoever first runs it is the only one who can re-run it — this keeps the workspace's qURL account from being switched to someone else)"
 	}
 	lines = append(lines, setupLine)
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
@@ -924,9 +933,9 @@ func (h *Handler) helpMessage() string {
 		// setalias/unsetalias reply ":warning: not configured" on a
 		// sandbox deploy without an aliasStore; mirror the PostDM gate
 		// above so help doesn't advertise verbs whose reply tells the
-		// user they can't be used. Keep user-facing copy on "shortcut"
-		// even though the admin verbs retain their historical
-		// set-alias/unset-alias names.
+		// user they can't be used. User-facing copy calls these
+		// "aliases" (not "shortcuts") even though the admin verbs retain
+		// their historical set-alias/unset-alias names.
 		//
 		// Gates on aliasStore (NOT AdminStore) by design: set-alias WRITES
 		// through the aliasStore and is admin-gated at the Slack manifest
@@ -938,8 +947,8 @@ func (h *Handler) helpMessage() string {
 		// shape, where set-alias would show without `/qurl aliases`, is not
 		// a real deployment: both come from the same QURL_*_TABLE env vars.)
 		lines = append(lines,
-			"• `/qurl set-alias $<alias> $<slug>` — Point a qURL shortcut at a tunnel slug in this channel (admin only)",
-			"• `/qurl unset-alias $<alias>` — Remove a qURL shortcut in this channel (admin only)",
+			"• `/qurl set-alias $<alias> $<slug>` — Point an alias at a tunnel slug in this channel (admin only)",
+			"• `/qurl unset-alias $<alias>` — Remove an alias from this channel (admin only)",
 		)
 	}
 	if h.cfg.AdminStore != nil {
@@ -952,7 +961,7 @@ func (h *Handler) helpMessage() string {
 		lines = append(lines,
 			"• `/qurl admin add @user` — Promote a Slack user to bot admin (admin only)",
 			"• `/qurl admin remove @user` — Demote a Slack user from bot admin (admin only)",
-			"• `/qurl admin list` — List the workspace owner and current bot admins (admin only)",
+			"• `/qurl admin list` — List who connected qURL (the owner) and the current bot admins (admin only)",
 			"• `/qurl admin revoke <qurl_id>` — Revoke a single qURL (admin only)",
 		)
 	}

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -308,7 +308,7 @@ func (h *Handler) handleAdminRemove(w http.ResponseWriter, teamID, callerUserID 
 		if errors.As(err, &se) {
 			switch {
 			case se.StatusCode == http.StatusBadRequest && se.Code == slackdata.ErrCodeCannotRemoveOwner:
-				respondSlack(w, fmt.Sprintf("Can't remove <@%s> — they're the workspace owner. Transfer ownership via OAuth re-install first.", target))
+				respondSlack(w, fmt.Sprintf("Can't remove <@%s> — they connected qURL to this workspace, so they can't be removed as an admin.", target))
 				return
 			case se.StatusCode == http.StatusNotFound && se.Code == slackdata.ErrCodeWorkspaceNotBound:
 				// Unreachable in practice: requireAdminSync short-
@@ -368,7 +368,7 @@ func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID st
 	// escapeMrkdwnCode posture in views.go). The user-visible copy
 	// omits the internal table name; the slog.Error below carries
 	// it for on-call triage.
-	ownerCopy := "(unknown — workspace owner record is missing; contact support)"
+	ownerCopy := "(unknown — the qURL setup record is missing; contact support)"
 	if looksLikeSlackUserID(ownerID) {
 		ownerCopy = fmt.Sprintf("<@%s>", ownerID)
 	} else {
@@ -397,7 +397,7 @@ func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID st
 		}
 		otherAdmins = append(otherAdmins, fmt.Sprintf("<@%s>", a))
 	}
-	body := "Owner: " + ownerCopy
+	body := "Owner (connected qURL): " + ownerCopy
 	if len(otherAdmins) > 0 {
 		body += "\nAdmins: " + strings.Join(otherAdmins, ", ")
 	}
@@ -426,18 +426,11 @@ func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID st
 // (a different code path), and admin_slack_user_ids could in
 // principle be hand-mutated. Cheap insurance against a malformed
 // value breaking out of the mention surface.
+//
+// Thin wrapper over slackdata.LooksLikeSlackUserID — the store layer
+// owns the shape check because BindWorkspace also depends on it (to
+// detect a legacy Auth0-sub owner_id for self-heal). Keeping one
+// implementation stops the two from drifting.
 func looksLikeSlackUserID(s string) bool {
-	if len(s) < 9 || len(s) > 64 {
-		return false
-	}
-	if s[0] != 'U' && s[0] != 'W' {
-		return false
-	}
-	for i := 1; i < len(s); i++ {
-		c := s[i]
-		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
-			return false
-		}
-	}
-	return true
+	return slackdata.LooksLikeSlackUserID(s)
 }

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -491,7 +491,7 @@ func TestHandleAdminRemove_OwnerRemoveRefused(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, reply := inv.invokeAdmin("admin remove <@"+testAdminOwnerID+">", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "workspace owner") {
+	if !strings.Contains(reply, "connected qURL to this workspace") {
 		t.Errorf("reply missing owner-remove guard: %q", reply)
 	}
 }
@@ -529,7 +529,7 @@ func TestHandleAdminList_HappyPath(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, reply := inv.invokeAdmin(testAdminListCmd, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "Owner: <@"+testAdminOwnerID+">") {
+	if !strings.Contains(reply, "Owner (connected qURL): <@"+testAdminOwnerID+">") {
 		t.Errorf("reply missing owner line: %q", reply)
 	}
 	if !strings.Contains(reply, "Admins:") {
@@ -573,7 +573,7 @@ func TestHandleAdminList_OwnerOnAdminSet(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, reply := inv.invokeAdmin(testAdminListCmd, testAdminTeamID, testAdminOwnerID)
-	if !strings.Contains(reply, "Owner: <@"+testAdminOwnerID+">") {
+	if !strings.Contains(reply, "Owner (connected qURL): <@"+testAdminOwnerID+">") {
 		t.Errorf("reply missing owner line: %q", reply)
 	}
 	// Both non-owner admins must appear on the Admins line.
@@ -605,7 +605,7 @@ func TestHandleAdminList_OwnerOnly(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, reply := inv.invokeAdmin(testAdminListCmd, testAdminTeamID, testAdminOwnerID)
-	if !strings.Contains(reply, "Owner: <@"+testAdminOwnerID+">") {
+	if !strings.Contains(reply, "Owner (connected qURL): <@"+testAdminOwnerID+">") {
 		t.Errorf("reply missing owner line: %q", reply)
 	}
 	if strings.Contains(reply, "Admins:") {
@@ -617,7 +617,7 @@ func TestHandleAdminList_OwnerOnly(t *testing.T) {
 // storage-corruption render path: when workspace_mappings is
 // missing owner_id (impossible today via readStringSet but
 // defensive against a future contract change), the reply renders
-// the explicit "(unknown — workspace owner record is missing;
+// the explicit "(unknown — the qURL setup record is missing;
 // contact support)" copy instead of a malformed `Owner: <@>`
 // mrkdwn link. User-visible copy omits the internal table name;
 // the slog.Error carries it for triage.
@@ -637,7 +637,7 @@ func TestHandleAdminList_EmptyOwnerCorruption(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, reply := inv.invokeAdmin(testAdminListCmd, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "workspace owner record is missing") {
+	if !strings.Contains(reply, "qURL setup record is missing") {
 		t.Errorf("reply missing storage-corruption surface: %q", reply)
 	}
 	if strings.Contains(reply, "Owner: <@>") {
@@ -1083,24 +1083,29 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		if strings.Contains(got, "/oauth/qurl/start?state=") {
 			t.Fatalf("non-owner: setup URL was minted (should be refused): %q", got)
 		}
-		// The reply must mention the existing owner so the requester
-		// knows whom to ask. The mention syntax `<@U…>` is what Slack
-		// renders into a clickable user reference.
+		// The reply must mention the person who connected qURL so the
+		// requester knows whom to ask. The mention syntax `<@U…>` is what
+		// Slack renders into a clickable user reference.
 		if !strings.Contains(got, "<@"+owner+">") {
 			t.Errorf("non-owner: reply missing owner mention <@%s>, got: %q", owner, got)
 		}
-		if !strings.Contains(got, "owner") {
-			t.Errorf("non-owner: reply missing 'owner' word for clarity, got: %q", got)
+		// Copy names who can re-run setup ("the person who first connected
+		// qURL") rather than the ambiguous "workspace owner" — guard the
+		// new framing stays.
+		if !strings.Contains(got, "connected qURL") {
+			t.Errorf("non-owner: reply missing 'connected qURL' framing for clarity, got: %q", got)
 		}
 	})
 
-	t.Run("shape-bad owner_id (pre-pivot Auth0 sub): refused without broken mention", func(t *testing.T) {
+	t.Run("shape-bad owner_id (pre-pivot Auth0 sub): setup allowed so the legacy row can be reclaimed", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		// Migration-day state: a pre-pivot row whose owner_id holds the
-		// Auth0 id_token sub, not a Slack ID. A non-owner rerun must be
-		// refused WITHOUT interpolating the sub into a `<@…>` mention
-		// (which Slack would render visibly broken). Seed the row
-		// directly since BindWorkspace now only ever writes Slack IDs.
+		// Auth0 id_token sub, not a Slack ID. No Slack user can ever match
+		// it, so the gate must NOT dead-end — it falls through to mint the
+		// setup URL, and BindWorkspace self-heals on the callback by
+		// reclaiming the orphaned row for the caller (first-come-claims).
+		// The reply must not leak the raw Auth0 sub. Seed the row directly
+		// since BindWorkspace now only ever writes Slack IDs.
 		const auth0Sub = "auth0|653fpre-pivot-subxyz"
 		ts.ddb.seedItem(t, ts.tableNames.workspace, map[string]ddbtypes.AttributeValue{
 			fAttrSlackTeamID:       stringMember(team),
@@ -1112,17 +1117,14 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		wireSetup(t, h)
 
 		got := invokeSetup(t, h, stranger)
-		if strings.Contains(got, "/oauth/qurl/start?state=") {
-			t.Fatalf("shape-bad owner: setup URL was minted (should be refused): %q", got)
+		if !strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Fatalf("shape-bad owner: expected setup URL so the legacy row can be reclaimed, got: %q", got)
 		}
 		if strings.Contains(got, auth0Sub) {
-			t.Errorf("shape-bad owner: reply leaked the raw Auth0 sub (anywhere, incl. the mention surface): %q", got)
+			t.Errorf("shape-bad owner: reply leaked the raw Auth0 sub: %q", got)
 		}
 		if strings.Contains(got, "<@") {
-			t.Errorf("shape-bad owner: reply rendered a mention surface instead of the malformed-record fallback: %q", got)
-		}
-		if !strings.Contains(got, "malformed") {
-			t.Errorf("shape-bad owner: reply missing the malformed-record fallback copy, got: %q", got)
+			t.Errorf("shape-bad owner: reply rendered a mention surface (should be the plain setup-URL copy): %q", got)
 		}
 	})
 
@@ -1166,7 +1168,7 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		if strings.Contains(got, "/oauth/qurl/start?state=") {
 			t.Fatalf("CheckAdmin error: setup URL was minted (must fail closed): %q", got)
 		}
-		if !strings.Contains(got, "could not verify workspace ownership") {
+		if !strings.Contains(got, "could not verify who connected qURL") {
 			t.Errorf("CheckAdmin error: reply missing the upstream-error surface, got: %q", got)
 		}
 	})

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -182,7 +182,7 @@ func parseAliasArgs(text string, wantTarget bool) (parsed *aliasArgs, userMsg st
 }
 
 func validateChannelShortcutToken(tok string) (alias, reason string) {
-	return validateAliasTokenForNoun(tok, "Channel shortcut", "channel shortcut")
+	return validateAliasTokenForNoun(tok, "Channel alias", "channel alias")
 }
 
 func validateAliasTokenForNoun(tok, noun, nounLower string) (alias, reason string) {

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -125,7 +125,10 @@ func groupAliasEntriesByResource(entries []slackdata.PolicyEntry) []aliasGroup {
 		key := rid
 		if key == "" {
 			// No shared resource — key each resource-less row uniquely
-			// so two of them don't collapse into one line.
+			// so two of them don't collapse into one line. The "\x00"
+			// sentinel can't appear in a real resource_id (DDB string
+			// attrs written by this code are alias/slug/r_-id shaped), so
+			// it can't collide with a populated rid.
 			key = "\x00" + entries[i].Alias
 		}
 		gi, ok := idx[key]
@@ -185,6 +188,13 @@ loop:
 				// same resource, so one lookup (via the first alias)
 				// resolves the whole group. A tunnel carries a Slug and
 				// no TargetURL; a legacy URL binding the reverse.
+				//
+				// This single-fetch optimization assumes the upstream
+				// lookup-by-alias returns the canonical resource (the same
+				// one all aliases in the group are bound to in DDB), not an
+				// alias-specific view. True today; if GetResourceByAlias
+				// ever returned a per-alias view, a group line could pick up
+				// the wrong slug — fetch per alias then.
 				if r, rerr := c.GetResourceByAlias(ctx, g.aliases[0]); rerr == nil {
 					target = r.TargetURL
 					slug = r.Slug

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -90,43 +89,87 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 		return
 	}
 
-	// Render each entry as a line. Per-row resource fetch is
-	// best-effort — a failed fetch degrades to id-only rather than
-	// dropping the entry.
-	lines := fanoutAliasRows(ctx, log, c, entries, aliasesResourceFanoutLimit)
+	// Collapse the per-alias bindings into one group per tunnel: several
+	// aliases can point to the same slug, so the listing shows the slug
+	// once followed by every alias that resolves to it here. Per-group
+	// resource fetch is best-effort — a failed fetch degrades to a
+	// resource-id line rather than dropping the group.
+	groups := groupAliasEntriesByResource(entries)
+	lines := fanoutAliasGroups(ctx, log, c, groups, aliasesResourceFanoutLimit)
 	sort.Strings(lines)
 
-	body := "*Aliases configured for this channel:*\n" + strings.Join(lines, "\n")
+	body := "*Aliases configured for this channel:*\n" + strings.Join(lines, "\n") +
+		"\n\n_Each line is a tunnel `$<slug>` followed by the aliases that resolve to it here. Run `/qurl get` with the slug or any alias._"
 	_ = h.postResponse(log, responseURL, body)
 }
 
-// fanoutAliasRows renders the per-entry alias lines using a bounded
-// worker pool. The dispatcher honors ctx.Done() while waiting for a
-// semaphore slot — without this, a cancellation that fires while the
-// loop is queuing rows (more entries than `limit`) would block on
-// `sem <- {}` indefinitely (the workers only honor ctx through their
-// downstream HTTP call). Rows that don't get dispatched fall back to
-// id-only lines via [formatAliasLine] so the user still sees one
-// line per entry.
+// aliasGroup collects every channel alias bound to one resource, so
+// /qurl aliases renders a single line per tunnel (its slug plus all the
+// aliases that resolve to it) rather than one line per alias.
+type aliasGroup struct {
+	resourceID string
+	aliases    []string // channel aliases bound to resourceID, sorted
+}
+
+// groupAliasEntriesByResource collapses per-alias PolicyEntry rows into
+// one aliasGroup per resource_id — several aliases can point to the same
+// tunnel. Resource-less rows (legacy/synthetic, resource_id == "") each
+// become their own group keyed by alias so they aren't merged together
+// or dropped. Insertion order is preserved; the caller sorts the
+// rendered lines.
+func groupAliasEntriesByResource(entries []slackdata.PolicyEntry) []aliasGroup {
+	idx := make(map[string]int, len(entries))
+	groups := make([]aliasGroup, 0, len(entries))
+	for i := range entries {
+		rid := entries[i].ResourceID
+		key := rid
+		if key == "" {
+			// No shared resource — key each resource-less row uniquely
+			// so two of them don't collapse into one line.
+			key = "\x00" + entries[i].Alias
+		}
+		gi, ok := idx[key]
+		if !ok {
+			gi = len(groups)
+			groups = append(groups, aliasGroup{resourceID: rid})
+			idx[key] = gi
+		}
+		if entries[i].Alias != "" {
+			groups[gi].aliases = append(groups[gi].aliases, entries[i].Alias)
+		}
+	}
+	for i := range groups {
+		sort.Strings(groups[i].aliases)
+	}
+	return groups
+}
+
+// fanoutAliasGroups renders the per-group alias lines using a bounded
+// worker pool — one resource fetch per group, NOT per alias (grouping by
+// resource_id means two aliases on the same tunnel cost a single fetch).
+// The dispatcher honors ctx.Done() while waiting for a semaphore slot —
+// without this, a cancellation that fires while the loop is queuing rows
+// (more groups than `limit`) would block on `sem <- {}` indefinitely
+// (the workers only honor ctx through their downstream HTTP call).
+// Groups that don't get dispatched fall back to resource-id-only lines
+// via [formatAliasGroupLine] so the user still sees one line per group.
 //
-// Output order is non-deterministic — the caller sorts before
-// rendering.
-func fanoutAliasRows(ctx context.Context, log *slog.Logger, c *client.Client, entries []slackdata.PolicyEntry, limit int) []string {
+// Output order is non-deterministic — the caller sorts before rendering.
+func fanoutAliasGroups(ctx context.Context, log *slog.Logger, c *client.Client, groups []aliasGroup, limit int) []string {
 	if limit < 1 {
 		limit = 1
 	}
-	lines := make([]string, len(entries))
+	lines := make([]string, len(groups))
 	sem := make(chan struct{}, limit)
 	var wg sync.WaitGroup
 loop:
-	for i := range entries {
+	for i := range groups {
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			// Fill un-dispatched tail with id-only fallbacks.
-			for j := i; j < len(entries); j++ {
-				e := &entries[j]
-				lines[j] = formatAliasLine(e.Alias, "", "", e.ResourceID)
+			for j := i; j < len(groups); j++ {
+				lines[j] = formatAliasGroupLine(groups[j].resourceID, "", "", groups[j].aliases)
 			}
 			break loop
 		}
@@ -134,22 +177,15 @@ loop:
 		go func(idx int) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			e := &entries[idx]
-			alias := e.Alias
-			target := ""
-			slug := ""
-			if e.ResourceID != "" && e.Alias != "" {
-				// GetResourceByAlias is the customer-facing path that
-				// returns the full Resource (Alias, TargetURL, Slug, …).
-				// The Store row may carry alias=="" (legacy shape) — fall
-				// back to id-only in that case rather than swallowing a
-				// 404. Tunnel resources have no TargetURL but carry a
-				// Slug, which [formatAliasLine] surfaces in place of the
-				// resource_id.
-				if r, rerr := c.GetResourceByAlias(ctx, e.Alias); rerr == nil {
-					if r.Alias != "" {
-						alias = r.Alias
-					}
+			g := &groups[idx]
+			target, slug := "", ""
+			if g.resourceID != "" && len(g.aliases) > 0 {
+				// GetResourceByAlias returns the full Resource (Slug,
+				// TargetURL, …). Every alias in a group resolves to the
+				// same resource, so one lookup (via the first alias)
+				// resolves the whole group. A tunnel carries a Slug and
+				// no TargetURL; a legacy URL binding the reverse.
+				if r, rerr := c.GetResourceByAlias(ctx, g.aliases[0]); rerr == nil {
 					target = r.TargetURL
 					slug = r.Slug
 				} else if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
@@ -157,49 +193,57 @@ loop:
 					// can tell "request was cut short by SIGTERM /
 					// asyncWorkTimeout" apart from "upstream rejected
 					// this alias" when triaging.
-					log.Debug("aliases: resource fetch canceled before completion", "error", rerr, "resource_id", e.ResourceID)
+					log.Debug("aliases: resource fetch canceled before completion", "error", rerr, "resource_id", g.resourceID)
 				} else {
-					log.Debug("aliases: resource fetch failed in fanout", "error", rerr, "resource_id", e.ResourceID)
+					log.Debug("aliases: resource fetch failed in fanout", "error", rerr, "resource_id", g.resourceID)
 				}
 			}
-			lines[idx] = formatAliasLine(alias, target, slug, e.ResourceID)
+			lines[idx] = formatAliasGroupLine(g.resourceID, target, slug, g.aliases)
 		}(i)
 	}
 	wg.Wait()
 	return lines
 }
 
-// formatAliasLine renders one row of the /qurl aliases listing.
-// Right-hand side precedence, most to least specific:
+// formatAliasGroupLine renders one /qurl aliases line as
+// `<what the aliases resolve to> → <the aliases>`, so the slug/target
+// reads as the canonical thing and the `$alias` tokens as its alternate
+// names. The left side, most to least specific:
 //
-//   - target_url (URL/transit resource):   • `$<alias>` → <url>
-//   - slug (tunnel resource, no target):   • `$<alias>` → `$<slug>`
-//   - resource_id (fetch failed / legacy): • `$<alias>` → `<r_id>`
-//   - bare alias (nothing resolved):       • `$<alias>`
+//   - tunnel slug:        • `$<slug>` (tunnel) → `$<a1>`, `$<a2>`
+//   - legacy URL target:  • <url> (URL) → `$<a1>`, `$<a2>`
+//   - unresolved id:      • `<r_id>` (no slug) → `$<a1>`, `$<a2>`
+//   - nothing resolved:   • `$<a1>`, `$<a2>` (resource-less synthetic row)
 //
-// Tunnel-backed aliases have no target_url, so the slug is shown
-// instead of the opaque resource_id — it's the same `$<slug>` token
-// `/qurl list` renders and `/qurl get` accepts. resource_id remains the
-// last-resort fallback (a failed per-row fetch leaves slug empty), so
-// the user still sees one line per entry.
-func formatAliasLine(alias, target, slug, resourceID string) string {
-	if alias == "" {
-		alias = "(no alias)"
+// An alias equal to the slug is dropped from the right side — the install
+// flow binds `$<slug>` as a channel alias, so it would otherwise list
+// itself. A group whose only alias IS the slug renders just the slug.
+func formatAliasGroupLine(resourceID, target, slug string, aliases []string) string {
+	rhs := make([]string, 0, len(aliases))
+	for _, a := range aliases {
+		if a != slug {
+			rhs = append(rhs, "`$"+a+"`")
+		}
 	}
-	if target != "" {
-		return fmt.Sprintf("• `$%s` → %s", alias, target)
+	var left string
+	switch {
+	case slug != "":
+		left = "`$" + slug + "` (tunnel)"
+	case target != "":
+		left = target + " (URL)"
+	case resourceID != "":
+		left = "`" + resourceID + "` (no slug)"
+	default:
+		// No resource resolved at all — show the alias names alone so the
+		// row still renders (resource-less synthetic entry; a real
+		// PolicyEntry always carries a resource_id).
+		if len(rhs) == 0 {
+			return "• (no alias)"
+		}
+		return "• " + strings.Join(rhs, ", ")
 	}
-	if slug != "" {
-		return fmt.Sprintf("• `$%s` → `$%s`", alias, slug)
+	if len(rhs) == 0 {
+		return "• " + left
 	}
-	if resourceID != "" {
-		return fmt.Sprintf("• `$%s` → `%s`", alias, resourceID)
-	}
-	// Bare token, nothing resolved. Only reachable with an empty
-	// resourceID — and fanoutAliasRows only fetches (and thus only
-	// reaches this formatter at all) when ResourceID != "", so a real
-	// PolicyEntry row never lands here. This is the defensive escape
-	// hatch for a synthetic/empty entry, kept so the listing still
-	// renders one line per entry rather than dropping it.
-	return fmt.Sprintf("• `$%s`", alias)
+	return "• " + left + " → " + strings.Join(rhs, ", ")
 }

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -61,6 +61,42 @@ func TestHandleAliases_TunnelAliasShowsSlug(t *testing.T) {
 	}
 }
 
+// TestHandleAliases_MultipleAliasesOneTunnelCollapse fences change #2's
+// headline behavior: several aliases pointing at the SAME tunnel
+// collapse onto one line — `$<slug> (tunnel) → $<a1>, $<a2>` — with the
+// aliases sorted and a single resource fetch for the group (one lookup
+// via the first alias, not one per alias).
+func TestHandleAliases_MultipleAliasesOneTunnelCollapse(t *testing.T) {
+	ts := newAdminTestServers(t)
+	// Two aliases bound to the same tunnel resource_id.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		"dashboard":       "r_kktest01",
+		"kevin-dashboard": "r_kktest01",
+	})
+	// The group resolves via its first (sorted) alias — "dashboard". One
+	// fetch covers the whole group; assert a second per-alias fetch never
+	// fires by failing if the kevin-dashboard endpoint is hit.
+	var fetches atomic.Int32
+	ts.addCustomer("GET", "/v1/resources/by-alias/dashboard", func(w http.ResponseWriter, _ *http.Request) {
+		fetches.Add(1)
+		writeTunnelResourceFixture(t, w, "r_kktest01", "dashboard", "kktest")
+	})
+	ts.addCustomer("GET", "/v1/resources/by-alias/kevin-dashboard", func(w http.ResponseWriter, _ *http.Request) {
+		fetches.Add(1)
+		writeTunnelResourceFixture(t, w, "r_kktest01", "kevin-dashboard", "kktest")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$kktest` (tunnel) → `$dashboard`, `$kevin-dashboard`") {
+		t.Errorf("aliases reply did not collapse both aliases onto one slug line: %q", async)
+	}
+	if got := fetches.Load(); got != 1 {
+		t.Errorf("resource fetches = %d, want 1 (one fetch per tunnel group, not per alias)", got)
+	}
+}
+
 // TestHandleAliases_MultiAliasChannelDisplaysAllBindings fences the
 // post-pivot multi-binding behavior: a channel with three
 // alias_bindings emits a PolicyEntry per binding, and `/qurl

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -185,6 +185,43 @@ func TestHandleAliases_AdminStoreNil(t *testing.T) {
 	}
 }
 
+// TestGroupAliasEntriesByResource fences the grouping helper behind
+// /qurl aliases: aliases sharing a resource_id collapse into one group
+// (sorted), distinct resources stay separate, and resource-less rows
+// (the defensive empty-resource_id case) are keyed per-alias so they
+// don't merge into each other.
+func TestGroupAliasEntriesByResource(t *testing.T) {
+	groups := groupAliasEntriesByResource([]slackdata.PolicyEntry{
+		{Alias: "zeta", ResourceID: "r_one"},
+		{Alias: "alpha", ResourceID: "r_one"},
+		{Alias: "solo", ResourceID: "r_two"},
+		{Alias: "ghostA", ResourceID: ""},
+		{Alias: "ghostB", ResourceID: ""},
+	})
+	if len(groups) != 4 {
+		t.Fatalf("group count = %d, want 4 (r_one collapses 2 aliases, r_two, + 2 distinct resource-less)", len(groups))
+	}
+	byKey := map[string][]string{}
+	for i := range groups {
+		// Resource-less rows share resourceID "" — key the assertion map
+		// by the first alias so they stay distinguishable.
+		key := groups[i].resourceID
+		if key == "" {
+			key = groups[i].aliases[0]
+		}
+		byKey[key] = groups[i].aliases
+	}
+	if got := byKey["r_one"]; len(got) != 2 || got[0] != "alpha" || got[1] != "zeta" {
+		t.Errorf("r_one aliases = %v, want sorted [alpha zeta]", got)
+	}
+	if got := byKey["r_two"]; len(got) != 1 || got[0] != "solo" {
+		t.Errorf("r_two aliases = %v, want [solo]", got)
+	}
+	if len(byKey["ghostA"]) != 1 || len(byKey["ghostB"]) != 1 {
+		t.Errorf("resource-less rows merged: ghostA=%v ghostB=%v", byKey["ghostA"], byKey["ghostB"])
+	}
+}
+
 // TestFanoutAliasGroups_RespectsCtxCancellation fences the dispatcher
 // loop's ctx-aware semaphore acquire: a canceled ctx during dispatch
 // fills un-dispatched groups with id-only fallbacks (no goroutine

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -28,7 +28,9 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 	if !strings.Contains(async, "Aliases configured for this channel") {
 		t.Errorf("async reply missing header: %q", async)
 	}
-	if !strings.Contains(async, "`$prod-db` → https://prod.example.com") {
+	// Legacy URL binding: the alias points at a raw URL (no slug), so the
+	// line reads "<url> (URL) → `$<alias>`".
+	if !strings.Contains(async, "https://prod.example.com (URL) → `$prod-db`") {
 		t.Errorf("async reply missing prod-db line: %q", async)
 	}
 }
@@ -49,8 +51,10 @@ func TestHandleAliases_TunnelAliasShowsSlug(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$bastion` → `$ops-bastion`") {
-		t.Errorf("aliases reply missing alias→slug mapping: %q", async)
+	// Tunnel-backed: the slug is the canonical name (left of the arrow,
+	// labeled "(tunnel)") and the alias is its alternate name.
+	if !strings.Contains(async, "`$ops-bastion` (tunnel) → `$bastion`") {
+		t.Errorf("aliases reply missing slug→alias mapping: %q", async)
 	}
 	if strings.Contains(async, "r_bastion01") {
 		t.Errorf("aliases reply leaked opaque resource_id instead of slug: %q", async)
@@ -145,19 +149,20 @@ func TestHandleAliases_AdminStoreNil(t *testing.T) {
 	}
 }
 
-// TestFanoutAliasRows_RespectsCtxCancellation fences the dispatcher
+// TestFanoutAliasGroups_RespectsCtxCancellation fences the dispatcher
 // loop's ctx-aware semaphore acquire: a canceled ctx during dispatch
-// fills un-dispatched rows with id-only fallbacks (no goroutine
+// fills un-dispatched groups with id-only fallbacks (no goroutine
 // leaks, no deadlock).
-func TestFanoutAliasRows_RespectsCtxCancellation(t *testing.T) {
+func TestFanoutAliasGroups_RespectsCtxCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so the dispatcher bails on first iteration.
 
-	entries := []slackdata.PolicyEntry{
+	// Distinct resource_ids → one group per entry.
+	groups := groupAliasEntriesByResource([]slackdata.PolicyEntry{
 		{Alias: "a", ResourceID: "r_a", ChannelID: "C"},
 		{Alias: "b", ResourceID: "r_b", ChannelID: "C"},
 		{Alias: "c", ResourceID: "r_c", ChannelID: "C"},
-	}
+	})
 
 	var hits atomic.Int32
 	ts := newAdminTestServers(t)
@@ -172,7 +177,7 @@ func TestFanoutAliasRows_RespectsCtxCancellation(t *testing.T) {
 	}
 	log := slogTestLogger(t)
 
-	lines := fanoutAliasRows(ctx, log, c, entries, 1)
+	lines := fanoutAliasGroups(ctx, log, c, groups, 1)
 	if len(lines) != 3 {
 		t.Fatalf("lines len = %d, want 3", len(lines))
 	}
@@ -204,11 +209,11 @@ func TestFanoutAliasRows_RespectsCtxCancellation(t *testing.T) {
 //     `$alias` → `r_xxx` lines instead of `$alias` → https://...).
 //
 // Without this fence, a refactor that swallows ctx in
-// [fanoutAliasRows]'s per-row goroutine (e.g., dropping the
+// [fanoutAliasGroups]'s per-group goroutine (e.g., dropping the
 // ctx-canceled branch in the error switch) would leave the
 // dispatcher waiting on wg.Wait() past the response_url deadline,
 // silently failing the entire `/qurl aliases` reply.
-func TestFanoutAliasRows_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
+func TestFanoutAliasGroups_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 	const numEntries = 80
 	entries := make([]slackdata.PolicyEntry, numEntries)
 	for i := range entries {
@@ -218,6 +223,8 @@ func TestFanoutAliasRows_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 			ChannelID:  "C",
 		}
 	}
+	// Distinct resource_ids → one group per entry.
+	groups := groupAliasEntriesByResource(entries)
 
 	ts := newAdminTestServers(t)
 	// Every resource fetch blocks until ctx is canceled — simulates a
@@ -246,7 +253,7 @@ func TestFanoutAliasRows_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	lines := fanoutAliasRows(ctx, log, c, entries, aliasesResourceFanoutLimit)
+	lines := fanoutAliasGroups(ctx, log, c, groups, aliasesResourceFanoutLimit)
 	elapsed := time.Since(start)
 
 	if len(lines) != numEntries {

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -27,7 +27,7 @@ const commonGetMintFailedMessage = "Failed to mint qURL. Please try again."
 // The breadcrumb points only at `/qurl list` (not `/qurl aliases`): list is
 // ungated and now renders each tunnel's channel `$alias` shortcuts inline, so
 // it's the single surface that always works and shows both slugs and aliases.
-const urlNotSupportedGetMessage = "`/qurl get` only works with a `$slug` or `$alias` now — raw URLs aren't supported. Run `/qurl list` to see your tunnels and their channel shortcuts."
+const urlNotSupportedGetMessage = "`/qurl get` only works with a `$slug` or `$alias` now — raw URLs aren't supported. Run `/qurl list` to see your tunnels and their channel aliases."
 
 // resourceIDNotSupportedGetMessage is the user-facing copy for a `$r_<id>`
 // `/qurl get` (the resource-id form is gone). Same terse-sentinel
@@ -126,7 +126,7 @@ func noResourceForAliasMessage(alias string) string {
 // caller can't reopen the Slack-fence-escaping surface the parser guards.
 func legacyAliasBindingMessage(alias string) string {
 	if !aliasCharsetPattern.MatchString(alias) {
-		return "That channel shortcut points at a target that's no longer supported. Please ask your Slack admin to re-point it at a tunnel with `/qurl set-alias`."
+		return "That channel alias points at a target that's no longer supported. Please ask your Slack admin to re-point it at a tunnel with `/qurl set-alias`."
 	}
 	return fmt.Sprintf("`$%s` points at a target that's no longer supported. Please ask your Slack admin to re-point it at a tunnel with `/qurl set-alias $%s $<slug>`.", alias, alias)
 }

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -107,7 +107,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		return
 	}
 	if h.aliasStore == nil {
-		respondTunnelInstallModalError(w, "Channel shortcut storage is not configured on this Slack bot deployment.")
+		respondTunnelInstallModalError(w, "Channel alias storage is not configured on this Slack bot deployment.")
 		return
 	}
 

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -140,7 +140,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	}
 
 	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") +
-		"\n\n_Copy any `$slug` or `$alias` and run `/qurl get` on it to mint a one-time qURL link. Any `(also …)` aliases shown are specific to this channel._"
+		"\n\n_Each `$<slug>` is a tunnel's name; the `(alias: …)` names are alternate names for it in this channel. Copy a slug or an alias and run `/qurl get` on it to mint a one-time qURL link._"
 	if page.HasMore {
 		// page.HasMore is a master-list signal — more resources of ANY
 		// type, not necessarily more tunnels — so this footer can fire
@@ -216,15 +216,15 @@ func tunnelDisplayToken(r *client.Resource, boundAliases []string) string {
 // line in /qurl list output:
 //
 //   - Slug only:           • `$<slug>`
-//   - With bound aliases:  • `$<slug>` (also `$<alias>`, `$<alias2>`)
+//   - With bound aliases:  • `$<slug>` (aliases: `$<alias>`, `$<alias2>`)
 //   - With description:    • `$<slug>` → <description>
 //
 // The primary token is [tunnelDisplayToken] (slug-first; never the opaque
-// r_<id>). `boundAliases` are the channel `$alias` shortcuts that resolve
+// r_<id>). `boundAliases` are the channel `$alias` names that resolve
 // to this tunnel in `/qurl get` — a tunnel can have several. They render
-// as "(also …)" so the user sees every name that works, EXCLUDING the
-// primary token itself (the install flow binds `$<slug>` as a channel
-// alias, so the slug would otherwise appear twice). The token-in-backticks
+// as "(alias: …)" / "(aliases: …)" so the user sees every name that works,
+// EXCLUDING the primary token itself (the install flow binds `$<slug>` as a
+// channel alias, so the slug would otherwise appear twice). The token-in-backticks
 // shape lets Slack render each as inline code. There is no `(tunnel)` label
 // or `[slug:...]` fragment — the whole list is tunnels and the token IS the
 // slug. The arrow joins to the human-readable description when one is set.
@@ -253,7 +253,11 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 		}
 	}
 	if len(extras) > 0 {
-		line += " (also " + strings.Join(extras, ", ") + ")"
+		label := "aliases: "
+		if len(extras) == 1 {
+			label = "alias: "
+		}
+		line += " (" + label + strings.Join(extras, ", ") + ")"
 	}
 	if r.Description != "" {
 		line += " → " + r.Description

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -86,7 +86,7 @@ func TestHandleList_RendersAllTunnels(t *testing.T) {
 
 // TestHandleList_ShowsBoundAliases fences the slug + bound-alias
 // rendering: a tunnel with several channel `$alias` shortcuts shows the
-// slug as the token and the OTHER aliases as "(also …)", sorted, with
+// slug as the token and the OTHER aliases as "(aliases: …)", sorted, with
 // the slug-binding itself excluded (the install flow binds `$<slug>` as
 // a channel alias, so it must not be repeated).
 func TestHandleList_ShowsBoundAliases(t *testing.T) {
@@ -107,7 +107,7 @@ func TestHandleList_ShowsBoundAliases(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$kktest` (also `$kevin-dashboard`, `$ops`) → Slack tunnel install for kktest") {
+	if !strings.Contains(async, "`$kktest` (aliases: `$kevin-dashboard`, `$ops`) → Slack tunnel install for kktest") {
 		t.Errorf("async reply missing slug + bound-aliases row: %q", async)
 	}
 }
@@ -117,7 +117,7 @@ func TestHandleList_ShowsBoundAliases(t *testing.T) {
 // pinned independently of the combined end-to-end TestHandleList_*
 // tests. In particular it locks the self-binding exclusion: the
 // install-flow binds `$<slug>` as a channel alias, and that name must
-// NOT re-appear in the "(also …)" extras.
+// NOT re-appear in the "(aliases: …)" extras.
 func TestFormatTunnelListLine(t *testing.T) {
 	tunnel := func(slug, desc string) *client.Resource {
 		return &client.Resource{
@@ -136,12 +136,12 @@ func TestFormatTunnelListLine(t *testing.T) {
 	}{
 		{name: "slug only, no aliases, no description", resource: tunnel(testListAliasProdDB, ""), boundAliases: nil, want: "• `$prod-db`"},
 		{name: "slug + description, no aliases", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: nil, want: "• `$prod-db` → Prod database"},
-		{name: "slug + one non-slug alias", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasGrafana}, want: "• `$prod-db` (also `$grafana`)"},
-		{name: "self-binding slug excluded from extras", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana}, want: "• `$prod-db` (also `$grafana`) → Prod database"},
+		{name: "slug + one non-slug alias", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`)"},
+		{name: "self-binding slug excluded from extras", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`) → Prod database"},
 		{name: "only the self-binding slug bound — no extras rendered", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasProdDB}, want: "• `$prod-db`"},
 		// Slug-less, resource-alias-less tunnel: no `$<token>` of its own.
 		{name: "slug-less tunnel with no bound alias renders bare resource_id", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: nil, want: "• `r_noslug0001` (no slug — ask your Slack admin to set one)"},
-		{name: "slug-less tunnel with bound aliases promotes first to primary", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: []string{testListAliasGrafana, "metrics"}, want: "• `$grafana` (also `$metrics`)"},
+		{name: "slug-less tunnel with bound aliases promotes first to primary", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: []string{testListAliasGrafana, "metrics"}, want: "• `$grafana` (alias: `$metrics`)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -228,7 +228,7 @@ func (h *Handler) handleTunnel(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	if h.aliasStore == nil {
-		respondSlack(w, "Channel shortcut storage is not configured on this Slack bot deployment. Contact the operator.")
+		respondSlack(w, "Channel alias storage is not configured on this Slack bot deployment. Contact the operator.")
 		return
 	}
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
@@ -265,7 +265,7 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 		return
 	}
 	if h.aliasStore == nil {
-		respondSlack(w, "Channel shortcut storage is not configured on this Slack bot deployment. Contact the operator.")
+		respondSlack(w, "Channel alias storage is not configured on this Slack bot deployment. Contact the operator.")
 		return
 	}
 	if h.cfg.OpenView == nil {
@@ -578,9 +578,9 @@ func (h *Handler) ensureTunnelAlias(ctx context.Context, teamID, channelID, alia
 	}
 	if found {
 		if existing == resourceID {
-			return fmt.Sprintf("qURL shortcut `$%s` is ready in this channel.", alias), nil
+			return fmt.Sprintf("qURL alias `$%s` is ready in this channel.", alias), nil
 		}
-		return fmt.Sprintf("qURL shortcut `$%s` is already used in this channel. Run `/qurl unset-alias $%s` first, or pick a different shortcut.", alias, alias), slackdata.ErrAliasAlreadyBound
+		return fmt.Sprintf("qURL alias `$%s` is already used in this channel. Run `/qurl unset-alias $%s` first, or pick a different alias.", alias, alias), slackdata.ErrAliasAlreadyBound
 	}
 	if err := h.aliasStore.BindChannelAlias(ctx, teamID, channelID, alias, resourceID); err != nil {
 		if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
@@ -589,12 +589,12 @@ func (h *Handler) ensureTunnelAlias(ctx context.Context, teamID, channelID, alia
 			// conflict to the admin.
 			existing, found, lookupErr := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, alias)
 			if lookupErr == nil && found && existing == resourceID {
-				return fmt.Sprintf("qURL shortcut `$%s` is ready in this channel.", alias), nil
+				return fmt.Sprintf("qURL alias `$%s` is ready in this channel.", alias), nil
 			}
 		}
-		return ":warning: failed to bind the channel shortcut; no bootstrap key was minted.", err
+		return ":warning: failed to bind the channel alias; no bootstrap key was minted.", err
 	}
-	return fmt.Sprintf("qURL shortcut `$%s` is ready in this channel.", alias), nil
+	return fmt.Sprintf("qURL alias `$%s` is ready in this channel.", alias), nil
 }
 
 type preparedTunnelInstallMessage struct {

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -384,7 +384,7 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 	}
 	for _, want := range []string{
 		"qURL tunnel `" + testTunnelSlug + "` is ready to install.",
-		"qURL shortcut `$" + testTunnelSlug + "` is ready in this channel.",
+		"qURL alias `$" + testTunnelSlug + "` is ready in this channel.",
 		"The shell block below prompts for it",
 		"Run this whole block on the Linux Docker host",
 		testTunnelKeyHistoryNote,
@@ -1139,7 +1139,7 @@ func TestTunnelInstallModalSubmissionMintsKubernetesInstructions(t *testing.T) {
 	}
 	for _, want := range []string{
 		"qURL tunnel `" + testTunnelSlug + "` is ready to install.",
-		"qURL shortcut `$team-dash` is ready in this channel.",
+		"qURL alias `$team-dash` is ready in this channel.",
 		"Target environment: Kubernetes.",
 		"The shell block below prompts for it",
 		"QURL_BOOTSTRAP_SECRET='qurl-tunnel-" + testTunnelSlug + "'",
@@ -1408,7 +1408,7 @@ func TestTunnelInstallModalRejectsMissingAliasStore(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "Channel shortcut storage is not configured") {
+	if !strings.Contains(w.Body.String(), "Channel alias storage is not configured") {
 		t.Fatalf("modal response = %s, want channel-shortcut store rejection", w.Body.String())
 	}
 }
@@ -1743,7 +1743,7 @@ func TestRenderTunnelInstallMessageWarnsOnDefaultImage(t *testing.T) {
 		Alias:       testTunnelSlug,
 		LocalPort:   defaultTunnelLocalPort,
 		Environment: tunnelEnvDocker,
-	}, &client.APIKey{APIKey: testTunnelAPIKey, ExpiresAt: &expiresAt}, "qURL shortcut `$prod-dashboard` is ready in this channel.")
+	}, &client.APIKey{APIKey: testTunnelAPIKey, ExpiresAt: &expiresAt}, "qURL alias `$prod-dashboard` is ready in this channel.")
 	if err != nil {
 		t.Fatalf("renderTunnelInstallMessage: %v", err)
 	}
@@ -1774,7 +1774,7 @@ func TestRenderTunnelInstallMessageRejectsUnsafeBootstrapKey(t *testing.T) {
 		Alias:       testTunnelSlug,
 		LocalPort:   defaultTunnelLocalPort,
 		Environment: tunnelEnvDocker,
-	}, &client.APIKey{APIKey: "lv_live_bad`key", ExpiresAt: &expiresAt}, "qURL shortcut `$prod-dashboard` is ready in this channel.")
+	}, &client.APIKey{APIKey: "lv_live_bad`key", ExpiresAt: &expiresAt}, "qURL alias `$prod-dashboard` is ready in this channel.")
 	if err == nil || !strings.Contains(err.Error(), "unsupported characters") {
 		t.Fatalf("renderTunnelInstallMessage err = %v, want unsupported-character rejection", err)
 	}
@@ -2172,7 +2172,7 @@ func TestTunnelInstallRetryRemintsWhenAliasAlreadyMatches(t *testing.T) {
 		t.Fatalf("first async reply = %q, want mint failure", first)
 	}
 	_, _, second := newAdminSlashInvoker(t, h).invokeAdminAsync(testTunnelInstallCmd, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(second, "lv_live_retry_bootstrap") || !strings.Contains(second, "qURL shortcut `$"+testTunnelSlug+"` is ready in this channel.") {
+	if !strings.Contains(second, "lv_live_retry_bootstrap") || !strings.Contains(second, "qURL alias `$"+testTunnelSlug+"` is ready in this channel.") {
 		t.Fatalf("second async reply = %q, want successful remint against existing alias", second)
 	}
 	if apiKeyHits != 2 {
@@ -2197,7 +2197,7 @@ func TestEnsureTunnelAliasRecoversConcurrentSameResourceBind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureTunnelAlias: %v", err)
 	}
-	if !strings.Contains(status, "qURL shortcut `$"+testTunnelSlug+"` is ready in this channel.") {
+	if !strings.Contains(status, "qURL alias `$"+testTunnelSlug+"` is ready in this channel.") {
 		t.Fatalf("status = %q, want idempotent ready copy", status)
 	}
 }
@@ -2297,7 +2297,7 @@ func TestTunnelInstallRefusesExistingDifferentAliasBeforeMintingKey(t *testing.T
 	h.SetAliasStore(h.cfg.AdminStore)
 	_, _, async := newAdminSlashInvoker(t, h).invokeAdminAsync(testTunnelInstallCmd, testAdminTeamID, testAdminUserID)
 
-	if !strings.Contains(async, "qURL shortcut") || !strings.Contains(async, "already used") {
+	if !strings.Contains(async, "qURL alias") || !strings.Contains(async, "already used") {
 		t.Fatalf("async reply = %q, want already-bound refusal", async)
 	}
 	if apiKeyHits != 0 {

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -365,6 +365,112 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 	})
 }
 
+// TestBindWorkspace_ReclaimsLegacyAuth0SubRow fences the self-heal path
+// for a pre-pivot row whose owner_id is an Auth0 sub (not a Slack ID).
+// No Slack user can ever match it, so the workspace would be permanently
+// locked; BindWorkspace must reclaim the orphaned row for the caller via
+// a compare-and-swap on the exact legacy owner_id.
+func TestBindWorkspace_ReclaimsLegacyAuth0SubRow(t *testing.T) {
+	const legacyAuth0Sub = "auth0|653fpre-pivot-subxyz"
+
+	t.Run("shape-bad owner_id is reclaimed for the caller", func(t *testing.T) {
+		var putCalls int
+		var reclaimPut *dynamodb.PutItemInput
+		store := newStore(&stubDDB{
+			putItemFn: func(in *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+				putCalls++
+				if putCalls == 1 {
+					// Initial conditional bind: the row already exists.
+					return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
+				}
+				// Second PutItem is the reclaim CAS.
+				reclaimPut = in
+				return &dynamodb.PutItemOutput{}, nil
+			},
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:     &ddbtypes.AttributeValueMemberS{Value: legacyAuth0Sub},
+				}}, nil
+			},
+		})
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: testCallerSlackID}, testCallerSlackID)
+		if err != nil {
+			t.Fatalf("BindWorkspace reclaim: got %v, want nil (legacy row should be reclaimed)", err)
+		}
+		if putCalls != 2 {
+			t.Fatalf("PutItem calls = %d, want 2 (initial conditional bind + reclaim CAS)", putCalls)
+		}
+		if reclaimPut == nil {
+			t.Fatal("reclaim PutItem not captured")
+		}
+		// The reclaim must be a CAS on the exact legacy owner_id so a
+		// concurrent reclaim can't double-write.
+		if got := aws.ToString(reclaimPut.ConditionExpression); got != "owner_id = :legacy" {
+			t.Errorf("reclaim ConditionExpression = %q, want %q", got, "owner_id = :legacy")
+		}
+		legacyVal, ok := reclaimPut.ExpressionAttributeValues[":legacy"].(*ddbtypes.AttributeValueMemberS)
+		if !ok || legacyVal.Value != legacyAuth0Sub {
+			t.Errorf("reclaim CAS :legacy = %+v, want %q", reclaimPut.ExpressionAttributeValues[":legacy"], legacyAuth0Sub)
+		}
+		// The reclaimed row's owner_id must be the caller's Slack ID.
+		newOwner, ok := reclaimPut.Item[attrOwnerID].(*ddbtypes.AttributeValueMemberS)
+		if !ok || newOwner.Value != testCallerSlackID {
+			t.Errorf("reclaim new owner_id = %+v, want %q", reclaimPut.Item[attrOwnerID], testCallerSlackID)
+		}
+	})
+
+	t.Run("reclaim loses the race → AlreadyBound", func(t *testing.T) {
+		var putCalls int
+		store := newStore(&stubDDB{
+			putItemFn: func(_ *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+				putCalls++
+				// Both the initial bind and the reclaim CAS hit a CCFE:
+				// a concurrent caller already replaced the legacy owner_id
+				// with a valid Slack owner.
+				return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
+			},
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:     &ddbtypes.AttributeValueMemberS{Value: legacyAuth0Sub},
+				}}, nil
+			},
+		})
+		err := store.BindWorkspace(context.Background(), &WorkspaceMapping{TeamID: "T", OwnerID: testCallerSlackID}, testCallerSlackID)
+		var ae *Error
+		if !errors.As(err, &ae) {
+			t.Fatalf("got %v, want *Error", err)
+		}
+		if ae.Code != ErrCodeWorkspaceAlreadyBound {
+			t.Errorf("Code = %q, want %q (lost reclaim race must refuse)", ae.Code, ErrCodeWorkspaceAlreadyBound)
+		}
+		if putCalls != 2 {
+			t.Errorf("PutItem calls = %d, want 2 (initial bind + reclaim attempt)", putCalls)
+		}
+	})
+}
+
+// TestLooksLikeSlackUserID fences the shape predicate that both the
+// handler (mention-surface guard) and BindWorkspace (legacy-reclaim
+// detection) depend on — a pre-pivot Auth0 sub must read as invalid so
+// the reclaim path fires, and real Slack IDs must read as valid so a
+// healthy owner_id is never mistaken for a legacy one.
+func TestLooksLikeSlackUserID(t *testing.T) {
+	valid := []string{"UCALLER01", "WENTERPRISE01", "U012345678"}
+	invalid := []string{"", "auth0|653fpre-pivot-subxyz", "google-oauth2|123", "u012345678", "U12", "UABCDEF!1"}
+	for _, s := range valid {
+		if !LooksLikeSlackUserID(s) {
+			t.Errorf("LooksLikeSlackUserID(%q) = false, want true", s)
+		}
+	}
+	for _, s := range invalid {
+		if LooksLikeSlackUserID(s) {
+			t.Errorf("LooksLikeSlackUserID(%q) = true, want false", s)
+		}
+	}
+}
+
 // TestBindWorkspace_WritesSeedAdminAttribute fences the forensic-
 // attribution promise documented at workspace.go's
 // attrSeedAdminSlackUser comment block: BindWorkspace MUST stamp the

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -372,6 +373,7 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 // a compare-and-swap on the exact legacy owner_id.
 func TestBindWorkspace_ReclaimsLegacyAuth0SubRow(t *testing.T) {
 	const legacyAuth0Sub = "auth0|653fpre-pivot-subxyz"
+	const legacyCreatedAt = "2026-05-01T00:00:00Z"
 
 	t.Run("shape-bad owner_id is reclaimed for the caller", func(t *testing.T) {
 		var putCalls int
@@ -391,6 +393,7 @@ func TestBindWorkspace_ReclaimsLegacyAuth0SubRow(t *testing.T) {
 				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
 					attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T"},
 					attrOwnerID:     &ddbtypes.AttributeValueMemberS{Value: legacyAuth0Sub},
+					attrCreatedAt:   &ddbtypes.AttributeValueMemberS{Value: legacyCreatedAt},
 				}}, nil
 			},
 		})
@@ -417,6 +420,12 @@ func TestBindWorkspace_ReclaimsLegacyAuth0SubRow(t *testing.T) {
 		newOwner, ok := reclaimPut.Item[attrOwnerID].(*ddbtypes.AttributeValueMemberS)
 		if !ok || newOwner.Value != testCallerSlackID {
 			t.Errorf("reclaim new owner_id = %+v, want %q", reclaimPut.Item[attrOwnerID], testCallerSlackID)
+		}
+		// The orphaned row's original created_at must be preserved (the
+		// durable "predates #510" signal), not overwritten with `now`.
+		gotCreated, ok := reclaimPut.Item[attrCreatedAt].(*ddbtypes.AttributeValueMemberS)
+		if !ok || gotCreated.Value != legacyCreatedAt {
+			t.Errorf("reclaim created_at = %+v, want preserved %q", reclaimPut.Item[attrCreatedAt], legacyCreatedAt)
 		}
 	})
 
@@ -457,8 +466,16 @@ func TestBindWorkspace_ReclaimsLegacyAuth0SubRow(t *testing.T) {
 // the reclaim path fires, and real Slack IDs must read as valid so a
 // healthy owner_id is never mistaken for a legacy one.
 func TestLooksLikeSlackUserID(t *testing.T) {
-	valid := []string{"UCALLER01", "WENTERPRISE01", "U012345678"}
-	invalid := []string{"", "auth0|653fpre-pivot-subxyz", "google-oauth2|123", "u012345678", "U12", "UABCDEF!1"}
+	valid := []string{
+		"UCALLER01", "WENTERPRISE01", "U012345678",
+		"U" + strings.Repeat("A", 8),  // 9 chars — lower length bound.
+		"U" + strings.Repeat("A", 63), // 64 chars — upper length bound.
+	}
+	invalid := []string{
+		"", "auth0|653fpre-pivot-subxyz", "google-oauth2|123", "u012345678", "U12", "UABCDEF!1",
+		"U" + strings.Repeat("A", 7),  // 8 chars — one under the lower bound.
+		"U" + strings.Repeat("A", 64), // 65 chars — one over the upper bound.
+	}
 	for _, s := range valid {
 		if !LooksLikeSlackUserID(s) {
 			t.Errorf("LooksLikeSlackUserID(%q) = false, want true", s)

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -244,17 +244,8 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 	// transfer verb would rewrite it), while seed_admin_slack_user_id is
 	// the write-once forensic record of who originally claimed the workspace.
 	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName: aws.String(s.WorkspaceMappingsName),
-		Item: map[string]ddbtypes.AttributeValue{
-			attrSlackTeamID:        stringAttr(m.TeamID),
-			attrOwnerID:            stringAttr(m.OwnerID),
-			attrSeedAdminSlackUser: stringAttr(seedAdmin),
-			attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
-				Value: []string{seedAdmin},
-			},
-			attrCreatedAt: stringAttr(created.Format(time.RFC3339)),
-			attrUpdatedAt: stringAttr(nowISO),
-		},
+		TableName:           aws.String(s.WorkspaceMappingsName),
+		Item:                workspaceMappingItem(m.TeamID, m.OwnerID, seedAdmin, created, nowISO),
 		ConditionExpression: aws.String("attribute_not_exists(slack_team_id)"),
 	})
 	if err == nil {
@@ -362,6 +353,24 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 	}
 }
 
+// workspaceMappingItem builds the workspace_mappings DDB item written by
+// both the initial conditional bind and the legacy-row reclaim — the two
+// differ only in their ConditionExpression, so the item shape lives in
+// one place. See BindWorkspace for why owner_id and
+// seed_admin_slack_user_id are kept as distinct attributes.
+func workspaceMappingItem(teamID, ownerID, seedAdmin string, created time.Time, nowISO string) map[string]ddbtypes.AttributeValue {
+	return map[string]ddbtypes.AttributeValue{
+		attrSlackTeamID:        stringAttr(teamID),
+		attrOwnerID:            stringAttr(ownerID),
+		attrSeedAdminSlackUser: stringAttr(seedAdmin),
+		attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
+			Value: []string{seedAdmin},
+		},
+		attrCreatedAt: stringAttr(created.Format(time.RFC3339)),
+		attrUpdatedAt: stringAttr(nowISO),
+	}
+}
+
 // reclaimLegacyWorkspace overwrites a pre-pivot workspace_mappings row
 // whose owner_id is a shape-bad Auth0 sub (detected by BindWorkspace).
 // The caller becomes the new owner and sole admin — identical to a
@@ -381,17 +390,8 @@ func (s *Store) reclaimLegacyWorkspace(ctx context.Context, m *WorkspaceMapping,
 		created = now
 	}
 	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName: aws.String(s.WorkspaceMappingsName),
-		Item: map[string]ddbtypes.AttributeValue{
-			attrSlackTeamID:        stringAttr(m.TeamID),
-			attrOwnerID:            stringAttr(m.OwnerID),
-			attrSeedAdminSlackUser: stringAttr(seedAdmin),
-			attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
-				Value: []string{seedAdmin},
-			},
-			attrCreatedAt: stringAttr(created.Format(time.RFC3339)),
-			attrUpdatedAt: stringAttr(nowISO),
-		},
+		TableName:           aws.String(s.WorkspaceMappingsName),
+		Item:                workspaceMappingItem(m.TeamID, m.OwnerID, seedAdmin, created, nowISO),
 		ConditionExpression: aws.String("owner_id = :legacy"),
 		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 			":legacy": stringAttr(legacyOwner),

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -108,6 +108,32 @@ const bindDisambiguationBudget = 300 * time.Millisecond
 // single shared const would tie the two together implicitly.
 const addAdminDisambiguationBudget = 300 * time.Millisecond
 
+// LooksLikeSlackUserID reports whether s matches Slack's documented
+// user-ID grammar — `U…` (workspace) or `W…` (Enterprise Grid) prefix
+// followed by 8-63 uppercase-alphanumeric chars (9-64 chars total).
+//
+// This is the single source of truth for the Slack-ID shape check; the
+// handler package's looksLikeSlackUserID delegates here. Two callers
+// depend on it: the handler interpolates owner_id into `<@%s>` mrkdwn
+// mentions (a malformed value must not break out of the mention
+// surface), and BindWorkspace uses it to detect a pre-pivot Auth0-sub
+// owner_id so it can self-heal a legacy row (see BindWorkspace).
+func LooksLikeSlackUserID(s string) bool {
+	if len(s) < 9 || len(s) > 64 {
+		return false
+	}
+	if s[0] != 'U' && s[0] != 'W' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
 // CheckAdmin returns (isAdmin, ownerID) for the workspace.
 //
 // Workspace not yet bound to an owner → (false, "", nil). The handler
@@ -169,6 +195,10 @@ func (s *Store) CheckAdmin(ctx context.Context, teamID, slackUserID string) (isA
 //     circuits this way — admins added via /qurl admin add cannot
 //     re-run /setup, by design (prevents them from rotating the
 //     workspace credential to a different Auth0 account).
+//   - the existing owner_id is a shape-bad pre-pivot Auth0 sub →
+//     reclaim the orphaned row for the caller and return nil (the
+//     callback then mints as on a fresh install). See
+//     reclaimLegacyWorkspace.
 //   - any other caller (admin or non-admin) → ErrCodeWorkspaceAlreadyBound.
 //     The callback renders a rebind-refused page; no key is minted
 //     so there's nothing to revoke and the existing owner's
@@ -292,6 +322,20 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 				Title:      "BindWorkspace: caller is the existing workspace owner",
 			}
 		}
+		if existingOwner != "" && !LooksLikeSlackUserID(existingOwner) {
+			// Legacy/orphaned row: owner_id is a pre-pivot Auth0 sub
+			// (`auth0|…`), not a Slack user ID. No Slack user can ever
+			// equal it, so the workspace is permanently locked for
+			// everyone — including the real owner. Self-heal by
+			// reclaiming the row for this caller, the same first-come-
+			// claims posture an unbound workspace already has. Before
+			// #510 owner_id was the Auth0 sub; the migration left these
+			// rows behind, and the old recovery ("operator deletes the
+			// row") needed manual DDB access. This makes /qurl setup
+			// recover them on its own.
+			slog.Warn("BindWorkspace: existing owner_id is shape-bad (pre-pivot Auth0 sub) — reclaiming row for caller (first-come-claims)", "team_id", m.TeamID, "new_owner", seedAdmin, "legacy_owner_len", len(existingOwner))
+			return s.reclaimLegacyWorkspace(ctx, m, seedAdmin, existingOwner)
+		}
 		if existingOwner == "" {
 			// A row exists but carries no owner_id. This shouldn't happen —
 			// every BindWorkspace PutItem writes a non-empty OwnerID — so it
@@ -316,6 +360,58 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 		Code:       ErrCodeWorkspaceAlreadyBound,
 		Title:      "BindWorkspace: workspace is owned by a different Slack user",
 	}
+}
+
+// reclaimLegacyWorkspace overwrites a pre-pivot workspace_mappings row
+// whose owner_id is a shape-bad Auth0 sub (detected by BindWorkspace).
+// The caller becomes the new owner and sole admin — identical to a
+// fresh bind, just replacing the orphaned row instead of creating one.
+//
+// The PutItem is conditioned on `owner_id = :legacy` (the exact value
+// BindWorkspace read on the strong-consistent disambiguation GetItem),
+// so two callers racing to reclaim the same legacy row can't both win:
+// the loser's condition fails because the owner_id is no longer the
+// legacy value, and it surfaces AlreadyBound — the same refusal any
+// non-owner rebind gets.
+func (s *Store) reclaimLegacyWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmin, legacyOwner string) error {
+	now := s.nowOrDefault().UTC()
+	nowISO := now.Format(time.RFC3339)
+	created := m.CreatedAt
+	if created.IsZero() {
+		created = now
+	}
+	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:        stringAttr(m.TeamID),
+			attrOwnerID:            stringAttr(m.OwnerID),
+			attrSeedAdminSlackUser: stringAttr(seedAdmin),
+			attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{
+				Value: []string{seedAdmin},
+			},
+			attrCreatedAt: stringAttr(created.Format(time.RFC3339)),
+			attrUpdatedAt: stringAttr(nowISO),
+		},
+		ConditionExpression: aws.String("owner_id = :legacy"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":legacy": stringAttr(legacyOwner),
+		},
+	})
+	if err == nil {
+		return nil
+	}
+	var ccfe *ddbtypes.ConditionalCheckFailedException
+	if errors.As(err, &ccfe) {
+		// Lost the reclaim race — a concurrent caller already replaced
+		// the legacy owner_id with a valid Slack owner. Refuse, the same
+		// safe default as any other non-owner rebind.
+		return &Error{
+			StatusCode: http.StatusConflict,
+			Code:       ErrCodeWorkspaceAlreadyBound,
+			Title:      "BindWorkspace: legacy reclaim lost the race to a concurrent owner",
+		}
+	}
+	return ddbToError("BindWorkspace.reclaim", err)
 }
 
 // AddAdmin promotes targetUserID to bot admin on the (teamID)

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -132,6 +133,22 @@ func LooksLikeSlackUserID(s string) bool {
 		}
 	}
 	return true
+}
+
+// legacyOwnerPrefix returns the bounded provider prefix of a shape-bad
+// owner_id for logging — `auth0|`, `google-oauth2|`, etc. — so on-call
+// can confirm a pre-pivot row from CloudWatch without a DDB read. It
+// stops at (and includes) the first `|`, or the first 8 chars if there
+// is none, so the per-user identifier after the provider is never
+// logged.
+func legacyOwnerPrefix(s string) string {
+	if i := strings.IndexByte(s, '|'); i >= 0 && i <= 24 {
+		return s[:i+1]
+	}
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
 }
 
 // CheckAdmin returns (isAdmin, ownerID) for the workspace.
@@ -324,8 +341,15 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 			// rows behind, and the old recovery ("operator deletes the
 			// row") needed manual DDB access. This makes /qurl setup
 			// recover them on its own.
-			slog.Warn("BindWorkspace: existing owner_id is shape-bad (pre-pivot Auth0 sub) — reclaiming row for caller (first-come-claims)", "team_id", m.TeamID, "new_owner", seedAdmin, "legacy_owner_len", len(existingOwner))
-			return s.reclaimLegacyWorkspace(ctx, m, seedAdmin, existingOwner)
+			// Log the provider prefix (e.g. `auth0|`) — not the full sub —
+			// so on-call can confirm "yes, pre-pivot row" from CloudWatch
+			// without a DDB read. The prefix carries no per-user identifier.
+			slog.Warn("BindWorkspace: existing owner_id is shape-bad (pre-pivot Auth0 sub) — reclaiming row for caller (first-come-claims)", "team_id", m.TeamID, "new_owner", seedAdmin, "legacy_owner_prefix", legacyOwnerPrefix(existingOwner), "legacy_owner_len", len(existingOwner))
+			// Preserve the orphaned row's original created_at so the reclaim
+			// keeps the one durable signal that this workspace predates the
+			// #510 migration (the comment on reclaimLegacyWorkspace explains
+			// the fallback when it's absent).
+			return s.reclaimLegacyWorkspace(ctx, m, seedAdmin, existingOwner, readString(check.Item, attrCreatedAt))
 		}
 		if existingOwner == "" {
 			// A row exists but carries no owner_id. This shouldn't happen —
@@ -382,16 +406,25 @@ func workspaceMappingItem(teamID, ownerID, seedAdmin string, created time.Time, 
 // the loser's condition fails because the owner_id is no longer the
 // legacy value, and it surfaces AlreadyBound — the same refusal any
 // non-owner rebind gets.
-func (s *Store) reclaimLegacyWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmin, legacyOwner string) error {
+func (s *Store) reclaimLegacyWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmin, legacyOwner, existingCreatedAt string) error {
 	now := s.nowOrDefault().UTC()
 	nowISO := now.Format(time.RFC3339)
 	created := m.CreatedAt
 	if created.IsZero() {
 		created = now
 	}
+	item := workspaceMappingItem(m.TeamID, m.OwnerID, seedAdmin, created, nowISO)
+	// Preserve the orphaned row's original created_at verbatim when the
+	// disambiguation read found one — it's the durable "this predates
+	// #510" signal, and keeping the raw string avoids a parse/format
+	// round-trip that could trip on a non-RFC3339 legacy value. Falls
+	// back to the freshly-stamped created above when absent.
+	if existingCreatedAt != "" {
+		item[attrCreatedAt] = stringAttr(existingCreatedAt)
+	}
 	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName:           aws.String(s.WorkspaceMappingsName),
-		Item:                workspaceMappingItem(m.TeamID, m.OwnerID, seedAdmin, created, nowISO),
+		Item:                item,
 		ConditionExpression: aws.String("owner_id = :legacy"),
 		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 			":legacy": stringAttr(legacyOwner),

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -135,13 +135,14 @@ func LooksLikeSlackUserID(s string) bool {
 	return true
 }
 
-// legacyOwnerPrefix returns the bounded provider prefix of a shape-bad
+// LegacyOwnerPrefix returns the bounded provider prefix of a shape-bad
 // owner_id for logging — `auth0|`, `google-oauth2|`, etc. — so on-call
 // can confirm a pre-pivot row from CloudWatch without a DDB read. It
 // stops at (and includes) the first `|`, or the first 8 chars if there
 // is none, so the per-user identifier after the provider is never
-// logged.
-func legacyOwnerPrefix(s string) string {
+// logged. Exported so the slash-command gate (handler package) logs the
+// same field as BindWorkspace at the other reclaim-detection surface.
+func LegacyOwnerPrefix(s string) string {
 	if i := strings.IndexByte(s, '|'); i >= 0 && i <= 24 {
 		return s[:i+1]
 	}
@@ -331,10 +332,12 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 			}
 		}
 		if existingOwner != "" && !LooksLikeSlackUserID(existingOwner) {
-			// Legacy/orphaned row: owner_id is a pre-pivot Auth0 sub
-			// (`auth0|…`), not a Slack user ID. No Slack user can ever
-			// equal it, so the workspace is permanently locked for
-			// everyone — including the real owner. Self-heal by
+			// Legacy/orphaned row: owner_id isn't a Slack user ID —
+			// overwhelmingly a pre-pivot Auth0 sub (`auth0|…`), but the
+			// predicate is the canonical "no Slack user can ever match
+			// this" signal (it also catches a tampered email, a stray
+			// newline, etc.). Either way the workspace is structurally
+			// locked for everyone — including the real owner. Self-heal by
 			// reclaiming the row for this caller, the same first-come-
 			// claims posture an unbound workspace already has. Before
 			// #510 owner_id was the Auth0 sub; the migration left these
@@ -344,7 +347,7 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 			// Log the provider prefix (e.g. `auth0|`) — not the full sub —
 			// so on-call can confirm "yes, pre-pivot row" from CloudWatch
 			// without a DDB read. The prefix carries no per-user identifier.
-			slog.Warn("BindWorkspace: existing owner_id is shape-bad (pre-pivot Auth0 sub) — reclaiming row for caller (first-come-claims)", "team_id", m.TeamID, "new_owner", seedAdmin, "legacy_owner_prefix", legacyOwnerPrefix(existingOwner), "legacy_owner_len", len(existingOwner))
+			slog.Warn("BindWorkspace: existing owner_id is shape-bad (pre-pivot Auth0 sub) — reclaiming row for caller (first-come-claims)", "team_id", m.TeamID, "new_owner", seedAdmin, "legacy_owner_prefix", LegacyOwnerPrefix(existingOwner), "legacy_owner_len", len(existingOwner))
 			// Preserve the orphaned row's original created_at so the reclaim
 			// keeps the one durable signal that this workspace predates the
 			// #510 migration (the comment on reclaimLegacyWorkspace explains

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -159,7 +159,7 @@ func TunnelInstallModal(meta TunnelInstallModalMetadata) ([]byte, error) {
 			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
 			inputBlock(tunnelInstallBlockSlug, "qURL tunnel slug", "3-64 lowercase letters, numbers, and hyphens. Start with a letter, end with a letter or number.", false,
 				plainTextInput(tunnelInstallActionSlug, "prod-dashboard", "")),
-			inputBlock(tunnelInstallBlockShortcut, "Channel shortcut", "Optional. Leave blank to use the tunnel slug.", true,
+			inputBlock(tunnelInstallBlockShortcut, "Channel alias", "Optional. Leave blank to use the tunnel slug.", true,
 				plainTextInput(tunnelInstallActionShortcut, "prod", "")),
 			inputBlock(tunnelInstallBlockEnvironment, "Target environment", "Choose the runtime shape so Slack can tailor the install output. Docker snippets assume a Linux host.", false,
 				staticSelect(tunnelInstallActionEnvironment, []map[string]any{

--- a/apps/slack/internal/views_test.go
+++ b/apps/slack/internal/views_test.go
@@ -208,7 +208,7 @@ func TestTunnelInstallModal_Shape(t *testing.T) {
 	body := string(raw)
 	for _, want := range []string{
 		"qURL tunnel slug",
-		"Channel shortcut",
+		"Channel alias",
 		"Target environment",
 		"Docker snippets assume a Linux host",
 		string(tunnelEnvDocker),


### PR DESCRIPTION
Fixes several Slack-bot issues raised together. All changes are under `apps/slack/`.

## 1. "shortcut" → "alias" in user-facing copy
Channel aliases were called "shortcuts" in help, tunnel-install replies, the install modal label, and error copy. They're aliases — alternate names that resolve to a tunnel slug. Renamed every user-facing string to "alias". Internal identifiers (`tunnelInstallBlockShortcut`, `validateChannelShortcutToken`) and operator log-field keys are left unchanged to keep the diff surgical.

## 2. `/qurl aliases` — group by tunnel, label which token is which
Before: one line per alias as `` `$dashboard` → `$kktest` `` (or `` `$dashboard` → r_cnaip_fprni `` when the fetch failed) — both sides `$`-prefixed with no way to tell the slug from the alias.

After: grouped by tunnel, slug first and labeled, with all its aliases on the right:
```
• `$kktest` (tunnel) → `$dashboard`, `$kevin-dashboard`
```
Several aliases for one slug now collapse onto a single line. This also fetches one resource per tunnel instead of one per alias.

## 3. `/qurl list` — say "aliases", explain slug vs alias
`(also …)` gave no hint the extras were aliases. Now `(alias: …)` / `(aliases: …)`, and the footer explains the model:
```
• `$kktest` (alias: `$kevin-dashboard`) → Slack tunnel install for kktest

Each `$<slug>` is a tunnel's name; the `(alias: …)` names are alternate names for it in this channel. Copy a slug or an alias and run /qurl get on it to mint a one-time qURL link.
```

## 4. `/qurl help` — slug/alias glossary
Added one line (shown where aliases exist): _A tunnel's `$slug` is its name. A `$alias` is an alternate name for a tunnel in a channel — several aliases can point to one slug. Use either with `/qurl get`._

## 5. `/qurl setup` — self-heal legacy owner rows (the lock-out bug)
Running `/qurl setup` returned **"this workspace's stored owner record is malformed … contact support"** and minted nothing.

Root cause: pre-#510, `owner_id` held the Auth0 `sub`; #510 changed the owner model to the installer's Slack user ID. Rows written before that migration still hold an Auth0 sub. The owner gate compares `owner_id` to the caller's Slack ID, which **no Slack user can ever match** — so the workspace was permanently locked for everyone, *including its real owner*, recoverable only by an operator deleting the DDB row.

Fix: a shape-bad `owner_id` (fails the Slack-ID grammar check) is treated as an orphaned row and reclaimed for the caller — first-come-claims, the same posture an unbound workspace already has, and consistent once reclaimed (it becomes a normal #510-model row with the gate active). Mechanics:
- The slash-command gate falls through (mints the setup URL) instead of dead-ending, for a shape-bad owner only. A *valid* different-owner still gets the friendly refusal.
- `BindWorkspace` detects the shape-bad existing owner on the post-conflict disambiguation read and reclaims via a **compare-and-swap on the exact legacy value**, so a concurrent reclaim can't double-write (the loser gets the normal "already bound" refusal).

The Slack-ID shape check now lives in `slackdata.LooksLikeSlackUserID` (single source of truth; the handler's `looksLikeSlackUserID` delegates to it).

## 6. Owner-gate wording
The gate copy said "workspace owner", conflating with the *Slack* workspace owner. It's the person who first ran `/qurl setup` (the qURL account owner), and only they can re-run it — this is what stops another bot-admin from re-OAuthing the workspace to a different account. Copy now says "the person who first connected qURL". Applied to the gate refusal, `/qurl admin list` output, admin-remove-owner, and the upstream-error message.

## Tests
- New `BindWorkspace` coverage: reclaim of a legacy Auth0-sub row (asserts the CAS condition + new owner) and the lost-reclaim-race path.
- New `LooksLikeSlackUserID` table test.
- Rewrote the `/qurl setup` shape-bad-owner gate test to assert self-heal (setup proceeds, no Auth0-sub leak) instead of the old lock-out.
- Updated `/qurl aliases`, `/qurl list`, tunnel-install, and admin-copy assertions to the new strings.

Full `apps/slack` + `shared` + `slackdata` suites pass; gofmt, go vet, golangci-lint (0 issues), and pre-commit all clean. (Two pre-existing `apps/cli` failures are env-dependent config-resolution tests, untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)