### PR TITLE
feat(slack): add per-row "Create qURL" button to /qurl list

### DIFF
--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -248,11 +248,18 @@ func (h *Handler) processGet(ctx context.Context, log *slog.Logger, values url.V
 		userID:    userID,
 		triggerID: triggerID,
 	})
+	h.finishGet(log, responseURL, text, err)
+}
+
+// finishGet posts a [Handler.getWork] outcome to response_url as an
+// ephemeral: the rendered link on success, or the [*userError] message
+// (prefixed with `:warning:`) on failure. A non-userError leak is a
+// programmer mistake — log it loud and surface the generic catch-all so
+// internals never reach Slack. Shared by the `/qurl get` slash path
+// ([Handler.processGet]) and the `/qurl list` "Create qURL" button
+// ([Handler.processButtonGet]) so both render identical replies.
+func (h *Handler) finishGet(log *slog.Logger, responseURL, text string, err error) {
 	if err != nil {
-		// All errors from getWork are *userError today; surface the
-		// message verbatim. If a non-userError ever leaks through
-		// (programmer mistake), surface the generic catch-all so we
-		// don't leak internals.
 		var ue *userError
 		if errors.As(err, &ue) {
 			_ = h.postResponse(log, responseURL, ":warning: "+ue.msg)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -39,22 +39,122 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 		"view_id", payload.View.ID,
 	)
 
-	if payload.Type != "view_submission" {
-		// Buttons + select menus + shortcut entries land here. Ack
-		// 200 with an empty body and ignore until a feature wires
-		// the dispatch.
+	switch payload.Type {
+	case "block_actions":
+		// Button clicks in messages — currently the per-row "Create qURL"
+		// button on `/qurl list`. handleBlockActions acks and dispatches.
+		h.handleBlockActions(w, payload)
+	case "view_submission":
+		switch payload.View.CallbackID {
+		case callbackIDTunnelInstall:
+			h.handleTunnelInstallSubmission(w, payload)
+		default:
+			// Unknown callback_id — ack 200 (Slack hangs the modal
+			// otherwise) and log so a future view drift is visible.
+			slog.Info("unknown view_submission callback_id", "callback_id", payload.View.CallbackID)
+			respondJSON(w, http.StatusOK, map[string]any{})
+		}
+	default:
+		// Select menus, shortcuts, and any other interaction type we
+		// don't wire yet. Ack 200 with an empty body and ignore.
+		respondJSON(w, http.StatusOK, map[string]any{})
+	}
+}
+
+// handleBlockActions routes Slack block_actions interactions (button
+// clicks in posted messages). The only button today is "Create qURL" on
+// each `/qurl list` row, which mints a one-time qURL for that row's
+// tunnel — the same resolve→authorize→mint work as `/qurl get $<slug>`.
+//
+// Slack requires a fast 200 ack on the interaction, so the mint runs on
+// the bounded async pool and the link is delivered out-of-band via the
+// interaction's response_url as a NEW ephemeral message (replace_original
+// defaults to false), leaving the list message itself intact.
+func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interactionPayload) {
+	action, ok := findListCreateQurlAction(payload.Actions)
+	if !ok {
+		// A button we don't handle (or an empty actions array). Ack and
+		// ignore so Slack doesn't surface an error to the clicking user.
 		respondJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
-	switch payload.View.CallbackID {
-	case callbackIDTunnelInstall:
-		h.handleTunnelInstallSubmission(w, payload)
-	default:
-		// Unknown callback_id — ack 200 (Slack hangs the modal
-		// otherwise) and log so a future view drift is visible.
-		slog.Info("unknown view_submission callback_id", "callback_id", payload.View.CallbackID)
+
+	responseURL := payload.ResponseURL
+	log := slog.With(
+		"command", "list_create_qurl",
+		"team_id", payload.Team.ID,
+		"channel_id", payload.Channel.ID,
+		"user_id", payload.User.ID,
+	)
+
+	// The button value is the `$<slug>`/`$<alias>` token (sigil stripped)
+	// written when the list rendered. Re-validate it through the SAME
+	// grammar `/qurl get` uses so a malformed value fails the same way a
+	// typed token would, instead of reaching the resolve/mint path or
+	// burning an upstream slug lookup. Our own buttons always carry a
+	// valid token, so this is defense-in-depth; the notice is posted
+	// out-of-band (h.Go, not the async pool) to keep the ack prompt.
+	token, tokErr := parseAliasToken("$" + strings.TrimSpace(action.Value))
+	if tokErr != nil {
+		log.Warn("list create-qurl: button carried an unparseable token", "error", tokErr)
+		h.Go(func() { _ = h.postResponse(log, responseURL, ":warning: "+unexpectedGetShapeMessage) })
 		respondJSON(w, http.StatusOK, map[string]any{})
+		return
 	}
+
+	cmd := &Command{
+		Subcommand: SubcmdGet,
+		Alias:      token,
+		Flags:      map[string]string{},
+		Raw:        "get $" + token,
+	}
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		h.processButtonGet(ctx, log, responseURL, payload.Team.ID, payload.Channel.ID, payload.User.ID, payload.TriggerID, cmd)
+	}) {
+		// Pool saturated — don't let the click be a silent no-op. h.Go is
+		// wg-tracked but does NOT consume an async slot, so reporting the
+		// saturation can't itself deepen it.
+		log.Warn("async pool saturated — dropping list Create qURL click")
+		h.Go(func() { _ = h.postResponse(log, responseURL, ackBusy) })
+	}
+	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+// processButtonGet is the async-worker body for the `/qurl list`
+// "Create qURL" button. It mints a one-time qURL for the row's tunnel via
+// the same [Handler.getWork] pipeline as `/qurl get $<slug>` (resolve the
+// token → channel-authorize → rate-limit → mint) and posts the outcome to
+// the interaction's response_url. The cmd carries no dm/reason flags —
+// the button is the plain one-time-use mint.
+func (h *Handler) processButtonGet(ctx context.Context, log *slog.Logger, responseURL, teamID, channelID, userID, triggerID string, cmd *Command) {
+	if channelID == "" {
+		// Channel-scope guard mirrors processGet: the resolve path is
+		// channel-scoped, so a channel-less interaction can't authorize.
+		log.Warn("list create-qurl: empty channel_id; refusing channel-less invocation")
+		_ = h.postResponse(log, responseURL, ":warning: "+channelRequiredMessage)
+		return
+	}
+	text, err := h.getWork(ctx, log, getWorkArgs{
+		cmd:       cmd,
+		teamID:    teamID,
+		channelID: channelID,
+		userID:    userID,
+		triggerID: triggerID,
+	})
+	h.finishGet(log, responseURL, text, err)
+}
+
+// findListCreateQurlAction returns the "Create qURL" list-row button from
+// a block_actions payload's actions array (Slack sends one entry per
+// clicked element). Matches on action_id so an unrelated button on a
+// future message doesn't trigger a mint.
+func findListCreateQurlAction(actions []interactionAction) (interactionAction, bool) {
+	for _, a := range actions {
+		if a.ActionID == listCreateQurlActionID {
+			return a, true
+		}
+	}
+	return interactionAction{}, false
 }
 
 func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {
@@ -302,9 +402,9 @@ func tunnelWebRefKindValidationMessage(env tunnelInstallEnvironment, kind tunnel
 	return ""
 }
 
-// interactionPayload is the subset of Slack's view_submission
-// payload we read. Fields we don't touch are intentionally elided so
-// the JSON unmarshal is forgiving to upstream additions.
+// interactionPayload is the subset of Slack's view_submission and
+// block_actions payloads we read. Fields we don't touch are intentionally
+// elided so the JSON unmarshal is forgiving to upstream additions.
 type interactionPayload struct {
 	Type string `json:"type"`
 	Team struct {
@@ -322,6 +422,23 @@ type interactionPayload struct {
 		} `json:"state"`
 	} `json:"view"`
 	TriggerID string `json:"trigger_id"`
+	// Channel, ResponseURL, and Actions are populated on block_actions
+	// (button click) payloads. Channel is the conversation the button was
+	// clicked in (the mint authorizes against it); ResponseURL is where
+	// the minted link is delivered; Actions carries the clicked element(s).
+	Channel struct {
+		ID string `json:"id"`
+	} `json:"channel"`
+	ResponseURL string              `json:"response_url"`
+	Actions     []interactionAction `json:"actions"`
+}
+
+// interactionAction is one entry of a block_actions payload's `actions`
+// array (the elements the user interacted with). For our list button,
+// Value carries the `$<slug>`/`$<alias>` token (sigil stripped).
+type interactionAction struct {
+	ActionID string `json:"action_id"`
+	Value    string `json:"value"`
 }
 
 type interactionStateValue struct {

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -144,10 +144,11 @@ func (h *Handler) processButtonGet(ctx context.Context, log *slog.Logger, respon
 	h.finishGet(log, responseURL, text, err)
 }
 
-// findListCreateQurlAction returns the "Create qURL" list-row button from
-// a block_actions payload's actions array (Slack sends one entry per
-// clicked element). Matches on action_id so an unrelated button on a
-// future message doesn't trigger a mint.
+// findListCreateQurlAction returns the first "Create qURL" list-row button
+// from a block_actions payload's actions array. Slack sends one entry per
+// clicked element, so a single button click yields exactly one match and
+// taking the first is correct for that contract. Matches on action_id so
+// an unrelated button on a future message doesn't trigger a mint.
 func findListCreateQurlAction(actions []interactionAction) (interactionAction, bool) {
 	for _, a := range actions {
 		if a.ActionID == listCreateQurlActionID {

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -75,6 +75,10 @@ func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interaction
 	if !ok {
 		// A button we don't handle (or an empty actions array). Ack and
 		// ignore so Slack doesn't surface an error to the clicking user.
+		// Log the action_ids present so a future button that's rendered
+		// into a message but never wired here surfaces as a breadcrumb
+		// rather than a silent no-op.
+		slog.Info("block_actions: no recognized action", "team_id", payload.Team.ID, "action_ids", blockActionIDs(payload.Actions))
 		respondJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
@@ -156,6 +160,16 @@ func findListCreateQurlAction(actions []interactionAction) (interactionAction, b
 		}
 	}
 	return interactionAction{}, false
+}
+
+// blockActionIDs lists the action_ids present in a block_actions payload,
+// for the no-recognized-action log breadcrumb.
+func blockActionIDs(actions []interactionAction) []string {
+	ids := make([]string, 0, len(actions))
+	for _, a := range actions {
+		ids = append(ids, a.ActionID)
+	}
+	return ids
 }
 
 func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -47,13 +47,15 @@ const listCreateButtonLabel = "Create qURL"
 
 // listCreateButtonMaxRows caps how many tunnel rows /qurl list renders as
 // interactive section+button blocks. Slack rejects a message with more
-// than 50 blocks; reserving the header, footer, and optional has-more
-// note, 45 rows stays comfortably under that ceiling. A workspace with
-// more tunnels than this degrades to the plain-text listing (every tunnel
-// still visible — the text path has no block ceiling — just without the
-// per-row button) rather than a message Slack would refuse to render.
-// Tunnels are created deliberately (via `/qurl tunnel install`), so a real
-// workspace is far below this; see [listResourcesScanLimit].
+// than 50 blocks; the rendered shape is header (1) + N row sections +
+// footer (1) + optional has-more note (1), so 45 rows tops out at 48 —
+// 2 blocks of deliberate headroom against a future non-row block. A
+// workspace with more tunnels than this degrades to the plain-text
+// listing (every tunnel still visible — the text path has no block
+// ceiling — just without the per-row button) rather than a message Slack
+// would refuse to render. Tunnels are created deliberately (via `/qurl
+// tunnel install`), so a real workspace is far below this; see
+// [listResourcesScanLimit].
 const listCreateButtonMaxRows = 45
 
 // listFooterText is the guidance line under /qurl list when rendered as

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -40,6 +40,36 @@ const listResourcesScanLimit = 100
 // rather than the old admin/non-admin branch.
 const listTunnelsEmptyMessage = ":mag: No tunnels found in this workspace. A Slack admin can set one up with `/qurl tunnel install <slug>`."
 
+// listCreateButtonLabel is the text on the per-row "Create qURL" button.
+// Clicking it mints a one-time qURL for that row's tunnel — the same work
+// as typing `/qurl get $<slug>`. (Brand spelling: lowercase q, uppercase URL.)
+const listCreateButtonLabel = "Create qURL"
+
+// listCreateButtonMaxRows caps how many tunnel rows /qurl list renders as
+// interactive section+button blocks. Slack rejects a message with more
+// than 50 blocks; reserving the header, footer, and optional has-more
+// note, 45 rows stays comfortably under that ceiling. A workspace with
+// more tunnels than this degrades to the plain-text listing (every tunnel
+// still visible — the text path has no block ceiling — just without the
+// per-row button) rather than a message Slack would refuse to render.
+// Tunnels are created deliberately (via `/qurl tunnel install`), so a real
+// workspace is far below this; see [listResourcesScanLimit].
+const listCreateButtonMaxRows = 45
+
+// listFooterText is the guidance line under /qurl list when rendered as
+// plain text — both the Block Kit fallback (`text`) and the visible
+// message when the tunnel set is too large for per-row buttons (see
+// [listCreateButtonMaxRows]). It names the typed path and the
+// one-time-use default; the button path is named only in
+// [listFooterButtons], shown when the buttons are actually present.
+const listFooterText = "Copy any `$slug` or `$alias` and run `/qurl get` to mint a link. Every qURL is one-time use — it opens access once, then expires. Any `(also …)` shortcuts shown are specific to this channel."
+
+// listFooterButtons is the guidance line beneath the interactive /qurl
+// list (the version with a per-row Create qURL button). It names BOTH
+// ways to mint — tapping the button and the typed command — and the
+// one-time-use default.
+const listFooterButtons = "Tap *Create qURL* on any tunnel, or run `/qurl get $slug` (or `$alias`), to mint a link. Every qURL is one-time use — it opens access once, then expires. Any `(also …)` shortcuts shown are specific to this channel."
+
 // handleListResources implements `/qurl list`. It lists the workspace's
 // tunnel resources (type=tunnel only — URL/transit resources are
 // filtered out) so each line is a copy-paste-ready `$<slug>` token the
@@ -134,22 +164,57 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		return resources[i].ResourceID < resources[j].ResourceID
 	})
 
+	// Render each tunnel as a section block carrying a "Create qURL"
+	// accessory button (so a click mints the one-time link without the
+	// user copy-pasting `/qurl get $slug`), and in parallel build the
+	// plain-text `body` Slack uses as the block fallback. useButtons is
+	// false when the tunnel set exceeds Slack's per-message block ceiling
+	// (see listCreateButtonMaxRows) — then only the text path renders.
+	useButtons := len(resources) <= listCreateButtonMaxRows
 	lines := make([]string, 0, len(resources))
+	var blocks []any
+	if useButtons {
+		blocks = make([]any, 0, len(resources)+3)
+		blocks = append(blocks, sectionBlock("*Protected Tunnel Resources:*"))
+	}
 	for i := range resources {
-		lines = append(lines, formatTunnelListLine(&resources[i], aliasMap[resources[i].ResourceID]))
+		line := formatTunnelListLine(&resources[i], aliasMap[resources[i].ResourceID])
+		lines = append(lines, line)
+		if !useButtons {
+			continue
+		}
+		// displayTok is "" only for a slug-less, alias-less tunnel — the
+		// "(no slug …)" row, which has no `$<token>` that `/qurl get` (or
+		// the button) could mint against — so that row gets no button.
+		if tok := displayTok[resources[i].ResourceID]; tok != "" {
+			blocks = append(blocks, sectionWithButton(line, listCreateButtonLabel, listCreateQurlActionID, tok))
+		} else {
+			blocks = append(blocks, sectionBlock(line))
+		}
 	}
 
-	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") +
-		"\n\n_Copy any `$slug` or `$alias` and run `/qurl get` on it to mint a one-time qURL link. Any `(also …)` aliases shown are specific to this channel._"
+	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"
+	if useButtons {
+		blocks = append(blocks, contextBlock(listFooterButtons))
+	}
 	if page.HasMore {
 		// page.HasMore is a master-list signal — more resources of ANY
 		// type, not necessarily more tunnels — so this footer can fire
 		// even when every tunnel is already shown. See the #531 caveat
 		// on listResourcesScanLimit; until then we warn rather than
 		// risk implying the listing is exhaustive.
-		body += fmt.Sprintf("\n_…more resources past the first %d-row scan — some tunnels may not be shown._", listResourcesScanLimit)
+		hasMore := fmt.Sprintf("…more resources past the first %d-row scan — some tunnels may not be shown.", listResourcesScanLimit)
+		body += "\n_" + hasMore + "_"
+		if useButtons {
+			blocks = append(blocks, contextBlock(hasMore))
+		}
 	}
-	_ = h.postResponse(log, responseURL, body)
+
+	if !useButtons {
+		_ = h.postResponse(log, responseURL, body)
+		return
+	}
+	_ = h.postResponseBlocks(log, responseURL, body, blocks)
 }
 
 // filterTunnelResources returns only the tunnel-type resources from the

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -187,6 +187,47 @@ func TestHandleBlockActions_UnparseableTokenRejected(t *testing.T) {
 	}
 }
 
+// TestHandleBlockActions_NotAllowedNonAdmin fences the headline security
+// property at the button boundary: clicking "Create qURL" cannot mint a
+// tunnel the user couldn't already mint by typing the command. A
+// non-admin clicks the button for a slug whose resource isn't in this
+// channel's allow-set; the button routes through the same
+// resolveTokenForGet → resourceAllowedForUser gate as `/qurl get`, so it
+// gets the anti-enumeration "not configured for this channel" copy, the
+// resolved resource_id never leaks, and the mint never runs. Mirrors
+// TestHandleGet_DollarSlugNotAllowedNonAdmin on the interaction path.
+func TestHandleBlockActions_NotAllowedNonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "", []string{"r_other_alloc"})
+	addTunnelSlugResource(t, ts)
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		writeCreateFixture(t, w, "https://qurl.link/should-not", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, listCreateQurlActionID, testTunnelSlug)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("ack = %d %q, want 200 and {}", w.Code, w.Body.String())
+	}
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, "`$"+testTunnelSlug+"` is not configured for this channel") {
+		t.Errorf("button bypassed channel authorization — missing not-configured copy: %q", async)
+	}
+	if strings.Contains(async, testResourceIDFix) {
+		t.Errorf("resolved resource_id leaked in rejection message: %q", async)
+	}
+	if mintHits.Load() != 0 {
+		t.Errorf("button minted a tunnel not allowed in this channel (hits = %d)", mintHits.Load())
+	}
+}
+
 // TestHandleList_OverflowDegradesToText fences the block-ceiling guard:
 // a tunnel set larger than listCreateButtonMaxRows renders as plain text
 // (no blocks) so every tunnel still shows — rather than a >50-block

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -1,0 +1,184 @@
+package internal
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// parseSlackBlocks unwraps the `blocks` array from a response_url
+// payload. Returns nil when the payload carried no blocks (text-only).
+func parseSlackBlocks(t *testing.T, body []byte) []any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal reply: %v body=%s", err, body)
+	}
+	blocks, _ := got["blocks"].([]any)
+	return blocks
+}
+
+// createQurlButtonValues extracts the `value` of every "Create qURL"
+// accessory button across the list blocks, in order.
+func createQurlButtonValues(t *testing.T, blocks []any) []string {
+	t.Helper()
+	var vals []string
+	for _, b := range blocks {
+		block, _ := b.(map[string]any)
+		acc, ok := block["accessory"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if acc["action_id"] != listCreateQurlActionID {
+			continue
+		}
+		v, _ := acc["value"].(string)
+		vals = append(vals, v)
+	}
+	return vals
+}
+
+// listCreateQurlBlockActionsBody encodes a Slack block_actions
+// interaction for the "Create qURL" list button — the wire shape a row
+// click produces. `value` is the row's token (sigil stripped).
+func listCreateQurlBlockActionsBody(t *testing.T, teamID, userID, channelID, responseURL, actionID, value string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"type":         "block_actions",
+		"team":         map[string]any{"id": teamID},
+		"user":         map[string]any{"id": userID},
+		"channel":      map[string]any{"id": channelID},
+		"trigger_id":   "trigger_test",
+		"response_url": responseURL,
+		"actions": []map[string]any{
+			{"action_id": actionID, "block_id": "row_block", "value": value},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal block_actions payload: %v", err)
+	}
+	return url.Values{"payload": {string(payload)}}.Encode()
+}
+
+// TestHandleList_RendersCreateQurlButtons fences the interactive list:
+// every tunnel with a `$<token>` renders a "Create qURL" accessory
+// button valued by that token, the slug-less row gets NO button (it has
+// no token to mint against), and the plain-text fallback still carries
+// the complete listing for notifications / accessibility.
+func TestHandleList_RendersCreateQurlButtons(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB},
+			{testKeyResourceID: "r_stage_db_bb", testKeyType: client.ResourceTypeTunnel, testKeySlug: "stage-db"},
+			// Slug-less, alias-less tunnel: no `$<token>` → no button.
+			{testKeyResourceID: "r_noslug0001", testKeyType: client.ResourceTypeTunnel},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	body := inv.captured.waitForBody(t, 2*time.Second)
+
+	blocks := parseSlackBlocks(t, body)
+	if len(blocks) == 0 {
+		t.Fatalf("list response carried no blocks: %s", body)
+	}
+	vals := createQurlButtonValues(t, blocks)
+	// Rows sort by token: stage-db < prod-db? No — "prod-db" < "stage-db",
+	// and the tokenless row sorts last. So buttons are [prod-db, stage-db].
+	wantVals := []string{testListAliasProdDB, "stage-db"}
+	if len(vals) != len(wantVals) {
+		t.Fatalf("Create qURL button values = %v, want %v", vals, wantVals)
+	}
+	for i := range wantVals {
+		if vals[i] != wantVals[i] {
+			t.Errorf("button[%d] value = %q, want %q (all: %v)", i, vals[i], wantVals[i], vals)
+		}
+	}
+
+	// Text fallback still lists every tunnel, including the buttonless
+	// slug-less row, plus the one-time-use guidance.
+	fallback := parseSlackText(t, body)
+	for _, want := range []string{"`$prod-db`", "`$stage-db`", "no slug", "/qurl get", "one-time use"} {
+		if !strings.Contains(fallback, want) {
+			t.Errorf("text fallback missing %q: %q", want, fallback)
+		}
+	}
+}
+
+// TestHandleBlockActions_CreateQurlMints fences the button click: a
+// block_actions interaction for the "Create qURL" button acks 200 with
+// an empty body and mints a one-time qURL for the row's tunnel via the
+// same pipeline as `/qurl get $<slug>`, delivering the link to the
+// interaction's response_url.
+func TestHandleBlockActions_CreateQurlMints(t *testing.T) {
+	ts := newAdminTestServers(t)
+	// Bind $prod-db → r_prod_db in C_test so the token resolves, exactly
+	// as the typed `/qurl get $prod-db` happy path does.
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeCreateFixture(t, w, "https://qurl.link/btn", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, listCreateQurlActionID, "prod-db")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	if strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("block_actions ack = %q, want empty JSON object", w.Body.String())
+	}
+
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, "https://qurl.link/btn") {
+		t.Errorf("async reply missing minted link: %q", async)
+	}
+	if !strings.Contains(async, "one-time use") {
+		t.Errorf("async reply missing one-time-use note: %q", async)
+	}
+}
+
+// TestHandleBlockActions_UnknownActionIgnored fences the routing: a
+// block_actions payload whose action_id we don't recognize is acked 200
+// (so Slack doesn't error the user) and never reaches the mint.
+func TestHandleBlockActions_UnknownActionIgnored(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, "some_other_button", "prod-db")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("unknown-action ack = %d %q, want 200 and {}", w.Code, w.Body.String())
+	}
+	// No async worker is started for an unmatched action; the brief wait
+	// gives a (buggy) one a chance to fire so the negative assertion bites.
+	time.Sleep(50 * time.Millisecond)
+	if mintHits.Load() != 0 {
+		t.Errorf("mint reached for an unrecognized action (hits = %d)", mintHits.Load())
+	}
+}

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -151,6 +152,77 @@ func TestHandleBlockActions_CreateQurlMints(t *testing.T) {
 	}
 	if !strings.Contains(async, "one-time use") {
 		t.Errorf("async reply missing one-time-use note: %q", async)
+	}
+}
+
+// TestHandleBlockActions_UnparseableTokenRejected fences the
+// defense-in-depth re-validation: a button value that our renderer would
+// never emit (here, uppercase + spaces) fails parseAliasToken the same
+// way a typed token would, so the click is rejected with the
+// "couldn't process" copy and never reaches the mint.
+func TestHandleBlockActions_UnparseableTokenRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, listCreateQurlActionID, "Not A Token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("ack = %d %q, want 200 and {}", w.Code, w.Body.String())
+	}
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, "Couldn't process") {
+		t.Errorf("async reply missing rejection copy: %q", async)
+	}
+	if mintHits.Load() != 0 {
+		t.Errorf("mint reached for an unparseable token (hits = %d)", mintHits.Load())
+	}
+}
+
+// TestHandleList_OverflowDegradesToText fences the block-ceiling guard:
+// a tunnel set larger than listCreateButtonMaxRows renders as plain text
+// (no blocks) so every tunnel still shows — rather than a >50-block
+// message Slack would reject. Locks the cap so a future bump that would
+// breach the ceiling fails here.
+func TestHandleList_OverflowDegradesToText(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	n := listCreateButtonMaxRows + 1 // one past the cap → text-only path
+	resources := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		resources = append(resources, map[string]any{
+			testKeyResourceID: fmt.Sprintf("r_tun_%03d", i),
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       fmt.Sprintf("tun-%03d", i),
+		})
+	}
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, resources, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	body := inv.captured.waitForBody(t, 2*time.Second)
+	if blocks := parseSlackBlocks(t, body); blocks != nil {
+		t.Errorf("expected text-only fallback past the button cap, got %d blocks", len(blocks))
+	}
+	text := parseSlackText(t, body)
+	// First and last rows both present → the text path truncates nothing.
+	for _, want := range []string{"`$tun-000`", fmt.Sprintf("`$tun-%03d`", n-1), "/qurl get"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text fallback missing %q", want)
+		}
 	}
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -183,6 +183,25 @@ func (h *Handler) postResponse(log *slog.Logger, responseURL, text string) bool 
 	return h.postResponseBody(log, responseURL, body)
 }
 
+// postResponseBlocks POSTs an ephemeral Block Kit follow-up to Slack's
+// response_url. fallbackText is the plain-text rendering Slack shows in
+// notifications and to clients that can't render blocks — Slack treats a
+// blocks message's `text` as the accessibility/notification fallback, so
+// it MUST still carry the full listing. Same SSRF-fenced delivery,
+// single-attempt-with-logging posture as [Handler.postResponse].
+func (h *Handler) postResponseBlocks(log *slog.Logger, responseURL, fallbackText string, blocks []any) bool {
+	body, err := json.Marshal(map[string]any{
+		respFieldResponseType: respTypeEphemeral,
+		respFieldText:         fallbackText,
+		blockKitFieldBlocks:   blocks,
+	})
+	if err != nil {
+		log.Error("marshal response_url blocks payload failed", "error", err)
+		return false
+	}
+	return h.postResponseBody(log, responseURL, body)
+}
+
 func (h *Handler) postErrorResponse(log *slog.Logger, responseURL, message string, replaceOriginal bool) bool {
 	body, err := ErrorResponse(message, replaceOriginal)
 	if err != nil {

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -26,6 +26,16 @@ const (
 	callbackIDTunnelInstall  = "tunnel_install"
 )
 
+// listCreateQurlActionID is the action_id on the "Create qURL" button
+// rendered next to each `/qurl list` row. The block_actions handler
+// matches on it to mint a one-time qURL for that row's tunnel — the same
+// resolve→authorize→mint work as `/qurl get $<slug>`. The button's value
+// carries the row's `$<slug>`/`$<alias>` token with the `$` sigil
+// stripped. Reused as the action_id on every row (Slack only requires
+// action_id uniqueness within a block, not across the message), so the
+// clicked row is identified by the button's value, not its action_id.
+const listCreateQurlActionID = "list_create_qurl"
+
 const (
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"
@@ -279,6 +289,28 @@ func sectionBlock(text string) map[string]any {
 		"text": map[string]any{
 			"type": "mrkdwn",
 			"text": text,
+		},
+	}
+}
+
+// sectionWithButton returns a `section` block whose accessory is a
+// button. Slack renders an accessory to the RIGHT of the section text —
+// Block Kit has no leading/left accessory slot, so the right-aligned
+// accessory is the idiomatic "one action per row" shape. `value` rides
+// along on the button and is echoed back in the block_actions payload
+// when the button is clicked, so the handler knows which row was tapped.
+func sectionWithButton(text, buttonText, actionID, value string) map[string]any {
+	return map[string]any{
+		"type": "section",
+		"text": map[string]any{
+			"type": "mrkdwn",
+			"text": text,
+		},
+		"accessory": map[string]any{
+			"type":      "button",
+			"text":      plainTextObj(buttonText),
+			"action_id": actionID,
+			"value":     value,
 		},
 	}
 }


### PR DESCRIPTION
## What

Adds a **Create qURL** button to every tunnel row in `/qurl list` (and `/qurl-sandbox list`). Clicking it mints a one-time qURL for that row's tunnel and posts the link as a new ephemeral message — the same result as typing `/qurl get $<slug>`, without the copy-paste.

## Why

`/qurl list` already shows each tunnel's `$slug`/`$alias` and tells users to run `/qurl get` on it. The button removes that manual step for the common case while leaving the typed command fully intact.

## How

- **List rendering** moves from a single text blob to Block Kit blocks: one `section` per tunnel with a **Create qURL** accessory button (Block Kit renders accessories to the right of the row — there is no leading-accessory slot, so this is the idiomatic per-row button). The button's `value` carries the row's `$slug`/`$alias` token.
  - Slug-less `(no slug …)` rows get **no** button — there's no token to mint against.
  - Past Slack's 50-block-per-message ceiling the listing degrades to the existing plain-text version, so every tunnel stays visible.
  - The message still carries the full text listing as the Block Kit fallback (notifications / accessibility).
- **Interaction handling**: `block_actions` payloads are now routed; the click reuses the existing `getWork` pipeline via a new `processButtonGet`, so token resolution, **channel authorization**, and rate limiting are identical to the typed command. The button cannot mint anything a user couldn't already mint by typing `/qurl get` in that channel — for a non-admin in a channel where the tunnel isn't allowed, it returns the same "not configured for this channel" message.
  - Slack requires a fast ack, so the mint runs on the bounded async pool and the link is delivered out-of-band via the interaction's `response_url`, leaving the list message intact.
- **Footer copy** now names both ways to mint (the button and `/qurl get`) and spells out that every qURL is **one-time use by default**.

## One-time use

Unchanged behavior, now stated explicitly in the list footer and already on the mint reply (`(one-time use)`). Both the typed command and the button mint one-time links.

## Testing

- `go test ./...` (slack app) passes, including new tests: button rendering per row (and no button on slug-less rows), the `block_actions` mint-and-deliver path, and unknown-action routing.
- `-race` clean on the list/get/interaction tests.
- `golangci-lint` (v2.10.1, the CI-pinned version) reports 0 issues; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)