### PR TITLE
fix(slack): show tunnel slug in /qurl aliases, never resource_id

### DIFF
--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -92,14 +92,16 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 	// Collapse the per-alias bindings into one group per tunnel: several
 	// aliases can point to the same slug, so the listing shows the slug
 	// once followed by every alias that resolves to it here. Per-group
-	// resource fetch is best-effort — a failed fetch degrades to a
-	// resource-id line rather than dropping the group.
+	// resource fetch is best-effort — a failed fetch degrades to an
+	// alias-only line (never the opaque resource_id) rather than dropping
+	// the group.
 	groups := groupAliasEntriesByResource(entries)
 	lines := fanoutAliasGroups(ctx, log, c, groups, aliasesResourceFanoutLimit)
 	sort.Strings(lines)
 
-	body := "*Aliases configured for this channel:*\n" + strings.Join(lines, "\n") +
-		"\n\n_Each line is a tunnel `$<slug>` followed by the aliases that resolve to it here. Run `/qurl get` with the slug or any alias._"
+	body := "*Aliases configured for this channel:*\n" +
+		"_Format: `$<slug>` → the aliases that resolve to it. Run `/qurl get` with the slug or any alias._\n" +
+		strings.Join(lines, "\n")
 	_ = h.postResponse(log, responseURL, body)
 }
 
@@ -154,8 +156,8 @@ func groupAliasEntriesByResource(entries []slackdata.PolicyEntry) []aliasGroup {
 // without this, a cancellation that fires while the loop is queuing rows
 // (more groups than `limit`) would block on `sem <- {}` indefinitely
 // (the workers only honor ctx through their downstream HTTP call).
-// Groups that don't get dispatched fall back to resource-id-only lines
-// via [formatAliasGroupLine] so the user still sees one line per group.
+// Groups that don't get dispatched fall back to alias-only lines via
+// [formatAliasGroupLine] so the user still sees one line per group.
 //
 // Output order is non-deterministic — the caller sorts before rendering.
 func fanoutAliasGroups(ctx context.Context, log *slog.Logger, c *client.Client, groups []aliasGroup, limit int) []string {
@@ -170,9 +172,10 @@ loop:
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
-			// Fill un-dispatched tail with id-only fallbacks.
+			// Fill un-dispatched tail with alias-only fallbacks — no fetch
+			// happened, so there's no slug and (by design) no resource_id.
 			for j := i; j < len(groups); j++ {
-				lines[j] = formatAliasGroupLine(groups[j].resourceID, "", "", groups[j].aliases)
+				lines[j] = formatAliasGroupLine("", "", groups[j].aliases)
 			}
 			break loop
 		}
@@ -182,33 +185,27 @@ loop:
 			defer func() { <-sem }()
 			g := &groups[idx]
 			target, slug := "", ""
-			if g.resourceID != "" && len(g.aliases) > 0 {
-				// GetResourceByAlias returns the full Resource (Slug,
-				// TargetURL, …). Every alias in a group resolves to the
-				// same resource, so one lookup (via the first alias)
-				// resolves the whole group. A tunnel carries a Slug and
-				// no TargetURL; a legacy URL binding the reverse.
-				//
-				// This single-fetch optimization assumes the upstream
-				// lookup-by-alias returns the canonical resource (the same
-				// one all aliases in the group are bound to in DDB), not an
-				// alias-specific view. True today; if GetResourceByAlias
-				// ever returned a per-alias view, a group line could pick up
-				// the wrong slug — fetch per alias then.
-				if r, rerr := c.GetResourceByAlias(ctx, g.aliases[0]); rerr == nil {
+			if g.resourceID != "" {
+				// Resolve the group's canonical resource directly by the
+				// resource_id we already hold from channel_policies, via
+				// GET /v1/resources/{id}. The response carries the full
+				// Resource: a tunnel has a Slug and no TargetURL; a legacy
+				// URL binding the reverse. One fetch covers the whole group
+				// — every alias in it points at this same resource_id.
+				if r, rerr := c.GetResource(ctx, g.resourceID); rerr == nil {
 					target = r.TargetURL
 					slug = r.Slug
 				} else if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
 					// Distinct log from the 404/5xx branch so operators
 					// can tell "request was cut short by SIGTERM /
 					// asyncWorkTimeout" apart from "upstream rejected
-					// this alias" when triaging.
+					// this id" when triaging.
 					log.Debug("aliases: resource fetch canceled before completion", "error", rerr, "resource_id", g.resourceID)
 				} else {
 					log.Debug("aliases: resource fetch failed in fanout", "error", rerr, "resource_id", g.resourceID)
 				}
 			}
-			lines[idx] = formatAliasGroupLine(g.resourceID, target, slug, g.aliases)
+			lines[idx] = formatAliasGroupLine(target, slug, g.aliases)
 		}(i)
 	}
 	wg.Wait()
@@ -216,19 +213,23 @@ loop:
 }
 
 // formatAliasGroupLine renders one /qurl aliases line as
-// `<what the aliases resolve to> → <the aliases>`, so the slug/target
-// reads as the canonical thing and the `$alias` tokens as its alternate
+// `$<slug> → <the aliases>`, so the immutable tunnel slug reads as the
+// canonical name and the `$alias` tokens as its channel-scoped alternate
 // names. The left side, most to least specific:
 //
-//   - tunnel slug:        • `$<slug>` (tunnel) → `$<a1>`, `$<a2>`
-//   - legacy URL target:  • <url> (URL) → `$<a1>`, `$<a2>`
-//   - unresolved id:      • `<r_id>` (no slug) → `$<a1>`, `$<a2>`
-//   - nothing resolved:   • `$<a1>`, `$<a2>` (resource-less synthetic row)
+//   - tunnel slug:        • `$<slug>` → `$<a1>`, `$<a2>`
+//   - legacy URL target:  • <url> (legacy URL) → `$<a1>`, `$<a2>`
+//   - slug unresolved:    • `$<a1>`, `$<a2>`
+//
+// The opaque resource_id is never surfaced to users: a group whose slug
+// can't be resolved (upstream fetch failed, or a legacy resource that
+// predates the slug requirement) degrades to listing its channel aliases
+// alone — the user can still `/qurl get $alias`.
 //
 // An alias equal to the slug is dropped from the right side — the install
 // flow binds `$<slug>` as a channel alias, so it would otherwise list
 // itself. A group whose only alias IS the slug renders just the slug.
-func formatAliasGroupLine(resourceID, target, slug string, aliases []string) string {
+func formatAliasGroupLine(target, slug string, aliases []string) string {
 	rhs := make([]string, 0, len(aliases))
 	for _, a := range aliases {
 		if a != slug {
@@ -238,15 +239,13 @@ func formatAliasGroupLine(resourceID, target, slug string, aliases []string) str
 	var left string
 	switch {
 	case slug != "":
-		left = "`$" + slug + "` (tunnel)"
+		left = "`$" + slug + "`"
 	case target != "":
-		left = target + " (URL)"
-	case resourceID != "":
-		left = "`" + resourceID + "` (no slug)"
+		left = target + " (legacy URL)"
 	default:
-		// No resource resolved at all — show the alias names alone so the
-		// row still renders (resource-less synthetic entry; a real
-		// PolicyEntry always carries a resource_id).
+		// No slug resolved — never fall back to the opaque resource_id.
+		// Show the channel aliases alone so the row still renders and
+		// `/qurl get $alias` still works.
 		if len(rhs) == 0 {
 			return "• (no alias)"
 		}

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 // TestHandleAliases_HappyPath fences the canonical /qurl aliases
-// flow: LookupChannelAlias → per-row resource fetch → rendered
-// list. Single alias binding on the channel.
+// flow: GetChannelPolicy → per-group resource fetch (by resource_id) →
+// rendered list. Single alias binding on the channel.
 func TestHandleAliases_HappyPath(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
-	ts.addCustomer("GET", "/v1/resources/by-alias/prod-db", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("GET", "/v1/resources/"+testResourceIDFix, func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceFixtureWithTarget(t, w, testResourceIDFix, "prod-db", "https://prod.example.com")
 	})
 	h := newAdminTestHandler(t, ts)
@@ -28,32 +28,33 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 	if !strings.Contains(async, "Aliases configured for this channel") {
 		t.Errorf("async reply missing header: %q", async)
 	}
-	// Legacy URL binding: the alias points at a raw URL (no slug), so the
-	// line reads "<url> (URL) → `$<alias>`".
-	if !strings.Contains(async, "https://prod.example.com (URL) → `$prod-db`") {
+	// Legacy URL binding: the resource has a target_url and no slug, so the
+	// line reads "<url> (legacy URL) → `$<alias>`".
+	if !strings.Contains(async, "https://prod.example.com (legacy URL) → `$prod-db`") {
 		t.Errorf("async reply missing prod-db line: %q", async)
 	}
 }
 
-// TestHandleAliases_TunnelAliasShowsSlug fences the alias→slug rendering
-// for tunnel-backed aliases: a tunnel resource has no target_url, so the
-// row shows the tunnel's `$<slug>` (the same token /qurl list renders
-// and /qurl get accepts) instead of the opaque resource_id.
+// TestHandleAliases_TunnelAliasShowsSlug fences the resource_id→slug
+// rendering for tunnel-backed aliases: a tunnel resource has no
+// target_url, so the row shows the tunnel's `$<slug>` (the same token
+// /qurl list renders and /qurl get accepts) instead of the opaque
+// resource_id.
 func TestHandleAliases_TunnelAliasShowsSlug(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
 		"bastion": "r_bastion01",
 	})
-	ts.addCustomer("GET", "/v1/resources/by-alias/bastion", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("GET", "/v1/resources/r_bastion01", func(w http.ResponseWriter, _ *http.Request) {
 		writeTunnelResourceFixture(t, w, "r_bastion01", "bastion", "ops-bastion")
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
-	// Tunnel-backed: the slug is the canonical name (left of the arrow,
-	// labeled "(tunnel)") and the alias is its alternate name.
-	if !strings.Contains(async, "`$ops-bastion` (tunnel) → `$bastion`") {
+	// Tunnel-backed: the slug is the canonical name (left of the arrow)
+	// and the alias is its alternate name.
+	if !strings.Contains(async, "`$ops-bastion` → `$bastion`") {
 		t.Errorf("aliases reply missing slug→alias mapping: %q", async)
 	}
 	if strings.Contains(async, "r_bastion01") {
@@ -63,9 +64,9 @@ func TestHandleAliases_TunnelAliasShowsSlug(t *testing.T) {
 
 // TestHandleAliases_MultipleAliasesOneTunnelCollapse fences change #2's
 // headline behavior: several aliases pointing at the SAME tunnel
-// collapse onto one line — `$<slug> (tunnel) → $<a1>, $<a2>` — with the
-// aliases sorted and a single resource fetch for the group (one lookup
-// via the first alias, not one per alias).
+// collapse onto one line — `$<slug> → $<a1>, $<a2>` — with the aliases
+// sorted and a single resource fetch for the group (one by-id lookup
+// covers the whole group, not one per alias).
 func TestHandleAliases_MultipleAliasesOneTunnelCollapse(t *testing.T) {
 	ts := newAdminTestServers(t)
 	// Two aliases bound to the same tunnel resource_id.
@@ -73,23 +74,19 @@ func TestHandleAliases_MultipleAliasesOneTunnelCollapse(t *testing.T) {
 		"dashboard":       "r_kktest01",
 		"kevin-dashboard": "r_kktest01",
 	})
-	// The group resolves via its first (sorted) alias — "dashboard". One
-	// fetch covers the whole group; assert a second per-alias fetch never
-	// fires by failing if the kevin-dashboard endpoint is hit.
+	// The group resolves once by its shared resource_id. One fetch covers
+	// the whole group regardless of how many aliases point at it; assert
+	// the by-id endpoint is hit exactly once.
 	var fetches atomic.Int32
-	ts.addCustomer("GET", "/v1/resources/by-alias/dashboard", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("GET", "/v1/resources/r_kktest01", func(w http.ResponseWriter, _ *http.Request) {
 		fetches.Add(1)
 		writeTunnelResourceFixture(t, w, "r_kktest01", "dashboard", "kktest")
-	})
-	ts.addCustomer("GET", "/v1/resources/by-alias/kevin-dashboard", func(w http.ResponseWriter, _ *http.Request) {
-		fetches.Add(1)
-		writeTunnelResourceFixture(t, w, "r_kktest01", "kevin-dashboard", "kktest")
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$kktest` (tunnel) → `$dashboard`, `$kevin-dashboard`") {
+	if !strings.Contains(async, "`$kktest` → `$dashboard`, `$kevin-dashboard`") {
 		t.Errorf("aliases reply did not collapse both aliases onto one slug line: %q", async)
 	}
 	if got := fetches.Load(); got != 1 {
@@ -110,15 +107,15 @@ func TestHandleAliases_MultiAliasChannelDisplaysAllBindings(t *testing.T) {
 		"alpha": "r_alpha",
 		"mu":    "r_mu",
 	})
-	// Per-alias resource fetch returns the alias label + a unique
-	// target URL so we can assert all three lines independently.
-	ts.addCustomer("GET", "/v1/resources/by-alias/alpha", func(w http.ResponseWriter, _ *http.Request) {
+	// Per-group resource fetch (by resource_id) returns a unique target
+	// URL so we can assert all three lines independently.
+	ts.addCustomer("GET", "/v1/resources/r_alpha", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceFixtureWithTarget(t, w, "r_alpha", "alpha", "https://alpha.example.com")
 	})
-	ts.addCustomer("GET", "/v1/resources/by-alias/mu", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("GET", "/v1/resources/r_mu", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceFixtureWithTarget(t, w, "r_mu", "mu", "https://mu.example.com")
 	})
-	ts.addCustomer("GET", "/v1/resources/by-alias/zeta", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("GET", "/v1/resources/r_zeta", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceFixtureWithTarget(t, w, "r_zeta", "zeta", "https://zeta.example.com")
 	})
 	h := newAdminTestHandler(t, ts)
@@ -224,7 +221,7 @@ func TestGroupAliasEntriesByResource(t *testing.T) {
 
 // TestFanoutAliasGroups_RespectsCtxCancellation fences the dispatcher
 // loop's ctx-aware semaphore acquire: a canceled ctx during dispatch
-// fills un-dispatched groups with id-only fallbacks (no goroutine
+// fills un-dispatched groups with alias-only fallbacks (no goroutine
 // leaks, no deadlock).
 func TestFanoutAliasGroups_RespectsCtxCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -239,7 +236,7 @@ func TestFanoutAliasGroups_RespectsCtxCancellation(t *testing.T) {
 
 	var hits atomic.Int32
 	ts := newAdminTestServers(t)
-	ts.addCustomerPrefix("GET", "/v1/resources/by-alias/", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomerPrefix("GET", "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
 		hits.Add(1)
 		w.WriteHeader(http.StatusOK)
 	})
@@ -254,11 +251,11 @@ func TestFanoutAliasGroups_RespectsCtxCancellation(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("lines len = %d, want 3", len(lines))
 	}
-	// All three should be id-only fallbacks because ctx is canceled
-	// before any worker dispatched.
+	// All three should be alias-only fallbacks because ctx is canceled
+	// before any worker dispatched — never the opaque resource_id.
 	for i, l := range lines {
-		if !strings.Contains(l, "`r_") {
-			t.Errorf("line[%d] = %q, want id-only fallback", i, l)
+		if !strings.Contains(l, "`$") || strings.Contains(l, "r_") {
+			t.Errorf("line[%d] = %q, want alias-only fallback (no resource_id)", i, l)
 		}
 	}
 	// At most one hit may have leaked through before the cancel was
@@ -277,9 +274,10 @@ func TestFanoutAliasGroups_RespectsCtxCancellation(t *testing.T) {
 //   - return one line per entry (no entry silently dropped),
 //   - return within ctx.Deadline() + a small grace (no goroutine
 //     leak that holds onto the worker pool past timeout),
-//   - degrade un-dispatched and slow-fetched rows to id-only
+//   - degrade un-dispatched and slow-fetched rows to alias-only
 //     fallbacks (the user sees a complete list, just with some
-//     `$alias` → `r_xxx` lines instead of `$alias` → https://...).
+//     bare `$alias` lines instead of `$slug` → `$alias`), never
+//     leaking the opaque resource_id.
 //
 // Without this fence, a refactor that swallows ctx in
 // [fanoutAliasGroups]'s per-group goroutine (e.g., dropping the
@@ -304,7 +302,7 @@ func TestFanoutAliasGroups_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 	// slow customer API where per-call latency is on the order of the
 	// remaining ctx budget. The handler's ctx is propagated through
 	// the SDK; the handler.go semaphore-and-ctx logic must observe it.
-	ts.addCustomerPrefix("GET", "/v1/resources/by-alias/", func(w http.ResponseWriter, r *http.Request) {
+	ts.addCustomerPrefix("GET", "/v1/resources/", func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 		// Reply doesn't matter — ctx-canceled errors surface to the
 		// caller via the SDK's request layer, not from the response
@@ -321,7 +319,7 @@ func TestFanoutAliasGroups_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 	// 150ms deadline keeps the test cheap while still letting the
 	// dispatcher fan out the first batch of 8 workers (limit) before
 	// ctx fires. The remaining 72 entries hit the ctx-aware semaphore
-	// branch and fall back to id-only fallbacks.
+	// branch and fall back to alias-only fallbacks.
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
@@ -346,17 +344,21 @@ func TestFanoutAliasGroups_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 			t.Errorf("line[%d] empty — entry was dropped, not fallback-rendered", i)
 		}
 	}
-	// At least the tail of the list (the un-dispatched majority) MUST
-	// have rendered as id-only `r_xx` fallbacks, never as upstream
-	// targets (the upstream never returned anything other than 503).
-	idOnly := 0
+	// The upstream never resolved a slug (it only ever 503'd or was
+	// ctx-canceled), so every line must be an alias-only fallback — and
+	// the opaque resource_id must never leak. Count the fallbacks and pin
+	// that none carry an `r_` id.
+	fallbacks := 0
 	for _, l := range lines {
-		if strings.Contains(l, "`r_") {
-			idOnly++
+		if strings.Contains(l, "r_") {
+			t.Errorf("line leaked opaque resource_id: %q", l)
+		}
+		if strings.Contains(l, "`$alias-") {
+			fallbacks++
 		}
 	}
-	if idOnly < numEntries-aliasesResourceFanoutLimit {
-		t.Errorf("id-only fallback count = %d, want ≥%d (un-dispatched rows must fall back)", idOnly, numEntries-aliasesResourceFanoutLimit)
+	if fallbacks < numEntries-aliasesResourceFanoutLimit {
+		t.Errorf("alias-only fallback count = %d, want ≥%d (un-dispatched rows must fall back)", fallbacks, numEntries-aliasesResourceFanoutLimit)
 	}
 }
 
@@ -375,13 +377,14 @@ func TestHandleAliases_OtherChannelsDoNotLeak(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		ts.seedPolicySet(t, testAdminTeamID, "C_other_"+string(rune('a'+i)), "leak-canary", []string{"r_leak"})
 	}
-	ts.addCustomer("GET", "/v1/resources/by-alias/primary", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomer("GET", "/v1/resources/r_primary", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceFixtureWithTarget(t, w, "r_primary", "primary", "https://prod.example.com")
 	})
-	ts.addCustomerPrefix("GET", "/v1/resources/by-alias/", func(w http.ResponseWriter, _ *http.Request) {
+	ts.addCustomerPrefix("GET", "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
 		// Force a 404 on any non-primary fetch — if the handler leaks
 		// a sibling channel's alias, the resource fetch lands here
-		// and renders as id-only (not the prod-example.com URL).
+		// and renders as an alias-only fallback (not the prod-example.com
+		// URL).
 		w.WriteHeader(http.StatusNotFound)
 	})
 	h := newAdminTestHandler(t, ts)

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -254,7 +254,9 @@ func TestFanoutAliasGroups_RespectsCtxCancellation(t *testing.T) {
 	// All three should be alias-only fallbacks because ctx is canceled
 	// before any worker dispatched — never the opaque resource_id.
 	for i, l := range lines {
-		if !strings.Contains(l, "`$") || strings.Contains(l, "r_") {
+		// Match the backtick-prefixed `r_ shape a leaked id would take, not
+		// a bare "r_" that a future alias could legitimately contain.
+		if !strings.Contains(l, "`$") || strings.Contains(l, "`r_") {
 			t.Errorf("line[%d] = %q, want alias-only fallback (no resource_id)", i, l)
 		}
 	}
@@ -345,20 +347,22 @@ func TestFanoutAliasGroups_DeadlineDuringFanoutDoesNotLeak(t *testing.T) {
 		}
 	}
 	// The upstream never resolved a slug (it only ever 503'd or was
-	// ctx-canceled), so every line must be an alias-only fallback — and
-	// the opaque resource_id must never leak. Count the fallbacks and pin
-	// that none carry an `r_` id.
+	// ctx-canceled), so every line — dispatched and un-dispatched alike —
+	// must be an alias-only fallback, and the opaque resource_id must
+	// never leak. Match the backtick-prefixed `r_ shape formatAliasGroupLine
+	// would emit for a leaked id, so an alias that merely contains "r_"
+	// can't false-positive.
 	fallbacks := 0
 	for _, l := range lines {
-		if strings.Contains(l, "r_") {
+		if strings.Contains(l, "`r_") {
 			t.Errorf("line leaked opaque resource_id: %q", l)
 		}
 		if strings.Contains(l, "`$alias-") {
 			fallbacks++
 		}
 	}
-	if fallbacks < numEntries-aliasesResourceFanoutLimit {
-		t.Errorf("alias-only fallback count = %d, want ≥%d (un-dispatched rows must fall back)", fallbacks, numEntries-aliasesResourceFanoutLimit)
+	if fallbacks != numEntries {
+		t.Errorf("alias-only fallback count = %d, want %d (every row falls back under a failing upstream)", fallbacks, numEntries)
 	}
 }
 

--- a/apps/slack/internal/handler_test_helpers_test.go
+++ b/apps/slack/internal/handler_test_helpers_test.go
@@ -56,10 +56,11 @@ func writeResourceFixtureWithTarget(t *testing.T, w http.ResponseWriter, resourc
 	}
 }
 
-// writeTunnelResourceFixture writes the by-alias resource envelope for
+// writeTunnelResourceFixture writes the by-id resource envelope for
 // a TUNNEL resource: no target_url, carries a slug + active status.
-// Used by the aliases tests to exercise the alias→slug rendering branch
-// (formatAliasLine prefers the slug over the opaque resource_id).
+// Used by the aliases tests to exercise the resource_id→slug rendering
+// branch (formatAliasGroupLine prefers the slug over the opaque
+// resource_id).
 func writeTunnelResourceFixture(t *testing.T, w http.ResponseWriter, resourceID, alias, slug string) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -126,9 +126,9 @@ var ErrUpdateResourceAliasClearExclusive = errors.New("update resource: alias an
 // guard on Create.
 var ErrUpdateResourceNoFieldsSet = errors.New("update resource: input has no fields set")
 
-// ErrGetResourceByAliasEmpty is returned by GetResourceByAlias when alias
+// ErrGetResourceEmptyID is returned by GetResource when the resource ID
 // is the empty string.
-var ErrGetResourceByAliasEmpty = errors.New("get resource by alias: alias is empty")
+var ErrGetResourceEmptyID = errors.New("get resource: resource id is empty")
 
 // StatusActive indicates the qURL is live and accepting access requests.
 const StatusActive = "active"
@@ -280,7 +280,7 @@ type AccessPolicy struct {
 type CreateInput struct {
 	TargetURL string `json:"target_url,omitempty"`
 	// ResourceID, when set, mints a qURL bound to an existing resource
-	// (e.g. a tunnel resource resolved via GetResourceByAlias). Mutually
+	// (e.g. a tunnel resource resolved via GetResource). Mutually
 	// exclusive with TargetURL on the wire.
 	ResourceID   string        `json:"resource_id,omitempty"`
 	Description  string        `json:"description,omitempty"`
@@ -587,8 +587,8 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 // --- Resources ---
 //
 // These methods target the post-PR-3a.2 surface in qurl-service: alias
-// fields on `Resource`, the `GET /v1/resources/by-alias/{alias}` endpoint,
-// and `clear_alias` on `PATCH /v1/resources/{id}`. The OpenAPI schema for
+// fields on `Resource` and `clear_alias` on `PATCH /v1/resources/{id}`.
+// The OpenAPI schema for
 // PR-3a.2 has not shipped at the time this client method set lands — they
 // are added here so the Slack `setalias`/`get` flows in PR-3c.3+ have a
 // stable Go surface to call against. Until PR-3a.2 ships in qurl-service,
@@ -886,7 +886,7 @@ func (c *Client) RevokeAPIKey(ctx context.Context, keyID string) error {
 
 // UpdateResource updates a resource's mutable properties (alias, description,
 // access policy, etc.). resourceID must be a `r_…` ID; alias-keyed updates
-// must first resolve via GetResourceByAlias.
+// must first resolve the alias to its resource_id.
 //
 // Validation order (first match wins): trim resourceID → empty
 // resourceID → nil input → no-fields-set → trim Alias → exclusivity
@@ -922,7 +922,7 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 		return nil, ErrUpdateResourceNoFieldsSet
 	}
 	// Trim *input.Alias for symmetry with the resourceID and
-	// GetResourceByAlias trim contracts. Shallow-copy input so the
+	// GetResource trim contracts. Shallow-copy input so the
 	// trim doesn't mutate the caller's struct, then re-point Alias at
 	// the trimmed value. The trimmed string is what hits the wire and
 	// what the empty-pointer guard below sees.
@@ -965,26 +965,25 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, input *U
 	return &out, nil
 }
 
-// GetResourceByAlias resolves an alias to its underlying resource.
-//
-// alias must NOT include the leading `$` sigil used in Slack/Discord
-// surfaces — pass the bare alias string. Returns a typed APIError with
-// 404 status if the alias is not registered for the caller's owner.
-func (c *Client) GetResourceByAlias(ctx context.Context, alias string) (*Resource, error) {
+// GetResource fetches a single resource by its `r_…` ID via
+// GET /v1/resources/{id}. The response carries the full Resource,
+// including the tunnel Slug for type=tunnel rows. Returns a typed
+// APIError with 404 status when the ID is unknown to the caller's owner.
+func (c *Client) GetResource(ctx context.Context, resourceID string) (*Resource, error) {
 	// Normalize then validate (same posture as UpdateResource on
-	// resourceID) — strips surrounding whitespace so trimmed value
+	// resourceID) — strips surrounding whitespace so the trimmed value
 	// is what hits the wire, and rejects whitespace-only as empty.
-	alias = strings.TrimSpace(alias)
-	if alias == "" {
-		return nil, ErrGetResourceByAliasEmpty
+	resourceID = strings.TrimSpace(resourceID)
+	if resourceID == "" {
+		return nil, ErrGetResourceEmptyID
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/resources/by-alias/"+url.PathEscape(alias), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/resources/"+url.PathEscape(resourceID), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
 	var out Resource
-	if _, err := c.do(req, &out, "GET /v1/resources/by-alias/:alias"); err != nil {
+	if _, err := c.do(req, &out, "GET /v1/resources/:id"); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -588,11 +588,11 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 //
 // These methods target the post-PR-3a.2 surface in qurl-service: alias
 // fields on `Resource` and `clear_alias` on `PATCH /v1/resources/{id}`.
-// The OpenAPI schema for
-// PR-3a.2 has not shipped at the time this client method set lands — they
-// are added here so the Slack `setalias`/`get` flows in PR-3c.3+ have a
-// stable Go surface to call against. Until PR-3a.2 ships in qurl-service,
-// these methods will return 404/400 from the API.
+// The OpenAPI schema for PR-3a.2 has not shipped at the time this client
+// method set lands — they are added here so the Slack `setalias`/`get`
+// flows in PR-3c.3+ have a stable Go surface to call against. Until
+// PR-3a.2 ships in qurl-service, these methods will return 404/400 from
+// the API.
 
 // Resource represents a qURL resource (the durable object behind a qURL link).
 //

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -586,13 +586,10 @@ func (c *Client) MintLink(ctx context.Context, id string) (*MintOutput, error) {
 
 // --- Resources ---
 //
-// These methods target the post-PR-3a.2 surface in qurl-service: alias
-// fields on `Resource` and `clear_alias` on `PATCH /v1/resources/{id}`.
-// The OpenAPI schema for PR-3a.2 has not shipped at the time this client
-// method set lands — they are added here so the Slack `setalias`/`get`
-// flows in PR-3c.3+ have a stable Go surface to call against. Until
-// PR-3a.2 ships in qurl-service, these methods will return 404/400 from
-// the API.
+// These methods target the resource surface in qurl-service: alias
+// fields on `Resource`, the `GET /v1/resources/{id}` lookup, and
+// `clear_alias` on `PATCH /v1/resources/{id}`. That schema has shipped;
+// the Slack `setalias`/`get`/`aliases` flows call against it.
 
 // Resource represents a qURL resource (the durable object behind a qURL link).
 //

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -2009,8 +2009,8 @@ func TestUpdateResourceNilInputRejected(t *testing.T) {
 	}
 }
 
-func TestGetResourceByAlias(t *testing.T) {
-	const wantPath = "/v1/resources/by-alias/" + testAlias
+func TestGetResource(t *testing.T) {
+	const wantPath = "/v1/resources/" + testResourceIDAlt
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
@@ -2020,38 +2020,39 @@ func TestGetResourceByAlias(t *testing.T) {
 		}
 		apiEnvelope(t, w, map[string]any{
 			"resource_id": testResourceIDAlt,
-			"alias":       testAlias,
-			"target_url":  testTargetURL,
-			"type":        ResourceTypeURL,
+			"slug":        testTunnelSlug,
+			"type":        ResourceTypeTunnel,
 			"status":      StatusActive,
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.GetResourceByAlias(context.Background(), testAlias)
+	got, err := c.GetResource(context.Background(), testResourceIDAlt)
 	if err != nil {
-		t.Fatalf("GetResourceByAlias: %v", err)
+		t.Fatalf("GetResource: %v", err)
 	}
 	if got.ResourceID != testResourceIDAlt {
 		t.Errorf("got ResourceID %q", got.ResourceID)
 	}
-	if got.Alias != testAlias {
-		t.Errorf("got Alias %q, want %q", got.Alias, testAlias)
+	// Slug decode is the contract this method exists for — /qurl aliases
+	// renders the tunnel slug resolved here, never the opaque resource_id.
+	if got.Slug != testTunnelSlug {
+		t.Errorf("got Slug %q, want %q", got.Slug, testTunnelSlug)
 	}
 	// Pin response-side decode of Type and Status — the schema is
 	// the contract, and round-tripping these fields catches future
 	// JSON-tag regressions on the response side.
-	if got.Type != ResourceTypeURL {
-		t.Errorf("got Type %q, want %q", got.Type, ResourceTypeURL)
+	if got.Type != ResourceTypeTunnel {
+		t.Errorf("got Type %q, want %q", got.Type, ResourceTypeTunnel)
 	}
 	if got.Status != StatusActive {
 		t.Errorf("got Status %q, want %q", got.Status, StatusActive)
 	}
 }
 
-func TestGetResourceByAliasEscapesPathSegment(t *testing.T) {
-	// Aliases are validated server-side as `^[a-z][a-z0-9-]{1,62}[a-z0-9]$`
+func TestGetResourceEscapesPathSegment(t *testing.T) {
+	// Resource IDs are validated server-side as `^r_[a-z0-9_-]{11}$`
 	// (no `/`, no `%`), so reserved bytes won't reach this method via the
 	// Slack/Discord parsers. But the client method should still escape its
 	// input — defensive for direct programmatic callers and to keep a future
@@ -2066,17 +2067,17 @@ func TestGetResourceByAliasEscapesPathSegment(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.GetResourceByAlias(context.Background(), "weird/alias"); err != nil {
-		t.Fatalf("GetResourceByAlias: %v", err)
+	if _, err := c.GetResource(context.Background(), "weird/id"); err != nil {
+		t.Fatalf("GetResource: %v", err)
 	}
-	const want = "/v1/resources/by-alias/weird%2Falias"
+	const want = "/v1/resources/weird%2Fid"
 	if gotEscapedPath != want {
-		t.Errorf("alias path-escape: got %q, want %q", gotEscapedPath, want)
+		t.Errorf("resourceID path-escape: got %q, want %q", gotEscapedPath, want)
 	}
 }
 
 // TestUpdateResourceEscapesIDPathSegment is the symmetric path-escape
-// pin for UpdateResource (mirror of TestGetResourceByAliasEscapesPathSegment).
+// pin for UpdateResource (mirror of TestGetResourceEscapesPathSegment).
 // Server-side resource_id format is `^r_[a-z0-9_-]{11}$` so reserved
 // bytes won't reach this method via normal flows; the test is
 // defensive for direct programmatic callers and keeps a future
@@ -2102,30 +2103,30 @@ func TestUpdateResourceEscapesIDPathSegment(t *testing.T) {
 	}
 }
 
-func TestGetResourceByAliasEmptyRejected(t *testing.T) {
+func TestGetResourceEmptyRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	_, err := c.GetResourceByAlias(context.Background(), "")
-	if !errors.Is(err, ErrGetResourceByAliasEmpty) {
-		t.Fatalf("expected ErrGetResourceByAliasEmpty, got %v", err)
+	_, err := c.GetResource(context.Background(), "")
+	if !errors.Is(err, ErrGetResourceEmptyID) {
+		t.Fatalf("expected ErrGetResourceEmptyID, got %v", err)
 	}
 }
 
-// TestGetResourceByAliasWhitespaceRejected pins the strings.TrimSpace
-// guard — a whitespace-only alias would hit the wire as
-// `/v1/resources/by-alias/%20%20` and 400 server-side. Companion to
-// TestGetResourceByAliasEmptyRejected.
-func TestGetResourceByAliasWhitespaceRejected(t *testing.T) {
+// TestGetResourceWhitespaceRejected pins the strings.TrimSpace
+// guard — a whitespace-only ID would hit the wire as
+// `/v1/resources/%20%20` and 400 server-side. Companion to
+// TestGetResourceEmptyRejected.
+func TestGetResourceWhitespaceRejected(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
-	_, err := c.GetResourceByAlias(context.Background(), "   ")
-	if !errors.Is(err, ErrGetResourceByAliasEmpty) {
-		t.Fatalf("expected ErrGetResourceByAliasEmpty on whitespace, got %v", err)
+	_, err := c.GetResource(context.Background(), "   ")
+	if !errors.Is(err, ErrGetResourceEmptyID) {
+		t.Fatalf("expected ErrGetResourceEmptyID on whitespace, got %v", err)
 	}
 }
 
-// TestGetResourceByAliasTrimsSurroundingWhitespace pins the
-// "trim then validate AND send" contract for the alias path
+// TestGetResourceTrimsSurroundingWhitespace pins the
+// "trim then validate AND send" contract for the resource-id path
 // (mirror of TestUpdateResourceTrimsSurroundingWhitespace).
-func TestGetResourceByAliasTrimsSurroundingWhitespace(t *testing.T) {
+func TestGetResourceTrimsSurroundingWhitespace(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
@@ -2134,16 +2135,16 @@ func TestGetResourceByAliasTrimsSurroundingWhitespace(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.GetResourceByAlias(context.Background(), "  "+testAlias+"  "); err != nil {
-		t.Fatalf("GetResourceByAlias: %v", err)
+	if _, err := c.GetResource(context.Background(), "  "+testResourceIDAlt+"  "); err != nil {
+		t.Fatalf("GetResource: %v", err)
 	}
-	wantPath := "/v1/resources/by-alias/" + testAlias
+	wantPath := "/v1/resources/" + testResourceIDAlt
 	if gotPath != wantPath {
 		t.Errorf("trimmed value should hit the wire: got %q, want %q", gotPath, wantPath)
 	}
 }
 
-func TestGetResourceByAliasNotFound(t *testing.T) {
+func TestGetResourceNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusNotFound)
@@ -2151,8 +2152,8 @@ func TestGetResourceByAliasNotFound(t *testing.T) {
 			"error": map[string]any{
 				"title":  "Not Found",
 				"status": 404,
-				"detail": "alias not found",
-				"code":   "alias_not_found",
+				"detail": "resource not found",
+				"code":   "not_found",
 			},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -2162,7 +2163,7 @@ func TestGetResourceByAliasNotFound(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.GetResourceByAlias(context.Background(), "missing-alias")
+	_, err := c.GetResource(context.Background(), "r_missing0001")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2173,15 +2174,15 @@ func TestGetResourceByAliasNotFound(t *testing.T) {
 	if apiErr.StatusCode != http.StatusNotFound {
 		t.Errorf("got status %d, want 404", apiErr.StatusCode)
 	}
-	if apiErr.Code != "alias_not_found" {
-		t.Errorf("got code %q, want alias_not_found", apiErr.Code)
+	if apiErr.Code != "not_found" {
+		t.Errorf("got code %q, want not_found", apiErr.Code)
 	}
 }
 
 // TestCreateResourceAliasInUse pins the typed *APIError shape on the
 // `alias_in_use` 409 path documented in CreateResourceInput's doc comment
 // (alias attempted on an already-existing resource missing an alias).
-// Symmetric with TestGetResourceByAliasNotFound — pins the error envelope
+// Symmetric with TestGetResourceNotFound — pins the error envelope
 // for the second new resource method.
 func TestCreateResourceAliasInUse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## What

`/qurl aliases` now shows each tunnel by its **slug** and never the opaque resource ID.

**Before** (every row fell back to the resource ID):
```
Aliases configured for this channel:
• r_0pxn89qcm9i (no slug) → $kevin-dashboard, $kevin-test-dashboard
• r_cnaip_fprni (no slug) → $dashboard
```

**After**:
```
Aliases configured for this channel:
Format: $<slug> → the aliases that resolve to it. Run /qurl get with the slug or any alias.
• $kktest → $kevin-dashboard, $kevin-test-dashboard
• $dashboard-slug → $dashboard
```

## Why

The listing resolved each tunnel's slug by calling `GetResourceByAlias`, which hits `GET /v1/resources/by-alias/{alias}`. qurl-service removed that path — alias lookup moved to `GET /v1/resources?alias=`, and `slug` is now surfaced on `ResourceData`. So the call always errored, the slug never resolved, and every row degraded to the `r_<id> (no slug)` fallback. (`/qurl get` and `/qurl list` were unaffected — they resolve via the channel binding store and `ListResources`, not the dead endpoint.)

## How

- **shared/client:** add `GetResource(id)` → `GET /v1/resources/{id}` (returns the full resource, including the tunnel slug). Remove the dead-endpoint `GetResourceByAlias` — its only caller was `/qurl aliases`.
- **handler_aliases:** resolve each group by the `resource_id` already held in `channel_policies` (no reason to round-trip through an alias), then render `$<slug> → $<aliases>` under a format legend.
- **Never surface the resource ID:** a group whose slug can't be resolved (upstream fetch failed, or a legacy resource predating the slug requirement) degrades to listing its channel aliases alone — the user can still `/qurl get $alias`.

## Test

- `go test ./shared/client/ ./apps/slack/internal/` — pass.
- Updated client tests (`GetResource*`) and aliases-handler tests to the by-id path; cancellation/deadline tests now assert the alias-only fallback and that no `r_<id>` ever leaks.
- `golangci-lint` clean; pre-commit green.
