### PR TITLE
feat(slack): set link/session/max-session limits on tunnel qURL mints

### DIFF
--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -52,6 +52,10 @@ const (
 	tunnelLinkExpiry      = "1m"
 	tunnelSessionDuration = "1h"
 	tunnelMaxSessions     = 1
+	// tunnelLinkExpiryHuman is the user-facing rendering of tunnelLinkExpiry
+	// for the Slack reply — "1 minute" reads clearer to a recipient than the
+	// terse "1m" duration syntax. Keep in sync with tunnelLinkExpiry above.
+	tunnelLinkExpiryHuman = "1 minute"
 )
 
 // urlNotSupportedGetMessage is the user-facing copy for a raw-URL
@@ -404,7 +408,7 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	// minting. That admit window is tight, so surface it at the point of
 	// sharing: a recipient who clicks after it lapses gets a dead link, and
 	// the suffix tells them why.
-	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use · link expires in " + tunnelLinkExpiry + ")"
+	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use · link expires in " + tunnelLinkExpiryHuman + ")"
 	if args.cmd.DM() {
 		return h.deliverGetDM(ctx, log, args.userID, message), nil
 	}

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -42,6 +42,12 @@ const commonGetMintFailedMessage = "Failed to mint qURL. Please try again."
 // session-limit support to be deployed (otherwise create returns 400 —
 // hence the gating in the PR). Per-visitor identity is IP-based for now;
 // layervai/qurl-service#777 tracks the cookie follow-up.
+//
+// As of qurl-service#778 these values are ALSO the server-side tunnel
+// defaults (session_duration→1h, and one_time_use→single-visitor when
+// max_sessions<=1), so setting them explicitly here is belt-and-suspenders:
+// it pins the bot's intent on the wire and decouples it from any future
+// change to the server defaults, rather than being load-bearing.
 const (
 	tunnelLinkExpiry      = "1m"
 	tunnelSessionDuration = "1h"

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -19,6 +19,27 @@ import (
 // because three different mapMintError branches need it.
 const commonGetMintFailedMessage = "Failed to mint qURL. Please try again."
 
+// Tunnel access limits applied to every `/qurl get` mint. `/qurl get` is
+// tunnel-only (raw URLs are unsupported — see urlNotSupportedGetMessage), so
+// these bound a shared tunnel link to a single short-lived viewer:
+//   - tunnelLinkExpiry: the link only admits a NEW visitor session for this
+//     long after minting (qurl-service `expires_in`).
+//   - tunnelSessionDuration: how long an admitted visitor session lasts
+//     (qurl-service `session_duration`).
+//   - tunnelMaxSessions: max concurrent visitor sessions (qurl-service
+//     `max_sessions`).
+//
+// Enforcement is entirely server-side (qurl-service + qurl-router); this just
+// sets the policy at mint time and requires the qurl-service tunnel
+// session-limit support to be deployed (otherwise create returns 400 —
+// hence the gating in the PR). Per-visitor identity is IP-based for now;
+// layervai/qurl-service#777 tracks the cookie follow-up.
+const (
+	tunnelLinkExpiry      = "1m"
+	tunnelSessionDuration = "1h"
+	tunnelMaxSessions     = 1
+)
+
 // urlNotSupportedGetMessage is the user-facing copy for a raw-URL
 // `/qurl get`. The parser flags the case with the terse
 // [ErrURLNotSupportedGet] sentinel; this is the rich reply the handler
@@ -314,8 +335,12 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		Reason: args.cmd.Reason(),
 		// One-time use is the only mode for `/qurl get` — there is no
 		// `once` flag; every minted link burns on first redemption.
-		OneTimeUse:     true,
-		IdempotencyKey: IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
+		OneTimeUse: true,
+		// Tunnel access limits — see the const block above.
+		ExpiresIn:       tunnelLinkExpiry,
+		SessionDuration: tunnelSessionDuration,
+		MaxSessions:     tunnelMaxSessions,
+		IdempotencyKey:  IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
 	}
 
 	boundResourceID, err := h.resolveTokenForGet(ctx, log, args.teamID, args.channelID, args.userID, alias)

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -29,6 +29,14 @@ const commonGetMintFailedMessage = "Failed to mint qURL. Please try again."
 //   - tunnelMaxSessions: max concurrent visitor sessions (qurl-service
 //     `max_sessions`).
 //
+// How the four limits stack (the OneTimeUse=true mint plus these three):
+// OneTimeUse burns the link on its first redemption, so in steady state only
+// one session is ever established and tunnelMaxSessions=1 is belt-and-
+// suspenders — it makes the "one viewer" intent explicit on the wire and
+// stays correct if the one-time-use default is ever relaxed. tunnelLinkExpiry
+// bounds the window to redeem; tunnelSessionDuration bounds how long that one
+// session then lives.
+//
 // Enforcement is entirely server-side (qurl-service + qurl-router); this just
 // sets the policy at mint time and requires the qurl-service tunnel
 // session-limit support to be deployed (otherwise create returns 400 —
@@ -385,9 +393,12 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		return "", &userError{msg: commonGetMintFailedMessage}
 	}
 
-	// Unconditional suffix — every `/qurl get` link is one-time use
-	// (see OneTimeUse above).
-	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use)"
+	// Unconditional suffix — every `/qurl get` link is one-time use (see
+	// OneTimeUse above) AND only admits a session within tunnelLinkExpiry of
+	// minting. That admit window is tight, so surface it at the point of
+	// sharing: a recipient who clicks after it lapses gets a dead link, and
+	// the suffix tells them why.
+	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use · link expires in " + tunnelLinkExpiry + ")"
 	if args.cmd.DM() {
 		return h.deliverGetDM(ctx, log, args.userID, message), nil
 	}

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -416,7 +416,7 @@ func TestHandleGet_DMRidesOneTimeSuffix(t *testing.T) {
 
 	_, _, async := inv.invokeAdminAsync("get $prod-db dm:true", testAdminTeamID, testAdminUserID)
 
-	wantSuffix := "(one-time use · link expires in " + tunnelLinkExpiry + ")"
+	wantSuffix := "(one-time use · link expires in " + tunnelLinkExpiryHuman + ")"
 	if !strings.HasSuffix(strings.TrimSpace(dmText), wantSuffix) {
 		t.Errorf("DM payload missing one-time-use/expiry suffix %q: %q", wantSuffix, dmText)
 	}
@@ -546,13 +546,13 @@ func TestCreateInputJSON_OneTimeDefault(t *testing.T) {
 	if got, _ := parsed["one_time_use"].(bool); !got {
 		t.Errorf("one_time_use = %v, want true (one-time use is the unconditional default)", parsed["one_time_use"])
 	}
-	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use · link expires in "+tunnelLinkExpiry+")") {
+	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use · link expires in "+tunnelLinkExpiryHuman+")") {
 		t.Errorf("async reply missing one-time-use/expiry suffix: %q", async)
 	}
 	// The tight admit window MUST be surfaced at the point of sharing so a
 	// late click isn't a silent dead link (cr #561).
-	if !strings.Contains(async, "link expires in "+tunnelLinkExpiry) {
-		t.Errorf("async reply does not surface the link-expiry window %q: %q", tunnelLinkExpiry, async)
+	if !strings.Contains(async, "link expires in "+tunnelLinkExpiryHuman) {
+		t.Errorf("async reply does not surface the link-expiry window %q: %q", tunnelLinkExpiryHuman, async)
 	}
 }
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -394,11 +394,12 @@ func TestHandleGet_DMVariantPostDMSuccess(t *testing.T) {
 	}
 }
 
-// TestHandleGet_DMRidesOneTimeSuffix fences that the (one-time use)
-// suffix rides into the DM payload (not the channel reply) on dm:true.
-// One-time use is the unconditional default for `/qurl get`, so the
-// suffix is always present; this guards against a future refactor that
-// reorders the suffix-append and DM-dispatch branches in getWork.
+// TestHandleGet_DMRidesOneTimeSuffix fences that the
+// "(one-time use · link expires in 1 minute)" suffix rides into the DM
+// payload (not the channel reply) on dm:true. That suffix is the
+// unconditional default for `/qurl get`, so it's always present; this guards
+// against a future refactor that reorders the suffix-append and DM-dispatch
+// branches in getWork.
 func TestHandleGet_DMRidesOneTimeSuffix(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
@@ -523,8 +524,8 @@ func TestCreateInputJSON_Reason(t *testing.T) {
 // TestCreateInputJSON_OneTimeDefault fences that one-time use is the
 // unconditional default for `/qurl get`: with no flag at all, the wire
 // body carries `one_time_use: true` and the async reply carries the
-// `(one-time use)` suffix. There is no `once` flag — every `/qurl get`
-// link burns on first redemption.
+// "(one-time use · link expires in 1 minute)" suffix. There is no `once`
+// flag — every `/qurl get` link burns on first redemption.
 func TestCreateInputJSON_OneTimeDefault(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -550,6 +550,42 @@ func TestCreateInputJSON_OneTimeDefault(t *testing.T) {
 	}
 }
 
+// TestCreateInputJSON_TunnelSessionLimits fences that every `/qurl get`
+// mint carries the tunnel access limits on the wire: a 1-minute link
+// expiry, a 1-hour session duration, and a single concurrent session.
+// `/qurl get` is tunnel-only, so these bound a shared tunnel link to one
+// short-lived viewer. Enforcement is server-side; this only fences that the
+// bot sets the policy (and that the resource-scoped body carries all three).
+func TestCreateInputJSON_TunnelSessionLimits(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var capturedBody []byte
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = b
+		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
+		t.Fatalf("unmarshal captured body: %v body=%s", err, capturedBody)
+	}
+	if got, _ := parsed["expires_in"].(string); got != tunnelLinkExpiry {
+		t.Errorf("expires_in = %q, want %q", parsed["expires_in"], tunnelLinkExpiry)
+	}
+	if got, _ := parsed["session_duration"].(string); got != tunnelSessionDuration {
+		t.Errorf("session_duration = %q, want %q", parsed["session_duration"], tunnelSessionDuration)
+	}
+	// JSON numbers decode to float64 through map[string]any.
+	if got, _ := parsed["max_sessions"].(float64); int(got) != tunnelMaxSessions {
+		t.Errorf("max_sessions = %v, want %d", parsed["max_sessions"], tunnelMaxSessions)
+	}
+}
+
 // TestCreateInputJSON_IdempotencyKeyHeader fences that the
 // Idempotency-Key header lands on the wire (not in the JSON body)
 // and is the sha256(team\x00channel\x00user\x00trigger). Alias-form,

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -394,6 +394,19 @@ func TestHandleGet_DMVariantPostDMSuccess(t *testing.T) {
 	}
 }
 
+// TestTunnelLinkExpiryConstsInSync is a tripwire: tunnelLinkExpiry (the wire
+// value sent as expires_in) and tunnelLinkExpiryHuman (the Slack reply copy)
+// are hand-maintained and must describe the same window. Without this, a bump
+// to one (e.g. "1m"→"5m") that forgets the other would silently diverge the
+// user-facing copy from the actual admit window. Pin the current pair; whoever
+// changes the window updates both consts AND this assertion. (cr #561.)
+func TestTunnelLinkExpiryConstsInSync(t *testing.T) {
+	if tunnelLinkExpiry != "1m" || tunnelLinkExpiryHuman != "1 minute" {
+		t.Errorf("link-expiry consts drifted: wire=%q human=%q — update BOTH the consts and this assertion together",
+			tunnelLinkExpiry, tunnelLinkExpiryHuman)
+	}
+}
+
 // TestHandleGet_DMRidesOneTimeSuffix fences that the
 // "(one-time use · link expires in 1 minute)" suffix rides into the DM
 // payload (not the channel reply) on dm:true. That suffix is the

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -416,13 +416,14 @@ func TestHandleGet_DMRidesOneTimeSuffix(t *testing.T) {
 
 	_, _, async := inv.invokeAdminAsync("get $prod-db dm:true", testAdminTeamID, testAdminUserID)
 
-	if !strings.HasSuffix(strings.TrimSpace(dmText), "(one-time use)") {
-		t.Errorf("DM payload missing one-time-use suffix: %q", dmText)
+	wantSuffix := "(one-time use · link expires in " + tunnelLinkExpiry + ")"
+	if !strings.HasSuffix(strings.TrimSpace(dmText), wantSuffix) {
+		t.Errorf("DM payload missing one-time-use/expiry suffix %q: %q", wantSuffix, dmText)
 	}
 	if !strings.Contains(dmText, "https://qurl.link/dm-once") {
 		t.Errorf("DM payload missing link: %q", dmText)
 	}
-	if strings.Contains(async, "(one-time use)") {
+	if strings.Contains(async, "one-time use") {
 		t.Errorf("one-time-use suffix leaked to channel ephemeral on dm:true: %q", async)
 	}
 	if strings.Contains(async, "https://qurl.link/dm-once") {
@@ -545,8 +546,13 @@ func TestCreateInputJSON_OneTimeDefault(t *testing.T) {
 	if got, _ := parsed["one_time_use"].(bool); !got {
 		t.Errorf("one_time_use = %v, want true (one-time use is the unconditional default)", parsed["one_time_use"])
 	}
-	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use)") {
-		t.Errorf("async reply missing one-time-use suffix: %q", async)
+	if !strings.HasSuffix(strings.TrimSpace(async), "(one-time use · link expires in "+tunnelLinkExpiry+")") {
+		t.Errorf("async reply missing one-time-use/expiry suffix: %q", async)
+	}
+	// The tight admit window MUST be surfaced at the point of sharing so a
+	// late click isn't a silent dead link (cr #561).
+	if !strings.Contains(async, "link expires in "+tunnelLinkExpiry) {
+		t.Errorf("async reply does not surface the link-expiry window %q: %q", tunnelLinkExpiry, async)
 	}
 }
 

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -282,12 +282,18 @@ type CreateInput struct {
 	// ResourceID, when set, mints a qURL bound to an existing resource
 	// (e.g. a tunnel resource resolved via GetResource). Mutually
 	// exclusive with TargetURL on the wire.
-	ResourceID   string        `json:"resource_id,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	ExpiresIn    string        `json:"expires_in,omitempty"`
-	OneTimeUse   bool          `json:"one_time_use,omitempty"`
-	MaxSessions  int           `json:"max_sessions,omitempty"`
-	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+	ResourceID  string `json:"resource_id,omitempty"`
+	Description string `json:"description,omitempty"`
+	ExpiresIn   string `json:"expires_in,omitempty"`
+	OneTimeUse  bool   `json:"one_time_use,omitempty"`
+	MaxSessions int    `json:"max_sessions,omitempty"`
+	// SessionDuration is the per-qURL session lifetime (e.g. "1h"): how
+	// long access lasts after a visitor reaches the content, distinct
+	// from ExpiresIn (the link's own expiry). Server-side it maps to
+	// CreateQurlRequest.session_duration. omitempty so the zero value
+	// stays off the wire and inherits the server/plan default.
+	SessionDuration string        `json:"session_duration,omitempty"`
+	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
 	// Reason is forwarded to the audit log when set (e.g. an
 	// operator-supplied "for incident #123" annotation from the
 	// `/qurl get $alias reason:"…"` slash-command flag). The server
@@ -390,12 +396,13 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 		endpoint = c.baseURL + "/v1/resources/" + url.PathEscape(input.ResourceID) + "/qurls"
 		logLabel = "POST /v1/resources/:id/qurls"
 		body, err = json.Marshal(createForResourceBody{
-			Description:  input.Description,
-			ExpiresIn:    input.ExpiresIn,
-			OneTimeUse:   input.OneTimeUse,
-			MaxSessions:  input.MaxSessions,
-			AccessPolicy: input.AccessPolicy,
-			Reason:       input.Reason,
+			Description:     input.Description,
+			ExpiresIn:       input.ExpiresIn,
+			OneTimeUse:      input.OneTimeUse,
+			MaxSessions:     input.MaxSessions,
+			SessionDuration: input.SessionDuration,
+			AccessPolicy:    input.AccessPolicy,
+			Reason:          input.Reason,
 		})
 	} else {
 		endpoint = c.baseURL + "/v1/qurls"
@@ -431,12 +438,13 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 // path, so it doesn't repeat in the body; target_url is absent for
 // the same reason — the resource already owns it).
 type createForResourceBody struct {
-	Description  string        `json:"description,omitempty"`
-	ExpiresIn    string        `json:"expires_in,omitempty"`
-	OneTimeUse   bool          `json:"one_time_use,omitempty"`
-	MaxSessions  int           `json:"max_sessions,omitempty"`
-	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
-	Reason       string        `json:"reason,omitempty"`
+	Description     string        `json:"description,omitempty"`
+	ExpiresIn       string        `json:"expires_in,omitempty"`
+	OneTimeUse      bool          `json:"one_time_use,omitempty"`
+	MaxSessions     int           `json:"max_sessions,omitempty"`
+	SessionDuration string        `json:"session_duration,omitempty"`
+	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
+	Reason          string        `json:"reason,omitempty"`
 }
 
 // Get retrieves a qURL by ID.

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -241,17 +241,21 @@ type ResponseMeta struct {
 
 // QURL represents a qURL resource as returned by the API.
 type QURL struct {
-	ResourceID   string        `json:"resource_id"`
-	TargetURL    string        `json:"target_url"`
-	Status       string        `json:"status"`
-	CreatedAt    time.Time     `json:"created_at"`
-	ExpiresAt    *time.Time    `json:"expires_at,omitempty"`
-	OneTimeUse   bool          `json:"one_time_use"`
-	MaxSessions  int           `json:"max_sessions,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	QURLSite     string        `json:"qurl_site,omitempty"`
-	QURLLink     string        `json:"qurl_link,omitempty"`
-	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
+	ResourceID  string     `json:"resource_id"`
+	TargetURL   string     `json:"target_url"`
+	Status      string     `json:"status"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	OneTimeUse  bool       `json:"one_time_use"`
+	MaxSessions int        `json:"max_sessions,omitempty"`
+	// SessionDuration is the per-qURL session lifetime in seconds (the
+	// read-back counterpart of CreateInput.SessionDuration). Symmetric with
+	// MaxSessions/ExpiresAt so an admin "show limits" view can surface it.
+	SessionDuration int           `json:"session_duration,omitempty"`
+	Description     string        `json:"description,omitempty"`
+	QURLSite        string        `json:"qurl_site,omitempty"`
+	QURLLink        string        `json:"qurl_link,omitempty"`
+	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
 }
 
 // AccessPolicy defines access restrictions for a qURL.

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -248,14 +248,16 @@ type QURL struct {
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 	OneTimeUse  bool       `json:"one_time_use"`
 	MaxSessions int        `json:"max_sessions,omitempty"`
-	// SessionDuration is the per-qURL session lifetime in seconds (the
-	// read-back counterpart of CreateInput.SessionDuration). Symmetric with
-	// MaxSessions/ExpiresAt so an admin "show limits" view can surface it.
-	SessionDuration int           `json:"session_duration,omitempty"`
-	Description     string        `json:"description,omitempty"`
-	QURLSite        string        `json:"qurl_site,omitempty"`
-	QURLLink        string        `json:"qurl_link,omitempty"`
-	AccessPolicy    *AccessPolicy `json:"access_policy,omitempty"`
+	// SessionDuration read-back is intentionally omitted: the bot doesn't
+	// consume it yet, and adding an `int` field would couple the WHOLE QURL
+	// decode to session_duration's wire type (a string-typed echo would fail
+	// json.Unmarshal for the entire struct, not just that field). Add it WITH
+	// a decode test against the confirmed number wire shape when a consumer
+	// (e.g. an admin "show limits" view) actually needs it. (cr #561.)
+	Description  string        `json:"description,omitempty"`
+	QURLSite     string        `json:"qurl_site,omitempty"`
+	QURLLink     string        `json:"qurl_link,omitempty"`
+	AccessPolicy *AccessPolicy `json:"access_policy,omitempty"`
 }
 
 // AccessPolicy defines access restrictions for a qURL.

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -248,12 +248,10 @@ type QURL struct {
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 	OneTimeUse  bool       `json:"one_time_use"`
 	MaxSessions int        `json:"max_sessions,omitempty"`
-	// SessionDuration read-back is intentionally omitted: the bot doesn't
-	// consume it yet, and adding an `int` field would couple the WHOLE QURL
-	// decode to session_duration's wire type (a string-typed echo would fail
-	// json.Unmarshal for the entire struct, not just that field). Add it WITH
-	// a decode test against the confirmed number wire shape when a consumer
-	// (e.g. an admin "show limits" view) actually needs it. (cr #561.)
+	// SessionDuration read-back is intentionally omitted (no consumer yet): an
+	// int field would couple the whole QURL decode to session_duration's wire
+	// type. Add it with a decode test when a consumer needs it. See qurl-service
+	// #778 for the wire shape (response is a number; CreateInput sends a string).
 	Description  string        `json:"description,omitempty"`
 	QURLSite     string        `json:"qurl_site,omitempty"`
 	QURLLink     string        `json:"qurl_link,omitempty"`

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1007,6 +1007,62 @@ func TestCreateTargetURLOnlyOmitsResourceID(t *testing.T) {
 	}
 }
 
+// TestCreateSessionDurationOnWire pins that CreateInput.SessionDuration
+// serializes as `session_duration` on both create wire shapes — the direct
+// `/v1/qurls` body (target_url form) and the resource-scoped
+// `/v1/resources/{id}/qurls` body — and that it omits when empty.
+func TestCreateSessionDurationOnWire(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input CreateInput
+	}{
+		{"target_url form", CreateInput{TargetURL: "https://example.com", SessionDuration: "1h"}},
+		{"resource_id form", CreateInput{ResourceID: "r_tunnel", SessionDuration: "1h"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+			}))
+			defer srv.Close()
+			c := testClient(srv.URL, "test-key")
+			if _, err := c.Create(context.Background(), tc.input); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(gotBody, &raw); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+			if got, _ := raw["session_duration"].(string); got != "1h" {
+				t.Errorf("session_duration = %v, want \"1h\"; body=%s", raw["session_duration"], gotBody)
+			}
+		})
+	}
+}
+
+// TestCreateSessionDurationOmittedWhenEmpty pins the omitempty contract so a
+// zero SessionDuration inherits the server/plan default rather than forcing 0.
+func TestCreateSessionDurationOmittedWhenEmpty(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+	}))
+	defer srv.Close()
+	c := testClient(srv.URL, "test-key")
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if _, ok := raw["session_duration"]; ok {
+		t.Errorf("session_duration must be omitted when empty; body=%s", gotBody)
+	}
+}
+
 // TestCreateTargetURLAndResourceIDMutuallyExclusive pins the client-side
 // fail-fast for the both-populated case. Mirror of the symmetric guard in
 // UpdateResource for (Alias, ClearAlias). Closes the third leg of the


### PR DESCRIPTION
## What

Every `/qurl get` mint (tunnel-only — raw URLs are unsupported) now sets three access limits, bounding a shared tunnel link to a single short-lived viewer:

| field | value | meaning |
|---|---|---|
| `expires_in` | `1m` | link only admits a **new** visitor session for 60s after minting |
| `session_duration` | `1h` | an admitted visitor session lasts up to 1 hour |
| `max_sessions` | `1` | one concurrent visitor session |

Also wires `SessionDuration` through `shared/client` (`CreateInput` + `createForResourceBody`) — it was missing — mapping to qurl-service's `session_duration` on both create wire shapes.

## Why

Tunnel qURLs are shared links to a customer's exposed service. Without limits, a link is reusable and concurrently accessible indefinitely until revoked. These bound exposure to **one viewer, for one hour, started within one minute of minting**.

## ⚠️ Deploy-order dependency (not a flag) — qurl-service#778 first

Enforcement is entirely **server-side** (qurl-service + qurl-router). This PR only sets the policy at mint time. The *pre-#778* qurl-service API **rejects** `max_sessions`/`session_duration` on tunnel resources with **400**, so this MUST deploy **after** qurl-service#778 is live in prod — else every `/qurl get` 400s. This PR is **ready** (cr-approved, all green, the #778 string-duration create contract is verified); merge/deploy it only once #778 is deployed. There is **no feature flag** — #778's session enforcement is unconditional on deploy.

- Per-visitor identity is **IP-based** in the interim; cookie follow-up tracked in **layervai/qurl-service#777**.

## Tests

- `apps/slack` — `TestCreateInputJSON_TunnelSessionLimits`: fences that the mint wire body carries `expires_in:1m`, `session_duration:1h`, `max_sessions:1` end-to-end through the resource-scoped create.
- `shared/client` — `TestCreateSessionDurationOnWire` (both wire shapes) + `TestCreateSessionDurationOmittedWhenEmpty` (omitempty contract).
- Full `shared/client` + `apps/slack/internal` suites pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
