### PR TITLE
feat(slack): add set/unset-display-name admin verbs for tunnels

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -786,19 +786,9 @@ func stripUnsetAliasPrefix(text string) string {
 	return rest
 }
 
-func setDisplayNameSubcommand(text string) bool {
-	matched, _ := slashVerb(text, "set-display-name")
-	return matched
-}
-
 func stripSetDisplayNamePrefix(text string) string {
 	_, rest := slashVerb(text, "set-display-name")
 	return rest
-}
-
-func unsetDisplayNameSubcommand(text string) bool {
-	matched, _ := slashVerb(text, "unset-display-name")
-	return matched
 }
 
 func stripUnsetDisplayNamePrefix(text string) string {
@@ -955,12 +945,18 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		h.handleSetAlias(w, values)
 	case unsetAliasSubcommand(text):
 		h.handleUnsetAlias(w, values)
-	case setDisplayNameSubcommand(text):
+	// Use slashSubcommand directly here (unlike set-alias's dedicated
+	// helper): the verb has a single canonical spelling, and the
+	// cross-repo dispatcher-drift check (qurl-integrations-infra) only
+	// extracts the slashSubcommand and …AliasSubcommand case shapes — a
+	// …DisplayNameSubcommand helper would be invisible to it and keep the
+	// infra manifest drift check red even after this merges.
+	case slashSubcommand(text, "set-display-name"):
 		// Bare `set-display-name` falls through too — the handler renders
 		// the usage hint, so the user gets the right grammar without a
 		// separate "missing args" branch here.
 		h.handleSetDisplayName(w, values)
-	case unsetDisplayNameSubcommand(text):
+	case slashSubcommand(text, "unset-display-name"):
 		h.handleUnsetDisplayName(w, values)
 	case isUserVerb(text):
 		// A user verb typed on the admin command — redirect to the user one.

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -684,7 +684,7 @@ func slashSubcommand(text, command string) bool {
 //
 // Immutable: read-only on the request hot path (slashVerb ranges it); a
 // var only because Go has no const slice. Do not mutate at runtime.
-var adminVerbs = []string{"admin", "tunnel", "set-alias", "setalias", "unset-alias", "unsetalias"}
+var adminVerbs = []string{"admin", "tunnel", "set-alias", "setalias", "unset-alias", "unsetalias", "set-display-name", "unset-display-name"}
 
 // userVerbs are the leading verb words that belong to `/qurl`. Used to
 // redirect a user who typed a user verb on `/qurl-admin`. `setup` is a
@@ -783,6 +783,26 @@ func unsetAliasSubcommand(text string) bool {
 
 func stripUnsetAliasPrefix(text string) string {
 	_, rest := slashVerb(text, "unsetalias", "unset-alias")
+	return rest
+}
+
+func setDisplayNameSubcommand(text string) bool {
+	matched, _ := slashVerb(text, "set-display-name")
+	return matched
+}
+
+func stripSetDisplayNamePrefix(text string) string {
+	_, rest := slashVerb(text, "set-display-name")
+	return rest
+}
+
+func unsetDisplayNameSubcommand(text string) bool {
+	matched, _ := slashVerb(text, "unset-display-name")
+	return matched
+}
+
+func stripUnsetDisplayNamePrefix(text string) string {
+	_, rest := slashVerb(text, "unset-display-name")
 	return rest
 }
 
@@ -889,8 +909,9 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 }
 
 // dispatchAdminCommand routes the admin-facing `/qurl-admin` verbs:
-// tunnel install, set-alias, unset-alias, admin add/remove/list/revoke,
-// and help. User verbs typed on `/qurl-admin` — including `setup`, which
+// tunnel install, set-alias, unset-alias, set-display-name,
+// unset-display-name, admin add/remove/list/revoke, and help. User verbs
+// typed on `/qurl-admin` — including `setup`, which
 // is a `/qurl` verb (first-come-claims; see handleSetup) — get a redirect
 // to `/qurl` so a user who fat-fingers the command gets a direct
 // correction.
@@ -934,6 +955,13 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		h.handleSetAlias(w, values)
 	case unsetAliasSubcommand(text):
 		h.handleUnsetAlias(w, values)
+	case setDisplayNameSubcommand(text):
+		// Bare `set-display-name` falls through too — the handler renders
+		// the usage hint, so the user gets the right grammar without a
+		// separate "missing args" branch here.
+		h.handleSetDisplayName(w, values)
+	case unsetDisplayNameSubcommand(text):
+		h.handleUnsetDisplayName(w, values)
 	case isUserVerb(text):
 		// A user verb typed on the admin command — redirect to the user one.
 		// Echoed text has backticks stripped (see the /qurl-side redirect).
@@ -1239,13 +1267,19 @@ func (h *Handler) adminHelpMessage(command string) string {
 		)
 	}
 	if h.cfg.AdminStore != nil {
-		// add/remove/list/revoke all require AdminStore — on sandbox
-		// deploys without the three QURL_*_TABLE env vars (see
-		// cmd/main.go), AdminStore is nil and these verbs render
-		// "Admin features are not configured". Gate the help lines on
-		// the same condition so the listing stays consistent with
-		// what the verbs will actually do.
+		// Every verb below gates on the in-code requireAdminSync (CheckAdmin
+		// against AdminStore), so they're listed only when AdminStore is
+		// wired — the same condition the verbs use at runtime. On sandbox
+		// deploys without the three QURL_*_TABLE env vars (see cmd/main.go),
+		// AdminStore is nil and these verbs render "Admin features are not
+		// configured", so gating the help lines on the same condition keeps
+		// the listing consistent with what the verbs actually do.
+		//
+		// set-display-name / unset-display-name set a friendly Display Name
+		// on a tunnel id (the `$<slug>` shown by `/qurl list`).
 		lines = append(lines,
+			"• `/qurl-admin set-display-name <id> <display name>` — Set a tunnel's friendly Display Name shown in `/qurl list` (admin only)",
+			"• `/qurl-admin unset-display-name <id>` — Reset a tunnel's Display Name to the default (admin only)",
 			"• `/qurl-admin admin add @user` — Promote a Slack user to bot admin (admin only)",
 			"• `/qurl-admin admin remove @user` — Demote a Slack user from bot admin (admin only)",
 			"• `/qurl-admin admin list` — List who connected qURL (the owner) and the current bot admins (admin only)",

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -952,9 +952,9 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 	// …DisplayNameSubcommand helper would be invisible to it and keep the
 	// infra manifest drift check red even after this merges.
 	case slashSubcommand(text, "set-display-name"):
-		// Bare `set-display-name` falls through too — the handler renders
-		// the usage hint, so the user gets the right grammar without a
-		// separate "missing args" branch here.
+		// A bare `set-display-name` (no args) matches this arm too; the
+		// handler then renders the usage hint, so the user gets the right
+		// grammar without a separate "missing args" branch here.
 		h.handleSetDisplayName(w, values)
 	case slashSubcommand(text, "unset-display-name"):
 		h.handleUnsetDisplayName(w, values)

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -175,7 +175,7 @@ loop:
 			// Fill un-dispatched tail with alias-only fallbacks — no fetch
 			// happened, so there's no slug and (by design) no resource_id.
 			for j := i; j < len(groups); j++ {
-				lines[j] = formatAliasGroupLine("", "", groups[j].aliases)
+				lines[j] = formatAliasGroupLine("", "", "", groups[j].aliases)
 			}
 			break loop
 		}
@@ -184,7 +184,7 @@ loop:
 			defer wg.Done()
 			defer func() { <-sem }()
 			g := &groups[idx]
-			target, slug := "", ""
+			target, slug, description := "", "", ""
 			if g.resourceID != "" {
 				// Resolve the group's canonical resource directly by the
 				// resource_id we already hold from channel_policies, via
@@ -195,6 +195,7 @@ loop:
 				if r, rerr := c.GetResource(ctx, g.resourceID); rerr == nil {
 					target = r.TargetURL
 					slug = r.Slug
+					description = r.Description
 				} else if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
 					// Distinct log from the 404/5xx branch so operators
 					// can tell "request was cut short by SIGTERM /
@@ -205,7 +206,7 @@ loop:
 					log.Debug("aliases: resource fetch failed in fanout", "error", rerr, "resource_id", g.resourceID)
 				}
 			}
-			lines[idx] = formatAliasGroupLine(target, slug, g.aliases)
+			lines[idx] = formatAliasGroupLine(target, slug, description, g.aliases)
 		}(i)
 	}
 	wg.Wait()
@@ -229,7 +230,13 @@ loop:
 // An alias equal to the slug is dropped from the right side — the install
 // flow binds `$<slug>` as a channel alias, so it would otherwise list
 // itself. A group whose only alias IS the slug renders just the slug.
-func formatAliasGroupLine(target, slug string, aliases []string) string {
+//
+// An em-dash joins the id to the tunnel's Display Name when present:
+// • `$<slug>` — <Display Name> → `$<a1>`. The Display Name reuses the
+// resource description field (see handleSetDisplayName) and is normally set;
+// the empty guard handles the alias-only fallback rows (no resource fetch,
+// so no description) and is defensive otherwise.
+func formatAliasGroupLine(target, slug, description string, aliases []string) string {
 	rhs := make([]string, 0, len(aliases))
 	for _, a := range aliases {
 		if a != slug {
@@ -240,6 +247,13 @@ func formatAliasGroupLine(target, slug string, aliases []string) string {
 	switch {
 	case slug != "":
 		left = "`$" + slug + "`"
+		// Append the tunnel's Display Name to the id when present. The
+		// description field doubles as the Display Name (see
+		// handleSetDisplayName); it's normally set, but the alias-only
+		// fallback rows pass "" (no resource fetch happened), so guard it.
+		if description != "" {
+			left += " — " + description
+		}
 	case target != "":
 		left = target + " (legacy URL)"
 	default:

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // TestHandleAliases_HappyPath fences the canonical /qurl aliases
@@ -76,9 +77,9 @@ func TestHandleAliases_ShowsDisplayName(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources/"+resID, func(w http.ResponseWriter, _ *http.Request) {
 		respondQURLEnvelope(t, w, map[string]any{
 			testKeyResourceID:  resID,
-			testKeyType:        "tunnel",
+			testKeyType:        client.ResourceTypeTunnel,
 			testKeySlug:        "ops-bastion",
-			testKeyStatus:      "active",
+			testKeyStatus:      client.StatusActive,
 			testKeyDescription: "Ops jump host",
 		})
 	})

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -62,6 +62,35 @@ func TestHandleAliases_TunnelAliasShowsSlug(t *testing.T) {
 	}
 }
 
+// TestHandleAliases_ShowsDisplayName fences the Display Name annotation on
+// the aliases view: when the resolved tunnel carries a description (which
+// doubles as the Display Name; install seeds it and admins set it via
+// `/qurl-admin set-display-name`), an em-dash joins it to the id ahead of
+// the alias mapping: • `$<slug>` — <Display Name> → `$<alias>`.
+func TestHandleAliases_ShowsDisplayName(t *testing.T) {
+	const resID = "r_dn_jumphost"
+	ts := newAdminTestServers(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		"bastion": resID,
+	})
+	ts.addCustomer("GET", "/v1/resources/"+resID, func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID:  resID,
+			testKeyType:        "tunnel",
+			testKeySlug:        "ops-bastion",
+			testKeyStatus:      "active",
+			testKeyDescription: "Ops jump host",
+		})
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$ops-bastion` — Ops jump host → `$bastion`") {
+		t.Errorf("aliases reply missing id + Display Name + alias mapping: %q", async)
+	}
+}
+
 // TestHandleAliases_MultipleAliasesOneTunnelCollapse fences change #2's
 // headline behavior: several aliases pointing at the SAME tunnel
 // collapse onto one line — `$<slug> → $<a1>, $<a2>` — with the aliases

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -74,15 +74,19 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 	if len([]rune(name)) > displayNameMaxLen {
 		return "", "", fmt.Sprintf("Display Name is too long (max %d characters).\n\n%s", displayNameMaxLen, displayNameUsage)
 	}
-	// Reject backticks and control bytes: the Display Name is echoed into a
-	// Slack reply and rendered next to the id inside an inline-code fence in
-	// `/qurl list` (`` `<id>` — <name> ``). A backtick breaks the fence,
-	// running an unterminated code span into the next row; a control byte
-	// garbles the line. Same rendering-hygiene rejection the alias-target
-	// parser applies. Other printable text (spaces, punctuation) is fine.
+	// Reject backticks, angle brackets, and control bytes. The Display Name
+	// is stored in `description` and rendered to EVERY user who runs
+	// `/qurl list` or `/qurl aliases` (not just the admin who set it), inside
+	// an inline-code fence (`` `<id>` — <name> ``). A backtick breaks the
+	// fence (running an unterminated code span into the next row); a control
+	// byte garbles the line; and Slack mrkdwn `<…>` is an injection vector —
+	// `<https://evil|Prod>` renders a disguised link and `<!channel>` /
+	// `<!here>` ping the workspace. Admins are trusted, but a stored value
+	// shown to all users is worth fencing at the parser (the alias-target
+	// parser rejects backticks for the same hygiene reason).
 	for _, r := range name {
-		if r == '`' || !unicode.IsPrint(r) {
-			return "", "", "Display Name can't contain backticks or control characters. Use plain text only.\n\n" + displayNameUsage
+		if r == '`' || r == '<' || r == '>' || !unicode.IsPrint(r) {
+			return "", "", "Display Name can't contain backticks, angle brackets, or control characters. Use plain text only.\n\n" + displayNameUsage
 		}
 	}
 	return idTok, name, ""
@@ -243,7 +247,10 @@ func (h *Handler) resolveAndResetTunnelDisplayName(ctx context.Context, log *slo
 	if msg != "" {
 		return msg
 	}
-	reset := defaultTunnelDisplayName(id)
+	// Revert using the resolved slug (resolveTunnelByID guarantees
+	// r.Slug == id) so the value provably matches what install wrote with
+	// args.Slug, without depending on that invariant holding at a distance.
+	reset := defaultTunnelDisplayName(resource.Slug)
 	if _, err := c.UpdateResource(ctx, resource.ResourceID, &client.UpdateResourceInput{Description: &reset}); err != nil {
 		log.Error("unset-display-name update failed", "error", err, "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
 		return sanitizeAPIError(err, "Failed to reset the Display Name")

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -1,0 +1,270 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// displayNameMaxLen caps the Display Name length at the qurl-service
+// resource `description` field's bound (the field these verbs reuse for
+// storage). Parsing rejects above-cap names so the user sees a friendlier
+// error than the eventual upstream rejection.
+const displayNameMaxLen = 500
+
+// defaultTunnelDisplayName is the Display Name a tunnel gets at install
+// time and the value `unset-display-name` reverts to. The Display Name
+// reuses the resource description field (there is no separate field), so a
+// tunnel always has one: install seeds this default, admins refine it with
+// set-display-name, and unset restores it. Install (processTunnelInstall)
+// and unset (resolveAndResetTunnelDisplayName) MUST construct the string
+// the same way so unset matches what a fresh install would have produced —
+// hence this single constructor.
+func defaultTunnelDisplayName(slug string) string {
+	return "Slack tunnel install for " + slug
+}
+
+// displayNameUsage is the help-text body returned when set-display-name /
+// unset-display-name is invoked with an obvious typo. Centralized so the
+// missing-arg path and the validation-rejection path share one copy.
+const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <display name>`\n• `/qurl-admin unset-display-name <id>`\n\nThe id is the tunnel token shown by `/qurl list` (without the `$`). The Display Name is free text up to 500 characters."
+
+// parseSetDisplayNameArgs splits a `set-display-name <id> <display name>`
+// body into the tunnel id (first whitespace-delimited token) and the
+// Display Name (the rest of the line). The Display Name is trimmed and may
+// contain spaces; surrounding single or double quotes are tolerated and
+// stripped. Returns (id, name, "") on success or ("", "", userMsg) with the
+// ephemeral copy to surface when the grammar doesn't match.
+//
+// Returns a plain-string user message rather than an error for the same
+// reason parseAliasArgs does: this is surface copy carrying sentence
+// punctuation that ST1005 rejects on error-typed values.
+func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
+	text = strings.TrimSpace(text)
+	idTok, rest, found := strings.Cut(text, " ")
+	if idTok == "" {
+		return "", "", "Missing tunnel id.\n\n" + displayNameUsage
+	}
+	if !tunnelSlugPattern.MatchString(idTok) {
+		return "", "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(idTok), displayNameUsage)
+	}
+	if !found {
+		return "", "", "Missing Display Name.\n\n" + displayNameUsage
+	}
+	name = strings.TrimSpace(stripSurroundingQuotes(strings.TrimSpace(rest)))
+	if name == "" {
+		return "", "", "Missing Display Name.\n\n" + displayNameUsage
+	}
+	if len([]rune(name)) > displayNameMaxLen {
+		return "", "", fmt.Sprintf("Display Name is too long (max %d characters).\n\n%s", displayNameMaxLen, displayNameUsage)
+	}
+	// Reject control bytes: the Display Name is echoed into a Slack reply
+	// and rendered next to the id in `/qurl list`; a control byte would
+	// garble both. Printable text (including spaces and punctuation) is
+	// fine — this is free-text copy, not a token.
+	for _, r := range name {
+		if !unicode.IsPrint(r) {
+			return "", "", "Display Name contains an unsupported character. Use plain text only.\n\n" + displayNameUsage
+		}
+	}
+	return idTok, name, ""
+}
+
+// parseUnsetDisplayNameArgs validates a `unset-display-name <id>` body:
+// exactly one token, a valid tunnel id. Returns (id, "") or ("", userMsg).
+func parseUnsetDisplayNameArgs(text string) (id, userMsg string) {
+	tokens := strings.Fields(text)
+	if len(tokens) != 1 {
+		return "", "Provide exactly one tunnel id.\n\n" + displayNameUsage
+	}
+	if !tunnelSlugPattern.MatchString(tokens[0]) {
+		return "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(tokens[0]), displayNameUsage)
+	}
+	return tokens[0], ""
+}
+
+// stripSurroundingQuotes removes one matched pair of surrounding single or
+// double quotes from s, so `set-display-name api "Prod API"` and
+// `... 'Prod API'` both yield the unquoted name. A lone or mismatched quote
+// is left untouched — it's part of the name.
+func stripSurroundingQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	first, last := s[0], s[len(s)-1]
+	if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// handleSetDisplayName routes `/qurl-admin set-display-name <id> <name>`.
+//
+// **Admin restriction:** Enforced in code via requireAdminSync (a
+// CheckAdmin lookup against AdminStore) — the same gate the alias and
+// membership verbs use. Slack does NOT restrict a slash command to
+// workspace admins, so this code gate is the only real boundary; it runs
+// before any tunnel lookup, so a non-admin is denied before any resource
+// interaction.
+//
+// **Storage:** the Display Name is stored in the tunnel resource's
+// `description` field via PATCH /v1/resources/{id} — there is no separate
+// field and no qurl-service change. Resolution + update are two upstream
+// calls, so this runs async (acks immediately, posts the result via
+// response_url) like the slug-targeted set-alias path.
+func (h *Handler) handleSetDisplayName(w http.ResponseWriter, values url.Values) {
+	text := strings.TrimSpace(values.Get(fieldText))
+	rest := stripSetDisplayNamePrefix(text)
+
+	id, name, userMsg := parseSetDisplayNameArgs(rest)
+	if userMsg != "" {
+		respondSlack(w, userMsg)
+		return
+	}
+
+	teamID, userID, ok := h.displayNameValidate(w, values, "set_display_name")
+	if !ok {
+		return
+	}
+
+	// Admin gate, in code. Runs after the team/user-id read but before the
+	// tunnel resolve + PATCH, so a non-admin is denied before any resource
+	// interaction. The parser usage hints above are surfaced before the
+	// gate (the grammar is public — it's in the ungated `/qurl-admin help`),
+	// matching the set-alias posture.
+	if !h.requireAdminSync(w, teamID, userID, AdminActionSetDisplayName) {
+		return
+	}
+
+	h.runAsync(w, "set_display_name", values, func(ctx context.Context, log *slog.Logger) {
+		msg := h.resolveAndSetTunnelDisplayName(ctx, log, teamID, id, name)
+		_ = h.postResponse(log, values.Get(fieldResponseURL), msg)
+	})
+}
+
+// handleUnsetDisplayName routes `/qurl-admin unset-display-name <id>`.
+// Same in-code admin gate as handleSetDisplayName. Reverts the Display
+// Name to the install default ("Slack tunnel install for <id>") by PATCHing
+// the resource description — it does NOT blank it, because a tunnel always
+// has a Display Name (the description field doubles as it).
+func (h *Handler) handleUnsetDisplayName(w http.ResponseWriter, values url.Values) {
+	text := strings.TrimSpace(values.Get(fieldText))
+	rest := stripUnsetDisplayNamePrefix(text)
+
+	id, userMsg := parseUnsetDisplayNameArgs(rest)
+	if userMsg != "" {
+		respondSlack(w, userMsg)
+		return
+	}
+
+	teamID, userID, ok := h.displayNameValidate(w, values, "unset_display_name")
+	if !ok {
+		return
+	}
+
+	if !h.requireAdminSync(w, teamID, userID, AdminActionUnsetDisplayName) {
+		return
+	}
+
+	h.runAsync(w, "unset_display_name", values, func(ctx context.Context, log *slog.Logger) {
+		msg := h.resolveAndResetTunnelDisplayName(ctx, log, teamID, id)
+		_ = h.postResponse(log, values.Get(fieldResponseURL), msg)
+	})
+}
+
+// displayNameValidate pulls team_id + user_id off the form and verifies
+// AdminStore is wired (the in-code admin gate needs it). Returns
+// (teamID, userID, ok); on !ok the helper has already written the
+// user-facing response. No aliasStore check — these verbs don't touch the
+// channel-alias store; they only read/write the tunnel resource via
+// qurl-service and gate on AdminStore.
+func (h *Handler) displayNameValidate(w http.ResponseWriter, values url.Values, verb string) (teamID, userID string, ok bool) {
+	teamID = strings.TrimSpace(values.Get(fieldTeamID))
+	userID = strings.TrimSpace(values.Get(fieldUserID))
+	if teamID == "" || userID == "" {
+		slog.Warn("display-name verb missing team_id or user_id", "verb", verb, "team_id_present", teamID != "", "user_id_present", userID != "")
+		respondSlack(w, "Could not read your Slack workspace or user ID from the command payload.")
+		return
+	}
+	if h.cfg.AdminStore == nil {
+		// Soft-fail when AdminStore is not configured (sandbox deploys
+		// without the QURL_*_TABLE env vars). Surfacing a configuration
+		// error rather than silently dropping makes the bot's state
+		// debuggable from the operator side.
+		slog.Warn("display-name verb invoked with no AdminStore wired — refusing", "verb", verb)
+		respondSlack(w, "Admin features are not configured for this deployment.")
+		return
+	}
+	ok = true
+	return
+}
+
+// resolveAndSetTunnelDisplayName resolves the tunnel by id, then PATCHes its
+// description to the Display Name, and renders the admin-facing result.
+func (h *Handler) resolveAndSetTunnelDisplayName(ctx context.Context, log *slog.Logger, teamID, id, name string) string {
+	c, resource, msg := h.resolveTunnelByID(ctx, log, teamID, id)
+	if msg != "" {
+		return msg
+	}
+	if _, err := c.UpdateResource(ctx, resource.ResourceID, &client.UpdateResourceInput{Description: &name}); err != nil {
+		log.Error("set-display-name update failed", "error", err, "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
+		return sanitizeAPIError(err, "Failed to update the Display Name")
+	}
+	slog.Info("tunnel display name set", "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
+	return fmt.Sprintf("✅ Display Name updated for `%s`: %s", id, name)
+}
+
+// resolveAndResetTunnelDisplayName resolves the tunnel by id, then PATCHes
+// its description back to the install default ([defaultTunnelDisplayName]),
+// and renders the admin-facing result. This reverts — it does not blank —
+// because a tunnel always has a Display Name (the description field doubles
+// as it). Reusing the install-default constructor keeps the reset value
+// identical to what a fresh install would have produced.
+func (h *Handler) resolveAndResetTunnelDisplayName(ctx context.Context, log *slog.Logger, teamID, id string) string {
+	c, resource, msg := h.resolveTunnelByID(ctx, log, teamID, id)
+	if msg != "" {
+		return msg
+	}
+	reset := defaultTunnelDisplayName(id)
+	if _, err := c.UpdateResource(ctx, resource.ResourceID, &client.UpdateResourceInput{Description: &reset}); err != nil {
+		log.Error("unset-display-name update failed", "error", err, "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
+		return sanitizeAPIError(err, "Failed to reset the Display Name")
+	}
+	slog.Info("tunnel display name reset", "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
+	return fmt.Sprintf("✅ Display Name reset for `%s`.", id)
+}
+
+// resolveTunnelByID looks up the active tunnel whose id (slug) is `id` and
+// returns an authenticated client plus the resolved resource. On any
+// failure it returns (nil, nil, userMsg) with msg set to the ephemeral copy
+// to surface; callers `if msg != "" { return msg }`.
+func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamID, id string) (c *client.Client, resource *client.Resource, userMsg string) {
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("display-name: failed to get API key", "error", err, "team_id", teamID, "id", id)
+		return nil, nil, authErrorMessage(err)
+	}
+	page, err := c.ListResources(ctx, client.ListResourcesInput{Slug: id})
+	if err != nil {
+		log.Error("display-name: tunnel id resolution failed", "error", err, "team_id", teamID, "id", id)
+		return nil, nil, sanitizeAPIError(err, "Failed to look up the tunnel")
+	}
+	for i := range page.Resources {
+		r := &page.Resources[i]
+		// Defense-in-depth: re-assert type/slug/active even though the
+		// server's `?slug=` filter is single-purpose, so an upstream
+		// regression can't surface a non-tunnel, wrong-id, or revoked
+		// resource into the PATCH target.
+		if r.Type == client.ResourceTypeTunnel && r.Slug == id && r.Status == client.StatusActive {
+			return c, r, ""
+		}
+	}
+	log.Info("display-name: no active tunnel for id", "team_id", teamID, "id", id)
+	return nil, nil, fmt.Sprintf("No tunnel with id `%s` was found. Run `/qurl list` to see your tunnel ids.", id)
+}

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -47,7 +47,17 @@ const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <displa
 // punctuation that ST1005 rejects on error-typed values.
 func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 	text = strings.TrimSpace(text)
-	idTok, rest, found := strings.Cut(text, " ")
+	// Split the id off the first run of whitespace (any kind), matching
+	// parseUnsetDisplayNameArgs' strings.Fields tokenization — so a tab- or
+	// newline-separated `<id> <name>` parses the same as a space-separated
+	// one, rather than folding the whitespace into the id and failing the
+	// slug check with a confusing error.
+	idTok, rest := text, ""
+	found := false
+	if i := strings.IndexFunc(text, unicode.IsSpace); i >= 0 {
+		idTok, rest = text[:i], strings.TrimLeftFunc(text[i:], unicode.IsSpace)
+		found = true
+	}
 	if idTok == "" {
 		return "", "", "Missing tunnel id.\n\n" + displayNameUsage
 	}
@@ -64,13 +74,15 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 	if len([]rune(name)) > displayNameMaxLen {
 		return "", "", fmt.Sprintf("Display Name is too long (max %d characters).\n\n%s", displayNameMaxLen, displayNameUsage)
 	}
-	// Reject control bytes: the Display Name is echoed into a Slack reply
-	// and rendered next to the id in `/qurl list`; a control byte would
-	// garble both. Printable text (including spaces and punctuation) is
-	// fine — this is free-text copy, not a token.
+	// Reject backticks and control bytes: the Display Name is echoed into a
+	// Slack reply and rendered next to the id inside an inline-code fence in
+	// `/qurl list` (`` `<id>` — <name> ``). A backtick breaks the fence,
+	// running an unterminated code span into the next row; a control byte
+	// garbles the line. Same rendering-hygiene rejection the alias-target
+	// parser applies. Other printable text (spaces, punctuation) is fine.
 	for _, r := range name {
-		if !unicode.IsPrint(r) {
-			return "", "", "Display Name contains an unsupported character. Use plain text only.\n\n" + displayNameUsage
+		if r == '`' || !unicode.IsPrint(r) {
+			return "", "", "Display Name can't contain backticks or control characters. Use plain text only.\n\n" + displayNameUsage
 		}
 	}
 	return idTok, name, ""

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -59,7 +59,9 @@ func TestParseSetDisplayNameArgs(t *testing.T) {
 		{name: "invalid id (too short)", input: "ab foo", wantErr: true, wantMsgSub: "valid tunnel id"},
 		{name: "name too long rejected", input: id + " " + strings.Repeat("a", displayNameMaxLen+1), wantErr: true, wantMsgSub: "too long"},
 		{name: "name at length cap accepted", input: id + " " + strings.Repeat("a", displayNameMaxLen), wantID: id, wantName: strings.Repeat("a", displayNameMaxLen)},
-		{name: "control byte in name rejected", input: id + " bad\x01name", wantErr: true, wantMsgSub: "unsupported character"},
+		{name: "control byte in name rejected", input: id + " bad\x01name", wantErr: true, wantMsgSub: "control characters"},
+		{name: "backtick in name rejected", input: id + " Prod `code` API", wantErr: true, wantMsgSub: "backticks"},
+		{name: "tab-separated id and name parses", input: id + "\tProd API", wantID: id, wantName: testDisplayNameProdAPI},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -1,0 +1,349 @@
+package internal
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// Repeated test literals, named to satisfy goconst and keep the
+// expected-copy assertions in one place.
+const (
+	testDisplayNameProdAPI    = "Prod API"
+	testDisplayNameMissingMsg = "Missing Display Name"
+)
+
+// --- install-default constructor -----------------------------------------
+
+func TestDefaultTunnelDisplayName(t *testing.T) {
+	// Install seeds this and unset-display-name reverts to it. The string
+	// must match install's auto-fill exactly, so a fresh install and a
+	// post-unset tunnel read identically.
+	if got, want := defaultTunnelDisplayName("prod-dashboard"), "Slack tunnel install for prod-dashboard"; got != want {
+		t.Errorf("defaultTunnelDisplayName = %q, want %q", got, want)
+	}
+}
+
+// --- parser unit tests ---------------------------------------------------
+
+func TestParseSetDisplayNameArgs(t *testing.T) {
+	const id = "prod-dashboard"
+	cases := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		wantID   string
+		wantName string
+		// wantMsgSub, when set on a wantErr case, asserts which rejection copy fired.
+		wantMsgSub string
+	}{
+		{name: "single-word name", input: id + " Prod", wantID: id, wantName: "Prod"},
+		{name: "multi-word name", input: id + " Prod API gateway", wantID: id, wantName: "Prod API gateway"},
+		{name: "double-quoted name unquoted", input: id + ` "Prod API"`, wantID: id, wantName: testDisplayNameProdAPI},
+		{name: "single-quoted name unquoted", input: id + " 'Prod API'", wantID: id, wantName: testDisplayNameProdAPI},
+		{name: "surrounding whitespace trimmed", input: id + "    Prod API   ", wantID: id, wantName: testDisplayNameProdAPI},
+		{name: "name with internal punctuation kept", input: id + " Staging DB (replica)", wantID: id, wantName: "Staging DB (replica)"},
+		{name: "lone quote kept as part of name", input: id + ` it's fine`, wantID: id, wantName: "it's fine"},
+
+		{name: "missing everything", input: "", wantErr: true, wantMsgSub: "Missing tunnel id"},
+		{name: "id only, no name", input: id, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
+		{name: "id then only whitespace", input: id + "    ", wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
+		{name: "id then empty quotes", input: id + ` ""`, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
+		{name: "invalid id (uppercase)", input: "Prod foo", wantErr: true, wantMsgSub: "valid tunnel id"},
+		{name: "invalid id (too short)", input: "ab foo", wantErr: true, wantMsgSub: "valid tunnel id"},
+		{name: "name too long rejected", input: id + " " + strings.Repeat("a", displayNameMaxLen+1), wantErr: true, wantMsgSub: "too long"},
+		{name: "name at length cap accepted", input: id + " " + strings.Repeat("a", displayNameMaxLen), wantID: id, wantName: strings.Repeat("a", displayNameMaxLen)},
+		{name: "control byte in name rejected", input: id + " bad\x01name", wantErr: true, wantMsgSub: "unsupported character"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotName, msg := parseSetDisplayNameArgs(tc.input)
+			if tc.wantErr {
+				if msg == "" {
+					t.Fatalf("expected rejection, got id=%q name=%q", gotID, gotName)
+				}
+				if tc.wantMsgSub != "" && !strings.Contains(msg, tc.wantMsgSub) {
+					t.Errorf("rejection copy = %q, want substring %q", msg, tc.wantMsgSub)
+				}
+				return
+			}
+			if msg != "" {
+				t.Fatalf("unexpected rejection: %s", msg)
+			}
+			if gotID != tc.wantID {
+				t.Errorf("id = %q, want %q", gotID, tc.wantID)
+			}
+			if gotName != tc.wantName {
+				t.Errorf("name = %q, want %q", gotName, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestParseUnsetDisplayNameArgs(t *testing.T) {
+	const id = "prod-dashboard"
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		wantID  string
+	}{
+		{name: "happy", input: id, wantID: id},
+		{name: "missing id", input: "", wantErr: true},
+		{name: "trailing args rejected", input: id + " extra", wantErr: true},
+		{name: "invalid id rejected", input: "Prod", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, msg := parseUnsetDisplayNameArgs(tc.input)
+			if tc.wantErr {
+				if msg == "" {
+					t.Fatalf("expected rejection, got id=%q", gotID)
+				}
+				return
+			}
+			if msg != "" {
+				t.Fatalf("unexpected rejection: %s", msg)
+			}
+			if gotID != tc.wantID {
+				t.Errorf("id = %q, want %q", gotID, tc.wantID)
+			}
+		})
+	}
+}
+
+// --- handler-level tests -------------------------------------------------
+
+// capturedPatch records the description sent on the most recent
+// PATCH /v1/resources/{id}. Pointer field distinguishes "no PATCH seen"
+// (nil) from "PATCH with empty/clear description" (&"").
+type capturedPatch struct {
+	description *string
+	calls       atomic.Int32
+}
+
+// displayNameQURLServer answers the two upstream calls the display-name
+// verbs make: GET /v1/resources?slug=<id> resolves a single active tunnel
+// (resource_id "r_"+id) when the id matches knownSlug (else empty list,
+// driving the not-found copy), and PATCH /v1/resources/{id} records the
+// body's description and echoes a resource back.
+func displayNameQURLServer(t *testing.T, knownSlug string, capPatch *capturedPatch) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == testResourcesPath:
+			slug := r.URL.Query().Get("slug")
+			if slug != knownSlug {
+				respondQURLEnvelope(t, w, []map[string]any{})
+				return
+			}
+			respondQURLEnvelope(t, w, []map[string]any{{
+				testKeyResourceID: "r_" + slug,
+				testKeyType:       client.ResourceTypeTunnel,
+				testKeySlug:       slug,
+				testKeyStatus:     client.StatusActive,
+			}})
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/resources/"):
+			capPatch.calls.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read PATCH body: %v", err)
+			}
+			var in struct {
+				Description *string `json:"description"`
+			}
+			if err := json.Unmarshal(body, &in); err != nil {
+				t.Fatalf("unmarshal PATCH body: %v", err)
+			}
+			capPatch.description = in.Description
+			id := strings.TrimPrefix(r.URL.Path, "/v1/resources/")
+			respondQURLEnvelope(t, w, map[string]any{
+				testKeyResourceID: id,
+				testKeyType:       client.ResourceTypeTunnel,
+				testKeyStatus:     client.StatusActive,
+			})
+		default:
+			t.Fatalf("unexpected upstream request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestSetDisplayName_Happy(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameQURLServer(t, testTunnelSlug, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	_, ack, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testTunnelSlug+" Prod API gateway", testAliasTeamID, "U_alias_admin")
+
+	if ack != ackWorkingOnIt {
+		t.Fatalf("ack = %q, want async working copy", ack)
+	}
+	if !strings.Contains(async, "Display Name updated") || !strings.Contains(async, "Prod API gateway") || !strings.Contains(async, "`"+testTunnelSlug+"`") {
+		t.Errorf("async reply = %q, want success copy with id + name", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1", capPatch.calls.Load())
+	}
+	if capPatch.description == nil || *capPatch.description != "Prod API gateway" {
+		t.Errorf("PATCH description = %v, want pointer to %q", capPatch.description, "Prod API gateway")
+	}
+}
+
+func TestSetDisplayName_MultiWordQuoted(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameQURLServer(t, testTunnelSlug, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync(`set-display-name `+testTunnelSlug+` "Staging DB (read replica)"`, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "Staging DB (read replica)") {
+		t.Errorf("async reply = %q, want the quoted multi-word name", async)
+	}
+	if capPatch.description == nil || *capPatch.description != "Staging DB (read replica)" {
+		t.Errorf("PATCH description = %v, want unquoted multi-word name", capPatch.description)
+	}
+}
+
+func TestUnsetDisplayName_Happy(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameQURLServer(t, testTunnelSlug, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("unset-display-name "+testTunnelSlug, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "Display Name reset") || !strings.Contains(async, "`"+testTunnelSlug+"`") {
+		t.Errorf("async reply = %q, want reset copy with id", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1", capPatch.calls.Load())
+	}
+	// Unset REVERTS to the install default, it does not blank: the PATCH
+	// carries the same string a fresh install would have written, so the
+	// tunnel still has a Display Name.
+	want := defaultTunnelDisplayName(testTunnelSlug)
+	if capPatch.description == nil || *capPatch.description != want {
+		t.Errorf("PATCH description = %v, want pointer to %q (install default)", capPatch.description, want)
+	}
+}
+
+func TestSetDisplayName_TunnelNotFound(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	// knownSlug is a DIFFERENT id, so the lookup returns an empty list.
+	h := newTestHandler(t, displayNameQURLServer(t, "some-other-tunnel", capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testTunnelSlug+" Prod", testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "No tunnel with id") || !strings.Contains(async, "/qurl list") {
+		t.Errorf("async reply = %q, want friendly not-found copy pointing at /qurl list", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired despite missing tunnel (calls = %d)", capPatch.calls.Load())
+	}
+}
+
+func TestSetDisplayName_NonAdminDenied(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	var upstreamHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	h := newTestHandler(t, srv)
+	// AdminStore names U_admin / U_alias_admin; "U_not_admin" is not among them.
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	status, reply := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdmin("set-display-name "+testTunnelSlug+" Prod", testAliasTeamID, "U_not_admin")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(reply, "admin-only") {
+		t.Errorf("reply = %q, want admin-only denial", reply)
+	}
+	if upstreamHits.Load() != 0 {
+		t.Errorf("upstream hit despite non-admin gate (hits = %d)", upstreamHits.Load())
+	}
+}
+
+func TestUnsetDisplayName_NonAdminDenied(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	var upstreamHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	h := newTestHandler(t, srv)
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	status, reply := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdmin("unset-display-name "+testTunnelSlug, testAliasTeamID, "U_not_admin")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(reply, "admin-only") {
+		t.Errorf("reply = %q, want admin-only denial", reply)
+	}
+	if upstreamHits.Load() != 0 {
+		t.Errorf("upstream hit despite non-admin gate (hits = %d)", upstreamHits.Load())
+	}
+}
+
+func TestSetDisplayName_ParserErrorDoesNotHitUpstream(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	var upstreamHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	h := newTestHandler(t, srv)
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	// Missing the Display Name argument: the parser rejects synchronously,
+	// before the admin gate or any upstream call.
+	status, reply := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdmin("set-display-name "+testTunnelSlug, testAliasTeamID, "U_alias_admin")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(reply, testDisplayNameMissingMsg) {
+		t.Errorf("reply = %q, want missing-Display-Name usage hint", reply)
+	}
+	if upstreamHits.Load() != 0 {
+		t.Errorf("upstream hit on parser-rejection path (hits = %d)", upstreamHits.Load())
+	}
+}
+
+func TestSetDisplayName_NoAdminStoreWired(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	// No seedAliasAdminGate: AdminStore stays nil, so the verb soft-fails
+	// with the not-configured copy before any upstream call.
+	body, sign := aliasSlashRequest(t, "set-display-name "+testTunnelSlug+" Prod", testAliasTeamID, testAliasChannelID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, "not configured") {
+		t.Errorf("response = %q, want not-configured copy", got)
+	}
+}

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -61,6 +61,8 @@ func TestParseSetDisplayNameArgs(t *testing.T) {
 		{name: "name at length cap accepted", input: id + " " + strings.Repeat("a", displayNameMaxLen), wantID: id, wantName: strings.Repeat("a", displayNameMaxLen)},
 		{name: "control byte in name rejected", input: id + " bad\x01name", wantErr: true, wantMsgSub: "control characters"},
 		{name: "backtick in name rejected", input: id + " Prod `code` API", wantErr: true, wantMsgSub: "backticks"},
+		{name: "angle-bracket broadcast rejected", input: id + " Prod <!here>", wantErr: true, wantMsgSub: "angle brackets"},
+		{name: "angle-bracket disguised link rejected", input: id + " <https://evil|Prod>", wantErr: true, wantMsgSub: "angle brackets"},
 		{name: "tab-separated id and name parses", input: id + "\tProd API", wantID: id, wantName: testDisplayNameProdAPI},
 	}
 	for _, tc := range cases {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -294,7 +294,7 @@ func tunnelDisplayToken(r *client.Resource, boundAliases []string) string {
 // channel alias, so the slug would otherwise appear twice). The token-in-backticks
 // shape lets Slack render each as inline code. There is no `(tunnel)` label
 // or `[slug:...]` fragment — the whole list is tunnels and the token IS the
-// slug. The arrow joins to the human-readable description when one is set.
+// slug. An em-dash joins to the tunnel's Display Name.
 //
 // A slug-less, resource-alias-less tunnel with a bound channel `$alias` has
 // that alias promoted to the primary token (by [tunnelDisplayToken]) so the
@@ -305,6 +305,12 @@ func tunnelDisplayToken(r *client.Resource, boundAliases []string) string {
 // alias-shaped token), so the row renders the bare resource_id WITHOUT a `$`
 // sigil and spells out that it's not usable from Slack until an admin sets a
 // slug — keeping the "copy a token and get it" promise honest.
+//
+// An em-dash joins the id to the tunnel's Display Name. The Display Name
+// reuses the resource description field (see handleSetDisplayName) and is
+// always set — install seeds a default and admins refine it with
+// `/qurl-admin set-display-name` — so it normally renders. The empty guard
+// is defensive only.
 func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 	token := tunnelDisplayToken(r, boundAliases)
 	var line string
@@ -326,8 +332,12 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 		}
 		line += " (" + label + strings.Join(extras, ", ") + ")"
 	}
+	// Show the tunnel's Display Name next to the id. The description field
+	// doubles as the Display Name (see handleSetDisplayName) and is always
+	// set, so this normally renders; the empty guard is defensive only (an
+	// upstream returning a blank description shouldn't dangle an em-dash).
 	if r.Description != "" {
-		line += " → " + r.Description
+		line += " — " + r.Description
 	}
 	return line
 }

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -98,6 +98,9 @@ func TestHandleList_ShowsBoundAliases(t *testing.T) {
 		"kevin-dashboard": resID,
 		"ops":             resID,
 	})
+	// Description doubles as the Display Name and is always set; here it
+	// carries the install default ("Slack tunnel install for <slug>"). The
+	// row shows the bound aliases AND the Display Name after the em-dash.
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: resID, testKeyType: client.ResourceTypeTunnel, testKeySlug: "kktest", testKeyDescription: "Slack tunnel install for kktest"},
@@ -107,13 +110,13 @@ func TestHandleList_ShowsBoundAliases(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$kktest` (aliases: `$kevin-dashboard`, `$ops`) → Slack tunnel install for kktest") {
-		t.Errorf("async reply missing slug + bound-aliases row: %q", async)
+	if !strings.Contains(async, "`$kktest` (aliases: `$kevin-dashboard`, `$ops`) — Slack tunnel install for kktest") {
+		t.Errorf("async reply missing slug + bound-aliases + Display Name row: %q", async)
 	}
 }
 
 // TestFormatTunnelListLine fences the per-row rendering contract
-// directly so the slug-only and slug+description (no-alias) shapes are
+// directly so the slug-only and slug + Display Name (no-alias) shapes are
 // pinned independently of the combined end-to-end TestHandleList_*
 // tests. In particular it locks the self-binding exclusion: the
 // install-flow binds `$<slug>` as a channel alias, and that name must
@@ -134,10 +137,11 @@ func TestFormatTunnelListLine(t *testing.T) {
 		boundAliases []string
 		want         string
 	}{
-		{name: "slug only, no aliases, no description", resource: tunnel(testListAliasProdDB, ""), boundAliases: nil, want: "• `$prod-db`"},
-		{name: "slug + description, no aliases", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: nil, want: "• `$prod-db` → Prod database"},
+		{name: "slug only, no aliases, no Display Name", resource: tunnel(testListAliasProdDB, ""), boundAliases: nil, want: "• `$prod-db`"},
+		{name: "slug + Display Name, no aliases", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: nil, want: "• `$prod-db` — Prod database"},
 		{name: "slug + one non-slug alias", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`)"},
-		{name: "self-binding slug excluded from extras", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`) → Prod database"},
+		{name: "self-binding slug excluded from extras", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`) — Prod database"},
+		{name: "install-default description renders as Display Name", resource: tunnel(testListAliasProdDB, "Slack tunnel install for "+testListAliasProdDB), boundAliases: nil, want: "• `$prod-db` — Slack tunnel install for " + testListAliasProdDB},
 		{name: "only the self-binding slug bound — no extras rendered", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasProdDB}, want: "• `$prod-db`"},
 		// Slug-less, resource-alias-less tunnel: no `$<token>` of its own.
 		{name: "slug-less tunnel with no bound alias renders bare resource_id", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: nil, want: "• `r_noslug0001` (no slug — ask your Slack admin to set one)"},
@@ -419,10 +423,10 @@ func TestHandleList_TunnelResourceIDFallback(t *testing.T) {
 	}
 }
 
-// TestHandleList_TunnelWithDescription fences the trailing
-// "→ <description>" annotation, and that an undescribed tunnel renders
-// just the bare token (no dangling arrow).
-func TestHandleList_TunnelWithDescription(t *testing.T) {
+// TestHandleList_TunnelWithDisplayName fences the trailing
+// "— <Display Name>" annotation, and that a tunnel with no Display Name
+// renders just the bare token (no dangling em-dash).
+func TestHandleList_TunnelWithDisplayName(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -435,14 +439,14 @@ func TestHandleList_TunnelWithDescription(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$ops-bastion` → ops jump host") {
-		t.Errorf("async reply missing slug + description row: %q", async)
+	if !strings.Contains(async, "`$ops-bastion` — ops jump host") {
+		t.Errorf("async reply missing slug + Display Name row: %q", async)
 	}
 	if !strings.Contains(async, "`$no-desc-tun`") {
-		t.Errorf("async reply missing undescribed tunnel row: %q", async)
+		t.Errorf("async reply missing no-Display-Name tunnel row: %q", async)
 	}
-	if strings.Contains(async, "`$no-desc-tun` →") {
-		t.Errorf("undescribed tunnel should not render a trailing arrow: %q", async)
+	if strings.Contains(async, "`$no-desc-tun` —") {
+		t.Errorf("tunnel with no Display Name should not render a trailing em-dash: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -440,11 +440,19 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, te
 		return
 	}
 
+	// The description doubles as the tunnel's user-facing Display Name
+	// (see handleSetDisplayName — there's no separate field). Install
+	// seeds it with a sensible default so every tunnel has a Display Name
+	// from the moment it exists; admins refine it with
+	// `/qurl-admin set-display-name` and revert to this default with
+	// `/qurl-admin unset-display-name`. find_or_create only applies the
+	// description on first create, so re-installing an admin-renamed
+	// tunnel keeps the admin's Display Name.
 	resource, err := c.CreateResource(ctx, &client.CreateResourceInput{
 		Type:         client.ResourceTypeTunnel,
 		Slug:         args.Slug,
 		FindOrCreate: true,
-		Description:  "Slack tunnel install for " + args.Slug,
+		Description:  defaultTunnelDisplayName(args.Slug),
 	})
 	if err != nil {
 		log.Error("tunnel install: create/find resource failed", "error", err, "slug", args.Slug)
@@ -497,7 +505,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, te
 		return
 	}
 
-	msg, err := preparedMessage.render(args, key, aliasStatus, h.now())
+	msg, err := preparedMessage.render(args, key, aliasStatus, resource.Description, h.now())
 	if err != nil {
 		log.Error("tunnel install: render failed after bootstrap key mint", "error", err, "slug", args.Slug, "resource_id", resource.ResourceID, "key_id", key.KeyID)
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, c, key, "message_render_failed")
@@ -630,7 +638,7 @@ func (h *Handler) prepareTunnelInstallMessage(args *tunnelInstallArgs) (prepared
 	}, nil
 }
 
-func (p preparedTunnelInstallMessage) render(args *tunnelInstallArgs, key *client.APIKey, aliasStatus string, now time.Time) (string, error) {
+func (p preparedTunnelInstallMessage) render(args *tunnelInstallArgs, key *client.APIKey, aliasStatus, tunnelDisplayName string, now time.Time) (string, error) {
 	if key == nil {
 		return "", errors.New("bootstrap api key is missing")
 	}
@@ -644,7 +652,17 @@ func (p preparedTunnelInstallMessage) render(args *tunnelInstallArgs, key *clien
 	var b strings.Builder
 	b.WriteString("qURL tunnel `")
 	b.WriteString(args.Slug)
-	b.WriteString("` is ready to install.\n")
+	b.WriteString("`")
+	// Show the tunnel's Display Name next to the id. It reuses the resource
+	// description (see handleSetDisplayName) and is always set — install
+	// seeds the default, admins refine it — so it normally renders. The
+	// empty guard is defensive only (an upstream that ever returned a blank
+	// description shouldn't dangle an em-dash).
+	if tunnelDisplayName != "" {
+		b.WriteString(" — ")
+		b.WriteString(tunnelDisplayName)
+	}
+	b.WriteString(" is ready to install.\n")
 	b.WriteString(aliasStatus)
 	b.WriteString("\n\nBootstrap key ")
 	b.WriteString(tunnelBootstrapExpiryLabel(key, now))
@@ -672,7 +690,12 @@ func (h *Handler) renderTunnelInstallMessage(args *tunnelInstallArgs, key *clien
 	if err != nil {
 		return "", err
 	}
-	return prepared.render(args, key, aliasStatus, h.now())
+	// Focused-test convenience wrapper: passes an empty Display Name so
+	// these tests fence the rest of the install block in isolation. The
+	// production path (processTunnelInstall) passes resource.Description,
+	// and the Display-Name-on-install behavior is covered by a dedicated
+	// test that drives render directly.
+	return prepared.render(args, key, aliasStatus, "", h.now())
 }
 
 func tunnelImageNote(usingDefaultImage bool) string {

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -431,6 +431,69 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 	}
 }
 
+// TestTunnelInstallReinstallShowsExistingDisplayName pins the PR's core UX
+// promise end-to-end: when find_or_create returns an EXISTING tunnel whose
+// description (its Display Name) an admin already customized, the install
+// confirmation renders that admin name — not defaultTunnelDisplayName. It
+// guards the processTunnelInstall→render linkage (render is fed
+// resource.Description, the server's value, not a locally-built default), so
+// re-installing an admin-renamed tunnel never silently clobbers the name in
+// the confirmation. (render's own show/hide-on-empty behavior is unit-tested
+// by TestRenderTunnelInstall_ShowsDisplayNameOnReinstall.)
+func TestTunnelInstallReinstallShowsExistingDisplayName(t *testing.T) {
+	now := fixedNow
+	const existingDisplayName = "Admin renamed prod gateway"
+
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		// find_or_create returns the EXISTING resource, carrying the admin's
+		// previously-set Display Name in description (not the install default).
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID:   testTunnelResourceID,
+			testKeyType:         client.ResourceTypeTunnel,
+			testKeySlug:         testTunnelSlug,
+			testKeyStatus:       client.StatusActive,
+			testKeyDescription:  existingDisplayName,
+			"knock_resource_id": "qurl-tunnel-server",
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelAPIKey,
+			"name":            "Slack tunnel bootstrap " + testTunnelSlug,
+			"scopes":          []string{tunnelScopeAgent, tunnelScopeWrite},
+			testKeyStatus:     client.StatusActive,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+			testKeyExpiresAt:  now.Add(time.Hour).Format(time.RFC3339),
+		})
+	})
+
+	h := newAdminTestHandler(t, ts)
+	freezeTunnelBootstrapNow(t, h, now)
+	h.cfg.TunnelImage = testTunnelImageRef
+	h.SetAliasStore(h.cfg.AdminStore)
+
+	inv := newAdminSlashInvoker(t, h)
+	if _, ack := inv.invokeAdmin(testTunnelInstallCmd+" port:9090", testAdminTeamID, testAdminUserID); !strings.Contains(ack, "Working") {
+		t.Fatalf("ack = %q, want async working copy", ack)
+	}
+	var asyncEnvelope map[string]string
+	if err := json.Unmarshal(inv.captured.waitForBody(t, 2*time.Second), &asyncEnvelope); err != nil {
+		t.Fatalf("unmarshal tunnel install response_url body: %v", err)
+	}
+	async := asyncEnvelope[respFieldText]
+
+	if !strings.Contains(async, existingDisplayName) {
+		t.Errorf("re-install confirmation missing the admin's existing Display Name %q:\n%s", existingDisplayName, async)
+	}
+	if strings.Contains(async, defaultTunnelDisplayName(testTunnelSlug)) {
+		t.Errorf("re-install confirmation rendered the install default instead of the admin's Display Name:\n%s", async)
+	}
+}
+
 func TestTunnelInstallBareOpensGuidedModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -372,6 +372,12 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 	if resourceBody[testKeyType] != client.ResourceTypeTunnel || resourceBody[testKeySlug] != testTunnelSlug || resourceBody["find_or_create"] != true {
 		t.Errorf("resource body = %+v, want tunnel find-or-create slug", resourceBody)
 	}
+	// Install seeds the description (which doubles as the Display Name) with
+	// the install default, so every tunnel has a Display Name from creation;
+	// admins refine it with `/qurl-admin set-display-name`.
+	if got, want := resourceBody[testKeyDescription], defaultTunnelDisplayName(testTunnelSlug); got != want {
+		t.Errorf("resource body description = %v, want install default %q", got, want)
+	}
 	if apiKeyBody[testKeyPurpose] != client.APIKeyPurposeTunnelBootstrap || apiKeyBody[testKeyTunnelSlug] != testTunnelSlug || apiKeyBody["expires_in"] != tunnelBootstrapTTL {
 		t.Errorf("api key body = %+v, want constrained tunnel bootstrap key", apiKeyBody)
 	}
@@ -1774,6 +1780,49 @@ func TestRenderTunnelInstallMessageRejectsUnsafeBootstrapKey(t *testing.T) {
 	}, &client.APIKey{APIKey: "lv_live_bad`key", ExpiresAt: &expiresAt}, "qURL alias `$prod-dashboard` is ready in this channel.")
 	if err == nil || !strings.Contains(err.Error(), "unsupported characters") {
 		t.Fatalf("renderTunnelInstallMessage err = %v, want unsupported-character rejection", err)
+	}
+}
+
+// TestRenderTunnelInstall_ShowsDisplayName fences the install
+// confirmation's id line: it shows the tunnel's Display Name (resource
+// description, always set in production) next to the id; the empty-guard
+// case (defensive — a blank description) shows just the id with no
+// dangling em-dash.
+func TestRenderTunnelInstall_ShowsDisplayNameOnReinstall(t *testing.T) {
+	now := fixedNow
+	expiresAt := now.Add(time.Hour)
+	args := &tunnelInstallArgs{
+		Slug:        testTunnelSlug,
+		Alias:       testTunnelSlug,
+		LocalPort:   defaultTunnelLocalPort,
+		Environment: tunnelEnvDocker,
+	}
+	h := NewHandler(Config{TunnelImage: testTunnelImageRef})
+	freezeTunnelBootstrapNow(t, h, now)
+	prepared, err := h.prepareTunnelInstallMessage(args)
+	if err != nil {
+		t.Fatalf("prepareTunnelInstallMessage: %v", err)
+	}
+	key := &client.APIKey{APIKey: testTunnelAPIKey, ExpiresAt: &expiresAt}
+	const aliasStatus = "qURL alias `$prod-dashboard` is ready in this channel."
+
+	withName, err := prepared.render(args, key, aliasStatus, "Prod API gateway", now)
+	if err != nil {
+		t.Fatalf("render with Display Name: %v", err)
+	}
+	if !strings.Contains(withName, "qURL tunnel `"+testTunnelSlug+"` — Prod API gateway is ready to install.") {
+		t.Errorf("install confirmation missing Display Name on id line:\n%s", withName)
+	}
+
+	withoutName, err := prepared.render(args, key, aliasStatus, "", now)
+	if err != nil {
+		t.Fatalf("render without Display Name: %v", err)
+	}
+	if !strings.Contains(withoutName, "qURL tunnel `"+testTunnelSlug+"` is ready to install.") {
+		t.Errorf("install confirmation should show a bare id line when no Display Name is set:\n%s", withoutName)
+	}
+	if strings.Contains(withoutName, "—") {
+		t.Errorf("install confirmation should not render an em-dash with no Display Name:\n%s", withoutName)
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -1783,7 +1783,7 @@ func TestRenderTunnelInstallMessageRejectsUnsafeBootstrapKey(t *testing.T) {
 	}
 }
 
-// TestRenderTunnelInstall_ShowsDisplayName fences the install
+// TestRenderTunnelInstall_ShowsDisplayNameOnReinstall fences the install
 // confirmation's id line: it shows the tunnel's Display Name (resource
 // description, always set in production) next to the id; the empty-guard
 // case (defensive — a blank description) shows just the id with no

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -70,9 +70,11 @@ const (
 // lines; naming them keeps a typo from becoming a silent mislabel in the
 // audit trail.
 const (
-	AdminActionSetAlias      AdminAction = "set_alias"
-	AdminActionUnsetAlias    AdminAction = "unset_alias"
-	AdminActionTunnelInstall AdminAction = "tunnel_install"
+	AdminActionSetAlias         AdminAction = "set_alias"
+	AdminActionUnsetAlias       AdminAction = "unset_alias"
+	AdminActionTunnelInstall    AdminAction = "tunnel_install"
+	AdminActionSetDisplayName   AdminAction = "set_display_name"
+	AdminActionUnsetDisplayName AdminAction = "unset_display_name"
 )
 
 // Command is the parsed shape of a `/qurl …` slash command.


### PR DESCRIPTION
## What

Adds two new `/qurl-admin` verbs (`/qurl-sandbox-admin` in sandbox — same binary, env-agnostic suffix routing) that let workspace admins put a friendly **Display Name** on a tunnel's **id** (internally the `slug`):

```
/qurl-admin set-display-name <id> <display name>
/qurl-admin unset-display-name <id>
```

## How it works

**Storage — no qurl-service change.** The Display Name reuses the tunnel resource's existing `description` field, set via the existing `client.UpdateResource` → `PATCH /v1/resources/{id}`. There is no new field and no API change.

**Install auto-fill is intentionally KEPT.** Tunnel install still seeds the description with `"Slack tunnel install for <slug>"`. That means a tunnel **always has a Display Name** from the moment it exists — the install string is just the default. `set-display-name` modifies it; admins don't start from "empty." Because the Display Name is always present, there is no empty-state handling and no legacy-string suppression — the render sites simply show `description`.

**`unset-display-name` reverts, it does not blank.** It PATCHes the description back to the same `"Slack tunnel install for <id>"` default that install writes. A single shared constructor (`defaultTunnelDisplayName`) is used by both install and unset so the reset value is byte-identical to what a fresh install produces.

**Parsing & gating.** `set` parses the first whitespace token as the id and the *rest* of the line as the Display Name (free text, spaces allowed, surrounding quotes tolerated, validated non-empty, ≤ 500 chars, printable-only). `unset` takes exactly one id. Both gate on the in-code `requireAdminSync` admin check (Slack does not enforce admin-only on slash commands) and resolve the tunnel by id before any PATCH — a non-admin or a bad id never reaches an upstream write. Not-found returns a friendly message pointing at `/qurl list`.

## Render changes

The Display Name is surfaced next to the id (joined with an em-dash) in:
- `/qurl list` (`formatTunnelListLine`) — already showed `description`; reworded to "id"/"Display Name" terminology.
- `/qurl aliases` (`formatAliasGroupLine`) — now shows it.
- The tunnel install confirmation (`handler_tunnel_compose`/`render`).

These are surgical: the Display Name shows next to the id; the list/aliases layout is otherwise unchanged.

## User-facing copy

Self-explanatory, jargon-free, uses **"id"** and **"Display Name"** only (never "label"/"description"/"slug"/"name"). Success: `✅ Display Name updated for \`<id>\`: <name>` / `✅ Display Name reset for \`<id>\`.`

## Coordination / ordering

- **Pairs with infra PR https://github.com/layervai/qurl-integrations-infra/pull/818**, which advertises these verbs in the slash-command usage hints. That infra PR must land **after** this bot PR so the dispatcher-drift check passes (the bot must already accept the verbs the hints mention).
- **Land after #557** (which renames the slug's user-facing term from "name" → "id"). This branch is off `origin/main`, so shared files (`handler.go`, `handler_list.go`, `handler_aliases.go`) may have a trivial conflict with #557 at merge — expected; a small rebase may be needed. New copy already uses "id" to be forward-consistent.

## Tests

- Arg parsing: multi-word names, quoted names, missing id/name, invalid id, too-long, control bytes.
- Admin gate denies non-admins before any upstream call; parser rejections never hit upstream; no-AdminStore soft-fail.
- `set` PATCHes the typed text; `unset` PATCHes the install-default string (asserts the revert, not a blank).
- Render: Display Name appears next to the id in `/qurl list`, `/qurl aliases`, and the install confirmation.

`go build ./...`, `go test ./apps/slack/internal/...`, `gofmt`, and `golangci-lint` (via pre-commit) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)