### PR TITLE
chore(ci): bump Claude PR-review model to Opus 4.8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,4 +40,4 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          claude_args: '--model claude-opus-4-7 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
Bumps the automated Claude PR-review workflow from Opus 4.7 to Opus 4.8.

Opus 4.8 is GA on the first-party Anthropic API. `claude-code-action` forwards `--model` straight through to the API, so no action-version bump is needed — this is the one-line model-string swap. Anthropic's GitHub Actions docs recommend `claude-opus-4-8`.