### PR TITLE
feat(slack): render tunnel install snippets as copyable rich_text blocks

### DIFF
--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -976,9 +976,9 @@ var installFencedCodeBlock = regexp.MustCompile("(?s)```\\n(.*?)\\n```")
 // fallback, so the two renderings cannot drift.
 //
 // Returns (blocks, true) on success, or (nil, false) when the message carries
-// no code fence to enrich, a prose segment exceeds [slackSectionTextMaxBytes]
-// or a code segment exceeds [slackRichTextMaxBytes], or the block count would
-// exceed [slackMessageBlockMax]. A false result is the
+// no code fence to enrich, a fence is empty, a prose segment exceeds
+// [slackSectionTextMaxBytes] or a code segment exceeds [slackRichTextMaxBytes],
+// or the block count would exceed [slackMessageBlockMax]. A false result is the
 // caller's signal to post the plain-text message instead: the install flow
 // MUST stay deliverable (an unconfirmed delivery revokes the bootstrap key), so
 // blocks are strictly a best-effort enhancement over the always-safe text post.
@@ -1006,7 +1006,11 @@ func installMessageBlocks(msg string) ([]any, bool) {
 			return nil, false
 		}
 		code := msg[m[2]:m[3]]
-		if len(code) > slackRichTextMaxBytes {
+		if code == "" || len(code) > slackRichTextMaxBytes {
+			// An empty fence would produce a rich_text_preformatted element
+			// with an empty `text`, which Slack rejects outright; an oversize
+			// one trips the defensive ceiling. Neither is reachable from
+			// today's renderers, but both drop to the always-safe text post.
 			return nil, false
 		}
 		blocks = append(blocks, richTextPreformattedBlock(code))
@@ -1034,6 +1038,11 @@ func installMessageBlocks(msg string) ([]any, bool) {
 // blocks existed, so this path is never worse than that baseline: a Slack-side
 // rejection of the blocks payload (non-2xx) is retried as plain text before the
 // caller treats delivery as failed.
+//
+// If Slack actually persists the blocks post but the client reports failure
+// (e.g. a timeout), the text retry posts a second copy. Both carry the same
+// still-valid key and the key is not revoked, so this is benign — at worst the
+// operator sees two ephemeral install messages, never a leaked or stale key.
 func (h *Handler) postInstallInstructions(log *slog.Logger, responseURL, msg string) bool {
 	if blocks, ok := installMessageBlocks(msg); ok {
 		if h.postResponseBlocks(log, responseURL, msg, blocks) {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -962,9 +962,13 @@ const (
 )
 
 // installFencedCodeBlock matches a single ```\n<body>\n``` fence as produced by
-// slackCodeBlock. The body can never contain a nested ``` (slackCodeBlock
-// rejects that), so the non-greedy capture segments a rendered install message
-// unambiguously into code vs. surrounding prose.
+// slackCodeBlock. Segmentation is unambiguous only because slackCodeBlock is the
+// SOLE producer of ``` fences in install messages and the hand-written prose
+// contains no literal ```: so every fence is one it emitted, and a body can't
+// nest ``` (slackCodeBlock rejects that), letting the non-greedy capture cleanly
+// split code from surrounding prose. A future renderer that emitted a literal
+// ``` into prose could mis-segment — but only ever into the always-safe text
+// fallback, never a key leak.
 var installFencedCodeBlock = regexp.MustCompile("(?s)```\\n(.*?)\\n```")
 
 // installMessageBlocks converts a fully-rendered install message — prose

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -513,7 +513,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, te
 		return
 	}
 	log.Info("tunnel install succeeded", "slug", args.Slug, "shortcut", args.Alias, "environment", args.Environment, "resource_id", resource.ResourceID)
-	if !h.postResponse(log, responseURL, msg) {
+	if !h.postInstallInstructions(log, responseURL, msg) {
 		// This second post is best-effort too: if Slack never accepts either
 		// response_url call, the admin may see neither the install nor the
 		// revoke notice. The key is still revoked because delivery was not
@@ -932,4 +932,107 @@ func slackCodeBlock(body string) (string, error) {
 		return "", errors.New("slack code block body contains nested triple-backtick fence")
 	}
 	return "```\n" + body + "\n```", nil
+}
+
+const (
+	// slackSectionTextMaxBytes is Slack's documented per-`section` mrkdwn text
+	// limit. A prose run in the install message that exceeds it drops the whole
+	// message back to the plain-text post.
+	slackSectionTextMaxBytes = 3000
+	// slackRichTextMaxBytes caps a single rich_text_preformatted code segment.
+	// rich_text `text` elements carry NO documented length limit (unlike the
+	// 3000-char cap on `text`/mrkdwn composition objects), and Slack accepts
+	// multi-KB code blocks, so this is a defensive ceiling rather than a hard
+	// Slack bound: it sits well above the largest real install snippet (~3.8 KB,
+	// the Docker Compose shell block) with headroom for installer growth, and
+	// far below Slack's 40000-char message-text ceiling. An oversize segment
+	// drops to the plain-text post — and [Handler.postInstallInstructions]
+	// retries as text even if Slack ever rejects an over-large blocks payload —
+	// so this is a first-try optimization, not the delivery safety boundary.
+	slackRichTextMaxBytes = 12000
+	// slackMessageBlockMax is Slack's per-message block ceiling. The install
+	// message produces roughly two blocks per code segment plus prose, far
+	// below this; the guard is defensive against a future renderer that fans
+	// out far more segments.
+	slackMessageBlockMax = 50
+)
+
+// installFencedCodeBlock matches a single ```\n<body>\n``` fence as produced by
+// slackCodeBlock. The body can never contain a nested ``` (slackCodeBlock
+// rejects that), so the non-greedy capture segments a rendered install message
+// unambiguously into code vs. surrounding prose.
+var installFencedCodeBlock = regexp.MustCompile("(?s)```\\n(.*?)\\n```")
+
+// installMessageBlocks converts a fully-rendered install message — prose
+// interleaved with ```\n…\n``` code fences (see
+// [preparedTunnelInstallMessage.render]) — into Block Kit blocks: each prose
+// run becomes a `section` mrkdwn block and each fenced snippet becomes a
+// [richTextPreformattedBlock] (a copyable code block). It derives the blocks
+// from the SAME string that is also posted as the message's plain-text
+// fallback, so the two renderings cannot drift.
+//
+// Returns (blocks, true) on success, or (nil, false) when the message carries
+// no code fence to enrich, a single segment exceeds [slackBlockTextMaxBytes],
+// or the block count would exceed [slackMessageBlockMax]. A false result is the
+// caller's signal to post the plain-text message instead: the install flow
+// MUST stay deliverable (an unconfirmed delivery revokes the bootstrap key), so
+// blocks are strictly a best-effort enhancement over the always-safe text post.
+func installMessageBlocks(msg string) ([]any, bool) {
+	matches := installFencedCodeBlock.FindAllStringSubmatchIndex(msg, -1)
+	if len(matches) == 0 {
+		return nil, false
+	}
+	blocks := make([]any, 0, len(matches)*2+1)
+	appendProse := func(s string) bool {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return true
+		}
+		if len(s) > slackSectionTextMaxBytes {
+			return false
+		}
+		blocks = append(blocks, sectionBlock(s))
+		return true
+	}
+	last := 0
+	for _, m := range matches {
+		// m[0:2] is the full fence; m[2:4] is the captured body.
+		if !appendProse(msg[last:m[0]]) {
+			return nil, false
+		}
+		code := msg[m[2]:m[3]]
+		if len(code) > slackRichTextMaxBytes {
+			return nil, false
+		}
+		blocks = append(blocks, richTextPreformattedBlock(code))
+		last = m[1]
+	}
+	if !appendProse(msg[last:]) {
+		return nil, false
+	}
+	if len(blocks) == 0 || len(blocks) > slackMessageBlockMax {
+		return nil, false
+	}
+	return blocks, true
+}
+
+// postInstallInstructions delivers the rendered install message, preferring the
+// Block Kit rendering (copyable rich_text_preformatted snippets) and falling
+// back to the plain-text post on any block-path miss. Returns whether SOME
+// rendering was delivered — the caller revokes the bootstrap key only when
+// delivery is unconfirmed, so this reports false only when neither the blocks
+// NOR the text post landed.
+//
+// The text post is the same single-call delivery the install flow used before
+// blocks existed, so this path is never worse than that baseline: a Slack-side
+// rejection of the blocks payload (non-2xx) is retried as plain text before the
+// caller treats delivery as failed.
+func (h *Handler) postInstallInstructions(log *slog.Logger, responseURL, msg string) bool {
+	if blocks, ok := installMessageBlocks(msg); ok {
+		if h.postResponseBlocks(log, responseURL, msg, blocks) {
+			return true
+		}
+		log.Warn("tunnel install: Block Kit follow-up delivery failed; retrying as plain text")
+	}
+	return h.postResponse(log, responseURL, msg)
 }

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -941,7 +941,7 @@ const (
 	// that passes is always within the character limit. At worst a multibyte
 	// run (e.g. the em-dash in the prose) trips slightly early and drops the
 	// whole message to the always-deliverable plain-text post — the safe
-	// direction. A prose run over this drops the whole message back to text.
+	// direction.
 	slackSectionTextMaxBytes = 3000
 	// slackRichTextMaxBytes caps a single rich_text_preformatted code segment.
 	// rich_text `text` elements carry NO documented length limit (unlike the

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -972,8 +972,9 @@ var installFencedCodeBlock = regexp.MustCompile("(?s)```\\n(.*?)\\n```")
 // fallback, so the two renderings cannot drift.
 //
 // Returns (blocks, true) on success, or (nil, false) when the message carries
-// no code fence to enrich, a single segment exceeds [slackBlockTextMaxBytes],
-// or the block count would exceed [slackMessageBlockMax]. A false result is the
+// no code fence to enrich, a prose segment exceeds [slackSectionTextMaxBytes]
+// or a code segment exceeds [slackRichTextMaxBytes], or the block count would
+// exceed [slackMessageBlockMax]. A false result is the
 // caller's signal to post the plain-text message instead: the install flow
 // MUST stay deliverable (an unconfirmed delivery revokes the bootstrap key), so
 // blocks are strictly a best-effort enhancement over the always-safe text post.

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -935,9 +935,13 @@ func slackCodeBlock(body string) (string, error) {
 }
 
 const (
-	// slackSectionTextMaxBytes is Slack's documented per-`section` mrkdwn text
-	// limit. A prose run in the install message that exceeds it drops the whole
-	// message back to the plain-text post.
+	// slackSectionTextMaxBytes guards a `section` mrkdwn run against Slack's
+	// 3000-*character* per-section limit. The guard measures bytes, an
+	// intentionally conservative proxy: byte length >= rune count, so a run
+	// that passes is always within the character limit. At worst a multibyte
+	// run (e.g. the em-dash in the prose) trips slightly early and drops the
+	// whole message to the always-deliverable plain-text post — the safe
+	// direction. A prose run over this drops the whole message back to text.
 	slackSectionTextMaxBytes = 3000
 	// slackRichTextMaxBytes caps a single rich_text_preformatted code segment.
 	// rich_text `text` elements carry NO documented length limit (unlike the
@@ -1011,7 +1015,9 @@ func installMessageBlocks(msg string) ([]any, bool) {
 	if !appendProse(msg[last:]) {
 		return nil, false
 	}
-	if len(blocks) == 0 || len(blocks) > slackMessageBlockMax {
+	// blocks is non-empty here: len(matches) > 0, and every match appends a
+	// rich_text block, so only the upper bound can trip.
+	if len(blocks) > slackMessageBlockMax {
 		return nil, false
 	}
 	return blocks, true

--- a/apps/slack/internal/handler_tunnel_richtext_test.go
+++ b/apps/slack/internal/handler_tunnel_richtext_test.go
@@ -81,8 +81,12 @@ func sectionTexts(t *testing.T, blocks []any) []string {
 		if !ok || bm[blockKeyType] != blockTypeSection {
 			continue
 		}
-		txt, _ := bm[blockKeyText].(map[string]any)[blockKeyText].(string)
-		out = append(out, txt)
+		txtObj, ok := bm[blockKeyText].(map[string]any)
+		if !ok {
+			t.Fatalf("section block text is not a composition object: %#v", bm)
+		}
+		s, _ := txtObj[blockKeyText].(string)
+		out = append(out, s)
 	}
 	return out
 }
@@ -157,15 +161,35 @@ func TestInstallMessageBlocks_PreservesOrderAndProse(t *testing.T) {
 	}
 }
 
-// TestInstallMessageBlocks_FallbackPaths fences the (nil,false) signals that
-// route the caller to the always-safe plain-text post: no code fence to
-// enrich, and a single code segment over the per-block cap.
+// TestInstallMessageBlocks_FallbackPaths fences every (nil,false) signal that
+// routes the caller to the always-safe plain-text post: no code fence to
+// enrich, an empty fence, an oversize prose run, an oversize code segment, and
+// a block count over the per-message cap.
 func TestInstallMessageBlocks_FallbackPaths(t *testing.T) {
-	if _, ok := installMessageBlocks("just prose, no code fence at all"); ok {
-		t.Error("want ok=false when the message has no code fence")
+	cases := []struct {
+		name string
+		msg  string
+	}{
+		{"no fence", "just prose, no code fence at all"},
+		{"empty fence", "intro\n\n```\n\n```\n\nfooter"},
+		{
+			"oversize prose",
+			strings.Repeat("p", slackSectionTextMaxBytes+1) + "\n\n```\ncode\n```",
+		},
+		{
+			"oversize code",
+			"intro\n\n```\n" + strings.Repeat("x", slackRichTextMaxBytes+1) + "\n```\n\nfooter",
+		},
+		{
+			"too many blocks",
+			strings.Repeat("```\nx\n```\n\n", slackMessageBlockMax+1),
+		},
 	}
-	oversize := "intro\n\n```\n" + strings.Repeat("x", slackRichTextMaxBytes+1) + "\n```\n\nfooter"
-	if _, ok := installMessageBlocks(oversize); ok {
-		t.Error("want ok=false when a code segment exceeds slackRichTextMaxBytes")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := installMessageBlocks(tc.msg); ok {
+				t.Errorf("want ok=false for %s (should drop to plain-text post)", tc.name)
+			}
+		})
 	}
 }

--- a/apps/slack/internal/handler_tunnel_richtext_test.go
+++ b/apps/slack/internal/handler_tunnel_richtext_test.go
@@ -92,7 +92,7 @@ func sectionTexts(t *testing.T, blocks []any) []string {
 // lands in a copyable rich_text_preformatted block and never leaks into a
 // prose section, and every code segment is within the per-block cap. This
 // doubles as the size measurement: an oversize real snippet would flip ok to
-// false and fail here, surfacing the need to bump slackBlockTextMaxBytes.
+// false and fail here, surfacing the need to bump slackRichTextMaxBytes.
 func TestInstallMessageBlocks_AllEnvironments(t *testing.T) {
 	for _, env := range []tunnelInstallEnvironment{
 		tunnelEnvDocker,

--- a/apps/slack/internal/handler_tunnel_richtext_test.go
+++ b/apps/slack/internal/handler_tunnel_richtext_test.go
@@ -1,0 +1,171 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// Block Kit type/key literals, hoisted so the assertions don't trip goconst.
+const (
+	blockTypeSection              = "section"
+	blockTypeRichText             = "rich_text"
+	blockTypeRichTextPreformatted = "rich_text_preformatted"
+	blockKeyType                  = "type"
+	blockKeyText                  = "text"
+	blockKeyElements              = "elements"
+)
+
+// renderInstallForEnv renders a full install message for one environment via
+// the same helper the production path drives, so installMessageBlocks is
+// exercised against real installer output rather than a hand-built fixture.
+func renderInstallForEnv(t *testing.T, env tunnelInstallEnvironment) string {
+	t.Helper()
+	now := fixedNow
+	expiresAt := now.Add(time.Hour)
+	h := NewHandler(Config{TunnelImage: testTunnelImageRef})
+	freezeTunnelBootstrapNow(t, h, now)
+	msg, err := h.renderTunnelInstallMessage(&tunnelInstallArgs{
+		Slug:        testTunnelSlug,
+		Alias:       testTunnelSlug,
+		LocalPort:   defaultTunnelLocalPort,
+		Environment: env,
+	}, &client.APIKey{APIKey: testTunnelAPIKey, ExpiresAt: &expiresAt}, "qURL alias `$prod-dashboard` is ready in this channel.")
+	if err != nil {
+		t.Fatalf("renderTunnelInstallMessage(%v): %v", env, err)
+	}
+	return msg
+}
+
+// richTextCodeTexts extracts the code string from every
+// rich_text_preformatted block, asserting the nested shape matches what
+// richTextPreformattedBlock produces.
+func richTextCodeTexts(t *testing.T, blocks []any) []string {
+	t.Helper()
+	var out []string
+	for _, b := range blocks {
+		bm, ok := b.(map[string]any)
+		if !ok || bm[blockKeyType] != blockTypeRichText {
+			continue
+		}
+		elems, ok := bm[blockKeyElements].([]any)
+		if !ok || len(elems) != 1 {
+			t.Fatalf("rich_text block has unexpected elements: %#v", bm)
+		}
+		pre, ok := elems[0].(map[string]any)
+		if !ok || pre[blockKeyType] != blockTypeRichTextPreformatted {
+			t.Fatalf("rich_text element is not preformatted: %#v", elems[0])
+		}
+		inner, ok := pre[blockKeyElements].([]any)
+		if !ok || len(inner) != 1 {
+			t.Fatalf("preformatted has unexpected elements: %#v", pre)
+		}
+		txt, ok := inner[0].(map[string]any)
+		if !ok || txt[blockKeyType] != blockKeyText {
+			t.Fatalf("preformatted inner element is not text: %#v", inner[0])
+		}
+		s, _ := txt[blockKeyText].(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+// sectionTexts extracts the mrkdwn body from every section block.
+func sectionTexts(t *testing.T, blocks []any) []string {
+	t.Helper()
+	var out []string
+	for _, b := range blocks {
+		bm, ok := b.(map[string]any)
+		if !ok || bm[blockKeyType] != blockTypeSection {
+			continue
+		}
+		txt, _ := bm[blockKeyText].(map[string]any)[blockKeyText].(string)
+		out = append(out, txt)
+	}
+	return out
+}
+
+// TestInstallMessageBlocks_AllEnvironments fences that every real install
+// message renders as Block Kit (no plain-text fallback), the bootstrap key
+// lands in a copyable rich_text_preformatted block and never leaks into a
+// prose section, and every code segment is within the per-block cap. This
+// doubles as the size measurement: an oversize real snippet would flip ok to
+// false and fail here, surfacing the need to bump slackBlockTextMaxBytes.
+func TestInstallMessageBlocks_AllEnvironments(t *testing.T) {
+	for _, env := range []tunnelInstallEnvironment{
+		tunnelEnvDocker,
+		tunnelEnvCompose,
+		tunnelEnvECSFargate,
+		tunnelEnvKubernetes,
+	} {
+		t.Run(string(env), func(t *testing.T) {
+			msg := renderInstallForEnv(t, env)
+			blocks, ok := installMessageBlocks(msg)
+			if !ok {
+				t.Fatalf("installMessageBlocks ok=false for a real %s install (largest segment over cap %d?); msg len=%d", env, slackRichTextMaxBytes, len(msg))
+			}
+
+			codes := richTextCodeTexts(t, blocks)
+			sections := sectionTexts(t, blocks)
+			if len(codes) == 0 || len(sections) == 0 {
+				t.Fatalf("%s: want both section and rich_text blocks, got sections=%d code=%d", env, len(sections), len(codes))
+			}
+
+			keyInCode := false
+			for _, c := range codes {
+				if strings.Contains(c, testTunnelAPIKey) {
+					keyInCode = true
+				}
+				if len(c) > slackRichTextMaxBytes {
+					t.Errorf("%s: code block exceeds cap (%d > %d)", env, len(c), slackRichTextMaxBytes)
+				}
+			}
+			if !keyInCode {
+				t.Errorf("%s: bootstrap key not found in any rich_text_preformatted block", env)
+			}
+			for _, s := range sections {
+				if strings.Contains(s, testTunnelAPIKey) {
+					t.Errorf("%s: bootstrap key leaked into a prose section block", env)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallMessageBlocks_PreservesOrderAndProse fences the segmentation:
+// prose and code alternate in source order, prose becomes sections, fences
+// become rich_text, and the captured code is verbatim (fence markers stripped).
+func TestInstallMessageBlocks_PreservesOrderAndProse(t *testing.T) {
+	msg := "Step one.\n\n```\ncode-A\n```\n\nStep two.\n\n```\ncode-B\n```"
+	blocks, ok := installMessageBlocks(msg)
+	if !ok {
+		t.Fatal("ok=false for a well-formed prose/code message")
+	}
+	wantTypes := []string{blockTypeSection, blockTypeRichText, blockTypeSection, blockTypeRichText}
+	if len(blocks) != len(wantTypes) {
+		t.Fatalf("block count = %d, want %d: %#v", len(blocks), len(wantTypes), blocks)
+	}
+	for i, want := range wantTypes {
+		if got := blocks[i].(map[string]any)[blockKeyType]; got != want {
+			t.Errorf("block[%d] type = %v, want %s", i, got, want)
+		}
+	}
+	if codes := richTextCodeTexts(t, blocks); len(codes) != 2 || codes[0] != "code-A" || codes[1] != "code-B" {
+		t.Errorf("codes = %#v, want [code-A code-B]", codes)
+	}
+}
+
+// TestInstallMessageBlocks_FallbackPaths fences the (nil,false) signals that
+// route the caller to the always-safe plain-text post: no code fence to
+// enrich, and a single code segment over the per-block cap.
+func TestInstallMessageBlocks_FallbackPaths(t *testing.T) {
+	if _, ok := installMessageBlocks("just prose, no code fence at all"); ok {
+		t.Error("want ok=false when the message has no code fence")
+	}
+	oversize := "intro\n\n```\n" + strings.Repeat("x", slackRichTextMaxBytes+1) + "\n```\n\nfooter"
+	if _, ok := installMessageBlocks(oversize); ok {
+		t.Error("want ok=false when a code segment exceeds slackRichTextMaxBytes")
+	}
+}

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -2275,7 +2275,15 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	blocksMarker := `"` + blockKitFieldBlocks + `"`
+	// bodyHasBlocks decodes a response_url payload and reports whether it
+	// carries a Block Kit `blocks` array — a structural check rather than a
+	// substring match on the JSON key spelling. Pure (no t.Fatalf), so it is
+	// safe to call from the server goroutine below.
+	bodyHasBlocks := func(body string) bool {
+		var env map[string]any
+		_ = json.Unmarshal([]byte(body), &env)
+		return env[blockKitFieldBlocks] != nil
+	}
 	var posts []string
 	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -2285,7 +2293,7 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 		posts = append(posts, string(body))
 		// Reject the Block Kit post (carries a blocks array); accept the
 		// plain-text retry.
-		if strings.Contains(string(body), blocksMarker) {
+		if bodyHasBlocks(string(body)) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -2309,10 +2317,10 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 	if len(posts) != 2 {
 		t.Fatalf("response_url posts = %d, want 2 (rejected blocks, then accepted text): %v", len(posts), posts)
 	}
-	if !strings.Contains(posts[0], blocksMarker) {
+	if !bodyHasBlocks(posts[0]) {
 		t.Errorf("first post should be the Block Kit attempt: %s", posts[0])
 	}
-	if strings.Contains(posts[1], blocksMarker) {
+	if bodyHasBlocks(posts[1]) {
 		t.Errorf("second post (text retry) should not carry blocks: %s", posts[1])
 	}
 	if !strings.Contains(posts[1], testTunnelAPIKey) {

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -354,11 +354,18 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 	h.SetAliasStore(h.cfg.AdminStore)
 	inv := newAdminSlashInvoker(t, h)
 	status, ack := inv.invokeAdmin(testTunnelInstallCmd+" port:9090", testAdminTeamID, testAdminUserID)
-	var asyncEnvelope map[string]string
+	// The install message now posts as Block Kit (copyable rich_text snippets)
+	// with the full text carried as the accessibility/notification fallback, so
+	// the response_url body carries both `text` and `blocks` — decode into
+	// map[string]any (a map[string]string unmarshal fails on the blocks array).
+	var asyncEnvelope map[string]any
 	if err := json.Unmarshal(inv.captured.waitForBody(t, 2*time.Second), &asyncEnvelope); err != nil {
 		t.Fatalf("unmarshal tunnel install response_url body: %v", err)
 	}
-	async := asyncEnvelope[respFieldText]
+	async, _ := asyncEnvelope[respFieldText].(string)
+	if asyncEnvelope[blockKitFieldBlocks] == nil {
+		t.Errorf("tunnel install body missing blocks (expected Block Kit rendering)")
+	}
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -480,11 +487,11 @@ func TestTunnelInstallReinstallShowsExistingDisplayName(t *testing.T) {
 	if _, ack := inv.invokeAdmin(testTunnelInstallCmd+" port:9090", testAdminTeamID, testAdminUserID); !strings.Contains(ack, "Working") {
 		t.Fatalf("ack = %q, want async working copy", ack)
 	}
-	var asyncEnvelope map[string]string
+	var asyncEnvelope map[string]any
 	if err := json.Unmarshal(inv.captured.waitForBody(t, 2*time.Second), &asyncEnvelope); err != nil {
 		t.Fatalf("unmarshal tunnel install response_url body: %v", err)
 	}
-	async := asyncEnvelope[respFieldText]
+	async, _ := asyncEnvelope[respFieldText].(string)
 
 	if !strings.Contains(async, existingDisplayName) {
 		t.Errorf("re-install confirmation missing the admin's existing Display Name %q:\n%s", existingDisplayName, async)
@@ -2220,11 +2227,96 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
 	}
-	if len(responseBodies) == 0 || !strings.Contains(responseBodies[0], testTunnelAPIKey) {
-		t.Fatalf("first response_url body = %v, want original install body with bootstrap key", responseBodies)
+	// When Slack rejects every post, the delivery sequence is: the Block Kit
+	// install post, the plain-text retry (postInstallInstructions' fallback),
+	// then the revoked-key discard notice. The key is revoked because none were
+	// confirmed; the first post still carries the bootstrap key and the last is
+	// the discard notice.
+	if len(responseBodies) != 3 {
+		t.Fatalf("response_url posts = %d, want 3 (blocks attempt, text retry, discard notice): %v", len(responseBodies), responseBodies)
 	}
-	if len(responseBodies) != 2 || !strings.Contains(responseBodies[1], "bootstrap key was revoked") || !strings.Contains(responseBodies[1], "discard it") {
-		t.Fatalf("response_url bodies = %v, want original delivery plus revoked-key discard follow-up", responseBodies)
+	if !strings.Contains(responseBodies[0], testTunnelAPIKey) {
+		t.Fatalf("first response_url body = %v, want original install body with bootstrap key", responseBodies[0])
+	}
+	last := responseBodies[len(responseBodies)-1]
+	if !strings.Contains(last, "bootstrap key was revoked") || !strings.Contains(last, "discard it") {
+		t.Fatalf("last response_url body = %q, want revoked-key discard follow-up", last)
+	}
+}
+
+// TestTunnelInstallFallsBackToTextWhenBlocksRejected fences the delivery safety
+// net: if Slack rejects the Block Kit install post (e.g. an over-large
+// rich_text payload) but accepts a plain-text post, postInstallInstructions
+// retries as text, the install is delivered, and the bootstrap key is NOT
+// revoked. This is the property that lets the rich_text rendering be a
+// best-effort enhancement layered over the always-safe plain-text post.
+func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelAPIKey,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+		})
+	})
+	var revokeHits int
+	ts.addCustomer(http.MethodDelete, "/v1/api-keys/"+testTunnelAPIKeyID, func(w http.ResponseWriter, _ *http.Request) {
+		revokeHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	blocksMarker := `"` + blockKitFieldBlocks + `"`
+	var posts []string
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read response_url body: %v", err)
+		}
+		posts = append(posts, string(body))
+		// Reject the Block Kit post (carries a blocks array); accept the
+		// plain-text retry.
+		if strings.Contains(string(body), blocksMarker) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.TunnelImage = testTunnelImageRef
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
+		Slug:        testTunnelSlug,
+		Alias:       testTunnelSlug,
+		LocalPort:   defaultTunnelLocalPort,
+		Environment: tunnelEnvDocker,
+	}, h.now())
+
+	if revokeHits != 0 {
+		t.Fatalf("bootstrap key revoke hits = %d, want 0 (plain-text fallback delivered the install)", revokeHits)
+	}
+	if len(posts) != 2 {
+		t.Fatalf("response_url posts = %d, want 2 (rejected blocks, then accepted text): %v", len(posts), posts)
+	}
+	if !strings.Contains(posts[0], blocksMarker) {
+		t.Errorf("first post should be the Block Kit attempt: %s", posts[0])
+	}
+	if strings.Contains(posts[1], blocksMarker) {
+		t.Errorf("second post (text retry) should not carry blocks: %s", posts[1])
+	}
+	if !strings.Contains(posts[1], testTunnelAPIKey) {
+		t.Errorf("text retry should carry the bootstrap key: %s", posts[1])
 	}
 }
 

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -40,6 +40,7 @@ const (
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"
 	blockKitFieldClose           = "close"
+	blockKitFieldElements        = "elements"
 	blockKitFieldPrivateMetadata = "private_metadata"
 	blockKitFieldSubmit          = "submit"
 	blockKitFieldTitle           = "title"
@@ -293,6 +294,34 @@ func sectionBlock(text string) map[string]any {
 	}
 }
 
+// richTextPreformattedBlock returns a `rich_text` block wrapping a single
+// `rich_text_preformatted` element — Slack's structured code block. Unlike a
+// triple-backtick mrkdwn fence inside a `section`, the preformatted element
+// renders with a copy affordance in the Slack client and never risks
+// fence-escaping issues, so it is the right surface for the multi-line shell /
+// YAML / JSON snippets the tunnel installer hands operators to paste.
+//
+// `code` is emitted verbatim as a single `text` element. Rich-text
+// `text` elements are NOT mrkdwn-parsed, so the snippet's own backticks,
+// `<…>`, and `*` render literally — exactly what a copy-paste block wants.
+// Callers pass raw, already-validated snippet text.
+func richTextPreformattedBlock(code string) map[string]any {
+	return map[string]any{
+		"type": "rich_text",
+		blockKitFieldElements: []any{
+			map[string]any{
+				"type": "rich_text_preformatted",
+				blockKitFieldElements: []any{
+					map[string]any{
+						"type": "text",
+						"text": code,
+					},
+				},
+			},
+		},
+	}
+}
+
 // sectionWithButton returns a `section` block whose accessory is a
 // button. Slack renders an accessory to the RIGHT of the section text —
 // Block Kit has no leading/left accessory slot, so the right-aligned
@@ -320,7 +349,7 @@ func sectionWithButton(text, buttonText, actionID, value string) map[string]any 
 func contextBlock(text string) map[string]any {
 	return map[string]any{
 		"type": "context",
-		"elements": []any{
+		blockKitFieldElements: []any{
 			map[string]any{
 				"type": "mrkdwn",
 				"text": text,


### PR DESCRIPTION
## What
The `/qurl-admin tunnel install` confirmation (guided modal + typed forms) hands operators a long message: the bootstrap key plus per-environment shell / YAML / JSON snippets. Those were triple-backtick mrkdwn fences in a single `text` field. This renders each fenced snippet as a Block Kit **`rich_text_preformatted`** block (prose runs become `section` blocks), so each snippet gets Slack's native **copy button** — the bootstrap key, the Docker / Docker-Compose shell scripts, the ECS task-definition JSON, and the Kubernetes manifests.

## How it stays safe
The bootstrap-key delivery is security-critical: an unconfirmed delivery revokes the key. This change is built so it can never deliver *less* than before:

- `installMessageBlocks` derives the blocks from the **same fully-rendered string** that is also sent as the message's plain-text fallback — it splits on the ` ``` ` fences `slackCodeBlock` already emits — so blocks and fallback can't drift.
- `postInstallInstructions` posts blocks, and on **any** block-path miss (no fence, an oversize segment, or Slack rejecting the blocks payload with a non-2xx) it **retries as the exact plain-text post the flow used before**. The key is revoked only when *neither* rendering lands.
- So: a workspace where Slack accepts the blocks gets copy buttons; a workspace where it doesn't gets the identical text message as today. No regression to delivery.

## Sizing
`rich_text` `text` elements have **no documented length cap** — the 3000-char limit applies only to `text`/mrkdwn composition objects (section text), confirmed against the official Slack SDK type definitions. Measured real install snippets: largest is the Docker Compose shell block at ~3.8 KB. The per-segment guard (`slackRichTextMaxBytes`) is a generous defensive ceiling, and the text-retry path covers the rest.

## Tests
- Every environment (Docker / Compose / ECS / Kubernetes) renders as blocks, with the bootstrap key in a copyable `rich_text_preformatted` block and **never** in a prose section. (This also measures real segment sizes — an oversize snippet would flip the result and fail the test.)
- New `TestTunnelInstallFallsBackToTextWhenBlocksRejected`: when Slack rejects the blocks post but accepts text, the install is delivered and the key is **not** revoked.
- Updated `TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails` for the new blocks → text-retry → discard-notice sequence on total failure (key still revoked).
- Segmentation preserves source order; fallback fires on no-fence and oversize inputs.
- `go test ./apps/slack/...` green; `golangci-lint --new-from-rev=origin/main` reports 0 new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)