### PR TITLE
fix(slack): accept $-prefixed id on display-name verbs; richer bare-verb hints

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1276,8 +1276,9 @@ func (h *Handler) adminHelpMessage(command string) string {
 		lines = append(lines,
 			"• `/qurl-admin set-display-name <id> <display name>` — Set a tunnel's friendly Display Name shown in `/qurl list` (admin only)",
 			"• `/qurl-admin unset-display-name <id>` — Reset a tunnel's Display Name to the default (admin only)",
-			// admin add/remove/list/revoke: keep this roster in sync with
-			// adminUsageMessage (handler_admin.go), the bare-`admin` arg hint.
+			// admin add/remove/list/revoke: keep this action set in sync with
+			// adminUsageMessage (handler_admin.go), the bare-`admin` arg hint —
+			// the verb roster must match, not the prose.
 			"• `/qurl-admin admin add @user` — Promote a Slack user to bot admin (admin only)",
 			"• `/qurl-admin admin remove @user` — Demote a Slack user from bot admin (admin only)",
 			"• `/qurl-admin admin list` — List who connected qURL (the owner) and the current bot admins (admin only)",

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1276,6 +1276,8 @@ func (h *Handler) adminHelpMessage(command string) string {
 		lines = append(lines,
 			"• `/qurl-admin set-display-name <id> <display name>` — Set a tunnel's friendly Display Name shown in `/qurl list` (admin only)",
 			"• `/qurl-admin unset-display-name <id>` — Reset a tunnel's Display Name to the default (admin only)",
+			// admin add/remove/list/revoke: keep this roster in sync with
+			// adminUsageMessage (handler_admin.go), the bare-`admin` arg hint.
 			"• `/qurl-admin admin add @user` — Promote a Slack user to bot admin (admin only)",
 			"• `/qurl-admin admin remove @user` — Demote a Slack user from bot admin (admin only)",
 			"• `/qurl-admin admin list` — List who connected qURL (the owner) and the current bot admins (admin only)",

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -20,6 +20,10 @@ import (
 // user learns the grammar rather than seeing the terse sentinel. "qURL bot
 // admin" (not "workspace admin") is deliberate: membership is the bot's own
 // admin set, not Slack's workspace-admin role.
+//
+// Keep this action roster in sync with the `/qurl-admin help` listing in
+// handler.go — the two are maintained independently and would otherwise drift
+// when an admin action is added or renamed.
 const adminUsageMessage = "Usage:\n• `/qurl-admin admin add @user` — promote a Slack user to qURL bot admin\n• `/qurl-admin admin remove @user` — demote a qURL bot admin\n• `/qurl-admin admin list` — show who connected qURL (the owner) and current bot admins\n• `/qurl-admin admin revoke <qurl_id>` — revoke a single qURL"
 
 // handleAdmin parses the `admin <verb> ...` form via the shared parser

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -14,6 +14,14 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+// adminUsageMessage is the arg hint shown when `/qurl-admin admin` is
+// invoked with no action (bare `admin`, which parses to
+// [ErrMissingAdminAction]). Lists the membership + revoke actions so the
+// user learns the grammar rather than seeing the terse sentinel. "qURL bot
+// admin" (not "workspace admin") is deliberate: membership is the bot's own
+// admin set, not Slack's workspace-admin role.
+const adminUsageMessage = "Usage:\n• `/qurl-admin admin add @user` — promote a Slack user to qURL bot admin\n• `/qurl-admin admin remove @user` — demote a qURL bot admin\n• `/qurl-admin admin list` — show who connected qURL (the owner) and current bot admins\n• `/qurl-admin admin revoke <qurl_id>` — revoke a single qURL"
+
 // handleAdmin parses the `admin <verb> ...` form via the shared parser
 // and dispatches to the action-specific handler. Every recognized verb
 // is sync — one DDB GetItem/UpdateItem or one qURL API DELETE — so the
@@ -38,6 +46,15 @@ func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	cmd, err := Parse(text)
 	if err != nil {
+		// Bare `admin` (no action) parses to ErrMissingAdminAction. List the
+		// available actions instead of the terse sentinel so the user learns
+		// the grammar. The action roster is public (it's in `/qurl-admin help`),
+		// so this hint is ungated — the admin gate is on execution, not
+		// discovery, matching the set-alias / set-display-name usage paths.
+		if errors.Is(err, ErrMissingAdminAction) {
+			respondSlack(w, ":warning: "+adminUsageMessage)
+			return
+		}
 		respondSlack(w, ":warning: "+err.Error())
 		return
 	}

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -21,9 +21,10 @@ import (
 // admin" (not "workspace admin") is deliberate: membership is the bot's own
 // admin set, not Slack's workspace-admin role.
 //
-// Keep this action roster in sync with the `/qurl-admin help` listing in
-// handler.go — the two are maintained independently and would otherwise drift
-// when an admin action is added or renamed.
+// Keep the action SET (add/remove/list/revoke) in sync with the `/qurl-admin
+// help` listing in handler.go — only the verb roster must match, not the prose
+// (help capitalizes and appends "(admin only)"). The two are maintained
+// independently and would otherwise drift when an action is added or renamed.
 const adminUsageMessage = "Usage:\n• `/qurl-admin admin add @user` — promote a Slack user to qURL bot admin\n• `/qurl-admin admin remove @user` — demote a qURL bot admin\n• `/qurl-admin admin list` — show who connected qURL (the owner) and current bot admins\n• `/qurl-admin admin revoke <qurl_id>` — revoke a single qURL"
 
 // handleAdmin parses the `admin <verb> ...` form via the shared parser
@@ -52,9 +53,12 @@ func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 	if err != nil {
 		// Bare `admin` (no action) parses to ErrMissingAdminAction. List the
 		// available actions instead of the terse sentinel so the user learns
-		// the grammar. The action roster is public (it's in `/qurl-admin help`),
-		// so this hint is ungated — the admin gate is on execution, not
-		// discovery, matching the set-alias / set-display-name usage paths.
+		// the grammar. This parser-level discovery hint is ungated (the admin
+		// gate is on execution, not discovery — matching set-alias /
+		// set-display-name). It stays shown even on a no-DDB deploy, where
+		// `/qurl-admin help` instead gates its admin lines behind AdminStore;
+		// the divergence is deliberate — parser feedback is useful regardless
+		// of wiring (see the handleAdmin doc comment).
 		if errors.Is(err, ErrMissingAdminAction) {
 			respondSlack(w, ":warning: "+adminUsageMessage)
 			return

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -819,7 +819,9 @@ func TestRemoveAdmin_Concurrent(t *testing.T) {
 // --- Dispatch-shell tests ---
 
 // TestHandleAdmin_BareAdminVerb fences the bare `admin` form — a
-// parser error, not a panic in the verb-dispatch switch.
+// parser error surfaced as the action-roster usage hint, not a panic
+// in the verb-dispatch switch or the terse "missing admin action"
+// sentinel.
 func TestHandleAdmin_BareAdminVerb(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -830,6 +832,13 @@ func TestHandleAdmin_BareAdminVerb(t *testing.T) {
 	_, reply := inv.invokeAdmin("admin", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, ":warning:") {
 		t.Errorf("reply missing parser-error surface: %q", reply)
+	}
+	// The bare-admin hint lists the available actions rather than echoing
+	// the terse sentinel, so the user learns the grammar.
+	for _, want := range []string{"admin add", "admin remove", "admin list", "admin revoke"} {
+		if !strings.Contains(reply, want) {
+			t.Errorf("bare-admin hint missing %q: %q", want, reply)
+		}
 	}
 }
 

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -838,6 +839,48 @@ func TestHandleAdmin_BareAdminVerb(t *testing.T) {
 	for _, want := range []string{"admin add", "admin remove", "admin list", "admin revoke"} {
 		if !strings.Contains(reply, want) {
 			t.Errorf("bare-admin hint missing %q: %q", want, reply)
+		}
+	}
+}
+
+// TestAdminRosters_InSync is the drift guard for the two independently
+// maintained admin-action rosters: adminUsageMessage (the bare-`admin` arg
+// hint, handler_admin.go) and the `/qurl-admin help` listing (adminHelpMessage,
+// handler.go). A cross-reference comment can't enforce parity, so this fails
+// CI if a future admin action is added to (or dropped from) one roster but not
+// the other.
+func TestAdminRosters_InSync(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	// adminHelpMessage gates the admin add/remove/list/revoke lines on
+	// AdminStore (the same condition the verbs use at runtime), so seed it.
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	help := h.adminHelpMessage(commandAdmin)
+
+	// Both rosters render each action as `<cmd> admin <verb>`, and <cmd> itself
+	// ends in `-admin`, so the verb is the token right after `admin admin`.
+	// That anchor skips the trailing `(admin only)` and the set-display-name
+	// lines, which contain a single `admin` only.
+	re := regexp.MustCompile(`admin admin (\w+)`)
+	extract := func(s string) map[string]bool {
+		set := map[string]bool{}
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			set[m[1]] = true
+		}
+		return set
+	}
+	hint, listing := extract(adminUsageMessage), extract(help)
+
+	if len(hint) == 0 || len(listing) == 0 {
+		t.Fatalf("extracted empty action set (hint=%v listing=%v) — a roster's `<cmd> admin <verb>` shape drifted", hint, listing)
+	}
+	for v := range hint {
+		if !listing[v] {
+			t.Errorf("bare-`admin` hint lists action %q that `/qurl-admin help` omits — rosters out of sync", v)
+		}
+	}
+	for v := range listing {
+		if !hint[v] {
+			t.Errorf("`/qurl-admin help` lists action %q that the bare-`admin` hint omits — rosters out of sync", v)
 		}
 	}
 }

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -35,6 +35,25 @@ func defaultTunnelDisplayName(slug string) string {
 // missing-arg path and the validation-rejection path share one copy.
 const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <display name>`\n• `/qurl-admin unset-display-name <id>`\n\nThe id is the tunnel token shown by `/qurl list` (the leading `$` is optional). The Display Name is free text up to 500 characters."
 
+// parseDisplayNameID strips an optional leading `$` from a tunnel-id token
+// and validates it against tunnelSlugPattern. Shared by the set/unset
+// display-name parsers so both accept the `$<id>` sigil form `/qurl list`
+// prints — matching every other tunnel-id/alias command (`/qurl get`,
+// `/qurl-admin set-alias`) — and reject identically. Stripping here rather
+// than widening tunnelSlugPattern keeps the slug grammar (shared with
+// install) intact. Returns (id, "") on success or ("", userMsg) with the
+// ephemeral copy to surface.
+func parseDisplayNameID(tok string) (id, userMsg string) {
+	id = strings.TrimPrefix(tok, "$")
+	if id == "" {
+		return "", "Missing tunnel id.\n\n" + displayNameUsage
+	}
+	if !tunnelSlugPattern.MatchString(id) {
+		return "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(id), displayNameUsage)
+	}
+	return id, ""
+}
+
 // parseSetDisplayNameArgs splits a `set-display-name <id> <display name>`
 // body into the tunnel id (first whitespace-delimited token) and the
 // Display Name (the rest of the line). The Display Name is trimmed and may
@@ -58,16 +77,11 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 		idTok, rest = text[:i], strings.TrimLeftFunc(text[i:], unicode.IsSpace)
 		found = true
 	}
-	// Accept an optional leading `$` on the id so set-display-name matches
-	// every other tunnel-id/alias command (`/qurl get`, `/qurl-admin set-alias`),
-	// which all take the `$<id>` sigil form `/qurl list` prints. Strip it here
-	// rather than widening tunnelSlugPattern (which the slug grammar shares).
-	idTok = strings.TrimPrefix(idTok, "$")
-	if idTok == "" {
-		return "", "", "Missing tunnel id.\n\n" + displayNameUsage
-	}
-	if !tunnelSlugPattern.MatchString(idTok) {
-		return "", "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(idTok), displayNameUsage)
+	// Strip the optional `$` and validate the id (shared with the unset
+	// parser via parseDisplayNameID).
+	id, userMsg = parseDisplayNameID(idTok)
+	if userMsg != "" {
+		return "", "", userMsg
 	}
 	if !found {
 		return "", "", "Missing Display Name.\n\n" + displayNameUsage
@@ -94,7 +108,7 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 			return "", "", "Display Name can't contain backticks, angle brackets, or control characters. Use plain text only.\n\n" + displayNameUsage
 		}
 	}
-	return idTok, name, ""
+	return id, name, ""
 }
 
 // parseUnsetDisplayNameArgs validates a `unset-display-name <id>` body:
@@ -104,16 +118,7 @@ func parseUnsetDisplayNameArgs(text string) (id, userMsg string) {
 	if len(tokens) != 1 {
 		return "", "Provide exactly one tunnel id.\n\n" + displayNameUsage
 	}
-	// Accept an optional leading `$` on the id, matching parseSetDisplayNameArgs
-	// and the rest of the tunnel-id/alias commands.
-	id = strings.TrimPrefix(tokens[0], "$")
-	if id == "" {
-		return "", "Missing tunnel id.\n\n" + displayNameUsage
-	}
-	if !tunnelSlugPattern.MatchString(id) {
-		return "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(id), displayNameUsage)
-	}
-	return id, ""
+	return parseDisplayNameID(tokens[0])
 }
 
 // stripSurroundingQuotes removes one matched pair of surrounding single or

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -38,11 +38,15 @@ const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <displa
 // parseDisplayNameID strips an optional leading `$` from a tunnel-id token
 // and validates it against tunnelSlugPattern. Shared by the set/unset
 // display-name parsers so both accept the `$<id>` sigil form `/qurl list`
-// prints — matching every other tunnel-id/alias command (`/qurl get`,
-// `/qurl-admin set-alias`) — and reject identically. Stripping here rather
-// than widening tunnelSlugPattern keeps the slug grammar (shared with
-// install) intact. Returns (id, "") on success or ("", userMsg) with the
-// ephemeral copy to surface.
+// prints. Note the sigil is *optional* here (bare and `$`-prefixed both
+// parse); `/qurl get` and `/qurl-admin set-alias` instead *require* it (a
+// missing `$` is ErrMissingSigil in parseAliasToken). So these verbs are the
+// lenient superset — accepting the sigil form a user copies from `/qurl
+// list`, not enforcing it. Stripping here rather than widening
+// tunnelSlugPattern keeps the slug grammar (shared with install) intact, and
+// the invalid-id message echoes the stripped id (matching parseAliasToken,
+// which echoes the post-`$` value). Returns (id, "") on success or
+// ("", userMsg) with the ephemeral copy to surface.
 func parseDisplayNameID(tok string) (id, userMsg string) {
 	id = strings.TrimPrefix(tok, "$")
 	if id == "" {

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -44,9 +44,10 @@ const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <displa
 // lenient superset — accepting the sigil form a user copies from `/qurl
 // list`, not enforcing it. Stripping here rather than widening
 // tunnelSlugPattern keeps the slug grammar (shared with install) intact, and
-// the invalid-id message echoes the stripped id (matching parseAliasToken,
-// which echoes the post-`$` value). Returns (id, "") on success or
-// ("", userMsg) with the ephemeral copy to surface.
+// the invalid-id message echoes the *stripped* id — the post-`$` value, as
+// parseAliasToken does (the Slack-escaping helper differs: echoText here,
+// truncateForError there). Returns (id, "") on success or ("", userMsg) with
+// the ephemeral copy to surface.
 func parseDisplayNameID(tok string) (id, userMsg string) {
 	id = strings.TrimPrefix(tok, "$")
 	if id == "" {

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -36,18 +36,13 @@ func defaultTunnelDisplayName(slug string) string {
 const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <display name>`\n• `/qurl-admin unset-display-name <id>`\n\nThe id is the tunnel token shown by `/qurl list` (the leading `$` is optional). The Display Name is free text up to 500 characters."
 
 // parseDisplayNameID strips an optional leading `$` from a tunnel-id token
-// and validates it against tunnelSlugPattern. Shared by the set/unset
-// display-name parsers so both accept the `$<id>` sigil form `/qurl list`
-// prints. Note the sigil is *optional* here (bare and `$`-prefixed both
-// parse); `/qurl get` and `/qurl-admin set-alias` instead *require* it (a
-// missing `$` is ErrMissingSigil in parseAliasToken). So these verbs are the
-// lenient superset — accepting the sigil form a user copies from `/qurl
-// list`, not enforcing it. Stripping here rather than widening
-// tunnelSlugPattern keeps the slug grammar (shared with install) intact, and
-// the invalid-id message echoes the *stripped* id — the post-`$` value, as
-// parseAliasToken does (the Slack-escaping helper differs: echoText here,
-// truncateForError there). Returns (id, "") on success or ("", userMsg) with
-// the ephemeral copy to surface.
+// and validates it against tunnelSlugPattern. Shared by both display-name
+// parsers so set/unset accept the `$<id>` form `/qurl list` prints and reject
+// identically. The sigil is optional here, whereas `/qurl get`/`set-alias`
+// require it (missing → ErrMissingSigil) — these verbs are the lenient
+// superset. Stripping beats widening tunnelSlugPattern (shared with install),
+// and the invalid-id echo shows the stripped id, matching parseAliasToken.
+// Returns (id, "") on success or ("", userMsg).
 func parseDisplayNameID(tok string) (id, userMsg string) {
 	id = strings.TrimPrefix(tok, "$")
 	if id == "" {

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -41,8 +41,9 @@ const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <displa
 // identically. The sigil is optional here, whereas `/qurl get`/`set-alias`
 // require it (missing → ErrMissingSigil) — these verbs are the lenient
 // superset. Stripping beats widening tunnelSlugPattern (shared with install),
-// and the invalid-id echo shows the stripped id, matching parseAliasToken.
-// Returns (id, "") on success or ("", userMsg).
+// and the invalid-id echo shows the stripped id, matching parseAliasToken on
+// the value (the Slack escaper differs). Returns (id, "") on success or
+// ("", userMsg).
 func parseDisplayNameID(tok string) (id, userMsg string) {
 	id = strings.TrimPrefix(tok, "$")
 	if id == "" {

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -33,7 +33,7 @@ func defaultTunnelDisplayName(slug string) string {
 // displayNameUsage is the help-text body returned when set-display-name /
 // unset-display-name is invoked with an obvious typo. Centralized so the
 // missing-arg path and the validation-rejection path share one copy.
-const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <display name>`\n• `/qurl-admin unset-display-name <id>`\n\nThe id is the tunnel token shown by `/qurl list` (without the `$`). The Display Name is free text up to 500 characters."
+const displayNameUsage = "Usage:\n• `/qurl-admin set-display-name <id> <display name>`\n• `/qurl-admin unset-display-name <id>`\n\nThe id is the tunnel token shown by `/qurl list` (the leading `$` is optional). The Display Name is free text up to 500 characters."
 
 // parseSetDisplayNameArgs splits a `set-display-name <id> <display name>`
 // body into the tunnel id (first whitespace-delimited token) and the
@@ -58,6 +58,11 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 		idTok, rest = text[:i], strings.TrimLeftFunc(text[i:], unicode.IsSpace)
 		found = true
 	}
+	// Accept an optional leading `$` on the id so set-display-name matches
+	// every other tunnel-id/alias command (`/qurl get`, `/qurl-admin set-alias`),
+	// which all take the `$<id>` sigil form `/qurl list` prints. Strip it here
+	// rather than widening tunnelSlugPattern (which the slug grammar shares).
+	idTok = strings.TrimPrefix(idTok, "$")
 	if idTok == "" {
 		return "", "", "Missing tunnel id.\n\n" + displayNameUsage
 	}
@@ -99,10 +104,16 @@ func parseUnsetDisplayNameArgs(text string) (id, userMsg string) {
 	if len(tokens) != 1 {
 		return "", "Provide exactly one tunnel id.\n\n" + displayNameUsage
 	}
-	if !tunnelSlugPattern.MatchString(tokens[0]) {
-		return "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(tokens[0]), displayNameUsage)
+	// Accept an optional leading `$` on the id, matching parseSetDisplayNameArgs
+	// and the rest of the tunnel-id/alias commands.
+	id = strings.TrimPrefix(tokens[0], "$")
+	if id == "" {
+		return "", "Missing tunnel id.\n\n" + displayNameUsage
 	}
-	return tokens[0], ""
+	if !tunnelSlugPattern.MatchString(id) {
+		return "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(id), displayNameUsage)
+	}
+	return id, ""
 }
 
 // stripSurroundingQuotes removes one matched pair of surrounding single or

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -59,6 +59,10 @@ func TestParseSetDisplayNameArgs(t *testing.T) {
 		// check, so this is "Missing tunnel id" (not "Missing Display Name").
 		{name: "lone dollar no name rejected", input: "$", wantErr: true, wantMsgSub: "Missing tunnel id"},
 		{name: "dollar then invalid id rejected", input: "$Prod foo", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
+		// TrimPrefix strips exactly one `$`, so `$$prod-dashboard` becomes
+		// `$prod-dashboard`, which still fails the slug check (matching
+		// parseAliasToken's single-strip). Pins that double-sigil doesn't resolve.
+		{name: "double dollar strips one, rejected", input: "$$prod-dashboard foo", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
 		{name: "id only, no name", input: id, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
 		{name: "id then only whitespace", input: id + "    ", wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
 		{name: "id then empty quotes", input: id + ` ""`, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -55,6 +55,9 @@ func TestParseSetDisplayNameArgs(t *testing.T) {
 
 		{name: "missing everything", input: "", wantErr: true, wantMsgSub: "Missing tunnel id"},
 		{name: "lone dollar id rejected", input: "$ Prod API", wantErr: true, wantMsgSub: "Missing tunnel id"},
+		// Bare `$` with no name: the empty-id check fires before the missing-name
+		// check, so this is "Missing tunnel id" (not "Missing Display Name").
+		{name: "lone dollar no name rejected", input: "$", wantErr: true, wantMsgSub: "Missing tunnel id"},
 		{name: "dollar then invalid id rejected", input: "$Prod foo", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
 		{name: "id only, no name", input: id, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
 		{name: "id then only whitespace", input: id + "    ", wantErr: true, wantMsgSub: testDisplayNameMissingMsg},

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -101,13 +101,17 @@ func TestParseUnsetDisplayNameArgs(t *testing.T) {
 		input   string
 		wantErr bool
 		wantID  string
+		// wantMsgSub, when set on a wantErr case, pins which rejection copy
+		// fired — the lone-`$` path returns the shared helper's "Missing
+		// tunnel id", distinct from the arity path's "Provide exactly one".
+		wantMsgSub string
 	}{
 		{name: "happy", input: id, wantID: id},
 		{name: "dollar-prefixed id accepted", input: "$" + id, wantID: id},
-		{name: "missing id", input: "", wantErr: true},
-		{name: "lone dollar rejected", input: "$", wantErr: true},
-		{name: "trailing args rejected", input: id + " extra", wantErr: true},
-		{name: "invalid id rejected", input: "Prod", wantErr: true},
+		{name: "missing id", input: "", wantErr: true, wantMsgSub: "Provide exactly one tunnel id"},
+		{name: "lone dollar rejected", input: "$", wantErr: true, wantMsgSub: "Missing tunnel id"},
+		{name: "trailing args rejected", input: id + " extra", wantErr: true, wantMsgSub: "Provide exactly one tunnel id"},
+		{name: "invalid id rejected", input: "Prod", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -115,6 +119,9 @@ func TestParseUnsetDisplayNameArgs(t *testing.T) {
 			if tc.wantErr {
 				if msg == "" {
 					t.Fatalf("expected rejection, got id=%q", gotID)
+				}
+				if tc.wantMsgSub != "" && !strings.Contains(msg, tc.wantMsgSub) {
+					t.Errorf("rejection copy = %q, want substring %q", msg, tc.wantMsgSub)
 				}
 				return
 			}

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -15,8 +15,9 @@ import (
 // Repeated test literals, named to satisfy goconst and keep the
 // expected-copy assertions in one place.
 const (
-	testDisplayNameProdAPI    = "Prod API"
-	testDisplayNameMissingMsg = "Missing Display Name"
+	testDisplayNameProdAPI      = "Prod API"
+	testDisplayNameMissingMsg   = "Missing Display Name"
+	testDisplayNameInvalidIDMsg = "valid tunnel id"
 )
 
 // --- install-default constructor -----------------------------------------
@@ -50,13 +51,16 @@ func TestParseSetDisplayNameArgs(t *testing.T) {
 		{name: "surrounding whitespace trimmed", input: id + "    Prod API   ", wantID: id, wantName: testDisplayNameProdAPI},
 		{name: "name with internal punctuation kept", input: id + " Staging DB (replica)", wantID: id, wantName: "Staging DB (replica)"},
 		{name: "lone quote kept as part of name", input: id + ` it's fine`, wantID: id, wantName: "it's fine"},
+		{name: "dollar-prefixed id accepted", input: "$" + id + ` "Prod API"`, wantID: id, wantName: testDisplayNameProdAPI},
 
 		{name: "missing everything", input: "", wantErr: true, wantMsgSub: "Missing tunnel id"},
+		{name: "lone dollar id rejected", input: "$ Prod API", wantErr: true, wantMsgSub: "Missing tunnel id"},
+		{name: "dollar then invalid id rejected", input: "$Prod foo", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
 		{name: "id only, no name", input: id, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
 		{name: "id then only whitespace", input: id + "    ", wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
 		{name: "id then empty quotes", input: id + ` ""`, wantErr: true, wantMsgSub: testDisplayNameMissingMsg},
-		{name: "invalid id (uppercase)", input: "Prod foo", wantErr: true, wantMsgSub: "valid tunnel id"},
-		{name: "invalid id (too short)", input: "ab foo", wantErr: true, wantMsgSub: "valid tunnel id"},
+		{name: "invalid id (uppercase)", input: "Prod foo", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
+		{name: "invalid id (too short)", input: "ab foo", wantErr: true, wantMsgSub: testDisplayNameInvalidIDMsg},
 		{name: "name too long rejected", input: id + " " + strings.Repeat("a", displayNameMaxLen+1), wantErr: true, wantMsgSub: "too long"},
 		{name: "name at length cap accepted", input: id + " " + strings.Repeat("a", displayNameMaxLen), wantID: id, wantName: strings.Repeat("a", displayNameMaxLen)},
 		{name: "control byte in name rejected", input: id + " bad\x01name", wantErr: true, wantMsgSub: "control characters"},
@@ -99,7 +103,9 @@ func TestParseUnsetDisplayNameArgs(t *testing.T) {
 		wantID  string
 	}{
 		{name: "happy", input: id, wantID: id},
+		{name: "dollar-prefixed id accepted", input: "$" + id, wantID: id},
 		{name: "missing id", input: "", wantErr: true},
+		{name: "lone dollar rejected", input: "$", wantErr: true},
 		{name: "trailing args rejected", input: id + " extra", wantErr: true},
 		{name: "invalid id rejected", input: "Prod", wantErr: true},
 	}

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -226,6 +226,38 @@ func TestSetDisplayName_MultiWordQuoted(t *testing.T) {
 	}
 }
 
+// TestSetDisplayName_DollarPrefixedID exercises the `$<id>` sigil form
+// end-to-end (parser → admin gate → resolve → PATCH), not just at the parser
+// layer: the leading `$` is stripped, the bare slug resolves the tunnel, the
+// description is PATCHed, and the success copy echoes the stripped id.
+func TestSetDisplayName_DollarPrefixedID(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameQURLServer(t, testTunnelSlug, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	_, ack, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name $"+testTunnelSlug+" Prod API gateway", testAliasTeamID, "U_alias_admin")
+
+	if ack != ackWorkingOnIt {
+		t.Fatalf("ack = %q, want async working copy", ack)
+	}
+	// Success copy echoes the STRIPPED id (no `$`), proving the sigil was
+	// removed before the resolve rather than carried into the PATCH target.
+	if !strings.Contains(async, "Display Name updated") || !strings.Contains(async, "`"+testTunnelSlug+"`") {
+		t.Errorf("async reply = %q, want success copy with stripped id", async)
+	}
+	if strings.Contains(async, "$"+testTunnelSlug) {
+		t.Errorf("async reply = %q, leaked the `$` sigil into the id echo", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1 (the `$<id>` form must resolve end-to-end)", capPatch.calls.Load())
+	}
+	if capPatch.description == nil || *capPatch.description != "Prod API gateway" {
+		t.Errorf("PATCH description = %v, want pointer to %q", capPatch.description, "Prod API gateway")
+	}
+}
+
 func TestUnsetDisplayName_Happy(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 	capPatch := &capturedPatch{}
@@ -244,6 +276,31 @@ func TestUnsetDisplayName_Happy(t *testing.T) {
 	// Unset REVERTS to the install default, it does not blank: the PATCH
 	// carries the same string a fresh install would have written, so the
 	// tunnel still has a Display Name.
+	want := defaultTunnelDisplayName(testTunnelSlug)
+	if capPatch.description == nil || *capPatch.description != want {
+		t.Errorf("PATCH description = %v, want pointer to %q (install default)", capPatch.description, want)
+	}
+}
+
+// TestUnsetDisplayName_DollarPrefixedID is the unset counterpart to
+// TestSetDisplayName_DollarPrefixedID: `unset-display-name $<id>` strips the
+// sigil, resolves the tunnel, and PATCHes the description back to the install
+// default end-to-end.
+func TestUnsetDisplayName_DollarPrefixedID(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameQURLServer(t, testTunnelSlug, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("unset-display-name $"+testTunnelSlug, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "Display Name reset") || !strings.Contains(async, "`"+testTunnelSlug+"`") {
+		t.Errorf("async reply = %q, want reset copy with stripped id", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1 (the `$<id>` form must resolve end-to-end)", capPatch.calls.Load())
+	}
 	want := defaultTunnelDisplayName(testTunnelSlug)
 	if capPatch.description == nil || *capPatch.description != want {
 		t.Errorf("PATCH description = %v, want pointer to %q (install default)", capPatch.description, want)

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -19,6 +19,13 @@ import (
 // because three different mapMintError branches need it.
 const commonGetMintFailedMessage = "Failed to mint qURL. Please try again."
 
+// getUsageMessage is the arg hint shown when `/qurl get` is invoked
+// with no token. Bare `get` parses to [ErrEmptyResource]; the
+// defensive empty-Alias guard below reuses the same copy so the user
+// learns the `$<id>|$<alias>` grammar rather than seeing a terse
+// sentinel.
+const getUsageMessage = "Usage: `/qurl get <$id|$alias>` to mint a one-time qURL for a tunnel. Run `/qurl list` to see what's available."
+
 // Tunnel access limits applied to every `/qurl get` mint. `/qurl get` is
 // tunnel-only (raw URLs are unsupported — see urlNotSupportedGetMessage), so
 // these bound a shared tunnel link to a single short-lived viewer:
@@ -219,6 +226,13 @@ func (h *Handler) handleGet(w http.ResponseWriter, values url.Values) {
 			respondSlack(w, ":warning: "+resourceIDNotSupportedGetMessage)
 			return
 		}
+		// Bare `get` (no token) parses to ErrEmptyResource. Surface the
+		// arg hint instead of the terse sentinel text so the user learns
+		// the grammar — same copy as the defensive empty-Alias guard below.
+		if errors.Is(err, ErrEmptyResource) {
+			respondSlack(w, ":warning: "+getUsageMessage)
+			return
+		}
 		respondSlack(w, ":warning: "+err.Error())
 		return
 	}
@@ -234,7 +248,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, values url.Values) {
 	// change adds a form that leaves Alias empty; surface the usage hint
 	// rather than silently dispatching an unmintable command.
 	if cmd.Alias == "" {
-		respondSlack(w, ":warning: Usage: `/qurl get <$id|$alias>` to mint a one-time qURL for a tunnel. Run `/qurl list` to see what's available.")
+		respondSlack(w, ":warning: "+getUsageMessage)
 		return
 	}
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -187,10 +187,10 @@ func TestHandleGet_MintTransportError(t *testing.T) {
 	}
 }
 
-// TestHandleGet_MissingAlias fences the parser-level "missing $alias"
-// surface. The slash-command body has `get` with no positional arg
-// → the handler replies synchronously with a Usage hint and never
-// kicks off async work.
+// TestHandleGet_MissingAlias fences the bare-`get` surface. The
+// slash-command body has `get` with no positional arg → the handler
+// replies synchronously with the `$<id>|$<alias>` Usage hint (the
+// getUsageMessage copy) and never kicks off async work.
 func TestHandleGet_MissingAlias(t *testing.T) {
 	ts := newAdminTestServers(t)
 	h := newAdminTestHandler(t, ts)
@@ -200,8 +200,11 @@ func TestHandleGet_MissingAlias(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
-	if !strings.Contains(ack, "$alias argument") {
-		t.Errorf("ack missing alias-hint: %q", ack)
+	if !strings.Contains(ack, "$id|$alias") {
+		t.Errorf("ack missing get usage hint: %q", ack)
+	}
+	if !strings.Contains(ack, "/qurl list") {
+		t.Errorf("ack missing /qurl list pointer: %q", ack)
 	}
 }
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -208,6 +208,28 @@ func TestHandleGet_MissingAlias(t *testing.T) {
 	}
 }
 
+// TestHandleGet_LoneSigil fences the `get $` surface — a lone `$` with no
+// slug/alias body. parseAliasToken returns ErrEmptyResource for the bare
+// sigil, so `get $` reaches the same getUsageMessage hint as bare `get` but
+// via a DISTINCT parse path (the ErrEmptyResource branch, not the no-arg
+// one), and likewise never kicks off async work.
+func TestHandleGet_LoneSigil(t *testing.T) {
+	ts := newAdminTestServers(t)
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	status, ack := inv.invokeAdmin("get $", testAdminTeamID, testAdminUserID)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(ack, "$id|$alias") {
+		t.Errorf("ack missing get usage hint: %q", ack)
+	}
+	if !strings.Contains(ack, "/qurl list") {
+		t.Errorf("ack missing /qurl list pointer: %q", ack)
+	}
+}
+
 // TestHandleGet_AdminStoreNil fences the fail-closed posture when
 // AdminStore is nil (sandbox / no-DDB deployment) and the user
 // requested the alias form: the channel-scoped lookup can't run, so


### PR DESCRIPTION
## What
- `set-display-name` / `unset-display-name` now accept an **optional** leading `$` on the tunnel id, so the `$<id>` form `/qurl list` prints works alongside the bare form (`$prod-dashboard` and `prod-dashboard` both resolve). Previously only the bare form was accepted, so a user who copied the `$<id>` straight out of `/qurl list` hit a confusing rejection.
  - Note: `/qurl get` and `/qurl-admin set-alias` *require* the `$` (a missing sigil is `ErrMissingSigil`). These display-name verbs are deliberately the **lenient superset** — sigil optional — not strict parity. The point is to accept the form `/qurl list` shows, not to mirror those verbs' strictness.
- Bare `/qurl get` (no token) now replies with the `$<id>|$<alias>` usage hint instead of the terse `missing or empty $alias argument`.
- Bare `/qurl-admin admin` (no action) now lists the available actions (add / remove / list / revoke) instead of `missing admin action`.

## Why
Command-UX papercut pass. Accepting only the bare id, and the terse bare-verb errors, were footguns: a user who typed the id the way `/qurl list` shows it, or ran a verb to discover its arguments, hit confusing errors instead of guidance.

## Notes
- `$` is stripped before the slug-pattern check rather than widening `tunnelSlugPattern` (which the slug grammar shares with install). The strip + empty-check + slug-validate path is shared by both display-name verbs via the `parseDisplayNameID` helper.
- The invalid-id error echoes the stripped id (e.g. `$Prod` → `` `Prod` `` ), matching `parseAliasToken`, which echoes its post-`$` value.
- The bare-`admin` hint says "qURL bot admin", not "workspace admin" — membership is the bot's own admin set, not Slack's workspace-admin role.

## Tests
- Parser unit tests cover `$`-prefixed and lone-`$` ids for both display-name verbs.
- Handler tests updated to assert the richer bare-`get` and bare-`admin` hints.
- `go test ./apps/slack/...` green; `golangci-lint --new-from-rev=origin/main` reports 0 new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
