### PR TITLE
ci: bump issue-priority reusable shim to ops-routines-workflows v0.7.0

### DIFF
--- a/.github/workflows/issue-priority.yml
+++ b/.github/workflows/issue-priority.yml
@@ -48,6 +48,6 @@ jobs:
     # reusable's own `sender.type != 'Bot'` check short-circuits them
     # before setFailed — net effect is a near-instant no-op run.
     if: ${{ github.actor != 'github-actions[bot]' }}
-    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
+    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@f9a4ab4e4697980ebd21efed7d643441f0ea0993 # v0.7.0
     permissions:
       issues: write


### PR DESCRIPTION
## What

Bumps the `issue-priority` reusable shim to `ops-routines-workflows` **v0.7.0** (ref-only — no other changes).

## Why

Previously, an issue created **out-of-band** (REST API / `gh issue create` / a stripped label) with no `priority: *` label hit the reusable's passive fall-through: a failed run that gates nothing, so the issue persisted with no priority. The required-dropdown issue forms only cover the web-UI path.

GitHub has no pre-create hook for issues, so v0.7.0 makes the gap **self-healing** instead: it attaches a `needs: priority` holding label (auto-created if the repo doesn't define it) + a one-time comment, keeps the run red until a real priority is set, then **strips the holding label automatically** once one is. No silent default — the author defines the priority. Bot-filed issues stay exempt at creation to avoid label-event recursion.

## Safety

Ref-only bump; the reusable's interface (`issues: write`, no inputs) is unchanged, it's fully tested upstream, and the behavior was validated live before this rollout. Released as `ops-routines-workflows` v0.7.0.
